### PR TITLE
LocaleSuggestions: use addLocaleToPath to support query strings

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -32,6 +32,14 @@ describe( 'utils', function() {
 			assert.equal( removeLocaleFromPath( '/start/flow/step' ), '/start/flow/step' );
 		} );
 
+		it( 'should remove the :lang part of the URL, keeping any query string', function() {
+			assert.equal( removeLocaleFromPath( '/start/flow/step/fr?foo=bar' ), '/start/flow/step?foo=bar' );
+		} );
+
+		it( 'should not change the URL if no lang is present', function() {
+			assert.equal( removeLocaleFromPath( '/start/flow/step?foo=bar' ), '/start/flow/step?foo=bar' );
+		} );
+
 		it( 'should not remove the :flow part of the URL', function() {
 			assert.equal( removeLocaleFromPath( '/start' ), '/start' );
 			assert.equal( removeLocaleFromPath( '/start/flow' ), '/start/flow' );

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -8,9 +8,23 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { removeLocaleFromPath, getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
+import { removeLocaleFromPath, addLocaleToPath, getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
 
 describe( 'utils', function() {
+	describe( '#addLocaleToPath', function() {
+		it( 'adds a locale to the path', function() {
+			assert.equal( addLocaleToPath( '/start/flow/step', 'fr' ), '/start/flow/step/fr' );
+		} );
+
+		it( 'adds a locale to the path, replacing any previous locale', function() {
+			assert.equal( addLocaleToPath( '/start/flow/step/de', 'fr' ), '/start/flow/step/fr' );
+		} );
+
+		it( 'adds a locale to the path, keeping query string intact', function() {
+			assert.equal( addLocaleToPath( '/start/flow/step?foo=bar', 'fr' ), '/start/flow/step/fr?foo=bar' );
+		} );
+	} );
+
 	describe( '#removeLocaleFromPath', function() {
 		it( 'should remove the :lang part of the URL', function() {
 			assert.equal( removeLocaleFromPath( '/start/fr' ), '/start' );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -62,14 +62,16 @@ const i18nUtils = {
 	 * @returns {string} original path minus locale slug
 	 */
 	removeLocaleFromPath: function( path ) {
-		const parts = getPathParts( path );
+		const urlParts = url.parse( path );
+		const queryString = urlParts.search || '';
+		const parts = getPathParts( urlParts.pathname );
 		const locale = parts.pop();
 
 		if ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) {
 			parts.push( locale );
 		}
 
-		return parts.join( '/' );
+		return parts.join( '/' ) + queryString;
 	}
 };
 export default i18nUtils;

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import find from 'lodash/find';
+import url from 'url';
 
 /**
  * Internal dependencies
@@ -37,6 +38,21 @@ const i18nUtils = {
 		const locale = parts.pop();
 
 		return ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) ? undefined : locale;
+	},
+
+	/**
+	 * Adds a locale slug to the current path.
+	 *
+	 * Will replace existing locale slug, if present.
+	 *
+	 * @param {string} path - original path
+	 * @param {string} locale - locale slug (eg: 'fr')
+	 * @returns {string} original path with new locale slug
+	*/
+	addLocaleToPath: function( path, locale ) {
+		const urlParts = url.parse( path );
+		const queryString = urlParts.search || '';
+		return i18nUtils.removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
 	},
 
 	/**

--- a/client/signup/locale-suggestions/index.jsx
+++ b/client/signup/locale-suggestions/index.jsx
@@ -68,7 +68,7 @@ module.exports = React.createClass( {
 	},
 
 	getPathWithLocale: function( locale ) {
-		return i18nUtils.removeLocaleFromPath( this.props.path ) + '/' + locale;
+		return i18nUtils.addLocaleToPath( this.props.path, locale );
 	},
 
 	updateLocales: function() {


### PR DESCRIPTION
Fixes #13280 

Previously, if a query string was part of the URL, and someone clicked on a language change link (created by `LocaleSuggestions`), several things would break. The locale would not be correctly added to the URL and instead it would be added to the last value in the query string. This breaks not only the locale change but also the theme setup during signup because the theme would become something like `pub/sela-2/fr`.

This change adds and uses a new function, `i18Utils.addLocaleToPath()` which will add locales to URLs, safely supporting query strings.

## Testing

NOTE: for an unknown reason, this may not work if you have devtools open. Please try these steps without devtools.

1. Starting at URL (logged-out and incognito): `/themes`
2. Click on a theme to show the theme page.
3. Click on "Pick this design" button.
4. You should end up on a URL like this `/start/with-theme/domains-theme-preselected?ref=calypshowcase&theme=twentyseventeen` (Make sure there's a query string with the theme!)
5. Click the language change link (see screenshot below). If you do not see a language link, try these instructions http://stackoverflow.com/questions/37221494/how-to-change-the-locale-in-chrome-browser
6. Verify that the language of the text on the page has changed.
7. Verify that **the query string still has the theme**, like this: `/start/with-theme/domains-theme-preselected/fr?ref=calypshowcase&theme=twentyseventeen`

<img width="1001" alt="screen_shot_2017-04-20_at_12_41_24_pm" src="https://cloud.githubusercontent.com/assets/2036909/25249689/beb7f2c0-25e0-11e7-8e1a-88111187ca88.png">

<img width="994" alt="screen_shot_2017-04-20_at_12_42_36_pm" src="https://cloud.githubusercontent.com/assets/2036909/25249694/c40a3d0a-25e0-11e7-90e5-3cf17eccc83c.png">

<img width="789" alt="screen_shot_2017-04-20_at_3_45_07_pm" src="https://cloud.githubusercontent.com/assets/2036909/25249643/8b95621a-25e0-11e7-96b6-860630adde7b.png">

