### PR TITLE
Notes: fetch list when notification comes in before panel is opened

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3026,7 +3026,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.1.7"
+      "version": "Automattic/notifications-panel#fix\/get-note"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3026,7 +3026,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "Automattic/notifications-panel#fix\/get-note"
+      "version": "1.1.8"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.1.7",
+    "notifications-panel": "Automattic/notifications-panel#fix\/get-note",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "Automattic/notifications-panel#fix\/get-note",
+    "notifications-panel": "1.1.8",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",


### PR DESCRIPTION
This fixes https://github.com/Automattic/wp-calypso/issues/13835 where sometimes notifications would not fully load if a new notification was triggered before the panel was opened

### Testing Instructions
- Navigate to http://calypso.localhost:3000
- Trigger a notification so the orange dot appears. An easy way to do this is to like one of your own posts. It's important to trigger this before the panel is ever opened.
- Open the panel and you should see the full list of notifications

Previously we saw behavior like:
![spinner](https://cloud.githubusercontent.com/assets/1270189/25866894/dd4362a8-34ac-11e7-910f-7c00e898df4e.gif)
