### PR TITLE
Happychat event: Add calypso_map_domain_step_add_domain_click to the event stream.

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -16,6 +16,7 @@ import DomainRegistrationSuggestion from 'components/domains/domain-registration
 import DomainProductPrice from 'components/domains/domain-product-price';
 import analyticsMixin from 'lib/mixins/analytics';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { recordAddDomainButtonClickInMapDomain } from 'state/domains/actions';
 import Notice from 'components/notice';
 
 const MapDomainStep = React.createClass( {
@@ -143,7 +144,7 @@ const MapDomainStep = React.createClass( {
 	registerSuggestedDomain: function( event ) {
 		event.preventDefault();
 
-		this.recordEvent( 'addDomainButtonClick', this.state.suggestion.domain_name, this.props.analyticsSection );
+		this.props.recordAddDomainButtonClickInMapDomain( this.state.suggestion.domain_name, this.props.analyticsSection );
 
 		return this.props.onRegisterDomain( this.state.suggestion );
 	},
@@ -188,4 +189,11 @@ const MapDomainStep = React.createClass( {
 	},
 } );
 
-module.exports = connect( state => ( { currentUser: getCurrentUser( state ) } ) )( localize( MapDomainStep ) );
+export default connect(
+	state => ( {
+		currentUser: getCurrentUser( state )
+	} ),
+	{
+		recordAddDomainButtonClickInMapDomain,
+	}
+)( localize( MapDomainStep ) );

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -235,20 +235,6 @@ const EVENTS = {
 				section
 			} );
 		},
-
-		addDomainButtonClick( domainName, section ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Clicked "Add" Button on a Domain Registration in Map Domain Step',
-				'Domain Name',
-				domainName
-			);
-
-			analytics.tracks.recordEvent( 'calypso_map_domain_step_add_domain_click', {
-				domain_name: domainName,
-				section
-			} );
-		}
 	},
 
 	siteRedirect: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -21,13 +21,12 @@ import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
 import analyticsMixin from 'lib/mixins/analytics';
 import signupUtils from 'signup/utils';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
-import { recordAddDomainButtonClick } from 'state/domains/actions';
+import { recordAddDomainButtonClick, recordAddDomainButtonClickInMapDomain } from 'state/domains/actions';
 
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 
-const registerDomainAnalytics = analyticsMixin( 'registerDomain' ),
-	mapDomainAnalytics = analyticsMixin( 'mapDomain' );
+const registerDomainAnalytics = analyticsMixin( 'registerDomain' );
 
 const DomainsStep = React.createClass( {
 	propTypes: {
@@ -149,7 +148,7 @@ const DomainsStep = React.createClass( {
 		const domainItem = cartItems.domainMapping( { domain } );
 		const isPurchasingItem = true;
 
-		mapDomainAnalytics.recordEvent( 'addDomainButtonClick', domain, 'signup' );
+		this.props.recordAddDomainButtonClickInMapDomain( domain, 'signup' );
 
 		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain mapping' ),
@@ -268,5 +267,6 @@ module.exports = connect(
 	} ),
 	{
 		recordAddDomainButtonClick,
+		recordAddDomainButtonClickInMapDomain,
 	}
 )( DomainsStep );

--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -20,6 +20,19 @@ export const recordAddDomainButtonClick = ( domainName, section ) => composeAnal
 	} ),
 );
 
+export const recordAddDomainButtonClickInMapDomain = ( domainName, section ) => composeAnalytics(
+	recordGoogleEvent(
+		'Domain Search',
+		'Clicked "Add" Button on a Domain Registration in Map Domain Step',
+		'Domain Name',
+		domainName
+	),
+	recordTracksEvent( 'calypso_map_domain_step_add_domain_click', {
+		domain_name: domainName,
+		section
+	} ),
+);
+
 export const recordRemoveDomainButtonClick = ( domainName ) => composeAnalytics(
 	recordGoogleEvent(
 		'Domain Search',

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -167,6 +167,8 @@ export const getEventMessageFromTracksData = ( { name, properties } ) => {
 			return `Changed theme from "${ properties.previous_theme }" to "${ properties.theme }"`;
 		case 'calypso_editor_featured_image_upload':
 			return 'Changed the featured image on the current post';
+		case 'calypso_map_domain_step_add_domain_click':
+			return `Add "${ properties.domain_name }" to the cart in the "Map a domain" step`;
 	}
 	return null;
 };


### PR DESCRIPTION
## Summary
This PR migrates `analytics.map.addDomainButtonClick` as an action creator `recordAddDomainButtonClickInMap`, and adds `calypso_map_domain_step_add_domain_click` to the hc event stream.

## Test Plan
1. Start a chat 
1. From the customer side, do this:
![demo-map-domain](https://cloud.githubusercontent.com/assets/1842898/25772220/4907c584-325e-11e7-8d01-61cfb4a75550.gif)
1. From the operator side, you should see the event show up.