### PR TITLE
Plans: Display monthly discounted price only if there is no related monthly plan

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -482,7 +482,7 @@ export default connect(
 						selectedSiteId,
 						plan,
 						{
-							isMonthly: showMonthly
+							isMonthly: showMonthlyPrice
 						} ),
 					features: getPlanFeaturesObject( planConstantObj.getFeatures( abtest ) ),
 					onUpgradeClick: onUpgradeClick


### PR DESCRIPTION
This PR fixes a bug with Jetpack plan discounts, where if a Jetpack yearly plan has some discount, the monthly (`yearlyPrice / 12`) price of the plan will be displayed instead of the actual yearly price.

To reproduce:
* Link your Jetpack site to your WPCOM sandbox.
* Apply D5279-code to your WPCOM sandbox.
* Buy a yearly Premium plan for your Jetpack site.
* Go to `/plans/$site`. 
* Make sure the yearly view is selected.
* Notice that the yearly discounted plan price is wrong:

![](https://cldup.com/L0ssGxZj39.png)

The current logic is correct, but it should only work for plans that don't have corresponding monthly plans, i.e. for .com plans. So this PR updates the discounted plan price to display the monthly price in that case only if there's no corresponding monthly plan. This keeps the functionality intact for .com plans, but resolves the issue for Jetpack plans.

To test this PR:
* Checkout this branch locally.
* Link your Jetpack site to your WPCOM sandbox.
* Apply D5279-code to your WPCOM sandbox.
* Buy a yearly Premium plan for your Jetpack site.
* Go to `/plans/$site`. 
* Make sure the yearly view is selected.
* Verify you're seeing the yearly price and not the monthly one:

![](https://cldup.com/7D1ugk8aO7.png)