### PR TITLE
Happychat: Send sharing connect/disconnect events

### DIFF
--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -34,7 +34,7 @@ import {
 	PLUGIN_SETUP_ACTIVATE,
 	POST_SAVE_SUCCESS,
 	PUBLICIZE_CONNECTION_CREATE,
-	PUBLICIZE_CONNECTION_CREATE_FAILURE,
+	PUBLICIZE_CONNECTION_DELETE,
 	PURCHASE_REMOVE_COMPLETED,
 	SITE_SETTINGS_SAVE_SUCCESS,
 } from 'state/action-types';
@@ -205,9 +205,9 @@ export const getEventMessageFromActionData = ( action ) => {
 		case POST_SAVE_SUCCESS:
 			return `Saved post "${ action.savedPost.title }" ${ action.savedPost.short_URL }`;
 		case PUBLICIZE_CONNECTION_CREATE:
-			return null;
-		case PUBLICIZE_CONNECTION_CREATE_FAILURE:
-			return null;
+			return `Connected ${ action.connection.label } sharing`;
+		case PUBLICIZE_CONNECTION_DELETE:
+			return `Disonnected ${ action.connection.label } sharing`;
 		case PURCHASE_REMOVE_COMPLETED:
 			return null;
 		case SITE_SETTINGS_SAVE_SUCCESS:

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -207,7 +207,7 @@ export const getEventMessageFromActionData = ( action ) => {
 		case PUBLICIZE_CONNECTION_CREATE:
 			return `Connected ${ action.connection.label } sharing`;
 		case PUBLICIZE_CONNECTION_DELETE:
-			return `Disonnected ${ action.connection.label } sharing`;
+			return `Disconnected ${ action.connection.label } sharing`;
 		case PURCHASE_REMOVE_COMPLETED:
 			return null;
 		case SITE_SETTINGS_SAVE_SUCCESS:


### PR DESCRIPTION
Send events to Happychat operators when a customer connects or disconnects a sharing service, e.g. Facebook or Twitter.

### To test

Open a Happychat session. Go to My Sites -> Sharing. Connect a few services — the operator should see these connection events come through. Now disconnect them — the operator should also see these disconnect events come through.