### PR TITLE
Notifications: Fix console warnings about nested a tags

### DIFF
--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -3,23 +3,18 @@
  */
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
-import isFunction from 'lodash/isFunction';
+import { isFunction, noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 class MasterbarItem extends Component {
-	constructor() {
-		super();
-		this._preloaded = false;
-		this.preload = this.preload.bind( this );
-	}
+	_preloaded = false;
 
-	preload() {
+	preload = () => {
 		if ( ! this._preloaded && isFunction( this.props.preloadSection ) ) {
 			this._preloaded = true;
 			this.props.preloadSection();
 		}
-	}
+	};
 
 	render() {
 		const itemClasses = classNames( 'masterbar__item', this.props.className, {
@@ -35,11 +30,10 @@ class MasterbarItem extends Component {
 					className={ itemClasses }
 					onTouchStart={ this.preload }
 					onMouseEnter={ this.preload }>
-					{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } />
-					}
-					<span className="masterbar__item-content">{
-						this.props.children
-					}</span>
+					{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
+					<span className="masterbar__item-content">
+						{ this.props.children }
+					</span>
 				</div>
 			);
 		}
@@ -53,12 +47,10 @@ class MasterbarItem extends Component {
 				className={ itemClasses }
 				onTouchStart={ this.preload }
 				onMouseEnter={ this.preload }>
-				{ !! this.props.icon &&
-				<Gridicon icon={ this.props.icon } size={ 24 } />
-				}
-				<span className="masterbar__item-content">{
-					this.props.children
-				}</span>
+				{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
+				<span className="masterbar__item-content">
+					{ this.props.children }
+				</span>
 			</a>
 		);
 	}

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -1,45 +1,48 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 import isFunction from 'lodash/isFunction';
 import Gridicon from 'gridicons';
 
-export default React.createClass( {
-	displayName: 'MasterbarItem',
-
-	propTypes: {
-		url: React.PropTypes.string,
-		onClick: React.PropTypes.func,
-		tooltip: React.PropTypes.string,
-		icon: React.PropTypes.string,
-		className: React.PropTypes.string,
-		isActive: React.PropTypes.bool,
-		preloadSection: React.PropTypes.func
-	},
-
-	_preloaded: false,
-
-	getDefaultProps() {
-		return {
-			icon: '',
-			onClick: noop
-		};
-	},
+class MasterbarItem extends Component {
+	constructor() {
+		super();
+		this._preloaded = false;
+		this.preload = this.preload.bind( this );
+	}
 
 	preload() {
 		if ( ! this._preloaded && isFunction( this.props.preloadSection ) ) {
 			this._preloaded = true;
 			this.props.preloadSection();
 		}
-	},
+	}
 
 	render() {
 		const itemClasses = classNames( 'masterbar__item', this.props.className, {
 			'is-active': this.props.isActive,
 		} );
+
+		if ( this.props.isNotesItem ) {
+			return (
+				<div
+					data-tip-target={ this.props.tipTarget }
+					onClick={ this.props.onClick }
+					title={ this.props.tooltip }
+					className={ itemClasses }
+					onTouchStart={ this.preload }
+					onMouseEnter={ this.preload }>
+					{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } />
+					}
+					<span className="masterbar__item-content">{
+						this.props.children
+					}</span>
+				</div>
+			);
+		}
 
 		return (
 			<a
@@ -51,12 +54,30 @@ export default React.createClass( {
 				onTouchStart={ this.preload }
 				onMouseEnter={ this.preload }>
 				{ !! this.props.icon &&
-					<Gridicon icon={ this.props.icon } size={ 24 } />
+				<Gridicon icon={ this.props.icon } size={ 24 } />
 				}
 				<span className="masterbar__item-content">{
-						this.props.children
+					this.props.children
 				}</span>
 			</a>
 		);
 	}
-} );
+}
+
+MasterbarItem.propTypes = {
+	url: React.PropTypes.string,
+	onClick: React.PropTypes.func,
+	tooltip: React.PropTypes.string,
+	icon: React.PropTypes.string,
+	className: React.PropTypes.string,
+	isActive: React.PropTypes.bool,
+	isNotesItem: React.PropTypes.bool,
+	preloadSection: React.PropTypes.func
+};
+
+MasterbarItem.defaultProps = {
+	icon: '',
+	onClick: noop
+};
+
+export default MasterbarItem;

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -15,19 +15,10 @@ import store from 'store';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class MasterbarItemNotifications extends Component {
-	constructor() {
-		super();
-
-		this.checkToggleNotes = this.checkToggleNotes.bind( this );
-		this.toggleNotesFrame = this.toggleNotesFrame.bind( this );
-		this.getNotificationLinkDomNode = this.getNotificationLinkDomNode.bind( this );
-		this.setNotesIndicator = this.setNotesIndicator.bind( this );
-
-		this.state = {
-			isShowingPopover: false,
-			animationState: 0,
-		};
-	}
+	state = {
+		isShowingPopover: false,
+		animationState: 0,
+	};
 
 	componentWillReceiveProps() {
 		this.user = this.props.user.get();
@@ -37,7 +28,7 @@ class MasterbarItemNotifications extends Component {
 		} );
 	}
 
-	checkToggleNotes( event, forceToggle ) {
+	checkToggleNotes = ( event, forceToggle ) => {
 		const target = event ? event.target : false;
 		const notificationNode = this.getNotificationLinkDomNode();
 
@@ -48,9 +39,9 @@ class MasterbarItemNotifications extends Component {
 		if ( this.state.isShowingPopover || forceToggle === true ) {
 			this.toggleNotesFrame( event );
 		}
-	}
+	};
 
-	toggleNotesFrame( event ) {
+	toggleNotesFrame = ( event ) => {
 		if ( event ) {
 			event.preventDefault && event.preventDefault();
 			event.stopPropagation && event.stopPropagation();
@@ -72,11 +63,11 @@ class MasterbarItemNotifications extends Component {
 				window.focus();
 			}
 		} );
-	}
+	};
 
-	getNotificationLinkDomNode() {
+	getNotificationLinkDomNode =() => {
 		return ReactDom.findDOMNode( this.refs.notificationLink );
-	}
+	};
 
 	/**
 	 * Uses the passed number of unseen notifications
@@ -86,7 +77,7 @@ class MasterbarItemNotifications extends Component {
 	 *
 	 * @param {Number} currentUnseenCount Number of reported unseen notifications
 	 */
-	setNotesIndicator( currentUnseenCount ) {
+	setNotesIndicator = ( currentUnseenCount ) => {
 		const existingUnseenCount = store.get( 'wpnotes_unseen_count' );
 		let newAnimationState = this.state.animationState;
 
@@ -105,7 +96,7 @@ class MasterbarItemNotifications extends Component {
 			newNote: ( currentUnseenCount > 0 ),
 			animationState: newAnimationState
 		} );
-	}
+	};
 
 	render() {
 		const classes = classNames( this.props.className, {

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -65,7 +65,7 @@ class MasterbarItemNotifications extends Component {
 		} );
 	};
 
-	getNotificationLinkDomNode =() => {
+	getNotificationLinkDomNode = () => {
 		return ReactDom.findDOMNode( this.refs.notificationLink );
 	};
 

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -14,24 +14,28 @@ import Notifications from 'notifications';
 import store from 'store';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-const MasterbarItemNotifications = React.createClass( {
-	propTypes: {
-		user: React.PropTypes.object.isRequired,
-		isActive: React.PropTypes.bool,
-		className: React.PropTypes.string,
-		onClick: React.PropTypes.func,
-		tooltip: React.PropTypes.string,
-	},
+class MasterbarItemNotifications extends Component {
+	constructor() {
+		super();
 
-	getInitialState() {
-		const user = this.props.user.get();
+		this.checkToggleNotes = this.checkToggleNotes.bind( this );
+		this.toggleNotesFrame = this.toggleNotesFrame.bind( this );
+		this.getNotificationLinkDomNode = this.getNotificationLinkDomNode.bind( this );
+		this.setNotesIndicator = this.setNotesIndicator.bind( this );
 
-		return {
+		this.state = {
 			isShowingPopover: false,
-			newNote: user && user.has_unseen_notes,
 			animationState: 0,
 		};
-	},
+	}
+
+	componentWillReceiveProps() {
+		this.user = this.props.user.get();
+
+		this.setState( {
+			newNote: this.user && this.user.has_unseen_notes,
+		} );
+	}
 
 	checkToggleNotes( event, forceToggle ) {
 		const target = event ? event.target : false;
@@ -44,7 +48,7 @@ const MasterbarItemNotifications = React.createClass( {
 		if ( this.state.isShowingPopover || forceToggle === true ) {
 			this.toggleNotesFrame( event );
 		}
-	},
+	}
 
 	toggleNotesFrame( event ) {
 		if ( event ) {
@@ -68,11 +72,11 @@ const MasterbarItemNotifications = React.createClass( {
 				window.focus();
 			}
 		} );
-	},
+	}
 
 	getNotificationLinkDomNode() {
 		return ReactDom.findDOMNode( this.refs.notificationLink );
-	},
+	}
 
 	/**
 	 * Uses the passed number of unseen notifications
@@ -101,7 +105,7 @@ const MasterbarItemNotifications = React.createClass( {
 			newNote: ( currentUnseenCount > 0 ),
 			animationState: newAnimationState
 		} );
-	},
+	}
 
 	render() {
 		const classes = classNames( this.props.className, {
@@ -117,6 +121,7 @@ const MasterbarItemNotifications = React.createClass( {
 				icon="bell"
 				onClick={ this.toggleNotesFrame }
 				isActive={ this.props.isActive }
+				isNotesItem={ true }
 				tooltip={ this.props.tooltip }
 				className={ classes }
 			>
@@ -128,11 +133,20 @@ const MasterbarItemNotifications = React.createClass( {
 				<Notifications
 					visible={ this.state.isShowingPopover }
 					checkToggle={ this.checkToggleNotes }
-					setIndicator={ this.setNotesIndicator } />
+					setIndicator={ this.setNotesIndicator }
+				/>
 			</MasterbarItem>
 		);
 	}
-} );
+}
+
+MasterbarItemNotifications.propTypes = {
+	user: React.PropTypes.object.isRequired,
+	isActive: React.PropTypes.bool,
+	className: React.PropTypes.string,
+	onClick: React.PropTypes.func,
+	tooltip: React.PropTypes.string,
+};
 
 const mapDispatchToProps = dispatch => ( {
 	recordOpening: unread_notifications => dispatch( recordTracksEvent( 'calypso_notification_open', { unread_notifications } ) )

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -219,13 +219,19 @@ $autobar-height: 20px;
 
 .masterbar__item-notifications {
 	margin-right: 12px;
+	cursor: pointer;
 
 	@include breakpoint( "<480px" ) {
 		margin-right: 0;
 	}
 
+	.gridicon {
+		cursor: pointer;
+	}
+
 	.gridicon + .masterbar__item-content {
 		padding: 0;
+		cursor: default;
 
 		@include breakpoint( "<480px" ) {
 			display: block;


### PR DESCRIPTION
All of the Notification panel code was wrapped in <a> tag which caused the following console warnings:

>Warning: validateDOMNesting(...): cannot appear as a descendant of . See ReduxWrappedLayout > Connect(Layout) > Layout > Connect(Localized(MasterbarLoggedIn)) > Localized(MasterbarLoggedIn) > MasterbarLoggedIn > Connect(MasterbarItemNotifications) > MasterbarItemNotifications > MasterbarItem > a > ... > a.

We are creating a special case for Notifications panel in order to render it inside of `<div>` tag instead.

### Testing instructions

1. Run this branch and test out Notifications panel. 
2. Verify that there are no warning or error messages in the console.