### PR TITLE
Reader: make usage of the word tag more consistent

### DIFF
--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -38,8 +38,8 @@ const exported = {
 			<AsyncLoad require="reader/tag-stream/main"
 				key={ 'tag-' + encodedTag }
 				postsStore={ tagStore }
-				tag={ encodedTag }
-				decodedTag={ tagSlug }
+				encodedTagSlug={ encodedTag }
+				decodedTagSlug={ tagSlug }
 				trackScrollPage={ trackScrollPage.bind(
 					null,
 					basePath,

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -16,7 +16,7 @@ import { isDiscoverEnabled } from 'reader/discover/helper';
 
 const TagEmptyContent = React.createClass( {
 	propTypes: {
-		tag: React.PropTypes.string
+		decodedTagSlug: React.PropTypes.string
 	},
 
 	shouldComponentUpdate() {
@@ -49,7 +49,7 @@ const TagEmptyContent = React.createClass( {
 
 		const message = this.translate(
 			'No posts have recently been tagged with {{tagName /}} for your language.',
-			{ components: { tagName: <em>{ decodeURIComponent( this.props.tag ) }</em> } }
+			{ components: { tagName: <em>{ this.props.decodedTagSlug }</em> } }
 		);
 
 		return ( <EmptyContent

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -25,7 +25,6 @@ class TagStreamHeader extends React.Component {
 
 	static propTypes = {
 		isPlaceholder: React.PropTypes.bool,
-		encodedTagSlug: React.PropTypes.string,
 		showFollow: React.PropTypes.bool,
 		following: React.PropTypes.bool,
 		onFollowToggle: React.PropTypes.func,

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -25,7 +25,7 @@ class TagStreamHeader extends React.Component {
 
 	static propTypes = {
 		isPlaceholder: React.PropTypes.bool,
-		tag: React.PropTypes.string,
+		encodedTagSlug: React.PropTypes.string,
 		showFollow: React.PropTypes.bool,
 		following: React.PropTypes.bool,
 		onFollowToggle: React.PropTypes.func,
@@ -42,7 +42,6 @@ class TagStreamHeader extends React.Component {
 	}
 
 	state = {
-		tag: this.props.tag,
 		tagImages: this.props.tagImages,
 		chosenTagImage: this.pickTagImage()
 	};

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -28,8 +28,8 @@ const TagStream = React.createClass( {
 	_isMounted: false,
 
 	propTypes: {
-		tag: React.PropTypes.string, // the tag slug encoded
-		decodedTag: React.PropTypes.string, // decoded tag slug
+		encodedTagSlug: React.PropTypes.string, // the tag slug encoded
+		decodedTagSlug: React.PropTypes.string, // decoded tag slug
 	},
 
 	getInitialState() {
@@ -49,7 +49,7 @@ const TagStream = React.createClass( {
 		} );
 		asyncRequire( 'twemoji', function( twemoji ) {
 			if ( self._isMounted ) {
-				const title = self.getTitle();
+				const title = self.props.decodedTagSlug;
 				self.setState( {
 					twemoji,
 					isEmojiTitle: title && twemoji.test( title )
@@ -63,7 +63,7 @@ const TagStream = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.tag !== this.props.tag ) {
+		if ( nextProps.encodedTagSlug !== this.props.encodedTagSlug ) {
 			this.checkForTwemoji( nextProps );
 		}
 	},
@@ -75,33 +75,29 @@ const TagStream = React.createClass( {
 		} );
 	},
 
-	getTitle() {
-		return decodeURIComponent( this.props.tag );
-	},
-
 	isSubscribed() {
-		const tag = find( this.props.tags, { slug: this.props.tag } );
+		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
 		return !! ( tag && tag.isFollowing );
 	},
 
 	toggleFollowing() {
-		const { decodedTag, unfollowTag, followTag } = this.props;
+		const { decodedTagSlug, unfollowTag, followTag } = this.props;
 		const isFollowing = this.isSubscribed(); // this is the current state, not the new state
 		const toggleAction = isFollowing ? unfollowTag : followTag;
-		toggleAction( decodedTag );
+		toggleAction( decodedTagSlug );
 		recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
-		recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', decodedTag );
+		recordGaEvent( isFollowing ? 'Clicked Unfollow Topic' : 'Clicked Follow Topic', decodedTagSlug );
 		recordTrack( isFollowing ? 'calypso_reader_reader_tag_unfollowed' : 'calypso_reader_reader_tag_followed', {
-			tag: decodedTag
+			tag: decodedTagSlug
 		} );
 	},
 
 	render() {
-		const emptyContent = ( <EmptyContent tag={ this.props.tag } /> );
-		const title = this.getTitle();
-		const tag = find( this.props.tags, { slug: this.props.tag } );
+		const emptyContent = ( <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } /> );
+		const title = this.props.decodedTagSlug;
+		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
 
-		let imageSearchString = this.props.tag;
+		let imageSearchString = this.props.encodedTagSlug;
 
 		// If the tag contains emoji, convert to text equivalent
 		if ( this.state.emojiText && this.state.isEmojiTitle ) {
@@ -113,12 +109,11 @@ const TagStream = React.createClass( {
 		return (
 			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
 				<QueryReaderFollowedTags />
-				<QueryReaderTag tag={ this.props.decodedTag } />
+				<QueryReaderTag tag={ this.props.decodedTagSlug } />
 				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
 				<TagStreamHeader
-					tag={ this.props.tag }
-					title={ this.getTitle() }
+					title={ title }
 					imageSearchString={ imageSearchString }
 					showFollow={ !! ( tag && tag.id ) }
 					following={ this.isSubscribed() }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -28,8 +28,8 @@ const TagStream = React.createClass( {
 	_isMounted: false,
 
 	propTypes: {
-		encodedTagSlug: React.PropTypes.string, // the tag slug encoded
-		decodedTagSlug: React.PropTypes.string, // decoded tag slug
+		encodedTagSlug: React.PropTypes.string,
+		decodedTagSlug: React.PropTypes.string,
 	},
 
 	getInitialState() {


### PR DESCRIPTION
Within the tag-related files it is currently difficult to follow what different variables are.  I think a big part of that is due to imprecise usage of the word `tag`.  Right now `tag` can actually mean one of three things:
1. encoded tag slug ( %e2%9d%a4)
2. decoded tag slug ( ❤ )
3. tag object from the api ( { slug, id, displayName, etc. } )

This PR attempts to name each what they are so that the code becomes easier to follow.