### PR TITLE
Signup: :Add padding to improve vertical alignment of the social buttons text

### DIFF
--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -39,8 +39,10 @@
 .signup-form__social-buttons {
 	button {
 		margin: 0 0 10px;
-		padding: 8px 14px;
 		width: 100%;
+	}
+	svg{
+		margin-top: -2px;
 	}
 }
 

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -39,6 +39,7 @@
 .signup-form__social-buttons {
 	button {
 		margin: 0 0 10px;
+		padding: 8px 14px;
 		width: 100%;
 	}
 }

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -41,7 +41,8 @@
 		margin: 0 0 10px;
 		width: 100%;
 	}
-	svg{
+
+	svg {
 		margin-top: -2px;
 	}
 }

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -87,7 +87,7 @@ class FacebookLoginButton extends Component {
 	render() {
 		return (
 			<button className="button" onClick={ this.handleClick }>
-				<svg className="social-buttons__logo" width="21" height="21" viewBox="-2 -1 23 23" xmlns="http://www.w3.org/2000/svg">
+				<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
 					{ /* eslint-disable max-len */ }
 					<path d="M18.86.041H1.14a1.1 1.1 0 0 0-1.099 1.1v17.718a1.1 1.1 0 0 0 1.1 1.1h9.539v-7.713H8.084V9.24h2.596V7.023c0-2.573 1.571-3.973 3.866-3.973 1.1 0 2.044.081 2.32.118v2.688l-1.592.001c-1.248 0-1.49.593-1.49 1.463v1.92h2.977l-.388 3.006h-2.59v7.713h5.076a1.1 1.1 0 0 0 1.1-1.1V1.14a1.1 1.1 0 0 0-1.1-1.099" fill="#3E68B5" fillRule="evenodd" />
 					{ /* eslint-enable max-len */ }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -75,7 +75,7 @@ class GoogleLoginButton extends Component {
 	render() {
 		return (
 			<button className="button" onClick={ this.handleClick }>
-				<svg className="social-buttons__logo" width="21" height="21" viewBox="0 0 20 21" xmlns="http://www.w3.org/2000/svg">
+				<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
 					{ /* eslint-disable max-len */ }
 					<g fill="none" fillRule="evenodd">
 						<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />


### PR DESCRIPTION
This is nitpicking, but on screens with high density the vertical alignment of the logos on the social buttons looks off:

![img_2835](https://cloud.githubusercontent.com/assets/57050/25275082/52e5e466-268b-11e7-94a6-cda6ea1cef36.png)

This pull request updates the SVG markup and position on those buttons to center the logos with the text.

Testing instructions:

1. Run git checkout update/social-signup-buttons and start your server, or open a live branch
2. Open the [Social signup](http://calypso.localhost:3000/start/social) flow in an incognito window
3. Check that the vertical alignment on the social buttons 