### PR TITLE
Do not send themes redux state for logged-in /themes path.

### DIFF
--- a/server/render/index.js
+++ b/server/render/index.js
@@ -96,7 +96,7 @@ export function serverRender( req, res ) {
 		links = getDocumentHeadLink( context.store.getState() );
 
 		let reduxSubtrees = [ 'documentHead' ];
-		// Send themes redux state only in logged-out scenario
+		// Send redux state only in logged-out scenario
 		if ( isSectionIsomorphic( context.store.getState() ) && ! context.user ) {
 			reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
 		}

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -96,13 +96,9 @@ export function serverRender( req, res ) {
 		links = getDocumentHeadLink( context.store.getState() );
 
 		let reduxSubtrees = [ 'documentHead' ];
-		if ( isSectionIsomorphic( context.store.getState() ) ) {
-			reduxSubtrees = reduxSubtrees.concat( [ 'ui' ] );
-
-			// Send themes redux state only in logged-out scenario
-			if ( ! context.user ) {
-				reduxSubtrees = reduxSubtrees.concat( [ 'themes' ] );
-			}
+		// Send themes redux state only in logged-out scenario
+		if ( isSectionIsomorphic( context.store.getState() ) && ! context.user ) {
+			reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
 		}
 
 		// Send state to client

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -97,7 +97,12 @@ export function serverRender( req, res ) {
 
 		let reduxSubtrees = [ 'documentHead' ];
 		if ( isSectionIsomorphic( context.store.getState() ) ) {
-			reduxSubtrees = reduxSubtrees.concat( [ 'ui', 'themes' ] );
+			reduxSubtrees = reduxSubtrees.concat( [ 'ui' ] );
+
+			// Send themes redux state only in logged-out scenario
+			if ( ! context.user ) {
+				reduxSubtrees = reduxSubtrees.concat( [ 'themes' ] );
+			}
 		}
 
 		// Send state to client


### PR DESCRIPTION
### Don't send ssr redux state for logged in user.
This will provide more consistent behavior across the Calypso together with #13755.
Right now direct hit to `/themes` was invalidating IndexedDB data after this PR previously stored data will be ready to use. 

#Testing
dev environment makes it very hard to test it as initial render happens always for logged-out user.
The only way to test it is to use docker - not very convenient or comment out following lines of code:
https://github.com/Automattic/wp-calypso/blob/aa3c35cdf642f15dd063d41166156fc943c7698e/server/render/index.js#L100-L102

and re building calypso. Commenting out will make the code work always as for logged-in user.