### PR TITLE
SEO Tools: Fix removal of custom title formatting

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -315,9 +315,25 @@ export const SeoForm = React.createClass( {
 			updatedOptions.advanced_seo_front_page_description = this.state.frontPageMetaDescription;
 		}
 
+		// Replace empty arrays with empty strings to fix custom format deletion bug.
+		updatedOptions.advanced_seo_title_formats = this.prepareEmptyFormats( updatedOptions.advanced_seo_title_formats );
+
 		this.props.saveSiteSettings( siteId, updatedOptions );
 
 		this.trackSubmission();
+	},
+
+	// Empty arrays for title formats were not working properly with saveSiteSettings.
+	// We are replacing them with empty strings here to allow users to delete custom title formats.
+	prepareEmptyFormats( updatedTitleFormats ) {
+		const emptyFormatTypes = pickBy(
+			updatedTitleFormats,
+			( titleFormat ) => Array.isArray( titleFormat ) && titleFormat.length === 0
+		);
+
+		Object.keys( emptyFormatTypes ).forEach( ( type ) => emptyFormatTypes[ type ] = '' );
+
+		return Object.assign( {}, updatedTitleFormats, emptyFormatTypes );
 	},
 
 	trackSubmission() {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -317,13 +317,13 @@ export const SeoForm = React.createClass( {
 			updatedOptions.advanced_seo_front_page_description = this.state.frontPageMetaDescription;
 		}
 
-		// Empty arrays for title formats were not working properly with saveSiteSettings.
-		// We are replacing them with empty strings here to allow users to delete custom title formats.
-		const prepareEmptyFormats = formats =>
-			mapValues( formats, format => isArray( format ) && 0 === format.length ? '' : format );
-
-		// Replace empty arrays with empty strings to fix custom format deletion bug.
-		updatedOptions.advanced_seo_title_formats = prepareEmptyFormats( updatedOptions.advanced_seo_title_formats );
+		// Since the absence of data indicates that there are no changes in the network request
+		// we need to send an indicator that we specifically want to clear the format
+		// We will pass an empty string in this case.
+		updatedOptions.advanced_seo_title_formats = mapValues(
+			updatedOptions.advanced_seo_title_formats,
+			format => isArray( format ) && 0 === format.length ? '' : format,
+		);
 
 		this.props.saveSiteSettings( siteId, updatedOptions );
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -7,8 +7,10 @@ import { Set } from 'immutable';
 import {
 	get,
 	includes,
+	isArray,
 	isEqual,
 	isString,
+	mapValues,
 	omit,
 	overSome,
 	pickBy,
@@ -315,25 +317,17 @@ export const SeoForm = React.createClass( {
 			updatedOptions.advanced_seo_front_page_description = this.state.frontPageMetaDescription;
 		}
 
+		// Empty arrays for title formats were not working properly with saveSiteSettings.
+		// We are replacing them with empty strings here to allow users to delete custom title formats.
+		const prepareEmptyFormats = formats =>
+			mapValues( formats, format => isArray( format ) && 0 === format.length ? '' : format );
+
 		// Replace empty arrays with empty strings to fix custom format deletion bug.
-		updatedOptions.advanced_seo_title_formats = this.prepareEmptyFormats( updatedOptions.advanced_seo_title_formats );
+		updatedOptions.advanced_seo_title_formats = prepareEmptyFormats( updatedOptions.advanced_seo_title_formats );
 
 		this.props.saveSiteSettings( siteId, updatedOptions );
 
 		this.trackSubmission();
-	},
-
-	// Empty arrays for title formats were not working properly with saveSiteSettings.
-	// We are replacing them with empty strings here to allow users to delete custom title formats.
-	prepareEmptyFormats( updatedTitleFormats ) {
-		const emptyFormatTypes = pickBy(
-			updatedTitleFormats,
-			( titleFormat ) => Array.isArray( titleFormat ) && titleFormat.length === 0
-		);
-
-		Object.keys( emptyFormatTypes ).forEach( ( type ) => emptyFormatTypes[ type ] = '' );
-
-		return Object.assign( {}, updatedTitleFormats, emptyFormatTypes );
 	},
 
 	trackSubmission() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/10003

Previously, it was not possible to delete existing custom title formats.
This was caused because passed empty format arrays were discarded
by `saveSiteSettings`. These are now replaced with empty strings instead,
in order for them to be correctly transmitted to API.

Test with: D5298-code
For Jetpack sites test with: ~https://github.com/Automattic/jetpack/pull/7044~ (merged)