### PR TITLE
Reader: Use localize() instead of i18n mixin

### DIFF
--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -34,11 +34,11 @@ const FeedError = React.createClass( {
 	render() {
 		const action = ( <a className="empty-content__action button is-primary"
 				onClick={ this.recordAction }
-				href="/read/search">{ this.translate( 'Find Sites to Follow' ) }</a>),
+				href="/read/search">{ this.props.translate( 'Find Sites to Follow' ) }</a>),
 			secondaryAction = (
 				<a className="empty-content__action button"
 					onClick={ this.recordSecondaryAction }
-					href="/discover">{ this.translate( 'Explore Discover' ) }</a> );
+					href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> );
 
 		return (
 			<ReaderMain>
@@ -62,4 +62,4 @@ FeedError.propTypes = {
 	sidebarTitle: React.PropTypes.string
 };
 
-export default FeedError;
+export default localize(FeedError);

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -62,4 +62,4 @@ FeedError.propTypes = {
 	sidebarTitle: React.PropTypes.string
 };
 
-export default localize(FeedError);
+export default localize( FeedError );

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -30,11 +30,11 @@ const FollowingEditEmptyContent = React.createClass( {
 	render() {
 		const action = ( <a className="empty-content__action button is-primary"
 				onClick={ this.recordAction }
-				href="/read/search">{ this.translate( 'Find Sites to Follow' ) }</a>),
+				href="/read/search">{ this.props.translate( 'Find Sites to Follow' ) }</a>),
 			secondaryAction = (
 				<a className="empty-content__action button"
 					onClick={ this.recordSecondaryAction }
-					href="/discover">{ this.translate( 'Explore Discover' ) }</a> );
+					href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> );
 
 		return (
 			<EmptyContent
@@ -49,4 +49,4 @@ const FollowingEditEmptyContent = React.createClass( {
 	}
 } );
 
-export default FollowingEditEmptyContent;
+export default localize(FollowingEditEmptyContent);

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -40,8 +40,8 @@ const FollowingEditEmptyContent = React.createClass( {
 			<EmptyContent
 				action={ action }
 				secondaryAction={ secondaryAction }
-				title={ i18n.translate( 'You haven\'t followed any sites yet' ) }
-				line={ i18n.translate( 'Search for a site or explore Discover.' ) }
+				title={ this.props.translate( 'You haven\'t followed any sites yet' ) }
+				line={ this.props.translate( 'Search for a site or explore Discover.' ) }
 				illustration={ '/calypso/images/drake/drake-404.svg' }
 				illustrationWidth={ 500 }
 			/>

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -49,4 +49,4 @@ const FollowingEditEmptyContent = React.createClass( {
 	}
 } );
 
-export default localize(FollowingEditEmptyContent);
+export default localize( FollowingEditEmptyContent );

--- a/client/reader/following-edit/export-button.jsx
+++ b/client/reader/following-edit/export-button.jsx
@@ -61,7 +61,7 @@ const FollowingExportButton = React.createClass( {
 
 	render() {
 		return (
-		    <Button
+			<Button
 				compact
 				disabled={ this.state.disabled }
 				onClick={ this.onClick } >

--- a/client/reader/following-edit/export-button.jsx
+++ b/client/reader/following-edit/export-button.jsx
@@ -71,4 +71,4 @@ const FollowingExportButton = React.createClass( {
 	}
 } );
 
-export default localize(FollowingExportButton);
+export default localize( FollowingExportButton );

--- a/client/reader/following-edit/export-button.jsx
+++ b/client/reader/following-edit/export-button.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import Blob from 'blob';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import noop from 'lodash/noop';
 import { saveAs } from 'browser-filesaver';
@@ -46,7 +47,7 @@ const FollowingExportButton = React.createClass( {
 		} );
 
 		if ( ! err && ! data.success ) {
-			err = new Error( this.translate( 'Error exporting Reader feed' ) );
+			err = new Error( this.props.translate( 'Error exporting Reader feed' ) );
 		}
 
 		if ( err ) {
@@ -60,14 +61,14 @@ const FollowingExportButton = React.createClass( {
 
 	render() {
 		return (
-			<Button
+		    <Button
 				compact
 				disabled={ this.state.disabled }
 				onClick={ this.onClick } >
-				{ this.translate( 'Export' ) }
+				{ this.props.translate( 'Export' ) }
 			</Button>
 		);
 	}
 } );
 
-export default FollowingExportButton;
+export default localize(FollowingExportButton);

--- a/client/reader/following-edit/import-button.jsx
+++ b/client/reader/following-edit/import-button.jsx
@@ -78,4 +78,4 @@ const FollowingImportButton = React.createClass( {
 	}
 } );
 
-export default localize(FollowingImportButton);
+export default localize( FollowingImportButton );

--- a/client/reader/following-edit/import-button.jsx
+++ b/client/reader/following-edit/import-button.jsx
@@ -69,7 +69,7 @@ const FollowingImportButton = React.createClass( {
 
 	render() {
 		return (
-		    <FilePicker accept=".xml,.opml" onPick={ this.onPick } >
+			<FilePicker accept=".xml,.opml" onPick={ this.onPick } >
 				<Button compact disabled={ this.state.disabled } >
 					{ this.props.translate( 'Import' ) }
 				</Button>

--- a/client/reader/following-edit/import-button.jsx
+++ b/client/reader/following-edit/import-button.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import noop from 'lodash/noop';
 
 /**
@@ -68,13 +69,13 @@ const FollowingImportButton = React.createClass( {
 
 	render() {
 		return (
-			<FilePicker accept=".xml,.opml" onPick={ this.onPick } >
+		    <FilePicker accept=".xml,.opml" onPick={ this.onPick } >
 				<Button compact disabled={ this.state.disabled } >
-					{ this.translate( 'Import' ) }
+					{ this.props.translate( 'Import' ) }
 				</Button>
 			</FilePicker>
 		);
 	}
 } );
 
-export default FollowingImportButton;
+export default localize(FollowingImportButton);

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -1,5 +1,6 @@
 // External dependencies
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import times from 'lodash/times';
 import trimStart from 'lodash/trimStart';
 import Immutable from 'immutable';
@@ -374,15 +375,16 @@ const FollowingEdit = React.createClass( {
 
 		const url = this.state.lastError.URL;
 
-		return ( <Notice
-					status="is-error"
-					showDismiss={ true }
-					onDismissClick={ this.dismissError }>
-					{ this.translate( 'Sorry - there was a problem unfollowing {{strong}}%(url)s{{/strong}}.', {
-						components: { strong: <strong /> },
-						args: { url: url } } )
-					}
-					</Notice>
+		return (
+		    <Notice
+						status="is-error"
+						showDismiss={ true }
+						onDismissClick={ this.dismissError }>
+						{ this.props.translate( 'Sorry - there was a problem unfollowing {{strong}}%(url)s{{/strong}}.', {
+							components: { strong: <strong /> },
+							args: { url: url } } )
+						}
+						</Notice>
 		);
 	},
 
@@ -395,9 +397,9 @@ const FollowingEdit = React.createClass( {
 		let errorMessage;
 
 		if ( lastError.info && lastError.info === 'already_subscribed' ) {
-			errorMessage = this.translate( 'You\'re already subscribed to that site.' );
+			errorMessage = this.props.translate( 'You\'re already subscribed to that site.' );
 		} else {
-			errorMessage = this.translate( 'Sorry, we couldn\'t find a feed for {{em}}%(url)s{{/em}}.', {
+			errorMessage = this.props.translate( 'Sorry, we couldn\'t find a feed for {{em}}%(url)s{{/em}}.', {
 				args: { url: this.state.searchString },
 				components: { em: <em/> }
 			} );
@@ -418,7 +420,7 @@ const FollowingEdit = React.createClass( {
 			return null;
 		}
 
-		const message = this.translate( 'Your Followed Sites list has been exported.' );
+		const message = this.props.translate( 'Your Followed Sites list has been exported.' );
 		return (
 			<Notice
 				key="notice-feed-export"
@@ -436,7 +438,7 @@ const FollowingEdit = React.createClass( {
 			return null;
 		}
 
-		const message = this.translate( '{{em}}%(name)s{{/em}} has been imported. Refresh this page to see the new sites you follow.', {
+		const message = this.props.translate( '{{em}}%(name)s{{/em}} has been imported. Refresh this page to see the new sites you follow.', {
 			args: { name: feedImport.fileName },
 			components: { em: <em/> }
 		} );
@@ -460,7 +462,7 @@ const FollowingEdit = React.createClass( {
 			return null;
 		}
 
-		const message = this.translate( 'Whoops, something went wrong. %(message)s. Please try again.', {
+		const message = this.props.translate( 'Whoops, something went wrong. %(message)s. Please try again.', {
 			args: { message: error.message }
 		} );
 		return (
@@ -516,9 +518,9 @@ const FollowingEdit = React.createClass( {
 		}
 
 		if ( this.state.windowWidth && this.state.windowWidth > 960 ) {
-			searchPlaceholder = this.translate( 'Search your followed sites' );
+			searchPlaceholder = this.props.translate( 'Search your followed sites' );
 		} else {
-			searchPlaceholder = this.translate( 'Search' );
+			searchPlaceholder = this.props.translate( 'Search' );
 		}
 
 		const containerClasses = classnames( {
@@ -527,9 +529,9 @@ const FollowingEdit = React.createClass( {
 		}, 'following-edit' );
 
 		return (
-			<ReaderMain className={ containerClasses }>
+		    <ReaderMain className={ containerClasses }>
 				<MobileBackToSidebar>
-					<h1>{ this.translate( 'Manage Followed Sites' ) }</h1>
+					<h1>{ this.props.translate( 'Manage Followed Sites' ) }</h1>
 				</MobileBackToSidebar>
 				{ this.renderFollowError() }
 				{ this.renderUnfollowError() }
@@ -543,7 +545,7 @@ const FollowingEdit = React.createClass( {
 					isSearchOpen={ this.state.isAddingOpen }
 					ref="feed-search" />
 
-				<SectionHeader className="following-edit__header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
+				<SectionHeader className="following-edit__header" label={ this.props.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
 					{ ! hasNoSubscriptions
 							? <FollowingExportButton
 									onExport={ this.handleFeedExport }
@@ -559,7 +561,7 @@ const FollowingEdit = React.createClass( {
 							? <Button
 								borderless
 								className="following-edit__search"
-								aria-label={ this.translate( 'Open Search', { context: 'button label' } ) }
+								aria-label={ this.props.translate( 'Open Search', { context: 'button label' } ) }
 								onClick={ this.toggleSearching }>
 								<Gridicon icon="search" />
 							</Button>
@@ -581,7 +583,7 @@ const FollowingEdit = React.createClass( {
 
 				{ this.state.isAttemptingFollow && ! this.state.lastError ? <SubscriptionPlaceholder key={ 'placeholder-add-feed' } /> : null }
 				{ subscriptionsToDisplay.length === 0 && this.props.search && ! this.state.isLoading
-					? <NoResults text={ this.translate( 'No subscriptions match that search.' ) } />
+					? <NoResults text={ this.props.translate( 'No subscriptions match that search.' ) } />
 					: <InfiniteList className="following-edit__sites"
 						items={ subscriptionsToDisplay }
 						lastPage={ this.state.isLastPage }
@@ -600,4 +602,4 @@ const FollowingEdit = React.createClass( {
 
 } );
 
-export default FollowingEdit;
+export default localize(FollowingEdit);

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -376,7 +376,7 @@ const FollowingEdit = React.createClass( {
 		const url = this.state.lastError.URL;
 
 		return (
-		    <Notice
+			<Notice
 						status="is-error"
 						showDismiss={ true }
 						onDismissClick={ this.dismissError }>
@@ -529,7 +529,7 @@ const FollowingEdit = React.createClass( {
 		}, 'following-edit' );
 
 		return (
-		    <ReaderMain className={ containerClasses }>
+			<ReaderMain className={ containerClasses }>
 				<MobileBackToSidebar>
 					<h1>{ this.props.translate( 'Manage Followed Sites' ) }</h1>
 				</MobileBackToSidebar>

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -602,4 +602,4 @@ const FollowingEdit = React.createClass( {
 
 } );
 
-export default localize(FollowingEdit);
+export default localize( FollowingEdit );

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -34,4 +34,4 @@ var FollowingEditNavigation = React.createClass( {
 	}
 } );
 
-export default localize(FollowingEditNavigation);
+export default localize( FollowingEditNavigation );

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 var FollowingEditNavigation = React.createClass( {
 
 	propTypes: { totalSubscriptions: React.PropTypes.number },
@@ -13,7 +15,7 @@ var FollowingEditNavigation = React.createClass( {
 			return null;
 		}
 
-		return this.translate(
+		return this.props.translate(
 			'%(count)d site',
 			'%(count)d sites',
 			{
@@ -32,4 +34,4 @@ var FollowingEditNavigation = React.createClass( {
 	}
 } );
 
-export default FollowingEditNavigation;
+export default localize(FollowingEditNavigation);

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 var FollowingEditNavigation = React.createClass( {

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -141,7 +141,8 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 		if ( isExternal ) {
 			return (
-				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card"
+					key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
 					<p>{ this.props.translate( 'RSS feeds do not allow for email notifications.' ) }</p>
 				</Card>
 			);
@@ -149,7 +150,8 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 		if ( this.props.isEmailBlocked ) {
 			return (
-				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card"
+					key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
 					<p>{ this.props.translate( 'You have blocked all email updates from your subscribed blogs.' ) }</p>
 					<p>{ this.props.translate( 'You can change this in your {{settingsLink}}Notification Settings{{/settingsLink}}.',
 						{

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
 /**
@@ -119,8 +120,8 @@ var FollowingEditNotificationSettings = React.createClass( {
 		}
 
 		return (
-			<div className="following-edit__notification-settings-error">
-				<FormInputValidation className="following-edit__notification-settings-error" isError text={ this.translate( 'Sorry, there was a problem changing your subscription settings.' ) } />
+		    <div className="following-edit__notification-settings-error">
+				<FormInputValidation className="following-edit__notification-settings-error" isError text={ this.props.translate( 'Sorry, there was a problem changing your subscription settings.' ) } />
 			</div>
 		);
 	},
@@ -140,17 +141,17 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 		if ( isExternal ) {
 			return (
-				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
-					<p>{ this.translate( 'RSS feeds do not allow for email notifications.' ) }</p>
+			    <Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+					<p>{ this.props.translate( 'RSS feeds do not allow for email notifications.' ) }</p>
 				</Card>
 			);
 		}
 
 		if ( this.props.isEmailBlocked ) {
 			return (
-				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
-					<p>{ this.translate( 'You have blocked all email updates from your subscribed blogs.' ) }</p>
-					<p>{ this.translate( 'You can change this in your {{settingsLink}}Notification Settings{{/settingsLink}}.',
+			    <Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+					<p>{ this.props.translate( 'You have blocked all email updates from your subscribed blogs.' ) }</p>
+					<p>{ this.props.translate( 'You can change this in your {{settingsLink}}Notification Settings{{/settingsLink}}.',
 						{
 							components: {
 								settingsLink: <a href="/me/notifications/subscriptions" />
@@ -163,24 +164,24 @@ var FollowingEditNotificationSettings = React.createClass( {
 		}
 
 		return (
-			<div>
+		    <div>
 				<Card className={ postEmailClasses } key={ 'notification-settings-posts-' + subscription.get( 'ID' ) }>
-					<span>{ this.translate( 'Emails for new posts' ) }</span>
+					<span>{ this.props.translate( 'Emails for new posts' ) }</span>
 					<span className="following-edit__form-toggle-wrapper">
 						<span className="following-edit__form-toggle-status">{ isPostEmailActive ? 'on' : 'off' }</span>
 						<FormToggle id="following-edit__form-toggle-post-emails" onChange={ this.handlePostEmailToggle } checked={ isPostEmailActive } disabled={ false } />
 					</span>
 					{ isPostEmailActive ?
 						<SegmentedControl compact={ true }>
-							<ControlItem selected={ emailDeliveryFrequency === DELIVERY_FREQUENCY_INSTANTLY } onClick={ this.handleEmailFrequencyClick.bind( this, DELIVERY_FREQUENCY_INSTANTLY ) } key={ 'delivery-frequency-instant' }>{ this.translate( 'Instant' ) }</ControlItem>
-							<ControlItem selected={ emailDeliveryFrequency === DELIVERY_FREQUENCY_DAILY } onClick={ this.handleEmailFrequencyClick.bind( this, DELIVERY_FREQUENCY_DAILY ) } key={ 'delivery-frequency-daily' }>{ this.translate( 'Daily' ) }</ControlItem>
-							<ControlItem selected={ emailDeliveryFrequency === DELIVERY_FREQUENCY_WEEKLY } onClick={ this.handleEmailFrequencyClick.bind( this, DELIVERY_FREQUENCY_WEEKLY ) } key={ 'delivery-frequency-weekly' }>{ this.translate( 'Weekly' ) }</ControlItem>
+							<ControlItem selected={ emailDeliveryFrequency === DELIVERY_FREQUENCY_INSTANTLY } onClick={ this.handleEmailFrequencyClick.bind( this, DELIVERY_FREQUENCY_INSTANTLY ) } key={ 'delivery-frequency-instant' }>{ this.props.translate( 'Instant' ) }</ControlItem>
+							<ControlItem selected={ emailDeliveryFrequency === DELIVERY_FREQUENCY_DAILY } onClick={ this.handleEmailFrequencyClick.bind( this, DELIVERY_FREQUENCY_DAILY ) } key={ 'delivery-frequency-daily' }>{ this.props.translate( 'Daily' ) }</ControlItem>
+							<ControlItem selected={ emailDeliveryFrequency === DELIVERY_FREQUENCY_WEEKLY } onClick={ this.handleEmailFrequencyClick.bind( this, DELIVERY_FREQUENCY_WEEKLY ) } key={ 'delivery-frequency-weekly' }>{ this.props.translate( 'Weekly' ) }</ControlItem>
 						</SegmentedControl> : null }
 					{ this.renderPostEmailError() }
 				</Card>
 
 				<Card className={ commentEmailClasses } key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
-					<span>{ this.translate( 'Emails for new comments' ) }</span>
+					<span>{ this.props.translate( 'Emails for new comments' ) }</span>
 					<span className="following-edit__form-toggle-wrapper">
 						<span className="following-edit__form-toggle-status">{ isCommentEmailActive ? 'on' : 'off' }</span>
 						<FormToggle id="following-edit__form-toggle-comment-emails" onChange={ this.handleCommentEmailToggle } checked={ isCommentEmailActive } disabled={ false } />
@@ -193,4 +194,4 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 } );
 
-export default FollowingEditNotificationSettings;
+export default localize(FollowingEditNotificationSettings);

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -120,7 +120,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 		}
 
 		return (
-		    <div className="following-edit__notification-settings-error">
+			<div className="following-edit__notification-settings-error">
 				<FormInputValidation className="following-edit__notification-settings-error" isError text={ this.props.translate( 'Sorry, there was a problem changing your subscription settings.' ) } />
 			</div>
 		);
@@ -141,7 +141,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 		if ( isExternal ) {
 			return (
-			    <Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
 					<p>{ this.props.translate( 'RSS feeds do not allow for email notifications.' ) }</p>
 				</Card>
 			);
@@ -149,7 +149,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 		if ( this.props.isEmailBlocked ) {
 			return (
-			    <Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
 					<p>{ this.props.translate( 'You have blocked all email updates from your subscribed blogs.' ) }</p>
 					<p>{ this.props.translate( 'You can change this in your {{settingsLink}}Notification Settings{{/settingsLink}}.',
 						{
@@ -164,7 +164,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 		}
 
 		return (
-		    <div>
+			<div>
 				<Card className={ postEmailClasses } key={ 'notification-settings-posts-' + subscription.get( 'ID' ) }>
 					<span>{ this.props.translate( 'Emails for new posts' ) }</span>
 					<span className="following-edit__form-toggle-wrapper">

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -194,4 +194,4 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 } );
 
-export default localize(FollowingEditNotificationSettings);
+export default localize( FollowingEditNotificationSettings );

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -41,4 +41,4 @@ const FollowingEditSortControls = React.createClass( {
 	}
 } );
 
-export default localize(FollowingEditSortControls);
+export default localize( FollowingEditSortControls );

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import noop from 'lodash/noop';
 
 /**
@@ -29,15 +30,15 @@ const FollowingEditSortControls = React.createClass( {
 		const sortOrder = this.props.sortOrder;
 
 		return (
-			<div className="following-edit__sort-controls">
-				<label htmlFor="sort-control-select">{ this.translate( 'Sort by' ) }</label>
+		    <div className="following-edit__sort-controls">
+				<label htmlFor="sort-control-select">{ this.props.translate( 'Sort by' ) }</label>
 				<select id="sort-control-select" ref="sortControlSelect" className="is-compact" onChange={ this.handleSelectChange } value={ sortOrder }>
-					<option value="date-followed">{ this.translate( 'By Date' ) }</option>
-					<option value="alpha">{ this.translate( 'By Name' ) }</option>
+					<option value="date-followed">{ this.props.translate( 'By Date' ) }</option>
+					<option value="alpha">{ this.props.translate( 'By Name' ) }</option>
 				</select>
 			</div>
 		);
 	}
 } );
 
-export default FollowingEditSortControls;
+export default localize(FollowingEditSortControls);

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -30,7 +30,7 @@ const FollowingEditSortControls = React.createClass( {
 		const sortOrder = this.props.sortOrder;
 
 		return (
-		    <div className="following-edit__sort-controls">
+			<div className="following-edit__sort-controls">
 				<label htmlFor="sort-control-select">{ this.props.translate( 'Sort by' ) }</label>
 				<select id="sort-control-select" ref="sortControlSelect" className="is-compact" onChange={ this.handleSelectChange } value={ sortOrder }>
 					<option value="date-followed">{ this.props.translate( 'By Date' ) }</option>

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -163,4 +163,4 @@ var FollowingEditSubscribeForm = React.createClass( {
 
 } );
 
-export default localize(FollowingEditSubscribeForm);
+export default localize( FollowingEditSubscribeForm );

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -142,7 +142,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 		}
 
 		return (
-		    <div className="following-edit__subscribe-form">
+			<div className="following-edit__subscribe-form">
 				<SearchCard
 					isOpen={ this.props.isSearchOpen }
 					autoFocus={ true }

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import url from 'url';
 import noop from 'lodash/noop';
 
@@ -141,14 +142,14 @@ var FollowingEditSubscribeForm = React.createClass( {
 		}
 
 		return (
-			<div className="following-edit__subscribe-form">
+		    <div className="following-edit__subscribe-form">
 				<SearchCard
 					isOpen={ this.props.isSearchOpen }
 					autoFocus={ true }
 					key="newSubscriptionSearch"
 					onSearch={ this.handleSearch }
 					onSearchClose={ this.handleSearchClose }
-					placeholder={ this.translate( 'Enter a site URL to follow', { context: 'field placeholder' } ) }
+					placeholder={ this.props.translate( 'Enter a site URL to follow', { context: 'field placeholder' } ) }
 					delaySearch={ false }
 					ref="followingEditSubscriptionSearch"
 					onKeyDown={ this.handleKeyDown }
@@ -162,4 +163,4 @@ var FollowingEditSubscribeForm = React.createClass( {
 
 } );
 
-export default FollowingEditSubscribeForm;
+export default localize(FollowingEditSubscribeForm);

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -35,22 +37,24 @@ var TagEmptyContent = React.createClass( {
 		var action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
-			href="/">{ this.translate( 'Back to Following' ) }</a> ),
+			href="/">{ this.props.translate( 'Back to Following' ) }</a> ),
 			secondaryAction = isDiscoverEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
-		return ( <EmptyContent
-			title={ this.translate( 'No Likes Yet' ) }
-			line={ this.translate( 'Posts that you like will appear here.' ) }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+		    <EmptyContent
+				title={ this.props.translate( 'No Likes Yet' ) }
+				line={ this.props.translate( 'Posts that you like will appear here.' ) }
+				action={ action }
+				secondaryAction={ secondaryAction }
+				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+				illustrationWidth={ 500 }
+				/>
+		);
 	}
 } );
 
-export default TagEmptyContent;
+export default localize(TagEmptyContent);

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -57,4 +57,4 @@ var TagEmptyContent = React.createClass( {
 	}
 } );
 
-export default localize(TagEmptyContent);
+export default localize( TagEmptyContent );

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -45,7 +45,7 @@ var TagEmptyContent = React.createClass( {
 				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return (
-		    <EmptyContent
+			<EmptyContent
 				title={ this.props.translate( 'No Likes Yet' ) }
 				line={ this.props.translate( 'Posts that you like will appear here.' ) }
 				action={ action }

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -13,16 +15,16 @@ import DocumentHead from 'components/data/document-head';
 var LikedStream = React.createClass( {
 
 	render: function() {
-		var title = this.translate( 'My Likes' ),
+		var title = this.props.translate( 'My Likes' ),
 			emptyContent = ( <EmptyContent /> );
 
 		return (
-			<Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true }>
-				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
+		    <Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true }>
+				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 			</Stream>
 		);
 	}
 
 } );
 
-export default LikedStream;
+export default localize(LikedStream);

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -27,4 +27,4 @@ var LikedStream = React.createClass( {
 
 } );
 
-export default localize(LikedStream);
+export default localize( LikedStream );

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -19,7 +19,7 @@ var LikedStream = React.createClass( {
 			emptyContent = ( <EmptyContent /> );
 
 		return (
-		    <Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true }>
+			<Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true }>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 			</Stream>
 		);

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -45,7 +45,7 @@ var ListEmptyContent = React.createClass( {
 				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return (
-		    <EmptyContent
+			<EmptyContent
 				title={ this.props.translate( 'No recent posts' ) }
 				line={ this.props.translate( 'The sites in this list have not posted anything recently.' ) }
 				action={ action }

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -57,4 +57,4 @@ var ListEmptyContent = React.createClass( {
 	}
 } );
 
-export default localize(ListEmptyContent);
+export default localize( ListEmptyContent );

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -35,22 +37,24 @@ var ListEmptyContent = React.createClass( {
 		var action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
-			href="/">{ this.translate( 'Back to Following' ) }</a> ),
+			href="/">{ this.props.translate( 'Back to Following' ) }</a> ),
 			secondaryAction = isDiscoverEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
-		return ( <EmptyContent
-			title={ this.translate( 'No recent posts' ) }
-			line={ this.translate( 'The sites in this list have not posted anything recently.' ) }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+		    <EmptyContent
+				title={ this.props.translate( 'No recent posts' ) }
+				line={ this.props.translate( 'The sites in this list have not posted anything recently.' ) }
+				action={ action }
+				secondaryAction={ secondaryAction }
+				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+				illustrationWidth={ 500 }
+				/>
+		);
 	}
 } );
 
-export default ListEmptyContent;
+export default localize(ListEmptyContent);

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -95,4 +95,4 @@ export default connect(
 			unfollowList
 		}, dispatch );
 	}
-)( localize(ListStream) );
+)( localize( ListStream ) );

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
@@ -48,7 +49,7 @@ const ListStream = React.createClass( {
 			emptyContent = ( <EmptyContent /> );
 
 		let	editUrl = null,
-			title = this.translate( 'Loading list' );
+			title = this.props.translate( 'Loading list' );
 
 		if ( list ) {
 			title = list.title;
@@ -61,8 +62,8 @@ const ListStream = React.createClass( {
 		}
 
 		return (
-			<Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>
-				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
+		    <Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>
+				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader
 					isPlaceholder={ ! list }
@@ -94,4 +95,4 @@ export default connect(
 			unfollowList
 		}, dispatch );
 	}
-)( ListStream );
+)( localize(ListStream) );

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -62,7 +62,7 @@ const ListStream = React.createClass( {
 		}
 
 		return (
-		    <Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>
+			<Stream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<ListStreamHeader

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -64,4 +64,4 @@ const ListMissing = React.createClass( {
 	}
 } );
 
-export default localize(ListMissing);
+export default localize( ListMissing );

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -49,7 +49,7 @@ const ListMissing = React.createClass( {
 				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return (
-		    <div>
+			<div>
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<EmptyContent
 				title={ this.props.translate( 'List not found' ) }

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -39,19 +41,19 @@ const ListMissing = React.createClass( {
 		const action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
-			href="/">{ this.translate( 'Back to Followed Sites' ) }</a> ),
+			href="/">{ this.props.translate( 'Back to Followed Sites' ) }</a> ),
 			secondaryAction = isDiscoverEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return (
-			<div>
+		    <div>
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
 				<EmptyContent
-				title={ this.translate( 'List not found' ) }
-				line={ this.translate( 'Sorry, we couldn\'t find that list.' ) }
+				title={ this.props.translate( 'List not found' ) }
+				line={ this.props.translate( 'Sorry, we couldn\'t find that list.' ) }
 				action={ action }
 				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
@@ -62,5 +64,4 @@ const ListMissing = React.createClass( {
 	}
 } );
 
-export default ListMissing
-;
+export default localize(ListMissing);

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
@@ -49,15 +50,15 @@ const PostExcerptLink = React.createClass( {
 		} );
 
 		return (
-			<div className={ classes }>
-				{ this.translate( 'Visit {{siteName/}} for the full post.', { components: { siteName } } ) }
+		    <div className={ classes }>
+				{ this.props.translate( 'Visit {{siteName/}} for the full post.', { components: { siteName } } ) }
 				<svg onClick={ this.toggleNotice } className="gridicon gridicon__help ignore-click" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" enableBackground="new 0 0 24 24"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm2.003-6.41c-.23.36-.6.704-1.108 1.028-.43.28-.7.482-.808.61-.108.13-.163.283-.163.46V13H11.04v-.528c0-.4.08-.74.245-1.017.163-.276.454-.546.872-.808.332-.21.57-.397.716-.565.145-.168.217-.36.217-.577 0-.172-.077-.308-.233-.41-.156-.1-.358-.15-.608-.15-.62 0-1.342.22-2.17.658l-.854-1.67c1.02-.58 2.084-.872 3.194-.872.913 0 1.63.202 2.15.603.52.4.78.948.78 1.64 0 .495-.116.924-.347 1.286z"/></svg>
 				<p className="post-excerpt-link__helper">
-					{ this.translate( 'The owner of this site only allows us to show a brief summary of their content. To view the full post, you\'ll have to visit their site.' ) }
+					{ this.props.translate( 'The owner of this site only allows us to show a brief summary of their content. To view the full post, you\'ll have to visit their site.' ) }
 				</p>
 			</div>
 		);
 	}
 } );
 
-export default PostExcerptLink;
+export default localize(PostExcerptLink);

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -50,7 +50,7 @@ const PostExcerptLink = React.createClass( {
 		} );
 
 		return (
-		    <div className={ classes }>
+			<div className={ classes }>
 				{ this.props.translate( 'Visit {{siteName/}} for the full post.', { components: { siteName } } ) }
 				<svg onClick={ this.toggleNotice } className="gridicon gridicon__help ignore-click" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" enableBackground="new 0 0 24 24"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm2.003-6.41c-.23.36-.6.704-1.108 1.028-.43.28-.7.482-.808.61-.108.13-.163.283-.163.46V13H11.04v-.528c0-.4.08-.74.245-1.017.163-.276.454-.546.872-.808.332-.21.57-.397.716-.565.145-.168.217-.36.217-.577 0-.172-.077-.308-.233-.41-.156-.1-.358-.15-.608-.15-.62 0-1.342.22-2.17.658l-.854-1.67c1.02-.58 2.084-.872 3.194-.872.913 0 1.63.202 2.15.603.52.4.78.948.78 1.64 0 .495-.116.924-.347 1.286z"/></svg>
 				<p className="post-excerpt-link__helper">

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -61,4 +61,4 @@ const PostExcerptLink = React.createClass( {
 	}
 } );
 
-export default localize(PostExcerptLink);
+export default localize( PostExcerptLink );

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -37,4 +37,4 @@ var ReadingTime = React.createClass( {
 
 } );
 
-export default localize(ReadingTime);
+export default localize( ReadingTime );

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import PureRenderMixin from 'react-pure-render/mixin';
 
 var ReadingTime = React.createClass( {
@@ -15,13 +16,13 @@ var ReadingTime = React.createClass( {
 			readingTime;
 
 		if ( timeInMinutes > 1 ) {
-			approxTime = ( <span className="reading-time__approx">( { this.translate( '~%d min', {
+			approxTime = ( <span className="reading-time__approx">( { this.props.translate( '~%d min', {
 				args: [ timeInMinutes ],
 				context: 'An approximate time to read something, in minutes'
 			} ) })</span> );
 		}
 
-		readingTime = this.translate(
+		readingTime = this.props.translate(
 			'%d word {{Time/}}',
 			'%d words {{Time/}}', {
 				count: words,
@@ -36,4 +37,4 @@ var ReadingTime = React.createClass( {
 
 } );
 
-export default ReadingTime;
+export default localize(ReadingTime);

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -150,4 +150,4 @@ const RecommendedForYou = React.createClass( {
 	}
 } );
 
-export default localize(RecommendedForYou);
+export default localize( RecommendedForYou );

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -129,7 +129,7 @@ const RecommendedForYou = React.createClass( {
 
 	render() {
 		return (
-		    <Main className="recommended-for-you">
+			<Main className="recommended-for-you">
 				<MobileBackToSidebar>
 					<h1>{ this.props.translate( 'Recommendations' ) }</h1>
 				</MobileBackToSidebar>

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import times from 'lodash/times';
 import url from 'url';
 
@@ -128,12 +129,12 @@ const RecommendedForYou = React.createClass( {
 
 	render() {
 		return (
-			<Main className="recommended-for-you">
+		    <Main className="recommended-for-you">
 				<MobileBackToSidebar>
-					<h1>{ this.translate( 'Recommendations' ) }</h1>
+					<h1>{ this.props.translate( 'Recommendations' ) }</h1>
 				</MobileBackToSidebar>
 
-				<h2 className="reader-recommended__heading">{ this.translate( 'We think you\'ll like' ) }</h2>
+				<h2 className="reader-recommended__heading">{ this.props.translate( 'We think you\'ll like' ) }</h2>
 				<InfiniteList
 					items={ this.state.recommendations }
 					fetchingNextPage={ this.state.fetching }
@@ -145,8 +146,8 @@ const RecommendedForYou = React.createClass( {
 					renderLoadingPlaceholders={ this.renderPlaceholders }
 					/>
 				</Main>
-			);
+		);
 	}
 } );
 
-export default RecommendedForYou;
+export default localize(RecommendedForYou);

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -17,7 +17,7 @@ const RecommendedNavigation = React.createClass( {
 		};
 
 		return (
-		    <SectionNav selectedText={ sectionNames[ current ] }>
+			<SectionNav selectedText={ sectionNames[ current ] }>
 				<NavTabs>
 					<NavItem path="/recommendations/mine" selected={ current === 'for-you' }>{ this.props.translate( 'For You' ) }</NavItem>
 					<NavItem path="/recommendations/posts" selected={ current === 'posts' }>{ this.props.translate( 'Posts' ) }</NavItem>

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -9,23 +10,23 @@ const RecommendedNavigation = React.createClass( {
 	render() {
 		const current = this.props.selected;
 		const sectionNames = {
-			'for-you': this.translate( 'Recommendations: For You' ),
-			posts: this.translate( 'Recommendations: Posts' ),
-			sites: this.translate( 'Recommendations: Sites' ),
-			tags: this.translate( 'Recommendations: Tags' )
+			'for-you': this.props.translate( 'Recommendations: For You' ),
+			posts: this.props.translate( 'Recommendations: Posts' ),
+			sites: this.props.translate( 'Recommendations: Sites' ),
+			tags: this.props.translate( 'Recommendations: Tags' )
 		};
 
 		return (
-			<SectionNav selectedText={ sectionNames[ current ] }>
+		    <SectionNav selectedText={ sectionNames[ current ] }>
 				<NavTabs>
-					<NavItem path="/recommendations/mine" selected={ current === 'for-you' }>{ this.translate( 'For You' ) }</NavItem>
-					<NavItem path="/recommendations/posts" selected={ current === 'posts' }>{ this.translate( 'Posts' ) }</NavItem>
-					<NavItem path="/recommendations" selected={ current === 'sites' }>{ this.translate( 'Topics' ) }</NavItem>
-					<NavItem path="/tags" selected={ current === 'tags' }>{ this.translate( 'Tags' ) }</NavItem>
+					<NavItem path="/recommendations/mine" selected={ current === 'for-you' }>{ this.props.translate( 'For You' ) }</NavItem>
+					<NavItem path="/recommendations/posts" selected={ current === 'posts' }>{ this.props.translate( 'Posts' ) }</NavItem>
+					<NavItem path="/recommendations" selected={ current === 'sites' }>{ this.props.translate( 'Topics' ) }</NavItem>
+					<NavItem path="/tags" selected={ current === 'tags' }>{ this.props.translate( 'Tags' ) }</NavItem>
 				</NavTabs>
 			</SectionNav>
-			);
+		);
 	}
 } );
 
-export default RecommendedNavigation;
+export default localize(RecommendedNavigation);

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -29,4 +29,4 @@ const RecommendedNavigation = React.createClass( {
 	}
 } );
 
-export default localize(RecommendedNavigation);
+export default localize( RecommendedNavigation );

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -45,7 +45,7 @@ var RecommendedPostsEmptyContent = React.createClass( {
 				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return (
-		    <EmptyContent
+			<EmptyContent
 				title={ this.props.translate( 'No Post Recommendations yet' ) }
 				line={ this.props.translate( 'Posts we recommend based on your WordPress.com activity will appear here.' ) }
 				action={ action }

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -57,4 +57,4 @@ var RecommendedPostsEmptyContent = React.createClass( {
 	}
 } );
 
-export default localize(RecommendedPostsEmptyContent);
+export default localize( RecommendedPostsEmptyContent );

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -35,22 +37,24 @@ var RecommendedPostsEmptyContent = React.createClass( {
 		var action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
-			href="/">{ this.translate( 'Back to Following' ) }</a> ),
+			href="/">{ this.props.translate( 'Back to Following' ) }</a> ),
 			secondaryAction = isDiscoverEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+				href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
-		return ( <EmptyContent
-			title={ this.translate( 'No Post Recommendations yet' ) }
-			line={ this.translate( 'Posts we recommend based on your WordPress.com activity will appear here.' ) }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+		    <EmptyContent
+				title={ this.props.translate( 'No Post Recommendations yet' ) }
+				line={ this.props.translate( 'Posts we recommend based on your WordPress.com activity will appear here.' ) }
+				action={ action }
+				secondaryAction={ secondaryAction }
+				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+				illustrationWidth={ 500 }
+				/>
+		);
 	}
 } );
 
-export default RecommendedPostsEmptyContent;
+export default localize(RecommendedPostsEmptyContent);

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -19,7 +19,7 @@ var RecommendationPostsStream = React.createClass( {
 			emptyContent = ( <EmptyContent /> );
 
 		return (
-		    <Stream { ...this.props }
+			<Stream { ...this.props }
 				listName = { title }
 				emptyContent = { emptyContent }
 				showFollowInHeader = { true }

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -31,4 +31,4 @@ var RecommendationPostsStream = React.createClass( {
 
 } );
 
-export default localize(RecommendationPostsStream);
+export default localize( RecommendationPostsStream );

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -14,8 +14,8 @@ import DocumentHead from 'components/data/document-head';
 var RecommendationPostsStream = React.createClass( {
 
 	render: function() {
-		var title = this.props.translate( 'Recommended Posts' ),
-			emptyContent = ( <EmptyContent /> );
+		const title = this.props.translate( 'Recommended Posts' );
+		const emptyContent = ( <EmptyContent /> );
 
 		return (
 			<Stream { ...this.props }

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -13,20 +15,20 @@ import DocumentHead from 'components/data/document-head';
 var RecommendationPostsStream = React.createClass( {
 
 	render: function() {
-		var title = this.translate( 'Recommended Posts' ),
+		var title = this.props.translate( 'Recommended Posts' ),
 			emptyContent = ( <EmptyContent /> );
 
 		return (
-			<Stream { ...this.props }
+		    <Stream { ...this.props }
 				listName = { title }
 				emptyContent = { emptyContent }
 				showFollowInHeader = { true }
 			>
-				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
+				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 			</Stream>
 		);
 	}
 
 } );
 
-export default RecommendationPostsStream;
+export default localize(RecommendationPostsStream);

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -56,7 +56,7 @@ const SearchEmptyContent = React.createClass( {
 		);
 
 		return (
-		    <EmptyContent
+			<EmptyContent
 				title={ this.props.translate( 'No Results' ) }
 				line={ message }
 				action={ action }

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -68,4 +68,4 @@ const SearchEmptyContent = React.createClass( {
 	}
 } );
 
-export default localize(SearchEmptyContent);
+export default localize( SearchEmptyContent );

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -40,28 +42,30 @@ const SearchEmptyContent = React.createClass( {
 		const action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
-			href="/">{ this.translate( 'Back to Following' ) }</a> );
+			href="/">{ this.props.translate( 'Back to Following' ) }</a> );
 
 		const secondaryAction = isDiscoverEnabled()
 			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }
-			href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+			href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
-		const message = this.translate(
+		const message = this.props.translate(
 			'No posts found for {{query /}} for your language.',
 			{ components: { query: <em>{ this.props.query }</em> } }
 		);
 
-		return ( <EmptyContent
-			title={ this.translate( 'No Results' ) }
-			line={ message }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+		    <EmptyContent
+				title={ this.props.translate( 'No Results' ) }
+				line={ message }
+				action={ action }
+				secondaryAction={ secondaryAction }
+				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+				illustrationWidth={ 500 }
+				/>
+		);
 	}
 } );
 
-export default SearchEmptyContent;
+export default localize(SearchEmptyContent);

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
@@ -19,7 +20,7 @@ import {
 } from 'reader/stats';
 import cssSafeUrl from 'lib/css-safe-url';
 
-export default React.createClass( {
+export default localize(React.createClass({
 	displayName: 'FeedFeatured',
 
 	mixins: [ PureRenderMixin ],
@@ -133,10 +134,10 @@ export default React.createClass( {
 		}
 
 		return (
-			<Card className="reader__featured-card">
+		    <Card className="reader__featured-card">
 				<div className="reader__featured-header">
-					<div className="reader__featured-title">{ this.translate( 'Highlights' ) }</div>
-					<div className="reader__featured-description">{ this.translate( 'What we’re reading this week.' ) }</div>
+					<div className="reader__featured-title">{ this.props.translate( 'Highlights' ) }</div>
+					<div className="reader__featured-description">{ this.props.translate( 'What we’re reading this week.' ) }</div>
 				</div>
 
 				<div className="reader__featured-posts">
@@ -145,4 +146,4 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+}));

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -20,7 +20,7 @@ import {
 } from 'reader/stats';
 import cssSafeUrl from 'lib/css-safe-url';
 
-export default localize(React.createClass({
+export default localize( React.createClass( {
 	displayName: 'FeedFeatured',
 
 	mixins: [ PureRenderMixin ],
@@ -146,4 +146,4 @@ export default localize(React.createClass({
 			</Card>
 		);
 	}
-}));
+} ) );

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -134,7 +134,7 @@ export default localize(React.createClass({
 		}
 
 		return (
-		    <Card className="reader__featured-card">
+			<Card className="reader__featured-card">
 				<div className="reader__featured-header">
 					<div className="reader__featured-title">{ this.props.translate( 'Highlights' ) }</div>
 					<div className="reader__featured-description">{ this.props.translate( 'What we’re reading this week.' ) }</div>

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -49,4 +49,4 @@ const FollowingEmptyContent = React.createClass( {
 	}
 } );
 
-export default localize(FollowingEmptyContent);
+export default localize( FollowingEmptyContent );

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -31,18 +33,20 @@ const FollowingEmptyContent = React.createClass( {
 			<a
 				className="empty-content__action button is-primary"
 				onClick={ this.recordAction }
-				href="/read/search">{ this.translate( 'Find Sites to Follow' ) }</a> ) : null,
+				href="/read/search">{ this.props.translate( 'Find Sites to Follow' ) }</a> ) : null,
 			secondaryAction = null;
 
-		return ( <EmptyContent
-			title={ this.translate( 'Welcome to Reader' ) }
-			line={ this.translate( 'Recent posts from sites you follow will appear here.' ) }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-all-done.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+		    <EmptyContent
+				title={ this.props.translate( 'Welcome to Reader' ) }
+				line={ this.props.translate( 'Recent posts from sites you follow will appear here.' ) }
+				action={ action }
+				secondaryAction={ secondaryAction }
+				illustration={ '/calypso/images/drake/drake-all-done.svg' }
+				illustrationWidth={ 500 }
+				/>
+		);
 	}
 } );
 
-export default FollowingEmptyContent;
+export default localize(FollowingEmptyContent);

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -37,7 +37,7 @@ const FollowingEmptyContent = React.createClass( {
 			secondaryAction = null;
 
 		return (
-		    <EmptyContent
+			<EmptyContent
 				title={ this.props.translate( 'Welcome to Reader' ) }
 				line={ this.props.translate( 'Recent posts from sites you follow will appear here.' ) }
 				action={ action }

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -46,4 +46,4 @@ var PostUnavailable = React.createClass( {
 
 } );
 
-export default localize(PostUnavailable);
+export default localize( PostUnavailable );

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import PureRenderMixin from 'react-pure-render/mixin';
 import config from 'config';
 
@@ -16,8 +17,8 @@ var PostUnavailable = React.createClass( {
 
 	componentWillMount: function() {
 		this.errors = {
-			unauthorized: this.translate( 'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.' ),
-			default: this.translate( 'An error occurred loading this post.' )
+			unauthorized: this.props.translate( 'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.' ),
+			default: this.props.translate( 'An error occurred loading this post.' )
 		};
 	},
 
@@ -45,4 +46,4 @@ var PostUnavailable = React.createClass( {
 
 } );
 
-export default PostUnavailable;
+export default localize(PostUnavailable);

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -39,28 +41,30 @@ const TagEmptyContent = React.createClass( {
 		const action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
-			href="/">{ this.translate( 'Back to Following' ) }</a> );
+			href="/">{ this.props.translate( 'Back to Following' ) }</a> );
 
 		const secondaryAction = isDiscoverEnabled()
 			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }
-			href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+			href="/discover">{ this.props.translate( 'Explore Discover' ) }</a> ) : null;
 
-		const message = this.translate(
+		const message = this.props.translate(
 			'No posts have recently been tagged with {{tagName /}} for your language.',
 			{ components: { tagName: <em>{ this.props.decodedTagSlug }</em> } }
 		);
 
-		return ( <EmptyContent
-			title={ this.translate( 'No recent posts' ) }
-			line={ message }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+		    <EmptyContent
+				title={ this.props.translate( 'No recent posts' ) }
+				line={ message }
+				action={ action }
+				secondaryAction={ secondaryAction }
+				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+				illustrationWidth={ 500 }
+				/>
+		);
 	}
 } );
 
-export default TagEmptyContent;
+export default localize(TagEmptyContent);

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -67,4 +67,4 @@ const TagEmptyContent = React.createClass( {
 	}
 } );
 
-export default localize(TagEmptyContent);
+export default localize( TagEmptyContent );

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -55,7 +55,7 @@ const TagEmptyContent = React.createClass( {
 		);
 
 		return (
-		    <EmptyContent
+			<EmptyContent
 				title={ this.props.translate( 'No recent posts' ) }
 				line={ message }
 				action={ action }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -134,4 +134,4 @@ export default connect(
 		followTag: requestFollowTag,
 		unfollowTag: requestUnfollowTag,
 	}
-)( localize(TagStream) );
+)( localize( TagStream ) );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -108,7 +108,7 @@ const TagStream = React.createClass( {
 		}
 
 		return (
-		    <Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
+			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -107,10 +108,10 @@ const TagStream = React.createClass( {
 		}
 
 		return (
-			<Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
+		    <Stream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />
-				<DocumentHead title={ this.translate( '%s ‹ Reader', { args: title } ) } />
+				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 				{ this.props.showBack && <HeaderBack /> }
 				<TagStreamHeader
 					title={ title }
@@ -133,4 +134,4 @@ export default connect(
 		followTag: requestFollowTag,
 		unfollowTag: requestUnfollowTag,
 	}
-)( TagStream );
+)( localize(TagStream) );

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -39,7 +39,10 @@ const UpdateNotice = React.createClass( {
 			<div className={ counterClasses } onClick={ this.handleClick } >
 				<DocumentHead unreadCount={ this.props.count } />
 				<Gridicon icon="arrow-up" size={ 18 } />
-				{ this.props.translate( '%s new post', '%s new posts', { args: [ this.props.cappedUnreadCount ], count: this.props.count } ) }
+				{ this.props.translate(
+					'%s new post', '%s new posts',
+					{ args: [ this.props.cappedUnreadCount ], count: this.props.count }
+				) }
 			</div>
 		);
 	},

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -54,4 +54,4 @@ export default connect(
 	state => ( {
 		cappedUnreadCount: getDocumentHeadCappedUnreadCount( state )
 	} )
-)( localize(UpdateNotice) );
+)( localize( UpdateNotice ) );

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { noop } from 'lodash';
@@ -35,10 +36,10 @@ const UpdateNotice = React.createClass( {
 		} );
 
 		return (
-			<div className={ counterClasses } onClick={ this.handleClick } >
+		    <div className={ counterClasses } onClick={ this.handleClick } >
 				<DocumentHead unreadCount={ this.props.count } />
 				<Gridicon icon="arrow-up" size={ 18 } />
-				{ this.translate( '%s new post', '%s new posts', { args: [ this.props.cappedUnreadCount ], count: this.props.count } ) }
+				{ this.props.translate( '%s new post', '%s new posts', { args: [ this.props.cappedUnreadCount ], count: this.props.count } ) }
 			</div>
 		);
 	},
@@ -53,4 +54,4 @@ export default connect(
 	state => ( {
 		cappedUnreadCount: getDocumentHeadCappedUnreadCount( state )
 	} )
-)( UpdateNotice );
+)( localize(UpdateNotice) );

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -36,7 +36,7 @@ const UpdateNotice = React.createClass( {
 		} );
 
 		return (
-		    <div className={ counterClasses } onClick={ this.handleClick } >
+			<div className={ counterClasses } onClick={ this.handleClick } >
 				<DocumentHead unreadCount={ this.props.count } />
 				<Gridicon icon="arrow-up" size={ 18 } />
 				{ this.props.translate( '%s new post', '%s new posts', { args: [ this.props.cappedUnreadCount ], count: this.props.count } ) }


### PR DESCRIPTION
Let's continue the tradition of using the Reader as a guinea pig for trying out new codemods 😁 

Branch made by running the codemod from https://github.com/Automattic/wp-calypso/pull/13597, and `s/localize\((\S*)\)/localize( $1 )/g`.

To test:
* Verify that the Reader is still properly localized.