### PR TITLE
Fix: http-envelope-normalizer: return request object

### DIFF
--- a/client/lib/wp/handlers/http-envelope-normalizer.js
+++ b/client/lib/wp/handlers/http-envelope-normalizer.js
@@ -5,7 +5,7 @@
  * @return {Function} handler wrapper
  */
 export function requestHandler( handler ) {
-	return ( params, fn ) => {
+	return ( params, fn ) => (
 		handler( params, ( err, response ) => {
 			const { code, message, data = {} } = response || {};
 			const { status } = data;
@@ -21,8 +21,8 @@ export function requestHandler( handler ) {
 			}
 
 			return fn( err, response );
-		} );
-	};
+		} )
+	);
 }
 
 /**


### PR DESCRIPTION
Resolves #13791

This wrapper appears to try and detect error-like messages in responses
from `wpcom.js` calls and turn them into proper JavaScript `Error`s.

Previously however instead of returning the request object it created it
was returning `undefined`. `wpcom.js` is supposed to return _either_ an
XHR object _or_ a promise for the request. In this case, any code
depending on the return value (XHR updloads, promise resolvers, etc...)
would throw a `TypeError` because `undefined` has no properties.

Now the code _returns_ the augmented request object instead of merely
_calling_ it.

**Testing**

Open the live branch or the local branch and navigate as described in #13791 

```
My Sites > Plans > Themes > Sharing
```

In **master** it should throw in the console with a message about `xhr.onload`

In _this branch_ it shouldn't. Instead it should work as expected.

cc: @retrofox