### PR TITLE
Empty Content: Darker subheading for better a11y

### DIFF
--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -29,7 +29,7 @@
 }
 
 .empty-content__line {
-	color: $gray;
+	color: darken( $gray, 20% );
 	font-size: 22px;
 	font-weight: 300;
 	margin-bottom: 40px;


### PR DESCRIPTION
It's minor, but the subheading on 404 page has a really low contrast at the moment. This PR intends to add a higher contrast with `#4f748e` which gives a sufficient contrast ratio with both background colours, `#ffffff` (4.97:1) and `#f3f6f8` (4.58:1).

Before:
![screen shot 2017-05-03 at 11 14 46](https://cloud.githubusercontent.com/assets/908665/25656623/d993363e-2ff1-11e7-9b75-6b94ae2b8030.png)

After:
![screen shot 2017-05-03 at 11 15 02](https://cloud.githubusercontent.com/assets/908665/25656627/e19dae0e-2ff1-11e7-998b-cc9207a999df.png)

 