### PR TITLE
NUX: Add param to disallow flow resuming

### DIFF
--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -15,9 +15,10 @@ A flow is defined by two properties, `steps` and `destination`:
 - `steps` is an array listing the steps in the flow, in the order they should be presented to users. You can see a list of available steps from `/client/signup/config/steps.js`.
 - `destination` is a `string` or `function` that determines which page users should be redirected to once they complete the last step in the flow. If provided as a `function`, it is called with all of the dependencies provided in the signup flow, and the user is redirected to whatever it returns.
 
-There are also two optional properties:
+There are also three optional properties:
 - `description` is a brief description of what the flow is for.
 - `lastModified` is a date stamp for when the flow was last updated.
+- `disallowResume` is a boolean that, when true, will send you back to step 1 if you refreshed the page
 
 Example:
 ```javascript

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -213,7 +213,8 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 		steps: [ 'site-or-domain', 'themes', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'An experimental approach for WordPress.com/domains',
-		lastModified: '2017-01-16'
+		disallowResume: true,
+		lastModified: '2017-05-09'
 	};
 
 	flows[ 'site-selected' ] = {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -168,7 +168,7 @@ const Signup = React.createClass( {
 			step => ( -1 !== flowSteps.indexOf( step.stepName ) ),
 		);
 
-		if ( flowStepsInProgressStore.length > 0 ) {
+		if ( flowStepsInProgressStore.length > 0 && ! flow.disallowResume ) {
 			// we loaded progress from local storage, attempt to resume progress
 			return this.resumeProgress();
 		}


### PR DESCRIPTION
Some flows should be restarted on refresh instead of resumed. Add a param to allow a flow to decide how it handles resuming.

Testing a non-resumable flow:
- Visit calypso.localhost:3000/start/domain-first?new=testing-some-domain-666.live
- Select New site
- Pick a Theme
- Refresh
- Should be sent back to the first step

Testing a resumable flow:
- Visit calypso.localhost:3000/start
- Pick a design type
- Pick a theme
- Refresh
- Should end up on the domains step as before

Fixes: https://github.com/Automattic/wp-calypso/issues/12118