### PR TITLE
This prevented section nav from un-collapsing in mobile view.

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -334,10 +334,6 @@
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
-.theme__sheet-content .section-nav {
-	height: 50px;
-}
-
 .theme__sheet-features-list {
 	text-align: center;
 	margin: -10px;


### PR DESCRIPTION
###Info
This reverts one change from #13313 that was targeted to:
`Fix: loading section-nav had jumpy height.`
This changes made Section Nave not un-collapsable in mobile view. It made the height fixed so even when section nav should expand it just made the expanded part not visible.

### Testing
Open theme sheet of a theme. Reduce screen size to the point where section nave will fold. Yo should see the arrow down icon on right side. Click the icon. Section nav should expand.