### PR TITLE
Site Settings: Move Protect propTypes and defaultProps in class

### DIFF
--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -27,6 +27,20 @@ import ExternalLink from 'components/external-link';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
 class Protect extends Component {
+	static propTypes = {
+		onChangeField: PropTypes.func.isRequired,
+		setFieldValue: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {}
+	};
+
 	handleAddToWhitelist = () => {
 		const { setFieldValue } = this.props;
 		let whitelist = trimEnd( this.getProtectWhitelist() );
@@ -157,20 +171,6 @@ class Protect extends Component {
 		);
 	}
 }
-
-Protect.defaultProps = {
-	isSavingSettings: false,
-	isRequestingSettings: true,
-	fields: {}
-};
-
-Protect.propTypes = {
-	onChangeField: PropTypes.func.isRequired,
-	setFieldValue: PropTypes.func.isRequired,
-	isSavingSettings: PropTypes.bool,
-	isRequestingSettings: PropTypes.bool,
-	fields: PropTypes.object,
-};
 
 export default connect(
 	( state ) => {


### PR DESCRIPTION
This janitorial PR moves the `propTypes` and `defaultProps` in the `Protect` card inside the class. There's no need to have them declared outside of it.

To test:
* Checkout this PR.
* Go to `/settings/security/$site` where `$site` is one of your Jetpack sites.
* Verify the Protect card works properly and there are no react warnings.