### PR TITLE
Jetpack: A/B test regarding headlines

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,4 +82,14 @@ module.exports = {
 		},
 		defaultVariation: 'skip',
 	},
+	jetpackPlansHeadlines: {
+		datestamp: '20170508',
+		variations: {
+			headlineA: 25,
+			headlineB: 25,
+			headlineC: 25,
+			headlineD: 25
+		},
+		defaultVariation: 'headlineA',
+	},
 };

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import StepHeader from '../step-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
+import { abtest } from 'lib/abtest';
 
 class JetpackPlansGrid extends Component {
 	static propTypes = {
@@ -33,6 +34,17 @@ class JetpackPlansGrid extends Component {
 
 		let headerText = translate( 'Your site is now connected!' );
 		let subheaderText = translate( 'Now pick a plan that\'s right for you.' );
+
+		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineB' ) {
+			subheaderText = translate( 'Simple, affordable pricing.' );
+		}
+		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineC' ) {
+			subheaderText = translate( 'Protect your site from data loss.' );
+		}
+		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineD' ) {
+			subheaderText = translate( 'Protect your data from hackers.' );
+		}
+
 		if ( showFirst ) {
 			headerText = translate( 'You are moments away from connecting your site' );
 		}

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -36,13 +36,13 @@ class JetpackPlansGrid extends Component {
 		let subheaderText = translate( 'Now pick a plan that\'s right for you.' );
 
 		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineB' ) {
-			subheaderText = translate( 'Simple, affordable pricing.' );
+			headerText = translate( 'Simple, affordable pricing.' );
 		}
 		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineC' ) {
-			subheaderText = translate( 'Protect your site from data loss.' );
+			headerText = translate( 'Protect your site from data loss.' );
 		}
 		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineD' ) {
-			subheaderText = translate( 'Protect your data from hackers.' );
+			headerText = translate( 'Protect your data from hackers.' );
 		}
 
 		if ( showFirst ) {


### PR DESCRIPTION
This PR adds an A/B test changing the jetpack connect plans header text. 

![image](https://cloud.githubusercontent.com/assets/1554855/25849230/f448dce2-34bd-11e7-96b0-4fdb91c9a94e.png)



How to test
=======
0. Connect a jetpack site and get to the plans selection step (or alternatively go to calypso.localhost:3000/jetpack/connect/plans/[site_slug] with an already connected site)
1. You should see the base "Now pick  a plan ..." header
2. Open the dev console and enter `localStorage.setItem( 'ABTests', '{"jetpackPlansHeadlines_20170508":"headlineB"}' );` 
3. Reload and check the subtitle has changed
4. Repeat 2 & 3 for 'headlineC' and 'headlineD' 
