### PR TITLE
Pages: display pages hierarchically

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -290,6 +290,7 @@
 @import 'my-sites/no-results/style';
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
+@import 'my-sites/pages/page-card-info/style';
 @import 'my-sites/people/delete-user/style';
 @import 'my-sites/people/edit-team-member-form/style';
 @import 'my-sites/people/people-list-item/style';

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -6,61 +6,109 @@ import { connect } from 'react-redux';
 import { identity } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import CompactCard from 'components/card/compact';
-import { getSiteFrontPageType, getSitePostsPage } from 'state/sites/selectors';
+import Card from 'components/card';
+import {
+	getSiteFrontPageType,
+	getSitePostsPage,
+	getSiteFrontPage,
+} from 'state/sites/selectors';
 
 class BlogPostsPage extends React.Component {
 
 	static propTypes = {
 		site: React.PropTypes.object,
+		pages: React.PropTypes.array,
 	}
 
 	static defaultProps = {
 		translate: identity,
 	}
 
-	state = {
-		showPageActions: false,
+	getPageProperty( { pageId, property } ) {
+		return this.props.pages.filter( page => page.ID === pageId ).map( page => page[ property ] ).shift();
 	}
 
-	togglePageActions = () => {
-		this.setState( { showPageActions: ! this.state.showPageActions } );
+	getPostsPageLink( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) {
+		if ( isStaticHomePageWithNoPostsPage ) {
+			return null;
+		}
+
+		if ( ! isCurrentlySetAsHomepage ) {
+			return this.getPageProperty( { pageId: this.props.postsPage, property: 'URL' } );
+		}
+
+		return this.props.site.URL;
+	}
+
+	renderPostsPageInfo( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) {
+		const { translate } = this.props;
+
+		if ( isStaticHomePageWithNoPostsPage ) {
+			return (
+				<span>
+					<Gridicon size={ 12 } icon="not-visible" className="blog-posts-page__not-used-icon" />
+					{ this.props.translate( 'Not in use.' ) + ' ' }
+					{
+						this.props.translate( '"%(pageTitle)s" is the front page.', {
+							args: {
+								pageTitle: this.getPageProperty( { pageId: this.props.frontPage, property: 'title' } ),
+							}
+						} )
+					}
+				</span>
+			);
+		}
+
+		if ( isCurrentlySetAsHomepage ) {
+			return (
+				<span>
+					<Gridicon size={ 12 } icon="house" className="blog-posts-page__front-page-icon" />
+					{ translate( 'Front page is showing your latest posts.' ) }
+				</span>
+			);
+		}
+
+		return (
+			<span>
+				{
+					translate( '"%(pageTitle)s" page is showing your latest posts.', {
+						args: {
+							pageTitle: this.getPageProperty( { pageId: this.props.postsPage, property: 'title' } ),
+						}
+					} )
+				}
+			</span>
+		);
 	}
 
 	render() {
 		const { translate } = this.props;
-
 		const isStaticHomePageWithNoPostsPage = this.props.frontPageType === 'page' && ! this.props.postsPage;
 		const isCurrentlySetAsHomepage = this.props.frontPageType === 'posts';
-		const shouldShow = this.props.isFrontPage || isStaticHomePageWithNoPostsPage;
-
-		if ( ! shouldShow ) {
-			return null;
-		}
 
 		return (
-			<CompactCard className="blog-posts-page">
-				{ isStaticHomePageWithNoPostsPage &&
-					<div className="blog-posts-page__not-used-badge">{ translate( 'Not Used' ) }</div> }
-				{ isCurrentlySetAsHomepage &&
-					<Gridicon icon="house" size={ 18 } className="blog-posts-page__home-badge" /> }
+			<Card href={ this.getPostsPageLink( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) }
+				target="_blank" rel="noopener noreferrer" className="blog-posts-page" >
 				<div className="blog-posts-page__details">
-					<div className="blog-posts-page__title">
+					<div className={ classNames( {
+						'blog-posts-page__title': true,
+						'is-disabled': isStaticHomePageWithNoPostsPage,
+					} ) } >
 						{ translate( 'Blog Posts' ) }
 					</div>
-					<div className="blog-posts-page__info">
-						{
-							isCurrentlySetAsHomepage
-							? translate( 'Your latest posts, shown on homepage' )
-							: translate( 'Your latest posts' )
-						}
+					<div className={ classNames( {
+						'blog-posts-page__info': true,
+						'is-disabled': isStaticHomePageWithNoPostsPage,
+					} ) } >
+						{ this.renderPostsPageInfo( { isStaticHomePageWithNoPostsPage, isCurrentlySetAsHomepage } ) }
 					</div>
 				</div>
-			</CompactCard>
+			</Card>
 		);
 	}
 }
@@ -70,7 +118,8 @@ export default connect(
 		return {
 			frontPageType: getSiteFrontPageType( state, props.site.ID ),
 			isFrontPage: getSiteFrontPageType( state, props.site.ID ) === 'posts',
-			postsPage: getSitePostsPage( state, props.site.ID )
+			postsPage: getSitePostsPage( state, props.site.ID ),
+			frontPage: getSiteFrontPage( state, props.site.ID ),
 		};
 	}
 )( localize( BlogPostsPage ) );

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -1,31 +1,16 @@
 .blog-posts-page {
 	display: flex;
 	align-items: center;
+	padding: 16px 24px;
 }
 
-.blog-posts-page__home-badge {
-	flex: 0 0 auto;
-	margin: 2px 8px 0 0;
-	color: $gray;
-	align-self: flex-start;
-}
-
-.blog-posts-page__not-used-badge {
-	flex: 0 0 auto;
-	margin: 0 24px 0 0;
-	padding: 5px 16px;
-	background-color: $gray;
-	border-radius: 3px;
-	color: $white;
-	font-size: 12px;
+.blog-posts-page__front-page-icon,
+.blog-posts-page__not-used-icon {
+	margin-right: 6px;
 }
 
 .blog-posts-page__details {
 	flex: 1 1 auto;
-}
-
-.blog-posts-page__actions {
-	flex: 0 0 auto;
 }
 
 .blog-posts-page__title {
@@ -34,10 +19,18 @@
 	font-weight: 500;
 	font-family: $serif;
 	margin-right: 33px;
+
+	&.is-disabled {
+		color: $gray;
+	}
 }
 
 .blog-posts-page__info {
 	color: $gray;
 	font-size: 12px;
 	margin: 0 33px 0 0;
+
+	&.is-disabled {
+		color: lighten( $gray, 10% );
+	}
 }

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -16,7 +16,7 @@
 .blog-posts-page__title {
 	display: inline;
 	color: $gray-dark;
-	font-weight: 500;
+	font-weight: bold;
 	font-family: $serif;
 	margin-right: 33px;
 
@@ -26,7 +26,7 @@
 }
 
 .blog-posts-page__info {
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	margin: 0 33px 0 0;
 

--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -1,3 +1,21 @@
+/**
+ * External dependencies
+ */
+
+import {
+	assign,
+	forEach,
+	groupBy,
+	includes,
+	map,
+	reduce,
+	sortBy,
+} from 'lodash';
+
+// Helpers used by sortPagesHierarchically but not exposed externally
+const sortByMenuOrder = list => sortBy( list, 'menu_order' );
+const getParentId = page => page.parent && page.parent.ID;
+
 module.exports = {
 	editLinkForPage: function( page, site ) {
 		if ( ! ( page && page.ID ) || ! ( site && site.ID ) ) {
@@ -21,5 +39,38 @@ module.exports = {
 			return false;
 		}
 		return site.options.page_on_front === page.ID;
+	},
+
+	sortPagesHierarchically: function( pages ) {
+		const pageIds = map( pages, 'ID' );
+
+		const pagesByParent = reduce( groupBy( pages, getParentId ), ( result, list, parentId ) => {
+			if ( ! parentId || parentId === 'false' || ! includes( pageIds, parseInt( parentId, 10 ) ) ) {
+				// If we don't have the parent in our list, promote the page to "top level"
+				result.false = sortByMenuOrder( ( result.false || [] ).concat( list ) );
+				return result;
+			}
+
+			result[ parentId ] = sortByMenuOrder( list );
+			return result;
+		}, {} );
+
+		const sortedPages = [];
+
+		const insertChildren = ( pageId, indentLevel ) => {
+			const children = pagesByParent[ pageId ] || [];
+
+			forEach( children, child => {
+				sortedPages.push( assign( {}, child, { indentLevel } ) );
+				insertChildren( child.ID, indentLevel + 1 );
+			} );
+		};
+
+		forEach( pagesByParent.false, topLevelPage => {
+			sortedPages.push( topLevelPage );
+			insertChildren( topLevelPage.ID, 1 );
+		} );
+
+		return sortedPages;
 	}
 };

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isFrontPage,
+	isPostsPage,
+} from 'state/pages/selectors';
+
+function PageCardInfo( { translate, moment, page, showTimestamp, isFront, isPosts, siteUrl } ) {
+	const iconSize = 12;
+
+	return (
+		<div className="page-card-info">
+			{ siteUrl &&
+				<div className="page-card-info__site-url">
+					{ siteUrl }
+				</div>
+			}
+			<div>
+				{ showTimestamp &&
+					<span className="page-card-info__item">
+						<Gridicon icon="time" size={ iconSize } className="page-card-info__item-icon" />
+						<span className="page-card-info__item-text">
+							{ moment( page.modified ).fromNow() }
+						</span>
+					</span>
+				}
+				{ isFront &&
+					<span className="page-card-info__item">
+						<Gridicon icon="house" size={ iconSize } className="page-card-info__item-icon" />
+						<span className="page-card-info__item-text">
+							{ translate( 'Front page' ) }
+						</span>
+					</span>
+				}
+				{ isPosts &&
+					<span className="page-card-info__item">
+						<Gridicon icon="posts" size={ iconSize } className="page-card-info__item-icon" />
+						<span className="page-card-info__item-text">
+							{ translate( 'Your latest posts' ) }
+						</span>
+					</span>
+				}
+			</div>
+		</div>
+	);
+}
+
+export default connect(
+	( state, props ) => {
+		return {
+			isFront: isFrontPage( state, props.page.site_ID, props.page.ID ),
+			isPosts: isPostsPage( state, props.page.site_ID, props.page.ID ),
+		};
+	}
+)( localize( PageCardInfo ) );

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -1,0 +1,31 @@
+.page-card-info {
+	color: $gray-text-min;
+	font-size: 12px;
+	vertical-align: middle;
+}
+
+.page-card-info__item {
+	display: inline-block;
+	margin-right: 12px;
+}
+
+.page-card-info__item-icon {
+	margin-right: 4px;
+}
+
+.page-card-info__item-icon,
+.page-card-info__item-text {
+	vertical-align: middle;
+}
+
+.page-card-info__item-text {
+	line-height: 1;
+
+	&::first-letter {
+		text-transform: capitalize;
+	}
+}
+
+.page-card-info__site-url {
+	font-style: italic;
+}

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -204,7 +204,7 @@ var Pages = React.createClass( {
 		this.addLoadingRows( rows, 1 );
 
 		return (
-			<div id="pages" className="page-list">
+			<div id="pages" className="pages__page-list">
 				{ rows }
 			</div>
 		);
@@ -236,7 +236,7 @@ var Pages = React.createClass( {
 		}, this );
 
 		return (
-			<div id="pages" className="page-list">
+			<div id="pages" className="pages__page-list">
 				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 				{ rows }
 			</div>
@@ -253,11 +253,11 @@ var Pages = React.createClass( {
 				return page;
 			}
 			// Get the site the page belongs to
-			const site = this.props.sites.getSite( page.site_ID );
+			const _site = this.props.sites.getSite( page.site_ID );
 
 			// Render each page
 			return (
-				<Page key={ 'page-' + page.global_ID } page={ page } site={ site } multisite={ this.props.siteID === false } />
+				<Page key={ 'page-' + page.global_ID } page={ page } site={ _site } multisite={ this.props.siteID === false } />
 			);
 		}, this );
 
@@ -270,7 +270,7 @@ var Pages = React.createClass( {
 		);
 
 		return (
-			<div id="pages" className="page-list">
+			<div id="pages" className="pages__page-list">
 				{ blogPostsPage }
 				{ rows }
 				{ this.props.lastPage && pages.length ? <div className="infinite-scroll-end" /> : null }
@@ -280,7 +280,7 @@ var Pages = React.createClass( {
 
 	renderNoContent: function() {
 		return (
-			<div id="pages" className="page-list">
+			<div id="pages" className="pages__page-list">
 				<div key="page-list-no-results">{ this.getNoContentMessage() }</div>
 			</div>
 		);

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -336,7 +336,7 @@ const Page = React.createClass( {
 			canEdit = utils.userCan( 'edit_post', this.props.page ),
 			depthIndicator;
 
-		if ( page.parent ) {
+		if ( ! this.props.hierarchical && page.parent ) {
 			depthIndicator = '— ';
 		}
 
@@ -380,8 +380,28 @@ const Page = React.createClass( {
 			ref="popoverMenuButton" />
 		) : null;
 
+		const cardClasses = {
+			page: true,
+			'is-indented': this.props.hierarchical && this.props.hierarchyLevel > 0,
+		};
+
+		const hierarchyIndentClasses = {
+			'page__hierarchy-indent': true,
+			'is-indented': cardClasses[ 'is-indented' ],
+		};
+
+		if ( cardClasses[ 'is-indented' ] ) {
+			cardClasses[ 'is-indented-level-' + this.props.hierarchyLevel ] = true;
+			hierarchyIndentClasses[ 'is-indented-level-' + this.props.hierarchyLevel ] = true;
+		}
+
+		const hierarchyIndent = cardClasses[ 'is-indented' ] && (
+			<div className={ classNames( hierarchyIndentClasses ) } ></div>
+		);
+
 		return (
-			<CompactCard className="page">
+			<CompactCard className={ classNames( cardClasses ) } >
+				{ hierarchyIndent }
 				{ this.props.multisite ? <SiteIcon site={ site } size={ 34 } /> : null }
 				<a className="page__title"
 					href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -25,6 +25,7 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	classNames = require( 'classnames' );
 
 import MenuSeparator from 'components/popover/menu-separator';
+import PageCardInfo from './page-card-info';
 import { hasStaticFrontPage, isSitePreviewable } from 'state/sites/selectors';
 import {
 	isFrontPage,
@@ -403,19 +404,23 @@ const Page = React.createClass( {
 			<CompactCard className={ classNames( cardClasses ) } >
 				{ hierarchyIndent }
 				{ this.props.multisite ? <SiteIcon site={ site } size={ 34 } /> : null }
-				<a className="page__title"
-					href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
-					title={ canEdit ?
-						this.translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } ) :
-						this.translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } ) }
-					onClick={ this.analyticsEvents.pageTitle }
-					>
-					{ depthIndicator }
-					{ this.props.isFrontPage ? <Gridicon icon="house" size={ 18 } /> : null }
-					{ title }
-				</a>
-				{ this.props.isPostsPage ? <div className="page__posts-page">{ this.translate( 'Your latest posts' ) }</div> : null }
-				{ this.props.multisite ? <span className="page__site-url">{ this.getSiteDomain() }</span> : null }
+				<div className="page__main">
+					<a className="page__title"
+						href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
+						title={ canEdit ?
+							this.translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } ) :
+							this.translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } ) }
+						onClick={ this.analyticsEvents.pageTitle }
+						>
+						{ depthIndicator }
+						{ title }
+					</a>
+					<PageCardInfo
+						page={ page }
+						showTimestamp={ this.props.hierarchical }
+						siteUrl={ this.props.multisite && this.getSiteDomain() }
+					/>
+				</div>
 				{ ellipsisGridicon }
 				{ popoverMenu }
 				<ReactCSSTransitionGroup

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -159,7 +159,8 @@ const Page = React.createClass( {
 			site = this.props.site,
 			parentTitle, parentHref, parentLink;
 
-		if ( ! page.parent ) {
+		// If we're in hierarchical view, we don't show child info in the context menu, as it's redudant.
+		if ( this.props.hierarchical || ! page.parent ) {
 			return null;
 		}
 

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -47,6 +47,80 @@
 		}
 	}
 
+	&.is-indented {
+		padding-left: 136px;
+
+		&.is-indented-level-1 {
+			padding-left: 40px;
+		}
+
+		&.is-indented-level-2 {
+			padding-left: 56px;
+		}
+
+		&.is-indented-level-3 {
+			padding-left: 70px;
+		}
+
+		&.is-indented-level-4 {
+			padding-left: 88px;
+		}
+
+		&.is-indented-level-5 {
+			padding-left: 104px;
+		}
+
+		&.is-indented-level-6 {
+			padding-left: 120px;
+		}
+
+		&.is-indented-level-7 {
+			padding-left: 136px;
+		}
+	}
+
+}
+
+.page__hierarchy-indent{
+	background: $gray-light;
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 100%;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+
+	&.is-indented {
+		width: 112px;
+
+		&.is-indented-level-1 {
+			width: 16px;
+		}
+
+		&.is-indented-level-2 {
+			width: 32px;
+		}
+
+		&.is-indented-level-3 {
+			width: 48px;
+		}
+
+		&.is-indented-level-4 {
+			width: 64px;
+		}
+
+		&.is-indented-level-5 {
+			width: 80px;
+		}
+
+		&.is-indented-level-6 {
+			width: 96px;
+		}
+
+		&.is-indented-level-7 {
+			width: 112px;
+		}
+	}
 }
 
 .page__title,

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -36,14 +36,16 @@
 
 // <Page> component
 .page {
+	align-items: center;
+	display: flex;
 
 	.site-icon {
 		display: none;
 
 		@include breakpoint( ">660px" ) {
 			display: block;
-			float: left;
 			margin-right: 10px;
+			min-width: 34px;
 		}
 	}
 
@@ -123,11 +125,15 @@
 	}
 }
 
+.page__main {
+	flex-grow: 1;
+}
+
 .page__title,
 .page__title:visited {
 	display: inline;
 	color: $gray-dark;
-	font-weight: 500;
+	font-weight: bold;
 	font-family: $serif;
 	margin-right: 33px;
 
@@ -137,29 +143,12 @@
 	}
 }
 
-.page__posts-page {
-	color: $gray;
-	display: block;
-	font-size: 12px;
-	margin-top: -3px;
-}
-
-.page__site-url {
-	color: $gray;
-	display: block;
-	font-size: 12px;
-	font-style: italic;
-	margin-top: -3px;
-}
-
 .page__actions-toggle {
-	color: $gray;
+	color: $gray-text-min;
 	cursor: pointer;
 	font-size: 24px;
-	margin: 17px 24px;
-	position: absolute;
-		right: 0;
-		top: 0;
+	margin-left: 24px;
+	min-width: 24px;
 	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
 	&.is-active {

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -1,6 +1,6 @@
 // Page list
 
-.page-list {
+.pages__page-list {
 	margin: 0;
 	width: 100%;
 

--- a/client/my-sites/pages/test/helpers.js
+++ b/client/my-sites/pages/test/helpers.js
@@ -1,0 +1,181 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { sortPagesHierarchically } from '../helpers';
+
+describe( 'helpers', () => {
+	describe( 'sortPagesHierarchically()', () => {
+		it( 'should place children under parents', () => {
+			const testData = [
+				{
+					ID: 1,
+					parent: {
+						ID: 2
+					}
+				},
+				{
+					ID: 2,
+					parent: false
+				},
+				{
+					ID: 3,
+					parent: {
+						ID: 1
+					}
+				}
+			];
+
+			const sortedPages = sortPagesHierarchically( testData );
+
+			expect( sortedPages ).to.deep.equal( [
+				{
+					ID: 2,
+					parent: false
+				},
+				{
+					ID: 1,
+					indentLevel: 1,
+					parent: {
+						ID: 2
+					}
+				},
+				{
+					ID: 3,
+					indentLevel: 2,
+					parent: {
+						ID: 1
+					}
+				}
+			] );
+		} );
+
+		it( 'should sort first by hierarchy, then by menu_order', () => {
+			const testData = [
+				{
+					ID: 1,
+					menu_order: 0,
+					parent: false,
+				},
+				{
+					ID: 2,
+					menu_order: 5,
+					parent: {
+						ID: 1
+					}
+				},
+				{
+					ID: 3,
+					menu_order: 2,
+					parent: {
+						ID: 1
+					}
+				},
+				{
+					ID: 4,
+					menu_order: 6,
+					parent: false
+				}
+			];
+
+			const sortedPages = sortPagesHierarchically( testData );
+
+			expect( sortedPages ).to.deep.equal( [
+				{
+					ID: 1,
+					menu_order: 0,
+					parent: false
+				},
+				{
+					ID: 3,
+					indentLevel: 1,
+					menu_order: 2,
+					parent: {
+						ID: 1
+					}
+				},
+				{
+					ID: 2,
+					indentLevel: 1,
+					menu_order: 5,
+					parent: {
+						ID: 1
+					}
+				},
+				{
+					ID: 4,
+					menu_order: 6,
+					parent: false
+				}
+			] );
+		} );
+
+		it( 'should place orphaned children at top-level, with their children properly beneath them', ()=> {
+			const testData = [
+				{
+					ID: 1,
+					menu_order: 1,
+					parent: false
+				},
+				{
+					ID: 2,
+					menu_order: 2,
+					parent: {
+						ID: 3
+					}
+				},
+				{
+					ID: 3,
+					menu_order: 3,
+					parent: {
+						ID: 5
+					}
+				},
+				{
+					ID: 4,
+					menu_order: 4,
+					parent: {
+						ID: 1
+					}
+				}
+			];
+
+			const sortedPages = sortPagesHierarchically( testData );
+
+			expect( sortedPages ).to.deep.equal( [
+				{
+					ID: 1,
+					menu_order: 1,
+					parent: false
+				},
+				{
+					ID: 4,
+					indentLevel: 1,
+					menu_order: 4,
+					parent: {
+						ID: 1
+					}
+				},
+				{
+					ID: 3,
+					menu_order: 3,
+					parent: {
+						ID: 5
+					}
+				},
+				{
+					ID: 2,
+					indentLevel: 1,
+					menu_order: 2,
+					parent: {
+						ID: 3
+					}
+				}
+			] );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR displays pages listed on `/pages` hierarchically under the following conditions:

* You are viewing a listing of pages for a single site.
* You are viewing published pages and are not performing a search.
* You have 100 or fewer published pages.

In any other case, pages are displayed chronologically (as they were previously).

Before:
![image](https://cloud.githubusercontent.com/assets/363749/25906656/dbd4574c-356a-11e7-87b9-1e3352856ea1.png)

After:
![image](https://cloud.githubusercontent.com/assets/363749/25906598/b8624684-356a-11e7-959c-6eac23b222bd.png)

This PR also moves the position of the "Blog Posts" block from the bottom of the page to the top, and updates its appearance.

Before:
![image](https://cloud.githubusercontent.com/assets/363749/25908181/233a173a-356f-11e7-8708-50734f45508d.png)

After:
![image](https://cloud.githubusercontent.com/assets/363749/25908228/3e8db62c-356f-11e7-9d2f-6e26faea68bb.png)

Many of the pieces of this PR were tested independently as parts of PRs into this feature branch:

* Function to sort pages hierarchically was tested via #13294 
* Displaying pages hierarchically was tested via #13474
* Moving the blog posts block was tested via #13531
* Updating the design was tested via #13729

General testing:
* Apply this PR
* Create a site that contains pages with hierarchy.
* Visit `/pages`
* Verify that pages that are children of another page are shown hierarchically when there are fewer than 100 pages
* Verify that drafts, scheduled, and trashed show up as normal, non-hierarchically.
* Verify that search shows up as normal, non-hierarchically.
* Verify that orphaned children show up as top-level pages
* Verify that `menu_order` is obeyed for sorting (after hierarchy)