### PR TITLE
Invalidate old themes queries in IndexedDB.

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -310,7 +310,7 @@ export const queries = ( () => {
 	}
 
 	// Time after which queries storred in IndexedDb will be invalidated.
-	// days * hours_in_day * minutes_in_hour * seconds_in_hour * miliseconds_in_second
+	// days * hours_in_day * minutes_in_hour * seconds_in_minute * miliseconds_in_second
 	const MAX_THEMES_AGE = 1 * 24 * 60 * 60 * 1000;
 
 	return createReducer( {}, {

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -309,6 +309,9 @@ export const queries = ( () => {
 		};
 	}
 
+	// days * hours_in_day * minuets_in_hour * seconds_in_hour * miliseconds_in_second
+	const MAX_THEMES_AGE = 1 * 24 * 60 * 60 * 1000;
+
 	return createReducer( {}, {
 		[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query, themes, found } ) => {
 			return applyToManager(
@@ -321,9 +324,14 @@ export const queries = ( () => {
 			return applyToManager( state, siteId, 'removeItem', false, themeId );
 		},
 		[ SERIALIZE ]: ( state ) => {
-			return mapValues( state, ( { data, options } ) => ( { data, options } ) );
+			const serializedState = mapValues( state, ( { data, options } ) => ( { data, options } ) );
+			return Object.assign( serializedState, { _timestamp: Date.now() } );
 		},
 		[ DESERIALIZE ]: ( state ) => {
+			if ( state._timestamp && state._timestamp + MAX_THEMES_AGE < Date.now() ) {
+				return {};
+			}
+			delete state._timestamp;
 			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
 				return {};
 			}

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -309,7 +309,8 @@ export const queries = ( () => {
 		};
 	}
 
-	// days * hours_in_day * minuets_in_hour * seconds_in_hour * miliseconds_in_second
+	// Time after which queries storred in IndexedDb will be invalidated.
+	// days * hours_in_day * minutes_in_hour * seconds_in_hour * miliseconds_in_second
 	const MAX_THEMES_AGE = 1 * 24 * 60 * 60 * 1000;
 
 	return createReducer( {}, {
@@ -325,18 +326,18 @@ export const queries = ( () => {
 		},
 		[ SERIALIZE ]: ( state ) => {
 			const serializedState = mapValues( state, ( { data, options } ) => ( { data, options } ) );
-			return Object.assign( serializedState, { _timestamp: Date.now() } );
+			return { ...serializedState, _timestamp: Date.now() };
 		},
 		[ DESERIALIZE ]: ( state ) => {
 			if ( state._timestamp && state._timestamp + MAX_THEMES_AGE < Date.now() ) {
 				return {};
 			}
-			delete state._timestamp;
-			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
+			const noTimestampState = omit( state, '_timestamp' );
+			if ( ! isValidStateWithSchema( noTimestampState, queriesSchema ) ) {
 				return {};
 			}
 
-			return mapValues( state, ( { data, options } ) => {
+			return mapValues( noTimestampState, ( { data, options } ) => {
 				return new ThemeQueryManager( data, options );
 			} );
 		},

--- a/client/state/themes/test/reducer.js
+++ b/client/state/themes/test/reducer.js
@@ -353,6 +353,9 @@ describe( 'reducer', () => {
 
 			const state = queries( original, { type: SERIALIZE } );
 
+			// _timestamp is not part of the data
+			delete state._timestamp;
+
 			expect( state ).to.deep.equal( {
 				2916284: {
 					data: {


### PR DESCRIPTION
### Info
Locally stored themes can drift out of sync if we don't re-fetch the data. Right now the persistent state is refreshed every 7 days. This can be too long for themes. This PR tries to solve this problem by adding timestamp and check just for themes queries. Themes will be invalidated after 24 hours. This should be enough  

### Testing
It is really hard to test this because it would require to wait 24h :) The fastest way is to modify this value:
https://github.com/Automattic/wp-calypso/pull/13755/files#diff-40ab1217977ee8f85be34d691f55b624R314 to invalidate after something like a minute. 
Then go to `/themes` and scroll to load more pages, Then open dev-tools -> Application tab -> IndexedDB -> calypso store and inspect what is stored for themes. 
Now two scenarios:
1. leave Calypso go to `wp.com` and navigate to themes -- **before** the timeout that you have set and inspect calypso store - all previously seen items should be there.
2 leave Calypso go to `wp.com` and navigate to themes -- **after** the timeout that you have set and inspect calypso store - only the first freshly fetched page should be there. 
