### PR TITLE
Bring back targeting for post types in sidebar

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -21,7 +21,9 @@ export default React.createClass( {
 		onNavigate: React.PropTypes.func,
 		icon: React.PropTypes.string,
 		selected: React.PropTypes.bool,
-		preloadSectionName: React.PropTypes.string
+		preloadSectionName: React.PropTypes.string,
+		testTarget: React.PropTypes.string,
+		tipTarget: React.PropTypes.string
 	},
 
 	_preloaded: false,
@@ -38,7 +40,11 @@ export default React.createClass( {
 		const classes = classnames( this.props.className, { selected: this.props.selected } );
 
 		return (
-			<li className={ classes } data-tip-target={ this.props.tipTarget } >
+			<li
+				className={ classes }
+				data-tip-target={ this.props.tipTarget }
+				data-post-type={ this.props.postType }
+			>
 				<a
 					onClick={ this.props.onNavigate }
 					href={ this.props.link }

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -168,6 +168,7 @@ class PublishMenu extends PureComponent {
 				onNavigate={ this.onNavigate( menuItem.name ) }
 				icon={ icon }
 				preloadSectionName={ preload }
+				postType={ menuItem.name }
 			>
 				{ menuItem.name === 'media' && (
 					<MediaLibraryUploadButton className="sidebar__button" site={ site } href={ menuItem.buttonLink }>


### PR DESCRIPTION
We removed very generic CSS classes from sidebar items for post types in #13773 and that broke E2E tests. This brings the data back as data-attr, so it cannot collide with other CSS and still can be uniquely targeted.

