### PR TITLE
Site Settings: Add stats link to stats card

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -174,7 +174,7 @@ class JetpackSiteStats extends Component {
 				</FoldableCard>
 
 				<CompactCard href={ '/stats/day/' + siteId }>
-					{ translate( 'View your stats' ) }
+					{ translate( 'View your site stats' ) }
 				</CompactCard>
 			</div>
 		);

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -21,7 +21,7 @@ import ExternalLink from 'components/external-link';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QuerySiteRoles from 'components/data/query-site-roles';
 import { getStatsPathForTab } from 'lib/route/path';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
 import {
 	isJetpackModuleActive,
@@ -102,6 +102,7 @@ class JetpackSiteStats extends Component {
 		const {
 			siteId,
 			siteRoles,
+			siteSlug,
 			translate
 		} = this.props;
 		const header = (
@@ -174,7 +175,7 @@ class JetpackSiteStats extends Component {
 					</FormFieldset>
 				</FoldableCard>
 
-				<CompactCard href={ getStatsPathForTab( 'day', siteId ) }>
+				<CompactCard href={ getStatsPathForTab( 'day', siteSlug ) }>
 					{ translate( 'View your site stats' ) }
 				</CompactCard>
 			</div>
@@ -190,6 +191,7 @@ export default connect(
 
 		return {
 			siteId,
+			siteSlug: getSelectedSiteSlug( state, siteId ),
 			statsModuleActive: !! isJetpackModuleActive( state, siteId, 'stats' ),
 			moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			siteRoles: getSiteRoles( state, siteId ),

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -20,6 +20,7 @@ import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QuerySiteRoles from 'components/data/query-site-roles';
+import { getStatsPathForTab } from 'lib/route/path';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
 import {
@@ -173,7 +174,7 @@ class JetpackSiteStats extends Component {
 					</FormFieldset>
 				</FoldableCard>
 
-				<CompactCard href={ '/stats/day/' + siteId }>
+				<CompactCard href={ getStatsPathForTab( 'day', siteId ) }>
 					{ translate( 'View your site stats' ) }
 				</CompactCard>
 			</div>

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import Gridicon from 'gridicons';
 import FoldableCard from 'components/foldable-card';
+import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
@@ -171,6 +172,10 @@ class JetpackSiteStats extends Component {
 						}
 					</FormFieldset>
 				</FoldableCard>
+
+				<CompactCard href={ '/stats/day/' + siteId }>
+					{ translate( 'View your stats' ) }
+				</CompactCard>
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -386,7 +386,7 @@
 	margin-top: 3px;
 }
 
-.site-settings__foldable-card + .card.is-compact {
+.site-settings__foldable-card + .card.is-compact:last-child {
 	margin-top: -16px;
 	margin-bottom: 16px;
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -385,3 +385,8 @@
 .site-settings__add-to-whitelist {
 	margin-top: 3px;
 }
+
+.site-settings__foldable-card + .card.is-compact {
+	margin-top: -16px;
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
This PR adds a link to Stats in the Stats card in the Traffic settings section for Jetpack sites.

Fixes #12911.

Before:
![](https://cldup.com/eFwijrhC8S.png)

After:
![](https://cldup.com/ZJwD8tpF2v.png)

To test:
* Checkout this branch.
* Go to `/settings/traffic/$site` where `$site` is one of your Jetpack sites.
* Verify the new link is shown in the Stats card.
* Verify the new link works properly and leads to the Day view of Stats for that site.