### PR TITLE
Site Settings: Preload traffic section in section navigation

### DIFF
--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -91,6 +91,7 @@ export class SiteSettingsNavigation extends Component {
 
 					<NavItem
 						path={ `/settings/traffic/${ site.slug }` }
+						preloadSectionName="settings-traffic"
 						selected={ section === 'traffic' }
 					>
 						{ strings.traffic }


### PR DESCRIPTION
This PR updates the Traffic section to be preloaded when hovered on the settings section navigation. Relies on #13459, which renames the traffic settings directory. Addresses part of #12659.

To test:
* Checkout this branch
* Go to `/settings/general/$site`.
* Inspect the network requests (Network tab in Chrome).
* Roll your mouse over the **Traffic** nav item.
* Verify the `settings-traffic` chunk gets loaded immediately.
* Roll over something else, then roll over **Traffic** again.
* Verify the `settings-traffic` chunk is not requested anymore.