### PR TITLE
Fix copy in vertical signup flow

### DIFF
--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -19,6 +19,7 @@ import BlogImage from './blog-image';
 import PageImage from './page-image';
 import GridImage from './grid-image';
 import StoreImage from './store-image';
+import { abtest } from 'lib/abtest';
 
 class DesignTypeWithStoreStep extends Component {
 	constructor( props ) {
@@ -166,6 +167,10 @@ class DesignTypeWithStoreStep extends Component {
 
 		if ( this.state.showStore ) {
 			return translate( 'Create your WordPress Store' );
+		}
+
+		if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
+			return 'We\'re excited to hear more about your project.';
 		}
 
 		return translate( 'Hello! Let’s create your new site.' );


### PR DESCRIPTION
I noticed some weird copy in the vertical signup flow. This PR updates the copy in the second step for a better flow.

## Current
Step 1: `Let's create your new WordPress.com site!`
Step 2: `Hello! Let’s create your new site.`

![screen shot 2017-04-24 at 2 06 05 pm](https://cloud.githubusercontent.com/assets/6981253/25351762/afa16644-28f7-11e7-9b19-457a72cd0fdd.png)

![screen shot 2017-04-24 at 2 08 14 pm](https://cloud.githubusercontent.com/assets/6981253/25351765/b2cea0ca-28f7-11e7-9300-d7044dd0b231.png)


## Proposed 
Step 1: `Let's create your new WordPress.com site!`
Step 2: `We're excited to hear more about your project.`

![screen shot 2017-04-24 at 2 06 05 pm](https://cloud.githubusercontent.com/assets/6981253/25351762/afa16644-28f7-11e7-9b19-457a72cd0fdd.png)

![screen shot 2017-04-24 at 2 09 23 pm](https://cloud.githubusercontent.com/assets/6981253/25351780/b73db844-28f7-11e7-9ce0-2a10c7c89568.png)

@markryall @travisw can you please review?