### PR TITLE
Sidebar: Check site prop before access

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -201,7 +201,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		if ( ! config.isEnabled( 'manage/plugins' ) ) {
-			if ( ! this.props.siteId ) {
+			if ( ! site ) {
 				return null;
 			}
 
@@ -442,7 +442,7 @@ export class MySitesSidebar extends Component {
 		const cutOffDate = new Date( '2015-09-07' );
 
 		// VIP sites should always show a WP Admin link regardless of the current user.
-		if ( site.is_vip ) {
+		if ( site && site.is_vip ) {
 			return true;
 		}
 


### PR DESCRIPTION
Followup from #13409.

This PR fixes the remaining accesses of the `site` prop without guards. I don't see any errors from these but it seems prudent to add the guards in.
