### PR TITLE
Update TinyMCE to 4.6.x

### DIFF
--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -26,17 +26,13 @@ q {
 	quotes: none;
 }
 a:link,
-a:visited {
-	color: $blue-medium;
-}
+a:visited,
 a:hover,
 a:active {
-	color: $blue-light;
-	outline: 0;
+	color: $blue-medium;
 }
 
 code {
-	background: $gray-light;
 	font-family: $code;
 	padding: 1px 4px;
 	border-radius: 2px;
@@ -184,4 +180,26 @@ hr {
 	height: 1px;
 	margin: 8px 0;
 	background: lighten( $gray, 20 );
+}
+
+/* Styles for formatting the boundaries of anchors and code elements */
+.mce-content-body a[data-mce-selected] {
+	padding: 0 2px;
+	margin: 0 -2px;
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px rgba( $blue-medium, 0.2 );
+	background: rgba( $blue-medium, 0.2 );
+	color: $blue-dark;
+}
+
+.mce-content-body code {
+	padding: 2px 4px;
+	margin: 0;
+	border-radius: 2px;
+	color: $gray-dark;
+	background: lighten( $gray, 30% );
+}
+
+.mce-content-body code[data-mce-selected] {
+	background: lighten( $gray, 20% );
 }

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -106,7 +106,7 @@ function wpLink( editor ) {
 	 * Link Preview
 	 */
 
-	tinymce.ui.WPLinkPreview = tinymce.ui.Control.extend( {
+	tinymce.ui.Factory.add( 'WPLinkPreview', tinymce.ui.Control.extend( {
 		url: '#',
 		renderHtml: function() {
 			return (
@@ -155,7 +155,7 @@ function wpLink( editor ) {
 				tinymce.$( this.getEl().firstChild ).attr( 'href', this.url ).text( url );
 			}
 		}
-	} );
+	} ) );
 
 	editor.addButton( 'wp_link_preview', {
 		type: 'WPLinkPreview',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26,6 +26,13 @@
         }
       }
     },
+    "Base64": {
+      "version": "0.2.1"
+    },
+    "JSONStream": {
+      "version": "0.8.4",
+      "dev": true
+    },
     "abab": {
       "version": "1.0.3",
       "dev": true
@@ -96,13 +103,13 @@
       "dev": true
     },
     "aproba": {
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     "are-we-there-yet": {
       "version": "1.1.4",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.9"
+          "version": "2.2.10"
         },
         "string_decoder": {
           "version": "1.0.1"
@@ -327,7 +334,15 @@
       "dev": true
     },
     "babel-plugin-lodash": {
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2"
+        },
+        "minimatch": {
+          "version": "3.0.4"
+        }
+      }
     },
     "babel-plugin-member-expression-literals": {
       "version": "1.0.1",
@@ -602,9 +617,6 @@
     "base62": {
       "version": "0.1.1"
     },
-    "Base64": {
-      "version": "0.2.1"
-    },
     "base64-arraybuffer": {
       "version": "0.1.2"
     },
@@ -648,7 +660,7 @@
       "version": "1.2.1",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.9"
+          "version": "2.2.10"
         },
         "string_decoder": {
           "version": "1.0.1"
@@ -732,9 +744,6 @@
     "buffer": {
       "version": "4.9.1"
     },
-    "buffer-shims": {
-      "version": "1.0.0"
-    },
     "builtin-modules": {
       "version": "1.1.1"
     },
@@ -770,7 +779,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000676"
+      "version": "1.0.30000677"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1362,6 +1371,10 @@
     "dot-case": {
       "version": "1.1.2"
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "dev": true
+    },
     "draft-js": {
       "version": "0.8.1"
     },
@@ -1385,7 +1398,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.9",
+          "version": "2.2.10",
           "dev": true
         },
         "string_decoder": {
@@ -1901,7 +1914,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.9",
+          "version": "2.2.10",
           "dev": true
         },
         "string_decoder": {
@@ -2102,7 +2115,8 @@
       "version": "0.0.0"
     },
     "glob": {
-      "version": "7.0.3"
+      "version": "7.0.3",
+      "dev": true
     },
     "glob-base": {
       "version": "0.3.0"
@@ -2114,7 +2128,15 @@
       "version": "9.17.0"
     },
     "globby": {
-      "version": "6.1.0"
+      "version": "6.1.0",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2"
+        },
+        "minimatch": {
+          "version": "3.0.4"
+        }
+      }
     },
     "globjoin": {
       "version": "0.1.4",
@@ -2181,7 +2203,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.9",
+          "version": "2.2.10",
           "dev": true
         },
         "string_decoder": {
@@ -3157,10 +3179,6 @@
     "jsonpointer": {
       "version": "2.0.0"
     },
-    "JSONStream": {
-      "version": "0.8.4",
-      "dev": true
-    },
     "jsprim": {
       "version": "1.4.0",
       "dependencies": {
@@ -3471,7 +3489,7 @@
       "version": "0.3.0",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.9"
+          "version": "2.2.10"
         },
         "string_decoder": {
           "version": "1.0.1"
@@ -3656,11 +3674,14 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.0"
+      "version": "1.7.1"
     },
     "node-gyp": {
       "version": "3.6.2",
       "dependencies": {
+        "glob": {
+          "version": "7.1.2"
+        },
         "minimatch": {
           "version": "3.0.4"
         },
@@ -3695,6 +3716,12 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3"
+        },
+        "glob": {
+          "version": "7.1.2"
+        },
+        "minimatch": {
+          "version": "3.0.4"
         },
         "supports-color": {
           "version": "2.0.0"
@@ -4413,7 +4440,7 @@
       "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.9",
+          "version": "2.2.10",
           "dev": true
         },
         "string_decoder": {
@@ -4446,7 +4473,7 @@
           "version": "3.0.4"
         },
         "readable-stream": {
-          "version": "2.2.9"
+          "version": "2.2.10"
         },
         "string_decoder": {
           "version": "1.0.1"
@@ -4714,7 +4741,7 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1"
+      "version": "5.1.0"
     },
     "samsam": {
       "version": "1.1.2",
@@ -4745,6 +4772,12 @@
         },
         "cliui": {
           "version": "3.2.0"
+        },
+        "glob": {
+          "version": "7.1.2"
+        },
+        "minimatch": {
+          "version": "3.0.4"
         },
         "yargs": {
           "version": "7.1.0"
@@ -5052,9 +5085,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31"
-    },
     "string-length": {
       "version": "1.0.1",
       "dev": true
@@ -5068,6 +5098,9 @@
     },
     "string.prototype.padend": {
       "version": "3.0.0"
+    },
+    "string_decoder": {
+      "version": "0.10.31"
     },
     "stringify-object": {
       "version": "2.4.0",
@@ -5142,7 +5175,7 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.9",
+          "version": "2.2.10",
           "dev": true
         },
         "resolve-from": {
@@ -5176,7 +5209,7 @@
           "version": "6.4.0"
         },
         "readable-stream": {
-          "version": "2.2.9"
+          "version": "2.2.10"
         },
         "string_decoder": {
           "version": "1.0.1"
@@ -5244,7 +5277,7 @@
       "version": "1.5.4",
       "dependencies": {
         "readable-stream": {
-          "version": "2.2.9"
+          "version": "2.2.10"
         },
         "string_decoder": {
           "version": "1.0.1"
@@ -5270,7 +5303,7 @@
       "dev": true
     },
     "throat": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "dev": true
     },
     "through": {
@@ -5302,7 +5335,7 @@
       "version": "1.2.0"
     },
     "tinymce": {
-      "version": "4.5.6"
+      "version": "4.6.3"
     },
     "title-case": {
       "version": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "store": "1.3.16",
     "striptags": "2.1.1",
     "superagent": "2.1.0",
-    "tinymce": "4.5.6",
+    "tinymce": "4.6.3",
     "to-title-case": "0.1.5",
     "tracekit": "0.4.3",
     "tween.js": "16.3.1",


### PR DESCRIPTION
This will need thorough testing.

Also `a[data-mce-selected]` and `code[data-mce-selected]` will have to be styled in the editor content.

Changelog: https://github.com/tinymce/tinymce-dist/blob/4.6.0/changelog.txt

Biggest features relevant for us:

* Inline caret boundaries for links and code elements.
* Internal paste flag.