### PR TITLE
Notes: turn off rubberband-scroll-disable

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -70,7 +70,7 @@
 		"reader/search": true,
 		"resume-editing": true,
 		"republicize": false,
-		"rubberband-scroll-disable": true,
+		"rubberband-scroll-disable": false,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-desktop/issues/298 where we were unable to scroll up in notifications until we reached the bottom.

To reproduce bad behavior:
- `ENABLE_FEATURES=rubberband-scroll-disable make run`

cc @Automattic/lannister @artpi 