### PR TITLE
Reader: make intro card dismissible

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -4,26 +4,27 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
  */
+import QueryPreferences from 'components/data/query-preferences';
+import { savePreference } from 'state/preferences/actions';
+import { getPreference } from 'state/preferences/selectors';
 
 const FollowingIntro = ( props ) => {
 
-	// @todo Return null if the user does not have is_new_reader = true in preferences
-
-	const handleIntroClose = () => {
-		// @todo Remove is_new_reader from preferences
-	};
+	if ( ! props.isNewReader ) {
+		return null;
+	}
 
 	return (
 		<header className="following__intro">
-
+			<QueryPreferences />
 			<div className="following__intro-header">
-
 				<div className="following__intro-copy">
-
 						{ props.translate(
 							'{{strong}}Welcome!{{/strong}} Reader is a custom magazine. ' +
 							'{{link}}Follow your favorite sites{{/link}} and their latest ' +
@@ -37,21 +38,29 @@ const FollowingIntro = ( props ) => {
 								}
 							}
 						) }
-
 				</div>
 
 				<div className="following__intro-close"
-					onClick={ handleIntroClose }
+					onClick={ props.dismiss }
 					title={ props.translate( 'Close' ) }
 					aria-label={ props.translate( 'Close' ) }>
 						<Gridicon icon="cross-circle" className="following__intro-close-icon" title={ props.translate( 'Close' ) } />
 						<span className="following__intro-close-icon-bg" />
 				</div>
-
 			</div>
-
 		</header>
 	);
 };
 
-export default localize( FollowingIntro );
+export default connect(
+	( state ) => {
+		return {
+			isNewReader: getPreference( state, 'is_new_reader' )
+		};
+	},
+	( dispatch ) => bindActionCreators( {
+		dismiss: () => {
+			return savePreference( 'is_new_reader', false );
+		}
+	}, dispatch )
+)( localize( FollowingIntro ) );

--- a/config/development.json
+++ b/config/development.json
@@ -119,7 +119,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/combined-cards": true,
-		"reader/following-intro": false,
+		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,


### PR DESCRIPTION
This PR makes the Reader intro card dismissible. Once you've clicked the 'x', your preference is saved and you shouldn't see it again.

<img width="1251" alt="screen shot 2017-05-08 at 15 03 16" src="https://cloud.githubusercontent.com/assets/17325/25805390/bad93790-33ff-11e7-932e-440920f4860c.png">

### How it works

When a new user is created, we give them the attribute `is_new_reader` = true. 

When you click the close button, we use the savePreference action from state/preferences to set the value of `is_new_reader` to false.

### Future

We didn't use the similar 'dismissible-card' block here because we have a custom attribute, and it does the reverse to the attribute value (we set it from true to false, not vice versa). We could potentially enhance the dismissible card block in the future to handle this use case.

I'd also prefer that we delete the attribute completely rather than setting it to false, but a `deletePreference` action and the corresponding endpoint do not currently exist.

### To test

Create a brand new user and make sure that you are shown the intro banner when you first visit the following stream at `/`. When you've dismissed the intro, you should not see it again, whether in the same session or subsequent sessions.
