### PR TITLE
Replace Intergalactic with Intergalactic 2

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -55,11 +55,11 @@ export const themes = [
 	},
 	{
 		name: 'Intergalactic',
-		slug: 'intergalactic',
+		slug: 'intergalactic-2',
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
-		demo_uri: 'https://intergalacticdemo.wordpress.com',
+		demo_uri: 'https://intergalactic2demo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
Replace Intergalactic with Intergalactic 2 in themes in signup.

Testing instructions:

* Switch to this PR 
* Go to calypso.local:3000(?)/start/ 
* Click “A list of your latest posts“ 
* Make sure Intergalactic 2 shows up instead of Intergalactic