### PR TITLE
Build: fix get-circle-string-artifact-url

### DIFF
--- a/bin/get-circle-string-artifact-url
+++ b/bin/get-circle-string-artifact-url
@@ -4,7 +4,7 @@
 // eg: node bin/get-circle-string-artifact-url | xargs curl
 
 const https = require('https');
-const path = '/api/v1/project/Automattic/wp-calypso/latest/artifacts?branch=master&filter=successful&circle-token=' + process.env.CIRCLE_CI_TOKEN;
+const path = '/api/v1/project/Automattic/wp-calypso/latest/artifacts?branch=master&filter=successful';
 
 const options = {
 	host: 'circleci.com',

--- a/bin/get-circle-string-artifact-url
+++ b/bin/get-circle-string-artifact-url
@@ -23,9 +23,9 @@ https.get( options, ( response ) => {
 
 	response.on( 'end', () => {
 		const artifacts = JSON.parse( body );
-		const artifact = artifacts.filter( ( artifact ) => artifact.pretty_path === '$CIRCLE_ARTIFACTS/translate/calypso-strings.pot' ).shift();
+		const artifact = artifacts.filter( ( artifact ) => artifact.pretty_path.match( /\/calypso-strings\.pot$/ ) ).shift();
 		if( ! artifact ) {
-			console.error( 'failed to get latest build artifact information from circle ci', artifacts );
+			console.error( 'failed to find pot in circle ci', artifacts );
 			process.exit( 1 );
 		}
 		console.log( artifact.url );


### PR DESCRIPTION
This PR fixes the script we use to get the download url of the translations strings that are generated in circle ci. ( See #4949 )

## Testing
- No functional changes to calypso
- running `node bin/get-circle-string-artifact-url` returns the latest calypso string artifact url from https://circleci.com/gh/Automattic/wp-calypso/tree/master
- running `node bin/get-circle-string-artifact-url | xargs curl` returns the expected calypso-strings
