### PR TITLE
Reader: fix errant comma in combined cards when author name is blacklisted 

### DIFF
--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -2,15 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 import * as stats from 'reader/stats';
-
-const authorNameBlacklist = [ 'admin' ];
 
 const ReaderAuthorLink = ( { author, post, siteUrl, children, className } ) => {
 	const recordAuthorClick = ( { } ) => {
@@ -28,7 +27,7 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className } ) => {
 	const authorName = get( author, 'name', null );
 
 	// If the author name is blacklisted, don't return anything
-	if ( ! authorName || includes( authorNameBlacklist, authorName.toLowerCase() ) ) {
+	if ( ! authorName || isAuthorNameBlacklisted( authorName ) ) {
 		return null;
 	}
 

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -21,6 +21,7 @@ import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import * as stats from 'reader/stats';
 import ReaderCombinedCardPostPlaceholder from 'blocks/reader-combined-card/placeholders/post';
+import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {
@@ -76,7 +77,7 @@ class ReaderCombinedCardPost extends React.Component {
 			return <ReaderCombinedCardPostPlaceholder />;
 		}
 
-		const hasAuthorName = has( post, 'author.name' );
+		const hasAuthorName = has( post, 'author.name' ) && ! isAuthorNameBlacklisted( post.author.name );
 		let featuredAsset = null;
 		if ( post.canonical_media && post.canonical_media.mediaType === 'video' ) {
 			featuredAsset = <ReaderFeaturedVideo { ...post.canonical_media } videoEmbed={ post.canonical_media } allowPlaying={ false } />;

--- a/client/reader/lib/author-name-blacklist/index.js
+++ b/client/reader/lib/author-name-blacklist/index.js
@@ -1,0 +1,16 @@
+/**
+ * External Dependencies
+ */
+import { includes } from 'lodash';
+
+const authorNameBlacklist = [ 'admin' ];
+
+/**
+ * Is the provided author name blacklisted?
+ *
+ * @param {string} authorName Author name
+ * @returns {boolean} True if blacklisted
+ */
+export const isAuthorNameBlacklisted = ( authorName ) => {
+	return includes( authorNameBlacklist, authorName.toLowerCase() );
+};


### PR DESCRIPTION
@fraying noticed in #13431 that we show a comma separator even when an author name is blacklisted. 

This PR moves the blacklisting check out to a lib, so the combined card can find out whether the author name is blacklisted before outputting the comma.

Before:

<img width="810" alt="6cbe7288-2a71-11e7-8a0b-4885acf9a6d7" src="https://cloud.githubusercontent.com/assets/17325/25488528/2d101bc0-2b5f-11e7-8dfe-9a78f4819d73.png">

After:

![screen shot 2017-04-27 at 15 30 28](https://cloud.githubusercontent.com/assets/17325/25488531/2ee14ce4-2b5f-11e7-98de-4751ab2607e6.png)

Fixes #13431.

### To test

Visit http://calypso.localhost:3000/tag/farming and look for combined cards from 'Sufficient Living'.