### PR TITLE
Framework: Cleanup getOption and setOption from JetpackSite

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import debugFactory from 'debug';
-
-/**
  * Internal dependencies
  */
 var wpcom = require( 'lib/wp' ),
@@ -14,8 +9,6 @@ var wpcom = require( 'lib/wp' ),
 	config = require( 'config' );
 
 inherits( JetpackSite, Site );
-
-const debug = debugFactory( 'calypso:site:jetpack' );
 
 function JetpackSite( attributes ) {
 	if ( ! ( this instanceof JetpackSite ) ) {
@@ -114,36 +107,6 @@ JetpackSite.prototype.callHome = function() {
 		this.callingHome = false;
 		this.emit( 'change' );
 	}.bind( this ) );
-};
-
-JetpackSite.prototype.getOption = function( query, callback ) {
-	wpcom.undocumented().site( this.ID ).getOption( query, function( error, data ) {
-		this.emit( 'change' );
-
-		if ( error ) {
-			debug( 'error getting option', error );
-		}
-
-		callback && callback( error, data );
-	}.bind( this ) );
-
-	this.emit( 'change' );
-};
-
-JetpackSite.prototype.setOption = function( query, callback ) {
-	query.site_option = query.site_option || false;
-	query.is_array = query.is_array || false;
-	wpcom.undocumented().site( this.ID ).setOption( query, function( error, data ) {
-		this.emit( 'change' );
-
-		if ( error ) {
-			debug( 'error getting option', error );
-		}
-
-		callback && callback( error, data );
-	}.bind( this ) );
-
-	this.emit( 'change' );
 };
 
 module.exports = JetpackSite;

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -209,7 +209,14 @@ function configure( site, plugin, dispatch ) {
 	}
 
 	const saveOption = () => {
-		return site.setOption( { option_name: option, option_value: optionValue }, ( error, data ) => {
+		const query = {
+			option_name: option,
+			option_value: optionValue,
+			site_option: false,
+			is_array: false,
+		};
+
+		return wpcom.undocumented().site( site.ID ).setOption( query, ( error, data ) => {
 			if ( ( ! error ) && ( 'vaultpress' === plugin.slug ) && versionCompare( plugin.version, '1.8.3', '>' ) ) {
 				const response = JSON.parse( data.option_value );
 				if ( 'response' === response.action && 'broken' === response.status ) {
@@ -238,7 +245,7 @@ function configure( site, plugin, dispatch ) {
 		return saveOption();
 	}
 
-	return site.getOption( { option_name: option }, ( getError, getData ) => {
+	return wpcom.undocumented().site( site.ID ).getOption( { option_name: option }, ( getError, getData ) => {
 		if ( get( getData, 'option_value' ) === optionValue ) {
 			// Already registered with this key
 			dispatch( {


### PR DESCRIPTION
This PR alters the plugin setup process to use `wpcom` directly, rather than using `getOption` and `setOption` methods from `JetpackSite`. This also allows us to remove these methods from `JetpackSite`.

To test:
* Checkout this branch.
* Go to `http://calypso.localhost:3000/plugins/setup/$site`, where `$site` is one of your Jetpack sites with Professional plan.
* Verify the setup process works correctly like before.