### PR TITLE
Update devdocs plugin item

### DIFF
--- a/client/components/feature-example/docs/example.jsx
+++ b/client/components/feature-example/docs/example.jsx
@@ -40,6 +40,7 @@ module.exports = React.createClass( {
 				key={ `plugin-item-mock-${ plugin.slug }` }
 				plugin={ plugin }
 				sites={ [] }
+				hasUpdate={ () => false }
 				selectedSite={ selectedSite }
 				progress={ [] } />
 		} );


### PR DESCRIPTION
A `PluginItem` accepts a function `hasUpdate` as of a recent pull request, https://github.com/Automattic/wp-calypso/pull/13522.

This updates devdocs to reflect the change so devdocs is not broken.

cc @enejb 