### PR TITLE
State: opt-in to persistence part 2

### DIFF
--- a/bin/codemods/combine-reducer-with-persistence
+++ b/bin/codemods/combine-reducer-with-persistence
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/*
+	This codemod converts combineReducers imports to use combineReducersWithPersistence
+
+	How to use:
+	./bin/codemods/combine-reducer-with-persistence path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const helpers = require( './helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=bin/codemods/src/combine-reducer-with-persistence.js',
+	...config.jscodeshiftArgs,
+
+	// Transform target
+	args[ 0 ],
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/bin/codemods/combine-state-utils-imports
+++ b/bin/codemods/combine-state-utils-imports
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/*
+	This codemod combines state/utils imports
+
+	How to use:
+	./bin/codemods/combine-state-utils-imports path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const helpers = require( './helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=bin/codemods/src/combine-state-utils-imports.js',
+	...config.jscodeshiftArgs,
+
+	// Transform target
+	args[ 0 ],
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/bin/codemods/src/combine-reducer-with-persistence.js
+++ b/bin/codemods/src/combine-reducer-with-persistence.js
@@ -1,0 +1,78 @@
+/*
+ This codemod updates
+
+ import { combineReducers } from 'redux'; to
+ import { combineReducersWithPersistence } from 'state/utils';
+
+ and updates
+
+ combineReducers( {
+    //...
+ } )
+
+ with
+
+ combineReducersWithPersistence( {
+    //...
+ } )
+ */
+
+module.exports = function ( file, api ) {
+	// alias the jscodeshift API
+	const j = api.jscodeshift;
+	// parse JS code into an AST
+	const root = j( file.source );
+
+	//remove combineReducer import
+	const combineReducerImport = root.find( j.ImportDeclaration, {
+		source: {
+			type: 'Literal',
+			value: 'redux',
+		},
+	} ).filter( ( importDeclaration ) => {
+		if ( importDeclaration.value.specifiers.length === 1 ) {
+			return importDeclaration.value.specifiers[ 0 ].imported.name === 'combineReducers';
+		}
+		return false;
+	} );
+
+	if ( ! combineReducerImport.length ) {
+		return;
+	}
+
+	combineReducerImport.remove();
+
+	// find the first external import
+	const firstInternalImport = root.find( j.ImportDeclaration ).filter( ( item ) => {
+		if ( item.node.comments && item.node.comments.length > 0 ) {
+			return item.node.comments[ 0 ].value.match( /Internal dependencies/ );
+		}
+		return false;
+	} );
+
+	const combineReducersImport = () => {
+		return j.importDeclaration(
+			[
+				j.importSpecifier(
+					j.identifier( 'combineReducersWithPersistence' ),
+				)
+			],
+			j.literal( 'state/utils' )
+		);
+	};
+	//note the extra whitespace coming from https://github.com/benjamn/recast/issues/371
+	firstInternalImport.insertAfter( combineReducersImport );
+
+	//update combineReducers call
+	const renameIdentifier = ( newName ) => imported => {
+		j( imported ).replaceWith( () => j.identifier( newName ) );
+	};
+	const combineReducerIdentifier = root.find( j.CallExpression ).find( j.Identifier ).filter(
+		( identifier ) => identifier.value.name === 'combineReducers'
+	);
+
+	combineReducerIdentifier.forEach( renameIdentifier( 'combineReducersWithPersistence' ) );
+
+	// print
+	return root.toSource( { quote: 'single' } );
+};

--- a/bin/codemods/src/combine-state-utils-imports.js
+++ b/bin/codemods/src/combine-state-utils-imports.js
@@ -1,0 +1,78 @@
+/*
+ This codemod updates
+
+ import { createReducer } from 'state/utils';
+ import { combineReducersWithPersistence as bar, baz } from 'state/utils'
+
+ to
+
+ import { baz, combineReducersWithPersistence as bar, createReducer } from 'state/utils';
+ */
+
+module.exports = function ( file, api ) {
+	// alias the jscodeshift API
+	const j = api.jscodeshift;
+	// parse JS code into an AST
+	const root = j( file.source );
+
+	const stateUtilsImports = root.find( j.ImportDeclaration, {
+		source: {
+			type: 'Literal',
+			value: 'state/utils',
+		},
+	} );
+
+	if ( stateUtilsImports.length < 2 ) {
+		return;
+	}
+
+	//grab each identifier
+	const importNames = [];
+	stateUtilsImports.find( j.ImportSpecifier ).forEach( item => {
+		importNames.push( {
+			local: item.value.local.name,
+			imported: item.value.imported.name
+		} );
+	} );
+
+	//sort by imported name
+	importNames.sort(( a, b ) => {
+		if( a.imported < b.imported ) {
+			return -1;
+		}
+		if( a.imported > b.imported ) {
+			return 1;
+		}
+		return 0;
+	} );
+
+	//Save Comment if possible
+	const comments = stateUtilsImports.at( 0 ).get().node.comments;
+
+	const addImport = ( importNames ) => {
+		const names = importNames.map( name => {
+			if ( name.local === name.imported ) {
+				return j.importSpecifier( j.identifier( name.local ) );
+			}
+			if ( name.local !== name.imported ) {
+				return j.importSpecifier( j.identifier( name.imported ), j.identifier( name.local ) );
+			}
+		} );
+		const combinedImport = j.importDeclaration(
+			names,
+			j.literal( 'state/utils' )
+		);
+		combinedImport.comments = comments;
+		return combinedImport;
+	};
+
+	//replace the first one with the combined import
+	stateUtilsImports.at( 0 ).replaceWith( addImport( importNames ) );
+	//remove the rest
+	for ( let i = 1; i < stateUtilsImports.length; i ++ ) {
+		stateUtilsImports.at( i ).remove();
+	}
+
+	// print
+	return root.toSource( { quote: 'single' } );
+};

--- a/client/extensions/woocommerce/state/reducer.js
+++ b/client/extensions/woocommerce/state/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import ui from './ui/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import wcApi from './wc-api/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	ui,
 	wcApi,
 } );

--- a/client/extensions/woocommerce/state/ui/products/reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import edits from './edits-reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import variations from './variations/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	edits,
 	variations,
 } );

--- a/client/extensions/woocommerce/state/ui/products/variations/reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/reducer.js
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import edits from './edits-reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	edits
 } );

--- a/client/extensions/woocommerce/state/ui/reducer.js
+++ b/client/extensions/woocommerce/state/ui/reducer.js
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import products from './products/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	products
 } );

--- a/client/extensions/woocommerce/state/wc-api/reducer.js
+++ b/client/extensions/woocommerce/state/wc-api/reducer.js
@@ -3,7 +3,6 @@
  */
 import error from './error-reducer';
 import productCategories from './product-categories/reducer';
-import { withoutPersistence } from 'state/utils';
 
 const initialState = {};
 
@@ -12,7 +11,7 @@ const handlers = {
 	...error,
 };
 
-export default withoutPersistence( ( state = initialState, action ) => {
+export default function( state = initialState, action ) {
 	const { type, payload } = action;
 	const { siteId } = payload || {};
 	const handler = handlers[ type ];
@@ -29,4 +28,5 @@ export default withoutPersistence( ( state = initialState, action ) => {
 	}
 
 	return state;
-} );
+}
+

--- a/client/extensions/woocommerce/state/wc-api/test/reducer.js
+++ b/client/extensions/woocommerce/state/wc-api/test/reducer.js
@@ -8,16 +8,10 @@ import { expect } from 'chai';
  */
 import reducer from '../reducer';
 import { error } from '../actions';
-import { SERIALIZE, DESERIALIZE } from 'state/action-types';
 
 describe( 'reducer', () => {
 	it( 'should initialize to an empty object', () => {
 		expect( reducer( undefined, { type: '@@UNKNOWN_ACTION' } ) ).to.eql( {} );
-	} );
-
-	it( 'should resist persisting', () => {
-		expect( reducer( undefined, { type: SERIALIZE } ) ).to.eql( null );
-		expect( reducer( undefined, { type: DESERIALIZE } ) ).to.eql( {} );
 	} );
 
 	it( 'should create a site object when an action for that site occurrs.', () => {

--- a/client/extensions/wp-super-cache/state/cache/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
 	WP_SUPER_CACHE_DELETE_CACHE_FAILURE,

--- a/client/extensions/wp-super-cache/state/cache/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
 	WP_SUPER_CACHE_DELETE_CACHE_FAILURE,
@@ -73,7 +69,7 @@ const items = createReducer( {}, {
 	[ WP_SUPER_CACHE_TEST_CACHE_SUCCESS ]: ( state, { siteId, data } ) => ( { ...state, [ siteId ]: data } ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	deleteStatus,
 	items,
 	testing,

--- a/client/extensions/wp-super-cache/state/notices/reducer.js
+++ b/client/extensions/wp-super-cache/state/notices/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_NOTICES,

--- a/client/extensions/wp-super-cache/state/notices/reducer.js
+++ b/client/extensions/wp-super-cache/state/notices/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_NOTICES,
@@ -39,7 +35,7 @@ const items = createReducer( {}, {
 	[ WP_SUPER_CACHE_RECEIVE_NOTICES ]: ( state, action ) => ( { ...state, [ action.siteId ]: action.notices } ),
 }, itemsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 } );

--- a/client/extensions/wp-super-cache/state/reducer.js
+++ b/client/extensions/wp-super-cache/state/reducer.js
@@ -1,17 +1,13 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import cache from './cache/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import notices from './notices/reducer';
 import settings from './settings/reducer';
 import stats from './stats/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	cache,
 	notices,
 	settings,

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,
@@ -86,7 +82,7 @@ const items = createReducer( {}, {
 	} ),
 }, itemsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	saveStatus,

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -6,8 +6,8 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { statsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_DELETE_FILE,

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { statsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_DELETE_FILE,
@@ -96,7 +96,7 @@ const items = createReducer( {}, {
 	},
 }, statsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	deleting,
 	generateStatus,
 	items,

--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -2,9 +2,8 @@
  * Internal dependencies
  */
 import reset from './reset/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import settings from './settings/reducer';
-import { createReducer } from 'state/utils';
 
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,

--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -1,14 +1,9 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import reset from './reset/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import settings from './settings/reducer';
-
 import { createReducer } from 'state/utils';
 
 import {
@@ -23,7 +18,7 @@ const isFetchingSettings = createReducer( false, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: () => false,
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	settings,
 	reset,
 	isFetchingSettings,

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -6,8 +6,8 @@ import { stubTrue, stubFalse } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { stubTrue, stubFalse } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
 	ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE,
@@ -26,7 +26,7 @@ import {
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 } from 'state/action-types';
 
-const options = combineReducers( {
+const options = combineReducersWithPersistence( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: stubFalse,
@@ -54,7 +54,7 @@ const method = createReducer( null, {
 	[ ACCOUNT_RECOVERY_RESET_SET_METHOD ]: ( state, action ) => action.method,
 } );
 
-const requestReset = combineReducers( {
+const requestReset = combineReducersWithPersistence( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS ]: stubFalse,
@@ -72,7 +72,7 @@ const key = createReducer( null, {
 	[ ACCOUNT_RECOVERY_RESET_SET_VALIDATION_KEY ]: ( state, action ) => action.key,
 } );
 
-const validate = combineReducers( {
+const validate = combineReducersWithPersistence( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS ]: stubFalse,
@@ -86,7 +86,7 @@ const validate = combineReducers( {
 	} ),
 } );
 
-const resetPassword = combineReducers( {
+const resetPassword = combineReducersWithPersistence( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS ]: stubFalse,
@@ -104,7 +104,7 @@ const resetPassword = combineReducers( {
 	} ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	options,
 	userData,
 	method,

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
 
@@ -128,8 +123,8 @@ const isReady = createReducer( false, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: () => true,
 } );
 
-export default combineReducers( {
-	data: combineReducers( {
+export default combineReducersWithPersistence( {
+	data: combineReducersWithPersistence( {
 		phone,
 		phoneValidated,
 		email,

--- a/client/state/analytics/reducer.js
+++ b/client/state/analytics/reducer.js
@@ -2,9 +2,7 @@
  * Internal dependencies
  */
 import {
-	ANALYTICS_TRACKING_ON,
-	DESERIALIZE,
-	SERIALIZE,
+	ANALYTICS_TRACKING_ON
 } from 'state/action-types';
 
 export const analyticsTracking = ( state = {}, { type, meta } ) => {
@@ -13,13 +11,6 @@ export const analyticsTracking = ( state = {}, { type, meta } ) => {
 			return meta.analytics.reduce( ( newState, { payload: trackingTool } ) => {
 				return { ...newState, [ trackingTool ]: true };
 			}, state );
-
-		// This is for tracking tools that get attached to the DOM once on component mount, and
-		// monitor continuously then. Since we need to re-attach them when the user reloads a page,
-		// we don't want to serialize state but always start initialized as 'not tracking'.
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/application/reducer.js
+++ b/client/state/application/reducer.js
@@ -5,8 +5,7 @@ import {
 	CONNECTION_LOST,
 	CONNECTION_RESTORED
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 export const connectionState = createReducer( 'CHECKING', {
 	[ CONNECTION_LOST ]: () => 'OFFLINE',

--- a/client/state/application/reducer.js
+++ b/client/state/application/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
 	CONNECTION_LOST,
 	CONNECTION_RESTORED
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 
 export const connectionState = createReducer( 'CHECKING', {
@@ -17,6 +13,6 @@ export const connectionState = createReducer( 'CHECKING', {
 	[ CONNECTION_RESTORED ]: () => 'ONLINE'
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	connectionState
 } );

--- a/client/state/automated-transfer/eligibility/reducer.js
+++ b/client/state/automated-transfer/eligibility/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { property, sortBy } from 'lodash';
 
 /**
@@ -10,6 +9,7 @@ import { property, sortBy } from 'lodash';
 import {
 	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as UPDATE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 export const eligibilityHolds = ( state = [], action ) =>
 	UPDATE === action.type
@@ -26,7 +26,7 @@ export const lastUpdate = ( state = 0, action ) =>
 		? action.lastUpdate
 		: state;
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	eligibilityHolds,
 	eligibilityWarnings,
 	lastUpdate,

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -7,11 +7,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import eligibility from './eligibility/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
-import {
-	keyedReducer,
-	withSchemaValidation,
-} from 'state/utils';
+import { combineReducersWithPersistence, keyedReducer, withSchemaValidation } from 'state/utils';
 import { transferStates } from './constants';
 import { automatedTransfer as schema } from './schema';
 import {

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import eligibility from './eligibility/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	keyedReducer,
 	withSchemaValidation,
@@ -30,7 +30,7 @@ export const status = ( state = null, action ) => get( {
 	[ TRANSFER_UPDATE ]: 'complete' === action.status ? transferStates.COMPLETE : state,
 }, action.type, state );
 
-export const siteReducer = combineReducers( {
+export const siteReducer = combineReducersWithPersistence( {
 	eligibility,
 	status,
 } );

--- a/client/state/billing-transactions/reducer.js
+++ b/client/state/billing-transactions/reducer.js
@@ -10,9 +10,8 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { billingTransactionsSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 /**
  * Returns the updated items state after an action has been dispatched.

--- a/client/state/billing-transactions/reducer.js
+++ b/client/state/billing-transactions/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -15,6 +10,7 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { billingTransactionsSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -58,7 +54,7 @@ export const sendingReceiptEmail = createReducer( {}, {
 	[ BILLING_RECEIPT_EMAIL_SEND_SUCCESS ]: ( state, { receiptId } ) => ( { ...state, [ receiptId ]: false } ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	sendingReceiptEmail,

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -146,6 +146,7 @@ export function items( state = Immutable.Map(), action ) {
 
 	return state;
 }
+items.hasCustomPersistence = true;
 
 /***
  * Stores information regarding requests status per requestId
@@ -171,6 +172,7 @@ export function requests( state = Immutable.Map(), action ) {
 
 	return state;
 }
+requests.hasCustomPersistence = true;
 
 /***
  * Stores latest comments count for post we've seen from the server
@@ -190,6 +192,7 @@ export function totalCommentsCount( state = Immutable.Map(), action ) {
 
 	return state;
 }
+totalCommentsCount.hasCustomPersistence = true;
 
 export default combineReducersWithPersistence( {
 	items,

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import Immutable from 'immutable';
-import { combineReducers } from 'redux';
-
 /**
  * Internal dependencies
  */
@@ -23,6 +21,7 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 } from '../action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	getCommentParentKey,
 	updateExistingIn
@@ -192,7 +191,7 @@ export function totalCommentsCount( state = Immutable.Map(), action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requests,
 	totalCommentsCount

--- a/client/state/country-states/reducer.js
+++ b/client/state/country-states/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -12,6 +7,7 @@ import {
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -27,7 +23,7 @@ export const isFetching = createReducer( {}, {
 	[ COUNTRY_STATES_REQUEST_FAILURE ]: ( state, { countryCode } ) => ( { ...state, [ countryCode ]: false } )
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isFetching,
 	items,
 } );

--- a/client/state/country-states/reducer.js
+++ b/client/state/country-states/reducer.js
@@ -7,9 +7,8 @@ import {
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { itemSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 // Stores the complete list of states, indexed by locale key
 export const items = createReducer( {}, {

--- a/client/state/current-user/email-verification/reducer.js
+++ b/client/state/current-user/email-verification/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	EMAIL_VERIFY_REQUEST,
 	EMAIL_VERIFY_REQUEST_SUCCESS,

--- a/client/state/current-user/email-verification/reducer.js
+++ b/client/state/current-user/email-verification/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	EMAIL_VERIFY_REQUEST,
 	EMAIL_VERIFY_REQUEST_SUCCESS,
@@ -28,7 +24,7 @@ export const errorMessage = createReducer( '', {
 	[ EMAIL_VERIFY_STATE_RESET ]: () => '',
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	status,
 	errorMessage,
 } );

--- a/client/state/current-user/gravatar-status/reducer.js
+++ b/client/state/current-user/gravatar-status/reducer.js
@@ -7,8 +7,7 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 export const isUploading = createReducer( false, {
 	[ GRAVATAR_UPLOAD_REQUEST ]: () => true,

--- a/client/state/current-user/gravatar-status/reducer.js
+++ b/client/state/current-user/gravatar-status/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -12,6 +7,7 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 
 export const isUploading = createReducer( false, {
@@ -28,7 +24,7 @@ export const tempImage = createReducer( {}, {
 	}
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isUploading,
 	tempImage
 } );

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -15,8 +15,7 @@ import {
 	SITES_UPDATE,
 	PLANS_RECEIVE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
 import gravatarStatus from './gravatar-status/reducer';
 import emailVerification from './email-verification/reducer';

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { get, isEqual, reduce } from 'lodash';
 
 /**
@@ -17,6 +16,7 @@ import {
 	SITES_UPDATE,
 	PLANS_RECEIVE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
 import gravatarStatus from './gravatar-status/reducer';
@@ -97,7 +97,7 @@ export function capabilities( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	id,
 	currencyCode,
 	capabilities,

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -9,7 +9,6 @@ import { get, isEqual, reduce } from 'lodash';
 import {
 	CURRENT_USER_ID_SET,
 	CURRENT_USER_FLAGS_RECEIVE,
-	DESERIALIZE,
 	SITE_RECEIVE,
 	SITE_PLANS_FETCH_COMPLETED,
 	SITES_RECEIVE,
@@ -17,7 +16,7 @@ import {
 	PLANS_RECEIVE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
+import { createReducer } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
 import gravatarStatus from './gravatar-status/reducer';
 import emailVerification from './email-verification/reducer';
@@ -85,17 +84,11 @@ export function capabilities( state = {}, action ) {
 				memo[ site.ID ] = site.capabilities;
 				return memo;
 			}, state );
-
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, capabilitiesSchema ) ) {
-				return state;
-			}
-
-			return {};
 	}
 
 	return state;
 }
+capabilities.schema = capabilitiesSchema;
 
 export default combineReducersWithPersistence( {
 	id,

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -8,6 +8,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { useSandbox } from 'test/helpers/use-sinon';
+import { withSchemaValidation } from 'state/utils';
 import {
 	CURRENT_USER_ID_SET,
 	DESERIALIZE,
@@ -18,7 +19,8 @@ import {
 	SITES_RECEIVE,
 	SITES_UPDATE
 } from 'state/action-types';
-import reducer, { id, capabilities, currencyCode } from '../reducer';
+import reducer, { id, capabilities as unwrappedCapabilities, currencyCode } from '../reducer';
+const capabilities = withSchemaValidation( unwrappedCapabilities.schema, unwrappedCapabilities );
 
 describe( 'reducer', () => {
 	useSandbox( ( sandbox ) => {

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,
@@ -31,7 +27,7 @@ export const link = createReducer( [], {
 	[ DOCUMENT_HEAD_LINK_SET ]: ( state, action ) => ( action.link )
 }, linkSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	link,
 	meta,
 	title,

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,

--- a/client/state/domains/reducer.js
+++ b/client/state/domains/reducer.js
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import suggestions from './suggestions/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	suggestions
 } );

--- a/client/state/domains/suggestions/reducer.js
+++ b/client/state/domains/suggestions/reducer.js
@@ -6,12 +6,9 @@ import {
 	DOMAINS_SUGGESTIONS_REQUEST,
 	DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
 	DOMAINS_SUGGESTIONS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
-import { isValidStateWithSchema } from 'state/utils';
 import { getSerializedDomainsSuggestionsQuery } from './utils';
 
 /**
@@ -31,16 +28,10 @@ export function items( state = {}, action ) {
 				} );
 			}
 			return state;
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemsSchema ) ) {
-				return state;
-			}
-			return {};
 	}
 	return state;
 }
+items.schema = itemsSchema;
 
 /**
  * Tracks domains suggestions request state, indexed by a serialized query.
@@ -61,9 +52,6 @@ export function requesting( state = {}, action ) {
 				} );
 			}
 			return state;
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -93,9 +81,6 @@ export function errors( state = {}, action ) {
 				} );
 			}
 			return state;
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/domains/suggestions/reducer.js
+++ b/client/state/domains/suggestions/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,6 +9,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 import { getSerializedDomainsSuggestionsQuery } from './utils';
@@ -104,7 +100,7 @@ export function errors( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	errors

--- a/client/state/domains/suggestions/test/reducer.js
+++ b/client/state/domains/suggestions/test/reducer.js
@@ -15,12 +15,15 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { withSchemaValidation } from 'state/utils';
 import reducer, {
-	items,
+	items as unwrappedItems,
 	requesting,
 	errors
 } from '../reducer';
 import { useSandbox } from 'test/helpers/use-sinon';
+
+const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	let sandbox;
@@ -263,24 +266,6 @@ describe( 'reducer', () => {
 				'{"query":"foobar","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true
 			} );
 		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true
-				} );
-				const state = requesting( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true
-				} );
-				const state = requesting( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-		} );
 	} );
 
 	describe( '#errors()', () => {
@@ -396,24 +381,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error,
 				'{"query":"foobar","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': error2
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': new Error()
-				} );
-				const state = errors( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': new Error()
-				} );
-				const state = errors( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/followers/reducer.js
+++ b/client/state/followers/reducer.js
@@ -17,8 +17,6 @@ import {
 	FOLLOWER_REMOVE_ERROR,
 	FOLLOWER_REMOVE_REQUEST,
 	FOLLOWER_REMOVE_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { getSerializedQuery, normalizeFollower } from 'state/followers/utils';
@@ -30,9 +28,6 @@ export function items( state = {}, action ) {
 			return Object.assign( {}, state, keyBy( action.data.subscribers.map( normalizeFollower ), 'ID' ) );
 		case FOLLOWER_REMOVE_SUCCESS:
 			return Object.assign( {}, omit( state, action.follower.ID ) );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -64,9 +59,6 @@ export function queries( state = {}, action ) {
 				}
 				return query;
 			} ) );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -86,9 +78,6 @@ export function queryRequests( state = {}, action ) {
 		case FOLLOWERS_REQUEST_ERROR:
 			const serializedQuery = getSerializedQuery( action.query );
 			return Object.assign( {}, state, { [ serializedQuery ]: FOLLOWERS_REQUEST === action.type } );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -99,9 +88,6 @@ export function removeFromSiteRequests( state = {}, action ) {
 		case FOLLOWER_REMOVE_REQUEST:
 		case FOLLOWER_REMOVE_SUCCESS:
 			return Object.assign( {}, state, { [ action.siteId ]: FOLLOWER_REMOVE_REQUEST === action.type } );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/followers/reducer.js
+++ b/client/state/followers/reducer.js
@@ -6,7 +6,6 @@ import union from 'lodash/union';
 import mapValues from 'lodash/mapValues';
 import without from 'lodash/without';
 import omit from 'lodash/omit';
-import { combineReducers } from 'redux';
 
 /**
  * Internal dependencies
@@ -21,6 +20,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { getSerializedQuery, normalizeFollower } from 'state/followers/utils';
 import { FOLLOWERS_PER_PAGE } from 'state/followers/constants';
 
@@ -106,7 +106,7 @@ export function removeFromSiteRequests( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	queries,
 	queryRequests,

--- a/client/state/geo/reducer.js
+++ b/client/state/geo/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -12,6 +7,7 @@ import {
 	GEO_REQUEST_FAILURE,
 	GEO_REQUEST_SUCCESS
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import { geoSchema } from './schema';
 
@@ -41,7 +37,7 @@ export const geo = createReducer( null, {
 	[ GEO_RECEIVE ]: ( state, action ) => action.geo
 }, geoSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	geo
 } );

--- a/client/state/geo/reducer.js
+++ b/client/state/geo/reducer.js
@@ -7,8 +7,7 @@ import {
 	GEO_REQUEST_FAILURE,
 	GEO_REQUEST_SUCCESS
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { geoSchema } from './schema';
 
 /**

--- a/client/state/google-apps-users/reducer.js
+++ b/client/state/google-apps-users/reducer.js
@@ -1,13 +1,12 @@
 /**
  * External Dependencies
  */
-
-import { combineReducers } from 'redux';
 import uniqBy from 'lodash/uniqBy';
 
 /**
  * Internal Dependencies
  */
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	GOOGLE_APPS_USERS_FETCH,
 	GOOGLE_APPS_USERS_FETCH_COMPLETED,
@@ -41,7 +40,7 @@ export function loaded( state = false, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	loaded
 } );

--- a/client/state/google-apps-users/reducer.js
+++ b/client/state/google-apps-users/reducer.js
@@ -11,18 +11,12 @@ import {
 	GOOGLE_APPS_USERS_FETCH,
 	GOOGLE_APPS_USERS_FETCH_COMPLETED,
 	GOOGLE_APPS_USERS_FETCH_FAILED,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 
 export function items( state = [], action ) {
 	switch ( action.type ) {
 		case GOOGLE_APPS_USERS_FETCH_COMPLETED:
 			return uniqBy( state.concat( action.items ), 'email' );
-		case SERIALIZE:
-			return [];
-		case DESERIALIZE:
-			return [];
 	}
 	return state;
 }
@@ -30,8 +24,6 @@ export function items( state = [], action ) {
 export function loaded( state = false, action ) {
 	switch ( action.type ) {
 		case GOOGLE_APPS_USERS_FETCH:
-		case SERIALIZE:
-		case DESERIALIZE:
 			return false;
 		case GOOGLE_APPS_USERS_FETCH_FAILED:
 		case GOOGLE_APPS_USERS_FETCH_COMPLETED:

--- a/client/state/google-apps-users/test/reducer.js
+++ b/client/state/google-apps-users/test/reducer.js
@@ -10,8 +10,6 @@ import deepFreeze from 'deep-freeze';
 import {
 	GOOGLE_APPS_USERS_FETCH,
 	GOOGLE_APPS_USERS_FETCH_COMPLETED,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 
 import {
@@ -23,18 +21,6 @@ describe( 'reducer', () => {
 	describe( '#items()', () => {
 		it( 'should default to an empty array', () => {
 			const state = items( undefined, {} );
-
-			assert.deepEqual( state, [] );
-		} );
-
-		it( 'should return empty array for serialize', () => {
-			const state = items( deepFreeze( [ 1, 2 ] ), { type: SERIALIZE } );
-
-			assert.deepEqual( state, [] );
-		} );
-
-		it( 'should return empty array for deserialize', () => {
-			const state = items( deepFreeze( [ 1, 2 ] ), { type: DESERIALIZE } );
 
 			assert.deepEqual( state, [] );
 		} );

--- a/client/state/happiness-engineers/reducer.js
+++ b/client/state/happiness-engineers/reducer.js
@@ -6,8 +6,8 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { itemsSchema } from './schema';
 import {
 	HAPPINESS_ENGINEERS_FETCH,

--- a/client/state/happiness-engineers/reducer.js
+++ b/client/state/happiness-engineers/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { map } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	HAPPINESS_ENGINEERS_FETCH,
@@ -45,7 +45,7 @@ export const items = createReducer( null, {
 	}
 }, itemsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -32,12 +32,11 @@ import {
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 	HAPPYCHAT_SET_GEO_LOCATION,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	HAPPYCHAT_CHAT_STATUS_DEFAULT,
 } from './selectors';
 import { HAPPYCHAT_MAX_STORED_MESSAGES } from './constants';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { timelineSchema, geoLocationSchema } from './schema';
 
 /**

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -37,7 +37,7 @@ import {
 	HAPPYCHAT_CHAT_STATUS_DEFAULT,
 } from './selectors';
 import { HAPPYCHAT_MAX_STORED_MESSAGES } from './constants';
-import { createReducer } from 'state/utils';
+import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { timelineSchema, geoLocationSchema } from './schema';
 
 /**
@@ -136,6 +136,7 @@ const timeline = ( state = [], action ) => {
 	}
 	return state;
 };
+timeline.hasCustomPersistence = true;
 
 /**
  * Tracks the current message the user has typed into the happychat client
@@ -165,9 +166,6 @@ export const message = ( state = '', action ) => {
  */
 const connectionStatus = ( state = 'uninitialized', action ) => {
 	switch ( action.type ) {
-		case DESERIALIZE:
-			// Always boot up in the uninitialized state
-			return 'uninitialized';
 		case HAPPYCHAT_CONNECTING:
 			return 'connecting';
 		case HAPPYCHAT_CONNECTED:
@@ -182,8 +180,6 @@ const connectionStatus = ( state = 'uninitialized', action ) => {
 
 const connectionError = ( state = null, action ) => {
 	switch ( action.type ) {
-		case DESERIALIZE:
-			return null;
 		case HAPPYCHAT_CONNECTED:
 			return null;
 		case HAPPYCHAT_DISCONNECTED:
@@ -210,10 +206,6 @@ const connectionError = ( state = null, action ) => {
  */
 const chatStatus = ( state = HAPPYCHAT_CHAT_STATUS_DEFAULT, action ) => {
 	switch ( action.type ) {
-		case SERIALIZE:
-			return HAPPYCHAT_CHAT_STATUS_DEFAULT;
-		case DESERIALIZE:
-			return state;
 		case HAPPYCHAT_SET_CHAT_STATUS:
 			return action.status;
 	}
@@ -221,7 +213,7 @@ const chatStatus = ( state = HAPPYCHAT_CHAT_STATUS_DEFAULT, action ) => {
 };
 
 /**
- * Tracks wether happychat.io is accepting new chats.
+ * Tracks whether happychat.io is accepting new chats.
  *
  * @param  {Boolean} state  Current happychat status
  * @param  {Object}  action Action playload
@@ -229,10 +221,6 @@ const chatStatus = ( state = HAPPYCHAT_CHAT_STATUS_DEFAULT, action ) => {
  */
 const isAvailable = ( state = false, action ) => {
 	switch ( action.type ) {
-		case SERIALIZE:
-			return false;
-		case DESERIALIZE:
-			return state;
 		case HAPPYCHAT_SET_AVAILABLE:
 			return action.isAvailable;
 	}
@@ -241,15 +229,13 @@ const isAvailable = ( state = false, action ) => {
 
 export const lastActivityTimestamp = ( state = null, action ) => {
 	switch ( action.type ) {
-		case SERIALIZE:
-		case DESERIALIZE:
-			return state;
 		case HAPPYCHAT_SEND_MESSAGE:
 		case HAPPYCHAT_RECEIVE_EVENT:
 			return Date.now();
 	}
 	return state;
 };
+lastActivityTimestamp.schema = { type: 'number' };
 
 /**
  * Tracks the last time Happychat had focus. This lets us determine things like
@@ -270,7 +256,10 @@ export const lostFocusAt = ( state = null, action ) => {
 			}
 			return state;
 		case DESERIALIZE:
-			return state;
+			if ( isValidStateWithSchema( state, { type: 'number' } ) ) {
+				return state;
+			}
+			return null;
 		case HAPPYCHAT_BLUR:
 			return Date.now();
 		case HAPPYCHAT_FOCUS:
@@ -278,6 +267,7 @@ export const lostFocusAt = ( state = null, action ) => {
 	}
 	return state;
 };
+lastActivityTimestamp.hasCustomPersistence = true;
 
 export default combineReducersWithPersistence( {
 	chatStatus,

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import {
 	concat,
 	filter,
@@ -33,6 +32,7 @@ import {
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 	HAPPYCHAT_SET_GEO_LOCATION,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	HAPPYCHAT_CHAT_STATUS_DEFAULT,
 } from './selectors';
@@ -279,7 +279,7 @@ export const lostFocusAt = ( state = null, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	chatStatus,
 	connectionError,
 	connectionStatus,

--- a/client/state/help/courses/reducer.js
+++ b/client/state/help/courses/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	HELP_COURSES_RECEIVE,
 } from 'state/action-types';

--- a/client/state/help/courses/reducer.js
+++ b/client/state/help/courses/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	HELP_COURSES_RECEIVE,
 } from 'state/action-types';
@@ -15,6 +11,6 @@ export const items = createReducer( null, {
 	[ HELP_COURSES_RECEIVE ]: ( state, { courses } ) => courses
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items
 } );

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	DIRECTLY_INITIALIZATION_START,
 	DIRECTLY_INITIALIZATION_SUCCESS,
@@ -25,6 +21,6 @@ export const status = createReducer( STATUS_UNINITIALIZED, {
 	[ DIRECTLY_INITIALIZATION_ERROR ]: () => STATUS_ERROR,
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	status,
 } );

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	DIRECTLY_INITIALIZATION_START,
 	DIRECTLY_INITIALIZATION_SUCCESS,

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -1,16 +1,12 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import courses from './courses/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import directly from './directly/reducer';
 import ticket from './ticket/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	courses,
 	directly,
 	ticket,

--- a/client/state/help/ticket/reducer.js
+++ b/client/state/help/ticket/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
@@ -36,7 +32,7 @@ const requestError = createReducer( null, {
 	[ HELP_TICKET_CONFIGURATION_DISMISS_ERROR ]: () => null,
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isReady,
 	isRequesting,
 	isUserEligible,

--- a/client/state/help/ticket/reducer.js
+++ b/client/state/help/ticket/reducer.js
@@ -1,8 +1,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import thunkMiddleware from 'redux-thunk';
-import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 
 /**
  * Internal dependencies
  */
+import { combineReducersWithPersistence } from 'state/utils';
 import analyticsTracking from './analytics/reducer';
 import sitesSync from './sites/enhancer';
 import noticesMiddleware from './notices/middleware';
@@ -70,7 +71,7 @@ import config from 'config';
  */
 
 // Consolidate the extension reducers under 'extensions' for namespacing.
-const extensions = combineReducers( extensionsModule.reducers() );
+const extensions = combineReducersWithPersistence( extensionsModule.reducers() );
 
 const reducers = {
 	analyticsTracking,
@@ -128,7 +129,7 @@ const reducers = {
 	wordads,
 };
 
-export const reducer = combineReducers( reducers );
+export const reducer = combineReducersWithPersistence( reducers );
 
 /**
  * @typedef {Object} ReduxStore

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -35,7 +35,11 @@ import {
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
-import { jetpackConnectSessionsSchema } from './schema';
+import {
+	jetpackConnectSessionsSchema,
+	jetpackAuthAttemptsSchema,
+	jetpackConnectSelectedPlansSchema,
+} from './schema';
 import { isStale } from './utils';
 import { JETPACK_CONNECT_AUTHORIZE_TTL, AUTH_ATTEMPS_TTL } from './constants';
 import { urlToSlug } from 'lib/url';
@@ -75,6 +79,7 @@ export function jetpackConnectSessions( state = {}, action ) {
 	}
 	return state;
 }
+jetpackConnectSessions.hasCustomPersistence = true;
 
 export function jetpackConnectSite( state = {}, action ) {
 	const defaultState = {
@@ -117,9 +122,6 @@ export function jetpackConnectSite( state = {}, action ) {
 		case JETPACK_CONNECT_CONFIRM_JETPACK_STATUS:
 			return Object.assign( {}, state, { installConfirmedByUser: action.status } );
 		case JETPACK_CONNECT_COMPLETE_FLOW:
-			return {};
-		case SERIALIZE:
-		case DESERIALIZE:
 			return {};
 	}
 	return state;
@@ -239,6 +241,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 	}
 	return state;
 }
+jetpackConnectAuthorize.hasCustomPersistence = true;
 
 export function jetpackAuthAttempts( state = {}, action ) {
 	switch ( action.type ) {
@@ -256,12 +259,10 @@ export function jetpackAuthAttempts( state = {}, action ) {
 			return Object.assign( {}, state, { [ slug ]: { attempt: attemptNumber, timestamp: currentTimestamp } } );
 		case JETPACK_CONNECT_COMPLETE_FLOW:
 			return {};
-		case DESERIALIZE:
-		case SERIALIZE:
-			state;
 	}
 	return state;
 }
+jetpackAuthAttempts.schema = jetpackAuthAttemptsSchema;
 
 export function jetpackSSO( state = {}, action ) {
 	switch ( action.type ) {
@@ -283,9 +284,6 @@ export function jetpackSSO( state = {}, action ) {
 			return Object.assign( {}, state, { isAuthorizing: false, authorizationError: false, ssoUrl: action.ssoUrl } );
 		case JETPACK_CONNECT_SSO_AUTHORIZE_ERROR:
 			return Object.assign( {}, state, { isAuthorizing: false, authorizationError: action.error, ssoUrl: false } );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -299,12 +297,10 @@ export function jetpackConnectSelectedPlans( state = {}, action ) {
 			return { '*': state[ '*' ] };
 		case JETPACK_CONNECT_COMPLETE_FLOW:
 			return {};
-		case SERIALIZE:
-		case DESERIALIZE:
-			return state;
 	}
 	return state;
 }
+jetpackConnectSelectedPlans.schema = jetpackConnectSelectedPlansSchema;
 
 export default combineReducersWithPersistence( {
 	jetpackConnectSite,

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -33,8 +33,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { isValidStateWithSchema } from 'state/utils';
+import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
 import {
 	jetpackConnectSessionsSchema,
 	jetpackAuthAttemptsSchema,

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -2,8 +2,6 @@
  * External dependencis
  */
 import { isEmpty, omit, pickBy } from 'lodash';
-import { combineReducers } from 'redux';
-
 /**
  * Internal dependencies
  */
@@ -35,7 +33,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { jetpackConnectSessionsSchema } from './schema';
 import { isStale } from './utils';
@@ -308,7 +306,7 @@ export function jetpackConnectSelectedPlans( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	jetpackConnectSite,
 	jetpackSSO,
 	jetpackConnectAuthorize,

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -57,3 +57,24 @@ export const jetpackConnectAuthorizeSchema = {
 		}
 	}
 };
+
+export const jetpackAuthAttemptsSchema = {
+	type: 'object',
+	additionalProperties: false,
+	patternProperties: {
+		'^.+$': {
+			type: 'object',
+			required: [ 'attempt', 'timestamp' ],
+			attempt: { type: 'number' },
+			timestamp: { type: 'number' }
+		}
+	}
+};
+
+export const jetpackConnectSelectedPlansSchema = {
+	type: 'object',
+	additionalProperties: false,
+	patternProperties: {
+		'^.+$': { type: [ 'string', 'null' ] }
+	}
+};

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -314,28 +314,6 @@ describe( 'reducer', () => {
 			expect( state ).to.have.property( 'installConfirmedByUser' )
 				.to.be.true;
 		} );
-
-		it( 'should not persist state', () => {
-			const originalState = deepFreeze( {
-				url: 'https://example.wordpress.com'
-			} );
-			const state = jetpackConnectSite( originalState, {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.be.eql( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const originalState = deepFreeze( {
-				url: 'https://example.wordpress.com'
-			} );
-			const state = jetpackConnectSite( originalState, {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.be.eql( {} );
-		} );
 	} );
 
 	describe( '#jetpackConnectAuthorize()', () => {
@@ -636,19 +614,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should not persist state', () => {
-			const original = deepFreeze( {
-				isAuthorizing: false,
-				site_id: 0,
-				authorizationError: false,
-				ssoUrl: 'http://example.wordpress.com'
-			} );
-
-			const state = jetpackSSO( original, { type: SERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
-
 		it( 'should set isValidating to true when validating', () => {
 			const state = jetpackSSO( undefined, {
 				type: JETPACK_CONNECT_SSO_VALIDATION_REQUEST
@@ -738,30 +703,6 @@ describe( 'reducer', () => {
 			const state = jetpackSSO( undefined, action );
 
 			expect( state ).to.have.property( 'ssoUrl', action.ssoUrl );
-		} );
-
-		it( 'should not persist state', () => {
-			const originalState = deepFreeze( {
-				ssoUrl: 'http://example.wordpress.com',
-				siteUrl: 'http://example.wordpress.com'
-			} );
-			const state = jetpackSSO( originalState, {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.be.eql( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const originalState = deepFreeze( {
-				ssoUrl: 'http://example.wordpress.com',
-				siteUrl: 'http://example.wordpress.com'
-			} );
-			const state = jetpackSSO( originalState, {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.be.eql( {} );
 		} );
 	} );
 

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -13,8 +13,6 @@ import {
 	JETPACK_SYNC_STATUS_REQUEST,
 	JETPACK_SYNC_STATUS_SUCCESS,
 	JETPACK_SYNC_STATUS_ERROR,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { getExpectedResponseKeys } from './utils';
@@ -45,9 +43,6 @@ export function fullSyncRequest( state = {}, action ) {
 					{ isRequesting: false, scheduled: false, error: action.error },
 				)
 			} );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -98,9 +93,6 @@ export function syncStatus( state = {}, action ) {
 					pick( action.data, getExpectedResponseKeys() )
 				)
 			} );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencis
  */
-import { combineReducers } from 'redux';
 import { pick, get } from 'lodash';
 
 /**
@@ -17,6 +16,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { getExpectedResponseKeys } from './utils';
 
 export function fullSyncRequest( state = {}, action ) {
@@ -105,7 +105,7 @@ export function syncStatus( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	syncStatus,
 	fullSyncRequest
 } );

--- a/client/state/jetpack-sync/test/reducer.js
+++ b/client/state/jetpack-sync/test/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -14,7 +13,6 @@ import {
 	JETPACK_SYNC_START_REQUEST,
 	JETPACK_SYNC_START_SUCCESS,
 	JETPACK_SYNC_START_ERROR,
-	SERIALIZE,
 } from 'state/action-types';
 
 import reducer, {
@@ -174,17 +172,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should not persist state', () => {
-			const original = deepFreeze( {
-				123456: {
-					isRequesting: true
-				}
-			} );
-
-			const state = syncStatus( original, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-
 		it( 'should add a property with key matching site ID', () => {
 			const state = syncStatus( undefined, { type: JETPACK_SYNC_STATUS_REQUEST, siteId: 123456 } );
 			expect( state ).to.have.property( '123456' );
@@ -286,17 +273,6 @@ describe( 'reducer', () => {
 	describe( '#fullSyncRequest()', () => {
 		it( 'should default to an empty object', () => {
 			const state = fullSyncRequest( undefined, {} );
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should not persist state', () => {
-			const original = deepFreeze( {
-				123456: {
-					isRequesting: true
-				}
-			} );
-
-			const state = fullSyncRequest( original, { type: SERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 

--- a/client/state/jetpack/connection/reducer.js
+++ b/client/state/jetpack/connection/reducer.js
@@ -10,8 +10,7 @@ import {
 	JETPACK_DISCONNECT_REQUEST_FAILURE,
 	JETPACK_DISCONNECT_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 const createRequestReducer = ( requesting ) => {
 	return ( state, { siteId } ) => ( {

--- a/client/state/jetpack/connection/reducer.js
+++ b/client/state/jetpack/connection/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -15,6 +10,7 @@ import {
 	JETPACK_DISCONNECT_REQUEST_FAILURE,
 	JETPACK_DISCONNECT_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 
 const createRequestReducer = ( requesting ) => {
@@ -56,7 +52,7 @@ export const disconnectRequests = createReducer( {}, {
 	[ JETPACK_DISCONNECT_REQUEST_SUCCESS ]: createRequestReducer( false )
 } );
 
-export const reducer = combineReducers( {
+export const reducer = combineReducersWithPersistence( {
 	items,
 	requests,
 	disconnectRequests

--- a/client/state/jetpack/jumpstart/reducer.js
+++ b/client/state/jetpack/jumpstart/reducer.js
@@ -18,8 +18,7 @@ import {
 	JETPACK_JUMPSTART_STATUS_REQUEST_SUCCESS,
 	JETPACK_JUMPSTART_STATUS_REQUEST_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 const createRequestReducer = ( data ) => {
 	return ( state, { siteId } ) => {

--- a/client/state/jetpack/jumpstart/reducer.js
+++ b/client/state/jetpack/jumpstart/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { merge } from 'lodash';
 
 /**
@@ -19,6 +18,7 @@ import {
 	JETPACK_JUMPSTART_STATUS_REQUEST_SUCCESS,
 	JETPACK_JUMPSTART_STATUS_REQUEST_FAILURE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 
 const createRequestReducer = ( data ) => {
@@ -63,7 +63,7 @@ export const requests = createReducer( {}, {
 	[ JETPACK_JUMPSTART_STATUS_REQUEST_SUCCESS ]: createRequestReducer( { requesting: false } )
 } );
 
-export const reducer = combineReducers( {
+export const reducer = combineReducersWithPersistence( {
 	items,
 	requests
 } );

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -20,8 +20,7 @@ import {
 	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 const createItemsReducer = ( active ) => {
 	return ( state, { siteId, moduleSlug } ) => {

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { forEach, get, merge, pickBy } from 'lodash';
 
 /**
@@ -21,6 +20,7 @@ import {
 	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 
 const createItemsReducer = ( active ) => {
@@ -122,7 +122,7 @@ export const requests = createReducer( {}, {
 	[ JETPACK_MODULES_REQUEST_SUCCESS ]: createModuleListRequestReducer( false )
 } );
 
-export const reducer = combineReducers( {
+export const reducer = combineReducersWithPersistence( {
 	items,
 	requests
 } );

--- a/client/state/jetpack/reducer.js
+++ b/client/state/jetpack/reducer.js
@@ -1,17 +1,13 @@
 /**
- * External dependencis
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { reducer as connection } from './connection/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import { reducer as jumpstart } from './jumpstart/reducer';
 import { reducer as modules } from './modules/reducer';
 import { reducer as settings } from './settings/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	connection,
 	jumpstart,
 	modules,

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { mapValues, merge } from 'lodash';
 
 /**
@@ -22,6 +21,7 @@ import {
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	JETPACK_SETTINGS_UPDATE_FAILURE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import { normalizeSettings } from './utils';
 
@@ -134,7 +134,7 @@ export const saveRequests = createReducer( {}, {
 	} )
 } );
 
-export const reducer = combineReducers( {
+export const reducer = combineReducersWithPersistence( {
 	items,
 	requests,
 	saveRequests

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -21,8 +21,7 @@ import {
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	JETPACK_SETTINGS_UPDATE_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { normalizeSettings } from './utils';
 
 const createRequestsReducer = ( data ) => {

--- a/client/state/login/magic-login/reducer.js
+++ b/client/state/login/magic-login/reducer.js
@@ -1,8 +1,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 import {
 	CHECK_YOUR_EMAIL_PAGE,

--- a/client/state/login/magic-login/reducer.js
+++ b/client/state/login/magic-login/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 
 import {
 	CHECK_YOUR_EMAIL_PAGE,
@@ -89,7 +85,7 @@ export const requestEmailSuccess = createReducer( false, {
 	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS ]: () => true,
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	emailAddressFormInput,
 	isFetchingEmail,
 	requestAuthError,

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -1,14 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { createReducer, combineReducersWithPersistence } from 'state/utils';
 import magicLogin from './magic-login/reducer';
-
 import {
 	LOGIN_REQUEST,
 	LOGIN_REQUEST_FAILURE,
@@ -83,7 +77,7 @@ export const twoFactorAuthPushPoll = createReducer( { inProgress: false, success
 	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED ]: state => ( { ...state, inProgress: false, success: true } ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isRequesting,
 	isRequestingTwoFactorAuth,
 	magicLogin,

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -15,8 +15,7 @@ import {
 	MEDIA_REQUEST_SUCCESS,
 	MEDIA_REQUESTING
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import MediaQueryManager from 'lib/query-manager/media';
 
 export const queries = ( () => {

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { omit } from 'lodash';
-
 /**
  * Internal dependencies
  */
@@ -17,6 +15,7 @@ import {
 	MEDIA_REQUEST_SUCCESS,
 	MEDIA_REQUESTING
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import MediaQueryManager from 'lib/query-manager/media';
 
@@ -112,7 +111,7 @@ export const mediaItemRequests = createReducer( {}, {
 	}
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	queries,
 	queryRequests,
 	mediaItemRequests

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -12,8 +12,7 @@ import {
 	NOTICE_REMOVE,
 	ROUTE_SET
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 export const items = createReducer( {}, {
 	[ NOTICE_CREATE ]: ( state, action ) => {

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import omit from 'lodash/omit';
 import reduce from 'lodash/reduce';
 
@@ -13,6 +12,7 @@ import {
 	NOTICE_REMOVE,
 	ROUTE_SET
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 
 export const items = createReducer( {}, {
@@ -51,6 +51,6 @@ export const items = createReducer( {}, {
 	}
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items
 } );

--- a/client/state/nps-survey/reducer.js
+++ b/client/state/nps-survey/reducer.js
@@ -11,8 +11,7 @@ import {
 	NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_FAILURE,
 	NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import {
 	NOT_SUBMITTED,
 	SUBMITTING,

--- a/client/state/nps-survey/reducer.js
+++ b/client/state/nps-survey/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -16,6 +11,7 @@ import {
 	NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_FAILURE,
 	NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import {
 	NOT_SUBMITTED,
@@ -56,7 +52,7 @@ export const score = createReducer( null, {
 	},
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isSessionEligible,
 	wasShownThisSession,
 	surveyState,

--- a/client/state/page-templates/reducer.js
+++ b/client/state/page-templates/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	PAGE_TEMPLATES_RECEIVE,
@@ -50,7 +46,7 @@ export const items = createReducer( {}, {
 	}
 }, itemsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/page-templates/reducer.js
+++ b/client/state/page-templates/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { itemsSchema } from './schema';
 import {
 	PAGE_TEMPLATES_RECEIVE,

--- a/client/state/plans/reducer.js
+++ b/client/state/plans/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,7 +9,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
@@ -92,7 +87,7 @@ export const error = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	error

--- a/client/state/plans/reducer.js
+++ b/client/state/plans/reducer.js
@@ -6,11 +6,8 @@ import {
 	PLANS_REQUEST,
 	PLANS_REQUEST_SUCCESS,
 	PLANS_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
-import { isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -26,19 +23,11 @@ export const items = ( state = [], action ) => {
 	switch ( action.type ) {
 		case PLANS_RECEIVE:
 			return action.plans.slice( 0 );
-
-		case DESERIALIZE:
-			const isValidState = isValidStateWithSchema( state, itemsSchema );
-			if ( isValidState ) {
-				return state;
-			}
-			return [];
-		case SERIALIZE:
-			return state;
 	}
 
 	return state;
 };
+items.schema = itemsSchema;
 
 /**
  * `Reducer` function which handles request/response actions
@@ -54,10 +43,6 @@ export const requesting = ( state = false, action ) => {
 		case PLANS_REQUEST_SUCCESS:
 		case PLANS_REQUEST_FAILURE:
 			return action.type === PLANS_REQUEST;
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;
@@ -78,10 +63,6 @@ export const error = ( state = false, action ) => {
 
 		case PLANS_REQUEST_FAILURE:
 			return true;
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;

--- a/client/state/plans/test/reducer.js
+++ b/client/state/plans/test/reducer.js
@@ -8,10 +8,11 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { useSandbox } from 'test/helpers/use-sinon';
+import { withSchemaValidation } from 'state/utils';
 
 // Reducers
 import plansReducer, {
-	items as itemsReducer,
+	items,
 	requesting as requestReducer,
 	error as errorReducer
 } from '../reducer';
@@ -30,6 +31,8 @@ import {
  * Fixture data
  */
 import { WPCOM_RESPONSE } from './fixture';
+
+const itemsReducer = withSchemaValidation( items.schema, items );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import {
 	uniqBy,
 	omit,
@@ -11,6 +10,7 @@ import {
  * Internal dependencies
  */
 import status from './status/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	PLUGINS_RECEIVE,
 	PLUGINS_REQUEST,
@@ -128,7 +128,7 @@ function plugin( state, action ) {
 	}
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isRequesting,
 	plugins,
 	status

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -23,8 +23,6 @@ import {
 	PLUGIN_AUTOUPDATE_DISABLE_REQUEST_SUCCESS,
 	PLUGIN_INSTALL_REQUEST_SUCCESS,
 	PLUGIN_REMOVE_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { pluginsSchema } from './schema';
 import { createReducer } from 'state/utils';
@@ -38,9 +36,6 @@ export function isRequesting( state = {}, action ) {
 			return Object.assign( {}, state, { [ action.siteId ]: true } );
 		case PLUGINS_RECEIVE:
 			return Object.assign( {}, state, { [ action.siteId ]: false } );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 		default:
 			return state;
 	}

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -10,7 +10,7 @@ import {
  * Internal dependencies
  */
 import status from './status/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import {
 	PLUGINS_RECEIVE,
 	PLUGINS_REQUEST,
@@ -25,7 +25,6 @@ import {
 	PLUGIN_REMOVE_REQUEST_SUCCESS,
 } from 'state/action-types';
 import { pluginsSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 /*
  * Tracks the requesting state for installed plugins on a per-site index.

--- a/client/state/plugins/installed/status/reducer.js
+++ b/client/state/plugins/installed/status/reducer.js
@@ -23,8 +23,6 @@ import {
 	PLUGIN_REMOVE_REQUEST,
 	PLUGIN_REMOVE_REQUEST_SUCCESS,
 	PLUGIN_REMOVE_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 
 /*
@@ -55,9 +53,6 @@ export default function status( state = {}, action ) {
 		case PLUGIN_INSTALL_REQUEST_FAILURE:
 		case PLUGIN_REMOVE_REQUEST_FAILURE:
 			return Object.assign( {}, state, { [ siteId ]: statusForSite( state[ siteId ], action ) } );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 		default:
 			return state;
 	}

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -1,7 +1,6 @@
 /**
 * External dependencies
 */
-import { combineReducers } from 'redux';
 import forEach from 'lodash/forEach';
 
 /**
@@ -18,6 +17,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { pluginInstructionSchema } from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 
@@ -160,7 +160,7 @@ function pluginStatus( state, action ) {
 	}
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isRequesting,
 	hasRequested,
 	plugins

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -17,9 +17,8 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
 import { pluginInstructionSchema } from './schema';
-import { isValidStateWithSchema } from 'state/utils';
 
 /*
  * Tracks the requesting state for premium plugin "instructions" (the list

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -31,9 +31,6 @@ export function isRequesting( state = {}, action ) {
 			return Object.assign( {}, state, { [ action.siteId ]: true } );
 		case PLUGIN_SETUP_INSTRUCTIONS_RECEIVE:
 			return Object.assign( {}, state, { [ action.siteId ]: false } );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 		default:
 			return state;
 	}
@@ -47,9 +44,6 @@ export function hasRequested( state = {}, action ) {
 	switch ( action.type ) {
 		case PLUGIN_SETUP_INSTRUCTIONS_RECEIVE:
 			return Object.assign( {}, state, { [ action.siteId ]: true } );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 		default:
 			return state;
 	}
@@ -75,7 +69,7 @@ export function plugins( state = {}, action ) {
 			}
 			return state;
 		case SERIALIZE:
-			let processedState = {};
+			const processedState = {};
 			// Save the error state as a string message.
 			forEach( state, ( pluginList, key ) => {
 				processedState[ key ] = pluginList.map( ( item ) => {
@@ -95,6 +89,7 @@ export function plugins( state = {}, action ) {
 			return state;
 	}
 }
+plugins.hasCustomPersistence = true;
 
 /*
  * Tracks the list of premium plugin objects for a single site

--- a/client/state/plugins/reducer.js
+++ b/client/state/plugins/reducer.js
@@ -1,16 +1,12 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import wporg from './wporg/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import premium from './premium/reducer';
 import installed from './installed/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	wporg,
 	premium,
 	installed

--- a/client/state/plugins/wporg/reducer.js
+++ b/client/state/plugins/wporg/reducer.js
@@ -7,7 +7,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { combineReducers } from 'redux';
+import { combineReducersWithPersistence } from 'state/utils';
 
 function updatePluginState( state = {}, pluginSlug, attributes ) {
 	return Object.assign( {},
@@ -48,7 +48,7 @@ export function items( state = {}, action ) {
 	}
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	fetchingItems
 } );

--- a/client/state/plugins/wporg/reducer.js
+++ b/client/state/plugins/wporg/reducer.js
@@ -4,8 +4,6 @@
 import {
 	WPORG_PLUGIN_DATA_RECEIVE,
 	FETCH_WPORG_PLUGIN_DATA,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 
@@ -22,10 +20,6 @@ export function fetchingItems( state = {}, action ) {
 			return Object.assign( {}, state, { [ action.pluginSlug ]: true } );
 		case WPORG_PLUGIN_DATA_RECEIVE:
 			return Object.assign( {}, state, { [ action.pluginSlug ]: false } );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -38,11 +32,6 @@ export function items( state = {}, action ) {
 				return updatePluginState( state, pluginSlug, Object.assign( { fetched: true, wporg: true }, action.data ) );
 			}
 			return updatePluginState( state, pluginSlug, Object.assign( { fetched: false, wporg: false } ) );
-
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 		default:
 			return state;
 	}

--- a/client/state/plugins/wporg/test/reducer.js
+++ b/client/state/plugins/wporg/test/reducer.js
@@ -10,8 +10,6 @@ import deepFreeze from 'deep-freeze';
 import {
 	WPORG_PLUGIN_DATA_RECEIVE,
 	FETCH_WPORG_PLUGIN_DATA,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { items, fetchingItems } from '../reducer';
 
@@ -45,16 +43,6 @@ describe( 'wporg reducer', () => {
 					dolly: { wporg: false, fetched: false }
 				} );
 		} );
-		it( 'never persists state because this is not implemented', () => {
-			const plugins = { my: { plugin: { shape: {} } } };
-			const state = items( plugins, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-		it( 'never loads persisted state because this is not implemented', () => {
-			const plugins = { my: { plugin: { shape: {} } } };
-			const state = items( plugins, { type: DESERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
 	} );
 	describe( 'fetchingItems', () => {
 		it( 'should track when fetches start', () => {
@@ -87,16 +75,6 @@ describe( 'wporg reducer', () => {
 				pluginSlug: 'dolly'
 			} );
 			expect( state ).to.deep.equal( { akismet: true, dolly: false } );
-		} );
-		it( 'never persists state', () => {
-			const plugins = { my: { plugin: { shape: {} } } };
-			const state = fetchingItems( plugins, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-		it( 'never loads persisted state', () => {
-			const plugins = { my: { plugin: { shape: {} } } };
-			const state = fetchingItems( plugins, { type: DESERIALIZE } );
-			expect( state ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/state/post-formats/reducer.js
+++ b/client/state/post-formats/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { postFormatsItemsSchema } from './schema';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import {
 	POST_FORMATS_RECEIVE,
@@ -43,7 +39,7 @@ export const items = createReducer( {}, {
 	}
 }, postFormatsItemsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/post-formats/reducer.js
+++ b/client/state/post-formats/reducer.js
@@ -2,8 +2,7 @@
  * Internal dependencies
  */
 import { postFormatsItemsSchema } from './schema';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import {
 	POST_FORMATS_RECEIVE,
 	POST_FORMATS_REQUEST,

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -6,8 +6,8 @@ import keyBy from 'lodash/keyBy';
 /**
  * Internal dependencies
  */
-import { isValidStateWithSchema } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
+
 import * as schema from './schema';
 import taxonomies from './taxonomies/reducer';
 import {

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import keyBy from 'lodash/keyBy';
 
 /**
  * Internal dependencies
  */
 import { isValidStateWithSchema } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import * as schema from './schema';
 import taxonomies from './taxonomies/reducer';
 import {
@@ -71,7 +71,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items,
 	taxonomies

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -35,10 +35,6 @@ export function requesting( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: POST_TYPES_REQUEST === action.type
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -64,8 +60,9 @@ export function items( state = {}, action ) {
 			if ( isValidStateWithSchema( state, schema.items ) ) {
 				return state;
 			}
-
 			return {};
+		case SERIALIZE:
+			return state;
 	}
 
 	return state;

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -70,6 +70,7 @@ export function items( state = {}, action ) {
 
 	return state;
 }
+items.hasCustomPersistence = true;
 
 export default combineReducersWithPersistence( {
 	requesting,

--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -38,10 +38,6 @@ export function requesting( state = {}, action ) {
 					[ action.postType ]: POST_TYPES_TAXONOMIES_REQUEST === action.type
 				}
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -70,6 +66,8 @@ export function items( state = {}, action ) {
 			}
 
 			return {};
+		case SERIALIZE:
+			return state;
 	}
 
 	return state;

--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -15,8 +15,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { isValidStateWithSchema } from 'state/utils';
+import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**

--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import merge from 'lodash/merge';
 import keyBy from 'lodash/keyBy';
 
@@ -16,6 +15,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
@@ -75,7 +75,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/post-types/taxonomies/test/reducer.js
+++ b/client/state/post-types/taxonomies/test/reducer.js
@@ -151,36 +151,6 @@ describe( 'reducer', () => {
 				}
 			} );
 		} );
-
-		it( 'should never persist state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					post: false,
-					page: false
-				},
-				77203074: {
-					post: true
-				}
-			} );
-			const state = requesting( original, { type: SERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					post: false,
-					page: false
-				},
-				77203074: {
-					post: true
-				}
-			} );
-			const state = requesting( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( '#items()', () => {

--- a/client/state/post-types/test/reducer.js
+++ b/client/state/post-types/test/reducer.js
@@ -88,26 +88,6 @@ describe( 'reducer', () => {
 				2916284: false
 			} );
 		} );
-
-		it( 'should not persist state', () => {
-			const state = requesting( deepFreeze( {
-				2916284: true
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const state = requesting( deepFreeze( {
-				2916284: true
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( '#items()', () => {

--- a/client/state/posts/counts/reducer.js
+++ b/client/state/posts/counts/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import omit from 'lodash/omit';
@@ -23,6 +22,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { countsSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -190,7 +190,7 @@ export const counts = ( () => {
 	}, countsSchema );
 } )();
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	counts
 } );

--- a/client/state/posts/counts/reducer.js
+++ b/client/state/posts/counts/reducer.js
@@ -20,9 +20,8 @@ import {
 	POST_SAVE,
 	POSTS_RECEIVE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { countsSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 /**
  * Returns the updated post types requesting state after an action has been

--- a/client/state/posts/counts/reducer.js
+++ b/client/state/posts/counts/reducer.js
@@ -19,8 +19,6 @@ import {
 	POST_DELETE,
 	POST_SAVE,
 	POSTS_RECEIVE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { countsSchema } from './schema';
@@ -45,10 +43,6 @@ export function requesting( state = {}, action ) {
 					[ action.postType ]: POST_COUNTS_REQUEST === action.type
 				}
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/posts/counts/test/reducer.js
+++ b/client/state/posts/counts/test/reducer.js
@@ -156,36 +156,6 @@ describe( 'reducer', () => {
 				}
 			} );
 		} );
-
-		it( 'should never persist state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					post: false,
-					page: false
-				},
-				77203074: {
-					post: true
-				}
-			} );
-			const state = requesting( original, { type: SERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					post: false,
-					page: false
-				},
-				77203074: {
-					post: true
-				}
-			} );
-			const state = requesting( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( '#counts()', () => {

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { merge } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import itemsSchema from './schema';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import {
 	POST_LIKES_RECEIVE,
@@ -62,7 +62,7 @@ export const items = createReducer( {}, {
 	}
 }, itemsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -7,8 +7,7 @@ import { merge } from 'lodash';
  * Internal dependencies
  */
 import itemsSchema from './schema';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import {
 	POST_LIKES_RECEIVE,
 	POST_LIKES_REQUEST,

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -98,10 +98,6 @@ export function siteRequests( state = {}, action ) {
 					[ action.postId ]: POST_REQUEST === action.type
 				} )
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -125,10 +121,6 @@ export function queryRequests( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ serializedQuery ]: POSTS_REQUEST === action.type
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -299,10 +291,6 @@ export function edits( state = {}, action ) {
 					'' === key ? savedPost.ID : key
 				) )
 			};
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues, mapKeys } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	EDITOR_START,
 	EDITOR_STOP,
@@ -308,7 +308,7 @@ export function edits( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	counts,
 	items,
 	siteRequests,

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -7,7 +7,7 @@ import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues, map
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	EDITOR_START,
 	EDITOR_STOP,
@@ -38,7 +38,6 @@ import {
 	mergeIgnoringArrays,
 	normalizePostForState
 } from './utils';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { itemsSchema, queriesSchema } from './schema';
 
 /**

--- a/client/state/posts/revisions/reducer.js
+++ b/client/state/posts/revisions/reducer.js
@@ -11,8 +11,6 @@ import {
 	POST_REVISIONS_REQUEST,
 	POST_REVISIONS_REQUEST_FAILURE,
 	POST_REVISIONS_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 
@@ -26,10 +24,6 @@ export function requesting( state = {}, action ) {
 					[ action.postId ]: action.type === POST_REVISIONS_REQUEST,
 				},
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/posts/revisions/reducer.js
+++ b/client/state/posts/revisions/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { keyBy, merge } from 'lodash';
 
 /**
@@ -15,6 +14,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 export function requesting( state = {}, action ) {
 	switch ( action.type ) {
@@ -50,7 +50,7 @@ export function revisions( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	revisions,
 } );

--- a/client/state/posts/revisions/test/reducer.js
+++ b/client/state/posts/revisions/test/reducer.js
@@ -12,8 +12,6 @@ import {
 	POST_REVISIONS_REQUEST,
 	POST_REVISIONS_REQUEST_FAILURE,
 	POST_REVISIONS_REQUEST_SUCCESS,
-	DESERIALIZE,
-	SERIALIZE,
 } from 'state/action-types';
 import reducer, {
 	requesting,
@@ -123,30 +121,6 @@ describe( 'reducer', () => {
 					10: true,
 				},
 			} );
-		} );
-
-		it( 'should not persist state', () => {
-			const state = requesting( deepFreeze( {
-				12345678: {
-					50: true,
-				},
-			} ), {
-				type: SERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const state = requesting( deepFreeze( {
-				12345678: {
-					50: true,
-				},
-			} ), {
-				type: DESERIALIZE,
-			} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -214,26 +214,6 @@ describe( 'reducer', () => {
 				'2916284:{"search":"Hello"}': false
 			} );
 		} );
-
-		it( 'should never persist state', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"Hello"}': true
-			} );
-
-			const state = queryRequests( original, { type: SERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"Hello"}': true
-			} );
-
-			const state = queryRequests( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( '#queries()', () => {
@@ -689,30 +669,6 @@ describe( 'reducer', () => {
 				}
 			} );
 		} );
-
-		it( 'never persists state', () => {
-			const state = siteRequests( deepFreeze( {
-				2916284: {
-					841: true
-				}
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'never loads persisted state', () => {
-			const state = siteRequests( deepFreeze( {
-				2916284: {
-					841: true
-				}
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( '#edits()', () => {
@@ -1117,30 +1073,6 @@ describe( 'reducer', () => {
 					}
 				}
 			} );
-		} );
-
-		it( 'should not persist state', () => {
-			const state = edits( deepFreeze( {
-				2916284: {
-					'': {
-						title: 'Ribs & Chicken'
-					}
-				}
-			} ), { type: SERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const state = edits( deepFreeze( {
-				2916284: {
-					'': {
-						title: 'Ribs & Chicken'
-					}
-				}
-			} ), { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { omit } from 'lodash';
 
 /**
@@ -15,6 +14,7 @@ import {
 	PREFERENCES_FETCH_FAILURE,
 	PREFERENCES_SAVE_SUCCESS
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { remoteValuesSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -64,7 +64,7 @@ const lastFetchedTimestamp = createReducer( false, {
 	[ PREFERENCES_FETCH_SUCCESS ]: () => Date.now(),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	localValues,
 	remoteValues,
 	fetching,

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -14,9 +14,8 @@ import {
 	PREFERENCES_FETCH_FAILURE,
 	PREFERENCES_SAVE_SUCCESS
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { remoteValuesSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 /**
  * Returns the updated local values state after an action has been dispatched.

--- a/client/state/preview/reducer.js
+++ b/client/state/preview/reducer.js
@@ -3,9 +3,6 @@
  */
 import * as ActionTypes from 'state/action-types';
 import { previewSchema } from './schema';
-import { isValidStateWithSchema } from 'state/utils';
-
-const initialState = {};
 
 const siteInitialState = {
 	previousCustomizations: [],
@@ -43,7 +40,7 @@ function siteReducer( newState = siteInitialState, action ) {
 	return state;
 }
 
-export default function( state = initialState, action ) {
+const preview = function( state = {}, action ) {
 	switch ( action.type ) {
 		case ActionTypes.PREVIEW_MARKUP_RECEIVE:
 		case ActionTypes.PREVIEW_CUSTOMIZATIONS_CLEAR:
@@ -51,13 +48,9 @@ export default function( state = initialState, action ) {
 		case ActionTypes.PREVIEW_CUSTOMIZATIONS_UNDO:
 		case ActionTypes.PREVIEW_CUSTOMIZATIONS_SAVED:
 			return Object.assign( {}, state, { [ action.siteId ]: siteReducer( state[ action.siteId ], action ) } );
-		case ActionTypes.SERIALIZE:
-			return state;
-		case ActionTypes.DESERIALIZE:
-			if ( isValidStateWithSchema( state, previewSchema ) ) {
-				return state;
-			}
-			return initialState;
 	}
 	return state;
-}
+};
+preview.schema = previewSchema;
+
+export default preview;

--- a/client/state/products-list/reducer.js
+++ b/client/state/products-list/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -11,6 +6,7 @@ import {
 	PRODUCTS_LIST_REQUEST,
 	PRODUCTS_LIST_REQUEST_FAILURE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { productsListSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -26,7 +22,7 @@ export const isFetching = createReducer( false, {
 	[ PRODUCTS_LIST_REQUEST_FAILURE ]: () => false
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isFetching,
 	items,
 } );

--- a/client/state/products-list/reducer.js
+++ b/client/state/products-list/reducer.js
@@ -6,9 +6,8 @@ import {
 	PRODUCTS_LIST_REQUEST,
 	PRODUCTS_LIST_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { productsListSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 // Stores the complete list of products, indexed by the product key
 export const items = createReducer( {}, {

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import debugFactory from 'debug';
 import omit from 'lodash/omit';
 
@@ -9,6 +8,7 @@ import omit from 'lodash/omit';
  * Internal dependencies
  */
 import { isValidStateWithSchema } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	settingsSchema,
 	systemSchema,
@@ -168,7 +168,7 @@ function settings( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	settings,
 	system
 } );

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -115,6 +115,7 @@ function system( state = {}, action ) {
 
 	return state;
 }
+system.hasCustomPersistence = true;
 
 // If you change this, also change the corresponding test
 const UNPERSISTED_SETTINGS_NODES = [
@@ -167,6 +168,7 @@ function settings( state = {}, action ) {
 
 	return state;
 }
+settings.hasCustomPersistence = true;
 
 export default combineReducersWithPersistence( {
 	settings,

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -7,8 +7,8 @@ import omit from 'lodash/omit';
 /**
  * Internal dependencies
  */
-import { isValidStateWithSchema } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
+
 import {
 	settingsSchema,
 	systemSchema,

--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import { uniqBy } from 'lodash';
+
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
 /**

--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { uniqBy } from 'lodash';
-
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
 /**
@@ -63,7 +62,7 @@ export const total = createReducer(
 	}
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	total,
 } );

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import { combineReducers } from 'redux';
 import { assign, keyBy, map, omit, omitBy, reduce } from 'lodash';
 
 /**
@@ -15,9 +14,8 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { decodeEntities } from 'lib/formatting';
-
 import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
@@ -127,7 +125,7 @@ export const lastFetched = createReducer(
 	}
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	lastFetched,
 	queuedRequests,

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -97,9 +97,6 @@ export function queuedRequests( state = {}, action ) {
 		case READER_FEED_REQUEST_SUCCESS:
 		case READER_FEED_REQUEST_FAILURE:
 			return omit( state, action.payload.feed_ID );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -14,9 +14,8 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
 import { decodeEntities } from 'lib/formatting';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
 const actionMap = {

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -22,10 +22,9 @@ import {
 	READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { prepareComparableUrl } from './utils';
 import { items as itemsSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 function updatePostSubscription( state, { payload, type } ) {
 	const follow = find( state, { blog_ID: +payload.blogId } );

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { find, get, isEqual, merge, omitBy, pickBy, reduce } from 'lodash';
 
 /**
@@ -23,6 +22,7 @@ import {
 	READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL,
 	SERIALIZE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { prepareComparableUrl } from './utils';
 import { items as itemsSchema } from './schema';
 import { createReducer } from 'state/utils';
@@ -196,7 +196,7 @@ export const lastSyncTime = createReducer( null, {
 	},
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	itemsCount,
 	lastSyncTime,

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import keyBy from 'lodash/keyBy';
 import map from 'lodash/map';
 import union from 'lodash/union';
@@ -31,6 +30,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 
@@ -237,7 +237,7 @@ export function missingLists( state = [], action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	subscribedLists,
 	updatedLists,

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -27,12 +27,9 @@ import {
 	READER_LISTS_REQUEST_SUCCESS,
 	READER_LISTS_REQUEST_FAILURE,
 	READER_LISTS_UNFOLLOW_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } from './schema';
-import { isValidStateWithSchema } from 'state/utils';
 
 /**
  * Tracks all known list objects, indexed by list ID.
@@ -62,16 +59,10 @@ export function items( state = {}, action ) {
 			}
 			listForDescriptionChange.description = action.description;
 			return Object.assign( {}, state, keyBy( [ listForDescriptionChange ], 'ID' ) );
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			if ( ! isValidStateWithSchema( state, itemsSchema ) ) {
-				return {};
-			}
-			return state;
 	}
 	return state;
 }
+items.schema = itemsSchema;
 
 /**
  * Tracks which list IDs the current user is subscribed to.
@@ -89,16 +80,10 @@ export function subscribedLists( state = [], action ) {
 			return filter( state, listId => {
 				return listId !== action.data.list.ID;
 			} );
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			if ( ! isValidStateWithSchema( state, subscriptionsSchema ) ) {
-				return [];
-			}
-			return state;
 	}
 	return state;
 }
+subscribedLists.schema = subscriptionsSchema;
 
 /**
  * Tracks which list IDs have been updated recently. Used to show the correct success message.
@@ -120,17 +105,10 @@ export function updatedLists( state = [], action ) {
 			return filter( state, listId => {
 				return listId !== action.listId;
 			} );
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			if ( ! isValidStateWithSchema( state, updatedListsSchema ) ) {
-				return [];
-			}
-			return state;
 	}
 	return state;
 }
-
+updatedLists.schema = updatedListsSchema;
 /**
  * Returns the updated requests state after an action has been dispatched.
  *
@@ -144,10 +122,6 @@ export function isRequestingList( state = false, action ) {
 		case READER_LIST_REQUEST_SUCCESS:
 		case READER_LIST_REQUEST_FAILURE:
 			return READER_LIST_REQUEST === action.type;
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;
@@ -166,10 +140,6 @@ export function isRequestingLists( state = false, action ) {
 		case READER_LISTS_REQUEST_SUCCESS:
 		case READER_LISTS_REQUEST_FAILURE:
 			return READER_LISTS_REQUEST === action.type;
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;
@@ -192,17 +162,11 @@ export function errors( state = {}, action ) {
 		case READER_LIST_DISMISS_NOTICE:
 			// Remove the dismissed list ID
 			return omit( state, action.listId );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			if ( ! isValidStateWithSchema( state, errorsSchema ) ) {
-				return {};
-			}
-			return state;
 	}
 
 	return state;
 }
+errors.schema = errorsSchema;
 
 /**
  * A missing list is one that's been requested, but we couldn't find (API response 404-ed).
@@ -229,9 +193,6 @@ export function missingLists( state = [], action ) {
 				return state;
 			}
 			return union( state, [ { owner: action.owner, slug: action.slug } ] );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return state;
 	}
 
 	return state;

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -6,10 +6,9 @@ import keyBy from 'lodash/keyBy';
 /**
  * Internal dependencies
  */
-import { READER_POSTS_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { READER_POSTS_RECEIVE } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
-import { isValidStateWithSchema } from 'state/utils';
 
 /**
  * Tracks all known post objects, indexed by post ID.
@@ -23,16 +22,10 @@ export function items( state = {}, action ) {
 		case READER_POSTS_RECEIVE: {
 			return Object.assign( {}, state, keyBy( action.posts, 'global_ID' ) );
 		}
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			if ( ! isValidStateWithSchema( state, itemsSchema ) ) {
-				return {};
-			}
-			return state;
 	}
 	return state;
 }
+items.schema = itemsSchema;
 
 export default combineReducersWithPersistence( {
 	items,

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import keyBy from 'lodash/keyBy';
 
 /**
  * Internal dependencies
  */
 import { READER_POSTS_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 
@@ -34,6 +34,6 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 } );

--- a/client/state/reader/recommended-sites/reducer.js
+++ b/client/state/reader/recommended-sites/reducer.js
@@ -2,13 +2,16 @@
  * External dependencies
  */
 import { uniqBy } from 'lodash';
-import { combineReducers } from 'redux';
 
 /**
  * Internal dependencies
  */
 import { READER_RECOMMENDED_SITES_RECEIVE } from 'state/action-types';
-import { createReducer, keyedReducer } from 'state/utils';
+import {
+	createReducer,
+	keyedReducer,
+	combineReducersWithPersistence
+} from 'state/utils';
 
 /**
  * Tracks mappings between randomization seeds and site recs.
@@ -42,7 +45,7 @@ export const pagingOffset = keyedReducer(
 	} )
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	pagingOffset,
 } );

--- a/client/state/reader/reducer.js
+++ b/client/state/reader/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import lists from './lists/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import feeds from './feeds/reducer';
 import follows from './follows/reducer';
 import sites from './sites/reducer';
@@ -19,7 +15,7 @@ import teams from './teams/reducer';
 import feedSearches from './feed-searches/reducer';
 import recommendedSites from './recommended-sites/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	feeds,
 	follows,
 	lists,

--- a/client/state/reader/related-posts/reducer.js
+++ b/client/state/reader/related-posts/reducer.js
@@ -8,8 +8,8 @@ import map from 'lodash/map';
 /**
  * Internal Dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	READER_RELATED_POSTS_RECEIVE,
 	READER_RELATED_POSTS_REQUEST,

--- a/client/state/reader/related-posts/reducer.js
+++ b/client/state/reader/related-posts/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import { combineReducers } from 'redux';
 import assign from 'lodash/assign';
 import partial from 'lodash/partial';
 import map from 'lodash/map';
@@ -10,6 +9,7 @@ import map from 'lodash/map';
  * Internal Dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	READER_RELATED_POSTS_RECEIVE,
 	READER_RELATED_POSTS_REQUEST,
@@ -49,7 +49,7 @@ export const queuedRequests = createReducer(
 	}
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	queuedRequests,
 } );

--- a/client/state/reader/site-blocks/reducer.js
+++ b/client/state/reader/site-blocks/reducer.js
@@ -10,8 +10,7 @@ import {
 	READER_SITE_UNBLOCK_REQUEST_SUCCESS,
 } from 'state/action-types';
 
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer, keyedReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, keyedReducer } from 'state/utils';
 
 /**
  * Tracks all known site block statuses, indexed by site ID.

--- a/client/state/reader/site-blocks/reducer.js
+++ b/client/state/reader/site-blocks/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,6 +9,8 @@ import {
 	READER_SITE_UNBLOCK_REQUEST_FAILURE,
 	READER_SITE_UNBLOCK_REQUEST_SUCCESS,
 } from 'state/action-types';
+
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer, keyedReducer } from 'state/utils';
 
 /**
@@ -34,6 +31,6 @@ export const items = keyedReducer(
 	)
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 } );

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -14,8 +14,7 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
 import { decodeEntities } from 'lib/formatting';

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -103,6 +103,7 @@ export function items( state = {}, action ) {
 	const handler = actionMap[ action.type ] || defaultHandler;
 	return handler( state, action );
 }
+items.hasCustomPersistence = true;
 
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {
@@ -113,9 +114,6 @@ export function queuedRequests( state = {}, action ) {
 		case READER_SITE_REQUEST_SUCCESS:
 		case READER_SITE_REQUEST_FAILURE:
 			return omit( state, action.payload.ID );
-		case SERIALIZE: // do not serialize in flight data
-		case DESERIALIZE:
-			return {};
 		// we intentionally don't update state on READER_SITE_UPDATE because those can't affect inflight requests
 	}
 	return state;

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import { combineReducers } from 'redux';
 import { assign, keyBy, map, omit, omitBy, reduce, trim } from 'lodash';
 
 /**
@@ -15,7 +14,7 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
@@ -143,7 +142,7 @@ export const lastFetched = createReducer(
 	}
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	queuedRequests,
 	lastFetched,

--- a/client/state/reader/tags/images/reducer.js
+++ b/client/state/reader/tags/images/reducer.js
@@ -6,8 +6,6 @@ import {
 	READER_TAG_IMAGES_REQUEST,
 	READER_TAG_IMAGES_REQUEST_SUCCESS,
 	READER_TAG_IMAGES_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 
@@ -30,10 +28,6 @@ export function items( state = {}, action ) {
 				...state,
 				[ action.tag ]: images,
 			};
-		// Always return default state - we don't want to serialize images yet
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -56,10 +50,6 @@ export function requesting( state = {}, action ) {
 				...state,
 				[ action.tag ]: action.type === READER_TAG_IMAGES_REQUEST,
 			};
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/reader/tags/images/reducer.js
+++ b/client/state/reader/tags/images/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,6 +9,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 /**
  * Tracks all known image objects, indexed by tag name.
@@ -68,7 +64,7 @@ export function requesting( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 } );

--- a/client/state/reader/tags/images/test/reducer.js
+++ b/client/state/reader/tags/images/test/reducer.js
@@ -11,8 +11,6 @@ import {
 	READER_TAG_IMAGES_RECEIVE,
 	READER_TAG_IMAGES_REQUEST,
 	READER_TAG_IMAGES_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'state/action-types';
 import { items, requesting } from '../reducer';
 
@@ -100,26 +98,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				pineapple: false,
 				pen: false,
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					pineapple: false,
-					pen: true,
-				} );
-				const state = requesting( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					pineapple: false,
-					pen: true,
-				} );
-				const state = requesting( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/reader/tags/reducer.js
+++ b/client/state/reader/tags/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import images from './images/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import items from './items/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	images,
 	items,
 } );

--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -2,9 +2,8 @@
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { itemsSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 export const items = createReducer(
 	[],

--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External Dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -23,7 +19,7 @@ export const isRequesting = createReducer( false, {
 	[ READER_TEAMS_RECEIVE ]: () => false,
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	isRequesting,
 } );

--- a/client/state/reader/thumbnails/reducer.js
+++ b/client/state/reader/thumbnails/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,6 +9,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 /**
  * Tracks mappings between embedUrls (iframe.src) --> thumbnails
@@ -76,7 +72,7 @@ export function requesting( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 } );

--- a/client/state/reader/thumbnails/reducer.js
+++ b/client/state/reader/thumbnails/reducer.js
@@ -6,8 +6,6 @@ import {
 	READER_THUMBNAIL_REQUEST_SUCCESS,
 	READER_THUMBNAIL_REQUEST_FAILURE,
 	READER_THUMBNAIL_RECEIVE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 
@@ -39,10 +37,6 @@ export function items( state = {}, action ) {
 				...state,
 				[ action.embedUrl ]: action.thumbnailUrl,
 			};
-		// Always return default state - we don't want to serialize thumbnails
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -65,9 +59,6 @@ export function requesting( state = {}, action ) {
 				...state,
 				[ action.embedUrl ]: action.type === READER_THUMBNAIL_REQUEST,
 			};
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/reader/thumbnails/test/reducer.js
+++ b/client/state/reader/thumbnails/test/reducer.js
@@ -12,8 +12,6 @@ import {
 	READER_THUMBNAIL_REQUEST_SUCCESS,
 	READER_THUMBNAIL_REQUEST_FAILURE,
 	READER_THUMBNAIL_RECEIVE,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'state/action-types';
 import { items, requesting } from '../reducer';
 
@@ -98,24 +96,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				[ embedUrl ]: false,
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					[ embedUrl ]: true,
-				} );
-				const state = requesting( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					[ embedUrl ]: true,
-				} );
-				const state = requesting( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/receipts/reducer.js
+++ b/client/state/receipts/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -13,6 +8,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 export const initialReceiptState = {
 	data: null,
@@ -62,6 +58,6 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items
 } );

--- a/client/state/receipts/reducer.js
+++ b/client/state/receipts/reducer.js
@@ -5,8 +5,6 @@ import {
 	RECEIPT_FETCH,
 	RECEIPT_FETCH_COMPLETED,
 	RECEIPT_FETCH_FAILED,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 
@@ -49,10 +47,6 @@ export function items( state = {}, action ) {
 				error: action.error,
 				isRequesting: false
 			} );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/receipts/test/reducer.js
+++ b/client/state/receipts/test/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -11,8 +10,6 @@ import {
 	RECEIPT_FETCH,
 	RECEIPT_FETCH_COMPLETED,
 	RECEIPT_FETCH_FAILED,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { items } from '../reducer';
 
@@ -87,32 +84,6 @@ describe( 'reducer', () => {
 					hasLoadedFromServer: true,
 					isRequesting: false
 				}
-			} );
-		} );
-		describe( 'persistence', () => {
-			it( 'does not persist data because this is not implemented yet', () => {
-				const original = deepFreeze( {
-					11111111: {
-						data: { amount: 10 },
-						error: null,
-						hasLoadedFromServer: true,
-						isRequesting: true
-					}
-				} );
-				const state = items( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-			it( 'does not load persisted data because this is not implemented yet', () => {
-				const original = deepFreeze( {
-					11111111: {
-						data: { amount: 10 },
-						error: null,
-						hasLoadedFromServer: true,
-						isRequesting: true
-					}
-				} );
-				const state = items( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { keyBy, omit, without } from 'lodash';
 
 /**
@@ -16,6 +15,7 @@ import {
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -46,7 +46,7 @@ export const items = createReducer( {}, {
 	},
 }, itemSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isFetching,
 	items,
 } );

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -15,9 +15,8 @@ import {
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { itemSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 // Tracks fetching state for keyring connections
 export const isFetching = createReducer( false, {

--- a/client/state/sharing/publicize/publicize-actions/reducer.js
+++ b/client/state/sharing/publicize/publicize-actions/reducer.js
@@ -20,9 +20,8 @@ import {
 	PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS,
 	PUBLICIZE_SHARE_ACTION_EDIT_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { publicizeActionsSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 function updateDataForPost( newValue, state, siteId, postId, actionId ) {
 	if ( typeof actionId !== 'undefined' ) {

--- a/client/state/sharing/publicize/publicize-actions/reducer.js
+++ b/client/state/sharing/publicize/publicize-actions/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { omit, get } from 'lodash';
 
 /**
@@ -21,6 +20,7 @@ import {
 	PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS,
 	PUBLICIZE_SHARE_ACTION_EDIT_FAILURE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { publicizeActionsSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -98,7 +98,7 @@ export const editingSharePostAction = createReducer( {}, {
 		( state, { siteId, postId, actionId } ) => updateDataForPost( true, state, siteId, postId, actionId ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	scheduled,
 	published,
 	fetchingSharePostActionsScheduled,

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { keyBy, omit, omitBy } from 'lodash';
-
 /**
  * Internal dependencies
  */
@@ -23,6 +21,7 @@ import {
 	PUBLICIZE_SHARE_FAILURE,
 	PUBLICIZE_SHARE_DISMISS
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { connectionsSchema } from './schema';
 import { createReducer } from 'state/utils';
 import sharePostActions from './publicize-actions/reducer';
@@ -79,7 +78,7 @@ export const connections = createReducer( {}, {
 	[ PUBLICIZE_CONNECTION_UPDATE ]: ( state, { connection } ) => ( { ...state, [ connection.ID ]: connection } ),
 }, connectionsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	fetchingConnection,
 	fetchingConnections,
 	fetchedConnections,

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -21,9 +21,8 @@ import {
 	PUBLICIZE_SHARE_FAILURE,
 	PUBLICIZE_SHARE_DISMISS
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { connectionsSchema } from './schema';
-import { createReducer } from 'state/utils';
 import sharePostActions from './publicize-actions/reducer';
 
 export const sharePostStatus = createReducer( {}, {

--- a/client/state/sharing/reducer.js
+++ b/client/state/sharing/reducer.js
@@ -1,16 +1,12 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import keyring from './keyring/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import publicize from './publicize/reducer';
 import services from './services/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	keyring,
 	publicize,
 	services,

--- a/client/state/sharing/services/reducer.js
+++ b/client/state/sharing/services/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -12,6 +7,7 @@ import {
 	KEYRING_SERVICES_REQUEST_FAILURE,
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -27,7 +23,7 @@ export const isFetching = createReducer( false, {
 	[ KEYRING_SERVICES_REQUEST_FAILURE ]: () => false
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isFetching,
 	items,
 } );

--- a/client/state/sharing/services/reducer.js
+++ b/client/state/sharing/services/reducer.js
@@ -7,9 +7,8 @@ import {
 	KEYRING_SERVICES_REQUEST_FAILURE,
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { itemSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 // Stores the list of available keyring services
 export const items = createReducer( {}, {

--- a/client/state/shortcodes/reducer.js
+++ b/client/state/shortcodes/reducer.js
@@ -7,8 +7,7 @@ import { merge } from 'lodash';
  * Internal dependencies
  */
 import { shortcodesSchema } from './schema';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import {
 	SHORTCODE_RECEIVE,
 	SHORTCODE_REQUEST,

--- a/client/state/shortcodes/reducer.js
+++ b/client/state/shortcodes/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { merge } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { shortcodesSchema } from './schema';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import {
 	SHORTCODE_RECEIVE,
@@ -59,7 +59,7 @@ export const items = createReducer( {}, {
 	}
 }, shortcodesSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/signup/optional-dependencies/reducer.js
+++ b/client/state/signup/optional-dependencies/reducer.js
@@ -4,8 +4,7 @@
 import {
 	SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { suggestedUsernameSchema } from './schema';
 
 const suggestedUsername = createReducer( '',

--- a/client/state/signup/optional-dependencies/reducer.js
+++ b/client/state/signup/optional-dependencies/reducer.js
@@ -1,15 +1,10 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
 	SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import { suggestedUsernameSchema } from './schema';
 
@@ -22,7 +17,7 @@ const suggestedUsername = createReducer( '',
 	suggestedUsernameSchema
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	suggestedUsername
 } );
 

--- a/client/state/signup/reducer.js
+++ b/client/state/signup/reducer.js
@@ -1,16 +1,12 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import dependencyStore from './dependency-store/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import optionalDependencies from './optional-dependencies/reducer';
 import steps from './steps/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	dependencyStore,
 	optionalDependencies,
 	steps,

--- a/client/state/signup/steps/reducer.js
+++ b/client/state/signup/steps/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import siteTitle from './site-title/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import survey from './survey/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	siteTitle,
 	survey,
 } );

--- a/client/state/site-roles/reducer.js
+++ b/client/state/site-roles/reducer.js
@@ -2,8 +2,7 @@
  * Internal dependencies
  */
 import { siteRolesSchema } from './schema';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import {
 	SITE_ROLES_RECEIVE,
 	SITE_ROLES_REQUEST,

--- a/client/state/site-roles/reducer.js
+++ b/client/state/site-roles/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { siteRolesSchema } from './schema';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import {
 	SITE_ROLES_RECEIVE,
@@ -42,7 +38,7 @@ export const items = createReducer( {}, {
 	[ SITE_ROLES_RECEIVE ]: ( state, { siteId, roles } ) => ( { ...state, [ siteId ]: roles } )
 }, siteRolesSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/site-settings/exporter/reducers.js
+++ b/client/state/site-settings/exporter/reducers.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -20,7 +15,7 @@ import {
 	EXPORT_STARTED,
 	EXPORT_FAILURE
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { States } from './constants';
 
 export function selectedPostType( state = null, action ) {
@@ -165,7 +160,7 @@ export function downloadURL( state = null, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	selectedPostType,
 	selectedAdvancedSettings,
 	exportingState,

--- a/client/state/site-settings/exporter/reducers.js
+++ b/client/state/site-settings/exporter/reducers.js
@@ -7,8 +7,6 @@ import {
 	EXPORT_ADVANCED_SETTINGS_RECEIVE,
 	EXPORT_POST_TYPE_SET,
 	EXPORT_POST_TYPE_FIELD_SET,
-	SERIALIZE,
-	DESERIALIZE,
 	EXPORT_CLEAR,
 	EXPORT_COMPLETE,
 	EXPORT_START_REQUEST,
@@ -22,10 +20,6 @@ export function selectedPostType( state = null, action ) {
 	switch ( action.type ) {
 		case EXPORT_POST_TYPE_SET:
 			return action.postType;
-		case SERIALIZE:
-			return null;
-		case DESERIALIZE:
-			return null;
 	}
 	return state;
 }
@@ -56,10 +50,6 @@ export function selectedAdvancedSettings( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: postTypes( state[ action.siteId ], action )
 			} );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -92,10 +82,6 @@ export function exportingState( state = {}, { type, siteId } ) {
 			return Object.assign( {}, state, {
 				[ siteId ]: States.READY
 			} );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -117,10 +103,6 @@ export function fetchingAdvancedSettings( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: false
 			} );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -137,10 +119,6 @@ export function advancedSettings( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: action.advancedSettings
 			} );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -150,10 +128,6 @@ export function downloadURL( state = null, action ) {
 		case EXPORT_COMPLETE:
 			return action.downloadURL;
 		case EXPORT_CLEAR:
-			return null;
-		case SERIALIZE:
-			return null;
-		case DESERIALIZE:
 			return null;
 	}
 

--- a/client/state/site-settings/exporter/test/reducer.js
+++ b/client/state/site-settings/exporter/test/reducer.js
@@ -11,13 +11,9 @@ import {
 	EXPORT_ADVANCED_SETTINGS_FETCH,
 	EXPORT_ADVANCED_SETTINGS_RECEIVE,
 	EXPORT_POST_TYPE_FIELD_SET,
-	DESERIALIZE,
-	SERIALIZE
 } from 'state/action-types';
 import {
-	selectedPostType,
 	selectedAdvancedSettings,
-	exportingState,
 	advancedSettings,
 	fetchingAdvancedSettings
 } from '../reducers';
@@ -25,38 +21,9 @@ import {
 	SAMPLE_ADVANCED_SETTINGS,
 	SAMPLE_ADVANCED_SETTINGS_EMPTY,
 } from './data';
-import { States } from '../constants';
 
 describe( 'reducer', () => {
-	describe( 'selectedPostType', () => {
-		it( 'does not persist state', () => {
-			const postType = 'feedback';
-			const state = selectedPostType( postType, { type: SERIALIZE } );
-			expect( state ).to.be.null;
-		} );
-		it( 'does not load persisted state', () => {
-			const postType = 'feedback';
-			const state = selectedPostType( postType, { type: DESERIALIZE } );
-			expect( state ).to.be.null;
-		} );
-	} );
-
 	describe( 'selectedAdvancedSettings', () => {
-		const selectedSettings = {
-			2916284: {
-				post: { category: 1 },
-				page: { author: 95752520 },
-			}
-		};
-		it( 'does not persist state', () => {
-			const state = selectedAdvancedSettings( selectedSettings, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-		it( 'does not load persisted state', () => {
-			const state = selectedAdvancedSettings( selectedSettings, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-
 		it( 'should set post category', () => {
 			const state = selectedAdvancedSettings( {}, {
 				type: EXPORT_POST_TYPE_FIELD_SET,
@@ -90,28 +57,7 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( 'exportingState', () => {
-		it( 'does not persist state', () => {
-			const state = exportingState( { 100658273: States.EXPORTING }, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-		it( 'does not load persisted state', () => {
-			const state = exportingState( { 100658273: States.EXPORTING }, { type: DESERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-	} );
-
 	describe( '#fetchingAdvancedSettings()', () => {
-		it( 'should not persist state', () => {
-			const state = fetchingAdvancedSettings( { 100658273: true }, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const state = fetchingAdvancedSettings( { 100658273: true }, { type: DESERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-
 		it( 'should index fetching status by site ID', () => {
 			const state = fetchingAdvancedSettings( null, {
 				type: EXPORT_ADVANCED_SETTINGS_FETCH,
@@ -153,18 +99,6 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#advancedSettings()', () => {
-		it( 'does not persist data because this is not implemented yet', () => {
-			const settings = { 100658273: SAMPLE_ADVANCED_SETTINGS };
-			const state = advancedSettings( settings, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'does not load persisted data because this is not implemented yet', () => {
-			const settings = { 100658273: SAMPLE_ADVANCED_SETTINGS };
-			const state = advancedSettings( settings, { type: DESERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-
 		it( 'should index settings by site ID', () => {
 			const state = advancedSettings( null, {
 				type: EXPORT_ADVANCED_SETTINGS_RECEIVE,

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import exporter from './exporter/reducers';
 import { items as itemSchemas } from './schema';
 import {
@@ -86,7 +86,7 @@ export const items = createReducer( {}, {
 	}
 }, itemSchemas );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	exporter,
 	items,
 	requesting,

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -6,8 +6,8 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import exporter from './exporter/reducers';
 import { items as itemSchemas } from './schema';
 import {

--- a/client/state/sites/connection/reducer.js
+++ b/client/state/sites/connection/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	SITE_CONNECTION_STATUS_RECEIVE,
 	SITE_CONNECTION_STATUS_REQUEST,

--- a/client/state/sites/connection/reducer.js
+++ b/client/state/sites/connection/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	SITE_CONNECTION_STATUS_RECEIVE,
 	SITE_CONNECTION_STATUS_REQUEST,
@@ -27,7 +23,7 @@ export const requesting = createReducer( {}, {
 	[ SITE_CONNECTION_STATUS_REQUEST_SUCCESS ]: createRequestingReducer( false ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 } );

--- a/client/state/sites/domains/reducer.js
+++ b/client/state/sites/domains/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,7 +9,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
@@ -100,7 +95,7 @@ export const errors = ( state = {}, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	errors

--- a/client/state/sites/domains/reducer.js
+++ b/client/state/sites/domains/reducer.js
@@ -6,11 +6,8 @@ import {
 	SITE_DOMAINS_REQUEST,
 	SITE_DOMAINS_REQUEST_SUCCESS,
 	SITE_DOMAINS_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
-import { isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -31,17 +28,11 @@ export const items = ( state = {}, action ) => {
 					[ siteId ]: action.domains
 				}
 			);
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemsSchema ) ) {
-				return state;
-			}
-			return {};
-		case SERIALIZE:
-			return state;
 	}
 
 	return state;
 };
+items.schema = itemsSchema;
 
 /**
  * `Reducer` function which handles request/response actions
@@ -59,9 +50,6 @@ export const requesting = ( state = {}, action ) => {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: action.type === SITE_DOMAINS_REQUEST
 			} );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -86,10 +74,6 @@ export const errors = ( state = {}, action ) => {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: action.error
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/sites/domains/test/reducer.js
+++ b/client/state/sites/domains/test/reducer.js
@@ -8,10 +8,11 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import domainsReducer, {
-	items as itemsReducer,
+	items,
 	requesting as requestReducer,
 	errors as errorsReducer
 } from '../reducer';
+import { withSchemaValidation } from 'state/utils';
 
 /**
  * Action types constantes
@@ -46,6 +47,8 @@ import {
 } from './fixture';
 
 import { useSandbox } from 'test/helpers/use-sinon';
+
+const itemsReducer = withSchemaValidation( items.schema, items );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/sites/guided-transfer/reducer.js
+++ b/client/state/sites/guided-transfer/reducer.js
@@ -10,9 +10,8 @@ import {
 	GUIDED_TRANSFER_STATUS_REQUEST_FAILURE,
 	GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { guidedTransferStatusSchema } from './schema';
-import { createReducer } from 'state/utils';
 
 // Stores the status of guided transfers per site
 export const status = createReducer( {}, {

--- a/client/state/sites/guided-transfer/reducer.js
+++ b/client/state/sites/guided-transfer/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -15,6 +10,7 @@ import {
 	GUIDED_TRANSFER_STATUS_REQUEST_FAILURE,
 	GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { guidedTransferStatusSchema } from './schema';
 import { createReducer } from 'state/utils';
 
@@ -65,7 +61,7 @@ export const isSaving = createReducer( {}, {
 		( { ...state, [ action.siteId ]: false } ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	error,
 	isFetching,
 	isSaving,

--- a/client/state/sites/media-storage/reducer.js
+++ b/client/state/sites/media-storage/reducer.js
@@ -11,12 +11,9 @@ import {
 	SITE_MEDIA_STORAGE_REQUEST,
 	SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
 	SITE_MEDIA_STORAGE_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
-import { isValidStateWithSchema } from 'state/utils';
 
 /**
  * Tracks media-storage information, indexed by site ID.
@@ -32,16 +29,10 @@ export function items( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: mediaStorage
 			} );
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemsSchema ) ) {
-				return state;
-			}
-			return {};
 	}
 	return state;
 }
+items.schema = itemsSchema;
 
 /**
  * Tracks media-storage fetching state, indexed by site ID.
@@ -58,10 +49,6 @@ export function fetchingItems( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: action.type === SITE_MEDIA_STORAGE_REQUEST
 			} );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/sites/media-storage/reducer.js
+++ b/client/state/sites/media-storage/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import pick from 'lodash/pick';
 
 /**
@@ -15,6 +14,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { itemsSchema } from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 
@@ -66,7 +66,7 @@ export function fetchingItems( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	fetchingItems
 } );

--- a/client/state/sites/media-storage/test/reducer.js
+++ b/client/state/sites/media-storage/test/reducer.js
@@ -15,11 +15,14 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { withSchemaValidation } from 'state/utils';
 import reducer, {
-	items,
+	items as unwrappedItems,
 	fetchingItems
 } from '../reducer';
 import { useSandbox } from 'test/helpers/use-sinon';
+
+const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	let sandbox;
@@ -225,38 +228,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: false,
 				77203074: true
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					2916284: {
-						max_storage_bytes: 3221225472,
-						storage_used_bytes: 56000
-					},
-					77203074: {
-						max_storage_bytes: 3221225472,
-						storage_used_bytes: 323506
-					}
-				} );
-				const state = fetchingItems( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					2916284: {
-						max_storage_bytes: 3221225472,
-						storage_used_bytes: 56000
-					},
-					77203074: {
-						max_storage_bytes: 3221225472,
-						storage_used_bytes: 323506
-					}
-				} );
-				const state = fetchingItems( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/sites/monitor/reducer.js
+++ b/client/state/sites/monitor/reducer.js
@@ -6,8 +6,8 @@ import { stubFalse, stubTrue } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer, keyedReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, keyedReducer } from 'state/utils';
+
 import {
 	SITE_MONITOR_SETTINGS_RECEIVE,
 	SITE_MONITOR_SETTINGS_REQUEST,

--- a/client/state/sites/monitor/reducer.js
+++ b/client/state/sites/monitor/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { stubFalse, stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer, keyedReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	SITE_MONITOR_SETTINGS_RECEIVE,
 	SITE_MONITOR_SETTINGS_REQUEST,
@@ -34,7 +34,7 @@ export const updating = keyedReducer( 'siteId', createReducer( {}, {
 	[ SITE_MONITOR_SETTINGS_UPDATE_FAILURE ]: stubFalse,
 } ) );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	updating,

--- a/client/state/sites/plans/reducer.js
+++ b/client/state/sites/plans/reducer.js
@@ -14,8 +14,6 @@ import {
 	SITE_PLANS_TRIAL_CANCEL,
 	SITE_PLANS_TRIAL_CANCEL_COMPLETED,
 	SITE_PLANS_TRIAL_CANCEL_FAILED,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 
 export const initialSiteState = {
@@ -82,13 +80,6 @@ export function plans( state = {}, action ) {
 				error: action.error,
 				isRequesting: false
 			} );
-
-		case SERIALIZE:
-			//TODO: we have full instances of moment.js on sites.plans[siteID].data
-			return {};
-
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/sites/plans/test/reducer.js
+++ b/client/state/sites/plans/test/reducer.js
@@ -14,8 +14,6 @@ import {
 	SITE_PLANS_TRIAL_CANCEL_FAILED,
 	SITE_PLANS_TRIAL_CANCEL_COMPLETED,
 	SITE_PLANS_REMOVE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { plans } from '../reducer';
 
@@ -292,44 +290,6 @@ describe( 'reducer', () => {
 					isRequesting: false
 				}
 			} );
-		} );
-
-		it( 'never persists state because this is not implemented', () => {
-			const original = Object.freeze( {
-					11111111: {
-						data: null,
-						error: 'Unable to fetch site plans',
-						hasLoadedFromServer: false,
-						isRequesting: false
-					}
-				} ),
-				state = plans( original, {
-					type: SERIALIZE
-				} );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'never loads persisted state because this is not implemented', () => {
-			const original = Object.freeze( {
-					11111111: {
-						data: null,
-						error: null,
-						hasLoadedFromServer: false,
-						isRequesting: false
-					},
-					22222222: {
-						data: [],
-						error: null,
-						hasLoadedFromServer: true,
-						isRequesting: false
-					}
-				} ),
-				state = plans( original, {
-					type: DESERIALIZE
-				} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { pick, omit, merge, get, includes, reduce, isEqual, stubFalse, stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { plans } from './plans/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import connection from './connection/reducer';
 import domains from './domains/reducer';
 import guidedTransfer from './guided-transfer/reducer';
@@ -263,7 +263,7 @@ export const deleting = keyedReducer( 'siteId', createReducer( {}, {
 	[ SITE_DELETE_SUCCESS ]: stubFalse
 } ) );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	connection,
 	deleting,
 	domains,

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -7,7 +7,6 @@ import { pick, omit, merge, get, includes, reduce, isEqual, stubFalse, stubTrue 
  * Internal dependencies
  */
 import { plans } from './plans/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
 import connection from './connection/reducer';
 import domains from './domains/reducer';
 import guidedTransfer from './guided-transfer/reducer';
@@ -15,7 +14,6 @@ import monitor from './monitor/reducer';
 import vouchers from './vouchers/reducer';
 import updates from './updates/reducer';
 import sharingButtons from './sharing-buttons/reducer';
-
 import mediaStorage from './media-storage/reducer';
 import {
 	MEDIA_DELETE,
@@ -35,12 +33,11 @@ import {
 	SITES_REQUEST_FAILURE,
 	SITES_REQUEST_SUCCESS,
 	SITES_UPDATE,
-	DESERIALIZE,
 	THEME_ACTIVATE_SUCCESS,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 } from 'state/action-types';
 import { sitesSchema } from './schema';
-import { createReducer, isValidStateWithSchema, keyedReducer } from 'state/utils';
+import { createReducer, keyedReducer, combineReducersWithPersistence } from 'state/utils';
 
 /**
  * Constants
@@ -203,16 +200,11 @@ export function items( state = {}, action ) {
 
 			return state;
 		}
-
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, sitesSchema ) ) {
-				return state;
-			}
-			return {};
 	}
 
 	return state;
 }
+items.schema = sitesSchema;
 
 /**
  * Returns the updated requesting state after an action has been dispatched.

--- a/client/state/sites/sharing-buttons/reducer.js
+++ b/client/state/sites/sharing-buttons/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	SHARING_BUTTONS_RECEIVE,
@@ -64,7 +64,7 @@ export const items = createReducer( {}, {
 	} )
 }, itemSchemas );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	saveRequests

--- a/client/state/sites/sharing-buttons/reducer.js
+++ b/client/state/sites/sharing-buttons/reducer.js
@@ -6,8 +6,8 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { items as itemSchemas } from './schema';
 import {
 	SHARING_BUTTONS_RECEIVE,

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -8,6 +8,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { useSandbox } from 'test/helpers/use-sinon';
+import { withSchemaValidation } from 'state/utils';
 import {
 	MEDIA_DELETE,
 	SITE_DELETE,
@@ -31,7 +32,9 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import reducer, { items, requestingAll, requesting, deleting } from '../reducer';
+import reducer, { items as unwrappedItems, requestingAll, requesting, deleting } from '../reducer';
+
+const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	useSandbox( ( sandbox ) => {

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { isEmpty, merge, stubFalse, stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer, keyedReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 
 import {
 	SITE_RECEIVE,
@@ -73,7 +73,7 @@ export const errors = keyedReducer( 'siteId', createReducer( undefined, {
 	[ SITE_UPDATES_REQUEST_FAILURE ]: stubTrue,
 } ) );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	wordpressUpdateStatus,

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -6,8 +6,7 @@ import { isEmpty, merge, stubFalse, stubTrue } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer, keyedReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, keyedReducer } from 'state/utils';
 
 import {
 	SITE_RECEIVE,

--- a/client/state/sites/vouchers/reducer.js
+++ b/client/state/sites/vouchers/reducer.js
@@ -10,11 +10,8 @@ import {
 	SITE_VOUCHERS_REQUEST,
 	SITE_VOUCHERS_REQUEST_SUCCESS,
 	SITE_VOUCHERS_REQUEST_FAILURE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
-import { isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -53,17 +50,11 @@ export const items = ( state = {}, action ) => {
 					[ siteId ]: vouchers
 				}
 			);
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemsSchema ) ) {
-				return state;
-			}
-			return {};
-		case SERIALIZE:
-			return state;
 	}
 
 	return state;
 };
+items.schema = itemsSchema;
 
 /**
  * `Reducer` function which handles request/response actions
@@ -87,9 +78,6 @@ export const requesting = ( state = {}, { type, siteId } ) => {
 					assign: type === SITE_VOUCHERS_ASSIGN_REQUEST
 				}
 			} );
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -124,10 +112,6 @@ export const errors = ( state = {}, { type, siteId, error } ) => {
 				}
 
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/sites/vouchers/reducer.js
+++ b/client/state/sites/vouchers/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -18,7 +13,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
@@ -138,7 +133,7 @@ export const errors = ( state = {}, { type, siteId, error } ) => {
 	return state;
 };
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	requesting,
 	errors

--- a/client/state/sites/vouchers/test/reducer.js
+++ b/client/state/sites/vouchers/test/reducer.js
@@ -8,10 +8,11 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import vouchersReducer, {
-	items as itemsReducer,
+	items,
 	requesting as requestReducer,
 	errors as errorsReducer
 } from '../reducer';
+import { withSchemaValidation } from 'state/utils';
 
 /**
  * Action types
@@ -43,6 +44,8 @@ import {
 } from './fixture';
 
 import { useSandbox } from 'test/helpers/use-sinon';
+
+const itemsReducer = withSchemaValidation( items.schema, items );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -8,11 +8,9 @@ import { merge, get } from 'lodash';
  */
 import { createReducer } from 'state/utils';
 import { combineReducersWithPersistence } from 'state/utils';
-import { isValidStateWithSchema } from 'state/utils';
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
 import {
-	DESERIALIZE,
 	SITE_STATS_RECEIVE,
 	SITE_STATS_REQUEST,
 	SITE_STATS_REQUEST_FAILURE,
@@ -86,17 +84,11 @@ export function items( state = {}, action ) {
 					}
 				}
 			};
-
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemSchema ) ) {
-				return state;
-			}
-
-			return {};
 	}
 
 	return state;
 }
+items.schema = itemSchema;
 
 export default combineReducersWithPersistence( {
 	requests,

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { merge, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { isValidStateWithSchema } from 'state/utils';
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
@@ -98,7 +98,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requests,
 	items
 } );

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -6,8 +6,8 @@ import { merge, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
 import {

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -17,9 +17,12 @@ import {
 	SITE_STATS_REQUEST_SUCCESS,
 } from 'state/action-types';
 import reducer, {
-	items,
+	items as unwrappedItems,
 	requests
 } from '../reducer';
+import { withSchemaValidation } from 'state/utils';
+
+const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 /**
  * Test Data

--- a/client/state/stats/posts/reducer.js
+++ b/client/state/stats/posts/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { get, merge } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isValidStateWithSchema } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	SERIALIZE,
@@ -80,7 +80,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items
 } );

--- a/client/state/stats/posts/reducer.js
+++ b/client/state/stats/posts/reducer.js
@@ -6,12 +6,9 @@ import { get, merge } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isValidStateWithSchema } from 'state/utils';
 import { combineReducersWithPersistence } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
-	SERIALIZE,
-	DESERIALIZE,
 	POST_STATS_RECEIVE,
 	POST_STATS_REQUEST,
 	POST_STATS_REQUEST_FAILURE,
@@ -38,10 +35,6 @@ export function requesting( state = {}, action ) {
 					}
 				}
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -68,17 +61,11 @@ export function items( state = {}, action ) {
 					}
 				}
 			};
-
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemSchemas ) ) {
-				return state;
-			}
-
-			return {};
 	}
 
 	return state;
 }
+items.schema = itemSchemas;
 
 export default combineReducersWithPersistence( {
 	requesting,

--- a/client/state/stats/posts/test/reducer.js
+++ b/client/state/stats/posts/test/reducer.js
@@ -16,7 +16,10 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { requesting, items } from '../reducer';
+import { requesting, items as unwrappedItems } from '../reducer';
+import { withSchemaValidation } from 'state/utils';
+
+const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	useSandbox( ( sandbox ) => {
@@ -152,32 +155,6 @@ describe( 'reducer', () => {
 					2454: { views: false }
 				}
 			} );
-		} );
-
-		it( 'should not persist state', () => {
-			const previousState = deepFreeze( {
-				2916284: {
-					2454: { views: true }
-				}
-			}	);
-			const state = requesting( previousState, {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should not load persisted state', () => {
-			const previousState = deepFreeze( {
-				2916284: {
-					2454: { views: true }
-				}
-			}	);
-			const state = requesting( previousState, {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/state/stats/reducer.js
+++ b/client/state/stats/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import posts from './posts/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import lists from './lists/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	posts,
 	lists
 } );

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -2,8 +2,6 @@
  * Internal dependencies
  */
 import {
-	SERIALIZE,
-	DESERIALIZE,
 	STORED_CARDS_ADD_COMPLETED,
 	STORED_CARDS_FETCH,
 	STORED_CARDS_FETCH_COMPLETED,
@@ -44,11 +42,6 @@ export const hasLoadedFromServer = ( state = false, action ) => {
 	switch ( action.type ) {
 		case STORED_CARDS_FETCH_COMPLETED:
 			return true;
-
-		// return initial state when serializing/deserializing
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;
@@ -70,11 +63,6 @@ export const isFetching = ( state = false, action ) => {
 		case STORED_CARDS_FETCH_COMPLETED:
 		case STORED_CARDS_FETCH_FAILED:
 			return false;
-
-		// return initial state when serializing/deserializing
-		case SERIALIZE:
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;
@@ -95,11 +83,6 @@ export const isDeleting = ( state = false, action ) => {
 
 		case STORED_CARDS_DELETE_FAILED:
 		case STORED_CARDS_DELETE_COMPLETED:
-			return false;
-
-		// return initial state when serializing/deserializing
-		case SERIALIZE:
-		case DESERIALIZE:
 			return false;
 	}
 

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -17,6 +12,7 @@ import {
 	STORED_CARDS_DELETE_COMPLETED,
 	STORED_CARDS_DELETE_FAILED
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import { storedCardsSchema } from './schema';
 
@@ -110,7 +106,7 @@ export const isDeleting = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	hasLoadedFromServer,
 	isDeleting,
 	isFetching,

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -10,8 +10,7 @@ import {
 	STORED_CARDS_DELETE_COMPLETED,
 	STORED_CARDS_DELETE_FAILED
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { storedCardsSchema } from './schema';
 
 /**

--- a/client/state/support/reducer.js
+++ b/client/state/support/reducer.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
-
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	SUPPORT_USER_ACTIVATE,
 	SUPPORT_USER_TOKEN_FETCH,
@@ -86,7 +85,7 @@ export function username( state = null, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	errorMessage,
 	isSupportUser,
 	isTransitioning,

--- a/client/state/support/reducer.js
+++ b/client/state/support/reducer.js
@@ -9,18 +9,12 @@ import {
 	SUPPORT_USER_PREFILL,
 	SUPPORT_USER_SET_USERNAME,
 	SUPPORT_USER_TOGGLE_DIALOG,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 
 export function isSupportUser( state = false, { type } ) {
 	switch ( type ) {
 		case SUPPORT_USER_ACTIVATE:
 			return true;
-		case SERIALIZE:
-			return false;
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;
@@ -31,10 +25,6 @@ export function isTransitioning( state = false, { type } ) {
 		case SUPPORT_USER_TOKEN_FETCH:
 			return true;
 		case SUPPORT_USER_ERROR:
-			return false;
-		case SERIALIZE:
-			return false;
-		case DESERIALIZE:
 			return false;
 	}
 	return state;
@@ -48,10 +38,6 @@ export function showDialog( state = false, { type } ) {
 			return true;
 		case SUPPORT_USER_PREFILL:
 			return true;
-		case SERIALIZE:
-			return false;
-		case DESERIALIZE:
-			return false;
 	}
 
 	return state;
@@ -63,10 +49,6 @@ export function errorMessage( state = null, action ) {
 			return action.errorMessage;
 		case SUPPORT_USER_ACTIVATE:
 			return null;
-		case SERIALIZE:
-			return null;
-		case DESERIALIZE:
-			return null;
 	}
 
 	return state;
@@ -77,10 +59,6 @@ export function username( state = null, action ) {
 		case SUPPORT_USER_PREFILL:
 		case SUPPORT_USER_SET_USERNAME:
 			return action.username;
-		case SERIALIZE:
-			return null;
-		case DESERIALIZE:
-			return null;
 	}
 	return state;
 }

--- a/client/state/support/test/reducer.js
+++ b/client/state/support/test/reducer.js
@@ -8,14 +8,9 @@ import { expect } from 'chai';
  */
 import {
 	SUPPORT_USER_ACTIVATE,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import {
 	isSupportUser,
-	isTransitioning,
-	showDialog,
-	errorMessage
 } from '../reducer';
 
 describe( 'reducer', () => {
@@ -26,65 +21,6 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.equal( true );
-		} );
-
-		it( 'should never persist state', () => {
-			const state = isSupportUser( true, {
-				type: SERIALIZE
-			} );
-			expect( state ).to.equal( false );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const state = isSupportUser( true, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.equal( false );
-		} );
-	} );
-	describe( '#isTransitioning()', () => {
-		it( 'should never persist state', () => {
-			const state = isTransitioning( true, {
-				type: SERIALIZE
-			} );
-			expect( state ).to.equal( false );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const state = isTransitioning( true, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.equal( false );
-		} );
-	} );
-	describe( '#showDialog()', () => {
-		it( 'should never persist state', () => {
-			const state = showDialog( true, {
-				type: SERIALIZE
-			} );
-			expect( state ).to.equal( false );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const state = showDialog( true, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.equal( false );
-		} );
-	} );
-	describe( '#errorMessage()', () => {
-		it( 'should never persist state', () => {
-			const state = errorMessage( true, {
-				type: SERIALIZE
-			} );
-			expect( state ).to.equal( null );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const state = errorMessage( true, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.equal( null );
 		} );
 	} );
 } );

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import mapValues from 'lodash/mapValues';
 import merge from 'lodash/merge';
 
@@ -17,6 +16,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { isValidStateWithSchema, createReducer } from 'state/utils';
 import { getSerializedTermsQuery } from './utils';
@@ -116,7 +116,7 @@ export const queries = createReducer( {}, {
 	}
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	queries,
 	queryRequests
 } );

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -16,9 +16,8 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
-import { isValidStateWithSchema, createReducer } from 'state/utils';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
 

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -44,10 +44,6 @@ export function queryRequests( state = {}, action ) {
 					}
 				}
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -126,34 +126,6 @@ describe( 'reducer', () => {
 				}
 			} );
 		} );
-
-		it( 'should never persist state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					category: {
-						'{"search":"ribs"}': false
-					}
-				}
-			} );
-
-			const state = queryRequests( original, { type: SERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const original = deepFreeze( {
-				2916284: {
-					category: {
-						'{"search":"ribs"}': false
-					}
-				}
-			} );
-
-			const state = queryRequests( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
 	} );
 
 	describe( 'queries()', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -611,6 +611,32 @@ describe( 'utils', () => {
 			const invalid = veryNested( { bob: { person: { height: 22, date: new Date( -5 ) } }, count: 123 }, write );
 			expect( invalid ).to.eql( { bob: { person: { height: 160, date: -5 } }, count: 1 } );
 		} );
+
+		it( 'uses the provided validation from withSchemaValidation', () => {
+			reducers = combineReducersWithPersistence( {
+				height: withSchemaValidation( schema, height ),
+				count
+			} );
+
+			const valid = reducers( { height: 22, count: 44 }, write );
+			expect( valid ).to.eql( { height: 22, count: 1 } );
+
+			const invalid = reducers( { height: -1, count: 44 }, load );
+			expect( invalid ).to.eql( { height: 160, count: 1 } );
+		} );
+
+		it( 'uses the provided validation from createReducer', () => {
+			reducers = combineReducersWithPersistence( {
+				height: createReducer( 160, {}, schema ),
+				count
+			} );
+
+			const valid = reducers( { height: 22, count: 44 }, write );
+			expect( valid ).to.eql( { height: 22, count: 1 } );
+
+			const invalid = reducers( { height: -1, count: 44 }, load );
+			expect( invalid ).to.eql( { height: 160, count: 1 } );
+		} );
 	} );
 
 	describe( '#withoutPersistence', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -429,14 +429,6 @@ describe( 'utils', () => {
 			const validated = withSchemaValidation( null, age );
 			expect( validated( 5, grow ) ).to.equal( 6 );
 		} );
-
-		it( 'supports reducers with custom handlers', () => {
-			const validated = withSchemaValidation( null, date );
-			expect( validated( 44, load ).getTime() ).to.equal( 44 );
-			expect( validated( -5, load ).getTime() ).to.equal( 0 );
-			expect( validated( new Date( 24 ), write ) ).to.equal( 24 );
-			expect( validated( new Date( 24 ), grow ).getTime() ).to.equal( 25 );
-		} );
 	} );
 
 	describe( '#combineReducersWithPersistence', () => {

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -7,7 +7,7 @@ import { mapValues, omit } from 'lodash';
  * Internal dependencies
  */
 import ThemeQueryManager from 'lib/query-manager/theme';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -36,7 +36,6 @@ import {
 	getSerializedThemesQuery,
 	getThemeIdFromStylesheet
 } from './utils';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	queriesSchema,
 	activeThemesSchema,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { mapValues, omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ThemeQueryManager from 'lib/query-manager/theme';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -390,7 +390,7 @@ export const themeFilters = createReducer( {}, {
 	[ THEME_FILTERS_ADD ]: ( state, { filters } ) => ( filters )
 }, themeFiltersSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	queries,
 	queryRequests,
 	queryRequestErrors,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -85,10 +85,6 @@ export function activationRequests( state = {}, action ) {
 				...state,
 				[ action.siteId ]: THEME_ACTIVATE === action.type
 			};
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -132,10 +128,6 @@ export function activeThemeRequests( state = {}, action ) {
 				...state,
 				[ action.siteId ]: ACTIVE_THEME_REQUEST === action.type
 			};
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -160,10 +152,6 @@ export function themeRequests( state = {}, action ) {
 					[ action.themeId ]: THEME_REQUEST === action.type
 				} )
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -188,10 +176,6 @@ export function themeInstalls( state = {}, action ) {
 					[ action.themeId ]: THEME_INSTALL === action.type
 				} )
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;
@@ -238,10 +222,6 @@ export function queryRequests( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ serializedQuery ]: THEMES_REQUEST === action.type
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -166,26 +166,6 @@ describe( 'reducer', () => {
 				'2916284:{"search":"Hello"}': false
 			} );
 		} );
-
-		it( 'should never persist state', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"Hello"}': true
-			} );
-
-			const state = queryRequests( original, { type: SERIALIZE } );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'should never load persisted state', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"Hello"}': true
-			} );
-
-			const state = queryRequests( original, { type: DESERIALIZE } );
-
-			expect( state ).to.deep.equal( {} );
-		} );
 	} );
 
 	describe( '#queryRequestErrors()', () => {
@@ -256,30 +236,6 @@ describe( 'reducer', () => {
 					'2916284:{"search":"Twenty"}': 'System error'
 				}
 			} );
-		} );
-
-		it( 'never persists state', () => {
-			const state = queryRequestErrors( deepFreeze( {
-				2916284: {
-					'2916284:{"search":"Twenty"}': null
-				}
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'never loads persisted state', () => {
-			const state = queryRequestErrors( deepFreeze( {
-				2916284: {
-					'2916284:{"search":"Twenty"}': null
-				}
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
 		} );
 	} );
 
@@ -544,30 +500,6 @@ describe( 'reducer', () => {
 				}
 			} );
 		} );
-
-		it( 'never persists state', () => {
-			const state = themeRequests( deepFreeze( {
-				2916284: {
-					841: true
-				}
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'never loads persisted state', () => {
-			const state = themeRequests( deepFreeze( {
-				2916284: {
-					841: true
-				}
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
 	} );
 
 	describe( '#themeRequestErrors()', () => {
@@ -817,26 +749,6 @@ describe( 'reducer', () => {
 				2916284: false
 			} );
 		} );
-
-		it( 'never persists state', () => {
-			const state = activationRequests( deepFreeze( {
-				2916284: true
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'never loads persisted state', () => {
-			const state = activationRequests( deepFreeze( {
-				2916284: true
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
 	} );
 
 	describe( '#themeInstalls()', () => {
@@ -917,30 +829,6 @@ describe( 'reducer', () => {
 				}
 			} );
 		} );
-
-		it( 'never persists state', () => {
-			const state = themeInstalls( deepFreeze( {
-				2211667: {
-					karuna: true
-				}
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'never loads persisted state', () => {
-			const state = themeInstalls( deepFreeze( {
-				2211667: {
-					karuna: false
-				}
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
 	} );
 
 	describe( '#completedActivationRequests()', () => {
@@ -968,26 +856,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.have.keys( [ '2211667' ] );
 			expect( state ).to.deep.equal( { 2211667: false } );
-		} );
-
-		it( 'never persists state', () => {
-			const state = completedActivationRequests( deepFreeze( {
-				2916284: true
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'never loads persisted state', () => {
-			const state = completedActivationRequests( deepFreeze( {
-				2916284: true
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
 		} );
 	} );
 
@@ -1054,26 +922,6 @@ describe( 'reducer', () => {
 			expect( state ).to.deep.equal( {
 				2916284: false
 			} );
-		} );
-
-		it( 'never persists state', () => {
-			const state = activeThemeRequests( deepFreeze( {
-				2916284: true
-			} ), {
-				type: SERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
-		} );
-
-		it( 'never loads persisted state', () => {
-			const state = activeThemeRequests( deepFreeze( {
-				2916284: true
-			} ), {
-				type: DESERIALIZE
-			} );
-
-			expect( state ).to.deep.equal( {} );
 		} );
 	} );
 } );

--- a/client/state/themes/themes-ui/reducer.js
+++ b/client/state/themes/themes-ui/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { THEME_BACK_PATH_SET } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 // Destination for 'back' button on theme sheet
 function backPath( state = '/themes', action ) {
@@ -17,4 +13,4 @@ function backPath( state = '/themes', action ) {
 	return state;
 }
 
-export default combineReducers( { backPath } );
+export default combineReducersWithPersistence( { backPath } );

--- a/client/state/themes/upload-theme/reducer.js
+++ b/client/state/themes/upload-theme/reducer.js
@@ -6,8 +6,8 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	THEME_UPLOAD_START,
 	THEME_UPLOAD_SUCCESS,

--- a/client/state/themes/upload-theme/reducer.js
+++ b/client/state/themes/upload-theme/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	THEME_UPLOAD_START,
 	THEME_UPLOAD_SUCCESS,
@@ -116,7 +116,7 @@ export const inProgress = createReducer( {}, {
 	} ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	uploadedThemeId,
 	uploadError,
 	progressLoaded,

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	TIMEZONES_RECEIVE,
 	TIMEZONES_REQUEST,

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	TIMEZONES_RECEIVE,
 	TIMEZONES_REQUEST,
@@ -34,7 +30,7 @@ export const isRequesting = ( state = false, { type } ) => (
 	type === TIMEZONES_REQUEST
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	rawOffsets,
 	labels,
 	byContinents,

--- a/client/state/ui/drop-zone/reducer.js
+++ b/client/state/ui/drop-zone/reducer.js
@@ -6,9 +6,7 @@ import {
 	DROPZONE_HIDE
 } from 'state/action-types';
 
-import { combineReducersWithPersistence } from 'state/utils';
-
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 // TODO(biskobe) - Can be improved with `keyedReducer` instead of state spread.
 const isVisible = createReducer( {},

--- a/client/state/ui/drop-zone/reducer.js
+++ b/client/state/ui/drop-zone/reducer.js
@@ -1,15 +1,12 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
 	DROPZONE_SHOW,
 	DROPZONE_HIDE
 } from 'state/action-types';
+
+import { combineReducersWithPersistence } from 'state/utils';
 
 import { createReducer } from 'state/utils';
 
@@ -27,6 +24,6 @@ const isVisible = createReducer( {},
 	}
 );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isVisible,
 } );

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -14,8 +14,7 @@ import {
 	IMAGE_EDITOR_STATE_RESET_ALL,
 	IMAGE_EDITOR_IMAGE_HAS_LOADED
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { AspectRatios } from './constants';
 
 export const defaultTransform = {

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -19,6 +14,7 @@ import {
 	IMAGE_EDITOR_STATE_RESET_ALL,
 	IMAGE_EDITOR_IMAGE_HAS_LOADED
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import { AspectRatios } from './constants';
 
@@ -181,7 +177,7 @@ export function aspectRatio( state = AspectRatios.FREE, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	hasChanges,
 	fileInfo,
 	transform,

--- a/client/state/ui/editor/last-draft/reducer.js
+++ b/client/state/ui/editor/last-draft/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { EDITOR_LAST_DRAFT_SET } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 /**
  * Returns the updated editor last draft site ID state after an action has been
@@ -42,7 +38,7 @@ export function postId( state = null, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	siteId,
 	postId
 } );

--- a/client/state/ui/editor/reducer.js
+++ b/client/state/ui/editor/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { EDITOR_START, POST_SAVE_SUCCESS } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import imageEditor from './image-editor/reducer';
 import videoEditor from './video-editor/reducer';
 import lastDraft from './last-draft/reducer';
@@ -31,7 +27,7 @@ export function postId( state = null, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	postId,
 	imageEditor,
 	videoEditor,

--- a/client/state/ui/editor/video-editor/reducer.js
+++ b/client/state/ui/editor/video-editor/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -12,6 +7,7 @@ import {
 	VIDEO_EDITOR_SHOW_ERROR,
 	VIDEO_EDITOR_SHOW_UPLOAD_PROGRESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 /**
  * Tracks whether or not the modal should close.
@@ -62,7 +58,7 @@ export const uploadProgress = ( state = null, { type, percentage } ) => {
  */
 export const showError = ( state = false, { type } ) => type === VIDEO_EDITOR_SHOW_ERROR;
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	closeModal,
 	showError,
 	uploadProgress,

--- a/client/state/ui/happychat/reducer.js
+++ b/client/state/ui/happychat/reducer.js
@@ -1,5 +1,7 @@
-import { combineReducers } from 'redux';
-
+/**
+ * Internal dependencies
+ */
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	HAPPYCHAT_OPEN,
 	HAPPYCHAT_MINIMIZING
@@ -32,4 +34,4 @@ const isMinimizing = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducers( { open, isMinimizing } );
+export default combineReducersWithPersistence( { open, isMinimizing } );

--- a/client/state/ui/media-modal/reducer.js
+++ b/client/state/ui/media-modal/reducer.js
@@ -1,18 +1,14 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import { MEDIA_MODAL_VIEW_SET } from 'state/action-types';
 
 export const view = createReducer( null, {
 	[ MEDIA_MODAL_VIEW_SET ]: ( state, action ) => action.view
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	view
 } );

--- a/client/state/ui/media-modal/reducer.js
+++ b/client/state/ui/media-modal/reducer.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import { MEDIA_MODAL_VIEW_SET } from 'state/action-types';
 
 export const view = createReducer( null, {

--- a/client/state/ui/nps-survey-notice/reducer.js
+++ b/client/state/ui/nps-survey-notice/reducer.js
@@ -4,8 +4,7 @@
 import {
 	NPS_SURVEY_DIALOG_IS_SHOWING,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 
 export const isNpsSurveyDialogShowing = createReducer( false, {
 	[ NPS_SURVEY_DIALOG_IS_SHOWING ]: ( state, { isShowing } ) =>

--- a/client/state/ui/nps-survey-notice/reducer.js
+++ b/client/state/ui/nps-survey-notice/reducer.js
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
 	NPS_SURVEY_DIALOG_IS_SHOWING,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 
 export const isNpsSurveyDialogShowing = createReducer( false, {
@@ -16,6 +12,6 @@ export const isNpsSurveyDialogShowing = createReducer( false, {
 		isShowing !== undefined ? isShowing : state,
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isNpsSurveyDialogShowing,
 } );

--- a/client/state/ui/olark/reducer.js
+++ b/client/state/ui/olark/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,6 +9,7 @@ import {
 	OLARK_OPERATORS_AWAY,
 	OLARK_SET_AVAILABILITY,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	STATUS_READY,
 	STATUS_TIMEOUT,
@@ -90,7 +86,7 @@ export function requesting( state = false, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	operatorStatus,
 	availability,
 	requesting,

--- a/client/state/ui/preview/reducer.js
+++ b/client/state/ui/preview/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -13,6 +8,7 @@ import {
 	PREVIEW_TYPE_SET,
 	PREVIEW_TYPE_RESET,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 export function currentPreviewUrl( state = null, action ) {
 	switch ( action.type ) {
@@ -43,7 +39,7 @@ export function activeDesignTool( state = null, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	currentPreviewUrl,
 	currentPreviewType,
 	activeDesignTool,

--- a/client/state/ui/query-arguments/reducer.js
+++ b/client/state/ui/query-arguments/reducer.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { isEqual, omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	ROUTE_SET,
 } from 'state/action-types';
@@ -34,7 +34,7 @@ const current = createReducer( {}, {
 			: state,
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	initial,
 	current,
 } );

--- a/client/state/ui/query-arguments/reducer.js
+++ b/client/state/ui/query-arguments/reducer.js
@@ -6,8 +6,8 @@ import { isEqual, omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
+
 import {
 	ROUTE_SET,
 } from 'state/action-types';

--- a/client/state/ui/reader/reducer.js
+++ b/client/state/ui/reader/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import sidebar from './sidebar/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import cardExpansions from './card-expansions/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	sidebar,
 	cardExpansions,
 } );

--- a/client/state/ui/reader/sidebar/reducer.js
+++ b/client/state/ui/reader/sidebar/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
 	READER_SIDEBAR_LISTS_TOGGLE,
 	READER_SIDEBAR_TAGS_TOGGLE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 export function isListsOpen( state = false, action ) {
 	switch ( action.type ) {
@@ -29,7 +25,7 @@ export function isTagsOpen( state = false, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	isListsOpen,
 	isTagsOpen
 } );

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -106,10 +106,13 @@ const reducer = combineReducersWithPersistence( {
 	isNotificationsOpen,
 } );
 
-export default function( state, action ) {
+const ui = function( state, action ) {
 	if ( SERIALIZE === action.type || DESERIALIZE === action.type ) {
 		return {};
 	}
 
 	return reducer( state, action );
-}
+};
+ui.hasCustomPersistence = true;
+
+export default ui;

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -9,8 +9,7 @@ import {
 	DESERIALIZE,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import editor from './editor/reducer';
 import dropZone from './drop-zone/reducer';
 import guidedTour from './guided-tours/reducer';

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -14,6 +9,7 @@ import {
 	DESERIALIZE,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import editor from './editor/reducer';
 import dropZone from './drop-zone/reducer';
@@ -88,7 +84,7 @@ export const isNotificationsOpen = function( state = false, { type } ) {
 	return state;
 };
 
-const reducer = combineReducers( {
+const reducer = combineReducersWithPersistence( {
 	section,
 	isLoading,
 	layoutFocus,

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import omit from 'lodash/omit';
 
 /**
@@ -13,6 +12,7 @@ import {
 	USER_SETTINGS_UNSAVED_SET,
 	USER_SETTINGS_UNSAVED_REMOVE,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 export const settings = ( state = null, { type, settingValues } ) =>
 	USER_SETTINGS_UPDATE === type
@@ -43,7 +43,7 @@ export const unsavedSettings = ( state = {}, action ) => {
 	}
 };
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	settings,
 	unsavedSettings,
 } );

--- a/client/state/users/reducer.js
+++ b/client/state/users/reducer.js
@@ -5,8 +5,6 @@ import suggestions from './suggestions/reducer';
 import { combineReducersWithPersistence } from 'state/utils';
 import {
 	USER_RECEIVE,
-	DESERIALIZE,
-	SERIALIZE
 } from 'state/action-types';
 
 /**
@@ -22,10 +20,6 @@ export function items( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.user.ID ]: action.user
 			} );
-		case DESERIALIZE:
-			return {};
-		case SERIALIZE:
-			return {};
 	}
 
 	return state;

--- a/client/state/users/reducer.js
+++ b/client/state/users/reducer.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import suggestions from './suggestions/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import {
 	USER_RECEIVE,
 	DESERIALIZE,
@@ -35,7 +31,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	suggestions,
 } );

--- a/client/state/users/suggestions/reducer.js
+++ b/client/state/users/suggestions/reducer.js
@@ -7,8 +7,7 @@ import {
 	USER_SUGGESTIONS_REQUEST_FAILURE,
 	USER_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**

--- a/client/state/users/suggestions/reducer.js
+++ b/client/state/users/suggestions/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -12,6 +7,7 @@ import {
 	USER_SUGGESTIONS_REQUEST_FAILURE,
 	USER_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import { itemsSchema } from './schema';
 
@@ -50,7 +46,7 @@ export const items = createReducer( {}, {
 	},
 }, itemsSchema );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	items,
 } );

--- a/client/state/users/test/reducer.js
+++ b/client/state/users/test/reducer.js
@@ -8,8 +8,6 @@ import { expect } from 'chai';
  */
 import {
 	USER_RECEIVE,
-	DESERIALIZE,
-	SERIALIZE
 } from 'state/action-types';
 import { items } from '../reducer';
 
@@ -58,64 +56,6 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				73705554: { ID: 73705554, login: 'testtwosites2014' }
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			it( 'does not persist state because this is not implemented yet', () => {
-				const state = Object.freeze( {
-					73705554: {
-						ID: 73705554,
-						display_name: 'Test User',
-						username: 'testuser',
-						avatar_URL: 'https://www.example.com',
-						site_count: 11,
-						visible_site_count: 5,
-						date: '2015-09-07T19:42:30+00:00',
-						has_unseen_notes: false,
-						newest_note_type: 'like',
-						phone_account: false,
-						email: 'test@example.com',
-						email_verified: true,
-						is_valid_google_apps_country: true,
-						logout_URL: 'https://www.example.com',
-						primary_blog_url: 'https://www.example.com',
-						meta: { links: {}, data: {} },
-						primarySiteSlug: 'www.example.com',
-						localeSlug: 'en',
-						isRTL: false
-					}
-				} );
-				const persistedState = items( state, { type: SERIALIZE } );
-				expect( persistedState ).to.eql( {} );
-			} );
-
-			it( 'does not load persisted state because this is not implemented yet', () => {
-				const persistedState = Object.freeze( {
-					73705554: {
-						ID: 73705554,
-						display_name: 'Test User',
-						username: 'testuser',
-						avatar_URL: 'https://www.example.com',
-						site_count: 11,
-						visible_site_count: 5,
-						date: '2015-09-07T19:42:30+00:00',
-						has_unseen_notes: false,
-						newest_note_type: 'like',
-						phone_account: false,
-						email: 'test@example.com',
-						email_verified: true,
-						is_valid_google_apps_country: true,
-						logout_URL: 'https://www.example.com',
-						primary_blog_url: 'https://www.example.com',
-						meta: { links: {}, data: {} },
-						primarySiteSlug: 'www.example.com',
-						localeSlug: 'en',
-						isRTL: false
-					}
-				} );
-				const state = items( persistedState, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -212,7 +212,7 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
 		};
 	}
 
-	return ( state = initialState, action ) => {
+	const reducer = ( state = initialState, action ) => {
 		const { type } = action;
 
 		if ( 'production' !== process.env.NODE_ENV && 'type' in action && ! type ) {
@@ -226,6 +226,11 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
 
 		return state;
 	};
+
+	//used to propagate actions properly when combined in combineReducersWithPersistence
+	reducer.hasCustomPersistence = true;
+
+	return reducer;
 }
 
 /**
@@ -273,27 +278,34 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
  * @returns {function} wrapped reducer handling validation on DESERIALIZE and
  * returns initial state if no schema is provided on SERIALIZE and DESERIALIZE.
  */
-export const withSchemaValidation = ( schema, reducer ) => ( state, action ) => {
-	const shouldDispatchAction = reducer.hasSchema || reducer.hasCustomPersistence;
+export const withSchemaValidation = ( schema, reducer ) => {
+	const wrappedReducer = ( state, action ) => {
+		const shouldDispatchAction = reducer.hasSchema || reducer.hasCustomPersistence;
 
-	if ( SERIALIZE === action.type ) {
-		return schema || shouldDispatchAction ? reducer( state, action ) : reducer( undefined, { type: '@@calypso/INIT' } );
-	}
-	if ( DESERIALIZE === action.type ) {
-		if ( shouldDispatchAction ) {
-			return reducer( state, action );
+		if ( SERIALIZE === action.type ) {
+			return schema || shouldDispatchAction ? reducer( state, action ) : reducer( undefined, { type: '@@calypso/INIT' } );
+		}
+		if ( DESERIALIZE === action.type ) {
+			if ( shouldDispatchAction ) {
+				return reducer( state, action );
+			}
+
+			if ( ! schema ) {
+				return reducer( undefined, { type: '@@calypso/INIT' } );
+			}
+
+			return state && isValidStateWithSchema( state, schema )
+				? state
+				: reducer( undefined, { type: '@@calypso/INIT' } );
 		}
 
-		if ( ! schema ) {
-			return reducer( undefined, { type: '@@calypso/INIT' } );
-		}
+		return reducer( state, action );
+	};
 
-		return state && isValidStateWithSchema( state, schema )
-			? state
-			: reducer( undefined, { type: '@@calypso/INIT' } );
-	}
+	//used to propagate actions properly when combined in combineReducersWithPersistence
+	wrappedReducer.hasCustomPersistence = true;
 
-	return reducer( state, action );
+	return wrappedReducer;
 };
 
 /**

--- a/client/state/wordads/approve/reducer.js
+++ b/client/state/wordads/approve/reducer.js
@@ -7,8 +7,6 @@ import {
 	WORDADS_SITE_APPROVE_REQUEST_FAILURE,
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_ERROR,
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import { combineReducersWithPersistence } from 'state/utils';
 
@@ -27,10 +25,6 @@ export function requesting( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: action.type === WORDADS_SITE_APPROVE_REQUEST
 			} );
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -53,9 +47,6 @@ export function requestErrors( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: null
 			} );
-		case DESERIALIZE:
-		case SERIALIZE:
-			return {};
 	}
 	return state;
 }
@@ -78,9 +69,6 @@ export function requestSuccess( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ action.siteId ]: true
 			} );
-		case DESERIALIZE:
-		case SERIALIZE:
-			return {};
 	}
 	return state;
 }

--- a/client/state/wordads/approve/reducer.js
+++ b/client/state/wordads/approve/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -15,6 +10,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 
 /**
  * Tracks all WordAds request status, indexed by site ID.
@@ -89,7 +85,7 @@ export function requestSuccess( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	requesting,
 	requestSuccess,
 	requestErrors,

--- a/client/state/wordads/approve/test/reducer.js
+++ b/client/state/wordads/approve/test/reducer.js
@@ -13,8 +13,6 @@ import {
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_SUCCESS,
 	WORDADS_SITE_APPROVE_REQUEST_FAILURE,
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_ERROR,
-	SERIALIZE,
-	DESERIALIZE
 } from 'state/action-types';
 import reducer, {
 	requesting,
@@ -75,26 +73,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: false,
 				77203074: false
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					2916284: false,
-					77203074: true
-				} );
-				const state = requesting( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					2916284: false,
-					77203074: true
-				} );
-				const state = requesting( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );
@@ -174,26 +152,6 @@ describe( 'reducer', () => {
 				77203074: 'something else went wrong'
 			} );
 		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					2916284: 'so many requestErrors',
-					77203074: null
-				} );
-				const state = requestErrors( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					2916284: null,
-					77203074: 'something went wrong'
-				} );
-				const state = requestErrors( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-		} );
 	} );
 
 	describe( '#requestSuccess()', () => {
@@ -266,26 +224,6 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				2916284: true,
 				77203074: true
-			} );
-		} );
-
-		describe( 'persistence', () => {
-			it( 'never persists state', () => {
-				const original = deepFreeze( {
-					2916284: true,
-					77203074: null
-				} );
-				const state = requestSuccess( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
-			} );
-
-			it( 'never loads persisted state', () => {
-				const original = deepFreeze( {
-					2916284: null,
-					77203074: true
-				} );
-				const state = requestSuccess( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/wordads/reducer.js
+++ b/client/state/wordads/reducer.js
@@ -1,15 +1,11 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import approve from './approve/reducer';
+import { combineReducersWithPersistence } from 'state/utils';
 import status from './status/reducer';
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	approve,
 	status
 } );

--- a/client/state/wordads/status/reducer.js
+++ b/client/state/wordads/status/reducer.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'redux';
-
-/**
  * Internal dependencies
  */
 import {
@@ -11,6 +6,7 @@ import {
 	WORDADS_STATUS_REQUEST_SUCCESS,
 	WORDADS_STATUS_REQUEST_FAILURE
 } from 'state/action-types';
+import { combineReducersWithPersistence } from 'state/utils';
 import { createReducer } from 'state/utils';
 import { wordadsStatusSchema } from './schema';
 
@@ -26,7 +22,7 @@ export const fetchingItems = createReducer( {}, {
 	[ WORDADS_STATUS_REQUEST_FAILURE ]: ( state, action ) => Object.assign( {}, state, { [ action.siteId ]: false } ),
 } );
 
-export default combineReducers( {
+export default combineReducersWithPersistence( {
 	items,
 	fetchingItems
 } );

--- a/client/state/wordads/status/reducer.js
+++ b/client/state/wordads/status/reducer.js
@@ -6,8 +6,7 @@ import {
 	WORDADS_STATUS_REQUEST_SUCCESS,
 	WORDADS_STATUS_REQUEST_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
-import { createReducer } from 'state/utils';
+import { combineReducersWithPersistence, createReducer } from 'state/utils';
 import { wordadsStatusSchema } from './schema';
 
 export const items = createReducer( {}, {

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -392,7 +392,7 @@ If you are not satisfied with the default handling, it is possible to implement 
 `DESERIALIZE` action handlers in your reducers to customize data persistence. Always use a schema with your custom 
 handlers to avoid data shape errors. 
 
-### Opt-in to Persistence ( [#13359](https://github.com/Automattic/wp-calypso/pull/13359) )
+### Opt-in to Persistence ( [#13542](https://github.com/Automattic/wp-calypso/pull/13542) )
 
 If we choose not to use `createReducer` we can opt-in to persistence by adding a schema as a property on the reducer. 
 We do this by combining all of our reducers using `combineReducersWithPersistence` at every level of the tree instead 

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -392,31 +392,13 @@ If you are not satisfied with the default handling, it is possible to implement 
 `DESERIALIZE` action handlers in your reducers to customize data persistence. Always use a schema with your custom 
 handlers to avoid data shape errors. 
 
-### Not persisting data
-
-Some subtrees may choose to never persist data. One such example of this is our online connection state. If connection 
-values are persisted we will not be able to reliably tell when the application is offline or online.
-
-If persisting state causes application errors, opting out of persistence is straightforward: in the `createReducer` util
-provide only the default state value as a first param and don't provide a schema as a third param. Behind the scenes 
-data is never going to be persisted and is always regenerated with default value. In this example, it happens to be `'CHECKING'`
-```javascript
-export const connectionState = createReducer( 'CHECKING', {
-	[CONNECTION_LOST]: () => 'OFFLINE',
-	[CONNECTION_RESTORED]: () => 'ONLINE'
-} );
-```
-
 ### Opt-in to Persistence ( [#13359](https://github.com/Automattic/wp-calypso/pull/13359) )
 
-Currently reducers are persisted by default if no handlers are given for `SERIALIZE` and `DESERIALIZE`. This is a major 
-problem since many people may not realize that this is happening, and we can run into the data shape errors as 
-noted above.
-
-In the **future** we can opt-in to persistence by adding a schema as a property on the reducer. We do this by combining 
-all of our reducers using `combineReducersWithPersistence` at every level of the tree instead of [combineReducers](http://redux.js.org/docs/api/combineReducers.html).
-Each reducer is then wrapped with `withSchemaValidation` which returns a wrapped reducer that validates on `DESERIALZE` 
-if a schema is present and returns initial state on both `SERIALIZE` and `DESERIALZE` if a schema is not present.
+If we choose not to use `createReducer` we can opt-in to persistence by adding a schema as a property on the reducer. 
+We do this by combining all of our reducers using `combineReducersWithPersistence` at every level of the tree instead 
+of [combineReducers](http://redux.js.org/docs/api/combineReducers.html). Each reducer is then wrapped with 
+`withSchemaValidation` which returns a wrapped reducer that validates on `DESERIALZE` if a schema is present and 
+returns initial state on both `SERIALIZE` and `DESERIALZE` if a schema is not present.
 
 To opt-out of persistence we combine the reducers without any attached schema.
 ```javascript
@@ -446,3 +428,9 @@ return combineReducersWithPersistence( {
     date,
 } );
 ```
+
+### Not persisting data
+
+Some subtrees may choose to never persist data. One such example of this is our online connection state. If connection 
+values are persisted we will not be able to reliably tell when the application is offline or online. Please remember
+to reason about if items should be persisted. 


### PR DESCRIPTION
Follow up to #13359 

This PR tries to address the issue that reducers are persisted by default if no handlers are given for `SERIALIZE` and `DESERIALIZE`. See the [persistence readme](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#data-persistence--2754-) for more context on how this currently works.

This PR updates all usages of `combineReducers` with the `combineReducersWithPersistence` util that was added in the last PR. This function basically wraps each reducer in `withSchemaValidation`, which provides some default handling

If a reducer is created with `createReducer` no changes are necessary.

For a plain reducer, we can mark that we'd like to persist state by adding a schema:
```jsx
age.schema = ageSchema;
return combineReducersWithPersistence( {
    age,
    height,
} );
```

For a reducer that has custom handlers (needs to perform transforms), we assume it's checking the schema already, so all we need to do is set a boolean bit on the reducer.
```jsx
date.hasCustomPersistence = true;
return combineReducersWithPersistence( {
    age,
    height,
    date,
} );

```
TODO:
- [x] Use codemod to update usages
- [x] Remove Opt-Out Cases / Test Cases
- [x] Simplify Opt-In Cases
- [x] Update tests
- [x] Update usages that use real transforms from and to a plain object.
- [x] Give folks a heads up with a blog post
- [x] Update data docs
- [x] Codemod to fix double imports eg: 
```
import { createReducer } from 'state/utils';
import { combineReducersWithPersistence } from 'state/utils';
```

Follow Up:
- [ ] Add eslint rule for using  `combineReducersWithPersistence ` over `combineReducers`

See related conversation in https://github.com/Automattic/wp-calypso/pull/13318#discussion_r112996396 that resparked this issue.