### PR TITLE
Purchases: Update manage purchase design

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import {
+	isJetpackPlan,
 	isDomainRegistration,
 	isPlan,
 	isTheme
@@ -55,6 +56,10 @@ function getPurchasesBySite( purchases, sites ) {
 function getName( purchase ) {
 	if ( isDomainRegistration( purchase ) ) {
 		return purchase.meta;
+	}
+
+	if ( isJetpackPlan( purchase ) ) {
+		return `Jetpack ${ purchase.productName }`;
 	}
 
 	return purchase.productName;

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -292,6 +292,25 @@ class ManagePurchase extends Component {
 		return null;
 	}
 
+	renderPlanDescription() {
+		const purchase = getPurchase( this.props );
+		if ( ! isPlan( purchase ) ) {
+			return null;
+		}
+
+		const { plan, selectedSite } = this.props;
+		return (
+			<div className="manage-purchase__content">
+				<span className="manage-purchase__description">
+					{ plan.getDescription() }
+				</span>
+				<span className="manage-purchase__settings-link">
+					<ProductLink selectedPurchase={ purchase } selectedSite={ selectedSite } />
+				</span>
+			</div>
+		);
+	}
+
 	renderPlaceholder() {
 		return (
 			<div>
@@ -319,7 +338,7 @@ class ManagePurchase extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const { plan, selectedSiteId, selectedSite, selectedPurchase } = this.props;
+		const { selectedSiteId, selectedSite, selectedPurchase } = this.props;
 		const purchase = getPurchase( this.props );
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
@@ -346,17 +365,7 @@ class ManagePurchase extends Component {
 							<PlanPrice rawPrice={ purchase.amount } currencyCode={ purchase.currencyCode } />
 						</div>
 					</header>
-					<div className="manage-purchase__content">
-						<span className="manage-purchase__description">
-							{ isPlan( purchase )
-								? plan.getDescription()
-								: null
-							}
-						</span>
-						<span className="manage-purchase__settings-link">
-							<ProductLink selectedPurchase={ purchase } selectedSite={ selectedSite } />
-						</span>
-					</div>
+					{ this.renderPlanDescription() }
 
 					<PurchaseMeta purchaseId={ selectedPurchase.id } />
 
@@ -414,13 +423,14 @@ class ManagePurchase extends Component {
 export default connect(
 	( state, props ) => {
 		const selectedPurchase = getByPurchaseId( state, props.purchaseId );
+		const isPurchasePlan = selectedPurchase && isPlan( selectedPurchase );
 		return {
 			hasLoadedSites: ! isRequestingSites( state ),
 			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 			selectedPurchase,
 			selectedSite: getSelectedSiteSelector( state ),
 			selectedSiteId: getSelectedSiteId( state ),
-			plan: selectedPurchase && applyTestFiltersToPlansList( selectedPurchase.productSlug, abtest ),
+			plan: isPurchasePlan && applyTestFiltersToPlansList( selectedPurchase.productSlug, abtest ),
 		};
 	}
 )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -317,10 +317,14 @@ class ManagePurchase extends Component {
 				<PurchaseSiteHeader isPlaceholder />
 				<Card className="manage-purchase__info is-placeholder">
 					<header className="manage-purchase__header">
-						<strong className="manage-purchase__content manage-purchase__title" />
-						<span className="manage-purchase__content manage-purchase__subtitle" />
-						<span className="manage-purchase__content manage-purchase__settings-link" />
+						<div className="manage-purchase__plan-icon" />
+						<strong className="manage-purchase__title" />
+						<span className="manage-purchase__subtitle" />
 					</header>
+					<div className="manage-purchase__content">
+						<span className="manage-purchase__description" />
+						<span className="manage-purchase__settings-link" />
+					</div>
 
 					<PurchaseMeta purchaseId={ false } />
 				</Card>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -31,6 +31,7 @@ import {
 	isRenewal,
 	isRenewing,
 	isSubscription,
+	purchaseType,
 } from 'lib/purchases';
 import {
 	canEditPaymentDetails,
@@ -303,15 +304,15 @@ class ManagePurchase extends Component {
 
 	renderPlanDescription() {
 		const purchase = getPurchase( this.props );
-		if ( ! isPlan( purchase ) ) {
-			return null;
-		}
-
 		const { plan, selectedSite } = this.props;
+
 		return (
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">
-					{ plan.getDescription() }
+					{ ( isPlan( purchase ) )
+						? plan.getDescription()
+						: purchaseType( purchase )
+					}
 				</span>
 				<span className="manage-purchase__settings-link">
 					<ProductLink selectedPurchase={ purchase } selectedSite={ selectedSite } />

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -57,6 +57,7 @@ import {
 	isPlan,
 	isDomainProduct,
 	isDomainRegistration,
+	isDomainMapping,
 	isTheme,
 } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
@@ -306,13 +307,23 @@ class ManagePurchase extends Component {
 
 	renderPlanDescription() {
 		const purchase = getPurchase( this.props );
-		const { plan, selectedSite, theme } = this.props;
+		const { plan, selectedSite, theme, translate } = this.props;
 
 		let description = purchaseType( purchase );
 		if ( isPlan( purchase ) ) {
 			description = plan.getDescription();
 		} else if ( isTheme( purchase ) && theme ) {
 			description = theme.description;
+		} else if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
+			description = translate(
+				'Replaces your site\'s free address with the domain %(domain)s, ' +
+				'making it easier to remember and easier to share.',
+				{
+					args: {
+						domain: selectedSite.domain,
+					}
+				}
+			);
 		}
 
 		return (

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -54,7 +54,8 @@ import {
 	isBusiness,
 	isPlan,
 	isDomainProduct,
-	isDomainRegistration
+	isDomainRegistration,
+	isTheme,
 } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
@@ -285,6 +286,14 @@ class ManagePurchase extends Component {
 			return (
 				<div className="manage-purchase__plan-icon">
 					<Gridicon icon="domains" size={ 54 } />
+				</div>
+			);
+		}
+
+		if ( isTheme( purchase ) ) {
+			return (
+				<div className="manage-purchase__plan-icon">
+					<Gridicon icon="themes" size={ 54 } />
 				</div>
 			);
 		}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import React from 'react';
+import React, { Component } from 'react';
 
 /**
  * Internal Dependencies
@@ -65,8 +65,8 @@ import * as upgradesActions from 'lib/upgrades/actions';
 
 const user = userFactory();
 
-const ManagePurchase = React.createClass( {
-	propTypes: {
+class ManagePurchase extends Component {
+	static propTypes = {
 		destinationType: React.PropTypes.string,
 		hasLoadedSites: React.PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
@@ -76,7 +76,7 @@ const ManagePurchase = React.createClass( {
 			React.PropTypes.bool,
 			React.PropTypes.undefined
 		] )
-	},
+	}
 
 	componentWillMount() {
 		if ( ! this.isDataValid() ) {
@@ -85,7 +85,7 @@ const ManagePurchase = React.createClass( {
 		}
 
 		recordPageView( 'manage', this.props );
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
@@ -94,7 +94,7 @@ const ManagePurchase = React.createClass( {
 		}
 
 		recordPageView( 'manage', this.props, nextProps );
-	},
+	}
 
 	isDataValid( props = this.props ) {
 		if ( isDataLoading( props ) ) {
@@ -102,7 +102,7 @@ const ManagePurchase = React.createClass( {
 		}
 
 		return Boolean( getPurchase( props ) );
-	},
+	}
 
 	handleRenew() {
 		const purchase = getPurchase( this.props ),
@@ -142,13 +142,17 @@ const ManagePurchase = React.createClass( {
 		upgradesActions.addItems( renewItems );
 
 		page( '/checkout/' + this.props.selectedSite.slug );
-	},
+	}
 
 	renderRenewButton() {
 		const purchase = getPurchase( this.props );
 		const { translate } = this.props;
 
-		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! isRenewable( purchase ) || isExpired( purchase ) || isExpiring( purchase ) || ! getSelectedSite( this.props ) ) {
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return null;
+		}
+
+		if ( ! isRenewable( purchase ) || isExpired( purchase ) || isExpiring( purchase ) || ! getSelectedSite( this.props ) ) {
 			return null;
 		}
 
@@ -157,7 +161,7 @@ const ManagePurchase = React.createClass( {
 				{ translate( 'Renew Now' ) }
 			</Button>
 		);
-	},
+	}
 
 	renderPlanDetails() {
 		if ( ! config.isEnabled( 'me/purchases-v2' ) ) {
@@ -170,7 +174,7 @@ const ManagePurchase = React.createClass( {
 				purchaseId={ this.props.purchaseId }
 			/>
 		);
-	},
+	}
 
 	renderEditPaymentMethodNavItem() {
 		const purchase = getPurchase( this.props );
@@ -193,7 +197,7 @@ const ManagePurchase = React.createClass( {
 		}
 
 		return null;
-	},
+	}
 
 	renderCancelPurchaseNavItem() {
 		const purchase = getPurchase( this.props ),
@@ -238,7 +242,7 @@ const ManagePurchase = React.createClass( {
 				{ text }
 			</CompactCard>
 		);
-	},
+	}
 
 	renderCancelPrivacyProtection() {
 		const purchase = getPurchase( this.props ),
@@ -254,73 +258,73 @@ const ManagePurchase = React.createClass( {
 				{ translate( 'Cancel Privacy Protection' ) }
 			</CompactCard>
 		);
-	},
+	}
+
+	renderPlaceholder() {
+		return (
+			<div>
+				<PurchaseSiteHeader isPlaceholder />
+				<Card className="manage-purchase__info is-placeholder">
+					<header className="manage-purchase__header">
+						<strong className="manage-purchase__content manage-purchase__title" />
+						<span className="manage-purchase__content manage-purchase__subtitle" />
+						<span className="manage-purchase__content manage-purchase__settings-link" />
+					</header>
+
+					<PurchaseMeta purchaseId={ false } />
+				</Card>
+
+				{ this.renderPlanDetails() }
+
+				<VerticalNavItem isPlaceholder />
+				<VerticalNavItem isPlaceholder />
+			</div>
+		);
+	}
 
 	renderPurchaseDetail() {
-		let classes,
-			purchase,
-			purchaseTypeSeparator,
-			purchaseTitleText,
-			purchaseTypeText,
-			siteName,
-			siteDomain,
-			productLink,
-			renewButton,
-			editPaymentMethodNavItem,
-			cancelPurchaseNavItem,
-			cancelPrivacyProtectionNavItem;
-
 		if ( isDataLoading( this.props ) ) {
-			classes = 'manage-purchase__info is-placeholder';
-			editPaymentMethodNavItem = <VerticalNavItem isPlaceholder />;
-			cancelPurchaseNavItem = <VerticalNavItem isPlaceholder />;
-		} else {
-			purchase = getPurchase( this.props );
-			classes = classNames( 'manage-purchase__info', {
-				'is-expired': purchase && isExpired( purchase )
-			} );
-			purchaseTypeSeparator = purchaseType( purchase ) ? '|' : '';
-			purchaseTitleText = getName( purchase );
-			purchaseTypeText = purchaseType( purchase );
-			siteName = purchase.siteName;
-			siteDomain = purchase.domain;
-			productLink = (
-				<ProductLink selectedPurchase={ purchase } selectedSite={ this.props.selectedSite } />
-			);
-			renewButton = this.renderRenewButton();
-			editPaymentMethodNavItem = this.renderEditPaymentMethodNavItem();
-			cancelPurchaseNavItem = this.renderCancelPurchaseNavItem();
-			cancelPrivacyProtectionNavItem = this.renderCancelPrivacyProtection();
+			return this.renderPlaceholder();
 		}
+
+		const purchase = getPurchase( this.props );
+		const classes = classNames( 'manage-purchase__info', {
+			'is-expired': purchase && isExpired( purchase )
+		} );
+		const purchaseTypeSeparator = purchaseType( purchase ) ? '|' : '';
+		const purchaseTypeText = purchaseType( purchase );
+		const siteName = purchase.siteName;
+		const siteDomain = purchase.domain;
 
 		return (
 			<div>
 				<PurchaseSiteHeader
 					siteId={ this.props.selectedSiteId }
 					name={ siteName }
-					domain={ siteDomain }
-					isPlaceholder={ isDataLoading( this.props ) } />
+					domain={ siteDomain } />
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
-						<strong className="manage-purchase__content manage-purchase__title">{ purchaseTitleText }</strong>
+						<strong className="manage-purchase__content manage-purchase__title">
+							{ getName( purchase ) }
+						</strong>
 						<span className="manage-purchase__content manage-purchase__subtitle">
 							{ purchaseTypeText } { purchaseTypeSeparator } { siteName ? siteName : siteDomain }
 						</span>
 						<span className="manage-purchase__content manage-purchase__settings-link">
-							{ productLink }
+							<ProductLink selectedPurchase={ purchase } selectedSite={ this.props.selectedSite } />
 						</span>
 					</header>
 
-					<PurchaseMeta purchaseId={ isDataLoading( this.props ) ? false : this.props.selectedPurchase.id } />
+					<PurchaseMeta purchaseId={ this.props.selectedPurchase.id } />
 
-					{ renewButton }
+					{ this.renderRenewButton() }
 				</Card>
 
 				{ this.renderPlanDetails() }
 
-				{ editPaymentMethodNavItem }
-				{ cancelPurchaseNavItem }
-				{ cancelPrivacyProtectionNavItem }
+				{ this.renderEditPaymentMethodNavItem() }
+				{ this.renderCancelPurchaseNavItem() }
+				{ this.renderCancelPrivacyProtection() }
 
 				<RemovePurchase
 					hasLoadedSites={ this.props.hasLoadedSites }
@@ -330,22 +334,24 @@ const ManagePurchase = React.createClass( {
 				/>
 			</div>
 		);
-	},
+	}
 
 	render() {
 		if ( ! this.isDataValid() ) {
 			return null;
 		}
 		const { selectedSite, selectedPurchase } = this.props;
-		let editCardDetailsPath;
-		if ( ! isDataLoading( this.props ) && selectedSite ) {
-			editCardDetailsPath = canEditPaymentDetails( selectedPurchase ) && getEditCardDetailsPath( selectedSite, selectedPurchase );
+		const classes = 'manage-purchase';
+
+		let editCardDetailsPath = false;
+		if ( ! isDataLoading( this.props ) && selectedSite && canEditPaymentDetails( selectedPurchase ) ) {
+			editCardDetailsPath = getEditCardDetailsPath( selectedSite, selectedPurchase );
 		}
 
 		return (
 			<span>
 				<QueryUserPurchases userId={ user.get().ID } />
-				<Main className="manage-purchase">
+				<Main className={ classes }>
 					<HeaderCake onClick={ goToList }>
 						{ titles.managePurchase }
 					</HeaderCake>
@@ -360,7 +366,7 @@ const ManagePurchase = React.createClass( {
 			</span>
 		);
 	}
-} );
+}
 
 export default connect(
 	( state, props ) => ( {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -381,6 +381,9 @@ class ManagePurchase extends Component {
 						<h2 className="manage-purchase__title">
 							{ getName( purchase ) }
 						</h2>
+						<div className="manage-purchase__description">
+							{ purchaseType( purchase ) }
+						</div>
 						<div className="manage-purchase__price">
 							<PlanPrice rawPrice={ purchase.amount } currencyCode={ purchase.currencyCode } />
 						</div>

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -17,7 +17,7 @@ import SectionHeader from 'components/section-header';
 import { isRequestingSites } from 'state/sites/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getPurchase, isDataLoading } from 'me/purchases/utils';
-import { getName } from 'lib/purchases';
+import { getName, isExpired } from 'lib/purchases';
 import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
 import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
@@ -40,6 +40,10 @@ class PurchasePlanDetails extends Component {
 		}
 
 		if ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) {
+			return null;
+		}
+
+		if ( isExpired( purchase ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -180,7 +180,7 @@ class PurchaseMeta extends Component {
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			return (
-				<span className="manage-purchase__content manage-purchase__detail">
+				<span className="manage-purchase__detail">
 					{ translate( 'Included with plan' ) }
 				</span>
 			);
@@ -200,7 +200,7 @@ class PurchaseMeta extends Component {
 			}
 
 			return (
-				<span className="manage-purchase__content manage-purchase__detail">
+				<span className="manage-purchase__detail">
 					<PaymentLogo type={ paymentLogoType( purchase ) } />
 					{ paymentInfo }
 				</span>
@@ -208,7 +208,7 @@ class PurchaseMeta extends Component {
 		}
 
 		return (
-			<span className="manage-purchase__content manage-purchase__detail">
+			<span className="manage-purchase__detail">
 				{ translate( 'None' ) }
 			</span>
 		);
@@ -224,7 +224,7 @@ class PurchaseMeta extends Component {
 
 		const paymentDetails = (
 			<span>
-				<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
+				<em className="manage-purchase__detail-label">{ translate( 'Payment method' ) }</em>
 				{ this.renderPaymentInfo() }
 			</span>
 		);
@@ -280,8 +280,8 @@ class PurchaseMeta extends Component {
 
 		return (
 			<li>
-				<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
-				<span className="manage-purchase__content manage-purchase__detail">
+				<em className="manage-purchase__detail-label">{ translate( 'Owner' ) }</em>
+				<span className="manage-purchase__detail">
 					<UserItem user={ { ...owner, name: owner.display_name } } />
 				</span>
 			</li>
@@ -315,12 +315,12 @@ class PurchaseMeta extends Component {
 				<ul className="manage-purchase__meta">
 					{ this.renderOwner() }
 					<li>
-						<em className="manage-purchase__content manage-purchase__detail-label">{ translate( 'Price' ) }</em>
-						<span className="manage-purchase__content manage-purchase__detail">{ this.renderPrice() }</span>
+						<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
+						<span className="manage-purchase__detail">{ this.renderPrice() }</span>
 					</li>
 					<li>
-						<em className="manage-purchase__content manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
-						<span className="manage-purchase__content manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
+						<em className="manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
+						<span className="manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
 					</li>
 					{ this.renderPaymentDetails() }
 				</ul>

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -294,8 +294,8 @@ class PurchaseMeta extends Component {
 				{
 					times( 4, ( i ) => (
 						<li key={ i }>
-							<em className="manage-purchase__content manage-purchase__detail-label" />
-							<span className="manage-purchase__content manage-purchase__detail" />
+							<em className="manage-purchase__detail-label" />
+							<span className="manage-purchase__detail" />
 						</li>
 					) )
 				}

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -151,7 +151,6 @@
 
 .manage-purchase__price .plan-price {
 	clear: none;
-	margin-top: -6px;
 }
 
 .manage-purchase__description {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -1,16 +1,20 @@
 .manage-purchase__info {
 	font-size: 13px;
-	padding: 16px;
+	padding: 0;
 
 	@include breakpoint ( ">660px" ) {
 		font-size: 14px;
-		padding: 16px 24px;
+		padding: 0;
 	}
 
 	&.is-expired {
 		background: $gray-light;
 
-		.manage-purchase__content {
+		.manage-purchase__header,
+		.manage-purchase__content,
+		.manage-purchase__detail-label,
+		.manage-purchase__detail,
+		.manage-purchase__detail .user {
 			opacity: .6;
 		}
 	}
@@ -70,64 +74,92 @@
 	}
 }
 
+.manage-purchase__header,
+.manage-purchase__content {
+	padding: 16px 24px;
+
+	@include breakpoint( "<660px" ) {
+		padding: 16px;
+	}
+}
+
 .manage-purchase__header {
 	overflow: auto;
-	padding: 0 0 16px 0;
+	border-width: 0 0 2px;
+	border-style: solid;
+
+	.is-personal & {
+		border-color: $alert-yellow;
+	}
+
+	.is-premium & {
+		border-color: $alert-green;
+	}
+
+	.is-business & {
+		border-color: $alert-purple;
+	}
+}
+
+.manage-purchase__plan-icon {
+	margin: 0 12px 0 0;
+	max-width: 56px;
+	width: 56px;
+	float: left;
+
+	.gridicons-domains {
+		padding: 4px;
+		border-radius: 50%;
+		background: $blue-medium;
+		fill: $white;
+	}
 }
 
 .manage-purchase__title {
-	color: $gray-dark;
+	color: $blue-wordpress;
 	display: block;
 	font-size: 18px;
 	font-weight: 400;
+	clear: none;
 
 	@include breakpoint( ">660px" ) {
-		font-family: $serif;
-		font-size: 24px;
-		font-weight: 700;
+		font-size: 22px;
 		padding-right: 100px;
 	}
 }
 
-.manage-purchase__subtitle {
-	color: darken( $gray, 10% );
+.manage-purchase__price .plan-price {
+	clear: none;
+	margin-top: -6px;
+}
+
+.manage-purchase__description {
+	color: $gray-text-min;
 	display: block;
-	font-size: 11px;
-	text-transform: uppercase;
 }
 
 .manage-purchase__settings-link {
-	font-size: 13px;
-	line-height: 1.75em;
-
-	.gridicon {
-		position: relative;
-		top: 2px;
-		left: 3px;
-		color: $gray;
-	}
+	display: block;
+	margin-top: 16px;
 }
 
 .manage-purchase__meta,
 .manage-purchase__contact-support {
-	margin: 0 -24px;
 	padding: 0 24px;
 	border-top: 1px solid lighten( $gray, 30% );
 
 	@include breakpoint( "<660px" ) {
-		margin: 0 -16px;
 		padding: 0 16px;
 	}
 }
 
 .manage-purchase__meta {
 	display: flex;
-	margin-bottom: -16px;
+	margin: 0;
 	list-style: none;
 	overflow: auto;
 
 	@include breakpoint( "<660px" ) {
-		margin-bottom: 0;
 		flex-direction: column;
 	}
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -85,19 +85,17 @@
 
 .manage-purchase__header {
 	overflow: auto;
-	border-width: 0 0 2px;
-	border-style: solid;
 
 	.is-personal & {
-		border-color: $alert-yellow;
+		border-bottom: 2px solid $alert-yellow;
 	}
 
 	.is-premium & {
-		border-color: $alert-green;
+		border-bottom: 2px solid $alert-green;
 	}
 
 	.is-business & {
-		border-color: $alert-purple;
+		border-bottom: 2px solid $alert-purple;
 	}
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -122,11 +122,16 @@
 	width: 56px;
 	float: left;
 
-	.gridicons-domains {
+	.gridicon {
+		box-sizing: border-box;
 		padding: 4px;
 		border-radius: 50%;
 		background: $blue-medium;
 		fill: $white;
+	}
+
+	.gridicons-themes {
+		border-radius: 8px;
 	}
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -102,6 +102,7 @@
 
 .manage-purchase__header {
 	overflow: auto;
+	border-bottom: 2px solid $blue-medium;
 
 	.is-personal & {
 		border-bottom: 2px solid $alert-yellow;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -28,15 +28,31 @@
 	}
 
 	&.is-placeholder {
-		.manage-purchase__content {
+		.manage-purchase__plan-icon,
+		.manage-purchase__title,
+		.manage-purchase__subtitle,
+		.manage-purchase__description,
+		.manage-purchase__settings-link,
+		.manage-purchase__detail-label,
+		.manage-purchase__detail {
 			@include placeholder( 23% );
 
 			display: block;
 		}
 
+		.manage-purchase__plan-icon {
+			height: 56px;
+			border-radius: 50%;
+		}
+
+		.manage-purchase__header {
+			border-bottom: 2px solid $gray-light;
+		}
+
 		.manage-purchase__subtitle,
 		.manage-purchase__title {
 			margin-bottom: 3px;
+			margin-left: 64px;
 		}
 
 		.manage-purchase__detail-label {
@@ -56,6 +72,7 @@
 		}
 
 		@include breakpoint( ">660px" ) {
+			.manage-purchase__description,
 			.manage-purchase__detail,
 			.manage-purchase__detail-label {
 				height: 40px;
@@ -159,6 +176,7 @@
 
 	@include breakpoint( "<660px" ) {
 		flex-direction: column;
+		padding-bottom: 16px;
 	}
 
 	li {


### PR DESCRIPTION
See #12746, implementing a new design for the Purchases section. This PR implements the new design for the main area of the single purchase view.

![screen shot 2017-05-01 at 1 43 13 pm](https://cloud.githubusercontent.com/assets/541093/25587933/378b5bb0-2e74-11e7-9def-73f3f3c38c1e.png)

There have been no functionality changes, only added data to this page to display the plan info, slight code restructuring, and some linting cleanup.

To test:

1. Visit `/me/purchases`
2. Check a wp.com plan purchase
3. Check a Jetpack plan purchase
4. Check a domain mapping purchase

And any other purchases you may have on your account