### PR TITLE
Fix usage of notice id in notices middleware for site deletion actions

### DIFF
--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -209,19 +209,19 @@ const onSiteMonitorSettingsUpdateFailure = ( dispatch ) => dispatch(
 const onSiteDelete = ( dispatch, { siteId }, getState ) => dispatch(
 	successNotice( translate( '%(siteDomain)s is being deleted.', {
 		args: { siteDomain: getSiteDomain( getState(), siteId ) }
-	} ), { duration: 5000, noticeId: 'site-delete' } )
+	} ), { duration: 5000, id: 'site-delete' } )
 );
 
 const onSiteDeleteSuccess = ( dispatch, { siteId }, getState ) => dispatch(
 	successNotice( translate( '%(siteDomain)s has been deleted.', {
 		args: { siteDomain: getSiteDomain( getState(), siteId ) }
-	} ), { duration: 5000, noticeId: 'site-delete' } )
+	} ), { duration: 5000, id: 'site-delete' } )
 );
 
 const onSiteDeleteFailure = ( dispatch, { error } ) => {
 	if ( error.error === 'active-subscriptions' ) {
 		return dispatch( errorNotice( translate( 'You must cancel any active subscriptions prior to deleting your site.' ), {
-			noticeId: 'site-delete',
+			id: 'site-delete',
 			showDismiss: false,
 			button: translate( 'Manage Purchases' ),
 			href: purchasesPaths.purchasesRoot()


### PR DESCRIPTION
The handlers of site delete notices introduced in #13473 were using a wrong option name (`noticeId`) for the notice options. The correct option name is `id`

#### Testing instructions

1. Check other handlers for simillar usage ([like this one](https://github.com/Automattic/wp-calypso/blob/master/client/state/notices/middleware.js#L170)) (`id: 'id'` ) and confirm the site delete handlers use the option correctly now (`id: 'site-delete'` instead of `noticeId: 'site-delete'`)