### PR TITLE
WooCommerce: Add product categories to Product Create

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -11,8 +11,9 @@ import { connect } from 'react-redux';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 import { getCurrentlyEditingProduct } from '../../state/ui/products/selectors';
+import { getProductCategories } from '../../state/wc-api/product-categories/selectors';
 import { editProduct, editProductAttribute } from '../../state/ui/products/actions';
-import { getProductCategories } from '../../state/wc-api/product-categories/actions';
+import { getProductCategories as fetchProductCategories } from '../../state/wc-api/product-categories/actions';
 import ProductForm from './product-form';
 
 class ProductCreate extends React.Component {
@@ -22,11 +23,11 @@ class ProductCreate extends React.Component {
 			id: PropTypes.isRequired,
 			type: PropTypes.string.isRequired,
 		} ),
-		dispatchGetProductCategories: PropTypes.func.isRequired,
+		dispatchFetchProductCategories: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {
-		const { product, siteId, dispatchGetProductCategories } = this.props;
+		const { product, siteId } = this.props;
 
 		if ( ! product ) {
 			this.props.editProduct( null, {
@@ -34,7 +35,7 @@ class ProductCreate extends React.Component {
 			} );
 		}
 
-		dispatchGetProductCategories( siteId );
+		this.props.dispatchFetchProductCategories( siteId );
 	}
 
 	componentWillUnmount() {
@@ -42,11 +43,12 @@ class ProductCreate extends React.Component {
 	}
 
 	render() {
-		const { product } = this.props;
+		const { product, productCategories } = this.props;
 
 		return (
 			<ProductForm
 				product={ product || { type: 'simple' } }
+				productCategories={ productCategories }
 				editProduct={ this.props.editProduct }
 				editProductAttribute={ this.props.editProductAttribute }
 			/>
@@ -57,10 +59,12 @@ class ProductCreate extends React.Component {
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const product = getCurrentlyEditingProduct( state );
+	const productCategories = getProductCategories( state, siteId );
 
 	return {
 		siteId,
 		product,
+		productCategories,
 	};
 }
 
@@ -69,7 +73,7 @@ function mapDispatchToProps( dispatch ) {
 		{
 			editProduct,
 			editProductAttribute,
-			dispatchGetProductCategories: getProductCategories,
+			dispatchFetchProductCategories: fetchProductCategories,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -1,27 +1,40 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
 import { getCurrentlyEditingProduct } from '../../state/ui/products/selectors';
 import { editProduct, editProductAttribute } from '../../state/ui/products/actions';
+import { getProductCategories } from '../../state/wc-api/product-categories/actions';
 import ProductForm from './product-form';
 
-class ProductCreate extends Component {
+class ProductCreate extends React.Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		product: PropTypes.shape( {
+			id: PropTypes.isRequired,
+			type: PropTypes.string.isRequired,
+		} ),
+		dispatchGetProductCategories: PropTypes.func.isRequired,
+	};
 
 	componentDidMount() {
-		const { product } = this.props;
+		const { product, siteId, dispatchGetProductCategories } = this.props;
 
 		if ( ! product ) {
 			this.props.editProduct( null, {
 				type: 'simple'
 			} );
 		}
+
+		dispatchGetProductCategories( siteId );
 	}
 
 	componentWillUnmount() {
@@ -42,9 +55,11 @@ class ProductCreate extends Component {
 }
 
 function mapStateToProps( state ) {
+	const siteId = getSelectedSiteId( state );
 	const product = getCurrentlyEditingProduct( state );
 
 	return {
+		siteId,
 		product,
 	};
 }
@@ -54,6 +69,7 @@ function mapDispatchToProps( dispatch ) {
 		{
 			editProduct,
 			editProductAttribute,
+			dispatchGetProductCategories: getProductCategories,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -13,7 +13,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentlyEditingProduct } from '../../state/ui/products/selectors';
 import { getProductCategories } from '../../state/wc-api/product-categories/selectors';
 import { editProduct, editProductAttribute } from '../../state/ui/products/actions';
-import { getProductCategories as fetchProductCategories } from '../../state/wc-api/product-categories/actions';
+import { fetchProductCategories } from '../../state/wc-api/product-categories/actions';
 import ProductForm from './product-form';
 
 class ProductCreate extends React.Component {
@@ -21,9 +21,10 @@ class ProductCreate extends React.Component {
 		siteId: PropTypes.number.isRequired,
 		product: PropTypes.shape( {
 			id: PropTypes.isRequired,
-			type: PropTypes.string.isRequired,
 		} ),
-		dispatchFetchProductCategories: PropTypes.func.isRequired,
+		fetchProductCategories: PropTypes.func.isRequired,
+		editProduct: PropTypes.func.isRequired,
+		editProductAttribute: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {
@@ -35,7 +36,7 @@ class ProductCreate extends React.Component {
 			} );
 		}
 
-		this.props.dispatchFetchProductCategories( siteId );
+		this.props.fetchProductCategories( siteId );
 	}
 
 	componentWillUnmount() {
@@ -73,7 +74,7 @@ function mapDispatchToProps( dispatch ) {
 		{
 			editProduct,
 			editProductAttribute,
-			dispatchFetchProductCategories: fetchProductCategories,
+			fetchProductCategories,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { find, pick, compact } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormFieldSet from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import TokenField from 'components/token-field';
+
+const ProductFormCategoriesCard = (
+	{ product, productCategories, editProduct, translate }
+) => {
+	const handleChange = ( categoryNames ) => {
+		const newCategories = compact( categoryNames.map( ( name ) => {
+			const category = find( productCategories, { name } );
+
+			if ( ! category ) {
+				// TODO: Add new product category to edit state.
+				// TODO: Remove 'compact' calls afterwards as they will no longer be needed.
+				return undefined;
+			}
+
+			return pick( category, 'id' );
+		} ) );
+
+		const data = { id: product.id, categories: newCategories };
+		editProduct( product, data );
+	};
+
+	const selectedCategories = product.categories || [];
+	const selectedCategoryNames = compact( selectedCategories.map( ( c ) => {
+		const category = find( productCategories, { id: c.id } );
+		return category && category.name || undefined;
+	} ) );
+	const productCategoryNames = productCategories.map( c => c.name );
+
+	return (
+		<Card className="products__categories-card">
+			<FormFieldSet>
+				<FormLabel htmlFor="categories">{ translate( 'Category' ) }</FormLabel>
+				<TokenField
+					name="categories"
+					placeholder={ translate( 'Enter category names' ) }
+					value={ selectedCategoryNames }
+					suggestions={ productCategoryNames }
+					onChange={ handleChange }
+				/>
+			</FormFieldSet>
+			<span className="products__categories-hint">{ translate( 'Add a category so this product is easy to find.' ) }</span>
+		</Card>
+	);
+};
+
+ProductFormCategoriesCard.propTypes = {
+	product: PropTypes.shape( {
+		id: PropTypes.isRequired,
+		type: PropTypes.string.isRequired,
+	} ),
+	productCategories: PropTypes.array.isRequired,
+	editProduct: PropTypes.func.isRequired,
+};
+
+export default localize( ProductFormCategoriesCard );
+

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { find, pick, compact } from 'lodash';
+import { find, pick, compact, escape, unescape } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,13 +12,14 @@ import Card from 'components/card';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import TokenField from 'components/token-field';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const ProductFormCategoriesCard = (
 	{ product, productCategories, editProduct, translate }
 ) => {
 	const handleChange = ( categoryNames ) => {
 		const newCategories = compact( categoryNames.map( ( name ) => {
-			const category = find( productCategories, { name } );
+			const category = find( productCategories, { name: escape( name ) } );
 
 			if ( ! category ) {
 				// TODO: Add new product category to edit state.
@@ -36,9 +37,9 @@ const ProductFormCategoriesCard = (
 	const selectedCategories = product.categories || [];
 	const selectedCategoryNames = compact( selectedCategories.map( ( c ) => {
 		const category = find( productCategories, { id: c.id } );
-		return category && category.name || undefined;
+		return category && unescape( category.name ) || undefined;
 	} ) );
-	const productCategoryNames = productCategories.map( c => c.name );
+	const productCategoryNames = productCategories.map( c => unescape( c.name ) );
 
 	return (
 		<Card className="products__categories-card">
@@ -51,8 +52,10 @@ const ProductFormCategoriesCard = (
 					suggestions={ productCategoryNames }
 					onChange={ handleChange }
 				/>
+				<FormSettingExplanation>
+					{ translate( 'Add a category so this product is easy to find.' ) }
+				</FormSettingExplanation>
 			</FormFieldSet>
-			<span className="products__categories-hint">{ translate( 'Add a category so this product is easy to find.' ) }</span>
 		</Card>
 	);
 };

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -6,6 +6,7 @@ import React, { Component, PropTypes } from 'react';
 /**
  * Internal dependencies
  */
+import ProductFormCategoriesCard from './product-form-categories-card';
 import ProductFormDetailsCard from './product-form-details-card';
 import ProductFormVariationsCard from './product-form-variations-card';
 
@@ -17,23 +18,32 @@ export default class ProductForm extends Component {
 			type: PropTypes.string.isRequired,
 			name: PropTypes.string,
 		} ),
+		productCategories: PropTypes.array.isRequired,
 		editProduct: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 	};
 
 	render() {
-		const { product } = this.props;
+		const { product, productCategories } = this.props;
+		const { editProduct, editProductAttribute } = this.props;
+
 		return (
 			<div className="woocommerce products__form">
 				<ProductFormDetailsCard
 					product={ product }
-					editProduct={ this.props.editProduct }
+					editProduct={ editProduct }
+				/>
+
+				<ProductFormCategoriesCard
+					product={ product }
+					productCategories={ productCategories }
+					editProduct={ editProduct }
 				/>
 
 				<ProductFormVariationsCard
 					product={ product }
-					editProduct={ this.props.editProduct }
-					editProductAttribute={ this.props.editProductAttribute }
+					editProduct={ editProduct }
+					editProductAttribute={ editProductAttribute }
 				/>
 			</div>
 		);


### PR DESCRIPTION
This adds a card with a token field to select categories for a product.  It works in product create.

Notice: It is not yet possible to create new product categories using this token field. There is a TODO comment in the code in the appropriate place to do so, but for now it is disabled.

To Test:
0. Ensure you have a WooCommerce site connected to your WPCOM account via Jetpack.
1. `make run`
2. Go to `http://calypso.localhost:3000/store/<woocommerce site>/products/add`
3. Click in the "Category" token field and ensure your available product categories show up.
4. Select a category.
5. Ensure it stays in the box when clicking away.
