### PR TITLE
Jetpack connect: Refactor site-url-input

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -118,7 +118,7 @@ class JetpackConnectMain extends Component {
 
 	dismissUrl = () => this.props.dismissUrl( this.state.currentUrl );
 
-	onURLChange = () => {
+	onUrlChange = () => {
 		this.setState( { currentUrl: this.getCurrentUrl() } );
 		this.dismissUrl();
 	}
@@ -152,7 +152,7 @@ class JetpackConnectMain extends Component {
 		);
 	}
 
-	onURLEnter = () => {
+	onUrlSubmit = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl
 		} );
@@ -349,8 +349,8 @@ class JetpackConnectMain extends Component {
 				<SiteUrlInput ref="siteUrlInputRef"
 					url={ this.state.initialUrl }
 					onTosClick={ this.handleOnClickTos }
-					onChange={ this.onURLChange }
-					onSubmit={ this.onURLEnter }
+					onChange={ this.onUrlChange }
+					onSubmit={ this.onUrlSubmit }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
 					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -60,23 +60,20 @@ class JetpackConnectMain extends Component {
 		url: PropTypes.string,
 	};
 
-	state = {
-		currentUrl: '',
-		shownUrl: '',
-		waitingForSites: false,
-	};
+	state = this.props.url
+		? {
+			currentUrl: this.cleanUrl( this.props.url ),
+			shownUrl: this.props.url,
+			waitingForSites: false
+		} : {
+			currentUrl: '',
+			shownUrl: '',
+			waitingForSites: false
+		};
 
 	componentWillMount() {
 		if ( this.props.url ) {
-			let url = this.props.url;
-			if ( url && url.substr( 0, 4 ) !== 'http' ) {
-				url = 'http://' + url;
-			}
-			this.setState( {
-				currentUrl: untrailingslashit( url ),
-				shownUrl: url,
-			} );
-			this.checkUrl( url );
+			this.checkUrl( this.cleanUrl( this.props.url ) );
 		}
 	}
 
@@ -134,7 +131,7 @@ class JetpackConnectMain extends Component {
 			this.props.jetpackConnectSite.isFetching;
 	}
 
-	handlePushUrl = ( url ) => {
+	handleUpdateUrl = ( url ) => {
 		this.setState( {
 			currentUrl: this.cleanUrl( url ),
 			shownUrl: url,
@@ -355,7 +352,7 @@ class JetpackConnectMain extends Component {
 				<SiteUrlInput
 					url={ this.state.shownUrl }
 					onTosClick={ this.handleOnClickTos }
-					onPushValue={ this.handlePushUrl }
+					onPushValue={ this.handleUpdateUrl }
 					onSubmit={ this.onUrlSubmit }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -133,7 +133,6 @@ class JetpackConnectMain extends Component {
 
 	handleUrlChange = ( event ) => {
 		const url = event.target.value;
-		this.dismissUrl();
 		this.setState( {
 			currentUrl: this.cleanUrl( url ),
 			shownUrl: url,

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -15,7 +15,7 @@ import Card from 'components/card';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import JetpackConnectNotices from './jetpack-connect-notices';
-import SiteURLInput from './site-url-input';
+import SiteUrlInput from './site-url-input';
 import {
 	getGlobalSelectedPlan,
 	getConnectingSite,
@@ -346,7 +346,7 @@ class JetpackConnectMain extends Component {
 					: null
 				}
 
-				<SiteURLInput ref="siteUrlInputRef"
+				<SiteUrlInput ref="siteUrlInputRef"
 					url={ this.state.initialUrl }
 					onTosClick={ this.handleOnClickTos }
 					onChange={ this.onURLChange }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -355,7 +355,6 @@ class JetpackConnectMain extends Component {
 					onTosClick={ this.handleOnClickTos }
 					onChange={ this.handleUrlChange }
 					onSubmit={ this.handleUrlSubmit }
-					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
 					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites }
 					isInstall={ this.isInstall() } />

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -156,7 +156,7 @@ class JetpackConnectMain extends Component {
 		);
 	}
 
-	onUrlSubmit = () => {
+	handleUrlSubmit = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl
 		} );
@@ -354,7 +354,7 @@ class JetpackConnectMain extends Component {
 					url={ this.state.shownUrl }
 					onTosClick={ this.handleOnClickTos }
 					onChange={ this.handleUrlChange }
-					onSubmit={ this.onUrlSubmit }
+					onSubmit={ this.handleUrlSubmit }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
 					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -62,8 +62,8 @@ class JetpackConnectMain extends Component {
 
 	state = {
 		currentUrl: '',
+		shownUrl: '',
 		waitingForSites: false,
-		initialUrl: null,
 	};
 
 	componentWillMount() {
@@ -72,7 +72,10 @@ class JetpackConnectMain extends Component {
 			if ( url && url.substr( 0, 4 ) !== 'http' ) {
 				url = 'http://' + url;
 			}
-			this.setState( { currentUrl: untrailingslashit( url ), initialUrl: url } );
+			this.setState( {
+				currentUrl: untrailingslashit( url ),
+				shownUrl: url,
+			} );
 			this.checkUrl( url );
 		}
 	}
@@ -118,11 +121,6 @@ class JetpackConnectMain extends Component {
 
 	dismissUrl = () => this.props.dismissUrl( this.state.currentUrl );
 
-	onUrlChange = () => {
-		this.setState( { currentUrl: this.getCurrentUrl() } );
-		this.dismissUrl();
-	}
-
 	isCurrentUrlFetched() {
 		return this.props.jetpackConnectSite &&
 			this.state.currentUrl === this.props.jetpackConnectSite.url &&
@@ -136,8 +134,16 @@ class JetpackConnectMain extends Component {
 			this.props.jetpackConnectSite.isFetching;
 	}
 
-	getCurrentUrl() {
-		let url = this.refs.siteUrlInputRef.state.value.trim().toLowerCase();
+	handlePushUrl = ( url ) => {
+		this.setState( {
+			currentUrl: this.cleanUrl( url ),
+			shownUrl: url,
+		} );
+		this.dismissUrl();
+	}
+
+	cleanUrl( inputUrl ) {
+		let url = inputUrl.trim().toLowerCase();
 		if ( url && url.substr( 0, 4 ) !== 'http' ) {
 			url = 'http://' + url;
 		}
@@ -346,10 +352,10 @@ class JetpackConnectMain extends Component {
 					: null
 				}
 
-				<SiteUrlInput ref="siteUrlInputRef"
-					url={ this.state.initialUrl }
+				<SiteUrlInput
+					url={ this.state.shownUrl }
 					onTosClick={ this.handleOnClickTos }
-					onChange={ this.onUrlChange }
+					onPushValue={ this.handlePushUrl }
 					onSubmit={ this.onUrlSubmit }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -133,11 +133,11 @@ class JetpackConnectMain extends Component {
 
 	handleUrlChange = ( event ) => {
 		const url = event.target.value;
+		this.dismissUrl();
 		this.setState( {
 			currentUrl: this.cleanUrl( url ),
 			shownUrl: url,
 		} );
-		this.dismissUrl();
 	}
 
 	cleanUrl( inputUrl ) {

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -350,7 +350,7 @@ class JetpackConnectMain extends Component {
 					url={ this.state.initialUrl }
 					onTosClick={ this.handleOnClickTos }
 					onChange={ this.onURLChange }
-					onClick={ this.onURLEnter }
+					onSubmit={ this.onURLEnter }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
 					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() || this.state.waitingForSites }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -131,7 +131,8 @@ class JetpackConnectMain extends Component {
 			this.props.jetpackConnectSite.isFetching;
 	}
 
-	handleUpdateUrl = ( url ) => {
+	handleUrlChange = ( event ) => {
+		const url = event.target.value;
 		this.setState( {
 			currentUrl: this.cleanUrl( url ),
 			shownUrl: url,
@@ -352,7 +353,7 @@ class JetpackConnectMain extends Component {
 				<SiteUrlInput
 					url={ this.state.shownUrl }
 					onTosClick={ this.handleOnClickTos }
-					onPushValue={ this.handleUpdateUrl }
+					onChange={ this.handleUrlChange }
 					onSubmit={ this.onUrlSubmit }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -29,12 +29,12 @@ class JetpackConnectSiteURLInput extends Component {
 		url: PropTypes.string,
 	};
 
-	componentWillMount() {
-		if ( this.props.url ) {
-			this.setState( { value: untrailingslashit( this.props.url ), shownValue: this.props.url } );
-		} else {
-			this.setState( { value: '', shownValue: '' } );
-		}
+	constructor( props ) {
+		super( props );
+
+		this.state = this.props.url
+			? { value: untrailingslashit( this.props.url ), shownValue: this.props.url }
+			: { value: '', shownValue: '' };
 	}
 
 	componentDidUpdate() {

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -49,18 +49,18 @@ class JetpackConnectSiteURLInput extends Component {
 		this.refs.siteUrl.refs.textField.focus();
 	}
 
-	onChange = ( event ) => {
+	handleChange = ( event ) => {
 		this.setState( {
 			value: untrailingslashit( event.target.value ),
 			shownValue: event.target.value
 		}, this.props.onChange );
 	};
 
-	onClick = () => this.props.onClick( this.state.value );
+	handleClick = () => this.props.onClick( this.state.value );
 
 	handleKeyPress = ( event ) => {
 		if ( 13 === event.keyCode ) {
-			this.onClick();
+			this.handleClick();
 		}
 	};
 
@@ -105,7 +105,7 @@ class JetpackConnectSiteURLInput extends Component {
 			id: 'siteUrl',
 			autoCapitalize: 'off',
 			autoFocus: 'autofocus',
-			onChange: this.onChange,
+			onChange: this.handleChange,
 			disabled: this.props.isFetching,
 			placeholder: i18n.translate( 'http://www.yoursite.com' ),
 			onKeyUp: this.handleKeyPress,
@@ -128,7 +128,7 @@ class JetpackConnectSiteURLInput extends Component {
 					{ this.renderTermsOfServiceLink() }
 					<Button primary
 						disabled={ ( ! this.state.value || this.props.isFetching || hasError ) }
-						onClick={ this.onClick }>{ this.renderButtonLabel() }</Button>
+						onClick={ this.handleClick }>{ this.renderButtonLabel() }</Button>
 				</Card>
 			</div>
 		);

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import Spinner from 'components/spinner';
-import untrailingslashit from 'lib/route/untrailingslashit';
 
 class JetpackConnectSiteUrlInput extends Component {
 	static propTypes = {
@@ -24,14 +24,15 @@ class JetpackConnectSiteUrlInput extends Component {
 		] ),
 		isFetching: PropTypes.bool,
 		isInstall: PropTypes.bool,
-		onChange: PropTypes.func,
+		onPushValue: PropTypes.func,
 		onSubmit: PropTypes.func,
 		url: PropTypes.string,
 	};
 
-	state = this.props.url
-		? { value: untrailingslashit( this.props.url ), shownValue: this.props.url }
-		: { value: '', shownValue: '' };
+	static defaultProps = {
+		onPushValue: noop,
+		url: '',
+	};
 
 	componentDidUpdate() {
 		if ( ! this.props.isError ) {
@@ -46,13 +47,10 @@ class JetpackConnectSiteUrlInput extends Component {
 	}
 
 	handleChange = ( event ) => {
-		this.setState( {
-			value: untrailingslashit( event.target.value ),
-			shownValue: event.target.value
-		}, this.props.onChange );
+		this.props.onPushValue( event.target.value );
 	};
 
-	handleSubmit = () => this.props.onSubmit( this.state.value );
+	handleSubmit = () => this.props.onSubmit();
 
 	handleKeyPress = ( event ) => {
 		if ( 13 === event.keyCode ) {
@@ -115,7 +113,7 @@ class JetpackConnectSiteUrlInput extends Component {
 						disabled={ this.props.isFetching }
 						placeholder={ translate( 'http://www.yoursite.com' ) }
 						onKeyUp={ this.handleKeyPress }
-						value={ this.state.shownValue || '' }
+						value={ this.props.url }
 					/>
 					{ this.props.isFetching
 						? <Spinner duration={ 30 } />
@@ -125,7 +123,7 @@ class JetpackConnectSiteUrlInput extends Component {
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
 					<Button primary
-						disabled={ ( ! this.state.value || this.props.isFetching || hasError ) }
+						disabled={ ( ! this.props.url || this.props.isFetching || hasError ) }
 						onClick={ this.handleSubmit }>{ this.renderButtonLabel() }</Button>
 				</Card>
 			</div>

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -102,17 +102,6 @@ class JetpackConnectSiteURLInput extends Component {
 	render() {
 		const { translate } = this.props;
 		const hasError = this.props.isError && ( 'notExists' !== this.props.isError );
-		const textInputProps = {
-			ref: 'siteUrl',
-			id: 'siteUrl',
-			autoCapitalize: 'off',
-			autoFocus: 'autofocus',
-			onChange: this.handleChange,
-			disabled: this.props.isFetching,
-			placeholder: translate( 'http://www.yoursite.com' ),
-			onKeyUp: this.handleKeyPress,
-			value: this.state.shownValue || ''
-		};
 
 		return (
 			<div>
@@ -121,7 +110,17 @@ class JetpackConnectSiteURLInput extends Component {
 					<Gridicon
 						size={ 24 }
 						icon="globe" />
-					<FormTextInput { ...textInputProps } />
+					<FormTextInput
+						ref="siteUrl"
+						id="siteUrl"
+						autoCapitalize="off"
+						autoFocus="autofocus"
+						onChange={ this.handleChange }
+						disabled={ this.props.isFetching }
+						placeholder={ translate( 'http://www.yoursite.com' ) }
+						onKeyUp={ this.handleKeyPress }
+						value={ this.state.shownValue || '' }
+					/>
 					{ this.props.isFetching
 						? <Spinner duration={ 30 } />
 						: null

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -24,13 +24,13 @@ class JetpackConnectSiteUrlInput extends Component {
 		] ),
 		isFetching: PropTypes.bool,
 		isInstall: PropTypes.bool,
-		onPushValue: PropTypes.func,
+		onChange: PropTypes.func,
 		onSubmit: PropTypes.func,
 		url: PropTypes.string,
 	};
 
 	static defaultProps = {
-		onPushValue: noop,
+		onChange: noop,
 		url: '',
 	};
 
@@ -45,10 +45,6 @@ class JetpackConnectSiteUrlInput extends Component {
 
 		this.refs.siteUrl.refs.textField.focus();
 	}
-
-	handleChange = ( event ) => {
-		this.props.onPushValue( event.target.value );
-	};
 
 	handleSubmit = () => this.props.onSubmit();
 
@@ -97,6 +93,7 @@ class JetpackConnectSiteUrlInput extends Component {
 		const {
 			isError,
 			isFetching,
+			onChange,
 			translate,
 			url,
 		} = this.props;
@@ -114,7 +111,7 @@ class JetpackConnectSiteUrlInput extends Component {
 						id="siteUrl"
 						autoCapitalize="off"
 						autoFocus="autofocus"
-						onChange={ this.handleChange }
+						onChange={ onChange }
 						disabled={ isFetching }
 						placeholder={ translate( 'http://www.yoursite.com' ) }
 						onKeyUp={ this.handleKeyPress }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -58,6 +58,12 @@ class JetpackConnectSiteURLInput extends Component {
 
 	onClick = () => this.props.onClick( this.state.value );
 
+	handleKeyPress = ( event ) => {
+		if ( 13 === event.keyCode ) {
+			this.onClick();
+		}
+	};
+
 	renderButtonLabel() {
 		if ( ! this.props.isFetching ) {
 			if ( ! this.props.isInstall ) {
@@ -67,12 +73,6 @@ class JetpackConnectSiteURLInput extends Component {
 		}
 		return i18n.translate( 'Connecting…' );
 	}
-
-	handleKeyPress = ( event ) => {
-		if ( 13 === event.keyCode ) {
-			this.onClick();
-		}
-	};
 
 	getTermsOfServiceUrl() {
 		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -16,6 +16,19 @@ import Spinner from 'components/spinner';
 import untrailingslashit from 'lib/route/untrailingslashit';
 
 class JetpackConnectSiteURLInput extends Component {
+	static propTypes = {
+		handleOnClickTos: PropTypes.func,
+		isError: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.bool,
+		] ),
+		isFetching: PropTypes.bool,
+		isInstall: PropTypes.bool,
+		onChange: PropTypes.func,
+		onClick: PropTypes.func,
+		url: PropTypes.string,
+	};
+
 	constructor() {
 		super();
 		this.onChange = this.onChange.bind( this );

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -29,13 +29,6 @@ class JetpackConnectSiteURLInput extends Component {
 		url: PropTypes.string,
 	};
 
-	constructor() {
-		super();
-		this.onChange = this.onChange.bind( this );
-		this.onClick = this.onClick.bind( this );
-		this.handleKeyPress = this.handleKeyPress.bind( this );
-	}
-
 	componentWillMount() {
 		if ( this.props.url ) {
 			this.setState( { value: untrailingslashit( this.props.url ), shownValue: this.props.url } );
@@ -56,16 +49,14 @@ class JetpackConnectSiteURLInput extends Component {
 		this.refs.siteUrl.refs.textField.focus();
 	}
 
-	onChange( event ) {
+	onChange = ( event ) => {
 		this.setState( {
 			value: untrailingslashit( event.target.value ),
 			shownValue: event.target.value
 		}, this.props.onChange );
-	}
+	};
 
-	onClick() {
-		this.props.onClick( this.state.value );
-	}
+	onClick = () => this.props.onClick( this.state.value );
 
 	renderButtonLabel() {
 		if ( ! this.props.isFetching ) {
@@ -77,11 +68,11 @@ class JetpackConnectSiteURLInput extends Component {
 		return i18n.translate( 'Connecting…' );
 	}
 
-	handleKeyPress( event ) {
+	handleKeyPress = ( event ) => {
 		if ( 13 === event.keyCode ) {
 			this.onClick();
 		}
-	}
+	};
 
 	getTermsOfServiceUrl() {
 		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -26,6 +26,7 @@ class JetpackConnectSiteUrlInput extends Component {
 		isInstall: PropTypes.bool,
 		onChange: PropTypes.func,
 		onSubmit: PropTypes.func,
+		translate: PropTypes.func.isRequired,
 		url: PropTypes.string,
 	};
 

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -25,7 +25,7 @@ class JetpackConnectSiteUrlInput extends Component {
 		isFetching: PropTypes.bool,
 		isInstall: PropTypes.bool,
 		onChange: PropTypes.func,
-		onClick: PropTypes.func,
+		onSubmit: PropTypes.func,
 		url: PropTypes.string,
 	};
 
@@ -52,11 +52,11 @@ class JetpackConnectSiteUrlInput extends Component {
 		}, this.props.onChange );
 	};
 
-	handleClick = () => this.props.onClick( this.state.value );
+	handleSubmit = () => this.props.onSubmit( this.state.value );
 
 	handleKeyPress = ( event ) => {
 		if ( 13 === event.keyCode ) {
-			this.handleClick();
+			this.handleSubmit();
 		}
 	};
 
@@ -126,7 +126,7 @@ class JetpackConnectSiteUrlInput extends Component {
 					{ this.renderTermsOfServiceLink() }
 					<Button primary
 						disabled={ ( ! this.state.value || this.props.isFetching || hasError ) }
-						onClick={ this.handleClick }>{ this.renderButtonLabel() }</Button>
+						onClick={ this.handleSubmit }>{ this.renderButtonLabel() }</Button>
 				</Card>
 			</div>
 		);

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -123,8 +123,9 @@ class JetpackConnectSiteURLInput extends Component {
 						icon="globe" />
 					<FormTextInput { ...textInputProps } />
 					{ this.props.isFetching
-						? ( <Spinner duration={ 30 } /> )
-						: null }
+						? <Spinner duration={ 30 } />
+						: null
+					}
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -46,11 +46,9 @@ class JetpackConnectSiteUrlInput extends Component {
 		this.refs.siteUrl.refs.textField.focus();
 	}
 
-	handleSubmit = () => this.props.onSubmit();
-
 	handleKeyPress = ( event ) => {
 		if ( 13 === event.keyCode ) {
-			this.handleSubmit();
+			this.props.onSubmit();
 		}
 	};
 
@@ -94,6 +92,7 @@ class JetpackConnectSiteUrlInput extends Component {
 			isError,
 			isFetching,
 			onChange,
+			onSubmit,
 			translate,
 			url,
 		} = this.props;
@@ -127,7 +126,7 @@ class JetpackConnectSiteUrlInput extends Component {
 					<Button
 						primary
 						disabled={ ( ! url || isFetching || hasError ) }
-						onClick={ this.handleSubmit }
+						onClick={ onSubmit }
 					>
 						{ this.renderButtonLabel() }
 					</Button>

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -94,8 +94,13 @@ class JetpackConnectSiteUrlInput extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
-		const hasError = this.props.isError && ( 'notExists' !== this.props.isError );
+		const {
+			isError,
+			isFetching,
+			translate,
+			url,
+		} = this.props;
+		const hasError = isError && ( 'notExists' !== isError );
 
 		return (
 			<div>
@@ -110,21 +115,25 @@ class JetpackConnectSiteUrlInput extends Component {
 						autoCapitalize="off"
 						autoFocus="autofocus"
 						onChange={ this.handleChange }
-						disabled={ this.props.isFetching }
+						disabled={ isFetching }
 						placeholder={ translate( 'http://www.yoursite.com' ) }
 						onKeyUp={ this.handleKeyPress }
-						value={ this.props.url }
+						value={ url }
 					/>
-					{ this.props.isFetching
+					{ isFetching
 						? <Spinner duration={ 30 } />
 						: null
 					}
 				</div>
 				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
-					<Button primary
-						disabled={ ( ! this.props.url || this.props.isFetching || hasError ) }
-						onClick={ this.handleSubmit }>{ this.renderButtonLabel() }</Button>
+					<Button
+						primary
+						disabled={ ( ! url || isFetching || hasError ) }
+						onClick={ this.handleSubmit }
+					>
+						{ this.renderButtonLabel() }
+					</Button>
 				</Card>
 			</div>
 		);

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -15,7 +15,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import Spinner from 'components/spinner';
 import untrailingslashit from 'lib/route/untrailingslashit';
 
-
 class JetpackConnectSiteURLInput extends Component {
 	constructor() {
 		super();

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -29,13 +29,9 @@ class JetpackConnectSiteUrlInput extends Component {
 		url: PropTypes.string,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = this.props.url
-			? { value: untrailingslashit( this.props.url ), shownValue: this.props.url }
-			: { value: '', shownValue: '' };
-	}
+	state = this.props.url
+		? { value: untrailingslashit( this.props.url ), shownValue: this.props.url }
+		: { value: '', shownValue: '' };
 
 	componentDidUpdate() {
 		if ( ! this.props.isError ) {

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import i18n from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
 /**
@@ -65,23 +65,24 @@ class JetpackConnectSiteURLInput extends Component {
 	};
 
 	renderButtonLabel() {
+		const { translate } = this.props;
 		if ( ! this.props.isFetching ) {
 			if ( ! this.props.isInstall ) {
-				return i18n.translate( 'Connect Now' );
+				return translate( 'Connect Now' );
 			}
-			return i18n.translate( 'Start Installation' );
+			return translate( 'Start Installation' );
 		}
-		return i18n.translate( 'Connecting…' );
+		return translate( 'Connecting…' );
 	}
 
 	getTermsOfServiceUrl() {
-		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';
+		return 'https://' + getLocaleSlug() + '.wordpress.com/tos/';
 	}
 
 	renderTermsOfServiceLink() {
 		return (
 			<p className="jetpack-connect__tos-link">{
-				i18n.translate(
+				this.props.translate(
 					'By connecting your site you agree to our fascinating {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
@@ -99,6 +100,7 @@ class JetpackConnectSiteURLInput extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
 		const hasError = this.props.isError && ( 'notExists' !== this.props.isError );
 		const textInputProps = {
 			ref: 'siteUrl',
@@ -107,14 +109,14 @@ class JetpackConnectSiteURLInput extends Component {
 			autoFocus: 'autofocus',
 			onChange: this.handleChange,
 			disabled: this.props.isFetching,
-			placeholder: i18n.translate( 'http://www.yoursite.com' ),
+			placeholder: translate( 'http://www.yoursite.com' ),
 			onKeyUp: this.handleKeyPress,
 			value: this.state.shownValue || ''
 		};
 
 		return (
 			<div>
-				<FormLabel htmlFor="siteUrl">{ i18n.translate( 'Site Address' ) }</FormLabel>
+				<FormLabel htmlFor="siteUrl">{ translate( 'Site Address' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
 					<Gridicon
 						size={ 24 }
@@ -135,4 +137,4 @@ class JetpackConnectSiteURLInput extends Component {
 	}
 }
 
-export default JetpackConnectSiteURLInput;
+export default localize( JetpackConnectSiteURLInput );

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -15,7 +15,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import Spinner from 'components/spinner';
 import untrailingslashit from 'lib/route/untrailingslashit';
 
-class JetpackConnectSiteURLInput extends Component {
+class JetpackConnectSiteUrlInput extends Component {
 	static propTypes = {
 		handleOnClickTos: PropTypes.func,
 		isError: PropTypes.oneOfType( [
@@ -137,4 +137,4 @@ class JetpackConnectSiteURLInput extends Component {
 	}
 }
 
-export default localize( JetpackConnectSiteURLInput );
+export default localize( JetpackConnectSiteUrlInput );

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -34,16 +34,18 @@ class JetpackConnectSiteUrlInput extends Component {
 		url: '',
 	};
 
+	focusInput = noop;
+
+	refInput = ( formInputComponent ) => {
+		this.focusInput = () => formInputComponent.focus();
+	};
+
 	componentDidUpdate() {
 		if ( ! this.props.isError ) {
 			return;
 		}
 
-		if ( ! this.refs.siteUrl.refs.textField ) {
-			return;
-		}
-
-		this.refs.siteUrl.refs.textField.focus();
+		this.focusInput();
 	}
 
 	handleKeyPress = ( event ) => {
@@ -106,7 +108,7 @@ class JetpackConnectSiteUrlInput extends Component {
 						size={ 24 }
 						icon="globe" />
 					<FormTextInput
-						ref="siteUrl"
+						ref={ this.refInput }
 						id="siteUrl"
 						autoCapitalize="off"
 						autoFocus="autofocus"


### PR DESCRIPTION
Lint fixes required for: Separate jetpack-connect from signup #12991

* Pass linter (remove line break).
* Add `propTypes`.
* Update method binding (fat arrows).
* Reorder methods coherently.
* Rename methods according to conventions.
* Change `componentWillMount` for preferable `constructor` usage.
* Use `localize` + `this.props.translate` over `i18n.translate`.
* Remove unneeded object creation and spread.

To test:

1. Use this branch.
1. Test the following paths:
   * http://calypso.localhost:3000/jetpack/connect/
   * http://calypso.localhost:3000/jetpack/connect/?url=somesite
1. Try a variety of urls (wordpress.com, connected site, bad url, etc.)
1. Test buttons, render etc.
1. Ensure there are no regressions. Watch the console for any errors/warnings.