### PR TITLE
Update/plugin update notice version

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -164,12 +164,24 @@ class PluginItem extends Component {
 					text={ translate( 'Updated' ) } />
 			);
 		}
+
+		const updated_versions = this.props.plugin.sites.map( site => {
+			if ( site.plugin.update && site.plugin.update.new_version ) {
+				return site.plugin.update.new_version;
+			}
+			return false;
+		} ).filter( version => version );
+
 		return (
 			<Notice isCompact
 				icon="sync"
 				status="is-warning"
 				inline={ true }
-				text={ translate( 'A newer version is available' ) } />
+				text={ translate(
+							'Version %(newPluginVersion)s is available',
+							{ args: { newPluginVersion: updated_versions[ 0 ] } }
+						) } />
+
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -317,12 +317,13 @@ class PluginMeta extends Component {
 						className="plugin-meta__version-notice"
 						showDismiss={ false }
 						icon="sync"
-						text={ i18n.translate( 'A new version is available.' ) }>
+						text={ i18n.translate(
+							'Version %(newPluginVersion)s is available',
+							{ args: { newPluginVersion: newVersions[ 0 ].newVersion } }
+						) }>
 						<NoticeAction onClick={ this.handlePluginUpdatesSingleSite }>
 							{
-								i18n.translate( 'Update to %(newPluginVersion)s',
-									{ args: { newPluginVersion: newVersions[ 0 ].newVersion } }
-								)
+								i18n.translate( 'Update' )
 							}
 						</NoticeAction>
 					</Notice>


### PR DESCRIPTION
Replaces #8124

Udpates the Plugin Item in include the plugin version as well as the plugin meta to include the plugin version


**Before:**
![screen shot 2017-05-04 at 08 15 07](https://cloud.githubusercontent.com/assets/115071/25710688/d1448cca-30a1-11e7-838c-6ede18e98885.png)
![screen shot 2017-05-04 at 08 14 58](https://cloud.githubusercontent.com/assets/115071/25710690/d48793aa-30a1-11e7-89d3-b5648917ddf7.png)


**After:**
![screen shot 2017-05-04 at 08 12 30](https://cloud.githubusercontent.com/assets/115071/25710626/a64bd37a-30a1-11e7-9804-98e297b89860.png)
![screen shot 2017-05-04 at 08 12 19](https://cloud.githubusercontent.com/assets/115071/25710632/a93515d8-30a1-11e7-80d6-617836873ae5.png)

cc: @rcoll, @rickybanister 