### PR TITLE
Show entire selected plan check mark

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -228,6 +228,7 @@ $plan-features-sidebar-width: 272px;
 	right: -3px;
 	transform: translate( 25%, -25% );
 	fill: $alert-green;
+	overflow: visible;
 
 	@include breakpoint( "<1280px" ) {
 		display: none;


### PR DESCRIPTION
The check mark for the selected plan was cropped. Add `overflow: visible;` to the checkmark to ensure the entire SVG is visible.

## Test

Open `/plans/:site` with a viewport `>1280px`. Verify that the checkmark is visible and display is otherwise unaffected. You should see the after view.

## Before

(Note the checkbox on the active Premium plan is cropped)

![check-cropped](https://cloud.githubusercontent.com/assets/841763/25346956/a4226da0-2919-11e7-8b47-94f3e6515347.png)

## After

![check-nocrop](https://cloud.githubusercontent.com/assets/841763/25346969/a96b34cc-2919-11e7-97ed-1e74fe00027b.png)
