### PR TITLE
Reader SubscriptionListItem: decode html entities

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -19,6 +19,7 @@ import {
 	getSiteDescription,
 	getSiteAuthorName
 } from 'reader/get-helpers';
+import { decodeEntities } from 'lib/formatting';
 
 function ReaderSubscriptionListItem( {
 	url,
@@ -31,12 +32,12 @@ function ReaderSubscriptionListItem( {
 	followSource,
 	isEmailBlocked,
 } ) {
-	const siteTitle = getSiteName( { feed, site } );
+	const siteTitle = decodeEntities( getSiteName( { feed, site } ) );
 	const siteAuthor = site && site.owner;
-	const siteExcerpt = getSiteDescription( { feed, site } );
+	const siteExcerpt = decodeEntities( getSiteDescription( { feed, site } ) );
 	// prefer a users name property
 	// if that doesn't exist settle for combining first and last name
-	const authorName = getSiteAuthorName( site );
+	const authorName = decodeEntities( getSiteAuthorName( site ) );
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );
 	const streamUrl = getStreamUrl( feedId, siteId );

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -19,7 +19,6 @@ import {
 	getSiteDescription,
 	getSiteAuthorName
 } from 'reader/get-helpers';
-import { decodeEntities } from 'lib/formatting';
 
 function ReaderSubscriptionListItem( {
 	url,
@@ -32,12 +31,12 @@ function ReaderSubscriptionListItem( {
 	followSource,
 	isEmailBlocked,
 } ) {
-	const siteTitle = decodeEntities( getSiteName( { feed, site } ) );
+	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
-	const siteExcerpt = decodeEntities( getSiteDescription( { feed, site } ) );
+	const siteExcerpt = getSiteDescription( { feed, site } );
 	// prefer a users name property
 	// if that doesn't exist settle for combining first and last name
-	const authorName = decodeEntities( getSiteAuthorName( site ) );
+	const authorName = getSiteAuthorName( site );
 	const siteIcon = get( site, 'icon.img' );
 	const feedIcon = get( feed, 'image' );
 	const streamUrl = getStreamUrl( feedId, siteId );

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -8,6 +8,7 @@ import { trim } from 'lodash';
 /**
  * Internal Dependencies
  */
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Given a feed, site, or post: return the url. return false if one could not be found.
@@ -47,17 +48,21 @@ export const getSiteName = ( { feed, site, post } = {} ) => {
 		siteName = ( !! siteUrl ) ? url.parse( siteUrl ).hostname : null;
 	}
 
-	return siteName;
+	return decodeEntities( siteName );
 };
 
 export const getSiteDescription = ( { site, feed } ) => {
-	return ( site && site.description ) || ( feed && feed.description );
+	return decodeEntities(
+		( site && site.description ) || ( feed && feed.description )
+	);
 };
 
 export const getSiteAuthorName = site => {
 	const siteAuthor = site && site.owner;
-	return siteAuthor && (
+	const authorFullName = siteAuthor && (
 		siteAuthor.name ||
 		trim( `${ siteAuthor.first_name || '' } ${ siteAuthor.last_name || '' }` )
 	);
+
+	return decodeEntities( authorFullName );
 };


### PR DESCRIPTION
Currently the search results for feeds hands the ui encoded html entities. 
This looks like this:

![screenshot 2017-04-24 12 30 58](https://cloud.githubusercontent.com/assets/4924246/25354967/e26240d4-28e9-11e7-9372-227814ca876d.png)
- Gravatar isn't displayed
- `&amp;` should be `&`


We should decode them in `ReaderSubscriptionListItem`
