### PR TITLE
Add a language switching button to sidebar footer

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -24,6 +24,7 @@ const config = require( 'config' ),
 	translatorJumpstart = require( 'lib/translator-jumpstart' ),
 	nuxWelcome = require( 'layout/nux-welcome' ),
 	emailVerification = require( 'components/email-verification' ),
+	languageChangeConfirmation = require( 'components/language-change-confirmation' ),
 	viewport = require( 'lib/viewport' ),
 	pushNotificationsInit = require( 'state/push-notifications/actions' ).init,
 	syncHandler = require( 'lib/wp/sync-handler' ),
@@ -175,6 +176,8 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	} );
 
 	page( '*', emailVerification );
+
+	page( '*', languageChangeConfirmation );
 
 	// delete any lingering local storage data from signup
 	if ( ! startsWith( window.location.pathname, '/start' ) ) {

--- a/client/components/language-change-confirmation/index.js
+++ b/client/components/language-change-confirmation/index.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+
+import i18n from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+
+import { successNotice } from 'state/notices/actions';
+
+/**
+ * Page middleware for showing a confirmation notice after changing interface language.
+ * Checks if the query string contains 'updated=language' and if it does, removes the
+ * query string from the URL and shows a notice on the next page.
+ */
+
+export default function languageChangeConfirmation( context, next ) {
+	const showNotice = ( 'language' === context.query.updated );
+
+	if ( showNotice ) {
+		context.store.dispatch( successNotice(
+			i18n.translate( 'Your language was changed successfully.' ),
+			{ displayOnNextPage: true }
+		) );
+
+		page.replace( window.location.pathname );
+	}
+
+	next();
+}

--- a/client/components/language-picker/button.jsx
+++ b/client/components/language-picker/button.jsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import QueryUserSettings from 'components/data/query-user-settings';
+import config from 'config';
+import { getOriginalUserSetting } from 'state/selectors';
+import { saveUserSettings } from 'state/user-settings/actions';
+import { errorNotice } from 'state/notices/actions';
+import LanguagePickerModal from './modal';
+
+class LanguageButton extends Component {
+	state = {
+		open: false
+	}
+
+	toggleOpen = () => {
+		this.setState( { open: ! this.state.open } );
+	}
+
+	handleClose = () => {
+		this.setState( { open: false } );
+	}
+
+	// Action creator returning an action thunk: data => dispatch => { thunk }
+	handleSaveSuccess = () => () => {
+		window.location = window.location.pathname + '?updated=language';
+	}
+
+	// Action creator returning an action thunk: error => dispatch => { thunk }
+	handleSaveFailure = () => ( dispatch ) => {
+		dispatch( errorNotice( this.props.translate( 'There was a problem changing your language.' ) ) );
+	}
+
+	selectLanguage = ( newLanguageSlug ) => {
+		if ( newLanguageSlug === this.props.languageSlug ) {
+			return;
+		}
+
+		this.props.saveUserSettings(
+			{ language: newLanguageSlug },
+			this.handleSaveSuccess,
+			this.handleSaveFailure
+		);
+	}
+
+	// TODO: Reorganize the styles and get rid of the eslint errors
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	renderIcon( languageSlug ) {
+		if ( ! languageSlug ) {
+			return <div className="sidebar__footer-lang-icon is-loading" />;
+		}
+
+		const [ langCode, langSubcode ] = languageSlug.split( '-' );
+
+		return (
+			<div className="sidebar__footer-lang-icon">
+				<div>
+					{ langCode }
+					{ langSubcode && <br /> }
+					{ langSubcode }
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const { languageSlug, translate } = this.props;
+
+		return (
+			<Button
+				className="sidebar__footer-lang"
+				borderless
+				title={ translate( 'Interface Language' ) }
+				onClick={ this.toggleOpen }
+			>
+				<QueryUserSettings />
+				{ this.renderIcon( languageSlug ) }
+				<LanguagePickerModal
+					isVisible={ this.state.open }
+					languages={ config( 'languages' ) }
+					onClose={ this.handleClose }
+					onSelected={ this.selectLanguage }
+					selected={ languageSlug }
+				/>
+			</Button>
+		);
+	}
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}
+
+export default connect(
+	state => ( {
+		// Look at the original setting - there might be an unsaved /me/account
+		// form displayed on the page, and we don't want to display the unsaved
+		// change - only the committed one.
+		languageSlug: getOriginalUserSetting( state, 'language' )
+	} ),
+	{ saveUserSettings }
+)( localize( LanguageButton ) );

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -12,11 +12,13 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import config from 'config';
 import HappychatButton from 'components/happychat/button';
+import LanguageButton from 'components/language-picker/button';
 import { isHappychatChatActive } from 'state/happychat/selectors';
 
 const SidebarFooter = ( { translate, children, isHappychatButtonVisible } ) => (
 	<div className="sidebar__footer">
 		{ children }
+		<LanguageButton />
 		<Button
 			className="sidebar__footer-help"
 			borderless

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -356,7 +356,8 @@ form.sidebar__button {
 	margin-right: auto;
 
 	&.sidebar__footer-help,
-	&.sidebar__footer-chat {
+	&.sidebar__footer-chat,
+	&.sidebar__footer-lang {
 		border-left: 1px solid darken( $sidebar-bg-color, 10% );
 		flex: 0 1 40px;
 		margin-right: 0;
@@ -369,7 +370,7 @@ form.sidebar__button {
 
 	}
 
-	&.sidebar__footer-help {
+	&.sidebar__footer-lang {
 		margin-left: auto;
 	}
 
@@ -419,6 +420,21 @@ form.sidebar__button {
 .layout.is-section-help .sidebar .sidebar__footer-help {
 	background-color: $sidebar-selected-color;
 	color: $white;
+}
+
+.sidebar__footer-lang-icon {
+	width: 24px;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1.0;
+	text-align: left;
+
+	&.is-loading {
+		animation: loading-dot-pulse 0.8s ease-in-out infinite;
+		background-color: lighten( $gray, 20% );
+	}
 }
 
 .sidebar__region {

--- a/client/my-sites/sidebar/test/sidebar.jsx
+++ b/client/my-sites/sidebar/test/sidebar.jsx
@@ -22,6 +22,7 @@ describe( 'MySitesSidebar', () => {
 		mockery.registerMock( './publish-menu', EmptyComponent );
 		mockery.registerMock( 'layout/sidebar', EmptyComponent );
 		mockery.registerMock( 'components/tooltip', EmptyComponent );
+		mockery.registerMock( 'components/language-picker/button', EmptyComponent );
 
 		MySitesSidebar = require( '../sidebar' ).MySitesSidebar;
 	} );

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -30,12 +30,18 @@ export const fetchUserSettings = () => ( {
 /**
  * Post settings to WordPress.com API at /me/settings endpoint
  *
- * @param {Object} settingsOverride - default settings object
+ * @param {Object} [settingsOverride] - default settings object
+ * @param {Function} [onSuccess] - action creator for action to be dispatched on success.
+ * Function that takes one param (data) and returns a Redux action.
+ * @param {Function} [onFailure] - action creator for action to be dispatched on failure.
+ * Function that takes one param (error) and returns a Redux action.
  * @return {Object} Action object
  */
-export const saveUserSettings = ( settingsOverride ) => ( {
+export const saveUserSettings = ( settingsOverride, onSuccess, onFailure ) => ( {
 	type: USER_SETTINGS_SAVE,
-	settingsOverride
+	settingsOverride,
+	onSuccess,
+	onFailure,
 } );
 
 /**


### PR DESCRIPTION
This PR adds a language switching button to every sidebar footer. On click, it opens the new `LanguagePicker` dialog (from #13112) and lets the user change the interface language.

![language-sidebar-button](https://cloud.githubusercontent.com/assets/664258/25481712/ba98c0ac-2b4e-11e7-9ce3-21b8df52be75.png)

This is a spinoff from the umbrella PR #12544 that is the main PR of my trial project -- see there for more details and context.

This PR has three parts:
- add support for `onSuccess` and `onFailure` 'action callbacks' to the `saveUserSettings` action creator. Architecture-wise, this is the best I can do at the moment. @dmsnell might have suggestions on how to evolve this towards a more declarative and offline-compatible style.

- add a `LanguageButton` component that is directly connected to the Redux store and uses the new `user-settings` module in the data layer (from #12819) to read and write data. Also adds the button to the `SidebarFooter`. Maybe the `client/blocks/language-button` directory would be a better home for this component?

- after the interface language is changed, the page needs to reload and show a success notice. This is implemented as a `page` middleware. Inspired by `client/components/email-verification`.

![language-change-notice](https://cloud.githubusercontent.com/assets/664258/25481772/fa489d3a-2b4e-11e7-8026-5a84e635aeb7.png)
