### PR TITLE
Jetpack: Remove jetpack no-monthly test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,15 +16,6 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	jetpackNoMonthly: {
-		datestamp: '20170410',
-		variations: {
-			showMonthly: 50,
-			dontShowMonthly: 50
-		},
-		defaultVariation: 'showMonthly',
-		allowExistingUsers: true
-	},
 	signupSurveyStep: {
 		datestamp: '20170329',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -504,7 +504,7 @@ export default connect(
 					planObject: planObject,
 					popular: popular,
 					newPlan: newPlan,
-					hideMonthly: isInSignup && abtest( 'jetpackNoMonthly' ) === 'dontShowMonthly',
+					hideMonthly: false,
 					primaryUpgrade: (
 						( currentPlan === PLAN_PERSONAL && plan === PLAN_PREMIUM ) ||
 						( currentPlan === PLAN_PREMIUM && plan === PLAN_BUSINESS ) ||


### PR DESCRIPTION
This PR revert the changes introduced by https://github.com/Automattic/wp-calypso/pull/12994

The test was not a success, so we are reverting to the default variation.

How To Test: 
Basically, get the same test steps than #12994 but make sure you always get the old variation:

· You need an unconnected jetpack site
· Go to calypso.localhost:3000, open the dev console, and force the new variation : localStorage.setItem( 'ABTests', '{"jetpackNoMonthly_20170410":"dontShowMonthly"}' );
· Connect the site. Once you are in the plans page, you SHOULD see the monthly/yearly selector.
· Once you have connected the site, go to calypso.localhost:3000/plans and select it.
· You should see the monthly/yearly selector there
