### PR TITLE
Provide a method for generating variations based off of product attributes.

### DIFF
--- a/client/extensions/woocommerce/lib/generate-variations/README.md
+++ b/client/extensions/woocommerce/lib/generate-variations/README.md
@@ -1,0 +1,57 @@
+Generate Variations
+==========
+
+Given a WooCommerce product object, this library will generate new WooCommerce variation objects based on the available product attributes.
+
+Example
+==========
+```javascript
+import generateVariations from 'lib/generate-variations';
+
+// Provide a WooCommerce Product Object (from state or server)
+const product = { id: 1, attributes: [
+	{
+		name: 'Color',
+		options: [ 'Red', 'Blue' ],
+		variation: true,
+	},
+	{
+		name: 'Size',
+		options: [ 'Small' ],
+		variation: true,
+	},
+] };
+
+const variations = generateVariations( product );
+```
+
+variations will contain the following:
+
+```javascript
+[
+	{
+		attributes: [
+			{
+				name: 'Color',
+				option: 'Red'
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			},
+		]
+	},
+	{
+		attributes: [
+			{
+				name: 'Color',
+				option: 'Blue'
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			},
+		]
+	},
+]
+```

--- a/client/extensions/woocommerce/lib/generate-variations/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/index.js
@@ -1,0 +1,36 @@
+// http://stackoverflow.com/questions/12303989/cartesian-product-of-multiple-arrays-in-javascript
+const f = ( a, b ) => [].concat( ...a.map( c => b.map( d => [].concat( c, d ) ) ) );
+const cartesian = ( a, b, ...c ) => b ? cartesian( f( a, b ), ...c ) : a;
+
+/**
+ * Generates variation objects based on a product's attributes.
+ *
+ * @param {Object} product Product object.
+ * @return {Array} Array of variation objects.
+ */
+export default function generateVariations( product ) {
+	const { attributes } = product;
+	const variationTypeOptions = [];
+	const variationTypeNames = [];
+	const variationTypes = (
+		attributes &&
+		attributes.filter( attribute => attribute.variation && attribute.name && attribute.options.length > 0 )
+	) || [];
+
+	variationTypes.forEach( function( variationType ) {
+		variationTypeOptions.push( variationType.options );
+		variationTypeNames.push( variationType.name );
+	} );
+
+	const combinations = cartesian( ...variationTypeOptions );
+	return combinations && combinations.map( function( combination ) {
+		return {
+			attributes: Array.isArray( combination ) && combination.map( function( option, i ) {
+				return {
+					name: variationTypeNames[ i ],
+					option,
+				};
+			} ) || [ { name: variationTypeNames[ 0 ], option: combination } ],
+		};
+	} ) || [];
+}

--- a/client/extensions/woocommerce/lib/generate-variations/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/index.js
@@ -1,36 +1,48 @@
-// http://stackoverflow.com/questions/12303989/cartesian-product-of-multiple-arrays-in-javascript
-const f = ( a, b ) => [].concat( ...a.map( c => b.map( d => [].concat( c, d ) ) ) );
-const cartesian = ( a, b, ...c ) => b ? cartesian( f( a, b ), ...c ) : a;
-
 /**
  * Generates variation objects based on a product's attributes.
  *
  * @param {Object} product Product object.
  * @return {Array} Array of variation objects.
  */
-export default function generateVariations( product ) {
-	const { attributes } = product;
-	const variationTypeOptions = [];
-	const variationTypeNames = [];
-	const variationTypes = (
+export default function generateVariations( { attributes } ) {
+	const variationTypes = [];
+	const variationAttributes = (
 		attributes &&
 		attributes.filter( attribute => attribute.variation && attribute.name && attribute.options.length > 0 )
 	) || [];
 
-	variationTypes.forEach( function( variationType ) {
-		variationTypeOptions.push( variationType.options );
-		variationTypeNames.push( variationType.name );
+	variationAttributes.forEach( function( attribute ) {
+		variationTypes.push( attribute.options.map( function( option ) {
+			return {
+				name: attribute.name,
+				option,
+			};
+		} ) );
 	} );
 
-	const combinations = cartesian( ...variationTypeOptions );
-	return combinations && combinations.map( function( combination ) {
-		return {
-			attributes: Array.isArray( combination ) && combination.map( function( option, i ) {
-				return {
-					name: variationTypeNames[ i ],
-					option,
-				};
-			} ) || [ { name: variationTypeNames[ 0 ], option: combination } ],
-		};
-	} ) || [];
+	return cartesian( ...variationTypes ).map( function( combination ) {
+		return { attributes: combination };
+	} );
+}
+
+// http://stackoverflow.com/a/29585704
+function cartesian( ...arrays ) {
+	let i, j, l, m;
+	const o = [];
+
+	if ( ! arrays || arrays.length === 0 ) {
+		return arrays;
+	}
+	const array1 = arrays.splice( 0, 1 )[ 0 ];
+	arrays = cartesian( ...arrays );
+	for ( i = 0, l = array1.length; i < l; i++ ) {
+		if ( arrays && arrays.length ) {
+			for ( j = 0, m = arrays.length; j < m; j++ ) {
+				o.push( [ array1[ i ] ].concat( arrays[ j ] ) );
+			}
+		} else {
+			o.push( [ array1[ i ] ] );
+		}
+	}
+	return o;
 }

--- a/client/extensions/woocommerce/lib/generate-variations/test/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/test/index.js
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import generateVariations from '../index';
+
+describe( 'generateVariations', () => {
+	it( 'returns an empty array when passed a product with no attributes', () => {
+		const product = { id: 1 };
+		const variations = generateVariations( product );
+		expect( variations ).to.eql( [] );
+	} );
+	it( 'returns an empty array when passed a product with non-variation attributes', () => {
+		const product = { id: 1, attributes: [
+			{
+				name: 'Test Attribute',
+				options: [ 'Option' ],
+				variation: false,
+				uid: 'edit_0',
+			}
+		] };
+		const variations = generateVariations( product );
+		expect( variations ).to.eql( [] );
+	} );
+	it( 'generates simple variations when passed a product with one product variation attribute', () => {
+		const product = { id: 1, attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue' ],
+				variation: true,
+				uid: 'edit_0',
+			}
+		] };
+
+		const variations = generateVariations( product );
+		expect( variations[ 0 ] ).to.eql( {
+			attributes: [
+				{
+					name: 'Color',
+					option: 'Red',
+				},
+			]
+		} );
+
+		expect( variations[ 1 ] ).to.eql( {
+			attributes: [
+				{
+					name: 'Color',
+					option: 'Blue',
+				},
+			]
+		} );
+	} );
+	it( 'generates a cartesian of variations when passed a product with multiple variation attributes', () => {
+		const product = { id: 1, attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue' ],
+				variation: true,
+				uid: 'edit_0',
+			},
+			{
+				name: 'Size',
+				options: [ 'Small' ],
+				variation: true,
+				uid: 'edit_1',
+			},
+		] };
+
+		const variations = generateVariations( product );
+
+		expect( variations[ 0 ] ).to.eql( {
+			attributes: [
+				{
+					name: 'Color',
+					option: 'Red'
+				},
+				{
+					name: 'Size',
+					option: 'Small',
+				}
+			]
+		} );
+
+		expect( variations[ 1 ] ).to.eql( {
+			attributes: [
+				{
+					name: 'Color',
+					option: 'Blue'
+				},
+				{
+					name: 'Size',
+					option: 'Small',
+				}
+			]
+		} );
+	} );
+	it( 'generates a complex cartesian of variations when passed a product with multiple variation attributes and multiple options', () => {
+		const product = { id: 1, attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue', 'Green' ],
+				variation: true,
+				uid: 'edit_0',
+			},
+			{
+				name: 'Size',
+				options: [ 'Small', 'Medium' ],
+				variation: true,
+				uid: 'edit_1',
+			},
+			{
+				name: 'Sleeves',
+				options: [ 'Short', 'Long' ],
+				variation: true,
+				uid: 'edit_2',
+			},
+		] };
+
+		const variations = generateVariations( product );
+
+		expect( variations.length ).to.eql( 12 );
+		expect( variations[ 0 ] ).to.eql( {
+			attributes: [
+				{
+					name: 'Color',
+					option: 'Red',
+				},
+				{
+					name: 'Size',
+					option: 'Small',
+				},
+				{
+					name: 'Sleeves',
+					option: 'Short',
+				},
+			]
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { get, find, isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getVariation } from '../../../variations/selectors';
+
+function getVariationEditsStateForProduct( state, productId ) {
+	const woocommerce = state.extensions.woocommerce;
+	const variations = get( woocommerce, 'ui.products.variations.edits', [] );
+	return find( variations, ( v ) => productId === v.productId );
+}
+
+/**
+ * Gets the accumulated edits for a variation, if any.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} variationId The id of the variation (or { index: # } )
+ * @return {Object} The current accumulated edits
+ */
+export function getVariationEdits( state, productId, variationId ) {
+	const edits = getVariationEditsStateForProduct( state, productId );
+	const bucket = isNumber( variationId ) && 'updates' || 'creates';
+	const array = get( edits, bucket, [] );
+	return find( array, ( v ) => variationId === v.id );
+}
+
+/**
+ * Gets a variation with local edits overlayed on top of fetched data.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} variationId The id of the variation (or { index: # } )
+ * @return {Object} The product data merged between the fetched data and edits
+ */
+export function getVariationWithLocalEdits( state, productId, variationId ) {
+	const existing = isNumber( variationId );
+	const variation = existing && getVariation( state, productId, variationId );
+	const variationEdits = getVariationEdits( state, productId, variationId );
+
+	return ( variation || variationEdits ) && { ...variation, ...variationEdits } || undefined;
+}
+
+/**
+ * Gets the variation being currently edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Object} Variation object that is merged between fetched data and edits
+ */
+export function getCurrentlyEditingVariation( state, productId ) {
+	const edits = getVariationEditsStateForProduct( state, productId ) || {};
+	const { currentlyEditingId } = edits;
+
+	return getVariationWithLocalEdits( state, productId, currentlyEditingId );
+}
+
+/**
+ * Gets an array of variation objects for a product, including new ones being edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Array} Array of variation objects.
+ */
+export function getProductVariationsWithLocalEdits( state, productId ) {
+	const edits = getVariationEditsStateForProduct( state, productId );
+	const creates = get( edits, 'creates', undefined );
+	// TODO Merge in existing variations loaded by the API for existing products.
+	return creates;
+}

--- a/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { set } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getVariationEdits,
+	getVariationWithLocalEdits,
+	getCurrentlyEditingVariation,
+	getProductVariationsWithLocalEdits,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	let state;
+
+	beforeEach( () => {
+		state = {
+			extensions: {
+				woocommerce: {
+					products: [
+						// TODO: After the product API code is in, add more fields here.
+						{ id: 2 },
+					],
+					variations: [
+						// TODO: After the variation API code is in, add more fields here.
+						{ id: 3 },
+					],
+					ui: {
+						products: {
+							variations: {
+							}
+						}
+					},
+				},
+			},
+		};
+	} );
+
+	describe( 'getVariationEdits', () => {
+		it( 'should get a variation from "creates"', () => {
+			const newVariation = { id: { index: 1 }, name: 'New Variation' };
+			const productId = { index: 0 };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', productId );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getVariationEdits( state, productId, newVariation.id ) ).to.equal( newVariation );
+		} );
+
+		it( 'should get a variation from "updates"', () => {
+			const updateVariation = { id: 3, name: 'Existing Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].updates', [ updateVariation ] );
+
+			expect( getVariationEdits( state, 2, updateVariation.id ) ).to.equal( updateVariation );
+		} );
+
+		it( 'should return undefined if no edits are found for productId', () => {
+			expect( getVariationEdits( state, 2, 3 ) ).to.not.exist;
+			expect( getVariationEdits( state, 2, { index: 9 } ) ).to.not.exist;
+		} );
+
+		it( 'should return undefined if no edits are found for variationId', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			expect( getVariationEdits( state, 2, 3 ) ).to.not.exist;
+			expect( getVariationEdits( state, 2, { index: 9 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getVariationWithLocalEdits', () => {
+		it( 'should get just edits for a variation in "creates"', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getVariationWithLocalEdits( state, 2, newVariation.id ) ).to.eql( newVariation );
+		} );
+
+		it( 'should get just fetched data for a variation that has no edits', () => {
+			const variations = state.extensions.woocommerce.variations;
+
+			expect( getVariationWithLocalEdits( state, 2, 3 ) ).to.eql( variations[ 0 ] );
+		} );
+
+		it( 'should get both fetched data and edits for a variation in "updates"', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			const variations = state.extensions.woocommerce.variations;
+
+			const existingVariation = { id: 3, name: 'Existing Variation' };
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].updates', [ existingVariation ] );
+
+			const combinedVariation = { ...variations[ 0 ], ...existingVariation };
+			expect( getVariationWithLocalEdits( state, 2, 3 ) ).to.eql( combinedVariation );
+		} );
+
+		it( 'should return undefined if no variation is found for variationId', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 42 );
+			expect( getVariationWithLocalEdits( state, 42, 43 ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+		} );
+
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getVariationWithLocalEdits( state, 42, 43 ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingVariation', () => {
+		it( 'should return undefined if there are no edits', () => {
+			expect( getCurrentlyEditingVariation( state, 2 ) ).to.not.exist;
+		} );
+
+		it( 'should get the last edited variation', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+			set( uiVariations, 'edits[0].currentlyEditingId', newVariation.id );
+
+			expect( getCurrentlyEditingVariation( state, 2 ) ).to.eql( newVariation );
+		} );
+	} );
+
+	describe( 'getProductVariationsWithLocalEdits', () => {
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getProductVariationsWithLocalEdits( state, 4 ) ).to.not.exist;
+		} );
+		it( 'should get variations from "creates"', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getProductVariationsWithLocalEdits( state, 2 ) ).to.eql( [ newVariation ] );
+		} );
+		// TODO Tests for dealing with fetched/existing variations and combined (creates & existing).
+	} );
+} );

--- a/client/extensions/woocommerce/state/variations/selectors.js
+++ b/client/extensions/woocommerce/state/variations/selectors.js
@@ -1,0 +1,12 @@
+/**
+ * Gets variation fetched from server.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} productId Numeric product id.
+ * @param {Number} variationId Numeric variation id.
+ * @return {Object} Variation object from API.
+ */
+export function getVariation( state, productId, variationId ) {
+	// TODO: Add fetched variations data.
+	return productId && variationId === 3 && { id: variationId } || undefined;
+}


### PR DESCRIPTION
This PR introduces a helper method for generating variation objects based on a product's available attributes.

It accepts a product object and will return an array of API-ready variation objects that can later be used for actually creating the variations in state to allow editing of details.

It includes tests and an example.

I am putting it in a `lib/` directory where these types of methods can live (per https://github.com/Automattic/wp-calypso/pull/12702#issuecomment-292266600).

To Test:
* Run `make test` and make sure all tests pass.

