### PR TITLE
Themes: Fix title tag, add `og:title` meta

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -25,20 +25,11 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
 import { isATEnabled } from 'lib/automated-transfer';
-import { getThemeShowcaseDescription } from 'state/selectors';
+import { getThemeShowcaseDescription, getThemeShowcaseTitle } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import ThemesSearchCard from './themes-magic-search-card';
 import QueryThemeFilters from 'components/data/query-theme-filters';
-
-function getThemeShowcaseTitle( tier ) {
-	const titles = {
-		'': 'WordPress Themes',
-		free: 'Free WordPress Themes',
-		premium: 'Premium WordPress Themes',
-	};
-	return titles[ tier ];
-}
 
 const subjectsMeta = {
 	photo: { icon: 'camera', order: 1 },
@@ -144,6 +135,7 @@ const ThemeShowcase = React.createClass( {
 			vertical,
 			isLoggedIn,
 			pathName,
+			title,
 		} = this.props;
 		const tier = config.isEnabled( 'upgrades/premium-themes' ) ? this.props.tier : 'free';
 
@@ -178,7 +170,7 @@ const ThemeShowcase = React.createClass( {
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<Main className="themes">
-				<DocumentHead title={ getThemeShowcaseTitle( tier ) } meta={ metas } link={ links } />
+				<DocumentHead title={ title } meta={ metas } link={ links } />
 				<PageViewTracker path={ this.props.analyticsPath } title={ this.props.analyticsPageTitle } />
 				{ ! isLoggedIn && (
 					<SubMasterbarNav
@@ -247,6 +239,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	siteSlug: getSiteSlug( state, siteId ),
 	isJetpack: isJetpackSite( state, siteId ),
 	description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
+	title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -143,6 +143,7 @@ const ThemeShowcase = React.createClass( {
 
 		const metas = [
 			{ name: 'description', property: 'og:description', content: this.props.description },
+			{ property: 'og:title', content: title },
 			{ property: 'og:url', content: canonicalUrl },
 			{ property: 'og:type', content: 'website' }
 		];

--- a/client/state/selectors/get-theme-showcase-title.js
+++ b/client/state/selectors/get-theme-showcase-title.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { get, includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { findThemeFilterTerm, getThemeFilterTerm } from './';
+
+export default function getThemeShowcaseTitle( state, { filter, tier, vertical } = {} ) {
+	if ( vertical ) {
+		const name = get( getThemeFilterTerm( state, 'subject', vertical ), 'name' );
+		if ( name ) {
+			return `${ name } WordPress Themes`;
+		}
+	}
+
+	// If we have *one* filter, use its name
+	if ( filter && ! includes( filter, '+' ) ) {
+		const filterName = get( findThemeFilterTerm( state, filter ), 'name' );
+		if ( filterName ) {
+			return `${ filterName } WordPress Themes`;
+		}
+	}
+
+	if ( tier === 'free' ) {
+		return 'Free WordPress Themes';
+	} else if ( tier === 'premium' ) {
+		return 'Premium WordPress Themes';
+	}
+
+	return 'WordPress Themes';
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -81,6 +81,7 @@ export getThemeFilters from './get-theme-filters';
 export getThemeFilterTerm from './get-theme-filter-term';
 export getThemeFilterTerms from './get-theme-filter-terms';
 export getThemeShowcaseDescription from './get-theme-showcase-description';
+export getThemeShowcaseTitle from './get-theme-showcase-title';
 export getTimezones from './get-timezones';
 export getSiteTimezoneName from './get-site-timezone-name';
 export getSiteTimezoneValue from './get-site-timezone-value';

--- a/client/state/selectors/test/get-theme-showcase-title.js
+++ b/client/state/selectors/test/get-theme-showcase-title.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getThemeShowcaseTitle } from '../';
+import { state } from './fixtures/theme-filters';
+
+describe( 'getThemeShowcaseTitle()', () => {
+	it( 'should return the correct title for a known vertical', () => {
+		const title = getThemeShowcaseTitle( state, { vertical: 'business' } );
+		expect( title ).to.equal( 'Business WordPress Themes' );
+	} );
+
+	it( 'should return the correct title for a known filter', () => {
+		const title = getThemeShowcaseTitle( state, { filter: 'minimal' } );
+		expect( title ).to.equal( 'Minimal WordPress Themes' );
+	} );
+
+	it( 'should fall back to tier if multiple filters are specified', () => {
+		const title = getThemeShowcaseTitle( state, { filter: 'artwork+blog', tier: 'free' } );
+		expect( title ).to.equal( 'Free WordPress Themes' );
+	} );
+
+	it( 'should return correct title if only premium tier is specified', () => {
+		const title = getThemeShowcaseTitle( state, { tier: 'premium' } );
+		expect( title ).to.equal( 'Premium WordPress Themes' );
+	} );
+
+	it( 'should return correct title if only free tier is specified', () => {
+		const title = getThemeShowcaseTitle( state, { tier: 'free' } );
+		expect( title ).to.equal( 'Free WordPress Themes' );
+	} );
+
+	it( 'should return the generic Theme Showcase title if no additional args are provided', () => {
+		const title = getThemeShowcaseTitle( state );
+		expect( title ).to.equal( 'WordPress Themes' );
+	} );
+} );


### PR DESCRIPTION
Add a new `getThemeShowcaseTitle()` that contains all logic (much like the `getThemeShowcaseDescription()` one), and use that in `ThemeShowcase`. Also, add an `og:title` meta. If it makes FB happy :man_shrugging: 

To test:
* Restart Calypso
* While logged out, verify in Page Source that there's a suitable `title` in the following cases (you need to land on these pages directly):
  * https://wordpress.com/themes/
  * https://wordpress.com/themes/business
  * https://wordpress.com/themes/premium
  * https://wordpress.com/themes/free
  * https://wordpress.com/themes/filter/featured-image-header
  * https://wordpress.com/themes/filter/accessibility-ready+blog
* Verify there's also a corresponding `og:title` meta.
