### PR TITLE
Themes: Add fallback descriptions for verticals/filters

### DIFF
--- a/client/state/selectors/get-theme-showcase-description.js
+++ b/client/state/selectors/get-theme-showcase-description.js
@@ -20,7 +20,7 @@ export default function getThemeShowcaseDescription( state, { filter, tier, ver
 	}
 
 	// If we have *one* filter, use its description
-	if ( filter && ! includes( filter, ',' ) ) {
+	if ( filter && ! includes( filter, '+' ) ) {
 		const filterDescription = get( findThemeFilterTerm( state, filter ), 'description' );
 		if ( filterDescription ) {
 			return filterDescription;

--- a/client/state/selectors/get-theme-showcase-description.js
+++ b/client/state/selectors/get-theme-showcase-description.js
@@ -9,10 +9,14 @@ import { get, includes } from 'lodash';
 import { findThemeFilterTerm, getThemeFilterTerm } from './';
 
 export default function getThemeShowcaseDescription( state, { filter, tier, vertical } = {} ) {
-	// If we have a vertical, use its description
-	const description = get( getThemeFilterTerm( state, 'subject', vertical ), 'description' );
-	if ( description ) {
-		return description;
+	if ( vertical ) {
+		const description = get( getThemeFilterTerm( state, 'subject', vertical ), 'description' );
+		if ( description ) {
+			return description;
+		}
+		return `Discover ${ vertical } WordPress Themes on the WordPress.com Showcase. ` +
+		'Here you can browse and find the best WordPress designs available on ' +
+		'WordPress.com to discover the one that is just right for you.';
 	}
 
 	// If we have *one* filter, use its description
@@ -21,6 +25,9 @@ export default function getThemeShowcaseDescription( state, { filter, tier, ver
 		if ( filterDescription ) {
 			return filterDescription;
 		}
+		return `Discover WordPress Themes supporting ${ filter } on the WordPress.com Showcase. ` +
+		'Here you can browse and find the best WordPress designs available on WordPress.com ' +
+		'to discover the one that is just right for you.';
 	}
 
 	if ( tier === 'free' ) {

--- a/client/state/selectors/test/get-theme-showcase-description.js
+++ b/client/state/selectors/test/get-theme-showcase-description.js
@@ -20,9 +20,11 @@ describe( 'getThemeShowcaseDescription()', () => {
 		expect( description ).to.equal( 'Whether you\'re minimalist at heart, like keeping things clean, or just want to focus — ...' );
 	} );
 
-	it( 'should fall back to the tier description for an unknown vertical', () => {
+	it( 'should fall back to generic vertical description for an unknown vertical', () => {
 		const description = getThemeShowcaseDescription( state, { vertical: 'blahg', tier: 'free' } );
-		expect( description ).to.equal( 'Discover Free WordPress Themes on the WordPress.com Theme Showcase.' );
+		expect( description ).to.equal( 'Discover blahg WordPress Themes on the WordPress.com Showcase. \
+Here you can browse and find the best WordPress designs available on \
+WordPress.com to discover the one that is just right for you.' );
 	} );
 
 	it( 'should return the generic Theme Showcase description if no additional args are provided', () => {


### PR DESCRIPTION
Add a fallback description for verticals and filters that do not have a `description` field populated in the /v1.2/theme-filters API endpoint.

**To Test**
* Logged-out
* Visit a 'vertical' url with no description, for example: `view-source:http://calypso.localhost:3000/themes/art`
* Expected: `<meta name="description"` should be populated with unique string featuring the vertical
* Visit a filter url with no description, for example: `view-source:http://calypso.localhost:3000/themes/filter/orange`
* Expected `<meta name="description"` should be populated with unique string featuring the filter
* Filters/verticals with descriptions, for example, `/themes/blog` or `/themes/filter/blog` should still use it
* Multiple filters, for example, `blue+orange`, still fall back to a generic message


