### PR TITLE
Extensions: WP Super Cache - Disable UI if settings are being requested

### DIFF
--- a/client/extensions/wp-super-cache/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/accepted-filenames.jsx
@@ -34,16 +34,18 @@ const AcceptedFilenames = ( {
 	},
 	handleChange,
 	handleToggle,
+	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Accepted Filenames & Rejected URIs' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card>
@@ -51,6 +53,7 @@ const AcceptedFilenames = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! single }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'single' ) }>
 							<span>
 								{ translate( 'Single Posts (is_single)' ) }
@@ -59,6 +62,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! pages }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'pages' ) }>
 							<span>
 								{ translate( 'Pages (is_page)' ) }
@@ -67,6 +71,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! frontpage }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'frontpage' ) }>
 							<span>
 								{ translate( 'Front Page (is_front_page)' ) }
@@ -75,6 +80,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! home }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'home' ) }>
 							<span>
 								{ translate( 'Home (is_home)' ) }
@@ -83,6 +89,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! archives }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'archives' ) }>
 							<span>
 								{ translate( 'Archives (is_archive)' ) }
@@ -91,6 +98,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! tag }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'tag' ) }>
 							<span>
 								{ translate( 'Tags (is_tag)' ) }
@@ -99,6 +107,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! category }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'category' ) }>
 							<span>
 								{ translate( 'Category (is_category)' ) }
@@ -107,6 +116,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! feed }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'feed' ) }>
 							<span>
 								{ translate( 'Feeds (is_feed)' ) }
@@ -115,6 +125,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! search }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'search' ) }>
 							<span>
 								{ translate( 'Search Pages (is_search)' ) }
@@ -123,6 +134,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! author }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'author' ) }>
 							<span>
 								{ translate( 'Author Pages (is_author)' ) }
@@ -149,6 +161,7 @@ const AcceptedFilenames = ( {
 
 					<FormFieldset>
 						<FormTextarea
+							disabled={ isRequesting }
 							onChange={ handleChange( 'wp_rejected_uri' ) }
 							value={ wp_rejected_uri || '' } />
 						<FormSettingExplanation>
@@ -163,6 +176,7 @@ const AcceptedFilenames = ( {
 
 					<FormFieldset>
 						<FormTextarea
+							disabled={ isRequesting }
 							onChange={ handleChange( 'wp_accepted_files' ) }
 							value={ wp_accepted_files || '' } />
 						<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/advanced.jsx
+++ b/client/extensions/wp-super-cache/advanced.jsx
@@ -36,16 +36,18 @@ const Advanced = ( {
 		wp_supercache_cache_list,
 	},
 	handleToggle,
+	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Advanced' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card>
@@ -53,7 +55,7 @@ const Advanced = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! wp_cache_mfunc_enabled }
-							disabled={ '1' === super_cache_enabled }
+							disabled={ isRequesting || ( '1' === super_cache_enabled ) }
 							onChange={ handleToggle( 'wp_cache_mfunc_enabled' ) }>
 							<span>
 								{ translate(
@@ -76,6 +78,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_mobile_enabled }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_mobile_enabled' ) }>
 							<span>
 								{ translate(
@@ -123,6 +126,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_disable_utf8 }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_disable_utf8' ) }>
 							<span>
 								{ translate(
@@ -134,6 +138,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_clear_on_post_edit }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_clear_on_post_edit' ) }>
 							<span>
 								{ translate( 'Clear all cache files when a post or page is published or updated.' ) }
@@ -142,6 +147,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_front_page_checks }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_front_page_checks' ) }>
 							<span>
 								{ translate(
@@ -155,6 +161,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_refresh_single_only }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_refresh_single_only' ) }>
 							<span>
 								{ translate( 'Only refresh current page when comments made.' ) }
@@ -163,6 +170,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_supercache_cache_list }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_supercache_cache_list' ) }>
 							<span>
 								{ translate( 'List the newest cached pages on this page.' ) }
@@ -172,6 +180,7 @@ const Advanced = ( {
 						{ ! wp_cache_disable_locking &&
 							<FormToggle
 								checked={ !! wp_cache_mutex_disabled }
+								disabled={ isRequesting }
 								onChange={ handleToggle( 'wp_cache_mutex_disabled' ) }>
 								<span>
 									{ translate( 'Coarse file locking. You do not need this as it will slow down your website.' ) }
@@ -181,6 +190,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_super_cache_late_init }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_super_cache_late_init' ) }>
 							<span>
 								{ translate(
@@ -191,6 +201,7 @@ const Advanced = ( {
 						{ !! _wp_using_ext_object_cache &&
 							<FormToggle
 								checked={ !! wp_cache_object_cache }
+								disabled={ isRequesting }
 								onChange={ handleToggle( 'wp_cache_object_cache' ) }>
 								<span>
 									{ translate( 'Use object cache to store cached files. (Experimental)' ) }

--- a/client/extensions/wp-super-cache/cache-location.jsx
+++ b/client/extensions/wp-super-cache/cache-location.jsx
@@ -20,22 +20,25 @@ const CacheLocation = ( {
 		wp_cache_location,
 	},
 	handleChange,
+	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Cache Location' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card>
 				<form>
 					<FormFieldset>
 						<FormTextInput
+							disabled={ isRequesting }
 							onChange={ handleChange( 'wp_cache_location' ) }
 							value={ wp_cache_location || '' } />
 						<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -24,16 +24,18 @@ const Caching = ( {
 	},
 	handleRadio,
 	handleToggle,
+	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Caching' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card>
@@ -41,6 +43,7 @@ const Caching = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! wp_cache_enabled }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_enabled' ) }>
 							<span>
 								{ translate( 'Caching On {{em}}(Recommended){{/em}}',
@@ -56,6 +59,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ '1' === super_cache_enabled }
+								disabled={ isRequesting }
 								name="super_cache_enabled"
 								onChange={ handleRadio }
 								value="1" />
@@ -67,6 +71,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ '2' === super_cache_enabled }
+								disabled={ isRequesting }
 								name="super_cache_enabled"
 								onChange={ handleRadio }
 								value="2" />
@@ -83,6 +88,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ '0' === super_cache_enabled }
+								disabled={ isRequesting }
 								name="super_cache_enabled"
 								onChange={ handleRadio }
 								value="0" />

--- a/client/extensions/wp-super-cache/cdn-tab.jsx
+++ b/client/extensions/wp-super-cache/cdn-tab.jsx
@@ -29,6 +29,7 @@ const CdnTab = ( {
 	},
 	handleChange,
 	handleToggle,
+	isRequesting,
 	siteUrl,
 	translate,
 } ) => {
@@ -36,10 +37,11 @@ const CdnTab = ( {
 		<div>
 			<SectionHeader label={ translate( 'CDN' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 
@@ -48,6 +50,7 @@ const CdnTab = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! ossdlcdn }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'ossdlcdn' ) }>
 							<span>
 								{ translate( 'Enable CDN Support' ) }
@@ -61,6 +64,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
+							disabled={ isRequesting }
 							id="ossdl_off_cdn_url"
 							onChange={ handleChange( 'ossdl_off_cdn_url' ) }
 							value={ ossdl_off_cdn_url || '' } />
@@ -81,6 +85,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
+							disabled={ isRequesting }
 							id="ossdl_off_include_dirs"
 							onChange={ handleChange( 'ossdl_off_include_dirs' ) }
 							value={ ossdl_off_include_dirs || '' } />
@@ -102,6 +107,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
+							disabled={ isRequesting }
 							id="ossdl_off_exclude"
 							onChange={ handleChange( 'ossdl_off_exclude' ) }
 							value={ ossdl_off_exclude || '' } />
@@ -124,6 +130,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
+							disabled={ isRequesting }
 							id="ossdl_cname"
 							onChange={ handleChange( 'ossdl_cname' ) }
 							value={ ossdl_cname || '' } />
@@ -154,6 +161,7 @@ const CdnTab = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! ossdl_https }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'ossdl_https' ) }>
 							<span>
 								{ translate( 'Skip https URLs to avoid "mixed content" errors' ) }

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -24,6 +24,7 @@ const DirectlyCachedFiles = ( {
 		wp_cache_writable,
 	},
 	handleChange,
+	isRequesting,
 	siteUrl,
 	translate,
 } ) => {
@@ -33,10 +34,11 @@ const DirectlyCachedFiles = ( {
 		<div>
 			<SectionHeader label={ translate( 'Directly Cached Files' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card className="wp-super-cache__directly-cached-files">
@@ -93,6 +95,7 @@ const DirectlyCachedFiles = ( {
 						<form>
 							<FormFieldset>
 								<FormTextInput
+									disabled={ isRequesting }
 									onChange={ handleChange( 'new_direct_page' ) } />
 							</FormFieldset>
 
@@ -110,6 +113,7 @@ const DirectlyCachedFiles = ( {
 									<FormTextInputWithAction
 										action={ translate( 'Delete Cached File' ) }
 										defaultValue={ page }
+										disabled={ isRequesting }
 										key={ page } />
 								</FormFieldset>
 							) ) }

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -23,6 +23,7 @@ const EasyTab = ( {
 		is_cache_enabled,
 	},
 	handleToggle,
+	isRequesting,
 	site,
 	translate,
 } ) => {
@@ -36,7 +37,10 @@ const EasyTab = ( {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Caching' ) }>
-				<Button compact primary>
+				<Button
+					compact
+					primary
+					disabled={ isRequesting }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
@@ -44,6 +48,7 @@ const EasyTab = ( {
 				<form>
 					<FormToggle
 						checked={ is_cache_enabled }
+						disabled={ isRequesting }
 						onChange={ handleToggle( 'is_cache_enabled' ) }>
 						<span>
 							{ translate( 'Caching On {{em}}(Recommended){{/em}}',

--- a/client/extensions/wp-super-cache/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/expiry-time.jsx
@@ -35,6 +35,7 @@ const ExpiryTime = ( {
 	handleRadio,
 	handleSelect,
 	handleToggle,
+	isRequesting,
 	translate,
 } ) => {
 	const renderCacheTimeout = () => {
@@ -46,6 +47,7 @@ const ExpiryTime = ( {
 
 				<FormTextInput
 					className="wp-super-cache__cache-timeout"
+					disabled={ isRequesting }
 					onChange={ handleChange( 'cache_max_time' ) }
 					value={ cache_max_time || '' } />
 				{ translate( 'seconds' ) }
@@ -71,13 +73,14 @@ const ExpiryTime = ( {
 				<FormLabel>
 					<FormRadio
 						checked={ 'interval' === cache_schedule_type }
+						disabled={ isRequesting }
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="interval" />
 					<span>
 						{ translate( 'Timer' ) }
 						<FormTextInput
-							disabled={ 'interval' !== cache_schedule_type }
+							disabled={ isRequesting || ( 'interval' !== cache_schedule_type ) }
 							onChange={ handleChange( 'cache_time_interval' ) }
 							value={ cache_time_interval || '' } />
 						{ translate( 'seconds' ) }
@@ -90,13 +93,14 @@ const ExpiryTime = ( {
 				<FormLabel className="wp-super-cache__clock">
 					<FormRadio
 						checked={ 'time' === cache_schedule_type }
+						disabled={ isRequesting }
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="time" />
 					<span>
 						{ translate( 'Clock' ) }
 						<FormTextInput
-							disabled={ 'time' !== cache_schedule_type }
+							disabled={ isRequesting || ( 'time' !== cache_schedule_type ) }
 							onChange={ handleChange( 'cache_scheduled_time' ) }
 							value={ cache_scheduled_time || '' } />
 						{ translate( 'HH:MM' ) }
@@ -113,8 +117,8 @@ const ExpiryTime = ( {
 					</FormLabel>
 
 					<FormSelect
+						disabled={ isRequesting || ( 'time' !== cache_schedule_type ) }
 						id="cache_schedule_interval"
-						disabled={ 'time' !== cache_schedule_type }
 						name="cache_schedule_interval"
 						onChange={ handleSelect }
 						value={ cache_schedule_interval || 'five_minutes_interval' }>
@@ -140,6 +144,7 @@ const ExpiryTime = ( {
 
 				<FormToggle
 					checked={ !! cache_gc_email_me }
+					disabled={ isRequesting }
 					id="cache_gc_email_me"
 					onChange={ handleToggle( 'cache_gc_email_me' ) }>
 					<span>
@@ -154,10 +159,11 @@ const ExpiryTime = ( {
 		<div>
 			<SectionHeader label={ translate( 'Expiry Time & Garbage Collection' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card>

--- a/client/extensions/wp-super-cache/fix-config.jsx
+++ b/client/extensions/wp-super-cache/fix-config.jsx
@@ -19,9 +19,9 @@ const FixConfig = ( { translate } ) => {
 				<form>
 					<div>
 						<Button
-							compact={ true }
+							compact
 							type="submit">
-								{ translate( 'Restore Default Configuration' ) }
+							{ translate( 'Restore Default Configuration' ) }
 						</Button>
 					</div>
 				</form>

--- a/client/extensions/wp-super-cache/lock-down.jsx
+++ b/client/extensions/wp-super-cache/lock-down.jsx
@@ -55,9 +55,9 @@ const LockDown = ( {
 					</p>
 					<div>
 						<Button
-							compact={ true }
+							compact
 							type="submit">
-								{ ! wp_lock_down ? translate( 'Enable Lock Down' ) : translate( 'Disable Lock Down' ) }
+							{ ! wp_lock_down ? translate( 'Enable Lock Down' ) : translate( 'Disable Lock Down' ) }
 						</Button>
 					</div>
 				</form>

--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -29,16 +29,18 @@ const Miscellaneous = ( {
 		wp_supercache_304,
 	},
 	handleToggle,
+	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Miscellaneous' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card>
@@ -57,6 +59,7 @@ const Miscellaneous = ( {
 						{ ! wp_cache_compression_disabled &&
 						<FormToggle
 							checked={ !! cache_compression }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'cache_compression' ) }>
 							<span>
 								{ translate(
@@ -71,6 +74,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_not_logged_in }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_not_logged_in' ) }>
 							<span>
 								{ translate(
@@ -84,6 +88,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! cache_rebuild_files }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'cache_rebuild_files' ) }>
 							<span>
 								{ translate(
@@ -98,7 +103,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_supercache_304 }
-							disabled={ '1' === super_cache_enabled }
+							disabled={ isRequesting || ( '1' === super_cache_enabled ) }
 							onChange={ handleToggle( 'wp_supercache_304' ) }>
 							<span>
 								{ translate(
@@ -132,6 +137,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_no_cache_for_get }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_no_cache_for_get' ) }>
 							<span>
 								{ translate( 'Don’t cache pages with GET parameters. (?x=y at the end of a url)' ) }
@@ -140,6 +146,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_make_known_anon }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_make_known_anon' ) }>
 							<span>
 								{ translate( 'Make known users anonymous so they’re served supercached static files.' ) }
@@ -148,6 +155,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_hello_world }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'wp_cache_hello_world' ) }>
 							<span>
 								{ translate( 'Proudly tell the world your server is {{fry}}Stephen Fry proof{{/fry}}! ' +

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -26,10 +26,12 @@ import WrapSettingsForm from './wrap-settings-form';
  */
 const renderCachePreloadInterval = ( {
 	handleChange,
+	isRequesting,
 	preload_interval,
 } ) => (
 	<FormTextInput
 		className="wp-super-cache__preload-interval"
+		disabled={ isRequesting }
 		min="0"
 		name="preload_interval"
 		onChange={ handleChange( 'preload_interval' ) }
@@ -60,6 +62,7 @@ const PreloadTab = ( {
 	handleChange,
 	handleSelect,
 	handleToggle,
+	isRequesting,
 	translate,
 } ) => {
 	const statusEmailAmountSelectValues = [
@@ -89,10 +92,11 @@ const PreloadTab = ( {
 		<div>
 			<SectionHeader label={ ( 'Preload' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 
@@ -101,6 +105,7 @@ const PreloadTab = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! preload_on }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'preload_on' ) }>
 							<span>
 								{ translate( 'Preload mode. (Garbage collection only on legacy cache files. Recommended.)' ) }
@@ -109,6 +114,7 @@ const PreloadTab = ( {
 
 						<FormToggle
 							checked={ preload_refresh }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'preload_refresh' ) }>
 							<span>
 								{ translate(
@@ -119,6 +125,7 @@ const PreloadTab = ( {
 										components: {
 											number: renderCachePreloadInterval( {
 												handleChange,
+												isRequesting,
 												preload_interval,
 											} )
 										}
@@ -138,6 +145,7 @@ const PreloadTab = ( {
 
 						<FormToggle
 							checked={ !! preload_taxonomies }
+							disabled={ isRequesting }
 							onChange={ handleToggle( 'preload_taxonomies' ) }>
 							<span>
 								{ translate( 'Preload tags, categories and other taxonomies.' ) }
@@ -151,6 +159,7 @@ const PreloadTab = ( {
 						</FormLabel>
 						<FormSelect
 							className="wp-super-cache__preload-posts"
+							disabled={ isRequesting }
 							id="preload_posts"
 							name="preload_posts"
 							onChange={ handleSelect }
@@ -166,6 +175,7 @@ const PreloadTab = ( {
 							{ translate( 'Status Emails' ) }
 						</FormLegend>
 						<FormSelect
+							disabled={ isRequesting }
 							id="preload_email_volume"
 							name="preload_email_volume"
 							onChange={ handleSelect }

--- a/client/extensions/wp-super-cache/rejected-user-agents.jsx
+++ b/client/extensions/wp-super-cache/rejected-user-agents.jsx
@@ -20,22 +20,25 @@ const RejectedUserAgents = ( {
 		wp_rejected_user_agent,
 	},
 	handleChange,
+	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Rejected User Agents' ) }>
 				<Button
-					compact={ true }
-					primary={ true }
+					compact
+					primary
+					disabled={ isRequesting }
 					type="submit">
-						{ translate( 'Save Settings' ) }
+					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
 			<Card>
 				<form>
 					<FormFieldset>
 						<FormTextarea
+							disabled={ isRequesting }
 							onChange={ handleChange( 'wp_rejected_user_agent' ) }
 							value={ wp_rejected_user_agent || '' } />
 						<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -11,9 +11,12 @@ import { localize } from 'i18n-calypso';
  */
 import { protectForm } from 'lib/protect-form';
 import trackForm from 'lib/track-form';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSettings } from './state/selectors';
 import QuerySettings from './query-settings';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getSettings,
+	isRequestingSettings,
+} from './state/selectors';
 
 const wrapSettingsForm = getFormSettings => SettingsForm => {
 	class WrappedSettingsForm extends Component {
@@ -263,8 +266,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				preload_refresh: true,
 				preload_taxonomies: false,
 			} );
+			const isRequesting = isRequestingSettings( state, siteId ) && ! settings;
 
 			return {
+				isRequesting,
 				settings,
 				siteId,
 			};


### PR DESCRIPTION
This PR disables the UI while the settings are being fetched. UI elements that are not dependent on the settings (e.g. "Delete Cache" button) are not disabled.