### PR TITLE
Add Stats context menu item to Pages

### DIFF
--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -7,6 +7,14 @@ module.exports = {
 		return '/page/' + site.slug + '/' + page.ID;
 	},
 
+	statsLinkForPage: function( page, site ) {
+		if ( ! ( page && page.ID ) || ! ( site && site.ID ) ) {
+			return null;
+		}
+
+		return '/stats/post/' + page.ID + '/' + site.slug;
+	},
+
 	// TODO: switch all usage of this function to `isFrontPage` in `state/pages/selectors`
 	isFrontPage: function( page, site ) {
 		if ( ! page || ! page.ID || ! site || ! site.options ) {

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -229,17 +229,23 @@ const Page = React.createClass( {
 
 		if ( this.props.page.status !== 'trash' ) {
 			return (
-				<PopoverMenuItem className="page__trash-item" onClick={ this.updateStatusTrash }>
-					<Gridicon icon="trash" size={ 18 } />
-					{ this.translate( 'Trash' ) }
-				</PopoverMenuItem>
+				<div>
+					<MenuSeparator />
+					<PopoverMenuItem className="page__trash-item" onClick={ this.updateStatusTrash }>
+						<Gridicon icon="trash" size={ 18 } />
+						{ this.translate( 'Trash' ) }
+					</PopoverMenuItem>
+				</div>
 			);
 		} else {
 			return (
-				<PopoverMenuItem className="page__delete-item" onClick={ this.updateStatusDelete }>
-					<Gridicon icon="trash" size={ 18 } />
-					{ this.translate( 'Delete' ) }
-				</PopoverMenuItem>
+				<div>
+					<MenuSeparator />
+					<PopoverMenuItem className="page__delete-item" onClick={ this.updateStatusDelete }>
+						<Gridicon icon="trash" size={ 18 } />
+						{ this.translate( 'Delete' ) }
+					</PopoverMenuItem>
+				</div>
 			);
 		}
 	},

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -69,6 +69,9 @@ const Page = React.createClass( {
 		},
 		viewPage: function() {
 			recordEvent( 'Clicked View Page' );
+		},
+		statsPage: function() {
+			recordEvent( 'Clicked Stats Page' );
 		}
 	},
 
@@ -271,6 +274,7 @@ const Page = React.createClass( {
 	},
 
 	statsPage: function() {
+		this.analyticsEvents.statsPage();
 		page( helpers.statsLinkForPage( this.props.page, this.props.site ) );
 	},
 

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -353,9 +353,9 @@ const Page = React.createClass( {
 				position={ 'bottom left' }
 				context={ this.refs && this.refs.popoverMenuButton }
 			>
-				{ viewItem }
-				{ publishItem }
 				{ editItem }
+				{ publishItem }
+				{ viewItem }
 				{ statsItem }
 				{ copyItem }
 				{ restoreItem }

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -336,9 +336,10 @@ const Page = React.createClass( {
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
 		const copyItem = this.getCopyItem();
+		const statsItem = this.getStatsItem();
 		const moreInfoItem = this.popoverMoreInfo();
 		const hasMenuItems = (
-			viewItem || publishItem || editItem ||
+			viewItem || publishItem || editItem || statsItem ||
 			restoreItem || sendToTrashItem || moreInfoItem
 		);
 		const popoverMenu = hasMenuItems ? (
@@ -351,6 +352,7 @@ const Page = React.createClass( {
 				{ viewItem }
 				{ publishItem }
 				{ editItem }
+				{ statsItem }
 				{ copyItem }
 				{ restoreItem }
 				{ sendToTrashItem }

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -275,6 +275,10 @@ const Page = React.createClass( {
 	},
 
 	getStatsItem: function() {
+		if ( this.props.page.status !== 'publish' ) {
+			return null;
+		}
+
 		return (
 			<PopoverMenuItem onClick={ this.statsPage }>
 				<Gridicon icon="stats" size={ 18 } />

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -270,6 +270,19 @@ const Page = React.createClass( {
 		);
 	},
 
+	statsPage: function() {
+		page( helpers.statsLinkForPage( this.props.page, this.props.site ) );
+	},
+
+	getStatsItem: function() {
+		return (
+			<PopoverMenuItem onClick={ this.statsPage }>
+				<Gridicon icon="stats" size={ 18 } />
+				{ this.translate( 'Stats' ) }
+			</PopoverMenuItem>
+		);
+	},
+
 	editPage: function() {
 		this.analyticsEvents.editPage();
 		page( helpers.editLinkForPage( this.props.page, this.props.site ) );


### PR DESCRIPTION
This PR seeks to add a Stats menu item that links directly to the correct Stats page for the given page.

<img width="252" alt="screen shot 2017-04-27 at 5 08 03 pm" src="https://cloud.githubusercontent.com/assets/1017839/25490102/1e31d7bc-2b6c-11e7-97c9-e2bb33dc1117.png">

- Stats menu will be visible for pages both in All Sites mode and when a single site is selected.
- Only Published pages will expose this menu item, draft/scheduled/trashed pages will not.
- If the Stats menu is clicked then the Stats page for the given page will be opened.

Testing instructions: verify that the aforementioned conditions are true.