### PR TITLE
Login: Prompt users to use the old login page if unproxied

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import FormsButton from 'components/forms/form-button';
 import FormInputValidation from 'components/forms/form-input-validation';
 import Card from 'components/card';
@@ -70,7 +71,24 @@ export class LoginForm extends Component {
 			} );
 
 			if ( error.field === 'global' ) {
-				this.props.errorNotice( error.message );
+				if ( error.message === 'proxy_required' ) {
+					// TODO: Remove once the proxy requirement is removed from the API
+
+					let redirectTo = '';
+
+					if ( typeof window !== 'undefined' && window.location.search.indexOf( '?redirect_to=' ) === 0 ) {
+						redirectTo = window.location.search;
+					}
+
+					this.props.errorNotice(
+						<p>
+							{ 'This endpoint is restricted to proxied Automatticians for now. Please use ' }
+							<a href={ config( 'login_url' ) + redirectTo }>the old login page</a>.
+						</p>
+					);
+				} else {
+					this.props.errorNotice( error.message );
+				}
 			}
 		} );
 	};

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -107,7 +107,7 @@ export class LoginForm extends Component {
 					{ this.props.title }
 				</div>
 
-				<form onSubmit={ this.onSubmitForm }>
+				<form onSubmit={ this.onSubmitForm } method="post">
 					<Card className="login__form">
 						<div className="login__form-userdata">
 							<label htmlFor="usernameOrEmail" className="login__form-userdata-username">

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -92,8 +92,14 @@ export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch =
 				data: response.body && response.body.data,
 			} );
 		} ).catch( ( error ) => {
-			const message = getMessageFromHTTPError( error );
-			const field = loginErrorFields[ get( error, 'response.body.data.errors', [] )[ 0 ] ];
+			let message = getMessageFromHTTPError( error );
+			let field = loginErrorFields[ get( error, 'response.body.data.errors', [] )[ 0 ] ];
+
+			if ( error.crossDomain ) {
+				// We use custom field/message values here as this case is handled with JSX in `LoginForm`
+				field = 'global';
+				message = 'proxy_required';
+			}
 
 			dispatch( {
 				type: LOGIN_REQUEST_FAILURE,


### PR DESCRIPTION
Fixes #13775.

![screen shot 2017-05-08 at 4 04 52 pm](https://cloud.githubusercontent.com/assets/1130674/25828944/1f2d1e0c-3408-11e7-89b6-5221ac644890.png)

This PR adds a special error message to `LoginForm` when users try to log in through the Calypso login while unproxied.

**Note**
The first six commits from this PR are from #13731, which updates the way notices are handled on login. Once that is merged, I will remove those commits from this PR. In the meantime, you can just review the last commit.

**Testing**
- Visit http://calypso.localhost:3000 while unproxied.
- Submit the form.
- Assert that you see the message above.

- [x] Code
- [x] Product