### PR TITLE
Reader: Show longer excerpts for recs without images

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -202,7 +202,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	padding-top: 11px;
 
 	.reader-related-card-v2__post {
-		max-height: 104px;
+		max-height: 206px;
 
 		&::after {
 			@include long-content-fade( $size: 30% );
@@ -226,7 +226,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.has-thumbnail {
 
 			.reader-related-card-v2__post {
-				max-height: 104px;
+				max-height: 106px;
 
 				@media #{$reader-related-card-v2-breakpoint-medium} {
 					max-height: 108px;
@@ -254,10 +254,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-top: 40px;
 
 		.reader-related-card-v2__post {
-			max-height: 110px;
+			max-height: 206px;
 
-			@include breakpoint( "<960px" ) {
-				max-height: 109px;
+			@media #{$reader-related-card-v2-breakpoint-medium} {
+				max-height: 108px;
+			}
+
+			@media #{$reader-related-card-v2-breakpoint-small} {
+				max-height: 108px;
 			}
 
 			@include breakpoint( "<480px" ) {

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -533,7 +533,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	// Clamp to 3 lines on larger viewports
 	@include breakpoint( ">660px" ) {
 		overflow: hidden;
-		max-height: 16px * 1.5 * 3;
+		max-height: 16px * 1.6 * 3;
 		word-wrap: break-word;
 
 		&::after {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -93,13 +93,17 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 110px;
-
-		@media #{$reader-related-card-v2-breakpoint-small} {
-			max-height: 103px;
-		}
+		max-height: 208px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
+			max-height: 206px;
+		}
+
+		@include breakpoint( "<660px" ) {
+			max-height: 206px;
+		}
+
+		@media #{$reader-related-card-v2-breakpoint-small} {
 			max-height: 103px;
 		}
 

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -625,8 +625,12 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			max-height: 107px;
 		}
 
+		@include breakpoint( "<660px" ) {
+			max-height: 207px;
+		}
+
 		@media #{$reader-related-card-v2-breakpoint-small} {
-			max-height: 103px;
+			max-height: 104px;
 		}
 
 		.reader-related-card-v2__excerpt {

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -619,7 +619,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 206px;
+		max-height: 208px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
 			max-height: 107px;

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -619,7 +619,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__post {
-		max-height: 130px;
+		max-height: 206px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
 			max-height: 107px;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/13388

Updated recs in:
- Search
- Full-post
- Following stream

## Search
**Before:**
<img width="754" alt="screenshot 2017-04-26 11 40 48" src="https://cloud.githubusercontent.com/assets/4924246/25452079/358dd76a-2a79-11e7-91c7-36e9ebcf9d98.png">

**After:**
<img width="760" alt="screenshot 2017-04-26 11 40 04" src="https://cloud.githubusercontent.com/assets/4924246/25452100/4768c576-2a79-11e7-91c6-137a29f2ea72.png">

## Full-post:
**Before:**
<img width="740" alt="screenshot 2017-04-26 11 44 23" src="https://cloud.githubusercontent.com/assets/4924246/25452146/640ef0a6-2a79-11e7-842b-6598b4f5179e.png">

**After:**
<img width="743" alt="screenshot 2017-04-26 11 44 34" src="https://cloud.githubusercontent.com/assets/4924246/25452156/6c732c58-2a79-11e7-9587-651723844ddb.png">

**Before:**
<img width="732" alt="screenshot 2017-04-26 12 12 45" src="https://cloud.githubusercontent.com/assets/4924246/25452217/ae793458-2a79-11e7-9980-650afa0ff917.png">

**After:**
<img width="769" alt="screenshot 2017-04-26 11 55 45" src="https://cloud.githubusercontent.com/assets/4924246/25452173/7c018a84-2a79-11e7-864c-dca811b79acc.png">

## Following stream:
**Before:**
<img width="756" alt="screenshot 2017-04-26 11 58 36" src="https://cloud.githubusercontent.com/assets/4924246/25452398/5a10ec84-2a7a-11e7-9145-d94b3b75ea13.png">

**After:**
<img width="664" alt="screenshot 2017-04-26 12 38 49" src="https://cloud.githubusercontent.com/assets/4924246/25453324/52c449aa-2a7d-11e7-8ebf-deb90d654552.png">
