### PR TITLE
	Domains: Remove Sites List from Domain Management section

### DIFF
--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -19,8 +19,7 @@ import paths from 'my-sites/upgrades/paths';
 import ProductsList from 'lib/products-list';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import TransferData from 'components/data/domain-management/transfer';
 import WhoisData from 'components/data/domain-management/whois';
@@ -293,8 +292,7 @@ export default {
 
 	domainManagementIndex( pageContext ) {
 		const state = pageContext.store.getState();
-		const siteId = getSelectedSiteId( state );
-		const siteSlug = getSiteSlug( state, siteId );
+		const siteSlug = getSelectedSiteSlug( state );
 
 		page.redirect( '/domains/manage' + ( siteSlug ? `/${ siteSlug }` : '' ) );
 	},
@@ -319,7 +317,7 @@ export default {
 		const siteId = getSelectedSiteId( state );
 		const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
 		if ( isAutomatedTransfer ) {
-			const siteSlug = getSiteSlug( state, siteId );
+			const siteSlug = getSelectedSiteSlug( state );
 			page.redirect( `/domains/manage/${ siteSlug }` );
 			return;
 		}

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -32,7 +32,7 @@ const setTitle = function( title, pageContext ) {
 	pageContext.store.dispatch( setDocumentHeadTitle( title ) );
 };
 
-module.exports = {
+export default {
 	domainManagementList( pageContext ) {
 		setTitle(
 			i18n.translate( 'Domain Management' ),

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -19,7 +19,6 @@ import paths from 'my-sites/upgrades/paths';
 import ProductsList from 'lib/products-list';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
-import SitesList from 'lib/sites-list';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -27,8 +26,7 @@ import TransferData from 'components/data/domain-management/transfer';
 import WhoisData from 'components/data/domain-management/whois';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
 
-const productsList = new ProductsList(),
-	sites = new SitesList();
+const productsList = new ProductsList();
 
 const setTitle = function( title, pageContext ) {
 	pageContext.store.dispatch( setDocumentHeadTitle( title ) );
@@ -293,8 +291,12 @@ module.exports = {
 		);
 	},
 
-	domainManagementIndex() {
-		page.redirect( '/domains/manage' + ( sites.getSelectedSite() ? ( '/' + sites.getSelectedSite().slug ) : '' ) );
+	domainManagementIndex( pageContext ) {
+		const state = pageContext.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const siteSlug = getSiteSlug( state, siteId );
+
+		page.redirect( '/domains/manage' + ( siteSlug ? `/${ siteSlug }` : '' ) );
 	},
 
 	domainManagementTransfer( pageContext ) {


### PR DESCRIPTION
Part of #8726.

### Testing
1. Go to https://calypso.live/domains/unknow-name.
2. You should get redirected to https://calypso.live/domains/manage.
3. Go to https://calypso.live/domains/:site-slug.
4. You should get redirected to https://calypso.live/domains/manage/:site-slug.

### Review

* [ ] Code
* [ ] Product