### PR TITLE
Analytics: Do Not Track disables ad-tracking and Google Analytics

### DIFF
--- a/client/lib/analytics/test/config/index.js
+++ b/client/lib/analytics/test/config/index.js
@@ -3,5 +3,9 @@ module.exports = function( key ) {
 		return true;
 	}
 
+	if ( key === 'google_analytics_enabled' ) {
+		return false;
+	}
+
 	throw new Error( 'key ' + key + ' not expected to be needed' );
 };

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -1,0 +1,55 @@
+/**
+ * Whether Do Not Track is enabled in the user's browser.
+ *
+ * @returns {Boolean} true if Do Not Track is enabled in the user's browser.
+ */
+function doNotTrack() {
+	return '1' === navigator.doNotTrack;
+}
+
+/**
+ * Whether the current URL can potentially contain personally identifiable info.
+ *
+ * @returns {Boolean} true if the current URL can potentially contain personally identifiable info.
+ */
+function isPiiUrl() {
+	// If this list catches things that are not necessarily forbidden we're ok with
+	// a little bit of approximation as long as we do catch the ones that we have to.
+	// We need to be quite aggressive with how we filter candiate pages as failing
+	// to protect our users' privacy puts us in breach of our own TOS and our
+	// retargeting partners' TOS. We also see personally identifiable information in
+	// unexpected places like email addresses in users' posts URLs and titles for
+	// various (usually accidental) reasons. We also pass PII in URLs like
+	// `wordpress.com/jetpack/connect` etc.
+	const forbiddenPatterns = [
+		'@',
+		'%40',
+		'first=',
+		'last=',
+		'email=',
+		'email_address=',
+		'user_email=',
+		'address-1=',
+		'country-code=',
+		'phone=',
+		'last-name=',
+		'first-name=',
+		'wordpress.com/jetpack/connect',
+		'wordpress.com/error-report',
+	];
+
+	const href = document.location.href;
+
+	for ( const pattern of forbiddenPatterns ) {
+		if ( href.indexOf( pattern ) !== -1 ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+module.exports = {
+	doNotTrack: doNotTrack,
+	isPiiUrl: isPiiUrl
+};


### PR DESCRIPTION
This PR disables ad-tracking/remarketing and Google Analytics when Do Not Track is enabled.

The idea is that enabling Do Not Track should have the same effect as disabling `ad-tracking` and Google Analytics from Calypso's config. Do Not Track does not affect Tracks events.

# Implementation - Ad Tracking

I've basically substituted all `config.isEnabled( 'ad-tracking' )` occurrences with the `isAdTrackingAllowed()` function (previously called `isRetargetAllowed()`) which centralises the logic on whether ad-tracking should be performed based on whether:

1. `'ad-tracking'` is disabled
2. `Do Not Track` is enabled
3. `document.location.href` may contain personally identifiable information

# Implementation - Google Analytics

Here as well, using `isGoogleAnalyticsEnabled`, I've centralised the check on whether GA should be disabled based on whether:

1. `config( 'google_analytics_enabled' )` is false
2. `Do Not Track` is enabled

There are two changes in behaviour when GA is disabled:

1. We don't load the GA script (previously we were loading it even if we weren't using it).
2. `analytics.ga.recordPageView/recordEvent/recordTiming` now immediately return. Previously they were initialising GA, logging debug info then check if GA was disabled, which appears both wasteful and misleading.

# Testing

## Enabling GA & ad-tracking

- In `config/development.json` enable both `google_analytics_enabled` and `ad-tracking`
- Restart Calypso
- In Chromes JS console enable all debug logs: `localStorage.setItem('debug', 'calypso:analytics:*');`
- Visiting for example http://calypso.localhost:3000 should show these entries:

  - `calypso:analytics:ga Recording Page View` (Google Analytics is working)
  - `calypso:analytics:ad-tracking Retargeting` (ad-tracking is working)

![do-not-track-1](https://cloud.githubusercontent.com/assets/10284338/25234855/a63d29b0-25e3-11e7-8c85-d38291bbb8bc.png)

Visiting a URL containing potential personally identifiable information like:

- http://calypso.localhost:3000/?email=noone

Should show no new `calypso:analytics:ad-tracking` logs in Chrome's JS console (ie ad tracking has been blocked for PII reasons) while `calypso:analytics:ga` entries should still be visible.

## Enabling "Do Not Track"

- Enable Do Not Track from Chrome's `Settings -> Show advanced settings -> Privacy -> Send a "Do Not Track" request`.
- Visiting for example http://calypso.localhost:3000 should show no entries for:

  - `calypso:analytics:ga` (Google Analytics is disabled)
  - `calypso:analytics:ad-tracking` (ad-tracking is disabled)

- Disable Do Not Track setting in Chrome
- Reload Calypso
- `calypso:analytics:ga` and `calypso:analytics:ad-tracking` should now be back

## Disabling GA & ad-tracking

- In `config/development.json` disable both `google_analytics_enabled` and `ad-tracking`
- Restart Calypso
- Visiting for example http://calypso.localhost:3000 should show no entries for:

  - `calypso:analytics:ga` (Google Analytics is disabled)
  - `calypso:analytics:ad-tracking` (ad-tracking is disabled)

![do-not-track-2](https://cloud.githubusercontent.com/assets/10284338/25235530/ab956fba-25e5-11e7-8b60-75f9b5a2ce3a.png)

