### PR TITLE
Update WooCommerce extension URLs to move site later in the route

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -42,11 +42,11 @@ const Controller = {
 
 export default function() {
 	if ( config.isEnabled( 'woocommerce/extension-dashboard' ) ) {
-		page( '/store/:site?', siteSelection, navigation, Controller.dashboard );
-		page( '/store/:site?/products/add', siteSelection, navigation, Controller.addProduct );
+		page( '/store/:site', siteSelection, navigation, Controller.dashboard );
+		page( '/store/products/:site/add', siteSelection, navigation, Controller.addProduct );
 	}
 
 	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
-		page( '/store/stats/:site?', siteSelection, navigation, Controller.stats );
+		page( '/store/stats/:site', siteSelection, navigation, Controller.stats );
 	}
 }


### PR DESCRIPTION
Fixes #13566 

Description of changes:
- Moves site part of URL towards end for dashboard, add product and stats routes (the only routes in the controller right now)
- Makes the site mandatory (we do not have designs/plans for 'global' views for the MVP)

To Test:
- `npm test`
- Make sure urls like `http://calypso.localhost:3000/store/{yoursitehere}` and `http://calypso.localhost:3000/store/products/{yoursitehere}/add` and `http://calypso.localhost:3000/store/stats/{yoursitehere}` work
- Note: To see the stats view, you'll have to set `woocommerce/extension-stats` to true in `config/development.json'
