### PR TITLE
Reader SubscriptionListItem: use blavatar for multi-author sites

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -20,6 +20,7 @@ const ReaderAvatar = ( {
 		siteUrl,
 		isCompact = false,
 		preferGravatar = false,
+		preferBlavatar = false,
 		showPlaceholder = false,
 		onClick,
 	} ) => {
@@ -58,9 +59,13 @@ const ReaderAvatar = ( {
 		}
 	}
 
+
 	// If we have an avatar and we prefer it, don't even consider the site icon
 	if ( hasAvatar && preferGravatar ) {
 		hasSiteIcon = false;
+	} else if ( hasSiteIcon && preferBlavatar ) {
+		hasAvatar = false;
+		showPlaceholder = false;
 	}
 
 	const hasBothIcons = hasSiteIcon && hasAvatar;

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -54,6 +54,8 @@ function ReaderSubscriptionListItem( {
 	const feedUrl = url || getFeedUrl( { feed, site } );
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isFollowing = ( site && site.is_following ) || ( feed && feed.is_following );
+	const preferBlavatar = get( site, 'is_multi_author', false );
+	const preferGravatar = ! preferBlavatar;
 
 	return (
 		<div className={ classnames( 'reader-subscription-list-item', className ) }>
@@ -62,7 +64,8 @@ function ReaderSubscriptionListItem( {
 					siteIcon={ siteIcon }
 					feedIcon={ feedIcon }
 					author={ siteAuthor }
-					preferGravatar={ true }
+					preferBlavatar={ preferBlavatar }
+					preferGravatar={ preferGravatar }
 					siteUrl={ streamUrl }
 					isCompact={ true }
 				/>


### PR DESCRIPTION
As the title describes.

To test:
Go to http://calypso.localhost:3000/devdocs/blocks/reader-subscription-list-item and compare it with wpcalypso

To do in an api patch: fix the `has_avatar` flag so that the math with bad drawings appears properly