### PR TITLE
Reader: Fix aliased text in Search suggestions

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -24,7 +24,7 @@
 	top: 0;
 	padding-top: 47px;
 	z-index: 20;
-	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements aliasing in Safari
+	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 
 	@include breakpoint( ">660px" ) {
 		padding-top: 77px;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -24,6 +24,7 @@
 	top: 0;
 	padding-top: 47px;
 	z-index: 20;
+	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements aliasing in Safari
 
 	@include breakpoint( ">660px" ) {
 		padding-top: 77px;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/12649

Initially, I thought this was caused by a class that's being added to the suggestions in Search. But apparently, this is a known issue in Safari for text that's within a fixed element.

**Before:**
<img width="320" alt="screenshot 2017-05-01 14 35 09" src="https://cloud.githubusercontent.com/assets/4924246/25596123/7a5df67a-2e7c-11e7-8775-e40f7a062170.png">

**After:**
<img width="255" alt="screenshot 2017-05-01 14 35 16" src="https://cloud.githubusercontent.com/assets/4924246/25596132/80641dce-2e7c-11e7-96a8-ba6266d42191.png">
