### PR TITLE
SSR: Cache State, Take Two

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import debugFactory from 'debug';
-import Lru from 'lru';
 import startsWith from 'lodash/startsWith';
 
 /**
@@ -14,7 +13,6 @@ import ThemeSheetComponent from './main';
 import ThemeNotFoundError from './theme-not-found-error';
 import LayoutLoggedOut from 'layout/logged-out';
 import {
-	receiveTheme,
 	requestTheme,
 	setBackPath
 } from 'state/themes/actions';
@@ -22,11 +20,6 @@ import { getTheme, getThemeRequestErrors } from 'state/themes/selectors';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:themes' );
-const HOUR_IN_MS = 3600000;
-const themeDetailsCache = new Lru( {
-	max: 500,
-	maxAge: HOUR_IN_MS
-} );
 
 export function fetchThemeDetailsData( context, next ) {
 	if ( ! config.isEnabled( 'manage/themes/details' ) || ! context.isServerSide ) {
@@ -34,12 +27,10 @@ export function fetchThemeDetailsData( context, next ) {
 	}
 
 	const themeSlug = context.params.slug;
-	const theme = themeDetailsCache.get( themeSlug );
+	const theme = getTheme( context.store.getState(), 'wpcom', themeSlug );
 
 	if ( theme ) {
 		debug( 'found theme!', theme.id );
-		context.store.dispatch( receiveTheme( theme, 'wpcom' ) );
-		context.renderCacheKey = context.path + theme.timestamp;
 		return next();
 	}
 
@@ -49,7 +40,6 @@ export function fetchThemeDetailsData( context, next ) {
 			if ( ! themeDetails ) {
 				const error = getThemeRequestErrors( context.store.getState(), themeSlug, 'wpcom' );
 				debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
-				context.renderCacheKey = 'theme not found';
 				const err = {
 					status: 404,
 					message: 'Theme Not Found',
@@ -57,10 +47,6 @@ export function fetchThemeDetailsData( context, next ) {
 				};
 				return next( err );
 			}
-			debug( 'caching', themeSlug );
-			themeDetails.timestamp = Date.now();
-			context.renderCacheKey = context.path + themeDetails.timestamp;
-			themeDetailsCache.set( themeSlug, themeDetails );
 			next();
 		} )
 		.catch( next );

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -19,7 +19,6 @@ import { requestThemes, requestThemeFilters, receiveThemes, setBackPath } from '
 import { getThemesForQuery, getThemesFoundForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 import { getThemeFilters } from 'state/selectors';
-import { THEME_FILTERS_ADD } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:themes' );
 const HOUR_IN_MS = 3600000;
@@ -27,10 +26,6 @@ const themesQueryCache = new Lru( {
 	max: 500,
 	maxAge: HOUR_IN_MS
 } );
-
-// The filters cache is straight-forward since requestThemeFilters() always returns the same
-// list of all available filters.
-let filters = {};
 
 function getProps( context ) {
 	const { tier, filter, vertical, site_id: siteId } = context.params;
@@ -151,15 +146,14 @@ export function fetchThemeData( context, next ) {
 
 export function fetchThemeFilters( context, next ) {
 	const { store } = context;
-	if ( ! isEmpty( filters ) ) {
+
+	if ( ! isEmpty( getThemeFilters( store.getState() ) ) ) {
 		debug( 'found theme filters in cache' );
-		store.dispatch( { type: THEME_FILTERS_ADD, filters } );
 		return next();
 	}
 
 	const unsubscribe = store.subscribe( () => {
-		filters = getThemeFilters( store.getState() );
-		if ( ! isEmpty( filters ) ) {
+		if ( ! isEmpty( getThemeFilters( store.getState() ) ) ) {
 			unsubscribe();
 			return next();
 		}

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -99,11 +99,6 @@ export function fetchThemeData( context, next ) {
 		return next();
 	}
 
-	if ( ! isEmpty( context.query ) ) {
-		// Don't server-render URLs with query params
-		return next();
-	}
-
 	const siteId = 'wpcom';
 	const query = {
 		search: context.query.s,

--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -22,11 +22,13 @@ React components used on the server will be rendered to HTML by being passed to 
 
 ### Caching
 
-Because it is necessary to serve the redux state along with a server-rendered page, we use two levels of cache on the server: one to store raw query data, from which we can generate and serve redux state, and one to store rendered layouts.
+Because it is necessary to serve the redux state along with a server-rendered page, we use two levels of cache on the server: one to store the redux state, and one to store rendered layouts.
 
 ##### Data Cache
 
-Caching data is currently left to the controller for a [given](../client/my-sites/themes/controller.jsx) [section](../client/my-sites/theme/controller.jsx). Request timestamps are used to force expiration.
+At render time, the Redux state is [serialized and cached](../server/render/index.js), using the current path as the cache key, unless there is a query string, in which case we don't cache.
+
+This means that all data that was fetched to render a given page is available the next time the corresponding route is hit. A section controller thus only needs to check if the required data is available (using selectors), and dispatch the corresponding fetching action if it isn't; see the [themes controller](../client/my-sites/themes/controller.jsx) for an example.
 
 ##### Render Cache
 

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -17,7 +17,9 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 					route( err, req.context, next );
 				},
 				// We need 4 args so Express knows this is an error-handling middleware
+				// TODO: Ideally, there'd be a dedicated serverRenderError middleware in server/render
 				( err, req, res, next ) => { // eslint-disable-line no-unused-vars
+					req.error = err;
 					serverRender( req, res.status( err.status ) );
 				}
 			);

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -119,8 +119,8 @@ function getCurrentCommitShortChecksum() {
 }
 
 function getDefaultContext( request ) {
-	// context.path is set to req.url, see server/isomorphic-routing#getEnhancedContext()
-	const serializeCachedServerState = stateCache.get( request.url ) || {};
+	// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
+	const serializeCachedServerState = stateCache.get( request.path ) || {};
 	const cachedServerState = reducer( getInitialServerState( serializeCachedServerState ), { type: DESERIALIZE } );
 
 	const context = Object.assign( {}, request.context, {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -8,7 +8,7 @@ import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,9 @@ import utils from 'bundler/utils';
 import sectionsModule from '../../client/sections';
 import { serverRouter } from 'isomorphic-routing';
 import { serverRender } from 'render';
-import { createReduxStore } from 'state';
+import stateCache from 'state-cache';
+import { createReduxStore, reducer } from 'state';
+import { DESERIALIZE } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -37,6 +39,12 @@ const staticFiles = [
 ];
 
 const sections = sectionsModule.get();
+
+function getInitialServerState( serializedServerState ) {
+	// Bootstrapped state from a server-render
+	const serverState = reducer( serializedServerState, { type: DESERIALIZE } );
+	return pick( serverState, Object.keys( serializedServerState ) );
+}
 
 /**
  * Generates a hash of a files contents to be used as a version parameter on asset requests.
@@ -111,6 +119,10 @@ function getCurrentCommitShortChecksum() {
 }
 
 function getDefaultContext( request ) {
+	// context.path is set to req.url, see server/isomorphic-routing#getEnhancedContext()
+	const serializeCachedServerState = stateCache.get( request.url ) || {};
+	const cachedServerState = reducer( getInitialServerState( serializeCachedServerState ), { type: DESERIALIZE } );
+
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
 		urls: generateStaticUrls( request ),
@@ -126,7 +138,7 @@ function getDefaultContext( request ) {
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
-		store: createReduxStore()
+		store: createReduxStore( cachedServerState )
 	} );
 
 	context.app = {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -122,7 +122,7 @@ function getCurrentCommitShortChecksum() {
 function getDefaultContext( request ) {
 	// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
 	const serializeCachedServerState = stateCache.get( request.path ) || {};
-	const cachedServerState = getInitialServerState( serializeCachedServerState );
+	const initialServerState = getInitialServerState( serializeCachedServerState );
 
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,
@@ -139,7 +139,7 @@ function getDefaultContext( request ) {
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		devDocsURL: '/devdocs',
-		store: createReduxStore( cachedServerState )
+		store: createReduxStore( initialServerState )
 	} );
 
 	context.app = {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -121,7 +121,7 @@ function getCurrentCommitShortChecksum() {
 function getDefaultContext( request ) {
 	// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
 	const serializeCachedServerState = stateCache.get( request.path ) || {};
-	const cachedServerState = reducer( getInitialServerState( serializeCachedServerState ), { type: DESERIALIZE } );
+	const cachedServerState = getInitialServerState( serializeCachedServerState );
 
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -40,6 +40,7 @@ const staticFiles = [
 
 const sections = sectionsModule.get();
 
+// TODO: Re-use (a modified version of) client/state/initial-state#getInitialServerState here
 function getInitialServerState( serializedServerState ) {
 	// Bootstrapped state from a server-render
 	const serverState = reducer( serializedServerState, { type: DESERIALIZE } );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -8,7 +8,7 @@ import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get, pick } from 'lodash';
+import { get, isEmpty, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -120,9 +120,13 @@ function getCurrentCommitShortChecksum() {
 }
 
 function getDefaultContext( request ) {
-	// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
-	const serializeCachedServerState = stateCache.get( request.path ) || {};
-	const initialServerState = getInitialServerState( serializeCachedServerState );
+	let initialServerState = {};
+	// We don't cache routes with query params
+	if ( isEmpty( request.query ) ) {
+		// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
+		const serializeCachedServerState = stateCache.get( request.path ) || {};
+		initialServerState = getInitialServerState( serializeCachedServerState );
+	}
 
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -80,7 +80,8 @@ export function serverRender( req, res ) {
 	}
 
 	if ( config.isEnabled( 'server-side-rendering' ) && context.layout && ! context.user ) {
-		const key = context.renderCacheKey || JSON.stringify( context.layout );
+		// context.pathname doesn't include querystring, so it's a suitable cache key.
+		const key = context.pathname || JSON.stringify( context.layout );
 		Object.assign( context, render( context.layout, key ) );
 	}
 
@@ -98,7 +99,7 @@ export function serverRender( req, res ) {
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
 		// And cache on the server, too
 		const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
-		stateCache.set( context.path, serverState );
+		stateCache.set( context.pathname, serverState );
 	}
 
 	context.head = { title, metas, links };

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -17,6 +17,9 @@ import {
 	getDocumentHeadMeta,
 	getDocumentHeadLink
 } from 'state/document-head/selectors';
+import { reducer } from 'state';
+import { SERIALIZE } from 'state/action-types';
+import stateCache from 'state-cache';
 
 const debug = debugFactory( 'calypso:server-render' );
 const markupCache = new Lru( { max: 3000 } );
@@ -91,7 +94,11 @@ export function serverRender( req, res ) {
 			reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
 		}
 
+		// Send state to client. Don't we need to serialize here?
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
+		// And cache on the server, too
+		const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
+		stateCache.set( context.path, serverState );
 	}
 
 	context.head = { title, metas, links };

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -100,7 +100,7 @@ export function serverRender( req, res ) {
 			reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
 		}
 
-		// Send state to client. Don't we need to serialize here?
+		// Send state to client
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
 		// And cache on the server, too
 		if ( isEmpty( context.query ) ) {

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -81,9 +81,9 @@ export function serverRender( req, res ) {
 		context.i18nLocaleScript = '//widgets.wp.com/languages/calypso/' + context.lang + '.js';
 	}
 
-	if ( config.isEnabled( 'server-side-rendering' ) && context.layout && ! context.user ) {
+	if ( config.isEnabled( 'server-side-rendering' ) && context.layout && ! context.user && isEmpty( context.query ) ) {
 		// context.pathname doesn't include querystring, so it's a suitable cache key.
-		let key = context.pathname || JSON.stringify( context.layout );
+		let key = context.pathname;
 		if ( req.error ) {
 			key = req.error.message;
 		}

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -4,7 +4,7 @@
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
 import Lru from 'lru';
-import pick from 'lodash/pick';
+import { isEmpty, pick } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -98,8 +98,11 @@ export function serverRender( req, res ) {
 		// Send state to client. Don't we need to serialize here?
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
 		// And cache on the server, too
-		const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
-		stateCache.set( context.pathname, serverState );
+		if ( isEmpty( context.query ) ) {
+			// Don't cache if we have query params
+			const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
+			stateCache.set( context.pathname, serverState );
+		}
 	}
 
 	context.head = { title, metas, links };

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -22,7 +22,11 @@ import { SERIALIZE } from 'state/action-types';
 import stateCache from 'state-cache';
 
 const debug = debugFactory( 'calypso:server-render' );
-const markupCache = new Lru( { max: 3000 } );
+const HOUR_IN_MS = 3600000;
+const markupCache = new Lru( {
+	max: 3000,
+	maxAge: HOUR_IN_MS
+} );
 
 function bumpStat( group, name ) {
 	const statUrl = `http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_${ group }=${ name }&t=${ Math.random() }`;

--- a/server/state-cache/index.js
+++ b/server/state-cache/index.js
@@ -1,0 +1,12 @@
+/**
+ * External Dependencies
+ */
+import Lru from 'lru';
+
+const HOUR_IN_MS = 3600000;
+const stateCache = new Lru( {
+	max: 500,
+	maxAge: HOUR_IN_MS
+} );
+
+export default stateCache;


### PR DESCRIPTION
Supersedes #10988, and fixes #13352.

_tl;dr: Simplify server-side API data caching by leveraging Redux state serialization._

Previously, controllers of SSR'd sections were responsible for caching API data. But there's a better way: We're already sending Redux state to the client at server-render time, so why not also cache on the server side, and use that as the initial state when creating the Redux store for the next request (given that this is in logged-out mode, i.e. the cache key -- the route -- maps one-to-one to the state, with the exception of errors like 404s, where one error page can be enough for different invalid routes).

Furthermore, this PR removes `renderCacheKey` and just uses `context.pathname` for _markup_ cache. Previously, we were using concatenated path and API data (~state) cache timestamp as key. Creating the markup cache key isn't the section controller's responsibility now. (If we still need the timestamp, we can add it back when caching in `server/render`.)

To test:
* Restart Calypso using `DEBUG="calypso:server-render" make run`
* Verify that the theme showcase still works as before. 
* Verify that the 404 page for inexistent themes only takes up one cache slot: 
  * Logged-out, land on http://calypso.localhost:3000/theme/blah. You should get a 404
  * In the node console, you should see that your request triggered a `calypso:server-render cache miss for key +0ms Theme Not Found` (among other things)
  * Land on http://calypso.localhost:3000/theme/bleh -- no cache miss!
* Most importantly, verify that #13352 is fixed!

Questions:
* Do we want to increase [cache size](https://github.com/Automattic/wp-calypso/pull/13339/files#diff-43858cb8bd16f173b243a0584f1f83b2R8) now?
* Do we need to add back time stamps to markup cache keys? I'm not sure the old timestamps were really doing anything, since we never expired them AFAICS, so it seems we were effectively just relying on the LRU.