### PR TITLE
Stats: Preserve StatsNavigation site slug in Insights

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -25,11 +25,11 @@ import StatsFirstView from '../stats-first-view';
 import SectionHeader from 'components/section-header';
 import StatsViews from '../stats-views';
 import Followers from '../stats-followers';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
 const StatsInsights = ( props ) => {
-	const { followList, isJetpack, siteId, translate } = props;
+	const { followList, isJetpack, siteId, siteSlug, translate } = props;
 	const moduleStrings = statsStrings();
 
 	let tagsList;
@@ -48,7 +48,7 @@ const StatsInsights = ( props ) => {
 		<Main wideLayout>
 			<StatsFirstView />
 			<SidebarNavigation />
-			<StatsNavigation section="insights" />
+			<StatsNavigation section="insights" slug={ siteSlug } />
 			<div>
 				<PostingActivity />
 				<SectionHeader label={ translate( 'All Time Views' ) } />
@@ -97,7 +97,8 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		return {
 			isJetpack: isJetpackSite( state, siteId ),
-			siteId
+			siteId,
+			siteSlug: getSelectedSiteSlug( state, siteId ),
 		};
 	}
 );


### PR DESCRIPTION
This PR fixes #13470, where site slug is being lost from the `StatsNavigation` when in Insights.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/stats/insights/$site where `$site` is one of your sites.
* Click on "Days" in the stats period navigation.
* Verify you see the stats for the current site, and not for all sites.