### PR TITLE
Sidebar: Use Redux sites instead of sites-list for Add Site link

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -466,7 +466,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	getAddNewSiteUrl() {
-		if ( this.props.sites.getJetpack().length ||
+		if ( this.props.hasJetpackSites ||
 			abtest( 'newSiteWithJetpack' ) === 'showNewJetpackSite' ) {
 			return '/jetpack/new/?ref=calypso-selector';
 		}


### PR DESCRIPTION
This PR updates the "Add new Site" link in the sidebar to use Redux sites instead of sites-list. We already have the `hasJetpackSites` connected prop there, which makes it an easy job. We might want to do that a dedicated selector in a future PR.

To test:
* Checkout this branch
* Login as a user with no Jetpack sites.
* Click "My SItes" -> "Switch Site" and click on "Add New Site".
* Verify you're directed to create a new .com site (`/start`)
* Login as a user with at least one Jetpack site.
* Click "My SItes" -> "Switch Site" and click on "Add New Site".
* Verify you're directed to the new site creation flow (`/jetpack/new`)