### PR TITLE
State: relax schema for vip plans

### DIFF
--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -46,9 +46,9 @@ export const sitesSchema = {
 				},
 				plan: {
 					type: 'object',
-					required: [ 'product_id', 'product_slug', 'expired' ],
+					required: [ 'product_id', 'product_slug' ],
 					properties: {
-						product_id: { type: 'number' },
+						product_id: { type: [ 'number', 'string' ] },
 						product_slug: { type: 'string' },
 						product_name_short: { type: [ 'string', 'null' ] },
 						free_trial: { type: 'boolean' },


### PR DESCRIPTION
This PR relaxes the schema a bit so we don't throw out all sites data when someone has a vip plan. For a vip plan the endpoint is returning a string for `product_id` and does not provide the `expired` prop.

### Testing Instructions
- No functional changes
- We shouldn't see a schema validation warning when a user has a vip site