### PR TITLE
Jetpack plugins - prioritize order for updates, part 2

### DIFF
--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -195,7 +195,7 @@ PluginsStore = {
 			return;
 		}
 		plugins = sortBy( plugins, function( plugin ) {
-			return plugin.slug;
+			return plugin.name;
 		} );
 		if ( ! plugins ) {
 			return [];

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -11,6 +11,7 @@ import isEqual from 'lodash/isEqual';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import Card from 'components/card';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsActions from 'lib/plugins/actions';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
@@ -57,6 +58,7 @@ module.exports = React.createClass( {
 			inProgress: React.PropTypes.array,
 		} ),
 		hasAllNoManageSites: React.PropTypes.bool,
+		hasUpdate: React.PropTypes.func,
 	},
 
 	getDefaultProps() {
@@ -99,12 +101,6 @@ module.exports = React.createClass( {
 
 	ago( date ) {
 		return i18n.moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
-	},
-
-	hasUpdate() {
-		return this.props.sites.some( function( site ) {
-			return site.plugin && site.plugin.update && site.canUpdateFiles;
-		} );
 	},
 
 	doing() {
@@ -192,7 +188,6 @@ module.exports = React.createClass( {
 				);
 			}
 		}
-
 		if ( this.props.isAutoManaged ) {
 			return (
 				<div className="plugin-item__last_updated">
@@ -201,7 +196,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		if ( this.hasUpdate() ) {
+		if ( this.props.hasUpdate( pluginData ) ) {
 			return this.renderUpdateFlag();
 		}
 
@@ -310,7 +305,7 @@ module.exports = React.createClass( {
 			numberOfWarningIcons++;
 		}
 
-		if ( this.hasUpdate() ) {
+		if ( this.props.hasUpdate( plugin ) ) {
 			numberOfWarningIcons++;
 		}
 
@@ -341,9 +336,12 @@ module.exports = React.createClass( {
 				</div>
 			);
 		}
+
+		const CardType = this.props.isCompact ? CompactCard : Card;
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div>
-				<CompactCard className="plugin-item">
+				<CardType className="plugin-item">
 					{ ! this.props.isSelectable
 						? null
 						: <input className="plugin-item__checkbox"
@@ -359,10 +357,11 @@ module.exports = React.createClass( {
 						{ this.pluginMeta( plugin ) }
 					</a>
 					{ this.props.selectedSite ? this.renderActions() : this.renderSiteCount() }
-				</CompactCard>
+				</CardType>
 				{ errorNotices }
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 } );

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -6,7 +6,7 @@ import page from 'page';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { find, get, includes, isEmpty, isEqual, negate, range, reduce } from 'lodash';
+import { find, get, includes, isEmpty, isEqual, negate, range, reduce, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -222,6 +222,10 @@ export const PluginsList = React.createClass( {
 			.map( p => p.sites ) // list of plugins -> list of list of sites
 			.reduce( flattenArrays, [] ) // flatten the list into one big list of sites
 			.forEach( site => action( site, site.plugin ) );
+	},
+
+	pluginHasUpdate( plugin ) {
+		return plugin.sites.some( site => site.plugin && site.plugin.update && site.canUpdateFiles );
 	},
 
 	updateAllPlugins() {
@@ -461,8 +465,9 @@ export const PluginsList = React.createClass( {
 					haveActiveSelected={ this.props.plugins.some( this.filterSelection.active.bind( this ) ) }
 					haveInactiveSelected={ this.props.plugins.some( this.filterSelection.inactive.bind( this ) ) }
 					haveUpdatesSelected= { this.props.plugins.some( this.filterSelection.updates.bind( this ) ) } />
-				<div className={ itemListClasses }>{ this.props.plugins.map( this.renderPlugin ) }</div>
-
+				<div className={ itemListClasses }>
+					{ this.orderPluginsByUpdates( this.props.plugins ).map( this.renderPlugin ) }
+				</div>
 			</div>
 		);
 	},
@@ -481,7 +486,14 @@ export const PluginsList = React.createClass( {
 		};
 	},
 
-	renderPlugin( plugin ) {
+	orderPluginsByUpdates( plugins ) {
+		return sortBy( plugins, plugin => {
+			// Bring the plugins requiring updates to the front of the array
+			return this.pluginHasUpdate( plugin ) ? 0 : 1;
+		} );
+	},
+
+	renderPlugin( plugin, index ) {
 		const selectThisPlugin = this.togglePlugin.bind( this, plugin );
 		const allowedPluginActions = this.getAllowedPluginActions( plugin );
 		const isSelectable = this.state.bulkManagementActive && ( allowedPluginActions.autoupdate || allowedPluginActions.activation );
@@ -497,9 +509,11 @@ export const PluginsList = React.createClass( {
 				isSelected={ this.isSelected( plugin ) }
 				isSelectable={ isSelectable }
 				onClick={ selectThisPlugin }
+				hasUpdate = { this.pluginHasUpdate }
 				selectedSite={ this.props.selectedSite }
 				pluginLink={ '/plugins/' + encodeURIComponent( plugin.slug ) + this.siteSuffix() }
 				allowedActions = { allowedPluginActions }
+				isCompact={ index !== this.props.pluginUpdateCount - 1 }
 				isAutoManaged = { ! allowedPluginActions.autoupdate } />
 		);
 	},


### PR DESCRIPTION
This is a redo of https://github.com/Automattic/wp-calypso/pull/8111 where discussion tailed off on the merits of A/B testing and how this scenario may not deserve a testing round. Instead of updating that branch, I found it easier to create a new PR from master, cherry-picking the commit in question and leaving out the A/B testing.

### Changes `/plugins`
* Plugins requiring changes are grouped at the top.
* Plugins are arranged in alphabetical order by name

### Before
![screen shot 2017-05-01 at 4 53 38 pm](https://cloud.githubusercontent.com/assets/1922453/25572424/187ef9fa-2e8f-11e7-92fc-8d47f7d99eda.png)

### After
![screen shot 2017-05-01 at 4 53 49 pm](https://cloud.githubusercontent.com/assets/1922453/25572431/215961a0-2e8f-11e7-805f-38cd79b9821c.png)

@rickybanister, could you confirm that these changes are still desirable?