### PR TITLE
SitesDropdown: Partial dumping of SitesList

### DIFF
--- a/client/components/sites-dropdown/README.md
+++ b/client/components/sites-dropdown/README.md
@@ -23,6 +23,6 @@ render() {
 * `selectedSiteId` (`number`) — Id of the initial selected site
 * `showAllSites` (`bool`) — `true` to display the _All My Sites_ option
 * `onClose` (`function`) — called on site selection
-* `onSiteSelect` (`function`) - called with the site `slug` on site selection
+* `onSiteSelect` (`function`) - called with the site's `ID` on site selection
 * `filter` (`function`) - If present, passed to `sites.filter()` to display a subset of sites. Return `true` to display a site.
 * `isPlaceholder` (`bool`) - `true` to display as a placeholder

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 import Gridicon from 'gridicons';
@@ -13,11 +14,12 @@ import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import SiteSelector from 'components/site-selector';
 import sitesList from 'lib/sites-list';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedOrPrimarySiteId } from 'state/selectors';
 
 const sites = sitesList();
 
-export default class SitesDropdown extends PureComponent {
-
+class SitesDropdown extends PureComponent {
 	static propTypes = {
 		selectedSiteId: React.PropTypes.number,
 		showAllSites: React.PropTypes.bool,
@@ -34,39 +36,23 @@ export default class SitesDropdown extends PureComponent {
 		isPlaceholder: false
 	}
 
-	constructor( props ) {
-		super( props );
-
-		this.selectSite = this.selectSite.bind( this );
-		this.toggleOpen = this.toggleOpen.bind( this );
-		this.onClose = this.onClose.bind( this );
-
-		const selectedSite = props.selectedSiteId
-			? sites.getSite( props.selectedSiteId )
-			: sites.getPrimary();
-
-		this.state = {
-			selectedSiteSlug: selectedSite && selectedSite.slug
-		};
+	state = {
+		selectedSiteId: this.props.selectedOrPrimarySiteId,
 	}
 
-	getSelectedSite() {
-		return sites.getSite( this.state.selectedSiteSlug );
-	}
-
-	selectSite( siteSlug ) {
-		this.props.onSiteSelect( siteSlug );
+	selectSite = ( siteID ) => {
+		this.props.onSiteSelect( siteID );
 		this.setState( {
-			selectedSiteSlug: siteSlug,
+			selectedSiteId: siteID,
 			open: false
 		} );
 	}
 
-	toggleOpen() {
+	toggleOpen = () => {
 		this.setState( { open: ! this.state.open } );
 	}
 
-	onClose( e ) {
+	onClose = ( e ) => {
 		this.setState( { open: false } );
 		this.props.onClose && this.props.onClose( e );
 	}
@@ -81,7 +67,7 @@ export default class SitesDropdown extends PureComponent {
 						{
 							this.props.isPlaceholder
 							? <SitePlaceholder />
-							: <Site site={ this.getSelectedSite() } indicator={ false } />
+							: <Site site={ this.props.selectedSite } indicator={ false } />
 						}
 						<Gridicon icon="chevron-down" />
 					</div>
@@ -91,7 +77,7 @@ export default class SitesDropdown extends PureComponent {
 							autoFocus={ true }
 							onClose={ this.onClose }
 							onSiteSelect={ this.selectSite }
-							selected={ this.state.selectedSiteSlug }
+							selected={ this.state.selectedSiteId }
 							hideSelected={ true }
 							filter={ this.props.filter }
 						/>
@@ -101,3 +87,10 @@ export default class SitesDropdown extends PureComponent {
 		);
 	}
 }
+
+export default connect(
+	( state ) => ( {
+		selectedSite: getSelectedSite( state ),
+		selectedOrPrimarySiteId: getSelectedOrPrimarySiteId( state ),
+	} )
+)( SitesDropdown );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -40,10 +40,15 @@ export class SitesDropdown extends PureComponent {
 		selectedSiteId: this.props.selectedOrPrimarySiteId,
 	}
 
-	selectSite = ( siteID ) => {
-		this.props.onSiteSelect( siteID );
+	selectSite = ( siteSlug ) => {
+		// SiteSelector gives us a slug, but we want to pass an ID to our onSiteSelect
+		// callback prop so it's consistent with the selectedSiteId prop. We also use
+		// a siteId for our internal state.
+		// TODO: Change SiteSelector to also use site IDs instead of slugs and objects.
+		const siteId = sites.getSite( siteSlug );
+		this.props.onSiteSelect( siteId );
 		this.setState( {
-			selectedSiteId: siteID,
+			selectedSiteId: siteId,
 			open: false
 		} );
 	}

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -14,7 +14,6 @@ import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import SiteSelector from 'components/site-selector';
 import sitesList from 'lib/sites-list';
-import { getSite } from 'state/sites/selectors';
 import { getPrimarySiteId } from 'state/selectors';
 
 const sites = sitesList();
@@ -53,6 +52,10 @@ export class SitesDropdown extends PureComponent {
 		} );
 	}
 
+	getSelectedSite = () => {
+		return sites.getSite( this.state.selectedSiteId );
+	}
+
 	toggleOpen = () => {
 		this.setState( { open: ! this.state.open } );
 	}
@@ -72,7 +75,7 @@ export class SitesDropdown extends PureComponent {
 						{
 							this.props.isPlaceholder
 							? <SitePlaceholder />
-							: <Site site={ this.props.getSite( this.state.selectedSiteId ) } indicator={ false } />
+							: <Site site={ this.getSelectedSite() } indicator={ false } />
 						}
 						<Gridicon icon="chevron-down" />
 					</div>
@@ -82,7 +85,7 @@ export class SitesDropdown extends PureComponent {
 							autoFocus={ true }
 							onClose={ this.onClose }
 							onSiteSelect={ this.selectSite }
-							selected={ this.state.selectedSiteId }
+							selected={ get( this.getSelectedSite(), 'slug' ) }
 							hideSelected={ true }
 							filter={ this.props.filter }
 						/>
@@ -95,7 +98,6 @@ export class SitesDropdown extends PureComponent {
 
 export default connect(
 	( state ) => ( {
-		getSite: ( siteId ) => getSite( state, siteId ),
 		primarySiteId: getPrimarySiteId( state ),
 	} )
 )( SitesDropdown );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -19,7 +19,7 @@ import { getSelectedOrPrimarySiteId } from 'state/selectors';
 
 const sites = sitesList();
 
-class SitesDropdown extends PureComponent {
+export class SitesDropdown extends PureComponent {
 	static propTypes = {
 		selectedSiteId: React.PropTypes.number,
 		showAllSites: React.PropTypes.bool,

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -14,7 +14,7 @@ import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import SiteSelector from 'components/site-selector';
 import sitesList from 'lib/sites-list';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
 import { getSelectedOrPrimarySiteId } from 'state/selectors';
 
 const sites = sitesList();
@@ -67,7 +67,7 @@ export class SitesDropdown extends PureComponent {
 						{
 							this.props.isPlaceholder
 							? <SitePlaceholder />
-							: <Site site={ this.props.selectedSite } indicator={ false } />
+							: <Site site={ this.props.getSite( this.state.selectedSiteId ) } indicator={ false } />
 						}
 						<Gridicon icon="chevron-down" />
 					</div>
@@ -90,7 +90,7 @@ export class SitesDropdown extends PureComponent {
 
 export default connect(
 	( state ) => ( {
-		selectedSite: getSelectedSite( state ),
+		getSite: ( siteId ) => getSite( state, siteId ),
 		selectedOrPrimarySiteId: getSelectedOrPrimarySiteId( state ),
 	} )
 )( SitesDropdown );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -35,11 +35,21 @@ export class SitesDropdown extends PureComponent {
 		isPlaceholder: false
 	}
 
-	state = {
-		selectedSiteId: this.props.selectedSiteId || this.props.primarySiteId,
+	constructor( props ) {
+		super( props );
+
+		this.selectSite = this.selectSite.bind( this );
+		this.getSelectedSite = this.getSelectedSite.bind( this );
+		this.siteFilter = this.siteFilter.bind( this );
+		this.toggleOpen = this.toggleOpen.bind( this );
+		this.onClose = this.onClose.bind( this );
+
+		this.state = {
+			selectedSiteId: this.props.selectedSiteId || this.props.primarySiteId
+		};
 	}
 
-	selectSite = ( siteSlug ) => {
+	selectSite( siteSlug ) {
 		// SiteSelector gives us a slug, but we want to pass an ID to our onSiteSelect
 		// callback prop so it's consistent with the selectedSiteId prop. We also use
 		// a siteId for our internal state.
@@ -52,20 +62,20 @@ export class SitesDropdown extends PureComponent {
 		} );
 	}
 
-	getSelectedSite = () => {
+	getSelectedSite() {
 		return sites.getSite( this.state.selectedSiteId );
 	}
 
 	// Our filter prop handles siteIds, while SiteSelector's filter prop needs objects
-	siteFilter = ( site ) => {
+	siteFilter( site ) {
 		return this.props.filter( site.ID );
 	}
 
-	toggleOpen = () => {
+	toggleOpen() {
 		this.setState( { open: ! this.state.open } );
 	}
 
-	onClose = ( e ) => {
+	onClose( e ) {
 		this.setState( { open: false } );
 		this.props.onClose && this.props.onClose( e );
 	}

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -56,6 +56,11 @@ export class SitesDropdown extends PureComponent {
 		return sites.getSite( this.state.selectedSiteId );
 	}
 
+	// Our filter prop handles siteIds, while SiteSelector's filter prop needs objects
+	siteFilter = ( site ) => {
+		return this.props.filter( site.ID );
+	}
+
 	toggleOpen = () => {
 		this.setState( { open: ! this.state.open } );
 	}
@@ -87,7 +92,7 @@ export class SitesDropdown extends PureComponent {
 							onSiteSelect={ this.selectSite }
 							selected={ get( this.getSelectedSite(), 'slug' ) }
 							hideSelected={ true }
-							filter={ this.props.filter }
+							filter={ this.props.filter && this.siteFilter }
 						/>
 					}
 				</div>

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
+import { get, noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -15,7 +15,7 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import SiteSelector from 'components/site-selector';
 import sitesList from 'lib/sites-list';
 import { getSite } from 'state/sites/selectors';
-import { getSelectedOrPrimarySiteId } from 'state/selectors';
+import { getPrimarySiteId } from 'state/selectors';
 
 const sites = sitesList();
 
@@ -37,7 +37,7 @@ export class SitesDropdown extends PureComponent {
 	}
 
 	state = {
-		selectedSiteId: this.props.selectedOrPrimarySiteId,
+		selectedSiteId: this.props.selectedSiteId || this.props.primarySiteId,
 	}
 
 	selectSite = ( siteSlug ) => {
@@ -45,7 +45,7 @@ export class SitesDropdown extends PureComponent {
 		// callback prop so it's consistent with the selectedSiteId prop. We also use
 		// a siteId for our internal state.
 		// TODO: Change SiteSelector to also use site IDs instead of slugs and objects.
-		const siteId = sites.getSite( siteSlug );
+		const siteId = get( sites.getSite( siteSlug ), 'ID' );
 		this.props.onSiteSelect( siteId );
 		this.setState( {
 			selectedSiteId: siteId,
@@ -96,6 +96,6 @@ export class SitesDropdown extends PureComponent {
 export default connect(
 	( state ) => ( {
 		getSite: ( siteId ) => getSite( state, siteId ),
-		selectedOrPrimarySiteId: getSelectedOrPrimarySiteId( state ),
+		primarySiteId: getPrimarySiteId( state ),
 	} )
 )( SitesDropdown );

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -26,7 +26,7 @@ describe( 'index', function() {
 	let SitesDropdown;
 
 	before( function() {
-		SitesDropdown = require( '../index.jsx' );
+		SitesDropdown = require( '../index.jsx' ).SitesDropdown;
 	} );
 
 	describe( 'component rendering', function() {
@@ -50,14 +50,9 @@ describe( 'index', function() {
 	} );
 
 	describe( 'component state', function() {
-		it( "should initially consider as selected the user's primary site, when is not specified something different", function() {
-			const sitesDropdown = shallow( <SitesDropdown /> );
-			expect( sitesDropdown.instance().state.selectedSiteSlug ).to.be.equal( 'primary.wordpress.com' );
-		} );
-
-		it( 'should initially consider as selected the site whose id is passed as `selectedSiteId` prop', function() {
-			const sitesDropdown = shallow( <SitesDropdown selectedSiteId={ 42 } /> );
-			expect( sitesDropdown.instance().state.selectedSiteSlug ).to.be.equal( 'foo.wordpress.com' );
+		it( 'should initially consider as selected the selectedOrPrimarySiteId prop', function() {
+			const sitesDropdown = shallow( <SitesDropdown selectedOrPrimarySiteId={ 1234567 } /> );
+			expect( sitesDropdown.instance().state.selectedSiteId ).to.be.equal( 1234567 );
 		} );
 	} );
 

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -51,7 +51,7 @@ describe( 'index', function() {
 
 	describe( 'component state', function() {
 		it( 'should initially consider as selected the selectedOrPrimarySiteId prop', function() {
-			const sitesDropdown = shallow( <SitesDropdown selectedOrPrimarySiteId={ 1234567 } /> );
+			const sitesDropdown = shallow( <SitesDropdown selectedSiteId={ 1234567 } /> );
 			expect( sitesDropdown.instance().state.selectedSiteId ).to.be.equal( 1234567 );
 		} );
 	} );
@@ -67,13 +67,13 @@ describe( 'index', function() {
 				}
 			};
 
-			SitesDropdown.prototype.selectSite.call( fakeContext, 'foobar' );
+			SitesDropdown.prototype.selectSite.call( fakeContext, 'primary.wordpress.com' );
 
 			sinon.assert.calledOnce( siteSelectedSpy );
-			sinon.assert.calledWith( siteSelectedSpy, 'foobar' );
+			sinon.assert.calledWith( siteSelectedSpy, 1 );
 
 			sinon.assert.calledOnce( setStateSpy );
-			sinon.assert.calledWith( setStateSpy, { open: false, selectedSiteSlug: 'foobar' } );
+			sinon.assert.calledWith( setStateSpy, { open: false, selectedSiteId: 1 } );
 		} );
 	} );
 
@@ -110,7 +110,7 @@ describe( 'index', function() {
 	describe( 'getSelectedSite', function() {
 		it( 'should return a site on the basis of the component `selectedSiteSlug` state property', function() {
 			const fakeState = {
-				selectedSiteSlug: 'foo.wordpress.com'
+				selectedSiteId: 42
 			};
 			const selectedSite = SitesDropdown.prototype.getSelectedSite.call( { state: fakeState } );
 			expect( selectedSite ).to.be.eql( {

--- a/client/components/sites-dropdown/test/lib/sites-list/index.js
+++ b/client/components/sites-dropdown/test/lib/sites-list/index.js
@@ -11,10 +11,6 @@ const sites = {
 };
 
 class SiteList {
-	getPrimary() {
-		return sites[ '1' ];
-	}
-
 	getSite( siteId ) {
 		if ( sites[ siteId ] ) {
 			return sites[ siteId ];

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -46,10 +46,8 @@ import SitesDropdown from 'components/sites-dropdown';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getLanguage } from 'lib/i18n-utils';
 
-import _sites from 'lib/sites-list';
 import _user from 'lib/user';
 
-const sites = _sites();
 const user = _user();
 
 /**
@@ -270,10 +268,9 @@ const Account = React.createClass( {
 		} );
 	},
 
-	onSiteSelect( siteSlug ) {
-		const selectedSite = sites.getSite( siteSlug );
-		if ( selectedSite ) {
-			this.updateUserSetting( 'primary_site_ID', selectedSite.ID );
+	onSiteSelect( siteId ) {
+		if ( siteId ) {
+			this.updateUserSetting( 'primary_site_ID', siteId );
 		}
 	},
 

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -21,14 +21,8 @@ import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
-import siteList from 'lib/sites-list';
 import ChatClosureNotice from '../chat-closure-notice';
 import { getSelectedOrPrimarySiteId } from 'state/selectors';
-
-/**
- * Module variables
- */
-const sites = siteList();
 
 export const HelpContactForm = React.createClass( {
 	mixins: [ LinkedStateMixin, PureRenderMixin ],
@@ -93,9 +87,8 @@ export const HelpContactForm = React.createClass( {
 		this.props.valueLink.requestChange( this.state );
 	},
 
-	setSite( siteSlug ) {
-		const site = sites.getSite( siteSlug );
-		this.setState( { siteId: site.ID } );
+	setSite( siteId ) {
+		this.setState( { siteId } );
 	},
 
 	trackClickStats( selectionName, selectedOption ) {

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -23,7 +23,7 @@ import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import siteList from 'lib/sites-list';
 import ChatClosureNotice from '../chat-closure-notice';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedOrPrimarySiteId } from 'state/selectors';
 
 /**
  * Module variables
@@ -77,7 +77,7 @@ export const HelpContactForm = React.createClass( {
 			howYouFeel: 'unspecified',
 			message: '',
 			subject: '',
-			siteId: this.getSiteId()
+			siteId: this.props.siteId
 		};
 	},
 
@@ -91,19 +91,6 @@ export const HelpContactForm = React.createClass( {
 
 	componentDidUpdate() {
 		this.props.valueLink.requestChange( this.state );
-	},
-
-	getSiteId() {
-		if ( this.props.selectedSiteId ) {
-			return this.props.selectedSiteId;
-		}
-
-		const primarySite = sites.getPrimary();
-		if ( primarySite ) {
-			return primarySite.ID;
-		}
-
-		return null;
 	},
 
 	setSite( siteSlug ) {
@@ -273,10 +260,8 @@ export const HelpContactForm = React.createClass( {
 	}
 } );
 
-const mapStateToProps = ( state ) => {
-	return {
-		selectedSiteId: getSelectedSiteId( state )
-	};
-};
+const mapStateToProps = ( state ) => ( {
+	siteId: getSelectedOrPrimarySiteId( state )
+} );
 
 export default connect( mapStateToProps )( localize( HelpContactForm ) );

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -84,7 +84,7 @@ export default React.createClass( {
 				<Card className="sites__selector-wrapper">
 					<SiteSelector
 						autoFocus={ true }
-						filter={ ( site ) => this.filterSites( site ) }
+						filter={ this.filterSites }
 						onSiteSelect={ this.onSiteSelect }
 						sites={ this.props.sites }
 						groups={ true }

--- a/client/state/selectors/get-selected-or-primary-site-id.js
+++ b/client/state/selectors/get-selected-or-primary-site-id.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPrimarySiteId } from 'state/selectors';
+
+/**
+ * Returns the currently selected ID, or the primary Site ID, if none is selected.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?Number}       The currently selected site ID, or the user's primary site's ID
+ */
+export default function getSelectedOrPrimarySiteId( state ) {
+	const selectedSiteId = getSelectedSiteId( state );
+	if ( selectedSiteId ) {
+		return selectedSiteId;
+	}
+
+	return getPrimarySiteId( state );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -65,6 +65,7 @@ export getReaderFollowForBlog from './get-reader-follow-for-blog';
 export getReaderFollows from './get-reader-follows';
 export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
+export getSelectedOrPrimarySiteId from './get-selected-or-primary-site-id';
 export getSharingButtons from './get-sharing-buttons';
 export getSiteConnectionStatus from './get-site-connection-status';
 export getSiteGmtOffset from './get-site-gmt-offset';

--- a/client/state/selectors/test/get-selected-or-primary-site-id.js
+++ b/client/state/selectors/test/get-selected-or-primary-site-id.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedOrPrimarySiteId } from '../';
+
+describe( 'getSelectedOrPrimarySiteId()', () => {
+	context( 'with no site selected', () => {
+		it( 'should return null if there is no current user', ( ) => {
+			const siteId = getSelectedOrPrimarySiteId( {
+				currentUser: {},
+				ui: {},
+			} );
+			expect( siteId ).to.be.null;
+		} );
+
+		it( 'should return current user\'s primary site\'s ID', () => {
+			const siteId = getSelectedOrPrimarySiteId( {
+				currentUser: { id: 12345678 },
+				ui: {},
+				users: { items: { 12345678: { primary_blog: 7654321 } } },
+			} );
+			expect( siteId ).to.equal( 7654321 );
+		} );
+	} );
+
+	context( 'with a site selected', () => {
+		it( 'should return the selected site\'s ID', ( ) => {
+			const siteId = getSelectedOrPrimarySiteId( {
+				ui: { selectedSiteId: 2916284 }
+			} );
+			expect( siteId ).to.equal( 2916284 );
+		} );
+	} );
+} );


### PR DESCRIPTION
Make SitesDropdown use siteIds instead of slugs for all relevant props:
* `selectedSiteId` (same as before)
* `onSiteSelect` callback arg
* `filter` callback arg

Consumers are updated accordingly. Also, change internal state representation to IDs instead of mixing IDs and site objects.

Since the `SiteSelector` component that `SitesDropdown` uses still mixes IDs, slugs, and objects, `SitesDropdown` now translates props and callback prop args accordingly. (`SitesSelector` and its consumers will be changed in a subsequent PR.)

The bottom line is that due to the bundling of logic in this one component, we can fortunately drop some `sites-list` dependencies from its consumers.

To test: Test the following instances of `SitesDropdown`:
* `/themes`: The `ThemesSiteSelectorModal`. Click on any theme's '...' menu, and select an action item (like 'Activate'). Select a site, and proceed. The action should be executed for that selected site.
* `/me/account`: Verify that changing your primary website works.
* `/help/contact`: Select a site you need help with, spam HEs 😛  Caveat: #13120/#13291

Follow-up PR:
* SiteSelector
* SiteSelector consumers
  * components/sites-popover
  * my-sites/picker: No `onSiteSelect` or `filter` callback props
  * my-sites/sites/sites

Supersedes #9624 