### PR TITLE
Use React.Children API instead of treating children as array

### DIFF
--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -14,7 +14,7 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		let hasRegions = this.props.children.some( el => el.type === SidebarRegion );
+		const hasRegions = React.Children.toArray( this.props.children ).some( el => el.type === SidebarRegion );
 
 		return (
 			<ul className={ classNames( 'sidebar', this.props.className, { 'has-regions': hasRegions } ) } onClick={ this.props.onClick } data-tip-target="sidebar">


### PR DESCRIPTION
Fixes #13564 

To test:
- `npm test`
- Make sure sidebars with regions (e.g. my-sites) and without (e.g. all the rest) continue to render correctly

cc @coderkevin @justinshreve @belcherj @jeffstieler @marcinbot or @DanReyLop for an easy review :)