### PR TITLE
Reader: Fix Combined Cards exceeding container

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -46,7 +46,6 @@
 .reader-combined-card__post-details {
 	font-family: $serif;
 	overflow: hidden;
-	white-space: nowrap;
 	width: 100%;
 
 	@include breakpoint( "<960px" ) {
@@ -71,7 +70,6 @@
 	overflow: hidden;
 	position: relative;
 	word-wrap: break-word;
-	white-space: nowrap;
 
 	&:hover,
 	&:focus {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/13441

**Before:**
![screenshot 2017-04-26 16 56 44](https://cloud.githubusercontent.com/assets/4924246/25462067/6e7f5cd8-2aa1-11e7-98e5-3371238dbc4d.png)

**After:**
![screenshot 2017-04-26 16 56 49](https://cloud.githubusercontent.com/assets/4924246/25462070/725db4f8-2aa1-11e7-8d29-e235a44495bf.png)
