### PR TITLE
Themes: retired theme sheet

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -67,7 +67,10 @@ const ThemeSheet = React.createClass( {
 		screenshots: React.PropTypes.array,
 		price: React.PropTypes.string,
 		description: React.PropTypes.string,
-		descriptionLong: React.PropTypes.string,
+		descriptionLong: React.PropTypes.oneOfType( [
+			React.PropTypes.string,
+			React.PropTypes.bool // happens if no content: false
+		] ),
 		supportDocumentation: React.PropTypes.string,
 		download: React.PropTypes.string,
 		taxonomies: React.PropTypes.object,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -72,6 +72,7 @@ const ThemeSheet = React.createClass( {
 		download: React.PropTypes.string,
 		taxonomies: React.PropTypes.object,
 		stylesheet: React.PropTypes.string,
+		retired: React.PropTypes.bool,
 		// Connected props
 		isLoggedIn: React.PropTypes.bool,
 		isActive: React.PropTypes.bool,
@@ -194,15 +195,11 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderScreenshot() {
-		let screenshot;
-		if ( ! this.props.isWpcomTheme ) {
-			screenshot = this.props.screenshot;
-		} else {
-			screenshot = this.getFullLengthScreenshot();
-		}
-		const img = screenshot && <img className="theme__sheet-img" src={ screenshot + '?w=680' } />;
+		const { demo_uri, retired, isWpcomTheme } = this.props;
+		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
+		const img = screenshotFull && <img className="theme__sheet-img" src={ screenshotFull + '?w=680' } />;
 
-		if ( this.props.demo_uri ) {
+		if ( demo_uri && ! retired ) {
 			return (
 				<div className="theme__sheet-screenshot is-active" onClick={ this.previewAction }>
 					{ this.renderPreviewButton() }
@@ -248,11 +245,19 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderSectionContent( section ) {
-		return {
+		const activeSection = {
 			'': this.renderOverviewTab(),
 			setup: this.renderSetupTab(),
 			support: this.renderSupportTab(),
 		}[ section ];
+
+		return (
+			<div className="theme__sheet-content">
+				{ this.renderSectionNav( section ) }
+				{ activeSection }
+				<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
+			</div>
+		);
 	},
 
 	renderDescription() {
@@ -450,6 +455,29 @@ const ThemeSheet = React.createClass( {
 		return <ThemesRelatedCard currentTheme={ this.props.id } />;
 	},
 
+	renderRetired() {
+		return (
+			<div className="theme__sheet-content">
+				<Card className="theme__retired-theme-message">
+					<Gridicon icon="cross-circle" size={ 48 } />
+					<div className="theme__retired-theme-message-details">
+						<div className="theme__retired-theme-message-details-title">{ i18n.translate( 'This theme is retired' ) }</div>
+						<div>
+							{ i18n.translate( 'We invite you to try out a newer theme; start by browsing our WordPress theme directory.' ) }
+						</div>
+					</div>
+					<Button
+						primary={ true }
+						href={ '/themes/' }>
+						{ i18n.translate( 'See all themes' ) }
+					</Button>
+				</Card>
+
+				<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
+			</div>
+		);
+	},
+
 	renderPrice() {
 		let price = this.props.price;
 		if ( ! this.isLoaded() || this.props.isActive || this.props.isPurchased ) {
@@ -478,7 +506,7 @@ const ThemeSheet = React.createClass( {
 
 	renderSheet() {
 		const section = this.validateSection( this.props.section );
-		const { siteId } = this.props;
+		const { siteId, retired } = this.props;
 
 		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteId ? '/:site_id' : '' }`;
 		const analyticsPageTitle = `Themes > Details Sheet${ section ? ' > ' + titlecase( section ) : '' }${ siteId ? ' > Site' : '' }`;
@@ -521,15 +549,12 @@ const ThemeSheet = React.createClass( {
 				<HeaderCake className="theme__sheet-action-bar"
 					backHref={ this.props.backPath }
 					backText={ i18n.translate( 'All Themes' ) }>
-					{ this.renderButton() }
+					{ ! retired && this.renderButton() }
 				</HeaderCake>
 				<div className="theme__sheet-columns">
 					<div className="theme__sheet-column-left">
-						<div className="theme__sheet-content">
-							{ this.renderSectionNav( section ) }
-							{ this.renderSectionContent( section ) }
-							<div className="theme__sheet-footer-line"><Gridicon icon="my-sites" /></div>
-						</div>
+						{ ! retired && this.renderSectionContent( section ) }
+						{ retired && this.renderRetired() }
 					</div>
 					<div className="theme__sheet-column-right">
 						{ this.renderScreenshot() }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -472,7 +472,7 @@ const ThemeSheet = React.createClass( {
 					<Button
 						primary={ true }
 						href={ '/themes/' }>
-						{ i18n.translate( 'See all themes' ) }
+						{ i18n.translate( 'See All Themes' ) }
 					</Button>
 				</Card>
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -425,6 +425,40 @@
 	}
 }
 
+.theme__retired-theme-message {
+	display: flex;
+	align-items: center;
+	margin-bottom: 40px;
+
+	@include breakpoint( "<960px" ) {
+		flex-wrap: wrap;
+	}
+
+	.gridicon {
+		color: lighten( $gray, 20% );
+		flex: 0 0 auto;
+	}
+
+	.button {
+		flex: 0 0 auto;
+
+		@include breakpoint( "<960px" ) {
+			flex: 1 1 100%;
+			margin-top: 20px;
+			text-align: center;
+		}
+	}
+}
+
+.theme__retired-theme-message-details {
+	flex: 1 1 20px;
+	padding: 0 20px;
+
+	.theme__retired-theme-message-details-title {
+		font-size: 20px;
+	}
+}
+
 .theme__sheet-footer-line {
 	color: lighten( $gray, 20% );
 	border-top: 1px solid lighten( $gray, 20% );


### PR DESCRIPTION
This PR implements the theme sheet for retired themes, goal:

1. Provide a clear message about a retired theme.
2. Provide a proper redirect from old showcases for retired themes.

![screen shot 2017-04-24 at 19 24 07](https://cloud.githubusercontent.com/assets/4389/25352360/b75c3770-2923-11e7-8544-8db6a632fecd.png)

![screen shot 2017-04-24 at 19 23 56](https://cloud.githubusercontent.com/assets/4389/25352375/bfcaadc4-2923-11e7-8185-2f28b837c855.png)

### To test

1. Open directly any URL of a retired theme, like `/theme/ecto`.
2. Check the page shows the right UI, and there's no way to activate the theme.
3. Try navigating to the full showcase list.
4. Test now a properly valid theme and see it shows up properly.


