### PR TITLE
Reader: fix treatment of video derived thumbnails within related-post

### DIFF
--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -85,10 +85,9 @@ export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSit
 		return <RelatedPostCardPlaceholder />;
 	}
 
-	const featuredImage = post.canonical_image;
 	const postLink = getPostUrl( post );
 	const classes = classnames( 'reader-related-card-v2', {
-		'has-thumbnail': !! featuredImage,
+		'has-thumbnail': !! post.canonical_media,
 		'has-excerpt': post.excerpt && post.excerpt.length > 1
 	} );
 	const postClickTracker = partial( onPostClick, post );
@@ -127,7 +126,7 @@ export function RelatedPostCard( { post, site, siteId, onPostClick = noop, onSit
 				<div className="reader-related-card-v2__site-info">
 					<h1 className="reader-related-card-v2__title">{ post.title }</h1>
 					<div className="reader-related-card-v2__excerpt post-excerpt">
-						{ featuredImage ? post.short_excerpt : post.better_excerpt_no_html }
+						{ !! post.canonical_media ? post.short_excerpt : post.better_excerpt_no_html }
 					</div>
 				</div>
 			</a>


### PR DESCRIPTION
I recently made a change where relatedposts + recs are able to derive images from embedded videos as opposed to just images.  There are two things that I didn't update though:
1. use the short_excerpt instead of better_excerpt_no_html
2. apply has-thumbnail

And on top of those, @jancavan also discovered a bug where RP was applying `has-thumbnail` even if the image wasn't big enough.

fixes https://github.com/Automattic/wp-calypso/issues/13478

To test:
1. http://calypso.localhost:3000/read/blogs/101129525/posts/1869 --> the RPs should have long excerpts
2. http://calypso.localhost:3000/read/search --> make sure no recs with images have longer excerpts