### PR TITLE
Always scroll to top when changing theme in themeSheet.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -102,8 +102,18 @@ const ThemeSheet = React.createClass( {
 		};
 	},
 
-	componentDidMount() {
+	scrollToTop() {
 		window.scroll( 0, 0 );
+	},
+
+	componentDidMount() {
+		this.scrollToTop();
+	},
+
+	componentWillUpdate( nextProps ) {
+		if ( nextProps.id !== this.props.id ) {
+			this.scrollToTop();
+		}
 	},
 
 	isLoaded() {


### PR DESCRIPTION
### Info
When changing themes using Next theme with combination of browser back button sometimes  theme sheet did not scroll to the top. 
It was originally found by @folletto and described in this comment:
https://github.com/Automattic/wp-calypso/pull/13548#issuecomment-298609151
With full steps to reproduce listed here:
https://github.com/Automattic/wp-calypso/pull/13548#issuecomment-298613122

### Testing
Verify that behavior outlined in the comments ^ are not observed anymore.