### PR TITLE
Reader Manage Following Refresh: format header and add link back to sidebar on mobile

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -13,13 +13,13 @@ import qs from 'qs';
  */
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
-import HeaderBack from 'reader/header-back';
 import SearchInput from 'components/search';
 import ReaderMain from 'components/reader-main';
 import { getReaderFeedsForQuery } from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
 import FollowingManageSubscriptions from './subscriptions';
 import SitesWindowScroller from './sites-window-scroller';
+import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 
 class FollowingManage extends Component {
 	static propTypes = {
@@ -93,9 +93,11 @@ class FollowingManage extends Component {
 		return (
 			<ReaderMain className="following-manage">
 				<DocumentHead title={ 'Manage Following' } />
-				{ this.props.showBack && <HeaderBack /> }
+				<MobileBackToSidebar>
+					<h1>{ translate( 'Manage Followed Sites' ) }</h1>
+				</MobileBackToSidebar>
 				{ searchResults.length === 0 && <QueryReaderFeedsSearch query={ sitesQuery } /> }
-				<h1 className="following-manage__header">{ translate( 'Follow Something New' ) }</h1>
+				<h2 className="following-manage__header">{ translate( 'Follow Something New' ) }</h2>
 				<div ref={ this.handleStreamMounted } />
 				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="following-manage__input-card">

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -95,7 +95,7 @@ class FollowingManage extends Component {
 				<DocumentHead title={ 'Manage Following' } />
 				{ this.props.showBack && <HeaderBack /> }
 				{ searchResults.length === 0 && <QueryReaderFeedsSearch query={ sitesQuery } /> }
-				<h1 className="following-manage__header"> { translate( 'Follow Something New' ) } </h1>
+				<h1 className="following-manage__header">{ translate( 'Follow Something New' ) }</h1>
 				<div ref={ this.handleStreamMounted } />
 				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="following-manage__input-card">

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,3 +1,14 @@
+.following-manage__header {
+	font-weight: 600;
+	margin: 14px 0 14px 14px;
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 36px;
+		margin-bottom: 20px;
+		margin-left: 0;
+	}
+}
+
 .following-manage__search-new {
 	margin: 0;
 }

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -3,9 +3,7 @@
 	margin: 14px 0 14px 14px;
 
 	@include breakpoint( ">660px" ) {
-		margin-top: 36px;
-		margin-bottom: 20px;
-		margin-left: 0;
+		margin: 36px 0 20px;
 	}
 }
 


### PR DESCRIPTION
Before:

<img width="367" alt="screen shot 2017-04-25 at 17 17 16" src="https://cloud.githubusercontent.com/assets/17325/25396049/0ec601be-29db-11e7-9ac7-9d67a8603334.png">

After:

<img width="402" alt="screen shot 2017-04-25 at 17 17 37" src="https://cloud.githubusercontent.com/assets/17325/25396074/25387ca6-29db-11e7-85b6-4e0957d925be.png">
<img width="408" alt="screen shot 2017-04-25 at 17 17 46" src="https://cloud.githubusercontent.com/assets/17325/25396075/253d8a7a-29db-11e7-8a03-b59a7ad92bf0.png">
