### PR TITLE
AB Tests: Allow testing for locales other than English or for another specific locale

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -32,7 +32,8 @@ You should include the following information:
 
 There are also several optional configuration settings available:
 
-* `allowAnyLocale` - Relaxes the locale restraint on the A/B test, allowing users of any locale to be allocated to a test.  Don't forget: this means strings will need to be translated.
+* `targetLocales` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `targetLocales` to `any`, for all non English locales by setting it to `not-en`, or for a specific locale by setting the value to the locale slug, i.e: `targetLocales: 'de'`
+Don't forget: any test that runs for locales other than English means strings will need to be translated.
 
 Next, in your code, import the `abtest` method from the `abtest` module:
 
@@ -108,8 +109,6 @@ To account for this, the A/B test module is smart enough to know that if the use
 ## Dealing with ineligible users
 
 By default, users are only included in the test if their locale is set to English (`en`), the current date is on or after the datestamp you set, they have not participated in a test with the same name in the past, and they registered on or after the date that the test started.
-
-The locale restriction can be relaxed by adding `allowAnyLocale: true` to the test configuration.
 
 In cases where the user is ineligible, the `abtest` function will return the value for `defaultVariation` value that you specify in the config file. This value should be one of the variations contained in `variations`.
 

--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -32,7 +32,7 @@ You should include the following information:
 
 There are also several optional configuration settings available:
 
-* `targetLocales` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `targetLocales` to `any`, for all non English locales by setting it to `not-en`, or for a specific locale by setting the value to the locale slug, i.e: `targetLocales: 'de'`
+* `targetLocales` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `targetLocales` to false, or to any specific locale or locales  `targetLocales: ['de']`
 Don't forget: any test that runs for locales other than English means strings will need to be translated.
 
 Next, in your code, import the `abtest` method from the `abtest` module:

--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -32,7 +32,7 @@ You should include the following information:
 
 There are also several optional configuration settings available:
 
-* `localeTargets` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `localeTargets` to false, or to an array of a specific locale or locales  `localeTargets: ['de']`
+* `localeTargets` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `localeTargets` to 'any', or to an array of a specific locale or locales  `localeTargets: ['de']`
 Don't forget: any test that runs for locales other than English means strings will need to be translated.
 
 Next, in your code, import the `abtest` method from the `abtest` module:

--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -32,7 +32,7 @@ You should include the following information:
 
 There are also several optional configuration settings available:
 
-* `targetLocales` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `targetLocales` to false, or to any specific locale or locales  `targetLocales: ['de']`
+* `localeTargets` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `localeTargets` to false, or to an array of a specific locale or locales  `localeTargets: ['de']`
 Don't forget: any test that runs for locales other than English means strings will need to be translated.
 
 Next, in your code, import the `abtest` method from the `abtest` module:

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -57,7 +57,7 @@ module.exports = {
 			original: 80
 		},
 		defaultVariation: 'original',
-		allowAnyLocale: true,
+		localeTargets: 'any',
 	},
 	newSiteWithJetpack: {
 		datestamp: '20170419',

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -164,7 +164,7 @@ ABTest.prototype.isEligibleForAbTest = function() {
 		const localeMatcher = new RegExp( '^' + this.localeTarget + '-?', 'i' );
 		let isTargetLocale = true;
 
-		if ( isUserSignedIn() && user.get().localeSlug !== this.localeTarget ) {
+		if ( isUserSignedIn() && ! user.get().localeSlug.match( localeMatcher ) ) {
 			debug( '%s: User has a %s locale', this.experimentId, this.localeTarget );
 			isTargetLocale = false;
 		}

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { includes, keys, reduce, some } from 'lodash';
+import { includes, keys, reduce, some, map } from 'lodash';
 import store from 'store';
 import i18n from 'i18n-calypso';
 
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
  */
 import activeTests from 'lib/abtest/active-tests';
 import analytics from 'lib/analytics';
+import config from 'config';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 
@@ -87,6 +88,13 @@ ABTest.prototype.init = function( name ) {
 		throw new Error( 'A default variation is specified for ' + name + ' but it is not part of the variations' );
 	}
 
+	const languageSlugs = map( config( 'languages' ), 'langSlug' );
+	const localeTargets = [ 'not-en', 'any' ].concat( languageSlugs );
+
+	if ( testConfig.localeTargets && ! includes( localeTargets, testConfig.localeTargets ) ) {
+		throw new Error( 'localeTargets can by "any", "not-en" or any single locale slug.' );
+	}
+
 	const variationDatestamp = testConfig.datestamp;
 
 	this.name = name;
@@ -96,7 +104,7 @@ ABTest.prototype.init = function( name ) {
 	this.defaultVariation = testConfig.defaultVariation;
 	this.variationNames = variationNames;
 	this.experimentId = name + '_' + variationDatestamp;
-	this.allowAnyLocale = testConfig.allowAnyLocale === true;
+	this.allowAnyLocale = testConfig.localeTargets === 'any';
 	this.allowExistingUsers = testConfig.allowExistingUsers === true;
 };
 

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -156,21 +156,22 @@ ABTest.prototype.isEligibleForAbTest = function() {
 
 	if ( this.localeTargets ) {
 		const localeMatcher = new RegExp( '^(' + this.localeTargets.join( '|' ) + ')', 'i' );
+		const userLocale = user.get().localeSlug;
 
-		if ( isUserSignedIn() && ! user.get().localeSlug.match( localeMatcher ) ) {
-			debug( '%s: User has a %s locale', this.experimentId, this.localeTarget );
+		if ( isUserSignedIn() && ! userLocale.match( localeMatcher ) ) {
+			debug( '%s: User has a %s locale', this.experimentId, userLocale );
 			return false;
 		}
 		if ( ! isUserSignedIn() && ! clientLanguage.match( localeMatcher ) ) {
-			debug( '%s: Logged-out user has a %s navigator.language preference', this.experimentId, this.localeTarget );
+			debug( '%s: Logged-out user has a %s navigator.language preference', this.experimentId, userLocale );
 			return false;
 		}
 		if ( ! isUserSignedIn() && ! clientLanguagesPrimary.match( localeMatcher ) ) {
-			debug( '%s: Logged-out user has a %s navigator.languages primary preference', this.experimentId, this.localeTarget );
+			debug( '%s: Logged-out user has a %s navigator.languages primary preference', this.experimentId, userLocale );
 			return false;
 		}
 		if ( ! isUserSignedIn() && ! localeFromSession.match( localeMatcher ) ) {
-			debug( '%s: Logged-out user has the %s locale in session', this.experimentId, this.localeTarget );
+			debug( '%s: Logged-out user has the %s locale in session', this.experimentId, userLocale );
 			return false;
 		}
 	}

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -91,11 +91,14 @@ ABTest.prototype.init = function( name ) {
 		throw new Error( 'A default variation is specified for ' + name + ' but it is not part of the variations' );
 	}
 
+	// Default: only run for 'en' locale.
 	this.localeTargets = [ 'en' ];
 	if ( testConfig.localeTargets ) {
 		if ( 'any' === testConfig.localeTargets ) {
+			// Allow any locales.
 			this.localeTargets = false;
 		} else if ( isArray( testConfig.localeTargets ) && every( testConfig.localeTargets, langSlugIsValid ) ) {
+			// Allow specific locales.
 			this.localeTargets = testConfig.localeTargets;
 		} else {
 			throw new Error( 'localeTargets can be either "any" or an array of one or more valid language slugs' );

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -95,7 +95,7 @@ ABTest.prototype.init = function( name ) {
 		! every( testConfig.localeTargets, ( target ) => {
 			return languageSlugs.indexOf( target ) !== -1;
 		} ) ) {
-		throw new Error( 'localeTargets can by "any", "not-en" or any single locale slug.' );
+		throw new Error( 'localeTargets array contains invalid language slugs.' );
 	}
 
 	const variationDatestamp = testConfig.datestamp;

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -33,6 +33,15 @@ describe( 'abtest', () => {
 				defaultVariation: 'hide',
 				allowExistingUsers: false
 			},
+			mockedTestAllowAnyLocale: {
+				datestamp: '20160627',
+				variations: {
+					hide: 50,
+					show: 50
+				},
+				defaultVariation: 'hide',
+				allowAnyLocale: true
+			},
 			mockedTestAllowExisting: {
 				datestamp: '20160627',
 				variations: {
@@ -119,14 +128,27 @@ describe( 'abtest', () => {
 					date: DATE_AFTER
 				};
 			} );
-			it( 'should call store.set for new users with English settings', () => {
-				abtest( 'mockedTest' );
-				expect( setSpy ).to.have.been.calledOnce;
+			describe( 'English only users allowed (default)', () => {
+				it( 'should call store.set for new users with English settings', () => {
+					abtest( 'mockedTest' );
+					expect( setSpy ).to.have.been.calledOnce;
+				} );
+				it( 'should return default and skip store.set for new users with non-English settings', () => {
+					mockedUser.localeSlug = 'de';
+					expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
+					expect( setSpy ).not.to.have.been.called;
+				} );
 			} );
-			it( 'should return default and skip store.set for new users with non-English settings', () => {
-				mockedUser.localeSlug = 'de';
-				expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );
-				expect( setSpy ).not.to.have.been.called;
+			describe( 'all locales allowed', () => {
+				it( 'should call store.set for new users with English settings', () => {
+					abtest( 'mockedTestAllowAnyLocale' );
+					expect( setSpy ).to.have.been.calledOnce;
+				} );
+				it( 'should call store.set for new users with non-English settings', () => {
+					mockedUser.localeSlug = 'de';
+					abtest( 'mockedTestAllowAnyLocale' );
+					expect( setSpy ).to.have.been.calledOnce;
+				} );
 			} );
 		} );
 

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -40,7 +40,7 @@ describe( 'abtest', () => {
 					show: 50
 				},
 				defaultVariation: 'hide',
-				allowAnyLocale: true
+				localeTargets: 'any',
 			},
 			mockedTestAllowExisting: {
 				datestamp: '20160627',

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -42,6 +42,24 @@ describe( 'abtest', () => {
 				defaultVariation: 'hide',
 				localeTargets: 'any',
 			},
+			mockedTestNotEnLocale: {
+				datestamp: '20160627',
+				variations: {
+					hide: 50,
+					show: 50
+				},
+				defaultVariation: 'hide',
+				localeTargets: 'not-en',
+			},
+			mockedTestFrLocale: {
+				datestamp: '20160627',
+				variations: {
+					hide: 50,
+					show: 50
+				},
+				defaultVariation: 'hide',
+				localeTargets: 'fr',
+			},
 			mockedTestAllowExisting: {
 				datestamp: '20160627',
 				variations: {
@@ -147,6 +165,29 @@ describe( 'abtest', () => {
 				it( 'should call store.set for new users with non-English settings', () => {
 					mockedUser.localeSlug = 'de';
 					abtest( 'mockedTestAllowAnyLocale' );
+					expect( setSpy ).to.have.been.calledOnce;
+				} );
+			} );
+			describe( 'not-en locales only', () => {
+				it( 'should return default and skip store.set for new users with English settings', () => {
+					expect( abtest( 'mockedTestNotEnLocale' ) ).to.equal( 'hide' );
+					expect( setSpy ).not.to.have.been.called;
+				} );
+				it( 'should call store.set for new users with non-English settings', () => {
+					mockedUser.localeSlug = 'de';
+					abtest( 'mockedTestNotEnLocale' );
+					expect( setSpy ).to.have.been.calledOnce;
+				} );
+			} );
+			describe( 'fr locale only', () => {
+				it( 'should return default and skip store.set for new users with non-french settings', () => {
+					mockedUser.localeSlug = 'de';
+					expect( abtest( 'mockedTestFrLocale' ) ).to.equal( 'hide' );
+					expect( setSpy ).not.to.have.been.called;
+				} );
+				it( 'should call store.set for new users with fr settings', () => {
+					mockedUser.localeSlug = 'fr';
+					abtest( 'mockedTestFrLocale' );
 					expect( setSpy ).to.have.been.calledOnce;
 				} );
 			} );

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -151,6 +151,11 @@ describe( 'abtest', () => {
 					abtest( 'mockedTest' );
 					expect( setSpy ).to.have.been.calledOnce;
 				} );
+				it( 'should call store.set for new users with English-Canada settings', () => {
+					mockedUser.localeSlug = 'en-ca';
+					abtest( 'mockedTest' );
+					expect( setSpy ).to.have.been.calledOnce;
+				} );
 				it( 'should return default and skip store.set for new users with non-English settings', () => {
 					mockedUser.localeSlug = 'de';
 					expect( abtest( 'mockedTest' ) ).to.equal( 'hide' );

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -40,16 +40,16 @@ describe( 'abtest', () => {
 					show: 50
 				},
 				defaultVariation: 'hide',
-				localeTargets: 'any',
+				localeTargets: false,
 			},
-			mockedTestNotEnLocale: {
+			multipeLocaleNotEn: {
 				datestamp: '20160627',
 				variations: {
 					hide: 50,
 					show: 50
 				},
 				defaultVariation: 'hide',
-				localeTargets: 'not-en',
+				localeTargets: [ 'fr', 'de' ],
 			},
 			mockedTestFrLocale: {
 				datestamp: '20160627',
@@ -58,7 +58,7 @@ describe( 'abtest', () => {
 					show: 50
 				},
 				defaultVariation: 'hide',
-				localeTargets: 'fr',
+				localeTargets: [ 'fr' ],
 			},
 			mockedTestAllowExisting: {
 				datestamp: '20160627',
@@ -173,14 +173,14 @@ describe( 'abtest', () => {
 					expect( setSpy ).to.have.been.calledOnce;
 				} );
 			} );
-			describe( 'not-en locales only', () => {
+			describe( 'specific locales only', () => {
 				it( 'should return default and skip store.set for new users with English settings', () => {
-					expect( abtest( 'mockedTestNotEnLocale' ) ).to.equal( 'hide' );
+					expect( abtest( 'multipeLocaleNotEn' ) ).to.equal( 'hide' );
 					expect( setSpy ).not.to.have.been.called;
 				} );
 				it( 'should call store.set for new users with non-English settings', () => {
 					mockedUser.localeSlug = 'de';
-					abtest( 'mockedTestNotEnLocale' );
+					abtest( 'multipeLocaleNotEn' );
 					expect( setSpy ).to.have.been.calledOnce;
 				} );
 			} );

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -40,7 +40,7 @@ describe( 'abtest', () => {
 					show: 50
 				},
 				defaultVariation: 'hide',
-				localeTargets: false,
+				localeTargets: 'any',
 			},
 			multipeLocaleNotEn: {
 				datestamp: '20160627',


### PR DESCRIPTION
Current abtests settings only allow for testing on "en" users, or all users using the `allowAnyLocale` option.

This PR introduces the ability to target "not-en" as well as any single specific locale by replacing `allowAnyLocale` with `targetLocales` which defaults to `en` but can also take `any`,`not-en`, or a specific locale slug as a value.
