### PR TITLE
Improve Notice status validation with oneOf

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -21,8 +21,12 @@ export const Notice = React.createClass( {
 	},
 
 	propTypes: {
-		// we should validate the allowed statuses
-		status: PropTypes.string,
+		status: PropTypes.oneOf( [
+			'is-info',
+			'is-success',
+			'is-error',
+			'is-warning',
+		] ),
 		showDismiss: PropTypes.bool,
 		isCompact: PropTypes.bool,
 		duration: React.PropTypes.number,


### PR DESCRIPTION
`status` was only validated as `string`. Change this to validate using `oneOf` with valid strings.

To test:

* Use this branch
* Test that valid notices raise no warnings:
  * `'is-info'`
  * `'is-success'`
  * `'is-error'`
  * `'is-warning'`
* Test that invalid notices DO raise warnings in the console:
  * `'whateverbadwarningyouwant'`
* A handy place to test this is by visiting http://calypso.localhost:3000/jetpack/connect?url=https://wordpress.com and changing [this line](https://github.com/Automattic/wp-calypso/blob/b04bd88ee05dfb11875a8de2f9a71c11b25bcaf1/client/signup/jetpack-connect/jetpack-connect-notices.jsx#L81).
* Make sure the notice isn't broken!

This change should only affect dev environment and should only serve to nag devs who provide a bad value.