### PR TITLE
Framework: Fix InfiniteScroll mix-in

### DIFF
--- a/client/lib/mixins/infinite-scroll/index.js
+++ b/client/lib/mixins/infinite-scroll/index.js
@@ -36,8 +36,7 @@ module.exports = function( nextPageMethod ) {
 				documentHeight = document.body.scrollHeight,
 				viewportHeight = window.innerHeight,
 				scrollOffset = 2 * viewportHeight,
-				triggeredByScroll = options.triggeredByScroll,
-				self = this;
+				triggeredByScroll = options.triggeredByScroll;
 
 			if ( scrollPosition >= ( documentHeight - viewportHeight - scrollOffset ) ) {
 
@@ -49,11 +48,11 @@ module.exports = function( nextPageMethod ) {
 
 				// scroll check may be triggered while dispatching an action,
 				// we cannot create new action while dispatching old one
-				setTimeout( function() {
-					self[ nextPageMethod ]( {
+				window.requestAnimationFrame( () => {
+					this[ nextPageMethod ]( {
 						triggeredByScroll: triggeredByScroll
 					} );
-				}, 0 );
+				} );
 			}
 		}
 	};


### PR DESCRIPTION
The current `InfiniteScroll` implementation used `setTimeout` that caused a bug on Chrome where `nextPageMethod` would not trigger for a few seconds after `setTimeout(..., 0)` was invoked.

To make the async callback more reliable, I replaced `setTimeout` with `window.requestAnimationFrame`.

---

### Testing

Open `/themes` using Google Chrome:

**Before**  
Quickly scroll as far as you can to the bottom, notice as nothing happens for 3-4 seconds before the next batch of placeholders is displayed.

**After**  
Quickly scroll to the bottom. Placeholders for the next batch of themes should appear as soon as the previous batch has loaded.