### PR TITLE
Framework: Initialize the localStorage shim sooner in the boot process

### DIFF
--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -1,5 +1,6 @@
-// Initialize localStorage polyfill before any dependencies are loaded
-require( 'lib/local-storage' )();
+// Initialize polyfills before any dependencies are loaded
+import './polyfills';
+
 if ( process.env.NODE_ENV === 'development' ) {
 	require( 'lib/wrap-es6-functions' )();
 }

--- a/client/boot/polyfills.js
+++ b/client/boot/polyfills.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import localStoragePolyfill from 'lib/local-storage';
+
+localStoragePolyfill();


### PR DESCRIPTION
As reported in #6555, after merging #12395 there was a regression in handling the Private Browsing mode in Safari.

From the stack trace and error, it seems like [we are not injecting the `localStorage` shim soon enough](http://stackoverflow.com/a/27081419/181497). Right now, we are [injecting it in `boot/app.js`](https://github.com/Automattic/wp-calypso/blob/master/client/boot/app.js#L2).
I've done some simple debugging of this - added `console.log` to the top of `boot/common.js` and `boot/app.js` and the results are interesting:
<img width="1273" alt="screen shot 2017-05-08 at 13 06 23" src="https://cloud.githubusercontent.com/assets/3392497/25802023/cdadff9a-33f0-11e7-9fcc-9a23bed09100.png">

From the looks of it, `boot/common.js` is executed first (and subsequently, for example, the user is loaded first) before the shim is injected in `boot/app.js`.
~~The simplest fix would be to move the initialization to `boot/common.js` (which this PR does), since that seems to fix the issue:~~
As discussed below, the proper (and simplest) fix would be to create a `polyfills.js` file that injects the needed polyfills (just the local-storage one, for now) as soon as it is imported. This should ensure the polyfills get initialized before any other imports:
<img width="1255" alt="screen shot 2017-05-10 at 19 47 49" src="https://cloud.githubusercontent.com/assets/3392497/25913089/d2eaf89e-35b9-11e7-95a7-9f6da6254e2a.png">

Related, alternative approach: #7232. However, I like this approach better, because then we don't have to deal with cachebusting, having a separate file to download, etc. And it's more visible that the polyfills are injected at the very beginning of the boot process - it's hard to miss being in `boot/app.js`, while the approach in #7232 requires looking into `server/pages/index.jade`, which is probably less "visible" [citation needed] 😉 

## Testing
Enable debug messaging (`localStorage.setItem( 'debug', 'calypso:*' );` should be enough) and verify that the local-storage polyfill is initialized before, for example, the user is fetched (as can be seen in the screenshot above).

Fixes #6555 