### PR TITLE
Site Settings: Cleanup Traffic section controller

### DIFF
--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -15,7 +15,6 @@ import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import SeoForm from './form';
 
 export class SeoSettings extends Component {
-
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.purchasesError ) {
 			notices.error( nextProps.purchasesError );
@@ -23,20 +22,19 @@ export class SeoSettings extends Component {
 	}
 
 	render() {
-		const { site, siteId, upgradeToBusiness } = this.props;
+		const { site, siteId } = this.props;
 
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
-				{ site && <SeoForm { ...{ site, upgradeToBusiness } } /> }
+				{ site && <SeoForm site={ site } /> }
 			</div>
 		);
 	}
 }
 
 SeoSettings.propTypes = {
-	upgradeToBusiness: PropTypes.func,
 	section: PropTypes.string,
 	//connected
 	hasLoadedSitePurchasesFromServer: PropTypes.bool,

--- a/client/my-sites/site-settings/settings-controller.js
+++ b/client/my-sites/site-settings/settings-controller.js
@@ -10,18 +10,21 @@ import analytics from 'lib/analytics';
 import route from 'lib/route';
 import { sectionify } from 'lib/route/path';
 import titlecase from 'to-title-case';
-import utils from 'lib/site/utils';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 export default {
 	siteSettings( context, next ) {
 		let analyticsPageTitle = 'Site Settings';
 		const basePath = route.sectionify( context.path );
-		const site = getSelectedSite( context.store.getState() );
 		const section = sectionify( context.path ).split( '/' )[ 2 ];
+		const state = context.store.getState();
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
+		const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 
 		// if site loaded, but user cannot manage site, redirect
-		if ( site && ! utils.userCan( 'manage_options', site ) ) {
+		if ( site && ! canManageOptions ) {
 			page.redirect( '/stats' );
 			return;
 		}

--- a/client/my-sites/site-settings/traffic/controller.js
+++ b/client/my-sites/site-settings/traffic/controller.js
@@ -1,45 +1,20 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import route from 'lib/route';
 import TrafficMain from 'my-sites/site-settings/traffic/main';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { canCurrentUser } from 'state/selectors';
 
 export default {
 	traffic( context ) {
-		const analyticsPageTitle = 'Site Settings > Traffic';
-		const basePath = route.sectionify( context.path );
-		const state = context.store.getState();
-		const site = getSelectedSite( state );
-		const siteId = getSelectedSiteId( state );
-		const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
-
-		// if site loaded, but user cannot manage site, redirect
-		if ( site && ! canManageOptions ) {
-			page.redirect( '/stats' );
-			return;
-		}
-
-		const upgradeToBusiness = () => page( '/checkout/' + site.domain + '/business' );
-
 		renderWithReduxStore(
-			React.createElement( TrafficMain, {
-				...{ upgradeToBusiness }
-			} ),
+			React.createElement( TrafficMain ),
 			document.getElementById( 'primary' ),
 			context.store
 		);
-
-		// analytics tracking
-		analytics.pageView.record( basePath + '/:site', analyticsPageTitle );
 	}
 };

--- a/client/my-sites/site-settings/traffic/index.js
+++ b/client/my-sites/site-settings/traffic/index.js
@@ -8,13 +8,20 @@ import page from 'page';
  */
 import controller from './controller';
 import mySitesController from 'my-sites/controller';
+import settingsController from 'my-sites/site-settings/settings-controller';
 
 const redirectToTrafficSection = ( context ) => {
 	page.redirect( '/settings/traffic/' + ( context.params.site_id || '' ) );
 };
 
 export default function() {
-	page( '/settings/traffic/:site_id', mySitesController.siteSelection, mySitesController.navigation, controller.traffic );
+	page(
+		'/settings/traffic/:site_id',
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		settingsController.siteSettings,
+		controller.traffic
+	);
 
 	// redirect legacy urls
 	page( '/settings/analytics/:site_id?', redirectToTrafficSection );

--- a/client/my-sites/site-settings/traffic/main.jsx
+++ b/client/my-sites/site-settings/traffic/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight, partialRight, pick } from 'lodash';
@@ -39,7 +39,6 @@ const SiteSettingsTraffic = ( {
 	trackEvent,
 	translate,
 	updateFields,
-	upgradeToBusiness
 } ) => (
 	<Main className="traffic__main site-settings">
 		<DocumentHead title={ translate( 'Site Settings' ) } />
@@ -75,7 +74,7 @@ const SiteSettingsTraffic = ( {
 		}
 		<AnalyticsSettings />
 		<SeoSettingsHelpCard />
-		<SeoSettingsMain upgradeToBusiness={ upgradeToBusiness } />
+		<SeoSettingsMain />
 		<Sitemaps
 			isSavingSettings={ isSavingSettings }
 			isRequestingSettings={ isRequestingSettings }
@@ -83,10 +82,6 @@ const SiteSettingsTraffic = ( {
 		/>
 	</Main>
 );
-
-SiteSettingsTraffic.propTypes = {
-	upgradeToBusiness: PropTypes.func.isRequired,
-};
 
 const connectComponent = connect(
 	( state ) => {


### PR DESCRIPTION
This PR cleans up the Traffic section - `upgradeToBusiness` is unused, so we're completely removing it. Also, it updates the traffic section to use the main settings controller, thus removing some duplicated code. Some of this code become obsolete in the attempts to improve performance and split settings to separate chunks.

To test:
* Checkout this branch
* Go to `/settings/traffic/$site` and verify there are no regressions in the Traffic and particularly the SEO settings for:
  * Jetpack site with non-professional plan
  * Jetpack site with a professional plan
  * .com site with a business plan
  * .com site with a non-business plan