### PR TITLE
Upgrades: add tracking back to componentDidMount

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -74,6 +74,10 @@ const Checkout = React.createClass( {
 			return;
 		}
 
+		if ( this.props.cart.hasLoadedFromServer ) {
+			this.trackPageView();
+		}
+
 		if ( this.props.cart.hasLoadedFromServer && this.props.product ) {
 			this.addProductToCart();
 		}
@@ -85,12 +89,6 @@ const Checkout = React.createClass( {
 	componentWillReceiveProps: function( nextProps ) {
 		if ( ! this.props.cart.hasLoadedFromServer && nextProps.cart.hasLoadedFromServer && this.props.product ) {
 			this.addProductToCart();
-		}
-
-		// Note that `hasPendingServerUpdates` will go from `null` to `false` on NUX checkout
-		// and from `true` to `false` on post-NUX checkout
-		if ( this.props.cart.hasPendingServerUpdates !== false && nextProps.cart.hasPendingServerUpdates === false ) {
-			this.trackPageView( nextProps );
 		}
 	},
 


### PR DESCRIPTION
The tracking function was not called if the user already had something in the cart and just clicked the Checkout button in the popup cart as displayed on the screenshot:

![checkout-tracking](https://cloud.githubusercontent.com/assets/82778/25524653/384a9988-2c14-11e7-9a32-b4aa3cf485c3.gif)

To test:
1. localStorage.setItem('debug', 'calypso:analytics:tracks');
2. Add a plan to the shopping cart
3. Navigate back to plans
4. Click to the shopping cart and verify that the calypso_checkout_page_view event is there

Props @scruffian 