### PR TITLE
Pages: Move the blog posts block to the top of the Pages page

### DIFF
--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -50,8 +51,8 @@ class BlogPostsPage extends React.Component {
 		if ( isStaticHomePageWithNoPostsPage ) {
 			return (
 				<span>
-					<Gridicon size={ 12 } icon="not-visible" />
-					{ this.props.translate( 'Not in use.' ) }
+					<Gridicon size={ 12 } icon="not-visible" className="blog-posts-page__not-used-icon" />
+					{ this.props.translate( 'Not in use.' ) + ' ' }
 					{
 						this.props.translate( '"%(pageTitle)s" is the front page.', {
 							args: {
@@ -66,6 +67,7 @@ class BlogPostsPage extends React.Component {
 		if ( isCurrentlySetAsHomepage ) {
 			return (
 				<span>
+					<Gridicon size={ 12 } icon="house" className="blog-posts-page__front-page-icon" />
 					{ translate( 'Front page is showing your latest posts.' ) }
 				</span>
 			);
@@ -91,12 +93,18 @@ class BlogPostsPage extends React.Component {
 
 		return (
 			<Card href={ this.getPostsPageLink( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) }
-				target="_blank" rel="noopener noreferrer" className="blog-posts-page">
+				target="_blank" rel="noopener noreferrer" className="blog-posts-page" >
 				<div className="blog-posts-page__details">
-					<div className="blog-posts-page__title">
+					<div className={ classNames( {
+						'blog-posts-page__title': true,
+						'is-disabled': isStaticHomePageWithNoPostsPage,
+					} ) } >
 						{ translate( 'Blog Posts' ) }
 					</div>
-					<div className="blog-posts-page__info">
+					<div className={ classNames( {
+						'blog-posts-page__info': true,
+						'is-disabled': isStaticHomePageWithNoPostsPage,
+					} ) } >
 						{ this.renderPostsPageInfo( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) }
 					</div>
 				</div>

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -1,31 +1,16 @@
 .blog-posts-page {
 	display: flex;
 	align-items: center;
+	padding: 16px 24px;
 }
 
-.blog-posts-page__home-badge {
-	flex: 0 0 auto;
-	margin: 2px 8px 0 0;
-	color: $gray;
-	align-self: flex-start;
-}
-
-.blog-posts-page__not-used-badge {
-	flex: 0 0 auto;
-	margin: 0 24px 0 0;
-	padding: 5px 16px;
-	background-color: $gray;
-	border-radius: 3px;
-	color: $white;
-	font-size: 12px;
+.blog-posts-page__front-page-icon,
+.blog-posts-page__not-used-icon {
+	margin-right: 6px;
 }
 
 .blog-posts-page__details {
 	flex: 1 1 auto;
-}
-
-.blog-posts-page__actions {
-	flex: 0 0 auto;
 }
 
 .blog-posts-page__title {
@@ -34,10 +19,18 @@
 	font-weight: 500;
 	font-family: $serif;
 	margin-right: 33px;
+
+	&.is-disabled {
+		color: $gray;
+	}
 }
 
 .blog-posts-page__info {
 	color: $gray;
 	font-size: 12px;
 	margin: 0 33px 0 0;
+
+	&.is-disabled {
+		color: lighten( $gray, 10% );
+	}
 }

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -19,6 +19,8 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	mapStatus = require( 'lib/route' ).mapPostStatus,
 	sortPagesHierarchically = require( './helpers' ).sortPagesHierarchically;
 
+import BlogPostsPage from './blog-posts-page';
+
 var PageList = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
@@ -235,12 +237,13 @@ var Pages = React.createClass( {
 
 		return (
 			<div id="pages" className="page-list">
+				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 				{ rows }
 			</div>
 		);
 	},
 
-	renderChronological: function( { pages } ) {
+	renderChronological: function( { pages, site } ) {
 		if ( ! this.props.search ) {
 			// we're listing in reverse chrono. use the markers.
 			pages = this._insertTimeMarkers( pages );
@@ -262,8 +265,13 @@ var Pages = React.createClass( {
 			this.addLoadingRows( rows, 1 );
 		}
 
+		const blogPostsPage = ( site && status === 'published' ) && (
+			<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
+		);
+
 		return (
 			<div id="pages" className="page-list">
+				{ blogPostsPage }
 				{ rows }
 				{ this.props.lastPage && pages.length ? <div className="infinite-scroll-end" /> : null }
 			</div>


### PR DESCRIPTION
This PR moves the blog-posts block to the top of the Pages page, and updates the styles in preparation for hierarchical pages.

![image](https://cloud.githubusercontent.com/assets/363749/25591913/20ae8e3c-2e7c-11e7-8830-7ed18af1c750.png)

To test:

* Make sure the scenarios appear correct and make sense (the first image is the wp-admin setting, the second is the blog posts block from this PR)

**Scenario 1**

![image](https://cloud.githubusercontent.com/assets/363749/25591896/0e4e4e26-2e7c-11e7-928f-4eb91335b16c.png)

![image](https://cloud.githubusercontent.com/assets/363749/25591924/2d4239b4-2e7c-11e7-9f71-a0c4abd4a49a.png)

**Scenario 2**

![image](https://cloud.githubusercontent.com/assets/363749/25591941/3d6d1e58-2e7c-11e7-892a-ebe3fb1d5c31.png)

![image](https://cloud.githubusercontent.com/assets/363749/25592036/ba0aff20-2e7c-11e7-80e7-cc18debfa0c2.png)


**Scenario 3**

![image](https://cloud.githubusercontent.com/assets/363749/25591975/60e9a856-2e7c-11e7-915e-6f7a48ea9f19.png)

![image](https://cloud.githubusercontent.com/assets/363749/25591998/8a652b60-2e7c-11e7-931c-2ab9f10094ec.png)

**Scenario 4**
![image](https://cloud.githubusercontent.com/assets/363749/25592012/98005a60-2e7c-11e7-840e-1c91bac14715.png)

![image](https://cloud.githubusercontent.com/assets/363749/25591998/8a652b60-2e7c-11e7-931c-2ab9f10094ec.png)

