### PR TITLE
WooCommerce: Add header to product create page.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -18,6 +18,7 @@ import { editProductVariation } from '../../state/ui/products/variations/actions
 import { fetchProductCategories } from '../../state/wc-api/product-categories/actions';
 import { getProductCategories } from '../../state/wc-api/product-categories/selectors';
 import ProductForm from './product-form';
+import ProductHeader from './product-header';
 
 class ProductCreate extends React.Component {
 	static propTypes = {
@@ -55,11 +56,28 @@ class ProductCreate extends React.Component {
 		// TODO: Remove the product we added here from the edit state.
 	}
 
+	onTrash = () => {
+		// TODO: Add action dispatch to trash this product.
+	}
+
+	onDuplicate = () => {
+		// TODO: Add action dispatch to duplicate this product.
+	}
+
+	onSave = () => {
+		// TODO: Add action dispatch to save this product.
+	}
+
 	render() {
 		const { product, className, variations, productCategories } = this.props;
 
 		return (
 			<Main className={ className }>
+				<ProductHeader
+					onTrash={ this.onTrash }
+					onDuplicate={ this.onDuplicate }
+					onSave={ this.onSave }
+				/>
 				<ProductForm
 					product={ product || { type: 'simple' } }
 					variations={ variations }

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -60,10 +60,6 @@ class ProductCreate extends React.Component {
 		// TODO: Add action dispatch to trash this product.
 	}
 
-	onDuplicate = () => {
-		// TODO: Add action dispatch to duplicate this product.
-	}
-
 	onSave = () => {
 		// TODO: Add action dispatch to save this product.
 	}
@@ -75,7 +71,6 @@ class ProductCreate extends React.Component {
 			<Main className={ className }>
 				<ProductHeader
 					onTrash={ this.onTrash }
-					onDuplicate={ this.onDuplicate }
 					onSave={ this.onSave }
 				/>
 				<ProductForm

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import StickyPanel from 'components/sticky-panel';
+
+const ProductHeader = ( { onTrash, onDuplicate, onSave, translate } ) => {
+	const trashButton = onTrash &&
+		<Button borderless onClick={ onTrash }><Gridicon icon="trash" /></Button>;
+
+	const duplicateButton = onDuplicate &&
+		<Button onClick={ onDuplicate }>{ translate( 'Duplicate' ) }</Button>;
+
+	const saveButton = onSave &&
+		<Button primary onClick={ onSave }>{ translate( 'Save' ) }</Button>;
+
+	return (
+		<StickyPanel>
+			<Card className="products__header">
+				<span>Breadcrumbs > go > here</span>
+				<div className="products__header-right">
+					{ trashButton }
+					{ duplicateButton }
+					{ saveButton }
+				</div>
+			</Card>
+		</StickyPanel>
+	);
+};
+
+ProductHeader.propTypes = {
+	onTrash: PropTypes.func,
+	onDuplicate: PropTypes.func,
+	onSave: PropTypes.func,
+};
+
+export default localize( ProductHeader );
+

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -11,12 +11,9 @@ import Gridicon from 'gridicons';
 import ActionHeader from '../../components/action-header';
 import Button from 'components/button';
 
-const ProductHeader = ( { onTrash, onDuplicate, onSave, translate } ) => {
+const ProductHeader = ( { onTrash, onSave, translate } ) => {
 	const trashButton = onTrash &&
 		<Button borderless onClick={ onTrash }><Gridicon icon="trash" /></Button>;
-
-	const duplicateButton = onDuplicate &&
-		<Button onClick={ onDuplicate }>{ translate( 'Duplicate' ) }</Button>;
 
 	const saveButton = onSave &&
 		<Button primary onClick={ onSave }>{ translate( 'Save' ) }</Button>;
@@ -24,7 +21,6 @@ const ProductHeader = ( { onTrash, onDuplicate, onSave, translate } ) => {
 	return (
 		<ActionHeader>
 			{ trashButton }
-			{ duplicateButton }
 			{ saveButton }
 		</ActionHeader>
 	);
@@ -32,7 +28,6 @@ const ProductHeader = ( { onTrash, onDuplicate, onSave, translate } ) => {
 
 ProductHeader.propTypes = {
 	onTrash: PropTypes.func,
-	onDuplicate: PropTypes.func,
 	onSave: PropTypes.func,
 };
 

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -8,9 +8,8 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import ActionHeader from '../../components/action-header';
 import Button from 'components/button';
-import StickyPanel from 'components/sticky-panel';
 
 const ProductHeader = ( { onTrash, onDuplicate, onSave, translate } ) => {
 	const trashButton = onTrash &&
@@ -23,16 +22,11 @@ const ProductHeader = ( { onTrash, onDuplicate, onSave, translate } ) => {
 		<Button primary onClick={ onSave }>{ translate( 'Save' ) }</Button>;
 
 	return (
-		<StickyPanel>
-			<Card className="products__header">
-				<span>Breadcrumbs > go > here</span>
-				<div className="products__header-right">
-					{ trashButton }
-					{ duplicateButton }
-					{ saveButton }
-				</div>
-			</Card>
-		</StickyPanel>
+		<ActionHeader>
+			{ trashButton }
+			{ duplicateButton }
+			{ saveButton }
+		</ActionHeader>
 	);
 };
 

--- a/client/extensions/woocommerce/components/action-header.js
+++ b/client/extensions/woocommerce/components/action-header.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import StickyPanel from 'components/sticky-panel';
+
+const ActionHeader = ( { children } ) => {
+	// TODO: Implement breadcrumbs component.
+
+	return (
+		<StickyPanel>
+			<Card className="components__action-header">
+				<span>Breadcrumbs > go > here</span>
+				<div className="components__action-header-actions">
+					{ children }
+				</div>
+			</Card>
+		</StickyPanel>
+	);
+};
+
+export default ActionHeader;
+

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -14,9 +14,9 @@ const ActionHeader = ( { children } ) => {
 
 	return (
 		<StickyPanel>
-			<Card className="components__action-header">
+			<Card className="action-header__header">
 				<span>Breadcrumbs > go > here</span>
-				<div className="components__action-header-actions">
+				<div className="action-header__actions">
 					{ children }
 				</div>
 			</Card>

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -1,0 +1,14 @@
+
+.action-header__header {
+	width: 100%;
+}
+
+.action-header__actions {
+	position: absolute;
+	top: 16px;
+	right: 24px;
+
+	.button {
+		margin-left: 8px;
+	}
+}

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -9,6 +9,6 @@
 	right: 24px;
 
 	.button {
-		margin-left: 8px;
+		margin-left: 16px;
 	}
 }

--- a/client/extensions/woocommerce/state/wc-api/error-reducer.js
+++ b/client/extensions/woocommerce/state/wc-api/error-reducer.js
@@ -34,4 +34,3 @@ function clearApiError( siteState ) {
 
 	return { ...remaining };
 }
-

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -17,6 +17,19 @@
 	@import 'app/settings/shipping/style';
 	@import 'components/list/style';
 
+	.products__header {
+		width: 100%;
+	}
+
+	.products__header-right {
+		position: absolute;
+		top: 16px;
+		right: 24px;
+
+		.button {
+			margin-left: 8px;
+		}
+	}
 }
 
 .store-sidebar__sidebar {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -17,11 +17,11 @@
 	@import 'app/settings/shipping/style';
 	@import 'components/list/style';
 
-	.products__header {
+	.components__action-header {
 		width: 100%;
 	}
 
-	.products__header-right {
+	.components__action-header-actions {
 		position: absolute;
 		top: 16px;
 		right: 24px;

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -11,6 +11,7 @@
 	@import 'app/products/product-form';
 	@import 'app/settings/payments/style';
 
+	@import 'components/action-header/style';
 	@import 'components/address-view/style';
 	@import 'components/extended-header/style';
 	@import 'components/form-dimensions-input/style';


### PR DESCRIPTION
This adds a header to the product create page for the Save, Duplicate, and Trash buttons.
It also adds a placeholder for the breadcrumbs component.