### PR TITLE
Avoid className collisions in sidebar of My Sites

### DIFF
--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -66,7 +66,6 @@ class PublishMenu extends PureComponent {
 			{
 				name: 'post',
 				label: this.props.translate( 'Blog Posts' ),
-				className: 'posts',
 				capability: 'edit_posts',
 				config: 'manage/posts',
 				queryable: true,
@@ -79,7 +78,6 @@ class PublishMenu extends PureComponent {
 			{
 				name: 'page',
 				label: this.props.translate( 'Pages' ),
-				className: 'pages',
 				capability: 'edit_pages',
 				queryable: true,
 				config: 'manage/pages',
@@ -94,7 +92,6 @@ class PublishMenu extends PureComponent {
 			items.push( {
 				name: 'media',
 				label: this.props.translate( 'Media' ),
-				className: 'media-section',
 				capability: 'upload_files',
 				queryable: true,
 				config: 'manage/media',
@@ -203,7 +200,6 @@ class PublishMenu extends PureComponent {
 			return memo.concat( {
 				name: postType.name,
 				label: decodeEntities( get( postType.labels, 'menu_name', postType.label ) ),
-				className: postType.name,
 				config: 'manage/custom-post-types',
 				queryable: postType.api_queryable,
 

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -159,8 +159,7 @@ class PublishMenu extends PureComponent {
 		}
 
 		const className = this.props.itemLinkClass(
-			menuItem.paths ? menuItem.paths : menuItem.link,
-			menuItem.className
+			menuItem.paths ? menuItem.paths : menuItem.link
 		);
 
 		return (


### PR DESCRIPTION
Reported in #13395

I'm not sure about implications when we remove the className, but I haven't found any CSS rule targeting those classes. They also don't follow our class guidelines and can easily collide with other generic (and unrelated) CSS classes like `.design`. We should be fine with them gone for now and we can easily bring them back later in some prefixed form, once we have a use for them.

### To test:
 
1. Have a site with custom post types
2. Visit My Sites
3. Sidebar should have no glitches like in the original issue
4. Make sure when you click the post type, it is highlighted as active

| Before | After |
| --- | --- |
| <img width="272" alt="screen shot 2017-05-08 at 16 21 12" src="https://cloud.githubusercontent.com/assets/156676/25823597/94f36234-340a-11e7-9c32-7ba9a8aa35b6.png"> | <img width="267" alt="screen shot 2017-05-08 at 16 22 23" src="https://cloud.githubusercontent.com/assets/156676/25823601/98cb52ae-340a-11e7-8527-9c937e0063c0.png"> |

