### PR TITLE
Add link to next theme on wpcom themes.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -274,7 +274,7 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderOverviewTab() {
-		const { isWpcomTheme, download } = this.props;
+		const { isWpcomTheme, download, next } = this.props;
 
 		return (
 			<div>
@@ -284,6 +284,11 @@ const ThemeSheet = React.createClass( {
 				{ this.renderFeaturesCard() }
 				{ download && <ThemeDownloadCard href={ download } /> }
 				{ isWpcomTheme && this.renderRelatedThemes() }
+				{ isWpcomTheme &&
+					<SectionHeader
+						href={ next }
+						label={ i18n.translate( 'Next theme' ) }
+					/> }
 			</div>
 		);
 	},

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -103,10 +103,6 @@ const ThemeSheet = React.createClass( {
 	},
 
 	componentDidMount() {
-		this.scrollToTop();
-	},
-
-	scrollToTop() {
 		window.scroll( 0, 0 );
 	},
 
@@ -284,8 +280,7 @@ const ThemeSheet = React.createClass( {
 		const nextThemeHref = `/theme/${ next }${ sitePart }`;
 		return <SectionHeader
 			href={ nextThemeHref }
-			label={ i18n.translate( 'Next theme' ) }
-			onClick={ this.scrollToTop } />;
+			label={ i18n.translate( 'Next theme' ) } />;
 	},
 
 	renderOverviewTab() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -103,6 +103,10 @@ const ThemeSheet = React.createClass( {
 	},
 
 	componentDidMount() {
+		this.scrollToTop();
+	},
+
+	scrollToTop() {
 		window.scroll( 0, 0 );
 	},
 
@@ -280,7 +284,8 @@ const ThemeSheet = React.createClass( {
 		const nextThemeHref = `/theme/${ next }${ sitePart }`;
 		return <SectionHeader
 			href={ nextThemeHref }
-			label={ i18n.translate( 'Next theme' ) } />;
+			label={ i18n.translate( 'Next theme' ) }
+			onClick={ this.scrollToTop } />;
 	},
 
 	renderOverviewTab() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -273,8 +273,18 @@ const ThemeSheet = React.createClass( {
 		return <div>{ this.props.description }</div>;
 	},
 
+	renderNextTheme() {
+		const { next, siteSlug } = this.props;
+		const sitePart = siteSlug ? `/${ siteSlug }` : '';
+
+		const nextThemeHref = `/theme/${ next }${ sitePart }`;
+		return <SectionHeader
+			href={ nextThemeHref }
+			label={ i18n.translate( 'Next theme' ) } />;
+	},
+
 	renderOverviewTab() {
-		const { isWpcomTheme, download, next } = this.props;
+		const { isWpcomTheme, download } = this.props;
 
 		return (
 			<div>
@@ -284,11 +294,7 @@ const ThemeSheet = React.createClass( {
 				{ this.renderFeaturesCard() }
 				{ download && <ThemeDownloadCard href={ download } /> }
 				{ isWpcomTheme && this.renderRelatedThemes() }
-				{ isWpcomTheme &&
-					<SectionHeader
-						href={ next }
-						label={ i18n.translate( 'Next theme' ) }
-					/> }
+				{ isWpcomTheme && this.renderNextTheme() }
 			</div>
 		);
 	},

--- a/client/my-sites/theme/themes-related-card/style.scss
+++ b/client/my-sites/theme/themes-related-card/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	margin-top: 16px;
 	margin-left: 0px;
+	margin-bottom: 0;
 	flex-flow: row nowrap;
 	justify-content: space-around;
 


### PR DESCRIPTION
### Info
Since Calypso themes showcase uses infinite scroll the web crawlers have problem discovering all themes that are available from showcase. One of solutions for that problem is to make all themes visible as a link from within the showcase. @seear had a fantastic idea to add `Next theme` link to all theme sheet. This way all themes can be visited by just following that link. `Next theme` link is created only for wpcom themes - themes located on Jetpack site should not have that link.
To make it work we need code from D5396 to land.  It adds next property to theme object that allows creating link to next theme. 

It looks like this:
![image](https://cloud.githubusercontent.com/assets/17271089/25610448/8015d360-2f23-11e7-8f98-ef419724de97.png)

### Testing
Either wait for D5396 or sandbox public-api with changes from that diff.
Open some theme page and scroll to bottom. Link should be there and should link to the next theme :)