### PR TITLE
Use i18n-calypso for translate in jetpack-connect components

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -6,10 +6,11 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import page from 'page';
 import urlModule from 'url';
-import i18n from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 const debug = require( 'debug' )( 'calypso:jetpack-connect:authorize-form' );
 import cookie from 'cookie';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -167,7 +168,7 @@ const LoggedOutForm = React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
-					{ this.translate( 'Already have an account? Sign in' ) }
+					{ i18n.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.clickHelpButton } />
 			</LoggedOutFormLinks>
@@ -186,7 +187,7 @@ const LoggedOutForm = React.createClass( {
 					submitting={ this.isSubmitting() }
 					save={ this.save }
 					submitForm={ this.submitForm }
-					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
+					submitButtonText={ i18n.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }
 					suggestedUsername={ userData && userData.username ? userData.username : '' }
 				/>
@@ -374,7 +375,7 @@ const LoggedInForm = React.createClass( {
 		const { authorizeError } = this.props.jetpackConnectAuthorize;
 		return (
 			<div className="jetpack-connect__error-details">
-				<FormLabel>{ this.translate( 'Error Details' ) }</FormLabel>
+				<FormLabel>{ i18n.translate( 'Error Details' ) }</FormLabel>
 				<FormSettingExplanation>
 					{ authorizeError.message }
 				</FormSettingExplanation>
@@ -383,18 +384,18 @@ const LoggedInForm = React.createClass( {
 	},
 
 	renderXmlrpcFeedback() {
-		const xmlrpcErrorText = this.translate( 'We had trouble connecting.' );
+		const xmlrpcErrorText = i18n.translate( 'We had trouble connecting.' );
 		return (
 			<div>
 				<div className="jetpack-connect__notices-container">
 					<Notice icon="notice" status="is-error" text={ xmlrpcErrorText } showDismiss={ false }>
 						<NoticeAction onClick={ this.handleResolve }>
-							{ this.translate( 'Try again' ) }
+							{ i18n.translate( 'Try again' ) }
 						</NoticeAction>
 					</Notice>
 				</div>
 				<p>
-					{ this.translate(
+					{ i18n.translate(
 						'WordPress.com was unable to reach your site and approve the connection. ' +
 						'Try again by clicking the button above; ' +
 						'if that doesn\'t work you may need to {{link}}contact support{{/link}}.', {
@@ -456,37 +457,37 @@ const LoggedInForm = React.createClass( {
 		if ( ! this.props.isAlreadyOnSitesList &&
 			! this.props.isFetchingSites &&
 			queryObject.already_authorized ) {
-			return this.translate( 'Go back to your site' );
+			return i18n.translate( 'Go back to your site' );
 		}
 
 		if ( authorizeError && ! this.retryingAuth ) {
-			return this.translate( 'Try again' );
+			return i18n.translate( 'Try again' );
 		}
 
 		if ( this.props.isFetchingSites ) {
-			return this.translate( 'Preparing authorization' );
+			return i18n.translate( 'Preparing authorization' );
 		}
 
 		if ( authorizeSuccess && isRedirectingToWpAdmin ) {
-			return this.translate( 'Returning to your site' );
+			return i18n.translate( 'Returning to your site' );
 		}
 
 		if ( authorizeSuccess ) {
-			return this.translate( 'Finishing up!', {
+			return i18n.translate( 'Finishing up!', {
 				context: 'Shown during a jetpack authorization process, while we retrieve the info we need to show the last page'
 			} );
 		}
 
 		if ( isAuthorizing || this.retryingAuth ) {
-			return this.translate( 'Authorizing your connection' );
+			return i18n.translate( 'Authorizing your connection' );
 		}
 
 		if ( this.props.isAlreadyOnSitesList ) {
-			return this.translate( 'Return to your site' );
+			return i18n.translate( 'Return to your site' );
 		}
 
 		if ( ! this.retryingAuth ) {
-			return this.translate( 'Approve' );
+			return i18n.translate( 'Approve' );
 		}
 	},
 
@@ -507,7 +508,7 @@ const LoggedInForm = React.createClass( {
 				className="jetpack-connect__sso-actions-modal-link" />
 		);
 
-		const text = this.translate(
+		const text = i18n.translate(
 			'By connecting your site, you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
 			{
 				components: {
@@ -528,13 +529,13 @@ const LoggedInForm = React.createClass( {
 
 	getUserText() {
 		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
-		let text = this.translate( 'Connecting as {{strong}}%(user)s{{/strong}}', {
+		let text = i18n.translate( 'Connecting as {{strong}}%(user)s{{/strong}}', {
 			args: { user: this.props.user.display_name },
 			components: { strong: <strong /> }
 		} );
 
 		if ( authorizeSuccess || this.props.isAlreadyOnSitesList ) {
-			text = this.translate( 'Connected as {{strong}}%(user)s{{/strong}}', {
+			text = i18n.translate( 'Connected as {{strong}}%(user)s{{/strong}}', {
 				args: { user: this.props.user.display_name },
 				components: { strong: <strong /> }
 			} );
@@ -564,7 +565,7 @@ const LoggedInForm = React.createClass( {
 		const backToWpAdminLink = (
 			<LoggedOutFormLinkItem icon={ true } href={ redirect_after_auth }>
 				<Gridicon size={ 18 } icon="arrow-left" />
-				{ this.translate( 'Return to %(sitename)s', {
+				{ i18n.translate( 'Return to %(sitename)s', {
 					args: { sitename: decodeEntities( blogname ) }
 				} ) }
 			</LoggedOutFormLinkItem>
@@ -579,7 +580,7 @@ const LoggedInForm = React.createClass( {
 				<LoggedOutFormLinks>
 					{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
 					<LoggedOutFormLinkItem href={ this.getRedirectionTarget() }>
-						{ this.translate( 'I\'m not interested in upgrades' ) }
+						{ i18n.translate( 'I\'m not interested in upgrades' ) }
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>
 			);
@@ -589,10 +590,10 @@ const LoggedInForm = React.createClass( {
 			<LoggedOutFormLinks>
 				{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
 				<LoggedOutFormLinkItem href={ login( { legacy: true, redirectTo } ) }>
-					{ this.translate( 'Sign in as a different user' ) }
+					{ i18n.translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
-					{ this.translate( 'Create a new account' ) }
+					{ i18n.translate( 'Create a new account' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.clickHelpButton } />
 			</LoggedOutFormLinks>
@@ -674,10 +675,10 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 			<Main className="jetpack-connect__main-error">
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-whoops.svg"
-					title={ this.translate(
+					title={ this.props.translate(
 						'Oops, this URL should not be accessed directly'
 					) }
-					action={ this.translate( 'Get back to Jetpack Connect screen' ) }
+					action={ this.props.translate( 'Get back to Jetpack Connect screen' ) }
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
@@ -736,7 +737,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 	}
 } );
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const remoteSiteUrl = getAuthorizationRemoteSite( state );
 		const siteSlug = urlToSlug( remoteSiteUrl );
@@ -772,4 +773,9 @@ export default connect(
 		retryAuth,
 		goToXmlrpcErrorFallbackUrl
 	}, dispatch )
+);
+
+export default flowRight(
+	connectComponent,
+	localize
 )( JetpackConnectAuthorizeForm );

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Gridicon from 'gridicons';
+import { flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -244,36 +246,36 @@ const JetpackConnectMain = React.createClass( {
 
 		if ( type === 'pro' || selectedPlan === 'jetpack_business' || selectedPlan === 'jetpack_business_monthly' ) {
 			return {
-				headerTitle: this.translate( 'Get Jetpack Professional' ),
-				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
+				headerTitle: this.props.translate( 'Get Jetpack Professional' ),
+				headerSubtitle: this.props.translate( 'To start securing and backing up your site, first install Jetpack, ' +
 					'then purchase and activate your plan.' ),
 			};
 		}
 		if ( type === 'premium' || selectedPlan === 'jetpack_premium' || selectedPlan === 'jetpack_premium_monthly' ) {
 			return {
-				headerTitle: this.translate( 'Get Jetpack Premium' ),
-				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
+				headerTitle: this.props.translate( 'Get Jetpack Premium' ),
+				headerSubtitle: this.props.translate( 'To start securing and backing up your site, first install Jetpack, ' +
 					'then purchase and activate your plan.' ),
 			};
 		}
 		if ( type === 'personal' || selectedPlan === 'jetpack_personal' || selectedPlan === 'jetpack_personal_monthly' ) {
 			return {
-				headerTitle: this.translate( 'Get Jetpack Personal' ),
-				headerSubtitle: this.translate( 'To start securing and backing up your site, first install Jetpack, ' +
+				headerTitle: this.props.translate( 'Get Jetpack Personal' ),
+				headerSubtitle: this.props.translate( 'To start securing and backing up your site, first install Jetpack, ' +
 					'then purchase and activate your plan.' ),
 			};
 		}
 
 		if ( type === 'install' ) {
 			return {
-				headerTitle: this.translate( 'Install Jetpack' ),
-				headerSubtitle: this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect ' +
+				headerTitle: this.props.translate( 'Install Jetpack' ),
+				headerSubtitle: this.props.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect ' +
 					'to your self-hosted WordPress site.' ),
 			};
 		}
 		return {
-			headerTitle: this.translate( 'Connect a self-hosted WordPress' ),
-			headerSubtitle: this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to ' +
+			headerTitle: this.props.translate( 'Connect a self-hosted WordPress' ),
+			headerSubtitle: this.props.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to ' +
 				'your self-hosted WordPress site.' ),
 		};
 	},
@@ -288,9 +290,9 @@ const JetpackConnectMain = React.createClass( {
 	getInstructionsData( status ) {
 		return {
 			headerTitle: ( 'notJetpack' === status )
-				? this.translate( 'Ready for installation' )
-				: this.translate( 'Ready for activation' ),
-			headerSubtitle: this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps.' ),
+				? this.props.translate( 'Ready for installation' )
+				: this.props.translate( 'Ready for activation' ),
+			headerSubtitle: this.props.translate( 'We\'ll need to send you to your site dashboard for a few manual steps.' ),
 			steps: ( 'notJetpack' === status )
 				? [ 'installJetpack', 'activateJetpackAfterInstall', 'connectJetpackAfterInstall' ]
 				: [ 'activateJetpack', 'connectJetpack' ],
@@ -298,8 +300,8 @@ const JetpackConnectMain = React.createClass( {
 				? this.installJetpack
 				: this.activateJetpack,
 			buttonText: ( 'notJetpack' === status )
-				? this.translate( 'Install Jetpack' )
-				: this.translate( 'Activate Jetpack' )
+				? this.props.translate( 'Install Jetpack' )
+				: this.props.translate( 'Activate Jetpack' )
 		};
 	},
 
@@ -307,11 +309,13 @@ const JetpackConnectMain = React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
-					{ this.translate( 'Install Jetpack manually' ) }
+					{ this.props.translate( 'Install Jetpack manually' ) }
 				</LoggedOutFormLinkItem>
 				{ this.isInstall()
 					? null
-					: <LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
+					: <LoggedOutFormLinkItem href="/start">
+						{ this.props.translate( 'Start a new site on WordPress.com' ) }
+					</LoggedOutFormLinkItem>
 				}
 				<HelpButton />
 			</LoggedOutFormLinks>
@@ -373,7 +377,7 @@ const JetpackConnectMain = React.createClass( {
 	renderNotJetpackButton() {
 		return (
 			<a className="jetpack-connect__no-jetpack-button" href="#" onClick={ this.confirmJetpackNotInstalled }>
-				{ this.translate( 'Don\'t have jetpack installed?' ) }
+				{ this.props.translate( 'Don\'t have jetpack installed?' ) }
 			</a>
 		);
 	},
@@ -382,7 +386,7 @@ const JetpackConnectMain = React.createClass( {
 		return (
 			<Button compact borderless className="jetpack-connect__back-button" onClick={ this.dismissUrl }>
 				<Gridicon icon="arrow-left" size={ 18 } />
-				{ this.translate( 'Back' ) }
+				{ this.props.translate( 'Back' ) }
 			</Button>
 		);
 	},
@@ -442,7 +446,7 @@ const JetpackConnectMain = React.createClass( {
 	}
 } );
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const getJetpackSite = ( url ) => {
 			return getJetpackSiteByUrl( state, url );
@@ -465,4 +469,8 @@ export default connect(
 		goToPluginInstall,
 		goToPluginActivation
 	}, dispatch )
+);
+export default flowRight(
+	connectComponent,
+	localize
 )( JetpackConnectMain );

--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ export default React.createClass( {
 	renderAlreadyHaveJetpackButton() {
 		return (
 			<a className="jetpack-connect__already-installed-jetpack-button" href="#" onClick={ this.confirmJetpackInstalled }>
-				{ preventWidows( this.translate( 'Already have Jetpack installed?' ) ) }
+				{ preventWidows( i18n.translate( 'Already have Jetpack installed?' ) ) }
 			</a>
 		);
 	},
@@ -39,7 +40,7 @@ export default React.createClass( {
 	renderNotJetpackButton() {
 		return (
 			<a className="jetpack-connect__no-jetpack-button" href="#" onClick={ this.confirmJetpackNotInstalled }>
-				{ preventWidows( this.translate( 'Don\'t have Jetpack installed?' ) ) }
+				{ preventWidows( i18n.translate( 'Don\'t have Jetpack installed?' ) ) }
 			</a>
 		);
 	},
@@ -55,37 +56,37 @@ export default React.createClass( {
 			onClick={ this.props.onClick } />;
 		const steps = {
 			installJetpack: {
-				title: this.translate( '1. Install Jetpack' ),
+				title: i18n.translate( '1. Install Jetpack' ),
 				text: this.props.isInstall
-					? this.translate( 'You will be redirected to your site\'s dashboard to install ' +
+					? i18n.translate( 'You will be redirected to your site\'s dashboard to install ' +
 					'Jetpack. Click the blue "Install Now" button.' )
-					: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s ' +
+					: i18n.translate( 'You will be redirected to the Jetpack plugin page on your site\'s ' +
 					'dashboard to install Jetpack. Click the blue install button.' ),
 				action: this.renderAlreadyHaveJetpackButton(),
 				example: <JetpackExampleInstall url={ this.props.currentUrl } onClick={ this.props.onClick } />
 			},
 			activateJetpackAfterInstall: {
-				title: this.translate( '2. Activate Jetpack' ),
-				text: this.translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ),
+				title: i18n.translate( '2. Activate Jetpack' ),
+				text: i18n.translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ),
 				action: null,
 				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ true } onClick={ this.props.onClick } />
 			},
 			connectJetpackAfterInstall: {
-				title: this.translate( '3. Connect Jetpack' ),
-				text: this.translate( 'Finally, click the "Connect to WordPress.com" button to finish the process.' ),
+				title: i18n.translate( '3. Connect Jetpack' ),
+				text: i18n.translate( 'Finally, click the "Connect to WordPress.com" button to finish the process.' ),
 				action: null,
 				example: jetpackConnectExample
 			},
 			activateJetpack: {
-				title: this.translate( '1. Activate Jetpack' ),
-				text: this.translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. ' +
+				title: i18n.translate( '1. Activate Jetpack' ),
+				text: i18n.translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. ' +
 					'Click the blue "Activate" link. ' ),
 				action: this.renderNotJetpackButton(),
 				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ false } onClick={ this.props.onClick } />
 			},
 			connectJetpack: {
-				title: this.translate( '2. Connect Jetpack' ),
-				text: this.translate( 'Then click the "Connect to WordPress.com" button to finish the process.' ),
+				title: i18n.translate( '2. Connect Jetpack' ),
+				text: i18n.translate( 'Then click the "Connect to WordPress.com" button to finish the process.' ),
 				action: null,
 				example: jetpackConnectExample
 			}

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -21,7 +22,7 @@ export default React.createClass( {
 		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
-			text: this.translate( 'That\'s not a valid url.' ),
+			text: i18n.translate( 'That\'s not a valid url.' ),
 			showDismiss: false
 		};
 
@@ -35,73 +36,73 @@ export default React.createClass( {
 		}
 		if ( this.props.noticeType === 'isDotCom' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
+			noticeValues.text = i18n.translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'notWordPress' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'That\'s not a WordPress site.' );
+			noticeValues.text = i18n.translate( 'That\'s not a WordPress site.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'notActiveJetpack' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'Jetpack is deactivated.' );
+			noticeValues.text = i18n.translate( 'Jetpack is deactivated.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'outdatedJetpack' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'You must update Jetpack before connecting.' );
+			noticeValues.text = i18n.translate( 'You must update Jetpack before connecting.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'jetpackIsDisconnected' ) {
 			noticeValues.icon = 'link-break';
-			noticeValues.text = this.translate( 'Jetpack is currently disconnected.' );
+			noticeValues.text = i18n.translate( 'Jetpack is currently disconnected.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'jetpackIsValid' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'plugins';
-			noticeValues.text = this.translate( 'Jetpack is connected.' );
+			noticeValues.text = i18n.translate( 'Jetpack is connected.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'notJetpack' ) {
 			noticeValues.status = 'is-noticeType';
 			noticeValues.icon = 'status';
-			noticeValues.text = this.translate( 'Jetpack couldn\'t be found.' );
+			noticeValues.text = i18n.translate( 'Jetpack couldn\'t be found.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'alreadyConnected' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
-			noticeValues.text = this.translate( 'This site is already connected!' );
+			noticeValues.text = i18n.translate( 'This site is already connected!' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'wordpress.com' ) {
-			noticeValues.text = this.translate( 'Oops, that\'s us.' );
+			noticeValues.text = i18n.translate( 'Oops, that\'s us.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'status';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'retryingAuth' ) {
-			noticeValues.text = this.translate( 'Error authorizing. Page is refreshing for an other attempt.' );
+			noticeValues.text = i18n.translate( 'Error authorizing. Page is refreshing for an other attempt.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'retryAuth' ) {
-			noticeValues.text = this.translate( 'In some cases, authorization can take a few attempts. Please try again.' );
+			noticeValues.text = i18n.translate( 'In some cases, authorization can take a few attempts. Please try again.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'secretExpired' ) {
-			noticeValues.text = this.translate( 'Oops, that took a while. You\'ll have to try again.' );
+			noticeValues.text = i18n.translate( 'Oops, that took a while. You\'ll have to try again.' );
 			noticeValues.status = 'is-error';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'defaultAuthorizeError' ) {
-			noticeValues.text = this.translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
+			noticeValues.text = i18n.translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
 				components: { link: <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer" /> }
 			} );
 			noticeValues.status = 'is-error';
@@ -109,7 +110,7 @@ export default React.createClass( {
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'alreadyConnectedByOtherUser' ) {
-			noticeValues.text = this.translate(
+			noticeValues.text = i18n.translate(
 				'This site is already connected to a different WordPress.com user, ' +
 				'you need to disconnect that user before you can connect another.'
 			);

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,18 +15,18 @@ export default React.createClass( {
 	displayName: 'JetpackPlansGrid',
 
 	renderConnectHeader() {
-		let headerText = this.translate( 'Your site is now connected!' );
-		let subheaderText = this.translate( 'Now pick a plan that\'s right for you.' );
+		let headerText = i18n.translate( 'Your site is now connected!' );
+		let subheaderText = i18n.translate( 'Now pick a plan that\'s right for you.' );
 		if ( this.props.showFirst ) {
-			headerText = this.translate( 'You are moments away from connecting your site' );
+			headerText = i18n.translate( 'You are moments away from connecting your site' );
 		}
 		if ( this.props.isLanding ) {
-			headerText = this.translate( 'Pick a plan that\'s right for you.' );
+			headerText = i18n.translate( 'Pick a plan that\'s right for you.' );
 			subheaderText = '';
 
 			if ( this.props.landingType === 'vaultpress' ) {
-				headerText = this.translate( 'Select your VaultPress plan.' );
-				subheaderText = this.translate( 'VaultPress backup and security plans are now cheaper as part of Jetpack.' );
+				headerText = i18n.translate( 'Select your VaultPress plan.' );
+				subheaderText = i18n.translate( 'VaultPress backup and security plans are now cheaper as part of Jetpack.' );
 			}
 		}
 		return (

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -9,6 +9,8 @@ import get from 'lodash/get';
 import map from 'lodash/map';
 import Gridicon from 'gridicons';
 import cookie from 'cookie';
+import { flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -157,12 +159,12 @@ const JetpackSSOForm = React.createClass( {
 		return (
 			<Notice
 				status="is-error"
-				text={ this.translate( 'Oops, something went wrong.' ) }
+				text={ this.props.translate( 'Oops, something went wrong.' ) }
 				showDismiss={ false }>
 				<NoticeAction
 					href={ get( this.props, 'blogDetails.admin_url', '#' ) }
 					onClick={ this.onTryAgainClick }>
-					{ this.translate( 'Try again' ) }
+					{ this.props.translate( 'Try again' ) }
 				</NoticeAction>
 			</Notice>
 		);
@@ -195,34 +197,34 @@ const JetpackSSOForm = React.createClass( {
 	getSharedDetailLabel( key ) {
 		switch ( key ) {
 			case 'ID':
-				key = this.translate( 'User ID', { context: 'User Field' } );
+				key = this.props.translate( 'User ID', { context: 'User Field' } );
 				break;
 			case 'login':
-				key = this.translate( 'Login', { context: 'User Field' } );
+				key = this.props.translate( 'Login', { context: 'User Field' } );
 				break;
 			case 'email':
-				key = this.translate( 'Email', { context: 'User Field' } );
+				key = this.props.translate( 'Email', { context: 'User Field' } );
 				break;
 			case 'url':
-				key = this.translate( 'URL', { context: 'User Field' } );
+				key = this.props.translate( 'URL', { context: 'User Field' } );
 				break;
 			case 'first_name':
-				key = this.translate( 'First Name', { context: 'User Field' } );
+				key = this.props.translate( 'First Name', { context: 'User Field' } );
 				break;
 			case 'last_name':
-				key = this.translate( 'Last Name', { context: 'User Field' } );
+				key = this.props.translate( 'Last Name', { context: 'User Field' } );
 				break;
 			case 'display_name':
-				key = this.translate( 'Display Name', { context: 'User Field' } );
+				key = this.props.translate( 'Display Name', { context: 'User Field' } );
 				break;
 			case 'description':
-				key = this.translate( 'Description', { context: 'User Field' } );
+				key = this.props.translate( 'Description', { context: 'User Field' } );
 				break;
 			case 'two_step_enabled':
-				key = this.translate( 'Two-Step Authentication', { context: 'User Field' } );
+				key = this.props.translate( 'Two-Step Authentication', { context: 'User Field' } );
 				break;
 			case 'external_user_id':
-				key = this.translate( 'External User ID', { context: 'User Field' } );
+				key = this.props.translate( 'External User ID', { context: 'User Field' } );
 				break;
 		}
 
@@ -232,8 +234,8 @@ const JetpackSSOForm = React.createClass( {
 	getSharedDetailValue( key, value ) {
 		if ( 'two_step_enabled' === key && value !== '' ) {
 			value = ( true === value )
-				? this.translate( 'Enabled' )
-				: this.translate( 'Disabled' );
+				? this.props.translate( 'Enabled' )
+				: this.props.translate( 'Disabled' );
 		}
 
 		return decodeEntities( value );
@@ -244,7 +246,7 @@ const JetpackSSOForm = React.createClass( {
 			<span className="jetpack-connect__sso-return-to-site">
 				<Gridicon icon="arrow-left" size={ 18 } />
 				{
-					this.translate( 'Return to %(siteName)s', {
+					this.props.translate( 'Return to %(siteName)s', {
 						args: {
 							siteName: get( this.props, 'blogDetails.title' )
 						}
@@ -257,7 +259,7 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	getTOSText() {
-		const text = this.translate(
+		const text = this.props.translate(
 			'By logging in you agree to {{detailsLink}}share details{{/detailsLink}} between WordPress.com and %(siteName)s.',
 			{
 				components: {
@@ -279,7 +281,7 @@ const JetpackSSOForm = React.createClass( {
 	},
 
 	getSubHeaderText() {
-		const text = this.translate(
+		const text = this.props.translate(
 			'To use Single Sign-On, WordPress.com needs to be able to connect to your account on %(siteName)s.', {
 				args: {
 					siteName: get( this.props, 'blogDetails.title' )
@@ -341,7 +343,7 @@ const JetpackSSOForm = React.createClass( {
 		const buttons = [
 			{
 				action: 'close',
-				label: this.translate( 'Got it', { context: 'Used in a button. Similar phrase would be, "I understand".' } )
+				label: this.props.translate( 'Got it', { context: 'Used in a button. Similar phrase would be, "I understand".' } )
 			}
 		];
 
@@ -354,7 +356,7 @@ const JetpackSSOForm = React.createClass( {
 				<div className="jetpack-connect__sso-terms-dialog-content">
 					<p className="jetpack-connect__sso-shared-details-intro">
 						{
-							this.translate(
+							this.props.translate(
 								'When you approve logging in with WordPress.com, we will send the following details to your site.'
 							)
 						}
@@ -371,10 +373,10 @@ const JetpackSSOForm = React.createClass( {
 			<Main>
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-whoops.svg"
-					title={ this.translate(
+					title={ this.props.translate(
 						'Oops, this URL should not be accessed directly'
 					) }
-					line={ this.translate(
+					line={ this.props.translate(
 						'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
 						{
 							components: {
@@ -382,7 +384,7 @@ const JetpackSSOForm = React.createClass( {
 							}
 						}
 					) }
-					action={ this.translate( 'Read Single Sign-On Documentation' ) }
+					action={ this.props.translate( 'Read Single Sign-On Documentation' ) }
 					actionURL="https://jetpack.com/support/sso/"
 				/>
 			</Main>
@@ -401,21 +403,21 @@ const JetpackSSOForm = React.createClass( {
 			<MainWrapper>
 				<div className="jetpack-connect__sso">
 					<StepHeader
-						headerText={ this.translate( 'Connect with WordPress.com' ) }
+						headerText={ this.props.translate( 'Connect with WordPress.com' ) }
 						subHeaderText={ this.getSubHeaderText() }
 					/>
 
 					{ this.renderSiteCard() }
 
 					<EmailVerificationGate
-						noticeText={ this.translate( 'You must verify your email to sign in with WordPress.com.' ) }
+						noticeText={ this.props.translate( 'You must verify your email to sign in with WordPress.com.' ) }
 						noticeStatus="is-info">
 						<Card>
 							{ user.email_verified && this.maybeRenderErrorNotice() }
 								<div className="jetpack-connect__sso-user-profile">
 									<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
 									<h3 className="jetpack-connect__sso-log-in-as">
-										{ this.translate(
+										{ this.props.translate(
 											'Log in as {{strong}}%s{{/strong}}',
 											{
 												args: user.display_name,
@@ -439,7 +441,7 @@ const JetpackSSOForm = React.createClass( {
 										primary
 										onClick={ this.onApproveSSO }
 										disabled={ this.isButtonDisabled() }>
-										{ this.translate( 'Log in' ) }
+										{ this.props.translate( 'Log in' ) }
 									</Button>
 								</LoggedOutFormFooter>
 						</Card>
@@ -447,7 +449,7 @@ const JetpackSSOForm = React.createClass( {
 
 					<LoggedOutFormLinks>
 						<LoggedOutFormLinkItem href={ this.getSignInLink() } onClick={ this.onClickSignInDifferentUser }>
-							{ this.translate( 'Sign in as a different user' ) }
+							{ this.props.translate( 'Sign in as a different user' ) }
 						</LoggedOutFormLinkItem>
 						<LoggedOutFormLinkItem
 							rel="external"
@@ -465,7 +467,7 @@ const JetpackSSOForm = React.createClass( {
 	}
 } );
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const jetpackSSO = getSSO( state );
 		return {
@@ -483,4 +485,9 @@ export default connect(
 		authorizeSSO,
 		validateSSONonce
 	}, dispatch )
+);
+
+export default flowRight(
+	connectComponent,
+	localize
 )( JetpackSSOForm );


### PR DESCRIPTION
Use `localize( Component )` and `this.props.translate` or `i18n.translate` over `this.translate`.

In some cases, `i18n.translate` has been used to limit the scope of linter-required changes.

This commit should not affect behavior, it is janitorial.

Fixes linter errors `wpcalypso/i18n-no-this-translate`.

This will be required for #12546.

To test:

Follow the various jetpack connect flows and ensure there are no regressions. These changes should be functionally equivalent to current behavior.

Depends on:

- [ ] #13366