### PR TITLE
State: Remove sites-list from WordAds approve actions

### DIFF
--- a/client/state/wordads/approve/actions.js
+++ b/client/state/wordads/approve/actions.js
@@ -9,7 +9,6 @@ import {
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_SUCCESS,
 } from 'state/action-types';
 import wpcom from 'lib/wp';
-import Sites from 'lib/sites-list';
 
 export const requestWordAdsApproval = siteId => dispatch => {
 	dispatch( {
@@ -19,15 +18,6 @@ export const requestWordAdsApproval = siteId => dispatch => {
 
 	return wpcom.undocumented().wordAdsApprove( siteId )
 	.then( result => {
-		if ( result.approved ) {
-			//We need to propagate this change to flux
-			const site = Sites().getSite( siteId );
-			if ( site && ! site.options.wordads ) {
-				site.options.wordads = true;
-				site.emit( 'change' );
-			}
-		}
-
 		dispatch( {
 			type: WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 			approved: result.approved,

--- a/client/state/wordads/approve/test/actions.js
+++ b/client/state/wordads/approve/test/actions.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
 import useNock from 'test/helpers/use-nock';
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	WORDADS_SITE_APPROVE_REQUEST,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
@@ -15,26 +15,18 @@ import {
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_ERROR,
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_SUCCESS
 } from 'state/action-types';
-
-import { useSandbox } from 'test/helpers/use-sinon';
-import useMockery from 'test/helpers/use-mockery';
+import {
+	dismissWordAdsError,
+	dismissWordAdsSuccess,
+	requestWordAdsApproval,
+} from '../actions';
 
 describe( 'actions', () => {
-	let sandbox, spy, requestWordAdsApproval, dismissWordAdsError, dismissWordAdsSuccess;
+	let sandbox, spy;
 
 	useSandbox( newSandbox => {
 		sandbox = newSandbox;
 		spy = sandbox.spy();
-	} );
-
-	useMockery( ( mockery ) => {
-		mockery.registerMock( 'lib/sites-list', function() {
-			return { getSite: noop };
-		} );
-		const actions = require( '../actions' );
-		requestWordAdsApproval = actions.requestWordAdsApproval;
-		dismissWordAdsError = actions.dismissWordAdsError;
-		dismissWordAdsSuccess = actions.dismissWordAdsSuccess;
 	} );
 
 	describe( '#dismissWordAdsError()', () => {


### PR DESCRIPTION
This PR removes sites-list from WordAds approval actions. Part of #13279. We can safely remove the sites-list usage, as it's no longer the single source of truth, and we're already handling the corresponding functionality in the sites reducer.

To test:
* Checkout this branch
* Verify all tests still pass:

```
npm run test-client client/state/wordads/
```