### PR TITLE
AT: allow only site owners to transfer a site

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -41,8 +41,8 @@ function getHoldMessages( siteSlug, translate ) {
 			supportUrl: 'https://support.wordpress.com/suspended-blogs/',
 		},
 		NON_ADMIN_USER: {
-			title: translate( 'Admin access required' ),
-			description: translate( 'Only site administrators are allowed to use this feature.' ),
+			title: translate( 'Site owner access required' ),
+			description: translate( 'Only site owners are allowed to use this feature.' ),
 			supportUrl: 'https://support.wordpress.com/user-roles/',
 		},
 		NOT_DOMAIN_OWNER: {


### PR DESCRIPTION
This is a calypso part of D5528-code

We want only site owners to be able to transfer a site and this reflects this change in warnings.
<img width="747" alt="zrzut ekranu 2017-05-08 o 18 35 02" src="https://cloud.githubusercontent.com/assets/3775068/25814428/bb01c282-341d-11e7-92b4-1f8fdb7bde02.png">

## Testing instructions
- Apply D5528-code
- Invite additional admin to your site
- Try to transfer as this additional admin
- Fail and see this message

