### PR TITLE
Jetpack Connect: update handling of sites list

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -33,7 +33,8 @@ import {
 	JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
 	JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 	JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
-	JETPACK_CONNECT_SSO_VALIDATION_ERROR
+	JETPACK_CONNECT_SSO_VALIDATION_ERROR,
+	SITES_RECEIVE
 } from 'state/action-types';
 import userFactory from 'lib/user';
 import config from 'config';
@@ -354,6 +355,10 @@ export default {
 					site: client_id
 				} );
 				debug( 'Sites list updated!', data );
+				dispatch( {
+					type: SITES_RECEIVE,
+					sites: data.sites
+				} );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
 					data: data


### PR DESCRIPTION
Dispatch SITES_RECEIVE after a succesful connection, and when the site's list is updated.

Fixes an error currently in production that is causing the connection process to end in an improper site's list.