### PR TITLE
Site Settings: Use Redux site for siteSettings route and settings main component

### DIFF
--- a/client/my-sites/site-settings/composing/default-post-format.jsx
+++ b/client/my-sites/site-settings/composing/default-post-format.jsx
@@ -28,7 +28,8 @@ const DefaultPostFormat = ( {
 } ) => {
 	return (
 		<FormFieldset>
-			<QueryPostFormats siteId={ siteId } />
+			{ siteId && <QueryPostFormats siteId={ siteId } /> }
+
 			<FormLabel htmlFor="default_post_format">
 				{ translate( 'Default Post Format' ) }
 			</FormLabel>

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -99,21 +99,21 @@ module.exports = {
 	importSite( context ) {
 		renderPage(
 			context,
-			<SiteSettingsComponent sites={ sites } section="import" />
+			<SiteSettingsComponent section="import" />
 		);
 	},
 
 	exportSite( context ) {
 		renderPage(
 			context,
-			<SiteSettingsComponent sites={ sites } section="export" />
+			<SiteSettingsComponent section="export" />
 		);
 	},
 
 	guidedTransfer( context ) {
 		renderPage(
 			context,
-			<SiteSettingsComponent sites={ sites } section="guidedTransfer" hostSlug={ context.params.host_slug } />
+			<SiteSettingsComponent section="guidedTransfer" hostSlug={ context.params.host_slug } />
 		);
 	},
 

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -21,8 +21,9 @@ import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import titlecase from 'to-title-case';
-import utils from 'lib/site/utils';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 /**
  * Module vars
@@ -64,41 +65,28 @@ module.exports = {
 	siteSettings( context ) {
 		let analyticsPageTitle = 'Site Settings';
 		const basePath = route.sectionify( context.path );
-		const fiveMinutes = 5 * 60 * 1000;
-		let site = sites.getSelectedSite();
+		const siteId = getSelectedSiteId( context.store.getState() );
 		const section = sectionify( context.path ).split( '/' )[ 2 ];
+		const state = context.store.getState();
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Site Settings', { textOnly: true } ) ) );
 
 		// if site loaded, but user cannot manage site, redirect
-		if ( site && ! utils.userCan( 'manage_options', site ) ) {
+		if ( siteId && ! canCurrentUser( state, siteId, 'manage_options' ) ) {
 			page.redirect( '/stats' );
 			return;
 		}
 
 		// if user went directly to jetpack settings page, redirect
-		if ( site.jetpack && ! config.isEnabled( 'manage/jetpack' ) ) {
-			window.location.href = '//wordpress.com/manage/' + site.ID;
+		if ( isJetpackSite( state, siteId ) && ! config.isEnabled( 'manage/jetpack' ) ) {
+			window.location.href = '//wordpress.com/manage/' + siteId;
 			return;
 		}
 
-		if ( ! site.latestSettings || new Date().getTime() - site.latestSettings > ( fiveMinutes ) ) {
-			if ( sites.initialized ) {
-				site.fetchSettings();
-			} else {
-				sites.once( 'change', function() {
-					site = sites.getSelectedSite();
-					site.fetchSettings();
-				} );
-			}
-		}
-
-		const upgradeToBusiness = () => page( '/checkout/' + site.domain + '/business' );
-
 		renderPage(
 			context,
-			<SiteSettingsComponent { ...{ sites, section, upgradeToBusiness } } />
+			<SiteSettingsComponent section={ section } />
 		);
 
 		// analytics tracking

--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -31,7 +31,7 @@ class JetpackModuleToggle extends Component {
 	};
 
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
+		siteId: PropTypes.number,
 		moduleSlug: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
 		checked: PropTypes.bool,

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -46,7 +46,6 @@ export class SiteSettingsComponent extends Component {
 	}
 
 	getSection() {
-		const { site } = this.props;
 		const { section, hostSlug } = this.props;
 
 		switch ( section ) {
@@ -58,7 +57,7 @@ export class SiteSettingsComponent extends Component {
 					/>
 				);
 			case 'security':
-				return <SiteSecurity site={ site } />;
+				return <SiteSecurity />;
 			case 'import':
 				return <ImportSettings />;
 			case 'export':
@@ -71,10 +70,6 @@ export class SiteSettingsComponent extends Component {
 	render() {
 		const { siteId } = this.props;
 		const { jetpackSettingsUiSupported, section } = this.props;
-
-		if ( ! site ) {
-			return null;
-		}
 
 		return (
 			<Main className="site-settings">

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -1,9 +1,9 @@
 /**
  * External Dependencies
  */
-import React from 'react';
-import i18n from 'i18n-calypso';
-
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
@@ -11,28 +11,30 @@ import config from 'config';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
+import { getSelectedSite } from 'state/ui/selectors';
 
-export default React.createClass( {
-	displayName: 'SiteSettingsNavigation',
+export class SiteSettingsNavigation extends Component {
 
-	propTypes: {
-		site: React.PropTypes.object.isRequired,
-		section: React.PropTypes.string
-	},
+	static propTypes = {
+		section: PropTypes.string,
+		// Connected props
+		site: PropTypes.object
+	};
 
 	getStrings() {
+		const { translate } = this.props;
 		return {
-			general: i18n.translate( 'General', { context: 'settings screen' } ),
-			writing: i18n.translate( 'Writing', { context: 'settings screen' } ),
-			discussion: i18n.translate( 'Discussion', { context: 'settings screen' } ),
-			traffic: i18n.translate( 'Traffic', { context: 'settings screen' } ),
-			security: i18n.translate( 'Security', { context: 'settings screen' } ),
-			'import': i18n.translate( 'Import', { context: 'settings screen' } ),
-			'export': i18n.translate( 'Export', { context: 'settings screen' } ),
+			general: translate( 'General', { context: 'settings screen' } ),
+			writing: translate( 'Writing', { context: 'settings screen' } ),
+			discussion: translate( 'Discussion', { context: 'settings screen' } ),
+			traffic: translate( 'Traffic', { context: 'settings screen' } ),
+			security: translate( 'Security', { context: 'settings screen' } ),
+			'import': translate( 'Import', { context: 'settings screen' } ),
+			'export': translate( 'Export', { context: 'settings screen' } ),
 		};
-	},
+	}
 
-	getImportPath() {
+	getImportPath = () => {
 		const { site } = this.props,
 			path = '/settings/import';
 
@@ -41,14 +43,14 @@ export default React.createClass( {
 		}
 
 		return [ path, site.slug ].join( '/' );
-	},
+	};
 
-	getExportPath() {
+	getExportPath = () => {
 		const { site } = this.props;
 		return site.jetpack
 			? `${ site.options.admin_url }export.php`
 			: `/settings/export/${ site.slug }`;
-	},
+	};
 
 	render() {
 		const { section, site } = this.props;
@@ -122,4 +124,10 @@ export default React.createClass( {
 			</SectionNav>
 		);
 	}
-} );
+}
+
+export default connect(
+	state => ( {
+		site: getSelectedSite( state )
+	} )
+)( localize( SiteSettingsNavigation ) );

--- a/client/my-sites/site-settings/press-this/index.jsx
+++ b/client/my-sites/site-settings/press-this/index.jsx
@@ -49,15 +49,19 @@ class PressThis extends Component {
 							'for a posting shortcut.'
 						) }
 					</p>
-					<p className="pressthis">
-						<PressThisLink
-							site={ site }
-							onClick={ this.recordEvent( 'Clicked Press This Button' ) }
-							onDragStart={ this.recordEvent( 'Dragged Press This Button' ) }>
-							<Gridicon icon="create" />
-							<span>{ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }</span>
-						</PressThisLink>
-					</p>
+					{
+						site && (
+							<p className="press-this__link-container">
+								<PressThisLink
+									site={ site }
+									onClick={ this.recordEvent( 'Clicked Press This Button' ) }
+									onDragStart={ this.recordEvent( 'Dragged Press This Button' ) }>
+									<Gridicon icon="create" />
+									<span>{ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }</span>
+								</PressThisLink>
+							</p>
+						)
+					}
 				</Card>
 			</div>
 		);

--- a/client/my-sites/site-settings/press-this/style.scss
+++ b/client/my-sites/site-settings/press-this/style.scss
@@ -4,7 +4,7 @@
 		display: none;
 	}
 
-	p.pressthis {
+	p.press-this__link-container {
 		margin: 20px 0;
 
 		a,

--- a/client/my-sites/site-settings/publishing-tools/style.scss
+++ b/client/my-sites/site-settings/publishing-tools/style.scss
@@ -6,7 +6,7 @@
 			box-shadow: none;
 		}
 
-		.pressthis {
+		.press-this__link-container {
 			margin-bottom: 0;
 		}
 	}

--- a/client/my-sites/site-settings/section-security.jsx
+++ b/client/my-sites/site-settings/section-security.jsx
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import FormSecurity from 'my-sites/site-settings/form-security';
+import { getSelectedSite } from 'state/ui/selectors';
 import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
@@ -24,7 +26,7 @@ const SiteSettingsSecurity = ( { site, translate } ) => {
 		);
 	}
 
-	if ( ! site.canManage() ) {
+	if ( ! site.canManage ) {
 		return (
 			<JetpackManageErrorPage
 				template="optInManage"
@@ -35,7 +37,7 @@ const SiteSettingsSecurity = ( { site, translate } ) => {
 		);
 	}
 
-	if ( ! site.versionCompare( '3.4', '>=' ) ) {
+	if ( ! site.hasMinimumJetpackVersion ) {
 		return (
 			<JetpackManageErrorPage
 				template="updateJetpack"
@@ -47,10 +49,20 @@ const SiteSettingsSecurity = ( { site, translate } ) => {
 
 	return (
 		<div>
-			<JetpackMonitor site={ site } />
+			<JetpackMonitor />
 			<FormSecurity />
 		</div>
 	);
 };
 
-export default localize( SiteSettingsSecurity );
+SiteSettingsSecurity.propTypes = {
+	site: PropTypes.object
+};
+
+export default connect(
+	state => {
+		return {
+			site: getSelectedSite( state )
+		};
+	}
+)( localize( SiteSettingsSecurity ) );

--- a/client/my-sites/site-settings/section-security.jsx
+++ b/client/my-sites/site-settings/section-security.jsx
@@ -9,12 +9,13 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import FormSecurity from 'my-sites/site-settings/form-security';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
-const SiteSettingsSecurity = ( { site, translate } ) => {
-	if ( ! site.jetpack ) {
+const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
+	if ( ! siteIsJetpack ) {
 		return (
 			<JetpackManageErrorPage
 				action={ translate( 'Manage general settings for %(site)s', { args: { site: site.name } } ) }
@@ -32,7 +33,7 @@ const SiteSettingsSecurity = ( { site, translate } ) => {
 				template="optInManage"
 				title= { translate( 'Looking to manage this site\'s security settings?' ) }
 				section="security-settings"
-				siteId={ site.ID }
+				siteId={ siteId }
 			/>
 		);
 	}
@@ -41,7 +42,7 @@ const SiteSettingsSecurity = ( { site, translate } ) => {
 		return (
 			<JetpackManageErrorPage
 				template="updateJetpack"
-				siteId={ site.ID }
+				siteId={ siteId }
 				version="3.4"
 			/>
 		);
@@ -56,13 +57,19 @@ const SiteSettingsSecurity = ( { site, translate } ) => {
 };
 
 SiteSettingsSecurity.propTypes = {
-	site: PropTypes.object
+	site: PropTypes.object,
+	siteId: PropTypes.number,
+	siteIsJetpack: PropTypes.bool,
 };
 
 export default connect(
 	state => {
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
 		return {
-			site: getSelectedSite( state )
+			site,
+			siteId,
+			siteIsJetpack: isJetpackSite( state, siteId )
 		};
 	}
 )( localize( SiteSettingsSecurity ) );


### PR DESCRIPTION
This PR updates the `siteSettings` route in the settings controller and the main controller component to not use `sites-list` for retrieving the current site's settings.

#### Changes introduced by this PR

* Makes the site settings controller drop usage of `sites.once` for the `siteSettings` route. (Involving general, writing, discussion, traffic, and security tabs).
* Drops the passing down ofthe `sites` object to `SiteSettingsComponent` from the controller.
* Refactors `SiteSettingsComponent` to pick the current site from the Redux state.
* ES6ifies the `SiteSettingsNavigation` component and makes it use the selected site form the redux state.
* Makes the DefaultPostForm component only query post formats if the site settings have been loaded.
* Makes the `SectionSecurity` component pick the selected site from Redux state.
* Makes the `PressThis` component only render the link if the site settings have been loaded.
* Removes `isRequired` from the siteId prop type in `JetpackModuleToggle` definition.

#### Testing instructions

1. Checkout this branch
1. Clear the redux state cache
1. Go to `/settings/general/:site`, for one of your sites.
1. Check the page loads correctly and no propTypes warnings and shown in the console.
1. Clear the redux state cache
1. Go to `/settings/writing/:site`, for one of your sites.
1. Check the page loads correctly and no propTypes warnings and shown in the console.
1. Clear the redux state cache
1. Go to `/settings/discussion/:site`, for one of your sites.
1. Check the page loads correctly and no propTypes warnings and shown in the console.
1. Clear the redux state cache
1. Go to `/settings/traffic/:site`, for one of your sites.
1. Check the page loads correctly and no propTypes warnings and shown in the console.
1. Go to `/settings/`, pick a site
1. Verify the general settings page loads correctly.
1. Clean your Redux state & cache and test the previous steps again.