### PR TITLE
Reader Following Manage Refresh: connect up sort controls

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -26,7 +26,7 @@ class FollowingManage extends Component {
 	static propTypes = {
 		sitesQuery: PropTypes.string,
 		subsQuery: PropTypes.string,
-		subsSort: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+		subsSortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 		translate: PropTypes.func,
 	};
 
@@ -34,7 +34,7 @@ class FollowingManage extends Component {
 		subsQuery: '',
 		sitesQuery: '',
 		forceRefresh: false,
-		subsSort: 'date-followed',
+		subsSortOrder: 'date-followed',
 	}
 
 	state = { width: 800 };
@@ -99,7 +99,7 @@ class FollowingManage extends Component {
 	fetchNextPage = offset => this.props.requestFeedSearch( this.props.sitesQuery, offset );
 
 	render() {
-		const { sitesQuery, subsQuery, subsSort, translate, searchResults } = this.props;
+		const { sitesQuery, subsQuery, subsSortOrder, translate, searchResults } = this.props;
 		const searchPlaceholderText = translate( 'Search millions of sites' );
 
 		return (
@@ -130,7 +130,7 @@ class FollowingManage extends Component {
 					<FollowingManageSubscriptions
 						width={ this.state.width }
 						query={ subsQuery }
-						sort={ subsSort }
+						sortOrder={ subsSortOrder }
 					/>
 				) }
 				{ ( !! sitesQuery && searchResults && (

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -34,6 +34,7 @@ class FollowingManage extends Component {
 		subsQuery: '',
 		sitesQuery: '',
 		forceRefresh: false,
+		subsSort: 'date-followed',
 	}
 
 	state = { width: 800 };
@@ -98,7 +99,7 @@ class FollowingManage extends Component {
 	fetchNextPage = offset => this.props.requestFeedSearch( this.props.sitesQuery, offset );
 
 	render() {
-		const { sitesQuery, subsQuery, translate, searchResults } = this.props;
+		const { sitesQuery, subsQuery, subsSort, translate, searchResults } = this.props;
 		const searchPlaceholderText = translate( 'Search millions of sites' );
 
 		return (
@@ -129,6 +130,7 @@ class FollowingManage extends Component {
 					<FollowingManageSubscriptions
 						width={ this.state.width }
 						query={ subsQuery }
+						sort={ subsSort }
 					/>
 				) }
 				{ ( !! sitesQuery && searchResults && (

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -26,6 +26,7 @@ class FollowingManage extends Component {
 	static propTypes = {
 		sitesQuery: PropTypes.string,
 		subsQuery: PropTypes.string,
+		subsSort: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 		translate: PropTypes.func,
 	};
 

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -32,8 +32,8 @@ class FollowingManageSortControls extends React.Component {
 
 		return (
 			<FormSelect className="following-manage__sort-controls" onChange={ this.handleSelectChange } value={ sortOrder }>
-				<option value="date-followed">{ this.props.translate( 'Sort by date' ) }</option>
-				<option value="alpha">{ this.props.translate( 'Sort by name' ) }</option>
+				<option value="date-followed">{ this.props.translate( 'Sort by date followed' ) }</option>
+				<option value="alpha">{ this.props.translate( 'Sort by site name' ) }</option>
 			</FormSelect>
 		);
 	}

--- a/client/reader/following-manage/sort-controls.jsx
+++ b/client/reader/following-manage/sort-controls.jsx
@@ -14,17 +14,17 @@ import FormSelect from 'components/forms/form-select';
 class FollowingManageSortControls extends React.Component {
 
 	static propTypes = {
-		onSelectChange: React.PropTypes.func,
+		onSortChange: React.PropTypes.func,
 		sortOrder: React.PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 	}
 
 	static defaultProps = {
-		onSelectChange: noop,
+		onSortChange: noop,
 		sortOrder: 'date-followed',
 	}
 
 	handleSelectChange = ( event ) => {
-		this.props.onSelectChange( event.target.value );
+		this.props.onSortChange( event.target.value );
 	}
 
 	render() {

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -38,6 +38,8 @@
 	}
 
 	.following-manage__subscriptions-header {
+		align-items: center;
+		display: flex;
 		flex: 1;
 		font-weight: 600;
 		padding-bottom: 15px;
@@ -75,9 +77,10 @@
 		color: darken( $gray, 10% );
 		font-size: 12px;
 		font-weight: normal;
+		width: 100%;
 
-		@include breakpoint( "<960px" ) {
-			width: 100%;
+		@include breakpoint( ">960px" ) {
+			min-width: 200px;
 		}
 	}
 
@@ -146,7 +149,10 @@
 }
 
 .following-manage__search-followed-input {
-	min-width: 200px;
+
+	@include breakpoint( ">960px" ) {
+		min-width: 200px;
+	}
 }
 
 .following-manage__sites-window-scroller-row-wrapper {

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -48,6 +48,21 @@
 		}
 	}
 
+	.following-manage__subscriptions-sort {
+		position: relative;
+
+		&::before {
+
+			@include breakpoint( "<960px" ) {
+
+				@include long-content-fade( $size: 20% );
+				height: 30px;
+				right: 30px;
+				top: 1px;
+			}
+		}
+	}
+
 	.following-manage__subscriptions-sort,
 	.following-manage__subscriptions-search {
 

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -30,7 +30,7 @@ class FollowingManageSubscriptions extends Component {
 		follows: PropTypes.array.isRequired,
 		doSearch: PropTypes.func.isRequired,
 		query: PropTypes.string,
-		sort: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 	};
 	state = { forceRefresh: false };
 
@@ -73,9 +73,9 @@ class FollowingManageSubscriptions extends Component {
 	}
 
 	render() {
-		const { follows, width, translate, query, followsCount, sort } = this.props;
+		const { follows, width, translate, query, followsCount, sortOrder } = this.props;
 		const filteredFollows = this.filterFollowsByQuery( query );
-		const sortedFollows = this.sortFollows( filteredFollows, sort );
+		const sortedFollows = this.sortFollows( filteredFollows, sortOrder );
 
 		return (
 			<div className="following-manage__subscriptions">
@@ -89,7 +89,7 @@ class FollowingManageSubscriptions extends Component {
 						}
 						</h1>
 					<div className="following-manage__subscriptions-sort">
-						<FollowingManageSortControls sortOrder={ sort } />
+						<FollowingManageSortControls sortOrder={ sortOrder } />
 					</div>
 					<div className="following-manage__subscriptions-search">
 						<FollowingManageSearchFollowed onSearch={ this.props.doSearch } initialValue={ query } />

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import escapeRegexp from 'escape-string-regexp';
 import { reverse, sortBy, trimStart } from 'lodash';
+import page from 'page';
 
 /**
  * Internal Dependencies
@@ -24,6 +25,7 @@ import { getSiteName, getSiteUrl, getSiteDescription, getSiteAuthorName } from '
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { formatUrlForDisplay, getFeedTitle } from 'reader/lib/feed-display-helper';
+import { addQueryArgs } from 'lib/url';
 
 class FollowingManageSubscriptions extends Component {
 	static propTypes = {
@@ -67,8 +69,15 @@ class FollowingManageSubscriptions extends Component {
 		return reverse( sortBy( follows, [ 'date_subscribed' ] ) );
 	}
 
+	handleSortChange = ( sort ) => {
+		page.replace( addQueryArgs( { sort }, window.location.pathname + window.location.search ) );
+	};
+
 	componentWillReceiveProps( nextProps ) {
-		const forceRefresh = ( nextProps.query !== this.props.query );
+		const forceRefresh = (
+			( nextProps.query !== this.props.query ) ||
+			( nextProps.sortOrder !== this.props.sortOrder )
+		);
 		this.setState( { forceRefresh } );
 	}
 
@@ -89,7 +98,10 @@ class FollowingManageSubscriptions extends Component {
 						}
 						</h1>
 					<div className="following-manage__subscriptions-sort">
-						<FollowingManageSortControls sortOrder={ sortOrder } />
+						<FollowingManageSortControls
+							sortOrder={ sortOrder }
+							onSortChange={ this.handleSortChange }
+						/>
 					</div>
 					<div className="following-manage__subscriptions-search">
 						<FollowingManageSearchFollowed onSearch={ this.props.doSearch } initialValue={ query } />

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -28,6 +28,7 @@ class FollowingManageSubscriptions extends Component {
 		follows: PropTypes.array.isRequired,
 		doSearch: PropTypes.func.isRequired,
 		query: PropTypes.string,
+		sort: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 	};
 	state = { forceRefresh: false };
 
@@ -55,7 +56,7 @@ class FollowingManageSubscriptions extends Component {
 	}
 
 	render() {
-		const { follows, width, translate, query, followsCount } = this.props;
+		const { follows, width, translate, query, followsCount, sort } = this.props;
 		const filteredFollows = this.filterFollowsByQuery( query );
 
 		return (
@@ -70,7 +71,7 @@ class FollowingManageSubscriptions extends Component {
 						}
 						</h1>
 					<div className="following-manage__subscriptions-sort">
-						<FollowingManageSortControls />
+						<FollowingManageSortControls sortOrder={ sort } />
 					</div>
 					<div className="following-manage__subscriptions-search">
 						<FollowingManageSearchFollowed onSearch={ this.props.doSearch } initialValue={ query } />

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -46,6 +46,7 @@ const exported = {
 		const mcKey = 'following_manage';
 		const sitesQuery = context.query.q;
 		const subsQuery = context.query.s;
+		const subsSort = context.query.sort;
 
 		setPageTitle( context, i18n.translate( 'Manage Followed Sites' ) );
 
@@ -58,6 +59,7 @@ const exported = {
 				initialFollowUrl={ context.query.follow }
 				sitesQuery={ sitesQuery }
 				subsQuery={ subsQuery }
+				subsSort={ subsSort }
 				context={ context }
 				userSettings={ userSettings }
 			/>,

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -46,7 +46,7 @@ const exported = {
 		const mcKey = 'following_manage';
 		const sitesQuery = context.query.q;
 		const subsQuery = context.query.s;
-		const subsSort = context.query.sort;
+		const subsSortOrder = context.query.sort;
 
 		setPageTitle( context, i18n.translate( 'Manage Followed Sites' ) );
 
@@ -59,7 +59,7 @@ const exported = {
 				initialFollowUrl={ context.query.follow }
 				sitesQuery={ sitesQuery }
 				subsQuery={ subsQuery }
-				subsSort={ subsSort }
+				subsSortOrder={ subsSortOrder }
 				context={ context }
 				userSettings={ userSettings }
 			/>,


### PR DESCRIPTION
This PR makes the sort controls dropdown actually filter the list of existing subscriptions.

![screen shot 2017-04-27 at 17 09 00](https://cloud.githubusercontent.com/assets/17325/25492860/3cfe0a76-2b6c-11e7-8bff-b198721f0f3d.png)

Todo:
- [x] accept sort= as a query string argument
- [x] update in query string when sort order is changed (@samouri)
- [x] apply current sort to list of subs
- [x] make sure current sort state is reflected in dropdown selection
- [x] be consistent about naming of `sort`/`sortOrder`