### PR TITLE
AT: Disable upgrade notifications on site selector

### DIFF
--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import config from 'config';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,9 +57,11 @@ export default React.createClass( {
 	},
 
 	showIndicator() {
-		// Until WP.com sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
-		return userCan( 'manage_options', this.props.site ) &&
-			this.props.site.jetpack &&
+		// Until WP.com and Automated Transfer sites have indicators (upgrades expiring, etc) we only show them for Jetpack sites
+		const { site } = this.props;
+		const isJetpackSite = site.jetpack && ! get( site, 'options.is_automated_transfer' );
+		return userCan( 'manage_options', site ) &&
+			isJetpackSite &&
 			( this.hasUpdate() || this.hasError() || this.hasWarning() || this.state.updateError );
 	},
 


### PR DESCRIPTION
This hides upgrade notifications in the site selector for Automated Transfer sites.

**Before**
![screen shot 2017-05-02 at 12 19 46 pm](https://cloud.githubusercontent.com/assets/744755/25635221/3be1faac-2f32-11e7-9a05-b5c0a6a7f300.png)

**After**

![screen shot 2017-05-02 at 12 20 21 pm](https://cloud.githubusercontent.com/assets/744755/25635229/40660c62-2f32-11e7-9fc8-f620de6d7dd6.png)

**Testing**
- Open site selector for a user with an AT site that requires an update. 
- The AT site card should not display the update indicator 
