### PR TITLE
Signup: Use color variant of social buttons

### DIFF
--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import SocialLogo from 'social-logos';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
 
@@ -88,15 +87,15 @@ class FacebookLoginButton extends Component {
 	render() {
 		return (
 			<button className="button" onClick={ this.handleClick }>
-				<span>
-					<SocialLogo className="social-buttons__logo" icon="facebook" size={ 24 } />
+				<svg className="social-buttons__logo" width="21" height="21" viewBox="-2 -1 23 23" xmlns="http://www.w3.org/2000/svg">
+					<path d="M18.86.041H1.14a1.1 1.1 0 0 0-1.099 1.1v17.718a1.1 1.1 0 0 0 1.1 1.1h9.539v-7.713H8.084V9.24h2.596V7.023c0-2.573 1.571-3.973 3.866-3.973 1.1 0 2.044.081 2.32.118v2.688l-1.592.001c-1.248 0-1.49.593-1.49 1.463v1.92h2.977l-.388 3.006h-2.59v7.713h5.076a1.1 1.1 0 0 0 1.1-1.1V1.14a1.1 1.1 0 0 0-1.1-1.099" fill="#3E68B5" fillRule="evenodd" />
+				</svg>
 
-					<span className="social-buttons__service-name">
-						{ this.props.translate( 'Continue with %(service)s', {
-							args: { service: 'Facebook' },
-							comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
-						} ) }
-					</span>
+				<span className="social-buttons__service-name">
+					{ this.props.translate( 'Continue with %(service)s', {
+						args: { service: 'Facebook' },
+						comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
+					} ) }
 				</span>
 			</button>
 		);

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -88,7 +88,9 @@ class FacebookLoginButton extends Component {
 		return (
 			<button className="button" onClick={ this.handleClick }>
 				<svg className="social-buttons__logo" width="21" height="21" viewBox="-2 -1 23 23" xmlns="http://www.w3.org/2000/svg">
+					{ /* eslint-disable max-len */ }
 					<path d="M18.86.041H1.14a1.1 1.1 0 0 0-1.099 1.1v17.718a1.1 1.1 0 0 0 1.1 1.1h9.539v-7.713H8.084V9.24h2.596V7.023c0-2.573 1.571-3.973 3.866-3.973 1.1 0 2.044.081 2.32.118v2.688l-1.592.001c-1.248 0-1.49.593-1.49 1.463v1.92h2.977l-.388 3.006h-2.59v7.713h5.076a1.1 1.1 0 0 0 1.1-1.1V1.14a1.1 1.1 0 0 0-1.1-1.099" fill="#3E68B5" fillRule="evenodd" />
+					{ /* eslint-enable max-len */ }
 				</svg>
 
 				<span className="social-buttons__service-name">

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import SocialLogo from 'social-logos';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
 
@@ -49,11 +48,11 @@ class GoogleLoginButton extends Component {
 		this.initialized = this.loadDependency()
 			.then( gapi => new Promise( resolve => gapi.load( 'client:auth2', resolve ) ).then( () => gapi ) )
 			.then( gapi => gapi.client.init( {
-					client_id: this.props.clientId,
-					scope: this.props.scope,
-					fetch_basic_profile: this.props.fetchBasicProfile,
-				} )
-				.then( () => gapi ) // don't try to return gapi.auth2.getAuthInstance() here, it has a `then` method
+				client_id: this.props.clientId,
+				scope: this.props.scope,
+				fetch_basic_profile: this.props.fetchBasicProfile,
+			} )
+			.then( () => gapi ) // don't try to return gapi.auth2.getAuthInstance() here, it has a `then` method
 			).catch( error => {
 				this.initialized = null;
 
@@ -76,15 +75,20 @@ class GoogleLoginButton extends Component {
 	render() {
 		return (
 			<button className="button" onClick={ this.handleClick }>
-				<span>
-					<SocialLogo className="social-buttons__logo" icon="google" size={ 24 } />
+				<svg className="social-buttons__logo" width="21" height="21" viewBox="0 0 20 21" xmlns="http://www.w3.org/2000/svg">
+					<g fill="none" fillRule="evenodd">
+						<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />
+						<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#34A853" />
+						<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#FBBC05" />
+						<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#EA4335" />
+					</g>
+				</svg>
 
-					<span className="social-buttons__service-name">
-						{ this.props.translate( 'Continue with %(service)s', {
-							args: { service: 'Google' },
-							comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
-						} ) }
-					</span>
+				<span className="social-buttons__service-name">
+					{ this.props.translate( 'Continue with %(service)s', {
+						args: { service: 'Google' },
+						comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
+					} ) }
 				</span>
 			</button>
 		);

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -76,11 +76,13 @@ class GoogleLoginButton extends Component {
 		return (
 			<button className="button" onClick={ this.handleClick }>
 				<svg className="social-buttons__logo" width="21" height="21" viewBox="0 0 20 21" xmlns="http://www.w3.org/2000/svg">
+					{ /* eslint-disable max-len */ }
 					<g fill="none" fillRule="evenodd">
 						<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />
 						<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#34A853" />
 						<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#FBBC05" />
 						<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#EA4335" />
+					{ /* eslint-enable max-len */ }
 					</g>
 				</svg>
 

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,12 +1,9 @@
 /*rtl:ignore*/
 
 .social-buttons__logo {
-	vertical-align: top;
-	position: relative;
-	top: 1px;
+	vertical-align: middle;
 }
 
 .social-buttons__service-name {
-	margin-left: 8px;
-	line-height: 23px;
+	margin-left: 9px;
 }

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -73,6 +73,7 @@ export default {
 		providesToken: true,
 		providesDependencies: [ 'bearer_token', 'username' ],
 		props: {
+			headerText: i18n.translate( 'Create your account.' ),
 			isSocialSignupEnabled: true
 		},
 	},

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -51,11 +51,26 @@ class StepWrapper extends Component {
 			if ( this.props.headerText ) {
 				return this.props.headerText;
 			}
-			return this.props.translate( 'Create your account.' );
+
+			return this.props.translate( "Let's get started." );
 		}
 
 		if ( this.props.fallbackHeaderText ) {
 			return this.props.fallbackHeaderText;
+		}
+	}
+
+	subHeaderText() {
+		if ( this.props.positionInFlow === 0 ) {
+			if ( this.props.subHeaderText ) {
+				return this.props.subHeaderText;
+			}
+
+			return this.props.translate( 'Welcome to the best place for your WordPress website.' );
+		}
+
+		if ( this.props.fallbackSubHeaderText ) {
+			return this.props.fallbackSubHeaderText;
 		}
 	}
 
@@ -68,11 +83,14 @@ class StepWrapper extends Component {
 		return (
 			<div className={ classes }>
 				<StepHeader
-					headerText={ this.headerText() }>
+					headerText={ this.headerText() }
+					subHeaderText={ this.subHeaderText() }>
 					{ ( headerButton ) }
 				</StepHeader>
+
 				<div className="step-wrapper__content is-animated-content">
 					{ stepContent }
+
 					<div className="step-wrapper__buttons">
 						{ this.renderBack() }
 						{ this.renderSkip() }

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -48,28 +48,28 @@ class StepWrapper extends Component {
 
 	headerText() {
 		if ( this.props.positionInFlow === 0 ) {
-			if ( this.props.headerText ) {
+			if ( this.props.headerText !== undefined ) {
 				return this.props.headerText;
 			}
 
 			return this.props.translate( "Let's get started." );
 		}
 
-		if ( this.props.fallbackHeaderText ) {
+		if ( this.props.fallbackHeaderText !== undefined ) {
 			return this.props.fallbackHeaderText;
 		}
 	}
 
 	subHeaderText() {
 		if ( this.props.positionInFlow === 0 ) {
-			if ( this.props.subHeaderText ) {
+			if ( this.props.subHeaderText !== undefined ) {
 				return this.props.subHeaderText;
 			}
 
 			return this.props.translate( 'Welcome to the best place for your WordPress website.' );
 		}
 
-		if ( this.props.fallbackSubHeaderText ) {
+		if ( this.props.fallbackSubHeaderText !== undefined ) {
 			return this.props.fallbackSubHeaderText;
 		}
 	}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -53,14 +53,15 @@ export class UserStep extends Component {
 	setSubHeaderText( props ) {
 		let subHeaderText = props.subHeaderText;
 
-		/**
-		 * Update the step sub-header if they only want to create an account, without a site.
-		 */
-		if ( 1 === signupUtils.getFlowSteps( props.flowName ).length ) {
+		if ( props.flowName === 'social' ) {
+			// Hides sub header for this particular flow
+			subHeaderText = '';
+		} else if ( 1 === signupUtils.getFlowSteps( props.flowName ).length ) {
+			// Displays specific sub header if users only want to create an account, without a site
 			subHeaderText = this.props.translate( 'Welcome to the wonderful WordPress.com community' );
 		}
 
-		this.setState( { subHeaderText: subHeaderText } );
+		this.setState( { subHeaderText } );
 	}
 
 	save = ( form ) => {


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/13172 that updates the buttons on the page of the new `Social` signup flow to use the colored version of Google and Facebook icons (previously we were displaying the black & white version):

<img width="430" alt="screenshot" src="https://cloud.githubusercontent.com/assets/594356/25234799/77e4a4f8-25e3-11e7-9b76-2a05f2a21036.png">

This pull request also adds the logic that handles the display of the header back. It was removed in https://github.com/Automattic/wp-calypso/pull/13172/commits/215f938ca76577045e29fda3ae21893d6b3d116c but several steps from different signup flows actually rely on it.

#### Testing instructions
 
1. Run `git checkout add/colored-social-buttons` and start your server, or open a [live branch](https://calypso.live/?branch=add/colored-social-buttons)
2. Open the [`Social` signup flow](http://calypso.localhost:3000/start/social) in an incognito window
3. Check that the page now looks like the mockup at p6qnuF-4hO-p2#comment-5677

You should also check that other signup flows now display the right header and sub headers, as before. I set up a [temporary branch](https://github.com/Automattic/wp-calypso/tree/try/master-before-signup-header-removal) with code from just before https://github.com/Automattic/wp-calypso/pull/13172/commits/215f938ca76577045e29fda3ae21893d6b3d116c to ease that process. Here are a few examples:

1. Open the [`Account` signup flow](http://calypso.localhost:3000/start/account) in an incognito window
2. Check that all pages from this flow matches [the ones](https://calypso.live/start/account?branch=try/master-before-signup-header-removal) available before the removal
3. Open the [`Jetpack` signup flow](http://calypso.localhost:3000/start/jetpack) in an incognito window
4. Check that all pages from this flow matches [the ones](https://calypso.live/start/jetpack?branch=try/master-before-signup-header-removal) available before the removal
5. Open the [`Domain First` signup flow](http://calypso.localhost:3000/start/domain-first?new=example.com) in an incognito window
6. Check that all pages from this flow matches [the ones](https://calypso.live/start/domain-first?new=example.com&branch=try/master-before-signup-header-removal) available before the removal

#### Reviews
 
- [x] Code
- [ ] Product
- [ ] Tests