### PR TITLE
Reader: connect recommended sites

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -49,7 +49,7 @@ export class RecommendedSites extends React.PureComponent {
 						map(
 							sites,
 							( site, index ) => {
-								const siteId = site.siteId;
+								const siteId = site.siteId || site.blogId;
 								return ( <li className="reader-recommended-sites__site-list-item" key={ `site-rec-${ siteId }` }>
 									<div className="reader-recommended-sites__recommended-site-dismiss">
 										<Button borderless

--- a/client/components/data/query-reader-recommended-sites/index.jsx
+++ b/client/components/data/query-reader-recommended-sites/index.jsx
@@ -12,18 +12,20 @@ import { requestRecommendedSites } from 'state/reader/recommended-sites/actions'
 class QueryReaderRecommendedSites extends Component {
 	static propTypes = {
 		seed: PropTypes.number,
+		offset: PropTypes.number,
 	};
 
 	static defaultProps = () => ( {
 		seed: 0,
+		offset: 0,
 	} )
 
 	componentWillMount() {
-		this.props.requestRecommendedSites( { seed: this.props.seed } );
+		this.props.requestRecommendedSites( { seed: this.props.seed, offset: this.props.offset } );
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		this.props.requestRecommnededSites( { seed: nextProps.seed } );
+		this.props.requestRecommendedSites( { seed: nextProps.seed, offset: nextProps.offset } );
 	}
 
 	render() {

--- a/client/components/data/query-reader-recommended-sites/index.jsx
+++ b/client/components/data/query-reader-recommended-sites/index.jsx
@@ -15,10 +15,10 @@ class QueryReaderRecommendedSites extends Component {
 		offset: PropTypes.number,
 	};
 
-	static defaultProps = () => ( {
+	static defaultProps = {
 		seed: 0,
 		offset: 0,
-	} )
+	};
 
 	componentWillMount() {
 		this.props.requestRecommendedSites( { seed: this.props.seed, offset: this.props.offset } );

--- a/client/components/data/query-reader-recommended-sites/index.jsx
+++ b/client/components/data/query-reader-recommended-sites/index.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestRecommendedSites } from 'state/reader/recommended-sites/actions';
+
+class QueryReaderRecommendedSites extends Component {
+	static propTypes = {
+		seed: PropTypes.number,
+	};
+
+	static defaultProps = () => ( {
+		seed: 0,
+	} )
+
+	componentWillMount() {
+		this.props.requestRecommendedSites( { seed: this.props.seed } );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.props.requestRecommnededSites( { seed: nextProps.seed } );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, { requestRecommendedSites } )( QueryReaderRecommendedSites );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { trim, debounce } from 'lodash';
+import { trim, debounce, random, take } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import qs from 'qs';
@@ -15,8 +15,14 @@ import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import SearchInput from 'components/search';
 import ReaderMain from 'components/reader-main';
-import { getReaderFeedsForQuery, getReaderFeedsCountForQuery } from 'state/selectors';
+import {
+	getReaderFeedsForQuery,
+	getReaderFeedsCountForQuery,
+	getReaderRecommendedSites,
+} from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
+import QueryReaderRecommendedSites from 'components/data/query-reader-recommended-sites';
+import RecommendedSites from 'blocks/reader-recommended-sites';
 import FollowingManageSubscriptions from './subscriptions';
 import FollowingManageSearchFeedsResults from './feed-search-results';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
@@ -45,6 +51,7 @@ class FollowingManage extends Component {
 
 	state = {
 		width: 800,
+		seed: random( 0, 10000 ),
 		forceRefresh: false,
 	};
 
@@ -129,7 +136,8 @@ class FollowingManage extends Component {
 			translate,
 			searchResults,
 			searchResultsCount,
-			showMoreResults
+			showMoreResults,
+			getRecommendedSites,
 		} = this.props;
 		const searchPlaceholderText = translate( 'Search millions of sites' );
 		const showExistingSubscriptions = ! ( !! sitesQuery && showMoreResults );
@@ -138,6 +146,7 @@ class FollowingManage extends Component {
 		if ( isSitesQueryUrl ) {
 			sitesQueryWithoutProtocol = withoutHttp( sitesQuery );
 		}
+		const recommendedSites = getRecommendedSites( this.state.seed );
 
 		return (
 			<ReaderMain className="following-manage">
@@ -146,6 +155,7 @@ class FollowingManage extends Component {
 					<h1>{ translate( 'Manage Followed Sites' ) }</h1>
 				</MobileBackToSidebar>
 				{ ! searchResults && ! isSitesQueryUrl && <QueryReaderFeedsSearch query={ sitesQuery } /> }
+				{ ! recommendedSites && <QueryReaderRecommendedSites seed={ this.state.seed } /> }
 				<h2 className="following-manage__header">{ translate( 'Follow Something New' ) }</h2>
 				<div ref={ this.handleStreamMounted } />
 				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
@@ -173,6 +183,9 @@ class FollowingManage extends Component {
 						</div>
 					) }
 				</div>
+				{ recommendedSites && ! sitesQuery && (
+					<RecommendedSites sites={ take( recommendedSites, 2 ) } />
+				) }
 				{ !! sitesQuery && ! isSitesQueryUrl && (
 					<FollowingManageSearchFeedsResults
 						searchResults={ searchResults }
@@ -201,6 +214,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		searchResults: getReaderFeedsForQuery( state, ownProps.sitesQuery ),
 		searchResultsCount: getReaderFeedsCountForQuery( state, ownProps.sitesQuery ),
+		getRecommendedSites: seed => getReaderRecommendedSites( state, seed ),
 	} ),
 	{ requestFeedSearch }
 )( localize( FollowingManage ) );

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -175,6 +175,10 @@
 	}
 }
 
+.following-manage .reader-recommended-sites {
+	border-bottom: 1px solid lighten( $gray, 30% );
+}
+
 .following-manage__search-followed {
 	margin-left: 0;
 }

--- a/client/state/selectors/get-reader-recommended-sites.js
+++ b/client/state/selectors/get-reader-recommended-sites.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the recommended sites for a given seed
+ *
+ * @param  {Object} state  Global state tree
+ * @param {Number} seed the elasticsearch seed for which to grab recs
+ * @return {Array}          Reader Tags
+ */
+export default function getReaderRecommendedSites( state, seed ) {
+	return state.reader.recommendedSites[ seed ];
+}

--- a/client/state/selectors/get-reader-recommended-sites.js
+++ b/client/state/selectors/get-reader-recommended-sites.js
@@ -3,7 +3,7 @@
  *
  * @param  {Object} state  Global state tree
  * @param {Number} seed the elasticsearch seed for which to grab recs
- * @return {Array}          Reader Tags
+ * @return {Array} Reader Sites
  */
 export default function getReaderRecommendedSites( state, seed ) {
 	return state.reader.recommendedSites[ seed ];

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -67,6 +67,7 @@ export getReaderFollowForBlog from './get-reader-follow-for-blog';
 export getReaderFollowForFeed from './get-reader-follow-for-feed';
 export getReaderFollows from './get-reader-follows';
 export getReaderFollowsCount from './get-reader-follows-count';
+export getReaderRecommendedSites from './get-reader-recommended-sites';
 export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getSelectedOrAllSites from './get-selected-or-all-sites';


### PR DESCRIPTION
Implement the recommendations from https://github.com/Automattic/wp-calypso/issues/12952

When the user has not entered a search term, two site recommendations should be shown:

**Wider viewports:**
![manage-following- desktop](https://cloud.githubusercontent.com/assets/4924246/24885804/6162248e-1e05-11e7-9e3b-7cd97a242eb5.jpg)


Recommendations should be formatted just like in-stream recommendations. Clicking Follow or Dismiss causes that site to disappear and a new one to appear. 