### PR TITLE
Themes: moving "Open Live Demo" on the tabs bar

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -90,9 +90,9 @@
 
 .theme__sheet-screenshot {
 	display: block;
-	position: relative;
-	top: -156px;
+	margin-top: -156px;
 	width: 98%;
+	z-index: 1;
 	box-shadow: 0 0 0 1px $transparent, 0px 2px 8px 0px transparentize( $gray-dark, 0.5 );
 	background-color: transparentize( white, 0.5 );
 	transition: all 200ms ease-in-out;
@@ -124,10 +124,6 @@
 		&.is-active:hover {
 			cursor: pointer;
 			box-shadow: 0 0 0 1px $gray, 0px 2px 10px 0px transparentize( $gray-dark, 0.5 );
-
-			.theme__sheet-preview-link {
-				color: $white;
-			}
 		}
 	}
 }
@@ -140,17 +136,20 @@
 .theme__sheet-preview-link {
 	display: flex;
 	position: absolute;
-		top: -24px;
-	color: lighten( $gray, 30% );
+		top: 269px;
+		right: calc( 50% + 30px );
+	margin: 0 auto;
+	padding: 10px;
+	color: $blue-wordpress;
+	font-size: 14px;
 	cursor: pointer;
 	transition: all ease-in-out 100ms;
 
 	&:hover {
-		color: $white;
+		color: $blue-medium;
 	}
 
 	.theme__sheet-preview-link-text {
-		font-size: 12px;
 		margin-top: 2px;
 	}
 
@@ -333,6 +332,10 @@
 	color: transparent;
 	background-color: rgba(255, 255, 255, 0.4);
 	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
+.theme__sheet-content .section-nav {
+	height: 50px;
 }
 
 .theme__sheet-features-list {


### PR DESCRIPTION
Trying a different position for the "Open Live Demo" link to make it more visible: right of the section nav.

Pure CSS PR.

![screen shot 2017-04-21 at 18 40 36](https://cloud.githubusercontent.com/assets/4389/25289582/1ac51bb0-26c2-11e7-9143-a3fd637823fe.png)



Also: fix loading section-nav had jumpy height.

### To test

1. Open any theme (`/theme/$name`)
2. Check the position of the "Open live demo" link, make sure it's properly aligned.
3. Check all the browsers you can ;) 