### PR TITLE
Reader: Connect email subs component

### DIFF
--- a/client/blocks/reader-subscription-list-item/email-settings.jsx
+++ b/client/blocks/reader-subscription-list-item/email-settings.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes, Component } from 'react';
-import { noop } from 'lodash';
+import { connect } from 'react-redux';
+import { find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,13 +14,21 @@ import Popover from 'components/popover/index';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
 import FormToggle from 'components/forms/form-toggle';
+import { getReaderFollows } from 'state/selectors';
+import {
+	subscribeToNewPostEmail,
+	updateNewPostEmailSubscription,
+	unsubscribeToNewPostEmail,
+	subscribeToNewCommentEmail,
+	unsubscribeToNewCommentEmail,
+} from 'state/reader/follows/actions';
 
 class ReaderEmailSubscriptionSettingsPopout extends Component {
 	static displayName = 'ReaderEmailSubscriptionSettingsPopout';
 	static propTypes = {
-		feedId: PropTypes.number,
 		siteId: PropTypes.number,
 	};
+
 	state = {
 		showPopover: false,
 	};
@@ -37,11 +46,37 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 	}
 
 	setSelected = text => () => {
+		const { siteId } = this.props;
 		this.setState( { selected: text } );
+		this.props.updateNewPostEmailSubscription( siteId, text );
+	}
+
+	toggleNewPostEmail = () => {
+		const { notifyOnNewPosts, siteId } = this.props;
+
+		if ( notifyOnNewPosts ) {
+			this.props.unsubscribeToNewPostEmail( siteId );
+		} else {
+			this.props.subscribeToNewPostEmail( siteId );
+		}
+	}
+
+	toggleNewCommentEmail = () => {
+		const { notifyOnNewComments, siteId } = this.props;
+
+		if ( notifyOnNewComments ) {
+			this.props.unsubscribeToNewCommentEmail( siteId );
+		} else {
+			this.props.subscribeToNewCommentEmail( siteId );
+		}
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, notifyOnNewComments, notifyOnNewPosts } = this.props;
+
+		if ( ! this.props.siteId ) {
+			return null;
+		}
 
 		return (
 			<div>
@@ -68,16 +103,16 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 						<div className="reader-subscription-list-item__email-popout-toggle">
 							{ translate( 'New posts' ) }
 							<FormToggle
-								onChange={ noop /* fire off dispatch */ }
-								checked={ true /* get from selector*/ }
+								onChange={ this.toggleNewPostEmail }
+								checked={ notifyOnNewPosts }
 							/>
 						</div>
 						<SegmentedControl>
 							<ControlItem
-								selected={ this.state.selected === 'instant' }
-								onClick={ this.setSelected( 'instant' ) }
+								selected={ this.state.selected === 'instantly' }
+								onClick={ this.setSelected( 'instantly' ) }
 							>
-								{ translate( 'Instant' ) }
+								{ translate( 'Instantly' ) }
 							</ControlItem>
 							<ControlItem
 								selected={ this.state.selected === 'daily' }
@@ -95,8 +130,8 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 						<div className="reader-subscription-list-item__email-popout-toggle">
 							New comments
 							<FormToggle
-								onChange={ noop /* fire off dispatch */ }
-								checked={ false /* get from selector*/ }
+								onChange={ this.toggleNewCommentEmail }
+								checked={ notifyOnNewComments }
 							/>
 						</div>
 					</div>
@@ -106,5 +141,29 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 	}
 }
 
-export default localize( ReaderEmailSubscriptionSettingsPopout );
+const mapStateToProps = ( state, ownProps ) => {
+	const follow = find( getReaderFollows( state ), { blog_ID: ownProps.siteId } );
+
+	const currentDeliveryMethods = get( follow, [ 'delivery_methods', 'email' ], {} );
+	const notifyOnNewPosts = !! currentDeliveryMethods.send_posts;
+	const deliveryFrequency = currentDeliveryMethods.post_delivery_frequency;
+	const notifyOnNewComments = !! currentDeliveryMethods.send_comments;
+
+	return {
+		notifyOnNewComments,
+		notifyOnNewPosts,
+		deliveryFrequency
+	};
+};
+
+export default connect(
+	mapStateToProps,
+	{
+		subscribeToNewPostEmail,
+		unsubscribeToNewPostEmail,
+		updateNewPostEmailSubscription,
+		subscribeToNewCommentEmail,
+		unsubscribeToNewCommentEmail,
+	}
+)( localize( ReaderEmailSubscriptionSettingsPopout ) );
 

--- a/client/blocks/reader-subscription-list-item/email-settings.jsx
+++ b/client/blocks/reader-subscription-list-item/email-settings.jsx
@@ -27,11 +27,19 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 	static displayName = 'ReaderEmailSubscriptionSettingsPopout';
 	static propTypes = {
 		siteId: PropTypes.number,
+		deliveryFrequency: PropTypes.string,
 	};
 
 	state = {
 		showPopover: false,
+		selected: this.props.deliveryFrequency,
 	};
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.deliveryFrequency !== this.props.deliveryFrequency ) {
+			this.setState( { selected: nextProps.deliveryFrequency } );
+		}
+	}
 
 	togglePopoverVisibility = () => {
 		this.setState( { showPopover: ! this.state.showPopover } );
@@ -107,26 +115,28 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 								checked={ notifyOnNewPosts }
 							/>
 						</div>
-						<SegmentedControl>
-							<ControlItem
-								selected={ this.state.selected === 'instantly' }
-								onClick={ this.setSelected( 'instantly' ) }
-							>
-								{ translate( 'Instantly' ) }
-							</ControlItem>
-							<ControlItem
-								selected={ this.state.selected === 'daily' }
-								onClick={ this.setSelected( 'daily' ) }
-							>
-								{ translate( 'Daily' ) }
-							</ControlItem>
-							<ControlItem
-								selected={ this.state.selected === 'weekly' }
-								onClick={ this.setSelected( 'weekly' ) }
-							>
-								{ translate( 'Weekly' ) }
-							</ControlItem>
-						</SegmentedControl>
+						{ notifyOnNewPosts && (
+							<SegmentedControl>
+								<ControlItem
+									selected={ this.state.selected === 'instantly' }
+									onClick={ this.setSelected( 'instantly' ) }
+								>
+									{ translate( 'Instantly' ) }
+								</ControlItem>
+								<ControlItem
+									selected={ this.state.selected === 'daily' }
+									onClick={ this.setSelected( 'daily' ) }
+								>
+									{ translate( 'Daily' ) }
+								</ControlItem>
+								<ControlItem
+									selected={ this.state.selected === 'weekly' }
+									onClick={ this.setSelected( 'weekly' ) }
+								>
+									{ translate( 'Weekly' ) }
+								</ControlItem>
+							</SegmentedControl>
+						) }
 						<div className="reader-subscription-list-item__email-popout-toggle">
 							New comments
 							<FormToggle

--- a/client/blocks/reader-subscription-list-item/email-settings.jsx
+++ b/client/blocks/reader-subscription-list-item/email-settings.jsx
@@ -60,23 +60,19 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 	}
 
 	toggleNewPostEmail = () => {
-		const { notifyOnNewPosts, siteId } = this.props;
+		const toggleSubscription = this.props.notifyOnNewPosts
+			? this.props.unsubscribeToNewPostEmail
+			: this.props.subscribeToNewPostEmail;
 
-		if ( notifyOnNewPosts ) {
-			this.props.unsubscribeToNewPostEmail( siteId );
-		} else {
-			this.props.subscribeToNewPostEmail( siteId );
-		}
+		toggleSubscription( this.props.siteId );
 	}
 
 	toggleNewCommentEmail = () => {
-		const { notifyOnNewComments, siteId } = this.props;
+		const toggleSubscription = this.props.notifyOnNewComments
+			? this.props.unsubscribeToNewCommentEmail
+			: this.props.subscribeToNewCommentEmail;
 
-		if ( notifyOnNewComments ) {
-			this.props.unsubscribeToNewCommentEmail( siteId );
-		} else {
-			this.props.subscribeToNewCommentEmail( siteId );
-		}
+		toggleSubscription( this.props.siteId );
 	}
 
 	render() {
@@ -154,15 +150,13 @@ class ReaderEmailSubscriptionSettingsPopout extends Component {
 const mapStateToProps = ( state, ownProps ) => {
 	const follow = find( getReaderFollows( state ), { blog_ID: ownProps.siteId } );
 
-	const currentDeliveryMethods = get( follow, [ 'delivery_methods', 'email' ], {} );
-	const notifyOnNewPosts = !! currentDeliveryMethods.send_posts;
-	const deliveryFrequency = currentDeliveryMethods.post_delivery_frequency;
-	const notifyOnNewComments = !! currentDeliveryMethods.send_comments;
+	const deliveryMethods = get( follow, [ 'delivery_methods', 'email' ], {} );
+	const { send_posts, post_delivery_frequency, send_comments } = deliveryMethods;
 
 	return {
-		notifyOnNewComments,
-		notifyOnNewPosts,
-		deliveryFrequency
+		notifyOnNewComments: !! send_comments,
+		notifyOnNewPosts: !! send_posts,
+		deliveryFrequency: post_delivery_frequency,
 	};
 };
 

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -24,6 +24,7 @@ function ReaderSubscriptionListItem( {
 	className = '',
 	translate,
 	followSource,
+	isEmailBlocked,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -69,7 +70,7 @@ function ReaderSubscriptionListItem( {
 			</div>
 			<div className="reader-subscription-list-item__options">
 				<FollowButton siteUrl={ siteUrl } followSource={ followSource } />
-				{ isFollowing && <EmailSettings /> }
+				{ isFollowing && isEmailBlocked !== true && <EmailSettings siteId={ siteId } /> }
 			</div>
 		</div>
 	);

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -70,7 +70,7 @@ function ReaderSubscriptionListItem( {
 			</div>
 			<div className="reader-subscription-list-item__options">
 				<FollowButton siteUrl={ siteUrl } followSource={ followSource } />
-				{ isFollowing && isEmailBlocked !== true && <EmailSettings siteId={ siteId } /> }
+				{ isFollowing && ! isEmailBlocked && <EmailSettings siteId={ siteId } /> }
 			</div>
 		</div>
 	);

--- a/client/reader/following-manage/connected-subscription-list-item.jsx
+++ b/client/reader/following-manage/connected-subscription-list-item.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import connectSite from 'lib/reader-connect-site';
 import SubscriptionListItem from 'blocks/reader-subscription-list-item/';
+import userSettings from 'lib/user-settings';
 
 export default localize( connectSite(
 	( { feed, site, translate, url, feedId, siteId } ) => (
@@ -19,6 +20,7 @@ export default localize( connectSite(
 			site={ site }
 			feed={ feed }
 			url={ url }
+			isEmailBlocked={ userSettings.getSetting( 'subscription_delivery_email_blocked' ) }
 		/>
 	)
 ) );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { trim, debounce } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -23,7 +23,7 @@ import SitesWindowScroller from './sites-window-scroller';
 
 class FollowingManage extends Component {
 	static propTypes = {
-		query: React.PropTypes.string,
+		query: PropTypes.string,
 	};
 	state = { width: 800 };
 

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -18,7 +18,7 @@ import FollowingManageSearchFollowed from './search-followed';
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {
 		follows: PropTypes.array.isRequired,
-	}
+	};
 
 	render() {
 		const { follows, width, translate } = this.props;


### PR DESCRIPTION
The final piece in implementing: https://github.com/Automattic/wp-calypso/issues/12954 !

This PR seeks to make the new beautiful settings popout actually _work_.

Example settings popout:
![](https://cldup.com/ZHKZDQecVT.png)

#### To Test:
load up calypso.live and navigate to [following/manage](https://calypso.live/following/manage?branch=add/reader/connect-subs).   There are two situations in which the cog should be missing:
 1. RSS feeds. We don't support email notifications for those
 2. If you have disabled all email notifications