### PR TITLE
Jetpack Connect: Display notice when site is already connected

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -199,6 +199,10 @@ class JetpackConnectMain extends Component {
 			return false;
 		}
 
+		if ( this.checkProperty( 'isJetpackConnected' ) ) {
+			return 'alreadyConnected';
+		}
+
 		if ( this.checkProperty( 'userOwnsSite' ) ) {
 			return 'alreadyOwned';
 		}
@@ -236,9 +240,6 @@ class JetpackConnectMain extends Component {
 		}
 		if ( ! this.checkProperty( 'isJetpackConnected' ) ) {
 			return 'notConnectedJetpack';
-		}
-		if ( this.checkProperty( 'isJetpackConnected' ) ) {
-			return 'alreadyConnected';
 		}
 
 		return false;

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -229,10 +229,16 @@ class JetpackConnectMain extends Component {
 		if ( ! this.checkProperty( 'isJetpackActive' ) ) {
 			return 'notActiveJetpack';
 		}
-		if ( ! this.checkProperty( 'isJetpackConnected' ) ) {
+		if (
+			! this.checkProperty( 'isJetpackConnected' ) ||
+			( this.checkProperty( 'isJetpackConnected' ) && ! this.checkProperty( 'userOwnsSite' ) )
+		) {
 			return 'notConnectedJetpack';
 		}
-		if ( this.checkProperty( 'isJetpackConnected' ) ) {
+		if (
+			this.checkProperty( 'isJetpackConnected' ) &&
+			this.checkProperty( 'userOwnsSite' )
+		) {
 			return 'alreadyConnected';
 		}
 

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -103,11 +103,6 @@ class JetpackConnectMain extends Component {
 		) {
 			return this.props.goToRemoteAuth( this.state.currentUrl );
 		}
-		if ( this.getStatus() === 'alreadyOwned' &&
-			! this.props.jetpackConnectSite.isRedirecting
-		) {
-			return this.props.goToPlans( this.state.currentUrl );
-		}
 
 		if ( this.state.waitingForSites && ! this.props.isRequestingSites ) {
 			// eslint-disable-next-line react/no-did-update-set-state
@@ -199,10 +194,6 @@ class JetpackConnectMain extends Component {
 			return false;
 		}
 
-		if ( this.checkProperty( 'isJetpackConnected' ) ) {
-			return 'alreadyConnected';
-		}
-
 		if ( this.checkProperty( 'userOwnsSite' ) ) {
 			return 'alreadyOwned';
 		}
@@ -240,6 +231,9 @@ class JetpackConnectMain extends Component {
 		}
 		if ( ! this.checkProperty( 'isJetpackConnected' ) ) {
 			return 'notConnectedJetpack';
+		}
+		if ( this.checkProperty( 'isJetpackConnected' ) ) {
+			return 'alreadyConnected';
 		}
 
 		return false;

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -76,6 +76,12 @@ class JetpackConnectNotices extends Component {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
 			noticeValues.text = translate( 'This site is already connected!' );
+			return noticeValues;
+		}
+		if ( this.props.noticeType === 'alreadyOwned' ) {
+			noticeValues.status = 'is-success';
+			noticeValues.icon = 'status';
+			noticeValues.text = translate( 'This site is already connected!' );
 			noticeValues.showDismiss = false;
 			noticeValues.children = (
 				<NoticeAction href={ '/plans/my-plan/' + urlToSlug( this.props.url ) }>

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -76,6 +76,7 @@ class JetpackConnectNotices extends Component {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
 			noticeValues.text = translate( 'This site is already connected!' );
+			noticeValues.showDismiss = false;
 			noticeValues.children = (
 				<NoticeAction href={ '/plans/my-plan/' + urlToSlug( this.props.url ) }>
 					{ translate( 'Visit' ) }

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -14,7 +14,7 @@ import { urlToSlug } from 'lib/url';
 class JetpackConnectNotices extends Component {
 	static propTypes = {
 		noticeType: PropTypes.string,
-		siteUrl: PropTypes.string
+		url: PropTypes.string
 	}
 
 	getNoticeValues() {
@@ -130,8 +130,7 @@ class JetpackConnectNotices extends Component {
 	}
 
 	render() {
-		const urlSlug = this.props.url ? urlToSlug( this.props.url ) : '';
-		const values = this.getNoticeValues( urlSlug );
+		const values = this.getNoticeValues();
 		if ( values ) {
 			return (
 				<div className="jetpack-connect__notices-container">

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -1,27 +1,29 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import { urlToSlug } from 'lib/url';
 
-export default React.createClass( {
-	displayName: 'JetpackConnectNotices',
-
-	propTypes: {
+class JetpackConnectNotices extends Component {
+	static propTypes = {
 		noticeType: PropTypes.string,
 		siteUrl: PropTypes.string
-	},
+	}
 
 	getNoticeValues() {
+		const { translate } = this.props;
+
 		const noticeValues = {
 			icon: 'notice',
 			status: 'is-error',
-			text: this.translate( 'That\'s not a valid url.' ),
+			text: translate( 'That\'s not a valid url.' ),
 			showDismiss: false
 		};
 
@@ -35,73 +37,79 @@ export default React.createClass( {
 		}
 		if ( this.props.noticeType === 'isDotCom' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
+			noticeValues.text = translate( 'That\'s a WordPress.com site, so you don\'t need to connect it.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'notWordPress' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'That\'s not a WordPress site.' );
+			noticeValues.text = translate( 'That\'s not a WordPress site.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'notActiveJetpack' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'Jetpack is deactivated.' );
+			noticeValues.text = translate( 'Jetpack is deactivated.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'outdatedJetpack' ) {
 			noticeValues.icon = 'block';
-			noticeValues.text = this.translate( 'You must update Jetpack before connecting.' );
+			noticeValues.text = translate( 'You must update Jetpack before connecting.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'jetpackIsDisconnected' ) {
 			noticeValues.icon = 'link-break';
-			noticeValues.text = this.translate( 'Jetpack is currently disconnected.' );
+			noticeValues.text = translate( 'Jetpack is currently disconnected.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'jetpackIsValid' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'plugins';
-			noticeValues.text = this.translate( 'Jetpack is connected.' );
+			noticeValues.text = translate( 'Jetpack is connected.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'notJetpack' ) {
 			noticeValues.status = 'is-noticeType';
 			noticeValues.icon = 'status';
-			noticeValues.text = this.translate( 'Jetpack couldn\'t be found.' );
+			noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'alreadyConnected' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
-			noticeValues.text = this.translate( 'This site is already connected!' );
+			noticeValues.text = translate( 'This site is already connected!' );
+			noticeValues.showDismiss = false;
+			noticeValues.children = (
+				<NoticeAction href={ '/plans/my-plan/' + urlToSlug( this.props.url ) }>
+					{ translate( 'Visit' ) }
+				</NoticeAction>
+			);
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'wordpress.com' ) {
-			noticeValues.text = this.translate( 'Oops, that\'s us.' );
+			noticeValues.text = translate( 'Oops, that\'s us.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'status';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'retryingAuth' ) {
-			noticeValues.text = this.translate( 'Error authorizing. Page is refreshing for an other attempt.' );
+			noticeValues.text = translate( 'Error authorizing. Page is refreshing for an other attempt.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'retryAuth' ) {
-			noticeValues.text = this.translate( 'In some cases, authorization can take a few attempts. Please try again.' );
+			noticeValues.text = translate( 'In some cases, authorization can take a few attempts. Please try again.' );
 			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'secretExpired' ) {
-			noticeValues.text = this.translate( 'Oops, that took a while. You\'ll have to try again.' );
+			noticeValues.text = translate( 'Oops, that took a while. You\'ll have to try again.' );
 			noticeValues.status = 'is-error';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'defaultAuthorizeError' ) {
-			noticeValues.text = this.translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
+			noticeValues.text = translate( 'Error authorizing your site. Please {{link}}contact support{{/link}}.', {
 				components: { link: <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer" /> }
 			} );
 			noticeValues.status = 'is-error';
@@ -109,7 +117,7 @@ export default React.createClass( {
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'alreadyConnectedByOtherUser' ) {
-			noticeValues.text = this.translate(
+			noticeValues.text = translate(
 				'This site is already connected to a different WordPress.com user, ' +
 				'you need to disconnect that user before you can connect another.'
 			);
@@ -119,7 +127,7 @@ export default React.createClass( {
 		}
 
 		return;
-	},
+	}
 
 	render() {
 		const urlSlug = this.props.url ? urlToSlug( this.props.url ) : '';
@@ -133,4 +141,6 @@ export default React.createClass( {
 		}
 		return null;
 	}
-} );
+}
+
+export default localize( JetpackConnectNotices );

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -76,7 +76,6 @@ class JetpackConnectNotices extends Component {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
 			noticeValues.text = translate( 'This site is already connected!' );
-			noticeValues.showDismiss = false;
 			noticeValues.children = (
 				<NoticeAction href={ '/plans/my-plan/' + urlToSlug( this.props.url ) }>
 					{ translate( 'Visit' ) }

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -72,13 +72,7 @@ class JetpackConnectNotices extends Component {
 			noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
 			return noticeValues;
 		}
-		if ( this.props.noticeType === 'alreadyConnected' ) {
-			noticeValues.status = 'is-success';
-			noticeValues.icon = 'status';
-			noticeValues.text = translate( 'This site is already connected!' );
-			return noticeValues;
-		}
-		if ( this.props.noticeType === 'alreadyOwned' ) {
+		if ( this.props.noticeType === 'alreadyConnected' || this.props.noticeType === 'alreadyOwned' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
 			noticeValues.text = translate( 'This site is already connected!' );

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -119,6 +119,7 @@ export default {
 				wpcom.undocumented().getSiteConnectInfo( url, 'hasJetpack' ),
 				wpcom.undocumented().getSiteConnectInfo( url, 'isJetpackActive' ),
 				wpcom.undocumented().getSiteConnectInfo( url, 'isWordPressDotCom' ),
+				wpcom.undocumented().getSiteConnectInfo( url, 'isJetpackConnected' ),
 			] ).then( ( data, error ) => {
 				_fetching[ url ] = null;
 				data = data ? Object.assign.apply( Object, data ) : null;


### PR DESCRIPTION
This PR fixes #13529, where if you try to connect an already connected Jetpack site, you get redirected to the **My Plan** page without explanation.

This PR suggests that we move the logic for "already connected" case above, so in case user tries to connect an already connected site, a notice with a notice action will appear. Clicking the notice action will actually redirect the user to the **My Plan** page.

In addition, this PR addresses a couple of minor drive-by stuff:

* Pleasing the linter by altering `JetpackConnectNotices` to use an ES6 class.
* Fixing a misusage of `url` / `siteUrl` prop in `JetpackConnectNotices`, altering the component to use a consistent prop for that. Also cleaning up unnecessary usage of that prop within the component.

Side note: generally this implementation is a hybrid between #9503 and what we had before it.

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/jetpack/connect`
* Submit a URL of a site that's already connected.
* Verify you see the notice:
![](https://cldup.com/S3LrOZeGVY.png)
* Click the "Visit" link and verify it leads to the "My Plan" page for that site.
* Test with some other cases and verify notices work like they did before:
  * Non-connected Jetpack site without Jetpack
  * Non-connected Jetpack site with Jetpack deactivated
  * Non-WordPress site
  * A WordPress.com site
  * A wrong, non-existing URL
* Verify connecting a valid Jetpack site still works properly.