### PR TITLE
Reader: add placeholder for subscription list item

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -180,8 +180,24 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		word-break: break-all;
 		width: 100%;
 
-		&::after{
-			@include long-content-fade( $size: 20% );
+		&:not(.is-placeholder) {
+			&::after {
+				@include long-content-fade( $size: 20% );
+			}
+		}
+
+		&.is-placeholder {
+			margin-top: 2px;
+		}
+	}
+
+	.reader-subscription-list-item.reader-subscription-list-item__placeholder {
+		.reader-subscription-list-item__site-url.is-placeholder {
+			margin-top: 2px;
+		}
+
+		.reader-subscription-list-item__site-excerpt.is-placeholder {
+			max-width: 70%;
 		}
 	}
 }

--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -8,8 +8,8 @@ import { map } from 'lodash';
  * Internal dependencies
  */
 import ConnectedReaderSubscriptionListItem from 'reader/following-manage/connected-subscription-list-item';
+import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
 import Card from 'components/card';
-
 
 const sites = {
 	'longreads': { siteId: 70135762 },
@@ -33,6 +33,7 @@ export default class ReaderSubscriptionListItemExample extends PureComponent {
 							{ ...site }
 						/>
 				) }
+				<ReaderSubscriptionListItemPlaceholder />
 			</Card>
 
 		);

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -21,7 +21,7 @@ import {
 	getSiteUrl,
 } from 'reader/get-helpers';
 import untrailingslashit from 'lib/route/untrailingslashit';
-
+import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
 
 /**
  * Takes in a string and removes the starting https, www., and removes a trailing slash
@@ -56,6 +56,10 @@ function ReaderSubscriptionListItem( {
 	const isFollowing = ( site && site.is_following ) || ( feed && feed.is_following );
 	const preferBlavatar = get( site, 'is_multi_author', false );
 	const preferGravatar = ! preferBlavatar;
+
+	if ( ! site && ! feed ) {
+		return <ReaderSubscriptionListItemPlaceholder />;
+	}
 
 	return (
 		<div className={ classnames( 'reader-subscription-list-item', className ) }>

--- a/client/blocks/reader-subscription-list-item/placeholder.jsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.jsx
@@ -15,21 +15,21 @@ const ReaderSubscriptionListItemPlaceholder = () => {
 				<ReaderAvatar showPlaceholder={ true } isCompact={ true } />
 			</div>
 			<div className="reader-subscription-list-item__byline">
-				<span className="reader-subscription-list-item__site-title">
+				<span className="reader-subscription-list-item__site-title is-placeholder">
 					Site title
 				</span>
-				<div className="reader-subscription-list-item__site-excerpt">
+				<div className="reader-subscription-list-item__site-excerpt is-placeholder">
 					Description of the site
 				</div>
 				<span className="reader-subscription-list-item__by-text">
-					by author
+					by author name
 				</span>
 				<span className="reader-subscription-list-item__site-url">
 					www.example.com
 				</span>
 			</div>
 			<div className="reader-subscription-list-item__options">
-				banana
+				<div className="reader-subscription-list-item__follow">Follow here</div>
 			</div>
 		</div>
 	);

--- a/client/blocks/reader-subscription-list-item/placeholder.jsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.jsx
@@ -21,10 +21,10 @@ const ReaderSubscriptionListItemPlaceholder = () => {
 				<div className="reader-subscription-list-item__site-excerpt is-placeholder">
 					Description of the site
 				</div>
-				<span className="reader-subscription-list-item__by-text">
+				<span className="reader-subscription-list-item__by-text is-placeholder">
 					by author name
 				</span>
-				<span className="reader-subscription-list-item__site-url">
+				<span className="reader-subscription-list-item__site-url is-placeholder">
 					www.example.com
 				</span>
 			</div>

--- a/client/blocks/reader-subscription-list-item/placeholder.jsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.jsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ReaderAvatar from 'blocks/reader-avatar';
+
+const ReaderSubscriptionListItemPlaceholder = () => {
+	return (
+		<div className="reader-subscription-list-item reader-subscription-list-item__placeholder">
+			<div>
+				<ReaderAvatar showPlaceholder={ true } isCompact={ true } />
+			</div>
+			<div className="reader-subscription-list-item__byline">
+				<span className="reader-subscription-list-item__site-title">
+					Site title
+				</span>
+				<div className="reader-subscription-list-item__site-excerpt">
+					Description of the site
+				</div>
+				<span className="reader-subscription-list-item__by-text">
+					by author
+				</span>
+				<span className="reader-subscription-list-item__site-url">
+					www.example.com
+				</span>
+			</div>
+			<div className="reader-subscription-list-item__options">
+				banana
+			</div>
+		</div>
+	);
+};
+
+export default ReaderSubscriptionListItemPlaceholder;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -208,3 +208,13 @@
 	color: lighten( $gray, 10% );
 	display: block;
 }
+
+// Placeholders
+.reader-subscription-list-item.reader-subscription-list-item__placeholder {
+	.reader-subscription-list-item__site-title,
+	.reader-subscription-list-item__site-excerpt,
+	.reader-subscription-list-item__by-text,
+	.reader-subscription-list-item__site-url {
+		@include placeholder();
+	}
+}

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -23,8 +23,10 @@
 	position: relative;
 	width: 100%;
 
-	&::after{
-		@include long-content-fade( $size: 20% );
+	&:not(.is-placeholder) {
+		&::after {
+			@include long-content-fade( $size: 20% );
+		}
 	}
 }
 
@@ -41,9 +43,14 @@
 	}
 
 	&::after{
-		@include long-content-fade( $size: 20% );
 		height: 16px * 1.4;
 		top: auto;
+	}
+
+	&:not(.is-placeholder) {
+		&::after {
+			@include long-content-fade( $size: 20% );
+		}
 	}
 }
 
@@ -214,7 +221,34 @@
 	.reader-subscription-list-item__site-title,
 	.reader-subscription-list-item__site-excerpt,
 	.reader-subscription-list-item__by-text,
-	.reader-subscription-list-item__site-url {
+	.reader-subscription-list-item__site-url,
+	.reader-subscription-list-item__follow {
 		@include placeholder();
+	}
+
+	.reader-subscription-list-item__site-excerpt {
+		margin-top: 2px;
+	}
+
+	.reader-subscription-list-item__site-title {
+		max-width: 60%;
+	}
+
+	.reader-subscription-list-item__site-excerpt {
+		max-width: 80%;
+	}
+
+	.reader-subscription-list-item__site-url {
+		max-width: 40%;
+		margin-top: -1px;
+	}
+
+	.reader-subscription-list-item__follow {
+		width: 20px;
+		height: 20px;
+
+		@include breakpoint( ">660px" ) {
+			width: 72px;
+		}
 	}
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -248,7 +248,7 @@
 		height: 20px;
 
 		@include breakpoint( ">660px" ) {
-			width: 72px;
+			width: 16px * 1.5 * 3;
 		}
 	}
 }


### PR DESCRIPTION
Adds a loading placeholder for the subscription list item, used on the new Manage Following.

### To test

Take a look at:

http://calypso.localhost:3000/devdocs/blocks/reader-subscription-list-item

The last item should be a placeholder.

You can also look at the new Manage Following:

http://calypso.localhost:3000/following/manage

The new placeholders should appear for both recommendations and existing follows:

<img width="755" alt="screen shot 2017-05-11 at 15 42 56" src="https://cloud.githubusercontent.com/assets/17325/25952399/dab30790-3660-11e7-8ef1-f953e8f3396c.png">
<img width="767" alt="screen shot 2017-05-11 at 15 43 05" src="https://cloud.githubusercontent.com/assets/17325/25952400/daf32a96-3660-11e7-9894-3b4636a11c2f.png">

