### PR TITLE
Reader: fix recs appearing as search

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -125,7 +125,11 @@ const Search = React.createClass( {
 			this.setState( { isOpen: nextProps.isOpen } );
 		}
 
-		if ( this.props.value !== nextProps.value && nextProps.value && nextProps.value !== this.state.keyword ) {
+		if (
+			( this.props.value !== nextProps.value ) &&
+			( nextProps.value || nextProps.value === '' ) &&
+			( nextProps.value !== this.state.keyword )
+		) {
 			this.setState( { keyword: nextProps.value } );
 		}
 	},

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -190,8 +190,8 @@ class SearchStream extends Component {
 							delaySearch={ true }
 							delayTimeout={ 500 }
 							placeholder={ searchPlaceholderText }
-							initialValue={ query }
-							value={ query }>
+							initialValue={ query || '' }
+							value={ query || '' }>
 						</SearchInput>
 						{ query &&
 							<SegmentedControl compact

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -104,8 +104,10 @@ class ReaderStream extends React.Component {
 		transformStreamItems: identity,
 	};
 
-	getStateFromStores( store = this.props.postsStore, recommendationsStore = this.props.recommendationsStore ) {
-		const posts = map( store.get(), this.props.transformStreamItems );
+	getStateFromStores( props = this.props ) {
+		const { postsStore: store, recommendationsStore } = props;
+
+		const posts = map( store.get(), props.transformStreamItems );
 		const recs = recommendationsStore ? recommendationsStore.get() : null;
 		// do we have enough recs? if we have a store, but not enough recs, we should fetch some more...
 		if ( recommendationsStore ) {
@@ -121,7 +123,7 @@ class ReaderStream extends React.Component {
 			items = injectRecommendations( posts, recs, getDistanceBetweenRecs() );
 		}
 
-		if ( this.props.shouldCombineCards ) {
+		if ( props.shouldCombineCards ) {
 			items = combineCards( items );
 		}
 
@@ -138,8 +140,8 @@ class ReaderStream extends React.Component {
 
 	state = this.getStateFromStores();
 
-	updateState = ( store ) => {
-		this.setState( this.getStateFromStores( store ) );
+	updateState = ( props = this.props ) => {
+		this.setState( this.getStateFromStores( props ) );
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
@@ -222,7 +224,7 @@ class ReaderStream extends React.Component {
 			nextProps.recommendationsStore && nextProps.recommendationsStore.on( 'change', this.updateState );
 			this.props.resetCardExpansions();
 
-			this.updateState( nextProps.postsStore, nextProps.recommendationsStore );
+			this.updateState( nextProps );
 			this._list && this._list.reset();
 		}
 	}


### PR DESCRIPTION
fixes: https://github.com/Automattic/wp-calypso/issues/13386

A couple implementation notes here:
1. `updateStateFromStore` wasn't picking up the latest props. I modified it to take in props instead of the state object so that it has access to all of nextProps including `transformStreamItems`. @blowery can you review this part?
2. `Search` component prop named value would ignore any changes made to it that were falsy.  Made it impossible to programmatically set the value to empty because it `''` is falsey :(. Will need to get wider 👀  on this change.  