### PR TITLE
Editor: Show word count when text is selected in Editor

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -100,6 +100,7 @@ const EVENTS = {
 	focus: 'onFocus',
 	hide: 'onHide',
 	init: 'onInit',
+	mouseUp: 'onMouseUp',
 	redo: 'onRedo',
 	remove: 'onRemove',
 	reset: 'onReset',

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -52,14 +52,17 @@ class EditorWordCount extends PureComponent {
 
 		return (
 			this.props.translate(
-				'%(selectedText)s word selected %(separator)s',
-				'%(selectedText)s words selected %(separator)s',
+				'%(selectedText)s word selected {{span}}%(separator)s{{/span}}',
+				'%(selectedText)s words selected {{span}}%(separator)s{{/span}}',
 				{
 					count: selectedText,
 					args: {
 						selectedText: selectedText,
 						separator: '/ ',
 					},
+					components: {
+						span: <span className="editor-word-count__separator" />
+					}
 				}
 			)
 		);

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -93,7 +93,7 @@ const EditorWordCount = React.createClass( {
 
 		return (
 			<div className="editor-word-count">
-				<span className="editor-word-count__is-selected-text">{ this.getSelectedTextCount() }</span>
+				<span className="editor-word-count__is-selected-text"><strong>{ this.getSelectedTextCount() }</strong></span>
 				{ this.props.translate(
 					'%d word',
 					'%d words',

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,9 +17,7 @@ import { countWords } from 'lib/text-utils';
  */
 const user = userModule();
 
-export default React.createClass( {
-	displayName: 'EditorWordCount',
-
+const EditorWordCount = React.createClass( {
 	propTypes: {
 		selectedText: React.PropTypes.string
 	},
@@ -49,6 +48,28 @@ export default React.createClass( {
 		} );
 	},
 
+	getSelectedTextCount() {
+		const selectedText = textUtils.countWords( this.props.selectedText );
+
+		if ( ! selectedText ) {
+			return null;
+		}
+
+		return (
+			this.props.translate(
+				'%(selectedText)s word selected %(separator)s',
+				'%(selectedText)s words selected %(separator)s',
+				{
+					count: selectedText,
+					args: {
+						selectedText: selectedText,
+						separator: '/ ',
+					},
+				}
+			)
+		);
+	},
+
 	render() {
 		const currentUser = user.get();
 		const localeSlug = currentUser && currentUser.localeSlug || 'en';
@@ -68,15 +89,12 @@ export default React.createClass( {
 				return null;
 		}
 
-<<<<<<< HEAD
-		const wordCount = countWords( this.state.rawContent );
-=======
 		const wordCount = textUtils.countWords( ( this.props.selectedText || this.state.rawContent ) );
->>>>>>> Editor: Show word count when text is selected in Editor
 
 		return (
 			<div className="editor-word-count">
-				{ this.translate(
+				<span className="editor-word-count__is-selected-text">{ this.getSelectedTextCount() }</span>
+				{ this.props.translate(
 					'%d word',
 					'%d words',
 					{
@@ -88,3 +106,5 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default localize( EditorWordCount );

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -16,7 +16,7 @@ import { countWords } from 'lib/text-utils';
  */
 const user = userModule();
 
-class EditorWordCount extends PureComponent {
+export class EditorWordCount extends PureComponent {
 	static propTypes = {
 		selectedText: React.PropTypes.string
 	};
@@ -44,7 +44,7 @@ class EditorWordCount extends PureComponent {
 	}
 
 	getSelectedTextCount = () => {
-		const selectedText = textUtils.countWords( this.props.selectedText );
+		const selectedText = countWords( this.props.selectedText );
 
 		if ( ! selectedText ) {
 			return null;
@@ -87,7 +87,7 @@ class EditorWordCount extends PureComponent {
 				return null;
 		}
 
-		const wordCount = textUtils.countWords( ( this.props.selectedText || this.state.rawContent ) );
+		const wordCount = countWords( ( this.props.selectedText || this.state.rawContent ) );
 
 		return (
 			<div className="editor-word-count">

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,38 +16,34 @@ import { countWords } from 'lib/text-utils';
  */
 const user = userModule();
 
-const EditorWordCount = React.createClass( {
-	propTypes: {
+class EditorWordCount extends PureComponent {
+	static propTypes = {
 		selectedText: React.PropTypes.string
-	},
+	};
 
-	mixins: [ PureRenderMixin ],
-
-	getInitialState() {
-		return {
-			rawContent: ''
-		};
-	},
+	state = {
+		rawContent: ''
+	};
 
 	componentWillMount() {
 		PostEditStore.on( 'rawContentChange', this.onRawContentChange );
-	},
+	}
 
 	componentDidMount() {
 		this.onRawContentChange();
-	},
+	}
 
 	componentWillUnmount() {
 		PostEditStore.removeListener( 'rawContentChange', this.onRawContentChange );
-	},
+	}
 
-	onRawContentChange() {
+	onRawContentChange = () => {
 		this.setState( {
 			rawContent: PostEditStore.getRawContent()
 		} );
-	},
+	}
 
-	getSelectedTextCount() {
+	getSelectedTextCount = () => {
 		const selectedText = textUtils.countWords( this.props.selectedText );
 
 		if ( ! selectedText ) {
@@ -68,7 +63,7 @@ const EditorWordCount = React.createClass( {
 				}
 			)
 		);
-	},
+	}
 
 	render() {
 		const currentUser = user.get();
@@ -105,6 +100,6 @@ const EditorWordCount = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default localize( EditorWordCount );

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -19,6 +19,10 @@ const user = userModule();
 export default React.createClass( {
 	displayName: 'EditorWordCount',
 
+	propTypes: {
+		selectedText: React.PropTypes.string
+	},
+
 	mixins: [ PureRenderMixin ],
 
 	getInitialState() {
@@ -64,7 +68,11 @@ export default React.createClass( {
 				return null;
 		}
 
+<<<<<<< HEAD
 		const wordCount = countWords( this.state.rawContent );
+=======
+		const wordCount = textUtils.countWords( ( this.props.selectedText || this.state.rawContent ) );
+>>>>>>> Editor: Show word count when text is selected in Editor
 
 		return (
 			<div className="editor-word-count">

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -87,7 +87,7 @@ export class EditorWordCount extends PureComponent {
 				return null;
 		}
 
-		const wordCount = countWords( ( this.props.selectedText || this.state.rawContent ) );
+		const wordCount = countWords( this.state.rawContent );
 
 		return (
 			<div className="editor-word-count">

--- a/client/post-editor/editor-word-count/style.scss
+++ b/client/post-editor/editor-word-count/style.scss
@@ -25,3 +25,7 @@
 .editor-word-count__is-selected-text {
 	color: darken( $gray, 10% );
 }
+
+.editor-word-count__separator {
+	color: lighten( $gray, 10% );
+}

--- a/client/post-editor/editor-word-count/style.scss
+++ b/client/post-editor/editor-word-count/style.scss
@@ -23,5 +23,5 @@
 }
 
 .editor-word-count__is-selected-text {
-	color: $gray-text;
+	color: darken( $gray, 10% );
 }

--- a/client/post-editor/editor-word-count/style.scss
+++ b/client/post-editor/editor-word-count/style.scss
@@ -21,3 +21,7 @@
 		}
 	}
 }
+
+.editor-word-count__is-selected-text {
+	color: $gray-text;
+}

--- a/client/post-editor/editor-word-count/test/index.jsx
+++ b/client/post-editor/editor-word-count/test/index.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { noop } from 'lodash';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'EditorWordCount', () => {
+	let EditorWordCount;
+
+	useFakeDom();
+	useMockery();
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/wp', {
+			me: () => ( {
+				get: noop
+			} )
+		} );
+	} );
+
+	before( function() {
+		EditorWordCount = require( '../' ).EditorWordCount;
+	} );
+
+	it( 'should display word count if selected text is provided', () => {
+		const wrapper = mount( <EditorWordCount selectedText={ 'Selected text' } translate={ translate } /> );
+		wrapper.setState( { rawContent: 'Selected text' } );
+		expect( wrapper.text() ).to.equal( '2 words selected / 2 words' );
+	} );
+
+	it( 'should not display word count if no selected text is provided', () => {
+		const wrapper = mount( <EditorWordCount selectedText={ null } translate={ translate } /> );
+		wrapper.setState( { rawContent: 'Selected text' } );
+		expect( wrapper.text() ).to.equal( '2 words' );
+	} );
+
+	it( 'should display 0 words if no content in post', () => {
+		const wrapper = mount( <EditorWordCount selectedText={ null } translate={ translate } /> );
+		wrapper.setState( { rawContent: '' } );
+		expect( wrapper.text() ).to.equal( '0 words' );
+	} );
+} );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import tinyMCE from 'tinymce/tinymce';
 
 /**
  * Internal dependencies
@@ -91,6 +92,7 @@ export const PostEditor = React.createClass( {
 			isSaving: false,
 			isPublishing: false,
 			notice: null,
+			selectedText: null,
 			showVerifyEmailDialog: false,
 			showAutosaveDialog: true,
 			isLoadingAutosave: false,
@@ -231,6 +233,21 @@ export const PostEditor = React.createClass( {
 		}
 	},
 
+	getSelectedText: function() {
+		const selectedText = tinyMCE.activeEditor.selection.getContent() || null;
+		if ( this.state.selectedText !== selectedText ) {
+			this.setState( { selectedText: selectedText || null } );
+		}
+	},
+
+	onEditorKeyUp: function( event ) {
+		if ( event.code === 'AltLeft' || 'AltRight' ) {
+			this.getSelectedText();
+		}
+
+		this.debouncedSaveRawContent();
+	},
+
 	render: function() {
 		const site = this.props.selectedSite || undefined;
 		const mode = this.getEditorMode();
@@ -363,11 +380,15 @@ export const PostEditor = React.createClass( {
 								onSetContent={ this.debouncedSaveRawContent }
 								onInit={ this.onEditorInitialized }
 								onChange={ this.onEditorContentChange }
-								onKeyUp={ this.debouncedSaveRawContent }
+								onKeyUp={ this.onEditorKeyUp }
 								onFocus={ this.onEditorFocus }
+								onMouseUp={ this.getSelectedText }
+								onBlur={ this.getSelectedText }
 								onTextEditorChange={ this.onEditorContentChange } />
 						</div>
-						<EditorWordCount />
+						<EditorWordCount
+							selectedText={ this.state.selectedText }
+						/>
 					</div>
 					<EditorSidebar
 						toggleSidebar={ this.toggleSidebar }
@@ -951,6 +972,10 @@ export const PostEditor = React.createClass( {
 
 		if ( mode === 'html' ) {
 			this.editor.setEditorContent( content );
+
+			if ( this.state.selectedText ) {
+				this.getSelectedText();
+			}
 		}
 
 		this.props.setEditorModePreference( mode );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -240,11 +240,8 @@ export const PostEditor = React.createClass( {
 		}
 	},
 
-	onEditorKeyUp: function( event ) {
-		if ( event.code === 'AltLeft' || 'AltRight' ) {
-			this.getSelectedText();
-		}
-
+	onEditorKeyUp: function() {
+		this.getSelectedText();
 		this.debouncedSaveRawContent();
 	},
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import tinyMCE from 'tinymce/tinymce';
+import tinyMce from 'tinymce/tinymce';
 
 /**
  * Internal dependencies
@@ -22,7 +22,6 @@ const actions = require( 'lib/posts/actions' ),
 	EditorTitle = require( 'post-editor/editor-title' ),
 	EditorPageSlug = require( 'post-editor/editor-page-slug' ),
 	TinyMCE = require( 'components/tinymce' ),
-	EditorWordCount = require( 'post-editor/editor-word-count' ),
 	SegmentedControl = require( 'components/segmented-control' ),
 	SegmentedControlItem = require( 'components/segmented-control/item' ),
 	InvalidURLDialog = require( 'post-editor/invalid-url-dialog' ),
@@ -48,6 +47,7 @@ import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
 import EditorForbidden from 'post-editor/editor-forbidden';
 import EditorNotice from 'post-editor/editor-notice';
+import EditorWordCount from 'post-editor/editor-word-count';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import QueryPreferences from 'components/data/query-preferences';
@@ -215,6 +215,18 @@ export const PostEditor = React.createClass( {
 		}
 	},
 
+	getSelectedText: function() {
+		const selectedText = tinyMce.activeEditor.selection.getContent() || null;
+		if ( this.state.selectedText !== selectedText ) {
+			this.setState( { selectedText: selectedText || null } );
+		}
+	},
+
+	onEditorKeyUp: function() {
+		this.getSelectedText();
+		this.debouncedSaveRawContent();
+	},
+
 	handleConfirmationSidebarPreferenceChange: function( event ) {
 		this.setState( { confirmationSidebarPreference: event.target.checked } );
 	},
@@ -231,18 +243,6 @@ export const PostEditor = React.createClass( {
 			stats.recordStat( 'open-sidebar' );
 			stats.recordEvent( 'Sidebar Toggle', 'open' );
 		}
-	},
-
-	getSelectedText: function() {
-		const selectedText = tinyMCE.activeEditor.selection.getContent() || null;
-		if ( this.state.selectedText !== selectedText ) {
-			this.setState( { selectedText: selectedText || null } );
-		}
-	},
-
-	onEditorKeyUp: function() {
-		this.getSelectedText();
-		this.debouncedSaveRawContent();
 	},
 
 	render: function() {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -125,6 +125,7 @@ export const PostEditor = React.createClass( {
 		this.debouncedAutosave = debounce( this.throttledAutosave, 3000 );
 		this.switchEditorVisualMode = this.switchEditorMode.bind( this, 'tinymce' );
 		this.switchEditorHtmlMode = this.switchEditorMode.bind( this, 'html' );
+		this.debouncedCopySelectedText = debounce( this.copySelectedText, 200 );
 		this.onPreviewClick = this.onPreview.bind( this, 'preview' );
 		this.onViewClick = this.onPreview.bind( this, 'view' );
 		this.useDefaultSidebarFocus();
@@ -164,6 +165,7 @@ export const PostEditor = React.createClass( {
 		this.debouncedAutosave.cancel();
 		this.throttledAutosave.cancel();
 		this.debouncedSaveRawContent.cancel();
+		this.debouncedCopySelectedText.cancel();
 		this._previewWindow = null;
 		clearTimeout( this._switchEditorTimeout );
 	},
@@ -215,7 +217,7 @@ export const PostEditor = React.createClass( {
 		}
 	},
 
-	getSelectedText: function() {
+	copySelectedText: function() {
 		const selectedText = tinyMce.activeEditor.selection.getContent() || null;
 		if ( this.state.selectedText !== selectedText ) {
 			this.setState( { selectedText: selectedText || null } );
@@ -223,7 +225,7 @@ export const PostEditor = React.createClass( {
 	},
 
 	onEditorKeyUp: function() {
-		this.getSelectedText();
+		this.debouncedCopySelectedText();
 		this.debouncedSaveRawContent();
 	},
 
@@ -379,8 +381,8 @@ export const PostEditor = React.createClass( {
 								onChange={ this.onEditorContentChange }
 								onKeyUp={ this.onEditorKeyUp }
 								onFocus={ this.onEditorFocus }
-								onMouseUp={ this.getSelectedText }
-								onBlur={ this.getSelectedText }
+								onMouseUp={ this.copySelectedText }
+								onBlur={ this.copySelectedText }
 								onTextEditorChange={ this.onEditorContentChange } />
 						</div>
 						<EditorWordCount
@@ -971,7 +973,9 @@ export const PostEditor = React.createClass( {
 			this.editor.setEditorContent( content );
 
 			if ( this.state.selectedText ) {
-				this.getSelectedText();
+				// Word count is not available in the HTML mode
+				// This resets the word count if it exists
+				this.copySelectedText();
 			}
 		}
 

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -60,6 +60,7 @@ describe( 'PostEditor', function() {
 		mockery.registerMock( 'post-editor/restore-post-dialog', MOCK_COMPONENT );
 		mockery.registerMock( 'post-editor/editor-sidebar', MOCK_COMPONENT );
 		mockery.registerMock( 'post-editor/editor-status-label', MOCK_COMPONENT );
+		mockery.registerMock( 'tinymce/tinymce', MOCK_COMPONENT );
 		mockery.registerMock( './editor-preview', MOCK_COMPONENT );
 		mockery.registerMock( 'lib/preferences/actions', { set() {} } );
 		mockery.registerMock( 'lib/wp', {


### PR DESCRIPTION
This is an initial attempt at addressing #13488 and adding a word count when text is selected within the editor. Rather than adding an additional word count, which would get confusing, this replaces the existing word count for the entire post with the word count of the current selection when text is highlighted.

You'll notice I moved `this.debouncedSaveRawContent` into a separate call for `this.onEditorKeyUp`. That way, we can check the event to see if text was highlighted with the keyboard. I still need to check the keycodes to make sure they word across all platforms.

This code currently only works in the Visual editor as it doesn't appear as though we load everything in the HTML editor.

## To Test
1. Load this branch and visit the editor.
2. Try selecting text. The word count should change based on your selection. Try clicking out of the text area and then back in (click buttons, title fields, switch editors, etc). The word count should adjust appropriately. Try using your keyboard to select text. Word count should work as intended.

## GIF
![wordcount](https://cloud.githubusercontent.com/assets/7240478/25581256/09c1e5d0-2e44-11e7-8784-1e9faf3feb06.gif)

Addresses: #13488