### PR TITLE
Editor: wpcom-view: dump sites-list, select from Redux state

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -19,10 +19,9 @@ var tinymce = require( 'tinymce/tinymce' ),
 /**
  * Internal dependencies
  */
-var views = require( './views' ),
-	sites = require( 'lib/sites-list' )();
-
+import views from './views';
 import { renderWithReduxStore } from 'lib/react-helpers';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * WordPress View plugin.
@@ -81,24 +80,26 @@ function wpview( editor ) {
 			return;
 		}
 
+		const store = editor.getParam( 'redux_store' );
+		const siteId = getSelectedSiteId( store.getState() );
+
 		$( '.wpview-wrap' ).each( function( index, view ) {
-			var $view = $( view ),
-				type;
+			const $view = $( view );
 
 			if ( undefined !== $view.attr( 'data-wpview-rendered' ) ) {
 				return;
 			}
 
-			type = $view.attr( 'data-wpview-type' );
+			const type = $view.attr( 'data-wpview-type' );
 
 			renderWithReduxStore(
 				React.createElement( views.components[ type ], {
 					content: getText( view ),
-					siteId: sites.getSelectedSite() ? sites.getSelectedSite().ID : null,
+					siteId,
 					onResize: debounce( triggerNodeChanged, 500 )
 				} ),
-				$view.find( '.wpview-body' )[0],
-				editor.getParam( 'redux_store' )
+				$view.find( '.wpview-body' )[ 0 ],
+				store
 			);
 
 			$view.attr( 'data-wpview-rendered', '' );


### PR DESCRIPTION
Part of #8726

# To test

1. Open Editor (`/post/siteId`)
2. Add anything that uses `wpcom-view` — e.g., a gallery (`GalleryView`), a video embed (`VideoView`).
3. Make sure that everything, specifically the wpcom-view view, is rendered properly.
4. By means of manual inspection (web tools), make sure the correct site ID is passed as prop `siteId` to the view (e.g. `GalleryView`) and down (to the nested `Shortcode`).