### PR TITLE
Plans: Replace the current plan checkmark with a "Your Plan" banner

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -43,7 +43,7 @@ const PlanFeaturesActions = ( {
 		upgradeButton = (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				<Gridicon size={ 18 } icon="checkmark" />
-				{ canPurchase ? translate( 'Manage your plan' ) : translate( 'View plan' ) }
+				{ canPurchase ? translate( 'Manage Plan' ) : translate( 'View Plan' ) }
 			</Button>
 		);
 	} else if ( available || isPlaceholder ) {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -5,7 +5,6 @@ import { localize } from 'i18n-calypso';
 import noop from 'lodash/noop';
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -42,7 +41,6 @@ const PlanFeaturesActions = ( {
 	if ( current && ! isInSignup ) {
 		upgradeButton = (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
-				<Gridicon size={ 18 } icon="checkmark" />
 				{ canPurchase ? translate( 'Manage Plan' ) : translate( 'View Plan' ) }
 			</Button>
 		);

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -43,7 +43,7 @@ const PlanFeaturesActions = ( {
 		upgradeButton = (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				<Gridicon size={ 18 } icon="checkmark" />
-				{ canPurchase ? translate( 'Your plan' ) : translate( 'Current plan' ) }
+				{ canPurchase ? translate( 'Manage your plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
 	} else if ( available || isPlaceholder ) {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -5,7 +5,6 @@ import React, { Component, PropTypes } from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
@@ -58,9 +57,11 @@ class PlanFeaturesHeader extends Component {
 				{
 					newPlan && <Ribbon>{ translate( 'New' ) }</Ribbon>
 				}
+				{
+					current && <Ribbon>{ translate( 'Your Plan' ) }</Ribbon>
+				}
 				<div className="plan-features__header-figure" >
 					<PlanIcon plan={ planType } />
-					{ current && <Gridicon icon="checkmark-circle" className="plan-features__header-checkmark" /> }
 				</div>
 				<div className="plan-features__header-text">
 					<h4 className="plan-features__header-title">{ title }</h4>

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -408,19 +408,6 @@ $plan-features-sidebar-width: 272px;
 	width: 100%;
 	margin-top: 8px;
 
-	&.is-current {
-
-		.gridicon {
-			fill: $alert-green;
-			margin-right: 8px;
-		}
-	}
-
-	&.is-popular {
-		background-color: $alert-green;
-		border-color: darken( $alert-green, 20% );
-	}
-
 	@include breakpoint( "<660px" ) {
 		margin-top: 20px;
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -222,18 +222,6 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plan-features__header-checkmark {
-	position: absolute;
-	top: 0;
-	right: -3px;
-	transform: translate( 25%, -25% );
-	fill: $alert-green;
-
-	@include breakpoint( "<1280px" ) {
-		display: none;
-	}
-}
-
 .plan-features__header-text {
 	flex: 1;
 	padding: 6px 0 0 0;


### PR DESCRIPTION
Fixes #12436, switch the current plan indicator from checkmark to a ribbon & change the button label from "Your Plan" to "Manage your plan"

<img width="984" alt="screen shot 2017-04-26 at 1 51 48 pm" src="https://cloud.githubusercontent.com/assets/541093/25448757/87add280-2a87-11e7-87da-0b1dc82a465a.png">

To Test:

1. Check out this PR
2. Visit `/plans/$site`
3. Your current plan should now have a ribbon saying "Your Plan"
4. At >1280px wide, you don't see a checkmark
5. The button on your plan should say "Manage your plan" if you own the purchase, or "View plan" if you're just a member on the site.
