### PR TITLE
Google Apps: Properly handle alternative decimal separator

### DIFF
--- a/client/my-sites/upgrades/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/add-google-apps-card.jsx
@@ -32,9 +32,9 @@ const AddGoogleAppsCard = React.createClass( {
 		let price = gapps && gapps.cost_display;
 
 		// Gapps price is stored annually but we'd like to show a monthly price
-		price = price.replace( /(\d+\.?\d+)/, ( val ) => {
+		price = price.replace( /(\d+[.,]?\d+)/, ( val ) => {
 			const number = ( Math.round( parseFloat( val ) / 10 * 100 ) / 100 );
-			return number % 1 === 0 ? number : number.toFixed( 2 );
+			return number % 1 === 0 ? number : this.numberFormat( number, 2 );
 		} );
 
 		return (


### PR DESCRIPTION
When calculating the price per month for G Suite/Google Apps, we were expecting the `.` decimal point separator to be used. This lead to a weird output for locales that used `,` as the separator.

### Testing
Go to Domain Management -> Email, verify that the price per month is correctly formatted.

Before:
<img width="964" alt="screen shot 2017-05-01 at 12 01 30" src="https://cloud.githubusercontent.com/assets/3392497/25578224/c7cdb4be-2e6c-11e7-916f-b5129454da35.png">

After:
<img width="958" alt="screen shot 2017-05-01 at 12 01 00" src="https://cloud.githubusercontent.com/assets/3392497/25578228/cdaa6080-2e6c-11e7-9a9a-ef417bde6539.png">

Hattip to @senff for the report in `p2MSmN-606-p2` and @rantoncuadrado for additional testing 🙇 