### PR TITLE
Extensions: WPSC - Fix text area fields not saving

### DIFF
--- a/client/extensions/wp-super-cache/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/accepted-filenames.jsx
@@ -144,7 +144,7 @@ class AcceptedFilenames extends Component {
 							<FormTextarea
 								disabled={ isRequesting || isSaving }
 								onChange={ handleChange( 'cache_rejected_uri' ) }
-								value={ cache_rejected_uri && cache_rejected_uri.join( '\n' ) } />
+								value={ cache_rejected_uri } />
 							<FormSettingExplanation>
 								{ translate(
 									'Add here strings (not a filename) that forces a page not to be cached. For example, ' +
@@ -162,7 +162,7 @@ class AcceptedFilenames extends Component {
 							<FormTextarea
 								disabled={ isRequesting || isSaving }
 								onChange={ handleChange( 'cache_acceptable_files' ) }
-								value={ cache_acceptable_files && cache_acceptable_files.join( '\n' ) } />
+								value={ cache_acceptable_files } />
 							<FormSettingExplanation>
 								{ translate(
 									'Add here those filenames that can be cached, even if they match one of the rejected ' +

--- a/client/extensions/wp-super-cache/rejected-user-agents.jsx
+++ b/client/extensions/wp-super-cache/rejected-user-agents.jsx
@@ -45,7 +45,7 @@ const RejectedUserAgents = ( {
 						<FormTextarea
 							disabled={ isRequesting || isSaving }
 							onChange={ handleChange( 'cache_rejected_user_agent' ) }
-							value={ cache_rejected_user_agent && cache_rejected_user_agent.join( '\n' ) } />
+							value={ cache_rejected_user_agent } />
 						<FormSettingExplanation>
 							{ translate(
 								'Strings in the HTTP ’User Agent’ header that prevent WP-Cache from caching bot, ' +

--- a/client/extensions/wp-super-cache/state/settings/actions.js
+++ b/client/extensions/wp-super-cache/state/settings/actions.js
@@ -12,6 +12,7 @@ import {
 	WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,
 	WP_SUPER_CACHE_UPDATE_SETTINGS,
 } from '../action-types';
+import { normalizeSettings, sanitizeSettings } from './utils';
 
 /**
  * Returns an action object to be used in signalling that settings have been received.
@@ -37,7 +38,7 @@ export const requestSettings = ( siteId ) => {
 
 		return wp.req.get( { path: `/jetpack-blogs/${ siteId }/rest-api/` }, { path: '/wp-super-cache/v1/settings' } )
 			.then( ( { data } ) => {
-				dispatch( receiveSettings( siteId, data ) );
+				dispatch( receiveSettings( siteId, normalizeSettings( data ) || {} ) );
 				dispatch( {
 					type: WP_SUPER_CACHE_REQUEST_SETTINGS_SUCCESS,
 					siteId,
@@ -78,7 +79,7 @@ export const saveSettings = ( siteId, settings ) => {
 
 		return wp.req.post(
 			{ path: `/jetpack-blogs/${ siteId }/rest-api/` },
-			{ path: '/wp-super-cache/v1/settings', body: JSON.stringify( settings ), json: true } )
+			{ path: '/wp-super-cache/v1/settings', body: JSON.stringify( sanitizeSettings( settings ) ), json: true } )
 			.then( () => {
 				dispatch( updateSettings( siteId, settings ) );
 				dispatch( {

--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -1,23 +1,25 @@
 /**
+ * External dependencies
+ */
+import { mapValues } from 'lodash';
+
+/**
  * Normalize settings for use in Redux.
  *
  * @param  {Object} settings Raw settings
  * @return {Object} Normalized settings
  */
 export const normalizeSettings = settings => {
-	return Object.keys( settings ).reduce( ( acc, key ) => {
+	return mapValues( settings, ( setting, key ) => {
 		switch ( key ) {
 			case 'cache_acceptable_files':
 			case 'cache_rejected_uri':
 			case 'cache_rejected_user_agent':
-				acc[ key ] = settings[ key ].join( '\n' );
-				break;
+				return setting.join( '\n' );
 			default:
-				acc[ key ] = settings[ key ];
+				return setting;
 		}
-
-		return acc;
-	}, {} );
+	} );
 };
 
 /**
@@ -27,17 +29,14 @@ export const normalizeSettings = settings => {
  * @return {Object} Sanitized settings
  */
 export const sanitizeSettings = settings => {
-	return Object.keys( settings ).reduce( ( acc, key ) => {
+	return mapValues( settings, ( setting, key ) => {
 		switch ( key ) {
 			case 'cache_acceptable_files':
 			case 'cache_rejected_uri':
 			case 'cache_rejected_user_agent':
-				acc[ key ] = settings[ key ].split( '\n' );
-				break;
+				return setting.split( '\n' );
 			default:
-				acc[ key ] = settings[ key ];
+				return setting;
 		}
-
-		return acc;
-	}, {} );
+	} );
 };

--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -1,0 +1,43 @@
+/**
+ * Normalize settings for use in Redux.
+ *
+ * @param  {Object} settings Raw settings
+ * @return {Object} Normalized settings
+ */
+export const normalizeSettings = settings => {
+	return Object.keys( settings ).reduce( ( acc, key ) => {
+		switch ( key ) {
+			case 'cache_acceptable_files':
+			case 'cache_rejected_uri':
+			case 'cache_rejected_user_agent':
+				acc[ key ] = settings[ key ].join( '\n' );
+				break;
+			default:
+				acc[ key ] = settings[ key ];
+		}
+
+		return acc;
+	}, {} );
+};
+
+/**
+ * Sanitize settings before saving.
+ *
+ * @param  {Object} settings Normalized settings
+ * @return {Object} Sanitized settings
+ */
+export const sanitizeSettings = settings => {
+	return Object.keys( settings ).reduce( ( acc, key ) => {
+		switch ( key ) {
+			case 'cache_acceptable_files':
+			case 'cache_rejected_uri':
+			case 'cache_rejected_user_agent':
+				acc[ key ] = settings[ key ].split( '\n' );
+				break;
+			default:
+				acc[ key ] = settings[ key ];
+		}
+
+		return acc;
+	}, {} );
+};


### PR DESCRIPTION
Text area fields (namely the text areas in the _Accepted Filenames & Rejected URIs_ and _Rejected User Agents_ fields of the _Advanced_ tab) were not being saved because their values were being normalized directly in the `value` prop. In order for saving to work, the `value` prop must be just the name of the field to save.

Instead, these settings are now normalized in the data layer as they are received, and converted back to the expected format before saving.

_(Note: The Rejected User Agents field is not saving, but that's due to an issue with the API that has yet to be resolved.)_