### PR TITLE
Editor: Update border style of publish button when disabled

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -131,6 +131,7 @@ button {
 	&.is-busy {
 		background-size: 120px 100%;
 		background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72%);
+		border-color: darken( $blue-medium, 8% );
 	}
 }
 


### PR DESCRIPTION
This updates the border style of the publish button when it is disabled on publishing. Currently, the border is set to `lighten( $gray, 30% )` when a primary button is disabled (result of #12324). In the editor, this looks a bit off since the other buttons maintain the `darken( $blue-medium, 8% )` border.

Here's a visual comparison:

<img width="1029" alt="screen shot 2017-05-05 at 06 34 19" src="https://cloud.githubusercontent.com/assets/7240478/25745598/e772a5ca-315c-11e7-99ec-6964a3cff3b1.png">

To test this, load the editor for a new post and click the publish button to publish a post. You'll see the light gray border applied briefly.