### PR TITLE
Extensions: WPSC - Add support for deleting the cache on the Contents tab

### DIFF
--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -14,6 +14,30 @@ import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 
 class ContentsTab extends Component {
+	state = {
+		isDeleting: false,
+		isDeletingAll: false,
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.isDeleting && ! nextProps.isDeleting ) {
+			this.setState( {
+				isDeleting: false,
+				isDeletingAll: false,
+			} );
+		}
+	}
+
+	deleteCache = () => {
+		this.setState( { isDeleting: true } );
+		this.props.handleDeleteCache( false );
+	}
+
+	deleteAllCaches = () => {
+		this.setState( { isDeletingAll: true } );
+		this.props.handleDeleteCache( true );
+	}
+
 	render() {
 		const {
 			fields: {
@@ -22,6 +46,7 @@ class ContentsTab extends Component {
 				supercache,
 				wpcache,
 			},
+			isDeleting,
 			isMultisite,
 			translate,
 		} = this.props;
@@ -119,11 +144,19 @@ class ContentsTab extends Component {
 						<Button compact primary>
 							{ translate( 'Delete Expired' ) }
 						</Button>
-						<Button compact>
+						<Button
+							compact
+							busy={ this.state.isDeleting }
+							disabled={ isDeleting }
+							onClick={ this.deleteCache }>
 							{ translate( 'Delete Cache' ) }
 						</Button>
 						{ isMultisite &&
-							<Button compact>
+							<Button
+								compact
+								busy={ this.state.isDeletingAll }
+								disabled={ isDeleting }
+								onClick={ this.deleteAllCaches }>
 								{ translate( 'Delete Cache On All Blogs' ) }
 							</Button>
 						}

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -1,134 +1,139 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
-import Card from 'components/card';
 import CachedFiles from './cached-files';
+import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 
-const ContentsTab = ( {
-	fields: {
-		cache_max_time,
-		generated,
-		supercache,
-		wpcache,
-	},
-	isMultisite,
-	translate,
-} ) => {
-	return (
-		<div>
-			<SectionHeader label={ translate( 'Cache Contents' ) } />
-			<Card compact>
-				<div>
-				{ wpcache &&
-					<div className="wp-super-cache__cache-stat">
-						<span className="wp-super-cache__cache-stat-label">
-							{ translate(
-								'WP-Cache (%(size)s)',
-								{
-									args: { size: wpcache && wpcache.fsize || '0KB' },
-								}
-							) }
-						</span>
-						<span className="wp-super-cache__cache-stat-item">
-							{ `${ wpcache && wpcache.cached || 0 } Cached Pages` }
-						</span>
-						<span className="wp-super-cache__cache-stat-item">
-							{ `${ wpcache && wpcache.expired || 0 } Expired Pages` }
-						</span>
-					</div>
-				}
+class ContentsTab extends Component {
+	render() {
+		const {
+			fields: {
+				cache_max_time,
+				generated,
+				supercache,
+				wpcache,
+			},
+			isMultisite,
+			translate,
+		} = this.props;
 
-				{ supercache &&
-					<div className="wp-super-cache__cache-stat">
-						<span className="wp-super-cache__cache-stat-label">
-							{ translate(
-								'WP-Super-Cache (%(size)s)',
-								{
-									args: { size: supercache && supercache.fsize || '0KB' },
-								}
-							) }
-						</span>
-						<span className="wp-super-cache__cache-stat-item">
-							{ `${ supercache && supercache.cached || 0 } Cached Pages` }
-						</span>
-						<span className="wp-super-cache__cache-stat-item">
-							{ `${ supercache && supercache.expired || 0 } Expired Pages` }
-						</span>
-					</div>
-				}
-
-				{ ( wpcache || supercache ) &&
-					<p className="wp-super-cache__cache-stat-refresh">
-						{ translate(
-							'Cache stats last generated: %(generated)d minutes ago.',
-							{
-								args: { generated: generated || 0 },
-							}
-						) }
-					</p>
-				}
-					<Button compact>
-						{ translate( 'Regenerate Cache Stats' ) }
-					</Button>
-				</div>
-			</Card>
-
+		return (
 			<div>
-			{ wpcache && wpcache.cached_list &&
-				<CachedFiles header="Fresh WP-Cached Files" files={ wpcache.cached_list } />
-			}
-
-			{ wpcache && wpcache.expired_list &&
-				<CachedFiles header="Stale WP-Cached Files" files={ wpcache.expired_list } />
-			}
-
-			{ supercache && supercache.cached_list &&
-				<CachedFiles header="Fresh Super Cached Files" files={ supercache.cached_list } />
-			}
-
-			{ supercache && supercache.expired_list &&
-				<CachedFiles header="Stale Super Cached Files" files={ supercache.expired_list } />
-			}
-			</div>
-
-			<Card>
-				{ cache_max_time &&
-					<p>
-						{ translate(
-							'Expired files are files older than %(cache_max_time)d seconds. They are still used by ' +
-							'the plugin and are deleted periodically.',
-							{
-								args: { cache_max_time: cache_max_time || 0 }
-							}
-						) }
-					</p>
-				}
-				<div>
-					<Button compact primary>
-						{ translate( 'Delete Expired' ) }
-					</Button>
-					<Button compact>
-						{ translate( 'Delete Cache' ) }
-					</Button>
-					{ isMultisite &&
-						<Button compact>
-							{ translate( 'Delete Cache On All Blogs' ) }
-						</Button>
+				<SectionHeader label={ translate( 'Cache Contents' ) } />
+				<Card compact>
+					<div>
+					{ wpcache &&
+						<div className="wp-super-cache__cache-stat">
+							<span className="wp-super-cache__cache-stat-label">
+								{ translate(
+									'WP-Cache (%(size)s)',
+									{
+										args: { size: wpcache && wpcache.fsize || '0KB' },
+									}
+								) }
+							</span>
+							<span className="wp-super-cache__cache-stat-item">
+								{ `${ wpcache && wpcache.cached || 0 } Cached Pages` }
+							</span>
+							<span className="wp-super-cache__cache-stat-item">
+								{ `${ wpcache && wpcache.expired || 0 } Expired Pages` }
+							</span>
+						</div>
 					}
+
+					{ supercache &&
+						<div className="wp-super-cache__cache-stat">
+							<span className="wp-super-cache__cache-stat-label">
+								{ translate(
+									'WP-Super-Cache (%(size)s)',
+									{
+										args: { size: supercache && supercache.fsize || '0KB' },
+									}
+								) }
+							</span>
+							<span className="wp-super-cache__cache-stat-item">
+								{ `${ supercache && supercache.cached || 0 } Cached Pages` }
+							</span>
+							<span className="wp-super-cache__cache-stat-item">
+								{ `${ supercache && supercache.expired || 0 } Expired Pages` }
+							</span>
+						</div>
+					}
+
+					{ ( wpcache || supercache ) &&
+						<p className="wp-super-cache__cache-stat-refresh">
+							{ translate(
+								'Cache stats last generated: %(generated)d minutes ago.',
+								{
+									args: { generated: generated || 0 },
+								}
+							) }
+						</p>
+					}
+						<Button compact>
+							{ translate( 'Regenerate Cache Stats' ) }
+						</Button>
+					</div>
+				</Card>
+
+				<div>
+				{ wpcache && wpcache.cached_list &&
+					<CachedFiles header="Fresh WP-Cached Files" files={ wpcache.cached_list } />
+				}
+
+				{ wpcache && wpcache.expired_list &&
+					<CachedFiles header="Stale WP-Cached Files" files={ wpcache.expired_list } />
+				}
+
+				{ supercache && supercache.cached_list &&
+					<CachedFiles header="Fresh Super Cached Files" files={ supercache.cached_list } />
+				}
+
+				{ supercache && supercache.expired_list &&
+					<CachedFiles header="Stale Super Cached Files" files={ supercache.expired_list } />
+				}
 				</div>
-			</Card>
-		</div>
-	);
-};
+
+				<Card>
+					{ cache_max_time &&
+						<p>
+							{ translate(
+								'Expired files are files older than %(cache_max_time)d seconds. They are still used by ' +
+								'the plugin and are deleted periodically.',
+								{
+									args: { cache_max_time: cache_max_time || 0 }
+								}
+							) }
+						</p>
+					}
+					<div>
+						<Button compact primary>
+							{ translate( 'Delete Expired' ) }
+						</Button>
+						<Button compact>
+							{ translate( 'Delete Cache' ) }
+						</Button>
+						{ isMultisite &&
+							<Button compact>
+								{ translate( 'Delete Cache On All Blogs' ) }
+							</Button>
+						}
+					</div>
+				</Card>
+			</div>
+		);
+	}
+}
+
 const getFormSettings = settings => {
 	const cacheStats = pick( settings.cache_stats, [
 		'generated',

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -17,6 +17,7 @@ class ContentsTab extends Component {
 	state = {
 		isDeleting: false,
 		isDeletingAll: false,
+		isDeletingExpired: false,
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -24,18 +25,24 @@ class ContentsTab extends Component {
 			this.setState( {
 				isDeleting: false,
 				isDeletingAll: false,
+				isDeletingExpired: false,
 			} );
 		}
 	}
 
 	deleteCache = () => {
 		this.setState( { isDeleting: true } );
-		this.props.handleDeleteCache( false );
+		this.props.handleDeleteCache( false, false );
+	}
+
+	deleteExpiredCache = () => {
+		this.setState( { isDeletingExpired: true } );
+		this.props.handleDeleteCache( false, true );
 	}
 
 	deleteAllCaches = () => {
 		this.setState( { isDeletingAll: true } );
-		this.props.handleDeleteCache( true );
+		this.props.handleDeleteCache( true, false );
 	}
 
 	render() {
@@ -141,7 +148,12 @@ class ContentsTab extends Component {
 						</p>
 					}
 					<div>
-						<Button compact primary>
+						<Button
+							compact
+							primary
+							busy={ this.state.isDeletingExpired }
+							disabled={ isDeleting }
+							onClick={ this.deleteExpiredCache }>
 							{ translate( 'Delete Expired' ) }
 						</Button>
 						<Button

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { pick } from 'lodash';
 
 /**
@@ -14,6 +14,20 @@ import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 
 class ContentsTab extends Component {
+	static propTypes = {
+		fields: PropTypes.object,
+		handleDeleteCache: PropTypes.func.isRequired,
+		isDeleting: PropTypes.bool,
+		isMultisite: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		fields: {},
+		isDeleting: false,
+		isMultisite: false,
+	};
+
 	state = {
 		isDeleting: false,
 		isDeletingAll: false,

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -72,12 +72,12 @@ class EasyTab extends Component {
 
 	deleteCache = () => {
 		this.setState( { isDeleting: true } );
-		this.props.handleDeleteCache( false );
+		this.props.handleDeleteCache( false, false );
 	}
 
 	deleteAllCaches = () => {
 		this.setState( { isDeletingAll: true } );
-		this.props.handleDeleteCache( true );
+		this.props.handleDeleteCache( true, false );
 	}
 
 	testCache = () => this.props.handleTestCache( this.state.httpOnly );

--- a/client/extensions/wp-super-cache/state/cache/actions.js
+++ b/client/extensions/wp-super-cache/state/cache/actions.js
@@ -57,9 +57,11 @@ export const testCache = ( siteId, httpOnly ) => {
  * Deletes the cache for a site.
  *
  * @param  {Number} siteId Site ID
+ * @param  {Number} deleteAll Whether all caches should be deleted
+ * @param  {Number} deleteExpired Whether the expired files should be deleted
  * @returns {Function} Action thunk that deletes the cache for a given site
  */
-export const deleteCache = ( siteId, deleteAll ) => {
+export const deleteCache = ( siteId, deleteAll, deleteExpired ) => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: WP_SUPER_CACHE_DELETE_CACHE,
@@ -68,7 +70,7 @@ export const deleteCache = ( siteId, deleteAll ) => {
 
 		return wp.req.post(
 			{ path: `/jetpack-blogs/${ siteId }/rest-api/` },
-			{ path: '/wp-super-cache/v1/cache', body: JSON.stringify( { all: deleteAll } ), json: true } )
+			{ path: '/wp-super-cache/v1/cache', body: JSON.stringify( { all: deleteAll, expired: deleteExpired } ), json: true } )
 			.then( () => {
 				dispatch( {
 					type: WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -230,9 +230,9 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.saveSettings( siteId, pick( fields, settingsFields ) );
 		};
 
-		handleDeleteCache = allCaches => {
+		handleDeleteCache = ( deleteAll, deleteExpired ) => {
 			this.removeCacheNotices();
-			this.props.deleteCache( this.props.siteId, allCaches );
+			this.props.deleteCache( this.props.siteId, deleteAll, deleteExpired );
 		}
 
 		handleTestCache = httpOnly => {


### PR DESCRIPTION
This PR adds support for the _Delete Expired_, _Delete Cache_ and _Delete Cache on All Blogs_ buttons on the _Contents_ tab.

**Request In Progress**

![cache-delete-progress](https://cloud.githubusercontent.com/assets/1190420/25657249/f25b0132-2fca-11e7-8f05-d72bb9ee88df.jpg)

**Request Failure**

![cache-delete-failure](https://cloud.githubusercontent.com/assets/1190420/25533652/51ac643e-2bff-11e7-8b9a-5b5b1c3aa78a.jpg)

**Request Success**

![delete-cache-success](https://cloud.githubusercontent.com/assets/1190420/25657205/b28a02ce-2fca-11e7-9741-4131491336f1.jpg)