### PR TITLE
Add ccTLD Support

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -30,6 +30,8 @@ import FormButton from 'components/forms/form-button';
 import { countries } from 'components/phone-input/data';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 // Cannot convert to ES6 import
 const wpcom = require( 'lib/wp' ).undocumented(),
@@ -284,10 +286,34 @@ export default React.createClass( {
 	},
 
 	renderAddressFields() {
+		const frNotice = ( <Notice
+			status="is-info"
+			showDismiss={ false }
+			text={  "registrants must be a resident of the European Union, Switzerland, Norway, Iceland or Liechtenstein and must provide their place and date of birth in the OpenSRS Order Notes." }
+			icon="globe"
+			isCompact={ true }>
+			<NoticeAction href="#">
+				{ "Add As Additional Address" }
+			</NoticeAction>
+		</Notice> );
+		const deNotice = ( <Notice
+			status="is-info"
+			showDismiss={ false }
+			text="example.de requires an address in Germany"
+			icon="globe"
+			isCompact={ true }>
+			<NoticeAction href="#">
+				{ "Add As Additional Address" }
+			</NoticeAction>
+		</Notice> );
+
 		return (
 			<div>
-				<Input label={ this.translate( 'Address' ) } maxLength={ 40 } { ...this.getFieldProps( 'address-1' ) }/>
-
+				<Input
+					label={ this.translate( 'Address' ) }
+					maxLength={ 40 }
+					{ ...this.getFieldProps( 'address-1' ) }
+					notices={ [ frNotice, deNotice ] } />
 				<HiddenInput
 					label={ this.translate( 'Address Line 2' ) }
 					text={ this.translate( '+ Add Address Line 2' ) }

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import {
+	bind,
 	camelCase,
 	deburr,
 	head,
@@ -318,24 +319,41 @@ export default React.createClass( {
 	},
 
 	renderDetailsForm() {
-		const needsOnlyGoogleAppsDetails = this.needsOnlyGoogleAppsDetails();
+		const needsOnlyGoogleAppsFields = this.needsOnlyGoogleAppsDetails();
+		const fields = needsOnlyGoogleAppsFields
+			? [ 'name', 'country', 'postcode' ]
+			: [ 'name', 'organization', 'email', 'phone', 'country',
+				this.needsFax() ? 'fax' : '',
+				'address', 'city', 'state', 'postcode' ];
 
 		return (
 			<form>
-				{ this.renderNameFields() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderOrganizationField() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderEmailField() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderPhoneField() }
-				{ this.renderCountryField() }
-				{ ! needsOnlyGoogleAppsDetails && this.needsFax() && this.renderFaxField() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderAddressFields() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderCityField() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderStateField() }
-				{ this.renderPostalCodeField() }
-
+				{ map( fields, this.renderField, this ) }
 				{ this.renderSubmitButton() }
 			</form>
 		);
+	},
+
+	renderField( fieldName ) {
+		const renderFunctionsByFieldName = {
+			name: this.renderNameFields,
+			organization: this.renderOrganizationField,
+			email: this.renderEmailField,
+			phone: this.renderPhoneField,
+			country: this.renderCountryField,
+			fax: this.renderFaxField,
+			address: this.renderAddressFields,
+			city: this.renderCityField,
+			state: this.renderStateField,
+			postcode: this.renderPostalCodeField,
+		};
+
+		if ( ! renderFunctionsByFieldName[ fieldName ] ) {
+			fieldName && debug( 'Unrecognized field: ' + fieldName );
+			return null;
+		}
+
+		return bind( renderFunctionsByFieldName[ fieldName ], this )();
 	},
 
 	handleCheckboxChange() {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -12,6 +12,7 @@ import {
 	omit,
 	reduce,
 } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -32,6 +33,8 @@ import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 // Cannot convert to ES6 import
 const wpcom = require( 'lib/wp' ).undocumented(),
 	countriesList = countriesListForDomainRegistrations();
+
+const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:domain-details' );
 
 export default React.createClass( {
 	displayName: 'DomainDetailsForm',

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -207,6 +207,11 @@
 		input[ disabled ] {
 			cursor: not-allowed;
 		}
+
+		.notice {
+			width: 100%;
+			margin-bottom: 3px;
+		}
 	}
 
 	.form-button {

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -19,7 +19,7 @@ export default React.createClass( {
 	displayName: 'Input',
 
 	getDefaultProps() {
-		return { autoFocus: false, autoComplete: 'on' };
+		return { autoFocus: false, autoComplete: 'on', notices: [] };
 	},
 
 	componentDidMount() {
@@ -76,6 +76,7 @@ export default React.createClass( {
 		return (
 			<div className={ classes }>
 				<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
+				{ this.props.notices }
 				<FormTextInput
 					placeholder={ this.props.placeholder ? this.props.placeholder : this.props.label }
 					id={ this.props.name }


### PR DESCRIPTION
This PR updates the Domains UI to improve support for `.ca`, `.de` and `.fr` Top Level Domains, and aims to make it easier to accommodate more TLDs in the future.

Different TLDs, especially country code, can have quite varied requirements. To support the three mentioned, we need to support:

- Free Privacy that defaults on
- Whois privacy being unavailable
- Asking users to scroll through and then acknowledge the CIRA agreement before registering (for `.ca`)
- Additional fields (for `.fr`) that depend on the value of another field ( individuals need to provide personal details, while organizations need to supply tax details)
- "presence" requirements (addresses within a specific area for each domain)

In addition, there is significant duplication of functionality between `my-sites/upgrades/checkout/` (buying domains) and `/domains/manage/*` (managing domains). This complicates upgrading the code, so we want to unify these components as much as possible.