### PR TITLE
Reader: Hook up the redux follow button and sync

### DIFF
--- a/client/blocks/follow-button/redux.jsx
+++ b/client/blocks/follow-button/redux.jsx
@@ -1,0 +1,60 @@
+/**
+ * External Dependencies
+ */
+import React, { Component } from 'react';
+import { noop } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import FollowButton from './button';
+import { isFollowing } from 'state/selectors';
+import { follow, unfollow } from 'state/reader/follows/actions';
+
+class FollowButtonContainer extends Component {
+	static propTypes = {
+		siteUrl: React.PropTypes.string.isRequired,
+		iconSize: React.PropTypes.number,
+		onFollowToggle: React.PropTypes.func,
+		followLabel: React.PropTypes.string,
+		followingLabel: React.PropTypes.string
+	}
+
+	static defaultProps = {
+		onFollowToggle: noop
+	}
+
+	handleFollowToggle = ( following ) => {
+		if ( following ) {
+			this.props.follow( this.props.siteUrl );
+		} else {
+			this.props.unfollow( this.props.siteUrl );
+		}
+		this.props.onFollowToggle( following );
+	}
+
+	render() {
+		return (
+			<FollowButton
+				following={ this.props.following }
+				onFollowToggle={ this.handleFollowToggle }
+				iconSize={ this.props.iconSize }
+				tagName={ this.props.tagName }
+				disabled={ this.props.disabled }
+				followLabel={ this.props.followLabel }
+				followingLabel={ this.props.followingLabel }
+				className={ this.props.className } />
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		following: isFollowing( state, { feedUrl: ownProps.siteUrl } )
+	} ),
+	{
+		follow,
+		unfollow
+	}
+)( FollowButtonContainer );

--- a/client/components/reader-main/index.jsx
+++ b/client/components/reader-main/index.jsx
@@ -2,11 +2,13 @@
  * External Dependencies
  */
 import React from 'react';
+import config from 'config';
 
 /**
  * Internal Dependencies
  */
 import Main from 'components/main';
+import SyncReaderFollows from 'components/data/sync-reader-follows';
 
 /**
  * A specialization of `Main` that adds a class to the body of the document
@@ -24,6 +26,11 @@ export default class ReaderMain extends React.Component {
 	}
 
 	render() {
-		return ( <Main { ...this.props } /> );
+		const { children, ...props } = this.props;
+		return ( <Main { ...props } >
+			{ config.isEnabled( 'reader/following-manage-refresh' ) &&
+				<SyncReaderFollows key="syncReaderFollows" /> }
+			{ children }
+		</Main> );
 	}
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -5,6 +5,7 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal Dependencies
@@ -124,7 +125,9 @@ const exported = {
 	},
 
 	loadSubscriptions( context, next ) {
-		FeedSubscriptionActions.fetchAll();
+		if ( ! config.isEnabled( 'reader/following-manage-refresh' ) ) {
+			FeedSubscriptionActions.fetchAll();
+		}
 		next();
 	},
 

--- a/client/reader/follow-button/flux.jsx
+++ b/client/reader/follow-button/flux.jsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import FollowButtonContainer from 'blocks/follow-button';
+import FollowButton from 'blocks/follow-button/button';
+import {
+	recordFollow as recordFollowTracks,
+	recordUnfollow as recordUnfollowTracks,
+} from 'reader/stats';
+import {
+	recordFollow as recordFollowAction,
+	recordUnfollow as recordUnfollowAction,
+} from 'state/reader/follows/actions';
+
+function ReaderFollowButton( props ) {
+	const {
+		onFollowToggle,
+		railcar,
+		followSource,
+		isButtonOnly,
+		dispatchRecordFollow,
+		dispatchRecordUnfollow,
+		siteUrl,
+	} = props;
+
+	function recordFollowToggle( isFollowing ) {
+		if ( isFollowing ) {
+			dispatchRecordFollow( siteUrl );
+			recordFollowTracks( siteUrl, railcar, { follow_source: followSource } );
+		} else {
+			dispatchRecordUnfollow( siteUrl );
+			recordUnfollowTracks( siteUrl, railcar, { follow_source: followSource } );
+		}
+
+		if ( onFollowToggle ) {
+			onFollowToggle( isFollowing );
+		}
+	}
+
+	if ( isButtonOnly ) {
+		return (
+			<FollowButton { ...props } onFollowToggle={ recordFollowToggle } />
+		);
+	}
+
+	return (
+		<FollowButtonContainer { ...props } onFollowToggle={ recordFollowToggle } />
+	);
+}
+
+ReaderFollowButton.propTypes = {
+	onFollowToggle: React.PropTypes.func,
+	railcar: React.PropTypes.object,
+	followSource: React.PropTypes.string,
+};
+
+export default connect(
+	( state ) => ( {} ), // eslint-disable-line no-unused-vars
+	( dispatch ) => bindActionCreators( {
+		dispatchRecordFollow: recordFollowAction,
+		dispatchRecordUnfollow: recordUnfollowAction,
+	}, dispatch ),
+	null,
+	{ pure: true } // TODO: is this component pure?
+)( ReaderFollowButton );

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -1,72 +1,14 @@
 /**
- * External dependencies
+ * External Dependencies
  */
-import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import config from 'config';
 
 /**
- * Internal dependencies
+ * Internal Dependencies
  */
-import FollowButtonContainer from 'blocks/follow-button';
-import FollowButton from 'blocks/follow-button/button';
-import {
-	recordFollow as recordFollowTracks,
-	recordUnfollow as recordUnfollowTracks,
-} from 'reader/stats';
-import {
-	recordFollow as recordFollowAction,
-	recordUnfollow as recordUnfollowAction,
-} from 'state/reader/follows/actions';
+import FluxButton from './flux';
+import ReduxButton from './redux';
 
-function ReaderFollowButton( props ) {
-	const {
-		onFollowToggle,
-		railcar,
-		followSource,
-		isButtonOnly,
-		dispatchRecordFollow,
-		dispatchRecordUnfollow,
-		siteUrl,
-	} = props;
-
-	function recordFollowToggle( isFollowing ) {
-		if ( isFollowing ) {
-			dispatchRecordFollow( siteUrl );
-			recordFollowTracks( siteUrl, railcar, { follow_source: followSource } );
-		} else {
-			dispatchRecordUnfollow( siteUrl );
-			recordUnfollowTracks( siteUrl, railcar, { follow_source: followSource } );
-		}
-
-		if ( onFollowToggle ) {
-			onFollowToggle( isFollowing );
-		}
-	}
-
-	if ( isButtonOnly ) {
-		return (
-			<FollowButton { ...props } onFollowToggle={ recordFollowToggle } />
-		);
-	}
-
-	return (
-		<FollowButtonContainer { ...props } onFollowToggle={ recordFollowToggle } />
-	);
-}
-
-ReaderFollowButton.propTypes = {
-	onFollowToggle: React.PropTypes.func,
-	railcar: React.PropTypes.object,
-	followSource: React.PropTypes.string,
-};
-
-export default connect(
-	( state ) => ( {} ), // eslint-disable-line no-unused-vars
-	( dispatch ) => bindActionCreators( {
-		dispatchRecordFollow: recordFollowAction,
-		dispatchRecordUnfollow: recordUnfollowAction,
-	}, dispatch ),
-	null,
-	{ pure: true } // TODO: is this component pure?
-)( ReaderFollowButton );
+module.exports = config.isEnabled( 'reader/following-manage-refresh' )
+   ? ReduxButton
+   : FluxButton;

--- a/client/reader/follow-button/redux.jsx
+++ b/client/reader/follow-button/redux.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FollowButtonContainer from 'blocks/follow-button/redux';
+import FollowButton from 'blocks/follow-button/button';
+import {
+	recordFollow as recordFollowTracks,
+	recordUnfollow as recordUnfollowTracks,
+} from 'reader/stats';
+
+function ReaderFollowButton( props ) {
+	const {
+		onFollowToggle,
+		railcar,
+		followSource,
+		isButtonOnly,
+		siteUrl,
+	} = props;
+
+	function recordFollowToggle( isFollowing ) {
+		if ( isFollowing ) {
+			recordFollowTracks( siteUrl, railcar, { follow_source: followSource } );
+		} else {
+			recordUnfollowTracks( siteUrl, railcar, { follow_source: followSource } );
+		}
+
+		if ( onFollowToggle ) {
+			onFollowToggle( isFollowing );
+		}
+	}
+
+	if ( isButtonOnly ) {
+		return (
+			<FollowButton { ...props } onFollowToggle={ recordFollowToggle } />
+		);
+	}
+
+	return (
+		<FollowButtonContainer { ...props } onFollowToggle={ recordFollowToggle } />
+	);
+}
+
+ReaderFollowButton.propTypes = {
+	onFollowToggle: React.PropTypes.func,
+	railcar: React.PropTypes.object,
+	followSource: React.PropTypes.string,
+};
+
+export default ReaderFollowButton;


### PR DESCRIPTION
Adds in a new redux-bound follow button and hooks that up in the UI if the `reader/follow-manage-refresh` is active. Also hooks up the sync to make the button light up.