### PR TITLE
Reader: Teach the feed reducer and selector how to fetch stale feeds

### DIFF
--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -1,10 +1,12 @@
+/**
+ * External Dependencies
+ */
 import { combineReducers } from 'redux';
-import assign from 'lodash/assign';
-import keyBy from 'lodash/keyBy';
-import map from 'lodash/map';
-import omit from 'lodash/omit';
-import omitBy from 'lodash/omitBy';
+import { assign, keyBy, map, omit, omitBy, reduce } from 'lodash';
 
+/**
+ * Internal Dependencies
+ */
 import {
 	READER_FEED_REQUEST,
 	READER_FEED_REQUEST_SUCCESS,
@@ -16,7 +18,7 @@ import {
 
 import { decodeEntities } from 'lib/formatting';
 
-import { isValidStateWithSchema } from 'state/utils';
+import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
 const actionMap = {
@@ -54,28 +56,26 @@ function handleRequestFailure( state, action ) {
 }
 
 function adaptFeed( feed ) {
-	if ( feed.name ) {
-		feed.name = decodeEntities( feed.name );
-	}
-	feed.feed_ID = + feed.feed_ID;
-	feed.blog_ID = + feed.blog_ID;
-	return feed;
+	return {
+		feed_ID: +feed.feed_ID,
+		blog_ID: +feed.blog_ID,
+		name: feed.name && decodeEntities( feed.name ),
+		URL: feed.URL,
+		feed_URL: feed.feed_URL,
+		is_following: feed.is_following,
+		subscribers_count: feed.subscribers_count,
+	};
 }
 
 function handleRequestSuccess( state, action ) {
-	const feed = assign( {}, action.payload );
-	adaptFeed( feed );
+	const feed = adaptFeed( action.payload );
 	return assign( {}, state, {
 		[ feed.feed_ID ]: feed
 	} );
 }
 
 function handleFeedUpdate( state, action ) {
-	const feeds = map( action.payload, feed => {
-		feed = assign( {}, feed );
-		adaptFeed( feed );
-		return feed;
-	} );
+	const feeds = map( action.payload, feed => adaptFeed( feed ) );
 	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );
 }
 
@@ -101,7 +101,22 @@ export function queuedRequests( state = {}, action ) {
 	return state;
 }
 
+export const lastUpdated = createReducer( {}, {
+	[ READER_FEED_REQUEST_SUCCESS ]: ( state, action ) => ( {
+		...state,
+		[ action.payload.feed_ID ]: Date.now()
+	} ),
+	[ READER_FEED_UPDATE ]: ( state, action ) => {
+		const updates = reduce( action.payload, ( memo, feed ) => {
+			memo[ feed.feed_ID ] = Date.now();
+			return memo;
+		}, {} );
+		return assign( {}, state, updates );
+	}
+} );
+
 export default combineReducers( {
 	items,
+	lastUpdated,
 	queuedRequests
 } );

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -101,7 +101,7 @@ export function queuedRequests( state = {}, action ) {
 	return state;
 }
 
-export const lastUpdated = createReducer( {}, {
+export const lastFetched = createReducer( {}, {
 	[ READER_FEED_REQUEST_SUCCESS ]: ( state, action ) => ( {
 		...state,
 		[ action.payload.feed_ID ]: Date.now()
@@ -117,6 +117,6 @@ export const lastUpdated = createReducer( {}, {
 
 export default combineReducers( {
 	items,
-	lastUpdated,
+	lastFetched,
 	queuedRequests
 } );

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -75,7 +75,7 @@ function handleRequestSuccess( state, action ) {
 }
 
 function handleFeedUpdate( state, action ) {
-	const feeds = map( action.payload, feed => adaptFeed( feed ) );
+	const feeds = map( action.payload, adaptFeed );
 	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );
 }
 

--- a/client/state/reader/feeds/schema.js
+++ b/client/state/reader/feeds/schema.js
@@ -12,8 +12,7 @@ export const itemsSchema = {
 				URL: { type: [ 'string', 'null' ] },
 				feed_URL: { type: [ 'string', 'null' ] },
 				is_following: { type: [ 'boolean', 'null' ] },
-				subscribers_count: { type: [ 'integer', 'null' ] },
-				meta: { type: [ 'object', 'null' ] }
+				subscribers_count: { type: [ 'integer', 'null' ] }
 			}
 		}
 	},

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -22,7 +22,6 @@ function isStale( state, feedId ) {
 	return lastFetched <= ( Date.now() - DAY_IN_MILLIS );
 }
 
-
 /**
  * Returns a feed object
  *

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -1,3 +1,5 @@
+const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
+
 /**
 * Returns true if we should fetch the feed
 *
@@ -5,9 +7,6 @@
 * @param  {Number}  feedId The feed ID
 * @return {Boolean}        Whether feed should be fetched
 */
-
-const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
-
 export function shouldFeedBeFetched( state, feedId ) {
 	// we should fetch the feed if we don't have it,
 	// or we do have it

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -7,32 +7,29 @@ const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
 * @param  {Number}  feedId The feed ID
 * @return {Boolean}        Whether feed should be fetched
 */
+
 export function shouldFeedBeFetched( state, feedId ) {
-	// we should fetch the feed if we don't have it,
-	// or we do have it
-	// and it's been more than a day since we last fetched, and it's not already queued to be fetched
-	return ! state.reader.feeds.queuedRequests[ feedId ] &&
-		(
-			! getFeed( state, feedId ) ||
-			! lastUpdatedWithin( state, feedId, DAY_IN_MILLIS )
-		);
+	const isNotQueued = ! state.reader.feeds.queuedRequests[ feedId ];
+	const isMissing = ! getFeed( state, feedId );
+	return isNotQueued && ( isMissing || isStale( state, feedId ) );
 }
 
-function lastUpdatedWithin( state, feedId, timeInMillis ) {
-	const lastUpdated = state.reader.feeds.lastUpdated[ feedId ];
-	if ( ! lastUpdated ) {
+function isStale( state, feedId ) {
+	const lastFetched = state.reader.feeds.lastFetched[ feedId ];
+	if ( ! lastFetched ) {
 		return false;
 	}
-	return lastUpdated > ( Date.now() - timeInMillis );
+	return lastFetched <= ( Date.now() - DAY_IN_MILLIS );
 }
 
 /**
- * Get the feed object for the given feed id
- *
- * @param  {Object} state  Global state tree
- * @param  {Number} feedId The feed ID
- * @return {Object}        The feed object
- */
+* Returns a feed object
+*
+* @param  {Object}  state  Global state tree
+* @param  {Number}  feedId The feed ID
+* @return {Object}        Feed
+*/
+
 export function getFeed( state, feedId ) {
 	return state.reader.feeds.items[ feedId ];
 }

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -6,9 +6,25 @@
 * @return {Boolean}        Whether feed should be fetched
 */
 
+const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
+
 export function shouldFeedBeFetched( state, feedId ) {
-	return ! state.reader.feeds.queuedRequests[ feedId ] && // not currently queued
-		! state.reader.feeds.items[ feedId ]; // not currently loaded
+	// we should fetch the feed if we don't have it,
+	// or we do have it
+	// and it's been more than a day since we last fetched, and it's not already queued to be fetched
+	return ! state.reader.feeds.queuedRequests[ feedId ] &&
+		(
+			! getFeed( state, feedId ) ||
+			! lastUpdatedWithin( state, feedId, DAY_IN_MILLIS )
+		);
+}
+
+function lastUpdatedWithin( state, feedId, timeInMillis ) {
+	const lastUpdated = state.reader.feeds.lastUpdated[ feedId ];
+	if ( ! lastUpdated ) {
+		return false;
+	}
+	return lastUpdated > ( Date.now() - timeInMillis );
 }
 
 /**

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -1,12 +1,12 @@
 const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
 
 /**
-* Returns true if we should fetch the feed
-*
-* @param  {Object}  state  Global state tree
-* @param  {Number}  feedId The feed ID
-* @return {Boolean}        Whether feed should be fetched
-*/
+ * Returns true if we should fetch the feed
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  feedId The feed ID
+ * @return {Boolean}        Whether feed should be fetched
+ */
 
 export function shouldFeedBeFetched( state, feedId ) {
 	const isNotQueued = ! state.reader.feeds.queuedRequests[ feedId ];
@@ -22,13 +22,14 @@ function isStale( state, feedId ) {
 	return lastFetched <= ( Date.now() - DAY_IN_MILLIS );
 }
 
+
 /**
-* Returns a feed object
-*
-* @param  {Object}  state  Global state tree
-* @param  {Number}  feedId The feed ID
-* @return {Object}        Feed
-*/
+ * Returns a feed object
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  feedId The feed ID
+ * @return {Object}        Feed
+ */
 
 export function getFeed( state, feedId ) {
 	return state.reader.feeds.items[ feedId ];

--- a/client/state/reader/feeds/test/reducer.js
+++ b/client/state/reader/feeds/test/reducer.js
@@ -17,7 +17,7 @@ import {
 	DESERIALIZE
 } from 'state/action-types';
 
-import { items, queuedRequests } from '../reducer';
+import { items, queuedRequests, lastFetched, } from '../reducer';
 
 describe( 'reducer', ( ) => {
 	describe( 'items', ( ) => {
@@ -201,6 +201,26 @@ describe( 'reducer', ( ) => {
 					}
 				)
 			).to.deep.equal( {} );
+		} );
+	} );
+
+	describe( 'lastFetched', () => {
+		it( 'should update the last fetched time on request success', () => {
+			const original = deepFreeze( {} );
+			const action = {
+				type: READER_FEED_REQUEST_SUCCESS,
+				payload: { feed_ID: 1 }
+			};
+			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
+		} );
+
+		it( 'should update the last fetched time on feed update', () => {
+			const original = deepFreeze( {} );
+			const action = {
+				type: READER_FEED_UPDATE,
+				payload: [ { feed_ID: 1 } ]
+			};
+			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
 		} );
 	} );
 } );

--- a/client/state/reader/feeds/test/reducer.js
+++ b/client/state/reader/feeds/test/reducer.js
@@ -31,12 +31,19 @@ describe( 'reducer', ( ) => {
 					type: READER_FEED_REQUEST_SUCCESS,
 					payload: {
 						feed_ID: 1,
-						blog_ID: 2
+						blog_ID: 2,
+						feed_URL: 'http://example.com',
+						is_following: true,
 					}
 				} )[ 1 ]
 			).to.deep.equal( {
 				feed_ID: 1,
-				blog_ID: 2
+				blog_ID: 2,
+				feed_URL: 'http://example.com',
+				URL: undefined,
+				is_following: true,
+				name: undefined,
+				subscribers_count: undefined
 			} );
 		} );
 
@@ -53,7 +60,11 @@ describe( 'reducer', ( ) => {
 			).to.deep.equal( {
 				feed_ID: 1,
 				blog_ID: 2,
-				name: 'ben & jerries'
+				name: 'ben & jerries',
+				URL: undefined,
+				feed_URL: undefined,
+				is_following: undefined,
+				subscribers_count: undefined
 			} );
 		} );
 
@@ -112,7 +123,17 @@ describe( 'reducer', ( ) => {
 					name: 'new',
 					subscribers_count: 10
 				}
-			} ) ).to.deep.equal( { 666: { feed_ID: 666, blog_ID: 888, name: 'new', subscribers_count: 10 } } );
+			} ) ).to.deep.equal( {
+				666: {
+					feed_ID: 666,
+					blog_ID: 888,
+					name: 'new',
+					subscribers_count: 10,
+					feed_URL: undefined,
+					URL: undefined,
+					is_following: undefined,
+				}
+			} );
 		} );
 
 		it( 'should leave an existing entry alone if an error is received', ( ) => {
@@ -129,14 +150,35 @@ describe( 'reducer', ( ) => {
 			expect( items( startingState, {
 				type: READER_FEED_UPDATE,
 				payload: [
-					{ feed_ID: 666, blog_ID: 888, name: 'valid but new' },
-					{ feed_ID: 1, blog_ID: 777, name: 'first &amp; one' },
-					{ feed_ID: 2, blog_ID: 999, name: 'second' }
+					{ feed_ID: 666, blog_ID: 888, name: 'valid but new', is_following: true },
+					{ feed_ID: 1, blog_ID: 777, name: 'first &amp; one', is_following: true },
+					{ feed_ID: 2, blog_ID: 999, name: 'second', is_following: true }
 				]
 			} ) ).to.deep.equal( {
-				666: { feed_ID: 666, blog_ID: 888, name: 'valid but new' },
-				1: { feed_ID: 1, blog_ID: 777, name: 'first & one' },
-				2: { feed_ID: 2, blog_ID: 999, name: 'second' }
+				666: {
+					feed_ID: 666,
+					blog_ID: 888,
+					name: 'valid but new',
+					URL: undefined,
+					feed_URL: undefined,
+					is_following: true,
+					subscribers_count: undefined },
+				1: {
+					feed_ID: 1,
+					blog_ID: 777,
+					name: 'first & one',
+					URL: undefined,
+					feed_URL: undefined,
+					is_following: true,
+					subscribers_count: undefined },
+				2: {
+					feed_ID: 2,
+					blog_ID: 999,
+					name: 'second',
+					URL: undefined,
+					feed_URL: undefined,
+					is_following: true,
+					subscribers_count: undefined }
 			} );
 		} );
 	} );

--- a/client/state/reader/feeds/test/selectors.js
+++ b/client/state/reader/feeds/test/selectors.js
@@ -1,5 +1,11 @@
+/**
+ * External Dependencies
+ */
 import { expect } from 'chai';
 
+/**
+ * Internal Dependencies
+ */
 import { shouldFeedBeFetched } from '../selectors';
 
 describe( 'selectors', () => {
@@ -17,17 +23,36 @@ describe( 'selectors', () => {
 			}, 1 ) ).to.be.false;
 		} );
 
-		it( 'should return false if the feed is loaded', () => {
+		it( 'should return false if the feed is loaded and recent', () => {
 			expect( shouldFeedBeFetched( {
 				reader: {
 					feeds: {
 						queuedRequests: {},
 						items: {
 							1: {}
+						},
+						lastUpdated: {
+							1: Date.now()
 						}
 					}
 				}
 			}, 1 ) ).to.be.false;
+		} );
+
+		it( 'should return true if the feed is loaded, but old', () => {
+			expect( shouldFeedBeFetched( {
+				reader: {
+					feeds: {
+						queuedRequests: {},
+						items: {
+							1: {}
+						},
+						lastUpdated: {
+							1: 100
+						}
+					}
+				}
+			}, 1 ) ).to.be.true;
 		} );
 
 		it( 'should return true if the feed is not queued and not loaded', () => {
@@ -35,7 +60,8 @@ describe( 'selectors', () => {
 				reader: {
 					feeds: {
 						queuedRequests: {},
-						items: {}
+						items: {},
+						lastUpdated: {}
 					}
 				}
 			}, 1 ) ).to.be.true;
@@ -50,7 +76,8 @@ describe( 'selectors', () => {
 						},
 						items: {
 							2: {}
-						}
+						},
+						lastUpdated: {}
 					}
 				}
 			}, 1 ) ).to.be.true;

--- a/client/state/reader/feeds/test/selectors.js
+++ b/client/state/reader/feeds/test/selectors.js
@@ -31,7 +31,7 @@ describe( 'selectors', () => {
 						items: {
 							1: {}
 						},
-						lastUpdated: {
+						lastFetched: {
 							1: Date.now()
 						}
 					}
@@ -47,7 +47,7 @@ describe( 'selectors', () => {
 						items: {
 							1: {}
 						},
-						lastUpdated: {
+						lastFetched: {
 							1: 100
 						}
 					}
@@ -61,7 +61,7 @@ describe( 'selectors', () => {
 					feeds: {
 						queuedRequests: {},
 						items: {},
-						lastUpdated: {}
+						lastFetched: {}
 					}
 				}
 			}, 1 ) ).to.be.true;
@@ -77,7 +77,7 @@ describe( 'selectors', () => {
 						items: {
 							2: {}
 						},
-						lastUpdated: {}
+						lastFetched: {}
 					}
 				}
 			}, 1 ) ).to.be.true;

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -122,7 +122,7 @@ export function queuedRequests( state = {}, action ) {
 	return state;
 }
 
-export const lastUpdated = createReducer( {}, {
+export const lastFetched = createReducer( {}, {
 	[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => ( {
 		...state,
 		[ action.payload.ID ]: Date.now()
@@ -139,5 +139,5 @@ export const lastUpdated = createReducer( {}, {
 export default combineReducers( {
 	items,
 	queuedRequests,
-	lastUpdated,
+	lastFetched,
 } );

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -1,11 +1,20 @@
+/**
+ * External Dependencies
+ */
 import { combineReducers } from 'redux';
-import assign from 'lodash/assign';
-import omit from 'lodash/omit';
-import omitBy from 'lodash/omitBy';
-import keyBy from 'lodash/keyBy';
-import map from 'lodash/map';
-import trim from 'lodash/trim';
+import {
+	assign,
+	keyBy,
+	map,
+	omit,
+	omitBy,
+	reduce,
+	trim,
+ } from 'lodash';
 
+/**
+ * Internal Dependencies
+ */
 import {
 	READER_SITE_REQUEST,
 	READER_SITE_REQUEST_SUCCESS,
@@ -15,7 +24,7 @@ import {
 	SERIALIZE
 } from 'state/action-types';
 
-import { isValidStateWithSchema } from 'state/utils';
+import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
 
@@ -113,7 +122,22 @@ export function queuedRequests( state = {}, action ) {
 	return state;
 }
 
+export const lastUpdated = createReducer( {}, {
+	[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => ( {
+		...state,
+		[ action.payload.ID ]: Date.now()
+	} ),
+	[ READER_SITE_UPDATE ]: ( state, action ) => {
+		const updates = reduce( action.payload, ( memo, site ) => {
+			memo[ site.ID ] = Date.now();
+			return memo;
+		}, {} );
+		return assign( {}, state, updates );
+	}
+} );
+
 export default combineReducers( {
 	items,
-	queuedRequests
+	queuedRequests,
+	lastUpdated,
 } );

--- a/client/state/reader/sites/selectors.js
+++ b/client/state/reader/sites/selectors.js
@@ -9,19 +9,17 @@ const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
 */
 
 export function shouldSiteBeFetched( state, siteId ) {
-	return ! state.reader.sites.queuedRequests[ siteId ] && // not currently queued
-		(
-			! getSite( state, siteId ) ||
-			! lastUpdatedWithin( state, siteId, DAY_IN_MILLIS )
-		);
+	const isNotQueued = ! state.reader.sites.queuedRequests[ siteId ];
+	const isMissing = ! getSite( state, siteId );
+	return isNotQueued && ( isMissing || isStale( state, siteId ) );
 }
 
-function lastUpdatedWithin( state, siteId, timeInMillis ) {
-	const lastUpdated = state.reader.sites.lastUpdated[ siteId ];
-	if ( ! lastUpdated ) {
+function isStale( state, siteId ) {
+	const lastFetched = state.reader.sites.lastFetched[ siteId ];
+	if ( ! lastFetched ) {
 		return false;
 	}
-	return lastUpdated > ( Date.now() - timeInMillis );
+	return lastFetched <= ( Date.now() - DAY_IN_MILLIS );
 }
 
 /**

--- a/client/state/reader/sites/selectors.js
+++ b/client/state/reader/sites/selectors.js
@@ -1,5 +1,7 @@
+const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
+
 /**
-* Returns true if we should fetch the feed
+* Returns true if we should fetch the site
 *
 * @param  {Object}  state  Global state tree
 * @param  {Number}  siteId The site ID
@@ -8,7 +10,18 @@
 
 export function shouldSiteBeFetched( state, siteId ) {
 	return ! state.reader.sites.queuedRequests[ siteId ] && // not currently queued
-		! state.reader.sites.items[ siteId ]; // not currently loaded
+		(
+			! getSite( state, siteId ) ||
+			! lastUpdatedWithin( state, siteId, DAY_IN_MILLIS )
+		);
+}
+
+function lastUpdatedWithin( state, siteId, timeInMillis ) {
+	const lastUpdated = state.reader.sites.lastUpdated[ siteId ];
+	if ( ! lastUpdated ) {
+		return false;
+	}
+	return lastUpdated > ( Date.now() - timeInMillis );
 }
 
 /**

--- a/client/state/reader/sites/selectors.js
+++ b/client/state/reader/sites/selectors.js
@@ -1,12 +1,12 @@
 const DAY_IN_MILLIS = 24 * 60 * 1000 * 1000;
 
 /**
-* Returns true if we should fetch the site
-*
-* @param  {Object}  state  Global state tree
-* @param  {Number}  siteId The site ID
-* @return {Boolean}        Whether site should be fetched
-*/
+ * Returns true if we should fetch the site
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId The site ID
+ * @return {Boolean}        Whether site should be fetched
+ */
 
 export function shouldSiteBeFetched( state, siteId ) {
 	const isNotQueued = ! state.reader.sites.queuedRequests[ siteId ];
@@ -23,12 +23,12 @@ function isStale( state, siteId ) {
 }
 
 /**
-* Returns a site object
-*
-* @param  {Object}  state  Global state tree
-* @param  {Number}  siteId The site ID
-* @return {Object}        Site
-*/
+ * Returns a site object
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId The site ID
+ * @return {Object}        Site
+ */
 
 export function getSite( state, siteId ) {
 	return state.reader.sites.items[ siteId ];

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -16,7 +16,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE } from 'state/action-types';
 
-import { items, queuedRequests } from '../reducer';
+import { items, queuedRequests, lastFetched, } from '../reducer';
 
 describe( 'reducer', ( ) => {
 	describe( 'items', ( ) => {
@@ -205,6 +205,26 @@ describe( 'reducer', ( ) => {
 					}
 				)
 			).to.deep.equal( {} );
+		} );
+	} );
+
+	describe( 'lastFetched', () => {
+		it( 'should update the last fetched time on request success', () => {
+			const original = deepFreeze( {} );
+			const action = {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: { ID: 1 }
+			};
+			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
+		} );
+
+		it( 'should update the last fetched time on site update', () => {
+			const original = deepFreeze( {} );
+			const action = {
+				type: READER_SITE_UPDATE,
+				payload: [ { ID: 1 } ]
+			};
+			expect( lastFetched( original, action ) ).to.have.a.property( 1 ).that.is.a( 'number' );
 		} );
 	} );
 } );

--- a/client/state/reader/sites/test/selectors.js
+++ b/client/state/reader/sites/test/selectors.js
@@ -1,5 +1,11 @@
+/**
+ * External Dependencies
+ */
 import { expect } from 'chai';
 
+/**
+ * Internal Dependencies
+ */
 import { shouldSiteBeFetched } from '../selectors';
 
 describe( 'selectors', () => {
@@ -11,23 +17,43 @@ describe( 'selectors', () => {
 						queuedRequests: {
 							1: true
 						},
-						items: {}
+						items: {},
+						lastUpdated: {},
 					}
 				}
 			}, 1 ) ).to.be.false;
 		} );
 
-		it( 'should return false if the site is loaded', () => {
+		it( 'should return false if the site is loaded and recent', () => {
 			expect( shouldSiteBeFetched( {
 				reader: {
 					sites: {
 						queuedRequests: {},
 						items: {
 							1: {}
+						},
+						lastUpdated: {
+							1: Date.now()
 						}
 					}
 				}
 			}, 1 ) ).to.be.false;
+		} );
+
+		it( 'should return true if the site is loaded and was not updated recently', () => {
+			expect( shouldSiteBeFetched( {
+				reader: {
+					sites: {
+						queuedRequests: {},
+						items: {
+							1: {}
+						},
+						lastUpdated: {
+							1: 100
+						}
+					}
+				}
+			}, 1 ) ).to.be.true;
 		} );
 
 		it( 'should return true if the site is not queued and not loaded', () => {
@@ -35,7 +61,8 @@ describe( 'selectors', () => {
 				reader: {
 					sites: {
 						queuedRequests: {},
-						items: {}
+						items: {},
+						lastUpdated: {},
 					}
 				}
 			}, 1 ) ).to.be.true;
@@ -50,7 +77,8 @@ describe( 'selectors', () => {
 						},
 						items: {
 							2: {}
-						}
+						},
+						lastUpdated: {}
 					}
 				}
 			}, 1 ) ).to.be.true;

--- a/client/state/reader/sites/test/selectors.js
+++ b/client/state/reader/sites/test/selectors.js
@@ -18,7 +18,7 @@ describe( 'selectors', () => {
 							1: true
 						},
 						items: {},
-						lastUpdated: {},
+						lastFetched: {},
 					}
 				}
 			}, 1 ) ).to.be.false;
@@ -32,7 +32,7 @@ describe( 'selectors', () => {
 						items: {
 							1: {}
 						},
-						lastUpdated: {
+						lastFetched: {
 							1: Date.now()
 						}
 					}
@@ -48,7 +48,7 @@ describe( 'selectors', () => {
 						items: {
 							1: {}
 						},
-						lastUpdated: {
+						lastFetched: {
 							1: 100
 						}
 					}
@@ -62,7 +62,7 @@ describe( 'selectors', () => {
 					sites: {
 						queuedRequests: {},
 						items: {},
-						lastUpdated: {},
+						lastFetched: {},
 					}
 				}
 			}, 1 ) ).to.be.true;
@@ -78,7 +78,7 @@ describe( 'selectors', () => {
 						items: {
 							2: {}
 						},
-						lastUpdated: {}
+						lastFetched: {}
 					}
 				}
 			}, 1 ) ).to.be.true;


### PR DESCRIPTION
This teaches the feed reducer / selector / query component how to refetch stale feed data. Important points:

* Feed data is stale if it's more than a day old, or if we don't know when we last fetched it. 
* We're not serializing the update date, so a page refresh will also refresh all of the feed data. We'll have feed data for the initial render, but updated data will come in in the background.
* This also makes the shape of the feed data more explicit, removing the `meta` property which we don't actually use anywhere. This saves a bit of space on disk.

To test, load up the reader, then following manage. Then reload. Should see feed names immediately, but you should also see network requests in the background updating the data.