### PR TITLE
Editor: Remove sticky option if post is private or password protected

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -27,7 +27,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import EditorVisibility from 'post-editor/editor-visibility';
 
-class EditPostStatus extends Component {
+export class EditPostStatus extends Component {
 
 	static propTypes = {
 		moment: PropTypes.func,

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -26,7 +26,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import EditorVisibility from 'post-editor/editor-visibility';
-import PostEditStore from 'lib/posts/post-edit-store';
 
 export class EditPostStatus extends Component {
 
@@ -42,6 +41,7 @@ export class EditPostStatus extends Component {
 		postDate: PropTypes.string,
 		onPrivatePublish: PropTypes.func,
 		status: PropTypes.string,
+		isPostPrivate: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -101,12 +101,11 @@ export class EditPostStatus extends Component {
 	};
 
 	render() {
-		let isSticky, isPublished, isPending, canPublish, isScheduled, isPrivate, isPasswordProtected;
-		const { translate } = this.props;
+		let isSticky, isPublished, isPending, canPublish, isScheduled, isPasswordProtected;
+		const { translate, isPostPrivate } = this.props;
 
 		if ( this.props.post ) {
 			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
-			isPrivate = postUtils.isPrivate( PostEditStore.get() );
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
 			isPublished = postUtils.isPublished( this.props.savedPost );
@@ -145,7 +144,7 @@ export class EditPostStatus extends Component {
 					{ this.renderTZTooltop() }
 					{ this.renderPostSchedulePopover() }
 				</span>
-				{ this.props.type === 'post' && ! isPrivate && ! isPasswordProtected &&
+				{ this.props.type === 'post' && ! isPostPrivate && ! isPasswordProtected &&
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
 							{ translate( 'Stick to the front page' ) }

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -100,10 +100,12 @@ class EditPostStatus extends Component {
 	};
 
 	render() {
-		let isSticky, isPublished, isPending, canPublish, isScheduled;
+		let isSticky, isPublished, isPending, canPublish, isScheduled, isPrivate, isPasswordProtected;
 		const { translate } = this.props;
 
 		if ( this.props.post ) {
+			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
+			isPrivate = postUtils.isPrivate( this.props.post );
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
 			isPublished = postUtils.isPublished( this.props.savedPost );
@@ -142,7 +144,7 @@ class EditPostStatus extends Component {
 					{ this.renderTZTooltop() }
 					{ this.renderPostSchedulePopover() }
 				</span>
-				{ this.props.type === 'post' &&
+				{ this.props.type === 'post' && ! isPrivate && ! isPasswordProtected &&
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
 							{ translate( 'Stick to the front page' ) }

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -26,6 +26,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import EditorVisibility from 'post-editor/editor-visibility';
+import PostEditStore from 'lib/posts/post-edit-store';
 
 export class EditPostStatus extends Component {
 
@@ -105,7 +106,7 @@ export class EditPostStatus extends Component {
 
 		if ( this.props.post ) {
 			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
-			isPrivate = postUtils.isPrivate( this.props.post );
+			isPrivate = postUtils.isPrivate( PostEditStore.get() );
 			isSticky = this.props.post.sticky;
 			isPending = postUtils.isPending( this.props.post );
 			isPublished = postUtils.isPublished( this.props.savedPost );

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -3,16 +3,13 @@
 	align-content: center;
 	display: flex;
 	justify-content: space-between;
+	margin-bottom: 8px;
 
 	.gridicon {
 		margin-top: 2px;
 		margin-left: 4px;
 		vertical-align: top;
 	}
-}
-
-.edit-post-status__pending-review {
-	margin-top: 8px;
 }
 
 .edit-post-status__label-text {

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -3,7 +3,7 @@
 	align-content: center;
 	display: flex;
 	justify-content: space-between;
-	margin-bottom: 8px;
+	margin: 8px 0px;
 
 	.gridicon {
 		margin-top: 2px;
@@ -43,7 +43,7 @@
 	color: $gray-text;
 	font-size: 13px;
 	display: inline-block;
-	margin-bottom: 12px;
+	margin-bottom: 4px;
 	padding-right: 5px;
 	cursor: pointer;
 

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -35,7 +35,7 @@
 
 .edit-post-status__revert-to-draft {
 	display: block;
-	margin: 16px 0 0;
+	margin: 16px 0 8px;
 	width: 100%;
 }
 

--- a/client/post-editor/edit-post-status/test/index.jsx
+++ b/client/post-editor/edit-post-status/test/index.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { noop } from 'lodash';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+
+describe( 'EditPostStatus', function() {
+	let EditPostStatus;
+
+	useFakeDom();
+
+	before( function() {
+		EditPostStatus = require( '../' ).EditPostStatus;
+	} );
+
+	it( 'should hide sticky option for password protected posts', function() {
+		const wrapper = shallow(
+			<EditPostStatus post={ { password: 'password' } } type={ 'post' } />
+		);
+
+		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
+	} );
+
+	it( 'should hide sticky option for private posts', function() {
+		const wrapper = shallow(
+			<EditPostStatus post={ { status: 'private' } } type={ 'post' } />
+		);
+
+		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
+	} );
+
+	it( 'should show sticky option for published posts', function() {
+		const wrapper = shallow(
+			<EditPostStatus post={ { status: 'publish' } } type={ 'post' } translate={ noop } />
+		);
+
+		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 1 );
+	} );
+} );

--- a/client/post-editor/edit-post-status/test/index.jsx
+++ b/client/post-editor/edit-post-status/test/index.jsx
@@ -5,59 +5,50 @@ import React from 'react';
 import { expect } from 'chai';
 import { noop } from 'lodash';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
 
 describe( 'EditPostStatus', function() {
-	let EditPostStatus, PostEditStore, sandbox;
+	let EditPostStatus;
 
 	useFakeDom();
+	useMockery();
+
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/wp', {
+			me: () => ( {
+				get: noop
+			} )
+		} );
+	} );
 
 	before( function() {
 		EditPostStatus = require( '../' ).EditPostStatus;
-		PostEditStore = require( 'lib/posts/post-edit-store' );
-		sandbox = sinon.sandbox.create();
-	} );
-
-	afterEach( function() {
-		sandbox.restore();
 	} );
 
 	it( 'should hide sticky option for password protected posts', function() {
-		sandbox.stub( PostEditStore, 'get' ).returns( {
-			status: 'publish'
-		} );
-
 		const wrapper = shallow(
-			<EditPostStatus post={ { password: 'password' } } type={ 'post' } />
+			<EditPostStatus post={ { password: 'password' } } isPostPrivate={ false } type={ 'post' } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
 	} );
 
 	it( 'should hide sticky option for private posts', function() {
-		sandbox.stub( PostEditStore, 'get' ).returns( {
-			status: 'private'
-		} );
-
 		const wrapper = shallow(
-			<EditPostStatus post={ { password: '' } } type={ 'post' } />
+			<EditPostStatus post={ { password: '' } } isPostPrivate={ true } type={ 'post' } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
 	} );
 
 	it( 'should show sticky option for published posts', function() {
-		sandbox.stub( PostEditStore, 'get' ).returns( {
-			status: 'publish'
-		} );
-
 		const wrapper = shallow(
-			<EditPostStatus post={ { password: '' } } type={ 'post' } translate={ noop } />
+			<EditPostStatus post={ { password: '' } } type={ 'post' } isPostPrivate={ false } translate={ noop } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 1 );

--- a/client/post-editor/edit-post-status/test/index.jsx
+++ b/client/post-editor/edit-post-status/test/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { noop } from 'lodash';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -12,15 +13,25 @@ import { shallow } from 'enzyme';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
 describe( 'EditPostStatus', function() {
-	let EditPostStatus;
+	let EditPostStatus, PostEditStore, sandbox;
 
 	useFakeDom();
 
 	before( function() {
 		EditPostStatus = require( '../' ).EditPostStatus;
+		PostEditStore = require( 'lib/posts/post-edit-store' );
+		sandbox = sinon.sandbox.create();
+	} );
+
+	afterEach( function() {
+		sandbox.restore();
 	} );
 
 	it( 'should hide sticky option for password protected posts', function() {
+		sandbox.stub( PostEditStore, 'get' ).returns( {
+			status: 'publish'
+		} );
+
 		const wrapper = shallow(
 			<EditPostStatus post={ { password: 'password' } } type={ 'post' } />
 		);
@@ -29,16 +40,24 @@ describe( 'EditPostStatus', function() {
 	} );
 
 	it( 'should hide sticky option for private posts', function() {
+		sandbox.stub( PostEditStore, 'get' ).returns( {
+			status: 'private'
+		} );
+
 		const wrapper = shallow(
-			<EditPostStatus post={ { status: 'private' } } type={ 'post' } />
+			<EditPostStatus post={ { password: '' } } type={ 'post' } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 0 );
 	} );
 
 	it( 'should show sticky option for published posts', function() {
+		sandbox.stub( PostEditStore, 'get' ).returns( {
+			status: 'publish'
+		} );
+
 		const wrapper = shallow(
-			<EditPostStatus post={ { status: 'publish' } } type={ 'post' } translate={ noop } />
+			<EditPostStatus post={ { password: '' } } type={ 'post' } translate={ noop } />
 		);
 
 		expect( wrapper.find( '.edit-post-status__sticky' ) ).to.have.lengthOf( 1 );

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -14,28 +15,29 @@ import Tooltip from 'components/tooltip';
 import Button from 'components/button';
 import EditorActionBarViewLabel from './view-label';
 import EditorStatusLabel from 'post-editor/editor-status-label';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
 
-export default React.createClass( {
+class EditorActionBar extends Component {
 
-	displayName: 'EditorActionBar',
-
-	propTypes: {
+	static propTypes = {
 		isNew: React.PropTypes.bool,
 		onPrivatePublish: React.PropTypes.func,
 		post: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
 		site: React.PropTypes.object,
 		type: React.PropTypes.string
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			viewLinkTooltip: false
-		};
-	},
+	state = {
+		viewLinkTooltip: false
+	};
 
 	render() {
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
+		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
+		const isPrivate = utils.isPrivate( this.props.post );
 
 		return (
 			<div className="editor-action-bar">
@@ -56,7 +58,10 @@ export default React.createClass( {
 					}
 				</div>
 				<div className="editor-action-bar__cell is-right">
-					{ this.props.post && this.props.type === 'post' && <EditorSticky /> }
+					{ this.props.post && this.props.type === 'post' &&
+						! isPasswordProtected && ! isPrivate &&
+						<EditorSticky />
+					}
 					{ utils.isPublished( this.props.savedPost ) && (
 						<Button
 							href={ this.props.savedPost.URL }
@@ -82,4 +87,18 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
+
+		return {
+			siteId,
+			postId,
+			post
+		};
+	},
+)( EditorActionBar );

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -36,6 +36,9 @@ class EditorActionBar extends Component {
 	};
 
 	render() {
+		// We store password changes via Flux while we store privacy changes via Redux.
+		// This results in checking Flux for some items and Redux for others to correctly
+		// update based on post changes.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
 		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
 		const isPrivate = utils.isPrivate( PostEditStore.get() );

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -36,7 +36,7 @@ class EditorActionBar extends Component {
 	};
 
 	render() {
-		// We store password changes via Flux while we store privacy changes via Redux.
+		// We store privacy changes via Flux while we store password changes via Redux.
 		// This results in checking Flux for some items and Redux for others to correctly
 		// update based on post changes.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -18,7 +18,6 @@ import EditorStatusLabel from 'post-editor/editor-status-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
-import PostEditStore from 'lib/posts/post-edit-store';
 
 class EditorActionBar extends Component {
 
@@ -28,7 +27,9 @@ class EditorActionBar extends Component {
 		post: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
 		site: React.PropTypes.object,
-		type: React.PropTypes.string
+		type: React.PropTypes.string,
+		isPostPrivate: React.PropTypes.bool,
+		postAuthor: React.PropTypes.object,
 	};
 
 	state = {
@@ -38,10 +39,10 @@ class EditorActionBar extends Component {
 	render() {
 		// We store privacy changes via Flux while we store password changes via Redux.
 		// This results in checking Flux for some items and Redux for others to correctly
-		// update based on post changes.
+		// update based on post changes. Flux changes are passed down from parent components.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
 		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
-		const isPrivate = utils.isPrivate( PostEditStore.get() );
+		const { isPostPrivate, postAuthor } = this.props;
 
 		return (
 			<div className="editor-action-bar">
@@ -58,12 +59,13 @@ class EditorActionBar extends Component {
 							require="post-editor/editor-author"
 							post={ this.props.post }
 							isNew={ this.props.isNew }
+							postAuthor={ postAuthor }
 						/>
 					}
 				</div>
 				<div className="editor-action-bar__cell is-right">
 					{ this.props.post && this.props.type === 'post' &&
-						! isPasswordProtected && ! isPrivate &&
+						! isPasswordProtected && ! isPostPrivate &&
 						<EditorSticky />
 					}
 					{ utils.isPublished( this.props.savedPost ) && (

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -18,6 +18,7 @@ import EditorStatusLabel from 'post-editor/editor-status-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
+import PostEditStore from 'lib/posts/post-edit-store';
 
 class EditorActionBar extends Component {
 
@@ -37,7 +38,7 @@ class EditorActionBar extends Component {
 	render() {
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
 		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
-		const isPrivate = utils.isPrivate( this.props.post );
+		const isPrivate = utils.isPrivate( PostEditStore.get() );
 
 		return (
 			<div className="editor-action-bar">

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -15,7 +15,6 @@ import PostActions from 'lib/posts/actions';
 import touchDetect from 'lib/touch-detect';
 import * as stats from 'lib/posts/stats';
 import { getSelectedSite } from 'state/ui/selectors';
-import PostEditStore from 'lib/posts/post-edit-store';
 
 /**
  * Module dependencies
@@ -26,47 +25,20 @@ export class EditorAuthor extends Component {
 
 	static propTypes = {
 		post: React.PropTypes.object,
-		isNew: React.PropTypes.bool
+		isNew: React.PropTypes.bool,
+		postAuthor: React.PropTypes.object,
 	};
-
-	constructor( props ) {
-		super( props );
-		this.onChange = this.updatePostState.bind( this );
-		this.state = { post: props.post };
-	}
-
-	componentWillMount() {
-		// This is a hack since the author changes are stored in Flux.
-		// See #13636 for more details. Remove once author changes are
-		// migrated to Redux.
-		PostEditStore.on( 'change', this.onChange );
-	}
-
-	componentWillUnmount() {
-		PostEditStore.off( 'change', this.onChange );
-	}
-
-	shouldComponentUpdate( nextProps, nextState ) {
-		return this.state.post.author !== nextState.post.author;
-	}
-
-	updatePostState() {
-		this.setState( {
-			post: PostEditStore.get() || this.props.post
-		} );
-	}
 
 	render() {
 		// if it's not a new post and we are still loading
 		// show a placeholder component
-		const { translate, site } = this.props;
-		const { post } = this.state;
+		const { post, translate, site, postAuthor } = this.props;
 
 		if ( ! post && ! this.props.isNew ) {
 			return this.renderPlaceholder();
 		}
 
-		const author = ( post && post.author ) ? post.author : user.get();
+		const author = ( post && postAuthor ) ? postAuthor : user.get();
 		const name = author.display_name || author.name;
 		const Wrapper = this.userCanAssignAuthor() ? AuthorSelector : 'div';
 		const popoverPosition = touchDetect.hasTouch() ? 'bottom right' : 'bottom left';
@@ -107,8 +79,7 @@ export class EditorAuthor extends Component {
 	};
 
 	userCanAssignAuthor() {
-		const { site } = this.props;
-		const { post } = this.state;
+		const { post, site } = this.props;
 		const reassignCapability = 'edit_others_' + post.type + 's';
 
 		// if user cannot edit others posts

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -85,6 +85,7 @@ const EditorDrawer = React.createClass( {
 		type: React.PropTypes.string,
 		setPostDate: React.PropTypes.func,
 		onSave: React.PropTypes.func,
+		isPostPrivate: React.PropTypes.bool,
 	},
 
 	onExcerptChange: function( event ) {
@@ -333,6 +334,7 @@ const EditorDrawer = React.createClass( {
 					setPostDate={ this.props.setPostDate }
 					site={ this.props.site }
 					status={ postStatus }
+					isPostPrivate={ this.props.isPostPrivate }
 				/>
 			</Accordion>
 		);

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -24,10 +24,23 @@ export default class EditorSidebar extends Component {
 		type: PropTypes.string,
 		toggleSidebar: PropTypes.func,
 		setPostDate: PropTypes.func,
+		isPrivate: PropTypes.bool,
 	}
 
 	render() {
-		const { toggleSidebar, isNew, onTrashingPost, onPublish, onSave, post, savedPost, site, type, setPostDate } = this.props;
+		const { toggleSidebar,
+			isNew,
+			onTrashingPost,
+			onPublish,
+			onSave,
+			post,
+			savedPost,
+			site,
+			type,
+			setPostDate,
+			isPostPrivate,
+		} = this.props;
+
 		return (
 			<div className="post-editor__sidebar">
 				<EditorSidebarHeader toggleSidebar={ toggleSidebar } />
@@ -47,6 +60,7 @@ export default class EditorSidebar extends Component {
 					setPostDate={ setPostDate }
 					onPrivatePublish={ onPublish }
 					onSave={ onSave }
+					isPostPrivate={ isPostPrivate }
 				/>
 				<SidebarFooter>
 					<EditorDeletePost

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -166,7 +166,10 @@ const EditorVisibility = React.createClass( {
 				break;
 
 			case 'password':
-				reduxPostEdits = { password: this.props.savedPassword || ' ' };
+				reduxPostEdits = {
+					password: this.props.savedPassword || ' ',
+					sticky: false,
+				};
 				this.setState( { passwordIsValid: true } );
 				break;
 		}
@@ -193,7 +196,12 @@ const EditorVisibility = React.createClass( {
 		postActions.edit( {
 			status: 'private'
 		} );
-		this.props.editPost( siteId, postId, { password: '' } );
+
+		// Private posts cannot be sticky
+		this.props.editPost( siteId, postId, {
+			password: '',
+			sticky: false
+		} );
 
 		recordStat( 'visibility-set-private' );
 		recordEvent( 'Changed visibility', 'private' );

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -3,7 +3,7 @@
 	font-size: 13px;
 	justify-content: space-between;
 	align-items: center;
-	margin: 8px 0 0;
+	margin: 0;
 }
 
 .editor-visibility .button {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -253,7 +253,6 @@ export const PostEditor = React.createClass( {
 							<EditorActionBar
 								isNew={ this.state.isNew }
 								onPrivatePublish={ this.onPublish }
-								post={ this.state.post }
 								savedPost={ this.state.savedPost }
 								site={ site }
 								type={ this.props.type }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -256,6 +256,8 @@ export const PostEditor = React.createClass( {
 								savedPost={ this.state.savedPost }
 								site={ site }
 								type={ this.props.type }
+								isPostPrivate={ utils.isPrivate( this.state.post ) }
+								postAuthor={ this.state.post ? this.state.post.author : null }
 							/>
 							<div className="post-editor__site">
 								<Site
@@ -328,6 +330,7 @@ export const PostEditor = React.createClass( {
 						type={ this.props.type }
 						setPostDate={ this.setPostDate }
 						onSave={ this.onSave }
+						isPostPrivate={ utils.isPrivate( this.state.post ) }
 						/>
 					{ this.props.isSitePreviewable ?
 						<EditorPreview


### PR DESCRIPTION
This is an attempt to fix #13446. Right now, the sticky option appears on posts that are private or password protected. Per the original issue, this option is not available in wp-admin or in core.

I've labeled this as "In Progress" as I would like some feedback particularly on the tests added (described below).

A few notes:
- We set `sticky` to `false` when a post visibility is updated to either private or password protected. This means that currently "sticky" posts that are private or password protected will continue to be sticky until the visibility is flipped. Per the original report, it seems like there's some operation that removes the sticky flag from these posts over time as well.
- It was necessary to add the `export` statement [here](https://github.com/Automattic/wp-calypso/blob/2513d535bccfae77b46ebb92130b6031b44c878e/client/post-editor/edit-post-status/index.jsx#L30) for the tests to be run without the Redux store. Per the [Redux docs](http://redux.js.org/docs/recipes/WritingTests.html), there shouldn't be any adverse side effects since the default export will work elsewhere.
- I wrote some minor tests to make sure we have the correct behavior. With these tests though, I'm running into two errors that I'm not quite sure how to solve and would love some feedback:

> Warning: Failed prop type: Invalid prop `require` of type `string` supplied to `AsyncLoad`, expected `function`.`

I assume this is happening due to the `AsyncLoad` for [`components/post-schedule`](https://github.com/Automattic/wp-calypso/blob/2513d535bccfae77b46ebb92130b6031b44c878e/client/post-editor/edit-post-status/index.jsx#L234). I'm flummoxed on the workaround though.

> double callback!

The tests emit a double callback, but for the life of me, I can't figure out why/where. Would love another set of eyes. See relevant previous discussion in #4206 about this behavior.

## To Test
1. Load this branch and open a new post at http://calypso.localhost:3000/post/.
2. Under "Status" in the sidebar, try setting the post to password protected. The sticky option should disappear.
3. Set it back to public. The sticky option should reappear.
4. Publish it as a private post. The sticky option will disappear.

To test for regressions, visit wordpress.com/post and publish a private post as "sticky." Then, open that post in the branch. You should not see any regressions.

To run the tests, use: `npm run test-client client/post-editor/edit-post-status/test`

## GIF
![sticky](https://cloud.githubusercontent.com/assets/7240478/25689382/c7b1ca72-3044-11e7-8e9b-ba4c5214c90e.gif)