### PR TITLE
Pages: Remove dependency on SitesList

### DIFF
--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -7,8 +7,7 @@ var React = require( 'react' ),
 /**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	route = require( 'lib/route' ),
+var route = require( 'lib/route' ),
 	analytics = require( 'lib/analytics' ),
 	titlecase = require( 'to-title-case' ),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
@@ -49,7 +48,6 @@ var controller = {
 				context: context,
 				siteID: siteID,
 				status: status,
-				sites: sites,
 				search: search,
 				trackScrollPage: trackScrollPage.bind(
 					null,

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -1,21 +1,21 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	i18n = require( 'i18n-calypso' );
+import React from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
-var route = require( 'lib/route' ),
-	analytics = require( 'lib/analytics' ),
-	titlecase = require( 'to-title-case' ),
-	trackScrollPage = require( 'lib/track-scroll-page' ),
-	setTitle = require( 'state/document-head/actions' ).setDocumentHeadTitle;
+import route from 'lib/route';
+import analytics from 'lib/analytics';
+import titlecase from 'to-title-case';
+import trackScrollPage from 'lib/track-scroll-page';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 
 import { renderWithReduxStore } from 'lib/react-helpers';
 
-var controller = {
+const controller = {
 
 	pages: function( context ) {
 		var Pages = require( 'my-sites/pages/main' ),

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -1,86 +1,87 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:pages:pages' );
-
 import { connect } from 'react-redux';
+import React from 'react';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-var PageList = require( './page-list' ),
-	SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavItem = require( 'components/section-nav/item' ),
-	Search = require( 'components/search' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	URLSearch = require( 'lib/mixins/url-search' ),
-	config = require( 'config' ),
-	notices = require( 'notices' ),
-	Main = require( 'components/main' );
-
+import { localize } from 'i18n-calypso';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 } from 'state/ui/selectors';
+import config from 'config';
+import notices from 'notices';
+import urlSearch from 'lib/url-search';
+import Main from 'components/main';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import PageList from './page-list';
+import Search from 'components/search';
+import SectionNav from 'components/section-nav';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
+const debug = debugFactory( 'calypso:my-sites:pages:pages' );
 const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
 
-const PagesMain = React.createClass( {
+class PagesMain extends React.Component {
 
-	displayName: 'Pages',
+	static displayName = 'Pages';
 
-	mixins: [ URLSearch ],
-
-	propTypes: {
+	static propTypes = {
 		trackScrollPage: React.PropTypes.func.isRequired
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			perPage: 20
-		};
-	},
+	static defaultProps = {
+		perPage: 20
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this._setWarning( this.props.siteId );
-	},
+	}
 
-	componentDidMount: function() {
+	componentDidMount() {
 		debug( 'Pages React component mounted.' );
-	},
+	}
 
-	componentWillUpdate: function() {
+	componentWillUpdate() {
 		this._setWarning( this.props.siteId );
-	},
+	}
 
-	render: function() {
+	render() {
+		const {
+			doSearch,
+			search,
+			translate,
+		} = this.props;
 		const status = this.props.status || 'published';
 		const filterStrings = {
-			published: this.translate( 'Published', { context: 'Filter label for pages list' } ),
-			drafts: this.translate( 'Drafts', { context: 'Filter label for pages list' } ),
-			scheduled: this.translate( 'Scheduled', { context: 'Filter label for pages list' } ),
-			trashed: this.translate( 'Trashed', { context: 'Filter label for pages list' } )
+			published: translate( 'Published', { context: 'Filter label for pages list' } ),
+			drafts: translate( 'Drafts', { context: 'Filter label for pages list' } ),
+			scheduled: translate( 'Scheduled', { context: 'Filter label for pages list' } ),
+			trashed: translate( 'Trashed', { context: 'Filter label for pages list' } )
 		};
 		const searchStrings = {
-			published: this.translate( 'Search Published…', { context: 'Search placeholder for pages list', textOnly: true } ),
-			drafts: this.translate( 'Search Drafts…', { context: 'Search placeholder for pages list', textOnly: true } ),
-			scheduled: this.translate( 'Search Scheduled…', { context: 'Search placeholder for pages list', textOnly: true } ),
-			trashed: this.translate( 'Search Trashed…', { context: 'Search placeholder for pages list', textOnly: true } )
+			published: translate( 'Search Published…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			drafts: translate( 'Search Drafts…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			scheduled: translate( 'Search Scheduled…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			trashed: translate( 'Search Trashed…', { context: 'Search placeholder for pages list', textOnly: true } )
 		};
 		return (
 			<Main classname="pages">
 				<SidebarNavigation />
 				<SectionNav selectedText={ filterStrings[ status ] }>
-					<NavTabs label={ this.translate( 'Status', { context: 'Filter page group label for tabs' } ) }>
+					<NavTabs label={ translate( 'Status', { context: 'Filter page group label for tabs' } ) }>
 						{ this.getNavItems( filterStrings, status ) }
 					</NavTabs>
 					<Search
 						pinned
 						fitsContainer
-						onSearch={ this.doSearch }
-						initialValue={ this.props.search }
+						onSearch={ doSearch }
+						initialValue={ search }
 						placeholder={ searchStrings[ status ] }
 						analyticsGroup="Pages"
 						delaySearch={ true }
@@ -89,7 +90,7 @@ const PagesMain = React.createClass( {
 				<PageList { ...this.props } />
 			</Main>
 		);
-	},
+	}
 
 	getNavItems( filterStrings, currentStatus ) {
 		const {
@@ -113,17 +114,20 @@ const PagesMain = React.createClass( {
 				</NavItem>
 			);
 		} );
-	},
+	}
 
 	_setWarning( selectedSite ) {
+		const { translate } = this.props;
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.hasMinimumJetpackVersion ) {
 			notices.warning(
-				this.translate( 'Jetpack %(version)s is required to take full advantage of all page editing features.', { args: { version: config( 'jetpack_min_version' ) } } ),
-				{ button: this.translate( 'Update now' ), href: selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade' }
+				translate( 'Jetpack %(version)s is required to take full advantage of all page editing features.', {
+					args: { version: config( 'jetpack_min_version' ) }
+				} ),
+				{ button: translate( 'Update now' ), href: selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade' }
 			);
 		}
 	}
-} );
+}
 
 const mapState = state => {
 	return {
@@ -132,4 +136,4 @@ const mapState = state => {
 	};
 };
 
-export default connect( mapState )( PagesMain );
+export default connect( mapState )( localize( urlSearch( PagesMain ) ) );

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -4,6 +4,8 @@
 var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:pages:pages' );
 
+import { connect } from 'react-redux';
+
 /**
  * Internal dependencies
  */
@@ -12,20 +14,24 @@ var PageList = require( './page-list' ),
 	NavTabs = require( 'components/section-nav/tabs' ),
 	NavItem = require( 'components/section-nav/item' ),
 	Search = require( 'components/search' ),
-	observe = require( 'lib/mixins/data-observe' ),
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	URLSearch = require( 'lib/mixins/url-search' ),
 	config = require( 'config' ),
 	notices = require( 'notices' ),
 	Main = require( 'components/main' );
 
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+} from 'state/ui/selectors';
+
 const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
 
-module.exports = React.createClass( {
+const PagesMain = React.createClass( {
 
 	displayName: 'Pages',
 
-	mixins: [ observe( 'sites' ), URLSearch ],
+	mixins: [ URLSearch ],
 
 	propTypes: {
 		trackScrollPage: React.PropTypes.func.isRequired
@@ -38,17 +44,15 @@ module.exports = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
-		this._setWarning( selectedSite );
+		this._setWarning( this.props.siteId );
 	},
 
 	componentDidMount: function() {
 		debug( 'Pages React component mounted.' );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
-		var selectedSite = nextProps.sites.getSelectedSite();
-		this._setWarning( selectedSite );
+	componentWillUpdate: function() {
+		this._setWarning( this.props.siteId );
 	},
 
 	render: function() {
@@ -88,7 +92,13 @@ module.exports = React.createClass( {
 	},
 
 	getNavItems( filterStrings, currentStatus ) {
-		const siteFilter = this.props.sites.selected ? '/' + this.props.sites.selected : '';
+		const {
+			site,
+			siteId,
+		} = this.props;
+		const sitePart = site && site.slug || siteId;
+		const siteFilter = sitePart ? '/' + sitePart : '';
+
 		return statuses.map( function( status ) {
 			let path = `/pages${ siteFilter }`;
 			if ( status !== 'publish' ) {
@@ -114,3 +124,12 @@ module.exports = React.createClass( {
 		}
 	}
 } );
+
+const mapState = state => {
+	return {
+		site: getSelectedSite( state ),
+		siteId: getSelectedSiteId( state ),
+	};
+};
+
+export default connect( mapState )( PagesMain );

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -40,7 +40,7 @@ class PagesMain extends React.Component {
 	};
 
 	componentWillMount() {
-		this._setWarning( this.props.siteId );
+		this._setWarning( this.props.site );
 	}
 
 	componentDidMount() {
@@ -48,7 +48,7 @@ class PagesMain extends React.Component {
 	}
 
 	componentWillUpdate() {
-		this._setWarning( this.props.siteId );
+		this._setWarning( this.props.site );
 	}
 
 	render() {

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import {
 	getSelectedSite,
 	getSelectedSiteId,

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -129,11 +129,9 @@ class PagesMain extends React.Component {
 	}
 }
 
-const mapState = state => {
-	return {
-		site: getSelectedSite( state ),
-		siteId: getSelectedSiteId( state ),
-	};
-};
+const mapState = ( state ) => ( {
+	site: getSelectedSite( state ),
+	siteId: getSelectedSiteId( state ),
+} );
 
 export default connect( mapState )( localize( urlSearch( PagesMain ) ) );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -2,8 +2,13 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	omit = require( 'lodash/omit' );
+	PureRenderMixin = require( 'react-pure-render/mixin' );
+
+import { connect } from 'react-redux';
+import {
+	isEmpty,
+	omit,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,7 +16,6 @@ var React = require( 'react' ),
 var PostListFetcher = require( 'components/post-list-fetcher' ),
 	Page = require( './page' ),
 	infiniteScroll = require( 'lib/mixins/infinite-scroll' ),
-	observe = require( 'lib/mixins/data-observe' ),
 	EmptyContent = require( 'components/empty-content' ),
 	NoResults = require( 'my-sites/no-results' ),
 	actions = require( 'lib/posts/actions' ),
@@ -20,6 +24,10 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	sortPagesHierarchically = require( './helpers' ).sortPagesHierarchically;
 
 import BlogPostsPage from './blog-posts-page';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+} from 'state/ui/selectors';
 
 var PageList = React.createClass( {
 
@@ -28,7 +36,7 @@ var PageList = React.createClass( {
 	propTypes: {
 		context: React.PropTypes.object,
 		search: React.PropTypes.string,
-		sites: React.PropTypes.object,
+		hasSites: React.PropTypes.bool.isRequired,
 		siteID: React.PropTypes.any
 	},
 
@@ -52,7 +60,7 @@ var Pages = React.createClass( {
 
 	displayName: 'Pages',
 
-	mixins: [ infiniteScroll( 'fetchPages' ), observe( 'sites' ) ],
+	mixins: [ infiniteScroll( 'fetchPages' ) ],
 
 	propTypes: {
 		context: React.PropTypes.object.isRequired,
@@ -62,7 +70,7 @@ var Pages = React.createClass( {
 		posts: React.PropTypes.array.isRequired,
 		search: React.PropTypes.string,
 		siteID: React.PropTypes.any,
-		sites: React.PropTypes.object.isRequired,
+		hasSites: React.PropTypes.bool.isRequired,
 		trackScrollPage: React.PropTypes.func.isRequired,
 		hasRecentError: React.PropTypes.bool.isRequired
 	},
@@ -133,7 +141,9 @@ var Pages = React.createClass( {
 					} ) }
 			/>;
 		} else {
-			newPageLink = this.props.siteID ? '/page/' + this.props.siteID : '/page';
+			const { site, siteId } = this.props;
+			const sitePart = site && site.slug || siteId;
+			newPageLink = this.props.siteID ? '/page/' + sitePart : '/page';
 
 			if ( this.props.hasRecentError ) {
 				attributes = {
@@ -211,7 +221,7 @@ var Pages = React.createClass( {
 	},
 
 	renderPagesList: function( { pages } ) {
-		const site = this.props.sites.getSelectedSite();
+		const { site } = this.props;
 		const status = this.props.status || 'published';
 
 		// Pages only display hierarchically for published pages on single-sites when
@@ -252,12 +262,10 @@ var Pages = React.createClass( {
 			if ( ! ( 'site_ID' in page ) ) {
 				return page;
 			}
-			// Get the site the page belongs to
-			const _site = this.props.sites.getSite( page.site_ID );
 
 			// Render each page
 			return (
-				<Page key={ 'page-' + page.global_ID } page={ page } site={ _site } multisite={ this.props.siteID === false } />
+				<Page key={ 'page-' + page.global_ID } page={ page } multisite={ this.props.siteID === false } />
 			);
 		}, this );
 
@@ -287,13 +295,17 @@ var Pages = React.createClass( {
 	},
 
 	render: function() {
-		const pages = this.props.posts;
+		const {
+			hasSites,
+			loading,
+			posts,
+		} = this.props;
 
-		if ( pages.length && this.props.sites.initialized ) {
-			return this.renderPagesList( { pages } );
+		if ( posts.length && hasSites ) {
+			return this.renderPagesList( { pages: posts } );
 		}
 
-		if ( ( ! this.props.loading ) && this.props.sites.initialized ) {
+		if ( ( ! loading ) && hasSites ) {
 			return this.renderNoContent();
 		}
 
@@ -302,4 +314,12 @@ var Pages = React.createClass( {
 
 } );
 
-module.exports = PageList;
+const mapState = state => {
+	return {
+		hasSites: ! isEmpty( state.sites.items ),
+		site: getSelectedSite( state ),
+		siteID: getSelectedSiteId( state ),
+	};
+};
+
+module.exports = connect( mapState )( PageList );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -323,4 +323,4 @@ const mapState = state => {
 	};
 };
 
-module.exports = connect( mapState )( PageList );
+export default connect( mapState )( PageList );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -37,7 +37,8 @@ var PageList = React.createClass( {
 		context: React.PropTypes.object,
 		search: React.PropTypes.string,
 		hasSites: React.PropTypes.bool.isRequired,
-		siteID: React.PropTypes.any
+		site: React.PropTypes.object,
+		siteId: React.PropTypes.any
 	},
 
 	render: function() {
@@ -45,7 +46,7 @@ var PageList = React.createClass( {
 			<PostListFetcher
 				type="page"
 				number={ 100 }
-				siteID={ this.props.siteID }
+				siteID={ this.props.siteId }
 				status={ mapStatus( this.props.status ) }
 				search={ this.props.search }>
 				<Pages
@@ -69,7 +70,7 @@ var Pages = React.createClass( {
 		page: React.PropTypes.number.isRequired,
 		posts: React.PropTypes.array.isRequired,
 		search: React.PropTypes.string,
-		siteID: React.PropTypes.any,
+		siteId: React.PropTypes.any,
 		hasSites: React.PropTypes.bool.isRequired,
 		trackScrollPage: React.PropTypes.func.isRequired,
 		hasRecentError: React.PropTypes.bool.isRequired
@@ -143,7 +144,7 @@ var Pages = React.createClass( {
 		} else {
 			const { site, siteId } = this.props;
 			const sitePart = site && site.slug || siteId;
-			newPageLink = this.props.siteID ? '/page/' + sitePart : '/page';
+			newPageLink = this.props.siteId ? '/page/' + sitePart : '/page';
 
 			if ( this.props.hasRecentError ) {
 				attributes = {
@@ -318,7 +319,7 @@ const mapState = state => {
 	return {
 		hasSites: ! isEmpty( state.sites.items ),
 		site: getSelectedSite( state ),
-		siteID: getSelectedSiteId( state ),
+		siteId: getSelectedSiteId( state ),
 	};
 };
 

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -6,7 +6,6 @@ var React = require( 'react' ),
 
 import { connect } from 'react-redux';
 import {
-	isEmpty,
 	omit,
 } from 'lodash';
 
@@ -24,6 +23,9 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	sortPagesHierarchically = require( './helpers' ).sortPagesHierarchically;
 
 import BlogPostsPage from './blog-posts-page';
+import {
+	hasInitializedSites,
+} from 'state/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -317,7 +319,7 @@ var Pages = React.createClass( {
 
 const mapState = state => {
 	return {
-		hasSites: ! isEmpty( state.sites.items ),
+		hasSites: hasInitializedSites( state ),
 		site: getSelectedSite( state ),
 		siteId: getSelectedSiteId( state ),
 	};

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -205,7 +205,7 @@ var Pages = React.createClass( {
 			if ( i % 4 === 0 ) {
 				rows.push( <Placeholder.Marker key={ 'placeholder-marker-' + i } /> );
 			}
-			rows.push( <Placeholder.Page key={ 'placeholder-page-' + i } multisite={ this.props.siteID === false } /> );
+			rows.push( <Placeholder.Page key={ 'placeholder-page-' + i } multisite={ ! this.props.site } /> );
 		}
 	},
 

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -317,12 +317,10 @@ var Pages = React.createClass( {
 
 } );
 
-const mapState = state => {
-	return {
-		hasSites: hasInitializedSites( state ),
-		site: getSelectedSite( state ),
-		siteId: getSelectedSiteId( state ),
-	};
-};
+const mapState = ( state ) => ( {
+	hasSites: hasInitializedSites( state ),
+	site: getSelectedSite( state ),
+	siteId: getSelectedSiteId( state ),
+} );
 
 export default connect( mapState )( PageList );

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -26,7 +26,11 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 
 import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from './page-card-info';
-import { hasStaticFrontPage, isSitePreviewable } from 'state/sites/selectors';
+import {
+	getSite,
+	hasStaticFrontPage,
+	isSitePreviewable,
+} from 'state/sites/selectors';
 import {
 	isFrontPage,
 	isPostsPage,
@@ -253,7 +257,10 @@ const Page = React.createClass( {
 	},
 
 	getCopyItem: function() {
-		const { page: post, site } = this.props;
+		const {
+			page: post,
+			siteSlugOrId,
+		} = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
 			! utils.userCan( 'edit_post', post )
@@ -261,7 +268,7 @@ const Page = React.createClass( {
 			return null;
 		}
 		return (
-			<PopoverMenuItem onClick={ this.copyPage } href={ `/page/${ site.slug }?copy=${ post.ID }` }>
+			<PopoverMenuItem onClick={ this.copyPage } href={ `/page/${ siteSlugOrId }?copy=${ post.ID }` }>
 				<Gridicon icon="clipboard" size={ 18 } />
 				{ this.translate( 'Copy' ) }
 			</PopoverMenuItem>
@@ -466,12 +473,17 @@ const Page = React.createClass( {
 
 export default connect(
 	( state, props ) => {
+		const site = getSite( state, props.page.site_ID ) || {};
+		const siteSlugOrId = site.slug || site.ID || null;
+
 		return {
 			hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),
 			isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID ),
 			isPostsPage: isPostsPage( state, props.page.site_ID, props.page.ID ),
-			isPreviewable: false !== isSitePreviewable( state, props.site.ID ),
+			isPreviewable: false !== isSitePreviewable( state, props.page.site_ID ),
 			previewURL: getPreviewURL( props.page ),
+			site,
+			siteSlugOrId,
 		};
 	},
 	( dispatch ) => bindActionCreators( {

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -411,7 +411,7 @@ const Page = React.createClass( {
 		return (
 			<CompactCard className={ classNames( cardClasses ) } >
 				{ hierarchyIndent }
-				{ this.props.multisite ? <SiteIcon site={ site } size={ 34 } /> : null }
+				{ this.props.multisite ? <SiteIcon siteId={ page.site_ID } size={ 34 } /> : null }
 				<div className="page__main">
 					<a className="page__title"
 						href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -8,7 +8,10 @@ var React = require( 'react' ),
 
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { includes } from 'lodash';
+import {
+	get,
+	includes,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -473,8 +476,8 @@ const Page = React.createClass( {
 
 export default connect(
 	( state, props ) => {
-		const site = getSite( state, props.page.site_ID ) || {};
-		const siteSlugOrId = site.slug || site.ID || null;
+		const site = getSite( state, props.page.site_ID );
+		const siteSlugOrId = get( site, 'slug' ) || get( site, 'ID', null );
 
 		return {
 			hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),

--- a/client/state/selectors/has-initialized-sites.js
+++ b/client/state/selectors/has-initialized-sites.js
@@ -1,0 +1,8 @@
+/**
+ * Returns true if site selection has occured, else false
+ * @param  {Object}  state Global state tree
+ * @return {Boolean}       Has site selection occurred
+ */
+export default function hasInitializedSites( state ) {
+	return state.ui.siteSelectionInitialized;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -106,6 +106,7 @@ export getUserSetting from './get-user-setting';
 export getUserSettings from './get-user-settings';
 export getVisibleSites from './get-visible-sites';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
+export hasInitializedSites from './has-initialized-sites';
 export hasUnsavedUserSettings from './has-unsaved-user-settings';
 export hasUserSettings from './has-user-settings';
 export isAccountRecoveryResetOptionsReady from './is-account-recovery-reset-options-ready';

--- a/client/state/selectors/test/has-initialized-sites.js
+++ b/client/state/selectors/test/has-initialized-sites.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { hasInitializedSites } from '../';
+
+describe( 'hasInitializedSites()', () => {
+	it( 'should return false if site selection has not occurred', () => {
+		expect( hasInitializedSites( { ui: { siteSelectionInitialized: false } } ) ).to.be.false;
+	} );
+	it( 'should return true if site selection has occurred', () => {
+		expect( hasInitializedSites( { ui: { siteSelectionInitialized: true } } ) ).to.be.true;
+	} );
+} );

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -45,6 +45,10 @@ export function selectedSiteId( state = null, action ) {
 	return state;
 }
 
+export const siteSelectionInitialized = createReducer( false, {
+	[ SELECTED_SITE_SET ]: () => true,
+} );
+
 //TODO: do we really want to mix strings and booleans?
 export function section( state = false, action ) {
 	switch ( action.type ) {
@@ -96,6 +100,7 @@ const reducer = combineReducers( {
 	isPreviewShowing,
 	queryArguments,
 	selectedSiteId,
+	siteSelectionInitialized,
 	dropZone,
 	guidedTour,
 	editor,

--- a/client/state/ui/test/reducer.js
+++ b/client/state/ui/test/reducer.js
@@ -12,7 +12,11 @@ import {
 	DESERIALIZE,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'state/action-types';
-import reducer, { selectedSiteId, isNotificationsOpen } from '../reducer';
+import reducer, {
+	isNotificationsOpen,
+	selectedSiteId,
+	siteSelectionInitialized,
+} from '../reducer';
 
 describe( 'reducer', () => {
 	it( 'should include expected keys in return value', () => {
@@ -24,6 +28,7 @@ describe( 'reducer', () => {
 			'isPreviewShowing',
 			'queryArguments',
 			'selectedSiteId',
+			'siteSelectionInitialized',
 			'guidedTour',
 			'editor',
 			'dropZone',
@@ -99,6 +104,41 @@ describe( 'reducer', () => {
 				type: NOTIFICATIONS_PANEL_TOGGLE,
 			} );
 			expect( state ).to.equal( false );
+		} );
+	} );
+
+	describe( '#siteSelectionInitialized()', () => {
+		it( 'should default to false', () => {
+			const state = siteSelectionInitialized( undefined, {} );
+
+			expect( state ).to.be.false;
+		} );
+
+		it( 'should be true when a site is selected', () => {
+			const state = siteSelectionInitialized( null, {
+				type: SELECTED_SITE_SET,
+				siteId: 2916284,
+			} );
+
+			expect( state ).to.be.true;
+		} );
+
+		it( 'should be true if siteId is undefined', () => {
+			const state = siteSelectionInitialized( null, {
+				type: SELECTED_SITE_SET,
+				siteId: undefined,
+			} );
+
+			expect( state ).to.be.true;
+		} );
+
+		it( 'should be true if siteId is null', () => {
+			const state = siteSelectionInitialized( null, {
+				type: SELECTED_SITE_SET,
+				siteId: null,
+			} );
+
+			expect( state ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
Use state selectors instead!

Also included is some refactoring to appease the linter & generally tidy up the touched modules:
* `import`s vs. `require`s
* ES6 class vs. `createClass`
* `var` -> `const`
* Compose via the `url-search` lib vs the mixin

Now that #13314 was merged, this is no longer blocked by `updateSitesList`.

### TO TEST: 

* Visit the [Pages](http://calypso.localhost:3000/pages/) section for "All Sites"
* Change the status filter and make sure all appropriate pages are shown
* Ensure the ellipsis menu popover actions work as intended
* Search in each filter & make sure appropriate pages are shown (This seems to be broken in `master` for "All Sites" -- cannot get results searching at https://calypso.live/pages/published?branch=master)
* Select a site with some pages
* Repeat the above
* Repeat both of the above with clean cache and `localStorage`