### PR TITLE
Fix unbound logout handler in reauth

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -15,7 +15,7 @@ import userModule from 'lib/user';
 const user = userModule();
 const debug = debugModule( 'calypso:user:utilities' );
 
-export default {
+const userUtils = {
 	getLogoutUrl( redirect ) {
 		const userData = user.get();
 		let url = '/logout',
@@ -46,7 +46,7 @@ export default {
 	},
 
 	logout( redirect ) {
-		const logoutUrl = this.getLogoutUrl( redirect );
+		const logoutUrl = userUtils.getLogoutUrl( redirect );
 
 		// Clear any data stored locally within the user data module or localStorage
 		user.clear( () => location.href = logoutUrl );
@@ -63,6 +63,8 @@ export default {
 	needsVerificationForSite( site ) {
 		// do not allow publish for unverified e-mails,
 		// but allow if the site is VIP
-		return !user.get().email_verified && !( site && site.is_vip );
+		return ! user.get().email_verified && ! ( site && site.is_vip );
 	},
 };
+
+export default userUtils;


### PR DESCRIPTION
`userUtilities.logout` needed to be called correctly for resolution of an internal `this`. Rather than passing `userUtilities.logout` as a callback, this change wraps a call to `userUtilities.logout()` to ensure `logout` is correctly called on the `userUtilities` object.

**To test:**

1. Run this branch.
1. Go to /me and log in (must be 2FA account).
1. Remove the 2FA cookie from from `https://public-api.wordpress.com` (named `twostep_auth`).
1. Reload the page.
1. You should see a modal. Click "Not you? Sign Out".
1. Verify that you are correctly signed out with no related errors/warnings in the console.
1. Verify that the `recordClickEvent` is still recorded correctly.

Fixes #13401