### PR TITLE
Replace my-sites sidebar with store specific sidebar for store routes

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -2,11 +2,8 @@
  * External dependencies
  */
 import config from 'config';
-import debugFactory from 'debug';
 import page from 'page';
 import React from 'react';
-
-const debug = debugFactory( 'calypso:store-sidebar' );
 
 /**
  * Internal dependencies
@@ -20,123 +17,130 @@ import SettingsPayments from './app/settings/payments';
 import StatsController from './app/stats/controller';
 import StoreSidebar from './store-sidebar';
 
-const storePages = [
-	{
-		container: Dashboard,
-		configKey: 'woocommerce/extension-dashboard',
-		path: '/store/:site',
-		sidebarItem: {
-			icon: 'house',
-			isPrimary: true,
-			label: 'Dashboard',
-			slug: 'dashboard',
+const getStorePages = () => {
+	return [
+		{
+			container: Dashboard,
+			configKey: 'woocommerce/extension-dashboard',
+			path: '/store/:site',
+			sidebarItem: {
+				icon: 'house',
+				isPrimary: true,
+				label: 'Dashboard',
+				slug: 'dashboard',
+			},
 		},
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-products',
-		path: '/store/products/:site',
-		sidebarItem: {
-			icon: 'product',
-			isPrimary: true,
-			label: 'Products',
-			slug: 'products',
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-products',
+			path: '/store/products/:site',
+			sidebarItem: {
+				icon: 'product',
+				isPrimary: true,
+				label: 'Products',
+				slug: 'products',
+			},
 		},
-	},
-	{
-		container: ProductCreate,
-		configKey: 'woocommerce/extension-products',
-		path: '/store/products/:site/add',
-		sidebarItemButton: {
-			label: 'Add',
-			parentSlug: 'products',
-			slug: 'product-add',
+		{
+			container: ProductCreate,
+			configKey: 'woocommerce/extension-products',
+			path: '/store/products/:site/add',
+			sidebarItemButton: {
+				label: 'Add',
+				parentSlug: 'products',
+				slug: 'product-add',
+			},
 		},
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-products-import',
-		path: '/store/products/:site/import',
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-orders',
-		path: '/store/orders/:site',
-		sidebarItem: {
-			icon: 'pages',
-			isPrimary: true,
-			label: 'Orders',
-			slug: 'orders',
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-products-import',
+			path: '/store/products/:site/import',
 		},
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-orders',
-		path: '/store/orders/:site/add',
-		sidebarItemButton: {
-			label: 'Add',
-			parentSlug: 'orders',
-			slug: 'order-add',
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-orders',
+			path: '/store/orders/:site',
+			sidebarItem: {
+				icon: 'pages',
+				isPrimary: true,
+				label: 'Orders',
+				slug: 'orders',
+			},
 		},
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-promotions',
-		path: '/store/promotions/:site',
-		sidebarItem: {
-			icon: 'money',
-			isPrimary: true,
-			label: 'Promotions',
-			slug: 'promotions',
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-orders',
+			path: '/store/orders/:site/add',
+			sidebarItemButton: {
+				label: 'Add',
+				parentSlug: 'orders',
+				slug: 'order-add',
+			},
 		},
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-extensions',
-		path: '/store/extensions/:site',
-		sidebarItem: {
-			icon: 'plugins',
-			isPrimary: false,
-			label: 'Extensions',
-			slug: 'extensions',
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-promotions',
+			path: '/store/promotions/:site',
+			sidebarItem: {
+				icon: 'money',
+				isPrimary: true,
+				label: 'Promotions',
+				slug: 'promotions',
+			},
 		},
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-settings',
-		path: '/store/settings/:site',
-		sidebarItem: {
-			icon: 'cog',
-			isPrimary: false,
-			label: 'Settings',
-			slug: 'settings',
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-extensions',
+			path: '/store/extensions/:site',
+			sidebarItem: {
+				icon: 'plugins',
+				isPrimary: false,
+				label: 'Extensions',
+				slug: 'extensions',
+			},
 		},
-	},
-	{
-		container: SettingsPayments,
-		configKey: 'woocommerce/extension-settings-payments',
-		path: '/store/settings/:site/payments',
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-settings-shipping',
-		path: '/store/settings/:site/shipping',
-	},
-	{
-		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-		configKey: 'woocommerce/extension-settings-tax',
-		path: '/store/settings/:site/tax',
-	},
-];
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-settings',
+			path: '/store/settings/:site',
+			sidebarItem: {
+				icon: 'cog',
+				isPrimary: false,
+				label: 'Settings',
+				slug: 'settings',
+			},
+		},
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-settings-checkout',
+			path: '/store/settings/:site/checkout',
+		},
+		{
+			container: SettingsPayments,
+			configKey: 'woocommerce/extension-settings-payments',
+			path: '/store/settings/:site/payments',
+		},
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-settings-shipping',
+			path: '/store/settings/:site/shipping',
+		},
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-settings-tax',
+			path: '/store/settings/:site/tax',
+		},
+	];
+};
 
 function getStoreSidebarItems() {
-	return storePages.filter( storePage => storePage.sidebarItem ).map( storePage => {
+	return getStorePages().filter( storePage => storePage.sidebarItem ).map( storePage => {
 		return { path: storePage.path, ...storePage.sidebarItem };
 	} );
 }
 
 function getStoreSidebarItemButtons() {
-	return storePages.filter( storePage => storePage.sidebarItemButton ).map( storePage => {
+	return getStorePages().filter( storePage => storePage.sidebarItemButton ).map( storePage => {
 		return { path: storePage.path, ...storePage.sidebarItemButton };
 	} );
 }
@@ -154,8 +158,6 @@ function addStorePage( storePage, storeNavigation ) {
 function createStoreNavigation( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
-
-	debug( 'rendering store nav now, context.path:', context.path );
 
 	renderWithReduxStore(
 		React.createElement(
@@ -175,7 +177,7 @@ function createStoreNavigation( context, next ) {
 
 export default function() {
 	// Add pages that use the store navigation
-	storePages.forEach( function( storePage ) {
+	getStorePages().forEach( function( storePage ) {
 		if ( config.isEnabled( storePage.configKey ) ) {
 			addStorePage( storePage, createStoreNavigation );
 		}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -1,22 +1,148 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import page from 'page';
 import config from 'config';
+import debugFactory from 'debug';
+import page from 'page';
+import React from 'react';
+
+const debug = debugFactory( 'calypso:store-sidebar' );
 
 /**
  * Internal dependencies
  */
+import { getSelectedSite } from 'state/ui/selectors';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import ProductCreate from './app/products/product-create';
 import Dashboard from './app/dashboard';
 import SettingsPayments from './app/settings/payments';
 import StatsController from './app/stats/controller';
+import StoreSidebar from './store-sidebar';
 
-function addStorePage( storePage ) {
-	page( storePage.route, siteSelection, navigation, function( context ) {
+const storePages = [
+	{
+		container: Dashboard,
+		configKey: 'woocommerce/extension-dashboard',
+		path: '/store/:site',
+		sidebarItem: {
+			icon: 'house',
+			isPrimary: true,
+			label: 'Dashboard',
+			slug: 'dashboard',
+		},
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-products',
+		path: '/store/products/:site',
+		sidebarItem: {
+			icon: 'product',
+			isPrimary: true,
+			label: 'Products',
+			slug: 'products',
+		},
+	},
+	{
+		container: ProductCreate,
+		configKey: 'woocommerce/extension-products',
+		path: '/store/products/:site/add',
+		sidebarItemButton: {
+			label: 'Add',
+			parentSlug: 'products',
+			slug: 'product-add',
+		},
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-products-import',
+		path: '/store/products/:site/import',
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-orders',
+		path: '/store/orders/:site',
+		sidebarItem: {
+			icon: 'pages',
+			isPrimary: true,
+			label: 'Orders',
+			slug: 'orders',
+		},
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-orders',
+		path: '/store/orders/:site/add',
+		sidebarItemButton: {
+			label: 'Add',
+			parentSlug: 'orders',
+			slug: 'order-add',
+		},
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-promotions',
+		path: '/store/promotions/:site',
+		sidebarItem: {
+			icon: 'money',
+			isPrimary: true,
+			label: 'Promotions',
+			slug: 'promotions',
+		},
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-extensions',
+		path: '/store/extensions/:site',
+		sidebarItem: {
+			icon: 'plugins',
+			isPrimary: false,
+			label: 'Extensions',
+			slug: 'extensions',
+		},
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-settings',
+		path: '/store/settings/:site',
+		sidebarItem: {
+			icon: 'cog',
+			isPrimary: false,
+			label: 'Settings',
+			slug: 'settings',
+		},
+	},
+	{
+		container: SettingsPayments,
+		configKey: 'woocommerce/extension-settings-payments',
+		path: '/store/settings/:site/payments',
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-settings-shipping',
+		path: '/store/settings/:site/shipping',
+	},
+	{
+		container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+		configKey: 'woocommerce/extension-settings-tax',
+		path: '/store/settings/:site/tax',
+	},
+];
+
+function getStoreSidebarItems() {
+	return storePages.filter( storePage => storePage.sidebarItem ).map( storePage => {
+		return { path: storePage.path, ...storePage.sidebarItem };
+	} );
+}
+
+function getStoreSidebarItemButtons() {
+	return storePages.filter( storePage => storePage.sidebarItemButton ).map( storePage => {
+		return { path: storePage.path, ...storePage.sidebarItemButton };
+	} );
+}
+
+function addStorePage( storePage, storeNavigation ) {
+	page( storePage.path, siteSelection, storeNavigation, function( context ) {
 		renderWithReduxStore(
 			React.createElement( storePage.container, { className: 'woocommerce' } ),
 			document.getElementById( 'primary' ),
@@ -25,76 +151,37 @@ function addStorePage( storePage ) {
 	} );
 }
 
-export default function() {
-	const storePages = [
-		{
-			container: Dashboard,
-			configKey: 'woocommerce/extension-dashboard',
-			route: '/store/:site',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-products',
-			route: '/store/products/:site',
-		},
-		{
-			container: ProductCreate,
-			configKey: 'woocommerce/extension-products',
-			route: '/store/products/:site/add',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-products-import',
-			route: '/store/products/:site/import',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-orders',
-			route: '/store/orders/:site',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-orders',
-			route: '/store/orders/:site/add',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-promotions',
-			route: '/store/promotions/:site',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-extensions',
-			route: '/store/extensions/:site',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-settings',
-			route: '/store/settings/:site',
-		},
-		{
-			container: SettingsPayments,
-			configKey: 'woocommerce/extension-settings-payments',
-			route: '/store/settings/:site/payments',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-settings-shipping',
-			route: '/store/settings/:site/shipping',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-settings-tax',
-			route: '/store/settings/:site/tax',
-		},
-	];
+function createStoreNavigation( context, next ) {
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
 
+	debug( 'rendering store nav now, context.path:', context.path );
+
+	renderWithReduxStore(
+		React.createElement(
+			StoreSidebar, {
+				path: context.path,
+				site: selectedSite,
+				sidebarItems: getStoreSidebarItems(),
+				sidebarItemButtons: getStoreSidebarItemButtons(),
+			}
+		),
+		document.getElementById( 'secondary' ),
+		context.store
+	);
+
+	next();
+}
+
+export default function() {
+	// Add pages that use the store navigation
 	storePages.forEach( function( storePage ) {
 		if ( config.isEnabled( storePage.configKey ) ) {
-			addStorePage( storePage );
+			addStorePage( storePage, createStoreNavigation );
 		}
 	} );
 
+	// Add pages that use my-sites navigation instead
 	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
 		page( '/store/stats/:type/:period/:site', siteSelection, navigation, StatsController );
 	}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -112,11 +112,6 @@ const getStorePages = () => {
 			},
 		},
 		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-settings-checkout',
-			path: '/store/settings/:site/checkout',
-		},
-		{
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings-payments',
 			path: '/store/settings/:site/payments',

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -4,6 +4,7 @@
 import config from 'config';
 import page from 'page';
 import React from 'react';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -26,7 +27,7 @@ const getStorePages = () => {
 			sidebarItem: {
 				icon: 'house',
 				isPrimary: true,
-				label: 'Dashboard',
+				label: translate( 'Dashboard' ),
 				slug: 'dashboard',
 			},
 		},
@@ -37,7 +38,7 @@ const getStorePages = () => {
 			sidebarItem: {
 				icon: 'product',
 				isPrimary: true,
-				label: 'Products',
+				label: translate( 'Products' ),
 				slug: 'products',
 			},
 		},
@@ -46,7 +47,7 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-products',
 			path: '/store/products/:site/add',
 			sidebarItemButton: {
-				label: 'Add',
+				label: translate( 'Add' ),
 				parentSlug: 'products',
 				slug: 'product-add',
 			},
@@ -63,7 +64,7 @@ const getStorePages = () => {
 			sidebarItem: {
 				icon: 'pages',
 				isPrimary: true,
-				label: 'Orders',
+				label: translate( 'Orders' ),
 				slug: 'orders',
 			},
 		},
@@ -72,7 +73,7 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-orders',
 			path: '/store/orders/:site/add',
 			sidebarItemButton: {
-				label: 'Add',
+				label: translate( 'Add' ),
 				parentSlug: 'orders',
 				slug: 'order-add',
 			},
@@ -84,7 +85,7 @@ const getStorePages = () => {
 			sidebarItem: {
 				icon: 'money',
 				isPrimary: true,
-				label: 'Promotions',
+				label: translate( 'Promotions' ),
 				slug: 'promotions',
 			},
 		},
@@ -95,7 +96,7 @@ const getStorePages = () => {
 			sidebarItem: {
 				icon: 'plugins',
 				isPrimary: false,
-				label: 'Extensions',
+				label: translate( 'Extensions' ),
 				slug: 'extensions',
 			},
 		},
@@ -106,7 +107,7 @@ const getStorePages = () => {
 			sidebarItem: {
 				icon: 'cog',
 				isPrimary: false,
-				label: 'Settings',
+				label: translate( 'Settings' ),
 				slug: 'settings',
 			},
 		},

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import debugFactory from 'debug';
+import React, { Component, PropTypes } from 'react';
+
+const debug = debugFactory( 'calypso:store-sidebar' );
+
+/**
+ * Internal dependencies
+ */
+import Sidebar from 'layout/sidebar';
+import SidebarButton from 'layout/sidebar/button';
+import SidebarItem from 'layout/sidebar/item';
+import SidebarMenu from 'layout/sidebar/menu';
+import SidebarSeparator from 'layout/sidebar/separator';
+import StoreGroundControl from './store-ground-control';
+
+export default class StoreSidebar extends Component {
+	static propTypes = {
+		path: PropTypes.string.isRequired,
+		sidebarItems: PropTypes.array, // TODO enforce shape
+		sidebarItemButtons: PropTypes.array, // TODO enforce shape
+		site: PropTypes.object, // TODO enforce slug in shape
+	}
+
+	onNavigate = () => {
+		// TODO - this.props.setNextLayoutFocus( 'content' );
+		window.scrollTo( 0, 0 );
+	}
+
+	itemLink = ( path ) => {
+		const link = path.replace( ':site', this.props.site.slug );
+		return link;
+	}
+
+	itemLinkClass = ( path, existingClasses ) => {
+		const classSet = {};
+
+		if ( typeof existingClasses !== 'undefined' ) {
+			if ( ! Array.isArray( existingClasses ) ) {
+				existingClasses = [ existingClasses ];
+			}
+
+			existingClasses.forEach( function( className ) {
+				classSet[ className ] = true;
+			} );
+		}
+
+		classSet.selected = this.isItemLinkSelected( path );
+
+		return classNames( classSet );
+	}
+
+	isItemLinkSelected = ( paths ) => {
+		if ( ! Array.isArray( paths ) ) {
+			paths = [ paths ];
+		}
+
+		return paths.some( function( path ) {
+			return path === this.props.path || 0 === this.props.path.indexOf( path + '/' );
+		}, this );
+	}
+
+	renderSidebarMenuItems = ( items, buttons ) => {
+		return items.map( function( item, index ) {
+			const itemLink = this.itemLink( item.path );
+			return (
+				<SidebarItem
+					className={ this.itemLinkClass( itemLink, item.slug ) }
+					icon={ item.icon }
+					key={ index }
+					label={ item.label }
+					link={ itemLink }
+					onNavigate={ this.onNavigate }
+					preloadSectionName={ item.slug }
+				>
+				{
+					buttons.filter( button => button.parentSlug === item.slug ).map( button => {
+						return (
+							<SidebarButton href={ this.itemLink( button.path ) } key={ button.slug } >
+								{ button.label }
+							</SidebarButton>
+						);
+					} )
+				}
+				</SidebarItem>
+			);
+		}, this );
+	}
+
+	onBack = () => {
+		// TODO - decide what path should go in on back
+		// Probably stats/day/:site
+	}
+
+	render = () => {
+		const { path, sidebarItems, sidebarItemButtons, site } = this.props;
+		debug( 'rendering store sidebar for path:', path );
+
+		// The store sidebar only makes sense in the context of a site
+		if ( ! site ) {
+			debug( 'attempted to render store sidebar outside of site context' );
+			return null;
+		}
+
+		return (
+			<Sidebar className="store-sidebar__sidebar">
+				<StoreGroundControl onBack={ this.onBack } site={ site } />
+				<SidebarMenu>
+					<ul>
+						{ this.renderSidebarMenuItems( sidebarItems.filter( item => item.isPrimary ), sidebarItemButtons ) }
+						<SidebarSeparator />
+						{ this.renderSidebarMenuItems( sidebarItems.filter( item => ! item.isPrimary ), sidebarItemButtons ) }
+					</ul>
+				</SidebarMenu>
+			</Sidebar>
+		);
+	}
+}
+
+// TODO mapStateToProps
+// TODO connect setNextLayoutFocus and SetLayoutFocus

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import debugFactory from 'debug';
 import React, { Component, PropTypes } from 'react';
-
-const debug = debugFactory( 'calypso:store-sidebar' );
 
 /**
  * Internal dependencies
@@ -20,13 +17,23 @@ import StoreGroundControl from './store-ground-control';
 export default class StoreSidebar extends Component {
 	static propTypes = {
 		path: PropTypes.string.isRequired,
-		sidebarItems: PropTypes.array, // TODO enforce shape
-		sidebarItemButtons: PropTypes.array, // TODO enforce shape
-		site: PropTypes.object, // TODO enforce slug in shape
+		sidebarItems: PropTypes.arrayOf( PropTypes.shape( {
+			icon: PropTypes.string.isRequired,
+			isPrimary: PropTypes.bool.isRequired,
+			label: PropTypes.string.isRequired,
+			path: PropTypes.string.isRequired,
+			slug: PropTypes.string.isRequired,
+		} ) ),
+		sidebarItemButtons: PropTypes.arrayOf( PropTypes.shape( {
+			label: PropTypes.string.isRequired,
+			parentSlug: PropTypes.string.isRequired,
+			path: PropTypes.string.isRequired,
+			slug: PropTypes.string.isRequired,
+		} ) ),
+		site: PropTypes.object,
 	}
 
 	onNavigate = () => {
-		// TODO - this.props.setNextLayoutFocus( 'content' );
 		window.scrollTo( 0, 0 );
 	}
 
@@ -90,24 +97,17 @@ export default class StoreSidebar extends Component {
 		}, this );
 	}
 
-	onBack = () => {
-		// TODO - decide what path should go in on back
-		// Probably stats/day/:site
-	}
-
 	render = () => {
-		const { path, sidebarItems, sidebarItemButtons, site } = this.props;
-		debug( 'rendering store sidebar for path:', path );
+		const { sidebarItems, sidebarItemButtons, site } = this.props;
 
 		// The store sidebar only makes sense in the context of a site
 		if ( ! site ) {
-			debug( 'attempted to render store sidebar outside of site context' );
 			return null;
 		}
 
 		return (
 			<Sidebar className="store-sidebar__sidebar">
-				<StoreGroundControl onBack={ this.onBack } site={ site } />
+				<StoreGroundControl site={ site } />
 				<SidebarMenu>
 					<ul>
 						{ this.renderSidebarMenuItems( sidebarItems.filter( item => item.isPrimary ), sidebarItemButtons ) }
@@ -119,6 +119,3 @@ export default class StoreSidebar extends Component {
 		);
 	}
 }
-
-// TODO mapStateToProps
-// TODO connect setNextLayoutFocus and SetLayoutFocus

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -73,6 +73,13 @@ export default class StoreSidebar extends Component {
 	renderSidebarMenuItems = ( items, buttons ) => {
 		return items.map( function( item, index ) {
 			const itemLink = this.itemLink( item.path );
+			const itemButton = buttons.filter( button => button.parentSlug === item.slug ).map( button => {
+				return (
+					<SidebarButton href={ this.itemLink( button.path ) } key={ button.slug } >
+						{ button.label }
+					</SidebarButton>
+				);
+			} );
 			return (
 				<SidebarItem
 					className={ this.itemLinkClass( itemLink, item.slug ) }
@@ -83,15 +90,7 @@ export default class StoreSidebar extends Component {
 					onNavigate={ this.onNavigate }
 					preloadSectionName={ item.slug }
 				>
-				{
-					buttons.filter( button => button.parentSlug === item.slug ).map( button => {
-						return (
-							<SidebarButton href={ this.itemLink( button.path ) } key={ button.slug } >
-								{ button.label }
-							</SidebarButton>
-						);
-					} )
-				}
+				{ itemButton }
 				</SidebarItem>
 			);
 		}, this );

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -12,14 +12,15 @@ const Gridicon = require( 'gridicons' ),
 
 import Button from 'components/button';
 
-const StoreGroundControl = ( { onBack, site, translate } ) => {
+const StoreGroundControl = ( { site, translate } ) => {
+	const backLink = '/stats/day/' + site.slug;
+
 	return (
 		<div className="store-sidebar__ground-control">
 			<Button
 				borderless
 				className="store-sidebar__ground-control-back"
-				href={ '' }
-				onClick={ onBack }
+				href={ backLink }
 				aria-label={ translate( 'Go back' ) }
 			>
 				<Gridicon icon="arrow-left" />
@@ -38,8 +39,9 @@ const StoreGroundControl = ( { onBack, site, translate } ) => {
 };
 
 StoreGroundControl.propTypes = {
-	onBack: React.PropTypes.function,
-	site: React.PropTypes.object,
+	site: React.PropTypes.shape( {
+		slug: React.PropTypes.string.isRequired,
+	} ),
 };
 
 export default localize( StoreGroundControl );

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+const Gridicon = require( 'gridicons' ),
+	Site = require( 'blocks/site' );
+
+import Button from 'components/button';
+
+const StoreGroundControl = ( { onBack, site, translate } ) => {
+	return (
+		<div className="store-sidebar__ground-control">
+			<Button
+				borderless
+				className="store-sidebar__ground-control-back"
+				href={ '' }
+				onClick={ onBack }
+				aria-label={ translate( 'Go back' ) }
+			>
+				<Gridicon icon="arrow-left" />
+			</Button>
+			<div className="store-sidebar__ground-control-site">
+				<Site
+					compact
+					site={ site }
+					indicator={ false }
+					homeLink={ true }
+					externalLink={ true }
+				/>
+			</div>
+		</div>
+	);
+};
+
+StoreGroundControl.propTypes = {
+	onBack: React.PropTypes.function,
+	site: React.PropTypes.object,
+};
+
+export default localize( StoreGroundControl );

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -7,10 +7,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-const Gridicon = require( 'gridicons' ),
-	Site = require( 'blocks/site' );
-
 import Button from 'components/button';
+import Gridicon from 'gridicons';
+import Site from 'blocks/site';
 
 const StoreGroundControl = ( { site, translate } ) => {
 	const backLink = '/stats/day/' + site.slug;
@@ -30,8 +29,8 @@ const StoreGroundControl = ( { site, translate } ) => {
 					compact
 					site={ site }
 					indicator={ false }
-					homeLink={ true }
-					externalLink={ true }
+					homeLink
+					externalLink
 				/>
 			</div>
 		</div>

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -11,3 +11,24 @@
 	@import 'app/products/product-form';
 	@import 'components/form-dimensions-input/style';
 }
+
+.store-sidebar__sidebar {
+	.store-sidebar__ground-control {
+		align-items: center;
+		border-bottom: 1px solid darken( $sidebar-bg-color, 10% );
+		display: flex;
+		width: 100%;
+	}
+
+	.store-sidebar__ground-control-back {
+		flex: 0 0 auto;
+		margin-left: 7px;
+		margin-right: 7px;
+	}
+
+	.store-sidebar__ground-control-site {
+		border-left: 1px solid darken( $sidebar-bg-color, 10% );
+		display: inline-block;
+		flex-grow: 1;
+	}
+}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -13,6 +13,8 @@
 }
 
 .store-sidebar__sidebar {
+	display: block;
+
 	.store-sidebar__ground-control {
 		align-items: center;
 		border-bottom: 1px solid darken( $sidebar-bg-color, 10% );

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -16,6 +16,7 @@
 	.store-sidebar__ground-control {
 		align-items: center;
 		border-bottom: 1px solid darken( $sidebar-bg-color, 10% );
+		background-color: $white;
 		display: flex;
 		width: 100%;
 	}

--- a/client/layout/sidebar/separator.jsx
+++ b/client/layout/sidebar/separator.jsx
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const SidebarSeparator = () => (
+	<li className="sidebar__separator"></li>
+);
+
+export default SidebarSeparator;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -329,6 +329,10 @@ form.sidebar__button {
 	}
 }
 
+.sidebar .sidebar__separator {
+	border-bottom: 1px solid darken( $sidebar-bg-color, 10% );
+}
+
 .sidebar .sidebar__footer {
 	align-items: center;
 	padding: 0;


### PR DESCRIPTION
Ready for review. See #13514 

To test:
- Navigate to http://calypso.localhost:3000/store/{site}
- Make sure the sidebar renders, including highlighting the Dashboard link
- Click each of Products, Orders, Promotions, Extensions and Settings and ensure the URL updates (note that we have the same placeholder for each of these
- Click on the Add button on Products. Ensure you are navigated to the Product Add screen.
- Click on the site itself at the top of the sidebar. Ensure the site is opened in a new tab.
- Click on the left arrow/back arrow at the top of the sidebar. Ensure you are navigated to http://calypso.localhost:3000/stats/day/{site}

Does not include:

- Adding a Store item to the sites sidebar - that will be in a subsequent PR
- Detecting whether or not the referenced site actually has WooCommerce active - that will be in a subsequent PR

@justinshreve @coderkevin @belcherj - would love two reviewers on this large one :) talk amongst yourselves :) ty!

@kellychoffman @jameskoster - needs design check please - ty!