### PR TITLE
Reader: Show/hide bylines correctly

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import ReaderFollowButton from 'reader/follow-button';
+import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 import Site from 'blocks/site';
 import HeaderBack from 'reader/header-back';
 
@@ -89,7 +90,7 @@ class FeedHeader extends Component {
 					}
 					<div className="reader-feed-header__details">
 						<span className="reader-feed-header__description">{ description }</span>
-						{ ownerDisplayName && <span className="reader-feed-header__byline">
+						{ ownerDisplayName && ! isAuthorNameBlacklisted( ownerDisplayName ) && <span className="reader-feed-header__byline">
 							{ this.props.translate(
 								'by %(author)s',
 								{

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -97,7 +97,7 @@ class PostByline extends React.Component {
 					siteUrl={ streamUrl }
 					isCompact={ true } />
 				<div className="reader-post-card__byline-details">
-					{ shouldDisplayAuthor && <div className="reader-post-card__byline-author-site">
+					{ ( shouldDisplayAuthor || showSiteName ) && <div className="reader-post-card__byline-author-site">
 							<ReaderAuthorLink
 								className="reader-post-card__link"
 								author={ post.author }

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -19,6 +19,7 @@ import {
 } from 'reader/stats';
 import ReaderSiteStreamLink from 'blocks/reader-site-stream-link';
 import { getStreamUrl } from 'reader/route';
+import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 import ReaderAuthorLink from 'blocks/reader-author-link';
 import { areEqualIgnoringWhitespaceAndCase } from 'lib/string';
 
@@ -73,7 +74,7 @@ class PostByline extends React.Component {
 		const siteName = getSiteName( { site, feed, post } );
 		const hasAuthorName = has( post, 'author.name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
-		const shouldDisplayAuthor = ! isDiscoverPost && hasAuthorName && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
+		const shouldDisplayAuthor = ! isDiscoverPost && hasAuthorName && ! isAuthorNameBlacklisted( post.author.name ) && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );
@@ -93,25 +94,24 @@ class PostByline extends React.Component {
 					siteUrl={ streamUrl }
 					isCompact={ true } />
 				<div className="reader-post-card__byline-details">
-					<div className="reader-post-card__byline-author-site">
-						{ shouldDisplayAuthor &&
-						<ReaderAuthorLink
-							className="reader-post-card__link"
-							author={ post.author }
-							siteUrl={ streamUrl }
-							post={ post }>
-							{ post.author.name }
-						</ReaderAuthorLink>
-						}
-						{ shouldDisplayAuthor && showSiteName && ', ' }
-						{ showSiteName && <ReaderSiteStreamLink
-							className="reader-post-card__site reader-post-card__link"
-							feedId={ feedId }
-							siteId={ siteId }
-							post={ post }>
-							{ siteName }
-						</ReaderSiteStreamLink> }
-					</div>
+					{ shouldDisplayAuthor && <div className="reader-post-card__byline-author-site">
+							<ReaderAuthorLink
+								className="reader-post-card__link"
+								author={ post.author }
+								siteUrl={ streamUrl }
+								post={ post }>
+								{ post.author.name }
+							</ReaderAuthorLink>
+							{ showSiteName && ', ' }
+							{ showSiteName && <ReaderSiteStreamLink
+								className="reader-post-card__site reader-post-card__link"
+								feedId={ feedId }
+								siteId={ siteId }
+								post={ post }>
+								{ siteName }
+							</ReaderSiteStreamLink> }
+						</div>
+					}
 					<div className="reader-post-card__timestamp-and-tag">
 						{ post.date && post.URL &&
 							<span className="reader-post-card__timestamp">

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -74,7 +74,10 @@ class PostByline extends React.Component {
 		const siteName = getSiteName( { site, feed, post } );
 		const hasAuthorName = has( post, 'author.name' );
 		const hasMatchingAuthorAndSiteNames = hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
-		const shouldDisplayAuthor = ! isDiscoverPost && hasAuthorName && ! isAuthorNameBlacklisted( post.author.name ) && ( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
+		const shouldDisplayAuthor = ! isDiscoverPost &&
+			hasAuthorName &&
+			! isAuthorNameBlacklisted( post.author.name ) &&
+			( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
 		const streamUrl = getStreamUrl( feedId, siteId );
 		const siteIcon = get( site, 'icon.img' );
 		const feedIcon = get( feed, 'image' );


### PR DESCRIPTION
Fixes #13432 - This will hide the byline in the reader header if the author name is 'admin'. This also removes the extra space at the top of the reader cards by not rendering the author name portion of the byline, rather than just the name within the component.

**Example:**
![unspecified-1](https://cloud.githubusercontent.com/assets/1000280/25604538/a32a970a-2ec9-11e7-9a65-130616163765.png)

**Testing Instructions:**
Check some different feeds in the reader - here are a couple:
- Should show byline: http://calypso.localhost:3000/read/blogs/41425786
- Should hide byline: http://calypso.localhost:3000/read/blogs/118534215

Thanks!