### PR TITLE
Calypso signup: Theme selection copy optimization test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -42,6 +42,14 @@ module.exports = {
 		},
 		defaultVariation: 'hideSurveyStep',
 	},
+	signupThemeStepCopyChanges: {
+		datestamp: '20170420',
+		variations: {
+			original: 20,
+			modified: 80,
+		},
+		defaultVariation: 'original',
+	},
 	conciergeOfferOnCancel: {
 		datestamp: '20170410',
 		variations: {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -16,7 +16,7 @@ import StepWrapper from 'signup/step-wrapper';
 import Button from 'components/button';
 import { themes } from 'lib/signup/themes-data';
 import { abtest } from 'lib/abtest';
-
+import { getCurrentUser } from 'state/current-user/selectors';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 
 class ThemeSelectionStep extends Component {
@@ -59,7 +59,8 @@ class ThemeSelectionStep extends Component {
 			<SignupThemesList
 				surveyQuestion={ this.props.chosenSurveyVertical }
 				designType={ this.props.designType || this.props.signupDependencies.designType }
-				handleScreenshotClick={ this.pickTheme } />
+				handleScreenshotClick={ this.pickTheme }
+			/>
 		);
 	}
 
@@ -80,7 +81,7 @@ class ThemeSelectionStep extends Component {
 			{ context: 'Themes step subheader in Signup' }
 		);
 
-		if ( abtest( 'signupThemeStepCopyChanges' ) === 'modified' ) {
+		if ( abtest( 'signupThemeStepCopyChanges' ) === 'modified' && this.props.currentUser == null ) {
 			let siteType = this.props.signupDependencies.designType;
 
 			switch ( siteType ) {
@@ -113,15 +114,15 @@ class ThemeSelectionStep extends Component {
 				stepContent={ this.renderThemesList() }
 				defaultDependencies={ defaultDependencies }
 				headerButton={ this.renderJetpackButton() }
-				{ ...this.props } />
+				{ ...this.props }
+			/>
 		);
 	}
 }
 
 export default connect(
-	( state ) => {
-		return {
-			chosenSurveyVertical: getSurveyVertical( state )
-		};
-	}
+	( state ) => ( {
+		chosenSurveyVertical: getSurveyVertical( state ),
+		currentUser: getCurrentUser( state )
+	} )
 )( localize( ThemeSelectionStep ) );

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -15,6 +15,7 @@ import SignupThemesList from './signup-themes-list';
 import StepWrapper from 'signup/step-wrapper';
 import Button from 'components/button';
 import { themes } from 'lib/signup/themes-data';
+import { abtest } from 'lib/abtest';
 
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 
@@ -58,8 +59,7 @@ class ThemeSelectionStep extends Component {
 			<SignupThemesList
 				surveyQuestion={ this.props.chosenSurveyVertical }
 				designType={ this.props.designType || this.props.signupDependencies.designType }
-				handleScreenshotClick={ this.pickTheme }
-			/>
+				handleScreenshotClick={ this.pickTheme } />
 		);
 	}
 
@@ -74,22 +74,46 @@ class ThemeSelectionStep extends Component {
 	render = () => {
 		const defaultDependencies = this.props.useHeadstart ? { themeSlugWithRepo: 'pub/twentysixteen' } : undefined;
 		const { translate } = this.props;
-
-		const subHeaderText = translate(
+		let headerText = translate( 'Choose a theme.' );
+		let subHeaderText = translate(
 			'No need to overthink it. You can always switch to a different theme later.',
 			{ context: 'Themes step subheader in Signup' }
 		);
 
+		if ( abtest( 'signupThemeStepCopyChanges' ) === 'modified' ) {
+			let siteType = this.props.signupDependencies.designType;
+
+			switch ( siteType ) {
+				case 'blog':
+					siteType = 'blog';
+					break;
+				case 'grid':
+					siteType = 'portfolio';
+					break;
+				case 'page':
+					siteType = 'website';
+					break;
+				case undefined:
+					siteType = '';
+					break;
+				default:
+					siteType = 'website';
+			}
+
+			// Note: Don't make this translatable because it's only visible to English-language users
+			headerText = 'Here are our most popular ' + siteType + ' designs.';
+			subHeaderText = 'Pick one of these to get started or choose from hundreds more once your account is created.';
+		}
+
 		return (
 			<StepWrapper
-				fallbackHeaderText={ translate( 'Choose a theme.' ) }
+				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ subHeaderText }
 				subHeaderText={ subHeaderText }
 				stepContent={ this.renderThemesList() }
 				defaultDependencies={ defaultDependencies }
 				headerButton={ this.renderJetpackButton() }
-				{ ...this.props }
-			/>
+				{ ...this.props } />
 		);
 	}
 }


### PR DESCRIPTION
In March, we saw a drop in conversions for our theme selection step at signup. Updating the copy in our theme selection step to reflect choices from the previous step will increase conversions on that step by a minimum of 2%.

## Variations
Copy will be updated to reflect the user's choice from the previous step and also to let them know they can pick from hundreds of other themes at a later point. 

`original`:
![screen shot 2017-04-24 at 10 06 26 am](https://cloud.githubusercontent.com/assets/6981253/25343345/c6db2e82-28dc-11e7-95b7-3c3011770e25.png)

`modified`:
![screen shot 2017-04-24 at 10 54 40 am](https://cloud.githubusercontent.com/assets/6981253/25343335/c053d442-28dc-11e7-8f95-8d0c449c7b1d.png)
![screen shot 2017-04-24 at 10 54 46 am](https://cloud.githubusercontent.com/assets/6981253/25343336/c055543e-28dc-11e7-80ab-e9a011fc0461.png)
![screen shot 2017-04-24 at 10 54 52 am](https://cloud.githubusercontent.com/assets/6981253/25343337/c058bcfa-28dc-11e7-8258-f71cdabc22ba.png)

## Test parameters
Test name: `signupThemeStepCopyChanges`
Author: @fditrapani
Domain: Signup
Start: 2017-04-26
End: 2027-05-03
Baseline Conversion Rate: 80.7%
Minimum Detectable Effect: 2%
Statistical Power: 95%
Significance Level: 1%
Weekly Traffic: 244,393
Traffic Allocation: `original`: 50% – `modified`: 50%
Minimum Sample Size: <a href="http://www.evanmiller.org/ab-testing/sample-size.html#!80.7;95;1;1;0">55,910</a>

@markryall @travisw can you please review?