### PR TITLE
AT: Update/exclude db reset plugins

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -10,6 +10,7 @@ import get from 'lodash/get';
 import { includes } from 'lodash';
 import { isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -104,7 +105,7 @@ const PluginMeta = React.createClass( {
 				<div className="plugin-meta__actions">
 					<div className="plugin-item__count">
 						{
-							this.translate( 'Sites {{count/}}',
+							this.props.translate( 'Sites {{count/}}',
 								{
 									components: {
 										count: <Count count={ this.props.sites.length } />
@@ -129,7 +130,7 @@ const PluginMeta = React.createClass( {
 			return (
 				<div className="plugin-meta__actions">
 					<Button className="plugin-meta__active" compact borderless>
-						<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
+						<Gridicon icon="checkmark" />{ this.props.translate( 'Active' ) }
 					</Button>
 				</div>
 			);
@@ -186,7 +187,7 @@ const PluginMeta = React.createClass( {
 			</ExternalLink>
 		);
 
-		return this.translate( 'By {{linkToAuthor/}}', {
+		return this.props.translate( 'By {{linkToAuthor/}}', {
 			components: {
 				linkToAuthor
 			}
@@ -253,12 +254,12 @@ const PluginMeta = React.createClass( {
 		if ( selectedSite && this.isUnsupportedPluginForAT() && ( ! selectedSite.jetpack || automatedTransferSite ) ) {
 			return (
 				<Notice
-					text={ this.translate( 'Incompatible plugin: This plugin is not supported on WordPress.com.' ) }
+					text={ this.props.translate( 'Incompatible plugin: This plugin is not supported on WordPress.com.' ) }
 					status="is-warning"
 					showDismiss={ false }
 				>
 					<NoticeAction href="https://support.wordpress.com/incompatible-plugins/">
-						{ this.translate( 'More info' ) }
+						{ this.props.translate( 'More info' ) }
 					</NoticeAction>
 				</Notice>
 			);
@@ -278,7 +279,7 @@ const PluginMeta = React.createClass( {
 		if ( this.isOutOfDate() && newVersions.length === 0 ) {
 			return <Notice
 				className="plugin-meta__version-notice"
-				text={ this.translate( 'This plugin hasn\'t been updated in over 2 years. It may no longer be maintained or ' +
+				text={ this.props.translate( 'This plugin hasn\'t been updated in over 2 years. It may no longer be maintained or ' +
 					'supported and may have compatibility issues when used with more recent versions of WordPress' ) }
 				status="is-warning"
 				showDismiss={ false } />;
@@ -486,8 +487,8 @@ const PluginMeta = React.createClass( {
 					<div className="plugin-meta__upgrade_nudge">
 						<UpgradeNudge
 							feature={ FEATURE_UPLOAD_PLUGINS }
-							title={ this.translate( 'Upgrade to the Business plan to install plugins.' ) }
-							message={ this.translate( 'Upgrade to the Business plan to install plugins.' ) }
+							title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
+							message={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
 							event={ 'calypso_plugins_page_upgrade_nudge' }
 						/>
 					</div>
@@ -511,4 +512,4 @@ const mapStateToProps = state => {
 	};
 };
 
-export default connect( mapStateToProps )( PluginMeta );
+export default connect( mapStateToProps )( localize( PluginMeta ) );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -209,6 +209,7 @@ const PluginMeta = React.createClass( {
 			'wordpress-reset',
 			'wp-reset',
 			'advanced-reset-wp',
+			'advanced-wp-reset',
 		];
 
 		return includes( unsupportedPlugins, plugin.slug );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -193,7 +193,7 @@ const PluginMeta = React.createClass( {
 		} );
 	},
 
-	isUnsupportedPlugin() {
+	isUnsupportedPluginForAT() {
 		const { plugin } = this.props;
 
 		// Pressable prevents installation of some plugins, so we need to disable AT for them.
@@ -204,6 +204,10 @@ const PluginMeta = React.createClass( {
 			'wp-rocket',
 			'wp-super-cache',
 			'bwp-minify',
+			'wordpress-database-reset',
+			'wordpress-reset',
+			'wp-reset',
+			'advanced-reset-wp',
 		];
 
 		return includes( unsupportedPlugins, plugin.slug );
@@ -212,13 +216,13 @@ const PluginMeta = React.createClass( {
 	isWpcomInstallDisabled() {
 		const { isTransfering } = this.props;
 
-		return ! this.hasBusinessPlan() || this.isUnsupportedPlugin() || isTransfering;
+		return ! this.hasBusinessPlan() || this.isUnsupportedPluginForAT() || isTransfering;
 	},
 
 	isJetpackInstallDisabled() {
 		const { automatedTransferSite } = this.props;
 
-		return automatedTransferSite && this.isUnsupportedPlugin();
+		return automatedTransferSite && this.isUnsupportedPluginForAT();
 	},
 
 	getInstallButton() {
@@ -246,7 +250,7 @@ const PluginMeta = React.createClass( {
 	maybeDisplayUnsupportedNotice() {
 		const { selectedSite, automatedTransferSite } = this.props;
 
-		if ( selectedSite && this.isUnsupportedPlugin() && ( ! selectedSite.jetpack || automatedTransferSite ) ) {
+		if ( selectedSite && this.isUnsupportedPluginForAT() && ( ! selectedSite.jetpack || automatedTransferSite ) ) {
 			return (
 				<Notice
 					text={ this.translate( 'Incompatible plugin: WordPress.com already provides this feature.' ) }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -253,7 +253,7 @@ const PluginMeta = React.createClass( {
 		if ( selectedSite && this.isUnsupportedPluginForAT() && ( ! selectedSite.jetpack || automatedTransferSite ) ) {
 			return (
 				<Notice
-					text={ this.translate( 'Incompatible plugin: WordPress.com already provides this feature.' ) }
+					text={ this.translate( 'Incompatible plugin: This plugin is not supported on WordPress.com.' ) }
 					status="is-warning"
 					showDismiss={ false }
 				>


### PR DESCRIPTION
Several plugins are causing problems because they delete the jetpack connections that we rely upon. For now I'm excluding these plugins from being installed on AT sites. I'm also changing the messaging regarding incompatible plugins because the previous messaging ("WordPress.com already provides this feature.") was not strictly true for all the plugins on the list. I'm changing it to a more generic message.

![example messaging](http://cld.wthms.co/AUtyp+)

The linked info page hasn't been changed in this PR, but we need a better destination page once we launch this to all users. We can handle that separately.

Last I'm updating the plugin-meta component to use `localize` instead of `this.translate()` for translations. This is just to address the lint warnings.

### Testing
I'm making this change for five plugins. You can test by going to the plugin details page in calypso for each of these plugins and ensuring you do not get an installation button and that you see the referenced messaging for each of these plugins:

- wordpress-database-reset
- wordpress-reset
- wp-reset
- advanced-reset-wp
- advanced-wp-reset