### PR TITLE
Extensions: WPSC - Handle empty initial state

### DIFF
--- a/client/extensions/wp-super-cache/advanced-tab.jsx
+++ b/client/extensions/wp-super-cache/advanced-tab.jsx
@@ -24,7 +24,6 @@ const AdvancedTab = ( {
 		is_cache_enabled,
 		is_super_cache_enabled,
 	},
-	siteUrl,
 } ) => {
 	return (
 		<div>
@@ -37,7 +36,7 @@ const AdvancedTab = ( {
 			<RejectedUserAgents />
 			<LockDown />
 			{ is_cache_enabled && is_super_cache_enabled &&
-				<DirectlyCachedFiles siteUrl={ siteUrl } />
+				<DirectlyCachedFiles />
 			}
 			<FixConfig />
 		</div>

--- a/client/extensions/wp-super-cache/cdn-tab.jsx
+++ b/client/extensions/wp-super-cache/cdn-tab.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -79,7 +79,7 @@ const CdnTab = ( {
 								{ translate(
 									'The new URL to be used in place of %(url)s for rewriting. No trailing / please.',
 									{
-										args: { url: site && site.URL },
+										args: { url: get( site, 'URL' ) },
 									}
 								) }
 							</FormSettingExplanation>
@@ -147,7 +147,7 @@ const CdnTab = ( {
 									'off-site URL above). Use a comma as the delimiter. For pages with a large number of static files, ' +
 									'this can improve browser performance. CNAMEs may also need to be configured on your CDN.',
 									{
-										args: { url: site && site.URL },
+										args: { url: get( site, 'URL' ) },
 										components: {
 											a: (
 												<ExternalLink

--- a/client/extensions/wp-super-cache/cdn-tab.jsx
+++ b/client/extensions/wp-super-cache/cdn-tab.jsx
@@ -32,7 +32,7 @@ const CdnTab = ( {
 	handleSubmitForm,
 	isRequesting,
 	isSaving,
-	siteUrl,
+	site,
 	translate,
 } ) => {
 	return (
@@ -79,7 +79,7 @@ const CdnTab = ( {
 								{ translate(
 									'The new URL to be used in place of %(url)s for rewriting. No trailing / please.',
 									{
-										args: { url: siteUrl },
+										args: { url: site && site.URL },
 									}
 								) }
 							</FormSettingExplanation>
@@ -147,9 +147,7 @@ const CdnTab = ( {
 									'off-site URL above). Use a comma as the delimiter. For pages with a large number of static files, ' +
 									'this can improve browser performance. CNAMEs may also need to be configured on your CDN.',
 									{
-										args: {
-											url: siteUrl,
-										},
+										args: { url: site && site.URL },
 										components: {
 											a: (
 												<ExternalLink

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -21,6 +21,10 @@ import {
 } from 'state/notices/actions';
 import { generateStats } from './state/stats/actions';
 import {
+	getSiteTitle,
+	isJetpackSiteMultiSite,
+} from 'state/sites/selectors';
+import {
 	getStats,
 	isGeneratingStats,
 	isStatsGenerationSuccessful,
@@ -31,13 +35,17 @@ class ContentsTab extends Component {
 		fields: PropTypes.object,
 		handleDeleteCache: PropTypes.func.isRequired,
 		isDeleting: PropTypes.bool,
+		isMultisite: PropTypes.bool,
 		site: PropTypes.object.isRequired,
+		siteTitle: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
 		fields: {},
 		isDeleting: false,
+		isMultisite: false,
+		siteTitle: '',
 	};
 
 	state = {
@@ -63,13 +71,13 @@ class ContentsTab extends Component {
 
 		const {
 			isSuccessful,
-			site,
+			siteTitle,
 			translate,
 		} = this.props;
 
 		if ( isSuccessful ) {
 			this.props.successNotice(
-				translate( 'Cache stats regenerated on %(site)s.', { args: { site: site && site.title } } ),
+				translate( 'Cache stats regenerated on %(site)s.', { args: { site: siteTitle } } ),
 				{ id: 'wpsc-cache-stats' }
 			);
 		} else {
@@ -107,7 +115,7 @@ class ContentsTab extends Component {
 			},
 			isDeleting,
 			isGenerating,
-			site,
+			isMultisite,
 			stats,
 			translate,
 		} = this.props;
@@ -223,7 +231,7 @@ class ContentsTab extends Component {
 							onClick={ this.deleteCache }>
 							{ translate( 'Delete Cache' ) }
 						</Button>
-						{ site && site.is_multisite &&
+						{ isMultisite &&
 							<Button
 								compact
 								busy={ this.state.isDeletingAll }
@@ -245,10 +253,14 @@ const connectComponent = connect(
 		const stats = getStats( state, siteId );
 		const isGenerating = isGeneratingStats( state, siteId );
 		const isSuccessful = isStatsGenerationSuccessful( state, siteId );
+		const isMultisite = isJetpackSiteMultiSite( state, siteId );
+		const siteTitle = getSiteTitle( state, siteId );
 
 		return {
 			isGenerating,
+			isMultisite,
 			isSuccessful,
+			siteTitle,
 			stats,
 		};
 	},

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -31,14 +31,13 @@ class ContentsTab extends Component {
 		fields: PropTypes.object,
 		handleDeleteCache: PropTypes.func.isRequired,
 		isDeleting: PropTypes.bool,
-		isMultisite: PropTypes.bool,
+		site: PropTypes.object.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
 		fields: {},
 		isDeleting: false,
-		isMultisite: false,
 	};
 
 	state = {
@@ -108,7 +107,7 @@ class ContentsTab extends Component {
 			},
 			isDeleting,
 			isGenerating,
-			isMultisite,
+			site,
 			stats,
 			translate,
 		} = this.props;
@@ -224,7 +223,7 @@ class ContentsTab extends Component {
 							onClick={ this.deleteCache }>
 							{ translate( 'Delete Cache' ) }
 						</Button>
-						{ isMultisite &&
+						{ site && site.is_multisite &&
 							<Button
 								compact
 								busy={ this.state.isDeletingAll }

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -41,7 +41,7 @@ class DirectlyCachedFiles extends Component {
 			isRequesting,
 			isSaving,
 			setFieldArrayValue,
-			siteUrl,
+			site,
 			translate
 		} = this.props;
 		const cache_direct_pages = fields.cache_direct_pages || [];
@@ -96,7 +96,7 @@ class DirectlyCachedFiles extends Component {
 									'For example: to cache {{em}}%(url)s/about/{{/em}}, you would enter %(url)s/about/ or /about/. ' +
 									'The cached file will be generated the next time an anonymous user visits that page.',
 									{
-										args: { url: siteUrl },
+										args: { url: site && site.URL },
 										components: { em: <em /> },
 									}
 								) }

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -44,10 +44,8 @@ class DirectlyCachedFiles extends Component {
 			siteUrl,
 			translate
 		} = this.props;
-		const {
-			cache_direct_pages = [],
-			cache_path,
-		} = fields;
+		const cache_direct_pages = fields.cache_direct_pages || [];
+		const cache_path = fields.cache_path || '';
 		const notices = pick( this.props.notices, [
 			'cache_readonly',
 			'cache_writable',

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -29,8 +29,6 @@ class EasyTab extends Component {
 		isSaving: PropTypes.bool,
 		isTesting: PropTypes.bool,
 		site: PropTypes.object.isRequired,
-		siteId: PropTypes.number.isRequired,
-		testCache: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -21,7 +21,7 @@ const WPSuperCache = ( { site, tab } ) => {
 			case Tabs.ADVANCED:
 				return <AdvancedTab />;
 			case Tabs.CDN:
-				return <CdnTab siteUrl={ site.URL } />;
+				return <CdnTab />;
 			case Tabs.CONTENTS:
 				return <ContentsTab isMultisite={ site.is_multisite } />;
 			case Tabs.PRELOAD:

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -23,7 +23,7 @@ const WPSuperCache = ( { site, tab } ) => {
 			case Tabs.CDN:
 				return <CdnTab />;
 			case Tabs.CONTENTS:
-				return <ContentsTab isMultisite={ site.is_multisite } />;
+				return <ContentsTab />;
 			case Tabs.PRELOAD:
 				return <PreloadTab />;
 			default:

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -19,7 +19,7 @@ const WPSuperCache = ( { site, tab } ) => {
 	const renderTab = () => {
 		switch ( tab ) {
 			case Tabs.ADVANCED:
-				return <AdvancedTab siteUrl={ site.URL } />;
+				return <AdvancedTab />;
 			case Tabs.CDN:
 				return <CdnTab siteUrl={ site.URL } />;
 			case Tabs.CONTENTS:

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -27,7 +27,7 @@ const WPSuperCache = ( { site, tab } ) => {
 			case Tabs.PRELOAD:
 				return <PreloadTab />;
 			default:
-				return <EasyTab site={ site } />;
+				return <EasyTab />;
 		}
 	};
 

--- a/client/extensions/wp-super-cache/navigation.jsx
+++ b/client/extensions/wp-super-cache/navigation.jsx
@@ -48,7 +48,9 @@ const Navigation = ( { activeTab, site, translate } ) => {
 				path = `${ path }/${ tab }`;
 			}
 
-			path += `/${ site.slug }`;
+			if ( site ) {
+				path += `/${ site.slug }`;
+			}
 
 			return (
 				<SectionNavTabItem
@@ -72,12 +74,12 @@ const Navigation = ( { activeTab, site, translate } ) => {
 
 Navigation.propTypes = {
 	activeTab: PropTypes.string,
-	site: React.PropTypes.object.isRequired,
+	site: PropTypes.object,
 	translate: PropTypes.func.isRequired,
 };
 
 Navigation.defaultProps = {
-	activeTab: ''
+	activeTab: '',
 };
 
 export default localize( Navigation );

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -153,7 +153,7 @@ class PreloadTab extends Component {
 										'Refresh preloaded cache files every {{number /}} minute. ',
 										'Refresh preloaded cache files every {{number /}} minutes. ',
 										{
-											count: preload_interval,
+											count: preload_interval || 0,
 											components: {
 												number: renderCachePreloadInterval( {
 													handleChange,

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -150,8 +150,8 @@ class PreloadTab extends Component {
 								onChange={ this.handlePreloadRefreshChange }>
 								<span>
 									{ translate(
-										'Refresh preloaded cache files every {{number /}} minute. ',
-										'Refresh preloaded cache files every {{number /}} minutes. ',
+										'Refresh preloaded cache files every {{number /}} minute ',
+										'Refresh preloaded cache files every {{number /}} minutes ',
 										{
 											count: preload_interval || 0,
 											components: {
@@ -166,11 +166,11 @@ class PreloadTab extends Component {
 									) }
 
 									{ translate(
-										'(minimum %d minute)',
-										'(minimum %d minutes)',
+										'(minimum %(minutes)d minute).',
+										'(minimum %(minutes)d minutes).',
 										{
-											args: minimum_preload_interval,
-											count: minimum_preload_interval,
+											args: { minutes: minimum_preload_interval || 0 },
+											count: minimum_preload_interval || 0,
 										}
 									) }
 								</span>


### PR DESCRIPTION
If there is an empty initial state, errors appear in the console. This PR eliminates those errors by checking for the existence of data before using it.

To test, run `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in DevTools console and then refresh the page. No errors related to WP Super Cache should appear in the console.