### PR TITLE
Happychat: Send Tracks event information as a log event

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -81,6 +81,18 @@ class Connection extends EventEmitter {
 		);
 	}
 
+	sendLog( message ) {
+		this.openSocket.then(
+			socket => socket.emit( 'message', {
+				text: message,
+				id: uuid(),
+				type: 'log',
+				meta: { forOperator: true }
+			} ),
+			e => debug( 'failed to send message', e )
+		);
+	}
+
 	info( message ) {
 		this.openSocket.then(
 			socket => socket.emit( 'message', { text: message.text, id: uuid(), meta: { forOperator: true } } ),

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -87,7 +87,7 @@ class Connection extends EventEmitter {
 				text: message,
 				id: uuid(),
 				type: 'log',
-				meta: { forOperator: true }
+				meta: { forOperator: true, event_type: 'log' }
 			} ),
 			e => debug( 'failed to send message', e )
 		);

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -1,14 +1,18 @@
 /**
  * External dependencies
  */
-import isEmpty from 'lodash/isEmpty';
-import throttle from 'lodash/throttle';
+import {
+	has,
+	isEmpty,
+	throttle
+} from 'lodash';
 
 /**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
 import {
+	ANALYTICS_EVENT_RECORD,
 	HAPPYCHAT_CONNECT,
 	HAPPYCHAT_INITIALIZE,
 	HAPPYCHAT_SEND_BROWSER_INFO,
@@ -155,6 +159,20 @@ export const sendRouteSetEventMessage = ( connection, { getState }, action ) =>{
 	}
 };
 
+export const sendAnalytics = ( connection, { getState }, { meta: { analytics: analyticsMeta } } ) => {
+	const state = getState();
+	analyticsMeta.forEach( ( { type, payload: { service, name } } ) => {
+		if (
+			isHappychatClientConnected( state ) &&
+			isHappychatChatAssigned( state ) &&
+			type === ANALYTICS_EVENT_RECORD &&
+			service === 'tracks'
+		) {
+			connection.sendLog( `${ name }` );
+		}
+	} );
+};
+
 export default function( connection = null ) {
 	// Allow a connection object to be specified for
 	// testing. If blank, use a real connection.
@@ -163,6 +181,10 @@ export default function( connection = null ) {
 	}
 
 	return store => next => action => {
+		if ( has( action, 'meta.analytics' ) ) {
+			sendAnalytics( connection, store, action );
+		}
+
 		switch ( action.type ) {
 			case HAPPYCHAT_CONNECT:
 				connectChat( connection, store );

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -168,7 +168,7 @@ export const sendAnalyticsLogEvent = ( connection, { getState }, { meta: { analy
 			type === ANALYTICS_EVENT_RECORD &&
 			service === 'tracks'
 		) {
-			connection.sendLog( `${ name }` );
+			connection.sendLog( name );
 		}
 	} );
 };

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -159,7 +159,7 @@ export const sendRouteSetEventMessage = ( connection, { getState }, action ) =>{
 	}
 };
 
-export const sendAnalytics = ( connection, { getState }, { meta: { analytics: analyticsMeta } } ) => {
+export const sendAnalyticsLogEvent = ( connection, { getState }, { meta: { analytics: analyticsMeta } } ) => {
 	const state = getState();
 	analyticsMeta.forEach( ( { type, payload: { service, name } } ) => {
 		if (
@@ -182,7 +182,7 @@ export default function( connection = null ) {
 
 	return store => next => action => {
 		if ( has( action, 'meta.analytics' ) ) {
-			sendAnalytics( connection, store, action );
+			sendAnalyticsLogEvent( connection, store, action );
 		}
 
 		switch ( action.type ) {

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -340,7 +340,7 @@ describe( 'middleware', () => {
 			getState.returns( unconnectedState );
 			sendAnalyticsLogEvent( connection, { getState }, { meta: { analytics: analyticsMeta } } );
 
-			expect( connection.sendLog ).not.to.have.beenCalled;
+			expect( connection.sendLog ).not.to.have.been.called;
 		} );
 
 		it( 'should only send log events if the Happychat connection is assigned', () => {
@@ -350,7 +350,7 @@ describe( 'middleware', () => {
 			getState.returns( unassignedState );
 			sendAnalyticsLogEvent( connection, { getState }, { meta: { analytics: analyticsMeta } } );
 
-			expect( connection.sendLog ).not.to.have.beenCalled;
+			expect( connection.sendLog ).not.to.have.been.called;
 		} );
 	} );
 } );


### PR DESCRIPTION
This is part of an effort to see what useful information Happychat operators can get from actions users are taking during a support session. It inspects all actions in middleware and if an action is carrying analytics metadata that will be sent to tracks, it also sends it along to the Happychat service.

When this ships, operators on the production Happychat will start receiving these log events — but because there are no handlers for `log` type events, the messages will be thrown away. This is what we want, so we can test this in staging without affecting production.

### To test

Open a Happychat session in Calypso. Click around the Calypso interface to trigger some Tracks events. In particular, going to My Sites -> Plan will trigger an event. If you look at websocket frames in the Network inspector, you should see the socket event going through (see screenshot below).

In the HUD, you should not see anything happen.

<img width="1224" alt="screen shot 2017-05-05 at 11 17 40 am" src="https://cloud.githubusercontent.com/assets/518059/25741915/e84482a2-3184-11e7-8692-af15b15363a4.png">

