### PR TITLE
Domain Search: Add Traintracks

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { includes } from 'lodash';
+import { includes, isNumber } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,6 +12,7 @@ import DomainSuggestion from 'components/domains/domain-suggestion';
 import Gridicon from 'gridicons';
 import DomainSuggestionFlag from 'components/domains/domain-suggestion-flag';
 import { shouldBundleDomainWithPlan, getDomainPriceRule, hasDomainInCart } from 'lib/cart-values/cart-items';
+import { tracks } from 'lib/analytics';
 
 const DomainRegistrationSuggestion = React.createClass( {
 	propTypes: {
@@ -24,7 +25,34 @@ const DomainRegistrationSuggestion = React.createClass( {
 		} ).isRequired,
 		onButtonClick: React.PropTypes.func.isRequired,
 		domainsWithPlansOnly: React.PropTypes.bool.isRequired,
-		selectedSite: React.PropTypes.object
+		selectedSite: React.PropTypes.object,
+		railcarId: React.PropTypes.string,
+		uiPosition: React.PropTypes.number,
+		fetchAlgo: React.PropTypes.string,
+		query: React.PropTypes.string
+	},
+
+	componentDidMount() {
+		if ( this.props.railcarId && isNumber( this.props.uiPosition ) ) {
+			tracks.recordEvent( 'calypso_traintracks_render', {
+				railcar: this.props.railcarId,
+				ui_position: this.props.uiPosition,
+				fetch_algo: this.props.fetchAlgo,
+				rec_result: this.props.suggestion.domain_name,
+				fetch_query: this.props.query
+			} );
+		}
+	},
+
+	onClick( event ) {
+		if ( this.props.railcarId ) {
+			tracks.recordEvent( 'calypso_traintracks_interact', {
+				railcar: this.props.railcarId,
+				action: 'domain_added_to_cart'
+			} );
+		}
+
+		this.props.onButtonClick( event );
 	},
 
 	render() {
@@ -102,7 +130,7 @@ const DomainRegistrationSuggestion = React.createClass( {
 					buttonContent={ buttonContent }
 					cart={ cart }
 					domainsWithPlansOnly={ domainsWithPlansOnly }
-					onButtonClick={ this.props.onButtonClick }>
+					onButtonClick={ this.onClick }>
 				<h3>
 					{ domain }
 					{ domainFlags }

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -34,11 +34,18 @@ const DomainRegistrationSuggestion = React.createClass( {
 
 	componentDidMount() {
 		if ( this.props.railcarId && isNumber( this.props.uiPosition ) ) {
+			let resultSuffix = '';
+			if ( this.props.suggestion.isRecommended ) {
+				resultSuffix = 'recommended';
+			} else if ( this.props.suggestion.isBestAlternative ) {
+				resultSuffix = 'best-alternative';
+			}
+
 			tracks.recordEvent( 'calypso_traintracks_render', {
 				railcar: this.props.railcarId,
 				ui_position: this.props.uiPosition,
 				fetch_algo: this.props.fetchAlgo,
-				rec_result: this.props.suggestion.domain_name,
+				rec_result: `${ this.props.suggestion.domain_name }#${ resultSuffix }`,
 				fetch_query: this.props.query
 			} );
 		}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -36,16 +36,16 @@ const DomainRegistrationSuggestion = React.createClass( {
 		if ( this.props.railcarId && isNumber( this.props.uiPosition ) ) {
 			let resultSuffix = '';
 			if ( this.props.suggestion.isRecommended ) {
-				resultSuffix = 'recommended';
+				resultSuffix = '#recommended';
 			} else if ( this.props.suggestion.isBestAlternative ) {
-				resultSuffix = 'best-alternative';
+				resultSuffix = '#best-alternative';
 			}
 
 			tracks.recordEvent( 'calypso_traintracks_render', {
 				railcar: this.props.railcarId,
 				ui_position: this.props.uiPosition,
 				fetch_algo: this.props.fetchAlgo,
-				rec_result: `${ this.props.suggestion.domain_name }#${ resultSuffix }`,
+				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,
 				fetch_query: this.props.query
 			} );
 		}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -8,6 +8,7 @@ import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import React from 'react';
 import classNames from 'classnames';
 import {
+	endsWith,
 	includes,
 	times
 } from 'lodash';
@@ -148,7 +149,7 @@ var DomainSearchResults = React.createClass( {
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-${ i }` }
 						uiPosition={ i }
-						fetchAlgo={ this.props.fetchAlgo }
+						fetchAlgo={ endsWith( suggestion.domain_name, 'wordpress.com' ) ? 'wpcom' : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }
 						onButtonClick={ this.props.onClickResult.bind( null, suggestion ) } />
 				);

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -44,6 +44,8 @@ var DomainSearchResults = React.createClass( {
 		onAddMapping: React.PropTypes.func,
 		onClickMapping: React.PropTypes.func,
 		isSignupStep: React.PropTypes.bool,
+		railcarSeed: React.PropTypes.string,
+		fetchAlgo: React.PropTypes.string
 	},
 
 	renderDomainAvailability: function() {
@@ -135,7 +137,7 @@ var DomainSearchResults = React.createClass( {
 			mappingOffer;
 
 		if ( this.props.suggestions.length ) {
-			suggestionElements = this.props.suggestions.map( function( suggestion ) {
+			suggestionElements = this.props.suggestions.map( function( suggestion, i ) {
 				return (
 					<DomainRegistrationSuggestion
 						suggestion={ suggestion }
@@ -144,6 +146,10 @@ var DomainSearchResults = React.createClass( {
 						isSignupStep={ this.props.isSignupStep }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-${ i }` }
+						uiPosition={ i }
+						fetchAlgo={ this.props.fetchAlgo }
+						query={ this.props.lastDomainSearched }
 						onButtonClick={ this.props.onClickResult.bind( null, suggestion ) } />
 				);
 			}, this );

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -149,7 +149,7 @@ var DomainSearchResults = React.createClass( {
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 						railcarId={ `${ this.props.railcarSeed }-registration-suggestion-${ i }` }
 						uiPosition={ i }
-						fetchAlgo={ endsWith( suggestion.domain_name, 'wordpress.com' ) ? 'wpcom' : this.props.fetchAlgo }
+						fetchAlgo={ endsWith( suggestion.domain_name, '.wordpress.com' ) ? 'wpcom' : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }
 						onButtonClick={ this.props.onClickResult.bind( null, suggestion ) } />
 				);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -49,7 +49,8 @@ const SUGGESTION_QUANTITY = 10;
 const INITIAL_SUGGESTION_QUANTITY = 2;
 
 const analytics = analyticsMixin( 'registerDomain' ),
-	searchVendor = 'domainsbot';
+	searchVendor = 'domainsbot',
+	fetchAlgo = searchVendor + '/v1';
 
 let searchQueue = [],
 	searchStackTimer = null,
@@ -149,6 +150,13 @@ const RegisterDomainStep = React.createClass( {
 		};
 	},
 
+	getNewRailcarSeed() {
+		// Generate a 7 character random hash on base16. E.g. ac618a3
+		return Math.floor( ( 1 + Math.random() ) * 0x10000000 )
+			.toString( 16 )
+			.substring( 1 );
+	},
+
 	componentWillReceiveProps( nextProps ) {
 		// Reset state on site change
 		if ( nextProps.selectedSite && nextProps.selectedSite.slug !== ( this.props.selectedSite || {} ).slug ) {
@@ -182,7 +190,7 @@ const RegisterDomainStep = React.createClass( {
 		lastSearchTimestamp = null; // reset timer
 
 		if ( this.props.initialState ) {
-			const state = { ...this.props.initialState };
+			const state = { ...this.props.initialState, railcarSeed: this.getNewRailcarSeed() };
 
 			if ( state.lastSurveyVertical &&
 				( state.lastSurveyVertical !== this.props.surveyVertical ) ) {
@@ -304,7 +312,8 @@ const RegisterDomainStep = React.createClass( {
 
 		this.setState( {
 			lastDomainSearched: domain,
-			searchResults: []
+			searchResults: [],
+			railcarSeed: this.getNewRailcarSeed(),
 		} );
 
 		async.parallel(
@@ -515,6 +524,8 @@ const RegisterDomainStep = React.createClass( {
 				offerMappingOption={ this.props.offerMappingOption }
 				placeholderQuantity={ SUGGESTION_QUANTITY }
 				isSignupStep={ this.props.isSignupStep }
+				railcarSeed={ this.state.railcarSeed }
+				fetchAlgo={ fetchAlgo }
 				cart={ this.props.cart } />
 		);
 	},


### PR DESCRIPTION
This adds Traintracks for domain search in signup and domain search in Calypso.

Right now it treats signup and domains the same, they are sharing the code but we might differentiate them if it makes it easier.

@sirino Could you confirm this is in a shape that you can use?

