### PR TITLE
Reader Refresh Manage: React-Virtualized list should recalc on resize

### DIFF
--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { List, WindowScroller, CellMeasurerCache, CellMeasurer } from 'react-virtualized';
+import { debounce, defer } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -50,6 +51,22 @@ class SitesWindowScroller extends Component {
 		);
 	};
 
+	handleListMounted = list => {
+		this.listRef = list;
+	}
+
+	handleResize = debounce( () => {
+		this.heightCache.clearAll();
+		defer( () => this.listRef && this.listRef.recomputeRowHeights( 0 ) );
+	}, 50, { trailing: true } );
+
+	componentWillMount() {
+		window.addEventListener( 'resize', this.handleResize );
+	}
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.handleResize );
+	}
+
 	render() {
 		const { sites, width } = this.props;
 
@@ -65,6 +82,7 @@ class SitesWindowScroller extends Component {
 							rowRenderer={ this.siteRowRenderer }
 							scrollTop={ scrollTop }
 							width={ width }
+							ref={ this.handleListMounted }
 						/>
 					)}
 				</WindowScroller>


### PR DESCRIPTION
This PR fixes an issue where when on the Refresh Manage page, if you resize the window to < 480px, the followed list items don't resize properly.

I fixed it by telling react-virtualized to recalculate everything on every resize.

To Test:
- go to the calypso.live branch following/manage page and start with a big window.  Then minimize until the site descriptions break onto two lines.  It should be handled gracefully and the bottom border line should bump down