### PR TITLE
WooCommerce: Adjust product variation type component copy.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -97,11 +97,11 @@ export default class ProductVariationTypesForm extends Component {
 
 		return (
 			<div className="products__variation-types-form-wrapper">
-				<strong>{ i18n.translate( 'Variation types' ) }</strong>
+				<strong>{ i18n.translate( 'Okay, let\'s add some variations!' ) }</strong>
 				<p>
 					{ i18n.translate(
-						'Let\'s add some variations! A common {{em}}variation type{{/em}} is color. ' +
-						'The {{em}}values{{/em}} would be the colors the product is available in.',
+						'A common variation type is color. ' +
+						'The values would be the colors the product is available in.',
 						{ components: { em: <em /> } }
 					) }
 				</p>
@@ -109,7 +109,7 @@ export default class ProductVariationTypesForm extends Component {
 				<div className="products__variation-types-form-group">
 					<div className="products__variation-types-form-labels">
 						<FormLabel className="products__variation-types-form-label">{ i18n.translate( 'Variation type' ) }</FormLabel>
-						<FormLabel>{ i18n.translate( 'Variation values' ) }</FormLabel>
+						<FormLabel>{ i18n.translate( 'Values' ) }</FormLabel>
 					</div>
 					{inputs}
 				</div>


### PR DESCRIPTION
This adjusts the product variation type component copy slightly. These are some changes @kellychoffman wanted to make that I split out from #13698.

Should be a quick one to review :).

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Toggle the variation card.
* Verify copy is updated.