### PR TITLE
Marketing: Remove A/B test for concierge step on cancellation survey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
@@ -17,7 +17,7 @@ import {
 
 export default function stepsForProductAndSurvey( survey, product, canChat ) {
 	if ( survey && survey.questionOneRadio === 'tooHard' ) {
-		if ( includesProduct( [ PLAN_BUSINESS ], product ) && abtest( 'conciergeOfferOnCancel' ) === 'showConciergeOffer' ) {
+		if ( includesProduct( [ PLAN_BUSINESS ], product ) ) {
 			return [ INITIAL_STEP, CONCIERGE_STEP, FINAL_STEP ];
 		}
 

--- a/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
@@ -75,21 +75,13 @@ describe( 'stepsForProductAndSurvey', function() {
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
 		} );
 
-		it( 'should include concierge step if product is business plan and abtest variant is showConciergeOffer', function() {
+		it( 'should include concierge step if product is business plan', function() {
 			const product = { product_slug: PLAN_BUSINESS };
-			abtests.conciergeOfferOnCancel = 'showConciergeOffer';
 			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( [ INITIAL_STEP, CONCIERGE_STEP, FINAL_STEP ] );
 		} );
 
-		it( 'should not include concierge step if product is jetpack business plan and abtest variant is showConciergeOffer', function() {
+		it( 'should not include concierge step if product is jetpack business plan', function() {
 			const product = { product_slug: PLAN_JETPACK_BUSINESS };
-			abtests.conciergeOfferOnCancel = 'showConciergeOffer';
-			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
-		} );
-
-		it( 'should not include concierge step if product is business plan and abtest variant is hideConciergeOffer', function() {
-			const product = { product_slug: PLAN_BUSINESS };
-			abtests.conciergeOfferOnCancel = 'hideConciergeOffer';
 			expect( stepsForProductAndSurvey( survey, product ) ).to.deep.equal( [ INITIAL_STEP, FINAL_STEP ] );
 		} );
 	} );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -32,14 +32,6 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	conciergeOfferOnCancel: {
-		datestamp: '20170410',
-		variations: {
-			showConciergeOffer: 50,
-			hideConciergeOffer: 50,
-		},
-		defaultVariation: 'showConciergeOffer',
-	},
 	presaleChatButton: {
 		datestamp: '20170328',
 		variations: {


### PR DESCRIPTION
Currently, we're limiting the concierge offer shown during the cancellation survey to 50% of Business customers that answer "Too Hard" on the first question of the survey. This removes the A/B test so it's open to 100% of Business users. See my latest comment on p7EOS0-Jg-p2 for some additional background.

### To test
Try to cancel/remove a Business plan from http://calypso.localhost:3000/me/purchases/. If you select "Too Hard" under "Please tell us why you are canceling" and then click "Next Step," you should see the concierge offer:

<img width="554" alt="screen shot 2017-05-09 at 8 51 14 pm" src="https://cloud.githubusercontent.com/assets/7240478/25881286/45423aea-34f9-11e7-97d9-4202b47a2068.png">
