### PR TITLE
Desktop: Fix failing make test-osx command

### DIFF
--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -177,10 +177,8 @@ test: config-test package
 	@DESKTOP_APP_PATH=$(BUILD_DIR)/desktop $(ELECTRON_TEST) --inline-diffs --timeout 15000 build/desktop/desktop-test.js
 
 test-osx: osx
-	@rm -rf ./release/WordPress.com-darwin-x64-unpacked
-	@$(NPM_BIN)/asar e ./release/WordPress.com-darwin-x64/WordPress.com.app/Contents/Resources/app.asar ./release/WordPress.com-darwin-x64-unpacked
-	@mkdir ./release/WordPress.com-darwin-x64-unpacked/node_modules/electron-mocha
-	@cp -R ./node_modules/electron-mocha ./release/WordPress.com-darwin-x64-unpacked/node_modules/
-	@NODE_PATH=./release/WordPress.com-darwin-x64-unpackaged/node_modules ELECTRON_PATH=$(NPM_BIN)/electron ./release/WordPress.com-darwin-x64-unpacked/node_modules/electron-mocha/bin/electron-mocha --inline-diffs --timeout 5000 ./resource/test/osx.js
+	@mkdir -p ./release/WordPress.com-darwin-x64/node_modules/electron-mocha
+	@cp -R ./node_modules/electron-mocha ./release/WordPress.com-darwin-x64/node_modules/
+	@DESKTOP_APP_PATH=$(BUILD_DIR)/desktop NODE_PATH=./release/WordPress.com-darwin-x64-unpackaged/node_modules ELECTRON_PATH=$(NPM_BIN)/electron ./release/WordPress.com-darwin-x64/node_modules/electron-mocha/bin/electron-mocha --inline-diffs --timeout 5000 ./resource/test/osx.js
 
 .PHONY: run test

--- a/desktop/desktop/server/index.js
+++ b/desktop/desktop/server/index.js
@@ -43,6 +43,7 @@ function showAppWindow() {
 
 	mainWindow.webContents.on( 'did-finish-load', function() {
 		mainWindow.webContents.send( 'app-config', Config, Settings.isDebug(), System.getDetails() );
+		mainWindow.webContents.send( 'is-calypso' );
 
 		const ipc = electron.ipcMain;
 		ipc.on( 'mce-contextmenu', function( ev ) {

--- a/desktop/resource/test/osx.js
+++ b/desktop/resource/test/osx.js
@@ -6,23 +6,13 @@ const electron = require( 'electron' );
 const ipcMain = electron.ipcMain;
 const expect = require( 'chai' ).expect;
 
-/**
- * Internal dependencies
- */
-const boot = require( '../../release/WordPress.com-darwin-x64-unpacked/desktop/app' );
-
 describe( 'check app loads', function() {
 	it( 'should have calypso in DOM', function( done ) {
-		boot( function( mainWindow ) {
-			// We need to wait for the page to load before sending the request
-			mainWindow.webContents.on( 'did-finish-load', function() {
-				mainWindow.webContents.send( 'is-calypso' );
-			} );
-
-			ipcMain.on( 'is-calypso-response', function( ev, value ) {
-				expect( value ).to.be.true;
-				done();
-			} );
+		ipcMain.on( 'is-calypso-response', function( ev, value ) {
+			expect( value ).to.be.true;
+			done();
 		} );
+
+		require( '../../release/WordPress.com-darwin-x64/WordPress.com.app/Contents/Resources/app/desktop/desktop.js' );
 	} );
 } );


### PR DESCRIPTION
Since updating the build process in the `wp-desktop` project to bundle Calypsos server code, one of the test make commands (`make test-osx`) failed, complaining about one of the lines of the make recipe.

Further details about this can be found here: https://github.com/Automattic/wp-desktop/issues/281.

With consideration to how the build process has changed since that point, I've changed the approach to run the bundled 'server' code after setting up a listener. Note that we can't just require the bundled code as we normally would - `require`ing it runs the app code rather than giving a return value. This also means that we can't 

### Testing
1. `cd` in to `/desktop`.
1. Run `make test-osx`.
1. Make sure the single test passes.