### PR TITLE
Purchases: Add a "reconnect" notice to disconnected sites

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -104,7 +104,7 @@ class PurchaseItem extends Component {
 	}
 
 	render() {
-		const { isPlaceholder, purchase } = this.props;
+		const { isPlaceholder, isDisconnectedSite, purchase } = this.props;
 		const classes = classNames( 'purchase-item',
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
 			{ 'is-placeholder': isPlaceholder },
@@ -149,9 +149,12 @@ class PurchaseItem extends Component {
 		let props;
 		if ( ! isPlaceholder ) {
 			props = {
-				href: paths.managePurchase( this.props.slug, this.props.purchase.id ),
 				onClick: this.scrollToTop
 			};
+
+			if ( ! isDisconnectedSite ) {
+				props.href = paths.managePurchase( this.props.slug, this.props.purchase.id );
+			}
 		}
 
 		return (
@@ -164,6 +167,7 @@ class PurchaseItem extends Component {
 
 PurchaseItem.propTypes = {
 	isPlaceholder: React.PropTypes.bool,
+	isDisconnectedSite: React.PropTypes.bool,
 	purchase: React.PropTypes.object,
 	slug: React.PropTypes.string
 };

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -5,11 +5,13 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import React from 'react';
 import times from 'lodash/times';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies
  */
 import { getSite, isRequestingSite } from 'state/sites/selectors';
+import { isJetpackPlan } from 'lib/products-values';
 import QuerySites from 'components/data/query-sites';
 import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
@@ -32,6 +34,8 @@ const PurchasesSite = ( { hasLoadedSite, isPlaceholder, site, siteId, purchases,
 		) );
 	}
 
+	const isJetpack = some( purchases, purchase => isJetpackPlan( purchase ) );
+
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
 			<QuerySites siteId={ siteId } />
@@ -45,6 +49,7 @@ const PurchasesSite = ( { hasLoadedSite, isPlaceholder, site, siteId, purchases,
 
 			{ ( ! isPlaceholder && hasLoadedSite && ! site )
 				? <PurchaseReconnectNotice
+					isJetpack={ isJetpack }
 					name={ name }
 					domain={ domain } />
 				: null

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -27,6 +27,7 @@ const PurchasesSite = ( { hasLoadedSite, isPlaceholder, site, siteId, purchases,
 			<PurchaseItem
 				key={ purchase.id }
 				slug={ slug }
+				isDisconnectedSite={ ! site }
 				purchase={ purchase } />
 		) );
 	}

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -13,6 +13,7 @@ import { getSite, isRequestingSites } from 'state/sites/selectors';
 import QuerySites from 'components/data/query-sites';
 import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
+import PurchaseReconnectNotice from './reconnect-notice';
 
 const PurchasesSite = ( { isPlaceholder, site, siteId, purchases, name, domain, slug } ) => {
 	let items;
@@ -40,6 +41,13 @@ const PurchasesSite = ( { isPlaceholder, site, siteId, purchases, name, domain, 
 				isPlaceholder={ isPlaceholder } />
 
 			{ items }
+
+			{ ( ! isPlaceholder && ! site )
+				? <PurchaseReconnectNotice
+					name={ name }
+					domain={ domain } />
+				: null
+			}
 		</div>
 	);
 };

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -9,13 +9,13 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
-import { getSite, isRequestingSites } from 'state/sites/selectors';
+import { getSite, isRequestingSite } from 'state/sites/selectors';
 import QuerySites from 'components/data/query-sites';
 import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
 import PurchaseReconnectNotice from './reconnect-notice';
 
-const PurchasesSite = ( { isPlaceholder, site, siteId, purchases, name, domain, slug } ) => {
+const PurchasesSite = ( { hasLoadedSite, isPlaceholder, site, siteId, purchases, name, domain, slug } ) => {
 	let items;
 
 	if ( isPlaceholder ) {
@@ -42,7 +42,7 @@ const PurchasesSite = ( { isPlaceholder, site, siteId, purchases, name, domain, 
 
 			{ items }
 
-			{ ( ! isPlaceholder && ! site )
+			{ ( ! isPlaceholder && hasLoadedSite && ! site )
 				? <PurchaseReconnectNotice
 					name={ name }
 					domain={ domain } />
@@ -64,6 +64,6 @@ PurchasesSite.propTypes = {
 export default connect(
 	( state, { siteId } ) => ( {
 		site: getSite( state, siteId ),
-		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedSite: ! isRequestingSite( state, siteId ),
 	} )
 )( PurchasesSite );

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import React from 'react';
 import times from 'lodash/times';
@@ -8,10 +9,12 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
+import { getSite, isRequestingSites } from 'state/sites/selectors';
+import QuerySites from 'components/data/query-sites';
 import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
 
-const PurchasesSite = ( { isPlaceholder, siteId, purchases, name, domain, slug } ) => {
+const PurchasesSite = ( { isPlaceholder, site, siteId, purchases, name, domain, slug } ) => {
 	let items;
 
 	if ( isPlaceholder ) {
@@ -29,6 +32,7 @@ const PurchasesSite = ( { isPlaceholder, siteId, purchases, name, domain, slug }
 
 	return (
 		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
+			<QuerySites siteId={ siteId } />
 			<PurchaseSiteHeader
 				siteId={ siteId }
 				name={ name }
@@ -49,4 +53,9 @@ PurchasesSite.propTypes = {
 	slug: React.PropTypes.string,
 };
 
-export default PurchasesSite;
+export default connect(
+	( state, { siteId } ) => ( {
+		site: getSite( state, siteId ),
+		hasLoadedSites: ! isRequestingSites( state ),
+	} )
+)( PurchasesSite );

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+
+class PurchaseReconnectNotice extends Component {
+	static propTypes = {
+		name: React.PropTypes.string,
+		domain: React.PropTypes.string,
+	}
+
+	render() {
+		const { translate, name, domain } = this.props;
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-error"
+				text={ translate( '%(site)s has been disconnected from WordPress.com.', {
+					args: {
+						site: name,
+					}
+				} ) }>
+				<NoticeAction href={ `/jetpack/connect?url=${ domain }` }>
+					{ translate( 'Reconnect' ) }
+				</NoticeAction>
+			</Notice>
+		);
+	}
+}
+
+export default localize( PurchaseReconnectNotice );

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import support from 'lib/url/support';
 
 class PurchaseReconnectNotice extends Component {
 	static propTypes = {
@@ -17,19 +18,27 @@ class PurchaseReconnectNotice extends Component {
 	}
 
 	render() {
-		const { translate, name, domain } = this.props;
+		const { translate, name, isJetpack } = this.props;
+		let text = translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
+			args: {
+				site: name,
+			}
+		} );
+		if ( isJetpack ) {
+			text = translate( '%(site)s has been disconnected from WordPress.com.', {
+				args: {
+					site: name,
+				}
+			} );
+		}
 
 		return (
 			<Notice
 				showDismiss={ false }
 				status="is-error"
-				text={ translate( '%(site)s has been disconnected from WordPress.com.', {
-					args: {
-						site: name,
-					}
-				} ) }>
-				<NoticeAction href={ `/jetpack/connect?url=${ domain }` }>
-					{ translate( 'Reconnect' ) }
+				text={ text }>
+				<NoticeAction href={ isJetpack ? support.JETPACK_CONTACT_SUPPORT : support.CALYPSO_CONTACT }>
+					{ translate( 'Contact Support' ) }
 				</NoticeAction>
 			</Notice>
 		);


### PR DESCRIPTION
This fixes #12923, giving users a way of reconnecting sites that have active subscriptions, but are disconnected from wp.com.

To test:

- Disconnect a jetpack site with a paid plan
- Visit `/me/purchases`
- You should see a banner under the purchase, asking you to reconnect:

![screen shot 2017-04-24 at 4 44 56 pm](https://cloud.githubusercontent.com/assets/541093/25357864/6c3aedc4-290d-11e7-89b4-aabaad600a6a.png)
