### PR TITLE
Exclude domain only sites from free to paid upsell

### DIFF
--- a/client/state/selectors/eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/eligible-for-free-to-paid-upsell.js
@@ -3,6 +3,7 @@
  */
 import {
 	canCurrentUser,
+	isDomainOnlySite,
 	isMappedDomainSite,
 	isSiteOnFreePlan,
 	isUserRegistrationDaysWithinRange,
@@ -18,11 +19,12 @@ import {
  */
 const eligibleForFreeToPaidUpsell = ( state, siteId, moment ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+	const siteisDomainOnlySite = isDomainOnlySite( state, siteId );
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const registrationDaysIsWithinRange = isUserRegistrationDaysWithinRange( state, moment, 0, 180 );
 
-	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && registrationDaysIsWithinRange;
+	return userCanManageOptions && ! siteisDomainOnlySite && ! siteHasMappedDomain && siteIsOnFreePlan && registrationDaysIsWithinRange;
 };
 
 export default eligibleForFreeToPaidUpsell;

--- a/client/state/selectors/test/eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/eligible-for-free-to-paid-upsell.js
@@ -15,6 +15,7 @@ describe( 'eligibleForFreeToPaidUpsell', () => {
 	const siteId = 'siteId';
 
 	let canCurrentUser;
+	let isDomainOnlySite;
 	let isMappedDomainSite;
 	let isSiteOnFreePlan;
 	let isUserRegistrationDaysWithinRange;
@@ -22,12 +23,14 @@ describe( 'eligibleForFreeToPaidUpsell', () => {
 
 	useMockery( mockery => {
 		canCurrentUser = stub();
+		isDomainOnlySite = stub();
 		isMappedDomainSite = stub();
 		isSiteOnFreePlan = stub();
 		isUserRegistrationDaysWithinRange = stub();
 
 		mockery.registerMock( 'state/selectors/', {
 			canCurrentUser,
+			isDomainOnlySite,
 			isMappedDomainSite,
 			isSiteOnFreePlan,
 			isUserRegistrationDaysWithinRange
@@ -40,6 +43,7 @@ describe( 'eligibleForFreeToPaidUpsell', () => {
 
 	const meetAllConditions = () => {
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( true );
+		isDomainOnlySite.withArgs( state, siteId ).returns( false );
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
 		isUserRegistrationDaysWithinRange.withArgs( state, moment, 0, 180 ).returns( true );
@@ -48,6 +52,12 @@ describe( 'eligibleForFreeToPaidUpsell', () => {
 	it( 'should return false when user can not manage options', () => {
 		meetAllConditions();
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( false );
+		expect( eligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
+	} );
+
+	it( 'should return false when domain only site', () => {
+		meetAllConditions();
+		isDomainOnlySite.withArgs( state, siteId ).returns( true );
 		expect( eligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
 	} );
 


### PR DESCRIPTION
It is possible for the free to paid nudge to be displayed to users who created a domain only site and then moved that domain to another site (leaving the domain only site without a domain).

In this situation the nudge is currently being displayed and should not be.

Testing

* create a domain only site by following the sign up process from `/domains` and choosing not to create a site.
* the nudge should not be displayed on `/sites` for the domain only site (already the case in production)
* transfer the domain to another existing site for the same user
* verify that the nudge is still not displayed on `/sites` for the site