### PR TITLE
Notes: disable keyboard shortcuts when notifications panel is open

### DIFF
--- a/client/lib/keyboard-shortcuts/index.js
+++ b/client/lib/keyboard-shortcuts/index.js
@@ -50,6 +50,9 @@ function KeyboardShortcuts( keyBindings ) {
 	// save a copy of the bound last-key-pressed handler so it can be removed later
 	this.boundKeyHandler = this.handleKeyPress.bind( this );
 
+	// is the notifications panel open? If so we don't fire off key-handlers
+	this.isNotificationsOpen = false;
+
 	// bind the shortcuts if this is a browser environment
 	if ( typeof window !== 'undefined' ) {
 		keymaster.filter = ignoreDefaultAndContentEditableFilter;
@@ -91,6 +94,11 @@ KeyboardShortcuts.prototype.bindShortcut = function( eventName, keys, type, chec
 	keyCombinations.forEach( function( keys ) {
 		if ( 'sequence' === type ) {
 			keymaster( keys[ 1 ], function( event, handler ) {
+				// if the notifications panel is open, do not handle any sequences
+				if ( self.isNotificationsOpen ) {
+					return false;
+				}
+
 				if ( self.lastKey === keys[ 0 ] && self.lastKeyTime > Date.now() - self.timeLimit ) {
 					self.emitEvent( eventName, event, handler );
 
@@ -104,6 +112,11 @@ KeyboardShortcuts.prototype.bindShortcut = function( eventName, keys, type, chec
 		} else {
 			keys = keys.join( '+' );
 			keymaster( keys, function( event, handler ) {
+				// if the notifications panel is open, do not handle any presses besides `n` to toggle the panel
+				if ( self.isNotificationsOpen && self._getKey( event ) !== 'n' ) {
+					return false;
+				}
+
 				var keyValue;
 				// Check if the value of the pressed key matches. This is needed
 				// for keys being used with shift modifiers, as the charCode only
@@ -158,6 +171,10 @@ KeyboardShortcuts.prototype.handleKeyPress = function( event ) {
 		this.lastKey = String.fromCharCode( event.keyCode ).toLowerCase();
 		this.lastKeyTime = Date.now();
 	}
+};
+
+KeyboardShortcuts.prototype.setNotificationsOpen = function( isOpen ) {
+	this.isNotificationsOpen = isOpen;
 };
 
 // add EventEmitter methods to prototype

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -90,7 +90,9 @@ const updatedSelectedSiteForKeyboardShortcuts = ( dispatch, action, getState ) =
  * @param {function} getState - redux getState function
  */
 const updateNotificationsOpenForKeyboardShortcuts = ( dispatch, action, getState ) => {
-	keyboardShortcuts.setNotificationsOpen( isNotificationsOpen( getState() ) );
+	// flip the state here, since the reducer hasn't had a chance to update yet
+	const toggledState = ! isNotificationsOpen( getState() );
+	keyboardShortcuts.setNotificationsOpen( toggledState );
 };
 
 /**
@@ -114,10 +116,7 @@ const handler = ( dispatch, action, getState ) => {
 		//when the notifications panel is open keyboard events should not fire.
 		case NOTIFICATIONS_PANEL_TOGGLE:
 			if ( keyBoardShortcutsEnabled ) {
-				// Wait a tick for the reducer to update the state tree
-				setTimeout( () => {
-					updateNotificationsOpenForKeyboardShortcuts( dispatch, action, getState );
-				}, 0 );
+				updateNotificationsOpenForKeyboardShortcuts( dispatch, action, getState );
 			}
 			return;
 


### PR DESCRIPTION
This PR is needed for #12653, where we remove the notifications-panel iframe in Calypso. Both the notifications panel and Calypso have keyboard shortcuts. Because the iframe is removed, any overlapping shortcuts in Calypso and the panel will both fire. For example with notifications open, typing <kbd>j</kbd> will move to the next item in both Reader and the Notifications Panel.

In this PR we update the keyboard library to ignore any keypresses if the notifications panel is open. 

### Testing Instructions
- No functional Changes to Calypso
- When the notifications panel is open shortcuts like <kbd>j</kbd> do not work in the reader
- When the notifications panel is closed all implemented Calypso shortcuts should work.

cc @Automattic/lannister