### PR TITLE
WooCommerce: UI reducers no persist

### DIFF
--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { uniqueId } from 'lodash';
+import { createReducer } from 'state/utils';
 
 /**
  * Internal dependencies
@@ -12,18 +13,10 @@ import {
 } from '../../action-types';
 import { nextBucketIndex, getBucket } from '../helpers';
 
-const initialState = null;
-
-export default function( state = initialState, action ) {
-	const handlers = {
-		[ WOOCOMMERCE_EDIT_PRODUCT ]: editProductAction,
-		[ WOOCOMMERCE_EDIT_PRODUCT_ATTRIBUTE ]: editProductAttributeAction,
-	};
-
-	const handler = handlers[ action.type ];
-
-	return ( handler && handler( state, action ) ) || state;
-}
+export default createReducer( null, {
+	[ WOOCOMMERCE_EDIT_PRODUCT ]: editProductAction,
+	[ WOOCOMMERCE_EDIT_PRODUCT_ATTRIBUTE ]: editProductAttributeAction,
+} );
 
 function editProductAction( edits, action ) {
 	const { product, data } = action.payload;

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -1,22 +1,15 @@
 /**
  * Internal dependencies
  */
+import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_EDIT_PRODUCT_VARIATION,
 } from '../../../action-types';
 import { nextBucketIndex, getBucket } from '../../helpers';
 
-const initialState = null;
-
-export default function( state = initialState, action ) {
-	const handlers = {
-		[ WOOCOMMERCE_EDIT_PRODUCT_VARIATION ]: editProductVariationAction,
-	};
-
-	const handler = handlers[ action.type ];
-
-	return ( handler && handler( state, action ) ) || state;
-}
+export default createReducer( null, {
+	[ WOOCOMMERCE_EDIT_PRODUCT_VARIATION ]: editProductVariationAction,
+} );
 
 function editProductVariationAction( edits, action ) {
 	const { product, variation, data } = action.payload;


### PR DESCRIPTION
This sets the ui reducers to use `createReducer()` correctly with no
persistence as edits should be transient and not held in browser storage.