### PR TITLE
Framework: Revert js defer optimization after no measured benefit

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -129,28 +129,18 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		if i18nLocaleScript
 			script(src=i18nLocaleScript)
 		if 'development' === env || isDebug
-			script(defer, src=urls[ 'manifest' ])
-			script(defer, src=urls[ 'vendor' ])
+			script(src=urls[ 'manifest' ])
+			script(src=urls[ 'vendor' ])
+			script(src=urls[ jsFile ])
 			if chunk
-				script(defer, src=urls[ jsFile ])
-				script(defer, src=urls[ chunk ] onload='window.AppBoot()')
-			else
-				script(defer, src=urls[ jsFile ] onload='window.AppBoot()')
-		else if 'wpcalypso' === env
-			script(defer, src=urls[ 'manifest-min' ])
-			script(defer, src=urls[ 'vendor-min' ])
-			if chunk
-				script(defer, src=urls[ jsFile + '-min' ])
-				script(defer, src=urls[ chunk + '-min' ] onload='window.AppBoot()')
-			else
-				script(defer, src=urls[ jsFile + '-min' ] onload='window.AppBoot()')
+				script(src=urls[ chunk ])
 		else
 			script(src=urls[ 'manifest-min' ])
 			script(src=urls[ 'vendor-min' ])
 			script(src=urls[ jsFile + '-min' ])
 			if chunk
 				script(src=urls[ chunk + '-min' ])
-			script(type='text/javascript')!='window.AppBoot();'
+		script(type='text/javascript')!='window.AppBoot();'
 
 		noscript.wpcom-site__global-noscript
 			|Please enable JavaScript in your browser to enjoy WordPress.com.


### PR DESCRIPTION
Reverts #12995

This reverts commit b495f9a8aaa1310ff431e8bed5ef2acd4e5dff9b.

No measured performance advantage, so reverting for simplicity.

See #12995 for measurements. More discussion at p55Cj4-lD-p2.
