### PR TITLE
Purchases: Add the theme gridicon to theme purchases in list

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -19,7 +19,7 @@ import {
 	purchaseType,
 	showCreditCardExpiringWarning
 } from 'lib/purchases';
-import { isPlan, isDomainProduct } from 'lib/products-values';
+import { isPlan, isDomainProduct, isTheme } from 'lib/products-values';
 import Notice from 'components/notice';
 import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'gridicons';
@@ -122,6 +122,12 @@ class PurchaseItem extends Component {
 			icon = (
 				<div className="purchase-item__plan-icon">
 					<Gridicon icon="domains" size={ 24 } />
+				</div>
+			);
+		} else if ( purchase && isTheme( purchase ) ) {
+			icon = (
+				<div className="purchase-item__plan-icon">
+					<Gridicon icon="themes" size={ 24 } />
 				</div>
 			);
 		}

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -55,11 +55,18 @@
 	max-width: 32px;
 	width: 32px;
 
-	.gridicons-domains {
+	.gridicon {
 		padding: 4px;
-		border-radius: 50%;
 		background: $blue-medium;
 		fill: $white;
+	}
+
+	.gridicons-domains {
+		border-radius: 50%;
+	}
+
+	.gridicons-themes {
+		border-radius: 4px;
 	}
 }
 


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/issues/12746#issuecomment-300390062 @sirreal noticed that we're using the Theme icon in the purchase detail view, but not in the list view. This PR adds the theme icon to the list view, too. It should look like this:

<img width="735" alt="screen shot 2017-05-10 at 12 00 19 pm" src="https://cloud.githubusercontent.com/assets/541093/25908481/4fd219e2-3578-11e7-9246-489f56ad001c.png">

To test

1. Have a theme purchase
2. Visit /me/purchases
3. See the theme icon 🎉 

I used the similar style - rounded square rather than circle - but I dropped the border radius to 4px, since that seemed to match the icon at this size better.