### PR TITLE
Add selector for getting variation IDs associated with a product

### DIFF
--- a/client/extensions/woocommerce/state/products/selectors.js
+++ b/client/extensions/woocommerce/state/products/selectors.js
@@ -8,6 +8,12 @@
  */
 export function getProduct( state, productId ) {
 	// TODO: Add fetched product data.
-	return productId === 1 && { id: productId } || undefined;
+	switch ( productId ) {
+		case 1:
+			return { id: productId };
+		case 2:
+			return { id: productId, variations: [ 3 ] };
+		default:
+			undefined;
+	}
 }
-

--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -7,6 +7,7 @@ import { get, find, isNumber } from 'lodash';
  * Internal dependencies
  */
 import { getVariation } from '../../../variations/selectors';
+import { getProduct } from '../../../products/selectors';
 
 function getVariationEditsStateForProduct( state, productId ) {
 	const woocommerce = state.extensions.woocommerce;
@@ -57,4 +58,22 @@ export function getCurrentlyEditingVariation( state, productId ) {
 	const { currentlyEditingId } = edits;
 
 	return getVariationWithLocalEdits( state, productId, currentlyEditingId );
+}
+
+/**
+ * Gets variation IDs for a product, including new ones being edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Array} Array of variation IDs.
+ */
+export function getProductVariationIdsWithLocalEdits( state, productId ) {
+	const edits = getVariationEditsStateForProduct( state, productId );
+	const product = isNumber( productId ) && getProduct( state, productId );
+	const createIds = get( edits, 'creates', [] ).map( ( v ) => v.id );
+	const existingIds = product && product.variations || [];
+
+	return ( ( existingIds.length > 0 || createIds.length > 0 ) &&
+		[ ...existingIds, ...createIds ] ) ||
+		undefined;
 }

--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { get, find, isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getVariation } from '../../../variations/selectors';
+
+function getVariationEditsStateForProduct( state, productId ) {
+	const woocommerce = state.extensions.woocommerce;
+	const variations = get( woocommerce, 'ui.products.variations.edits', [] );
+	return find( variations, ( v ) => productId === v.productId );
+}
+
+/**
+ * Gets the accumulated edits for a variation, if any.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} variationId The id of the variation (or { index: # } )
+ * @return {Object} The current accumulated edits
+ */
+export function getVariationEdits( state, productId, variationId ) {
+	const edits = getVariationEditsStateForProduct( state, productId );
+	const bucket = isNumber( variationId ) && 'updates' || 'creates';
+	const array = get( edits, bucket, [] );
+	return find( array, ( v ) => variationId === v.id );
+}
+
+/**
+ * Gets a variation with local edits overlayed on top of fetched data.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} variationId The id of the variation (or { index: # } )
+ * @return {Object} The product data merged between the fetched data and edits
+ */
+export function getVariationWithLocalEdits( state, productId, variationId ) {
+	const existing = isNumber( variationId );
+	const variation = existing && getVariation( state, productId, variationId );
+	const variationEdits = getVariationEdits( state, productId, variationId );
+
+	return ( variation || variationEdits ) && { ...variation, ...variationEdits } || undefined;
+}
+
+/**
+ * Gets the variation being currently edited in the UI.
+ *
+ * @param {Object} state Global state tree
+ * @param {any} productId The id of the product (or { index: # } )
+ * @return {Object} Variation object that is merged between fetched data and edits
+ */
+export function getCurrentlyEditingVariation( state, productId ) {
+	const edits = getVariationEditsStateForProduct( state, productId ) || {};
+	const { currentlyEditingId } = edits;
+
+	return getVariationWithLocalEdits( state, productId, currentlyEditingId );
+}

--- a/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { set } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getVariationEdits,
+	getVariationWithLocalEdits,
+	getCurrentlyEditingVariation,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	let state;
+
+	beforeEach( () => {
+		state = {
+			extensions: {
+				woocommerce: {
+					products: [
+						// TODO: After the product API code is in, add more fields here.
+						{ id: 2 },
+					],
+					variations: [
+						// TODO: After the variation API code is in, add more fields here.
+						{ id: 3 },
+					],
+					ui: {
+						products: {
+							variations: {
+							}
+						}
+					},
+				},
+			},
+		};
+	} );
+
+	describe( 'getVariationEdits', () => {
+		it( 'should get a variation from "creates"', () => {
+			const newVariation = { id: { index: 1 }, name: 'New Variation' };
+			const productId = { index: 0 };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', productId );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getVariationEdits( state, productId, newVariation.id ) ).to.equal( newVariation );
+		} );
+
+		it( 'should get a variation from "updates"', () => {
+			const updateVariation = { id: 3, name: 'Existing Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].updates', [ updateVariation ] );
+
+			expect( getVariationEdits( state, 2, updateVariation.id ) ).to.equal( updateVariation );
+		} );
+
+		it( 'should return undefined if no edits are found for productId', () => {
+			expect( getVariationEdits( state, 2, 3 ) ).to.not.exist;
+			expect( getVariationEdits( state, 2, { index: 9 } ) ).to.not.exist;
+		} );
+
+		it( 'should return undefined if no edits are found for variationId', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			expect( getVariationEdits( state, 2, 3 ) ).to.not.exist;
+			expect( getVariationEdits( state, 2, { index: 9 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getVariationWithLocalEdits', () => {
+		it( 'should get just edits for a variation in "creates"', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getVariationWithLocalEdits( state, 2, newVariation.id ) ).to.eql( newVariation );
+		} );
+
+		it( 'should get just fetched data for a variation that has no edits', () => {
+			const variations = state.extensions.woocommerce.variations;
+
+			expect( getVariationWithLocalEdits( state, 2, 3 ) ).to.eql( variations[ 0 ] );
+		} );
+
+		it( 'should get both fetched data and edits for a variation in "updates"', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			const variations = state.extensions.woocommerce.variations;
+
+			const existingVariation = { id: 3, name: 'Existing Variation' };
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].updates', [ existingVariation ] );
+
+			const combinedVariation = { ...variations[ 0 ], ...existingVariation };
+			expect( getVariationWithLocalEdits( state, 2, 3 ) ).to.eql( combinedVariation );
+		} );
+
+		it( 'should return undefined if no variation is found for variationId', () => {
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 42 );
+			expect( getVariationWithLocalEdits( state, 42, 43 ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+		} );
+
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getVariationWithLocalEdits( state, 42, 43 ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingVariation', () => {
+		it( 'should return undefined if there are no edits', () => {
+			expect( getCurrentlyEditingVariation( state, 2 ) ).to.not.exist;
+		} );
+
+		it( 'should get the last edited variation', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+			set( uiVariations, 'edits[0].currentlyEditingId', newVariation.id );
+
+			expect( getCurrentlyEditingVariation( state, 2 ) ).to.eql( newVariation );
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getVariationEdits,
 	getVariationWithLocalEdits,
 	getCurrentlyEditingVariation,
+	getProductVariationIdsWithLocalEdits,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -22,7 +23,10 @@ describe( 'selectors', () => {
 				woocommerce: {
 					products: [
 						// TODO: After the product API code is in, add more fields here.
-						{ id: 2 },
+						{
+							id: 2,
+							variations: [ 3 ],
+						}
 					],
 					variations: [
 						// TODO: After the variation API code is in, add more fields here.
@@ -126,6 +130,23 @@ describe( 'selectors', () => {
 			set( uiVariations, 'edits[0].currentlyEditingId', newVariation.id );
 
 			expect( getCurrentlyEditingVariation( state, 2 ) ).to.eql( newVariation );
+		} );
+	} );
+
+	describe( 'getProductVariationIdsWithLocalEdits', () => {
+		it( 'should return undefined if no product is found for productId', () => {
+			expect( getProductVariationIdsWithLocalEdits( state, 4 ) ).to.not.exist;
+		} );
+		it( 'should get just fetched ids for a product with no new variation "creates"', () => {
+			expect( getProductVariationIdsWithLocalEdits( state, 2 ) ).to.eql( [ 3 ] );
+		} );
+		it( 'should get both fetched ids and index for a new variation in "creates"', () => {
+			const newVariation = { id: { index: 0 }, name: 'New Variation' };
+			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			set( uiVariations, 'edits[0].productId', 2 );
+			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+
+			expect( getProductVariationIdsWithLocalEdits( state, 2 ) ).to.eql( [ 3, { index: 0 } ] );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/variations/selectors.js
+++ b/client/extensions/woocommerce/state/variations/selectors.js
@@ -1,0 +1,12 @@
+/**
+ * Gets variation fetched from server.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} productId Numeric product id.
+ * @param {Number} variationId Numeric variation id.
+ * @return {Object} Variation object from API.
+ */
+export function getVariation( state, productId, variationId ) {
+	// TODO: Add fetched variations data.
+	return productId && variationId === 3 && { id: variationId } || undefined;
+}


### PR DESCRIPTION
We need a way of getting the variations associated with a specific product, so we can easily loop over and display our rows in the variation editing table (and potentially other places). For variations that already exist, you can use the `getProduct` selector and access `product.variations` (returned by the API once that is hooked up) which is a list of variation IDs.

This selector returns those and the index IDs for unsaved variations present in our edits state.

I separated this out from #13503 so that PR didn't grow much larger.

To Test:
* Run `make test` and make sure all tests pass.