### PR TITLE
Themes: Don't show price for uploaded themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -523,7 +523,7 @@ const ThemeSheet = React.createClass( {
 				href={ getUrl ? getUrl( this.props.id ) : null }
 				onClick={ this.onButtonClick }>
 				{ this.isLoaded() ? label : placeholder }
-				{ this.renderPrice() }
+				{ this.props.isWpcomTheme && this.renderPrice() }
 			</Button>
 		);
 	},


### PR DESCRIPTION
Fixes #12930

For themes that are not available on wpcom, do not render the price field. Since we have no price data for themes installed in Jetpack sites, the field was always rendering as 'Free', which is not necessarily correct.

**Before**
<img width="608" alt="screen shot 2017-05-05 at 12 11 54" src="https://cloud.githubusercontent.com/assets/7767559/25743405/1b5d755c-318c-11e7-908a-5f69dcac7467.png">

**After**
<img width="616" alt="screen shot 2017-05-05 at 12 12 09" src="https://cloud.githubusercontent.com/assets/7767559/25743412/2135cdd0-318c-11e7-9049-53d944a5b0c3.png">

**To Test**
* Go to http://calypso.localhost:3000/themes/{jetpack or AT site}
* Click on an uploaded theme (after uploading one if necessary)
* Check that the main button does not have a _Free_ label

Note: the label will still show for any theme that is available on wpcom
