### PR TITLE
Domains: Use ISO8601 format for dates

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -21,7 +21,7 @@ function createDomainObjects( dataTransferObject ) {
 
 	domains = dataTransferObject.map( ( domain ) => {
 		return {
-			autoRenewalDate: domain.auto_renewal_date,
+			autoRenewalMoment: domain.auto_renewal_date && i18n.moment( domain.auto_renewal_date ),
 			currentUserCanManage: domain.current_user_can_manage,
 			expirationMoment: domain.expiry && i18n.moment( domain.expiry ),
 			expired: domain.expired,

--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -23,7 +23,7 @@ function createDomainObjects( dataTransferObject ) {
 		return {
 			autoRenewalDate: domain.auto_renewal_date,
 			currentUserCanManage: domain.current_user_can_manage,
-			expirationMoment: domain.expiry ? i18n.moment( domain.expiry ) : null,
+			expirationMoment: domain.expiry && i18n.moment( domain.expiry ),
 			expired: domain.expired,
 			expirySoon: domain.expiry_soon,
 			googleAppsSubscription: assembleGoogleAppsSubscription( domain.google_apps_subscription ),
@@ -37,8 +37,7 @@ function createDomainObjects( dataTransferObject ) {
 			privateDomain: domain.private_domain,
 			pendingTransfer: domain.pending_transfer,
 			registrar: domain.registrar,
-			registrationDate: domain.registration_date,
-			registrationMoment: domain.registration_date && i18n.moment( domain.registration_date, 'MMMM D, YYYY', 'en' ).locale( false ),
+			registrationMoment: domain.registration_date && i18n.moment( domain.registration_date ),
 			hasZone: domain.has_zone,
 			pointsToWpcom: domain.points_to_wpcom,
 			type: getDomainType( domain )

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -34,7 +34,7 @@ describe( 'assembler', () => {
 		redirectDomainObject = {
 			autoRenewalDate: undefined,
 			currentUserCanManage: undefined,
-			expirationMoment: null,
+			expirationMoment: undefined,
 			expired: undefined,
 			expirySoon: undefined,
 			googleAppsSubscription: undefined,
@@ -48,7 +48,6 @@ describe( 'assembler', () => {
 			privateDomain: undefined,
 			pendingTransfer: undefined,
 			registrar: undefined,
-			registrationDate: undefined,
 			registrationMoment: undefined,
 			type: domainTypes.SITE_REDIRECT,
 			hasZone: undefined,

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -32,7 +32,7 @@ describe( 'assembler', () => {
 			wpcom_domain: true
 		} ),
 		redirectDomainObject = {
-			autoRenewalDate: undefined,
+			autoRenewalMoment: undefined,
 			currentUserCanManage: undefined,
 			expirationMoment: undefined,
 			expired: undefined,

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -83,14 +83,18 @@ function UndocumentedSite( id, wpcom ) {
 }
 
 UndocumentedSite.prototype.domains = function( callback ) {
-	return this.wpcom.req.get( '/sites/' + this._id + '/domains', function( error, response ) {
-		if ( error ) {
-			callback( error );
-			return;
-		}
+	return this.wpcom.req.get(
+		`/sites/${ this._id }/domains`,
+		{ apiVersion: '1.2' },
+		function( error, response ) {
+			if ( error ) {
+				callback( error );
+				return;
+			}
 
-		callback( null, response );
-	} );
+			callback( null, response );
+		}
+	);
 };
 
 UndocumentedSite.prototype.postFormatsList = function( callback ) {

--- a/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
@@ -117,4 +117,5 @@ const MappedDomain = React.createClass( {
 	}
 } );
 
+export { MappedDomain };
 export default localize( MappedDomain );

--- a/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
@@ -1,40 +1,41 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-const analyticsMixin = require( 'lib/mixins/analytics' ),
-	Card = require( 'components/card/compact' ),
-	Header = require( './card/header' ),
-	Property = require( './card/property' ),
-	SubscriptionSettings = require( './card/subscription-settings' ),
-	VerticalNav = require( 'components/vertical-nav' ),
-	VerticalNavItem = require( 'components/vertical-nav/item' ),
-	DomainWarnings = require( 'my-sites/upgrades/components/domain-warnings' ),
-	paths = require( 'my-sites/upgrades/paths' );
+import analyticsMixin from 'lib/mixins/analytics';
+import Card from 'components/card/compact';
+import Header from './card/header';
+import Property from './card/property';
+import SubscriptionSettings from './card/subscription-settings';
+import VerticalNav from 'components/vertical-nav';
+import VerticalNavItem from 'components/vertical-nav/item';
+import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
+import paths from 'my-sites/upgrades/paths';
 
 const MappedDomain = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
 
 	getAutoRenewalOrExpirationDate() {
-		const domain = this.props.domain;
+		const { domain, moment, translate } = this.props;
 
 		if ( domain.isAutoRenewing ) {
 			return (
-				<Property label={ this.translate( 'Mapping renews on' ) }>
-					{ domain.autoRenewalDate }
+				<Property label={ translate( 'Mapping renews on' ) }>
+					{ moment( domain.autoRenewalDate ).format( 'LL' ) }
 				</Property>
 			);
 		}
 
-		const expirationMessage = domain.expirationMoment && domain.expirationMoment.format( 'MMMM D, YYYY' ) ||
-			<em>{ this.translate( 'Never Expires', { context: 'Expiration detail for a mapped domain' } ) }</em>;
+		const expirationMessage = domain.expirationMoment && domain.expirationMoment.format( 'LL' ) ||
+			<em>{ translate( 'Never Expires', { context: 'Expiration detail for a mapped domain' } ) }</em>;
 
 		return (
-			<Property label={ this.translate( 'Mapping expires on' ) }>
+			<Property label={ translate( 'Mapping expires on' ) }>
 				{ expirationMessage }
 			</Property>
 		);
@@ -48,7 +49,7 @@ const MappedDomain = React.createClass( {
 		return <DomainWarnings
 			domain={ this.props.domain }
 			selectedSite={ this.props.selectedSite }
-			ruleWhiteList={ [ 'wrongNSMappedDomains' ] }/>;
+			ruleWhiteList={ [ 'wrongNSMappedDomains' ] } />;
 	},
 
 	render() {
@@ -67,8 +68,8 @@ const MappedDomain = React.createClass( {
 				<Header { ...this.props } />
 
 				<Card>
-					<Property label={ this.translate( 'Type', { context: 'A type of domain.' } ) }>
-						{ this.translate( 'Mapped Domain' ) }
+					<Property label={ this.props.translate( 'Type', { context: 'A type of domain.' } ) }>
+						{ this.props.translate( 'Mapped Domain' ) }
 					</Property>
 
 					{ this.getAutoRenewalOrExpirationDate() }
@@ -97,7 +98,7 @@ const MappedDomain = React.createClass( {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.translate( 'Email' ) }
+				{ this.props.translate( 'Email' ) }
 			</VerticalNavItem>
 		);
 	},
@@ -110,10 +111,10 @@ const MappedDomain = React.createClass( {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.translate( 'DNS Records' ) }
+				{ this.props.translate( 'DNS Records' ) }
 			</VerticalNavItem>
 		);
 	}
 } );
 
-module.exports = MappedDomain;
+export default localize( MappedDomain );

--- a/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
@@ -21,12 +21,12 @@ const MappedDomain = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
 
 	getAutoRenewalOrExpirationDate() {
-		const { domain, moment, translate } = this.props;
+		const { domain, translate } = this.props;
 
 		if ( domain.isAutoRenewing ) {
 			return (
 				<Property label={ translate( 'Mapping renews on' ) }>
-					{ moment( domain.autoRenewalDate ).format( 'LL' ) }
+					{ domain.autoRenewalMoment.format( 'LL' ) }
 				</Property>
 			);
 		}

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -23,19 +23,19 @@ const RegisteredDomain = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
 
 	getAutoRenewalOrExpirationDate() {
-		const { domain, moment, translate } = this.props;
+		const { domain, translate } = this.props;
 
 		if ( domain.isAutoRenewing ) {
 			return (
 				<Property label={ translate( 'Renews on' ) }>
-					{ moment( domain.autoRenewalDate ).format( 'LL' ) }
+					{ domain.autoRenewalMoment.format( 'LL' ) }
 				</Property>
 			);
 		}
 
 		return (
 			<Property label={ translate( 'Expires on' ) }>
-				{ domain.expirationMoment.format( 'MMMM D, YYYY' ) }
+				{ domain.expirationMoment.format( 'LL' ) }
 			</Property>
 		);
 	},

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -22,18 +23,18 @@ const RegisteredDomain = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
 
 	getAutoRenewalOrExpirationDate() {
-		const domain = this.props.domain;
+		const { domain, moment, translate } = this.props;
 
 		if ( domain.isAutoRenewing ) {
 			return (
-				<Property label={ this.translate( 'Renews on' ) }>
-					{ domain.autoRenewalDate }
+				<Property label={ translate( 'Renews on' ) }>
+					{ moment( domain.autoRenewalDate ).format( 'LL' ) }
 				</Property>
 			);
 		}
 
 		return (
-			<Property label={ this.translate( 'Expires on' ) }>
+			<Property label={ translate( 'Expires on' ) }>
 				{ domain.expirationMoment.format( 'MMMM D, YYYY' ) }
 			</Property>
 		);
@@ -54,6 +55,7 @@ const RegisteredDomain = React.createClass( {
 	getPrivacyProtection() {
 		const { hasPrivacyProtection, privateDomain, name, pendingTransfer } = this.props.domain,
 			{ slug } = this.props.selectedSite,
+			{ translate } = this.props,
 			privacyPath = paths.domainManagementContactsPrivacy( slug, name ),
 			transferPath = paths.domainManagementTransferOut( slug, name );
 
@@ -61,7 +63,7 @@ const RegisteredDomain = React.createClass( {
 			return this.getLabel( {
 				status: 'is-warning',
 				icon: 'notice',
-				message: this.translate( 'Pending Transfer', {
+				message: translate( 'Pending Transfer', {
 					context: 'An icon label when domain is pending transfer.'
 				} )
 			} );
@@ -73,7 +75,7 @@ const RegisteredDomain = React.createClass( {
 					status: 'is-success',
 					icon: 'lock',
 					href: privacyPath,
-					message: this.translate( 'On', {
+					message: translate( 'On', {
 						context: 'An icon label when Privacy Protection is enabled.'
 					} )
 				} );
@@ -83,7 +85,7 @@ const RegisteredDomain = React.createClass( {
 				status: 'is-warning',
 				icon: 'notice',
 				href: transferPath,
-				message: this.translate( 'Disabled for Transfer', {
+				message: translate( 'Disabled for Transfer', {
 					context: 'An icon label when Privacy Protection is temporarily disabled for transfer.'
 				} )
 			} );
@@ -93,7 +95,7 @@ const RegisteredDomain = React.createClass( {
 			status: 'is-warning',
 			icon: 'notice',
 			href: privacyPath,
-			message: this.translate( 'None', {
+			message: translate( 'None', {
 				context: 'An icon label when Privacy Protection is not purchased by the user.'
 			} )
 		} );
@@ -146,7 +148,7 @@ const RegisteredDomain = React.createClass( {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.translate( 'Email' ) }
+				{ this.props.translate( 'Email' ) }
 			</VerticalNavItem>
 		);
 	},
@@ -163,7 +165,7 @@ const RegisteredDomain = React.createClass( {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.translate( 'Name Servers and DNS' ) }
+				{ this.props.translate( 'Name Servers and DNS' ) }
 			</VerticalNavItem>
 		);
 	},
@@ -180,7 +182,7 @@ const RegisteredDomain = React.createClass( {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.translate( 'Contacts and Privacy' ) }
+				{ this.props.translate( 'Contacts and Privacy' ) }
 			</VerticalNavItem>
 		);
 	},
@@ -193,13 +195,13 @@ const RegisteredDomain = React.createClass( {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.translate( 'Transfer Domain' ) }
+				{ this.props.translate( 'Transfer Domain' ) }
 			</VerticalNavItem>
 		);
 	},
 
 	render() {
-		const domain = this.props.domain;
+		const { domain, translate } = this.props;
 
 		return (
 			<div>
@@ -208,17 +210,17 @@ const RegisteredDomain = React.createClass( {
 					<Header { ...this.props } />
 
 					<Card>
-						<Property label={ this.translate( 'Type', { context: 'A type of domain.' } ) }>
-							{ this.translate( 'Registered Domain' ) }
+						<Property label={ translate( 'Type', { context: 'A type of domain.' } ) }>
+							{ translate( 'Registered Domain' ) }
 						</Property>
 
-						<Property label={ this.translate( 'Registered on' ) }>
-							{ domain.registrationDate }
+						<Property label={ translate( 'Registered on' ) }>
+							{ domain.registrationMoment.format( 'LL' ) }
 						</Property>
 
 						{ this.getAutoRenewalOrExpirationDate() }
 
-						<Property label={ this.translate( 'Privacy Protection' ) }>
+						<Property label={ translate( 'Privacy Protection' ) }>
 							{ this.getPrivacyProtection() }
 						</Property>
 
@@ -235,4 +237,4 @@ const RegisteredDomain = React.createClass( {
 	}
 } );
 
-export default RegisteredDomain;
+export default localize( RegisteredDomain );

--- a/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
@@ -1,37 +1,38 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-const analyticsMixin = require( 'lib/mixins/analytics' ),
-	Card = require( 'components/card/compact' ),
-	Header = require( './card/header' ),
-	Property = require( './card/property' ),
-	SubscriptionSettings = require( './card/subscription-settings' ),
-	VerticalNav = require( 'components/vertical-nav' ),
-	VerticalNavItem = require( 'components/vertical-nav/item' ),
-	paths = require( 'my-sites/upgrades/paths' );
+import analyticsMixin from 'lib/mixins/analytics';
+import Card from 'components/card/compact';
+import Header from './card/header';
+import Property from './card/property';
+import SubscriptionSettings from './card/subscription-settings';
+import VerticalNav from 'components/vertical-nav';
+import VerticalNavItem from 'components/vertical-nav/item';
+import paths from 'my-sites/upgrades/paths';
 
 const SiteRedirect = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
 
 	getAutoRenewalOrExpirationDate() {
-		const domain = this.props.domain;
+		const { domain, moment, translate } = this.props;
 
 		if ( domain.isAutoRenewing ) {
 			return (
-				<Property label={ this.translate( 'Redirect renews on' ) }>
-					{ domain.autoRenewalDate }
+				<Property label={ translate( 'Redirect renews on' ) }>
+					{ moment( domain.autoRenewalDate ).format( 'LL' ) }
 				</Property>
 			);
 		}
 
 		return (
-			<Property label={ this.translate( 'Redirect expires on' ) }>
-				{ domain.expirationMoment.format( 'MMMM D, YYYY' ) }
+			<Property label={ translate( 'Redirect expires on' ) }>
+				{ domain.expirationMoment.format( 'LL' ) }
 			</Property>
 		);
 	},
@@ -47,8 +48,8 @@ const SiteRedirect = React.createClass( {
 					<Header { ...this.props } />
 
 					<Card>
-						<Property label={ this.translate( 'Type', { context: 'A type of domain.' } ) }>
-							{ this.translate( 'Site Redirect' ) }
+						<Property label={ this.props.translate( 'Type', { context: 'A type of domain.' } ) }>
+							{ this.props.translate( 'Site Redirect' ) }
 						</Property>
 
 						{ this.getAutoRenewalOrExpirationDate() }
@@ -68,10 +69,10 @@ const SiteRedirect = React.createClass( {
 	siteRedirectNavItem() {
 		return (
 			<VerticalNavItem path={ paths.domainManagementRedirectSettings( this.props.selectedSite.slug, this.props.domain.name ) }>
-				{ this.translate( 'Redirect Settings' ) }
+				{ this.props.translate( 'Redirect Settings' ) }
 			</VerticalNavItem>
 		);
 	}
 } );
 
-module.exports = SiteRedirect;
+export default localize( SiteRedirect );

--- a/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
@@ -20,12 +20,12 @@ const SiteRedirect = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
 
 	getAutoRenewalOrExpirationDate() {
-		const { domain, moment, translate } = this.props;
+		const { domain, translate } = this.props;
 
 		if ( domain.isAutoRenewing ) {
 			return (
 				<Property label={ translate( 'Redirect renews on' ) }>
-					{ moment( domain.autoRenewalDate ).format( 'LL' ) }
+					{ domain.autoRenewalMoment.format( 'LL' ) }
 				</Property>
 			);
 		}

--- a/client/my-sites/upgrades/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/upgrades/domain-management/edit/test/mapped-domain.js
@@ -3,6 +3,7 @@
  */
 import assert from 'assert';
 import sinon from 'sinon';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +27,8 @@ describe( 'mapped-domain', () => {
 				name: 'neverexpires.com',
 				expirationMoment: null
 			},
-			settingPrimaryDomain: false
+			settingPrimaryDomain: false,
+			translate: identity
 		};
 	} );
 
@@ -41,7 +43,7 @@ describe( 'mapped-domain', () => {
 
 		const ReactClass = require( 'react/lib/ReactClass' );
 		ReactClass.injection.injectMixin( require( 'i18n-calypso' ).mixin );
-		MappedDomain = require( '../mapped-domain.jsx' );
+		MappedDomain = require( '../mapped-domain.jsx' ).MappedDomain;
 	} );
 
 	it( 'should render when props.domain.expirationMoment is null', () => {

--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -67,7 +67,7 @@ export function getDecoratedSiteDomains( state, siteId ) {
 
 			// Add registration moment from registrationDate
 			registrationMoment: domain.registrationDate
-				? moment( domain.registrationDate, 'MMMM D, YYYY', 'en' ).locale( false )
+				? moment( domain.registrationDate )
 				: null,
 
 			// Add expiration moment from expiry

--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -65,12 +65,14 @@ export function getDecoratedSiteDomains( state, siteId ) {
 		return {
 			...domain,
 
-			// Add registration moment from registrationDate
+			autoRenewalMoment: domain.autoRenewalDate
+				? moment( domain.autoRenewalDate )
+				: null,
+
 			registrationMoment: domain.registrationDate
 				? moment( domain.registrationDate )
 				: null,
 
-			// Add expiration moment from expiry
 			expirationMoment: domain.expiry
 				? moment( domain.expiry )
 				: null

--- a/client/state/sites/domains/test/fixture.js
+++ b/client/state/sites/domains/test/fixture.js
@@ -17,7 +17,7 @@ export const SITE_ID_SECOND = 77203074;
 
 // testing primary-domain
 export const DOMAIN_PRIMARY = {
-	autoRenewalDate: 'February 7, 2017',
+	autoRenewalDate: '2017-02-07T00:00:00+00:00',
 	autoRenewing: true,
 	blogId: SITE_ID_FIRST,
 	canSetAsPrimary: true,
@@ -44,7 +44,7 @@ export const DOMAIN_PRIMARY = {
 	isPrimary: true,
 	isPrivate: false,
 	registrar: '',
-	registrationDate: 'March 9, 2016',
+	registrationDate: '2016-03-09T00:00:00+00:00',
 	type: 'MAPPED',
 	isWPCOMDomain: false
 };
@@ -87,7 +87,7 @@ export const DOMAIN_NOT_PRIMARY = {
 export const ERROR_MESSAGE_RESPONSE = 'There was a problem fetching site domains. Please try again later or contact support.';
 
 export const REST_API_SITE_DOMAIN_FIRST = {
-	auto_renewal_date: 'February 7, 2017',
+	auto_renewal_date: '2017-02-07T00:00:00+00:00',
 	auto_renewing: 1,
 	blog_id: SITE_ID_FIRST,
 	can_set_as_primary: true,
@@ -113,7 +113,7 @@ export const REST_API_SITE_DOMAIN_FIRST = {
 	primary_domain: true,
 	private_domain: false,
 	registrar: '',
-	registration_date: 'March 9, 2016',
+	registration_date: '2016-03-09T00:00:00+00:00',
 	type: 'mapping',
 	wpcom_domain: false
 };

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -59,6 +59,17 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#decorateSiteDomains()', () => {
+		it( 'should return decorated site domains with autoRenewalMoment', () => {
+			const state = getStateInstance(),
+				domains = getDomainsBySiteId( state, firstSiteId );
+
+			const decoratedDomains = getDecoratedSiteDomains( state, firstSiteId );
+
+			const domainAutoRenewalMoment = moment( domains[ 0 ].autoRenewalDate );
+
+			expect( decoratedDomains[ 0 ].autoRenewalMoment.date() ).to.equal( domainAutoRenewalMoment.date() );
+		} );
+
 		it( 'should return decorated site domains with registrationMoment', () => {
 			const state = getStateInstance(),
 				domains = getDomainsBySiteId( state, firstSiteId );

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -65,9 +65,7 @@ describe( 'selectors', () => {
 
 			const decoratedDomains = getDecoratedSiteDomains( state, firstSiteId );
 
-			const domainRegistrationMoment = moment(
-				domains[ 0 ].registrationDate, 'MMMM D, YYYY', 'en'
-			).locale( false );
+			const domainRegistrationMoment = moment( domains[ 0 ].registrationDate );
 
 			expect( decoratedDomains[ 0 ].registrationMoment.date() ).to.equal( domainRegistrationMoment.date() );
 		} );


### PR DESCRIPTION
Previously, we've returned localized strings from the backend for those dates. This had several disadvantages, the biggest being: messing up the parsing with non-en locales and missing the time part of the registration date.

Now, we use the ISO8601 format that should prevent those issues. We rely on i18n-calypso to provide locale-specific date format, that's accurate for the current locale, not just USA.

To keep everything consistent, I've made sure that we keep the `moment` versions in memory (they are more developer friendly and there's no reason to re-create them from strings every time we want to format or compare a date), but store the raw strings in redux.

### Testing
Requires `D5304-code` on the backend to introduce the 1.2 version of the endpoint.
Check out Domain Management section in Calypso for any differences in dates between the new endpoint and the old one.
Make sure that the domain warnings are shown when needed (and not when not needed ;)).

Be sure to test using non-`en` locale too.

Before (`en`):
<img width="657" alt="screen shot 2017-04-25 at 12 40 49" src="https://cloud.githubusercontent.com/assets/3392497/25381529/70d36b84-29b4-11e7-87ec-30fc79558b3a.png">

After (`en`) - spoiler: there should be no difference:
<img width="656" alt="screen shot 2017-04-25 at 12 41 06" src="https://cloud.githubusercontent.com/assets/3392497/25381539/7af53160-29b4-11e7-9f0f-707787444897.png">

Before (`pl`) - this is a weird format for a Polish locale - we don't capitalize the months like that and the month is missing declension:
<img width="655" alt="screen shot 2017-04-25 at 12 37 20" src="https://cloud.githubusercontent.com/assets/3392497/25381428/034e65dc-29b4-11e7-9516-cbe723566a69.png">

After (`pl`) - looking good now:
<img width="656" alt="screen shot 2017-04-25 at 12 36 49" src="https://cloud.githubusercontent.com/assets/3392497/25381432/074d1124-29b4-11e7-9ff3-eb1d24341a5b.png">

Fixes #13301