### PR TITLE
Themes: Validate 'vertical' url param dynamically

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -61,25 +61,15 @@ export function upload( context, next ) {
 	next();
 }
 
-export function singleSite( context, next ) {
+export function loggedIn( context, next ) {
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <SingleSiteComponent { ...getProps( context ) } />;
-	next();
-}
+	const Component = context.params.site_id ? SingleSiteComponent : MultiSiteComponent;
+	context.primary = <Component { ...getProps( context ) } />;
 
-export function multiSite( context, next ) {
-	const props = getProps( context );
-
-	// Scroll to the top
-	if ( typeof window !== 'undefined' ) {
-		window.scrollTo( 0, 0 );
-	}
-
-	context.primary = <MultiSiteComponent { ...props } />;
 	next();
 }
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -20,31 +20,14 @@ export default function( router ) {
 			res.redirect( 301, '/themes' + originalUrl.slice( '/design'.length ) );
 		} );
 
-		router(
+		const showcaseRoutes = [
 			'/themes/:tier(free|premium)?',
-			fetchThemeFilters,
-			fetchThemeData,
-			loggedOut,
-			makeLayout
-		);
-		router(
 			'/themes/:tier(free|premium)?/filter/:filter',
-			fetchThemeFilters,
-			validateFilters,
-			fetchThemeData,
-			loggedOut,
-			makeLayout
-		);
-		router(
 			'/themes/:vertical?/:tier(free|premium)?',
-			fetchThemeFilters,
-			validateVertical,
-			fetchThemeData,
-			loggedOut,
-			makeLayout
-		);
-		router(
 			'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+		];
+		router(
+			showcaseRoutes,
 			fetchThemeFilters,
 			validateVertical,
 			validateFilters,

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -3,7 +3,6 @@
  */
 import config from 'config';
 import { makeLayout } from 'controller';
-import { getSubjects } from './theme-filters.js';
 import {
 	fetchThemeData,
 	fetchThemeFilters,
@@ -12,21 +11,42 @@ import {
 	redirectFilterAndType,
 	redirectToThemeDetails
 } from './controller';
-import validateFilters from './validate-filters';
+import { validateFilters, validateVertical } from './validate-filters';
 
 export default function( router ) {
-	const verticals = getSubjects().join( '|' );
-
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		// Redirect interim showcase route to permanent one
 		router( [ '/design', '/design/*' ], ( { originalUrl, res } ) => {
 			res.redirect( 301, '/themes' + originalUrl.slice( '/design'.length ) );
 		} );
 
-		router( `/themes/:vertical(${ verticals })?/:tier(free|premium)?`, fetchThemeFilters, fetchThemeData, loggedOut, makeLayout );
 		router(
-			`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
+			'/themes/:tier(free|premium)?',
 			fetchThemeFilters,
+			fetchThemeData,
+			loggedOut,
+			makeLayout
+		);
+		router(
+			'/themes/:tier(free|premium)?/filter/:filter',
+			fetchThemeFilters,
+			validateFilters,
+			fetchThemeData,
+			loggedOut,
+			makeLayout
+		);
+		router(
+			'/themes/:vertical?/:tier(free|premium)?',
+			fetchThemeFilters,
+			validateVertical,
+			fetchThemeData,
+			loggedOut,
+			makeLayout
+		);
+		router(
+			'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+			fetchThemeFilters,
+			validateVertical,
 			validateFilters,
 			fetchThemeData,
 			loggedOut,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -6,13 +6,14 @@ import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
 import { makeNavigation, siteSelection, makeSites } from 'my-sites/controller';
 import { loggedIn, loggedOut, upload } from './controller';
-import { getSubjects } from './theme-filters';
-import validateFilters from './validate-filters';
+import { validateFilters, validateVertical } from './validate-filters';
 
 export default function( router ) {
 	const user = userFactory();
 	const isLoggedIn = !! user.get();
-	const verticals = getSubjects().join( '|' );
+	const siteId = '\\d+' + // numeric site id
+		'|' + // or
+		'[^\\\\/.]+\\.[^\\\\/]+'; // one-or-more non-slash-or-dot chars, then a dot, then one-or-more non-slashes
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
@@ -24,18 +25,31 @@ export default function( router ) {
 				);
 			}
 			router(
-				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/:site_id?`,
+				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
 				siteSelection, loggedIn, makeNavigation, makeLayout
 			);
 			router(
-				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id?`,
+				`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
 				validateFilters, siteSelection, loggedIn, makeNavigation, makeLayout
 			);
-		} else {
-			router( `/themes/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );
 			router(
-				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
+				`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
+				validateVertical, siteSelection, loggedIn, makeNavigation, makeLayout
+			);
+			router(
+				`/themes/:vertical?/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
+				validateVertical, validateFilters, siteSelection, loggedIn, makeNavigation, makeLayout
+			);
+		} else {
+			router( '/themes/:tier(free|premium)?', loggedOut, makeLayout );
+			router(
+				'/themes/:tier(free|premium)?/filter/:filter',
 				validateFilters, loggedOut, makeLayout
+			);
+			router( '/themes/:vertical?/:tier(free|premium)?', validateVertical, loggedOut, makeLayout );
+			router(
+				'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+				validateVertical, validateFilters, loggedOut, makeLayout
 			);
 		}
 	}

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -5,7 +5,7 @@ import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
 import { makeNavigation, siteSelection, makeSites } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut, upload } from './controller';
+import { loggedIn, loggedOut, upload } from './controller';
 import { getSubjects } from './theme-filters';
 import validateFilters from './validate-filters';
 
@@ -24,20 +24,12 @@ export default function( router ) {
 				);
 			}
 			router(
-				`/themes/:vertical(${ verticals })?/:tier(free|premium)?`,
-				siteSelection, multiSite, makeNavigation, makeLayout
+				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/:site_id?`,
+				siteSelection, loggedIn, makeNavigation, makeLayout
 			);
 			router(
-				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/:site_id`,
-				siteSelection, singleSite, makeNavigation, makeLayout
-			);
-			router(
-				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter`,
-				validateFilters, siteSelection, multiSite, makeNavigation, makeLayout
-			);
-			router(
-				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id`,
-				validateFilters, siteSelection, singleSite, makeNavigation, makeLayout
+				`/themes/:vertical(${ verticals })?/:tier(free|premium)?/filter/:filter/:site_id?`,
+				validateFilters, siteSelection, loggedIn, makeNavigation, makeLayout
 			);
 		} else {
 			router( `/themes/:vertical(${ verticals })?/:tier(free|premium)?`, loggedOut, makeLayout );

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -24,33 +24,14 @@ export default function( router ) {
 					siteSelection, upload, makeNavigation, makeLayout
 				);
 			}
-			router(
+			const loggedInRoutes = [
 				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
-				siteSelection,
-				loggedIn,
-				makeNavigation,
-				makeLayout
-			);
-			router(
 				`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
-				fetchThemeFilters,
-				validateFilters,
-				siteSelection,
-				loggedIn,
-				makeNavigation,
-				makeLayout
-			);
-			router(
 				`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
-				fetchThemeFilters,
-				validateVertical,
-				siteSelection,
-				loggedIn,
-				makeNavigation,
-				makeLayout
-			);
-			router(
 				`/themes/:vertical?/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
+			];
+			router(
+				loggedInRoutes,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,
@@ -60,27 +41,14 @@ export default function( router ) {
 				makeLayout
 			);
 		} else {
-			router(
+			const loggedOutRoutes = [
 				'/themes/:tier(free|premium)?',
-				loggedOut,
-				makeLayout
-			);
-			router(
 				'/themes/:tier(free|premium)?/filter/:filter',
-				fetchThemeFilters,
-				validateFilters,
-				loggedOut,
-				makeLayout
-			);
-			router(
 				'/themes/:vertical?/:tier(free|premium)?',
-				fetchThemeFilters,
-				validateVertical,
-				loggedOut,
-				makeLayout
-			);
-			router(
 				'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
+			];
+			router(
+				loggedOutRoutes,
 				fetchThemeFilters,
 				validateVertical,
 				validateFilters,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -5,7 +5,7 @@ import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
 import { makeNavigation, siteSelection, makeSites } from 'my-sites/controller';
-import { loggedIn, loggedOut, upload } from './controller';
+import { loggedIn, loggedOut, upload, fetchThemeFilters } from './controller';
 import { validateFilters, validateVertical } from './validate-filters';
 
 export default function( router ) {
@@ -26,30 +26,66 @@ export default function( router ) {
 			}
 			router(
 				`/themes/:tier(free|premium)?/:site_id(${ siteId })?`,
-				siteSelection, loggedIn, makeNavigation, makeLayout
+				siteSelection,
+				loggedIn,
+				makeNavigation,
+				makeLayout
 			);
 			router(
 				`/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
-				validateFilters, siteSelection, loggedIn, makeNavigation, makeLayout
+				fetchThemeFilters,
+				validateFilters,
+				siteSelection,
+				loggedIn,
+				makeNavigation,
+				makeLayout
 			);
 			router(
 				`/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })?`,
-				validateVertical, siteSelection, loggedIn, makeNavigation, makeLayout
+				fetchThemeFilters,
+				validateVertical,
+				siteSelection,
+				loggedIn,
+				makeNavigation,
+				makeLayout
 			);
 			router(
 				`/themes/:vertical?/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })?`,
-				validateVertical, validateFilters, siteSelection, loggedIn, makeNavigation, makeLayout
+				fetchThemeFilters,
+				validateVertical,
+				validateFilters,
+				siteSelection,
+				loggedIn,
+				makeNavigation,
+				makeLayout
 			);
 		} else {
-			router( '/themes/:tier(free|premium)?', loggedOut, makeLayout );
+			router(
+				'/themes/:tier(free|premium)?',
+				loggedOut,
+				makeLayout
+			);
 			router(
 				'/themes/:tier(free|premium)?/filter/:filter',
-				validateFilters, loggedOut, makeLayout
+				fetchThemeFilters,
+				validateFilters,
+				loggedOut,
+				makeLayout
 			);
-			router( '/themes/:vertical?/:tier(free|premium)?', validateVertical, loggedOut, makeLayout );
+			router(
+				'/themes/:vertical?/:tier(free|premium)?',
+				fetchThemeFilters,
+				validateVertical,
+				loggedOut,
+				makeLayout
+			);
 			router(
 				'/themes/:vertical?/:tier(free|premium)?/filter/:filter',
-				validateVertical, validateFilters, loggedOut, makeLayout
+				fetchThemeFilters,
+				validateVertical,
+				validateFilters,
+				loggedOut,
+				makeLayout
 			);
 		}
 	}

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -42,9 +42,10 @@ export function validateVertical( context, next ) {
 
 	if ( ! includes( getSubjects(), vertical ) ) {
 		if ( context.isServerSide ) {
-			return context.res.redirect( '/themes' );
+			return next( 'route' );
 		}
-		return page.redirect( '/themes' );
+		// Client-side: Terminate routing, rely on server-side rendered markup.
+		return;
 	}
 
 	next();

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -11,6 +11,10 @@ import { isValidTerm, sortFilterTerms, getSubjects } from './theme-filters';
 
 // Reorder and remove invalid filters to redirect to canonical URL
 export function validateFilters( context, next ) {
+	if ( ! context.params.filter ) {
+		return next();
+	}
+
 	// Page.js replaces + with \s
 	const filterParam = context.params.filter.replace( /\s/g, '+' );
 

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -2,14 +2,15 @@
  * External dependencies
  */
 import page from 'page';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { isValidTerm, sortFilterTerms } from './theme-filters';
+import { isValidTerm, sortFilterTerms, getSubjects } from './theme-filters';
 
 // Reorder and remove invalid filters to redirect to canonical URL
-module.exports = function validateFilter( context, next ) {
+export function validateFilters( context, next ) {
 	// Page.js replaces + with \s
 	const filterParam = context.params.filter.replace( /\s/g, '+' );
 
@@ -30,5 +31,21 @@ module.exports = function validateFilter( context, next ) {
 	}
 
 	next();
-};
+}
 
+export function validateVertical( context, next ) {
+	const { vertical } = context.params;
+
+	if ( ! vertical ) {
+		return next();
+	}
+
+	if ( ! includes( getSubjects(), vertical ) ) {
+		if ( context.isServerSide ) {
+			return context.res.redirect( '/themes' );
+		}
+		return page.redirect( '/themes' );
+	}
+
+	next();
+}


### PR DESCRIPTION
No visual changes. Prereq for dropping the [static filters data](https://github.com/Automattic/wp-calypso/blob/75be4cce0151e96ed50835d1ddc4022b7291c5f6/client/my-sites/themes/theme-filters.js#L25).

Validate the vertical route param dynamically in a middleware instead of statically in the route declaration. This will allow the vertical to be validated against data fetched via the API, rather than a
hardcoded list.

**To Test**
Check wordpress.com/themes continues to work with all combinations of filter, tier, and vertical, both logged-in and logged-out.
(Restart server build before testing if using a local checkout)
