### PR TITLE
Components: Add react-virtualized compatible FlexboxGrid component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -95,6 +95,7 @@
 @import 'components/faq/style';
 @import 'components/feature-example/style';
 @import 'components/first-view/style';
+@import 'components/flexbox-grid/style';
 @import 'components/foldable-card/style';
 @import 'components/forms/counted-textarea/style';
 @import 'components/forms/form-button/style';

--- a/client/components/flexbox-grid/README.md
+++ b/client/components/flexbox-grid/README.md
@@ -9,15 +9,16 @@ The grid is initially rendered as a static flexbox layout and switches to virtua
 | Property | Type | Required? | Description |
 |:---|:---|:---|:---|
 | width | Number |  | The total width of the grid component. This is necessery for the component to switch to virtual scroll. |
-| maxColumnWidth | Number |  | The minimum column width. Used for cells flex-base. |
-| columnCount | Number |  | The number of columns in a row. Used only for determining currently visible cells. Doesn't affect the view. |
-| rowCount | Number |  | The number of rows in the grid. Used only for determining currently visible cells. Doesn't affect the view. |
+| maxColumnWidth | Number | ✓ | The minimum column width. Used for cells flex-base. |
+| columnCount | Number | ✓ | The number of columns in a row. Used only for determining currently visible cells. Doesn't affect the view. |
+| rowHeight | Number |  | Used to determine the total height of the grid. |
+| rowCount | Number | ✓ | The number of rows in the grid. Used only for determining currently visible cells. Doesn't affect the view. |
 | scrollTop | Number |  | Scroll position relative to the top of the grid. Used for determining currently visible cells. |
 | cellRenderer | Function | ✓ | Responsible for rendering a cell given its index. Should implement the following signature: `({ index: number, key: number, style: object }): React.Component`. |
 | overscanRowCount | Number |  | Number of rows to render above & below the visible slice of the grid. Helps reduce flickering during scrolling. Default: 0. |
 | onCellsRendered | Function |  | Callback invoked each time the visible rows change. `({ startIndex: Number, stopIndex: Number }): void` |
 
-**Important:** Even though most of the properties are not required by definition, it's necessary to always provide **maxColumnWidth**, **columnCount**, **rowCount** and **scrollTop** together with **width** for virtual scrolling to work.
+**Important:** When providing a **width** property, **rowHeight** and **scrollTop** must also be provided for virtual scrolling to work.
 
 Cell inices start from `0` and go from left to right and from top to bottom.
 

--- a/client/components/flexbox-grid/README.md
+++ b/client/components/flexbox-grid/README.md
@@ -9,7 +9,7 @@ The grid is initially rendered as a static flexbox layout and switches to virtua
 | Property | Type | Required? | Description |
 |:---|:---|:---|:---|
 | width | Number |  | The total width of the grid component. This is necessery for the component to switch to virtual scroll. |
-| maxColumnWidth | Number | ✓ | The minimum column width. Used for cells flex-base. |
+| minColumnWidth | Number | ✓ | The minimum column width. Used for cells flex-base. |
 | columnCount | Number | ✓ | The number of columns in a row. Used only for determining currently visible cells. Doesn't affect the view. |
 | rowHeight | Number |  | Used to determine the total height of the grid. |
 | rowCount | Number | ✓ | The number of rows in the grid. Used only for determining currently visible cells. Doesn't affect the view. |
@@ -20,7 +20,7 @@ The grid is initially rendered as a static flexbox layout and switches to virtua
 
 **Important:** When providing a **width** property, **rowHeight** and **scrollTop** must also be provided for virtual scrolling to work.
 
-Cell inices start from `0` and go from left to right and from top to bottom.
+Cell indexes start from `0` and go from left to right and from top to bottom.
 
 ### Example
 

--- a/client/components/flexbox-grid/README.md
+++ b/client/components/flexbox-grid/README.md
@@ -1,0 +1,55 @@
+FlexboxGrid
+===========
+
+A SSR compatible drop-in replacement for *Grid* and *AutoSizer* components from [react-virtualized](https://github.com/bvaughn/react-virtualized).  
+The grid is initially rendered as a static flexbox layout and switches to virtual scroll once it is given its dimensions. The measuring itself is the responsibility of the parent component.
+
+### PropTypes
+
+| Property | Type | Required? | Description |
+|:---|:---|:---|:---|
+| width | Number |  | The total width of the grid component. This is necessery for the component to switch to virtual scroll. |
+| maxColumnWidth | Number |  | The minimum column width. Used for cells flex-base. |
+| columnCount | Number |  | The number of columns in a row. Used only for determining currently visible cells. Doesn't affect the view. |
+| rowCount | Number |  | The number of rows in the grid. Used only for determining currently visible cells. Doesn't affect the view. |
+| scrollTop | Number |  | Scroll position relative to the top of the grid. Used for determining currently visible cells. |
+| cellRenderer | Function | ✓ | Responsible for rendering a cell given its index. Should implement the following signature: `({ index: number, key: number, style: object }): React.Component`. |
+| overscanRowCount | Number |  | Number of rows to render above & below the visible slice of the grid. Helps reduce flickering during scrolling. Default: 0. |
+| onCellsRendered | Function |  | Callback invoked each time the visible rows change. `({ startIndex: Number, stopIndex: Number }): void` |
+
+**Important:** Even though most of the properties are not required by definition, it's necessary to always provide **maxColumnWidth**, **columnCount**, **rowCount** and **scrollTop** together with **width** for virtual scrolling to work.
+
+Cell inices start from `0` and go from left to right and from top to bottom.
+
+### Example
+
+```js
+const items = [
+	...
+];
+
+
+const MyComponent = () => {
+	const renderCell = ( { index, key, style } => {
+		return (
+			<div key={ key } style={ style }>{ index }</div>
+		);
+	} );
+
+	return {
+		<WindowScroller>
+			{ ( { scrollTop } ) => (
+				<FlexboxGrid
+					width={ 1000 }
+					minColumnWidth={ 200 }
+					columnCount={ 4 }
+					rowCount={ items.length / 4 }
+					scrollTop={ scrollTop }
+					cellRenderer={ renderCell }
+					overscanRowCount={ 3 }
+				/>
+			) }
+		</WindowScroller>
+	};	
+};
+```

--- a/client/components/flexbox-grid/index.jsx
+++ b/client/components/flexbox-grid/index.jsx
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { times } from 'lodash';
+import createCallbackMemoizer from 'react-virtualized/utils/createCallbackMemoizer';
+
+export default class FlexboxGrid extends React.PureComponent {
+
+	constructor() {
+		super();
+
+		this._onGridRenderedMemoizer = createCallbackMemoizer();
+	}
+
+	render() {
+		return (
+			<div className={ 'flexbox-grid' } style={ this.gridStyle() }>
+				<div className={ 'flexbox-grid__content' } style={ this.contentStyle() }>
+					{ this.renderVisibleCells() }
+				</div>
+			</div>
+		);
+	}
+
+	renderVisibleCells() {
+		const start = this.firstVisibleIndex();
+		const end = this.lastVisibleIndex();
+
+		this.invokeOnGridRenderedHelper( {
+			columnOverscanStartIndex: 0,
+			columnOverscanStopIndex: this.props.columnCount,
+			columnStartIndex: 0,
+			columnStopIndex: this.props.columnCount,
+			rowOverscanStartIndex: start / this.props.columnCount,
+			rowOverscanStopIndex: end / this.props.columnCount,
+			rowStartIndex: start / this.props.columnCount,
+			rowStopIndex: end / this.props.columnCount
+		} );
+
+		return times( end - start, idx => this.props.cellRenderer( {
+			index: start + idx,
+			key: idx,
+			style: { flex: `1 0 ${ this.props.minColumnWidth }px` }
+		} ) );
+	}
+
+	invokeOnGridRenderedHelper( renderedIndices ) {
+		this._onGridRenderedMemoizer( {
+			callback: this.onSectionRendered,
+			indices: renderedIndices
+		} );
+	}
+
+	onSectionRendered = ( { columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex } ) => {
+		const startIndex = rowStartIndex * this.props.columnCount + columnStartIndex;
+		const stopIndex = rowStopIndex * this.props.columnCount + columnStopIndex;
+
+		this.props.onCellsRendered( {
+			startIndex,
+			stopIndex
+		} );
+	}
+
+	gridStyle() {
+		if ( this.props.width === undefined ) {
+			return {};
+		}
+
+		return {
+			height: this.props.rowCount * this.props.rowHeight
+		};
+	}
+
+	contentStyle() {
+		if ( this.props.width === undefined ) {
+			return {};
+		}
+
+		return {
+			position: 'absolute',
+			top: `${ this.offsetTop() }px`,
+			left: 0
+		};
+	}
+
+	firstVisibleIndex() {
+		if ( this.props.width === undefined ) {
+			return 0;
+		}
+
+		let rowIdx = 0;
+		while ( rowIdx * this.props.rowHeight <= this.props.scrollTop ) {
+			++rowIdx;
+		}
+
+		return Math.max( rowIdx - this.props.overscanRowCount - 1, 0 ) * this.props.columnCount;
+	}
+
+	lastVisibleIndex() {
+		if ( this.props.width === undefined ) {
+			return 1000;
+		}
+
+		let rowIdx = 0;
+		while ( rowIdx * this.props.rowHeight < this.props.scrollTop + window.innerHeight ) {
+			++rowIdx;
+		}
+
+		return Math.min( rowIdx + this.props.overscanRowCount, this.props.rowCount ) * this.props.columnCount;
+	}
+
+	offsetTop() {
+		if ( this.props.width === undefined ) {
+			return 0;
+		}
+
+		return this.firstVisibleIndex() / this.props.columnCount * this.props.rowHeight;
+	}
+}

--- a/client/components/flexbox-grid/index.jsx
+++ b/client/components/flexbox-grid/index.jsx
@@ -28,6 +28,14 @@ export default class FlexboxGrid extends React.PureComponent {
 		this.onCellsRenderedMemoizer = createOnCellsRenderedMemoizer();
 	}
 
+	componentDidMount() {
+		this.invokeOnCellsRendered();
+	}
+
+	componentDidUpdate() {
+		this.invokeOnCellsRendered();
+	}
+
 	render() {
 		return (
 			<div className={ 'flexbox-grid' } style={ this.gridStyle() }>
@@ -42,26 +50,11 @@ export default class FlexboxGrid extends React.PureComponent {
 		const start = this.firstVisibleIndex();
 		const end = this.lastVisibleIndex();
 
-		this.onCellsRenderedMemoizer(
-			this.props.onCellsRendered,
-			{
-				startIndex: start,
-				stopIndex: end
-			}
-		);
-
 		return times( end - start, idx => this.props.cellRenderer( {
 			index: start + idx,
 			key: idx,
 			style: { flex: `1 0 ${ this.props.minColumnWidth }px` }
 		} ) );
-	}
-
-	invokeOnGridRenderedHelper( renderedIndices ) {
-		this._onGridRenderedMemoizer( {
-			callback: this.props.onCellsRendered,
-			indices: renderedIndices
-		} );
 	}
 
 	gridStyle() {
@@ -101,7 +94,7 @@ export default class FlexboxGrid extends React.PureComponent {
 
 	lastVisibleIndex() {
 		if ( this.props.width === undefined ) {
-			return 1000;
+           return 1000;
 		}
 
 		let rowIdx = 0;
@@ -118,5 +111,15 @@ export default class FlexboxGrid extends React.PureComponent {
 		}
 
 		return this.firstVisibleIndex() / this.props.columnCount * this.props.rowHeight;
+	}
+
+	invokeOnCellsRendered() {
+		this.onCellsRenderedMemoizer(
+			this.props.onCellsRendered,
+			{
+				startIndex: this.firstVisibleIndex(),
+				stopIndex: this.lastVisibleIndex()
+			}
+		);
 	}
 }

--- a/client/components/flexbox-grid/index.jsx
+++ b/client/components/flexbox-grid/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { times } from 'lodash';
+import { times, noop } from 'lodash';
 
 export default class FlexboxGrid extends React.PureComponent {
 	static propTypes = {
@@ -18,7 +18,8 @@ export default class FlexboxGrid extends React.PureComponent {
 	};
 
 	static defaultProps = {
-		overscanRowCount: 0
+		overscanRowCount: 0,
+		onCellsRendered: noop
 	};
 
 	componentDidMount() {

--- a/client/components/flexbox-grid/index.jsx
+++ b/client/components/flexbox-grid/index.jsx
@@ -4,34 +4,7 @@
 import React from 'react';
 import { times } from 'lodash';
 
-function createOnCellsRenderedMemoizer( ssrEnabled ) {
-	let cachedStartIndex = -1;
-	let cachedStopIndex = -1;
-
-	return ( callback, { startIndex, stopIndex } ) => {
-		if ( startIndex === cachedStartIndex && stopIndex === cachedStopIndex ) {
-			return;
-		}
-
-		if ( ssrEnabled && cachedStartIndex < 0 && cachedStopIndex < 0 ) {
-			startIndex = 0;
-			stopIndex = 0;
-		}
-
-		cachedStartIndex = startIndex;
-		cachedStopIndex = stopIndex;
-
-		callback( { startIndex, stopIndex } );
-	};
-}
-
 export default class FlexboxGrid extends React.PureComponent {
-
-	constructor( props ) {
-		super( props );
-
-		this.onCellsRenderedMemoizer = createOnCellsRenderedMemoizer( props.ssrEnabled );
-	}
 
 	componentDidMount() {
 		this.invokeOnCellsRendered();
@@ -137,12 +110,9 @@ export default class FlexboxGrid extends React.PureComponent {
 			return;
 		}
 
-		this.onCellsRenderedMemoizer(
-			this.props.onCellsRendered,
-			{
-				startIndex: this.firstVisibleIndex(),
-				stopIndex: this.lastVisibleIndex() - 1
-			}
-		);
+		this.props.onCellsRendered( {
+			startIndex: this.firstVisibleIndex(),
+			stopIndex: this.lastVisibleIndex() - 1
+		} );
 	}
 }

--- a/client/components/flexbox-grid/index.jsx
+++ b/client/components/flexbox-grid/index.jsx
@@ -1,10 +1,25 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { times } from 'lodash';
 
 export default class FlexboxGrid extends React.PureComponent {
+	static propTypes = {
+		width: PropTypes.number,
+		minColumnWidth: PropTypes.number.isRequired,
+		columnCount: PropTypes.number.isRequired,
+		rowHeight: PropTypes.number,
+		rowCount: PropTypes.number.isRequired,
+		scrollTop: PropTypes.number,
+		cellRenderer: PropTypes.func.isRequired,
+		overscanRowCount: PropTypes.number,
+		onCellsRendered: PropTypes.func,
+	};
+
+	static defaultProps = {
+		overscanRowCount: 0
+	};
 
 	componentDidMount() {
 		this.invokeOnCellsRendered();
@@ -41,7 +56,7 @@ export default class FlexboxGrid extends React.PureComponent {
 		}
 
 		return {
-			height: this.props.rowCount * this.props.rowHeight
+			height: `${ this.props.rowCount * this.props.rowHeight }px`
 		};
 	}
 
@@ -63,7 +78,7 @@ export default class FlexboxGrid extends React.PureComponent {
 		}
 
 		let rowIdx = 0;
-		while ( rowIdx * this.props.rowHeight < this.props.scrollTop ) {
+		while ( ( rowIdx + 1 ) * this.props.rowHeight < this.props.scrollTop ) {
 			++rowIdx;
 		}
 

--- a/client/components/flexbox-grid/index.jsx
+++ b/client/components/flexbox-grid/index.jsx
@@ -94,7 +94,7 @@ export default class FlexboxGrid extends React.PureComponent {
 
 	lastVisibleIndex() {
 		if ( this.props.width === undefined ) {
-           return 1000;
+			return this.props.rowCount * this.props.columnCount;
 		}
 
 		let rowIdx = 0;

--- a/client/components/flexbox-grid/style.scss
+++ b/client/components/flexbox-grid/style.scss
@@ -1,0 +1,13 @@
+.flexbox-grid {
+	display: block;
+	width: 100%;
+	overflow: hidden;
+	position: relative;
+}
+
+.flexbox-grid__content {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	width: 100%;
+}

--- a/client/components/flexbox-grid/test/index.jsx
+++ b/client/components/flexbox-grid/test/index.jsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import FlexboxGrid from '../';
+
+describe( 'FlexboxGrid', () => {
+	const cellRenderer = ( { index, key, style } ) => {
+		return (
+			<div key={ key } style={ style }>{ index }</div>
+		);
+	};
+
+	it( 'should render a static flexbox grid if no width is provided', () => {
+		const grid = shallow(
+			<FlexboxGrid
+				minColumnWidth={ 200 }
+				cellRenderer={ cellRenderer }
+				scrollTop={ 0 }
+				columnCount={ 2 }
+				rowCount={ 2 } />
+		);
+
+		expect( grid.prop( 'style' ) ).to.eql( {} );
+
+		const content = grid.find( 'div.flexbox-grid__content' );
+
+		expect( content.prop( 'style' ) ).to.eql( {} );
+
+		const cells = content.children();
+
+		expect( cells.length ).to.equal( 4 );
+
+		expect( cells.at( 0 ).text() ).to.equal( '0' );
+		expect( cells.at( 1 ).text() ).to.equal( '1' );
+		expect( cells.at( 2 ).text() ).to.equal( '2' );
+		expect( cells.at( 3 ).text() ).to.equal( '3' );
+
+		expect( cells.at( 0 ).prop( 'style' ) ).to.eql( { flex: '1 0 200px' } );
+		expect( cells.at( 1 ).prop( 'style' ) ).to.eql( { flex: '1 0 200px' } );
+		expect( cells.at( 2 ).prop( 'style' ) ).to.eql( { flex: '1 0 200px' } );
+		expect( cells.at( 3 ).prop( 'style' ) ).to.eql( { flex: '1 0 200px' } );
+	} );
+
+	it( 'should render an absolutely positioned grid if width is provided', () => {
+		global.window = { innerHeight: 1000 };
+
+		const grid = shallow(
+			<FlexboxGrid
+				width={ 900 }
+				minColumnWidth={ 200 }
+				cellRenderer={ cellRenderer }
+				scrollTop={ 0 }
+				columnCount={ 4 }
+				rowCount={ 2 }
+				rowHeight={ 100 } />
+		);
+
+		expect( grid.prop( 'style' ) ).to.eql( { height: '200px' } );
+
+		const content = grid.find( 'div.flexbox-grid__content' );
+
+		expect( content.prop( 'style' ) ).to.eql( {
+			position: 'absolute',
+			top: '0px',
+			left: 0
+		} );
+	} );
+
+	it( 'should render only the visible cells', () => {
+		global.window = { innerHeight: 400 };
+
+		const grid = shallow(
+			<FlexboxGrid
+				width={ 900 }
+				minColumnWidth={ 200 }
+				cellRenderer={ cellRenderer }
+				scrollTop={ 150 }
+				columnCount={ 4 }
+				rowCount={ 100 }
+				rowHeight={ 100 } />
+		);
+
+		expect( grid.prop( 'style' ) ).to.eql( { height: '10000px' } );
+
+		const content = grid.find( 'div.flexbox-grid__content' );
+
+		expect( content.prop( 'style' ) ).to.eql( {
+			position: 'absolute',
+			top: '100px',
+			left: 0
+		} );
+
+		const cells = content.children();
+
+		expect( cells.length ).to.equal( 20 );
+
+		expect( cells.at( 0 ).text() ).to.equal( '4' );
+		expect( cells.at( 19 ).text() ).to.equal( '23' );
+	} );
+
+	it( 'should pre-render additional rows if overscanRowCount is given', () => {
+		global.window = { innerHeight: 400 };
+
+		const grid = shallow(
+			<FlexboxGrid
+				width={ 900 }
+				minColumnWidth={ 200 }
+				cellRenderer={ cellRenderer }
+				scrollTop={ 1050 }
+				columnCount={ 4 }
+				rowCount={ 100 }
+				rowHeight={ 100 }
+				overscanRowCount={ 3 } />
+		);
+
+		expect( grid.prop( 'style' ) ).to.eql( { height: '10000px' } );
+
+		const content = grid.find( 'div.flexbox-grid__content' );
+
+		expect( content.prop( 'style' ) ).to.eql( {
+			position: 'absolute',
+			top: '700px',
+			left: 0
+		} );
+
+		const cells = content.children();
+
+		expect( cells.length ).to.equal( 44 );
+
+		expect( cells.at( 0 ).text() ).to.equal( '28' );
+		expect( cells.at( 43 ).text() ).to.equal( '71' );
+	} );
+} );


### PR DESCRIPTION
This pull request adds a `FlexboxGrid` component that's compatible with `react-virtualized`.

Standard `react-virtualized` components have some properties that make it impossible for them to be rendered on a server. `FlexboxGrid` replaces the combination of `AutoSizer` and `Grid` from the library and removes some of their limitations.   
Instead of not rendering anything during the first render, `FlexboxGrid` renders all available data using a static flexbox layout, and only virtualizes the grid from the second render on. This allows for CSS to do the heavy lifting and works well with server side rendering.

The component will be used to optimize themes showcase.

![showcase-js-enabled](https://cloud.githubusercontent.com/assets/8056203/25071492/9c24735c-22b9-11e7-87bb-2a05933de9be.gif)