### PR TITLE
Updated segmented control item to show data-e2e attribute

### DIFF
--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -125,6 +125,7 @@ var SegmentedControl = React.createClass( {
 					onClick={ this.selectItem.bind( this, item ) }
 					path={ item.path }
 					index={ index }
+					value={ item.value }
 				>
 					{ item.label }
 				</ControlItem>

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -14,6 +14,7 @@ var SegmentedControlItem = React.createClass( {
 		path: React.PropTypes.string,
 		selected: React.PropTypes.bool,
 		title: React.PropTypes.string,
+		value: React.PropTypes.string,
 		onClick: React.PropTypes.func
 	},
 
@@ -41,6 +42,7 @@ var SegmentedControlItem = React.createClass( {
 					ref="itemLink"
 					onClick={ this.props.onClick }
 					title={ this.props.title }
+					data-e2e-value={ this.props.value }
 					role="radio"
 					tabIndex={ 0 }
 					aria-selected={ this.props.selected }>


### PR DESCRIPTION
Adds a data-e2e-value attribute to segmented control items. This is for automated e2e testing purposes.

**To test**

Open: https://calypso.live/themes/?branch=add/data-e2e-value-for-segmented-control-items
Verify that the 'All', 'Free' and 'Premium' all have data-e2e-value attributes in the DOM.

This is to address: https://github.com/Automattic/wp-e2e-tests/issues/152

