### PR TITLE
Happychat: Add event message for featured image changes

### DIFF
--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -165,6 +165,8 @@ export const getEventMessageFromTracksData = ( { name, properties } ) => {
 			return 'Clicked "Add new site" button';
 		case 'calypso_themeshowcase_theme_activate':
 			return `Changed theme from "${ properties.previous_theme }" to "${ properties.theme }"`;
+		case 'calypso_editor_featured_image_upload':
+			return 'Changed the featured image on the current post';
 	}
 	return null;
 };


### PR DESCRIPTION
Notifies operators when a user changes the featured image of a post.

### To test

Start a Happychat session. Then navigate to a post and change the featured image. In the HUD hyou should see the message "Changed the featured image on the current post"