### PR TITLE
Fix/keyboard

### DIFF
--- a/client/lib/keyboard-shortcuts/index.js
+++ b/client/lib/keyboard-shortcuts/index.js
@@ -113,7 +113,7 @@ KeyboardShortcuts.prototype.bindShortcut = function( eventName, keys, type, chec
 			keys = keys.join( '+' );
 			keymaster( keys, function( event, handler ) {
 				// if the notifications panel is open, do not handle any presses besides `n` to toggle the panel
-				if ( self.isNotificationsOpen && self._getKey( event ) !== 'n' ) {
+				if ( self.isNotificationsOpen && ( self._getKey( event ) !== 'n' && event.keyCode !== 27 ) ) {
 					return;
 				}
 

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -156,7 +156,7 @@ export class Notifications extends Component {
 				} ) }
 			>
 				<NotificationsPanel
-					isShowing={ this.props.isShowing || true }
+					isShowing={ this.props.isShowing }
 					isVisible={ this.state.isVisible }
 					locale={ localeSlug }
 					onRender={ this.indicateRender }

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -160,7 +160,6 @@ export class Notifications extends Component {
 					isVisible={ this.state.isVisible }
 					locale={ localeSlug }
 					onRender={ this.indicateRender }
-					onTogglePanel={ this.props.checkToggle }
 					wpcom={ wpcom }
 				/>
 			</div>

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -98,6 +98,12 @@ export class Notifications extends Component {
 			event.preventDefault();
 			this.props.checkToggle( null, true );
 		}
+
+		if ( 27 === event.keyCode && this.props.isShowing ) {
+			event.stopPropagation();
+			event.preventDefault();
+			this.props.checkToggle( null, true );
+		}
 	};
 
 	handleVisibilityChange = () => this.setState( { isVisible: getIsVisible() } );

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -20,16 +20,15 @@ import cartStore from 'lib/cart/store';
 import { isNotificationsOpen } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+import keyboardShortcuts from 'lib/keyboard-shortcuts';
 
 /**
  * Module variables
  */
-const keyBoardShortcutsEnabled = config.isEnabled( 'keyboard-shortcuts' );
-let keyboardShortcuts;
+const globalKeyBoardShortcutsEnabled = config.isEnabled( 'keyboard-shortcuts' );
 let globalKeyboardShortcuts;
 
-if ( keyBoardShortcutsEnabled ) {
-	keyboardShortcuts = require( 'lib/keyboard-shortcuts' );
+if ( globalKeyBoardShortcutsEnabled ) {
 	globalKeyboardShortcuts = require( 'lib/keyboard-shortcuts/global' )();
 }
 
@@ -115,10 +114,7 @@ const handler = ( dispatch, action, getState ) => {
 
 		//when the notifications panel is open keyboard events should not fire.
 		case NOTIFICATIONS_PANEL_TOGGLE:
-			if ( keyBoardShortcutsEnabled ) {
-				updateNotificationsOpenForKeyboardShortcuts( dispatch, action, getState );
-			}
-			return;
+			return updateNotificationsOpenForKeyboardShortcuts( dispatch, action, getState );
 
 		case SELECTED_SITE_SET:
 		case SITE_RECEIVE:
@@ -127,7 +123,7 @@ const handler = ( dispatch, action, getState ) => {
 			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
 				updateSelectedSiteForCart( dispatch, action, getState );
-				if ( keyBoardShortcutsEnabled ) {
+				if ( globalKeyBoardShortcutsEnabled ) {
 					updatedSelectedSiteForKeyboardShortcuts( dispatch, action, getState );
 				}
 				if ( desktopEnabled ) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3026,7 +3026,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.1.3",
+    "notifications-panel": "1.1.4",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",


### PR DESCRIPTION
@See #12653 

The <kbd>j</kbd> and <kbd>k</kbd> keys were being trapped in _staging_ but nowhere else (before deploying to production). We have disabled key interception in the notes panel when it's hidden and removed a conditional check in the keyboard middleware.

Will do final tests in staging after merging.