### PR TITLE
Themes: Use '+' instead of ',' to separate filters in URLs

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -181,7 +181,7 @@ export function redirectSearchAndType( { res, params: { site, search, tier } } 
 export function redirectFilterAndType( { res, params: { site, filter, tier } } ) {
 	let parts;
 	if ( filter ) {
-		parts = [ tier, 'filter', filter.replace( '+', ',' ), site ]; // The Atlas Showcase used plusses, we use commas
+		parts = [ tier, 'filter', filter, site ];
 	} else {
 		parts = [ tier, site ];
 	}

--- a/client/my-sites/themes/test/theme-filters.js
+++ b/client/my-sites/themes/test/theme-filters.js
@@ -58,7 +58,7 @@ describe( 'theme-filters', () => {
 	describe( 'getSortedFilterTerms', () => {
 		it( 'should return terms from a mixed input string', () => {
 			const terms = getSortedFilterTerms( 'blah rah color:blue yah feature:post-slider blah' );
-			assert.equal( terms, 'blue,post-slider' );
+			assert.equal( terms, 'blue+post-slider' );
 		} );
 
 		it( 'should ignore invalid filters', () => {

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -273,7 +273,7 @@ export function getFilter( term ) {
  * For array of terms recreate full search string in
  * "taxonomy:term taxonomy:term" search-box format.
  *
- * @param {Array} terms - the terms slugs
+ * @param {string} terms - space or + separated list of filter terms
  * @return {string}     - complete taxonomy:term filter string, or empty string if term is not valid
  */
 export function prependFilterKeys( terms ) {

--- a/client/my-sites/themes/theme-filters.js
+++ b/client/my-sites/themes/theme-filters.js
@@ -278,7 +278,7 @@ export function getFilter( term ) {
  */
 export function prependFilterKeys( terms ) {
 	if ( terms ) {
-		return terms.split( ',' ).map( getFilter ).join( ' ' ) + ' ';
+		return terms.split( /[+\s]/ ).map( getFilter ).join( ' ' ) + ' ';
 	}
 	return '';
 }
@@ -325,7 +325,7 @@ export function getSortedFilterTerms( input ) {
 	const matches = input.match( FILTER_REGEX_GLOBAL );
 	if ( matches ) {
 		const terms = matches.filter( filterIsValid ).map( getTerm );
-		return sortFilterTerms( terms ).join( ',' );
+		return sortFilterTerms( terms ).join( '+' );
 	}
 	return '';
 }

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -1,6 +1,3 @@
-// TODO (seear): This middleware should be made isomorphic once we
-// have a solution for isomorphic redirects.
-
 /**
  * External dependencies
  */
@@ -13,9 +10,12 @@ import { isValidTerm, sortFilterTerms } from './theme-filters';
 
 // Reorder and remove invalid filters to redirect to canonical URL
 module.exports = function validateFilter( context, next ) {
-	const filterParam = context.params.filter;
-	const validFilters = filterParam.split( ',' ).filter( isValidTerm );
-	const sortedValidFilters = sortFilterTerms( validFilters ).join( ',' );
+	// Page.js replaces + with \s
+	const filterParam = context.params.filter.replace( /\s/g, '+' );
+
+	// Accept commas, which were previously used as canonical filter separators
+	const validFilters = filterParam.split( /[,+]/ ).filter( isValidTerm );
+	const sortedValidFilters = sortFilterTerms( validFilters ).join( '+' );
 
 	if ( sortedValidFilters !== filterParam ) {
 		const path = context.path;


### PR DESCRIPTION
Old: wordpress.com/themes/filter/one-column,breadcrumb-navigation,grid-layout
New: wordpress.com/themes/filter/one-column+breadcrumb-navigation+grid-layout

Commas are still accepted and redirected to canonical plusses.

Why: We were always undecided about whether comma or + would be best. Using + makes the task of redirecting old v2 theme showcase traffic to wordpress.com/themes simpler p4axMe-1kv-p2.

**Requires** D5324-code.

**To Test**
* Go to http://calypso.localhost:3000/themes
* Use the theme filtering by clicking on the search box
* Check that everything works as before
* Refresh the page to check server-requests
* Check the filter-related redirects from #12768 work as before

