### PR TITLE
Reader FeedSearch: start using the search results count to improve the ux

### DIFF
--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -21,6 +21,7 @@ const FollowingManageSearchFeedsResults = ( {
 	width,
 	fetchNextPage,
 	forceRefresh,
+	searchResultsCount,
 } ) => {
 	if ( ! searchResults ) {
 		return null; // todo: add placeholder
@@ -47,14 +48,16 @@ const FollowingManageSearchFeedsResults = ( {
 		return (
 			<div className="following-manage__search-results">
 				{ resultsToShow }
-				<div className="following-manage__show-more">
-					<Button compact icon
-						onClick={ showMoreResultsClicked }
-						className="following-manage__show-more-button button">
-							<Gridicon icon="chevron-down" />
-							{ translate( 'Show more' ) }
-					</Button>
-				</div>
+				{ searchResultsCount > 3 && (
+					<div className="following-manage__show-more">
+						<Button compact icon
+							onClick={ showMoreResultsClicked }
+							className="following-manage__show-more-button button">
+								<Gridicon icon="chevron-down" />
+								{ translate( 'Show more' ) }
+						</Button>
+					</div>
+				) }
 			</div>
 		);
 	}
@@ -65,7 +68,7 @@ const FollowingManageSearchFeedsResults = ( {
 				sites={ searchResults }
 				width={ width }
 				fetchNextPage={ fetchNextPage }
-				remoteTotalCount={ 200 }
+				remoteTotalCount={ searchResultsCount }
 				forceRefresh={ forceRefresh }
 			/>
 		</div>

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -45,19 +45,20 @@ const FollowingManageSearchFeedsResults = ( {
 				/>
 			)
 		);
+
 		return (
 			<div className="following-manage__search-results">
 				{ resultsToShow }
-				{ searchResultsCount > 3 && (
-					<div className="following-manage__show-more">
+				<div className="following-manage__show-more">
+					{ searchResultsCount > 3 && (
 						<Button compact icon
 							onClick={ showMoreResultsClicked }
 							className="following-manage__show-more-button button">
 								<Gridicon icon="chevron-down" />
 								{ translate( 'Show more' ) }
 						</Button>
-					</div>
-				) }
+					) }
+				</div>
 			</div>
 		);
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -15,7 +15,7 @@ import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import SearchInput from 'components/search';
 import ReaderMain from 'components/reader-main';
-import { getReaderFeedsForQuery } from 'state/selectors';
+import { getReaderFeedsForQuery, getReaderFeedsCountForQuery } from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
 import FollowingManageSubscriptions from './subscriptions';
 import FollowingManageSearchFeedsResults from './feed-search-results';
@@ -119,7 +119,15 @@ class FollowingManage extends Component {
 	}
 
 	render() {
-		const { sitesQuery, subsQuery, subsSortOrder, translate, searchResults, showMoreResults } = this.props;
+		const {
+			sitesQuery,
+			subsQuery,
+			subsSortOrder,
+			translate,
+			searchResults,
+			searchResultsCount,
+			showMoreResults
+		} = this.props;
 		const searchPlaceholderText = translate( 'Search millions of sites' );
 
 		return (
@@ -154,6 +162,7 @@ class FollowingManage extends Component {
 						width={ this.state.width }
 						fetchNextPage={ this.fetchNextPage }
 						forceRefresh={ this.state.forceRefresh }
+						searchResultsCount={ searchResultsCount }
 					/>
 				) }
 				{ ! ( !! sitesQuery && showMoreResults ) && (
@@ -172,6 +181,7 @@ class FollowingManage extends Component {
 export default connect(
 	( state, ownProps ) => ( {
 		searchResults: getReaderFeedsForQuery( state, ownProps.sitesQuery ),
+		searchResultsCount: getReaderFeedsCountForQuery( state, ownProps.sitesQuery ),
 	} ),
 	{ requestFeedSearch }
 )( localize( FollowingManage ) );

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -37,8 +37,9 @@ export function receiveFeeds( store, action, next, apiResponse ) {
 		feed_URL: feed.subscribe_URL,
 	} ) );
 
+	const total = apiResponse.total > 200 ? 200 : apiResponse.total;
 	store.dispatch(
-		receiveFeedSearch( action.payload.query, feeds )
+		receiveFeedSearch( action.payload.query, feeds, total )
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -63,18 +63,22 @@ describe( 'wpcom-api', () => {
 				const action = requestFeedSearch( query );
 				const dispatch = sinon.spy();
 				const next = sinon.spy();
-				const apiResponse = { feeds };
+				const apiResponse = { feeds, total: 500 };
 
 				receiveFeeds( { dispatch }, action, next, apiResponse );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
-					receiveFeedSearch( query, [ {
-						blog_ID: 'IM A BLOG',
-						feed_URL: 'feedUrl',
-						subscribe_URL: 'feedUrl',
-					} ] )
-				);
+					receiveFeedSearch( query,
+						[
+							{
+								blog_ID: 'IM A BLOG',
+								feed_URL: 'feedUrl',
+								subscribe_URL: 'feedUrl',
+							}
+						],
+						200,
+					) );
 			} );
 		} );
 

--- a/client/state/reader/feed-searches/actions.js
+++ b/client/state/reader/feed-searches/actions.js
@@ -11,8 +11,8 @@ export const requestFeedSearch = ( query, offset = 0 ) => ( {
 	payload: { query, offset },
 } );
 
-export const receiveFeedSearch = ( query, feeds ) => ( {
+export const receiveFeedSearch = ( query, feeds, total ) => ( {
 	type: READER_FEED_SEARCH_RECEIVE,
-	payload: feeds,
+	payload: { feeds, total },
 	query,
 } );

--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -1,18 +1,19 @@
 /**
  * External dependencies
  */
-import { createReducer, keyedReducer } from 'state/utils';
+import { combineReducers } from 'redux';
 import { uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { createReducer, keyedReducer } from 'state/utils';
 import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
 /**
  * Tracks mappings between queries --> feed results
  * Here is what the state tree may look like:
- * feedsearch: {
+ * feedSearches: {
 		items: {
 			'wordpress tavern': [ feed1, feed2, ],
 			...
@@ -25,9 +26,32 @@ import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
  */
 export const items = keyedReducer( 'query', createReducer( null, {
 	[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => uniqBy(
-		( state || [] ).concat( action.payload ),
+		( state || [] ).concat( action.payload.feeds ),
 		'URL',
 	)
 } ) );
 
-export default items;
+/**
+ * Tracks mappings between queries --> num results
+ * Here is what the state tree may look like:
+ * feedSearches: {
+		total: {
+			'wordpress tavern': 4,
+			'thingsldkjflskjfsdf': 0,
+			'chickens': 4000,
+			...
+		},
+	}
+ *
+ * @param  {Array}  state  Current state
+ * @param  {Object} action Action payload
+ * @return {Array}         Updated state
+ */
+export const total = keyedReducer( 'query', createReducer( null, {
+	[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => action.payload.total
+} ) );
+
+export default combineReducers( {
+	items,
+	total,
+} );

--- a/client/state/selectors/get-reader-feeds-count-for-query.js
+++ b/client/state/selectors/get-reader-feeds-count-for-query.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the number of feed results for a given query. from 0 to 200.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  query query
+ * @return {Array} list of feeds that are the result of that query
+ */
+export default function getReaderFeedsCountForQuery( state, query ) {
+	return state.reader.feedSearches.total[ query ];
+}

--- a/client/state/selectors/get-reader-feeds-for-query.js
+++ b/client/state/selectors/get-reader-feeds-for-query.js
@@ -1,10 +1,10 @@
 /**
- * Returns the url for a thumbnail for a given iframe.
+ * Returns the feeds result for a given query.
  *
  * @param  {Object}  state  Global state tree
  * @param  {String}  query query
  * @return {Array} list of feeds that are the result of that query
  */
 export default function getReaderFeedsForQuery( state, query ) {
-	return state.reader.feedSearches[ query ];
+	return state.reader.feedSearches.items[ query ];
 }

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -60,6 +60,7 @@ export getPostLikes from './get-post-likes';
 export getPrimarySiteId from './get-primary-site-id';
 export getRawOffsets from './get-raw-offsets';
 export getReaderFeedsForQuery from './get-reader-feeds-for-query';
+export getReaderFeedsCountForQuery from './get-reader-feeds-count-for-query';
 export getReaderFollowedTags from './get-reader-followed-tags';
 export getReaderFollowForBlog from './get-reader-follow-for-blog';
 export getReaderFollows from './get-reader-follows';


### PR DESCRIPTION
We recently landed a patch to the api so that we in addition to the actual feed results we also get the total number of results in the pipe.  We currently only want to display up to 200 of them.

This PR adds in the redux bits, data-layer bits, and visual tweaks to take advantage.

Before:
![](https://cldup.com/ohMkZHaCY7.png)

After:
![](https://cldup.com/Fdy6SZGqxe.png)
