### PR TITLE
Site Settings: add blog posts per page setting

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -329,6 +329,35 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	postsPerPageOption() {
+		const { eventTracker, fields, isRequestingSettings, onChangeField, translate, uniqueEventTracker } = this.props;
+		const showPostsPerPage = ( 'undefined' !== typeof fields.posts_per_page );
+
+		return showPostsPerPage && (
+			<FormFieldset className="site-settings__has-divider is-top-only">
+				<FormLabel htmlFor="posts_per_page">{ translate( 'Posts Per Page' ) }</FormLabel>
+				<ul>
+					<li>
+						<FormInput
+							name="posts_per_page"
+							type="number"
+							step="1"
+							min="1"
+							id="posts_per_page"
+							value={ fields.posts_per_page || '' }
+							onChange={ onChangeField( 'posts_per_page' ) }
+							disabled={ isRequestingSettings }
+							onClick={ eventTracker( 'Clicked Posts Per Page Field' ) }
+							onKeyPress={ uniqueEventTracker( 'Typed in Posts Per Page Field' ) } />
+							<FormSettingExplanation>
+								{ translate( 'On blog pages, the number of posts to show per page.' ) }
+							</FormSettingExplanation>
+					</li>
+				</ul>
+			</FormFieldset>
+		);
+	}
+
 	Timezone() {
 		const { fields, isRequestingSettings, siteIsJetpack, translate } = this.props;
 		if ( siteIsJetpack ) {
@@ -443,6 +472,7 @@ class SiteSettingsFormGeneral extends Component {
 						{ this.languageOptions() }
 						{ this.Timezone() }
 						{ this.holidaySnowOption() }
+						{ this.postsPerPageOption() }
 					</form>
 				</Card>
 
@@ -573,6 +603,7 @@ const getFormSettings = settings => {
 		jetpack_sync_non_public_post_stati: false,
 		holidaysnow: false,
 		api_cache: false,
+		posts_per_page: '',
 	};
 
 	if ( ! settings ) {
@@ -591,6 +622,8 @@ const getFormSettings = settings => {
 		holidaysnow: !! settings.holidaysnow,
 
 		api_cache: settings.api_cache,
+
+		posts_per_page: settings.posts_per_page,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -344,7 +344,7 @@ class SiteSettingsFormGeneral extends Component {
 							step="1"
 							min="1"
 							id="posts_per_page"
-							value={ fields.posts_per_page || '' }
+							value={ fields.posts_per_page || 10 }
 							onChange={ onChangeField( 'posts_per_page' ) }
 							disabled={ isRequestingSettings }
 							onClick={ eventTracker( 'Clicked Posts Per Page Field' ) }


### PR DESCRIPTION
This PR adds a setting to adjust the `posts_per_page` option to the "Site Profile" section of a site's "General" settings.

![image](https://cloud.githubusercontent.com/assets/363749/25755356/51bdde38-3188-11e7-8ca4-7009e6b82ff6.png)

The setting only shows up when the API returns the current settings.

To test:

* Visit the settings page for your site, and make sure that the setting does not appear when the API response lacks the current value.
* Apply D5487-code
* Reload the page and make sure that the setting appears at the bottom of the "Site Profile" section.
* Adjust and save the value, and make sure it matches the setting you see in wp-admin.