### PR TITLE
Woo Connect-Insights: Add routes

### DIFF
--- a/client/extensions/woocommerce/app/stats/controller.js
+++ b/client/extensions/woocommerce/app/stats/controller.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import page from 'page';
+import includes from 'lodash/includes';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithReduxStore } from 'lib/react-helpers';
+import AsyncLoad from 'components/async-load';
+import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
+
+function isValidParameters( context ) {
+	const validParameters = {
+		type: [ 'orders' ],
+		period: [ 'day', 'week', 'month', 'year' ],
+	};
+	return Object.keys( validParameters )
+		.every( param => includes( validParameters[ param ], context.params[ param ] ) );
+}
+
+export default function StatsController( context ) {
+	if ( ! isValidParameters( context ) ) {
+		page.redirect( `/store/stats/orders/day/${ context.params.site }` );
+	}
+
+	const props = {
+		type: context.params.type,
+		period: context.params.period,
+		startDate: context.query.start_date,
+		endDate: context.query.end_date,
+	};
+	renderWithReduxStore(
+		<AsyncLoad
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
+			placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
+			require="extensions/woocommerce/app/stats"
+			{ ...props }
+		/>,
+		document.getElementById( 'primary' ),
+		context.store
+	);
+}

--- a/client/extensions/woocommerce/app/stats/index.js
+++ b/client/extensions/woocommerce/app/stats/index.js
@@ -13,7 +13,7 @@ export default class Stats extends Component {
 	render() {
 		return (
 			<Main className="woocommerce stats" wideLayout={ true }>
-				<StatsNavigation />
+				<StatsNavigation { ...this.props } />
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/stats/stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/stats/stats-navigation/index.js
@@ -16,34 +16,27 @@ import SegmentedControl from 'components/segmented-control';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const StatsNavigation = props => {
-	const { translate, slug } = props;
-	const section = 'orders';
-	const sectionTitles = {
-		orders: translate( 'Orders' ),
-		customers: translate( 'Customers' ),
-		stock: translate( 'Stock' ),
-		taxes: translate( 'Taxes' ),
-		coupons: translate( 'Coupons' ),
-		subscriptions: translate( 'Subscriptions' ),
+	const { translate, slug, type, period } = props;
+	const periods = {
+		day: translate( 'Days' ),
+		week: translate( 'Weeks' ),
+		month: translate( 'Months' ),
+		year: translate( 'Years' ),
 	};
 	return (
-		<SectionNav selectedText={ sectionTitles[ section ] }>
+		<SectionNav selectedText={ periods[ period ] }>
 			<NavTabs label={ translate( 'Stats' ) }>
-				<NavItem path={ `/store/stats/${ slug }` } selected={ section === 'orders' }>
-					{ sectionTitles.orders }
-				</NavItem>
-				<NavItem path={ `/store/stats/${ slug }` } selected={ section === 'customers' }>
-					{ sectionTitles.customers }
-				</NavItem>
-				<NavItem path={ `/store/stats/${ slug }` } selected={ section === 'stock' }>
-					{ sectionTitles.stock }
-				</NavItem>
+				{ Object.keys( periods ).map( key => (
+					<NavItem path={ `/store/stats/${ type }/${ key }/${ slug }` } selected={ period === key }>
+						{ periods[ key ] }
+					</NavItem>
+				) ) }
 			</NavTabs>
 			<SegmentedControl
 				className="stats-navigation__control"
 				initialSelected="store"
 				options={ [
-					{ value: 'site', label: translate( 'Site' ), path: `/stats/day/${ slug }` },
+					{ value: 'site', label: translate( 'Site' ), path: `/stats/${ period }/${ slug }` },
 					{ value: 'store', label: translate( 'Store' ) },
 				] }
 			/>

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,7 +12,7 @@ import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import ProductCreate from './app/products/product-create';
 import Dashboard from './app/dashboard';
-import Stats from './app/stats';
+import StatsController from './app/stats/controller';
 
 const Controller = {
 	dashboard: function( context ) {
@@ -29,14 +29,6 @@ const Controller = {
 			document.getElementById( 'primary' ),
 			context.store
 		);
-	},
-
-	stats: function( context ) {
-		renderWithReduxStore(
-			React.createElement( Stats, { } ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
 	}
 };
 
@@ -47,6 +39,6 @@ export default function() {
 	}
 
 	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
-		page( '/store/stats/:site', siteSelection, navigation, Controller.stats );
+		page( '/store/stats/:type/:period/:site', siteSelection, navigation, StatsController );
 	}
 }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -126,7 +126,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				tipTarget="menus"
 				label={ this.props.translate( 'Stats' ) }
-				className={ this.itemLinkClass( '/stats', 'stats' ) }
+				className={ this.itemLinkClass( [ '/stats', '/store/stats' ], 'stats' ) }
 				link={ statsLink }
 				onNavigate={ this.onNavigate }
 				icon="stats-alt">

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -35,8 +35,14 @@ const StatsNavigation = ( props ) => {
 					className="stats-navigation__control"
 					initialSelected="site"
 					options={ [
-						{ value: 'site', label: translate( 'Site' ) },
-						{ value: 'store', label: translate( 'Store' ), path: `/store/stats/${ slug }` },
+						{
+							value: 'site',
+							label: translate( 'Site' )
+						},
+						{
+							value: 'store',
+							label: translate( 'Store' ),
+							path: `/store/stats/orders/${ section }/${ slug }` }
 					] }
 				/>
 			);

--- a/client/my-sites/stats/stats-page-placeholder/index.jsx
+++ b/client/my-sites/stats/stats-page-placeholder/index.jsx
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 
-const StatsPagePlaceholder = (
-	<div className="main is-wide-layout">
+const StatsPagePlaceholder = props => (
+	<div className={ classnames( 'main is-wide-layout', props.className ) }>
 		<Card className="stats-module stats-page-placeholder__header is-loading">
 			<div className="module-header">
 				<h3 className="module-header-title" />
@@ -23,4 +24,8 @@ const StatsPagePlaceholder = (
 	</div>
 );
 
-export default () => StatsPagePlaceholder;
+StatsPagePlaceholder.propTypes = {
+	className: PropTypes.string
+};
+
+export default StatsPagePlaceholder;


### PR DESCRIPTION
Add routes capable of handling
* A page type (orders)
* A period (7day)
* A segment to filter by (sales_by_product)

Similar to Site stats, an invalid url parameter redirects to a default ~page TBD~ parameters.

Test locally
```
ENABLE_FEATURES=woocommerce/extension-stats make run
```

Fixes https://github.com/Automattic/wp-calypso/issues/12973