### PR TITLE
Feature: Allow devs to pass arguments to the node command via env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
 run: welcome githooks install build
-	@$(NODE) build/bundle.js
+	@$(NODE) $(NODE_ARGS) build/bundle.js
 
 dashboard: install
 	@$(NODE_BIN)/webpack-dashboard -- make run

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -51,6 +51,10 @@ or limit it as before with:
 DEBUG=calypso:* make run
 ```
 
+### Debugging node
+
+Since building and starting the express server is done via a make target, the normal method of passing argument to the node process won't work. However, you can start the debugger via the `NODE_ARGS` environment variable. The value of this variable is passed to the node command when executing `make run`.  This means you can run the built-in inspector by running `NODE_ARGS="--inspect" make run`.  Starting the debugger is similar: `NODE_ARGS="--debug=5858" make run`.  If you would like to debug the build process as well, it might be convenient to have the debugger/inspector break on the first line and wait for you.  In that case, you should also pass in the `--debug-brk` option like so: `NODE_ARGS="--inspect --debug-brk" make run` (note: `--debug-brk` can also be used with the `--debug` flag).
+
 ## Monitoring builds and tests
 
 Throughout your Calypso development workflow, you will find yourself waiting — either for a build to finish or for tests to run. Rather than standing idle looking at terminals while you wait, you can use status indicators and/or system notifications.

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,6 +37,10 @@ To run Calypso locally, you'll need to add `127.0.0.1 calypso.localhost` to [you
 
 See [Development Workflow](../docs/development-workflow.md) for more.
 
+### Starting the node debugger
+
+The `make run` command will pass anything set in the `NODE_ARGS` environment variable as an option to the Node command.  This means that if you want to start up the debugger on a specific port you can run `NODE_ARGS="--debug=5858" make run`.  Starting the built-in inspector can also by done by running `NODE_ARGS="--inspect" make run`.  In either case, if you would like to debug the build process as well, it might be convenient to have the inspector break on the first line and wait for you.  In that case, you should also pass in the `--debug-brk` option like so `NODE_ARGS="--inspect --debug-brk" make run`.
+
 ## Using a portable development environment
 
 You can install Calypso very quickly via a portable development environment called [Calypso Bootstrap](https://github.com/Automattic/wp-calypso-bootstrap). It uses Vagrant and Puppet behind the scenes to install and configure a virtual machine with Calypso ready to run - with a single command.


### PR DESCRIPTION
**Feature:**
While working on some code in the Node server in a previous PR, I found it very helpful to enable Node's [built-in inspector/debugger](https://nodejs.org/en/docs/inspector/).  Just in case you're not aware, here's a [good article](https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27#.pmqejrn8q) on what that does.  However, in order to enable this feature, I had to manually edit the Makefile to add the `--inspect` flag to the run target, then be sure to undo that change before committing.  It was a bit annoying.

I'd like to add a separate make target which does the same thing as `run`, but it also passes the `--inspect` flag to Node.  

For reference [Visual Studio Code](https://code.visualstudio.com/Docs/editor/debugging) supports this as a debug configuration, anyone can hit a URL shown on the command line in Chrome/Chromium to use the browser's development tools, and the standard debugger gets started on port 9229.

**Notes:**
I thought about conditionally adding the flag based on an environment variable, but I'm too new to the code base and I wanted to be safe by making this feature explicitly opt-in through a separate make target.

**Changes:**
- Add a new make target called `make run-inspect` which starts Node with the `--inspect` flag.
- Update docs to note the new target/possible command and its usage.

cc: @yoavf @dmsnell