### PR TITLE
Billing: Fix search with null or undefined transaction data

### DIFF
--- a/client/me/billing-history/table-rows.js
+++ b/client/me/billing-history/table-rows.js
@@ -1,21 +1,24 @@
 /**
  * External dependencies
  */
-var i18n = require( 'i18n-calypso' ),
-	some = require( 'lodash/some' ),
-	values = require( 'lodash/values' ),
-	isDate = require( 'lodash/isDate' ),
-	omit = require( 'lodash/omit' ),
-	flatten = require( 'lodash/flatten' );
+import { moment } from 'i18n-calypso';
+import {
+	flatten,
+	isDate,
+	omit,
+	some,
+	values,
+	without,
+} from 'lodash';
 
 function formatDate( date ) {
-	return i18n.moment( date ).format( 'MMM D, YYYY' );
+	return moment( date ).format( 'MMM D, YYYY' );
 }
 
 function getSearchableStrings( transaction ) {
-	var rootStrings = values( omit( transaction, 'items' ) ),
+	const rootStrings = values( omit( transaction, 'items' ) ),
 		transactionItems = transaction.items || [],
-		itemStrings = flatten( transactionItems.map( values ) );
+		itemStrings = without( flatten( transactionItems.map( values ) ), null, undefined );
 
 	return rootStrings.concat( itemStrings );
 }
@@ -47,7 +50,7 @@ function filter( transactions, params ) {
 			transactions = transactions.slice( 0, params.date.newest );
 		} else if ( params.date.month || params.date.before ) {
 			transactions = transactions.filter( function( transaction ) {
-				var date = i18n.moment( transaction.date );
+				const date = moment( transaction.date );
 
 				if ( params.date.month ) {
 					return date.isSame( params.date.month, 'month' );

--- a/client/me/billing-history/table-rows.js
+++ b/client/me/billing-history/table-rows.js
@@ -18,9 +18,9 @@ function formatDate( date ) {
 function getSearchableStrings( transaction ) {
 	const rootStrings = values( omit( transaction, 'items' ) ),
 		transactionItems = transaction.items || [],
-		itemStrings = without( flatten( transactionItems.map( values ) ), null, undefined );
+		itemStrings = flatten( transactionItems.map( values ) );
 
-	return rootStrings.concat( itemStrings );
+	return without( rootStrings.concat( itemStrings ), null, undefined );
 }
 
 function search( transactions, searchQuery ) {


### PR DESCRIPTION
This PR fixes #13254, where searching in billing transactions that have one or more `null` or `undefined` attributes can cause an issue.

To test:
* Make sure you have at least one transaction with `null` or `undefined` attribute. Or use @gwwar's WordPress.com account :stuck_out_tongue_winking_eye: 
* Go to `/me/purchases/billing`
* Try searching and verify it doesn't break.