### PR TITLE
Purchases: Whitelist /me/purchases for domain-only

### DIFF
--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -8,9 +8,10 @@ export function getExitCheckoutUrl( cart, siteSlug ) {
 	let url = '/plans/';
 
 	if ( cartItems.hasRenewalItem( cart ) ) {
-		const renewalItem = cartItems.getRenewalItems( cart )[ 0 ];
+		const { purchaseId, purchaseDomain } = cartItems.getRenewalItems( cart )[ 0 ].extra,
+			siteName = siteSlug || purchaseDomain;
 
-		return managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
+		return managePurchase( siteName, purchaseId );
 	}
 
 	if ( cartItems.hasDomainRegistration( cart ) ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -5,7 +5,7 @@ import page from 'page';
 import ReactDom from 'react-dom';
 import React from 'react';
 import i18n from 'i18n-calypso';
-import { uniq, startsWith } from 'lodash';
+import { uniq, some, startsWith } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -165,11 +165,18 @@ function isPathAllowedForDomainOnlySite( path, domainName ) {
 	].map( pathFactory => pathFactory( domainName, domainName ) );
 
 	const otherPaths = [
-		`/checkout/${ domainName }`
-	];
+			`/checkout/${ domainName }`
+		],
+		startsWithPaths = [
+			'/checkout/thank-you',
+			`/me/purchases/${ domainName }`
+		];
 
-	return [ ...domainManagementPaths, ...otherPaths ].indexOf( path ) > -1 ||
-		startsWith( path, '/checkout/thank-you' );
+	if ( some( startsWithPaths, startsWithPath => startsWith( path, startsWithPath ) ) ) {
+		return true;
+	}
+
+	return [ ...domainManagementPaths, ...otherPaths ].indexOf( path ) > -1;
 }
 
 function onSelectedSiteAvailable( context ) {


### PR DESCRIPTION
Users weren't able to cancel the domain as the path was not whitelisted, and would see the default domain-only landing screen.

Test:
- Buy a domain on wordpress.com/domains
- Go to `Manage Purchases` (or manually visit `/me/purchases`)
- Click on the domain bought
- Make sure you are not redirected to domain-only landing page

Before:
![purchase domain only before](https://cloud.githubusercontent.com/assets/1103398/25443162/4f1aec8a-2aa7-11e7-8d5e-71bdc31794e4.png)

After:
![purchases domain only](https://cloud.githubusercontent.com/assets/1103398/25443177/5f9bdb6e-2aa7-11e7-9e9c-dca2eebd92d6.png)
