### PR TITLE
Extensions: WPSC - Adjust the parameters that are passed to the POST request

### DIFF
--- a/client/extensions/wp-super-cache/fix-config.jsx
+++ b/client/extensions/wp-super-cache/fix-config.jsx
@@ -30,4 +30,8 @@ const FixConfig = ( { translate } ) => {
 	);
 };
 
-export default WrapSettingsForm()( FixConfig );
+const getFormSettings = () => {
+	return {};
+};
+
+export default WrapSettingsForm( getFormSettings )( FixConfig );

--- a/client/extensions/wp-super-cache/state/settings/actions.js
+++ b/client/extensions/wp-super-cache/state/settings/actions.js
@@ -76,7 +76,9 @@ export const saveSettings = ( siteId, settings ) => {
 			siteId,
 		} );
 
-		return wp.req.post( { path: `/jetpack-blogs/${ siteId }/rest-api/` }, {}, { path: '/wp-super-cache/v1/settings', ...settings } )
+		return wp.req.post(
+			{ path: `/jetpack-blogs/${ siteId }/rest-api/` },
+			{ path: '/wp-super-cache/v1/settings', body: JSON.stringify( settings ), json: true } )
 			.then( () => {
 				dispatch( updateSettings( siteId, settings ) );
 				dispatch( {


### PR DESCRIPTION
This PR fixes the settings not being saved due to an incorrect format for the parameters passed to the `wp.req.post` function.