### PR TITLE
Themes: Preserve filter and tier when clicking vertical links

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -113,7 +113,9 @@ const ThemeShowcase = React.createClass( {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = ( tier && tier !== 'all' ) ? `/${ tier }` : '';
-		const filterSection = filter ? `/filter/${ filter }` : '';
+
+		let filterSection = filter ? `/filter/${ filter }` : '';
+		filterSection = filterSection.replace( /\s/g, '+' );
 
 		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
 		return buildUrl( url, searchString );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -85,28 +85,44 @@ const ThemeShowcase = React.createClass( {
 	doSearch( searchBoxContent ) {
 		const filter = getSortedFilterTerms( searchBoxContent );
 		const searchString = stripFilters( searchBoxContent );
-		this.updateUrl( this.props.tier, filter, searchString );
+		const url = this.constructUrl( { filter, searchString } );
+		page( url );
 	},
 
-	updateUrl( tier, filter, searchString = this.props.search ) {
-		const { siteSlug, vertical } = this.props;
+	/**
+	 * Returns a full showcase url from current props.
+	 *
+	 * @param {Object} sections fields from this object will override current props.
+	 * @param {String} sections.vertical override vertical prop
+	 * @param {String} sections.tier override tier prop
+	 * @param {String} sections.filter override filter prop
+	 * @param {String} sections.siteSlug override siteSlug prop
+	 * @param {String} sections.searchString override searchString prop
+	 *
+	 * @returns {String} Theme showcase url
+	 */
+	constructUrl( sections ) {
+		const {
+			vertical,
+			tier,
+			filter,
+			siteSlug,
+			searchString
+		} = { ...this.props, ...sections };
 
-		const url = this.constructUrl( vertical, tier, filter, siteSlug );
-		page( buildUrl( url, searchString ) );
-	},
-
-	constructUrl( vertical, tier, filter, siteSlug ) {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
 		const tierSection = ( tier && tier !== 'all' ) ? `/${ tier }` : '';
 		const filterSection = filter ? `/filter/${ filter }` : '';
 
-		return `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
+		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
+		return buildUrl( url, searchString );
 	},
 
 	onTierSelect( { value: tier } ) {
 		trackClick( 'search bar filter', tier );
-		this.updateUrl( tier, this.props.filter );
+		const url = this.constructUrl( { tier } );
+		page( url );
 	},
 
 	onUploadClick() {
@@ -136,7 +152,6 @@ const ThemeShowcase = React.createClass( {
 			filter,
 			translate,
 			siteSlug,
-			vertical,
 			isLoggedIn,
 			pathName,
 			title,
@@ -157,21 +172,19 @@ const ThemeShowcase = React.createClass( {
 
 		const headerIcons = [ {
 			label: 'new',
-			uri: this.constructUrl( '', this.props.tier, filter, siteSlug ),
+			uri: this.constructUrl( { vertical: '' } ),
 			icon: 'star'
 		} ].concat(
 			getSubjects()
 				.map( subject => subjectsMeta[ subject ] && {
 					label: subject,
-					uri: this.constructUrl( subject, this.props.tier, filter, siteSlug ),
+					uri: this.constructUrl( { vertical: subject } ),
 					icon: subjectsMeta[ subject ].icon,
 					order: subjectsMeta[ subject ].order
 				} )
 				.filter( icon => !! icon )
 				.sort( ( a, b ) => a.order - b.order )
 		);
-
-		const verticalSection = vertical ? `/${ vertical }` : '';
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
@@ -182,7 +195,7 @@ const ThemeShowcase = React.createClass( {
 					<SubMasterbarNav
 						options={ headerIcons }
 						fallback={ headerIcons[ 0 ] }
-						uri={ `/themes${ verticalSection }` } />
+						uri={ this.constructUrl() } />
 				)}
 				<div className="themes__content">
 					<QueryThemeFilters />

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -85,19 +85,23 @@ const ThemeShowcase = React.createClass( {
 	doSearch( searchBoxContent ) {
 		const filter = getSortedFilterTerms( searchBoxContent );
 		const searchString = stripFilters( searchBoxContent );
-		this.updateUrl( this.props.tier || 'all', filter, searchString );
+		this.updateUrl( this.props.tier, filter, searchString );
 	},
 
 	updateUrl( tier, filter, searchString = this.props.search ) {
 		const { siteSlug, vertical } = this.props;
 
+		const url = this.constructUrl( vertical, tier, filter, siteSlug );
+		page( buildUrl( url, searchString ) );
+	},
+
+	constructUrl( vertical, tier, filter, siteSlug ) {
 		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
 		const verticalSection = vertical ? `/${ vertical }` : '';
-		const tierSection = tier === 'all' ? '' : `/${ tier }`;
+		const tierSection = ( tier && tier !== 'all' ) ? `/${ tier }` : '';
 		const filterSection = filter ? `/filter/${ filter }` : '';
 
-		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
-		page( buildUrl( url, searchString ) );
+		return `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
 	},
 
 	onTierSelect( { value: tier } ) {
@@ -153,13 +157,13 @@ const ThemeShowcase = React.createClass( {
 
 		const headerIcons = [ {
 			label: 'new',
-			uri: '/themes',
+			uri: this.constructUrl( '', this.props.tier, filter, siteSlug ),
 			icon: 'star'
 		} ].concat(
 			getSubjects()
 				.map( subject => subjectsMeta[ subject ] && {
 					label: subject,
-					uri: `/themes/${ subject }`,
+					uri: this.constructUrl( subject, this.props.tier, filter, siteSlug ),
 					icon: subjectsMeta[ subject ].icon,
 					order: subjectsMeta[ subject ].order
 				} )


### PR DESCRIPTION
Fixes #13757

<img width="1240" alt="screen shot 2017-05-09 at 13 47 05" src="https://cloud.githubusercontent.com/assets/7767559/25851538/0d610d94-34be-11e7-9018-5c0c0b4bedc3.png">

**To Test**
* go to wordpress.com/themes (logged-out)
* click on a tier (for example _Free_)
* and/or click on a filter in the search box
* click on a vertical (for example _Music_)

**Expected**
* filter and tier should remain in the URL

Also check that logged-in filtering, site selection, and tiers work as before.
