### PR TITLE
Reader feed searches: should uniqify by feed_URL not by URL

### DIFF
--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -27,7 +27,7 @@ import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 export const items = keyedReducer( 'query', createReducer( null, {
 	[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => uniqBy(
 		( state || [] ).concat( action.payload.feeds ),
-		'URL',
+		'feed_URL',
 	)
 } ) );
 

--- a/client/state/reader/feed-searches/test/reducer.js
+++ b/client/state/reader/feed-searches/test/reducer.js
@@ -14,6 +14,7 @@ const query = 'macrumor';
 const feeds = freeze( [
 	{
 		URL: 'http://www.macrumors.com/macrumors.xml',
+		feed_URL: 'http://www.macrumors.com/macrumors.xml',
 		subscribe_URL: 'http://www.macrumors.com/macrumors.xml',
 		feed_ID: '8850855',
 		title: null,
@@ -21,6 +22,7 @@ const feeds = freeze( [
 	},
 	{
 		URL: 'http://feeds.macrumors.com/MacRumors-All',
+		feed_URL: 'http://feeds.macrumors.com/MacRumors-All',
 		subscribe_URL: 'http://feeds.macrumors.com/MacRumors-All',
 		feed_ID: '4210277',
 		title: null,


### PR DESCRIPTION
Context: Search on Manage.  @fraying noticed that searches will sometimes show the "Show More" button but not actually have any more content.

This was due to a bug where in the reducer we were uniqifying by URL instead of by feed_URL