### PR TITLE
Domains: Add a8c tags for TLDs still in development

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { endsWith } from 'lodash';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -28,22 +28,32 @@ const DomainRegistrationSuggestion = React.createClass( {
 
 	render() {
 		const { suggestion, translate } = this.props,
-			isAdded = hasDomainInCart( this.props.cart, suggestion.domain_name ),
+			domain = suggestion.domain_name,
+			isAdded = hasDomainInCart( this.props.cart, domain ),
 			domainFlags = [];
+
 		let buttonClasses, buttonContent;
 
-		if ( suggestion.domain_name ) {
+		if ( domain ) {
 			const newTLDs = [];
+			const a8cTLDs = [ '.ca', '.de', '.fr' ];
+			const tld = domain.substring( domain.indexOf( '.' ) );
 
-			if ( newTLDs.some(
-					( tld ) =>
-						endsWith( suggestion.domain_name, tld ) &&
-						suggestion.domain_name.substring( 0, suggestion.domain_name.length - ( tld.length + 1 ) ).indexOf( '.' ) === -1
-				) ) {
+			if ( includes( newTLDs, tld ) ) {
 				domainFlags.push(
 					<DomainSuggestionFlag
-						key={ `${ suggestion.domain_name }-new` }
+						key={ `${ domain }-new` }
 						content={ translate( 'New' ) }
+						status="success"
+					/>
+				);
+			}
+
+			if ( includes( a8cTLDs, tld ) ) {
+				domainFlags.push(
+					<DomainSuggestionFlag
+						key={ `${ domain }-a8c` }
+						content={ 'A8c' }
 						status="success"
 					/>
 				);
@@ -53,7 +63,7 @@ const DomainRegistrationSuggestion = React.createClass( {
 		if ( suggestion.isRecommended ) {
 			domainFlags.push(
 				<DomainSuggestionFlag
-					key={ `${ suggestion.domain_name }-recommended` }
+					key={ `${ domain }-recommended` }
 					content={ translate( 'Recommended' ) }
 					status="success"
 				/>
@@ -63,7 +73,7 @@ const DomainRegistrationSuggestion = React.createClass( {
 		if ( suggestion.isBestAlternative ) {
 			domainFlags.push(
 				<DomainSuggestionFlag
-					key={ `${ suggestion.domain_name }-best-alternative` }
+					key={ `${ domain }-best-alternative` }
 					content={ translate( 'Best Alternative' ) }
 				/>
 			);
@@ -83,14 +93,14 @@ const DomainRegistrationSuggestion = React.createClass( {
 			<DomainSuggestion
 					priceRule={ getDomainPriceRule( this.props.domainsWithPlansOnly, this.props.selectedSite, this.props.cart, suggestion ) }
 					price={ suggestion.product_slug && suggestion.cost }
-					domain={ suggestion.domain_name }
+					domain={ domain }
 					buttonClasses={ buttonClasses }
 					buttonContent={ buttonContent }
 					cart={ this.props.cart }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					onButtonClick={ this.props.onButtonClick }>
 				<h3>
-					{ suggestion.domain_name }
+					{ domain }
 					{ domainFlags }
 				</h3>
 			</DomainSuggestion>


### PR DESCRIPTION
This PR adds an `A8c` tag to the `.ca`, `.de` and `.fr` ccTLDs, to highlight that we're still working on these products and they're not visible to the public yet.

The pre-existing implementation explicitly checked for additional dots (e.g. `example.co.uk` would not match `.uk`), so I've simplified the logic a bit but preserved that behavior.

You can test by clicking the `Domains [Add]` button and entering some domain searches, and confirming that the tag appears only for the three intended tlds (Please don't try and actually register them just yet).

![domain_search_ _julesauspremiumtest_ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/25511602/12136ba4-2c0b-11e7-8906-8ee14f5e5812.jpg)
