### PR TITLE
Sidebar#plan: Check if site if falsey

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -268,13 +268,13 @@ export class MySitesSidebar extends Component {
 	}
 
 	plan() {
-		if ( ! this.props.siteId ) {
+		const { site, siteId, canUserManageOptions } = this.props;
+
+		if ( ! siteId || ! site ) {
 			return null;
 		}
 
-		const { site, canUserManageOptions } = this.props;
-
-		if ( site && ! canUserManageOptions ) {
+		if ( ! canUserManageOptions ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -268,9 +268,9 @@ export class MySitesSidebar extends Component {
 	}
 
 	plan() {
-		const { site, siteId, canUserManageOptions } = this.props;
+		const { site, canUserManageOptions } = this.props;
 
-		if ( ! siteId || ! site ) {
+		if ( ! site ) {
 			return null;
 		}
 
@@ -281,10 +281,7 @@ export class MySitesSidebar extends Component {
 		let planLink = '/plans' + this.props.siteSuffix;
 
 		// Show plan details for upgraded sites
-		if (
-			site &&
-			( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) )
-		) {
+		if ( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) ) {
 			planLink = '/plans/my-plan' + this.props.siteSuffix;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -349,7 +349,11 @@ export class MySitesSidebar extends Component {
 		let usersLink = '/people/team' + this.props.siteSuffix;
 		let addPeopleLink = '/people/new' + this.props.siteSuffix;
 
-		if ( site && ! canUserListUsers ) {
+		if ( ! site ) {
+			return null;
+		}
+
+		if ( ! canUserListUsers ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -357,10 +357,6 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( ! this.props.siteId ) {
-			return null;
-		}
-
 		if ( ! config.isEnabled( 'manage/people' ) && site.options ) {
 			usersLink = site.options.admin_url + 'users.php';
 		}


### PR DESCRIPTION
Purports to fix #13398. For research and testing instructions see there.

[This line](https://github.com/Automattic/wp-calypso/pull/13409/files#diff-3e29fa10a6f1fb8927b10336ff9ff66bL281) wasn't previously guarded for falsey `site`. It is now, by [this](https://github.com/Automattic/wp-calypso/pull/13409/files#diff-3e29fa10a6f1fb8927b10336ff9ff66bR273).