### PR TITLE
Reader: move legacy full post redirects into main Reader controller

### DIFF
--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -8,21 +8,18 @@ import page from 'page';
  */
 import { blogPost, feedPost } from './controller';
 import {
-	legacyRedirects,
 	updateLastRoute,
 	unmountSidebar,
 } from 'reader/controller';
 
 export default function() {
 	// Feed full post
-	page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );
 	page( '/read/feeds/:feed/posts/:post',
 		updateLastRoute,
 		unmountSidebar,
 		feedPost );
 
 	// Blog full post
-	page( '/read/post/id/:blog_id/:post_id', legacyRedirects );
 	page( '/read/blogs/:blog/posts/:post',
 		updateLastRoute,
 		unmountSidebar,

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -66,6 +66,10 @@ export default function() {
 			prettyRedirects,
 			sidebar,
 			blogListing );
+
+		// Old full post view
+		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );
+		page( '/read/post/id/:blog_id/:post_id', legacyRedirects );
 	}
 
 	// Automattic Employee Posts


### PR DESCRIPTION
In the past, full posts in Reader were accessed at some rather peculiar URLs, namely:

Site: http://calypso.localhost:3000/read/post/id/5276229/8772
Feed: http://calypso.localhost:3000/read/post/feed/12098/1445968343

These should redirect to the new full post URLs, but @designsimply discovered in #13645 that this was broken. 

The routes were present but the `reader/full-post` module was not set up to respond to the old paths. To remedy this, I've moved the legacy redirect rules to the main Reader controller, which responds to anything beginning with `read/`.

### To test

Visit an old Reader full post URL (such as the two above), and make sure you're redirected to the new full post view. If you see a blank page, something's gone pear-shaped.

Fixes #13645.
