### PR TITLE
Word Press logo alignment

### DIFF
--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -451,13 +451,18 @@
 			min-height: 91px;
 			padding: 20px 20px 20px 80px;
 			position: relative;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
 
 			&::before {
 				color: $blue-medium;
 				left: 10px;
 				position: absolute;
-				top: 15px;
 				@include noticon( '\f205', 60px );
+				@include breakpoint( ">660px" ) {
+					left: 20px;
+				}
 			}
 
 			> h6 {


### PR DESCRIPTION
cc @jeremeylduvall 

Hey Jeremey, so I fixed the Word Press logo alignment (#12928).  

Before: 

![screen shot 2017-04-27 at 9 06 35 am](https://cloud.githubusercontent.com/assets/20329318/25484928/ee2e6dec-2b29-11e7-9e58-f32d1c2a3454.png)

After: 

![screen shot 2017-04-27 at 9 14 15 am](https://cloud.githubusercontent.com/assets/20329318/25484932/f62d67e6-2b29-11e7-9a1d-6bd17efddb7c.png)


-If there is anything that I missed please do let me know! Thank you. 