### PR TITLE
Site Settings: Move Security section to a separate chunk

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -13,7 +13,6 @@ var config = require( 'config' ),
 module.exports = function() {
 	page( '/settings', controller.siteSelection, settingsController.redirectToGeneral );
 	page( '/settings/general/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
-	page( '/settings/security/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 
 	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
 

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -18,7 +18,6 @@ import GeneralSettings from './section-general';
 import ImportSettings from './section-import';
 import ExportSettings from './section-export';
 import GuidedTransfer from 'my-sites/guided-transfer';
-import SiteSecurity from './section-security';
 import SiteSettingsNavigation from './navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackDevModeNotice from './jetpack-dev-mode-notice';
@@ -56,8 +55,6 @@ export class SiteSettingsComponent extends Component {
 						hasLoadedSitePurchasesFromServer={ this.props.hasLoadedSitePurchasesFromServer }
 					/>
 				);
-			case 'security':
-				return <SiteSecurity />;
 			case 'import':
 				return <ImportSettings />;
 			case 'export':

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -99,6 +99,7 @@ export class SiteSettingsNavigation extends Component {
 					{
 						config.isEnabled( 'manage/security' ) && site.jetpack &&
 							<NavItem path={ `/settings/security/${ site.slug }` }
+							preloadSectionName="settings-security"
 							selected={ section === 'security' } >
 								{ strings.security }
 						</NavItem>

--- a/client/my-sites/site-settings/settings-security/controller.js
+++ b/client/my-sites/site-settings/settings-security/controller.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithReduxStore } from 'lib/react-helpers';
+import SecurityMain from 'my-sites/site-settings/settings-security/main';
+
+export default {
+	security( context ) {
+		renderWithReduxStore(
+			React.createElement( SecurityMain ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
+	},
+};

--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import controller from './controller';
+import settingsController from 'my-sites/site-settings/settings-controller';
+import mySitesController from 'my-sites/controller';
+
+export default function() {
+	page(
+		'/settings/security/:site_id',
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		settingsController.setScroll,
+		settingsController.siteSettings,
+		controller.security
+	);
+}

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -8,6 +8,10 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import FormSecurity from 'my-sites/site-settings/form-security';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -15,6 +19,10 @@ import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
 const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
+	if ( ! site ) {
+		return <div className="settings-security__loading wpcom-site__logo noticon noticon-wordpress" />;
+	}
+
 	if ( ! siteIsJetpack ) {
 		return (
 			<JetpackManageErrorPage
@@ -49,10 +57,13 @@ const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
 	}
 
 	return (
-		<div>
+		<Main className="settings-security__main site-settings">
+			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<SidebarNavigation />
+			<SiteSettingsNavigation site={ site } section="security" />
 			<JetpackMonitor />
 			<FormSecurity />
-		</div>
+		</Main>
 	);
 };
 

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -115,6 +115,13 @@ const sections = [
 		group: 'sites'
 	},
 	{
+		name: 'settings-security',
+		paths: [ '/settings/security' ],
+		module: 'my-sites/site-settings/settings-security',
+		secondary: true,
+		group: 'sites'
+	},
+	{
 		name: 'settings',
 		paths: [ '/settings' ],
 		module: 'my-sites/site-settings',


### PR DESCRIPTION
Recently we started splitting `settings` to smaller chunks. This has also been discussed in p4TIVU-5Zs-p2 and recommended by @dmsnell and @mtias. 

So this PR moves the Security settings section to a separate chunk. This is just one of the PRs that take care of this issue, others were:
* Move Writing section to a separate chunk - #12655
* Move Discussion section to a separate chunk - #12656 

This PR addresses part of #12659.

This is not introducing any functional or behavioral changes. But since it's affecting the functionality that resides within the Security settings section, extensive testing of that section and its settings will be required.

To test:
* Checkout this branch, or get it going on calypso.live
* Go to `/settings/security/$site`, where `$site` is one of your WordPress.com sites.
* Verify you see the message that additional security configuration is not required.
* Change to another tab and come back to Security, verify it works like before.
* Go to `/settings/security/$site`, where `$site` is one of your connected Jetpack sites.
* Verify the tab loads correctly with no errors/warnings.
* Change to another tab and come back to Security, verify it works like before.
* Play with all settings in the Security section and verify they are saved and retrieved correctly.
* Try loading this page with a clean redux state.
* Go to `/settings/general/$site` and refresh the page.
* Inspect the network requests (Network tab in Chrome).
* Roll your mouse over the **Security** nav item.
* Verify the `settings-security` chunk gets loaded immediately.
* Roll over something else, then roll over **Security** again.
* Verify the `settings-security` chunk is not requested anymore.