### PR TITLE
Fix MediaSettings lint/style issues

### DIFF
--- a/client/my-sites/site-settings/composing/after-the-deadline.jsx
+++ b/client/my-sites/site-settings/composing/after-the-deadline.jsx
@@ -182,8 +182,8 @@ class AfterTheDeadline extends Component {
 
 				<div className="composing__module-settings site-settings__child-settings">
 					<div className="composing__info-link-container site-settings__info-link-container">
-						<InfoPopover position={ 'left' }>
-							<ExternalLink href={ 'https://jetpack.com/support/spelling-and-grammar/' } icon target="_blank">
+						<InfoPopover position="left">
+							<ExternalLink href="https://jetpack.com/support/spelling-and-grammar/" icon target="_blank">
 								{ translate( 'Learn more about After the Deadline.' ) }
 							</ExternalLink>
 						</InfoPopover>

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -123,8 +123,8 @@ class CustomContentTypes extends Component {
 				<Card className="custom-content-types__card site-settings">
 					<FormFieldset>
 						<div className="custom-content-types__info-link-container site-settings__info-link-container">
-							<InfoPopover position={ 'left' }>
-								<ExternalLink href={ 'https://support.wordpress.com/custom-post-types/' } icon target="_blank">
+							<InfoPopover position="left">
+								<ExternalLink href="https://support.wordpress.com/custom-post-types/" icon target="_blank">
 									{ translate( 'Learn more about Custom Content Types.' ) }
 								</ExternalLink>
 							</InfoPopover>

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -132,8 +132,8 @@ class SiteSettingsFormJetpackMonitor extends Component {
 
 				<Card className="jetpack-monitor-settings">
 					<div className="site-settings__info-link-container">
-						<InfoPopover position={ 'left' }>
-							<ExternalLink href={ 'https://jetpack.com/support/monitor/' } icon target="_blank">
+						<InfoPopover position="left">
+							<ExternalLink href="https://jetpack.com/support/monitor/" icon target="_blank">
 								{ translate( 'Learn more about Monitor.' ) }
 							</ExternalLink>
 						</InfoPopover>

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -126,8 +126,8 @@ class JetpackSiteStats extends Component {
 				>
 					<FormFieldset>
 						<div className="site-settings__info-link-container">
-							<InfoPopover position={ 'left' }>
-								<ExternalLink href={ 'https://jetpack.com/support/wordpress-com-stats/' } target="_blank">
+							<InfoPopover position="left">
+								<ExternalLink href="https://jetpack.com/support/wordpress-com-stats/" target="_blank">
 									{ translate( 'Learn more about WordPress.com Stats' ) }
 								</ExternalLink>
 							</InfoPopover>

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -31,8 +31,8 @@ const Masterbar = ( {
 			<Card className="masterbar__card site-settings__security-settings">
 				<FormFieldset>
 					<div className="masterbar__info-link-container site-settings__info-link-container">
-						<InfoPopover position={ 'left' }>
-							<ExternalLink href={ 'https://jetpack.com/support/masterbar/' } icon target="_blank">
+						<InfoPopover position="left">
+							<ExternalLink href="https://jetpack.com/support/masterbar/" icon target="_blank">
 								{ translate( 'Learn more about the WordPress.com Toolbar.' ) }
 							</ExternalLink>
 						</InfoPopover>

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -45,8 +45,8 @@ const MediaSettings = ( {
 
 			<FormFieldset>
 				<div className="media-settings__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink target="_blank" icon={ true } href={ 'https://jetpack.com/support/photon' } >
+					<InfoPopover position="left">
+						<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/photon" >
 							{ translate( 'Learn more about Photon.' ) }
 						</ExternalLink>
 					</InfoPopover>
@@ -61,8 +61,8 @@ const MediaSettings = ( {
 			</FormFieldset>
 			<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
 				<div className="media-settings__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink target="_blank" icon={ true } href={ 'https://jetpack.com/support/carousel' } >
+					<InfoPopover position="left">
+						<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/carousel" >
 							{ translate( 'Learn more about Carousel.' ) }
 						</ExternalLink>
 					</InfoPopover>

--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -113,8 +113,8 @@ class Protect extends Component {
 				<FormFieldset>
 					<div className="protect__module-settings site-settings__child-settings">
 						<div className="protect__info-link-container site-settings__info-link-container">
-							<InfoPopover position={ 'left' }>
-								<ExternalLink href={ 'https://jetpack.com/support/protect' } target="_blank">
+							<InfoPopover position="left">
+								<ExternalLink href="https://jetpack.com/support/protect" target="_blank">
 									{ translate( 'Learn more about Jetpack protect' ) }
 								</ExternalLink>
 							</InfoPopover>

--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -102,8 +102,8 @@ class PublishingTools extends Component {
 		return (
 			<FormFieldset>
 				<div className="publishing-tools__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/post-by-email/' } icon target="_blank">
+					<InfoPopover position="left">
+						<ExternalLink href="https://jetpack.com/support/post-by-email/" icon target="_blank">
 							{ translate( 'Learn more about Post by Email.' ) }
 						</ExternalLink>
 					</InfoPopover>

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -53,7 +53,7 @@ class Sitemaps extends Component {
 
 		return (
 			<div className="sitemaps__info-link-container site-settings__info-link-container">
-				<InfoPopover position={ 'left' }>
+				<InfoPopover position="left">
 					<ExternalLink href={ url } icon target="_blank">
 						{ translate( 'Learn more about Sitemaps.' ) }
 					</ExternalLink>

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -39,8 +39,8 @@ const Sso = ( {
 			<Card className="sso__card site-settings__security-settings">
 				<FormFieldset>
 					<div className="sso__info-link-container site-settings__info-link-container">
-						<InfoPopover position={ 'left' }>
-							<ExternalLink href={ 'https://jetpack.com/support/sso' } icon target="_blank">
+						<InfoPopover position="left">
+							<ExternalLink href="https://jetpack.com/support/sso" icon target="_blank">
 								{ translate( 'Learn more about WordPress.com Secure Sign On.' ) }
 							</ExternalLink>
 						</InfoPopover>

--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -40,8 +40,8 @@ const Subscriptions = ( {
 			<CompactCard className="subscriptions__card site-settings__discussion-settings">
 				<FormFieldset>
 					<div className="subscriptions__info-link-container site-settings__info-link-container">
-						<InfoPopover position={ 'left' }>
-							<ExternalLink href={ 'https://jetpack.com/support/subscriptions' } icon target="_blank">
+						<InfoPopover position="left">
+							<ExternalLink href="https://jetpack.com/support/subscriptions" icon target="_blank">
 								{ translate( 'Learn more about Subscriptions.' ) }
 							</ExternalLink>
 						</InfoPopover>

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -85,8 +85,8 @@ class ThemeEnhancements extends Component {
 				</FormLegend>
 
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/infinite-scroll' } icon target="_blank">
+					<InfoPopover position="left">
+						<ExternalLink href="https://jetpack.com/support/infinite-scroll" icon target="_blank">
 							{ translate( 'Learn more about Infinite Scroll.' ) }
 						</ExternalLink>
 					</InfoPopover>
@@ -122,8 +122,8 @@ class ThemeEnhancements extends Component {
 		return (
 			<FormFieldset>
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
-					<InfoPopover position={ 'left' }>
-						<ExternalLink href={ 'https://jetpack.com/support/mobile-theme' } icon target="_blank">
+					<InfoPopover position="left">
+						<ExternalLink href="https://jetpack.com/support/mobile-theme" icon target="_blank">
 							{ translate( 'Learn more about Mobile Theme.' ) }
 						</ExternalLink>
 					</InfoPopover>

--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -26,7 +26,7 @@ let ThemeSetup = ( { site, themeId, theme, translate, activeSiteDomain, toggleDi
 	return (
 		<div className="main theme-setup" role="main">
 			{ site && <QueryActiveTheme siteId={ site.ID } /> }
-			{ themeId && <QueryTheme siteId={ 'wpcom' } themeId={ themeId } /> }
+			{ themeId && <QueryTheme siteId="wpcom" themeId={ themeId } /> }
 			<HeaderCake onClick={ onBack }><h1>{ translate( 'Theme Setup' ) }</h1></HeaderCake>
 			{ site && theme
 				? <ThemeSetupCard


### PR DESCRIPTION
Fixes #12278 

This approach to the RTL/LTR issue has been abandoned in favor of #13600.

This PR will be used to correct the simple lint issues in #12278. The only changes are of type `prop={ '...' }` -> `prop="..."`. I've limited the scope of the change to site-settings.

To test:

* Use this branch
* Test all the affected popovers in the various settings pages.
* Functionality should be identical.
* The only non-popover change is `QueryThemes` in theme settings. Ensure this query is executed properly.