### PR TITLE
[REDO] Happychat: Add hooks for more verbose Tracks events

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -81,6 +81,23 @@ class Connection extends EventEmitter {
 		);
 	}
 
+	// This is a temporary measure — we want to start sending some events that are
+	// picked up by the staged HUD but not by the production HUD. The only way to do this
+	// now is to send a different event type, and make the staging HUD render this event.
+	// Once the HUD side ships to production, we should delete this function and just use
+	// sendEvent for event messages.
+	sendStagingEvent( message ) {
+		this.openSocket.then(
+			socket => socket.emit( 'message', {
+				text: message,
+				id: uuid(),
+				type: 'customer-event-staging',
+				meta: { forOperator: true, event_type: 'customer-event-staging' }
+			} ),
+			e => debug( 'failed to send message', e )
+		);
+	}
+
 	sendLog( message ) {
 		this.openSocket.then(
 			socket => socket.emit( 'message', {

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -365,7 +365,9 @@ describe( 'middleware', () => {
 			const analyticsMeta = [
 				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'calypso_add_new_wordpress_click' } },
 				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'abc' } },
-				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'calypso_themeshowcase_theme_activate', properties: {} } },
+				{ type: ANALYTICS_EVENT_RECORD, payload: {
+					service: 'tracks', name: 'calypso_themeshowcase_theme_activate', properties: {}
+				} },
 				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'def' } },
 			];
 			sendAnalyticsLogEvent( connection, { getState }, { meta: { analytics: analyticsMeta } } );

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -303,9 +303,14 @@ describe( 'middleware', () => {
 		useSandbox( sandbox => {
 			connection = {
 				sendLog: sandbox.stub(),
+				sendStagingEvent: sandbox.stub(),
 			};
 
-			getState = sandbox.stub().returns( assignedState );
+			getState = sandbox.stub();
+		} );
+
+		beforeEach( () => {
+			getState.returns( assignedState );
 		} );
 
 		it( 'should ignore non-tracks analytics recordings', () => {
@@ -316,7 +321,8 @@ describe( 'middleware', () => {
 			];
 			sendAnalyticsLogEvent( connection, { getState }, { meta: { analytics: analyticsMeta } } );
 
-			expect( connection.sendLog ).not.to.have.beenCalled;
+			expect( connection.sendLog ).not.to.have.been.called;
+			expect( connection.sendStagingEvent ).not.to.have.been.called;
 		} );
 
 		it( 'should send log events for all listed tracks events', () => {
@@ -341,6 +347,7 @@ describe( 'middleware', () => {
 			sendAnalyticsLogEvent( connection, { getState }, { meta: { analytics: analyticsMeta } } );
 
 			expect( connection.sendLog ).not.to.have.been.called;
+			expect( connection.sendStagingEvent ).not.to.have.been.called;
 		} );
 
 		it( 'should only send log events if the Happychat connection is assigned', () => {
@@ -351,6 +358,19 @@ describe( 'middleware', () => {
 			sendAnalyticsLogEvent( connection, { getState }, { meta: { analytics: analyticsMeta } } );
 
 			expect( connection.sendLog ).not.to.have.been.called;
+			expect( connection.sendStagingEvent ).not.to.have.been.called;
+		} );
+
+		it( 'should only send a timeline event for whitelisted tracks events', () => {
+			const analyticsMeta = [
+				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'calypso_add_new_wordpress_click' } },
+				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'abc' } },
+				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'calypso_themeshowcase_theme_activate', properties: {} } },
+				{ type: ANALYTICS_EVENT_RECORD, payload: { service: 'tracks', name: 'def' } },
+			];
+			sendAnalyticsLogEvent( connection, { getState }, { meta: { analytics: analyticsMeta } } );
+
+			expect( connection.sendStagingEvent.callCount ).to.equal( 2 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This is a re-do of PR https://github.com/Automattic/wp-calypso/pull/13713

I forgot to merge that PR into `master`, but just into the parent branch (which had already been merged into `master`). The diff is the same and so this will be merged now.