### PR TITLE
Added label for publicize services e2e tests

### DIFF
--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -21,7 +21,8 @@ export default React.createClass( {
 	propTypes: {
 		post: PropTypes.object,
 		connection: PropTypes.object,
-		onRefresh: PropTypes.func
+		onRefresh: PropTypes.func,
+		label: PropTypes.string
 	},
 
 	getDefaultProps() {
@@ -79,7 +80,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { connection } = this.props;
+		const { connection, label } = this.props;
 
 		return (
 			<div className="editor-sharing__publicize-connection">
@@ -88,7 +89,7 @@ export default React.createClass( {
 						checked={ ! this.isConnectionSkipped() }
 						disabled={ this.isDisabled() }
 						onChange={ this.onChange } />
-					<span>{ connection && connection.external_display }</span>
+					<span data-e2e-service={ label }>{ connection && connection.external_display }</span>
 				</label>
 				{ this.renderBrokenConnection() }
 			</div>

--- a/client/post-editor/editor-sharing/publicize-services.jsx
+++ b/client/post-editor/editor-sharing/publicize-services.jsx
@@ -23,7 +23,8 @@ export const EditorSharingPublicizeServices = ( { connections, post, newConnecti
 						key={ connection.ID }
 						post={ post }
 						connection={ connection }
-						onRefresh={ newConnectionPopup } />
+						onRefresh={ newConnectionPopup }
+						label = { label } />
 				) }
 			</li>
 		) }


### PR DESCRIPTION
This PR adds a data-attribute for the publicize services. The change adds a new data-e2e-service attribute to the span tag where the account's name shows (such as @username for Twitter). This is to help with some updates to the e2e tests as we move from xpath to CSS.

For testing this change, we just need to make sure the attribute is properly added to the span tag, and that it shows the correct service name (e.g Twitter, Facebook, etc).