### PR TITLE
Framework: Cleanup isJetpack from site utils

### DIFF
--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -123,10 +123,6 @@ export default {
 		return false;
 	},
 
-	isJetpack( site ) {
-		return site && site.jetpack;
-	},
-
 	/**
 	 * Checks whether a site has a custom mapped URL.
 	 * @param  {Object}   site Site object


### PR DESCRIPTION
This PR removes `isJetpack` from `lib/site/utils` as it's no longer used.

No testing is required, just verify it is indeed not used anymore.