### PR TITLE
Reader: update position for react-virtualized windowscroller

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -99,7 +99,7 @@ class FollowingManage extends Component {
 		// here is to call updatePosition in a regular interval. the call takes about 0.1ms from empirical testing.
 		this.updatePosition = setInterval( () => {
 			this.windowScrollerRef && this.windowScrollerRef.updatePosition();
-		}, 100 );
+		}, 300 );
 	}
 
 	componentWillUnmount() {

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -72,13 +72,9 @@ class FollowingManage extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
-	handleStreamMounted = ( ref ) => {
-		this.streamRef = ref;
-	}
-
-	handleSearchBoxMounted = ( ref ) => {
-		this.searchBoxRef = ref;
-	}
+	handleStreamMounted = ref => this.streamRef = ref;
+	handleSearchBoxMounted = ref => this.searchBoxRef = ref;
+	handleWindowScrollerMounted = ref => this.windowScrollerRef = ref;
 
 	resizeSearchBox = () => {
 		if ( this.searchBoxRef && this.streamRef ) {
@@ -96,10 +92,19 @@ class FollowingManage extends Component {
 			debounce( this.resizeSearchBox, 50 )
 		);
 		this.resizeSearchBox();
+
+		// this is a total hack. In React-Virtualized you need to tell a WindowScroller when the things
+		// above it has moved with a call to updatePosision().  Our issue is we don't have a good moment
+		// where we know that the content above the WindowScroller has settled down and so instead the solution
+		// here is to call updatePosition in a regular interval. the call takes about 0.1ms from empirical testing.
+		this.updatePosition = setInterval( () => {
+			this.windowScrollerRef && this.windowScrollerRef.updatePosition();
+		}, 100 );
 	}
 
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.resizeListener );
+		clearInterval( this.windowScrollerRef );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -156,6 +161,7 @@ class FollowingManage extends Component {
 						width={ this.state.width }
 						query={ subsQuery }
 						sortOrder={ subsSortOrder }
+						windowScrollerRef={ this.handleWindowScrollerMounted }
 					/>
 				) }
 			</ReaderMain>

--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { List, WindowScroller, CellMeasurerCache, CellMeasurer, InfiniteLoader } from 'react-virtualized';
-import { debounce } from 'lodash';
+import { debounce, noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -22,7 +22,9 @@ class SitesWindowScroller extends Component {
 		fetchNextPage: PropTypes.func,
 		remoteTotalCount: PropTypes.number.isRequired,
 		forceRefresh: PropTypes.bool,
+		windowScrollerRef: PropTypes.func,
 	};
+	defaultProps = { windowScrollerRef: noop }
 
 	heightCache = new CellMeasurerCache( {
 		fixedWidth: true,
@@ -107,7 +109,7 @@ class SitesWindowScroller extends Component {
 					rowCount={ remoteTotalCount }
 				>
 				{ ( { onRowsRendered, registerChild } ) => (
-					<WindowScroller>
+					<WindowScroller ref={ this.props.windowScrollerRef }>
 						{ ( { height, scrollTop } ) => (
 							<List
 								autoHeight

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import escapeRegexp from 'escape-string-regexp';
-import { noop, reverse, sortBy, trimStart } from 'lodash';
+import { reverse, sortBy, trimStart } from 'lodash';
 import page from 'page';
 
 /**
@@ -35,8 +35,6 @@ class FollowingManageSubscriptions extends Component {
 		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 		windowScrollerRef: PropTypes.func,
 	};
-
-	defaultProps = { windowScrollerRef: noop }
 
 	state = { forceRefresh: false };
 

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import escapeRegexp from 'escape-string-regexp';
-import { reverse, sortBy, trimStart } from 'lodash';
+import { noop, reverse, sortBy, trimStart } from 'lodash';
 import page from 'page';
 
 /**
@@ -33,7 +33,11 @@ class FollowingManageSubscriptions extends Component {
 		doSearch: PropTypes.func.isRequired,
 		query: PropTypes.string,
 		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
+		windowScrollerRef: PropTypes.func,
 	};
+
+	defaultProps = { windowScrollerRef: noop }
+
 	state = { forceRefresh: false };
 
 	filterFollowsByQuery( query ) {
@@ -124,6 +128,7 @@ class FollowingManageSubscriptions extends Component {
 							width={ width }
 							remoteTotalCount={ sortedFollows.length }
 							forceRefresh={ this.state.forceRefresh }
+							windowScrollerRef={ this.props.windowScrollerRef }
 						/>
 					}
 				</div>


### PR DESCRIPTION
This PR seeks to fix the clipping that occurs when there is movement above the current follows area within Search on Manage.

cc @jancavan 