### PR TITLE
UrlPreview: Fix support of Jetpack sites in subdirectories

### DIFF
--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
 import { closePreview } from 'state/ui/preview/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPreviewUrl } from 'state/ui/preview/selectors';
-import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
+import { getSiteOption } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 
@@ -97,10 +97,11 @@ export default function urlPreview( WebPreview ) {
 
 	function mapStateToProps( state ) {
 		const selectedSiteId = getSelectedSiteId( state );
+		const selectedSite = getSelectedSite( state );
 		return {
-			selectedSite: getSelectedSite( state ),
+			selectedSite,
 			selectedSiteId,
-			selectedSiteUrl: 'https://' + getSiteSlug( state, selectedSiteId ),
+			selectedSiteUrl: selectedSite && selectedSite.URL,
 			selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
 			previewUrl: getPreviewUrl( state ),
 			isDomainOnlySite: isDomainOnlySite( state, selectedSiteId ),


### PR DESCRIPTION
This PR fixes #13803, where the site preview functionality does not work for Jetpack sites that are installed in subdirectories. The PR simply alters the `UrlPreview` block to use the site URL instead of the site slug. Why? Because slugs are known to encode forward slashes `/` to double colons `::`.

To test:
* Select one of your Jetpack sites that's installed in a subdirectory.
* Click the Site Icon in the current site box in the sidebar to preview the site.

![](https://cldup.com/RhL6qQXCG1.png)

* Wait for the WebPreview to load.
* Verify the page loads correctly.
* Test with a site that's not installed in a subdirectory and verify it works correctly, too.