### PR TITLE
Site Settings: Retrieve site visibility from settings in Traffic tab

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -45,6 +45,7 @@ import {
 } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
+	getSiteSettings,
 	getSiteSettingsSaveError,
 } from 'state/site-settings/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -61,6 +62,7 @@ import {
 import { hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_ADVANCED_SEO, PLAN_BUSINESS } from 'lib/plans/constants';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import {
 	requestSiteSettings,
 	saveSiteSettings
@@ -378,15 +380,13 @@ export const SeoForm = React.createClass( {
 			showAdvancedSeo,
 			showWebsiteMeta,
 			site,
+			siteSettings,
 			isFetchingSite,
 			isSeoToolsActive,
 			isVerificationToolsActive,
 			translate,
 		} = this.props;
 		const {
-			settings: {
-				blog_public = 1
-			} = {},
 			slug = '',
 			URL: siteUrl = '',
 		} = site;
@@ -403,7 +403,7 @@ export const SeoForm = React.createClass( {
 
 		let { googleCode, bingCode, pinterestCode, yandexCode } = this.state;
 
-		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
+		const isSitePrivate = siteSettings && parseInt( siteSettings.blog_public, 10 ) !== 1;
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
 		const isDisabled = isSitePrivate || isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
 		const isSeoDisabled = isDisabled || isSeoToolsActive === false;
@@ -447,6 +447,7 @@ export const SeoForm = React.createClass( {
 		/* eslint-disable react/jsx-no-target-blank */
 		return (
 			<div>
+				<QuerySiteSettings siteId={ siteId } />
 				{
 					siteIsJetpack &&
 					<QueryJetpackModules siteId={ siteId } />
@@ -756,6 +757,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteIsJetpack,
 		selectedSite: getSelectedSite( state ),
 		storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) ),
+		siteSettings: getSiteSettings( state, siteId ),
 		showAdvancedSeo: isAdvancedSeoEligible && isAdvancedSeoSupported,
 		showWebsiteMeta: !! get( site, 'options.advanced_seo_front_page_description', '' ),
 		jetpackManagementUrl,


### PR DESCRIPTION
This PR fixes #13414, where site visibility isn't being fetched properly in SEO settings. This happened because when migrating Traffic away from `sites-list` in #13258, we didn't update the `settings` to be retrieved from the settings redux tree. This PR fixes that by making sure settings will be queried, and fetching the privacy setting from there.

To test:
* Go to `/settings/traffic/$site` where `$site` is one of your private/hidden sites with Business/Professional plan.
* Verify you're seeing the notice properly:

![](https://cldup.com/6NshG42lQ6.png)

* Go to `/settings/traffic/$site` where `$site` is one of your public sites with Business/Professional plan.
* Verify you're not seeing the notice. 

