### PR TITLE
Avoid page reload after interface language is changed

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -104,15 +104,6 @@ const Account = React.createClass( {
 		this.updateUserSetting( event.target.name, event.target.checked );
 	},
 
-	updateLanguage( event ) {
-		const { value } = event.target;
-		const originalLanguage = this.props.userSettings.getOriginalSetting( 'language' );
-
-		this.updateUserSetting( 'language', value );
-		const redirect = value !== originalLanguage ? '/me/account' : false;
-		this.setState( { redirect } );
-	},
-
 	getEmailAddress() {
 		return this.hasPendingEmailChange()
 			? this.getUserSetting( 'new_user_email' )
@@ -525,7 +516,7 @@ const Account = React.createClass( {
 						onFocus={ this.recordFocusEvent( 'Interface Language Field' ) }
 						valueKey="langSlug"
 						value={ this.getUserSetting( 'language' ) || '' }
-						onChange={ this.updateLanguage }
+						onChange={ this.updateUsetSettingInput }
 					/>
 					{ this.thankTranslationContributors() }
 				</FormFieldset>

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -34,9 +34,7 @@ module.exports = {
 
 	getInitialState: function() {
 		return {
-			redirect: false,
 			submittingForm: false,
-			changingUsername: false,
 			usernameAction: 'new',
 			showNotice: false,
 		};
@@ -77,14 +75,6 @@ module.exports = {
 				}
 			} else {
 				this.props.markSaved && this.props.markSaved();
-
-				if ( this.state && this.state.redirect ) {
-					// Sometimes changes in settings require a url refresh to update the UI.
-					// For example when the user changes the language.
-					window.location = this.state.redirect + '?updated=success';
-					return;
-				}
-
 				this.setState( { showNotice: true } );
 				this.showNotice();
 				debug( 'Settings saved successfully ' + JSON.stringify( response ) );


### PR DESCRIPTION
The goal of this change is to avoid reloading the page after the interface language is changed and saved in the `me/account` form. Let's just refresh the UI in place by rerendering all React components that need to be updated!

There are several problems that need to be solved to make this work.

First, all React components that use `i18n.translate` to localize strings need to translate them again and rerender. That will happen if the component uses the `i18n.localize` HOC or the `i18n.mixin` mixin. Both will be notified by the `i18n` module and will call `forceUpdate`.

However, there are a few React components that call the `i18n.translate` function directly. (Just grep the sources to find them). These are not guaranteed to rerender. They will only if some parent calls `forceUpdate`, and there is no intermediate component that would return `shouldComponentUpdate() == true`.

Solution: migrate these `i18n.translate` callers to the `localize` HOC.

Then there are modules that call `i18n.translate` statically at module initializations. For these, the strings will never be translated again. I know about [protect-form](https://github.com/Automattic/wp-calypso/blob/master/client/lib/protect-form/index.jsx#L14-L15) doing this, and there might be others.

Second, there is some language-specific info that's rendered by the server into the index page that needs to be updated dynamically on language change. This is important mainly when switching between LTR and RTL languages:
- the `<html>` element has `lang` and `dir` attributes that need to be changed
- the `<body>` element has an `rtl` class when the language is RTL
- different stylesheets are loaded in the LTR and RTL cases. For LTR, we load `style.css`. For RTL, we load `style-rtl.css`, which is the `style.css` processed by [RTLCSS](http://rtlcss.com/). We'll need to reload the stylesheet at runtime, or find a way to merge them into one. (This would be much easier if more browsers supported CSS logical properties like `margin-block-start` or `border-inline-end`. But except Firefox, they don't.)

I pushed a commit that disables the page refresh on language change. It doesn't solve any of the problems mentioned above.