### PR TITLE
Stats: ensure QuerySiteStats for followers runs on all pages

### DIFF
--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import { get } from 'lodash';
 import Button from 'components/button';
 import Count from 'components/count';
 import QuerySiteStats from 'components/data/query-site-stats';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 
@@ -23,7 +23,7 @@ class FollowersCount extends Component {
 		return (
 			<div className="followers-count">
 				{ siteId && <QuerySiteStats statType="stats" siteId={ siteId } /> }
-				{ followers &&
+				{ isNumber( followers ) &&
 					<Button
 						borderless
 						href={ '/people/followers/' + slug }
@@ -38,12 +38,14 @@ class FollowersCount extends Component {
 }
 
 export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
+	const site = getSelectedSite( state );
+	const siteId = get( site, 'ID' );
 	const data = getSiteStatsNormalizedData( state, siteId, 'stats' );
+	const siteFollowers = get( site, 'subscribers_count' );
 
 	return {
 		slug: getSiteSlug( state, siteId ),
-		followers: get( data, 'followersBlog' ),
+		followers: get( data, 'followersBlog', siteFollowers ),
 		siteId,
 	};
 } )( localize( FollowersCount ) );

--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -20,20 +20,18 @@ class FollowersCount extends Component {
 	render() {
 		const { slug, followers, translate, siteId } = this.props;
 
-		if ( ! followers ) {
-			return null;
-		}
-
 		return (
 			<div className="followers-count">
 				{ siteId && <QuerySiteStats statType="stats" siteId={ siteId } /> }
-				<Button
-					borderless
-					href={ '/people/followers/' + slug }
-					title={ translate( 'Total of WordPress and Email Followers' ) }
-					>
-					{ translate( 'Followers' ) } <Count count={ followers } />
-				</Button>
+				{ followers &&
+					<Button
+						borderless
+						href={ '/people/followers/' + slug }
+						title={ translate( 'Total of WordPress and Email Followers' ) }
+						>
+						{ translate( 'Followers' ) } <Count count={ followers } />
+					</Button>
+				}
 			</div>
 		);
 	}
@@ -46,5 +44,6 @@ export default connect( ( state ) => {
 	return {
 		slug: getSiteSlug( state, siteId ),
 		followers: get( data, 'followersBlog' ),
+		siteId,
 	};
 } )( localize( FollowersCount ) );


### PR DESCRIPTION
In #10962 the refactoring of the `FollowersCount` component added logic that makes the `QuerySiteStats` call for the needed data never execute.  This wasn't really surfaced as an issue when the same query was executed on the then default Insights page - but now since the default stats page is 'Day' the followers button does not load until the Insights page is visited.

![stats_ _cooking_with_little_fudge_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/25719658/fe81fd2c-30be-11e7-84dc-0e7cdff0cc99.png)

__To Test__
- Clear out your local indexedb to ensure an empty state tree
- Launch this branch, click My Sites
- Note that the followers count for your site, as long as it is greater than 0, will be displayed after the payload from the `/stats` endpoint returns