### PR TITLE
Build: add integration test for get-circle-string-artifact-url

### DIFF
--- a/integration/bin/test/get-circle-string-artifact-url.js
+++ b/integration/bin/test/get-circle-string-artifact-url.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import child_process from 'child_process';
+import path from 'path';
+
+const scriptPath = path.join( '.', 'bin', 'get-circle-string-artifact-url' );
+
+describe( 'get-circle-string-artifact-url', () => {
+	it( 'We can fetch translation strings from CircleCi artifacts', () => {
+		const url = child_process.execSync( `node ${ scriptPath }` ).toString().trim();
+		expect( url ).to.match( /^https:\/\/.+\/calypso-strings\.pot$/ );
+	} );
+} );

--- a/package.json
+++ b/package.json
@@ -149,9 +149,11 @@
     "test-client": "NODE_ENV=test NODE_PATH=test:client TEST_ROOT=client test/runner.js",
     "test-server": "NODE_ENV=test NODE_PATH=test:server:client TEST_ROOT=server test/runner.js",
     "test-test": "NODE_ENV=test NODE_PATH=test:client TEST_ROOT=test test/runner.js",
+    "test-integration": "NODE_ENV=test NODE_PATH=test:integration:client TEST_ROOT=integration test/runner.js",
     "test-client:watch": "nodemon -e js,jsx --exec npm run test-client",
     "test-server:watch": "nodemon -e js,jsx --exec npm run test-server",
     "test-test:watch": "nodemon -e js,jsx --exec npm run test-test",
+    "test-integration:watch": "nodemon -e js,jsx --exec npm run test-integration",
     "lint": "bin/run-lint .",
     "css-lint": "stylelint 'client/**/*.scss' --syntax scss"
   },

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 ### How to add a new test file
 The single test runner supports automatic test discovery. We only need to put a test file into a `test` subfolder, next to the files we want to test.
-The runner uses this glob pattern `@(client|server|test)/**/test/*.@(js|jsx)` to find test files.
+The runner uses this glob pattern `@(client|server|test|integration)/**/test/*.@(js|jsx)` to find test files.
 
 We should use the same file names as the implementation files for the tests.
 Example: if we want to write unit tests covering the file `hello-world/index.jsx`, we should name a test file `hello-world/test/index.jsx`.
@@ -15,9 +15,9 @@ If we ever need to add non-test files to a `test` folder, we should put them in 
 ### How to run single test runner
 
 Executing `make test` from the root folder will run all test suites.
-Behind the scenes we maintain 3 test runners. This is because each folder (`client`, `server` & `test`) has a different `NODE_PATH` path.
+Behind the scenes we maintain 4 test runners. This is because each folder (`client`, `server`, `test`, and `integration`) has a different `NODE_PATH` path.
 
-We have also an npm run script for each folder: `npm run test-client`, `npm run test-server` and `npm run test-test`.
+We have also an npm run script for each folder: `npm run test-client`, `npm run test-server`, `npm run test-test`, `npm run test-integration`.
 We can pass a filename or set of files to these scripts to isolate your test run to a selected set of files.
 
 Example for client:
@@ -29,6 +29,8 @@ Example for client:
 > npm run test-client -- --reporter=dot #notice the -- separating out the params to pass to the runner
 > # runner knows about Mocha --grep flag
 > npm run test-client -- --grep "state ui" # to just run the state/ui tests
+> # run integration tests (these run daily)
+< npm run test-integration
 > # run single test suite from server folder
 > npm run test-server server/config/test/parser.js
 > # run single test suite from test folder


### PR DESCRIPTION
This PR adds an integration test for a script that we use as part of our translation process. This is useful to have since Calypso devs will be able to tell when this breaks. See p4TIVU-6vm-p2.

We currently don't have any integration tests in Calypso, and this is not an UI test that would be appropriate in https://github.com/Automattic/wp-e2e-tests which assumes that each suite uses a selenium webdriver. (Any unit tests will fail there, due to some browser clean up done in after to each suite).

Some open questions:
- Should we have an integration suite in Calypso? If not, where?
- How often should this suite run?

### Testing Instructions
- Run `npm run test-integration`
- Tests pass
- Verify that this suite does not run with `npm test`