### PR TITLE
Desktop: Stop loading desktop lib in web context to avoid errors

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -208,6 +208,10 @@ if ( calypsoEnv === 'production' ) {
 	) );
 }
 
+if ( ! config.isEnabled( 'desktop' ) ) {
+	webpackConfig.plugins.push( new webpack.NormalModuleReplacementPlugin( /^lib\/desktop$/, 'lodash/noop' ) );
+}
+
 if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 	webpackConfig.recordsPath = path.join( __dirname, '.webpack-cache', 'client-records.json' );
 	webpackConfig.plugins.unshift( new HardSourceWebpackPlugin( { cacheDirectory: path.join( __dirname, '.webpack-cache', 'client' ) } ) );

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -122,6 +122,10 @@ const webpackConfig = {
 	externals: getExternals()
 };
 
+if ( ! config.isEnabled( 'desktop' ) ) {
+	webpackConfig.plugins.push( new webpack.NormalModuleReplacementPlugin( /^lib\/desktop$/, 'lodash/noop' ) );
+}
+
 if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 	webpackConfig.recordsPath = path.join( __dirname, '.webpack-cache', 'server-records.json' );
 	webpackConfig.plugins.unshift( new HardSourceWebpackPlugin( { cacheDirectory: path.join( __dirname, '.webpack-cache', 'server' ) } ) );


### PR DESCRIPTION
I noticed the following error when executing `make run`:

```
ERROR in ./client/lib/desktop/index.js
Module not found: Error: Cannot resolve module 'electron' in /Users/gziolo/PhpstormProjects/wp-calypso/client/lib/desktop
resolve module electron in /Users/gziolo/PhpstormProjects/wp-calypso/client/lib/desktop
  looking for modules in /Users/gziolo/PhpstormProjects/wp-calypso/server
    /Users/gziolo/PhpstormProjects/wp-calypso/server/electron doesn't exist (module as directory)
    resolve 'file' electron in /Users/gziolo/PhpstormProjects/wp-calypso/server
      resolve file
        /Users/gziolo/PhpstormProjects/wp-calypso/server/electron doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/server/electron.json doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/server/electron.js doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/server/electron.jsx doesn't exist
  looking for modules in /Users/gziolo/PhpstormProjects/wp-calypso/client
    /Users/gziolo/PhpstormProjects/wp-calypso/client/electron doesn't exist (module as directory)
    resolve 'file' electron in /Users/gziolo/PhpstormProjects/wp-calypso/client
      resolve file
        /Users/gziolo/PhpstormProjects/wp-calypso/client/electron doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/client/electron.json doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/client/electron.js doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/client/electron.jsx doesn't exist
  looking for modules in /Users/gziolo/PhpstormProjects/wp-calypso
    /Users/gziolo/PhpstormProjects/wp-calypso/electron doesn't exist (module as directory)
    resolve 'file' electron in /Users/gziolo/PhpstormProjects/wp-calypso
      resolve file
        /Users/gziolo/PhpstormProjects/wp-calypso/electron doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/electron.json doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/electron.js doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/electron.jsx doesn't exist
  looking for modules in /Users/gziolo/PhpstormProjects/wp-calypso/node_modules
    /Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron doesn't exist (module as directory)
    resolve 'file' electron in /Users/gziolo/PhpstormProjects/wp-calypso/node_modules
      resolve file
        /Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron.json doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron.js doesn't exist
        /Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron.jsx doesn't exist
[/Users/gziolo/PhpstormProjects/wp-calypso/server/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/server/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/server/electron.json]
[/Users/gziolo/PhpstormProjects/wp-calypso/server/electron.js]
[/Users/gziolo/PhpstormProjects/wp-calypso/server/electron.jsx]
[/Users/gziolo/PhpstormProjects/wp-calypso/client/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/client/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/client/electron.json]
[/Users/gziolo/PhpstormProjects/wp-calypso/client/electron.js]
[/Users/gziolo/PhpstormProjects/wp-calypso/client/electron.jsx]
[/Users/gziolo/PhpstormProjects/wp-calypso/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/electron.json]
[/Users/gziolo/PhpstormProjects/wp-calypso/electron.js]
[/Users/gziolo/PhpstormProjects/wp-calypso/electron.jsx]
[/Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron]
[/Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron.json]
[/Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron.js]
[/Users/gziolo/PhpstormProjects/wp-calypso/node_modules/electron.jsx]
 @ ./client/lib/desktop/index.js 16:10-29
```
It might be introduced together with changes added in #13204.

This patch removes this error by replacing `lib/desktop` dependency with Lodash `noop` method when desktop environment is inactive.

### Testing
- Execute `make run` and make sure everything still works.
- Clone https://github.com/Automattic/wp-desktop and follow the Readme for install instructions
- From the Desktop directory, `cd calypso; git pull; git checkout fix/lib-desktop-error`
- From the Desktop directory `make run`
