### PR TITLE
Woo Connect-Insights: Add Wooommerce stats thunk

### DIFF
--- a/client/extensions/woocommerce/app/stats/stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/stats/stats-navigation/index.js
@@ -27,7 +27,11 @@ const StatsNavigation = props => {
 		<SectionNav selectedText={ periods[ period ] }>
 			<NavTabs label={ translate( 'Stats' ) }>
 				{ Object.keys( periods ).map( key => (
-					<NavItem path={ `/store/stats/${ type }/${ key }/${ slug }` } selected={ period === key }>
+					<NavItem
+						key={ key }
+						path={ `/store/stats/${ type }/${ key }/${ slug }` }
+						selected={ period === key }
+					>
 						{ periods[ key ] }
 					</NavItem>
 				) ) }

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -269,6 +269,19 @@ UndocumentedSite.prototype.runThemeSetup = function() {
 };
 
 /**
+ * Requests Store orders stats
+ *
+ * @param {object} query query parameters
+ * @return {Promise} A Promise to resolve when complete.
+ */
+UndocumentedSite.prototype.statsOrders = function( query ) {
+	return this.wpcom.req.get( {
+		path: `/sites/${ this._id }/stats/orders`,
+		apiNamespace: 'wpcom/v2',
+	}, query );
+};
+
+/**
  * Expose `UndocumentedSite` module
  */
 module.exports = UndocumentedSite;

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -10,6 +10,11 @@ import {
 } from 'state/action-types';
 
 /**
+ * External dependencies
+ */
+import includes from 'lodash/includes';
+
+/**
  * Returns an action object to be used in signalling that stats for a given type of stats and query
  * have been received.
  *
@@ -47,7 +52,10 @@ export function requestSiteStats( siteId, statType, query ) {
 			query
 		} );
 
-		const isUndocumented = 'statsPodcastDownloads' === statType;
+		const isUndocumented = includes( [
+			'statsPodcastDownloads',
+			'statsOrders'
+		], statType );
 		const options = 'statsVideo' === statType ? query.postId : query;
 		const site = isUndocumented
 			? wpcom.undocumented().site( siteId )


### PR DESCRIPTION
### Why
The `requestSiteStats` action uses a thunk to make a request. The thunk lives on a site object derived from `lib/wp`. Lets add a new thunk for gathering data for Woocommerce.

### How
In order to accept a new `statsType`, the wpcom site object needs a method by the same name. This method will be [called in the dispatched action](https://github.com/Automattic/wp-calypso/blob/master/client/state/stats/lists/actions.js#L56) to request stats.

This adds the ~`statsWoocommerce`~ `statsOrders` type and ensures the action knows it is "undocumented". Why undocumented?

>REST-API endpoints are left undocumented when they are new and expected to change. When the endpoints are considered stable and are documented, they will migrate into the wpcom.js repo.

~ https://github.com/Automattic/wp-calypso/blob/master/client/lib/wpcom-undocumented/README.md

### Also
I noticed `stats-navigation` was missing a `key` value for a jsx loop. This is a small PR, so the fix is piggy-backing.