### PR TITLE
Add AT prompt in cancellation flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -488,9 +488,9 @@ const CancelPurchaseForm = React.createClass( {
 	},
 
 	render() {
-		const { translate } = this.props;
-		if ( this.props.showSurvey ) {
-			if ( this.props.surveyStep === steps.INITIAL_STEP ) {
+		const { translate, showSurvey, surveyStep } = this.props;
+		if ( showSurvey ) {
+			if ( surveyStep === steps.INITIAL_STEP ) {
 				return (
 					<div>
 						<FormSectionHeading>
@@ -506,7 +506,7 @@ const CancelPurchaseForm = React.createClass( {
 			}
 
 			// Render concierge offer if appropriate
-			if ( this.props.surveyStep === steps.CONCIERGE_STEP ) {
+			if ( surveyStep === steps.CONCIERGE_STEP ) {
 				return (
 					<div>
 						<FormSectionHeading>
@@ -517,7 +517,7 @@ const CancelPurchaseForm = React.createClass( {
 				);
 			}
 
-			if ( this.props.surveyStep === steps.HAPPYCHAT_STEP ) {
+			if ( surveyStep === steps.HAPPYCHAT_STEP ) {
 				return (
 					<div>
 						<FormSectionHeading>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -19,11 +19,7 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import HappychatButton from 'components/happychat/button';
-import {
-	INITIAL_STEP,
-	CONCIERGE_STEP,
-	HAPPYCHAT_STEP,
-} from './steps';
+import * as steps from './steps';
 
 const CancelPurchaseForm = React.createClass( {
 	propTypes: {
@@ -494,7 +490,7 @@ const CancelPurchaseForm = React.createClass( {
 	render() {
 		const { translate } = this.props;
 		if ( this.props.showSurvey ) {
-			if ( this.props.surveyStep === INITIAL_STEP ) {
+			if ( this.props.surveyStep === steps.INITIAL_STEP ) {
 				return (
 					<div>
 						<FormSectionHeading>
@@ -510,7 +506,7 @@ const CancelPurchaseForm = React.createClass( {
 			}
 
 			// Render concierge offer if appropriate
-			if ( this.props.surveyStep === CONCIERGE_STEP ) {
+			if ( this.props.surveyStep === steps.CONCIERGE_STEP ) {
 				return (
 					<div>
 						<FormSectionHeading>
@@ -521,7 +517,7 @@ const CancelPurchaseForm = React.createClass( {
 				);
 			}
 
-			if ( this.props.surveyStep === HAPPYCHAT_STEP ) {
+			if ( this.props.surveyStep === steps.HAPPYCHAT_STEP ) {
 				return (
 					<div>
 						<FormSectionHeading>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -20,6 +20,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import HappychatButton from 'components/happychat/button';
 import * as steps from './steps';
+import BusinessATStep from './stepComponents/business-at-step';
+import UpgradeATStep from './stepComponents/upgrade-at-step';
 
 const CancelPurchaseForm = React.createClass( {
 	propTypes: {
@@ -526,6 +528,14 @@ const CancelPurchaseForm = React.createClass( {
 						{ this.renderLiveChat() }
 					</div>
 				);
+			}
+
+			if ( surveyStep === steps.BUSINESS_AT_STEP ) {
+				return <BusinessATStep />;
+			}
+
+			if ( surveyStep === steps.UPGRADE_AT_STEP ) {
+				return <UpgradeATStep />;
 			}
 
 			// Render cancellation step

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormFieldset from 'components/forms/form-fieldset';
+
+export class BusinessATStep extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	}
+
+	static defaultProps = {
+		translate: noop,
+	}
+
+	render() {
+		const { translate } = this.props;
+		const href = '#';
+
+		return (
+			<div>
+				<FormSectionHeading>
+					{ translate( 'New! Install Custom Plugins and Themes' ) }
+				</FormSectionHeading>
+				<FormFieldset>
+					<p>
+						{
+							translate(
+								'Have a theme or plugin you need to install to build the site you want? ' +
+								'Now you can! To learn more about uploading third-party plugins and themes, {{a}}click here{{/a}}.',
+								{
+									components: {
+										a: <a href={ href } />
+									}
+								}
+							)
+						}
+					</p>
+					<p>
+						{
+							translate(
+								'Are you sure you want to cancel your subscription and lose access to these new features?'
+							)
+						}
+					</p>
+				</FormFieldset>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = null;
+const mapDispatchToProps = null;
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)( localize( BusinessATStep ) );

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
@@ -23,7 +23,8 @@ export class BusinessATStep extends Component {
 
 	render() {
 		const { translate } = this.props;
-		const href = '#';
+		const pluginLink = <a href="https://en.support.wordpress.com/plugins/" />;
+		const themeLink = <a href="https://en.support.wordpress.com/themes/adding-new-themes/" />;
 
 		return (
 			<div>
@@ -35,12 +36,10 @@ export class BusinessATStep extends Component {
 						{
 							translate(
 								'Have a theme or plugin you need to install to build the site you want? ' +
-								'Now you can! To learn more about uploading third-party plugins and themes, {{a}}click here{{/a}}.',
-								{
-									components: {
-										a: <a href={ href } />
-									}
-								}
+								'Now you can! ' +
+								'Learn more about {{pluginLink}}installing plugins{{/pluginLink}} and ' +
+								'{{themeLink}}uploading themes{{/themeLink}} today.',
+								{ components: { pluginLink, themeLink } }
 							)
 						}
 					</p>

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
@@ -9,6 +9,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import TrackComponentView from 'lib/analytics/track-component-view';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 
@@ -50,6 +51,10 @@ export class BusinessATStep extends Component {
 							)
 						}
 					</p>
+					<TrackComponentView
+						eventName="calypso_cancellation_business_at_impression"
+						eventProperties={ { cta_name: 'cancellation_prompt' } }
+					/>
 				</FormFieldset>
 			</div>
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
@@ -24,11 +24,11 @@ export class BusinessATStep extends Component {
 	}
 
 	onClickPluginSupport = () => {
-		this.recordTracksEvent( 'calypso_cancellation_business_at_plugin_support_click' );
+		this.props.recordTracksEvent( 'calypso_cancellation_business_at_plugin_support_click' );
 	}
 
 	onClickThemeSupport = () => {
-		this.recordTracksEvent( 'calypso_cancellation_business_at_theme_support_click' );
+		this.props.recordTracksEvent( 'calypso_cancellation_business_at_theme_support_click' );
 	}
 
 	render() {
@@ -43,6 +43,7 @@ export class BusinessATStep extends Component {
 		);
 		const themeLink = (
 			<a
+				onClick={ this.onClickThemeSupport }
 				target="_blank"
 				rel="noopener noreferrer"
 				href="https://en.support.wordpress.com/themes/adding-new-themes/"

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
@@ -9,12 +9,13 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 
 export class BusinessATStep extends Component {
 	static propTypes = {
+		recordTracksEvent: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	}
 
@@ -22,10 +23,31 @@ export class BusinessATStep extends Component {
 		translate: noop,
 	}
 
+	onClickPluginSupport = () => {
+		this.recordTracksEvent( 'calypso_cancellation_business_at_plugin_support_click' );
+	}
+
+	onClickThemeSupport = () => {
+		this.recordTracksEvent( 'calypso_cancellation_business_at_theme_support_click' );
+	}
+
 	render() {
 		const { translate } = this.props;
-		const pluginLink = <a target="_blank" rel="noopener noreferrer" href="https://en.support.wordpress.com/plugins/" />;
-		const themeLink = <a target="_blank" rel="noopener noreferrer" href="https://en.support.wordpress.com/themes/adding-new-themes/" />;
+		const pluginLink = (
+			<a
+				onClick={ this.onClickPluginSupport }
+				target="_blank"
+				rel="noopener noreferrer"
+				href="https://en.support.wordpress.com/plugins/"
+			/>
+		);
+		const themeLink = (
+			<a
+				target="_blank"
+				rel="noopener noreferrer"
+				href="https://en.support.wordpress.com/themes/adding-new-themes/"
+			/>
+		);
 
 		return (
 			<div>
@@ -51,10 +73,6 @@ export class BusinessATStep extends Component {
 							)
 						}
 					</p>
-					<TrackComponentView
-						eventName="calypso_cancellation_business_at_impression"
-						eventProperties={ { cta_name: 'cancellation_prompt' } }
-					/>
 				</FormFieldset>
 			</div>
 		);
@@ -62,7 +80,7 @@ export class BusinessATStep extends Component {
 }
 
 const mapStateToProps = null;
-const mapDispatchToProps = null;
+const mapDispatchToProps = { recordTracksEvent };
 
 export default connect(
 	mapStateToProps,

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/business-at-step.jsx
@@ -23,8 +23,8 @@ export class BusinessATStep extends Component {
 
 	render() {
 		const { translate } = this.props;
-		const pluginLink = <a href="https://en.support.wordpress.com/plugins/" />;
-		const themeLink = <a href="https://en.support.wordpress.com/themes/adding-new-themes/" />;
+		const pluginLink = <a target="_blank" rel="noopener noreferrer" href="https://en.support.wordpress.com/plugins/" />;
+		const themeLink = <a target="_blank" rel="noopener noreferrer" href="https://en.support.wordpress.com/themes/adding-new-themes/" />;
 
 		return (
 			<div>

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -27,7 +27,7 @@ export class UpgradeATStep extends Component {
 	}
 
 	onClick = () => {
-		this.recordTracksEvent( 'calypso_cancellation_business_at_plugin_support_click' );
+		this.props.recordTracksEvent( 'calypso_cancellation_business_at_plugin_support_click' );
 	}
 
 	render() {

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -10,19 +10,24 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSite } from 'state/ui/selectors';
-import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import Button from 'components/button';
 
 export class UpgradeATStep extends Component {
 	static propTypes = {
-		translate: PropTypes.func.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
 		selectedSite: PropTypes.object.isRequired,
+		translate: PropTypes.func.isRequired,
 	}
 
 	static defaultProps = {
 		translate: noop,
+	}
+
+	onClick = () => {
+		this.recordTracksEvent( 'calypso_cancellation_business_at_plugin_support_click' );
 	}
 
 	render() {
@@ -48,13 +53,9 @@ export class UpgradeATStep extends Component {
 							)
 						}
 					</p>
-					<Button primary href={ href }>
+					<Button primary href={ href } onClick={ this.onClick }>
 						{ translate( 'Upgrade My Site' ) }
 					</Button>
-					<TrackComponentView
-						eventName="calypso_cancellation_upgrade_at_impression"
-						eventProperties={ { cta_name: 'cancellation_prompt' } }
-					/>
 				</FormFieldset>
 			</div>
 		);
@@ -64,7 +65,7 @@ export class UpgradeATStep extends Component {
 const mapStateToProps = ( state ) => ( {
 	selectedSite: getSelectedSite( state )
 } );
-const mapDispatchToProps = null;
+const mapDispatchToProps = { recordTracksEvent };
 
 export default connect(
 	mapStateToProps,

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormFieldset from 'components/forms/form-fieldset';
+import Button from 'components/button';
+
+export class UpgradeATStep extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	}
+
+	static defaultProps = {
+		translate: noop,
+	}
+
+	render() {
+		const { translate } = this.props;
+		const href = '#';
+
+		return (
+			<div>
+				<FormSectionHeading>
+					{ translate( 'New! Install Custom Plugins and Themes' ) }
+				</FormSectionHeading>
+				<FormFieldset>
+					<p>
+						{
+							translate(
+								'Did you know that you can now use third-party plugins and themes on the WordPress.com Business plan? ' +
+								'Claim a 25% discount when you upgrade your site today - enter the code BIZC25 at checkout.'
+							)
+						}
+					</p>
+					<Button primary href={ href }>
+						{ translate( 'Upgrade my site' ) }
+					</Button>
+				</FormFieldset>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = null;
+const mapDispatchToProps = null;
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)( localize( UpgradeATStep ) );

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -46,7 +46,7 @@ export class UpgradeATStep extends Component {
 						}
 					</p>
 					<Button primary href={ href }>
-						{ translate( 'Upgrade my site' ) }
+						{ translate( 'Upgrade My Site' ) }
 					</Button>
 				</FormFieldset>
 			</div>

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -9,6 +9,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { getSelectedSite } from 'state/ui/selectors';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import Button from 'components/button';
@@ -16,6 +17,7 @@ import Button from 'components/button';
 export class UpgradeATStep extends Component {
 	static propTypes = {
 		translate: PropTypes.func.isRequired,
+		selectedSite: PropTypes.object.isRequired,
 	}
 
 	static defaultProps = {
@@ -23,8 +25,8 @@ export class UpgradeATStep extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
-		const href = '#';
+		const { translate, selectedSite } = this.props;
+		const href = `/checkout/${ selectedSite.slug }/business`;
 
 		return (
 			<div>
@@ -54,7 +56,9 @@ export class UpgradeATStep extends Component {
 	}
 }
 
-const mapStateToProps = null;
+const mapStateToProps = ( state ) => ( {
+	selectedSite: getSelectedSite( state )
+} );
 const mapDispatchToProps = null;
 
 export default connect(

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -36,7 +36,12 @@ export class UpgradeATStep extends Component {
 						{
 							translate(
 								'Did you know that you can now use third-party plugins and themes on the WordPress.com Business plan? ' +
-								'Claim a 25% discount when you upgrade your site today - enter the code BIZC25 at checkout.'
+								'Claim a 25% discount when you upgrade your site today - {{b}}enter the code BIZC25 at checkout{{/b}}.',
+								{
+									components: {
+										b: <strong />
+									}
+								}
 							)
 						}
 					</p>

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -10,6 +10,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSite } from 'state/ui/selectors';
+import TrackComponentView from 'lib/analytics/track-component-view';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import Button from 'components/button';
@@ -50,6 +51,10 @@ export class UpgradeATStep extends Component {
 					<Button primary href={ href }>
 						{ translate( 'Upgrade My Site' ) }
 					</Button>
+					<TrackComponentView
+						eventName="calypso_cancellation_upgrade_at_impression"
+						eventProperties={ { cta_name: 'cancellation_prompt' } }
+					/>
 				</FormFieldset>
 			</div>
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/steps.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps.js
@@ -2,3 +2,5 @@ export const INITIAL_STEP = 'initial_step';
 export const CONCIERGE_STEP = 'concierge_step';
 export const HAPPYCHAT_STEP = 'happychat_step';
 export const FINAL_STEP = 'final_step';
+export const BUSINESS_AT_STEP = 'business_at_step';
+export const UPGRADE_AT_STEP = 'upgrade_at_step';

--- a/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
@@ -6,17 +6,27 @@ import { includesProduct } from 'lib/products-values';
 import { abtest } from 'lib/abtest';
 import * as steps from './steps';
 
-const CONCIERGE_PLANS = [ plans.PLAN_BUSINESS ];
-const HAPPYCHAT_PLANS = [ plans.PLAN_PERSONAL, plans.PLAN_PREMIUM ];
+const BUSINESS_PLANS = [ plans.PLAN_BUSINESS ];
+const PERSONAL_PREMIUM_PLANS = [ plans.PLAN_PERSONAL, plans.PLAN_PREMIUM ];
 
 export default function stepsForProductAndSurvey( survey, product, canChat ) {
 	if ( survey && survey.questionOneRadio === 'tooHard' ) {
-		if ( includesProduct( CONCIERGE_PLANS, product ) ) {
+		if ( includesProduct( BUSINESS_PLANS, product ) ) {
 			return [ steps.INITIAL_STEP, steps.CONCIERGE_STEP, steps.FINAL_STEP ];
 		}
 
-		if ( canChat && includesProduct( HAPPYCHAT_PLANS, product ) && abtest( 'chatOfferOnCancel' ) === 'show' ) {
+		if ( canChat && includesProduct( PERSONAL_PREMIUM_PLANS, product ) && abtest( 'chatOfferOnCancel' ) === 'show' ) {
 			return [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
+		}
+	}
+
+	if ( survey && survey.questionOneRadio === 'couldNotInstall' ) {
+		if ( includesProduct( BUSINESS_PLANS, product ) && abtest( 'ATPromptOnCancel' ) === 'show' ) {
+			return [ steps.INITIAL_STEP, steps.BUSINESS_AT_STEP, steps.FINAL_STEP ];
+		}
+
+		if ( includesProduct( PERSONAL_PREMIUM_PLANS, product ) && abtest( 'ATUpgradeOnCancel' ) === 'show' ) {
+			return [ steps.INITIAL_STEP, steps.UPGRADE_AT_STEP, steps.FINAL_STEP ];
 		}
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
@@ -1,30 +1,24 @@
 /**
  * Internal dependencies
  */
-import {
-	PLAN_BUSINESS,
-	PLAN_PREMIUM,
-	PLAN_PERSONAL,
-} from 'lib/plans/constants';
+import * as plans from 'lib/plans/constants';
 import { includesProduct } from 'lib/products-values';
 import { abtest } from 'lib/abtest';
-import {
-	INITIAL_STEP,
-	CONCIERGE_STEP,
-	HAPPYCHAT_STEP,
-	FINAL_STEP,
-} from './steps';
+import * as steps from './steps';
+
+const CONCIERGE_PLANS = [ plans.PLAN_BUSINESS ];
+const HAPPYCHAT_PLANS = [ plans.PLAN_PERSONAL, plans.PLAN_PREMIUM ];
 
 export default function stepsForProductAndSurvey( survey, product, canChat ) {
 	if ( survey && survey.questionOneRadio === 'tooHard' ) {
-		if ( includesProduct( [ PLAN_BUSINESS ], product ) ) {
-			return [ INITIAL_STEP, CONCIERGE_STEP, FINAL_STEP ];
+		if ( includesProduct( CONCIERGE_PLANS, product ) ) {
+			return [ steps.INITIAL_STEP, steps.CONCIERGE_STEP, steps.FINAL_STEP ];
 		}
 
-		if ( canChat && includesProduct( [ PLAN_PERSONAL, PLAN_PREMIUM ], product ) && abtest( 'chatOfferOnCancel' ) === 'show' ) {
-			return [ INITIAL_STEP, HAPPYCHAT_STEP, FINAL_STEP ];
+		if ( canChat && includesProduct( HAPPYCHAT_PLANS, product ) && abtest( 'chatOfferOnCancel' ) === 'show' ) {
+			return [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
 		}
 	}
 
-	return [ INITIAL_STEP, FINAL_STEP ];
+	return [ steps.INITIAL_STEP, steps.FINAL_STEP ];
 }

--- a/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
@@ -13,6 +13,8 @@ import * as steps from '../steps';
 const DEFAULT_STEPS = [ steps.INITIAL_STEP, steps.FINAL_STEP ];
 const DEFAULT_STEPS_WITH_HAPPYCHAT = [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
 const DEFAULT_STEPS_WITH_CONCIERGE = [ steps.INITIAL_STEP, steps.CONCIERGE_STEP, steps.FINAL_STEP ];
+const DEFAULT_STEPS_WITH_UPGRADE_AT_STEP = [ steps.INITIAL_STEP, steps.UPGRADE_AT_STEP, steps.FINAL_STEP ];
+const DEFAULT_STEPS_WITH_BUSINESS_AT_STEP = [ steps.INITIAL_STEP, steps.BUSINESS_AT_STEP, steps.FINAL_STEP ];
 
 describe( 'stepsForProductAndSurvey', function() {
 	const abtests = {};
@@ -77,6 +79,46 @@ describe( 'stepsForProductAndSurvey', function() {
 		it( 'should not include concierge step if product is jetpack business plan, function() {
 			const product = { product_slug: plans.PLAN_JETPACK_BUSINESS };
 			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( DEFAULT_STEPS );
+		} );
+	} );
+
+	describe( 'question one answer is "could not install"', function() {
+		const survey = { questionOneRadio: 'couldNotInstall' };
+
+		it( 'should include AT upgrade step if product is personal plan and abtest variant is show', function() {
+			const product = { product_slug: plans.PLAN_PERSONAL };
+			abtests.ATUpgradeOnCancel = 'show';
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS_WITH_UPGRADE_AT_STEP );
+		} );
+
+		it( 'should not include AT upgrade step if product is personal plan and abtest variant is hide', function() {
+			const product = { product_slug: plans.PLAN_PERSONAL };
+			abtests.ATUpgradeOnCancel = 'hide';
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		it( 'should include AT upgrade step if product is premium plan and abtest variant is show', function() {
+			const product = { product_slug: plans.PLAN_PREMIUM };
+			abtests.ATUpgradeOnCancel = 'show';
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS_WITH_UPGRADE_AT_STEP );
+		} );
+
+		it( 'should not include AT upgrade step if product is premium plan and abtest variant is hide', function() {
+			const product = { product_slug: plans.PLAN_PREMIUM };
+			abtests.ATUpgradeOnCancel = 'hide';
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+		} );
+
+		it( 'should include business AT step if product is personal plan and abtest variant is show', function() {
+			const product = { product_slug: plans.PLAN_BUSINESS };
+			abtests.ATPromptOnCancel = 'show';
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS_WITH_BUSINESS_AT_STEP );
+		} );
+
+		it( 'should not include business AT step if product is business plan and abtest variant is hide', function() {
+			const product = { product_slug: plans.PLAN_BUSINESS };
+			abtests.ATPromptOnCancel = 'hide';
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
@@ -7,18 +7,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import useMockery from 'test/helpers/use-mockery';
-import {
-	PLAN_BUSINESS,
-	PLAN_PREMIUM,
-	PLAN_PERSONAL,
-	PLAN_JETPACK_BUSINESS,
-} from 'lib/plans/constants';
-import {
-	INITIAL_STEP,
-	CONCIERGE_STEP,
-	HAPPYCHAT_STEP,
-	FINAL_STEP,
-} from '../steps';
+import * as plans from 'lib/plans/constants';
+import * as steps from '../steps';
+
+const DEFAULT_STEPS = [ steps.INITIAL_STEP, steps.FINAL_STEP ];
+const DEFAULT_STEPS_WITH_HAPPYCHAT = [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
+const DEFAULT_STEPS_WITH_CONCIERGE = [ steps.INITIAL_STEP, steps.CONCIERGE_STEP, steps.FINAL_STEP ];
 
 describe( 'stepsForProductAndSurvey', function() {
 	const abtests = {};
@@ -35,54 +29,54 @@ describe( 'stepsForProductAndSurvey', function() {
 	} );
 
 	it( 'should return default steps if no state or product', function() {
-		expect( stepsForProductAndSurvey() ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
+		expect( stepsForProductAndSurvey() ).to.deep.equal( DEFAULT_STEPS );
 	} );
 
 	describe( 'question one answer is "too hard"', function() {
 		const survey = { questionOneRadio: 'tooHard' };
 
 		it( 'should include happychat step if product is personal plan, abtest variant is show and happychat is available', function() {
-			const product = { product_slug: PLAN_PERSONAL };
+			const product = { product_slug: plans.PLAN_PERSONAL };
 			abtests.chatOfferOnCancel = 'show';
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( [ INITIAL_STEP, HAPPYCHAT_STEP, FINAL_STEP ] );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		it( 'should not include happychat step if product is personal plan but happychat is not available', function() {
-			const product = { product_slug: PLAN_PERSONAL };
-			expect( stepsForProductAndSurvey( survey, product, false ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
+			const product = { product_slug: plans.PLAN_PERSONAL };
+			expect( stepsForProductAndSurvey( survey, product, false ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 
 		it( 'should not include happychat step if product is personal plan, happychat is available but abtest variant is hide', function() {
-			const product = { product_slug: PLAN_PERSONAL };
+			const product = { product_slug: plans.PLAN_PERSONAL };
 			abtests.chatOfferOnCancel = 'hide';
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 
 		it( 'should include happychat step if product is premium plan, abtest is show and happychat is available', function() {
-			const product = { product_slug: PLAN_PREMIUM };
+			const product = { product_slug: plans.PLAN_PREMIUM };
 			abtests.chatOfferOnCancel = 'show';
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( [ INITIAL_STEP, HAPPYCHAT_STEP, FINAL_STEP ] );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		it( 'should not include happychat step if product is premium plan but happychat is not available', function() {
-			const product = { product_slug: PLAN_PREMIUM };
-			expect( stepsForProductAndSurvey( survey, product, false ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
+			const product = { product_slug: plans.PLAN_PREMIUM };
+			expect( stepsForProductAndSurvey( survey, product, false ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 
 		it( 'should not include happychat step if product is premium plan, happychat is available but abtest is hide', function() {
-			const product = { product_slug: PLAN_PREMIUM };
+			const product = { product_slug: plans.PLAN_PREMIUM };
 			abtests.chatOfferOnCancel = 'hide';
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 
-		it( 'should include concierge step if product is business plan', function() {
-			const product = { product_slug: PLAN_BUSINESS };
-			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( [ INITIAL_STEP, CONCIERGE_STEP, FINAL_STEP ] );
+		it( 'should include concierge step if product is business plan, function() {
+			const product = { product_slug: plans.PLAN_BUSINESS };
+			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( DEFAULT_STEPS_WITH_CONCIERGE );
 		} );
 
-		it( 'should not include concierge step if product is jetpack business plan', function() {
-			const product = { product_slug: PLAN_JETPACK_BUSINESS };
-			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
+		it( 'should not include concierge step if product is jetpack business plan, function() {
+			const product = { product_slug: plans.PLAN_JETPACK_BUSINESS };
+			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
@@ -71,12 +71,12 @@ describe( 'stepsForProductAndSurvey', function() {
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 
-		it( 'should include concierge step if product is business plan, function() {
+		it( 'should include concierge step if product is business plan', function() {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( DEFAULT_STEPS_WITH_CONCIERGE );
 		} );
 
-		it( 'should not include concierge step if product is jetpack business plan, function() {
+		it( 'should not include concierge step if product is jetpack business plan', function() {
 			const product = { product_slug: plans.PLAN_JETPACK_BUSINESS };
 			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( DEFAULT_STEPS );
 		} );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -76,4 +76,20 @@ module.exports = {
 		},
 		defaultVariation: 'headlineA',
 	},
+	ATPromptOnCancel: {
+		datestamp: '20170515',
+		variations: {
+			hide: 20,
+			show: 80,
+		},
+		defaultVariation: 'hide',
+	},
+	ATUpgradeOnCancel: {
+		datestamp: '20170515',
+		variations: {
+			hide: 20,
+			show: 80,
+		},
+		defaultVariation: 'hide',
+	},
 };

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -124,7 +124,7 @@ class CancelPurchaseButton extends Component {
 		const buttons = {
 			close: {
 				action: 'close',
-				label: translate( "No, I'll Keep It" )
+				label: translate( "I'll Keep It" )
 			},
 			next: {
 				action: 'next',
@@ -140,7 +140,7 @@ class CancelPurchaseButton extends Component {
 			},
 			cancel: {
 				action: 'cancel',
-				label: translate( 'Yes, Cancel Now' ),
+				label: translate( 'Cancel Now' ),
 				isPrimary: true,
 				disabled: this.state.submitting,
 				onClick: this.submitCancelAndRefundPurchase

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -311,7 +311,7 @@ class RemovePurchase extends Component {
 			cancel: {
 				action: 'cancel',
 				disabled: this.state.isRemoving,
-				label: translate( "No, I'll Keep It" )
+				label: translate( "I'll Keep It" )
 			},
 			next: {
 				action: 'next',
@@ -329,7 +329,7 @@ class RemovePurchase extends Component {
 				action: 'remove',
 				disabled: this.state.isRemoving,
 				isPrimary: true,
-				label: translate( 'Yes, Remove Now' ),
+				label: translate( 'Remove Now' ),
 				onClick: this.removePurchase
 			}
 		};


### PR DESCRIPTION
This adds an abtest for prompts during the cancellation process if the reason given is related to using a custom theme or plugin.

Business users will be encouraged to read AT support documentation.

Personal and Premium plans will see a prompt to upgrade to the business plan.

# Testing

You will need an account with a business plan and another site with either personal or premium.

Enable tracks debug logging by running `localStorage.setItem('debug', 'calypso:analytics:tracks');` in the console and reload.

## Personal/Premium

* Ensure the `ATUpgradeOnCancel` abtest variant is set to `show`
* Navigate to `/me/purchases`
* Select the personal/premium plan
* Click 'Remove WordPress.com Premium'
* Select 'I couldn't install a plugin/theme I wanted.' for first question
* Answer anything for the second question
* Click Next
* You should see a `calypso_purchases_cancel_survey_step` tracks event with `new_step`=`upgrade_at_step` and the following upgrade prompt:

![screen shot 2017-05-17 at 4 58 35 pm](https://cloud.githubusercontent.com/assets/1926/26142028/1c5650d8-3b22-11e7-932e-b9d76438a7a0.png)

* Clicking on 'Upgrade My Site' should fire a `calypso_cancellation_business_at_plugin_support_click` tracks event and take you to `/checkout/#SITE_SLUG/business`

If either `ATUpgradeOnCancel` abtest variant is set to `hide` or the answer to the first question is not 'I couldn't install a plugin/theme I wanted.' then you will not see this step.

## Business

* Ensure the `ATPromptOnCancel` abtest variant is set to `show`
* Navigate to `/me/purchases`
* Select the personal/premium plan
* Click 'Remove WordPress.com Business'
* Select 'I couldn't install a plugin/theme I wanted.' for first question
* Answer anything for the second question
* Click Next
* You should see a `calypso_purchases_cancel_survey_step` tracks event with `new_step`=`business_at_step` and the following upgrade prompt:

![screen shot 2017-05-17 at 5 05 34 pm](https://cloud.githubusercontent.com/assets/1926/26142240/12d98a7e-3b23-11e7-9219-ac96bf3cf08c.png)

* Clicking on 'installing plugins' should fire a `calypso_cancellation_business_at_plugin_support_click` tracks event and open a new browser tab with https://en.support.wordpress.com/plugins/
* Clicking on 'uploading themes' should fire a `calypso_cancellation_business_at_theme_support_click` tracks event and open a new browser tab with https://en.support.wordpress.com/themes/adding-new-themes/
 
If either `ATPromptOnCancel` abtest variant is set to `hide` or the answer to the first question is not 'I couldn't install a plugin/theme I wanted.' then you will not see this step.