### PR TITLE
Reader Tags: stop double encoding tag

### DIFF
--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -23,7 +23,7 @@ const exported = {
 				.toLowerCase()
 				.replace( /\s+/g, '-' )
 				.replace( /-{2,}/g, '-' ),
-			encodedTag = encodeURIComponent( tagSlug ).toLowerCase(),
+			encodedTag = tagSlug.toLowerCase(),
 			tagStore = feedStreamFactory( 'tag:' + tagSlug ),
 			mcKey = 'topic';
 


### PR DESCRIPTION
When gotten from the URL the value is already encoded.

Not actually an issue because the value is not used anywhere we would notice...yet.  Still weird though to see double encodings throughout react dev tools