### PR TITLE
[Login] Refactor wp-login before 2FA

### DIFF
--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import LoginBlock from 'blocks/login';
+
+export default function Login() {
+	return (
+		<LoginBlock title={ 'Sign in to connect to WordPress.com' } />
+	)
+}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -3,169 +3,59 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
-import FormsButton from 'components/forms/form-button';
-import Card from 'components/card';
-import FormPasswordInput from 'components/forms/form-password-input';
-import FormTextInput from 'components/forms/form-text-input';
-import FormCheckbox from 'components/forms/form-checkbox';
-import { loginUser } from 'state/login/actions';
-import Notice from 'components/notice';
 import { createFormAndSubmit } from 'lib/form';
-import { recordTracksEvent } from 'state/analytics/actions';
+import LoginForm from './login-form';
 
-export class Login extends Component {
+class Login extends Component {
 	static propTypes = {
-		loginUser: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
-		loginError: PropTypes.string,
-		redirectLocation: PropTypes.string,
 		title: PropTypes.string,
+		redirectLocation: PropTypes.string,
+		twoFactorEnabled: PropTypes.bool,
 	};
 
-	static defaultProps = {
-		title: '',
-	};
-
-	state = {
-		usernameOrEmail: '',
-		password: '',
-		rememberme: false,
-		submitting: false,
-		errorMessage: '',
-	};
-
-	dismissNotice = () => {
-		this.setState( {
-			errorMessage: ''
-		} );
-	};
-
-	onChangeField = ( event ) => {
-		const { name, value } = event.target;
-
-		this.setState( { [ name ]: value } );
-	};
-
-	onChangeRememberMe = ( event ) => {
-		const { name, checked } = event.target;
-
-		this.props.recordTracksEvent( 'calypso_login_block_remember_me_change', { new_value: checked } );
-
-		this.setState( { [ name ]: checked } );
-	};
-
-	onSubmitForm = ( event ) => {
-		event.preventDefault();
-		this.setState( {
-			submitting: true
-		} );
-
-		this.props.recordTracksEvent( 'calypso_login_block_login_submit' );
-
-		this.props.loginUser( this.state.usernameOrEmail, this.state.password ).then( () => {
-			this.props.recordTracksEvent( 'calypso_login_block_login_success' );
-			this.dismissNotice();
+	handleValidUsernamePassword = ( { usernameOrEmail, password, rememberMe } ) => {
+		if ( ! this.props.twoFactorEnabled ) {
 			createFormAndSubmit( config( 'login_url' ), {
-				log: this.state.usernameOrEmail,
-				pwd: this.state.password,
+				log: usernameOrEmail,
+				pwd: password,
 				redirect_to: this.props.redirectLocation || window.location.origin,
-				rememberme: this.state.rememberme ? 1 : 0,
+				rememberme: rememberMe ? 1 : 0,
 			} );
-		} ).catch( errorMessage => {
-			this.props.recordTracksEvent( 'calypso_login_block_login_failure', {
-				error_message: errorMessage
-			} );
-
-			this.setState( {
-				submitting: false,
-				errorMessage
-			} );
-		} );
+		}
 	};
 
-	renderNotices() {
-		if ( this.state.errorMessage ) {
-			return (
-				<Notice status="is-error"
-					text={ this.state.errorMessage }
-					onDismissClick={ this.dismissNotice } />
-			);
-		}
-	}
+	handleValid2FACode = () => {
+		// TODO: submit the form to /wp-login with the 2FA code
+	};
 
 	render() {
-		const isDisabled = {};
-		if ( this.state.submitting ) {
-			isDisabled.disabled = true;
+		const {
+			title,
+			twoFactorEnabled,
+		} = this.props;
+
+		if ( twoFactorEnabled ) {
+			return (
+				<div
+					onSuccess={ this.handleValid2FACode } />
+			);
 		}
 
 		return (
-			<div className="login">
-
-				{ this.renderNotices() }
-
-				<div className="login__form-header">
-					<div className="login__form-header-title">
-						{ this.props.title }
-					</div>
-				</div>
-
-				<form onSubmit={ this.onSubmitForm }>
-					<Card className="login__form">
-						<div className="login__form-userdata">
-							<label htmlFor="usernameOrEmail" className="login__form-userdata-username">
-								{ this.props.translate( 'Username or Email Address' ) }
-							</label>
-							<FormTextInput
-								className="login__form-userdata-username-input"
-								onChange={ this.onChangeField }
-								id="usernameOrEmail"
-								name="usernameOrEmail"
-								value={ this.state.usernameOrEmail }
-								{ ...isDisabled } />
-							<label htmlFor="password" className="login__form-userdata-username">
-								{ this.props.translate( 'Password' ) }
-							</label>
-							<FormPasswordInput
-								className="login__form-userdata-username-password"
-								onChange={ this.onChangeField }
-								id="password"
-								name="password"
-								value={ this.state.password }
-								{ ...isDisabled } />
-						</div>
-						<div className="login__form-remember-me">
-							<label>
-								<FormCheckbox
-									name="rememberme"
-									checked={ this.state.rememberme }
-									onChange={ this.onChangeRememberMe }
-									{ ...isDisabled } />
-								<span>{ this.props.translate( 'Stay logged in' ) }</span>
-							</label>
-						</div>
-						<div className="login__form-action">
-							<FormsButton primary { ...isDisabled }>
-								{ this.props.translate( 'Log in' ) }
-							</FormsButton>
-						</div>
-					</Card>
-				</form>
-			</div>
+			<LoginForm
+				title={ title }
+				onSuccess={ this.handleValidUsernamePassword } />
 		);
 	}
 }
 
 export default connect(
-	null,
-	{
-		loginUser,
-		recordTracksEvent
-	}
-)( localize( Login ) );
+	() => ( {
+		twoFactorEnabled: false
+	} ),
+)( Login );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormsButton from 'components/forms/form-button';
+import Card from 'components/card';
+import FormPasswordInput from 'components/forms/form-password-input';
+import FormTextInput from 'components/forms/form-text-input';
+import FormCheckbox from 'components/forms/form-checkbox';
+import { loginUser } from 'state/login/actions';
+import Notice from 'components/notice';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+export class LoginForm extends Component {
+	static propTypes = {
+		loginUser: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+		loginError: PropTypes.string,
+		onSuccess: PropTypes.func.isRequired,
+		title: PropTypes.string,
+	};
+
+	static defaultProps = {
+		title: '',
+	};
+
+	state = {
+		usernameOrEmail: '',
+		password: '',
+		rememberMe: false,
+		submitting: false,
+		errorMessage: '',
+	};
+
+	dismissNotice = () => {
+		this.setState( {
+			errorMessage: ''
+		} );
+	};
+
+	onChangeField = ( event ) => {
+		this.setState( {
+			[ event.target.name ]: event.target.value
+		} );
+	};
+
+	onChangeRememberMe = ( event ) => {
+		const { name, checked } = event.target;
+
+		this.props.recordTracksEvent( 'calypso_login_block_remember_me_change', { new_value: checked } );
+
+		this.setState( { [ name ]: checked } );
+	};
+
+	onSubmitForm = ( event ) => {
+		event.preventDefault();
+		this.setState( {
+			submitting: true
+		} );
+
+		this.props.recordTracksEvent( 'calypso_login_block_login_submit' );
+
+		this.props.loginUser( this.state.usernameOrEmail, this.state.password ).then( () => {
+			this.props.recordTracksEvent( 'calypso_login_block_login_success' );
+			this.dismissNotice();
+			this.props.onSuccess( this.state );
+		} ).catch( errorMessage => {
+			this.props.recordTracksEvent( 'calypso_login_block_login_failure', {
+				error_message: errorMessage
+			} );
+			this.setState( {
+				submitting: false,
+				errorMessage
+			} );
+		} );
+	};
+
+	renderNotices() {
+		if ( this.state.errorMessage ) {
+			return (
+				<Notice status="is-error"
+					text={ this.state.errorMessage }
+					onDismissClick={ this.dismissNotice } />
+			);
+		}
+	}
+
+	render() {
+		const isDisabled = {};
+		if ( this.state.submitting ) {
+			isDisabled.disabled = true;
+		}
+
+		return (
+			<div>
+				{ this.renderNotices() }
+
+				<div className="login__form-header">
+					<div className="login__form-header-title">
+						{ this.props.title }
+					</div>
+				</div>
+
+				<form onSubmit={ this.onSubmitForm }>
+					<Card className="login__form">
+						<div className="login__form-userdata">
+							<label htmlFor="usernameOrEmail" className="login__form-userdata-username">
+								{ this.props.translate( 'Username or Email Address' ) }
+							</label>
+							<FormTextInput
+								className="login__form-userdata-username-input"
+								onChange={ this.onChangeField }
+								id="usernameOrEmail"
+								name="usernameOrEmail"
+								value={ this.state.usernameOrEmail }
+								{ ...isDisabled } />
+							<label htmlFor="password" className="login__form-userdata-username">
+								{ this.props.translate( 'Password' ) }
+							</label>
+							<FormPasswordInput
+								className="login__form-userdata-username-password"
+								onChange={ this.onChangeField }
+								id="password"
+								name="password"
+								value={ this.state.password }
+								{ ...isDisabled } />
+						</div>
+						<div className="login__form-remember-me">
+							<label>
+								<FormCheckbox
+									name="rememberMe"
+									checked={ this.state.rememberMe }
+									onChange={ this.onChangeRememberMe }
+									{ ...isDisabled } />
+								<span>{ this.props.translate( 'Stay logged in' ) }</span>
+							</label>
+						</div>
+						<div className="login__form-action">
+							<FormsButton primary { ...isDisabled }>
+								{ this.props.translate( 'Log in' ) }
+							</FormsButton>
+						</div>
+					</Card>
+				</form>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		loginUser,
+		recordTracksEvent
+	}
+)( localize( LoginForm ) );

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -14,19 +14,19 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormsButton from 'components/forms/form-button';
 
-describe( 'Login', function() {
-	let Login;
+describe( 'LoginForm', function() {
+	let LoginForm;
 
 	useFakeDom();
 
 	before( () => {
-		Login = require( 'blocks/login' ).Login;
+		LoginForm = require( 'blocks/login/login-form' ).LoginForm;
 	} );
 
 	context( 'component rendering', () => {
 		it( 'displays a login form', () => {
 			const wrapper = shallow(
-				<Login translate={ noop } />
+				<LoginForm translate={ noop } />
 			);
 			expect( wrapper.find( FormTextInput ).length ).to.equal( 1 );
 			expect( wrapper.find( FormPasswordInput ).length ).to.equal( 1 );
@@ -35,7 +35,7 @@ describe( 'Login', function() {
 
 		it( 'shows the header text', () => {
 			const wrapper = shallow(
-				<Login
+				<LoginForm
 					translate={ noop }
 					title={ 'Sign in to connect to WordPress.com' } />
 			);

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -65,6 +65,7 @@ import ReaderExportButton from 'blocks/reader-export-button/docs/example';
 import ReaderImportButton from 'blocks/reader-import-button/docs/example';
 import SharingPreviewPane from 'blocks/sharing-preview-pane/docs/example';
 import ReaderShare from 'blocks/reader-share/docs/example';
+import Login from 'blocks/login/docs/example';
 
 export default React.createClass( {
 
@@ -112,6 +113,7 @@ export default React.createClass( {
 					<HappinessSupport />
 					<ImageEditor />
 					<LikeButtons />
+					<Login />
 					<PostEditButton />
 					<PlanStorage />
 					<PostSchedule />


### PR DESCRIPTION
This is a refactor on the wp-login component in order to prepare for the new 2FA components.

Concerning the changes here: 
- `Login` is moved from `client/blocks/login/index.jsx` to `client/blocks/login/login-form.jsx`
- `client/blocks/login/index.jsx` is now the entry point for all login screens and we set a prop to check wether 2FA is enabled or not
- The handler which submits the login request to `/wp-login.php` is now in the parent component `client/blocks/login/index.jsx` so we can decide upon the ajax response if we are ready to send the POST request or if we need to proceed with 2FA

### Testing Instructions
- apply patch locally or use calypso.live
- Start an incognito tab
- Test that there is no regression on /login
- Visit /devdocs and check that the login component displays without errors

### Reviews
- [x] Product
- [ ] Code
