### PR TITLE
Jetpack connect: separate LoggedOutForm from authorize-form

### DIFF
--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -97,8 +97,10 @@ class LoggedOutForm extends Component {
 	}
 
 	render() {
-		const { userData } = this.props.jetpackConnectAuthorize;
-		const isSubmitting = this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
+		const {
+			isAuthorizing,
+			userData,
+		} = this.props.jetpackConnectAuthorize;
 
 		return (
 			<div>
@@ -106,8 +108,8 @@ class LoggedOutForm extends Component {
 				{ this.renderFormHeader() }
 				<SignupForm
 					getRedirectToAfterLoginUrl={ window.location.href }
-					disabled={ isSubmitting }
-					submitting={ isSubmitting }
+					disabled={ isAuthorizing }
+					submitting={ isAuthorizing }
 					submitForm={ this.handleSubmitSignup }
 					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import debugModule from 'debug';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -112,7 +113,7 @@ class LoggedOutForm extends Component {
 					submitForm={ this.handleSubmitSignup }
 					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }
-					suggestedUsername={ userData && userData.username ? userData.username : '' }
+					suggestedUsername={ get( userData, 'username', '' ) }
 				/>
 				{ userData && this.renderLoginUser() }
 			</div>

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -49,7 +49,7 @@ class LoggedOutForm extends Component {
 		return this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
 	}
 
-	loginUser() {
+	renderLoginUser() {
 		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
 		const redirectTo = addQueryArgs( queryObject, window.location.href );
 		return (
@@ -118,7 +118,7 @@ class LoggedOutForm extends Component {
 					footerLink={ this.renderFooterLink() }
 					suggestedUsername={ userData && userData.username ? userData.username : '' }
 				/>
-				{ userData && this.loginUser() }
+				{ userData && this.renderLoginUser() }
 			</div>
 		);
 	}

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 
@@ -22,12 +22,10 @@ import SiteCard from './site-card';
 
 const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
 
-const LoggedOutForm = React.createClass( {
-	displayName: 'LoggedOutForm',
-
+class LoggedOutForm extends Component {
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
-	},
+	}
 
 	renderFormHeader() {
 		const { translate } = this.props;
@@ -46,16 +44,16 @@ const LoggedOutForm = React.createClass( {
 				{ siteCard }
 			</div>
 		);
-	},
+	}
 
-	submitForm( form, userData ) {
+	submitForm = ( form, userData ) => {
 		debug( 'submiting new account', form, userData );
 		this.props.createAccount( userData );
-	},
+	}
 
 	isSubmitting() {
 		return this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
-	},
+	}
 
 	loginUser() {
 		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
@@ -66,7 +64,7 @@ const LoggedOutForm = React.createClass( {
 				authorization={ 'Bearer ' + bearerToken }
 				redirectTo={ redirectTo } />
 		);
-	},
+	}
 
 	renderLocaleSuggestions() {
 		if ( ! this.props.locale ) {
@@ -76,7 +74,7 @@ const LoggedOutForm = React.createClass( {
 		return (
 			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 		);
-	},
+	}
 
 	renderFooterLink() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
@@ -90,7 +88,7 @@ const LoggedOutForm = React.createClass( {
 				<HelpButton onClick={ this.clickHelpButton } />
 			</LoggedOutFormLinks>
 		);
-	},
+	}
 
 	render() {
 		const { userData } = this.props.jetpackConnectAuthorize;
@@ -112,6 +110,6 @@ const LoggedOutForm = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default localize( LoggedOutForm );

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -40,26 +40,7 @@ class LoggedOutForm extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
 	}
 
-	renderFormHeader() {
-		const { translate } = this.props;
-		const headerText = translate( 'Create your account' );
-		const subHeaderText = translate( 'You are moments away from connecting your site.' );
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
-			? <SiteCard queryObject={ queryObject } />
-			: null;
-
-		return (
-			<div>
-				<StepHeader
-					headerText={ headerText }
-					subHeaderText={ subHeaderText } />
-				{ siteCard }
-			</div>
-		);
-	}
-
-	submitForm = ( form, userData ) => {
+	handleSubmitSignup = ( form, userData ) => {
 		debug( 'submiting new account', form, userData );
 		this.props.createAccount( userData );
 	}
@@ -76,6 +57,25 @@ class LoggedOutForm extends Component {
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
 				redirectTo={ redirectTo } />
+		);
+	}
+
+	renderFormHeader() {
+		const { translate } = this.props;
+		const headerText = translate( 'Create your account' );
+		const subHeaderText = translate( 'You are moments away from connecting your site.' );
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
+			? <SiteCard queryObject={ queryObject } />
+			: null;
+
+		return (
+			<div>
+				<StepHeader
+					headerText={ headerText }
+					subHeaderText={ subHeaderText } />
+				{ siteCard }
+			</div>
 		);
 	}
 
@@ -113,7 +113,7 @@ class LoggedOutForm extends Component {
 					getRedirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.isSubmitting() }
 					submitting={ this.isSubmitting() }
-					submitForm={ this.submitForm }
+					submitForm={ this.handleSubmitSignup }
 					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }
 					suggestedUsername={ userData && userData.username ? userData.username : '' }

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -80,13 +80,9 @@ class LoggedOutForm extends Component {
 	}
 
 	renderLocaleSuggestions() {
-		if ( ! this.props.locale ) {
-			return;
-		}
-
-		return (
-			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-		);
+		return this.props.locale
+			? <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+			: null;
 	}
 
 	renderFooterLink() {

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 
@@ -23,6 +23,19 @@ import SiteCard from './site-card';
 const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
 
 class LoggedOutForm extends Component {
+	static propTypes = {
+		createAccount: PropTypes.func.isRequired,
+		jetpackConnectAuthorize: PropTypes.shape( {
+			bearerToken: PropTypes.string,
+			isAuthorizing: PropTypes.bool,
+			queryObject: PropTypes.object.isRequired,
+			userData: PropTypes.object,
+		} ).isRequired,
+		locale: PropTypes.string,
+		path: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+	};
+
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
 	}

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import debugModule from 'debug';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -30,8 +30,9 @@ const LoggedOutForm = React.createClass( {
 	},
 
 	renderFormHeader() {
-		const headerText = i18n.translate( 'Create your account' );
-		const subHeaderText = i18n.translate( 'You are moments away from connecting your site.' );
+		const { translate } = this.props;
+		const headerText = translate( 'Create your account' );
+		const subHeaderText = translate( 'You are moments away from connecting your site.' );
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
 			? <SiteCard queryObject={ queryObject } />
@@ -84,7 +85,7 @@ const LoggedOutForm = React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
-					{ this.translate( 'Already have an account? Sign in' ) }
+					{ this.props.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.clickHelpButton } />
 			</LoggedOutFormLinks>
@@ -103,7 +104,7 @@ const LoggedOutForm = React.createClass( {
 					submitting={ this.isSubmitting() }
 					save={ this.save }
 					submitForm={ this.submitForm }
-					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
+					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }
 					suggestedUsername={ userData && userData.username ? userData.username : '' }
 				/>
@@ -113,4 +114,4 @@ const LoggedOutForm = React.createClass( {
 	}
 } );
 
-export default LoggedOutForm;
+export default localize( LoggedOutForm );

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -113,7 +113,6 @@ class LoggedOutForm extends Component {
 					getRedirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.isSubmitting() }
 					submitting={ this.isSubmitting() }
-					save={ this.save }
 					submitForm={ this.submitForm }
 					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -46,10 +46,6 @@ class LoggedOutForm extends Component {
 		this.props.createAccount( userData );
 	}
 
-	isSubmitting() {
-		return this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
-	}
-
 	renderLoginUser() {
 		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
 		const redirectTo = addQueryArgs( queryObject, window.location.href );
@@ -102,14 +98,16 @@ class LoggedOutForm extends Component {
 
 	render() {
 		const { userData } = this.props.jetpackConnectAuthorize;
+		const isSubmitting = this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
+
 		return (
 			<div>
 				{ this.renderLocaleSuggestions() }
 				{ this.renderFormHeader() }
 				<SignupForm
 					getRedirectToAfterLoginUrl={ window.location.href }
-					disabled={ this.isSubmitting() }
-					submitting={ this.isSubmitting() }
+					disabled={ isSubmitting }
+					submitting={ isSubmitting }
 					submitForm={ this.handleSubmitSignup }
 					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 					footerLink={ this.renderFooterLink() }

--- a/client/signup/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-out-form.jsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import debugModule from 'debug';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import HelpButton from './help-button';
+import { login } from 'lib/paths';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import addQueryArgs from 'lib/route/add-query-args';
+import LocaleSuggestions from 'signup/locale-suggestions';
+import SignupForm from 'components/signup-form';
+import WpcomLoginForm from 'signup/wpcom-login-form';
+import versionCompare from 'lib/version-compare';
+import StepHeader from '../step-header';
+import SiteCard from './site-card';
+
+const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
+
+const LoggedOutForm = React.createClass( {
+	displayName: 'LoggedOutForm',
+
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
+	},
+
+	renderFormHeader() {
+		const headerText = i18n.translate( 'Create your account' );
+		const subHeaderText = i18n.translate( 'You are moments away from connecting your site.' );
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
+			? <SiteCard queryObject={ queryObject } />
+			: null;
+
+		return (
+			<div>
+				<StepHeader
+					headerText={ headerText }
+					subHeaderText={ subHeaderText } />
+				{ siteCard }
+			</div>
+		);
+	},
+
+	submitForm( form, userData ) {
+		debug( 'submiting new account', form, userData );
+		this.props.createAccount( userData );
+	},
+
+	isSubmitting() {
+		return this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
+	},
+
+	loginUser() {
+		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
+		const redirectTo = addQueryArgs( queryObject, window.location.href );
+		return (
+			<WpcomLoginForm
+				log={ userData.username }
+				authorization={ 'Bearer ' + bearerToken }
+				redirectTo={ redirectTo } />
+		);
+	},
+
+	renderLocaleSuggestions() {
+		if ( ! this.props.locale ) {
+			return;
+		}
+
+		return (
+			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+		);
+	},
+
+	renderFooterLink() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		const redirectTo = addQueryArgs( queryObject, window.location.href );
+
+		return (
+			<LoggedOutFormLinks>
+				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
+					{ this.translate( 'Already have an account? Sign in' ) }
+				</LoggedOutFormLinkItem>
+				<HelpButton onClick={ this.clickHelpButton } />
+			</LoggedOutFormLinks>
+		);
+	},
+
+	render() {
+		const { userData } = this.props.jetpackConnectAuthorize;
+		return (
+			<div>
+				{ this.renderLocaleSuggestions() }
+				{ this.renderFormHeader() }
+				<SignupForm
+					getRedirectToAfterLoginUrl={ window.location.href }
+					disabled={ this.isSubmitting() }
+					submitting={ this.isSubmitting() }
+					save={ this.save }
+					submitForm={ this.submitForm }
+					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
+					footerLink={ this.renderFooterLink() }
+					suggestedUsername={ userData && userData.username ? userData.username : '' }
+				/>
+				{ userData && this.loginUser() }
+			</div>
+		);
+	}
+} );
+
+export default LoggedOutForm;

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -19,8 +19,6 @@ import Main from 'components/main';
 import StepHeader from '../step-header';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
-import SignupForm from 'components/signup-form';
-import WpcomLoginForm from 'signup/wpcom-login-form';
 import {
 	createAccount,
 	authorize,
@@ -45,7 +43,6 @@ import observe from 'lib/mixins/data-observe';
 import userUtilities from 'lib/user/utils';
 import Card from 'components/card';
 import Gravatar from 'components/gravatar';
-import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Spinner from 'components/spinner';
 import { decodeEntities } from 'lib/formatting';
@@ -66,103 +63,13 @@ import Plans from './plans';
 import CheckoutData from 'components/data/checkout';
 import { externalRedirect } from 'lib/route/path';
 import SiteCard from './site-card';
+import LoggedOutForm from './auth-logged-out-form';
 
 /**
  * Constants
  */
 const PLANS_PAGE = '/jetpack/connect/plans/';
 const MAX_AUTH_ATTEMPTS = 3;
-
-const LoggedOutForm = React.createClass( {
-	displayName: 'LoggedOutForm',
-
-	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
-	},
-
-	renderFormHeader() {
-		const headerText = i18n.translate( 'Create your account' );
-		const subHeaderText = i18n.translate( 'You are moments away from connecting your site.' );
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const siteCard = versionCompare( queryObject.jp_version, '4.0.3', '>' )
-			? <SiteCard queryObject={ queryObject } />
-			: null;
-
-		return (
-			<div>
-				<StepHeader
-					headerText={ headerText }
-					subHeaderText={ subHeaderText } />
-				{ siteCard }
-			</div>
-		);
-	},
-
-	submitForm( form, userData ) {
-		debug( 'submiting new account', form, userData );
-		this.props.createAccount( userData );
-	},
-
-	isSubmitting() {
-		return this.props.jetpackConnectAuthorize && this.props.jetpackConnectAuthorize.isAuthorizing;
-	},
-
-	loginUser() {
-		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
-		const redirectTo = addQueryArgs( queryObject, window.location.href );
-		return (
-			<WpcomLoginForm
-				log={ userData.username }
-				authorization={ 'Bearer ' + bearerToken }
-				redirectTo={ redirectTo } />
-		);
-	},
-
-	renderLocaleSuggestions() {
-		if ( ! this.props.locale ) {
-			return;
-		}
-
-		return (
-			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-		);
-	},
-
-	renderFooterLink() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const redirectTo = addQueryArgs( queryObject, window.location.href );
-
-		return (
-			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
-					{ this.translate( 'Already have an account? Sign in' ) }
-				</LoggedOutFormLinkItem>
-				<HelpButton onClick={ this.clickHelpButton } />
-			</LoggedOutFormLinks>
-		);
-	},
-
-	render() {
-		const { userData } = this.props.jetpackConnectAuthorize;
-		return (
-			<div>
-				{ this.renderLocaleSuggestions() }
-				{ this.renderFormHeader() }
-				<SignupForm
-					getRedirectToAfterLoginUrl={ window.location.href }
-					disabled={ this.isSubmitting() }
-					submitting={ this.isSubmitting() }
-					save={ this.save }
-					submitForm={ this.submitForm }
-					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
-					footerLink={ this.renderFooterLink() }
-					suggestedUsername={ userData && userData.username ? userData.username : '' }
-				/>
-				{ userData && this.loginUser() }
-			</div>
-		);
-	}
-} );
 
 const LoggedInForm = React.createClass( {
 	displayName: 'LoggedInForm',


### PR DESCRIPTION
Separate `LoggedOutForm` from `authorize-form` file.

To test:

* Verify that there are no regressions in the logged out authorize step (/jetpack/connect/authorize)

Part of: Separate jetpack-connect from signup #12991