### PR TITLE
WooCommerce: Add method for generating a formatted variation name

### DIFF
--- a/client/extensions/woocommerce/lib/formatted-variation-name/README.md
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/README.md
@@ -1,0 +1,70 @@
+Formatted Variation Name
+==========
+
+WooCommerce variations do not have a proper 'name' field.
+
+This method will return a formatted variation name based on the attribute options that a variation contains.
+
+Example (1 Attribute)
+==========
+```javascript
+import formattedVariationName from 'lib/formatted-variation-name';
+
+// Provide a WooCommerce Variation Object (from state or server)
+const variation = {
+	id: 1,
+	visible: true,
+	attributes: [
+		{
+			name: 'Color',
+			option: 'Red',
+		}
+] };
+
+return formattedVariationName( variation );
+```
+
+Returns `Red`.
+
+Example (Multiple Attributes)
+==========
+```javascript
+import formattedVariationName from 'lib/formatted-variation-name';
+
+// Provide a WooCommerce Variation Object (from state or server)
+const variation = {
+	id: 1,
+	visible: true,
+	attributes: [
+		{
+			name: 'Color',
+			option: 'Red',
+		},
+		{
+			name: 'Size',
+			option: 'Small',
+		}
+] };
+
+return formattedVariationName( variation );
+```
+
+Returns `Red - Small`.
+
+Example (Fallback)
+==========
+```javascript
+import formattedVariationName from 'lib/formatted-variation-name';
+
+// Provide a WooCommerce Variation Object (from state or server)
+// This is a variation that provides fallback settings for the other variations.
+const variation = {
+	id: 1,
+	visible: true,
+	attributes: []
+] };
+
+return formattedVariationName( variation, 'All Variations' );
+```
+
+Returns `All Variations`.

--- a/client/extensions/woocommerce/lib/formatted-variation-name/index.js
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/index.js
@@ -1,0 +1,12 @@
+/**
+ * Returns a formatted variation name for display based on attributes.
+ *
+ * @param {Object} variation Variation object.
+ * @param {String} fallbackName Fallback name to use if no attributes are passed.
+ * @return {String} Formatted variation name.
+ */
+export default function formattedVariationName( { attributes }, fallbackName = '' ) {
+	return Array.isArray( attributes ) && attributes.map( function( attribute ) {
+		return attribute.option;
+	} ).join( ' - ' ) || fallbackName;
+}

--- a/client/extensions/woocommerce/lib/formatted-variation-name/test/index.js
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/test/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import formattedVariationName from '../index';
+
+describe( 'formattedVariationName', () => {
+	it( 'returns fallback when passed a variation with no attributes', () => {
+		const variation = {
+			id: 1,
+			visible: true,
+		};
+		const name = formattedVariationName( variation, 'All Variations' );
+		expect( name ).to.eql( 'All Variations' );
+	} );
+	it( 'returns fallback when passed a variation with empty attributes', () => {
+		const variation = {
+			id: 1,
+			visible: true,
+			attributes: [],
+		};
+		const name = formattedVariationName( variation, 'All Variations' );
+		expect( name ).to.eql( 'All Variations' );
+	} );
+	it( 'returns simple name when passed a variation with one attribute', () => {
+		const variation = {
+			id: 1,
+			visible: true,
+			attributes: [ {
+				name: 'Color',
+				option: 'Red',
+			} ],
+		};
+		const name = formattedVariationName( variation );
+		expect( name ).to.eql( 'Red' );
+	} );
+	it( 'returns name containing all attribute options when passed a variation with multiple attributes', () => {
+		const variation = {
+			id: 1,
+			visible: true,
+			attributes: [
+				{
+					name: 'Color',
+					option: 'Red',
+				},
+				{
+					name: 'Size',
+					option: 'Small',
+				},
+				{
+					name: 'Sleeves',
+					option: 'Short Sleeves',
+				},
+			],
+		};
+		const name = formattedVariationName( variation );
+		expect( name ).to.eql( 'Red - Small - Short Sleeves' );
+	} );
+} );


### PR DESCRIPTION
This PR adds a method/helper lib for generating a display ready formatted name for variations.

Variations do not contain a proper name field. In other interfaces, these are built using the attribute options, just like in this PR. We need a method for this to reuse in various parts of our interface.

To Test:
* Run `make test` and make sure all tests pass.