### PR TITLE
Jetpack settings: Add VideoPress module toggle

### DIFF
--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -57,8 +57,8 @@ class MediaSettings extends Component {
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
 		return isVideoPressAvailable
-			? <FormFieldset className="media-settings__formfieldset has-divider is-top-only">
-				<div className="media-settings__info-link-container site-settings__info-link-container">
+			? <FormFieldset className="site-settings__formfieldset has-divider is-top-only">
+				<div className="site-settings__info-link-container">
 					<InfoPopover position="left">
 						<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/" >
 							{ translate( 'Learn more about VideoPress.' ) }
@@ -108,11 +108,11 @@ class MediaSettings extends Component {
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
 		return (
-			<div className="media-settings__wrapper">
-				<Card className="media-settings site-settings site-settings__module-settings">
+			<div className="site-settings__module-settings site-settings__media-settings">
+				<Card>
 					<QueryJetpackConnection siteId={ selectedSiteId } />
 					<FormFieldset>
-						<div className="media-settings__info-link-container site-settings__info-link-container">
+						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
 								<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/photon" >
 									{ translate( 'Learn more about Photon.' ) }
@@ -127,8 +127,8 @@ class MediaSettings extends Component {
 							disabled={ isRequestingOrSaving || photonModuleUnavailable }
 							/>
 					</FormFieldset>
-					<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
-						<div className="media-settings__info-link-container site-settings__info-link-container">
+					<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
+						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
 								<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/carousel" >
 									{ translate( 'Learn more about Carousel.' ) }
@@ -141,7 +141,7 @@ class MediaSettings extends Component {
 							label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
 							disabled={ isRequestingOrSaving }
 							/>
-						<div className="media-settings__module-settings site-settings__child-settings">
+						<div className="site-settings__child-settings">
 							<CompactFormToggle
 								checked={ fields.carousel_display_exif || false }
 								disabled={ isRequestingOrSaving || ! carouselActive }

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Banner from 'components/banner';
 import Card from 'components/card';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -21,6 +22,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
+	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 } from 'lib/plans/constants';
 import {
 	isJetpackModuleActive,
@@ -43,6 +45,41 @@ class MediaSettings extends Component {
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 	};
+
+	renderVideoSettings() {
+		const {
+			isRequestingSettings,
+			isSavingSettings,
+			isVideoPressAvailable,
+			siteId,
+			translate,
+		} = this.props;
+		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
+
+		return isVideoPressAvailable
+			? <FormFieldset className="media-settings__formfieldset has-divider is-top-only">
+				<div className="media-settings__info-link-container site-settings__info-link-container">
+					<InfoPopover position="left">
+						<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/" >
+							{ translate( 'Learn more about VideoPress.' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+				<JetpackModuleToggle
+					siteId={ siteId }
+					moduleSlug="videopress"
+					label={ translate( 'Fast, ad-free video hosting' ) }
+					disabled={ isRequestingOrSaving }
+				/>
+			</FormFieldset>
+			: <Banner
+				//description={ translate( 'Upgrade to Jetpack Premium to get 13gb of video.' ) }
+				event={ 'jetpack_video_settings' }
+				feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM }
+				plan={ PLAN_JETPACK_PREMIUM }
+				title={ translate( 'Host fast, high-quality, ad-free video.' ) }
+			/>;
+	}
 
 	render() {
 		const {
@@ -121,21 +158,7 @@ class MediaSettings extends Component {
 					</div>
 				</FormFieldset>
 
-				<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
-					<div className="media-settings__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/" >
-								{ translate( 'Learn more about VideoPress.' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
-					<JetpackModuleToggle
-						siteId={ siteId }
-						moduleSlug="videopress"
-						label={ translate( 'Fast, ad-free video hosting' ) }
-						disabled={ isRequestingOrSaving }
-					/>
-				</FormFieldset>
+				{ this.renderVideoSettings() }
 
 			</Card>
 		);

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -17,11 +17,18 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+} from 'lib/plans/constants';
+import {
 	isJetpackModuleActive,
 	isJetpackModuleUnavailableInDevelopmentMode,
 	isJetpackSiteInDevelopmentMode
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSitePlanSlug } from 'state/sites/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
@@ -135,12 +142,21 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, selectedSiteId, 'photon' );
 
+		const isVideoPressAvailable = [
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+		].includes( sitePlanSlug );
+
 		return {
-			selectedSiteId,
 			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),
+			isVideoPressAvailable,
 			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+			selectedSiteId,
 		};
 	},
 	{

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -32,111 +32,115 @@ import { getSitePlanSlug } from 'state/sites/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 
-const MediaSettings = ( {
-	fields,
-	handleAutosavingToggle,
-	onChangeField,
-	isRequestingSettings,
-	isSavingSettings,
-	siteId,
-	carouselActive,
-	photonModuleUnavailable,
-	selectedSiteId,
-	translate
-} ) => {
-	const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
-	const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
+class MediaSettings extends Component {
+	static propTypes = {
+		carouselActive: PropTypes.bool.isRequired,
+		fields: PropTypes.object,
+		handleAutosavingToggle: PropTypes.func.isRequired,
+		isRequestingSettings: PropTypes.bool,
+		isSavingSettings: PropTypes.bool,
+		isVideoPressAvailable: PropTypes.bool,
+		onChangeField: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+	};
 
-	return (
-		<Card className="media-settings site-settings site-settings__module-settings">
-			<QueryJetpackConnection siteId={ selectedSiteId } />
+	render() {
+		const {
+			carouselActive,
+			fields,
+			handleAutosavingToggle,
+			isRequestingSettings,
+			isSavingSettings,
+			onChangeField,
+			photonModuleUnavailable,
+			selectedSiteId,
+			siteId,
+			translate
+		} = this.props;
+		const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
+		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
-			<FormFieldset>
-				<div className="media-settings__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/photon" >
-							{ translate( 'Learn more about Photon.' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-				<JetpackModuleToggle
-					siteId={ siteId }
-					moduleSlug="photon"
-					label={ translate( 'Speed up your images and photos with Photon' ) }
-					description={ translate( 'Must be enabled to use tiled galleries.' ) }
-					disabled={ isRequestingOrSaving || photonModuleUnavailable }
+		return (
+			<Card className="media-settings site-settings site-settings__module-settings">
+				<QueryJetpackConnection siteId={ selectedSiteId } />
+
+				<FormFieldset>
+					<div className="media-settings__info-link-container site-settings__info-link-container">
+						<InfoPopover position="left">
+							<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/photon" >
+								{ translate( 'Learn more about Photon.' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+					<JetpackModuleToggle
+						siteId={ siteId }
+						moduleSlug="photon"
+						label={ translate( 'Speed up your images and photos with Photon' ) }
+						description={ translate( 'Must be enabled to use tiled galleries.' ) }
+						disabled={ isRequestingOrSaving || photonModuleUnavailable }
+						/>
+				</FormFieldset>
+
+				<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
+					<div className="media-settings__info-link-container site-settings__info-link-container">
+						<InfoPopover position="left">
+							<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/carousel" >
+								{ translate( 'Learn more about Carousel.' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+					<JetpackModuleToggle
+						siteId={ siteId }
+						moduleSlug="carousel"
+						label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
+						disabled={ isRequestingOrSaving }
+						/>
+					<div className="media-settings__module-settings site-settings__child-settings">
+						<CompactFormToggle
+							checked={ fields.carousel_display_exif || false }
+							disabled={ isRequestingOrSaving || ! carouselActive }
+							onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
+							{ translate( 'Show photo metadata in carousel, when available' ) }
+						</CompactFormToggle>
+						<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
+							{ translate( 'Background color' ) }
+						</FormLabel>
+						<FormSelect
+							name="carousel_background_color"
+							id="carousel_background_color"
+							value={ fields.carousel_background_color || 'black' }
+							onChange={ onChangeField( 'carousel_background_color' ) }
+							disabled={ isRequestingOrSaving || ! carouselActive } >
+							<option value="black" key="carousel_background_color_black">
+								{ translate( 'Black' ) }
+							</option>
+							<option value="white" key="carousel_background_color_white">
+								{ translate( 'White' ) }
+							</option>
+						</FormSelect>
+					</div>
+				</FormFieldset>
+
+				<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
+					<div className="media-settings__info-link-container site-settings__info-link-container">
+						<InfoPopover position="left">
+							<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/" >
+								{ translate( 'Learn more about VideoPress.' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
+					<JetpackModuleToggle
+						siteId={ siteId }
+						moduleSlug="videopress"
+						label={ translate( 'Fast, ad-free video hosting' ) }
+						disabled={ isRequestingOrSaving }
 					/>
-			</FormFieldset>
+				</FormFieldset>
 
-			<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
-				<div className="media-settings__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/carousel" >
-							{ translate( 'Learn more about Carousel.' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-				<JetpackModuleToggle
-					siteId={ siteId }
-					moduleSlug="carousel"
-					label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
-					disabled={ isRequestingOrSaving }
-					/>
-				<div className="media-settings__module-settings site-settings__child-settings">
-					<CompactFormToggle
-						checked={ fields.carousel_display_exif || false }
-						disabled={ isRequestingOrSaving || ! carouselActive }
-						onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
-						{ translate( 'Show photo metadata in carousel, when available' ) }
-					</CompactFormToggle>
-					<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
-						{ translate( 'Background color' ) }
-					</FormLabel>
-					<FormSelect
-						name="carousel_background_color"
-						id="carousel_background_color"
-						value={ fields.carousel_background_color || 'black' }
-						onChange={ onChangeField( 'carousel_background_color' ) }
-						disabled={ isRequestingOrSaving || ! carouselActive } >
-						<option value="black" key="carousel_background_color_black">
-							{ translate( 'Black' ) }
-						</option>
-						<option value="white" key="carousel_background_color_white">
-							{ translate( 'White' ) }
-						</option>
-					</FormSelect>
-				</div>
-			</FormFieldset>
-
-			<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
-				<div className="media-settings__info-link-container site-settings__info-link-container">
-					<InfoPopover position="left">
-						<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/" >
-							{ translate( 'Learn more about VideoPress.' ) }
-						</ExternalLink>
-					</InfoPopover>
-				</div>
-				<JetpackModuleToggle
-					siteId={ siteId }
-					moduleSlug="videopress"
-					label={ translate( 'Fast, ad-free video hosting' ) }
-					disabled={ isRequestingOrSaving }
-				/>
-			</FormFieldset>
-
-		</Card>
-	);
-};
-
-MediaSettings.propTypes = {
-	carouselActive: PropTypes.bool.isRequired,
-	isSavingSettings: PropTypes.bool,
-	isRequestingSettings: PropTypes.bool,
-	siteId: PropTypes.number.isRequired,
-	handleAutosavingToggle: PropTypes.func.isRequired,
-	onChangeField: PropTypes.func.isRequired,
-	fields: PropTypes.object
-};
+			</Card>
+		);
+	}
+}
 
 export default connect(
 	( state ) => {

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -38,6 +38,7 @@ const MediaSettings = ( {
 	translate
 } ) => {
 	const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
+	const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
 	return (
 		<Card className="media-settings site-settings site-settings__module-settings">
@@ -59,6 +60,7 @@ const MediaSettings = ( {
 					disabled={ isRequestingSettings || isSavingSettings || photonModuleUnavailable }
 					/>
 			</FormFieldset>
+
 			<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
 				<div className="media-settings__info-link-container site-settings__info-link-container">
 					<InfoPopover position="left">
@@ -98,6 +100,23 @@ const MediaSettings = ( {
 					</FormSelect>
 				</div>
 			</FormFieldset>
+
+			<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
+				<div className="media-settings__info-link-container site-settings__info-link-container">
+					<InfoPopover position="left">
+						<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/" >
+							{ translate( 'Learn more about VideoPress.' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+				<JetpackModuleToggle
+					siteId={ siteId }
+					moduleSlug="videopress"
+					label={ translate( 'Fast, ad-free video hosting' ) }
+					disabled={ isRequestingOrSaving }
+				/>
+			</FormFieldset>
+
 		</Card>
 	);
 };

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -72,8 +72,18 @@ class MediaSettings extends Component {
 					disabled={ isRequestingOrSaving }
 				/>
 			</FormFieldset>
+			: null;
+	}
+
+	renderVideoUpgradeNudge() {
+		const {
+			isVideoPressAvailable,
+			translate,
+		} = this.props;
+
+		return isVideoPressAvailable
+			? null
 			: <Banner
-				//description={ translate( 'Upgrade to Jetpack Premium to get 13gb of video.' ) }
 				event={ 'jetpack_video_settings' }
 				feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM }
 				plan={ PLAN_JETPACK_PREMIUM }
@@ -98,69 +108,69 @@ class MediaSettings extends Component {
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
 		return (
-			<Card className="media-settings site-settings site-settings__module-settings">
-				<QueryJetpackConnection siteId={ selectedSiteId } />
+			<div className="media-settings__wrapper">
+				<Card className="media-settings site-settings site-settings__module-settings">
+					<QueryJetpackConnection siteId={ selectedSiteId } />
+					<FormFieldset>
+						<div className="media-settings__info-link-container site-settings__info-link-container">
+							<InfoPopover position="left">
+								<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/photon" >
+									{ translate( 'Learn more about Photon.' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
+						<JetpackModuleToggle
+							siteId={ siteId }
+							moduleSlug="photon"
+							label={ translate( 'Speed up your images and photos with Photon' ) }
+							description={ translate( 'Must be enabled to use tiled galleries.' ) }
+							disabled={ isRequestingOrSaving || photonModuleUnavailable }
+							/>
+					</FormFieldset>
+					<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
+						<div className="media-settings__info-link-container site-settings__info-link-container">
+							<InfoPopover position="left">
+								<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/carousel" >
+									{ translate( 'Learn more about Carousel.' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
+						<JetpackModuleToggle
+							siteId={ siteId }
+							moduleSlug="carousel"
+							label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
+							disabled={ isRequestingOrSaving }
+							/>
+						<div className="media-settings__module-settings site-settings__child-settings">
+							<CompactFormToggle
+								checked={ fields.carousel_display_exif || false }
+								disabled={ isRequestingOrSaving || ! carouselActive }
+								onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
+								{ translate( 'Show photo metadata in carousel, when available' ) }
+							</CompactFormToggle>
+							<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
+								{ translate( 'Background color' ) }
+							</FormLabel>
+							<FormSelect
+								name="carousel_background_color"
+								id="carousel_background_color"
+								value={ fields.carousel_background_color || 'black' }
+								onChange={ onChangeField( 'carousel_background_color' ) }
+								disabled={ isRequestingOrSaving || ! carouselActive } >
+								<option value="black" key="carousel_background_color_black">
+									{ translate( 'Black' ) }
+								</option>
+								<option value="white" key="carousel_background_color_white">
+									{ translate( 'White' ) }
+								</option>
+							</FormSelect>
+						</div>
+					</FormFieldset>
+					{ this.renderVideoSettings() }
+				</Card>
+				{ this.renderVideoUpgradeNudge() }
+			</div>
 
-				<FormFieldset>
-					<div className="media-settings__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/photon" >
-								{ translate( 'Learn more about Photon.' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
-					<JetpackModuleToggle
-						siteId={ siteId }
-						moduleSlug="photon"
-						label={ translate( 'Speed up your images and photos with Photon' ) }
-						description={ translate( 'Must be enabled to use tiled galleries.' ) }
-						disabled={ isRequestingOrSaving || photonModuleUnavailable }
-						/>
-				</FormFieldset>
-
-				<FormFieldset className="media-settings__formfieldset has-divider is-top-only">
-					<div className="media-settings__info-link-container site-settings__info-link-container">
-						<InfoPopover position="left">
-							<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/carousel" >
-								{ translate( 'Learn more about Carousel.' ) }
-							</ExternalLink>
-						</InfoPopover>
-					</div>
-					<JetpackModuleToggle
-						siteId={ siteId }
-						moduleSlug="carousel"
-						label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
-						disabled={ isRequestingOrSaving }
-						/>
-					<div className="media-settings__module-settings site-settings__child-settings">
-						<CompactFormToggle
-							checked={ fields.carousel_display_exif || false }
-							disabled={ isRequestingOrSaving || ! carouselActive }
-							onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
-							{ translate( 'Show photo metadata in carousel, when available' ) }
-						</CompactFormToggle>
-						<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
-							{ translate( 'Background color' ) }
-						</FormLabel>
-						<FormSelect
-							name="carousel_background_color"
-							id="carousel_background_color"
-							value={ fields.carousel_background_color || 'black' }
-							onChange={ onChangeField( 'carousel_background_color' ) }
-							disabled={ isRequestingOrSaving || ! carouselActive } >
-							<option value="black" key="carousel_background_color_black">
-								{ translate( 'Black' ) }
-							</option>
-							<option value="white" key="carousel_background_color_white">
-								{ translate( 'White' ) }
-							</option>
-						</FormSelect>
-					</div>
-				</FormFieldset>
-
-				{ this.renderVideoSettings() }
-
-			</Card>
 		);
 	}
 }

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -56,8 +56,8 @@ class MediaSettings extends Component {
 		} = this.props;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
-		return isVideoPressAvailable
-			? <FormFieldset className="site-settings__formfieldset has-divider is-top-only">
+		return isVideoPressAvailable && (
+			<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
 				<div className="site-settings__info-link-container">
 					<InfoPopover position="left">
 						<ExternalLink target="_blank" icon href="https://jetpack.com/support/videopress/" >
@@ -72,7 +72,7 @@ class MediaSettings extends Component {
 					disabled={ isRequestingOrSaving }
 				/>
 			</FormFieldset>
-			: null;
+		);
 	}
 
 	renderVideoUpgradeNudge() {
@@ -81,14 +81,14 @@ class MediaSettings extends Component {
 			translate,
 		} = this.props;
 
-		return isVideoPressAvailable
-			? null
-			: <Banner
+		return ! isVideoPressAvailable && (
+			<Banner
 				event={ 'jetpack_video_settings' }
 				feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM }
 				plan={ PLAN_JETPACK_PREMIUM }
 				title={ translate( 'Host fast, high-quality, ad-free video.' ) }
-			/>;
+			/>
+		);
 	}
 
 	render() {
@@ -114,7 +114,7 @@ class MediaSettings extends Component {
 					<FormFieldset>
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
-								<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/photon" >
+								<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon" >
 									{ translate( 'Learn more about Photon.' ) }
 								</ExternalLink>
 							</InfoPopover>
@@ -130,7 +130,7 @@ class MediaSettings extends Component {
 					<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
-								<ExternalLink target="_blank" icon={ true } href="https://jetpack.com/support/carousel" >
+								<ExternalLink target="_blank" icon href="https://jetpack.com/support/carousel" >
 									{ translate( 'Learn more about Carousel.' ) }
 								</ExternalLink>
 							</InfoPopover>
@@ -140,7 +140,7 @@ class MediaSettings extends Component {
 							moduleSlug="carousel"
 							label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
 							disabled={ isRequestingOrSaving }
-							/>
+						/>
 						<div className="site-settings__child-settings">
 							<CompactFormToggle
 								checked={ fields.carousel_display_exif || false }

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -68,7 +68,7 @@ class MediaSettings extends Component {
 				<JetpackModuleToggle
 					siteId={ siteId }
 					moduleSlug="videopress"
-					label={ translate( 'Fast, ad-free video hosting' ) }
+					label={ translate( 'Enable fast, ad-free video hosting' ) }
 					disabled={ isRequestingOrSaving }
 				/>
 			</FormFieldset>

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -57,7 +57,7 @@ const MediaSettings = ( {
 					moduleSlug="photon"
 					label={ translate( 'Speed up your images and photos with Photon' ) }
 					description={ translate( 'Must be enabled to use tiled galleries.' ) }
-					disabled={ isRequestingSettings || isSavingSettings || photonModuleUnavailable }
+					disabled={ isRequestingOrSaving || photonModuleUnavailable }
 					/>
 			</FormFieldset>
 
@@ -73,12 +73,12 @@ const MediaSettings = ( {
 					siteId={ siteId }
 					moduleSlug="carousel"
 					label={ translate( 'Transform standard image galleries into full-screen slideshows' ) }
-					disabled={ isRequestingSettings || isSavingSettings }
+					disabled={ isRequestingOrSaving }
 					/>
 				<div className="media-settings__module-settings site-settings__child-settings">
 					<CompactFormToggle
 						checked={ fields.carousel_display_exif || false }
-						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive }
+						disabled={ isRequestingOrSaving || ! carouselActive }
 						onChange={ handleAutosavingToggle( 'carousel_display_exif' ) } >
 						{ translate( 'Show photo metadata in carousel, when available' ) }
 					</CompactFormToggle>
@@ -90,7 +90,7 @@ const MediaSettings = ( {
 						id="carousel_background_color"
 						value={ fields.carousel_background_color || 'black' }
 						onChange={ onChangeField( 'carousel_background_color' ) }
-						disabled={ isRequestingSettings || isSavingSettings || ! carouselActive } >
+						disabled={ isRequestingOrSaving || ! carouselActive } >
 						<option value="black" key="carousel_background_color_black">
 							{ translate( 'Black' ) }
 						</option>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -390,3 +390,7 @@
 	margin-top: -16px;
 	margin-bottom: 16px;
 }
+
+.media-settings__wrapper > .banner {
+	margin-top: -16px;
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -391,6 +391,6 @@
 	margin-bottom: 16px;
 }
 
-.media-settings__wrapper > .banner {
+.site-settings__media-settings > .banner {
 	margin-top: -16px;
 }


### PR DESCRIPTION
Add VideoPress module settings and storage bar to site settings.

To test:

* Run this branch
* CSS and `classNames` have been touched, make sure there are no style regressions throughout the process.
* Get a new Jetpack site on the free plan
* Visit http://calypso.localhost:3000/settings/writing/:jetpack-site
* You should see the upgrade banner.
* Ensure the banner works correctly.
  * Click the banner
  * You should go to the plans page and see the feature highlighted.
  * **Special care here!** I copied the banner from another place and the flow seems a little off. Should the plan be highlighted (button primary)?
* Upgrade to Personal
* Visit http://calypso.localhost:3000/settings/writing/:jetpack-site
* You should continue to see the upgrade banner.
* Upgrade to Premium
* Visit http://calypso.localhost:3000/settings/writing/:jetpack-site
* You should now see the toggle
* Test the toggle
  * Activation/deactivation in Calypso affects wp-admin
  * Activation/deactivation in wp-admin affects Calypso
* Upgrade to Professional
* Visit http://calypso.localhost:3000/settings/writing/:jetpack-site
* You should continue to see the toggle

Before (no toggle or banner):

![nothing](https://cloud.githubusercontent.com/assets/841763/25946288/b84ee82e-364a-11e7-83d8-8abc192ff070.png)

Banner:

![banner](https://cloud.githubusercontent.com/assets/841763/25945049/d5a29fec-3645-11e7-8559-2311938db26f.png)

Toggle:

![toggle](https://cloud.githubusercontent.com/assets/841763/25945055/d96d4212-3645-11e7-9da5-155b11a48dae.png)

Bonus points for confirming Video corresponds to the correct plans and checking downgraded sites.

Partially implements #12507 