### PR TITLE
Reader Analytics: Add eventprop `tag` for Tag stream events

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -96,6 +96,11 @@ export function recordTrack( eventName, eventProperties ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
 
+	if ( location === 'topic_page' ) {
+		const tag = window.location.pathname.split( '/tag/' ).pop();
+		eventProperties = Object.assign( { tag: tag }, eventProperties );
+	}
+
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'blog_id' in eventProperties && 'post_id' in eventProperties && ! ( 'is_jetpack' in eventProperties ) ) {
 			console.warn( 'consider using recordTrackForPost...', eventName, eventProperties ); //eslint-disable-line no-console

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -97,8 +97,7 @@ export function recordTrack( eventName, eventProperties ) {
 	}
 
 	if ( location === 'topic_page' && ! eventProperties.hasOwnProperty( 'tag' ) ) {
-		const tag = decodeURIComponent( window.location.pathname.split( '/tag/' ).pop() );
-		eventProperties = Object.assign( { tag: tag }, eventProperties );
+		eventProperties.tag = decodeURIComponent( window.location.pathname.split( '/tag/' ).pop() );
 	}
 
 	if ( process.env.NODE_ENV !== 'production' ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -97,7 +97,8 @@ export function recordTrack( eventName, eventProperties ) {
 	}
 
 	if ( location === 'topic_page' && ! eventProperties.hasOwnProperty( 'tag' ) ) {
-		eventProperties.tag = decodeURIComponent( window.location.pathname.split( '/tag/' ).pop() );
+		const tag = decodeURIComponent( window.location.pathname.split( '/tag/' ).pop() );
+		eventProperties = Object.assign( { tag: tag }, eventProperties );
 	}
 
 	if ( process.env.NODE_ENV !== 'production' ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -96,7 +96,7 @@ export function recordTrack( eventName, eventProperties ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
 
-	if ( location === 'topic_page' ) {
+	if ( location === 'topic_page' && ! eventProperties.hasOwnProperty( 'tag' ) ) {
 		const tag = window.location.pathname.split( '/tag/' ).pop();
 		eventProperties = Object.assign( { tag: tag }, eventProperties );
 	}

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -97,7 +97,7 @@ export function recordTrack( eventName, eventProperties ) {
 	}
 
 	if ( location === 'topic_page' && ! eventProperties.hasOwnProperty( 'tag' ) ) {
-		const tag = window.location.pathname.split( '/tag/' ).pop();
+		const tag = decodeURIComponent( window.location.pathname.split( '/tag/' ).pop() );
 		eventProperties = Object.assign( { tag: tag }, eventProperties );
 	}
 

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -85,14 +85,14 @@ const TagStream = React.createClass( {
 	},
 
 	toggleFollowing() {
-		const { tag, decodedTag, unfollowTag, followTag } = this.props;
+		const { decodedTag, unfollowTag, followTag } = this.props;
 		const isFollowing = this.isSubscribed(); // this is the current state, not the new state
 		const toggleAction = isFollowing ? unfollowTag : followTag;
 		toggleAction( decodedTag );
 		recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
-		recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', tag );
+		recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', decodedTag );
 		recordTrack( isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed', {
-			tag
+			decodedTag
 		} );
 	},
 

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -92,7 +92,7 @@ const TagStream = React.createClass( {
 		recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
 		recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', decodedTag );
 		recordTrack( isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed', {
-			decodedTag
+			tag: decodedTag
 		} );
 	},
 


### PR DESCRIPTION
Adds an eventprop `tag` for Tracks events that occur on posts in the tag stream. Addresses enhancement request #13157
