### PR TITLE
Reader: Update photo card gradient overlay

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -202,8 +202,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&::before {
 		content: '';
-		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 30%, rgba( 0, 0, 0, 0.37 ) 65%, rgba( 0, 0, 0, 1 ) 100% );
-		height: 105px;
+		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 0%, rgba( 0, 0, 0, 0.37 ) 65%, rgba( 0, 0, 0, 1 ) 110% );
+		height: 80px;
 		opacity: .4;
 		position: absolute;
 			bottom: 0;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -202,8 +202,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	&::before {
 		content: '';
-		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 36%, rgba( 0, 0, 0, 0.37 ) 73%, rgba( 0, 0, 0, 1 ) 100% );
-		height: 225px;
+		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 30%, rgba( 0, 0, 0, 0.37 ) 65%, rgba( 0, 0, 0, 1 ) 100% );
+		height: 105px;
 		opacity: .4;
 		position: absolute;
 			bottom: 0;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/10247

**Before:**
<img width="815" alt="screenshot 2017-04-28 21 24 18" src="https://cloud.githubusercontent.com/assets/4924246/25552876/a7f21280-2c59-11e7-8cc5-8ad9a537f00c.png">

**After:**
<img width="812" alt="screenshot 2017-04-28 21 31 22" src="https://cloud.githubusercontent.com/assets/4924246/25552887/1736f8c2-2c5a-11e7-9452-b1815c65784e.png">


