### PR TITLE
Use es6 class for jetpack-connect

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Gridicon from 'gridicons';
@@ -45,8 +45,13 @@ import {
  */
 const MINIMUM_JETPACK_VERSION = '3.9.6';
 
-const JetpackConnectMain = React.createClass( {
-	displayName: 'JetpackConnectSiteURLStep',
+class JetpackConnectMain extends Component {
+
+	state = {
+		currentUrl: '',
+		waitingForSites: false,
+		initialUrl: null,
+	};
 
 	componentWillMount() {
 		if ( this.props.url ) {
@@ -57,7 +62,7 @@ const JetpackConnectMain = React.createClass( {
 			this.setState( { currentUrl: untrailingslashit( url ), initialUrl: url } );
 			this.checkUrl( url );
 		}
-	},
+	}
 
 	componentDidMount() {
 		let from = 'direct';
@@ -76,32 +81,24 @@ const JetpackConnectMain = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from
 		} );
-	},
-
-	getInitialState() {
-		return {
-			currentUrl: '',
-			waitingForSites: false,
-			initialUrl: null
-		};
-	},
+	}
 
 	dismissUrl() {
 		this.props.dismissUrl( this.state.currentUrl );
-	},
+	}
 
 	isCurrentUrlFetched() {
 		return this.props.jetpackConnectSite &&
 			this.state.currentUrl === this.props.jetpackConnectSite.url &&
 			this.props.jetpackConnectSite.isFetched;
-	},
+	}
 
 	isCurrentUrlFetching() {
 		return this.state.currentUrl !== '' &&
 			this.props.jetpackConnectSite &&
 			this.state.currentUrl === this.props.jetpackConnectSite.url &&
 			this.props.jetpackConnectSite.isFetching;
-	},
+	}
 
 	getCurrentUrl() {
 		let url = this.refs.siteUrlInputRef.state.value.toLowerCase();
@@ -109,12 +106,12 @@ const JetpackConnectMain = React.createClass( {
 			url = 'http://' + url;
 		}
 		return untrailingslashit( url );
-	},
+	}
 
 	onURLChange() {
 		this.setState( { currentUrl: this.getCurrentUrl() } );
 		this.dismissUrl();
-	},
+	}
 
 	checkUrl( url ) {
 		return this.props.checkUrl(
@@ -122,7 +119,7 @@ const JetpackConnectMain = React.createClass( {
 			!! this.props.getJetpackSiteByUrl( url ),
 			this.props.type
 		);
-	},
+	}
 
 	onURLEnter() {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
@@ -133,7 +130,7 @@ const JetpackConnectMain = React.createClass( {
 		} else {
 			this.checkUrl( this.state.currentUrl );
 		}
-	},
+	}
 
 	installJetpack() {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
@@ -142,7 +139,7 @@ const JetpackConnectMain = React.createClass( {
 		} );
 
 		this.props.goToPluginInstall( this.state.currentUrl );
-	},
+	}
 
 	activateJetpack() {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
@@ -150,7 +147,7 @@ const JetpackConnectMain = React.createClass( {
 			type: 'activate_jetpack'
 		} );
 		this.props.goToPluginActivation( this.state.currentUrl );
-	},
+	}
 
 	checkProperty( propName ) {
 		return this.state.currentUrl &&
@@ -158,7 +155,7 @@ const JetpackConnectMain = React.createClass( {
 			this.props.jetpackConnectSite.data &&
 			this.isCurrentUrlFetched() &&
 			this.props.jetpackConnectSite.data[ propName ];
-	},
+	}
 
 	componentDidUpdate() {
 		if ( this.getStatus() === 'notConnectedJetpack' &&
@@ -177,13 +174,13 @@ const JetpackConnectMain = React.createClass( {
 			this.setState( { waitingForSites: false } );
 			this.checkUrl( this.state.currentUrl );
 		}
-	},
+	}
 
 	isRedirecting() {
 		return this.props.jetpackConnectSite &&
 			this.props.jetpackConnectSite.isRedirecting &&
 			this.isCurrentUrlFetched();
-	},
+	}
 
 	getStatus() {
 		if ( this.state.currentUrl === '' ) {
@@ -233,11 +230,11 @@ const JetpackConnectMain = React.createClass( {
 		}
 
 		return false;
-	},
+	}
 
 	handleOnClickTos() {
 		this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
-	},
+	}
 
 	getTexts() {
 		const { type, selectedPlan } = this.props;
@@ -276,14 +273,14 @@ const JetpackConnectMain = React.createClass( {
 			headerSubtitle: this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to ' +
 				'your self-hosted WordPress site.' ),
 		};
-	},
+	}
 
 	isInstall() {
 		return this.props.type === 'install' ||
 			this.props.type === 'pro' ||
 			this.props.type === 'premium' ||
 			this.props.type === 'personal';
-	},
+	}
 
 	getInstructionsData( status ) {
 		return {
@@ -301,7 +298,7 @@ const JetpackConnectMain = React.createClass( {
 				? this.translate( 'Install Jetpack' )
 				: this.translate( 'Activate Jetpack' )
 		};
-	},
+	}
 
 	renderFooter() {
 		return (
@@ -316,7 +313,7 @@ const JetpackConnectMain = React.createClass( {
 				<HelpButton />
 			</LoggedOutFormLinks>
 		);
-	},
+	}
 
 	renderSiteInput( status ) {
 		return (
@@ -337,7 +334,7 @@ const JetpackConnectMain = React.createClass( {
 					isInstall={ this.isInstall() } />
 			</Card>
 		);
-	},
+	}
 
 	renderLocaleSuggestions() {
 		if ( this.props.userModule.get() || ! this.props.locale ) {
@@ -347,7 +344,7 @@ const JetpackConnectMain = React.createClass( {
 		return (
 			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 		);
-	},
+	}
 
 	renderSiteEntry() {
 		const status = this.getStatus();
@@ -368,7 +365,7 @@ const JetpackConnectMain = React.createClass( {
 				</div>
 			</MainWrapper>
 		);
-	},
+	}
 
 	renderNotJetpackButton() {
 		return (
@@ -376,7 +373,7 @@ const JetpackConnectMain = React.createClass( {
 				{ this.translate( 'Don\'t have jetpack installed?' ) }
 			</a>
 		);
-	},
+	}
 
 	renderBackButton() {
 		return (
@@ -385,7 +382,7 @@ const JetpackConnectMain = React.createClass( {
 				{ this.translate( 'Back' ) }
 			</Button>
 		);
-	},
+	}
 
 	renderInstructions( instructionsData ) {
 		const jetpackVersion = this.checkProperty( 'jetpackVersion' ),
@@ -428,7 +425,7 @@ const JetpackConnectMain = React.createClass( {
 				</LoggedOutFormLinks>
 			</MainWrapper>
 		);
-	},
+	}
 
 	render() {
 		const status = this.getStatus();
@@ -440,7 +437,7 @@ const JetpackConnectMain = React.createClass( {
 		}
 		return this.renderSiteEntry();
 	}
-} );
+}
 
 export default connect(
 	state => {

--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -15,18 +15,17 @@ import JetpackExampleConnect from './example-components/jetpack-connect';
 
 const NEW_INSTRUCTIONS_JETPACK_VERSION = '4.2.0';
 
-export default React.createClass( {
-	displayName: 'JetpackInstallStep',
+export default class JetpackInstallStep extends Component {
 
 	confirmJetpackInstalled( event ) {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( true );
-	},
+	}
 
 	confirmJetpackNotInstalled( event ) {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( false );
-	},
+	}
 
 	renderAlreadyHaveJetpackButton() {
 		return (
@@ -34,7 +33,7 @@ export default React.createClass( {
 				{ preventWidows( this.translate( 'Already have Jetpack installed?' ) ) }
 			</a>
 		);
-	},
+	}
 
 	renderNotJetpackButton() {
 		return (
@@ -42,7 +41,7 @@ export default React.createClass( {
 				{ preventWidows( this.translate( 'Don\'t have Jetpack installed?' ) ) }
 			</a>
 		);
-	},
+	}
 
 	getStep( stepName ) {
 		const isLegacyVersion = (
@@ -91,7 +90,7 @@ export default React.createClass( {
 			}
 		};
 		return steps[ stepName ];
-	},
+	}
 
 	render() {
 		const step = this.getStep( this.props.stepName );
@@ -110,4 +109,4 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+}

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -9,13 +9,12 @@ import React, { PropTypes } from 'react';
 import Notice from 'components/notice';
 import { urlToSlug } from 'lib/url';
 
-export default React.createClass( {
-	displayName: 'JetpackConnectNotices',
+export default class JetpackConnectNotices extends Component {
 
-	propTypes: {
+	static propTypes = {
 		noticeType: PropTypes.string,
 		siteUrl: PropTypes.string
-	},
+	};
 
 	getNoticeValues() {
 		const noticeValues = {
@@ -119,7 +118,7 @@ export default React.createClass( {
 		}
 
 		return;
-	},
+	}
 
 	render() {
 		const urlSlug = this.props.url ? urlToSlug( this.props.url ) : '';
@@ -133,4 +132,4 @@ export default React.createClass( {
 		}
 		return null;
 	}
-} );
+}

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -10,8 +10,7 @@ import Main from 'components/main';
 import StepHeader from '../step-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 
-export default React.createClass( {
-	displayName: 'JetpackPlansGrid',
+export default class JetpackPlansGrid extends Component {
 
 	renderConnectHeader() {
 		let headerText = this.translate( 'Your site is now connected!' );
@@ -35,7 +34,7 @@ export default React.createClass( {
 				step={ 1 }
 				steps={ 3 } />
 		);
-	},
+	}
 
 	render() {
 		const defaultJetpackSite = { jetpack: true, plan: {}, isUpgradeable: () => true };
@@ -58,4 +57,4 @@ export default React.createClass( {
 			</Main>
 		);
 	}
-} );
+}

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
-import React from 'react';
 import { bindActionCreators } from 'redux';
 
 /**
@@ -16,26 +16,24 @@ import QueryPlans from 'components/data/query-plans';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 
-const PlansLanding = React.createClass( {
+class PlansLanding extends Component {
 
-	propTypes: {
-		sites: React.PropTypes.object,
-		sitePlans: React.PropTypes.object.isRequired,
-		intervalType: React.PropTypes.string
-	},
+	static propTypes = {
+		sites: PropTypes.object,
+		sitePlans: PropTypes.object.isRequired,
+		intervalType: PropTypes.string
+	};
 
-	getDefaultProps() {
-		return {
-			intervalType: 'yearly',
-			siteSlug: '*'
-		};
-	},
+	static defaultProps = {
+		intervalType: 'yearly',
+		siteSlug: '*'
+	};
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
 			jpc_from: this.props.landingType
 		} );
-	},
+	}
 
 	storeSelectedPlan( cartItem ) {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
@@ -46,7 +44,7 @@ const PlansLanding = React.createClass( {
 		setTimeout( () => {
 			page.redirect( CALYPSO_JETPACK_CONNECT );
 		}, 25 );
-	},
+	}
 
 	render() {
 		return (
@@ -58,7 +56,7 @@ const PlansLanding = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	() => {

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import debugModule from 'debug';
@@ -44,18 +44,15 @@ import EmailVerificationGate from 'components/email-verification/email-verificat
  */
 const debug = debugModule( 'calypso:jetpack-connect:sso' );
 
-const JetpackSSOForm = React.createClass( {
-	displayName: 'JetpackSSOForm',
+class JetpackSSOForm extends Component {
 
-	getInitialState() {
-		return {
-			showTermsDialog: false
-		};
-	},
+	state = {
+		showTermsDialog: false
+	};
 
 	componentWillMount() {
 		this.maybeValidateSSO();
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.maybeValidateSSO( nextProps );
@@ -71,7 +68,7 @@ const JetpackSSOForm = React.createClass( {
 			debug( 'Redirecting to: ' + redirect );
 			window.location.href = redirect;
 		}
-	},
+	}
 
 	onApproveSSO( event ) {
 		event.preventDefault();
@@ -87,23 +84,23 @@ const JetpackSSOForm = React.createClass( {
 
 		debug( 'Approving sso' );
 		this.props.authorizeSSO( siteId, ssoNonce, siteUrl );
-	},
+	}
 
 	onCancelClick( event ) {
 		debug( 'Clicked return to site link' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_return_to_site_link_click' );
 		this.returnToSiteFallback( event );
-	},
+	}
 
 	onTryAgainClick( event ) {
 		debug( 'Clicked try again link' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_try_again_link_click' );
 		this.returnToSiteFallback( event );
-	},
+	}
 
 	onClickSignInDifferentUser() {
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_sign_in_different_user_link_click' );
-	},
+	}
 
 	onClickSharedDetailsModal( event ) {
 		event.preventDefault();
@@ -111,13 +108,13 @@ const JetpackSSOForm = React.createClass( {
 		this.setState( {
 			showTermsDialog: true
 		} );
-	},
+	}
 
 	closeTermsDialog() {
 		this.setState( {
 			showTermsDialog: false
 		} );
-	},
+	}
 
 	returnToSiteFallback( event ) {
 		// If, for some reason, the API request failed and we do not have the admin URL,
@@ -127,17 +124,17 @@ const JetpackSSOForm = React.createClass( {
 			event.preventDefault();
 			window.history.back();
 		}
-	},
+	}
 
 	isButtonDisabled() {
 		const user = this.props.userModule.get();
 		const { nonceValid, isAuthorizing, isValidating, ssoUrl, authorizationError } = this.props;
 		return !! ( ! nonceValid || isAuthorizing || isValidating || ssoUrl || authorizationError || ! user.email_verified );
-	},
+	}
 
 	getSignInLink() {
 		return login( { legacy: true, redirectTo: window.location.href } );
-	},
+	}
 
 	maybeValidateSSO( props = this.props ) {
 		const { ssoNonce, siteId, nonceValid, isAuthorizing, isValidating } = props;
@@ -145,7 +142,7 @@ const JetpackSSOForm = React.createClass( {
 		if ( ssoNonce && siteId && 'undefined' === typeof nonceValid && ! isAuthorizing && ! isValidating ) {
 			this.props.validateSSONonce( siteId, ssoNonce );
 		}
-	},
+	}
 
 	maybeRenderErrorNotice() {
 		const { authorizationError, nonceValid } = this.props;
@@ -166,7 +163,7 @@ const JetpackSSOForm = React.createClass( {
 				</NoticeAction>
 			</Notice>
 		);
-	},
+	}
 
 	renderSiteCard() {
 		const { blogDetails } = this.props;
@@ -190,7 +187,7 @@ const JetpackSSOForm = React.createClass( {
 				{ site }
 			</CompactCard>
 		);
-	},
+	}
 
 	getSharedDetailLabel( key ) {
 		switch ( key ) {
@@ -227,7 +224,7 @@ const JetpackSSOForm = React.createClass( {
 		}
 
 		return key;
-	},
+	}
 
 	getSharedDetailValue( key, value ) {
 		if ( 'two_step_enabled' === key && value !== '' ) {
@@ -237,7 +234,7 @@ const JetpackSSOForm = React.createClass( {
 		}
 
 		return decodeEntities( value );
-	},
+	}
 
 	getReturnToSiteText() {
 		const text = (
@@ -254,7 +251,7 @@ const JetpackSSOForm = React.createClass( {
 		);
 
 		return this.maybeWrapWithPlaceholder( text );
-	},
+	}
 
 	getTOSText() {
 		const text = this.translate(
@@ -276,7 +273,7 @@ const JetpackSSOForm = React.createClass( {
 		);
 
 		return this.maybeWrapWithPlaceholder( text );
-	},
+	}
 
 	getSubHeaderText() {
 		const text = this.translate(
@@ -287,7 +284,7 @@ const JetpackSSOForm = React.createClass( {
 			}
 		);
 		return this.maybeWrapWithPlaceholder( text );
-	},
+	}
 
 	maybeWrapWithPlaceholder( input ) {
 		const title = get( this.props, 'blogDetails.title' );
@@ -300,7 +297,7 @@ const JetpackSSOForm = React.createClass( {
 				{ input }
 			</span>
 		);
-	},
+	}
 
 	renderSharedDetailsList() {
 		const expectedSharedDetails = {
@@ -335,7 +332,7 @@ const JetpackSSOForm = React.createClass( {
 				</tbody>
 			</table>
 		);
-	},
+	}
 
 	renderSharedDetailsDialog() {
 		const buttons = [
@@ -364,7 +361,7 @@ const JetpackSSOForm = React.createClass( {
 				</div>
 			</Dialog>
 		);
-	},
+	}
 
 	renderBadPathArgsError() {
 		return (
@@ -387,7 +384,7 @@ const JetpackSSOForm = React.createClass( {
 				/>
 			</Main>
 		);
-	},
+	}
 
 	render() {
 		const user = this.props.userModule.get();
@@ -463,7 +460,7 @@ const JetpackSSOForm = React.createClass( {
 			</MainWrapper>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => {


### PR DESCRIPTION
This PR updates `client/signup/jetpack/connect` to use es6 class declarations.

This PR omits `authorize-form`, which will be handled in a separate PR as it is more complicated and requires rewriting mixins.

This is part of a series of PRs which will allow us to move forward migrating `jetpack-connect` out of `signup`.

To test:

* Use this branch to run through various connection flows, the behaviour should remain unchanged.