### PR TITLE
Add placeholder to TokenField

### DIFF
--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -49,6 +49,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `isBorderless` - When true, renders tokens as without a background.
 - `maxLength` - If passed, `TokenField` will disable ability to add new tokens once number of tokens is greater than or equal to `maxLength`.
 - `disabled` - When true, tokens are not able to be added or removed.
+- `placeholder` - If passed, the `TokenField` input will show a placeholder string if no value tokens are present.
 
 ### Example
 

--- a/client/components/token-field/docs/example.jsx
+++ b/client/components/token-field/docs/example.jsx
@@ -29,6 +29,7 @@ var TokenFields = React.createClass( {
 		return {
 			tokenSuggestions: suggestions,
 			tokens: Object.freeze( [ 'foo', 'bar' ] ),
+			placeholderTokens: [],
 			disabledTokens: [ 'foo', 'bar' ],
 			statusTokens: Object.freeze( [ 'success', 'error', 'validating', 'none' ] )
 		};
@@ -66,6 +67,14 @@ var TokenFields = React.createClass( {
 						disabled
 						isBorderless
 						value={ this.state.disabledTokens } />
+				</Card>
+
+				<Card>
+					<h3>TokenField with Placeholder Text</h3>
+					<TokenField
+						placeholder="Red, Green, Blue"
+						value={ this.state.placeholderTokens }
+						onChange={ this._onPlaceholderTokensChange } />
 				</Card>
 			</div>
 		);
@@ -105,7 +114,11 @@ var TokenFields = React.createClass( {
 
 	_onTokensChange: function( value ) {
 		this.setState( { tokens: value } );
-	}
+	},
+
+	_onPlaceholderTokensChange: function( value ) {
+		this.setState( { placeholderTokens: value } );
+	},
 } );
 
 module.exports = TokenFields;

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -35,6 +35,7 @@ var TokenField = React.createClass( {
 		onFocus: React.PropTypes.func,
 		disabled: React.PropTypes.bool,
 		tokenizeOnSpace: React.PropTypes.bool,
+		placeholder: React.PropTypes.string,
 		value: function( props ) {
 			const value = props.value;
 			if ( ! Array.isArray( value ) ) {
@@ -58,6 +59,7 @@ var TokenField = React.createClass( {
 			suggestions: Object.freeze( [] ),
 			maxSuggestions: 100,
 			value: Object.freeze( [] ),
+			placeholder: '',
 			displayTransform: identity,
 			saveTransform: function( token ) {
 				return token.trim();
@@ -169,7 +171,7 @@ var TokenField = React.createClass( {
 	},
 
 	_renderInput: function() {
-		const { autoCapitalize, autoComplete, maxLength, value } = this.props;
+		const { autoCapitalize, autoComplete, maxLength, value, placeholder } = this.props;
 
 		let props = {
 			autoCapitalize,
@@ -180,6 +182,10 @@ var TokenField = React.createClass( {
 			value: this.state.incompleteTokenValue,
 			onBlur: this._onBlur,
 		};
+
+		if ( value.length === 0 && placeholder ) {
+			props.placeholder = placeholder;
+		}
 
 		if ( ! ( maxLength && value.length >= maxLength ) ) {
 			props = { ...props, onChange: this._onInputChange };

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -9,6 +9,7 @@ var TokenInput = React.createClass( {
 		onChange: React.PropTypes.func,
 		onBlur: React.PropTypes.func,
 		value: React.PropTypes.string,
+		placeholder: React.PropTypes.string,
 		disabled: React.PropTypes.bool
 	},
 
@@ -17,7 +18,8 @@ var TokenInput = React.createClass( {
 			onChange: function() {},
 			onBlur: function() {},
 			value: '',
-			disabled: false
+			disabled: false,
+			placeholder: '',
 		};
 	},
 
@@ -25,13 +27,15 @@ var TokenInput = React.createClass( {
 
 	render: function() {
 		const props = { ...this.props, onChange: this._onChange };
+		const { value, placeholder } = props;
+		const size = ( ( value.length === 0 && placeholder && placeholder.length ) || value.length ) + 1;
 
 		return (
 			<input
 				ref="input"
 				type="text"
 				{ ...props }
-				size={ this.props.value.length + 1 }
+				size={ size }
 				className="token-field__input"
 			/>
 		);

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -79,7 +79,7 @@ export default class ProductVariationTypesForm extends Component {
 					onChange={ this.updateName }
 				/>
 				<TokenField
-					placeholder={ i18n.translate( 'Comma separate these' ) }
+					placeholder={ i18n.translate( 'Red, Green, Blue' ) }
 					value={ attribute.options }
 					name="values"
 					/* eslint-disable react/jsx-no-bind */


### PR DESCRIPTION
This adds a placeholder prop to the TokenField input, allowing help text to be displayed when there are no tokens present.

Closes #12290.

To Test:
* Go to `http://calypso.localhost:3000/devdocs/design/token-fields`
* See the `TokenField with Placeholder Text` example with the placeholder text displayed.
* Type a token in, and see the placeholder text go away from the underlying input.

<img width="750" alt="screen shot 2017-05-09 at 10 22 10 am" src="https://cloud.githubusercontent.com/assets/689165/25863629/694f22ca-34a1-11e7-8059-b92535112d26.png">

cc @kellychoffman 