### PR TITLE
WooCommerce: Add variation modal.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -37,17 +37,21 @@ class ProductFormVariationsModal extends React.Component {
 		this.toggleVisible = this.toggleVisible.bind( this );
 	}
 
-	setDescription( e ) {
+	selectedVariation() {
 		const { selectedVariation } = this.state;
-		const { product, editProductVariation, variations } = this.props;
-		const variation = find( variations, ( v ) => selectedVariation === v.id );
+		const { variations } = this.props;
+		return find( variations, ( v ) => selectedVariation === v.id );
+	}
+
+	setDescription( e ) {
+		const { product, editProductVariation } = this.props;
+		const variation = this.selectedVariation();
 		editProductVariation( product, variation, { description: e.target.value } );
 	}
 
 	toggleVisible() {
-		const { selectedVariation } = this.state;
-		const { product, editProductVariation, variations } = this.props;
-		const variation = find( variations, ( v ) => selectedVariation === v.id );
+		const { product, editProductVariation } = this.props;
+		const variation = this.selectedVariation();
 		editProductVariation( product, variation, { visible: ! variation.visible } );
 	}
 
@@ -60,7 +64,7 @@ class ProductFormVariationsModal extends React.Component {
 	render() {
 		const { variations, translate } = this.props;
 		const { selectedVariation } = this.state;
-		const variation = find( variations, ( v ) => selectedVariation === v.id );
+		const variation = this.selectedVariation();
 
 		const navVariations = ( variations && variations.filter( v => v.attributes.length > 0 ) ) || [];
 		const navItems = navVariations.map( function( v, i ) {

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import formattedVariationName from '../../lib/formatted-variation-name';
+import FormFieldSet from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextArea from 'components/forms/form-textarea';
+import FormToggle from 'components/forms/form-toggle';
+import VerticalMenu from 'components/vertical-menu';
+
+class ProductFormVariationsModal extends React.Component {
+
+	static propTypes = {
+		product: PropTypes.object.isRequired,
+		variations: PropTypes.array.isRequired,
+		editProductVariation: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			selectedVariation: this.props.selectedVariation,
+		};
+
+		this.switchVariation = this.switchVariation.bind( this );
+		this.setDescription = this.setDescription.bind( this );
+		this.toggleVisible = this.toggleVisible.bind( this );
+	}
+
+	setDescription( e ) {
+		const { selectedVariation } = this.state;
+		const { product, editProductVariation, variations } = this.props;
+		const variation = find( variations, ( v ) => selectedVariation === v.id );
+		editProductVariation( product, variation, { description: e.target.value } );
+	}
+
+	toggleVisible() {
+		const { selectedVariation } = this.state;
+		const { product, editProductVariation, variations } = this.props;
+		const variation = find( variations, ( v ) => selectedVariation === v.id );
+		editProductVariation( product, variation, { visible: ! variation.visible } );
+	}
+
+	switchVariation( selectedVariation ) {
+		this.setState( {
+			selectedVariation
+		} );
+	}
+
+	render() {
+		const { variations, translate } = this.props;
+		const { selectedVariation } = this.state;
+		const variation = find( variations, ( v ) => selectedVariation === v.id );
+
+		const navVariations = ( variations && variations.filter( v => v.attributes.length > 0 ) ) || [];
+		const navItems = navVariations.map( function( v, i ) {
+			return (
+				<ModalNavItem key={ i } variation={ v } selected={ selectedVariation } />
+			);
+		} );
+
+		return (
+			<div className="products__product-form-modal-wrapper">
+				<h1>{ translate( 'Variation details' ) }</h1>
+
+				<VerticalMenu onClick={ this.switchVariation } className="products__product-form-modal-menu">
+					{navItems}
+				</VerticalMenu>
+
+				<div className="products__product-form-modal-contents">
+					<h2>{ formattedVariationName( variation ) }</h2>
+					<span className="products__product-form-sku">SKU:</span>
+
+					<FormFieldSet className="products__product-form-variation-description">
+						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
+						<FormTextArea name="description" value={ variation.description || '' } onChange={ this.setDescription } />
+						<FormSettingExplanation>{ translate(
+								'This will be displayed in addition to the main product description when this variation is selected.'
+						) }</FormSettingExplanation>
+					</FormFieldSet>
+
+					<FormLabel>
+						{ translate( 'Visible' ) }
+						<FormToggle
+							onChange={ this.toggleVisible }
+							checked={ variation.visible }
+						/>
+					</FormLabel>
+					<FormSettingExplanation>{ translate(
+						'Hidden variations cannot be selected for purchase by customers.'
+					) }</FormSettingExplanation>
+				</div>
+			</div>
+		);
+	}
+
+}
+
+const ModalNavItem = props => {
+	const {
+		onClick,
+		variation,
+		selected,
+	} = props;
+
+	const classes = classNames(
+		'vertical-menu__items',
+		{ 'is-selected': ( variation.id === selected ) }
+	);
+
+	const clickHandler = () => {
+		onClick( variation.id );
+	};
+
+	return (
+		<li className={ classes } onClick={ clickHandler }>
+			{ formattedVariationName( variation ) }
+		</li>
+	);
+};
+
+export default localize( ProductFormVariationsModal );

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -3,7 +3,6 @@
  */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -15,7 +14,14 @@ import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affi
 import FormDimensionsInput from '../../components/form-dimensions-input';
 import formattedVariationName from '../../lib/formatted-variation-name';
 
-const ProductFormVariationsRow = ( { product, variation, manageStock, editProductVariation } ) => {
+const ProductFormVariationsRow = ( {
+	product,
+	variation,
+	editProductVariation,
+	onShowDialog,
+	translate,
+	manageStock,
+} ) => {
 	// TODO: Consildate the following set/toggle functions with a helper (along with the form-details functions).
 	const setPrice = ( e ) => {
 		editProductVariation( product, variation, { regular_price: e.target.value } );
@@ -42,6 +48,10 @@ const ProductFormVariationsRow = ( { product, variation, manageStock, editProduc
 		editProductVariation( product, variation, { manage_stock: ! variation.manage_stock } );
 	};
 
+	const showDialog = () => {
+		onShowDialog( variation.id );
+	};
+
 	// A variation with empty attributes is a 'fallback variation'.
 	// We use this for the "All variations" row in the table, as defaults for the other variations.
 	const fallbackRow = ! variation.attributes.length;
@@ -55,14 +65,18 @@ const ProductFormVariationsRow = ( { product, variation, manageStock, editProduc
 				) }
 			</td>
 			<td className="products__product-id">
-				<div className="products__product-name-thumb">
-					{ ! fallbackRow && (
+				{ ! fallbackRow && (
+					<div className="products__product-name-thumb">
 						<div className="products__product-form-variation-image"></div>
-					) }
-					<div className="products__product-name">
-						{ formattedVariationName( variation, 'All variations' ) }
+						<span className="products__product-name products__variation-settings-link" onClick={ showDialog }>
+							{ formattedVariationName( variation ) }
+						</span>
 					</div>
-				</div>
+				) || (
+					<div className="products__product-name">
+						{ translate( 'All variations' ) }
+					</div>
+				) }
 			</td>
 			<td>
 				<FormCurrencyInput
@@ -109,11 +123,6 @@ const ProductFormVariationsRow = ( { product, variation, manageStock, editProduc
 						/>
 					) }
 				</div>
-			</td>
-			<td>
-				{ ! fallbackRow && (
-					<Gridicon icon="cog" />
-				) }
 			</td>
 		</tr>
 	);

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -8,6 +8,8 @@ import { isNumber } from 'lodash';
 /**
  * Internal dependencies
  */
+import Dialog from 'components/dialog';
+import ProductFormVariationsModal from './product-form-variations-modal';
 import ProductFormVariationsRow from './product-form-variations-row';
 
 class ProductFormVariationsTable extends React.Component {
@@ -17,6 +19,59 @@ class ProductFormVariationsTable extends React.Component {
 		product: PropTypes.object,
 		editProductVariation: PropTypes.func.isRequired,
 	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showDialog: false,
+			selectedVariation: null,
+		};
+
+		this.onShowDialog = this.onShowDialog.bind( this );
+		this.onCloseDialog = this.onCloseDialog.bind( this );
+	}
+
+	onShowDialog( selectedVariation ) {
+		this.setState( {
+			showDialog: true,
+			selectedVariation,
+		} );
+	}
+
+	onCloseDialog() {
+		this.setState( {
+			showDialog: false,
+			selectedVariation: null,
+		} );
+	}
+
+	renderModal() {
+		const { variations, product, editProductVariation, translate } = this.props;
+		const { showDialog, selectedVariation } = this.state;
+
+		const buttons = [
+			{ action: 'close', label: translate( 'Close' ) },
+		];
+
+		return (
+			<Dialog
+				isVisible={ showDialog }
+				buttons={ buttons }
+				onClose={ this.onCloseDialog }
+				className="products__product-form-variation-modal"
+				additionalClassNames="woocommerce"
+			>
+				<ProductFormVariationsModal
+					product={ product }
+					variations={ variations }
+					selectedVariation={ selectedVariation }
+					onShowDialog={ this.onShowDialog }
+					editProductVariation={ editProductVariation }
+				/>
+			</Dialog>
+		);
+	}
 
 	renderVariationRow( variation ) {
 		const { product, variations, editProductVariation } = this.props;
@@ -30,6 +85,7 @@ class ProductFormVariationsTable extends React.Component {
 				variation={ variation }
 				manageStock={ manageStock }
 				editProductVariation={ editProductVariation }
+				onShowDialog={ this.onShowDialog }
 			/>
 		);
 	}
@@ -46,13 +102,13 @@ class ProductFormVariationsTable extends React.Component {
 							<th className="products__product-price">{ translate( 'Price' ) }</th>
 							<th>{ translate( 'Dimensions & weight' ) }</th>
 							<th>{ translate( 'Manage stock' ) }</th>
-							<th></th>
 						</tr>
 					</thead>
 					<tbody>
-						{ variations && variations.map( ( variation ) => this.renderVariationRow( variation ) ) }
+						{ variations && variations.map( ( v ) => this.renderVariationRow( v ) ) }
 					</tbody>
 				</table>
+				{ this.renderModal() }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -60,7 +60,7 @@ class ProductFormVariationsTable extends React.Component {
 				buttons={ buttons }
 				onClose={ this.onCloseDialog }
 				className="products__product-form-variation-modal"
-				additionalClassNames="woocommerce"
+				additionalClassNames="woocommerce products__product-form-variation-dialog"
 			>
 				<ProductFormVariationsModal
 					product={ product }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -265,16 +265,21 @@
 	.vertical-menu {
 		width: 200px;
 		flex: 1 auto;
+		overflow-y: scroll;
+		max-height: 600px;
 	}
 
 	.vertical-menu__items {
 		padding-left: 16px;
+		min-height: 45px;
 	}
 
 	.products__product-form-modal-wrapper {
 		display: flex;
 		flex-flow: row wrap;
 		padding: 16px;
+		max-height: 80vh;
+		overflow-y: hidden;
 	}
 
 	h1 {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -1,3 +1,7 @@
+/**
+ * TODO: Variation modal width
+ */
+
 .form-label {
 	margin-bottom: 5px;
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -1,13 +1,5 @@
 .form-label {
-	margin-bottom: 16px;
-}
-
-.form-label {
-	margin-bottom: 16px;
-}
-
-.form-label {
-	margin-bottom: 16px;
+	margin-bottom: 5px;
 }
 
 .foldable-card.products__variation-card .foldable-card__content {
@@ -248,8 +240,13 @@
 	cursor: pointer;
 }
 
+.products__product-form-variation-dialog {
+	max-width: 600px;
+}
+
 .products__product-form-variation-modal {
 	min-width: 600px;
+	overflow-x: auto;
 
 	h2 {
 		margin-bottom: 0;
@@ -267,13 +264,13 @@
 	}
 
 	.vertical-menu__items {
-		padding-left: 10px;
+		padding-left: 16px;
 	}
 
 	.products__product-form-modal-wrapper {
 		display: flex;
 		flex-flow: row wrap;
-		padding: 10px;
+		padding: 16px;
 	}
 
 	h1 {
@@ -286,6 +283,6 @@
 	}
 
 	.form-toggle__wrapper {
-		margin-left: 5px;
+		margin-left: 8px;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -238,3 +238,54 @@
 .products__product-name {
 	font-size: 13px;
 }
+
+.products__product-form-sku {
+		color: $gray;
+}
+
+.products__variation-settings-link {
+	text-decoration: underline;
+	cursor: pointer;
+}
+
+.products__product-form-variation-modal {
+	min-width: 600px;
+
+	h2 {
+		margin-bottom: 0;
+		font-weight: bold;
+		font-size: 20px;
+	}
+
+	.products__product-form-variation-description {
+		margin-top: 1em;
+	}
+
+	.vertical-menu {
+		width: 200px;
+		flex: 1 auto;
+	}
+
+	.vertical-menu__items {
+		padding-left: 10px;
+	}
+
+	.products__product-form-modal-wrapper {
+		display: flex;
+		flex-flow: row wrap;
+		padding: 10px;
+	}
+
+	h1 {
+		flex: 1 100%;
+	}
+
+	.products__product-form-modal-contents {
+		padding-left: 40px;
+		flex: 1 auto;
+	}
+
+	.form-toggle__wrapper {
+		margin-left: 5px;
+	}
+}


### PR DESCRIPTION
This adds the variation modal that displays when you click the settings cog for a variation in the variation UI (#13698).

It allows you to configure the description and visible status. It also contains a placeholder for the SKU which we can implement once #13653 is handled.

You can also switch between variations within the modal.

Closes #13512.

To test:
* Visit `http://calypso.localhost:3000/store/products/:site/add`
* Start typing in some variation types.
* Click the cog for a variation and see that the modal opens.
* Type in the description box and toggle visible status.
* Switch to another modal using the modal navigation.
* Click done, and click the cog for another variation, to make sure that variation opens instead.

<img width="1280" alt="screen shot 2017-05-09 at 9 13 38 am" src="https://cloud.githubusercontent.com/assets/689165/25861275/1a05032c-3499-11e7-8e25-7373608b4958.png">

@kellychoffman @jameskoster This PR contains UI elements for review.