### PR TITLE
[Sharing] Fix Connect a different account

### DIFF
--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -14,7 +14,7 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import site from 'lib/site';
+import UsersStore from 'lib/users/store';
 
 class SharingConnection extends Component {
 	static propTypes = {
@@ -126,8 +126,7 @@ class SharingConnection extends Component {
 	}
 
 	getConnectionKeyringUserLabel() {
-		const { connection, siteId, translate, userId } = this.props;
-		const keyringUser = site( { ID: siteId } ).getUser( connection.keyring_connection_user_ID );
+		const { translate, keyringUser, userId } = this.props;
 
 		if ( keyringUser && userId !== keyringUser.ID ) {
 			return (
@@ -197,11 +196,14 @@ class SharingConnection extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
+		const keyringUserId = ownProps.connection.keyring_connection_user_ID;
+		const keyringUser = keyringUserId ? UsersStore.getUser( keyringUserId ) : null;
 
 		return {
 			siteId,
+			keyringUser,
 			userHasCaps: canCurrentUser( state, siteId, 'edit_others_posts' ),
 			userId: getCurrentUserId( state ),
 		};


### PR DESCRIPTION
This PR fixes the "Connect a different account" button in Sharing as well as the "CONNECTED BY <user>" string in the same component when accessed by another user.

### Testing Instructions
- Go to https://wordpress.com/sharing and select a site
- Connect your facebook account if it's not already done
- Click on Facebook, you should see the following error in the console:
```
Uncaught TypeError: Cannot read property 'product_slug' of undefined
```
- Click on  "Connect a different account", a popup should open and close but the dialog to change your profile should not appear
- Apply this patch locally and go to `http://calypso.localhost:3000/sharing/:siteSlug` of navigate to https://calypso.live/sharing/?branch=fix/socialize-connected-by (and select a site)
- Check that the error has disappeared and that clicking on "Connect a different account" actually works

### Reviews
- [x] Product
- [x] Code
