### PR TITLE
Site Settings: Don't attempt to save custom content types settings using the REST API

### DIFF
--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -124,31 +124,11 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		it( 'should skip jetpack_testimonial setting', () => {
+		it( 'should skip all Custom Content Types settings', () => {
 			const settings = {
 				some_other_setting: 123,
 				jetpack_testimonial: true,
-			};
-
-			expect( normalizeSettings( settings ) ).to.eql( {
-				some_other_setting: 123,
-			} );
-		} );
-
-		it( 'should skip jetpack_portfolio setting', () => {
-			const settings = {
-				some_other_setting: 123,
 				jetpack_portfolio: true,
-			};
-
-			expect( normalizeSettings( settings ) ).to.eql( {
-				some_other_setting: 123,
-			} );
-		} );
-
-		it( 'should skip custom-content-types setting', () => {
-			const settings = {
-				some_other_setting: 123,
 				'custom-content-types': true,
 			};
 
@@ -156,6 +136,7 @@ describe( 'utils', () => {
 				some_other_setting: 123,
 			} );
 		} );
+
 	} );
 
 	describe( 'sanitizeSettings()', () => {
@@ -226,31 +207,11 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		it( 'should skip jetpack_testimonial setting', () => {
+		it( 'should skip all Custom Content Types settings', () => {
 			const settings = {
 				some_other_setting: 123,
 				jetpack_testimonial: true,
-			};
-
-			expect( sanitizeSettings( settings ) ).to.eql( {
-				some_other_setting: 123,
-			} );
-		} );
-
-		it( 'should skip jetpack_portfolio setting', () => {
-			const settings = {
-				some_other_setting: 123,
 				jetpack_portfolio: true,
-			};
-
-			expect( sanitizeSettings( settings ) ).to.eql( {
-				some_other_setting: 123,
-			} );
-		} );
-
-		it( 'should skip custom-content-types setting', () => {
-			const settings = {
-				some_other_setting: 123,
 				'custom-content-types': true,
 			};
 

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -136,7 +136,6 @@ describe( 'utils', () => {
 				some_other_setting: 123,
 			} );
 		} );
-
 	} );
 
 	describe( 'sanitizeSettings()', () => {

--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -123,6 +123,39 @@ describe( 'utils', () => {
 				'infinite-scroll': true,
 			} );
 		} );
+
+		it( 'should skip jetpack_testimonial setting', () => {
+			const settings = {
+				some_other_setting: 123,
+				jetpack_testimonial: true,
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+			} );
+		} );
+
+		it( 'should skip jetpack_portfolio setting', () => {
+			const settings = {
+				some_other_setting: 123,
+				jetpack_portfolio: true,
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+			} );
+		} );
+
+		it( 'should skip custom-content-types setting', () => {
+			const settings = {
+				some_other_setting: 123,
+				'custom-content-types': true,
+			};
+
+			expect( normalizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+			} );
+		} );
 	} );
 
 	describe( 'sanitizeSettings()', () => {
@@ -192,6 +225,39 @@ describe( 'utils', () => {
 				'infinite-scroll': true,
 			} );
 		} );
+
+		it( 'should skip jetpack_testimonial setting', () => {
+			const settings = {
+				some_other_setting: 123,
+				jetpack_testimonial: true,
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+			} );
+		} );
+
+		it( 'should skip jetpack_portfolio setting', () => {
+			const settings = {
+				some_other_setting: 123,
+				jetpack_portfolio: true,
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+			} );
+		} );
+
+		it( 'should skip custom-content-types setting', () => {
+			const settings = {
+				some_other_setting: 123,
+				'custom-content-types': true,
+			};
+
+			expect( sanitizeSettings( settings ) ).to.eql( {
+				some_other_setting: 123,
+			} );
+		} );
 	} );
 
 	describe( 'filterSettingsByActiveModules()', () => {
@@ -231,9 +297,6 @@ describe( 'utils', () => {
 				'Phrases to Avoid': true,
 				'Redundant Expression': true,
 				ignored_phrases: true,
-				'custom-content-types': true,
-				jetpack_testimonial: true,
-				jetpack_portfolio: false,
 				comments: true,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
@@ -275,8 +338,6 @@ describe( 'utils', () => {
 				'Phrases to Avoid': true,
 				'Redundant Expression': true,
 				ignored_phrases: true,
-				jetpack_testimonial: true,
-				jetpack_portfolio: false,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
 				carousel_background_color: 'black',
@@ -324,9 +385,6 @@ describe( 'utils', () => {
 				'Phrases to Avoid': true,
 				'Redundant Expression': true,
 				ignored_phrases: true,
-				'custom-content-types': false,
-				jetpack_testimonial: true,
-				jetpack_portfolio: false,
 				comments: false,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
@@ -374,8 +432,6 @@ describe( 'utils', () => {
 				'Phrases to Avoid': true,
 				'Redundant Expression': true,
 				ignored_phrases: true,
-				jetpack_testimonial: true,
-				jetpack_portfolio: false,
 				highlander_comment_form_prompt: 'Leave a Reply',
 				jetpack_comment_form_color_scheme: 'light',
 				carousel_background_color: 'black',

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -15,6 +15,10 @@ export const normalizeSettings = ( settings ) => {
 			case 'carousel_background_color':
 				memo[ key ] = settings [ key ] === '' ? 'black' : settings[ key ];
 				break;
+			case 'custom-content-types':
+			case 'jetpack_testimonial':
+			case 'jetpack_portfolio':
+				break;
 			case 'jetpack_protect_global_whitelist':
 				const whitelist = get( settings[ key ], [ 'local' ], [] );
 				memo[ key ] = whitelist.join( '\n' );
@@ -49,6 +53,10 @@ export const sanitizeSettings = ( settings ) => {
 	return Object.keys( settings ).reduce( ( memo, key ) => {
 		switch ( key ) {
 			case 'post_by_email_address':
+				break;
+			case 'custom-content-types':
+			case 'jetpack_testimonial':
+			case 'jetpack_portfolio':
 				break;
 			case 'infinite-scroll':
 				break;
@@ -115,10 +123,6 @@ export const filterSettingsByActiveModules = ( settings ) => {
 			'Phrases to Avoid',
 			'Redundant Expression',
 			'ignored_phrases',
-		],
-		'custom-content-types': [
-			'jetpack_testimonial',
-			'jetpack_portfolio',
 		],
 		comments: [
 			'highlander_comment_form_prompt',


### PR DESCRIPTION
The settings for Testimonial and Portfolio custom content types are named `jetpack_testimonial` and `jetpack_portfolio`. This setting name is the same both in settings coming from the shadow site and from the sites REST API. This causes an undesired state when deciding whether to save settings using .com's settings endpoint or using the Jetpack site's REST API.

The problem is that if we send these settings directly to the REST API it may be the case that the custom-content-types modules is disabled and thus, the settings won't have effect. 

As we need these settings to be able to work for .com sites, I'm removing the from the settings response coming from the original site. 

#### Testing instructions


1. Run the unit tests: `npm run test-client client/state/jetpack/settings/test/utils.js`
