### PR TITLE
Checkout: Pass redux store so we can update it on sites fetch

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -230,6 +230,7 @@ const Checkout = React.createClass( {
 		const {
 			cart,
 			isDomainOnly,
+			reduxStore,
 			selectedSiteId,
 			transaction: {
 				step: {
@@ -309,9 +310,13 @@ const Checkout = React.createClass( {
 			const domainName = getDomainNameFromReceiptOrCart( receipt, cart );
 
 			if ( domainName ) {
-				fetchSitesAndUser( domainName, () => {
-					page( redirectPath );
-				} );
+				fetchSitesAndUser(
+					domainName,
+					() => {
+						page( redirectPath );
+					},
+					reduxStore
+				);
 
 				return;
 			}

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -230,6 +230,7 @@ module.exports = {
 			(
 				<CheckoutData>
 					<Checkout
+						reduxStore={ context.store }
 						productsList={ productsList }
 					/>
 				</CheckoutData>


### PR DESCRIPTION
As we're refetching all sites until the domain-only appears in there, and now we moved to redux, pass the redux store so it gets updated there too.

Test:
- http://calypso.localhost:3000/start/domain-first?new=domain-test-again-xxx-1.live
- Just a domain
- Finish checkout
- When you click "Go To Your Domain" you're properly sent to the site instead of seeing the site picker