### PR TITLE
Site Settings: Remove usage of siteSupportsJetpackSettingsUI() selector that was used for backwards compatibility with Jetpack < 4.5

### DIFF
--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -12,11 +12,7 @@ import CompactCard from 'components/card/compact';
 import DefaultPostFormat from './default-post-format';
 import AfterTheDeadline from './after-the-deadline';
 import DateTimeFormat from '../date-time-format';
-import {
-	isJetpackSite,
-	isJetpackMinimumVersion,
-	siteSupportsJetpackSettingsUi,
-} from 'state/sites/selectors';
+import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 const Composing = ( {
@@ -29,10 +25,10 @@ const Composing = ( {
 	hasDateTimeFormats,
 	isRequestingSettings,
 	isSavingSettings,
-	jetpackSettingsUISupported,
+	siteIsJetpack,
 	updateFields,
 } ) => {
-	const CardComponent = jetpackSettingsUISupported ? CompactCard : Card;
+	const CardComponent = siteIsJetpack ? CompactCard : Card;
 
 	return (
 		<div>
@@ -46,7 +42,7 @@ const Composing = ( {
 				/>
 			</CardComponent>
 
-			{ jetpackSettingsUISupported &&
+			{ siteIsJetpack &&
 				<AfterTheDeadline
 					handleToggle={ handleToggle }
 					setFieldValue={ setFieldValue }
@@ -92,7 +88,7 @@ export default connect(
 		const siteIsJetpack = isJetpackSite( state, siteId );
 
 		return {
-			jetpackSettingsUISupported: siteIsJetpack && siteSupportsJetpackSettingsUi( state, siteId ),
+			siteIsJetpack,
 			hasDateTimeFormats: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.7' ),
 		};
 	}

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -23,10 +23,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SectionHeader from 'components/section-header';
 import Subscriptions from './subscriptions';
 import wrapSettingsForm from './wrap-settings-form';
-import {
-	isJetpackSite,
-	siteSupportsJetpackSettingsUi
-} from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import JetpackModuleToggle from './jetpack-module-toggle';
@@ -77,8 +74,8 @@ class SiteSettingsFormDiscussion extends Component {
 	}
 
 	commentDisplaySettings() {
-		const { isJetpack, jetpackSettingsUISupported } = this.props;
-		if ( ! isJetpack || ! jetpackSettingsUISupported ) {
+		const { isJetpack } = this.props;
+		if ( ! isJetpack ) {
 			return null;
 		}
 
@@ -547,7 +544,6 @@ class SiteSettingsFormDiscussion extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			isJetpack,
-			jetpackSettingsUISupported,
 			translate
 		} = this.props;
 		return (
@@ -572,7 +568,7 @@ class SiteSettingsFormDiscussion extends Component {
 				</Card>
 
 				{
-					isJetpack && jetpackSettingsUISupported && (
+					isJetpack && (
 						<div>
 							<QueryJetpackModules siteId={ siteId } />
 
@@ -598,13 +594,11 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 
 		const isJetpack = isJetpackSite( state, siteId );
-		const jetpackSettingsUISupported = siteSupportsJetpackSettingsUi( state, siteId );
 		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
 
 		return {
 			siteId,
 			isJetpack,
-			jetpackSettingsUISupported,
 			isLikesModuleActive,
 		};
 	}

--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -16,7 +16,6 @@ import Protect from './protect';
 import Sso from './sso';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import {
 	isJetpackModuleActive,
 	isJetpackModuleUnavailableInDevelopmentMode,
@@ -48,7 +47,6 @@ class SiteSettingsFormSecurity extends Component {
 			handleSubmitForm,
 			isRequestingSettings,
 			isSavingSettings,
-			jetpackSettingsUiSupported,
 			onChangeField,
 			protectModuleActive,
 			protectModuleUnavailable,
@@ -56,10 +54,6 @@ class SiteSettingsFormSecurity extends Component {
 			siteId,
 			translate
 		} = this.props;
-
-		if ( ! jetpackSettingsUiSupported ) {
-			return null;
-		}
 
 		const disableProtect = ! protectModuleActive || protectModuleUnavailable;
 
@@ -98,10 +92,8 @@ const connectComponent = connect(
 		const protectModuleActive = !! isJetpackModuleActive( state, siteId, 'protect' );
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, siteId );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, siteId, 'protect' );
-		const jetpackSettingsUiSupported = siteSupportsJetpackSettingsUi( state, siteId );
 
 		return {
-			jetpackSettingsUiSupported,
 			protectModuleActive,
 			protectModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		};

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -15,11 +15,7 @@ import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import QueryTaxonomies from 'components/data/query-taxonomies';
 import TaxonomyCard from './taxonomies/taxonomy-card';
-import {
-	isJetpackSite,
-	isJetpackMinimumVersion,
-	siteSupportsJetpackSettingsUi
-} from 'state/sites/selectors';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
@@ -107,7 +103,7 @@ class SiteSettingsFormWriting extends Component {
 					updateFields={ updateFields }
 				/>
 				{
-					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
+					this.props.isJetpackSite && (
 						<div>
 							{
 								this.renderSectionHeader( translate( 'Media' ) )
@@ -123,7 +119,7 @@ class SiteSettingsFormWriting extends Component {
 					)
 				}
 				{
-					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
+					this.props.isJetpackSite && (
 						<div>
 							<QueryJetpackModules siteId={ this.props.siteId } />
 
@@ -156,7 +152,7 @@ class SiteSettingsFormWriting extends Component {
 					)
 				}
 
-				{ config.isEnabled( 'press-this' ) && ! ( this.props.isJetpackSite || this.props.jetpackSettingsUISupported ) && (
+				{ config.isEnabled( 'press-this' ) && ! this.props.isJetpackSite && (
 					<div>
 						{
 							this.renderSectionHeader( translate( 'Press This', {
@@ -177,7 +173,6 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
 			jetpackMasterbarSupported: isJetpackMinimumVersion( state, siteId, '4.8' ),
 			isJetpackSite: isJetpackSite( state, siteId ),
 			siteId

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -13,7 +13,7 @@ import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import GeneralSettings from './section-general';
 import ImportSettings from './section-import';
 import ExportSettings from './section-export';
@@ -31,7 +31,7 @@ export class SiteSettingsComponent extends Component {
 		purchasesError: PropTypes.object,
 		hasLoadedSitePurchasesFromServer: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
-		jetpackSettingsUiSupported: PropTypes.bool
+		siteIsJetpack: PropTypes.bool
 	};
 
 	static defaultProps = {
@@ -66,12 +66,12 @@ export class SiteSettingsComponent extends Component {
 
 	render() {
 		const { siteId } = this.props;
-		const { jetpackSettingsUiSupported, section } = this.props;
+		const { siteIsJetpack, section } = this.props;
 
 		return (
 			<Main className="site-settings">
 					{
-						jetpackSettingsUiSupported &&
+						siteIsJetpack &&
 						<JetpackDevModeNotice />
 					}
 					<SidebarNavigation />
@@ -88,15 +88,14 @@ export class SiteSettingsComponent extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const jetpackSite = isJetpackSite( state, siteId );
-		const jetpackUiSupported = siteSupportsJetpackSettingsUi( state, siteId );
+		const siteIsJetpack = isJetpackSite( state, siteId );
 
 		return {
 			siteId,
 			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 			purchasesError: getPurchasesError( state ),
 			sitePurchases: getSitePurchases( state, siteId ),
-			jetpackSettingsUiSupported: jetpackSite && jetpackUiSupported,
+			siteIsJetpack
 		};
 	}
 )( SiteSettingsComponent );

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -23,11 +23,10 @@ import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const SiteSettingsTraffic = ( {
 	fields,
-	jetpackSettingsUiSupported,
 	handleAutosavingToggle,
 	handleSubmitForm,
 	isJetpack,
@@ -45,7 +44,7 @@ const SiteSettingsTraffic = ( {
 		<SidebarNavigation />
 		<SiteSettingsNavigation site={ site } section="traffic" />
 
-		{ jetpackSettingsUiSupported &&
+		{ isJetpack &&
 			<JetpackSiteStats
 				handleAutosavingToggle={ handleAutosavingToggle }
 				setFieldValue={ setFieldValue }
@@ -88,12 +87,10 @@ const connectComponent = connect(
 		const site = getSelectedSite( state );
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const jetpackSettingsUiSupported = isJetpack && siteSupportsJetpackSettingsUi( state, siteId );
 
 		return {
 			site,
 			isJetpack,
-			jetpackSettingsUiSupported,
 		};
 	}
 );

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -30,7 +30,7 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import { removeNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
@@ -109,11 +109,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		};
 
 		submitForm = () => {
-			const { fields, settingsFields, siteId, jetpackSettingsUISupported } = this.props;
+			const { fields, settingsFields, siteId } = this.props;
 			this.props.removeNotice( 'site-settings-save' );
 
 			this.props.saveSiteSettings( siteId, pick( fields, settingsFields.site ) );
-			if ( jetpackSettingsUISupported ) {
+			if ( this.props.isJetpack ) {
 				this.props.updateSettings( siteId, pick( fields, settingsFields.jetpack ) );
 			}
 		};
@@ -201,7 +201,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				<div>
 					<QuerySiteSettings siteId={ this.props.siteId } />
 					{
-						this.props.jetpackSettingsUISupported &&
+						this.props.isJetpack &&
 						<QueryJetpackSettings siteId={ this.props.siteId } />
 					}
 					<SettingsForm { ...this.props } { ...utils } />
@@ -223,8 +223,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			};
 
 			const isJetpack = isJetpackSite( state, siteId );
-			const jetpackSettingsUISupported = isJetpack && siteSupportsJetpackSettingsUi( state, siteId );
-			if ( jetpackSettingsUISupported ) {
+			if ( isJetpack ) {
 				const jetpackSettings = getJetpackSettings( state, siteId );
 				isSavingSettings = isSavingSettings || isUpdatingJetpackSettings( state, siteId );
 				isSaveRequestSuccessful = isSaveRequestSuccessful && ! isJetpackSettingsSaveFailure( state, siteId );
@@ -234,6 +233,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			}
 
 			return {
+				isJetpack,
 				isRequestingSettings,
 				isSavingSettings,
 				isSaveRequestSuccessful,
@@ -241,7 +241,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				settings,
 				settingsFields,
 				siteId,
-				jetpackSettingsUISupported
 			};
 		},
 		dispatch => {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1026,15 +1026,3 @@ export const hasDefaultSiteTitle = ( state, siteId ) => {
 	// we are using startsWith here, as getSiteSlug returns "slug.wordpress.com"
 	return site.name === i18n.translate( 'Site Title' ) || startsWith( slug, site.name );
 };
-
-/**
- * Returns true if the site supports managing Jetpack settings remotely.
- * False otherwise.
- *
- * @param {Object} state  Global state tree
- * @param {Object} siteId Site ID
- * @return {?Boolean}     Whether site supports managing Jetpack settings remotely.
- */
-export const siteSupportsJetpackSettingsUi = ( state, siteId ) => {
-	return isJetpackMinimumVersion( state, siteId, '4.5.0' );
-};

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -56,8 +56,7 @@ import {
 	getSiteAdminUrl,
 	getCustomizerUrl,
 	getJetpackComputedAttributes,
-	hasDefaultSiteTitle,
-	siteSupportsJetpackSettingsUi
+	hasDefaultSiteTitle
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -3184,96 +3183,6 @@ describe( 'selectors', () => {
 
 				expect( customizerUrl ).to.equal( 'https://example.com/wp-admin/customize.php' );
 			} );
-		} );
-	} );
-
-	describe( 'siteSupportsJetpackSettingsUi()', () => {
-		it( 'should return null if the Jetpack version is not known', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://example.com',
-							jetpack: true,
-						}
-					}
-				}
-			}, 77203074 );
-
-			expect( supportsJetpackSettingsUI ).to.be.null;
-		} );
-
-		it( 'should return null if the site is not a Jetpack site', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://example.com',
-						}
-					}
-				}
-			}, 77203074 );
-
-			expect( supportsJetpackSettingsUI ).to.be.null;
-		} );
-
-		it( 'should return false if the Jetpack version is older than 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://example.com',
-							jetpack: true,
-							options: {
-								jetpack_version: '4.4.0'
-							}
-						}
-					}
-				}
-			}, 77203074 );
-
-			expect( supportsJetpackSettingsUI ).to.be.false;
-		} );
-
-		it( 'should return true if the Jetpack version is 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://example.com',
-							jetpack: true,
-							options: {
-								jetpack_version: '4.5.0'
-							}
-						}
-					}
-				}
-			}, 77203074 );
-
-			expect( supportsJetpackSettingsUI ).to.be.true;
-		} );
-
-		it( 'should return true if the Jetpack version is newer than 4.5', () => {
-			const supportsJetpackSettingsUI = siteSupportsJetpackSettingsUi( {
-				sites: {
-					items: {
-						77203074: {
-							ID: 77203074,
-							URL: 'https://example.com',
-							jetpack: true,
-							options: {
-								jetpack_version: '4.6.0'
-							}
-						}
-					}
-				}
-			}, 77203074 );
-
-			expect( supportsJetpackSettingsUI ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
We support only the last two Jetpack versions. Current version is 4.8 and these checks were made during the 4.4 - 4.6 transition. 

