### PR TITLE
Jetpack Plans: Remove an incorrect FAQ entry.

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -160,14 +160,6 @@ class PlansFeaturesMain extends Component {
 				/>
 
 				<FAQItem
-					question={ translate( 'Can I migrate my subscription to a different site?' ) }
-					answer={ translate(
-						'Absolutely. You are always free to activate your premium services on a different' +
-						' WordPress site.'
-					) }
-				/>
-
-				<FAQItem
 					question={ translate( 'What is the cancellation policy?' ) }
 					answer={ translate(
 						'You can request a cancellation within 30 days of purchase and receive a full refund.'


### PR DESCRIPTION
This change simply removes one of the FAQ entries from the Jetpack
Plans comparison page. The entry in question (“Can I migrate my
subscription to a different site?”) is unfortunately currently
incorrect, so it needs to be removed. Once proper subscription
migration is in place, we can certainly add it back into the mix.

To test:

1) Go to the /plans/ page for a Jetpack site.
2) Confirm that the entry in question is no longer visible.
3) Go to the /plans/ page for a WordPress.com site.
4) Confirm that nothing has been changed.