### PR TITLE
Framework: "JS off" message z-index should be always on top

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -27,6 +27,7 @@ $sidebar-width-min: 228px;
 	color: $white;
 	background: rgba( $gray-dark, 0.8 );
 	text-align: center;
+	z-index: z-index( 'root', '.wpcom-site__global-noscript' );
 }
 
 

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -152,6 +152,7 @@ $z-layers: (
 		'.fullscreen-fader': 200000,
 		'.guided-tours__overlay': 200050,
 		'.guided-tours__step': 201000,
+		'.wpcom-site__global-noscript': 300000, // JS off always visible
 		'#habla_window_div.habla_window_div_base': 99999999 //olark
 	),
 	'.ribbon': (


### PR DESCRIPTION
I noticed that the "Please enable JavaScript in your browser to enjoy WordPress.com." message when JS is disabled didn't have a z-index, and could easily fall behind other elements on the page.

I thus assigned a new z-index. Here's the comparison (← after | before →):

![screen shot 2017-05-09 at 14 28 43](https://cloud.githubusercontent.com/assets/4389/25853251/16519ae4-34c4-11e7-9b61-9abaf785d22d.png)
