### PR TITLE
Truncate the URL in the search preview to 79 characters

### DIFF
--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -26,6 +26,8 @@ const googleSnippet = firstValid(
 	hardTruncation( SNIPPET_LENGTH )
 );
 
+const googleUrl = hardTruncation( 79 );
+
 export const SearchPreview = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
@@ -44,7 +46,7 @@ export const SearchPreview = React.createClass( {
 						{ googleTitle( title ) }
 					</div>
 					<div className="seo-search-preview__url">
-						{ url } ▾
+						{ googleUrl( url ) } ▾
 					</div>
 					<div className="seo-search-preview__snippet">
 						{ googleSnippet( snippet || '' ) }


### PR DESCRIPTION
Resolves #10723 

Previously the search preview wasn't truncating the URL of a post which
resulted in major visual glitches as it overlapped the other content.

Now the URL gets hard-truncated at 79 to match what Google is currently
doing and shouldn't mess up so much.

Before:
<img width="606" alt="screen shot 2017-04-28 at 5 36 03 pm" src="https://cloud.githubusercontent.com/assets/5431237/25551406/563d236e-2c39-11e7-9aa0-6df8397a26e8.png">

After:
<img width="604" alt="screen shot 2017-04-28 at 5 31 20 pm" src="https://cloud.githubusercontent.com/assets/5431237/25551404/4ff10048-2c39-11e7-972d-c795b1ab7922.png">
