### PR TITLE
Updated style of Page card for hierarchical view

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -289,6 +289,7 @@
 @import 'my-sites/no-results/style';
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
+@import 'my-sites/pages/page-card-info/style';
 @import 'my-sites/people/delete-user/style';
 @import 'my-sites/people/edit-team-member-form/style';
 @import 'my-sites/people/people-list-item/style';

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -16,7 +16,7 @@
 .blog-posts-page__title {
 	display: inline;
 	color: $gray-dark;
-	font-weight: 500;
+	font-weight: bold;
 	font-family: $serif;
 	margin-right: 33px;
 
@@ -26,7 +26,7 @@
 }
 
 .blog-posts-page__info {
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	margin: 0 33px 0 0;
 

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isFrontPage,
+	isPostsPage,
+} from 'state/pages/selectors';
+
+function PageCardInfo( { translate, moment, page, showTimestamp, isFront, isPosts, siteUrl } ) {
+	const iconSize = 12;
+
+	return (
+		<div className="page-card-info">
+			{ siteUrl &&
+				<div className="page-card-info__site-url">
+					{ siteUrl }
+				</div>
+			}
+			<div>
+				{ showTimestamp &&
+					<span className="page-card-info__item">
+						<Gridicon icon="time" size={ iconSize } className="page-card-info__item-icon" />
+						<span className="page-card-info__item-text">
+							{ moment( page.modified ).fromNow() }
+						</span>
+					</span>
+				}
+				{ isFront &&
+					<span className="page-card-info__item">
+						<Gridicon icon="house" size={ iconSize } className="page-card-info__item-icon" />
+						<span className="page-card-info__item-text">
+							{ translate( 'Front page' ) }
+						</span>
+					</span>
+				}
+				{ isPosts &&
+					<span className="page-card-info__item">
+						<Gridicon icon="posts" size={ iconSize } className="page-card-info__item-icon" />
+						<span className="page-card-info__item-text">
+							{ translate( 'Your latest posts' ) }
+						</span>
+					</span>
+				}
+			</div>
+		</div>
+	);
+}
+
+export default connect(
+	( state, props ) => {
+		return {
+			isFront: isFrontPage( state, props.page.site_ID, props.page.ID ),
+			isPosts: isPostsPage( state, props.page.site_ID, props.page.ID ),
+		};
+	}
+)( localize( PageCardInfo ) );

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -1,0 +1,31 @@
+.page-card-info {
+	color: $gray-text-min;
+	font-size: 12px;
+	vertical-align: middle;
+}
+
+.page-card-info__item {
+	display: inline-block;
+	margin-right: 12px;
+}
+
+.page-card-info__item-icon {
+	margin-right: 4px;
+}
+
+.page-card-info__item-icon,
+.page-card-info__item-text {
+	vertical-align: middle;
+}
+
+.page-card-info__item-text {
+	line-height: 1;
+
+	&::first-letter {
+		text-transform: capitalize;
+	}
+}
+
+.page-card-info__site-url {
+	font-style: italic;
+}

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -25,6 +25,7 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	classNames = require( 'classnames' );
 
 import MenuSeparator from 'components/popover/menu-separator';
+import PageCardInfo from './page-card-info';
 import { hasStaticFrontPage, isSitePreviewable } from 'state/sites/selectors';
 import {
 	isFrontPage,
@@ -403,19 +404,23 @@ const Page = React.createClass( {
 			<CompactCard className={ classNames( cardClasses ) } >
 				{ hierarchyIndent }
 				{ this.props.multisite ? <SiteIcon site={ site } size={ 34 } /> : null }
-				<a className="page__title"
-					href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
-					title={ canEdit ?
-						this.translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } ) :
-						this.translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } ) }
-					onClick={ this.analyticsEvents.pageTitle }
-					>
-					{ depthIndicator }
-					{ this.props.isFrontPage ? <Gridicon icon="house" size={ 18 } /> : null }
-					{ title }
-				</a>
-				{ this.props.isPostsPage ? <div className="page__posts-page">{ this.translate( 'Your latest posts' ) }</div> : null }
-				{ this.props.multisite ? <span className="page__site-url">{ this.getSiteDomain() }</span> : null }
+				<div className="page__main">
+					<a className="page__title"
+						href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
+						title={ canEdit ?
+							this.translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } ) :
+							this.translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } ) }
+						onClick={ this.analyticsEvents.pageTitle }
+						>
+						{ depthIndicator }
+						{ title }
+					</a>
+					<PageCardInfo
+						page={ page }
+						showTimestamp={ this.props.hierarchical }
+						siteUrl={ this.props.multisite && this.getSiteDomain() }
+					/>
+				</div>
 				{ ellipsisGridicon }
 				{ popoverMenu }
 				<ReactCSSTransitionGroup

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -36,14 +36,16 @@
 
 // <Page> component
 .page {
+	align-items: center;
+	display: flex;
 
 	.site-icon {
 		display: none;
 
 		@include breakpoint( ">660px" ) {
 			display: block;
-			float: left;
 			margin-right: 10px;
+			min-width: 34px;
 		}
 	}
 
@@ -123,11 +125,15 @@
 	}
 }
 
+.page__main {
+	flex-grow: 1;
+}
+
 .page__title,
 .page__title:visited {
 	display: inline;
 	color: $gray-dark;
-	font-weight: 500;
+	font-weight: bold;
 	font-family: $serif;
 	margin-right: 33px;
 
@@ -137,29 +143,12 @@
 	}
 }
 
-.page__posts-page {
-	color: $gray;
-	display: block;
-	font-size: 12px;
-	margin-top: -3px;
-}
-
-.page__site-url {
-	color: $gray;
-	display: block;
-	font-size: 12px;
-	font-style: italic;
-	margin-top: -3px;
-}
-
 .page__actions-toggle {
-	color: $gray;
+	color: $gray-text-min;
 	cursor: pointer;
 	font-size: 24px;
-	margin: 17px 24px;
-	position: absolute;
-		right: 0;
-		top: 0;
+	margin-left: 24px;
+	min-width: 24px;
 	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
 	&.is-active {


### PR DESCRIPTION
This PR merges the styling changes for the hierarchical Pages view into the feature branch for hierarchical Pages. Some styling for non-hierarchical views (like all sites) was updated as well, for consistency. A slightly darker shade of gray (`$gray-text-min`) was used (vs. the mockup) for the info under the page title, in order to be more accessible -- this is also the same color used for similar information on the Posts screen.

Mockup:

![hierarchical](https://cloud.githubusercontent.com/assets/2098816/25762744/fc68b05e-31ad-11e7-9df6-b12e494c45f4.png)

Hierarchical view before:

![screencapture at fri may 5 16 10 42 edt 2017](https://cloud.githubusercontent.com/assets/2098816/25762620/74a5ee66-31ad-11e7-88e4-13a98652fcc6.png)

Hierarchical view after:

![screencapture at fri may 5 15 59 41 edt 2017](https://cloud.githubusercontent.com/assets/2098816/25762633/85cf61f4-31ad-11e7-9125-65cf7ce22205.png)

All sites view before:

![screencapture at fri may 5 16 10 54 edt 2017](https://cloud.githubusercontent.com/assets/2098816/25762645/978abda8-31ad-11e7-92c4-f9653b276b94.png)

All sites view after:

![screencapture at fri may 5 16 00 27 edt 2017](https://cloud.githubusercontent.com/assets/2098816/25762657/a1493022-31ad-11e7-8ffa-078039258445.png)

To test:

- Run branch and make sure things look as intended in hierarchical view
- Make sure no text is cutoff, especially when using a smaller window or a mobile device
- Make sure all Pages views (hierarchical as well as non-hierarchical) still present information in a readable, clean manner, with a design consistent with the rest of Calypso