### PR TITLE
Framework: Refactor siteUtils.getDefaultPostFormat to use a selector

### DIFF
--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -30,20 +30,6 @@ export default {
 		return site && site.options ? site.options.gmt_offset : null;
 	},
 
-	getDefaultPostFormat( site ) {
-		if ( ! site ) {
-			return;
-		}
-
-		if ( site.settings ) {
-			return site.settings.default_post_format;
-		}
-
-		if ( site.options ) {
-			return site.options.default_post_format;
-		}
-	},
-
 	getSiteFileModDisableReason( site, action = 'modifyFiles' ) {
 		if ( ! site || ! site.options || ! site.options.file_mod_disabled ) {
 			return;

--- a/client/post-editor/editor-post-formats/accordion.jsx
+++ b/client/post-editor/editor-post-formats/accordion.jsx
@@ -11,21 +11,22 @@ import classNames from 'classnames';
  */
 import Accordion from 'components/accordion';
 import QueryPostFormats from 'components/data/query-post-formats';
-import siteUtils from 'lib/site/utils';
 import PostFormats from './';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getPostFormats } from 'state/post-formats/selectors';
+import { getSiteDefaultPostFormat } from 'state/selectors';
 
 const EditorPostFormatsAccordion = React.createClass( {
 	propTypes: {
 		siteId: PropTypes.number,
 		site: PropTypes.object,
 		post: PropTypes.object,
-		postFormats: PropTypes.object
+		postFormats: PropTypes.object,
+		defaultPostFormat: PropTypes.string,
 	},
 
 	getFormatValue() {
-		const { post, site } = this.props;
+		const { post, defaultPostFormat } = this.props;
 		if ( ! post ) {
 			return;
 		}
@@ -34,7 +35,7 @@ const EditorPostFormatsAccordion = React.createClass( {
 			return post.format;
 		}
 
-		return siteUtils.getDefaultPostFormat( site );
+		return defaultPostFormat;
 	},
 
 	getSubtitle() {
@@ -83,7 +84,8 @@ export default connect(
 		return {
 			siteId,
 			site: getSelectedSite( state ),
-			postFormats: getPostFormats( state, siteId )
+			postFormats: getPostFormats( state, siteId ),
+			defaultPostFormat: getSiteDefaultPostFormat( state, siteId ),
 		};
 	}
 )( EditorPostFormatsAccordion );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1406,7 +1406,10 @@ describe( 'selectors', () => {
 							}
 						}
 					}
-				}
+				},
+				siteSettings: {
+					items: {},
+				},
 			}, 2916284, 841 );
 
 			expect( previewUrl ).to.equal( 'https://example.wordpress.com/post-url' );

--- a/client/state/selectors/get-site-default-post-format.js
+++ b/client/state/selectors/get-site-default-post-format.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { getRawSite, getSiteOption } from 'state/sites/selectors';
+
+/**
+ * Returns the default post format of a site.
+ * Returns null if the site is unknown.
+ *
+ * @param  {Object}    state   Global state tree
+ * @param  {Number}    siteId  The ID of the site we're querying
+ * @return {?String}           The default post format of that site
+ */
+export default function getSiteDefaultPostFormat( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	let defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
+	if ( ! defaultPostFormat || defaultPostFormat === '0' ) {
+		defaultPostFormat = 'standard';
+	}
+
+	return defaultPostFormat;
+}

--- a/client/state/selectors/get-site-default-post-format.js
+++ b/client/state/selectors/get-site-default-post-format.js
@@ -18,12 +18,12 @@ import { getSiteSettings } from 'state/site-settings/selectors';
  * @return {?String}           The default post format of that site
  */
 export default function getSiteDefaultPostFormat( state, siteId ) {
-	const site = getRawSite( state, siteId );
-	if ( ! site ) {
+	const siteSettings = getSiteSettings( state, siteId );
+	if ( ! siteSettings && ! getRawSite( state, siteId ) ) {
 		return null;
 	}
 
-	let defaultPostFormat = get( getSiteSettings( state, siteId ), 'default_post_format' );
+	let defaultPostFormat = get( siteSettings, 'default_post_format' );
 	if ( ! defaultPostFormat ) {
 		defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
 	}

--- a/client/state/selectors/get-site-default-post-format.js
+++ b/client/state/selectors/get-site-default-post-format.js
@@ -1,7 +1,13 @@
 /**
+ * External
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { getRawSite, getSiteOption } from 'state/sites/selectors';
+import { getSiteSettings } from 'state/site-settings/selectors';
 
 /**
  * Returns the default post format of a site.
@@ -17,7 +23,11 @@ export default function getSiteDefaultPostFormat( state, siteId ) {
 		return null;
 	}
 
-	let defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
+	let defaultPostFormat = get( getSiteSettings( state, siteId ), 'default_post_format' );
+	if ( ! defaultPostFormat ) {
+		defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
+	}
+
 	if ( ! defaultPostFormat || defaultPostFormat === '0' ) {
 		defaultPostFormat = 'standard';
 	}

--- a/client/state/selectors/get-site-default-post-format.js
+++ b/client/state/selectors/get-site-default-post-format.js
@@ -11,7 +11,7 @@ import { getSiteSettings } from 'state/site-settings/selectors';
 
 /**
  * Returns the default post format of a site.
- * Returns null if the site is unknown.
+ * Returns null if the site is unknown and settings have not been fetched.
  *
  * @param  {Object}    state   Global state tree
  * @param  {Number}    siteId  The ID of the site we're querying

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -69,6 +69,7 @@ export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getSharingButtons from './get-sharing-buttons';
 export getSiteConnectionStatus from './get-site-connection-status';
+export getSiteDefaultPostFormat from './get-site-default-post-format';
 export getSiteGmtOffset from './get-site-gmt-offset';
 export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';

--- a/client/state/selectors/test/are-all-sites-single-user.js
+++ b/client/state/selectors/test/are-all-sites-single-user.js
@@ -33,7 +33,10 @@ describe( 'areAllSitesSingleUser()', () => {
 						single_user_site: false
 					}
 				}
-			}
+			},
+			siteSettings: {
+				items: {},
+			},
 		};
 
 		const allAreSingleUser = areAllSitesSingleUser( state );
@@ -53,7 +56,10 @@ describe( 'areAllSitesSingleUser()', () => {
 						single_user_site: true
 					}
 				}
-			}
+			},
+			siteSettings: {
+				items: {},
+			},
 		};
 
 		const allAreSingleUser = areAllSitesSingleUser( state );

--- a/client/state/selectors/test/get-site-default-post-format.js
+++ b/client/state/selectors/test/get-site-default-post-format.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteDefaultPostFormat } from '../';
+
+describe( 'getSiteDefaultPostFormat()', () => {
+	const siteId = 2916284;
+
+	it( 'should return default post format for a known site', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: {
+						options: {
+							default_post_format: 'image',
+						}
+					},
+				}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.eql( 'image' );
+	} );
+
+	it( 'should return standard if post format is set to 0', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: {
+						options: {
+							default_post_format: '0',
+						}
+					},
+				}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.eql( 'standard' );
+	} );
+
+	it( 'should return standard if post format is missing for a known site', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: {
+						options: {
+							exampleOption: 'exampleValue',
+						}
+					},
+				}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.eql( 'standard' );
+	} );
+
+	it( 'should return null for an unknown site', () => {
+		const state = {
+			sites: {
+				items: {
+					77203074: {
+						options: {
+							default_post_format: 'image',
+						}
+					},
+				}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.be.null;
+	} );
+} );

--- a/client/state/selectors/test/get-site-default-post-format.js
+++ b/client/state/selectors/test/get-site-default-post-format.js
@@ -11,7 +11,7 @@ import { getSiteDefaultPostFormat } from '../';
 describe( 'getSiteDefaultPostFormat()', () => {
 	const siteId = 2916284;
 
-	it( 'should return default post format for a known site', () => {
+	it( 'should return default post format for a known site when settings have not been fetched', () => {
 		const state = {
 			sites: {
 				items: {
@@ -27,7 +27,24 @@ describe( 'getSiteDefaultPostFormat()', () => {
 		expect( output ).to.eql( 'image' );
 	} );
 
-	it( 'should prioritize default post format from settings', () => {
+	it( 'should return default post format when settings have been fetched and site is unknown', () => {
+		const state = {
+			siteSettings: {
+				items: {
+					[ siteId ]: {
+						default_post_format: 'aside',
+					},
+				},
+			},
+			sites: {
+				items: {}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.eql( 'aside' );
+	} );
+
+	it( 'should prioritize default post format from settings over post format from sites', () => {
 		const state = {
 			siteSettings: {
 				items: {
@@ -66,6 +83,22 @@ describe( 'getSiteDefaultPostFormat()', () => {
 		expect( output ).to.eql( 'standard' );
 	} );
 
+	it( 'should return standard if post format is set to an empty string', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: {
+						options: {
+							default_post_format: '',
+						}
+					},
+				}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.eql( 'standard' );
+	} );
+
 	it( 'should return standard if post format is missing for a known site', () => {
 		const state = {
 			sites: {
@@ -82,7 +115,26 @@ describe( 'getSiteDefaultPostFormat()', () => {
 		expect( output ).to.eql( 'standard' );
 	} );
 
-	it( 'should return null for an unknown site', () => {
+	it( 'should return standard if settings are fetched, but post format option is missing', () => {
+		const state = {
+			siteSettings: {
+				items: {
+					[ siteId ]: {
+						options: {
+							some_option: 'example',
+						}
+					},
+				},
+			},
+			sites: {
+				items: {}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.eql( 'standard' );
+	} );
+
+	it( 'should return null for an unknown site when settings have not been fetched', () => {
 		const state = {
 			sites: {
 				items: {

--- a/client/state/selectors/test/get-site-default-post-format.js
+++ b/client/state/selectors/test/get-site-default-post-format.js
@@ -13,9 +13,6 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return default post format for a known site', () => {
 		const state = {
-			siteSettings: {
-				items: {},
-			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -55,9 +52,6 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return standard if post format is set to 0', () => {
 		const state = {
-			siteSettings: {
-				items: {},
-			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -74,9 +68,6 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return standard if post format is missing for a known site', () => {
 		const state = {
-			siteSettings: {
-				items: {},
-			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -93,9 +84,6 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return null for an unknown site', () => {
 		const state = {
-			siteSettings: {
-				items: {},
-			},
 			sites: {
 				items: {
 					77203074: {

--- a/client/state/selectors/test/get-site-default-post-format.js
+++ b/client/state/selectors/test/get-site-default-post-format.js
@@ -13,6 +13,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return default post format for a known site', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -27,8 +30,34 @@ describe( 'getSiteDefaultPostFormat()', () => {
 		expect( output ).to.eql( 'image' );
 	} );
 
+	it( 'should prioritize default post format from settings', () => {
+		const state = {
+			siteSettings: {
+				items: {
+					[ siteId ]: {
+						default_post_format: 'aside',
+					},
+				},
+			},
+			sites: {
+				items: {
+					[ siteId ]: {
+						options: {
+							default_post_format: 'image',
+						}
+					},
+				}
+			}
+		};
+		const output = getSiteDefaultPostFormat( state, siteId );
+		expect( output ).to.eql( 'aside' );
+	} );
+
 	it( 'should return standard if post format is set to 0', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -45,6 +74,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return standard if post format is missing for a known site', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -61,6 +93,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return null for an unknown site', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					77203074: {

--- a/client/state/selectors/test/get-site-default-post-format.js
+++ b/client/state/selectors/test/get-site-default-post-format.js
@@ -13,6 +13,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return default post format for a known site when settings have not been fetched', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -21,7 +24,7 @@ describe( 'getSiteDefaultPostFormat()', () => {
 						}
 					},
 				}
-			}
+			},
 		};
 		const output = getSiteDefaultPostFormat( state, siteId );
 		expect( output ).to.eql( 'image' );
@@ -69,6 +72,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return standard if post format is set to 0', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -85,6 +91,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return standard if post format is set to an empty string', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -101,6 +110,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return standard if post format is missing for a known site', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					[ siteId ]: {
@@ -136,6 +148,9 @@ describe( 'getSiteDefaultPostFormat()', () => {
 
 	it( 'should return null for an unknown site when settings have not been fetched', () => {
 		const state = {
+			siteSettings: {
+				items: {},
+			},
 			sites: {
 				items: {
 					77203074: {

--- a/client/state/selectors/test/get-sites.js
+++ b/client/state/selectors/test/get-sites.js
@@ -42,7 +42,10 @@ describe( 'getSites()', () => {
 						}
 					}
 				}
-			}
+			},
+			siteSettings: {
+				items: {},
+			},
 		};
 		const sites = getSites( state );
 		expect( sites ).to.have.length( 2 );

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -42,7 +42,10 @@ describe( 'getVisibleSites()', () => {
 						}
 					}
 				}
-			}
+			},
+			siteSettings: {
+				items: {},
+			},
 		};
 		const sites = getVisibleSites( state );
 		expect( sites ).to.eql( [

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -116,7 +116,10 @@ describe( 'selectors', () => {
 								URL: 'https://example.wordpress.com'
 							}
 						}
-					}
+					},
+					siteSettings: {
+						items: {},
+					},
 				} );
 
 				it( 'returns a new sitePlanObject', () => {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -31,6 +31,7 @@ import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
+import { getSiteDefaultPostFormat } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -83,16 +84,10 @@ export function computeSiteOptions( state, siteId ) {
 	const isWpcomMappedDomain = getSiteOption( state, siteId, 'is_mapped_domain' ) && ! isJetpackSite( state, siteId );
 	const wpcomUrl = withoutHttp( getSiteOption( state, siteId, 'unmapped_url' ) );
 
-	// The 'standard' post format is saved as an option of '0'
-	let defaultPostFormat = getSiteOption( state, siteId, 'default_post_format' );
-	if ( ! defaultPostFormat || defaultPostFormat === '0' ) {
-		defaultPostFormat = 'standard';
-	}
-
 	return {
 		...site.options,
 		...isWpcomMappedDomain && { wpcom_url: wpcomUrl },
-		default_post_format: defaultPostFormat
+		default_post_format: getSiteDefaultPostFormat( state, siteId ),
 	};
 }
 

--- a/client/state/sites/test/enhancer.js
+++ b/client/state/sites/test/enhancer.js
@@ -26,7 +26,10 @@ const EXAMPLE_SITE = {
 
 describe( 'sitesSync()', () => {
 	let sitesListFactory, Site, store, sitesList;
-	const state = { sites: { items: {} } };
+	const state = {
+		sites: { items: {} },
+		siteSettings: { items: {} },
+	};
 
 	useFakeDom();
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -94,7 +94,10 @@ describe( 'selectors', () => {
 							}
 						}
 					}
-				}
+				},
+				siteSettings: {
+					items: {},
+				},
 			}, 2916284 );
 
 			expect( site ).to.eql( {
@@ -138,7 +141,10 @@ describe( 'selectors', () => {
 							}
 						}
 					}
-				}
+				},
+				siteSettings: {
+					items: {},
+				},
 			}, 2916284 );
 
 			expect( siteOptions ).to.eql( {
@@ -162,7 +168,10 @@ describe( 'selectors', () => {
 							}
 						}
 					}
-				}
+				},
+				siteSettings: {
+					items: {},
+				},
 			}, 2916284 );
 
 			expect( siteOptions ).to.eql( {
@@ -258,7 +267,10 @@ describe( 'selectors', () => {
 					items: {
 						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', single_user_site: true }
 					}
-				}
+				},
+				siteSettings: {
+					items: {},
+				},
 			}, 77203074 );
 
 			expect( singleUserSite ).to.be.true;
@@ -270,7 +282,10 @@ describe( 'selectors', () => {
 					items: {
 						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', single_user_site: false }
 					}
-				}
+				},
+				siteSettings: {
+					items: {},
+				},
 			}, 77203074 );
 
 			expect( singleUserSite ).to.be.false;

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -37,6 +37,9 @@ describe( 'selectors', () => {
 						2916284: { ID: 2916284, name: 'WordPress.com Example Blog', URL: 'https://example.com' }
 					}
 				},
+				siteSettings: {
+					items: {},
+				},
 				ui: {
 					selectedSiteId: 2916284
 				}


### PR DESCRIPTION
This PR removes `siteUtils.getDefaultPostFormat` and introduces a selector instead. Since this one is used only in one place, this PR also migrates that usage and removes the obsolete `siteUtils.getDefaultPostFormat` definition.

To test:
* Checkout this branch.
* Go to `http://calypso.localhost:3000/post/:site` for a site that has `'standard'` default post format and verify it's set properly when creating a post for that site.
* Go to `http://calypso.localhost:3000/post/:site` for a site that has another default post format (for example `'aside'` and verify it's set properly when creating a post for that site.
* Go to `http://calypso.localhost:3000/post/:site` for a site with default post format set to `'0'` and verify it's set properly when creating a post for that site.
* Go to `http://calypso.localhost:3000/post/:site` for a site with no default post format specified and verify it's set properly when creating a post for that site.
* Verify the tests of the new selector pass: `npm run test-client client/state/selectors/test/get-site-default-post-format.js`
* Verify the site selectors test still pass: `npm run test-client client/state/sites/test/selectors.js `

**Hint:** Want to quickly update your post format? Go to `/wp-admin/options.php` and change the `default_post_format` option manually.