### PR TITLE
Notes: fix notification bell

### DIFF
--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -33,13 +33,18 @@ class MasterbarItemNotifications extends Component {
 		animationState: 0,
 	};
 
+	componentWillMount() {
+		this.user = this.props.user.get();
+		this.setState( {
+			newNote: this.user && this.user.has_unseen_notes,
+		} );
+	}
+
 	componentWillReceiveProps( nextProps ) {
 		const {
 			isNotificationsOpen: isOpen,
 			recordOpening,
 		} = nextProps;
-
-		this.user = this.props.user.get();
 
 		if ( ! this.props.isNotificationsOpen && isOpen ) {
 			recordOpening( {
@@ -53,10 +58,6 @@ class MasterbarItemNotifications extends Component {
 			this.getNotificationLinkDomNode().blur();
 			window.focus();
 		}
-
-		this.setState( {
-			newNote: this.user && this.user.has_unseen_notes,
-		} );
 	}
 
 	checkToggleNotes = ( event, forceToggle ) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3026,7 +3026,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.1.6"
+      "version": "Automattic/notifications-panel#fix\/notification-bell"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3026,7 +3026,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "Automattic/notifications-panel#fix\/notification-bell"
+      "version": "1.1.7"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.1.6",
+    "notifications-panel": "Automattic/notifications-panel#fix\/notification-bell",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "Automattic/notifications-panel#fix\/notification-bell",
+    "notifications-panel": "1.1.7",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",


### PR DESCRIPTION
This PR attempts to resolve #13772 where the notifications bell can get into a stuck state, even after we've read all notifications.

### Testing Instructions
- Open an incognito window and sign is a different test user.
- Reply to a comment from your main account with the test user account.
- Go back to your main account and reload calypso. You should see the new notifications orange bubble.
- Open notifications and mark the notification as read by clicking on it.
- Orange Indicator is removed.