### PR TITLE
Framework: Remove sites-list from PostSelector example

### DIFF
--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -49,8 +49,12 @@ class PostSelectorExample extends Component {
 	}
 }
 
-export default connect(
+const ConnectedPostSelectorExample = connect(
 	( state ) => ( {
 		primarySiteId: getPrimarySiteId( state ),
 	} )
 )( PostSelectorExample );
+
+ConnectedPostSelectorExample.displayName = 'PostSelector';
+
+export default ConnectedPostSelectorExample;

--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -17,6 +17,12 @@ class PostSelectorExample extends Component {
 		selectedPostId: null,
 	};
 
+	toggleTypeLabels = () => {
+		this.setState( {
+			showTypeLabels: ! this.state.showTypeLabels
+		} );
+	};
+
 	setSelected = ( post ) => {
 		this.setState( {
 			selectedPostId: post.ID,
@@ -32,7 +38,7 @@ class PostSelectorExample extends Component {
 					<input
 						type="checkbox"
 						checked={ this.state.showTypeLabels }
-						onChange={ () => this.setState( { showTypeLabels: ! this.state.showTypeLabels } ) } />
+						onChange={ this.toggleTypeLabels } />
 					<span>Show Type Labels</span>
 				</FormLabel>
 				<PostSelector

--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -1,68 +1,56 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import PostSelector from '../';
-import observe from 'lib/mixins/data-observe';
-import sites from 'lib/sites-list';
 import FormLabel from 'components/forms/form-label';
+import { getPrimarySiteId } from 'state/selectors';
 
-const PostSelectorExample = React.createClass( {
-	mixins: [ observe( 'sites' ), PureRenderMixin ],
+class PostSelectorExample extends Component {
+	state = {
+		showTypeLabels: true,
+		selectedPostId: null,
+	};
 
-	getInitialState() {
-		return {
-			showTypeLabels: true,
-			selectedPostId: null,
-		};
-	},
-
-	setSelected( post ) {
+	setSelected = ( post ) => {
 		this.setState( {
 			selectedPostId: post.ID,
 		} );
-	},
+	};
 
 	render() {
-		const primary = this.props.sites.getPrimary();
+		const { primarySiteId } = this.props;
 
 		return (
-			<div>
-				<div style={ { width: 300 } }>
-					<FormLabel>
-						<input
-							type="checkbox"
-							checked={ this.state.showTypeLabels }
-							onChange={ () => this.setState( { showTypeLabels: ! this.state.showTypeLabels } ) } />
-						<span>Show Type Labels</span>
-					</FormLabel>
-					{ this.props.sites.initialized && (
-						<PostSelector
-							siteId={ primary ? primary.ID : 3584907 }
-							type="any"
-							orderBy="date"
-							order="DESC"
-							showTypeLabels={ this.state.showTypeLabels }
-							selected={ this.state.selectedPostId }
-							onChange={ this.setSelected } />
-					) }
-				</div>
+			<div style={ { width: 300 } }>
+				<FormLabel>
+					<input
+						type="checkbox"
+						checked={ this.state.showTypeLabels }
+						onChange={ () => this.setState( { showTypeLabels: ! this.state.showTypeLabels } ) } />
+					<span>Show Type Labels</span>
+				</FormLabel>
+				<PostSelector
+					siteId={ primarySiteId ? primarySiteId : 3584907 }
+					type="any"
+					orderBy="date"
+					order="DESC"
+					showTypeLabels={ this.state.showTypeLabels }
+					selected={ this.state.selectedPostId }
+					onChange={ this.setSelected }
+				/>
 			</div>
 		);
 	}
-} );
+}
 
-export default React.createClass( {
-	displayName: 'PostSelector',
-
-	mixins: [ PureRenderMixin ],
-
-	render() {
-		return <PostSelectorExample sites={ sites() } />;
-	}
-} );
+export default connect(
+	( state ) => ( {
+		primarySiteId: getPrimarySiteId( state ),
+	} )
+)( PostSelectorExample );


### PR DESCRIPTION
This PR removes `sites-list` from the `PostSelector` docs example. It also refactors the component to an ES6 class and removes the now unnecessary wrapping component.

To test:
* Checkout this branch
* Perform a code sanity check 👀  (it's an example, so it's not used anywhere).
* Go to http://calypso.localhost:3000/devdocs/blocks and verify the `PostSelector` block works as expected.