### PR TITLE
Themes: sheet on mobile had screenshot covering CTA bug

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -103,6 +103,7 @@
 
 	@include breakpoint( "<960px" ) {
 		position: relative;
+		margin-top: 0;
 		top: 0;
 		width: 100%;
 		height: 75vw; // force proportions
@@ -154,7 +155,8 @@
 	}
 
 	@include breakpoint( "<960px" ) {
-		top: 90%;
+		top: auto;
+		bottom: -10px;
 		left: 0;
 		right: 0;
 


### PR DESCRIPTION
Bug: the screenshot is covering the header and call to action on the theme sheet page on mobile.

Also, fix: "Open Live Demo" button position more reliable.

Current (bug):

![screen shot 2017-05-03 at 14 44 38](https://cloud.githubusercontent.com/assets/4389/25663285/26b1b504-300f-11e7-85f9-5b8fddeade2a.png)

This PR:

![screen shot 2017-05-03 at 14 45 48](https://cloud.githubusercontent.com/assets/4389/25663311/3aaf382e-300f-11e7-8270-33f40749c0b8.png)

### To test

1. Open any theme page on Calypso, on mobile
2. Check the header with the name and the CTA button is visible
3. Try to activate the theme
4. Try to navigate back to the full list


/ht @fditrapani for the bug discovery

