### PR TITLE
Editor: Fix React unknown props warnings in EditorAuthor wrapper

### DIFF
--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -41,10 +41,15 @@ export class EditorAuthor extends Component {
 		const name = author.display_name || author.name;
 		const Wrapper = this.userCanAssignAuthor() ? AuthorSelector : 'div';
 		const popoverPosition = touchDetect.hasTouch() ? 'bottom right' : 'bottom left';
+		const wrapperProps = this.userCanAssignAuthor() && {
+			siteId: post.site_ID,
+			onSelect: this.onSelect,
+			popoverPosition,
+		};
 
 		return (
 			<div className="editor-author">
-				<Wrapper siteId={ post.site_ID } onSelect={ this.onSelect } popoverPosition={ popoverPosition }>
+				<Wrapper { ...wrapperProps }>
 					<Gravatar size={ 26 } user={ author } />
 					<span className="editor-author__name">
 							{ translate( 'by %(name)s', { args: { name: name } } ) }

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -41,11 +41,13 @@ export class EditorAuthor extends Component {
 		const name = author.display_name || author.name;
 		const Wrapper = this.userCanAssignAuthor() ? AuthorSelector : 'div';
 		const popoverPosition = touchDetect.hasTouch() ? 'bottom right' : 'bottom left';
-		const wrapperProps = this.userCanAssignAuthor() && {
-			siteId: post.site_ID,
-			onSelect: this.onSelect,
-			popoverPosition,
-		};
+		const wrapperProps = this.userCanAssignAuthor()
+			? {
+				siteId: post.site_ID,
+				onSelect: this.onSelect,
+				popoverPosition,
+			}
+			: {};
 
 		return (
 			<div className="editor-author">


### PR DESCRIPTION
This PR fixes a React unknown props warning in `EditorAuthor` that occurs only when the user can't edit others posts. It can be reproduced easily with a Jetpack site by heading to add a new Portfolio item for example:

![](https://cldup.com/tykPf_tcwl.png)

![](https://cldup.com/A6-HKKFjiK.png)

To test:
* Checkout this branch
* Go to `/posts/$site` where `$site` is one of your Jetpack sites.
* Make sure Portfolio post type is enabled.
* Click the Add button near Portfolio to add a new item.
* Verify the warning is no longer shown.