### PR TITLE
Add `calypso_domain_search_add_button_click` and `calypso_domain_remove_button_click` to the hc main stream.

### DIFF
--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -163,6 +163,10 @@ export const getEventMessageFromTracksData = ( { name, properties } ) => {
 	switch ( name ) {
 		case 'calypso_add_new_wordpress_click':
 			return 'Clicked "Add new site" button';
+		case 'calypso_domain_search_add_button_click':
+			return `Clicked "Add" button to add domain "${ properties.domain_name }"`;
+		case 'calypso_domain_remove_button_click':
+			return `Clicked "Remove" button to remove domain "${ properties.domain_name }"`;
 		case 'calypso_themeshowcase_theme_activate':
 			return `Changed theme from "${ properties.previous_theme }" to "${ properties.theme }"`;
 		case 'calypso_editor_featured_image_upload':


### PR DESCRIPTION
## Summary
This PR adds `calypso_domain_search_add_button_click` and `calypso_domain_remove_button_click` to the Happychat event main stream.

## Test Plan

1. Start a chat.
1. Navigate to http://calypso.localhost:3000/domains/add/
1. Add a domain, and see `Clicked "Add" button to add domain...` event show up.
1. Click "back" button to navigate back.
1. Click the check mark to remove the added domain, and see `Clicked "Remove" button ...` event show up.
