### PR TITLE
Jetpack connect: Refactor JetpackPlansLanding

### DIFF
--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -66,14 +65,8 @@ export default connect(
 			calypsoStartedConnection: true
 		};
 	},
-	( dispatch ) => {
-		return Object.assign( {},
-			bindActionCreators( { selectPlanInAdvance }, dispatch ),
-			{
-				recordTracksEvent( eventName, props ) {
-					dispatch( recordTracksEvent( eventName, props ) );
-				}
-			}
-		);
+	{
+		recordTracksEvent,
+		selectPlanInAdvance,
 	}
 )( PlansLanding );

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { bindActionCreators } from 'redux';
@@ -19,9 +19,11 @@ const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 class PlansLanding extends Component {
 
 	static propTypes = {
-		sites: React.PropTypes.object,
-		sitePlans: React.PropTypes.object.isRequired,
-		intervalType: React.PropTypes.string
+		basePlansPath: PropTypes.string,
+		intervalType: PropTypes.string,
+		landingType: PropTypes.string,
+		sitePlans: PropTypes.object.isRequired,
+		sites: PropTypes.object,
 	};
 
 	static defaultProps = {

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
-import React from 'react';
 import { bindActionCreators } from 'redux';
 
 /**
@@ -16,28 +16,26 @@ import QueryPlans from 'components/data/query-plans';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 
-const PlansLanding = React.createClass( {
+class PlansLanding extends Component {
 
-	propTypes: {
+	static propTypes = {
 		sites: React.PropTypes.object,
 		sitePlans: React.PropTypes.object.isRequired,
 		intervalType: React.PropTypes.string
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			intervalType: 'yearly',
-			siteSlug: '*'
-		};
-	},
+	static defaultProps = {
+		intervalType: 'yearly',
+		siteSlug: '*',
+	};
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
 			jpc_from: this.props.landingType
 		} );
-	},
+	}
 
-	storeSelectedPlan( cartItem ) {
+	storeSelectedPlan = ( cartItem ) => {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
 			plan: cartItem ? cartItem.product_slug : 'free'
 		} );
@@ -46,7 +44,7 @@ const PlansLanding = React.createClass( {
 		setTimeout( () => {
 			page.redirect( CALYPSO_JETPACK_CONNECT );
 		}, 25 );
-	},
+	}
 
 	render() {
 		return (
@@ -58,7 +56,7 @@ const PlansLanding = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default connect(
 	() => {

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -34,7 +34,7 @@ class PlansLanding extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
 			plan: cartItem ? cartItem.product_slug : 'free'
 		} );
-		this.props.selectPlanInAdvance(	cartItem ? cartItem.product_slug : 'free', '*', );
+		this.props.selectPlanInAdvance( cartItem ? cartItem.product_slug : 'free', '*' );
 
 		setTimeout( () => {
 			page.redirect( CALYPSO_JETPACK_CONNECT );

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -24,11 +24,6 @@ class PlansLanding extends Component {
 		landingType: PropTypes.string,
 	};
 
-	static defaultProps = {
-		intervalType: 'yearly',
-		siteSlug: '*',
-	};
-
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
 			jpc_from: this.props.landingType

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -50,7 +50,6 @@ class PlansLanding extends Component {
 			<div>
 				<QueryPlans />
 				<PlansGrid { ...this.props }
-					sitePlans={ {} }
 					calypsoStartedConnection={ true }
 					onSelect={ this.storeSelectedPlan }
 					basePlansPath={ this.props.basePlansPath } />

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -18,9 +18,10 @@ const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 class PlansLanding extends Component {
 	static propTypes = {
 		basePlansPath: PropTypes.string,
+		hideFreePlan: PropTypes.bool,
 		intervalType: PropTypes.string,
+		isLanding: PropTypes.bool,
 		landingType: PropTypes.string,
-		sites: PropTypes.object,
 	};
 
 	static defaultProps = {

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -20,7 +20,6 @@ class PlansLanding extends Component {
 		basePlansPath: PropTypes.string,
 		intervalType: PropTypes.string,
 		landingType: PropTypes.string,
-		sitePlans: PropTypes.object.isRequired,
 		sites: PropTypes.object,
 	};
 
@@ -51,6 +50,8 @@ class PlansLanding extends Component {
 			<div>
 				<QueryPlans />
 				<PlansGrid { ...this.props }
+					sitePlans={ {} }
+					calypsoStartedConnection={ true }
 					onSelect={ this.storeSelectedPlan }
 					basePlansPath={ this.props.basePlansPath } />
 			</div>
@@ -58,15 +59,7 @@ class PlansLanding extends Component {
 	}
 }
 
-export default connect(
-	() => {
-		return {
-			sitePlans: {},
-			calypsoStartedConnection: true
-		};
-	},
-	{
-		recordTracksEvent,
-		selectPlanInAdvance,
-	}
-)( PlansLanding );
+export default connect( null, {
+	recordTracksEvent,
+	selectPlanInAdvance,
+} )( PlansLanding );

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -17,7 +17,6 @@ import QueryPlans from 'components/data/query-plans';
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 
 class PlansLanding extends Component {
-
 	static propTypes = {
 		basePlansPath: PropTypes.string,
 		intervalType: PropTypes.string,

--- a/client/signup/jetpack-connect/plans-landing.jsx
+++ b/client/signup/jetpack-connect/plans-landing.jsx
@@ -46,13 +46,26 @@ class PlansLanding extends Component {
 	}
 
 	render() {
+		const {
+			basePlansPath,
+			hideFreePlan,
+			intervalType,
+			isLanding,
+			landingType,
+		} = this.props;
 		return (
 			<div>
 				<QueryPlans />
-				<PlansGrid { ...this.props }
+
+				<PlansGrid
+					basePlansPath={ basePlansPath }
 					calypsoStartedConnection={ true }
+					hideFreePlan={ hideFreePlan }
+					intervalType={ intervalType }
+					isLanding={ isLanding }
+					landingType={ landingType }
 					onSelect={ this.storeSelectedPlan }
-					basePlansPath={ this.props.basePlansPath } />
+				/>
 			</div>
 		);
 	}


### PR DESCRIPTION
Pass linter (es6 class)

Lint fixes required for: Separate jetpack-connect from signup #12991

To test:

* Use this branch.
* Test the following paths:
  * http://calypso.localhost:3000/jetpack/connect/store
  * http://calypso.localhost:3000/jetpack/connect/store/monthly
  * http://calypso.localhost:3000/jetpack/connect/vaultpress
  * http://calypso.localhost:3000/jetpack/connect/vaultpress/monthly
  * http://calypso.localhost:3000/jetpack/connect/akismet
  * http://calypso.localhost:3000/jetpack/connect/akismet/monthly
* Test buttons, render etc.
* Ensure the `/monthly` versions display monthly pricing
* Ensure there are no regressions. Watch the console for any errors/warnings.