### PR TITLE
State: Add missing tests for sites selectors

### DIFF
--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -42,6 +42,7 @@ import {
 	canJetpackSiteManage,
 	canJetpackSiteUpdateFiles,
 	canJetpackSiteAutoUpdateFiles,
+	canJetpackSiteAutoUpdateCore,
 	hasJetpackSiteJetpackThemes,
 	hasJetpackSiteJetpackThemesExtendedFeatures,
 	isJetpackSiteSecondaryNetworkSite,
@@ -2327,6 +2328,44 @@ describe( 'selectors', () => {
 
 			const canAutoUpdateFiles = canJetpackSiteAutoUpdateFiles( state, siteId );
 			expect( canAutoUpdateFiles ).to.equal( false );
+		} );
+	} );
+
+	describe( '#canJetpackSiteAutoUpdateCore()', () => {
+		it( 'it should return `true` if the `file_mod_disabled` option does not contain `automatic_updater_disabled`', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: false,
+					jetpack: true,
+					options: {
+						file_mod_disabled: [],
+						jetpack_version: '3.4'
+					}
+				}
+			} );
+
+			const canAutoUpdateCore = canJetpackSiteAutoUpdateCore( state, siteId );
+			expect( canAutoUpdateCore ).to.equal( true );
+		} );
+
+		it( 'it should return `false` if the `file_mod_disabled` option contains `automatic_updater_disabled`', () => {
+			const state = createStateWithItems( {
+				[ siteId ]: {
+					ID: siteId,
+					URL: 'https://jetpacksite.me',
+					is_multisite: false,
+					jetpack: true,
+					options: {
+						file_mod_disabled: [ 'automatic_updater_disabled' ],
+						jetpack_version: '3.4'
+					}
+				}
+			} );
+
+			const canAutoUpdateCore = canJetpackSiteAutoUpdateCore( state, siteId );
+			expect( canAutoUpdateCore ).to.equal( false );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -28,6 +28,7 @@ import {
 	isRequestingSites,
 	isRequestingSite,
 	getSeoTitleFormats,
+	getSeoTitle,
 	getSiteBySlug,
 	getSiteByUrl,
 	getSitePlan,
@@ -986,6 +987,480 @@ describe( 'selectors', () => {
 				pages: [],
 				posts: [],
 			} );
+		} );
+	} );
+
+	describe( 'getSeoTitle()', () => {
+		it( 'should return an empty string when there is no site ID in data', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {}
+				}
+			}, 'frontPage', {} );
+
+			expect( seoTitle ).to.eql( '' );
+		} );
+
+		it( 'should convert site name and tagline for front page title type', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									front_page: [
+										{
+											value: 'siteName',
+										},
+										{
+											type: 'string',
+											value: ' | ',
+										},
+										{
+											value: 'tagline',
+										},
+									],
+								}
+							}
+						}
+					}
+				}
+			}, 'frontPage', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				}
+			} );
+
+			expect( seoTitle ).to.eql( 'Site Title | Site Tagline' );
+		} );
+
+		it( 'should default to site name for front page title type if no other title is set', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									front_page: [],
+								}
+							}
+						}
+					}
+				}
+			}, 'frontPage', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				}
+			} );
+
+			expect( seoTitle ).to.eql( 'Site Title' );
+		} );
+
+		it( 'should convert site name, tagline and post title for posts title type', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									posts: [
+										{
+											value: 'siteName',
+										},
+										{
+											type: 'string',
+											value: ' | ',
+										},
+										{
+											value: 'tagline',
+										},
+										{
+											type: 'string',
+											value: ' > ',
+										},
+										{
+											value: 'postTitle',
+										},
+									],
+								}
+							}
+						}
+					}
+				}
+			}, 'posts', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				post: {
+					title: 'Post Title',
+				}
+			} );
+
+			expect( seoTitle ).to.eql( 'Site Title | Site Tagline > Post Title' );
+		} );
+
+		it( 'should default to post title for posts title type if no other title is set', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									posts: [],
+								}
+							}
+						}
+					}
+				}
+			}, 'posts', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				post: {
+					title: 'Post Title',
+				}
+			} );
+
+			expect( seoTitle ).to.eql( 'Post Title' );
+		} );
+
+		it( 'should return empty string as post title for posts title type if post title is missing', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									posts: [],
+								}
+							}
+						}
+					}
+				}
+			}, 'posts', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				post: {}
+			} );
+
+			expect( seoTitle ).to.eql( '' );
+		} );
+
+		it( 'should convert site name, tagline and page title for pages title type', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									pages: [
+										{
+											value: 'siteName',
+										},
+										{
+											type: 'string',
+											value: ' | ',
+										},
+										{
+											value: 'tagline',
+										},
+										{
+											type: 'string',
+											value: ' > ',
+										},
+										{
+											value: 'pageTitle',
+										},
+									],
+								}
+							}
+						}
+					}
+				}
+			}, 'pages', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				post: {
+					title: 'Page Title',
+				}
+			} );
+
+			expect( seoTitle ).to.eql( 'Site Title | Site Tagline > Page Title' );
+		} );
+
+		it( 'should default to empty string for pages title type if no other title is set', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									pages: [],
+								}
+							}
+						}
+					}
+				}
+			}, 'pages', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				post: {
+					title: 'Page Title',
+				}
+			} );
+
+			expect( seoTitle ).to.eql( '' );
+		} );
+
+		it( 'should return empty string as page title for pages title type if page title is missing', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									pages: [],
+								}
+							}
+						}
+					}
+				}
+			}, 'pages', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				post: {}
+			} );
+
+			expect( seoTitle ).to.eql( '' );
+		} );
+
+		it( 'should convert site name, tagline and group name for groups title type', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									groups: [
+										{
+											value: 'siteName',
+										},
+										{
+											type: 'string',
+											value: ' | ',
+										},
+										{
+											value: 'tagline',
+										},
+										{
+											type: 'string',
+											value: ' > ',
+										},
+										{
+											value: 'groupTitle',
+										},
+									],
+								}
+							}
+						}
+					}
+				}
+			}, 'groups', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				tag: 'Tag Name',
+			} );
+
+			expect( seoTitle ).to.eql( 'Site Title | Site Tagline > Tag Name' );
+		} );
+
+		it( 'should default to empty string for groups title type if no other title is set', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									groups: [],
+								}
+							}
+						}
+					}
+				}
+			}, 'groups', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				}
+			} );
+
+			expect( seoTitle ).to.eql( '' );
+		} );
+
+		it( 'should convert site name, tagline and date for archives title type', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									archives: [
+										{
+											value: 'siteName',
+										},
+										{
+											type: 'string',
+											value: ' | ',
+										},
+										{
+											value: 'tagline',
+										},
+										{
+											type: 'string',
+											value: ' > ',
+										},
+										{
+											value: 'date',
+										},
+									],
+								}
+							}
+						}
+					}
+				}
+			}, 'archives', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				date: 'January 2000',
+			} );
+
+			expect( seoTitle ).to.eql( 'Site Title | Site Tagline > January 2000' );
+		} );
+
+		it( 'should default to empty string for archives title type if no other title is set', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									archives: [],
+								}
+							}
+						}
+					}
+				}
+			}, 'archives', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+			} );
+
+			expect( seoTitle ).to.eql( '' );
+		} );
+
+		it( 'should default to post title for a misc title type', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {}
+							}
+						}
+					}
+				}
+			}, 'exampleType', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+				post: {
+					title: 'Post Title'
+				}
+			} );
+
+			expect( seoTitle ).to.eql( 'Post Title' );
+		} );
+
+		it( 'should default to site name for a misc title type if post title is missing', () => {
+			const seoTitle = getSeoTitle( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {}
+							}
+						}
+					}
+				}
+			}, 'exampleType', {
+				site: {
+					ID: 2916284,
+					name: 'Site Title',
+					description: 'Site Tagline',
+				},
+			} );
+
+			expect( seoTitle ).to.eql( 'Site Title' );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -27,6 +27,7 @@ import {
 	getSiteOption,
 	isRequestingSites,
 	isRequestingSite,
+	getSeoTitleFormats,
 	getSiteBySlug,
 	getSiteByUrl,
 	getSitePlan,
@@ -915,6 +916,76 @@ describe( 'selectors', () => {
 			}, 2916284 );
 
 			expect( isRequesting ).to.be.false;
+		} );
+	} );
+
+	describe( 'getSeoTitleFormats()', () => {
+		it( 'should return an empty object for an unknown site', () => {
+			const seoTitleFormats = getSeoTitleFormats( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( seoTitleFormats ).to.eql( {} );
+		} );
+
+		it( 'should return an empty object when unavailable for a known site', () => {
+			const seoTitleFormats = getSeoTitleFormats( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {}
+							}
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( seoTitleFormats ).to.eql( {} );
+		} );
+
+		it( 'should return seo title formats by type if available', () => {
+			const seoTitleFormats = getSeoTitleFormats( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.com',
+							options: {
+								advanced_seo_title_formats: {
+									archives: [],
+									front_page: [
+										{
+											type: 'string',
+											value: 'Site Title',
+										}
+									],
+									groups: [],
+									pages: [],
+									posts: [],
+								}
+							}
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( seoTitleFormats ).to.eql( {
+				archives: [],
+				frontPage: [
+					{
+						type: 'string',
+						value: 'Site Title',
+					}
+				],
+				groups: [],
+				pages: [],
+				posts: [],
+			} );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -45,6 +45,7 @@ import {
 	canJetpackSiteAutoUpdateCore,
 	hasJetpackSiteJetpackThemes,
 	hasJetpackSiteJetpackThemesExtendedFeatures,
+	isJetpackSiteMultiSite,
 	isJetpackSiteSecondaryNetworkSite,
 	verifyJetpackModulesActive,
 	getJetpackSiteRemoteManagementUrl,
@@ -2513,6 +2514,66 @@ describe( 'selectors', () => {
 
 			const hasThemesExtendedFeatures = hasJetpackSiteJetpackThemesExtendedFeatures( state, siteId );
 			expect( hasThemesExtendedFeatures ).to.be.true;
+		} );
+	} );
+
+	describe( 'isJetpackSiteMultiSite()', () => {
+		it( 'should return null if the site is not known', () => {
+			const isMultisite = isJetpackSiteMultiSite( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( isMultisite ).to.be.null;
+		} );
+
+		it( 'should return null if the site is not a Jetpack site', () => {
+			const isMultisite = isJetpackSiteMultiSite( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							jetpack: false,
+							is_multisite: true,
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( isMultisite ).to.be.null;
+		} );
+
+		it( 'should return true if the site is a Jetpack multisite', () => {
+			const isMultisite = isJetpackSiteMultiSite( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							jetpack: true,
+							is_multisite: true,
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( isMultisite ).to.be.true;
+		} );
+
+		it( 'should return false if the site is a Jetpack single site', () => {
+			const isMultisite = isJetpackSiteMultiSite( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							jetpack: true,
+							is_multisite: false,
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( isMultisite ).to.be.false;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -24,6 +24,7 @@ import {
 	getSiteTitle,
 	getSiteThemeShowcasePath,
 	isSitePreviewable,
+	getSiteOption,
 	isRequestingSites,
 	isRequestingSite,
 	getSiteBySlug,
@@ -793,6 +794,69 @@ describe( 'selectors', () => {
 
 				expect( isPreviewable ).to.be.true;
 			} );
+		} );
+	} );
+
+	describe( 'getSiteOption()', () => {
+		it( 'should return null if site is not known', () => {
+			const siteOption = getSiteOption( {
+				sites: {
+					items: {}
+				}
+			}, 77203199, 'example_option' );
+
+			expect( siteOption ).to.be.null;
+		} );
+
+		it( 'should return null if the options are not known for that site', () => {
+			const siteOption = getSiteOption( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+						}
+					}
+				}
+			}, 77203199, 'example_option' );
+
+			expect( siteOption ).to.be.null;
+		} );
+
+		it( 'should return undefined if the option is not known for that site', () => {
+			const siteOption = getSiteOption( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							options: {
+								unmapped_url: 'https://example.wordpress.com'
+							}
+						}
+					}
+				}
+			}, 77203199, 'example_option' );
+
+			expect( siteOption ).to.be.undefined;
+		} );
+
+		it( 'should return the option value if the option is known for that site', () => {
+			const siteOption = getSiteOption( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							options: {
+								example_option: 'example value'
+							}
+						}
+					}
+				}
+			}, 77203199, 'example_option' );
+
+			expect( siteOption ).to.eql( 'example value' );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -32,6 +32,7 @@ import {
 	getSiteBySlug,
 	getSiteByUrl,
 	getSitePlan,
+	getSitePlanSlug,
 	isCurrentSitePlan,
 	isCurrentPlanPaid,
 	getSiteFrontPage,
@@ -1641,6 +1642,36 @@ describe( 'selectors', () => {
 				free_trial: false,
 				expired: false
 			} );
+		} );
+	} );
+
+	describe( 'getSitePlanSlug()', () => {
+		it( 'should return undefined if the plan slug is not known', () => {
+			const planSlug = getSitePlanSlug( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( planSlug ).to.be.undefined;
+		} );
+
+		it( 'should return the plan slug if it is known', () => {
+			const planSlug = getSitePlanSlug( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							plan: {
+								product_id: 1234,
+								product_slug: 'fake-plan',
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( planSlug ).to.eql( 'fake-plan' );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -56,6 +56,7 @@ import {
 	getSiteAdminUrl,
 	getCustomizerUrl,
 	getJetpackComputedAttributes,
+	hasDefaultSiteTitle,
 	siteSupportsJetpackSettingsUi
 } from '../selectors';
 
@@ -3273,6 +3274,66 @@ describe( 'selectors', () => {
 			}, 77203074 );
 
 			expect( supportsJetpackSettingsUI ).to.be.true;
+		} );
+	} );
+
+	describe( 'hasDefaultSiteTitle()', () => {
+		it( 'should return null if the site is not known', () => {
+			const hasDefaultTitle = hasDefaultSiteTitle( {
+				sites: {
+					items: {}
+				}
+			}, 77203074 );
+
+			expect( hasDefaultTitle ).to.be.null;
+		} );
+
+		it( 'should return true if the site title is "Site Title"', () => {
+			const hasDefaultTitle = hasDefaultSiteTitle( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'example.wordpress.com',
+							name: 'Site Title',
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( hasDefaultTitle ).to.be.true;
+		} );
+
+		it( 'should return true if the site title is equal to the site slug', () => {
+			const hasDefaultTitle = hasDefaultSiteTitle( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'example.wordpress.com',
+							name: 'example.wordpress.com',
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( hasDefaultTitle ).to.be.true;
+		} );
+
+		it( 'should return false if the site title is any other title', () => {
+			const hasDefaultTitle = hasDefaultSiteTitle( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'example.wordpress.com',
+							name: 'Example Site Name',
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( hasDefaultTitle ).to.be.false;
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 import config from 'config';
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
+	getRawSite,
 	getSite,
 	computeSiteOptions,
 	getSiteCollisions,
@@ -64,6 +65,34 @@ describe( 'selectors', () => {
 	beforeEach( () => {
 		getSite.memoizedSelector.cache.clear();
 		getSiteCollisions.memoizedSelector.cache.clear();
+	} );
+
+	describe( '#getRawSite()', () => {
+		it( 'it should return null if there is no such site', () => {
+			const rawSite = getRawSite( {
+				sites: {
+					items: {}
+				}
+			}, 77203199 );
+
+			expect( rawSite ).to.be.null;
+		} );
+
+		it( 'it should return the raw site object for site with that ID', () => {
+			const site = {
+				ID: 77203199,
+				URL: 'https://example.com'
+			};
+			const rawSite = getRawSite( {
+				sites: {
+					items: {
+						77203199: site,
+					}
+				}
+			}, 77203199 );
+
+			expect( rawSite ).to.eql( site );
+		} );
 	} );
 
 	describe( '#getSite()', () => {


### PR DESCRIPTION
Some of our sites selectors were lacking tests. This PR adds tests for all of them:

* `canJetpackSiteAutoUpdateCore()`
* `getRawSite()`
* `getSeoTitle()`
* `getSeoTitleFormats()`
* `getSiteOption()`
* `getSitePlanSlug()`
* `hasDefaultSiteTitle()`
* `isJetpackSiteMultiSite()`

To test:
* Checkout this branch
* Verify all site selectors tests pass:

```
npm run test-client client/state/sites/test/selectors.js
```