### PR TITLE
Purchases List: Hide the site updates indicator in the Site header

### DIFF
--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -54,7 +54,7 @@ class PurchaseSiteHeader extends Component {
 			);
 		} else if ( site ) {
 			header = (
-				<Site isCompact site={ site } />
+				<Site isCompact site={ site } indicator={ false } />
 			);
 		} else {
 			header = this.renderFauxSite( name, domain );


### PR DESCRIPTION
Fixes #13870, to quote @rickybanister:

> it doesn't seem to make sense to take someone away from their purchases to do an update

So we'll remove the site indicator from `Site` when it's being used as the purchase group header.

To test:

1. Have a site with a purchase that needs an update
2. Visit /me/purchases
3. There should be no yellow update indicator in the purchases list site headers.