### PR TITLE
Add isRtl selector

### DIFF
--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -139,6 +139,7 @@ export isRequestingSharingButtons from './is-requesting-sharing-buttons';
 export isRequestingSiteConnectionStatus from './is-requesting-site-connection-status';
 export isRequestingSiteMonitorSettings from './is-requesting-site-monitor-settings';
 export isRequestingTimezones from './is-requesting-timezones';
+export isRtl from './is-rtl';
 export isSavingSharingButtons from './is-saving-sharing-buttons';
 export isSendingBillingReceiptEmail from './is-sending-billing-receipt-email';
 export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful';

--- a/client/state/selectors/is-rtl.js
+++ b/client/state/selectors/is-rtl.js
@@ -4,7 +4,7 @@
 import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
- * Returns the isRtl value for the current user.
+ * Returns whether the current uses right-to-left directionality.
  *
  * @param  {Object}   state      Global state tree
  * @return {?Boolean}            Current user is rtl

--- a/client/state/selectors/is-rtl.js
+++ b/client/state/selectors/is-rtl.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Returns the isRtl value for the current user.
+ *
+ * @param  {Object}   state      Global state tree
+ * @return {?Boolean}            Current user is rtl
+ */
+export default function isRtl( state ) {
+	const currentUser = getCurrentUser( state );
+	if ( currentUser && 'isRTL' in currentUser ) {
+		return currentUser.isRTL;
+	}
+	return null;
+}

--- a/client/state/selectors/is-rtl.js
+++ b/client/state/selectors/is-rtl.js
@@ -11,7 +11,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
  */
 export default function isRtl( state ) {
 	const currentUser = getCurrentUser( state );
-	if ( currentUser && 'isRTL' in currentUser ) {
+	if ( currentUser && currentUser.hasOwnProperty( 'isRTL' ) ) {
 		return currentUser.isRTL;
 	}
 	return null;

--- a/client/state/selectors/test/is-rtl.js
+++ b/client/state/selectors/test/is-rtl.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isRtl } from '../';
+
+describe( 'isRtl()', () => {
+	it( 'should return null if there is no current user', () => {
+		const result = isRtl( {
+			currentUser: {
+				id: null
+			}
+		} );
+
+		expect( result ).to.be.null;
+	} );
+
+	it( 'should return null if the value is not known', () => {
+		const result = isRtl( {
+			users: {
+				items: {
+					123: { ID: 123 }
+				}
+			},
+			currentUser: {
+				id: 123
+			}
+		} );
+
+		expect( result ).to.be.null;
+	} );
+
+	it( 'should return true if the value is true', () => {
+		const result = isRtl( {
+			users: {
+				items: {
+					123: { ID: 123, isRTL: true }
+				}
+			},
+			currentUser: {
+				id: 123
+			}
+		} );
+
+		expect( result ).to.be.true;
+	} );
+
+	it( 'should return false if the value is false', () => {
+		const result = isRtl( {
+			users: {
+				items: {
+					123: { ID: 123, isRTL: false }
+				}
+			},
+			currentUser: {
+				id: 123
+			}
+		} );
+
+		expect( result ).to.be.false;
+	} );
+} );


### PR DESCRIPTION
`isRTL` may be important for positioning UI elements correctly.
There are cases where the full current user is not needed, but the
`isRTL` value is. An example is positioning of popovers.

See #12278 for an example of UI that depends on RTL.