### PR TITLE
Notification Settings: Remove sites-list

### DIFF
--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Immutable from 'immutable';
 import classNames from 'classnames';
@@ -14,10 +14,8 @@ import Card from 'components/card';
 import Header from './header';
 import SettingsForm from 'me/notification-settings/settings-form';
 
-const BlogSettings = React.createClass( {
-	displayName: 'BlogSettings',
-
-	propTypes: {
+class BlogSettings extends Component {
+	static propTypes = {
 		site: PropTypes.object.isRequired,
 		devices: PropTypes.object,
 		disableToggle: PropTypes.bool,
@@ -26,13 +24,14 @@ const BlogSettings = React.createClass( {
 		onToggle: PropTypes.func.isRequired,
 		onSave: PropTypes.func.isRequired,
 		onSaveToAll: PropTypes.func.isRequired
-	},
+	};
 
-	getInitialState() {
-		return {
-			isExpanded: false
-		};
-	},
+	state = { isExpanded: false	};
+
+	onToggle = () => {
+		const isExpanded = ! this.state.isExpanded;
+		this.setState( { isExpanded } );
+	};
 
 	render() {
 		const {
@@ -58,18 +57,27 @@ const BlogSettings = React.createClass( {
 			<Card className={ styles }>
 				<Header
 					{ ...{ site, settings, disableToggle } }
-					onToggle={ () => this.setState( { isExpanded: ! isExpanded } ) } />
+					onToggle={ this.onToggle } />
 				{ ( () => {
 					if ( isExpanded || disableToggle ) {
 						return <SettingsForm
-							{ ...{ sourceId, devices, settings, hasUnsavedChanges, isApplyAllVisible: ! disableToggle, onToggle, onSave, onSaveToAll } }
+							{ ...{
+								sourceId,
+								devices,
+								settings,
+								hasUnsavedChanges,
+								isApplyAllVisible: ! disableToggle,
+								onToggle,
+								onSave,
+								onSaveToAll
+							} }
 							settingKeys={ [ 'new_comment', 'comment_like', 'post_like', 'follow', 'achievement', 'mentions' ] } />;
 					}
 				} )() }
 			</Card>
 		);
 	}
-} );
+}
 
 const mapStateToProps = ( state, { siteId } ) => ( {
 	site: getSite( state, siteId )

--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -2,21 +2,23 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import Immutable from 'immutable';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import { getSite } from 'state/sites/selectors';
 import Card from 'components/card';
 import Header from './header';
 import SettingsForm from 'me/notification-settings/settings-form';
 
-export default React.createClass( {
+const BlogSettings = React.createClass( {
 	displayName: 'BlogSettings',
 
 	propTypes: {
-		blog: PropTypes.object.isRequired,
+		site: PropTypes.object.isRequired,
 		devices: PropTypes.object,
 		disableToggle: PropTypes.bool,
 		settings: PropTypes.instanceOf( Immutable.Map ).isRequired,
@@ -33,8 +35,20 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { blog, blog: { ID: sourceId }, settings, disableToggle, devices, hasUnsavedChanges, onToggle, onSave, onSaveToAll } = this.props;
+		const {
+			site,
+			site: { ID: sourceId },
+			settings,
+			disableToggle,
+			devices,
+			hasUnsavedChanges,
+			onToggle,
+			onSave,
+			onSaveToAll
+		} = this.props;
+
 		const { isExpanded } = this.state;
+
 		const styles = classNames( 'notification-settings-blog-settings', {
 			'is-compact': ! isExpanded,
 			'is-expanded': isExpanded
@@ -43,7 +57,7 @@ export default React.createClass( {
 		return (
 			<Card className={ styles }>
 				<Header
-					{ ...{ blog, settings, disableToggle } }
+					{ ...{ site, settings, disableToggle } }
 					onToggle={ () => this.setState( { isExpanded: ! isExpanded } ) } />
 				{ ( () => {
 					if ( isExpanded || disableToggle ) {
@@ -56,3 +70,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+const mapStateToProps = ( state, { siteId } ) => ( {
+	site: getSite( state, siteId )
+} );
+
+export default connect( mapStateToProps )( BlogSettings );

--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -26,7 +26,7 @@ class BlogSettings extends Component {
 		onSaveToAll: PropTypes.func.isRequired
 	};
 
-	state = { isExpanded: false	};
+	state = { isExpanded: false };
 
 	onToggle = () => {
 		const isExpanded = ! this.state.isExpanded;

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -75,9 +75,11 @@ class BlogSettingsHeader extends PureComponent {
 					<em>{ this.getLegend() }</em>
 				</div>
 				{ ! this.props.disableToggle
-					? <div className="blogs-settings__header-expand">
-							<a className={ 'noticon noticon-' + ( this.state.isExpanded ? 'collapse' : 'expand' ) }></a>
-						</div>
+					? (
+							<div className="blogs-settings__header-expand">
+								<a className={ 'noticon noticon-' + ( this.state.isExpanded ? 'collapse' : 'expand' ) }></a>
+							</div>
+						)
 					: null }
 			</header>
 		);

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -19,7 +19,7 @@ export default React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
-		blog: PropTypes.object.isRequired,
+		site: PropTypes.object.isRequired,
 		settings: PropTypes.instanceOf( Immutable.Map ).isRequired,
 		disableToggle: PropTypes.bool,
 		onToggle: PropTypes.func.isRequired
@@ -39,7 +39,7 @@ export default React.createClass( {
 		const isExpanded = ! this.state.isExpanded;
 		this.setState( { isExpanded } );
 
-		analytics.ga.recordEvent( 'Notification Settings', isExpanded ? 'Expanded Site' : 'Collapsed Site', this.props.blog.name );
+		analytics.ga.recordEvent( 'Notification Settings', isExpanded ? 'Expanded Site' : 'Collapsed Site', this.props.site.name );
 
 		this.props.onToggle();
 	},
@@ -74,9 +74,11 @@ export default React.createClass( {
 	},
 
 	render() {
+		const { site } = this.props;
+
 		return (
-			<header key={ this.props.blog.wpcom_url } className="notification-settings-blog-settings-header" onClick={ this.toggleExpanded }>
-				<SiteInfo site={ this.props.blog } indicator={ false }/>
+			<header key={ site.wpcom_url } className="notification-settings-blog-settings-header" onClick={ this.toggleExpanded }>
+				<SiteInfo site={ site } indicator={ false } />
 				<div className="notification-settings-blog-settings-header__legend">
 					<em>{ this.getLegend() }</em>
 				</div>

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -77,13 +77,13 @@ export default React.createClass( {
 		const { site } = this.props;
 
 		return (
-			<header key={ site.wpcom_url } className="notification-settings-blog-settings-header" onClick={ this.toggleExpanded }>
+			<header key={ site.wpcom_url } className="blogs-settings__header" onClick={ this.toggleExpanded }>
 				<SiteInfo site={ site } indicator={ false } />
-				<div className="notification-settings-blog-settings-header__legend">
+				<div className="blogs-settings__header-legend">
 					<em>{ this.getLegend() }</em>
 				</div>
 				{ ! this.props.disableToggle ?
-				<div className="notification-settings-blog-settings-header__expand">
+				<div className="blogs-settings__header-expand">
 					<a className={ 'noticon noticon-' + ( this.state.isExpanded ? 'collapse' : 'expand' ) }></a>
 				</div> :
 				null }

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
 import Immutable from 'immutable';
 import zip from 'lodash/zip';
 import includes from 'lodash/includes';
@@ -13,25 +13,17 @@ import includes from 'lodash/includes';
 import analytics from 'lib/analytics';
 import SiteInfo from 'blocks/site';
 
-export default React.createClass( {
-	displayName: 'BlogSettingsHeader',
-
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
+class BlogSettingsHeader extends PureComponent {
+	static propTypes = {
 		site: PropTypes.object.isRequired,
 		settings: PropTypes.instanceOf( Immutable.Map ).isRequired,
 		disableToggle: PropTypes.bool,
 		onToggle: PropTypes.func.isRequired
-	},
+	};
 
-	getInitialState() {
-		return {
-			isExpanded: false
-		};
-	},
+	state = { isExpanded: false };
 
-	toggleExpanded() {
+	toggleExpanded = () => {
 		if ( this.props.disableToggle ) {
 			return;
 		}
@@ -42,9 +34,9 @@ export default React.createClass( {
 		analytics.ga.recordEvent( 'Notification Settings', isExpanded ? 'Expanded Site' : 'Collapsed Site', this.props.site.name );
 
 		this.props.onToggle();
-	},
+	};
 
-	getLegend() {
+	getLegend = () => {
 		const tally = o => o.reduce( ( total, value ) => total + value );
 		const sizeAndSum = settings => [ settings.size, tally( settings ) ];
 
@@ -63,15 +55,15 @@ export default React.createClass( {
 		const [ size, count ] = zip.apply( null, counts ).map( tally );
 
 		if ( count === 0 ) {
-			return this.translate( 'no notifications' );
+			return this.props.translate( 'no notifications' );
 		}
 
 		if ( size === count ) {
-			return this.translate( 'all notifications' );
+			return this.props.translate( 'all notifications' );
 		}
 
-		return this.translate( 'some notifications' );
-	},
+		return this.props.translate( 'some notifications' );
+	};
 
 	render() {
 		const { site } = this.props;
@@ -82,12 +74,14 @@ export default React.createClass( {
 				<div className="blogs-settings__header-legend">
 					<em>{ this.getLegend() }</em>
 				</div>
-				{ ! this.props.disableToggle ?
-				<div className="blogs-settings__header-expand">
-					<a className={ 'noticon noticon-' + ( this.state.isExpanded ? 'collapse' : 'expand' ) }></a>
-				</div> :
-				null }
+				{ ! this.props.disableToggle
+					? <div className="blogs-settings__header-expand">
+							<a className={ 'noticon noticon-' + ( this.state.isExpanded ? 'collapse' : 'expand' ) }></a>
+						</div>
+					: null }
 			</header>
 		);
 	}
-} );
+}
+
+export default localize( BlogSettingsHeader );

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -4,18 +4,17 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { noop, sortBy } from 'lodash';
 import Immutable from 'immutable';
 
 /**
  * Internal dependencies
  */
-import { getSites } from 'state/selectors';
+import { getSites, getPrimarySiteId } from 'state/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import Blog from './blog';
 import InfiniteList from 'components/infinite-list';
 import Placeholder from './placeholder';
-import QuerySites from 'components/data/query-sites';
 import config from 'config';
 
 const createPlaceholder = () => <Placeholder />;
@@ -37,12 +36,7 @@ class BlogsSettings extends Component {
 		const { sites, translate } = this.props;
 
 		if ( ! sites || ! this.props.devices.initialized || ! this.props.settings ) {
-			return (
-				<div>
-					<QuerySites allSites />
-					<Placeholder />
-				</div>
-			);
+			return <Placeholder />;
 		}
 
 		if ( sites.length === 0 ) {
@@ -90,8 +84,11 @@ class BlogsSettings extends Component {
 	}
 }
 
-const mapStateToProps = state => ( {
-	sites: getSites( state )
-} );
+const mapStateToProps = state => {
+	const primarySiteId = getPrimarySiteId( state );
+	return {
+		sites: sortBy( getSites( state ), site => site.ID !== primarySiteId )
+	};
+};
 
 export default connect( mapStateToProps )( localize( BlogsSettings ) );

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 import Immutable from 'immutable';
 
 /**
@@ -16,10 +18,12 @@ import Placeholder from './placeholder';
 import QuerySites from 'components/data/query-sites';
 import config from 'config';
 
-const BlogsSettings = React.createClass( {
-	displayName: 'BlogsSettings',
+const createPlaceholder = () => <Placeholder />;
 
-	propTypes: {
+const getItemRef = ( { ID } ) => `blog-${ ID }`;
+
+class BlogsSettings extends Component {
+	static propTypes = {
 		sites: PropTypes.array.isRequired,
 		devices: PropTypes.object.isRequired,
 		settings: PropTypes.instanceOf( Immutable.List ),
@@ -27,10 +31,10 @@ const BlogsSettings = React.createClass( {
 		onToggle: PropTypes.func.isRequired,
 		onSave: PropTypes.func.isRequired,
 		onSaveToAll: PropTypes.func.isRequired
-	},
+	};
 
 	render() {
-		const { sites } = this.props;
+		const { sites, translate } = this.props;
 
 		if ( ! sites || ! this.props.devices.initialized || ! this.props.settings ) {
 			return (
@@ -43,14 +47,17 @@ const BlogsSettings = React.createClass( {
 
 		if ( sites.length === 0 ) {
 			return <EmptyContentComponent
-				title={ this.translate( 'You don\'t have any WordPress sites yet.' ) }
-				line={ this.translate( 'Would you like to start one?' ) }
-				action={ this.translate( 'Create Site' ) }
+				title={ translate( 'You don\'t have any WordPress sites yet.' ) }
+				line={ translate( 'Would you like to start one?' ) }
+				action={ translate( 'Create Site' ) }
 				actionURL={ config( 'signup_url' ) + '?ref=calypso-nosites' }
-				illustration={ '/calypso/images/drake/drake-nosites.svg' } />
+				illustration={ '/calypso/images/drake/drake-nosites.svg' } />;
 		}
 
 		const renderBlog = ( site, index, disableToggle = false ) => {
+			const onSave = () => this.props.onSave( site.ID );
+			const onSaveToAll = () => this.props.onSaveToAll( site.ID );
+
 			return (
 				<Blog
 					key={ `blog-${ site.ID }` }
@@ -60,10 +67,10 @@ const BlogsSettings = React.createClass( {
 					hasUnsavedChanges={ this.props.hasUnsavedChanges }
 					settings={ this.props.settings.find( settings => settings.get( 'blog_id' ) === site.ID ) }
 					onToggle={ this.props.onToggle }
-					onSave={ () => this.props.onSave( site.ID ) }
-					onSaveToAll={ () => this.props.onSaveToAll( site.ID ) } />
+					onSave={ onSave }
+					onSaveToAll={ onSaveToAll } />
 			);
-		}
+		};
 
 		if ( sites.length === 1 ) {
 			return renderBlog( sites[ 0 ], null, true );
@@ -73,18 +80,18 @@ const BlogsSettings = React.createClass( {
 			<InfiniteList
 				items={ sites }
 				lastPage={ true }
-				fetchNextPage={ () => {} }
+				fetchNextPage={ noop }
 				fetchingNextPage={ false }
 				guessedItemHeight={ 69 }
-				getItemRef={ site => `blog-${ site.ID }` }
+				getItemRef={ getItemRef }
 				renderItem={ renderBlog }
-				renderLoadingPlaceholders={ () => <Placeholder /> } />
+				renderLoadingPlaceholders={ createPlaceholder } />
 		);
 	}
-} );
+}
 
 const mapStateToProps = state => ( {
 	sites: getSites( state )
 } );
 
-export default connect( mapStateToProps )( BlogsSettings );
+export default connect( mapStateToProps )( localize( BlogsSettings ) );

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -4,13 +4,13 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, sortBy } from 'lodash';
+import { noop } from 'lodash';
 import Immutable from 'immutable';
 
 /**
  * Internal dependencies
  */
-import { getSites, getPrimarySiteId } from 'state/selectors';
+import { getSites } from 'state/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import Blog from './blog';
 import InfiniteList from 'components/infinite-list';
@@ -84,11 +84,8 @@ class BlogsSettings extends Component {
 	}
 }
 
-const mapStateToProps = state => {
-	const primarySiteId = getPrimarySiteId( state );
-	return {
-		sites: sortBy( getSites( state ), site => site.ID !== primarySiteId )
-	};
-};
+const mapStateToProps = state => ( {
+	sites: getSites( state )
+} );
 
 export default connect( mapStateToProps )( localize( BlogsSettings ) );

--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -17,7 +17,7 @@
 	}
 }
 
-.notification-settings-blog-settings-header,
+.blogs-settings__header,
 .notification-settings-blog-settings-placeholder__header {
 	display: flex;
 	color: $gray;
@@ -31,12 +31,12 @@
 	}
 }
 
-.notification-settings-blog-settings-header__legend {
+.blogs-settings__header-legend {
 	@extend %notification-settings-blog-settings-flexbox;
 	margin-right: 10px;
 }
 
-.notification-settings-blog-settings-header__expand {
+.blogs-settings__header-expand {
 	@extend %notification-settings-blog-settings-flexbox;
 	display: none;
 	color: lighten( $gray, 30% );

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -12,18 +12,17 @@ import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import devicesFactory from 'lib/devices';
-// import sitesFactory from 'lib/sites-list';
-import userFactory from 'lib/user';
+import NotificationsComponent from 'me/notification-settings/main';
+import CommentSettingsComponent from 'me/notification-settings/comment-settings';
+import WPcomSettingsComponent from 'me/notification-settings/wpcom-settings';
+import NotificationSubscriptions from 'me/notification-settings/reader-subscriptions';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 const devices = devicesFactory();
-// const sites = sitesFactory();
-const user = userFactory();
 
 export default {
 	notifications( context ) {
-		const NotificationsComponent = require( 'me/notification-settings/main' ),
-			basePath = context.path;
+		const basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
@@ -31,9 +30,7 @@ export default {
 
 		renderWithReduxStore(
 			React.createElement( NotificationsComponent, {
-				user: user,
 				userSettings: userSettings,
-				// blogs: sites,
 				devices: devices,
 				path: context.path
 			} ),
@@ -43,8 +40,7 @@ export default {
 	},
 
 	comments( context ) {
-		const CommentSettingsComponent = require( 'me/notification-settings/comment-settings' ),
-			basePath = context.path;
+		const basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
@@ -53,7 +49,6 @@ export default {
 		renderWithReduxStore(
 			React.createElement( CommentSettingsComponent,
 				{
-					user: user,
 					devices: devices,
 					path: context.path
 				}
@@ -64,8 +59,7 @@ export default {
 	},
 
 	updates( context ) {
-		const WPcomSettingsComponent = require( 'me/notification-settings/wpcom-settings' ),
-			basePath = context.path;
+		const basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
@@ -74,7 +68,6 @@ export default {
 		renderWithReduxStore(
 			React.createElement( WPcomSettingsComponent,
 				{
-					user: user,
 					devices: devices,
 					path: context.path
 				}
@@ -85,8 +78,7 @@ export default {
 	},
 
 	notificationSubscriptions( context ) {
-		const NotificationSubscriptions = require( 'me/notification-settings/reader-subscriptions' ),
-			basePath = context.path;
+		const basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -24,7 +24,8 @@ export default {
 	notifications( context ) {
 		const basePath = context.path;
 
-		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications' );
 
@@ -42,7 +43,8 @@ export default {
 	comments( context ) {
 		const basePath = context.path;
 
-		context.store.dispatch( setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Comments on other sites', { textOnly: true } ) ) );
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 
@@ -61,7 +63,8 @@ export default {
 	updates( context ) {
 		const basePath = context.path;
 
-		context.store.dispatch( setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Updates from WordPress.com', { textOnly: true } ) ) );
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Updates from WordPress.com' );
 
@@ -80,7 +83,8 @@ export default {
 	notificationSubscriptions( context ) {
 		const basePath = context.path;
 
-		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+		context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
 
 		analytics.ga.recordPageView( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -12,12 +12,12 @@ import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import devicesFactory from 'lib/devices';
-import sitesFactory from 'lib/sites-list';
+// import sitesFactory from 'lib/sites-list';
 import userFactory from 'lib/user';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 const devices = devicesFactory();
-const sites = sitesFactory();
+// const sites = sitesFactory();
 const user = userFactory();
 
 export default {
@@ -33,7 +33,7 @@ export default {
 			React.createElement( NotificationsComponent, {
 				user: user,
 				userSettings: userSettings,
-				blogs: sites,
+				// blogs: sites,
 				devices: devices,
 				path: context.path
 			} ),

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import observe from 'lib/mixins/data-observe';
-import { successNotice, errorNotice } from 'state/notices/actions'
+import { successNotice, errorNotice } from 'state/notices/actions';
 import Main from 'components/main';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
@@ -19,44 +19,40 @@ import PushNotificationSettings from './push-notification-settings';
 import store from 'lib/notification-settings-store';
 import { fetchSettings, toggle, saveSettings } from 'lib/notification-settings-store/actions';
 
-const NotificationSettings = React.createClass( {
-	displayName: 'NotificationSettings',
-
-	mixins: [ observe( 'devices', 'pushNotifications' ) ],
-
-	getInitialState() {
-		return {
-			settings: null,
-			hasUnsavedChanges: false
-		};
-	},
+class NotificationSettings extends Component {
+	state = {
+		settings: null,
+		hasUnsavedChanges: false
+	};
 
 	componentDidMount() {
 		store.on( 'change', this.onChange );
 		this.props.devices.get();
 		fetchSettings();
-	},
+	}
 
 	componentWillUnmount() {
 		store.off( 'change', this.onChange );
-	},
+	}
 
-	onChange() {
+	onChange = () => {
 		const state = store.getStateFor( 'blogs' );
 
 		if ( state.error ) {
-			this.props.errorNotice( this.translate( 'There was a problem saving your changes. Please, try again.' ) );
+			this.props.errorNotice( this.props.translate( 'There was a problem saving your changes. Please, try again.' ) );
 		}
 
 		if ( state.status === 'success' ) {
-			this.props.successNotice( this.translate( 'Settings saved successfully!' ) );
+			this.props.successNotice( this.props.translate( 'Settings saved successfully!' ) );
 		}
 
 		this.setState( state );
-	},
+	};
 
 	render() {
 		const findSettingsForBlog = blogId => this.state.settings.find( blog => blog.get( 'blog_id' ) === parseInt( blogId, 10 ) );
+		const onSave = blogId => saveSettings( 'blogs', findSettingsForBlog( blogId ) );
+		const onSaveToAll = blogId => saveSettings( 'blogs', findSettingsForBlog( blogId ), true );
 
 		return (
 			<Main className="notification-settings">
@@ -68,15 +64,15 @@ const NotificationSettings = React.createClass( {
 					devices={ this.props.devices }
 					settings={ this.state.settings }
 					hasUnsavedChanges={ this.state.hasUnsavedChanges }
-					onToggle={ ( source, stream, setting ) => toggle( source, stream, setting ) }
-					onSave={ blogId => saveSettings( 'blogs', findSettingsForBlog( blogId ) ) }
-					onSaveToAll={ blogId => saveSettings( 'blogs', findSettingsForBlog( blogId ), true ) } />
+					onToggle={ toggle }
+					onSave={ onSave }
+					onSaveToAll={ onSaveToAll } />
 			</Main>
 		);
 	}
-} );
+}
 
 export default connect(
 	null,
 	{ successNotice, errorNotice }
-)( NotificationSettings );
+)( localize( NotificationSettings ) );

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -17,13 +18,11 @@ import BlogsSettings from './blogs-settings';
 import PushNotificationSettings from './push-notification-settings';
 import store from 'lib/notification-settings-store';
 import { fetchSettings, toggle, saveSettings } from 'lib/notification-settings-store/actions';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 const NotificationSettings = React.createClass( {
 	displayName: 'NotificationSettings',
 
-	mixins: [ observe( 'sites', 'devices', 'pushNotifications' ) ],
+	mixins: [ observe( 'devices', 'pushNotifications' ) ],
 
 	getInitialState() {
 		return {
@@ -66,7 +65,6 @@ const NotificationSettings = React.createClass( {
 				<Navigation path={ this.props.path } />
 				<PushNotificationSettings pushNotifications={ this.props.pushNotifications } />
 				<BlogsSettings
-					blogs={ this.props.blogs }
 					devices={ this.props.devices }
 					settings={ this.state.settings }
 					hasUnsavedChanges={ this.state.hasUnsavedChanges }
@@ -80,5 +78,5 @@ const NotificationSettings = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
+	{ successNotice, errorNotice }
 )( NotificationSettings );


### PR DESCRIPTION
This PR removes `sites-list` and `UserStore` from Notification Settings (`me/notification-settings`), and adds minor changes to some `connect` exports.

To test:

- check out this branch
- go to http://calypso.localhost:3000/me/notifications
- verify that settings are saved and loaded as expected
- verify that the list of sites is complete
- verify that the primary site is displayed first
- verify it works correctly with a clean state.
- no other tabs under Notification Settings should be affected.

Part of #13279 