### PR TITLE
Enable comments on Jetpack sites

### DIFF
--- a/client/blocks/comments/helper.jsx
+++ b/client/blocks/comments/helper.jsx
@@ -8,7 +8,7 @@ export function shouldShowComments( post ) {
 		return true;
 	}
 
-	if ( ! post.is_jetpack && post.discussion && ( post.discussion.comments_open || post.discussion.comment_count > 0 ) ) {
+	if ( post.discussion && ( post.discussion.comments_open || post.discussion.comment_count > 0 ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
This is a minimal start for enabling comments on Jetpack sites in the Reader. See #923.

It appears to work fine in the simplest of cases, but I expect there's probably more to it. At a minimum, some formal testing is needed.