### PR TITLE
DocumentHead: Persist state

### DIFF
--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -6,62 +6,34 @@ import { combineReducers } from 'redux';
 /**
  * Internal dependencies
  */
+import { createReducer } from 'state/utils';
 import {
 	DOCUMENT_HEAD_LINK_ADD,
 	DOCUMENT_HEAD_META_ADD,
 	DOCUMENT_HEAD_TITLE_SET,
 	DOCUMENT_HEAD_UNREAD_COUNT_SET,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
+import { titleSchema, unreadCountSchema, linkSchema, metaSchema } from './schema';
 
-export function title( state = '', action ) {
-	switch ( action.type ) {
-		case DOCUMENT_HEAD_TITLE_SET:
-			return action.title;
-	}
+export const title = createReducer( '', {
+	[ DOCUMENT_HEAD_TITLE_SET ]: ( state, action ) => ( action.title )
+}, titleSchema );
 
-	return state;
-}
+export const unreadCount = createReducer( 0, {
+	[ DOCUMENT_HEAD_UNREAD_COUNT_SET ]: ( state, action ) => ( action.count )
+}, unreadCountSchema );
 
-export function unreadCount( state = 0, action ) {
-	switch ( action.type ) {
-		case DOCUMENT_HEAD_UNREAD_COUNT_SET:
-			return action.count;
-	}
+export const meta = createReducer( [ { property: 'og:site_name', content: 'WordPress.com' } ], {
+	[ DOCUMENT_HEAD_META_ADD ]: ( state, action ) => ( [ ...state, action.meta ] )
+}, metaSchema );
 
-	return state;
-}
+export const link = createReducer( [], {
+	[ DOCUMENT_HEAD_LINK_ADD ]: ( state, action ) => ( [ ...state, action.link ] )
+}, linkSchema );
 
-export function meta( state = [ { property: 'og:site_name', content: 'WordPress.com' } ], action ) {
-	switch ( action.type ) {
-		case DOCUMENT_HEAD_META_ADD:
-			return [ ...state, action.meta ];
-	}
-
-	return state;
-}
-
-export function link( state = [], action ) {
-	switch ( action.type ) {
-		case DOCUMENT_HEAD_LINK_ADD:
-			return [ ...state, action.link ];
-	}
-
-	return state;
-}
-
-const reducer = combineReducers( {
+export default combineReducers( {
 	link,
 	meta,
 	title,
 	unreadCount
 } );
-
-export default function( state, action ) {
-	if ( SERIALIZE === action.type || DESERIALIZE === action.type ) {
-		return {};
-	}
-
-	return reducer( state, action );
-}

--- a/client/state/document-head/schema.js
+++ b/client/state/document-head/schema.js
@@ -1,0 +1,30 @@
+export const titleSchema = {
+	type: 'string'
+};
+
+export const unreadCountSchema = {
+	type: 'number'
+};
+
+export const metaSchema = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			name: { type: 'string' },
+			property: { type: 'string' },
+			content: { type: 'string' },
+		}
+	}
+};
+
+export const linkSchema = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			name: { type: 'string' },
+			rel: { type: 'string' },
+		}
+	}
+};


### PR DESCRIPTION
Needed for #13339 (server-side persisting of title/meta/link tag data).

To test:
* Land in any Calypso section -- let's use http://calypso.localhost:3000/themes
* Using Redux DevTools, check state at the `@@INIT` event. The `documentHead` tree should contain data for `title` and `meta`:
![image](https://cloud.githubusercontent.com/assets/96308/25357382/e1e28944-293d-11e7-8a83-9aa1bd5300eb.png)

* Compare that to production, where `@@INIT` currently has only default values in the `documentHead` tree:
![image](https://cloud.githubusercontent.com/assets/96308/25357582/a3bc2d9a-293e-11e7-9a64-c9f420eb6cb0.png)

