### PR TITLE
Framework: Update eslint-plugin-wpcalypso to 3.2.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,8 @@ module.exports = {
 		'no-restricted-imports': [ 2, 'lib/sites-list', 'lib/mixins/data-observe' ],
 		'no-restricted-modules': [ 2, 'lib/sites-list', 'lib/mixins/data-observe' ],
 		'no-unused-expressions': 0, // Allows Chai `expect` expressions
+		'wpcalypso/jsx-classname-namespace': [ 2, {
+			rootFiles: [ 'index.js', 'index.jsx', 'main.js', 'main.jsx' ],
+		} ],
 	}
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -703,7 +703,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000665"
+      "version": "1.0.30000666"
     },
     "caseless": {
       "version": "0.12.0"
@@ -965,7 +965,7 @@
           "version": "6.0.4"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.4"
         }
       }
     },
@@ -1580,14 +1580,14 @@
       }
     },
     "eslint-plugin-wpcalypso": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "dev": true
     },
     "esmangle-evaluator": {
       "version": "1.0.1"
     },
     "espree": {
-      "version": "3.4.2",
+      "version": "3.4.3",
       "dev": true,
       "dependencies": {
         "acorn": {
@@ -1937,7 +1937,7 @@
           "version": "4.16.6"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.4"
         }
       }
     },
@@ -2106,7 +2106,7 @@
           "version": "7.1.1"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.4"
         }
       }
     },
@@ -2843,7 +2843,7 @@
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "dev": true
         },
         "supports-color": {
@@ -2889,7 +2889,7 @@
       "dev": true,
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "dev": true
         }
       }
@@ -2942,7 +2942,7 @@
       "version": "0.1.16",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.4"
         }
       }
     },
@@ -2953,7 +2953,7 @@
       "version": "3.6.1",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.4"
         },
         "semver": {
           "version": "5.3.0"
@@ -3043,7 +3043,7 @@
       }
     },
     "npmlog": {
-      "version": "4.0.2"
+      "version": "4.1.0"
     },
     "nth-check": {
       "version": "1.0.1",
@@ -3530,7 +3530,7 @@
       "version": "2.1.0",
       "dependencies": {
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.4"
         },
         "readable-stream": {
           "version": "2.2.9"
@@ -3723,7 +3723,7 @@
           "version": "7.1.1"
         },
         "minimatch": {
-          "version": "3.0.3"
+          "version": "3.0.4"
         }
       }
     },
@@ -4745,15 +4745,19 @@
           "dev": true
         },
         "engine.io": {
-          "version": "1.8.3",
+          "version": "1.8.4",
           "dev": true
         },
         "engine.io-client": {
-          "version": "1.8.3",
+          "version": "1.8.4",
           "dev": true,
           "dependencies": {
             "component-emitter": {
               "version": "1.2.1",
+              "dev": true
+            },
+            "ws": {
+              "version": "1.1.2",
               "dev": true
             }
           }
@@ -4795,7 +4799,7 @@
           "dev": true
         },
         "socket.io": {
-          "version": "1.7.3",
+          "version": "1.7.4",
           "dev": true
         },
         "socket.io-adapter": {
@@ -4803,7 +4807,7 @@
           "dev": true
         },
         "socket.io-client": {
-          "version": "1.7.3",
+          "version": "1.7.4",
           "dev": true,
           "dependencies": {
             "component-emitter": {
@@ -4827,7 +4831,7 @@
           }
         },
         "ws": {
-          "version": "1.1.2",
+          "version": "1.1.4",
           "dev": true
         },
         "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "eslint": "3.8.1",
     "eslint-config-wpcalypso": "0.6.0",
     "eslint-plugin-react": "6.4.1",
-    "eslint-plugin-wpcalypso": "3.1.1",
+    "eslint-plugin-wpcalypso": "3.2.0",
     "glob": "7.0.3",
     "jscodeshift": "0.3.30",
     "lodash-deep": "1.5.3",


### PR DESCRIPTION
This configures calypso's `wpcalypso/jsx-classname-namespace` rule to allow root components in `main.jsx` files. 

It removes a couple ( 5 if my greps are right ) of false positives + a false positive in the Hello World example from the devdocs.

A deeper discussion about this can be found on [eslint-plugin-wpcalypso PR#34](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/34) 

PS: I followed the [shrinkwrap devdocs](https://wpcalypso.wordpress.com/devdocs/docs/shrinkwrap.md) but it's the first time I play with shrinkmaps so there might be something I missed ;) , 