### PR TITLE
Update jetpack-connect-plans-grid

### DIFF
--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -10,22 +11,38 @@ import Main from 'components/main';
 import StepHeader from '../step-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 
-export default React.createClass( {
-	displayName: 'JetpackPlansGrid',
+class JetpackPlansGrid extends Component {
+	static propTypes = {
+		basePlansPath: PropTypes.string.isRequired,
+		hideFreePlan: PropTypes.bool,
+		intervalType: PropTypes.string,
+		isLanding: PropTypes.bool,
+		landingType: PropTypes.string,
+		onSelect: PropTypes.func,
+		selectedSite: PropTypes.object,
+		showFirst: PropTypes.bool,
+	};
 
 	renderConnectHeader() {
-		let headerText = this.translate( 'Your site is now connected!' );
-		let subheaderText = this.translate( 'Now pick a plan that\'s right for you.' );
-		if ( this.props.showFirst ) {
-			headerText = this.translate( 'You are moments away from connecting your site' );
+		const {
+			isLanding,
+			landingType,
+			showFirst,
+			translate,
+		} = this.props;
+
+		let headerText = translate( 'Your site is now connected!' );
+		let subheaderText = translate( 'Now pick a plan that\'s right for you.' );
+		if ( showFirst ) {
+			headerText = translate( 'You are moments away from connecting your site' );
 		}
-		if ( this.props.isLanding ) {
-			headerText = this.translate( 'Pick a plan that\'s right for you.' );
+		if ( isLanding ) {
+			headerText = translate( 'Pick a plan that\'s right for you.' );
 			subheaderText = '';
 
-			if ( this.props.landingType === 'vaultpress' ) {
-				headerText = this.translate( 'Select your VaultPress plan.' );
-				subheaderText = this.translate( 'VaultPress backup and security plans are now cheaper as part of Jetpack.' );
+			if ( landingType === 'vaultpress' ) {
+				headerText = translate( 'Select your VaultPress plan.' );
+				subheaderText = translate( 'VaultPress backup and security plans are now cheaper as part of Jetpack.' );
 			}
 		}
 		return (
@@ -35,7 +52,7 @@ export default React.createClass( {
 				step={ 1 }
 				steps={ 3 } />
 		);
-	},
+	}
 
 	render() {
 		const defaultJetpackSite = { jetpack: true, plan: {}, isUpgradeable: () => true };
@@ -58,4 +75,6 @@ export default React.createClass( {
 			</Main>
 		);
 	}
-} );
+}
+
+export default localize( JetpackPlansGrid );

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -13,7 +13,7 @@ import PlansFeaturesMain from 'my-sites/plans-features-main';
 
 class JetpackPlansGrid extends Component {
 	static propTypes = {
-		basePlansPath: PropTypes.string.isRequired,
+		basePlansPath: PropTypes.string,
 		hideFreePlan: PropTypes.bool,
 		intervalType: PropTypes.string,
 		isLanding: PropTypes.bool,


### PR DESCRIPTION
* Pass linter (es6 class, localize)
* Add propTypes

Lint fixes required for: Separate jetpack-connect from signup #12991

To test:

* Use this branch.
* Go to `/jetpack/connect`.
* Enter your site's URL (disconnected Jetpack site with no plans).
* Alternatively `/jetpack/connect/plans/:siteslug` may work under some conditions.
* Test buttons, render etc.
* Ensure there are no regressions. Watch the console (preserve log) for any errors/warnings.
