### PR TITLE
Domains: Hide primary domain notice for domain only sites

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -315,6 +315,10 @@ export default React.createClass( {
 	},
 
 	newDomains() {
+		if ( get( this.props, 'selectedSite.options.is_domain_only' ) ) {
+			return null;
+		}
+
 		const newDomains = this.getDomains().filter( ( domain ) =>
 				domain.registrationMoment &&
 				moment( domain.registrationMoment )


### PR DESCRIPTION
For a domain-only account, the concept of a "primary domain" doesn’t apply, so we should not show this notice to the user:

![domains5](https://cloud.githubusercontent.com/assets/1103398/25095945/6aeab5d8-238d-11e7-83ba-5d4a0e36f8b0.jpg)

### Testing
* Verify that the above notice is _not_ shown for _domain-only_ sites.
* Verify that the above notice _is_ shown for normal sites that had recently bought a domain.
* Verify that other domain warnings are working properly.

Fixes https://github.com/Automattic/wp-calypso/issues/13151