### PR TITLE
Themes: Retain filters and query string when activating

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -59,7 +59,8 @@ export function details( context, next ) {
 	}
 
 	context.primary = <ThemeSheetComponent id={ slug }
-		section={ section } />;
+		section={ section }
+		pathName={ context.pathname } />;
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
 }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -583,8 +583,7 @@ const ConnectedThemeSheet = connectOptions(
 		}
 
 		return (
-			<ThemesSiteSelectorModal { ...props }
-				sourcePath={ `/theme/${ props.id }${ props.section ? '/' + props.section : '' }` }>
+			<ThemesSiteSelectorModal { ...props }>
 				<ThemeSheet />
 			</ThemesSiteSelectorModal>
 		);

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -15,7 +15,7 @@ const MultiSiteThemeShowcase = connectOptions(
 	( props ) => (
 		<div>
 			<SidebarNavigation />
-			<ThemesSiteSelectorModal { ...props } sourcePath="/themes">
+			<ThemesSiteSelectorModal { ...props }>
 				<ThemeShowcase
 					source="showcase"
 					showUploadButton={ false } />

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -30,7 +30,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 		defaultOption: OPTION_SHAPE,
 		secondaryOption: OPTION_SHAPE,
 		// Will be prepended to site slug for a redirect on selection
-		sourcePath: PropTypes.string.isRequired,
+		pathName: PropTypes.string.isRequired,
 	},
 
 	getInitialState() {
@@ -43,9 +43,15 @@ const ThemesSiteSelectorModal = React.createClass( {
 	trackAndCallAction( site ) {
 		const action = this.state.selectedOption.action;
 		const themeId = this.state.selectedThemeId;
+		const { search } = this.props;
+
+		let redirectTarget = this.props.pathName + '/' + site.slug;
+		if ( search ) {
+			redirectTarget += '?s=' + search;
+		}
 
 		trackClick( 'site selector', this.props.name );
-		page( this.props.sourcePath + '/' + site.slug );
+		page( redirectTarget );
 
 		/**
 		 * Since this implies a route change, defer it in case other state


### PR DESCRIPTION
Previously, when activating a theme in multi-site mode, you'd be taken to the showcase's single-site mode for the site you'd select -- but any filters and search strings would be lost.

This PR retains them. It does so by passing on the full `pathName` from the controller, and using that to build the redirect target.

To test:
* Verify that the above is true.
* Make sure that activation still works from the theme sheet.

(This started as an attempted fix for #13506 -- however, that issue isn't fixed by this PR.)