### PR TITLE
Fix lint errors in jetpack-connect install step

### DIFF
--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -17,7 +17,6 @@ import JetpackExampleConnect from './example-components/jetpack-connect';
 const NEW_INSTRUCTIONS_JETPACK_VERSION = '4.2.0';
 
 class JetpackInstallStep extends Component {
-
 	static propTypes = {
 		currentUrl: PropTypes.string.isRequired,
 		confirmJetpackInstallStatus: PropTypes.func.isRequired,

--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,83 +16,100 @@ import JetpackExampleConnect from './example-components/jetpack-connect';
 
 const NEW_INSTRUCTIONS_JETPACK_VERSION = '4.2.0';
 
-export default React.createClass( {
-	displayName: 'JetpackInstallStep',
+class JetpackInstallStep extends Component {
 
-	confirmJetpackInstalled( event ) {
+	static propTypes = {
+		currentUrl: PropTypes.string.isRequired,
+		confirmJetpackInstallStatus: PropTypes.func.isRequired,
+		jetpackVersion: PropTypes.string,
+		onClick: PropTypes.func.isRequired,
+		isInstall: PropTypes.bool.isRequired,
+	};
+
+	confirmJetpackInstalled = ( event ) => {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( true );
-	},
+	}
 
-	confirmJetpackNotInstalled( event ) {
+	confirmJetpackNotInstalled = ( event ) => {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( false );
-	},
+	}
 
 	renderAlreadyHaveJetpackButton() {
 		return (
 			<a className="jetpack-connect__already-installed-jetpack-button" href="#" onClick={ this.confirmJetpackInstalled }>
-				{ preventWidows( this.translate( 'Already have Jetpack installed?' ) ) }
+				{ preventWidows( this.props.translate( 'Already have Jetpack installed?' ) ) }
 			</a>
 		);
-	},
+	}
 
 	renderNotJetpackButton() {
 		return (
 			<a className="jetpack-connect__no-jetpack-button" href="#" onClick={ this.confirmJetpackNotInstalled }>
-				{ preventWidows( this.translate( 'Don\'t have Jetpack installed?' ) ) }
+				{ preventWidows( this.props.translate( 'Don\'t have Jetpack installed?' ) ) }
 			</a>
 		);
-	},
+	}
 
 	getStep( stepName ) {
+		const {
+			currentUrl,
+			isInstall,
+			jetpackVersion,
+			onClick,
+			translate,
+		} = this.props;
+
 		const isLegacyVersion = (
-			this.props.jetpackVersion &&
-			versionCompare( this.props.jetpackVersion, NEW_INSTRUCTIONS_JETPACK_VERSION, '<' )
+			jetpackVersion &&
+			versionCompare( jetpackVersion, NEW_INSTRUCTIONS_JETPACK_VERSION, '<' )
 		);
+
 		const jetpackConnectExample = <JetpackExampleConnect
-			url={ this.props.currentUrl }
+			url={ currentUrl }
 			isLegacy={ isLegacyVersion }
-			onClick={ this.props.onClick } />;
+			onClick={ onClick } />;
+
 		const steps = {
 			installJetpack: {
-				title: this.translate( '1. Install Jetpack' ),
-				text: this.props.isInstall
-					? this.translate( 'You will be redirected to your site\'s dashboard to install ' +
+				title: translate( '1. Install Jetpack' ),
+				text: isInstall
+					? translate( 'You will be redirected to your site\'s dashboard to install ' +
 					'Jetpack. Click the blue "Install Now" button.' )
-					: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s ' +
+					: translate( 'You will be redirected to the Jetpack plugin page on your site\'s ' +
 					'dashboard to install Jetpack. Click the blue install button.' ),
 				action: this.renderAlreadyHaveJetpackButton(),
-				example: <JetpackExampleInstall url={ this.props.currentUrl } onClick={ this.props.onClick } />
+				example: <JetpackExampleInstall url={ currentUrl } onClick={ onClick } />
 			},
 			activateJetpackAfterInstall: {
-				title: this.translate( '2. Activate Jetpack' ),
-				text: this.translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ),
+				title: translate( '2. Activate Jetpack' ),
+				text: translate( 'Then you\'ll click the blue "Activate" link to activate Jetpack.' ),
 				action: null,
-				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ true } onClick={ this.props.onClick } />
+				example: <JetpackExampleActivate url={ currentUrl } isInstall={ true } onClick={ onClick } />
 			},
 			connectJetpackAfterInstall: {
-				title: this.translate( '3. Connect Jetpack' ),
-				text: this.translate( 'Finally, click the "Connect to WordPress.com" button to finish the process.' ),
+				title: translate( '3. Connect Jetpack' ),
+				text: translate( 'Finally, click the "Connect to WordPress.com" button to finish the process.' ),
 				action: null,
 				example: jetpackConnectExample
 			},
 			activateJetpack: {
-				title: this.translate( '1. Activate Jetpack' ),
-				text: this.translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. ' +
+				title: translate( '1. Activate Jetpack' ),
+				text: translate( 'You will be redirected to your site\'s dashboard to activate Jetpack. ' +
 					'Click the blue "Activate" link. ' ),
 				action: this.renderNotJetpackButton(),
-				example: <JetpackExampleActivate url={ this.props.currentUrl } isInstall={ false } onClick={ this.props.onClick } />
+				example: <JetpackExampleActivate url={ currentUrl } isInstall={ false } onClick={ onClick } />
 			},
 			connectJetpack: {
-				title: this.translate( '2. Connect Jetpack' ),
-				text: this.translate( 'Then click the "Connect to WordPress.com" button to finish the process.' ),
+				title: translate( '2. Connect Jetpack' ),
+				text: translate( 'Then click the "Connect to WordPress.com" button to finish the process.' ),
 				action: null,
 				example: jetpackConnectExample
 			}
 		};
 		return steps[ stepName ];
-	},
+	}
 
 	render() {
 		const step = this.getStep( this.props.stepName );
@@ -110,4 +128,6 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+}
+
+export default localize( JetpackInstallStep );

--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -18,11 +19,16 @@ const NEW_INSTRUCTIONS_JETPACK_VERSION = '4.2.0';
 
 class JetpackInstallStep extends Component {
 	static propTypes = {
-		currentUrl: PropTypes.string.isRequired,
 		confirmJetpackInstallStatus: PropTypes.func.isRequired,
-		jetpackVersion: PropTypes.string,
-		onClick: PropTypes.func.isRequired,
+		currentUrl: PropTypes.string,
 		isInstall: PropTypes.bool.isRequired,
+		jetpackVersion: PropTypes.string,
+		onClick: PropTypes.func,
+	};
+
+	static defaultProps = {
+		currentUrl: '',
+		onClick: noop,
 	};
 
 	confirmJetpackInstalled = ( event ) => {

--- a/client/signup/jetpack-connect/install-step.jsx
+++ b/client/signup/jetpack-connect/install-step.jsx
@@ -22,7 +22,10 @@ class JetpackInstallStep extends Component {
 		confirmJetpackInstallStatus: PropTypes.func.isRequired,
 		currentUrl: PropTypes.string,
 		isInstall: PropTypes.bool.isRequired,
-		jetpackVersion: PropTypes.string,
+		jetpackVersion: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.bool,
+		] ),
 		onClick: PropTypes.func,
 	};
 


### PR DESCRIPTION
Update to es6 class.
Fix usage of `this.translate`.
Add `propTypes`

Lint errors must be fixed before jetpack-connect can be moved (#12991).

To test:

* Use this branch.
* You must have a disconnected site with Jetpack not installed.
* Go to /jetpack/connect
* Enter your site's URL.
* Follow the steps, returning to /jetpack/connect after each step (install, activate, connect).
* Ensure there are no regressions. Watch the console (preserve log) for any errors/warnings.
* Bonus points for testing with old example (must use Jetpack `<4.2`) which uses a different connect example component.