### PR TITLE
Account Recovery: Make `Generate strong password` button functional.

### DIFF
--- a/client/account-recovery/account-recovery-root/index.jsx
+++ b/client/account-recovery/account-recovery-root/index.jsx
@@ -11,6 +11,7 @@ import { includes, kebabCase } from 'lodash';
  * Internal dependencies
  */
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import AccountPasswordData from 'lib/account-password-data';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
 import LostPasswordForm from 'account-recovery/lost-password-form';
@@ -117,7 +118,13 @@ const getForm = ( step ) => {
 		case STEPS.RESET_PASSWORD_SMS:
 			return <ResetPasswordSmsForm />;
 		case STEPS.RESET_PASSWORD_CONFIRM:
-			return <ResetPasswordConfirmForm />;
+			const generateStrongPassword = () => ( AccountPasswordData.generate() );
+
+			return (
+				<ResetPasswordConfirmForm
+					generateStrongPassword={ generateStrongPassword }
+				/>
+			);
 		case STEPS.RESET_PASSWORD_SUCCEEDED:
 			return <ResetPasswordSucceeded />;
 		case STEPS.VALIDATE_RESET_CODE:

--- a/client/account-recovery/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password-confirm-form/index.jsx
@@ -54,10 +54,12 @@ class ResetPasswordConfirmForm extends Component {
 	onGenerateStrongPassword = () => {
 		this.setState( { newPassword: this.props.generateStrongPassword() } );
 
-		if ( this.passwordInput.hidden() ) {
-			this.passwordInput.togglePasswordVisibility();
+		if ( this.passwordInputRef.hidden() ) {
+			this.passwordInputRef.togglePasswordVisibility();
 		}
 	}
+
+	capturePasswordInputRef = ( passwordInputRef ) => this.passwordInputRef = passwordInputRef;
 
 	render() {
 		const {
@@ -67,8 +69,6 @@ class ResetPasswordConfirmForm extends Component {
 		} = this.props;
 
 		const { newPassword } = this.state;
-
-		const capturePasswordInputRef = ( passwordInput ) => this.passwordInput = passwordInput;
 
 		return (
 			<Card>
@@ -80,7 +80,7 @@ class ResetPasswordConfirmForm extends Component {
 					<FormPasswordInput
 						className="reset-password-confirm-form__password-input-field"
 						id="password"
-						ref={ capturePasswordInputRef }
+						ref={ this.capturePasswordInputRef }
 						onChange={ this.updateNewPassword }
 						value={ newPassword }
 						autoFocus

--- a/client/account-recovery/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password-confirm-form/index.jsx
@@ -53,6 +53,10 @@ class ResetPasswordConfirmForm extends Component {
 
 	onGenerateStrongPassword = () => {
 		this.setState( { newPassword: this.props.generateStrongPassword() } );
+
+		if ( this.passwordInput.hidden() ) {
+			this.passwordInput.togglePasswordVisibility();
+		}
 	}
 
 	render() {
@@ -64,6 +68,8 @@ class ResetPasswordConfirmForm extends Component {
 
 		const { newPassword } = this.state;
 
+		const capturePasswordInputRef = ( passwordInput ) => this.passwordInput = passwordInput;
+
 		return (
 			<Card>
 				<h2 className="reset-password-confirm-form__title">{ translate( 'Reset your password' ) }</h2>
@@ -74,6 +80,7 @@ class ResetPasswordConfirmForm extends Component {
 					<FormPasswordInput
 						className="reset-password-confirm-form__password-input-field"
 						id="password"
+						ref={ capturePasswordInputRef }
 						onChange={ this.updateNewPassword }
 						value={ newPassword }
 						autoFocus

--- a/client/account-recovery/reset-password-confirm-form/index.jsx
+++ b/client/account-recovery/reset-password-confirm-form/index.jsx
@@ -51,6 +51,10 @@ class ResetPasswordConfirmForm extends Component {
 		this.setState( { newPassword: event.target.value } );
 	}
 
+	onGenerateStrongPassword = () => {
+		this.setState( { newPassword: this.props.generateStrongPassword() } );
+	}
+
 	render() {
 		const {
 			translate,
@@ -78,6 +82,7 @@ class ResetPasswordConfirmForm extends Component {
 						className="reset-password-confirm-form__button generate-password-button"
 						type="button"
 						isPrimary={ false }
+						onClick={ this.onGenerateStrongPassword }
 					>
 						{ translate( 'Generate strong password' ) }
 					</FormButton>


### PR DESCRIPTION
## Summary
This PR is based on #13364 and makes the "Generate strong password" button functional.
![demo-strong](https://cloud.githubusercontent.com/assets/1842898/25472675/e70e5858-2b5e-11e7-8247-416f7cec0f40.gif)

## Test Plan
1. Open an incognito window and make sure you are logged out.
1. Visit http://calypso.localhost:3000/account-recovery
1. Choose a test account and proceed as the instructions. At the final "New Password" page, click the "Generate strong password" button, and you should see a strong password is generated for you.
