### PR TITLE
Reader: Preserve line breaks during optimistic comment save

### DIFF
--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -8,7 +8,11 @@ export default class PostCommentContent extends React.Component {
 	render() {
 		// Don't trust comment content unless it was provided by the API
 		if ( this.props.isPlaceholder ) {
-			return <div className="comments__comment-content">{ this.props.content }</div>;
+			return <div className="comments__comment-content">{
+				this.props.content.split( '\n' ).map( ( item, key ) => {
+					return <span key={ key }>{ item }<br /></span>;
+				} )
+			}</div>;
 		}
 
 		/*eslint-disable react/no-danger*/

--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -8,11 +8,11 @@ export default class PostCommentContent extends React.Component {
 	render() {
 		// Don't trust comment content unless it was provided by the API
 		if ( this.props.isPlaceholder ) {
-			return <div className="comments__comment-content">{
+			return ( <div className="comments__comment-content">{
 				this.props.content.split( '\n' ).map( ( item, key ) => {
 					return <span key={ key }>{ item }<br /></span>;
 				} )
-			}</div>;
+			}</div> );
 		}
 
 		/*eslint-disable react/no-danger*/


### PR DESCRIPTION
This applies newline formatting to comments during the save process.

See #924

Steps to test are the same as documented in the issue:

1. Open a single post in the Reader
2. Add a multi-line comment
3. Submit the comment and watch where it is inserted into the page - it should immediately appear with multiple lines, not collapsed into a single line of text.
