### PR TITLE
Themes: add max-width to theme sheets

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -33,6 +33,8 @@
 .theme__sheet-columns {
 	display: flex;
 	flex-direction: row;
+	max-width: 1500px;
+	margin: 0 auto;
 
 	@include breakpoint( "<960px" ) {
 		flex-direction: column-reverse;


### PR DESCRIPTION
Pages that get too large are hard to read. Fixes #5700.

Before:

![screen shot 2017-04-21 at 16 42 32](https://cloud.githubusercontent.com/assets/4389/25285321/b8934314-26b1-11e7-9d3c-802f10b90ba6.png)

After:

![screen shot 2017-04-21 at 16 42 33](https://cloud.githubusercontent.com/assets/4389/25285354/d1183994-26b1-11e7-87bc-b80b359257bf.png)

Why 1500px you ask? 1500px allows the main text column to be at 670px of text (about 100 chars, about 12-14 words), which is the maximum length suggested for good readability.

![screen shot 2017-04-21 at 16 40 54](https://cloud.githubusercontent.com/assets/4389/25285451/35df47b4-26b2-11e7-80b7-93a794051e07.png)

/cc @kathrynwp  