### PR TITLE
Evaulated a/b test variant last to ensure all participants qualify

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
@@ -17,10 +17,11 @@ import {
 
 export default function stepsForProductAndSurvey( survey, product, canChat ) {
 	if ( survey && survey.questionOneRadio === 'tooHard' ) {
-		if ( abtest( 'conciergeOfferOnCancel' ) === 'showConciergeOffer' && includesProduct( [ PLAN_BUSINESS ], product ) ) {
+		if ( includesProduct( [ PLAN_BUSINESS ], product ) && abtest( 'conciergeOfferOnCancel' ) === 'showConciergeOffer' ) {
 			return [ INITIAL_STEP, CONCIERGE_STEP, FINAL_STEP ];
 		}
-		if ( canChat && abtest( 'chatOfferOnCancel' ) === 'show' && includesProduct( [ PLAN_PERSONAL, PLAN_PREMIUM ], product ) ) {
+
+		if ( canChat && includesProduct( [ PLAN_PERSONAL, PLAN_PREMIUM ], product ) && abtest( 'chatOfferOnCancel' ) === 'show' ) {
 			return [ INITIAL_STEP, HAPPYCHAT_STEP, FINAL_STEP ];
 		}
 	}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,5 +82,6 @@ module.exports = {
 			hide: 50,
 		},
 		defaultVariation: 'show',
+		allowExistingUsers: true,
 	},
 };


### PR DESCRIPTION
This change reorders the evaluation of conditions for participation in the current cancellation survey a/b tests.

Previously some users would be allocated to a variant when they may not have qualified for the test.

# Testing

* log in as a user with a personal or premium plan
* ensure an operator is available in happychat staging
* Browse to `/me/purchases`
* enable a/b test debug info in console `localStorage.setItem('debug', 'calypso:abtests');`
* start the cancellation process selecting 'too hard' as the answer for the  first question (and anything for the second question)
* you should see a chatOfferOnCancel abtest
* you should *not* see conciergeOfferOnCancel abtest