### PR TITLE
State: opt into persistence

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -591,5 +591,24 @@ describe( 'utils', () => {
 			const invalid = veryNested( { bob: { person: { age: -5, height: 22, date: new Date( -5 ) } }, count: 123 }, write );
 			expect( invalid ).to.eql( { bob: { person: { age: -5, height: 160, date: -5 } }, count: 1 } );
 		} );
+
+		it( 'deeply nested reducers work with reducer with a custom handler', () => {
+			reducers = combineReducersWithPersistence( {
+				height,
+				date
+			} );
+			const nested = combineReducersWithPersistence( {
+				person: reducers,
+			} );
+			const veryNested = combineReducersWithPersistence( {
+				bob: nested,
+				count
+			} );
+			const valid = veryNested( { bob: { person: { date: new Date( 234 ) } }, count: 122 }, write );
+			expect( valid ).to.eql( { bob: { person: { height: 160, date: 234 } }, count: 1 } );
+
+			const invalid = veryNested( { bob: { person: { height: 22, date: new Date( -5 ) } }, count: 123 }, write );
+			expect( invalid ).to.eql( { bob: { person: { height: 160, date: -5 } }, count: 1 } );
+		} );
 	} );
 } );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -478,8 +478,11 @@ describe( 'utils', () => {
 				person: reducers,
 				count
 			} );
-			const state = nested( { person: { age: 22 } }, load );
-			expect( state ).to.eql( { person: { age: 22, height: 160 }, count: 1 } );
+			const valid = nested( { person: { age: 22 } }, load );
+			expect( valid ).to.eql( { person: { age: 22, height: 160 }, count: 1 } );
+
+			const invalid = nested( { person: { age: -5, height: 100 } }, load );
+			expect( invalid ).to.eql( { person: { age: 0, height: 160 }, count: 1 } );
 		} );
 
 		it( 'deeply nested reducers work', () => {
@@ -490,8 +493,11 @@ describe( 'utils', () => {
 				bob: nested,
 				count
 			} );
-			const state = veryNested( { bob: { person: { age: 22 } } }, load );
-			expect( state ).to.eql( { bob: { person: { age: 22, height: 160 } }, count: 1 } );
+			const valid = veryNested( { bob: { person: { age: 22 } } }, load );
+			expect( valid ).to.eql( { bob: { person: { age: 22, height: 160 } }, count: 1 } );
+
+			const invalid = veryNested( { bob: { person: { age: -5, height: 22 } } }, load );
+			expect( invalid ).to.eql( { bob: { person: { age: 0, height: 160 } }, count: 1 } );
 		} );
 	} );
 } );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -389,7 +389,7 @@ describe( 'utils', () => {
 					return state;
 			}
 		};
-		date.hasCustomHandler = true;
+		date.hasCustomPersistence = true;
 
 		it( 'should return initial state without a schema on SERIALIZE', () => {
 			const validated = withSchemaValidation( null, age );
@@ -477,7 +477,7 @@ describe( 'utils', () => {
 					return state;
 			}
 		};
-		date.hasCustomHandler = true;
+		date.hasCustomPersistence = true;
 
 		let reducers;
 

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -473,7 +473,7 @@ describe( 'utils', () => {
 			expect( state ).to.eql( { age: 21, height: 172 } );
 		} );
 
-		it( 'nested reducers work', () => {
+		it( 'nested reducers work on load', () => {
 			const nested = combineReducersWithPersistence( {
 				person: reducers,
 				count
@@ -485,7 +485,19 @@ describe( 'utils', () => {
 			expect( invalid ).to.eql( { person: { age: 0, height: 160 }, count: 1 } );
 		} );
 
-		it( 'deeply nested reducers work', () => {
+		it( 'nested reducers work on persist', () => {
+			const nested = combineReducersWithPersistence( {
+				person: reducers,
+				count
+			} );
+			const valid = nested( { person: { age: 22 } }, write );
+			expect( valid ).to.eql( { person: { age: 22, height: 160 }, count: 1 } );
+
+			const invalid = nested( { person: { age: -5, height: 100 } }, write );
+			expect( invalid ).to.eql( { person: { age: -5, height: 160 }, count: 1 } );
+		} );
+
+		it( 'deeply nested reducers work on load', () => {
 			const nested = combineReducersWithPersistence( {
 				person: reducers
 			} );
@@ -493,11 +505,26 @@ describe( 'utils', () => {
 				bob: nested,
 				count
 			} );
-			const valid = veryNested( { bob: { person: { age: 22 } } }, load );
+			const valid = veryNested( { bob: { person: { age: 22 } }, count: 122 }, load );
 			expect( valid ).to.eql( { bob: { person: { age: 22, height: 160 } }, count: 1 } );
 
-			const invalid = veryNested( { bob: { person: { age: -5, height: 22 } } }, load );
+			const invalid = veryNested( { bob: { person: { age: -5, height: 22 } }, count: 123 }, load );
 			expect( invalid ).to.eql( { bob: { person: { age: 0, height: 160 } }, count: 1 } );
+		} );
+
+		it( 'deeply nested reducers work on persist', () => {
+			const nested = combineReducersWithPersistence( {
+				person: reducers
+			} );
+			const veryNested = combineReducersWithPersistence( {
+				bob: nested,
+				count
+			} );
+			const valid = veryNested( { bob: { person: { age: 22 } }, count: 122 }, write );
+			expect( valid ).to.eql( { bob: { person: { age: 22, height: 160 } }, count: 1 } );
+
+			const invalid = veryNested( { bob: { person: { age: -5, height: 22 } }, count: 123 }, write );
+			expect( invalid ).to.eql( { bob: { person: { age: -5, height: 160 } }, count: 1 } );
 		} );
 	} );
 } );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -429,6 +429,10 @@ describe( 'utils', () => {
 			'GROW' === action.type
 				? state + 1
 				: state;
+		const count = ( state = 1, action ) =>
+			'GROW' === action.type
+				? state + 1
+				: state;
 
 		let reducers;
 
@@ -467,6 +471,27 @@ describe( 'utils', () => {
 		it( 'actions work as expected', () => {
 			const state = reducers( appState, grow );
 			expect( state ).to.eql( { age: 21, height: 172 } );
+		} );
+
+		it( 'nested reducers work', () => {
+			const nested = combineReducersWithPersistence( {
+				person: reducers,
+				count
+			} );
+			const state = nested( { person: { age: 22 } }, load );
+			expect( state ).to.eql( { person: { age: 22, height: 160 }, count: 1 } );
+		} );
+
+		it( 'deeply nested reducers work', () => {
+			const nested = combineReducersWithPersistence( {
+				person: reducers
+			} );
+			const veryNested = combineReducersWithPersistence( {
+				bob: nested,
+				count
+			} );
+			const state = veryNested( { bob: { person: { age: 22 } } }, load );
+			expect( state ).to.eql( { bob: { person: { age: 22, height: 160 } }, count: 1 } );
 		} );
 	} );
 } );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -261,16 +261,20 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
  * @returns {function} wrapped reducer handling validation on DESERIALIZE
  */
 export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => {
+
+	const shouldDispatchAction = reducer.hasSchema || reducer.hasCustomHandler;
+
 	if ( SERIALIZE === action.type ) {
-		return schema || reducer.hasSchema ? reducer( state, action ) : reducer( undefined, { type: '@@calypso/INIT' } );
+		return schema || shouldDispatchAction ? reducer( state, action ) : reducer( undefined, { type: '@@calypso/INIT' } );
 	}
 	if ( DESERIALIZE === action.type ) {
-		if ( ! schema && ! reducer.hasSchema ) {
-			return reducer( undefined, { type: '@@calypso/INIT' } );
+
+		if ( shouldDispatchAction ) {
+			return reducer( state, action );
 		}
 
-		if ( ! schema && reducer.hasSchema ) {
-			return reducer( state, action );
+		if ( ! schema ) {
+			return reducer( undefined, { type: '@@calypso/INIT' } );
 		}
 
 		return state && isValidStateWithSchema( state, schema )

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -229,7 +229,7 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
 }
 
 /**
- * Creates schema-validating reducer
+ * Creates a schema-validating reducer
  *
  * Use this to wrap simple reducers with a schema-based
  * validation check when loading the initial state from
@@ -256,9 +256,20 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
  * age( -5, { type: DESERIALIZE } ) === 0
  * age( 23, { type: DESERIALIZE } ) === 23
  *
+ * If no schema is provided, the reducer will return initial state on SERIALIZE.
+ *
+ * @example
+ * const schema = { type: 'number', minimum: 0 }
+ * export const age = withSchemaValidation( null, age )
+ *
+ * ageReducer( -5, { type: SERIALIZE } ) === -5
+ * age( -5, { type: SERIALIZE } ) === 0
+ * age( 23, { type: SERIALIZE } ) === 0
+ *
  * @param {object} schema JSON-schema description of state
  * @param {function} reducer normal reducer from ( state, action ) to new state
- * @returns {function} wrapped reducer handling validation on DESERIALIZE
+ * @returns {function} wrapped reducer handling validation on DESERIALIZE and
+ * returns initial state if no schema is provided on SERIALIZE.
  */
 export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => {
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -262,7 +262,7 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
  */
 export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => {
 
-	const shouldDispatchAction = reducer.hasSchema || reducer.hasCustomHandler;
+	const shouldDispatchAction = reducer.hasSchema || reducer.hasCustomPersistence;
 
 	if ( SERIALIZE === action.type ) {
 		return schema || shouldDispatchAction ? reducer( state, action ) : reducer( undefined, { type: '@@calypso/INIT' } );
@@ -293,7 +293,7 @@ export function combineReducersWithPersistence( reducers ) {
 	let hasSchema = false;
 	const reducersWithPersistence = reduce( reducers, ( result, reducerWithSchema, key ) => {
 		const { schema } = reducerWithSchema;
-		hasSchema = hasSchema || !! schema || reducerWithSchema.hasSchema || reducerWithSchema.hasCustomHandler;
+		hasSchema = hasSchema || !! schema || reducerWithSchema.hasSchema || reducerWithSchema.hasCustomPersistence;
 		return { ...result, [ key ]: withSchemaValidation( schema, reducerWithSchema ) };
 	}, {} );
 	const combined = combineReducers( reducersWithPersistence );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -303,7 +303,7 @@ export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => 
  *         : state
  * const schema = { type: 'number', minimum: 0 };
  *
- * ageReducer.schema = schema;
+ * age.schema = schema;
  *
  * const combinedReducer = combineReducersWithPersistence( {
  *     age,
@@ -351,8 +351,6 @@ export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => 
  * @param {object} reducers - object containing the reducers to merge
  * @returns {function} - Returns the combined reducer function
  */
-
-//
 export function combineReducersWithPersistence( reducers ) {
 	let hasSchema = false;
 	const reducersWithPersistence = reduce( reducers, ( result, reducerWithSchema, key ) => {

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -352,13 +352,14 @@ export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => 
  * @returns {function} - Returns the combined reducer function
  */
 export function combineReducersWithPersistence( reducers ) {
-	let hasSchema = false;
-	const reducersWithPersistence = reduce( reducers, ( result, reducerWithSchema, key ) => {
-		const { schema } = reducerWithSchema;
-		hasSchema = hasSchema || !! schema || reducerWithSchema.hasSchema || reducerWithSchema.hasCustomPersistence;
-		return { ...result, [ key ]: withSchemaValidation( schema, reducerWithSchema ) };
-	}, {} );
-	const combined = combineReducers( reducersWithPersistence );
-	combined.hasSchema = hasSchema;
+	const [ validatedReducers, validatedReducersHasSchema ] = reduce( reducers, ( [ validated, hasSchema ], next, key ) => {
+		const { schema } = next;
+		return [
+			{ ...validated, [ key ]: withSchemaValidation( schema, next ) },
+			hasSchema || !! schema || next.hasSchema || next.hasCustomPersistence
+		];
+	}, [ {}, false ] );
+	const combined = combineReducers( validatedReducers );
+	combined.hasSchema = validatedReducersHasSchema;
 	return combined;
 }

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -268,7 +268,6 @@ export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => 
 		return schema || shouldDispatchAction ? reducer( state, action ) : reducer( undefined, { type: '@@calypso/INIT' } );
 	}
 	if ( DESERIALIZE === action.type ) {
-
 		if ( shouldDispatchAction ) {
 			return reducer( state, action );
 		}
@@ -294,7 +293,7 @@ export function combineReducersWithPersistence( reducers ) {
 	let hasSchema = false;
 	const reducersWithPersistence = reduce( reducers, ( result, reducerWithSchema, key ) => {
 		const { schema } = reducerWithSchema;
-		hasSchema = hasSchema || !! schema || reducerWithSchema.hasSchema;
+		hasSchema = hasSchema || !! schema || reducerWithSchema.hasSchema || reducerWithSchema.hasCustomHandler;
 		return { ...result, [ key ]: withSchemaValidation( schema, reducerWithSchema ) };
 	}, {} );
 	const combined = combineReducers( reducersWithPersistence );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -256,7 +256,8 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
  * age( -5, { type: DESERIALIZE } ) === 0
  * age( 23, { type: DESERIALIZE } ) === 23
  *
- * If no schema is provided, the reducer will return initial state on SERIALIZE.
+ * If no schema is provided, the reducer will return initial state on SERIALIZE
+ * and DESERIALIZE
  *
  * @example
  * const schema = { type: 'number', minimum: 0 }
@@ -265,14 +266,14 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
  * ageReducer( -5, { type: SERIALIZE } ) === -5
  * age( -5, { type: SERIALIZE } ) === 0
  * age( 23, { type: SERIALIZE } ) === 0
+ * age( 23, { type: DESERIALIZE } ) === 0
  *
  * @param {object} schema JSON-schema description of state
  * @param {function} reducer normal reducer from ( state, action ) to new state
  * @returns {function} wrapped reducer handling validation on DESERIALIZE and
- * returns initial state if no schema is provided on SERIALIZE.
+ * returns initial state if no schema is provided on SERIALIZE and DESERIALIZE.
  */
 export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => {
-
 	const shouldDispatchAction = reducer.hasSchema || reducer.hasCustomPersistence;
 
 	if ( SERIALIZE === action.type ) {

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -332,8 +332,9 @@ export const items = createReducer( defaultState, {
 	[DESERIALIZE]: state => fromJS( state )
 } );
 ```
-If your reducer state is already a plain object, the `SERIALIZE` and `DESERIALIZE` handlers are not needed.
-However, please note that the subtree can still see errors from changing data shapes, as described below.
+If your reducer state can be serialized by the browser without additional work (eg a plain object, string or boolean), 
+the `SERIALIZE` and `DESERIALIZE` handlers are not needed. However, please note that the subtree can still see errors 
+from changing data shapes, as described below.
 
 #### Problem: Data shapes change over time ( [#3101](https://github.com/Automattic/wp-calypso/pull/3101) )
 
@@ -417,7 +418,7 @@ all of our reducers using `combineReducersWithPersistence` at every level of the
 Each reducer is then wrapped with `withSchemaValidation` which returns a wrapped reducer that validates on `DESERIALZE` 
 if a schema is present and returns initial state on both `SERIALIZE` and `DESERIALZE` if a schema is not present.
 
-To opt-out of persistence we just combine the plain reducers.
+To opt-out of persistence we combine the reducers without any attached schema.
 ```javascript
 return combineReducersWithPersistence( {
     age,

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -387,7 +387,7 @@ export const items = createReducer( defaultState, {
 }, itemsSchema );
 ```
 
-If you are not satisfied with the default handling possible to implement your own `SERIALIZE` and
+If you are not satisfied with the default handling, it is possible to implement your own `SERIALIZE` and
 `DESERIALIZE` action handlers in your reducers to customize data persistence. Always use a schema with your custom 
 handlers to avoid data shape errors. 
 

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -398,7 +398,7 @@ values are persisted we will not be able to reliably tell when the application i
 
 If persisting state causes application errors, opting out of persistence is straightforward: in the `createReducer` util
 provide only the default state value as a first param and don't provide a schema as a third param. Behind the scenes 
-data is never going to be persisted and always regenerated with default value. In this example, it happens to be `'CHECKING'`
+data is never going to be persisted and is always regenerated with default value. In this example, it happens to be `'CHECKING'`
 ```javascript
 export const connectionState = createReducer( 'CHECKING', {
 	[CONNECTION_LOST]: () => 'OFFLINE',
@@ -408,7 +408,7 @@ export const connectionState = createReducer( 'CHECKING', {
 
 ### Opt-in to Persistence ( [#13359](https://github.com/Automattic/wp-calypso/pull/13359) )
 
-Currently reducers are persisted by default if no handlers are given for SERIALIZE and DESERIALIZE. This is a major 
+Currently reducers are persisted by default if no handlers are given for `SERIALIZE` and `DESERIALIZE`. This is a major 
 problem since many people may not realize that this is happening, and we can run into the data shape errors as 
 noted above.
 
@@ -417,7 +417,15 @@ all of our reducers using `combineReducersWithPersistence` at every level of the
 Each reducer is then wrapped with `withSchemaValidation` which returns a wrapped reducer that validates on `DESERIALZE` 
 if a schema is present and returns initial state on both `SERIALIZE` and `DESERIALZE` if a schema is not present.
 
-Usage looks like:
+To opt-out of persistence we just combine the plain reducers.
+```javascript
+return combineReducersWithPersistence( {
+    age,
+    height,
+} );
+```
+
+To persist, we add the schema as a property on the reducer:
 ```javascript
 age.schema = ageSchema;
 return combineReducersWithPersistence( {


### PR DESCRIPTION
This PR tries to address the issue that reducers are persisted by default if no handlers are given for `SERIALIZE` and `DESERIALIZE`. See the [persistence readme](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#data-persistence--2754-) for more context on how this currently works.

This PR does 2 things:
- Updates `withSchemaValidation` to return default state on `SERIALIZE` and `DESERIALIZE` if no schema is provided
- Adds a `combineReducersWithPersistence` util that we would use instead of `combineReducers` that basically wraps each reducer in `withSchemaValidation`

Usage would look like:
```jsx
age.schema = ageSchema;
return combineReducersWithPersistence( {
    age,
    height,
} );
```

For a reducer that has custom handlers (needs to perform transforms), we assume it's checking the schema already, so all we need to do is set a boolean bit on the reducer.
```jsx
date.hasCustomPersistence = true;
return combineReducersWithPersistence( {
    age,
    height,
    date,
} );
```

Let me know what folks think of the related approach and feel free to suggest better names. If we like it I'd suggest breaking up the PRs into:

- PR to add util method (This PR)
- Look for custom SERIALIZE/DESERIALZE usages that aren't performing the default actions. Eg any transforms from and to a plain object.
- Give folks a heads up with a blog post
- Port over all usages of `combineReducers`
- Add eslint rule for using  `combineReducersWithPersistence ` over `combineReducers`
- Update data docs

See related conversation in https://github.com/Automattic/wp-calypso/pull/13318#discussion_r112996396 that resparked this issue.