### PR TITLE
Set plans cta test to 100% for winner

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -11,8 +11,8 @@ module.exports = {
 	signupPlansCallToAction: {
 		datestamp: '20170403',
 		variations: {
-			original: 50,
-			modified: 50,
+			original: 0,
+			modified: 100, // Setting to 100% until strings are translated
 		},
 		defaultVariation: 'original',
 	},


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/13640

> We recently ran a test on the plans page in signup and changed the call to action from "Upgrade" to "Start with {PlanName}". The test improved conversions by 4-6% over the control. 

This PR sets the test to 100% for english visitors while the strings are translated for everyone else. 

## Screenshot
![image](https://cloud.githubusercontent.com/assets/6981253/25704974/9b4ff994-30a9-11e7-8f28-958955ab451f.png)

## Testing
Create a new site in Calypso. When you reach the plans page, it should look like the screenshot above.

cc @dzver @markryall @yoavf 