### PR TITLE
Site Picker: Add domain icon to domain-only site

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -121,6 +121,11 @@ export default React.createClass( {
 									<Gridicon icon="block" size={ 14 } />
 								</span>
 							}
+							{ site.options && site.options.is_domain_only &&
+								<span className="site__badge">
+									<Gridicon icon="domains" size={ 14 } />
+								</span>
+							}
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 							{ site.title }
 						</div>


### PR DESCRIPTION
Differentiate domain-only sites with a domains icon we use across Calypso.

Test:
- Visit http://calypso.localhost:3000/domains/manage

Before:
![domain only before](https://cloud.githubusercontent.com/assets/1103398/25438882/0f80d794-2a9b-11e7-9922-53e56c41a045.png)

After:
![domain only icon](https://cloud.githubusercontent.com/assets/1103398/25438894/159c0482-2a9b-11e7-940a-290b67f20754.png)
