### PR TITLE
Domain First Flow: Add back button to /domains

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -15,6 +15,7 @@ import Card from 'components/card';
 import DomainImage from 'signup/steps/design-type-with-store/domain-image';
 import PageImage from 'signup/steps/design-type-with-store/page-image';
 import { externalRedirect } from 'lib/route/path';
+import NavigationLink from 'signup/navigation-link';
 
 export default class SiteOrDomain extends Component {
 	componentWillMount() {
@@ -65,15 +66,29 @@ export default class SiteOrDomain extends Component {
 
 	renderChoices() {
 		return (
-			<div className="site-or-domain__choices">
-				{ this.getChoices().map( ( choice ) => (
-					<Card className="site-or-domain__choice" key={ choice.type }>
-						<a href="#" onClick={ ( event ) => this.handleClickChoice( event, choice.type ) }>
-							{ choice.image }
-							<h2>{ choice.label }</h2>
-						</a>
-					</Card>
-				) ) }
+			<div>
+				<div className="site-or-domain__choices">
+					{ this.getChoices().map( ( choice ) => (
+						<Card className="site-or-domain__choice" key={ choice.type }>
+							<a href="#" onClick={ ( event ) => this.handleClickChoice( event, choice.type ) }>
+								{ choice.image }
+								<h2>{ choice.label }</h2>
+							</a>
+						</Card>
+					) ) }
+				</div>
+				{ /* Hacky way to add back link to /domains */ }
+				<div className="site-or-domain__button">
+					<NavigationLink
+						direction="back"
+						flowName={ this.props.flowName }
+						positionInFlow={ 1 }
+						stepName={ this.props.stepName }
+						stepSectionName={ this.props.stepSectionName }
+						backUrl="https://wordpress.com/domains"
+						signupProgress={ this.props.signupProgress }
+					/>
+				</div>
 			</div>
 		);
 	}

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -66,29 +66,32 @@ export default class SiteOrDomain extends Component {
 
 	renderChoices() {
 		return (
-			<div>
-				<div className="site-or-domain__choices">
-					{ this.getChoices().map( ( choice ) => (
-						<Card className="site-or-domain__choice" key={ choice.type }>
-							<a href="#" onClick={ ( event ) => this.handleClickChoice( event, choice.type ) }>
-								{ choice.image }
-								<h2>{ choice.label }</h2>
-							</a>
-						</Card>
-					) ) }
-				</div>
-				{ /* Hacky way to add back link to /domains */ }
-				<div className="site-or-domain__button">
-					<NavigationLink
-						direction="back"
-						flowName={ this.props.flowName }
-						positionInFlow={ 1 }
-						stepName={ this.props.stepName }
-						stepSectionName={ this.props.stepSectionName }
-						backUrl="https://wordpress.com/domains"
-						signupProgress={ this.props.signupProgress }
-					/>
-				</div>
+			<div className="site-or-domain__choices">
+				{ this.getChoices().map( ( choice ) => (
+					<Card className="site-or-domain__choice" key={ choice.type }>
+						<a href="#" onClick={ ( event ) => this.handleClickChoice( event, choice.type ) }>
+							{ choice.image }
+							<h2>{ choice.label }</h2>
+						</a>
+					</Card>
+				) ) }
+			</div>
+		);
+	}
+
+	renderBackLink() {
+		// Hacky way to add back link to /domains
+		return (
+			<div className="site-or-domain__button">
+				<NavigationLink
+					direction="back"
+					flowName={ this.props.flowName }
+					positionInFlow={ 1 }
+					stepName={ this.props.stepName }
+					stepSectionName={ this.props.stepSectionName }
+					backUrl="https://wordpress.com/domains"
+					signupProgress={ this.props.signupProgress }
+				/>
 			</div>
 		);
 	}

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -96,6 +96,15 @@ export default class SiteOrDomain extends Component {
 		);
 	}
 
+	renderScreen() {
+		return (
+			<div>
+				{ this.renderChoices() }
+				{ this.renderBackLink() }
+			</div>
+		);
+	}
+
 	handleClickChoice( event, designType ) {
 		event.preventDefault();
 
@@ -140,7 +149,7 @@ export default class SiteOrDomain extends Component {
 				fallbackHeaderText={ this.props.headerText }
 				fallbackSubHeaderText={ this.props.subHeaderText }
 				signupProgress={ this.props.signupProgress }
-				stepContent={ this.renderChoices() } />
+				stepContent={ this.renderScreen() } />
 		);
 	}
 }

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -27,3 +27,7 @@
 		padding: 10px 15px;
 	}
 }
+
+.site-or-domain__button {
+	text-align: center;
+}


### PR DESCRIPTION
Add a back button to the first step of `domain-first` flow which links to `/domains`. Since `/domains` is a step of the flow but outside of Calypso, kind of hacky way to send people back, but still better than being stuck there.

Fixes: https://github.com/Automattic/wp-calypso/issues/12629