### PR TITLE
Reader: Prevent unnecessary site fetches for posts from external sites

### DIFF
--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -108,7 +108,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		return (
 			<span className={ classes }>
 				{ ! feed && post && post.feed_ID && <QueryReaderFeed feedId={ +post.feed_ID } /> }
-				{ ! site && post && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
+				{ ! site && post && ! post.is_external && post.site_ID && <QueryReaderSite siteId={ +post.site_ID } /> }
 				<EllipsisMenu
 					className="reader-post-options-menu__ellipsis-menu"
 					popoverClassName="reader-post-options-menu__popover"


### PR DESCRIPTION
To test, load the following stream with some pure external feeds followed. Verify that we don't make any site requests for sites with the feed ID by mistake.