### PR TITLE
Extensions: WPSC - Get compression warning from notices endpoint

### DIFF
--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -18,7 +18,6 @@ import WrapSettingsForm from './wrap-settings-form';
 const Miscellaneous = ( {
 	fields: {
 		cache_compression,
-		cache_compression_disabled,
 		cache_hello_world,
 		cache_mod_rewrite,
 		cache_rebuild,
@@ -30,8 +29,11 @@ const Miscellaneous = ( {
 	handleAutosavingToggle,
 	isRequesting,
 	isSaving,
+	notices,
 	translate,
 } ) => {
+	const compressionDisabled = notices && notices.compression_disabled;
+
 	return (
 		<div>
 			<SectionHeader
@@ -39,18 +41,14 @@ const Miscellaneous = ( {
 			</SectionHeader>
 			<Card>
 				<form>
-					{ cache_compression_disabled &&
-					<p>
-						{ translate(
-							' {{em}}Warning! Compression is disabled as gzencode() function was not found.{{/em}}',
-							{
-								components: { em: <em /> }
-							}
-						) }
-					</p>
+					{ compressionDisabled && compressionDisabled.message &&
+					<Notice
+						showDismiss={ false }
+						status={ compressionDisabled.type ? `is-${ compressionDisabled.type }` : 'is-info' }
+						text={ compressionDisabled.message } />
 					}
 					<FormFieldset>
-						{ ! cache_compression_disabled &&
+						{ ! compressionDisabled &&
 						<FormToggle
 							checked={ !! cache_compression }
 							disabled={ isRequesting || isSaving }
@@ -178,7 +176,6 @@ const Miscellaneous = ( {
 const getFormSettings = settings => {
 	return pick( settings, [
 		'cache_compression',
-		'cache_compression_disabled',
 		'cache_hello_world',
 		'cache_mod_rewrite',
 		'cache_rebuild',

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -221,14 +221,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const isSaving = isSavingSettings( state, siteId );
 			const isSaveSuccessful = isSettingsSaveSuccessful( state, siteId );
 			const notices = getNotices( state, siteId );
-			const settings = Object.assign( {}, getSettings( state, siteId ), {
-				// Miscellaneous
-				cache_compression_disabled: false,
-			} );
+			const settings = getSettings( state, siteId );
 			const isRequesting = isRequestingSettings( state, siteId ) && ! settings;
 			// Don't include read-only fields when saving.
 			const settingsFields = keys( omit( settings, [
-				'cache_compression_disabled',
 				'cache_direct_pages',
 				'cache_disable_locking',
 				'cache_mobile_browsers',


### PR DESCRIPTION
The compression warning now comes from the _notices_ endpoint, and the compression setting is not shown if the warning is present.

![compression-notice](https://cloud.githubusercontent.com/assets/1190420/25536790/febdf2a0-2c09-11e7-9ae5-bf6b2e10467e.jpg)
