### PR TITLE
Add suggested languages to LanguagePickerModal

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes, PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes, map, noop, partial } from 'lodash';
+import { find, includes, map, noop, partial, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,6 +33,7 @@ class LanguagePickerModal extends PureComponent {
 			filter: 'popular',
 			search: false,
 			selectedLanguageSlug: this.props.selected,
+			suggestedLanguages: this.getSuggestedLanguages(),
 		};
 	}
 
@@ -40,6 +41,12 @@ class LanguagePickerModal extends PureComponent {
 		if ( nextProps.selected !== this.state.selectedLanguageSlug ) {
 			this.setState( {
 				selectedLanguageSlug: nextProps.selected
+			} );
+		}
+
+		if ( nextProps.languages !== this.props.languages ) {
+			this.setState( {
+				suggestedLanguages: this.getSuggestedLanguages()
 			} );
 		}
 	}
@@ -74,6 +81,31 @@ class LanguagePickerModal extends PureComponent {
 			default:
 				return languages;
 		}
+	}
+
+	getSuggestedLanguages() {
+		if ( ! ( typeof navigator === 'object' && 'languages' in navigator ) ) {
+			return null;
+		}
+
+		const { languages } = this.props;
+
+		const suggestedLanguages = [];
+
+		for ( const langSlug of navigator.languages ) {
+			// Find the language first by its full code (e.g. en-US), and when it fails
+			// try only the base code (en). Don't add duplicates.
+			const lcLangSlug = langSlug.toLowerCase();
+			let language = find( languages, lang => lang.langSlug === lcLangSlug );
+			if ( ! language ) {
+				language = find( languages, lang => startsWith( lcLangSlug, lang.langSlug + '-' ) );
+			}
+			if ( language && ! includes( suggestedLanguages, language ) ) {
+				suggestedLanguages.push( language );
+			}
+		}
+
+		return suggestedLanguages;
 	}
 
 	handleSearch = ( search ) => {
@@ -140,6 +172,28 @@ class LanguagePickerModal extends PureComponent {
 		);
 	}
 
+	renderSuggestedLanguages() {
+		const { suggestedLanguages } = this.state;
+		if ( ! suggestedLanguages ) {
+			return null;
+		}
+
+		return (
+			<div className="language-picker__modal-suggested">
+				<div className="language-picker__modal-suggested-inner">
+					<div className="language-picker__modal-suggested-label">
+						{ this.props.translate( 'Suggested languages: ' ) }
+					</div>
+					<div className="language-picker__modal-suggested-list">
+						<div className="language-picker__modal-suggested-list-inner">
+							{ map( suggestedLanguages, this.renderLanguageItem ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
 	render() {
 		const { isVisible, translate } = this.props;
 
@@ -181,6 +235,7 @@ class LanguagePickerModal extends PureComponent {
 					/>
 				</SectionNav>
 				{ this.renderLanguageList() }
+				{ this.renderSuggestedLanguages() }
 			</Dialog>
 		);
 	}

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -137,30 +137,33 @@
 	}
 }
 
+.language-picker__modal-item {
+	display: inline-block;
+	white-space: nowrap;
+	overflow: hidden;
+}
+
 .language-picker__modal-list {
 	box-sizing: border-box;
 	width: 100%;
 	overflow-y: auto;
 	padding: 8px 16px;
 	flex: auto;
-}
 
-.language-picker__modal-item {
-	display: inline-block;
-	width: 100%;
-	white-space: nowrap;
-	overflow: hidden;
+	.language-picker__modal-item {
+		width: 100%;
 
-	@include breakpoint( ">480px") {
-		width: 50%;
-	}
+		@include breakpoint( ">480px") {
+			width: 50%;
+		}
 
-	@include breakpoint( ">660px" ) {
-		width: 33%;
-	}
+		@include breakpoint( ">660px" ) {
+			width: 33%;
+		}
 
-	@include breakpoint( ">960px" ) {
-		width: 25%;
+		@include breakpoint( ">960px" ) {
+			width: 25%;
+		}
 	}
 }
 
@@ -173,5 +176,39 @@
 	&.is-selected {
 		background: $blue-medium;
 		color: $white;
+	}
+}
+
+.language-picker__modal-suggested {
+	flex: none;
+	background: $gray-light;
+	border-top: 1px solid lighten( $gray, 30% );
+	padding: 8px 16px;
+
+	.language-picker__modal-suggested-inner {
+		display: flex;
+		overflow: hidden;
+	}
+
+	.language-picker__modal-suggested-label {
+		flex: none;
+		padding: 4px 8px;
+		white-space: nowrap;
+	}
+
+	.language-picker__modal-suggested-list {
+		flex: 1 1 0px;
+		height: 0;
+	}
+
+	.language-picker__modal-suggested-list-inner {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	.language-picker__modal-item {
+		flex: none;
+		width: auto;
+		margin-left: 16px;
 	}
 }


### PR DESCRIPTION
Display list of suggested languages based on`navigator.languages`, i.e., on browser settings. If the `navigator.languages` feature is missing from the browser, detect that fact and don't show the suggested list in that case.

Here is how the suggested languages look in the desktop screen version:

![suggested-desktop](https://cloud.githubusercontent.com/assets/664258/25526630/b593c716-2c14-11e7-870d-183b056809bd.png)

And this is the mobile version:

![suggested-mobile](https://cloud.githubusercontent.com/assets/664258/25526642/c5c14f96-2c14-11e7-87e9-8a40fe3fee24.png)

Open questions:
- should we limit the number of suggested languages displayed? The list in `navigator.languages` has unlimited length, in principle. When asking the server to guess the locale (`/locale-guess` wpcom endpoint), it returns max. 2 languages. Also, it's tricky to prevent the list of languages from overflowing horizontally.
- the suggested languages could almost certainly look better in the mobile version. Maybe @folletto has some nice ideas? 😃 

**Testing instructions:**
- play with your browsers language preferences (add, remove and reorder languages) and test if the "Suggested languages" list reflects the browser preferences correctly.
- test the layout of the "Suggested languages" list. Is it responsive? If there is not enough space for all list items, they should gradually disappear. Test this in all browsers -- the implementation involves some serious flexbox magic and I had to workaround many cross-browser differences and bugs. I tested on Mac in latest versions of Firefox, Safari and Chrome, and in IE11 on Windows 7. I don't have quick access to Edge, so I didn't test there yet.