### PR TITLE
Plugins: updates the external link to wp-admin for ValuePress plugin

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -293,8 +293,14 @@ const PluginMeta = React.createClass( {
 		}
 	},
 
-	getDefaultActionLinks() {
-		const adminUrl = get( this.props, 'selectedSite.options.admin_url' );
+	getDefaultActionLinks( plugin ) {
+		let adminUrl = get( this.props, 'selectedSite.options.admin_url' );
+		const pluginSlug = get( plugin, 'slug' );
+
+		if ( pluginSlug === 'vaultpress' ) {
+			adminUrl += '/admin.php?page=vaultpress';
+		}
+
 		return adminUrl
 			? { [ i18n.translate( 'WP Admin' ) ]: adminUrl }
 			: null;
@@ -428,7 +434,7 @@ const PluginMeta = React.createClass( {
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
 		let actionLinks = get( plugin, 'action_links' );
 		if ( get( plugin, 'active' ) && isEmpty( actionLinks ) ) {
-			actionLinks = this.getDefaultActionLinks();
+			actionLinks = this.getDefaultActionLinks( plugin );
 		}
 
 		return (


### PR DESCRIPTION
This patch updates the external link to WP-ADMIN for the VaultPress plugin.

### Testing

1) You need a site with VaultPress activated
2) Go to its admin page: eg: `http://calypso.localhost:3000/plugins/vaultpress/<site-with-vp-plugin>`

you should be able to see the `WP ADMIN` external link
<img src="https://cloud.githubusercontent.com/assets/77539/25855311/3b025e66-34a9-11e7-905f-918a32011f1e.png" width="300px" />

It should go straight to VaultPress section: `https://<site-with-vp-plugin>/wp-admin//admin.php?page=vaultpress`
