### PR TITLE
Domains: adds check for paid plan before nudging to plan

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -1,6 +1,10 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import React from 'react';
 import classNames from 'classnames';
 import {
@@ -42,7 +46,7 @@ var DomainSearchResults = React.createClass( {
 	},
 
 	renderDomainAvailability: function() {
-		const { availableDomain, lastDomainStatus, lastDomainSearched: domain } = this.props,
+		const { availableDomain, lastDomainStatus, lastDomainSearched: domain, translate } = this.props,
 			availabilityElementClasses = classNames( {
 				'domain-search-results__domain-is-available': availableDomain,
 				'domain-search-results__domain-not-available': ! availableDomain
@@ -59,7 +63,7 @@ var DomainSearchResults = React.createClass( {
 				<Notice
 					status="is-success"
 					showDismiss={ false }>
-					{ this.translate( '%(domain)s is available!', { args: { domain } } ) }
+					{ translate( '%(domain)s is available!', { args: { domain } } ) }
 				</Notice>
 			);
 
@@ -77,20 +81,20 @@ var DomainSearchResults = React.createClass( {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
 			if ( isNextDomainFree( this.props.cart ) ) {
-				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
+				mappingOffer = translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
 					'free.{{/small}}', { args: { domain }, components } );
-			} else if ( ! this.props.domainsWithPlansOnly ) {
-				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
+			} else if ( ! this.props.domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
+				mappingOffer = translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for ' +
 					'%(cost)s.{{/small}}', { args: { domain, cost: this.props.products.domain_map.cost_display }, components } );
 			} else {
-				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}}' +
+				mappingOffer = translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}}' +
 					' with WordPress.com Premium.{{/small}}', { args: { domain }, components }
 				);
 			}
 
 			const domainUnavailableMessage = lastDomainStatus === UNKNOWN
-				? this.translate( '.%(tld)s domains are not offered on WordPress.com.', { args: { tld: getTld( domain ) } } )
-				: this.translate( '%(domain)s is taken.', { args: { domain } } );
+				? translate( '.%(tld)s domains are not offered on WordPress.com.', { args: { tld: getTld( domain ) } } )
+				: translate( '%(domain)s is taken.', { args: { domain } } );
 
 			if ( this.props.offerMappingOption ) {
 				availabilityElement = (
@@ -173,4 +177,11 @@ var DomainSearchResults = React.createClass( {
 	}
 } );
 
-module.exports = DomainSearchResults;
+const mapStateToProps = ( state ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	return {
+		isSiteOnPaidPlan: !! isSiteOnPaidPlan( state, selectedSiteId ),
+	};
+};
+
+export default connect( mapStateToProps )( localize( DomainSearchResults ) );

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -180,7 +180,7 @@ var DomainSearchResults = React.createClass( {
 const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		isSiteOnPaidPlan: !! isSiteOnPaidPlan( state, selectedSiteId ),
+		isSiteOnPaidPlan: isSiteOnPaidPlan( state, selectedSiteId ),
 	};
 };
 

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -161,6 +161,7 @@ export isSharingButtonsSaveSuccessful from './is-sharing-buttons-save-successful
 export isSiteAutomatedTransfer from './is-site-automated-transfer';
 export isSiteBlocked from './is-site-blocked';
 export isSiteOnFreePlan from './is-site-on-free-plan';
+export isSiteOnPaidPlan from './is-site-on-paid-plan';
 export isSiteSupportingImageEditor from './is-site-supporting-image-editor';
 export isSiteUpgradeable from './is-site-upgradeable';
 export isValidThemeFilterTerm from './is-valid-theme-filter-term';

--- a/client/state/selectors/is-site-on-free-plan.js
+++ b/client/state/selectors/is-site-on-free-plan.js
@@ -16,7 +16,7 @@ const isSiteOnFreePlan = ( state, siteId ) => {
 	const currentPlan = getCurrentPlan( state, siteId );
 
 	if ( ! currentPlan ) {
-		return null;
+		return false;
 	}
 
 	return currentPlan.productSlug === PLAN_FREE;

--- a/client/state/selectors/is-site-on-free-plan.js
+++ b/client/state/selectors/is-site-on-free-plan.js
@@ -10,7 +10,7 @@ import { PLAN_FREE } from 'lib/plans/constants';
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {?Boolean} Whether site is on a free plan
+ * @return {Boolean} Whether site is on a free plan
  */
 const isSiteOnFreePlan = ( state, siteId ) => {
 	const currentPlan = getCurrentPlan( state, siteId );

--- a/client/state/selectors/is-site-on-free-plan.js
+++ b/client/state/selectors/is-site-on-free-plan.js
@@ -5,8 +5,8 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { PLAN_FREE } from 'lib/plans/constants';
 
 /**
- * Returns true if site is on a free plan, false if the site is not,
- * or null if the site is unknown.
+ * Returns true if site is on a free plan, false if the site is not
+ * or if the site or plan is unknown.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID

--- a/client/state/selectors/is-site-on-paid-plan.js
+++ b/client/state/selectors/is-site-on-paid-plan.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { PLAN_FREE } from 'lib/plans/constants';
+
+/**
+ * Returns true if site is on a paid plan, false if the site is not,
+ * or null if the site is unknown.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @return {?Boolean} Whether site is on a paid plan
+ */
+const isSiteOnPaidPlan = ( state, siteId ) => {
+	const currentPlan = getCurrentPlan( state, siteId );
+
+	if ( ! currentPlan ) {
+		return null;
+	}
+
+	return currentPlan.productSlug !== PLAN_FREE;
+};
+
+export default isSiteOnPaidPlan;

--- a/client/state/selectors/is-site-on-paid-plan.js
+++ b/client/state/selectors/is-site-on-paid-plan.js
@@ -5,8 +5,8 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { PLAN_FREE } from 'lib/plans/constants';
 
 /**
- * Returns true if site is on a paid plan, false if the site is not,
- * or null if the site is unknown.
+ * Returns true if site is on a paid plan, false if the site is not
+ * or if the site or plan is unknown.
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID

--- a/client/state/selectors/is-site-on-paid-plan.js
+++ b/client/state/selectors/is-site-on-paid-plan.js
@@ -10,7 +10,7 @@ import { PLAN_FREE } from 'lib/plans/constants';
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @return {?Boolean} Whether site is on a paid plan
+ * @return {Boolean} Whether site is on a paid plan
  */
 const isSiteOnPaidPlan = ( state, siteId ) => {
 	const currentPlan = getCurrentPlan( state, siteId );

--- a/client/state/selectors/is-site-on-paid-plan.js
+++ b/client/state/selectors/is-site-on-paid-plan.js
@@ -16,7 +16,7 @@ const isSiteOnPaidPlan = ( state, siteId ) => {
 	const currentPlan = getCurrentPlan( state, siteId );
 
 	if ( ! currentPlan ) {
-		return null;
+		return false;
 	}
 
 	return currentPlan.productSlug !== PLAN_FREE;

--- a/client/state/selectors/test/is-site-on-free-plan.js
+++ b/client/state/selectors/test/is-site-on-free-plan.js
@@ -28,9 +28,9 @@ describe( 'isSiteOnFreePlan', () => {
 		isSiteOnFreePlan = require( '../is-site-on-free-plan' );
 	} );
 
-	it( 'should return null when plan is not known', () => {
+	it( 'should return false when plan is not known', () => {
 		getCurrentPlan.returns( null );
-		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.null;
+		expect( isSiteOnFreePlan( state, 'site1' ) ).to.be.false;
 	} );
 
 	it( 'should return false when not on free plan', () => {

--- a/client/state/selectors/test/is-site-on-paid-plan.js
+++ b/client/state/selectors/test/is-site-on-paid-plan.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import {
+	PLAN_BUSINESS,
+	PLAN_FREE
+} from 'lib/plans/constants';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'isSiteOnPaidPlan', () => {
+	const state = deepFreeze( {} );
+	let getCurrentPlan;
+	let isSiteOnPaidPlan;
+
+	useMockery( mockery => {
+		getCurrentPlan = stub();
+		mockery.registerMock( 'state/sites/plans/selectors', { getCurrentPlan } );
+	} );
+
+	before( () => {
+		isSiteOnPaidPlan = require( '../is-site-on-paid-plan' );
+	} );
+
+	it( 'should return false when plan is not known', () => {
+		getCurrentPlan.returns( null );
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.false;
+	} );
+
+	it( 'should return false when on free plan', () => {
+		getCurrentPlan.returns( { productSlug: PLAN_FREE } );
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.false;
+	} );
+
+	it( 'should return true when on paid plan', () => {
+		getCurrentPlan.returns( { productSlug: PLAN_BUSINESS } );
+		expect( isSiteOnPaidPlan( state, 'site1' ) ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
I had noticed when testing a subdomain that attempting to map the domain asked me to upgrade to the Premium plan, even though I already have the business plan. This was determined by the test for whether domains-in-plans is supported for my user, but it was missing the check for existing plans.

So I was seeing this (incorrect):
![nudge to upgrade](http://cld.wthms.co/KoZ83+)

And after applying this patch I'm seeing this (correct):
![no nudge to upgrade](http://cld.wthms.co/pRF39+)

One note, I added a new selector, `is-site-on-paid-plan.js`. I considered just using the inverse of the existing selector, `is-site-on-free-plan.js`. The problem was that a missing site or plan would result in null for the free plan check, and I want it to be null for the paid check as well. Trying to account for that seemed too awkward versus having another tailored selector.

I'm also using the updated calypso-i18n module for translations. Unrelated, but didn't want lint warnings.

### Testing
In master, search for a domain on a site that already has the business plan. It should be a relatively new user (preferably one created this year), which will place it in the domains-in-plans-only variant. Confirm the issue in master, that you are asked to upgrade to premium even though you already have the business plan.

Then apply this branch and test again. It should now just ask you to map the domain. For extra credit, add the mapping to your cart and confirm the premium plan is not also added.