### PR TITLE
Reader: search on manage, 'show more'

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -205,5 +205,5 @@
 }
 
 .reader-subscription-list-item__site-url, .reader-subscription-list-item__site-url a {
-	color: $gray;
+	color: 	darken( $gray, 30% );
 }

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -1,0 +1,75 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { take, map } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal Dependencies
+ */
+import ConnectedSubscriptionListItem from './connected-subscription-list-item';
+import SitesWindowScroller from './sites-window-scroller';
+import Button from 'components/button';
+
+const FollowingManageSearchFeedsResults = ( {
+	showMoreResults,
+	showMoreResultsClicked,
+	searchResults,
+	translate,
+	width,
+	fetchNextPage,
+	forceRefresh,
+} ) => {
+	if ( ! searchResults ) {
+		return null; // todo: add placeholder
+	} else if ( searchResults.length === 0 ) {
+		return (
+			<p>
+				{ translate( 'There were no site results for your query.' ) }
+			</p>
+		);
+	}
+
+	if ( ! showMoreResults ) {
+		const resultsToShow = map(
+			take( searchResults, 3 ),
+			site => (
+				<ConnectedSubscriptionListItem
+					url={ site.URL }
+					feedId={ +site.feed_ID }
+					siteId={ +site.blog_ID }
+					key={ `search-result-site-id-${ site.feed_ID }` }
+				/>
+			)
+		);
+		return (
+			<div className="following-manage__search-results">
+				{ resultsToShow }
+				<div className="following-manage__show-more">
+					<Button compact icon
+						onClick={ showMoreResultsClicked }
+						className="following-manage__show-more-button button">
+							<Gridicon icon="chevron-down" />
+							Show more
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="following-manage__search-results">
+			<SitesWindowScroller
+				sites={ searchResults }
+				width={ width }
+				fetchNextPage={ fetchNextPage }
+				remoteTotalCount={ 200 }
+				forceRefresh={ forceRefresh }
+			/>
+		</div>
+	);
+};
+
+export default localize( FollowingManageSearchFeedsResults );

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -52,7 +52,7 @@ const FollowingManageSearchFeedsResults = ( {
 						onClick={ showMoreResultsClicked }
 						className="following-manage__show-more-button button">
 							<Gridicon icon="chevron-down" />
-							Show more
+							{ translate( 'Show more' ) }
 					</Button>
 				</div>
 			</div>

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -151,7 +151,7 @@ class FollowingManage extends Component {
 						forceRefresh={ this.state.forceRefresh }
 					/>
 				) }
-				{ ! ( !! sitesQuery && this.state.showMoreResults ) && (
+				{ ! ( !! sitesQuery && showMoreResults ) && (
 					<FollowingManageSubscriptions
 						width={ this.state.width }
 						query={ subsQuery }

--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -26,7 +26,7 @@ class SitesWindowScroller extends Component {
 
 	heightCache = new CellMeasurerCache( {
 		fixedWidth: true,
-		minHeight: 50,
+		minHeight: 70,
 	} );
 
 	siteRowRenderer = ( { index, key, style, parent } ) => {

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -34,8 +34,8 @@
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 	color: $gray;
-	font-size: 12px;
-	padding: 2px 8px 3px 10px;
+	font-size: 11px;
+	padding: 2px 9px 6px 11px;
 	position: relative;
 		top: -1px;
 

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -21,6 +21,37 @@
 	padding-top: 10px;
 }
 
+// Load more results
+.following-manage__show-more {
+	border-top: 1px solid lighten( $gray, 20% );
+	display: flex;
+	justify-content: center;
+	margin-top: 10px;
+}
+
+.following-manage__show-more-button.button {
+	border-top: 0;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+	color: $gray;
+	font-size: 12px;
+	padding: 2px 8px 3px 10px;
+	position: relative;
+		top: -1px;
+
+	.gridicon.gridicons-chevron-down {
+		height: 14px;
+		left: -4px;
+		top: 3px;
+		width: 14px;
+	}
+
+	&:hover {
+		color: darken( $gray, 10% );
+		cursor: pointer;
+	}
+}
+
 // Subscription controls
 .following-manage__subscriptions-controls {
 	display: flex;
@@ -74,7 +105,7 @@
 	}
 
 	.following-manage__subscriptions-sort .following-manage__sort-controls {
-		color: darken( $gray, 10% );
+		color: $gray;
 		font-size: 12px;
 		font-weight: normal;
 		width: 100%;

--- a/client/reader/following/controller.js
+++ b/client/reader/following/controller.js
@@ -44,9 +44,12 @@ const exported = {
 		const basePath = route.sectionify( context.path );
 		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage Followed Sites';
 		const mcKey = 'following_manage';
-		const sitesQuery = context.query.q;
-		const subsQuery = context.query.s;
-		const subsSortOrder = context.query.sort;
+		const {
+			q: sitesQuery,
+			s: subsQuery,
+			sort: subsSortOrder,
+			showMoreResults
+		} = context.query;
 
 		setPageTitle( context, i18n.translate( 'Manage Followed Sites' ) );
 
@@ -59,6 +62,7 @@ const exported = {
 				initialFollowUrl={ context.query.follow }
 				sitesQuery={ sitesQuery }
 				subsQuery={ subsQuery }
+				showMoreResults={ Boolean( showMoreResults ) }
 				subsSortOrder={ subsSortOrder }
 				context={ context }
 				userSettings={ userSettings }


### PR DESCRIPTION
Addition of the show more button + associated functionality:
1. default state = recs + subs
2. search active = 3 results + button + subs below
3. clicked button = just search results (same as currently doing a search)

cc @jancavan 

![manage-following- desktop 003](https://cloud.githubusercontent.com/assets/4924246/25506866/a889627c-2b5d-11e7-8a27-56e154e534b3.jpg)
