### PR TITLE
Themes: Fix Schema

### DIFF
--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -112,16 +112,18 @@ export const themeRequestErrorsSchema = {
 export const themeFiltersSchema = {
 	type: 'object',
 	patternProperties: {
+		// Taxonomy ID
 		'^\\w+$': {
-			type: 'array',
-			items: {
-				type: 'object',
-				patternProperties: {
-					'^\\w+$': {
-						properties: {
-							name: { type: 'string' },
-							description: { type: 'string' },
-						}
+			title: 'Taxonomy',
+			type: 'object',
+			patternProperties: {
+				// Term (i.e. filter) ID
+				'^\\w+$': {
+					title: 'Term',
+					type: 'object',
+					properties: {
+						name: { type: 'string' },
+						description: { type: 'string' },
 					}
 				}
 			},


### PR DESCRIPTION
There's a bug in the current themes schema (which I introduced with #13019) that causes state to not be properly persisted and rehydrated.

To test:

* Check out `master` (bug isn't visible in production)
* Land on http://calypso.localhost:3000/themes
* See this in the console:
![image](https://cloud.githubusercontent.com/assets/96308/25282706/97d377de-26b1-11e7-8835-f9ed8205aa2d.png)
* Check Redux devtools -- the `themes.themeFilters` state subtree is empty!
* Now switch to this branch
* Reload http://calypso.localhost:3000/themes
* No `state validation error`! And the `themes.themeFilters` state subtree has entries! 🎉 
* S'all good, man!