### PR TITLE
Jetpack connect: Separate site card component from authorize form

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import page from 'page';
-import urlModule from 'url';
 import i18n from 'i18n-calypso';
 import Gridicon from 'gridicons';
 const debug = require( 'debug' )( 'calypso:jetpack-connect:authorize-form' );
@@ -22,7 +21,6 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
-import QuerySites from 'components/data/query-sites';
 import {
 	createAccount,
 	authorize,
@@ -46,16 +44,13 @@ import JetpackConnectNotices from './jetpack-connect-notices';
 import observe from 'lib/mixins/data-observe';
 import userUtilities from 'lib/user/utils';
 import Card from 'components/card';
-import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Spinner from 'components/spinner';
-import Site from 'blocks/site';
 import { decodeEntities } from 'lib/formatting';
 import versionCompare from 'lib/version-compare';
 import EmptyContent from 'components/empty-content';
-import safeImageUrl from 'lib/safe-image-url';
 import Button from 'components/button';
 import { requestSites } from 'state/sites/actions';
 import { isRequestingSites } from 'state/sites/selectors';
@@ -70,39 +65,13 @@ import NoticeAction from 'components/notice/notice-action';
 import Plans from './plans';
 import CheckoutData from 'components/data/checkout';
 import { externalRedirect } from 'lib/route/path';
+import SiteCard from './site-card';
 
 /**
  * Constants
  */
 const PLANS_PAGE = '/jetpack/connect/plans/';
 const MAX_AUTH_ATTEMPTS = 3;
-
-const SiteCard = React.createClass( {
-	render() {
-		const { site_icon, blogname, home_url, site_url } = this.props.queryObject;
-		const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
-		const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
-		const url = decodeEntities( home_url );
-		const parsedUrl = urlModule.parse( url );
-		const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;
-		const site = {
-			ID: null,
-			url: url,
-			admin_url: decodeEntities( site_url + '/wp-admin' ),
-			domain: parsedUrl.host + path,
-			icon: siteIcon,
-			is_vip: false,
-			title: decodeEntities( blogname )
-		};
-
-		return (
-			<CompactCard className="jetpack-connect__site">
-				<QuerySites allSites />
-				<Site site={ site } />
-			</CompactCard>
-		);
-	}
-} );
 
 const LoggedOutForm = React.createClass( {
 	displayName: 'LoggedOutForm',

--- a/client/signup/jetpack-connect/site-card.jsx
+++ b/client/signup/jetpack-connect/site-card.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import urlModule from 'url';
 
 /**
@@ -14,6 +14,15 @@ import safeImageUrl from 'lib/safe-image-url';
 import { decodeEntities } from 'lib/formatting';
 
 class SiteCard extends Component {
+	static propTypes = {
+		queryObject: PropTypes.shape( {
+			site_icon: PropTypes.string,
+			blogname: PropTypes.string.isRequired,
+			home_url: PropTypes.string.isRequired,
+			site_url: PropTypes.string.isRequired,
+		} ).isRequired,
+	};
+
 	render() {
 		const {
 			site_icon,

--- a/client/signup/jetpack-connect/site-card.jsx
+++ b/client/signup/jetpack-connect/site-card.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import urlModule from 'url';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import QuerySites from 'components/data/query-sites';
+import Site from 'blocks/site';
+import safeImageUrl from 'lib/safe-image-url';
+import { decodeEntities } from 'lib/formatting';
+
+class SiteCard extends Component {
+	render() {
+		const {
+			site_icon,
+			blogname,
+			home_url,
+			site_url,
+		} = this.props.queryObject;
+		const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
+		const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
+		const url = decodeEntities( home_url );
+		const parsedUrl = urlModule.parse( url );
+		const path = ( parsedUrl.path === '/' ) ? '' : parsedUrl.path;
+		const site = {
+			ID: null,
+			url: url,
+			admin_url: decodeEntities( site_url + '/wp-admin' ),
+			domain: parsedUrl.host + path,
+			icon: siteIcon,
+			is_vip: false,
+			title: decodeEntities( blogname )
+		};
+
+		return (
+			<CompactCard className="jetpack-connect__site">
+				<QuerySites allSites />
+				<Site site={ site } />
+			</CompactCard>
+		);
+	}
+}
+
+export default SiteCard;


### PR DESCRIPTION
Separate `SiteCard` from `authorize-form`.

To test:

* Verify that there are no regressions in the authorize step (`/jetpack/connect/authorize`)
  * logged in
  * logged out

Part of: Separate jetpack-connect from signup #12991 