### PR TITLE
Reader: Link to Manage when flag is active

### DIFF
--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -20,8 +20,10 @@ import config from 'config';
 
 export default function() {
 	page( '/following/*', loadSubscriptions, initAbTests );
-	page( '/following/edit', updateLastRoute, sidebar, followingEdit );
 	if ( config.isEnabled( 'reader/following-manage-refresh' ) ) {
 		page( '/following/manage', updateLastRoute, sidebar, followingManage );
+		page.redirect( '/following/edit*', '/following/manage' );
+	} else {
+		page( '/following/edit', updateLastRoute, sidebar, followingEdit );
 	}
 }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -116,7 +116,8 @@ export const ReaderSidebar = React.createClass( {
 								<Gridicon icon="checkmark-circle" size={ 24 } />
 								<span className="menu-link-text">{ this.props.translate( 'Followed Sites' ) }</span>
 							</a>
-							<a href="/following/edit" className="sidebar__button">{ this.props.translate( 'Manage' ) }</a>
+							<a href={ config.isEnabled( 'reader/following-manage-refresh' ) ? '/following/manage' : '/following/edit' }
+								className="sidebar__button">{ this.props.translate( 'Manage' ) }</a>
 						</li>
 
 						<ReaderSidebarTeams teams={ this.props.teams } path={ this.props.path } />


### PR DESCRIPTION
Link to the new Manage screen when the flag is active. Also redirect traffic to /following/edit when the flag is inactive.

Semi-dependent on https://github.com/Automattic/wp-calypso/pull/13724, as that hooks up the follow button everywhere and makes edit consistent with the rest of the UI