### PR TITLE
Extensions: WPSC - Save settings

### DIFF
--- a/client/extensions/wp-super-cache/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/accepted-filenames.jsx
@@ -32,8 +32,9 @@ const AcceptedFilenames = ( {
 		wp_accepted_files,
 		wp_rejected_uri,
 	},
+	handleAutosavingToggle,
 	handleChange,
-	handleToggle,
+	handleSubmitForm,
 	isRequesting,
 	translate,
 } ) => {
@@ -44,7 +45,7 @@ const AcceptedFilenames = ( {
 					compact
 					primary
 					disabled={ isRequesting }
-					type="submit">
+					onClick={ handleSubmitForm }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
@@ -54,7 +55,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! single }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'single' ) }>
+							onChange={ handleAutosavingToggle( 'single' ) }>
 							<span>
 								{ translate( 'Single Posts (is_single)' ) }
 							</span>
@@ -63,7 +64,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! pages }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'pages' ) }>
+							onChange={ handleAutosavingToggle( 'pages' ) }>
 							<span>
 								{ translate( 'Pages (is_page)' ) }
 							</span>
@@ -72,7 +73,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! frontpage }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'frontpage' ) }>
+							onChange={ handleAutosavingToggle( 'frontpage' ) }>
 							<span>
 								{ translate( 'Front Page (is_front_page)' ) }
 							</span>
@@ -81,7 +82,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! home }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'home' ) }>
+							onChange={ handleAutosavingToggle( 'home' ) }>
 							<span>
 								{ translate( 'Home (is_home)' ) }
 							</span>
@@ -90,7 +91,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! archives }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'archives' ) }>
+							onChange={ handleAutosavingToggle( 'archives' ) }>
 							<span>
 								{ translate( 'Archives (is_archive)' ) }
 							</span>
@@ -99,7 +100,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! tag }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'tag' ) }>
+							onChange={ handleAutosavingToggle( 'tag' ) }>
 							<span>
 								{ translate( 'Tags (is_tag)' ) }
 							</span>
@@ -108,7 +109,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! category }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'category' ) }>
+							onChange={ handleAutosavingToggle( 'category' ) }>
 							<span>
 								{ translate( 'Category (is_category)' ) }
 							</span>
@@ -117,7 +118,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! feed }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'feed' ) }>
+							onChange={ handleAutosavingToggle( 'feed' ) }>
 							<span>
 								{ translate( 'Feeds (is_feed)' ) }
 							</span>
@@ -126,7 +127,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! search }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'search' ) }>
+							onChange={ handleAutosavingToggle( 'search' ) }>
 							<span>
 								{ translate( 'Search Pages (is_search)' ) }
 							</span>
@@ -135,7 +136,7 @@ const AcceptedFilenames = ( {
 						<FormToggle
 							checked={ !! author }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'author' ) }>
+							onChange={ handleAutosavingToggle( 'author' ) }>
 							<span>
 								{ translate( 'Author Pages (is_author)' ) }
 							</span>

--- a/client/extensions/wp-super-cache/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/accepted-filenames.jsx
@@ -36,6 +36,7 @@ const AcceptedFilenames = ( {
 	handleChange,
 	handleSubmitForm,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	return (
@@ -44,9 +45,12 @@ const AcceptedFilenames = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onClick={ handleSubmitForm }>
-					{ translate( 'Save Settings' ) }
+					{ isSaving
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
 				</Button>
 			</SectionHeader>
 			<Card>
@@ -54,7 +58,7 @@ const AcceptedFilenames = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! single }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'single' ) }>
 							<span>
 								{ translate( 'Single Posts (is_single)' ) }
@@ -63,7 +67,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! pages }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'pages' ) }>
 							<span>
 								{ translate( 'Pages (is_page)' ) }
@@ -72,7 +76,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! frontpage }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'frontpage' ) }>
 							<span>
 								{ translate( 'Front Page (is_front_page)' ) }
@@ -81,7 +85,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! home }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'home' ) }>
 							<span>
 								{ translate( 'Home (is_home)' ) }
@@ -90,7 +94,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! archives }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'archives' ) }>
 							<span>
 								{ translate( 'Archives (is_archive)' ) }
@@ -99,7 +103,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! tag }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'tag' ) }>
 							<span>
 								{ translate( 'Tags (is_tag)' ) }
@@ -108,7 +112,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! category }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'category' ) }>
 							<span>
 								{ translate( 'Category (is_category)' ) }
@@ -117,7 +121,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! feed }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'feed' ) }>
 							<span>
 								{ translate( 'Feeds (is_feed)' ) }
@@ -126,7 +130,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! search }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'search' ) }>
 							<span>
 								{ translate( 'Search Pages (is_search)' ) }
@@ -135,7 +139,7 @@ const AcceptedFilenames = ( {
 
 						<FormToggle
 							checked={ !! author }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'author' ) }>
 							<span>
 								{ translate( 'Author Pages (is_author)' ) }
@@ -162,7 +166,7 @@ const AcceptedFilenames = ( {
 
 					<FormFieldset>
 						<FormTextarea
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleChange( 'wp_rejected_uri' ) }
 							value={ wp_rejected_uri || '' } />
 						<FormSettingExplanation>
@@ -177,7 +181,7 @@ const AcceptedFilenames = ( {
 
 					<FormFieldset>
 						<FormTextarea
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleChange( 'wp_accepted_files' ) }
 							value={ wp_accepted_files || '' } />
 						<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/advanced.jsx
+++ b/client/extensions/wp-super-cache/advanced.jsx
@@ -7,7 +7,6 @@ import { pick } from 'lodash';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
 import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -35,20 +34,14 @@ const Advanced = ( {
 		wp_super_cache_late_init,
 		wp_supercache_cache_list,
 	},
-	handleToggle,
+	handleAutosavingToggle,
 	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
-			<SectionHeader label={ translate( 'Advanced' ) }>
-				<Button
-					compact
-					primary
-					disabled={ isRequesting }
-					type="submit">
-					{ translate( 'Save Settings' ) }
-				</Button>
+			<SectionHeader
+				label={ translate( 'Advanced' ) }>
 			</SectionHeader>
 			<Card>
 				<form>
@@ -56,7 +49,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_cache_mfunc_enabled }
 							disabled={ isRequesting || ( '1' === super_cache_enabled ) }
-							onChange={ handleToggle( 'wp_cache_mfunc_enabled' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_mfunc_enabled' ) }>
 							<span>
 								{ translate(
 								'Enable dynamic caching. Requires PHP or legacy caching. (See ' +
@@ -79,7 +72,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_cache_mobile_enabled }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_mobile_enabled' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_mobile_enabled' ) }>
 							<span>
 								{ translate(
 									'Mobile device support. (External plugin or theme required. See the ' +
@@ -127,7 +120,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_cache_disable_utf8 }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_disable_utf8' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_disable_utf8' ) }>
 							<span>
 								{ translate(
 									'Remove UTF8/blog charset support from .htaccess file. Only necessary if you see ' +
@@ -139,7 +132,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_cache_clear_on_post_edit }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_clear_on_post_edit' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_clear_on_post_edit' ) }>
 							<span>
 								{ translate( 'Clear all cache files when a post or page is published or updated.' ) }
 							</span>
@@ -148,7 +141,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_cache_front_page_checks }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_front_page_checks' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_front_page_checks' ) }>
 							<span>
 								{ translate(
 									'Extra homepage checks. (Very occasionally stops homepage caching) {{em}}(Recommended){{/em}}',
@@ -162,7 +155,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_cache_refresh_single_only }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_refresh_single_only' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_refresh_single_only' ) }>
 							<span>
 								{ translate( 'Only refresh current page when comments made.' ) }
 							</span>
@@ -171,7 +164,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_supercache_cache_list }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_supercache_cache_list' ) }>
+							onChange={ handleAutosavingToggle( 'wp_supercache_cache_list' ) }>
 							<span>
 								{ translate( 'List the newest cached pages on this page.' ) }
 							</span>
@@ -181,7 +174,7 @@ const Advanced = ( {
 							<FormToggle
 								checked={ !! wp_cache_mutex_disabled }
 								disabled={ isRequesting }
-								onChange={ handleToggle( 'wp_cache_mutex_disabled' ) }>
+								onChange={ handleAutosavingToggle( 'wp_cache_mutex_disabled' ) }>
 								<span>
 									{ translate( 'Coarse file locking. You do not need this as it will slow down your website.' ) }
 								</span>
@@ -191,7 +184,7 @@ const Advanced = ( {
 						<FormToggle
 							checked={ !! wp_super_cache_late_init }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_super_cache_late_init' ) }>
+							onChange={ handleAutosavingToggle( 'wp_super_cache_late_init' ) }>
 							<span>
 								{ translate(
 									'Late init. Display cached files after WordPress has loaded. Most useful in legacy mode.'
@@ -202,7 +195,7 @@ const Advanced = ( {
 							<FormToggle
 								checked={ !! wp_cache_object_cache }
 								disabled={ isRequesting }
-								onChange={ handleToggle( 'wp_cache_object_cache' ) }>
+								onChange={ handleAutosavingToggle( 'wp_cache_object_cache' ) }>
 								<span>
 									{ translate( 'Use object cache to store cached files. (Experimental)' ) }
 								</span>

--- a/client/extensions/wp-super-cache/advanced.jsx
+++ b/client/extensions/wp-super-cache/advanced.jsx
@@ -36,6 +36,7 @@ const Advanced = ( {
 	},
 	handleAutosavingToggle,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	return (
@@ -48,7 +49,7 @@ const Advanced = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! wp_cache_mfunc_enabled }
-							disabled={ isRequesting || ( '1' === super_cache_enabled ) }
+							disabled={ isRequesting || isSaving || ( '1' === super_cache_enabled ) }
 							onChange={ handleAutosavingToggle( 'wp_cache_mfunc_enabled' ) }>
 							<span>
 								{ translate(
@@ -71,7 +72,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_mobile_enabled }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_mobile_enabled' ) }>
 							<span>
 								{ translate(
@@ -119,7 +120,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_disable_utf8 }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_disable_utf8' ) }>
 							<span>
 								{ translate(
@@ -131,7 +132,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_clear_on_post_edit }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_clear_on_post_edit' ) }>
 							<span>
 								{ translate( 'Clear all cache files when a post or page is published or updated.' ) }
@@ -140,7 +141,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_front_page_checks }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_front_page_checks' ) }>
 							<span>
 								{ translate(
@@ -154,7 +155,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_refresh_single_only }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_refresh_single_only' ) }>
 							<span>
 								{ translate( 'Only refresh current page when comments made.' ) }
@@ -163,7 +164,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_supercache_cache_list }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_supercache_cache_list' ) }>
 							<span>
 								{ translate( 'List the newest cached pages on this page.' ) }
@@ -173,7 +174,7 @@ const Advanced = ( {
 						{ ! wp_cache_disable_locking &&
 							<FormToggle
 								checked={ !! wp_cache_mutex_disabled }
-								disabled={ isRequesting }
+								disabled={ isRequesting || isSaving }
 								onChange={ handleAutosavingToggle( 'wp_cache_mutex_disabled' ) }>
 								<span>
 									{ translate( 'Coarse file locking. You do not need this as it will slow down your website.' ) }
@@ -183,7 +184,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! wp_super_cache_late_init }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_super_cache_late_init' ) }>
 							<span>
 								{ translate(
@@ -194,7 +195,7 @@ const Advanced = ( {
 						{ !! _wp_using_ext_object_cache &&
 							<FormToggle
 								checked={ !! wp_cache_object_cache }
-								disabled={ isRequesting }
+								disabled={ isRequesting || isSaving }
 								onChange={ handleAutosavingToggle( 'wp_cache_object_cache' ) }>
 								<span>
 									{ translate( 'Use object cache to store cached files. (Experimental)' ) }

--- a/client/extensions/wp-super-cache/cache-location.jsx
+++ b/client/extensions/wp-super-cache/cache-location.jsx
@@ -20,6 +20,7 @@ const CacheLocation = ( {
 		wp_cache_location,
 	},
 	handleChange,
+	handleSubmitForm,
 	isRequesting,
 	translate,
 } ) => {
@@ -30,7 +31,7 @@ const CacheLocation = ( {
 					compact
 					primary
 					disabled={ isRequesting }
-					type="submit">
+					onClick={ handleSubmitForm }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>

--- a/client/extensions/wp-super-cache/cache-location.jsx
+++ b/client/extensions/wp-super-cache/cache-location.jsx
@@ -22,6 +22,7 @@ const CacheLocation = ( {
 	handleChange,
 	handleSubmitForm,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	return (
@@ -30,16 +31,19 @@ const CacheLocation = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onClick={ handleSubmitForm }>
-					{ translate( 'Save Settings' ) }
+					{ isSaving
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
 				</Button>
 			</SectionHeader>
 			<Card>
 				<form>
 					<FormFieldset>
 						<FormTextInput
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleChange( 'wp_cache_location' ) }
 							value={ wp_cache_location || '' } />
 						<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -22,8 +22,9 @@ const Caching = ( {
 		super_cache_enabled,
 		wp_cache_enabled,
 	},
+	handleAutosavingToggle,
 	handleRadio,
-	handleToggle,
+	handleSubmitForm,
 	isRequesting,
 	translate,
 } ) => {
@@ -34,7 +35,7 @@ const Caching = ( {
 					compact
 					primary
 					disabled={ isRequesting }
-					type="submit">
+					onClick={ handleSubmitForm }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
@@ -44,7 +45,7 @@ const Caching = ( {
 						<FormToggle
 							checked={ !! wp_cache_enabled }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_enabled' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_enabled' ) }>
 							<span>
 								{ translate( 'Enable Page Caching' ) }
 							</span>

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -26,6 +26,7 @@ const Caching = ( {
 	handleRadio,
 	handleSubmitForm,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	return (
@@ -34,9 +35,12 @@ const Caching = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onClick={ handleSubmitForm }>
-					{ translate( 'Save Settings' ) }
+					{ isSaving
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
 				</Button>
 			</SectionHeader>
 			<Card>
@@ -44,7 +48,7 @@ const Caching = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! wp_cache_enabled }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_enabled' ) }>
 							<span>
 								{ translate( 'Enable Page Caching' ) }
@@ -56,7 +60,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ '1' === super_cache_enabled }
-								disabled={ isRequesting }
+								disabled={ isRequesting || isSaving }
 								name="super_cache_enabled"
 								onChange={ handleRadio }
 								value="1" />
@@ -68,7 +72,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ '2' === super_cache_enabled }
-								disabled={ isRequesting }
+								disabled={ isRequesting || isSaving }
 								name="super_cache_enabled"
 								onChange={ handleRadio }
 								value="2" />
@@ -85,7 +89,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ '0' === super_cache_enabled }
-								disabled={ isRequesting }
+								disabled={ isRequesting || isSaving }
 								name="super_cache_enabled"
 								onChange={ handleRadio }
 								value="0" />

--- a/client/extensions/wp-super-cache/cdn-tab.jsx
+++ b/client/extensions/wp-super-cache/cdn-tab.jsx
@@ -27,8 +27,9 @@ const CdnTab = ( {
 		ossdl_off_include_dirs,
 		ossdlcdn,
 	},
+	handleAutosavingToggle,
 	handleChange,
-	handleToggle,
+	handleSubmitForm,
 	isRequesting,
 	siteUrl,
 	translate,
@@ -40,7 +41,7 @@ const CdnTab = ( {
 					compact
 					primary
 					disabled={ isRequesting }
-					type="submit">
+					onClick={ handleSubmitForm }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
@@ -51,7 +52,7 @@ const CdnTab = ( {
 						<FormToggle
 							checked={ !! ossdlcdn }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'ossdlcdn' ) }>
+							onChange={ handleAutosavingToggle( 'ossdlcdn' ) }>
 							<span>
 								{ translate( 'Enable CDN Support' ) }
 							</span>
@@ -162,7 +163,7 @@ const CdnTab = ( {
 						<FormToggle
 							checked={ !! ossdl_https }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'ossdl_https' ) }>
+							onChange={ handleAutosavingToggle( 'ossdl_https' ) }>
 							<span>
 								{ translate( 'Skip https URLs to avoid "mixed content" errors' ) }
 							</span>

--- a/client/extensions/wp-super-cache/cdn-tab.jsx
+++ b/client/extensions/wp-super-cache/cdn-tab.jsx
@@ -31,6 +31,7 @@ const CdnTab = ( {
 	handleChange,
 	handleSubmitForm,
 	isRequesting,
+	isSaving,
 	siteUrl,
 	translate,
 } ) => {
@@ -40,9 +41,12 @@ const CdnTab = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onClick={ handleSubmitForm }>
-					{ translate( 'Save Settings' ) }
+					{ isSaving
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
 				</Button>
 			</SectionHeader>
 
@@ -51,7 +55,7 @@ const CdnTab = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! ossdlcdn }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'ossdlcdn' ) }>
 							<span>
 								{ translate( 'Enable CDN Support' ) }
@@ -65,7 +69,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							id="ossdl_off_cdn_url"
 							onChange={ handleChange( 'ossdl_off_cdn_url' ) }
 							value={ ossdl_off_cdn_url || '' } />
@@ -86,7 +90,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							id="ossdl_off_include_dirs"
 							onChange={ handleChange( 'ossdl_off_include_dirs' ) }
 							value={ ossdl_off_include_dirs || '' } />
@@ -108,7 +112,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							id="ossdl_off_exclude"
 							onChange={ handleChange( 'ossdl_off_exclude' ) }
 							value={ ossdl_off_exclude || '' } />
@@ -131,7 +135,7 @@ const CdnTab = ( {
 						</FormLabel>
 
 						<FormTextInput
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							id="ossdl_cname"
 							onChange={ handleChange( 'ossdl_cname' ) }
 							value={ ossdl_cname || '' } />
@@ -162,7 +166,7 @@ const CdnTab = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! ossdl_https }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'ossdl_https' ) }>
 							<span>
 								{ translate( 'Skip https URLs to avoid "mixed content" errors' ) }

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { pick } from 'lodash';
 
 /**
@@ -11,119 +11,145 @@ import Button from 'components/button';
 import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
-import FormTextInputWithAction from 'components/forms/form-text-input-with-action';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 
-const DirectlyCachedFiles = ( {
-	fields: {
-		wp_cache_direct_pages,
-		wp_cache_path,
-		wp_cache_readonly,
-		wp_cache_writable,
-	},
-	handleChange,
-	isRequesting,
-	siteUrl,
-	translate,
-} ) => {
-	wp_cache_direct_pages = wp_cache_direct_pages || [];
+class DirectlyCachedFiles extends Component {
+	onKeyDown = event => {
+		if ( 13 !== event.keyCode ) {
+			return;
+		}
 
-	return (
-		<div>
-			<SectionHeader label={ translate( 'Directly Cached Files' ) }>
-				<Button
-					compact
-					primary
-					disabled={ isRequesting }
-					type="submit">
-					{ translate( 'Save Settings' ) }
-				</Button>
-			</SectionHeader>
-			<Card className="wp-super-cache__directly-cached-files">
-				{ !! wp_cache_readonly &&
-				<p>
-				{ translate(
-					'{{strong}}Warning!{{/strong}} You must make %(wp_cache_path)s wp_cache_writable to enable this feature. ' +
-					'As this is a security risk, please make it read-only after your page is generated.',
-					{
-						args: { wp_cache_path: wp_cache_path },
-						components: { strong: <strong /> },
-					}
-				) }
-				</p>
-				}
-				{ !! wp_cache_writable &&
-				<p>
-				{ translate(
-					'{{strong}}Warning!{{/strong}} %(wp_cache_path)s is wp_cache_writable. Please make it wp_cache_readonly after your ' +
-					'page is generated as this is a security risk.',
-					{
-						args: { wp_cache_path: wp_cache_path },
-						components: { strong: <strong /> },
-					}
-				) }
-				</p>
-				}
-				<p>
+		const newDirectPage = this.refs.newDirectPage.refs.textField;
+
+		if ( '' === newDirectPage.value.trim() ) {
+			return;
+		}
+
+		newDirectPage.value = '';
+		this.props.handleSubmitForm( event );
+	};
+
+	render() {
+		const {
+			fields,
+			handleChange,
+			handleSubmitForm,
+			isRequesting,
+			setFieldArrayValue,
+			siteUrl,
+			translate
+		} = this.props;
+		const {
+			wp_cache_direct_pages = [],
+			wp_cache_path,
+			wp_cache_readonly,
+			wp_cache_writable,
+		} = fields;
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Directly Cached Files' ) }>
+					<Button
+						compact
+						primary
+						disabled={ isRequesting }
+						onClick={ handleSubmitForm }>
+						{ translate( 'Save Settings' ) }
+					</Button>
+				</SectionHeader>
+				<Card className="wp-super-cache__directly-cached-files">
+					{ !! wp_cache_readonly &&
+					<p>
 					{ translate(
-						'Directly cached files are files created directly off %(wp_cache_path)s where your blog lives. This ' +
-						'feature is only useful if you are expecting a major Digg or Slashdot level of traffic to one post or page.',
+						'{{strong}}Warning!{{/strong}} You must make %(wp_cache_path)s wp_cache_writable to enable this feature. ' +
+						'As this is a security risk, please make it read-only after your page is generated.',
 						{
 							args: { wp_cache_path: wp_cache_path },
+							components: { strong: <strong /> },
 						}
 					) }
-				</p>
-					{ ! wp_cache_readonly &&
-					<div>
-						<p>
-							{ translate(
-								'For example: to cache {{em}}%(url)s/about/{{/em}}, you would enter %(url)s/about/ or /about/. ' +
-								'The cached file will be generated the next time an anonymous user visits that page.',
-								{
-									args: { url: siteUrl },
-									components: { em: <em /> },
-								}
-							) }
-						</p>
-						<p>
-							{ translate(
-								'Make the textbox blank to remove it from the list of direct pages and delete the cached file.'
-						) }
-						</p>
-						<form>
-							<FormFieldset>
-								<FormTextInput
-									disabled={ isRequesting }
-									onChange={ handleChange( 'new_direct_page' ) } />
-							</FormFieldset>
-
-							{ wp_cache_direct_pages.length > 0 &&
-							<FormLabel>
-								{ translate(
-									'Existing Direct Page',
-									'Existing Direct Pages',
-									{ count: wp_cache_direct_pages.length }
-								) }
-							</FormLabel>
-							}
-							{ wp_cache_direct_pages.map( ( page ) => (
-								<FormFieldset key={ page }>
-									<FormTextInputWithAction
-										action={ translate( 'Delete Cached File' ) }
-										defaultValue={ page }
-										disabled={ isRequesting }
-										key={ page } />
-								</FormFieldset>
-							) ) }
-						</form>
-					</div>
+					</p>
 					}
-			</Card>
-		</div>
-	);
-};
+					{ !! wp_cache_writable &&
+					<p>
+					{ translate(
+						'{{strong}}Warning!{{/strong}} %(wp_cache_path)s is wp_cache_writable. Please make it wp_cache_readonly ' +
+						'after your page is generated as this is a security risk.',
+						{
+							args: { wp_cache_path: wp_cache_path },
+							components: { strong: <strong /> },
+						}
+					) }
+					</p>
+					}
+					<p>
+						{ translate(
+							'Directly cached files are files created directly off %(wp_cache_path)s where your blog lives. This ' +
+							'feature is only useful if you are expecting a major Digg or Slashdot level of traffic to one post or page.',
+							{
+								args: { wp_cache_path: wp_cache_path },
+							}
+						) }
+					</p>
+						{ ! wp_cache_readonly &&
+						<div>
+							<p>
+								{ translate(
+									'For example: to cache {{em}}%(url)s/about/{{/em}}, you would enter %(url)s/about/ or /about/. ' +
+									'The cached file will be generated the next time an anonymous user visits that page.',
+									{
+										args: { url: siteUrl },
+										components: { em: <em /> },
+									}
+								) }
+							</p>
+							<form>
+								<FormFieldset>
+									<FormTextInput
+										disabled={ isRequesting }
+										onChange={ handleChange( 'new_direct_page' ) }
+										onKeyDown={ this.onKeyDown }
+										ref="newDirectPage" />
+								</FormFieldset>
+
+								{ wp_cache_direct_pages.length > 0 &&
+								<FormLabel>
+									{ translate(
+										'Existing Direct Page',
+										'Existing Direct Pages',
+										{ count: wp_cache_direct_pages.length }
+									) }
+								</FormLabel>
+								}
+
+								{ wp_cache_direct_pages.map( ( page, index ) => (
+									<FormFieldset key={ index }>
+										<FormTextInput
+											disabled={ isRequesting }
+											key={ index }
+											onChange={ setFieldArrayValue( 'wp_cache_direct_pages', index ) }
+											value={ page || '' } />
+									</FormFieldset>
+								) ) }
+
+								{ wp_cache_direct_pages.length > 0 &&
+								<FormSettingExplanation>
+									{ translate(
+										'Make the textbox blank to remove it from the list of direct pages and delete the cached file.'
+									) }
+								</FormSettingExplanation>
+								}
+							</form>
+						</div>
+						}
+				</Card>
+			</div>
+		);
+	}
+}
 
 const getFormSettings = settings => {
 	return pick( settings, [

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -38,6 +38,7 @@ class DirectlyCachedFiles extends Component {
 			handleChange,
 			handleSubmitForm,
 			isRequesting,
+			isSaving,
 			setFieldArrayValue,
 			siteUrl,
 			translate
@@ -55,9 +56,12 @@ class DirectlyCachedFiles extends Component {
 					<Button
 						compact
 						primary
-						disabled={ isRequesting }
+						disabled={ isRequesting || isSaving }
 						onClick={ handleSubmitForm }>
-						{ translate( 'Save Settings' ) }
+						{ isSaving
+							? translate( 'Saving…' )
+							: translate( 'Save Settings' )
+						}
 					</Button>
 				</SectionHeader>
 				<Card className="wp-super-cache__directly-cached-files">
@@ -109,7 +113,7 @@ class DirectlyCachedFiles extends Component {
 							<form>
 								<FormFieldset>
 									<FormTextInput
-										disabled={ isRequesting }
+										disabled={ isRequesting || isSaving }
 										onChange={ handleChange( 'new_direct_page' ) }
 										onKeyDown={ this.onKeyDown }
 										ref="newDirectPage" />
@@ -128,7 +132,7 @@ class DirectlyCachedFiles extends Component {
 								{ wp_cache_direct_pages.map( ( page, index ) => (
 									<FormFieldset key={ index }>
 										<FormTextInput
-											disabled={ isRequesting }
+											disabled={ isRequesting || isSaving }
 											key={ index }
 											onChange={ setFieldArrayValue( 'wp_cache_direct_pages', index ) }
 											value={ page || '' } />

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -22,6 +22,7 @@ const EasyTab = ( {
 		http_only,
 		is_cache_enabled,
 	},
+	handleAutosavingToggle,
 	handleToggle,
 	isRequesting,
 	site,
@@ -36,20 +37,15 @@ const EasyTab = ( {
 
 	return (
 		<div>
-			<SectionHeader label={ translate( 'Caching' ) }>
-				<Button
-					compact
-					primary
-					disabled={ isRequesting }>
-					{ translate( 'Save Settings' ) }
-				</Button>
+			<SectionHeader
+				label={ translate( 'Caching' ) }>
 			</SectionHeader>
 			<Card>
 				<form>
 					<FormToggle
 						checked={ is_cache_enabled }
 						disabled={ isRequesting }
-						onChange={ handleToggle( 'is_cache_enabled' ) }>
+						onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }>
 						<span>
 							{ translate( 'Enable Page Caching' ) }
 						</span>

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -25,6 +25,7 @@ const EasyTab = ( {
 	handleAutosavingToggle,
 	handleToggle,
 	isRequesting,
+	isSaving,
 	site,
 	translate,
 } ) => {
@@ -44,7 +45,7 @@ const EasyTab = ( {
 				<form>
 					<FormToggle
 						checked={ is_cache_enabled }
-						disabled={ isRequesting }
+						disabled={ isRequesting || isSaving }
 						onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }>
 						<span>
 							{ translate( 'Enable Page Caching' ) }

--- a/client/extensions/wp-super-cache/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/expiry-time.jsx
@@ -31,10 +31,11 @@ const ExpiryTime = ( {
 		wp_cache_next_gc,
 		wp_cache_preload_on,
 	},
+	handleAutosavingToggle,
 	handleChange,
 	handleRadio,
 	handleSelect,
-	handleToggle,
+	handleSubmitForm,
 	isRequesting,
 	translate,
 } ) => {
@@ -146,7 +147,7 @@ const ExpiryTime = ( {
 					checked={ !! cache_gc_email_me }
 					disabled={ isRequesting }
 					id="cache_gc_email_me"
-					onChange={ handleToggle( 'cache_gc_email_me' ) }>
+					onChange={ handleAutosavingToggle( 'cache_gc_email_me' ) }>
 					<span>
 						{ translate( 'Email me when the garbage collection runs.' ) }
 					</span>
@@ -162,7 +163,7 @@ const ExpiryTime = ( {
 					compact
 					primary
 					disabled={ isRequesting }
-					type="submit">
+					onClick={ handleSubmitForm }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>

--- a/client/extensions/wp-super-cache/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/expiry-time.jsx
@@ -37,6 +37,7 @@ const ExpiryTime = ( {
 	handleSelect,
 	handleSubmitForm,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	const renderCacheTimeout = () => {
@@ -48,7 +49,7 @@ const ExpiryTime = ( {
 
 				<FormTextInput
 					className="wp-super-cache__cache-timeout"
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onChange={ handleChange( 'cache_max_time' ) }
 					value={ cache_max_time || '' } />
 				{ translate( 'seconds' ) }
@@ -74,14 +75,14 @@ const ExpiryTime = ( {
 				<FormLabel>
 					<FormRadio
 						checked={ 'interval' === cache_schedule_type }
-						disabled={ isRequesting }
+						disabled={ isRequesting || isSaving }
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="interval" />
 					<span>
 						{ translate( 'Timer' ) }
 						<FormTextInput
-							disabled={ isRequesting || ( 'interval' !== cache_schedule_type ) }
+							disabled={ isRequesting || isSaving || ( 'interval' !== cache_schedule_type ) }
 							onChange={ handleChange( 'cache_time_interval' ) }
 							value={ cache_time_interval || '' } />
 						{ translate( 'seconds' ) }
@@ -94,14 +95,14 @@ const ExpiryTime = ( {
 				<FormLabel className="wp-super-cache__clock">
 					<FormRadio
 						checked={ 'time' === cache_schedule_type }
-						disabled={ isRequesting }
+						disabled={ isRequesting || isSaving }
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="time" />
 					<span>
 						{ translate( 'Clock' ) }
 						<FormTextInput
-							disabled={ isRequesting || ( 'time' !== cache_schedule_type ) }
+							disabled={ isRequesting || isSaving || ( 'time' !== cache_schedule_type ) }
 							onChange={ handleChange( 'cache_scheduled_time' ) }
 							value={ cache_scheduled_time || '' } />
 						{ translate( 'HH:MM' ) }
@@ -118,7 +119,7 @@ const ExpiryTime = ( {
 					</FormLabel>
 
 					<FormSelect
-						disabled={ isRequesting || ( 'time' !== cache_schedule_type ) }
+						disabled={ isRequesting || isSaving || ( 'time' !== cache_schedule_type ) }
 						id="cache_schedule_interval"
 						name="cache_schedule_interval"
 						onChange={ handleSelect }
@@ -145,7 +146,7 @@ const ExpiryTime = ( {
 
 				<FormToggle
 					checked={ !! cache_gc_email_me }
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					id="cache_gc_email_me"
 					onChange={ handleAutosavingToggle( 'cache_gc_email_me' ) }>
 					<span>
@@ -162,9 +163,12 @@ const ExpiryTime = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onClick={ handleSubmitForm }>
-					{ translate( 'Save Settings' ) }
+					{ isSaving
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
 				</Button>
 			</SectionHeader>
 			<Card>

--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -7,7 +7,6 @@ import { pick } from 'lodash';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
 import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -28,20 +27,14 @@ const Miscellaneous = ( {
 		wp_cache_not_logged_in,
 		wp_supercache_304,
 	},
-	handleToggle,
+	handleAutosavingToggle,
 	isRequesting,
 	translate,
 } ) => {
 	return (
 		<div>
-			<SectionHeader label={ translate( 'Miscellaneous' ) }>
-				<Button
-					compact
-					primary
-					disabled={ isRequesting }
-					type="submit">
-					{ translate( 'Save Settings' ) }
-				</Button>
+			<SectionHeader
+				label={ translate( 'Miscellaneous' ) }>
 			</SectionHeader>
 			<Card>
 				<form>
@@ -60,7 +53,7 @@ const Miscellaneous = ( {
 						<FormToggle
 							checked={ !! cache_compression }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'cache_compression' ) }>
+							onChange={ handleAutosavingToggle( 'cache_compression' ) }>
 							<span>
 								{ translate(
 									'Compress pages so they’re served more quickly to visitors. {{em}}(Recommended{{/em}})',
@@ -75,7 +68,7 @@ const Miscellaneous = ( {
 						<FormToggle
 							checked={ !! wp_cache_not_logged_in }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_not_logged_in' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_not_logged_in' ) }>
 							<span>
 								{ translate(
 									'Don’t cache pages for known users. {{em}}(Recommended){{/em}}',
@@ -89,7 +82,7 @@ const Miscellaneous = ( {
 						<FormToggle
 							checked={ !! cache_rebuild_files }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'cache_rebuild_files' ) }>
+							onChange={ handleAutosavingToggle( 'cache_rebuild_files' ) }>
 							<span>
 								{ translate(
 									'Cache rebuild. Serve a supercache file to anonymous users while a new ' +
@@ -104,7 +97,7 @@ const Miscellaneous = ( {
 						<FormToggle
 							checked={ !! wp_supercache_304 }
 							disabled={ isRequesting || ( '1' === super_cache_enabled ) }
-							onChange={ handleToggle( 'wp_supercache_304' ) }>
+							onChange={ handleAutosavingToggle( 'wp_supercache_304' ) }>
 							<span>
 								{ translate(
 									'304 Not Modified browser caching. Indicate when a page has not been ' +
@@ -138,7 +131,7 @@ const Miscellaneous = ( {
 						<FormToggle
 							checked={ !! wp_cache_no_cache_for_get }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_no_cache_for_get' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_no_cache_for_get' ) }>
 							<span>
 								{ translate( 'Don’t cache pages with GET parameters. (?x=y at the end of a url)' ) }
 							</span>
@@ -147,7 +140,7 @@ const Miscellaneous = ( {
 						<FormToggle
 							checked={ !! wp_cache_make_known_anon }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_make_known_anon' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_make_known_anon' ) }>
 							<span>
 								{ translate( 'Make known users anonymous so they’re served supercached static files.' ) }
 							</span>
@@ -156,7 +149,7 @@ const Miscellaneous = ( {
 						<FormToggle
 							checked={ !! wp_cache_hello_world }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'wp_cache_hello_world' ) }>
+							onChange={ handleAutosavingToggle( 'wp_cache_hello_world' ) }>
 							<span>
 								{ translate( 'Proudly tell the world your server is {{fry}}Stephen Fry proof{{/fry}}! ' +
 									'(places a message in your blog’s footer)',

--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -29,6 +29,7 @@ const Miscellaneous = ( {
 	},
 	handleAutosavingToggle,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	return (
@@ -52,7 +53,7 @@ const Miscellaneous = ( {
 						{ ! wp_cache_compression_disabled &&
 						<FormToggle
 							checked={ !! cache_compression }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'cache_compression' ) }>
 							<span>
 								{ translate(
@@ -67,7 +68,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_not_logged_in }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_not_logged_in' ) }>
 							<span>
 								{ translate(
@@ -81,7 +82,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! cache_rebuild_files }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'cache_rebuild_files' ) }>
 							<span>
 								{ translate(
@@ -96,7 +97,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_supercache_304 }
-							disabled={ isRequesting || ( '1' === super_cache_enabled ) }
+							disabled={ isRequesting || isSaving || ( '1' === super_cache_enabled ) }
 							onChange={ handleAutosavingToggle( 'wp_supercache_304' ) }>
 							<span>
 								{ translate(
@@ -130,7 +131,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_no_cache_for_get }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_no_cache_for_get' ) }>
 							<span>
 								{ translate( 'Don’t cache pages with GET parameters. (?x=y at the end of a url)' ) }
@@ -139,7 +140,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_make_known_anon }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_make_known_anon' ) }>
 							<span>
 								{ translate( 'Make known users anonymous so they’re served supercached static files.' ) }
@@ -148,7 +149,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! wp_cache_hello_world }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'wp_cache_hello_world' ) }>
 							<span>
 								{ translate( 'Proudly tell the world your server is {{fry}}Stephen Fry proof{{/fry}}! ' +

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -59,9 +59,10 @@ const PreloadTab = ( {
 		super_cache_enabled,
 		wp_cache_enabled,
 	},
+	handleAutosavingToggle,
 	handleChange,
 	handleSelect,
-	handleToggle,
+	handleSubmitForm,
 	isRequesting,
 	translate,
 } ) => {
@@ -95,7 +96,7 @@ const PreloadTab = ( {
 					compact
 					primary
 					disabled={ isRequesting }
-					type="submit">
+					onClick={ handleSubmitForm }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>
@@ -106,7 +107,7 @@ const PreloadTab = ( {
 						<FormToggle
 							checked={ !! preload_on }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'preload_on' ) }>
+							onChange={ handleAutosavingToggle( 'preload_on' ) }>
 							<span>
 								{ translate( 'Preload mode. (Garbage collection only on legacy cache files. Recommended.)' ) }
 							</span>
@@ -115,7 +116,7 @@ const PreloadTab = ( {
 						<FormToggle
 							checked={ preload_refresh }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'preload_refresh' ) }>
+							onChange={ handleAutosavingToggle( 'preload_refresh' ) }>
 							<span>
 								{ translate(
 									'Refresh preloaded cache files every {{number /}} minute. ',
@@ -146,7 +147,7 @@ const PreloadTab = ( {
 						<FormToggle
 							checked={ !! preload_taxonomies }
 							disabled={ isRequesting }
-							onChange={ handleToggle( 'preload_taxonomies' ) }>
+							onChange={ handleAutosavingToggle( 'preload_taxonomies' ) }>
 							<span>
 								{ translate( 'Preload tags, categories and other taxonomies.' ) }
 							</span>

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -27,11 +27,12 @@ import WrapSettingsForm from './wrap-settings-form';
 const renderCachePreloadInterval = ( {
 	handleChange,
 	isRequesting,
+	isSaving,
 	preload_interval,
 } ) => (
 	<FormTextInput
 		className="wp-super-cache__preload-interval"
-		disabled={ isRequesting }
+		disabled={ isRequesting || isSaving }
 		min="0"
 		name="preload_interval"
 		onChange={ handleChange( 'preload_interval' ) }
@@ -64,6 +65,7 @@ const PreloadTab = ( {
 	handleSelect,
 	handleSubmitForm,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	const statusEmailAmountSelectValues = [
@@ -95,9 +97,12 @@ const PreloadTab = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onClick={ handleSubmitForm }>
-					{ translate( 'Save Settings' ) }
+					{ isSaving
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
 				</Button>
 			</SectionHeader>
 
@@ -106,7 +111,7 @@ const PreloadTab = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! preload_on }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'preload_on' ) }>
 							<span>
 								{ translate( 'Preload mode. (Garbage collection only on legacy cache files. Recommended.)' ) }
@@ -115,7 +120,7 @@ const PreloadTab = ( {
 
 						<FormToggle
 							checked={ preload_refresh }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'preload_refresh' ) }>
 							<span>
 								{ translate(
@@ -127,6 +132,7 @@ const PreloadTab = ( {
 											number: renderCachePreloadInterval( {
 												handleChange,
 												isRequesting,
+												isSaving,
 												preload_interval,
 											} )
 										}
@@ -146,7 +152,7 @@ const PreloadTab = ( {
 
 						<FormToggle
 							checked={ !! preload_taxonomies }
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleAutosavingToggle( 'preload_taxonomies' ) }>
 							<span>
 								{ translate( 'Preload tags, categories and other taxonomies.' ) }
@@ -160,7 +166,7 @@ const PreloadTab = ( {
 						</FormLabel>
 						<FormSelect
 							className="wp-super-cache__preload-posts"
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							id="preload_posts"
 							name="preload_posts"
 							onChange={ handleSelect }
@@ -176,7 +182,7 @@ const PreloadTab = ( {
 							{ translate( 'Status Emails' ) }
 						</FormLegend>
 						<FormSelect
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							id="preload_email_volume"
 							name="preload_email_volume"
 							onChange={ handleSelect }

--- a/client/extensions/wp-super-cache/rejected-user-agents.jsx
+++ b/client/extensions/wp-super-cache/rejected-user-agents.jsx
@@ -20,6 +20,7 @@ const RejectedUserAgents = ( {
 		wp_rejected_user_agent,
 	},
 	handleChange,
+	handleSubmitForm,
 	isRequesting,
 	translate,
 } ) => {
@@ -30,7 +31,7 @@ const RejectedUserAgents = ( {
 					compact
 					primary
 					disabled={ isRequesting }
-					type="submit">
+					onClick={ handleSubmitForm }>
 					{ translate( 'Save Settings' ) }
 				</Button>
 			</SectionHeader>

--- a/client/extensions/wp-super-cache/rejected-user-agents.jsx
+++ b/client/extensions/wp-super-cache/rejected-user-agents.jsx
@@ -22,6 +22,7 @@ const RejectedUserAgents = ( {
 	handleChange,
 	handleSubmitForm,
 	isRequesting,
+	isSaving,
 	translate,
 } ) => {
 	return (
@@ -30,16 +31,19 @@ const RejectedUserAgents = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting }
+					disabled={ isRequesting || isSaving }
 					onClick={ handleSubmitForm }>
-					{ translate( 'Save Settings' ) }
+					{ isSaving
+						? translate( 'Saving…' )
+						: translate( 'Save Settings' )
+					}
 				</Button>
 			</SectionHeader>
 			<Card>
 				<form>
 					<FormFieldset>
 						<FormTextarea
-							disabled={ isRequesting }
+							disabled={ isRequesting || isSaving }
 							onChange={ handleChange( 'wp_rejected_user_agent' ) }
 							value={ wp_rejected_user_agent || '' } />
 						<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -96,6 +96,20 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
 		};
 
+		// Update a field that is stored as an array element.
+		setFieldArrayValue = ( name, index ) => event => {
+			const currentValue = this.props.fields[ name ];
+			const newValue = [
+				...currentValue.slice( 0, index ),
+				event.target.value,
+				...currentValue.slice( index + 1 ),
+			];
+
+			this.props.updateFields( {
+				[ name ]: newValue,
+			} );
+		};
+
 		handleSubmitForm = event => {
 			event.preventDefault();
 			this.submitForm();
@@ -115,6 +129,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				handleSelect: this.handleSelect,
 				handleSubmitForm: this.handleSubmitForm,
 				handleToggle: this.handleToggle,
+				setFieldArrayValue: this.setFieldArrayValue,
 			};
 
 			return (

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
 import { flowRight, isEqual, omit, pick } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -12,6 +13,7 @@ import { localize } from 'i18n-calypso';
 import { protectForm } from 'lib/protect-form';
 import trackForm from 'lib/track-form';
 import QuerySettings from './query-settings';
+import { saveSettings } from './state/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getSettings,
@@ -88,8 +90,21 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
 		};
 
+		handleAutosavingToggle = name => () => {
+			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] }, () => {
+				this.submitForm();
+			} );
+		};
+
+		submitForm = () => {
+			const { fields, siteId } = this.props;
+
+			this.props.saveSettings( siteId, fields );
+		};
+
 		render() {
 			const utils = {
+				handleAutosavingToggle: this.handleAutosavingToggle,
 				handleChange: this.handleChange,
 				handleRadio: this.handleRadio,
 				handleSelect: this.handleSelect,
@@ -274,6 +289,14 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				siteId,
 			};
 		},
+		dispatch => {
+			const boundActionCreators = bindActionCreators( {
+				saveSettings,
+			}, dispatch );
+			return {
+				...boundActionCreators,
+			};
+		}
 	);
 
 	return flowRight(

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -17,6 +17,7 @@ import { saveSettings } from './state/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getSettings,
+	isSavingSettings,
 	isRequestingSettings,
 } from './state/selectors';
 
@@ -144,6 +145,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 	const connectComponent = connect(
 		state => {
 			const siteId = getSelectedSiteId( state );
+			const isSaving = isSavingSettings( state, siteId );
 			const settings = Object.assign( {}, getSettings( state, siteId ), {
 				// Caching
 				wp_cache_enabled: true,
@@ -306,6 +308,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 
 			return {
 				isRequesting,
+				isSaving,
 				settings,
 				siteId,
 			};

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -3,7 +3,13 @@
  */
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
-import { flowRight, isEqual, omit, pick } from 'lodash';
+import {
+	flowRight,
+	isEqual,
+	keys,
+	omit,
+	pick,
+} from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -137,10 +143,14 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		};
 
 		submitForm = () => {
-			const { fields, siteId } = this.props;
+			const {
+				fields,
+				settingsFields,
+				siteId,
+			} = this.props;
 
 			this.props.removeNotice( 'wpsc-settings-save' );
-			this.props.saveSettings( siteId, fields );
+			this.props.saveSettings( siteId, pick( fields, settingsFields ) );
 		};
 
 		render() {
@@ -327,12 +337,34 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				preload_taxonomies: false,
 			} );
 			const isRequesting = isRequestingSettings( state, siteId ) && ! settings;
+			// Don't include read-only fields when saving.
+			const settingsFields = keys( omit( settings, [
+				'cache_compression_disabled',
+				'cache_direct_pages',
+				'cache_disable_locking',
+				'cache_mobile_browsers',
+				'cache_mobile_prefixes',
+				'cache_mod_rewrite',
+				'cache_next_gc',
+				'cache_readonly',
+				'cache_writable',
+				'generated',
+				'is_preload_enabled',
+				'is_preloading',
+				'lock_down',
+				'minimum_preload_interval',
+				'post_count',
+				'preload_refresh',
+				'supercache',
+				'wpcache',
+			] ) );
 
 			return {
 				isRequesting,
 				isSaveSuccessful,
 				isSaving,
 				settings,
+				settingsFields,
 				siteId,
 			};
 		},

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -86,14 +86,19 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.updateFields( { [ name ]: isNaN( parsedValue ) ? value : parsedValue } );
 		};
 
-		handleToggle = name => () => {
-			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
-		};
-
 		handleAutosavingToggle = name => () => {
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] }, () => {
 				this.submitForm();
 			} );
+		};
+
+		handleToggle = name => () => {
+			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
+		};
+
+		handleSubmitForm = event => {
+			event.preventDefault();
+			this.submitForm();
 		};
 
 		submitForm = () => {
@@ -108,6 +113,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				handleChange: this.handleChange,
 				handleRadio: this.handleRadio,
 				handleSelect: this.handleSelect,
+				handleSubmitForm: this.handleSubmitForm,
 				handleToggle: this.handleToggle,
 			};
 
@@ -293,6 +299,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const boundActionCreators = bindActionCreators( {
 				saveSettings,
 			}, dispatch );
+
 			return {
 				...boundActionCreators,
 			};


### PR DESCRIPTION
This PR adds functionality to save the WP Super Cache settings using the REST API. This functionality isn't currently testable since the plugin does not yet support POST requests.