### PR TITLE
WooCommerce: Add product-categories selector

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -1,27 +1,42 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
 import { getCurrentlyEditingProduct } from '../../state/ui/products/selectors';
+import { getProductCategories } from '../../state/wc-api/product-categories/selectors';
 import { editProduct, editProductAttribute } from '../../state/ui/products/actions';
+import { fetchProductCategories } from '../../state/wc-api/product-categories/actions';
 import ProductForm from './product-form';
 
-class ProductCreate extends Component {
+class ProductCreate extends React.Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		product: PropTypes.shape( {
+			id: PropTypes.isRequired,
+		} ),
+		fetchProductCategories: PropTypes.func.isRequired,
+		editProduct: PropTypes.func.isRequired,
+		editProductAttribute: PropTypes.func.isRequired,
+	};
 
 	componentDidMount() {
-		const { product } = this.props;
+		const { product, siteId } = this.props;
 
 		if ( ! product ) {
 			this.props.editProduct( null, {
 				type: 'simple'
 			} );
 		}
+
+		this.props.fetchProductCategories( siteId );
 	}
 
 	componentWillUnmount() {
@@ -29,11 +44,12 @@ class ProductCreate extends Component {
 	}
 
 	render() {
-		const { product } = this.props;
+		const { product, productCategories } = this.props;
 
 		return (
 			<ProductForm
 				product={ product || { type: 'simple' } }
+				productCategories={ productCategories }
 				editProduct={ this.props.editProduct }
 				editProductAttribute={ this.props.editProductAttribute }
 			/>
@@ -42,10 +58,14 @@ class ProductCreate extends Component {
 }
 
 function mapStateToProps( state ) {
+	const siteId = getSelectedSiteId( state );
 	const product = getCurrentlyEditingProduct( state );
+	const productCategories = getProductCategories( state, siteId );
 
 	return {
+		siteId,
 		product,
+		productCategories,
 	};
 }
 
@@ -54,6 +74,7 @@ function mapDispatchToProps( dispatch ) {
 		{
 			editProduct,
 			editProductAttribute,
+			fetchProductCategories,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { find, pick, compact, escape, unescape } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormFieldSet from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import TokenField from 'components/token-field';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const ProductFormCategoriesCard = (
+	{ product, productCategories, editProduct, translate }
+) => {
+	const handleChange = ( categoryNames ) => {
+		const newCategories = compact( categoryNames.map( ( name ) => {
+			const category = find( productCategories, { name: escape( name ) } );
+
+			if ( ! category ) {
+				// TODO: Add new product category to edit state.
+				// TODO: Remove 'compact' calls afterwards as they will no longer be needed.
+				return undefined;
+			}
+
+			return pick( category, 'id' );
+		} ) );
+
+		const data = { id: product.id, categories: newCategories };
+		editProduct( product, data );
+	};
+
+	const selectedCategories = product.categories || [];
+	const selectedCategoryNames = compact( selectedCategories.map( ( c ) => {
+		const category = find( productCategories, { id: c.id } );
+		return category && unescape( category.name ) || undefined;
+	} ) );
+	const productCategoryNames = productCategories.map( c => unescape( c.name ) );
+
+	return (
+		<Card className="products__categories-card">
+			<FormFieldSet>
+				<FormLabel htmlFor="categories">{ translate( 'Category' ) }</FormLabel>
+				<TokenField
+					name="categories"
+					placeholder={ translate( 'Enter category names' ) }
+					value={ selectedCategoryNames }
+					suggestions={ productCategoryNames }
+					onChange={ handleChange }
+				/>
+				<FormSettingExplanation>
+					{ translate( 'Add a category so this product is easy to find.' ) }
+				</FormSettingExplanation>
+			</FormFieldSet>
+		</Card>
+	);
+};
+
+ProductFormCategoriesCard.propTypes = {
+	product: PropTypes.shape( {
+		id: PropTypes.isRequired,
+		type: PropTypes.string.isRequired,
+	} ),
+	productCategories: PropTypes.array.isRequired,
+	editProduct: PropTypes.func.isRequired,
+};
+
+export default localize( ProductFormCategoriesCard );
+

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -6,6 +6,7 @@ import React, { Component, PropTypes } from 'react';
 /**
  * Internal dependencies
  */
+import ProductFormCategoriesCard from './product-form-categories-card';
 import ProductFormDetailsCard from './product-form-details-card';
 import ProductFormVariationsCard from './product-form-variations-card';
 
@@ -17,23 +18,32 @@ export default class ProductForm extends Component {
 			type: PropTypes.string.isRequired,
 			name: PropTypes.string,
 		} ),
+		productCategories: PropTypes.array.isRequired,
 		editProduct: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 	};
 
 	render() {
-		const { product } = this.props;
+		const { product, productCategories } = this.props;
+		const { editProduct, editProductAttribute } = this.props;
+
 		return (
 			<div className="woocommerce products__form">
 				<ProductFormDetailsCard
 					product={ product }
-					editProduct={ this.props.editProduct }
+					editProduct={ editProduct }
+				/>
+
+				<ProductFormCategoriesCard
+					product={ product }
+					productCategories={ productCategories }
+					editProduct={ editProduct }
 				/>
 
 				<ProductFormVariationsCard
 					product={ product }
-					editProduct={ this.props.editProduct }
-					editProductAttribute={ this.props.editProductAttribute }
+					editProduct={ editProduct }
+					editProductAttribute={ editProductAttribute }
 				/>
 			</div>
 		);

--- a/client/extensions/woocommerce/state/wc-api/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/wc-api/product-categories/selectors.js
@@ -1,0 +1,13 @@
+/**
+ * Gets product categories from API data.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId wpcom site id
+ * @return {Array} List of product categories
+ */
+export function getProductCategories( state, siteId ) {
+	const wcApi = state.extensions.woocommerce.wcApi || {};
+	const siteData = wcApi[ siteId ] || {};
+
+	return siteData.productCategories || [];
+}

--- a/client/extensions/woocommerce/state/wc-api/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/wc-api/product-categories/test/selectors.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getProductCategories } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#getProductCategories()', () => {
+		it( 'should return an empty array if data is not available.', () => {
+			const state = {
+				extensions: {
+					woocommerce: {}
+				}
+			};
+
+			expect( getProductCategories( state, 123 ) ).to.eql( [] );
+		} );
+
+		it( 'should give product categories from specified site', () => {
+			const categories123 = [
+				{ id: 1, name: 'cat1', slug: 'cat-1' },
+				{ id: 2, name: 'cat2', slug: 'cat-2' },
+			];
+
+			const categories345 = [
+				{ id: 3, name: 'cat3', slug: 'cat-3' },
+				{ id: 4, name: 'cat4', slug: 'cat-4' },
+			];
+
+			const state = {
+				extensions: {
+					woocommerce: {
+						wcApi: {
+							[ 123 ]: {
+								productCategories: categories123,
+							},
+							[ 345 ]: {
+								productCategories: categories345,
+							},
+						}
+					}
+				}
+			};
+
+			expect( getProductCategories( state, 123 ) ).to.equal( categories123 );
+			expect( getProductCategories( state, 345 ) ).to.equal( categories345 );
+		} );
+	} );
+} );


### PR DESCRIPTION
This adds a selector to get the product categories that have been fetched via the WooCommerce API for a given site.

To Test:
1. `make test` and ensure all tests pass.