### PR TITLE
Adds number input styling to affix component. closes #13716

### DIFF
--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -14,7 +14,8 @@
 	input[type="email"],
 	input[type="password"],
 	input[type="url"],
-	input[type="text"] {
+	input[type="text"],
+	input[type="number"] {
 		flex-grow: 1;
 
 		&:focus {


### PR DESCRIPTION
This 'fixes' the outline of number inputs appearing 'beneath' the suffix.

Before:

![suffix](https://cldup.com/4brjkloV8d-3000x3000.png)

After:

![suffix-new](https://cldup.com/4ICZkA0U7X-3000x3000.png)