### PR TITLE
Editor: restrict the basic editor tour to development

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -21,6 +21,7 @@ import {
 	Link,
 } from 'layout/guided-tours/config-elements';
 import {
+	isEnabled,
 	isNewUser,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
@@ -30,7 +31,7 @@ export const EditorBasicsTour = makeTour(
 		name="editorBasicsTour"
 		version="20170503"
 		path="/post/"
-		when={ and( isDesktop, isNewUser ) }
+		when={ and( isEnabled( 'guided-tours/editor-basics-tour' ), isDesktop, isNewUser ) }
 	>
 		<Step
 			name="init"

--- a/config/development.json
+++ b/config/development.json
@@ -48,6 +48,7 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
+		"guided-tours/editor-basics-tour": true,
 		"help": true,
 		"help/courses": true,
 		"jetpack/invites": true,


### PR DESCRIPTION
This PR disables the Editor Basics Tour in all environments except development so we can more thoroughly look at an issue with Chrome on Mac reported by @gemmagarner [here](https://github.com/Automattic/wp-calypso/pull/12351#issuecomment-298964478). 