### PR TITLE
Fix layout of the LanguagePickerModal dialog in Firefox

### DIFF
--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -123,6 +123,7 @@
 		display: flex;
 		flex-direction: column;
 		flex: auto;
+		min-height: 0; // permits the .language-picker__modal-list to shrink below its min height
 	}
 
 	.dialog__action-buttons {


### PR DESCRIPTION
In Firefox, when the list of languages in the `LanguagePickerModal` is long and is supposed to scroll, it doesn't scroll and overflows instead.

Actual:
![firefox-overflow](https://cloud.githubusercontent.com/assets/664258/25525732/90fcca6e-2c10-11e7-8880-b721c213a94e.png)

Expected:
![firefox-fixed](https://cloud.githubusercontent.com/assets/664258/25525734/9497aa40-2c10-11e7-9bd8-58aa3d16e822.png)

Fixed by adding an `overflow:hidden` property to the `.dialog__content` style.
This will change how the minimum content height of the element is evaluated
and will allow it to shrink properly.

Filed a [Gecko bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1360510), as the behavior is different from what Chrome and Safari do.