### PR TITLE
Removed a/b test for Plans CTA

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -8,14 +8,6 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
-	signupPlansCallToAction: {
-		datestamp: '20170403',
-		variations: {
-			original: 0,
-			modified: 100, // Setting to 100% until strings are translated
-		},
-		defaultVariation: 'original',
-	},
 	signupSurveyStep: {
 		datestamp: '20170329',
 		variations: {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -10,7 +10,6 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { abtest } from 'lib/abtest';
 
 const PlanFeaturesActions = ( {
 	canPurchase,
@@ -33,7 +32,7 @@ const PlanFeaturesActions = ( {
 		'plan-features__actions-button',
 		{
 			'is-current': current,
-			'is-primary': ( primaryUpgrade && ! isPlaceholder ) || ( isPopular && abtest( 'signupPlansCallToAction' ) === 'modified' )
+			'is-primary': ( primaryUpgrade && ! isPlaceholder ) || ( isPopular )
 		},
 		className
 	);
@@ -51,8 +50,12 @@ const PlanFeaturesActions = ( {
 		if ( isLandingPage ) {
 			buttonText = translate( 'Select', { context: 'button' } );
 		}
-		if ( isInSignup && ( abtest( 'signupPlansCallToAction' ) === 'modified' ) ) {
-			buttonText = 'Start with ' + planName;
+		if ( isInSignup ) {
+			buttonText = translate( 'Start with %(plan)s', {
+				args: {
+					plan: planName
+				}
+			} );
 		}
 
 		upgradeButton = (


### PR DESCRIPTION
We recently ran a test on the plans page in signup and changed the call to action from "Upgrade" to "Start with {PlanName}". The test improved conversions by 4-6% over the control. This PR removes the test so that the new text is shown to everyone. 

## Screenshot
![image](https://cloud.githubusercontent.com/assets/6981253/25703455/ab3f6732-30a3-11e7-91d8-c04c55e6dd63.png)

## Testing
* Start by creating a new account/site by visiting `http://calypso.localhost:3000/start`.
* Make your way to the plans step.  

cc @velesin @markryall @yoavf 