### PR TITLE
Domains: Remove componentWillReceiveProps siteId checks in MapDomain

### DIFF
--- a/client/my-sites/upgrades/map-domain/index.jsx
+++ b/client/my-sites/upgrades/map-domain/index.jsx
@@ -101,9 +101,7 @@ export class MapDomain extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.selectedSiteId !== this.props.selectedSiteId ) {
-			this.checkSiteIsUpgradeable( nextProps );
-		}
+		this.checkSiteIsUpgradeable( nextProps );
 	}
 
 	checkSiteIsUpgradeable( props ) {


### PR DESCRIPTION
In #12943 we introduced a `siteId` check in the `componentWillReceiveProps` method of `MapDomain` to avoid unnecessary renders. As @nb mentioned in https://github.com/Automattic/wp-calypso/pull/12943#discussion_r113300316, it's possible that the site's upgradeable status can change, and the component should react accordingly to that. Since there might be other edge cases we might have to account for, let's just remove this check for now.

To test this, let's let's just make sure everything works properly:

* Load the branch locally and visit http://calypso.localhost:3000/domains/add/mapping/:siteSlug.
* Verify that entering an invalid domain name such as `hello world` triggers an error message.
* Verify that entering a valid and taken domain name such as `nintendo.com` works and brings you to checkout with a domain mapping item added to your cart
* Verify that entering a valid and available domain name such as `djoafeeafw.com` shows you the option to purchase it and brings you to checkout when you click on Select.
* Check that switching site while on this page works as expected.