### PR TITLE
Update plugin-item default props

### DIFF
--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -37,3 +37,4 @@ render: function() {
 * `errors`: an array of update errors.
 * `notices`: an object of plugin notices: `completed`, `errors`, `inProgress`.
 * `hasAllNoManageSites`: a boolean to display an non managed plugin.
+* `hasUpdate`: a function to determine if a plugin has an update available. Defaults to a function returning false.

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -68,6 +68,7 @@ module.exports = React.createClass( {
 				autoupdate: true,
 			},
 			isAutoManaged: false,
+			hasUpdate: () => false,
 		}
 	},
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/13522 pulled the `hasUpdate` method out of `plugin-item` and into its parent component `plugin-list` for shareability. 

### Problem
`plugin-item` is used outside of the `plugin-list` context when Jetpack's manage is turned off. 
Specifically, its used to [populate mock plugin items](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/plugins/main.jsx#L296-L328). This will cause an error because the prop is not available.
```
this.props.hasUpdate is not a function
```

 In this case, and all others outside of `plugin-list`, the `hasUpdate` prop is not needed.

### Solution
Default the `hasUpdate` prop to `() => false`

cc @beaulebens @jessefriedman 