### PR TITLE
Reader: Update excerpts in recs to 4 lines

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -202,11 +202,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	padding-top: 11px;
 
 	.reader-related-card-v2__post {
-		max-height: 127px;
-
-		@include breakpoint( "<480px" ) {
-			max-height: 126px;
-		}
+		max-height: 104px;
 
 		&::after {
 			@include long-content-fade( $size: 30% );
@@ -520,7 +516,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	// Clamp to 2 lines on narrow viewports
 	@include breakpoint( "<660px" ) {
 		overflow: hidden;
-		max-height: 16px * 1.4 * 2;
+		max-height: 16px * 1.5 * 2;
 		word-wrap: break-word;
 
 		&::after {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -192,7 +192,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	&.has-excerpt {
 
 		.reader-related-card-v2__title {
-			margin-bottom: 10px;
+			margin-bottom: 9px;
 		}
 	}
 }
@@ -511,7 +511,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 .reader-related-card-v2__title {
 	font-size: 17px;
 	font-weight: 700;
-	line-height: 1.4;
+	line-height: 25px;
 
 	// Clamp to 2 lines on narrow viewports
 	@include breakpoint( "<660px" ) {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -161,7 +161,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		&::after {
 			@include long-content-fade( $size: 25% );
 				bottom: 0;
-				height: 22px;
+				height: 23px;
 				top: inherit;
 				visibility: visible;
 		}
@@ -230,14 +230,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.has-thumbnail {
 
 			.reader-related-card-v2__post {
-				max-height: 128px;
+				max-height: 104px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 127px;
+					max-height: 108px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 126px;
+					max-height: 104px;
 				}
 			}
 		}
@@ -283,18 +283,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 127px;
+				max-height: 104px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 153px;
+					max-height: 125px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 150px;
+					max-height: 130px;
 				}
 
 				@include breakpoint( "<480px" ) {
-					max-height: 140px;
+					max-height: 121px;
 				}
 			}
 		}

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -93,7 +93,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 130px;
+		max-height: 110px;
 
 		@media #{$reader-related-card-v2-breakpoint-small} {
 			max-height: 103px;
@@ -111,14 +111,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	 .has-thumbnail {
 
 		.reader-related-card-v2__post {
-			max-height: 130px;
+			max-height: 110px;
 
 			@media #{$reader-related-card-v2-breakpoint-small} {
-				max-height: 152px;
+				max-height: 104px;
 			}
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
-				max-height: 152px;
+				max-height: 104px;
 			}
 		}
 	}

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -565,14 +565,18 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			}
 
 			.reader-related-card-v2__post {
-				max-height: 130px;
+				max-height: 108px;
 
 				@media #{$reader-related-card-v2-breakpoint-small} {
-					max-height: 146px;
+					max-height: 128px;
 				}
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
-					max-height: 146px;
+					max-height: 128px;
+				}
+
+				@include breakpoint( "<480px" ) {
+					max-height: 120px;
 				}
 			}
 		}


### PR DESCRIPTION
This updates excerpts from 5 to 4 lines. Updated in:

## Full-post recs

**Before:**
<img width="717" alt="screenshot 2017-04-20 18 33 18" src="https://cloud.githubusercontent.com/assets/4924246/25258957/fcfb42e6-25f7-11e7-80bc-3707ef669492.png">
<img width="729" alt="screenshot 2017-04-20 18 33 25" src="https://cloud.githubusercontent.com/assets/4924246/25258956/fce984ca-25f7-11e7-9335-9f6e86b56b1e.png">

**After:**
<img width="743" alt="screenshot 2017-04-20 18 33 53" src="https://cloud.githubusercontent.com/assets/4924246/25258959/0207d42a-25f8-11e7-8025-a030cf3e1258.png">
<img width="743" alt="screenshot 2017-04-20 18 34 00" src="https://cloud.githubusercontent.com/assets/4924246/25258960/020815de-25f8-11e7-9c4b-e3dc08866339.png">

## In-stream recs

**Before:**
<img width="688" alt="screenshot 2017-04-20 18 39 42" src="https://cloud.githubusercontent.com/assets/4924246/25259095/ba9a3712-25f8-11e7-9914-31b48841c6cb.png">

**After:**
<img width="799" alt="screenshot 2017-04-20 18 35 59" src="https://cloud.githubusercontent.com/assets/4924246/25259018/457ed384-25f8-11e7-8380-f054eeca22dc.png">

## Search recs

**Before:**
<img width="805" alt="screenshot 2017-04-20 18 37 40" src="https://cloud.githubusercontent.com/assets/4924246/25259059/7d174a60-25f8-11e7-8055-8ccbf05894d7.png">

**After:**
<img width="794" alt="screenshot 2017-04-20 18 37 54" src="https://cloud.githubusercontent.com/assets/4924246/25259075/95e0d26e-25f8-11e7-8b54-2a9854bac259.png">
