### PR TITLE
Components: Add form-currency-input

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -99,6 +99,7 @@
 @import 'components/forms/counted-textarea/style';
 @import 'components/forms/form-button/style';
 @import 'components/forms/form-buttons-bar/style';
+@import 'components/forms/form-currency-input/style';
 @import 'components/forms/form-fieldset/style';
 @import 'components/forms/form-input-validation/style';
 @import 'components/forms/form-label/style';

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -13,6 +13,7 @@ var countriesList = require( 'lib/countries-list' ).forSms(),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
 	FormCheckbox = require( 'components/forms/form-checkbox' ),
 	FormCountrySelect = require( 'components/forms/form-country-select' ),
+	FormCurrencyInput = require( 'components/forms/form-currency-input' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
 	FormLabel = require( 'components/forms/form-label' ),
@@ -252,6 +253,16 @@ var FormFields = React.createClass( {
 					<FormFieldset>
 						<FormLabel>Form Media Phone Input</FormLabel>
 						<PhoneInput countryCode={ this.state.phoneInput.countryCode } value={ this.state.phoneInput.value } countriesList={ countriesList } onChange={ this.handlePhoneInputChange } />
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="currency_input">Form Currency Input</FormLabel>
+						<FormCurrencyInput
+							name="currency_input"
+							id="currency_input"
+							currencySymbolPrefix="$"
+							placeholder="Placeholder text..."
+						/>
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+
+export default function FormCurrencyInput( {
+	className,
+	currencySymbolPrefix,
+	currencySymbolSuffix,
+	...props
+} ) {
+	const classes = classNames( 'form-currency-input', className );
+
+	return (
+		<FormTextInputWithAffixes
+			{ ...props }
+			type="number"
+			className={ classes }
+			prefix={ currencySymbolPrefix }
+			suffix={ currencySymbolSuffix }
+		/>
+	);
+}
+

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -1,0 +1,13 @@
+.form-currency-input {
+	-webkit-appearance: none;
+
+	&:not( :focus ) {
+		&.is-error {
+			border-color: $alert-red;
+		}
+
+		&.is-error:hover {
+			border-color: darken( $alert-red, 10 );
+		}
+	}
+}


### PR DESCRIPTION
This adds a form-currency-input component, much like form-tel-component, which is designed to handle multiple forms of currency in a convenient component.

Note: This component relies on the local browser handling an input of type="number" to ensure a numeric input. It does not by itself restrict numeric formatting issues (trailing zeroes after the decimal, leading zeroes before the decimal, more than 2 places used after the decimal). The reason for this is because there may be cases where 1/10 of a cent might be used, or other special formatting needs. These can be easily handled by using this component as a controlled component and handling them within React state or Redux state reducer.

To Test:
Build and go to /devdocs/design and verify operation there.