### PR TITLE
Login: Update the design to match the mockups

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -119,24 +119,26 @@ export class Login extends Component {
 				<form onSubmit={ this.onSubmitForm }>
 					<Card className="login__form">
 						<div className="login__form-userdata">
-							<label className="login__form-userdata-username">
+							<label htmlFor="usernameOrEmail" className="login__form-userdata-username">
 								{ this.props.translate( 'Username or Email Address' ) }
-								<FormTextInput
-									className="login__form-userdata-username-input"
-									onChange={ this.onChangeField }
-									name="usernameOrEmail"
-									value={ this.state.usernameOrEmail }
-									{ ...isDisabled } />
 							</label>
-							<label className="login__form-userdata-username">
+							<FormTextInput
+								className="login__form-userdata-username-input"
+								onChange={ this.onChangeField }
+								id="usernameOrEmail"
+								name="usernameOrEmail"
+								value={ this.state.usernameOrEmail }
+								{ ...isDisabled } />
+							<label htmlFor="password" className="login__form-userdata-username">
 								{ this.props.translate( 'Password' ) }
-								<FormPasswordInput
-									className="login__form-userdata-username-password"
-									onChange={ this.onChangeField }
-									name="password"
-									value={ this.state.password }
-									{ ...isDisabled } />
 							</label>
+							<FormPasswordInput
+								className="login__form-userdata-username-password"
+								onChange={ this.onChangeField }
+								id="password"
+								name="password"
+								value={ this.state.password }
+								{ ...isDisabled } />
 						</div>
 						<div className="login__form-remember-me">
 							<label>
@@ -145,7 +147,7 @@ export class Login extends Component {
 									checked={ this.state.rememberme }
 									onChange={ this.onChangeRememberMe }
 									{ ...isDisabled } />
-								{ this.props.translate( 'Stay logged in' ) }
+								<span>{ this.props.translate( 'Stay logged in' ) }</span>
 							</label>
 						</div>
 						<div className="login__form-action">

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -4,7 +4,7 @@
 
 .login__form-userdata {
 	label {
-		color: #2e4453;
+		color: $gray-dark;
 		display: block;
 		font-size: 14px;
 		line-height: 1.5;
@@ -46,7 +46,7 @@
 		font-size: 14px;
 
 		&:hover{
-			color: #00aadc;
+			color: $blue-medium;
 		}
 	}
 	.gridicon{

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -4,10 +4,15 @@
 
 .login__form-userdata {
 	label {
+		color: #2e4453;
 		display: block;
-		line-height: 2em;
+		font-size: 14px;
+		line-height: 1.5;
 		font-weight: 500;
-		padding-bottom: 8px;
+		margin-bottom: 5px;
+	}
+	input{
+		margin-bottom: 20px;
 	}
 }
 
@@ -26,9 +31,25 @@
 }
 
 .login__form-remember-me {
-	margin: 5px 0 15px;
+	margin-bottom: 20px;
 
 	input {
 		margin-right: 10px;
+	}
+	label{
+		font-size: 14px;
+	}
+}
+
+.wp-login__footer{
+	a{
+		font-size: 14px;
+
+		&:hover{
+			color: #00aadc;
+		}
+	}
+	.gridicon{
+		vertical-align: text-bottom;
 	}
 }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -118,7 +118,7 @@ class Login extends React.Component {
 				href="#"
 				key="back-link"
 				onClick={ this.goBack }>
-					<Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Back' ) }
+					<Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Return' ) }
 				</a>;
 
 		return compact( [

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -104,27 +104,27 @@ class Login extends React.Component {
 				</a>;
 		}
 
+		const goBackLink = ! magicLoginView && <a
+			href="#"
+			key="back-link"
+			onClick={ this.goBack }>
+				<Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Return' ) }
+			</a>;
 		const showMagicLoginLink = magicLoginEnabled && ! magicLoginView && <a href="#"
 			key="magic-login-link"
 			onClick={ this.onMagicLoginRequestClick }>
 				{ translate( 'Email me a login link' ) }
 			</a>;
 		const resetPasswordLink = ! magicLoginView && <a
-				href={ config( 'login_url' ) + '?action=lostpassword' }
-				key="lost-password-link">
-					{ this.props.translate( 'Lost your password?' ) }
-				</a>;
-		const goBackLink = ! magicLoginView && <a
-				href="#"
-				key="back-link"
-				onClick={ this.goBack }>
-					<Gridicon icon="arrow-left" size={ 18 } /> { this.props.translate( 'Return' ) }
-				</a>;
+			href={ config( 'login_url' ) + '?action=lostpassword' }
+			key="lost-password-link">
+				{ this.props.translate( 'Lost your password?' ) }
+			</a>;
 
 		return compact( [
+			goBackLink,
 			showMagicLoginLink,
 			resetPasswordLink,
-			goBackLink,
 		] );
 	}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -10,14 +10,13 @@
 }
 
 .wp-login__footer {
-	text-align: center;
-
 	a {
 		border-bottom: 1px solid lighten( $gray, 20% );
 		color: $gray;
 		display: block;
 		font-weight: 500;
 		line-height: 4em;
+		padding: 0 24px;
 		text-decoration: none;
 	}
 


### PR DESCRIPTION
This pull request updates the design of the login form to make it matche the mockup:

![screen shot 2017-04-27 at 13 00 43](https://cloud.githubusercontent.com/assets/57050/25482405/8f7715e0-2b49-11e7-8488-4cf062d90269.png)


There's one extra link in this code: "Lost Your Password?" that I don't know if makes sense in combination with password links, but this PR focuses solely on the design.

Testing instructions:

- Run git checkout update/login-design and start your server, or open a live branch
- Open the Login page /start/social
- Check that the design matches the mockup