### PR TITLE
Reader Refresh Manage: add urls to SubscriptionListItem

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -74,7 +74,7 @@ function ReaderSubscriptionListItem( {
 					</span>
 				}
 			<div className="reader-subscription-list-item__site-url">
-				<a href={ siteUrl }> { siteUrl && stripUrl( siteUrl ) } </a>
+				<a href={ siteUrl }> { siteUrl && prepareComparableUrl( siteUrl ) } </a>
 			</div>
 			</div>
 			<div className="reader-subscription-list-item__options">

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -19,8 +19,12 @@ import {
 	getSiteDescription,
 	getSiteAuthorName
 } from 'reader/get-helpers';
+import untrailingslashit from 'lib/route/untrailingslashit';
 
-const stripUrl = url => url.replace( 'https://', '' ).replace( 'http://', '' ).replace( /\/$/, '' );
+// Remove the starting https, www. and remove trailing slash.
+const stripUrl = url => untrailingslashit(
+	url.replace( /^https?:\/\/(www\.)?/, '' )
+);
 
 function ReaderSubscriptionListItem( {
 	url,
@@ -36,8 +40,6 @@ function ReaderSubscriptionListItem( {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
 	const siteExcerpt = getSiteDescription( { feed, site } );
-	// prefer a users name property
-	// if that doesn't exist settle for combining first and last name
 	const authorName = getSiteAuthorName( site );
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -20,7 +20,7 @@ import {
 	getSiteAuthorName
 } from 'reader/get-helpers';
 
-const stripUrl = url => url.replace( 'https://', '' ).replace( 'http://', '' ).replace( '/', '' );
+const stripUrl = url => url.replace( 'https://', '' ).replace( 'http://', '' ).replace( /\/$/, '' );
 
 function ReaderSubscriptionListItem( {
 	url,

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -75,9 +75,11 @@ function ReaderSubscriptionListItem( {
 						}
 					</span>
 				}
-			<div className="reader-subscription-list-item__site-url">
-				<a href={ siteUrl }> { siteUrl && stripUrl( siteUrl ) } </a>
-			</div>
+			{ siteUrl && (
+				<div className="reader-subscription-list-item__site-url">
+					<a href={ siteUrl }> { stripUrl( siteUrl ) } </a>
+				</div>
+			) }
 			</div>
 			<div className="reader-subscription-list-item__options">
 				<FollowButton siteUrl={ siteUrl } followSource={ followSource } />

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -20,6 +20,8 @@ import {
 	getSiteAuthorName
 } from 'reader/get-helpers';
 
+const stripUrl = url => url.replace( 'https://', '' ).replace( 'http://', '' ).replace( '/', '' );
+
 function ReaderSubscriptionListItem( {
 	url,
 	feedId,
@@ -71,6 +73,9 @@ function ReaderSubscriptionListItem( {
 						}
 					</span>
 				}
+			<div className="reader-subscription-list-item__site-url">
+				<a href={ siteUrl }> { siteUrl && stripUrl( siteUrl ) } </a>
+			</div>
 			</div>
 			<div className="reader-subscription-list-item__options">
 				<FollowButton siteUrl={ siteUrl } followSource={ followSource } />

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -74,7 +74,7 @@ function ReaderSubscriptionListItem( {
 					</span>
 				}
 			<div className="reader-subscription-list-item__site-url">
-				<a href={ siteUrl }> { siteUrl && prepareComparableUrl( siteUrl ) } </a>
+				<a href={ siteUrl }> { siteUrl && stripUrl( siteUrl ) } </a>
 			</div>
 			</div>
 			<div className="reader-subscription-list-item__options">

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -203,3 +203,7 @@
 .reader-subscription-list-item__email-popout-wrapper .segmented-control__link {
 	background: $white;
 }
+
+.reader-subscription-list-item__site-url, .reader-subscription-list-item__site-url a {
+	color: $gray;
+}

--- a/client/lib/reader-feed-subscriptions/helper.js
+++ b/client/lib/reader-feed-subscriptions/helper.js
@@ -11,5 +11,5 @@ export function prepareSiteUrl( url ) {
 
 export function prepareComparableUrl( url ) {
 	const preparedUrl = prepareSiteUrl( url );
-	return preparedUrl && preparedUrl.replace( /^https?:\/\/(www\.)?/, '' ).toLowerCase();
+	return preparedUrl && preparedUrl.replace( /^https?:\/\//, '' ).toLowerCase();
 }

--- a/client/lib/reader-feed-subscriptions/helper.js
+++ b/client/lib/reader-feed-subscriptions/helper.js
@@ -11,5 +11,5 @@ export function prepareSiteUrl( url ) {
 
 export function prepareComparableUrl( url ) {
 	const preparedUrl = prepareSiteUrl( url );
-	return preparedUrl && preparedUrl.replace( /^https?:\/\//, '' ).toLowerCase();
+	return preparedUrl && preparedUrl.replace( /^https?:\/\/(www\.)?/, '' ).toLowerCase();
 }


### PR DESCRIPTION
This PR brings URLS back to the SubscriptionListItem Component.

Before:
<img width="732" alt="screen shot 2017-04-24 at 12 30 13 pm" src="https://cloud.githubusercontent.com/assets/4656974/25347705/cbb36084-28e9-11e7-830a-2b402f03ed83.png">

After:
<img width="727" alt="screen shot 2017-04-24 at 12 32 41 pm" src="https://cloud.githubusercontent.com/assets/4656974/25347817/23caba1a-28ea-11e7-9f60-28cf5f21d0df.png">

