### PR TITLE
Updated the split for the signupThemeStepCopyChanges test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -45,8 +45,8 @@ module.exports = {
 	signupThemeStepCopyChanges: {
 		datestamp: '20170420',
 		variations: {
-			original: 20,
-			modified: 80,
+			original: 50,
+			modified: 50,
 		},
 		defaultVariation: 'original',
 	},


### PR DESCRIPTION
I accidentally set the `signupThemeStepCopyChanges` a/b test with an 20/80 split when it should have been 50/50. This PR updates the split to 50/50.

@dzver can you take a look?