### PR TITLE
Begin to migrate domain-related analytics event from using the old mixin to the analytics middleware.

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -47,29 +47,6 @@ const EVENTS = {
 		}
 	},
 	registerDomain: {
-		addDomainButtonClick( domainName, section ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Clicked "Add" Button on a Domain Registration',
-				'Domain Name',
-				domainName
-			);
-
-			analytics.tracks.recordEvent( 'calypso_domain_search_add_button_click', {
-				domain_name: domainName,
-				section
-			} );
-		},
-
-		removeDomainButtonClick( domainName ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Clicked "Remove" Button on a Domain Registration',
-				'Domain Name',
-				domainName
-			);
-		},
-
 		mapDomainButtonClick( section ) {
 			analytics.ga.recordEvent(
 				'Domain Search',

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -23,7 +23,7 @@ import { currentUserHasFlag } from 'state/current-user/selectors';
 import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
-import { recordRegisterDomainEvent } from 'state/analytics/actions';
+import { recordAddDomainButtonClick, recordRemoveDomainButtonClick } from 'state/domains/actions';
 
 class DomainSearch extends Component {
 	static propTypes = {
@@ -75,7 +75,8 @@ class DomainSearch extends Component {
 	}
 
 	addDomain( suggestion ) {
-		this.props.recordRegisterDomainEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
+		this.props.recordAddDomainButtonClick( suggestion.domain_name, 'domains' );
+
 		const items = [
 			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
 		];
@@ -91,7 +92,7 @@ class DomainSearch extends Component {
 	}
 
 	removeDomain( suggestion ) {
-		this.props.recordRegisterDomainEvent( 'removeDomainButtonClick', suggestion.domain_name );
+		this.props.recordRemoveDomainButtonClick( suggestion.domain_name );
 		upgradesActions.removeDomainFromCart( suggestion );
 	}
 
@@ -157,6 +158,7 @@ export default connect(
 		productsList: state.productsList.items,
 	} ),
 	{
-		recordRegisterDomainEvent,
+		recordAddDomainButtonClick,
+		recordRemoveDomainButtonClick,
 	}
 )( localize( DomainSearch ) );

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -19,13 +19,11 @@ import UpgradesNavigation from 'my-sites/upgrades/navigation';
 import Main from 'components/main';
 import upgradesActions from 'lib/upgrades/actions';
 import cartItems from 'lib/cart-values/cart-items';
-import analyticsMixin from 'lib/mixins/analytics';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
-
-const analytics = analyticsMixin( 'registerDomain' );
+import { recordRegisterDomainEvent } from 'state/analytics/actions';
 
 class DomainSearch extends Component {
 	static propTypes = {
@@ -77,7 +75,7 @@ class DomainSearch extends Component {
 	}
 
 	addDomain( suggestion ) {
-		analytics.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
+		this.props.recordRegisterDomainEvent( 'addDomainButtonClick', suggestion.domain_name, 'domains' );
 		const items = [
 			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
 		];
@@ -93,7 +91,7 @@ class DomainSearch extends Component {
 	}
 
 	removeDomain( suggestion ) {
-		analytics.recordEvent( 'removeDomainButtonClick', suggestion.domain_name );
+		this.props.recordRegisterDomainEvent( 'removeDomainButtonClick', suggestion.domain_name );
 		upgradesActions.removeDomainFromCart( suggestion );
 	}
 
@@ -157,5 +155,8 @@ export default connect(
 		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 		productsList: state.productsList.items,
-	} )
+	} ),
+	{
+		recordRegisterDomainEvent,
+	}
 )( localize( DomainSearch ) );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -21,6 +21,7 @@ import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
 import analyticsMixin from 'lib/mixins/analytics';
 import signupUtils from 'signup/utils';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
+import { recordRegisterDomainEvent } from 'state/analytics/actions';
 
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
@@ -78,7 +79,7 @@ const DomainsStep = React.createClass( {
 			suggestion
 		};
 
-		registerDomainAnalytics.recordEvent( 'addDomainButtonClick', suggestion.domain_name, 'signup' );
+		this.props.recordRegisterDomainEvent( 'addDomainButtonClick', suggestion.domain_name, 'signup' );
 
 		SignupActions.saveSignupStep( stepData );
 
@@ -259,10 +260,13 @@ const DomainsStep = React.createClass( {
 	}
 } );
 
-module.exports = connect( ( state ) => {
-	return {
+module.exports = connect(
+	( state ) => ( {
 		// no user = DOMAINS_WITH_PLANS_ONLY
 		domainsWithPlansOnly: getCurrentUser( state ) ? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) : true,
 		surveyVertical: getSurveyVertical( state ),
-	};
-} ) ( DomainsStep );
+	} ),
+	{
+		recordRegisterDomainEvent,
+	}
+)( DomainsStep );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -21,7 +21,7 @@ import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
 import analyticsMixin from 'lib/mixins/analytics';
 import signupUtils from 'signup/utils';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
-import { recordRegisterDomainEvent } from 'state/analytics/actions';
+import { recordAddDomainButtonClick } from 'state/domains/actions';
 
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
@@ -79,7 +79,7 @@ const DomainsStep = React.createClass( {
 			suggestion
 		};
 
-		this.props.recordRegisterDomainEvent( 'addDomainButtonClick', suggestion.domain_name, 'signup' );
+		this.props.recordAddDomainButtonClick( suggestion.domain_name, 'signup' );
 
 		SignupActions.saveSignupStep( stepData );
 
@@ -267,6 +267,6 @@ module.exports = connect(
 		surveyVertical: getSurveyVertical( state ),
 	} ),
 	{
-		recordRegisterDomainEvent,
+		recordAddDomainButtonClick,
 	}
 )( DomainsStep );

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -101,3 +101,36 @@ export const recordPageView = ( url, title, service ) => ( {
 
 export const recordGooglePageView = ( url, title ) =>
 	recordPageView( url, title, 'ga' );
+
+export const recordRegisterDomainEvent = ( eventType, ...args ) => ( dispatch ) => {
+	const registerDomainEventHandlers = {
+		addDomainButtonClick: ( domainName, section ) => {
+			dispatch( recordGoogleEvent(
+				'Domain Search',
+				'Clicked "Add" Button on a Domain Registration',
+				'Domain Name',
+				domainName
+			) );
+
+			dispatch( recordTracksEvent( 'calypso_domain_search_add_button_click', {
+				domainName,
+				section,
+			} ) );
+		},
+
+		removeDomainButtonClick: ( domainName ) => {
+			dispatch( recordGoogleEvent(
+				'Domain Search',
+				'Clicked "Remove" Button on a Domain Registration',
+				'Domain Name',
+				domainName
+			) );
+
+			dispatch( recordTracksEvent( 'calypso_domain_remove_button_click', {
+				domainName,
+			} ) );
+		},
+	};
+
+	registerDomainEventHandlers[ eventType ]( ...args );
+};

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -101,36 +101,3 @@ export const recordPageView = ( url, title, service ) => ( {
 
 export const recordGooglePageView = ( url, title ) =>
 	recordPageView( url, title, 'ga' );
-
-export const recordRegisterDomainEvent = ( eventType, ...args ) => ( dispatch ) => {
-	const registerDomainEventHandlers = {
-		addDomainButtonClick: ( domainName, section ) => {
-			dispatch( recordGoogleEvent(
-				'Domain Search',
-				'Clicked "Add" Button on a Domain Registration',
-				'Domain Name',
-				domainName
-			) );
-
-			dispatch( recordTracksEvent( 'calypso_domain_search_add_button_click', {
-				domain_name: domainName,
-				section,
-			} ) );
-		},
-
-		removeDomainButtonClick: ( domainName ) => {
-			dispatch( recordGoogleEvent(
-				'Domain Search',
-				'Clicked "Remove" Button on a Domain Registration',
-				'Domain Name',
-				domainName
-			) );
-
-			dispatch( recordTracksEvent( 'calypso_domain_remove_button_click', {
-				domain_name: domainName,
-			} ) );
-		},
-	};
-
-	registerDomainEventHandlers[ eventType ]( ...args );
-};

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -113,7 +113,7 @@ export const recordRegisterDomainEvent = ( eventType, ...args ) => ( dispatch ) 
 			) );
 
 			dispatch( recordTracksEvent( 'calypso_domain_search_add_button_click', {
-				domainName,
+				domain_name: domainName,
 				section,
 			} ) );
 		},
@@ -127,7 +127,7 @@ export const recordRegisterDomainEvent = ( eventType, ...args ) => ( dispatch ) 
 			) );
 
 			dispatch( recordTracksEvent( 'calypso_domain_remove_button_click', {
-				domainName,
+				domain_name: domainName,
 			} ) );
 		},
 	};

--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import {
+	recordTracksEvent,
+	recordGoogleEvent,
+	composeAnalytics,
+} from 'state/analytics/actions';
+
+export const recordAddDomainButtonClick = ( domainName, section ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Clicked "Add" Button on a Domain Registration',
+		'Domain Name',
+		domainName
+	),
+	recordTracksEvent( 'calypso_domain_search_add_button_click', {
+		domain_name: domainName,
+		section,
+	} ),
+);
+
+export const recordRemoveDomainButtonClick = ( domainName ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Clicked "Remove" Button on a Domain Registration',
+		'Domain Name',
+		domainName
+	),
+	recordTracksEvent( 'calypso_domain_remove_button_click', {
+		domain_name: domainName,
+	} ),
+);

--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -2,9 +2,9 @@
  * Internal dependencies
  */
 import {
-	recordTracksEvent,
-	recordGoogleEvent,
 	composeAnalytics,
+	recordGoogleEvent,
+	recordTracksEvent,
 } from 'state/analytics/actions';
 
 export const recordAddDomainButtonClick = ( domainName, section ) => composeAnalytics(


### PR DESCRIPTION
## Summary
This PR implements a new action creator, `recordRegisterDomainEvents`, as the stub to start migrating analytics code from the old mixin to our current analytics middleware. To demonstrate, it migrates two events: `calypso_domain_search_add_button_click` and `calypso_domain_remove_button_click`. The following is a screen cast of when they are triggered:

![demo-add-remove-domain](https://cloud.githubusercontent.com/assets/1842898/25771043/d901b788-323d-11e7-80bb-02e10c7b55f6.gif)

## Test Plan
Unfortunately, there doesn't seem to be an easy way to inspect whether if there is a real request goes to ga / tracks. We can add log to [analytics.ga](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/index.js#L384) and [analytics.tracks](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/index.js#L222) so we can see them happen.

1. Go to `http://calypso.localhost:3000/domains/add`.
1. Click "Select" on a random domain. This is when you should find the `calypso_domain_search_add_button_click`
1. Navigate back by clicking "<"
1. Click the check mark to remove the selected domain. This is when you should find the `calypso_domain_remove_button_click`.