### PR TITLE
Remove unused variable sites from upgrades controller

### DIFF
--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -12,7 +12,6 @@ import { get, isEmpty } from 'lodash';
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
-import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
 import Main from 'components/main';
 import upgradesActions from 'lib/upgrades/actions';
@@ -31,7 +30,6 @@ import { getCurrentUser } from 'state/current-user/selectors';
 /**
  * Module variables
  */
-const sites = sitesFactory();
 const productsList = productsFactory();
 
 module.exports = {


### PR DESCRIPTION
Removes a `sites` variable declaration. This is not used anymore after #12943 got merged

#### Testing instructions

Confirm that the CI runs are not failing for this branch. They should be failing for any PR that is rebased against latest master.