### PR TITLE
Add selectors for variations edit state.

### DIFF
--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { get, find, isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getVariation } from '../../../variations/selectors';
+
+function getVariationEditsStateForProduct( state, productId ) {
+	const woocommerce = state.extensions.woocommerce;
+	const variations = get( woocommerce, 'ui.products.variations.edits', [] );
+	return find( variations, ( v ) => productId === v.productId );
+}
+
+/**
+ * Gets the accumulated edits for a variation, if any.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} variationId The id of the variation (or { index: # } )
+ * @return {Object} The current accumulated edits
+ */
+export function getVariationEdits( state, productId, variationId ) {
+	const edits = getVariationEditsStateForProduct( state, productId );
+	const bucket = isNumber( variationId ) && 'updates' || 'creates';
+	const array = get( edits, bucket, [] );
+	return find( array, ( v ) => variationId === v.id );
+}
+
+/**
+ * Gets a variation with local edits overlayed on top of fetched data.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} variationId The id of the variation (or { index: # } )
+ * @return {Object} The product data merged between the fetched data and edits
+ */
+export function getVariationWithLocalEdits( state, productId, variationId ) {
+	const existing = isNumber( variationId );
+	const variation = existing && getVariation( state, productId, variationId );
+	const variationEdits = getVariationEdits( state, productId, variationId );
+
+	return ( variation || variationEdits ) && { ...variation, ...variationEdits } || undefined;
+}
+
+/**
+ * Gets the variation being currently edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Object} Variation object that is merged between fetched data and edits
+ */
+export function getCurrentlyEditingVariation( state, productId ) {
+	const edits = getVariationEditsStateForProduct( state, productId ) || {};
+	const { currentlyEditingId } = edits;
+
+	return getVariationWithLocalEdits( state, productId, currentlyEditingId );
+}
+
+/**
+ * Gets an array of variation objects for a product, including new ones being edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Array} Array of variation objects.
+ */
+export function getProductVariationsWithLocalEdits( state, productId ) {
+	const edits = getVariationEditsStateForProduct( state, productId );
+	const creates = get( edits, 'creates', undefined );
+	// TODO Merge in existing variations loaded by the API for existing products.
+	return creates;
+}

--- a/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { set } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getVariationEdits,
+	getVariationWithLocalEdits,
+	getCurrentlyEditingVariation,
+	getProductVariationsWithLocalEdits,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	let state;
+
+	beforeEach( () => {
+		state = {
+			extensions: {
+				woocommerce: {
+					products: [
+						// TODO: After the product API code is in, add more fields here.
+						{ id: 2 },
+					],
+					variations: [
+						// TODO: After the variation API code is in, add more fields here.
+						{ id: 3 },
+					],
+					ui: {
+						products: {
+							variations: {
+							}
+						}
+					},
+				},
+			},
+		};
+	} );
+
+	describe( 'getVariationEdits', () => {
+		it( 'should get a variation from "creates"', () => {
+			const newVariation = { id: { index: 1 }, name: 'New Variation' };
+			const productId = { index: 0 };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', productId );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getVariationEdits( state, productId, newVariation.id ) ).to.equal( newVariation );
+		} );
+
+		it( 'should get a variation from "updates"', () => {
+			const updateVariation = { id: 3, name: 'Existing Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].updates', [ updateVariation ] );
+
+			expect( getVariationEdits( state, 2, updateVariation.id ) ).to.equal( updateVariation );
+		} );
+
+		it( 'should return undefined if no edits are found for productId', () => {
+			expect( getVariationEdits( state, 2, 3 ) ).to.not.exist;
+			expect( getVariationEdits( state, 2, { index: 9 } ) ).to.not.exist;
+		} );
+
+		it( 'should return undefined if no edits are found for variationId', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			expect( getVariationEdits( state, 2, 3 ) ).to.not.exist;
+			expect( getVariationEdits( state, 2, { index: 9 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getVariationWithLocalEdits', () => {
+		it( 'should get just edits for a variation in "creates"', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getVariationWithLocalEdits( state, 2, newVariation.id ) ).to.eql( newVariation );
+		} );
+
+		it( 'should get just fetched data for a variation that has no edits', () => {
+			const variations = state.extensions.woocommerce.variations;
+
+			expect( getVariationWithLocalEdits( state, 2, 3 ) ).to.eql( variations[ 0 ] );
+		} );
+
+		it( 'should get both fetched data and edits for a variation in "updates"', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			const variations = state.extensions.woocommerce.variations;
+
+			const existingVariation = { id: 3, name: 'Existing Variation' };
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].updates', [ existingVariation ] );
+
+			const combinedVariation = { ...variations[ 0 ], ...existingVariation };
+			expect( getVariationWithLocalEdits( state, 2, 3 ) ).to.eql( combinedVariation );
+		} );
+
+		it( 'should return undefined if no variation is found for variationId', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 42 );
+			expect( getVariationWithLocalEdits( state, 42, 43 ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+		} );
+
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getVariationWithLocalEdits( state, 42, 43 ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingVariation', () => {
+		it( 'should return undefined if there are no edits', () => {
+			expect( getCurrentlyEditingVariation( state, 2 ) ).to.not.exist;
+		} );
+
+		it( 'should get the last edited variation', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+			set( uiVariations, 'edits[0].currentlyEditingId', newVariation.id );
+
+			expect( getCurrentlyEditingVariation( state, 2 ) ).to.eql( newVariation );
+		} );
+	} );
+
+	describe( 'getProductVariationsWithLocalEdits', () => {
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getProductVariationsWithLocalEdits( state, 4 ) ).to.not.exist;
+		} );
+		it( 'should get variations from "creates"', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getProductVariationsWithLocalEdits( state, 2 ) ).to.eql( [ newVariation ] );
+		} );
+		// TODO Tests for dealing with fetched/existing variations and combined (creates & existing).
+	} );
+} );

--- a/client/extensions/woocommerce/state/variations/selectors.js
+++ b/client/extensions/woocommerce/state/variations/selectors.js
@@ -1,0 +1,12 @@
+/**
+ * Gets variation fetched from server.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} productId Numeric product id.
+ * @param {Number} variationId Numeric variation id.
+ * @return {Object} Variation object from API.
+ */
+export function getVariation( state, productId, variationId ) {
+	// TODO: Add fetched variations data.
+	return productId && variationId === 3 && { id: variationId } || undefined;
+}


### PR DESCRIPTION
This PR adds selectors for the variations edit state. It allows just the edits to be retrieved or the edits overlaid on top of the fetched data.

Follows the pattern we worked on from #13104.

To Test:
* Run `make test` and make sure all tests pass.