### PR TITLE
Theme Sheet: Add og:title meta

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -541,6 +541,7 @@ const ThemeSheet = React.createClass( {
 		} );
 
 		const metas = [
+			{ property: 'og:title', content: title },
 			{ property: 'og:url', content: canonicalUrl },
 			{ property: 'og:image', content: this.props.screenshot },
 			{ property: 'og:type', content: 'website' },


### PR DESCRIPTION
Because Facebook.

To test:
* Logged out, check Page Source for a Theme Sheet, e.g.
* Check for presence of `<meta property="og:title" content="Mood Theme">`