### PR TITLE
Site Settings: Fix right margin of Site Stats card info icon

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -354,7 +354,8 @@
 		padding: 24px;
 	}
 
-	.site-settings__info-link-container {
+	.composing__module-settings .site-settings__info-link-container,
+	.protect__module-settings .site-settings__info-link-container {
 		margin-right: -36px;
 		height: 0;
 	}


### PR DESCRIPTION
This PR fixes #13451, where the info icon in the Site Stats card goes outside of the card.

To test:
* Checkout this branch
* Go to `/settings/traffic/$site`, where `$site` is one of your Jetpack sites.
* Verify the info icon appears where expected:

![](https://cldup.com/QCex7e_jdi.png)

* Verify the rest of the info icons within a site settings foldable card are aligned the same way:
  * Writing > Composing (ATD settings)
  * Securty > Prevent brute force login attacks

