### PR TITLE
Jetpack connect: Refactor jetpack-connect-notices

### DIFF
--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -13,8 +13,28 @@ import { urlToSlug } from 'lib/url';
 
 class JetpackConnectNotices extends Component {
 	static propTypes = {
-		noticeType: PropTypes.string,
-		url: PropTypes.string
+		noticeType: PropTypes.oneOf( [
+			'alreadyConnected',
+			'alreadyConnectedByOtherUser',
+			'alreadyOwned',
+			'defaultAuthorizeError',
+			'isDotCom',
+			'jetpackIsValid',
+			'notActiveJetpack',
+
+			// notConnectedJetpack is expected, but no notice is shown.
+			'notConnectedJetpack',
+			'notExists',
+			'notJetpack',
+			'notWordPress',
+			'outdatedJetpack',
+			'retryAuth',
+			'retryingAuth',
+			'secretExpired',
+			'wordpress.com',
+		] ).isRequired,
+		translate: PropTypes.func.isRequired,
+		url: PropTypes.string,
 	}
 
 	getNoticeValues() {

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -18,7 +18,12 @@ class JetpackConnectNotices extends Component {
 	}
 
 	getNoticeValues() {
-		const { translate } = this.props;
+		const {
+			noticeType,
+			onDismissClick,
+			translate,
+			url,
+		} = this.props;
 
 		const noticeValues = {
 			icon: 'notice',
@@ -27,88 +32,88 @@ class JetpackConnectNotices extends Component {
 			showDismiss: false
 		};
 
-		if ( this.props.onDismissClick ) {
-			noticeValues.onDismissClick = this.props.onDismissClick;
+		if ( onDismissClick ) {
+			noticeValues.onDismissClick = onDismissClick;
 			noticeValues.showDismiss = true;
 		}
 
-		if ( this.props.noticeType === 'notExists' ) {
+		if ( noticeType === 'notExists' ) {
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'isDotCom' ) {
+		if ( noticeType === 'isDotCom' ) {
 			noticeValues.icon = 'block';
 			noticeValues.text = translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'notWordPress' ) {
+		if ( noticeType === 'notWordPress' ) {
 			noticeValues.icon = 'block';
 			noticeValues.text = translate( 'That\'s not a WordPress site.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'notActiveJetpack' ) {
+		if ( noticeType === 'notActiveJetpack' ) {
 			noticeValues.icon = 'block';
 			noticeValues.text = translate( 'Jetpack is deactivated.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'outdatedJetpack' ) {
+		if ( noticeType === 'outdatedJetpack' ) {
 			noticeValues.icon = 'block';
 			noticeValues.text = translate( 'You must update Jetpack before connecting.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'jetpackIsDisconnected' ) {
+		if ( noticeType === 'jetpackIsDisconnected' ) {
 			noticeValues.icon = 'link-break';
 			noticeValues.text = translate( 'Jetpack is currently disconnected.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'jetpackIsValid' ) {
+		if ( noticeType === 'jetpackIsValid' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'plugins';
 			noticeValues.text = translate( 'Jetpack is connected.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'notJetpack' ) {
+		if ( noticeType === 'notJetpack' ) {
 			noticeValues.status = 'is-noticeType';
 			noticeValues.icon = 'status';
 			noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'alreadyConnected' || this.props.noticeType === 'alreadyOwned' ) {
+		if ( noticeType === 'alreadyConnected' || noticeType === 'alreadyOwned' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
 			noticeValues.text = translate( 'This site is already connected!' );
 			noticeValues.showDismiss = false;
 			noticeValues.children = (
-				<NoticeAction href={ '/plans/my-plan/' + urlToSlug( this.props.url ) }>
+				<NoticeAction href={ '/plans/my-plan/' + urlToSlug( url ) }>
 					{ translate( 'Visit' ) }
 				</NoticeAction>
 			);
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'wordpress.com' ) {
+		if ( noticeType === 'wordpress.com' ) {
 			noticeValues.text = translate( 'Oops, that\'s us.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'status';
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'retryingAuth' ) {
+		if ( noticeType === 'retryingAuth' ) {
 			noticeValues.text = translate( 'Error authorizing. Page is refreshing for an other attempt.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'retryAuth' ) {
+		if ( noticeType === 'retryAuth' ) {
 			noticeValues.text = translate( 'In some cases, authorization can take a few attempts. Please try again.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'secretExpired' ) {
+		if ( noticeType === 'secretExpired' ) {
 			noticeValues.text = translate( 'Oops, that took a while. You\'ll have to try again.' );
 			noticeValues.status = 'is-error';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'defaultAuthorizeError' ) {
+		if ( noticeType === 'defaultAuthorizeError' ) {
 			noticeValues.text = translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
 				components: { link: <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer" /> }
 			} );
@@ -116,7 +121,7 @@ class JetpackConnectNotices extends Component {
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'alreadyConnectedByOtherUser' ) {
+		if ( noticeType === 'alreadyConnectedByOtherUser' ) {
 			noticeValues.text = translate(
 				'This site is already connected to a different WordPress.com user, ' +
 				'you need to disconnect that user before you can connect another.'

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -93,7 +93,7 @@ class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case 'notJetpack':
-				noticeValues.status = 'is-noticeType';
+				noticeValues.status = 'is-notice';
 				noticeValues.icon = 'status';
 				noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
 				return noticeValues;

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -57,98 +57,100 @@ class JetpackConnectNotices extends Component {
 			noticeValues.showDismiss = true;
 		}
 
-		if ( noticeType === 'notExists' ) {
-			return noticeValues;
-		}
-		if ( noticeType === 'isDotCom' ) {
-			noticeValues.icon = 'block';
-			noticeValues.text = translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
-			return noticeValues;
-		}
-		if ( noticeType === 'notWordPress' ) {
-			noticeValues.icon = 'block';
-			noticeValues.text = translate( 'That\'s not a WordPress site.' );
-			return noticeValues;
-		}
-		if ( noticeType === 'notActiveJetpack' ) {
-			noticeValues.icon = 'block';
-			noticeValues.text = translate( 'Jetpack is deactivated.' );
-			return noticeValues;
-		}
-		if ( noticeType === 'outdatedJetpack' ) {
-			noticeValues.icon = 'block';
-			noticeValues.text = translate( 'You must update Jetpack before connecting.' );
-			return noticeValues;
-		}
-		if ( noticeType === 'jetpackIsDisconnected' ) {
-			noticeValues.icon = 'link-break';
-			noticeValues.text = translate( 'Jetpack is currently disconnected.' );
-			return noticeValues;
-		}
-		if ( noticeType === 'jetpackIsValid' ) {
-			noticeValues.status = 'is-success';
-			noticeValues.icon = 'plugins';
-			noticeValues.text = translate( 'Jetpack is connected.' );
-			return noticeValues;
-		}
-		if ( noticeType === 'notJetpack' ) {
-			noticeValues.status = 'is-noticeType';
-			noticeValues.icon = 'status';
-			noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
-			return noticeValues;
-		}
-		if ( noticeType === 'alreadyConnected' || noticeType === 'alreadyOwned' ) {
-			noticeValues.status = 'is-success';
-			noticeValues.icon = 'status';
-			noticeValues.text = translate( 'This site is already connected!' );
-			noticeValues.showDismiss = false;
-			noticeValues.children = (
-				<NoticeAction href={ '/plans/my-plan/' + urlToSlug( url ) }>
-					{ translate( 'Visit' ) }
-				</NoticeAction>
-			);
-			return noticeValues;
-		}
-		if ( noticeType === 'wordpress.com' ) {
-			noticeValues.text = translate( 'Oops, that\'s us.' );
-			noticeValues.status = 'is-warning';
-			noticeValues.icon = 'status';
-			return noticeValues;
-		}
-		if ( noticeType === 'retryingAuth' ) {
-			noticeValues.text = translate( 'Error authorizing. Page is refreshing for an other attempt.' );
-			noticeValues.status = 'is-warning';
-			noticeValues.icon = 'notice';
-			return noticeValues;
-		}
-		if ( noticeType === 'retryAuth' ) {
-			noticeValues.text = translate( 'In some cases, authorization can take a few attempts. Please try again.' );
-			noticeValues.status = 'is-warning';
-			noticeValues.icon = 'notice';
-			return noticeValues;
-		}
-		if ( noticeType === 'secretExpired' ) {
-			noticeValues.text = translate( 'Oops, that took a while. You\'ll have to try again.' );
-			noticeValues.status = 'is-error';
-			noticeValues.icon = 'notice';
-			return noticeValues;
-		}
-		if ( noticeType === 'defaultAuthorizeError' ) {
-			noticeValues.text = translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
-				components: { link: <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer" /> }
-			} );
-			noticeValues.status = 'is-error';
-			noticeValues.icon = 'notice';
-			return noticeValues;
-		}
-		if ( noticeType === 'alreadyConnectedByOtherUser' ) {
-			noticeValues.text = translate(
-				'This site is already connected to a different WordPress.com user, ' +
-				'you need to disconnect that user before you can connect another.'
-			);
-			noticeValues.status = 'is-warning';
-			noticeValues.icon = 'notice';
-			return noticeValues;
+		switch ( noticeType ) {
+			case 'notExists':
+				return noticeValues;
+
+			case 'isDotCom':
+				noticeValues.icon = 'block';
+				noticeValues.text = translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
+				return noticeValues;
+
+			case 'notWordPress':
+				noticeValues.icon = 'block';
+				noticeValues.text = translate( 'That\'s not a WordPress site.' );
+				return noticeValues;
+
+			case 'notActiveJetpack':
+				noticeValues.icon = 'block';
+				noticeValues.text = translate( 'Jetpack is deactivated.' );
+				return noticeValues;
+
+			case 'outdatedJetpack':
+				noticeValues.icon = 'block';
+				noticeValues.text = translate( 'You must update Jetpack before connecting.' );
+				return noticeValues;
+
+			case 'jetpackIsDisconnected':
+				noticeValues.icon = 'link-break';
+				noticeValues.text = translate( 'Jetpack is currently disconnected.' );
+				return noticeValues;
+
+			case 'jetpackIsValid':
+				noticeValues.status = 'is-success';
+				noticeValues.icon = 'plugins';
+				noticeValues.text = translate( 'Jetpack is connected.' );
+				return noticeValues;
+
+			case 'notJetpack':
+				noticeValues.status = 'is-noticeType';
+				noticeValues.icon = 'status';
+				noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
+				return noticeValues;
+
+			case 'alreadyConnected':
+			case 'alreadyOwned':
+				noticeValues.status = 'is-success';
+				noticeValues.icon = 'status';
+				noticeValues.text = translate( 'This site is already connected!' );
+				noticeValues.showDismiss = false;
+				noticeValues.children = (
+					<NoticeAction href={ '/plans/my-plan/' + urlToSlug( url ) }>
+						{ translate( 'Visit' ) }
+					</NoticeAction>
+				);
+				return noticeValues;
+
+			case 'wordpress.com':
+				noticeValues.text = translate( 'Oops, that\'s us.' );
+				noticeValues.status = 'is-warning';
+				noticeValues.icon = 'status';
+				return noticeValues;
+
+			case 'retryingAuth':
+				noticeValues.text = translate( 'Error authorizing. Page is refreshing for an other attempt.' );
+				noticeValues.status = 'is-warning';
+				noticeValues.icon = 'notice';
+				return noticeValues;
+
+			case 'retryAuth':
+				noticeValues.text = translate( 'In some cases, authorization can take a few attempts. Please try again.' );
+				noticeValues.status = 'is-warning';
+				noticeValues.icon = 'notice';
+				return noticeValues;
+
+			case 'secretExpired':
+				noticeValues.text = translate( 'Oops, that took a while. You\'ll have to try again.' );
+				noticeValues.status = 'is-error';
+				noticeValues.icon = 'notice';
+				return noticeValues;
+
+			case 'defaultAuthorizeError':
+				noticeValues.text = translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
+					components: { link: <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer" /> }
+				} );
+				noticeValues.status = 'is-error';
+				noticeValues.icon = 'notice';
+				return noticeValues;
+
+			case 'alreadyConnectedByOtherUser':
+				noticeValues.text = translate(
+					'This site is already connected to a different WordPress.com user, ' +
+					'you need to disconnect that user before you can connect another.'
+				);
+				noticeValues.status = 'is-warning';
+				noticeValues.icon = 'notice';
+				return noticeValues;
 		}
 
 		return;

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -152,8 +152,6 @@ class JetpackConnectNotices extends Component {
 				noticeValues.icon = 'notice';
 				return noticeValues;
 		}
-
-		return;
 	}
 
 	render() {


### PR DESCRIPTION
This was a required PR before moving files for #12991. However, lint issues have been solved by #13599 (thanks @tyxla).

I've taken this opportunity to apply a few janitorial changes, but I'd be just as happy to close this PR and move on.

To test:

* Use this branch.
* Go to `/jetpack/connect`
* Enter your site's URL.
* `/jetpack/connect/url=[ mysiteurl ]` is a handy alternative
* Ensure there are no regressions. Watch the console (preserve log) for any errors/warnings.
* Connect sites under different conditions:
  * wordpress.com site: http://calypso.localhost:3000/jetpack/connect/?url=$site
  * Connected but for different user http://calypso.localhost:3000/jetpack/connect/?url=$site
  * wordpress.com http://calypso.localhost:3000/jetpack/connect/?url=wordpress.com
  * not jetpack http://calypso.localhost:3000/jetpack/connect/?url=google.com
  * invalid http://calypso.localhost:3000/jetpack/connect/?url=alsdkjfalksdjf
  * Outdated Jetpack (`<3.9.6`)
  * Jetpack not installed
  * Jetpack not activated
  * Many more!


---

### Outdated

Update to es6 class.
Fix usage of this.translate.
Fix/improve propTypes
Remaps bad noticeTypes:
* `jetpackIsDisconnected` -> `notConnectedJetpack`
* `jetpackIsValid ` -> `alreadyOwned`
Removes some irrelevant code.
Fix lint errors must be fixed before jetpack-connect can be moved (#12991).

To test:

* Use this branch.
* Go to `/jetpack/connect`
* Enter your site's URL.
* `/jetpack/connect/url=[ mysiteurl ]` is a handy alternative
* Ensure there are no regressions. Watch the console (preserve log) for any errors/warnings.
* Connect sites under different conditions:
  * wordpress.com site: http://calypso.localhost:3000/jetpack/connect/url=jonsurrell.wordpress.com
  * Connected but for different user http://calypso.localhost:3000/jetpack/connect/url=jonsurrell.wpsandbox.me
  * wordpress.com http://calypso.localhost:3000/jetpack/connect/url=wordpress.com
  * not jetpack http://calypso.localhost:3000/jetpack/connect/url=google.com
  * invalid http://calypso.localhost:3000/jetpack/connect/url=alsdkjfalksdjf
  * Outdated Jetpack (`<3.9.6`)
  * Jetpack not installed
  * Jetpack not activated
  * Many more!

This got much bigger than I expected, probably needs to be broken down.