### PR TITLE
Followers-count: ensure 'stats' is queried

### DIFF
--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -21,12 +21,11 @@ class FollowersCount extends Component {
 		const { slug, followers, translate, siteId } = this.props;
 
 		if ( ! followers ) {
-			return null;
+			return siteId && <QuerySiteStats statType="stats" siteId={ siteId } />;
 		}
 
 		return (
 			<div className="followers-count">
-				{ siteId && <QuerySiteStats statType="stats" siteId={ siteId } /> }
 				<Button
 					borderless
 					href={ '/people/followers/' + slug }
@@ -44,6 +43,7 @@ export default connect( ( state ) => {
 	const data = getSiteStatsNormalizedData( state, siteId, 'stats' );
 
 	return {
+		siteId,
 		slug: getSiteSlug( state, siteId ),
 		followers: get( data, 'followersBlog' ),
 	};


### PR DESCRIPTION
When looking at Site Stats for a Site, followers count was not appearing

#### Fix
It turns out the query-component was never being rendered. Some other component must have queried for `stats`because it used to work.

#### Steps to reproduce
1. Starting at URL: http://calypso.localhost:3000/stats/day/my-site-slug.
2. Ensure the site in question has at least one follower.

#### Before
![screen shot 2017-05-08 at 1 15 10 pm](https://cloud.githubusercontent.com/assets/1922453/25786948/c789600a-33f0-11e7-93b5-297b20974312.png)

#### After
![screen shot 2017-05-08 at 1 14 24 pm](https://cloud.githubusercontent.com/assets/1922453/25786941/adb84754-33f0-11e7-8269-e96fb53ea7fb.png)

Fixes https://github.com/Automattic/wp-calypso/issues/13744