### PR TITLE
Reader: count issue where we were giving the wrong count to react-virtualized

### DIFF
--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -122,7 +122,7 @@ class FollowingManageSubscriptions extends Component {
 						<SitesWindowScroller
 							sites={ sortedFollows }
 							width={ width }
-							remoteTotalCount={ followsCount }
+							remoteTotalCount={ sortedFollows.length }
 							forceRefresh={ this.state.forceRefresh }
 						/>
 					}


### PR DESCRIPTION
This fixes an issue where if you go to: https://wpcalypso.wordpress.com/following/manage and search within the subs you already follow, then its all janked up.

To test:
- open up live branch and go to following/manage.  Everything should work as expected when you filter within your own subs.