### PR TITLE
WooCommerce: Add debounce to the variation type name field

### DIFF
--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import i18n from 'i18n-calypso';
-import { find } from 'lodash';
+import { find, debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,10 @@ import Button from 'components/button';
 import TokenField from 'components/token-field';
 
 export default class ProductVariationTypesForm extends Component {
+
+	state = {
+		attributeNames: {},
+	};
 
 	static propTypes = {
 		product: PropTypes.shape( {
@@ -31,14 +35,8 @@ export default class ProductVariationTypesForm extends Component {
 		if ( ! product.attributes ) {
 			this.addType();
 		}
-	}
 
-	constructor( props ) {
-		super( props );
-
-		this.addType = this.addType.bind( this );
-		this.updateName = this.updateName.bind( this );
-		this.updateValues = this.updateValues.bind( this );
+		this.debouncedUpdateName = debounce( this.updateName, 300 );
 	}
 
 	getNewFields() {
@@ -49,34 +47,43 @@ export default class ProductVariationTypesForm extends Component {
 		};
 	}
 
-	addType() {
+	addType = () => {
 		const { product, editProductAttribute } = this.props;
 		editProductAttribute( product, null, this.getNewFields() );
 	}
 
-	updateName( e ) {
-		const { product, editProductAttribute } = this.props;
-		const attribute = product.attributes && find( product.attributes, function( a ) {
-			return a.uid === e.target.id;
-		} );
-		editProductAttribute( product, attribute, { name: e.target.value } );
+	updateNameHandler = ( e ) => {
+		const attributeNames = { ...this.state.attributeNames };
+		attributeNames[ e.target.id ] = e.target.value;
+		this.setState( { attributeNames } );
+		this.debouncedUpdateName( e.target.id, e.target.value );
 	}
 
-	updateValues( values, attribute ) {
+	updateName( attributeId, name ) {
+		const { product, editProductAttribute } = this.props;
+		const attribute = product.attributes && find( product.attributes, function( a ) {
+			return a.uid === attributeId;
+		} );
+		editProductAttribute( product, attribute, { name } );
+	}
+
+	updateValues = ( values, attribute ) => {
 		const { product, editProductAttribute } = this.props;
 		editProductAttribute( product, attribute, { options: values } );
 	}
 
 	renderInputs( attribute ) {
+		const { attributeNames } = this.state;
+		const attributeName = attributeNames && attributeNames[ attribute.uid ] || attribute.name;
 		return (
 			<div key={ attribute.uid } className="products__variation-types-form-fieldset">
 				<FormTextInput
 					placeholder={ i18n.translate( 'Color' ) }
-					value={ attribute.name }
+					value={ attributeName }
 					id={ attribute.uid }
 					name="type"
 					className="products__variation-types-form-field"
-					onChange={ this.updateName }
+					onChange={ this.updateNameHandler }
 				/>
 				<TokenField
 					placeholder={ i18n.translate( 'Comma separate these' ) }


### PR DESCRIPTION
This adds a debounce to the variation type name field so typing in the input box doesn't become slow with a huge number of variations. The TokenField already only updates once input is tokenized.

To test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Create a large number of variations. I.e. have a `Color` type with `Yellow, Blue Green, Pink, Purple, Black`, `Size` with `S,  M, L, XL, 2XL, 3XL`, `Sleeves` with `Short, Long`.
* Add an additional type called `Fabric` and make sure you can type in the box without a large slow-down of typing.