### PR TITLE
Themes: sub-masterbar style alignment, transitions

### DIFF
--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -99,6 +99,10 @@
 		}
 	}
 
+	&:visited {
+		color: $white; /* Safari fix */
+	}
+
 	&.is-selected {
 			background-color: $blue-dark;
 			color: $white;

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -40,6 +40,10 @@
 	flex: 1;
 	position: relative;
 	width: 100%;
+
+	.sub-masterbar-nav__dropdown:not( .is-collapsed ) & {
+		border-top: 1px solid lighten( $blue-dark, 2% );
+	}
 }
 
 .sub-masterbar-nav__items {
@@ -77,20 +81,28 @@
 	box-sizing: border-box;
 	background-color: transparent;
 	border: 0;
-	border-radius: 5px;
 	outline: 0;
-	color: $blue-light;
+	color: $white;
 	font-size: 14px;
 	cursor: pointer;
+	transition: all 200ms ease-in;
 
-	&:hover {
-		background-color: $blue-medium;
-		color: lighten( $gray, 30% );
+	&:hover,
+ 	&:focus {
+		background: lighten( $masterbar-color, 5% );
+		color: $white;
+		outline: 0;
+		transition: all 200ms ease-out;
+
+		@include breakpoint( ">660px" ) {
+			transform: translate3d( 0, -2px, 0 );
+		}
 	}
 
 	&.is-selected {
 			background-color: $blue-dark;
-			color: $gray-light;
+			color: $white;
+			border-radius: 5px;
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -108,8 +120,9 @@
 		width: 100px;
 		height: 62px;
 		margin: 0 10px 10px 0;
-		font-size: 11px;
+		font-size: 13px;
 		text-align: center;
+		border-radius: 5px;
 	}
 }
 
@@ -122,7 +135,7 @@
 }
 
 .sub-masterbar-nav__label {
-	text-transform: uppercase;
+	text-transform: capitalize;
 }
 
 .sub-masterbar-nav__switch {
@@ -143,7 +156,7 @@
 	transition: transform 0.2s;
 
 	&.is-open {
-		transform: rotate(90deg);
+		transform: rotate( 90deg );
 	}
 }
 
@@ -158,4 +171,9 @@
 		right: 15px;
 	color: lighten( $gray, 30% );
 	cursor: pointer;
+	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+	.sub-masterbar-nav__dropdown:not( .is-collapsed ) & {
+		transform: rotate( 180deg );
+	}
 }


### PR DESCRIPTION
Tweaked the recently merged SubMasterbarNav component (in #12585):

1. Aligned hover style to the masterbar
2. Moved to capitalized text (the all caps was a choice based on previous patterns)
3. All text white, larger font for readability and accessibility
4. Mobile: added chevron animation
5. Mobile: added thin line divider
6. Tweaked `:focus` state.
7. Fixed a Safari bug related to `:visited` color

![cap-](https://cloud.githubusercontent.com/assets/4389/25280383/ac06865c-26a1-11e7-81b0-d62349882c61.gif)

![cap-drop](https://cloud.githubusercontent.com/assets/4389/25280386/aeb6233a-26a1-11e7-8bbd-d29349007fd1.gif)

### To test

1. Open /themes — logged out
2. Try to hover, navigate and select the items in the bar, both desktop and mobile sizes

