### PR TITLE
Add pagination support to themes showcase. For SEO.

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -83,7 +83,7 @@ export function multiSite( context, next ) {
 }
 
 export function loggedOut( context, next ) {
-	if ( context.isServerSide && ! isEmpty( context.query ) ) {
+	if ( context.isServerSide && ! isEmpty( context.query.s ) ) {
 		// Don't server-render URLs with query params
 		return next();
 	}
@@ -99,12 +99,14 @@ export function fetchThemeData( context, next ) {
 		return next();
 	}
 
+	const page = context.query.page;
+
 	const siteId = 'wpcom';
 	const query = {
 		search: context.query.s,
 		tier: context.params.tier,
 		filter: compact( [ context.params.filter, context.params.vertical ] ).join( ',' ),
-		page: 1,
+		page: page ? page : 1,
 		number: DEFAULT_THEME_QUERY.number,
 	};
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -8,7 +8,7 @@ import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get, isEmpty, pick } from 'lodash';
+import { get, isEmpty, pick, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -122,7 +122,8 @@ function getCurrentCommitShortChecksum() {
 function getDefaultContext( request ) {
 	let initialServerState = {};
 	// We don't cache routes with query params
-	if ( isEmpty( request.query ) ) {
+
+	if ( isEmpty( omit( request.query, 'page' ) ) ) {
 		// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
 		const serializeCachedServerState = stateCache.get( request.path ) || {};
 		initialServerState = getInitialServerState( serializeCachedServerState );

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -4,7 +4,7 @@
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
 import Lru from 'lru';
-import { isEmpty, pick } from 'lodash';
+import { isEmpty, pick, omit } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -80,8 +80,8 @@ export function serverRender( req, res ) {
 	if ( context.lang !== config( 'i18n_default_locale_slug' ) ) {
 		context.i18nLocaleScript = '//widgets.wp.com/languages/calypso/' + context.lang + '.js';
 	}
-
-	if ( config.isEnabled( 'server-side-rendering' ) && context.layout && ! context.user && isEmpty( context.query ) ) {
+	const query = omit( context.query, 'page' );
+	if ( config.isEnabled( 'server-side-rendering' ) && context.layout && ! context.user && isEmpty( query ) ) {
 		// context.pathname doesn't include querystring, so it's a suitable cache key.
 		let key = context.pathname;
 		if ( req.error ) {
@@ -103,7 +103,7 @@ export function serverRender( req, res ) {
 		// Send state to client
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
 		// And cache on the server, too
-		if ( isEmpty( context.query ) ) {
+		if ( isEmpty( query ) ) {
 			// Don't cache if we have query params
 			const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
 			stateCache.set( context.pathname, serverState );


### PR DESCRIPTION
### Info
Add pagination capability to Themes Showcase.
Since Showcase uses Infinite scroll the web search engines have problem with crawling and indexing whole dataset. This is a stab on how to fix this problem.

new query arg was added ?page=* that allows deciding from which page of results we want to start loading themes.

Work in progress. This requires more work in case this approach gets selected.