### PR TITLE
Add/abtest plans copy updates - WIP

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -32,6 +32,14 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
+	signupPlansPageSimplification: {
+		datestamp: '20170504',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+	},
 	conciergeOfferOnCancel: {
 		datestamp: '20170410',
 		variations: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -9,6 +9,7 @@ import { compact, includes } from 'lodash';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import { abtest } from 'lib/abtest';
 
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
@@ -63,6 +64,9 @@ export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 export const FEATURE_REPUBLICIZE = 'republicize';
 export const FEATURE_REPUBLICIZE_SCHEDULING = 'republicize-scheduling';
+export const FEATURE_EVERYTHING_IN_FREE = 'everything-in-free';
+export const FEATURE_EVERYTHING_IN_PERSONAL = 'everything-in-personal';
+export const FEATURE_EVERYTHING_IN_PREMIUM = 'everything-in-premium';
 
 // jetpack features constants
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
@@ -105,16 +109,39 @@ export const PLANS_LIST = {
 		getProductId: () => 1,
 		getStoreSlug: () => PLAN_FREE,
 		getPathSlug: () => 'beginner',
-		getDescription: () => i18n.translate( 'Get a free website and be on your way to publishing your ' +
-			'first post in less than five minutes.' ),
-		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
-			FEATURE_WP_SUBDOMAIN,
-			FEATURE_JETPACK_ESSENTIAL,
-			FEATURE_COMMUNITY_SUPPORT,
-			FEATURE_FREE_THEMES,
-			FEATURE_BASIC_DESIGN,
-			FEATURE_3GB_STORAGE
-		],
+		getDescription: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return (
+					<span>
+						Try us for free and publish your
+						content in less than five minutes.
+					</span>
+				);
+			}
+
+			return i18n.translate( 'Get a free website and be on your way to publishing your ' +
+				'first post in less than five minutes.' );
+		},
+		getFeatures: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return [ // pay attention to ordering, it is used on /plan page
+					FEATURE_WP_SUBDOMAIN,
+					FEATURE_FREE_THEMES,
+					FEATURE_BASIC_DESIGN,
+					FEATURE_3GB_STORAGE,
+					FEATURE_COMMUNITY_SUPPORT,
+				];
+			}
+
+			return [ // pay attention to ordering, it is used on /plan page
+				FEATURE_WP_SUBDOMAIN,
+				FEATURE_JETPACK_ESSENTIAL,
+				FEATURE_COMMUNITY_SUPPORT,
+				FEATURE_FREE_THEMES,
+				FEATURE_BASIC_DESIGN,
+				FEATURE_3GB_STORAGE
+			];
+		},
 		getBillingTimeFrame: () => i18n.translate( 'for life' )
 	},
 
@@ -124,22 +151,44 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_FREE ], plan ),
 		getPathSlug: () => 'personal',
-		getDescription: () => i18n.translate( '{{strong}}Best for Personal Use:{{/strong}} Boost your' +
-			' website with a custom domain name, and remove all WordPress.com advertising. ' +
-			'Get access to high quality email and live chat support.', {
-				components: {
-					strong: <strong className="plans__features plan-features__targeted-description-heading" />
-				}
-			} ),
-		getFeatures: () => [
-			FEATURE_CUSTOM_DOMAIN,
-			FEATURE_JETPACK_ESSENTIAL,
-			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-			FEATURE_FREE_THEMES,
-			FEATURE_BASIC_DESIGN,
-			FEATURE_6GB_STORAGE,
-			FEATURE_NO_ADS
-		],
+		getDescription: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return (
+					<span>
+						Create a personal web presence and build your audience.
+					</span>
+				);
+			}
+
+			return i18n.translate( '{{strong}}Best for Personal Use:{{/strong}} Boost your' +
+					' website with a custom domain name, and remove all WordPress.com advertising. ' +
+					'Get access to high quality email and live chat support.', {
+						components: {
+							strong: <strong className="plans__features plan-features__targeted-description-heading" />
+						}
+					} );
+		},
+		getFeatures: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return [
+					FEATURE_EVERYTHING_IN_FREE,
+					FEATURE_CUSTOM_DOMAIN,
+					FEATURE_NO_ADS,
+					FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+					FEATURE_6GB_STORAGE,
+				];
+			}
+
+			return [
+				FEATURE_CUSTOM_DOMAIN,
+				FEATURE_JETPACK_ESSENTIAL,
+				FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+				FEATURE_FREE_THEMES,
+				FEATURE_BASIC_DESIGN,
+				FEATURE_6GB_STORAGE,
+				FEATURE_NO_ADS
+			];
+		},
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
 
@@ -150,26 +199,51 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'premium',
 		getStoreSlug: () => PLAN_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
-		getDescription: () => i18n.translate( '{{strong}}Best for Entrepreneurs & Freelancers:{{/strong}}' +
-			' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
-			' and the ability to monetize your site with ads.', {
-				components: {
-					strong: <strong className="plans__features plan-features__targeted-description-heading" />
-				}
-			} ),
-		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
-			FEATURE_CUSTOM_DOMAIN,
-			FEATURE_JETPACK_ESSENTIAL,
-			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-			FEATURE_UNLIMITED_PREMIUM_THEMES,
-			FEATURE_ADVANCED_DESIGN,
-			FEATURE_13GB_STORAGE,
-			FEATURE_NO_ADS,
-			FEATURE_WORDADS_INSTANT,
-			FEATURE_VIDEO_UPLOADS,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-		] ),
+		getDescription: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return (
+					<span>
+						Share your ideas with the world on a supercharged website.
+					</span>
+				);
+			}
+
+			return i18n.translate( '{{strong}}Best for Entrepreneurs & Freelancers:{{/strong}}' +
+					' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
+					' and the ability to monetize your site with ads.', {
+						components: {
+							strong: <strong className="plans__features plan-features__targeted-description-heading" />
+						}
+					} );
+		},
+		getFeatures: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return compact( [ // pay attention to ordering, shared features should align on /plan page
+					FEATURE_EVERYTHING_IN_PERSONAL,
+					FEATURE_UNLIMITED_PREMIUM_THEMES,
+					FEATURE_ADVANCED_DESIGN,
+					FEATURE_WORDADS_INSTANT,
+					FEATURE_VIDEO_UPLOADS,
+					isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+					isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
+					FEATURE_13GB_STORAGE,
+				] );
+			}
+
+			return compact( [ // pay attention to ordering, shared features should align on /plan page
+				FEATURE_CUSTOM_DOMAIN,
+				FEATURE_JETPACK_ESSENTIAL,
+				FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+				FEATURE_UNLIMITED_PREMIUM_THEMES,
+				FEATURE_ADVANCED_DESIGN,
+				FEATURE_13GB_STORAGE,
+				FEATURE_NO_ADS,
+				FEATURE_WORDADS_INSTANT,
+				FEATURE_VIDEO_UPLOADS,
+				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+				isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
+			] );
+		},
 		getPromotedFeatures: () => [
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_NO_ADS,
@@ -186,32 +260,58 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_BUSINESS,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
-		getDescription: () => i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
-			' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
-			' storage, and the ability to remove WordPress.com branding.', {
-				components: {
-					strong: <strong className="plans__features plan-features__targeted-description-heading" />
-				}
-			} ),
-		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
-			FEATURE_CUSTOM_DOMAIN,
-			FEATURE_JETPACK_ESSENTIAL,
-			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-			FEATURE_UNLIMITED_PREMIUM_THEMES,
-			FEATURE_ADVANCED_DESIGN,
-			FEATURE_UNLIMITED_STORAGE,
-			FEATURE_NO_ADS,
-			FEATURE_WORDADS_INSTANT,
-			FEATURE_VIDEO_UPLOADS,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
-			FEATURE_BUSINESS_ONBOARDING,
-			FEATURE_ADVANCED_SEO,
-			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_PLUGINS,
-			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_THEMES,
-			FEATURE_GOOGLE_ANALYTICS,
-			FEATURE_NO_BRANDING,
-		] ),
+		getDescription: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return (
+					<span>
+						Attract new customers with our most powerful plan.
+					</span>
+				);
+			}
+
+			return i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
+				' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
+				' storage, and the ability to remove WordPress.com branding.', {
+					components: {
+						strong: <strong className="plans__features plan-features__targeted-description-heading" />
+					}
+				} );
+		},
+		getFeatures: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return compact( [ // pay attention to ordering, shared features should align on /plan page
+					FEATURE_EVERYTHING_IN_PREMIUM,
+					FEATURE_UNLIMITED_STORAGE,
+					isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
+					FEATURE_BUSINESS_ONBOARDING,
+					FEATURE_ADVANCED_SEO,
+					isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_PLUGINS,
+					isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_THEMES,
+					FEATURE_GOOGLE_ANALYTICS,
+					FEATURE_NO_BRANDING,
+				] );
+			}
+
+			return compact( [ // pay attention to ordering, shared features should align on /plan page
+				FEATURE_CUSTOM_DOMAIN,
+				FEATURE_JETPACK_ESSENTIAL,
+				FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
+				FEATURE_UNLIMITED_PREMIUM_THEMES,
+				FEATURE_ADVANCED_DESIGN,
+				FEATURE_UNLIMITED_STORAGE,
+				FEATURE_NO_ADS,
+				FEATURE_WORDADS_INSTANT,
+				FEATURE_VIDEO_UPLOADS,
+				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+				isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
+				FEATURE_BUSINESS_ONBOARDING,
+				FEATURE_ADVANCED_SEO,
+				isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_PLUGINS,
+				isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_THEMES,
+				FEATURE_GOOGLE_ANALYTICS,
+				FEATURE_NO_BRANDING,
+			] );
+		},
 		getPromotedFeatures: () => [
 			FEATURE_UNLIMITED_STORAGE,
 			FEATURE_UNLIMITED_PREMIUM_THEMES,
@@ -413,6 +513,33 @@ export const PLANS_LIST = {
 };
 
 export const FEATURES_LIST = {
+	[ FEATURE_EVERYTHING_IN_FREE ]: {
+		getSlug: () => FEATURE_EVERYTHING_IN_FREE,
+		getTitle: () => 'Free Features',
+		getDescription: () => i18n.translate(
+			'Track website statistics with Google Analytics for a ' +
+			'deeper understanding of your website visitors and customers.'
+		)
+	},
+
+	[ FEATURE_EVERYTHING_IN_PERSONAL ]: {
+		getSlug: () => FEATURE_EVERYTHING_IN_PERSONAL,
+		getTitle: () => 'Personal Features',
+		getDescription: () => i18n.translate(
+			'Track website statistics with Google Analytics for a ' +
+			'deeper understanding of your website visitors and customers.'
+		)
+	},
+
+	[ FEATURE_EVERYTHING_IN_PREMIUM ]: {
+		getSlug: () => FEATURE_EVERYTHING_IN_PREMIUM,
+		getTitle: () => 'Premium Features',
+		getDescription: () => i18n.translate(
+			'Track website statistics with Google Analytics for a ' +
+			'deeper understanding of your website visitors and customers.'
+		)
+	},
+
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getSlug: () => FEATURE_GOOGLE_ANALYTICS,
 		getTitle: () => i18n.translate( 'Google Analytics Integration' ),
@@ -438,7 +565,13 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getSlug: () => FEATURE_CUSTOM_DOMAIN,
-		getTitle: () => i18n.translate( 'Custom Domain Name' ),
+		getTitle: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return 'Custom web address';
+			}
+
+			return i18n.translate( 'Custom Domain Name' );
+		},		
 		getDescription: ( abtest, domainName ) => {
 			if ( domainName ) {
 				return i18n.translate(
@@ -446,6 +579,10 @@ export const FEATURES_LIST = {
 						args: domainName
 					}
 				);
+			}
+
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return 'Get a free custom web address (eg: yourname.com) to use for your website.';
 			}
 
 			return i18n.translate(
@@ -466,11 +603,21 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
 		getSlug: () => FEATURE_UNLIMITED_PREMIUM_THEMES,
-		getTitle: () => i18n.translate( '{{strong}}Unlimited{{/strong}} Premium Themes', {
-			components: {
-				strong: <strong />
+		getTitle: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return (
+					<span>
+						<strong>Free</strong> Premium Themes
+					</span>
+				);
 			}
-		} ),
+
+			return i18n.translate( '{{strong}}Unlimited{{/strong}} Premium Themes', {
+				components: {
+					strong: <strong />
+				}
+			} );
+		},
 		getDescription: () => i18n.translate(
 			'Unlimited access to all of our advanced premium theme templates, ' +
 			'including templates specifically tailored for businesses.'
@@ -480,7 +627,13 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_VIDEO_UPLOADS ]: {
 		getSlug: () => FEATURE_VIDEO_UPLOADS,
-		getTitle: () => i18n.translate( 'VideoPress Support' ),
+		getTitle: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return 'Upload videos';
+			}
+
+			return i18n.translate( 'VideoPress Support' );
+		},
 		getDescription: () => i18n.translate(
 			'The easiest way to upload videos to your website and display them ' +
 			'using a fast, unbranded, customizable player with rich stats.'
@@ -521,7 +674,13 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_BASIC_DESIGN ]: {
 		getSlug: () => FEATURE_BASIC_DESIGN,
-		getTitle: () => i18n.translate( 'Basic Design Customization' ),
+		getTitle: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return 'Basic Customization';
+			}
+
+			return i18n.translate( 'Basic Design Customization' );
+		},
 		getDescription: () => i18n.translate(
 			'Customize your selected theme template with pre-set color schemes, ' +
 			'background designs, and font styles.'
@@ -531,11 +690,21 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_ADVANCED_DESIGN ]: {
 		getSlug: () => FEATURE_ADVANCED_DESIGN,
-		getTitle: () => i18n.translate( '{{strong}}Advanced{{/strong}} Design Customization', {
-			components: {
-				strong: <strong />
+		getTitle: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return (
+					<span>
+						<strong>Advanced</strong> Customization
+					</span>
+				);
 			}
-		} ),
+
+			return i18n.translate( '{{strong}}Advanced{{/strong}} Design Customization', {
+				components: {
+					strong: <strong />
+				}
+			} );
+		},
 		getDescription: () => i18n.translate(
 			'Customize your selected theme template with extended color schemes, ' +
 			'background designs, and complete control over website CSS.'
@@ -545,7 +714,13 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_NO_ADS ]: {
 		getSlug: () => FEATURE_NO_ADS,
-		getTitle: () => i18n.translate( 'Remove WordPress.com Ads' ),
+		getTitle: () => {
+			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+				return 'No WordPress.com Ads';
+			}
+
+			return i18n.translate( 'Remove WordPress.com Ads' );
+		},
 		getDescription: () => i18n.translate(
 			'Allow your visitors to visit and read your website without ' +
 			'seeing any WordPress.com advertising.'

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -9,7 +9,6 @@ import { compact, includes } from 'lodash';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import { abtest } from 'lib/abtest';
 
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
@@ -64,9 +63,17 @@ export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 export const FEATURE_REPUBLICIZE = 'republicize';
 export const FEATURE_REPUBLICIZE_SCHEDULING = 'republicize-scheduling';
+
+//PLANS TEST CONSTANTS
 export const FEATURE_EVERYTHING_IN_FREE = 'everything-in-free';
 export const FEATURE_EVERYTHING_IN_PERSONAL = 'everything-in-personal';
 export const FEATURE_EVERYTHING_IN_PREMIUM = 'everything-in-premium';
+export const FEATURE_CUSTOM_DOMAIN_TEST = 'custom-domain-test';
+export const FEATURE_UNLIMITED_PREMIUM_THEMES_TEST = 'premium-themes-test';
+export const FEATURE_VIDEO_UPLOADS_TEST = 'video-upload-test';
+export const FEATURE_BASIC_DESIGN_TEST = 'basic-design-test';
+export const FEATURE_ADVANCED_DESIGN_TEST = 'advanced-design-test';
+export const FEATURE_NO_ADS_TEST = 'no-adverts-test';
 
 // jetpack features constants
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
@@ -109,8 +116,8 @@ export const PLANS_LIST = {
 		getProductId: () => 1,
 		getStoreSlug: () => PLAN_FREE,
 		getPathSlug: () => 'beginner',
-		getDescription: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getDescription: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return (
 					<span>
 						Try us for free and publish your
@@ -122,12 +129,12 @@ export const PLANS_LIST = {
 			return i18n.translate( 'Get a free website and be on your way to publishing your ' +
 				'first post in less than five minutes.' );
 		},
-		getFeatures: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getFeatures: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return [ // pay attention to ordering, it is used on /plan page
 					FEATURE_WP_SUBDOMAIN,
 					FEATURE_FREE_THEMES,
-					FEATURE_BASIC_DESIGN,
+					FEATURE_BASIC_DESIGN_TEST,
 					FEATURE_3GB_STORAGE,
 					FEATURE_COMMUNITY_SUPPORT,
 				];
@@ -151,8 +158,8 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_FREE ], plan ),
 		getPathSlug: () => 'personal',
-		getDescription: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getDescription: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return (
 					<span>
 						Create a personal web presence and build your audience.
@@ -168,12 +175,12 @@ export const PLANS_LIST = {
 						}
 					} );
 		},
-		getFeatures: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getFeatures: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return [
 					FEATURE_EVERYTHING_IN_FREE,
-					FEATURE_CUSTOM_DOMAIN,
-					FEATURE_NO_ADS,
+					FEATURE_CUSTOM_DOMAIN_TEST,
+					FEATURE_NO_ADS_TEST,
 					FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 					FEATURE_6GB_STORAGE,
 				];
@@ -199,8 +206,8 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'premium',
 		getStoreSlug: () => PLAN_PREMIUM,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL ], plan ),
-		getDescription: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getDescription: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return (
 					<span>
 						Share your ideas with the world on a supercharged website.
@@ -216,14 +223,14 @@ export const PLANS_LIST = {
 						}
 					} );
 		},
-		getFeatures: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getFeatures: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return compact( [ // pay attention to ordering, shared features should align on /plan page
 					FEATURE_EVERYTHING_IN_PERSONAL,
-					FEATURE_UNLIMITED_PREMIUM_THEMES,
-					FEATURE_ADVANCED_DESIGN,
+					FEATURE_UNLIMITED_PREMIUM_THEMES_TEST,
+					FEATURE_ADVANCED_DESIGN_TEST,
 					FEATURE_WORDADS_INSTANT,
-					FEATURE_VIDEO_UPLOADS,
+					FEATURE_VIDEO_UPLOADS_TEST,
 					isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 					isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 					FEATURE_13GB_STORAGE,
@@ -260,8 +267,8 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_BUSINESS,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
-		getDescription: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getDescription: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return (
 					<span>
 						Attract new customers with our most powerful plan.
@@ -277,8 +284,8 @@ export const PLANS_LIST = {
 					}
 				} );
 		},
-		getFeatures: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
+		getFeatures: ( abtest ) => {
+			if ( abtest && abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
 				return compact( [ // pay attention to ordering, shared features should align on /plan page
 					FEATURE_EVERYTHING_IN_PREMIUM,
 					FEATURE_UNLIMITED_STORAGE,
@@ -513,6 +520,7 @@ export const PLANS_LIST = {
 };
 
 export const FEATURES_LIST = {
+	// Plans copy page test constants start
 	[ FEATURE_EVERYTHING_IN_FREE ]: {
 		getSlug: () => FEATURE_EVERYTHING_IN_FREE,
 		getTitle: () => 'Free Features',
@@ -540,6 +548,76 @@ export const FEATURES_LIST = {
 		)
 	},
 
+	[ FEATURE_CUSTOM_DOMAIN_TEST ]: {
+		getSlug: () => FEATURE_CUSTOM_DOMAIN_TEST,
+		getTitle: () => 'Custom web address',
+		getDescription: () => 'Get a free custom web address (eg: yourname.com) to use for your website.',
+	},
+
+	[ FEATURE_UNLIMITED_PREMIUM_THEMES_TEST ]: {
+		getSlug: () => FEATURE_UNLIMITED_PREMIUM_THEMES_TEST,
+		getTitle: () => {
+			return (
+				<span>
+					<strong>Free</strong> Premium Themes
+				</span>
+			);
+		},
+		getDescription: () => i18n.translate(
+			'Unlimited access to all of our advanced premium theme templates, ' +
+			'including templates specifically tailored for businesses.'
+		),
+		getStoreSlug: () => 'unlimited_themes'
+	},
+
+	[ FEATURE_VIDEO_UPLOADS_TEST ]: {
+		getSlug: () => FEATURE_VIDEO_UPLOADS_TEST,
+		getTitle: () => 'Upload videos',
+		getDescription: () => i18n.translate(
+			'The easiest way to upload videos to your website and display them ' +
+			'using a fast, unbranded, customizable player with rich stats.'
+		),
+		getStoreSlug: () => 'videopress'
+	},
+
+	[ FEATURE_BASIC_DESIGN_TEST ]: {
+		getSlug: () => FEATURE_BASIC_DESIGN_TEST,
+		getTitle: () => 'Basic Customization',
+		getDescription: () => i18n.translate(
+			'Customize your selected theme template with pre-set color schemes, ' +
+			'background designs, and font styles.'
+		),
+		getStoreSlug: () => FEATURE_ADVANCED_DESIGN
+	},
+
+	[ FEATURE_ADVANCED_DESIGN_TEST ]: {
+		getSlug: () => FEATURE_ADVANCED_DESIGN_TEST,
+		getTitle: () => {
+			return (
+				<span>
+					<strong>Advanced</strong> Customization
+				</span>
+			);
+		},
+		getDescription: () => i18n.translate(
+			'Customize your selected theme template with extended color schemes, ' +
+			'background designs, and complete control over website CSS.'
+		),
+		getStoreSlug: () => FEATURE_ADVANCED_DESIGN
+	},
+
+	[ FEATURE_NO_ADS_TEST ]: {
+		getSlug: () => FEATURE_NO_ADS_TEST,
+		getTitle: () => 'No WordPress.com Ads',
+		getDescription: () => i18n.translate(
+			'Allow your visitors to visit and read your website without ' +
+			'seeing any WordPress.com advertising.'
+		),
+		getStoreSlug: () => 'no-adverts/no-adverts.php'
+	},
+
+	// Plans copy page test constants End
+
 	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getSlug: () => FEATURE_GOOGLE_ANALYTICS,
 		getTitle: () => i18n.translate( 'Google Analytics Integration' ),
@@ -565,13 +643,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getSlug: () => FEATURE_CUSTOM_DOMAIN,
-		getTitle: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
-				return 'Custom web address';
-			}
-
-			return i18n.translate( 'Custom Domain Name' );
-		},		
+		getTitle: () => i18n.translate( 'Custom Domain Name' ),
 		getDescription: ( abtest, domainName ) => {
 			if ( domainName ) {
 				return i18n.translate(
@@ -579,10 +651,6 @@ export const FEATURES_LIST = {
 						args: domainName
 					}
 				);
-			}
-
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
-				return 'Get a free custom web address (eg: yourname.com) to use for your website.';
 			}
 
 			return i18n.translate(
@@ -603,21 +671,11 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
 		getSlug: () => FEATURE_UNLIMITED_PREMIUM_THEMES,
-		getTitle: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
-				return (
-					<span>
-						<strong>Free</strong> Premium Themes
-					</span>
-				);
+		getTitle: () => i18n.translate( '{{strong}}Unlimited{{/strong}} Premium Themes', {
+			components: {
+				strong: <strong />
 			}
-
-			return i18n.translate( '{{strong}}Unlimited{{/strong}} Premium Themes', {
-				components: {
-					strong: <strong />
-				}
-			} );
-		},
+		} ),
 		getDescription: () => i18n.translate(
 			'Unlimited access to all of our advanced premium theme templates, ' +
 			'including templates specifically tailored for businesses.'
@@ -627,13 +685,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_VIDEO_UPLOADS ]: {
 		getSlug: () => FEATURE_VIDEO_UPLOADS,
-		getTitle: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
-				return 'Upload videos';
-			}
-
-			return i18n.translate( 'VideoPress Support' );
-		},
+		getTitle: () => i18n.translate( 'VideoPress Support' ),
 		getDescription: () => i18n.translate(
 			'The easiest way to upload videos to your website and display them ' +
 			'using a fast, unbranded, customizable player with rich stats.'
@@ -674,13 +726,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_BASIC_DESIGN ]: {
 		getSlug: () => FEATURE_BASIC_DESIGN,
-		getTitle: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
-				return 'Basic Customization';
-			}
-
-			return i18n.translate( 'Basic Design Customization' );
-		},
+		getTitle: () => i18n.translate( 'Basic Design Customization' ),
 		getDescription: () => i18n.translate(
 			'Customize your selected theme template with pre-set color schemes, ' +
 			'background designs, and font styles.'
@@ -690,21 +736,11 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_ADVANCED_DESIGN ]: {
 		getSlug: () => FEATURE_ADVANCED_DESIGN,
-		getTitle: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
-				return (
-					<span>
-						<strong>Advanced</strong> Customization
-					</span>
-				);
+		getTitle: () => i18n.translate( '{{strong}}Advanced{{/strong}} Design Customization', {
+			components: {
+				strong: <strong />
 			}
-
-			return i18n.translate( '{{strong}}Advanced{{/strong}} Design Customization', {
-				components: {
-					strong: <strong />
-				}
-			} );
-		},
+		} ),
 		getDescription: () => i18n.translate(
 			'Customize your selected theme template with extended color schemes, ' +
 			'background designs, and complete control over website CSS.'
@@ -714,13 +750,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_NO_ADS ]: {
 		getSlug: () => FEATURE_NO_ADS,
-		getTitle: () => {
-			if ( abtest( 'signupPlansPageSimplification' ) === 'modified' ) {
-				return 'No WordPress.com Ads';
-			}
-
-			return i18n.translate( 'Remove WordPress.com Ads' );
-		},
+		getTitle: () => i18n.translate( 'Remove WordPress.com Ads' ),
 		getDescription: () => i18n.translate(
 			'Allow your visitors to visit and read your website without ' +
 			'seeing any WordPress.com advertising.'

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -48,8 +48,21 @@ import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { retargetViewPlans } from 'lib/analytics/ad-tracking';
 import { abtest } from 'lib/abtest';
+import Button from 'components/button'; //For signupPlansPageSimplification
 
 class PlanFeatures extends Component {
+	constructor( props ) {
+		super( props );
+		this.handleShowFeatureButtonClick = this.handleShowFeatureButtonClick.bind( this );
+		this.state = {
+			showFeatures: true,
+		};
+	}
+
+	toggleClass() {
+		const currentState = this.state.showFeatures;
+		this.setState( { showFeatures: ! currentState } );
+	}
 
 	render() {
 		const { planProperties } = this.props;
@@ -81,9 +94,44 @@ class PlanFeatures extends Component {
 							</tr>
 						</tbody>
 					</table>
+					{ this.renderShowFeaturesButton() }
 				</div>
 			</div>
 		);
+	}
+
+	renderShowFeaturesButton() {
+		if ( abtest( 'signupPlansPageSimplification' ) !== 'modified' ) {
+			return null;
+		}
+
+		const buttonClass = 'is-borderless';
+		const featuresHiddenClass = classNames( {
+			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.showFeatures,
+		} );
+
+		const featuresVisibleClass = classNames( {
+			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && ! this.state.showFeatures,
+		} );
+
+		return (
+			<div className={ 'plan-features__toggle-container' }>
+				<Button
+					className={ buttonClass }
+					onClick={ this.handleShowFeatureButtonClick }>
+					<span className={ featuresVisibleClass }>
+						Show features
+					</span>
+					<span className={ featuresHiddenClass }>
+						Hide features
+					</span>
+				</Button>
+			</div>
+		);
+	}
+
+	handleShowFeatureButtonClick() {
+		this.toggleClass();
 	}
 
 	renderUpgradeDisabledNotice() {
@@ -320,9 +368,13 @@ class PlanFeatures extends Component {
 
 	renderPlanFeatureRows() {
 		const longestFeatures = this.getLongestFeaturesList();
+		const classes = classNames( 'plan-features__row', {
+			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.showFeatures,
+		} );
+
 		return map( longestFeatures, ( featureKey, rowIndex ) => {
 			return (
-				<tr key={ rowIndex } className="plan-features__row">
+				<tr key={ rowIndex } className={ classes }>
 					{ this.renderPlanFeatureColumns( rowIndex ) }
 				</tr>
 			);
@@ -395,7 +447,9 @@ class PlanFeatures extends Component {
 			const classes = classNames(
 				'plan-features__table-item',
 				'has-border-bottom',
-				'is-bottom-buttons'
+				'is-bottom-buttons', {
+					'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.showFeatures,
+				}
 			);
 			return (
 				<td key={ planName } className={ classes }>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -55,13 +55,13 @@ class PlanFeatures extends Component {
 		super( props );
 		this.handleShowFeatureButtonClick = this.handleShowFeatureButtonClick.bind( this );
 		this.state = {
-			showFeatures: true,
+			hideFeatures: true,
 		};
 	}
 
 	toggleClass() {
-		const currentState = this.state.showFeatures;
-		this.setState( { showFeatures: ! currentState } );
+		const currentState = this.state.hideFeatures;
+		this.setState( { hideFeatures: ! currentState } );
 	}
 
 	render() {
@@ -94,7 +94,6 @@ class PlanFeatures extends Component {
 							</tr>
 						</tbody>
 					</table>
-					{ this.renderShowFeaturesButton() }
 				</div>
 			</div>
 		);
@@ -105,17 +104,21 @@ class PlanFeatures extends Component {
 			return null;
 		}
 
-		const buttonClass = 'is-borderless';
+		const showClass = abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.hideFeatures;
+
+		const buttonClass = 'is-borderless btn-toggle-features';
+		const containerClass = classNames( 'toggle-container' );
+
 		const featuresHiddenClass = classNames( {
-			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.showFeatures,
+			'plan-features__hide': showClass,
 		} );
 
 		const featuresVisibleClass = classNames( {
-			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && ! this.state.showFeatures,
+			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && ! this.state.hideFeatures,
 		} );
 
 		return (
-			<div className={ 'plan-features__toggle-container' }>
+			<div className={ containerClass }>
 				<Button
 					className={ buttonClass }
 					onClick={ this.handleShowFeatureButtonClick }>
@@ -296,6 +299,10 @@ class PlanFeatures extends Component {
 				'is-placeholder': isPlaceholder
 			} );
 
+			const descriptionClass = classNames('plan-features__description', {
+				'plan-features__description--test': abtest( 'signupPlansPageSimplification' ) === 'modified'
+			});
+
 			return (
 				<td key={ planName } className={ classes }>
 					{
@@ -304,7 +311,7 @@ class PlanFeatures extends Component {
 							: null
 					}
 
-					<p className="plan-features__description">
+					<p className={ descriptionClass }>
 						{ planConstantObj.getDescription( abtest ) }
 					</p>
 				</td>
@@ -350,6 +357,7 @@ class PlanFeatures extends Component {
 						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
+					{ this.renderShowFeaturesButton() }
 				</td>
 			);
 		} );
@@ -369,7 +377,7 @@ class PlanFeatures extends Component {
 	renderPlanFeatureRows() {
 		const longestFeatures = this.getLongestFeaturesList();
 		const classes = classNames( 'plan-features__row', {
-			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.showFeatures,
+			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.hideFeatures,
 		} );
 
 		return map( longestFeatures, ( featureKey, rowIndex ) => {
@@ -448,7 +456,7 @@ class PlanFeatures extends Component {
 				'plan-features__table-item',
 				'has-border-bottom',
 				'is-bottom-buttons', {
-					'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.showFeatures,
+					'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.hideFeatures,
 				}
 			);
 			return (

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -51,18 +51,30 @@ import { abtest } from 'lib/abtest';
 import Button from 'components/button'; //For signupPlansPageSimplification
 
 class PlanFeatures extends Component {
-	constructor( props ) {
-		super( props );
-		this.handleShowFeatureButtonClick = this.handleShowFeatureButtonClick.bind( this );
-		this.state = {
-			hideFeatures: true,
-		};
+	static propTypes = {
+		canPurchase: PropTypes.bool.isRequired,
+		onUpgradeClick: PropTypes.func,
+		// either you specify the plans prop or isPlaceholder prop
+		plans: PropTypes.array,
+		planProperties: PropTypes.array,
+		isInSignup: PropTypes.bool,
+		basePlansPath: PropTypes.string,
+		selectedFeature: PropTypes.string,
+		intervalType: PropTypes.string,
+		site: PropTypes.object
 	}
 
-	toggleClass() {
-		const currentState = this.state.hideFeatures;
-		this.setState( { hideFeatures: ! currentState } );
+	static defaultProps = {
+		onUpgradeClick: noop,
+		isInSignup: false,
+		basePlansPath: null,
+		intervalType: 'yearly',
+		site: {}
 	}
+
+	state = {
+		hideFeatures: true,
+	};
 
 	render() {
 		const { planProperties } = this.props;
@@ -99,45 +111,7 @@ class PlanFeatures extends Component {
 		);
 	}
 
-	renderShowFeaturesButton() {
-		if ( abtest( 'signupPlansPageSimplification' ) !== 'modified' ) {
-			return null;
-		}
-
-		const showClass = abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.hideFeatures;
-
-		const buttonClass = 'is-borderless btn-toggle-features';
-		const containerClass = classNames( 'toggle-container' );
-
-		const featuresHiddenClass = classNames( {
-			'plan-features__hide': showClass,
-		} );
-
-		const featuresVisibleClass = classNames( {
-			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && ! this.state.hideFeatures,
-		} );
-
-		return (
-			<div className={ containerClass }>
-				<Button
-					className={ buttonClass }
-					onClick={ this.handleShowFeatureButtonClick }>
-					<span className={ featuresVisibleClass }>
-						Show features
-					</span>
-					<span className={ featuresHiddenClass }>
-						Hide features
-					</span>
-				</Button>
-			</div>
-		);
-	}
-
-	handleShowFeatureButtonClick() {
-		this.toggleClass();
-	}
-
-	renderUpgradeDisabledNotice() {
+	renderUpgradeDisabledNotice = () => {
 		const { canPurchase, hasPlaceholders, translate } = this.props;
 
 		if ( hasPlaceholders || canPurchase ) {
@@ -154,7 +128,7 @@ class PlanFeatures extends Component {
 		);
 	}
 
-	renderMobileView() {
+	renderMobileView = () => {
 		const {
 			canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
 		} = this.props;
@@ -237,13 +211,13 @@ class PlanFeatures extends Component {
 		} );
 	}
 
-	renderMobileFeatures( features ) {
+	renderMobileFeatures = ( features ) => {
 		return map( features, ( currentFeature, index ) => {
 			return this.renderFeatureItem( currentFeature, index );
 		} );
 	}
 
-	renderPlanHeaders() {
+	renderPlanHeaders = () => {
 		const { planProperties, intervalType, site, basePlansPath } = this.props;
 
 		return map( planProperties, ( properties ) => {
@@ -285,7 +259,7 @@ class PlanFeatures extends Component {
 		} );
 	}
 
-	renderPlanDescriptions() {
+	renderPlanDescriptions = () => {
 		const { planProperties } = this.props;
 
 		return map( planProperties, ( properties ) => {
@@ -319,7 +293,7 @@ class PlanFeatures extends Component {
 		} );
 	}
 
-	renderTopButtons() {
+	renderTopButtons = () => {
 		const { canPurchase, isLandingPage, planProperties, isInSignup, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
@@ -363,7 +337,44 @@ class PlanFeatures extends Component {
 		} );
 	}
 
-	getLongestFeaturesList() {
+	renderShowFeaturesButton = () => {
+		if ( abtest( 'signupPlansPageSimplification' ) !== 'modified' ) {
+			return null;
+		}
+
+		const buttonClass = 'is-borderless btn-toggle-features';
+		const containerClass = classNames( 'toggle-container' );
+
+		const featuresHiddenClass = classNames( {
+			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.hideFeatures,
+		} );
+
+		const featuresVisibleClass = classNames( {
+			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && ! this.state.hideFeatures,
+		} );
+
+		return (
+			<div className={ containerClass }>
+				<Button
+					className={ buttonClass }
+					onClick={ this.handleShowFeatureButtonClick }>
+					<span className={ featuresVisibleClass }>
+						Show features
+					</span>
+					<span className={ featuresHiddenClass }>
+						Hide features
+					</span>
+				</Button>
+			</div>
+		);
+	}
+
+	handleShowFeatureButtonClick = () => {
+		const currentState = this.state.hideFeatures;
+		this.setState( { hideFeatures: ! currentState } );
+	}
+
+	getLongestFeaturesList = () => {
 		const { planProperties } = this.props;
 
 		return reduce( planProperties, ( longest, properties ) => {
@@ -374,7 +385,7 @@ class PlanFeatures extends Component {
 		}, [] );
 	}
 
-	renderPlanFeatureRows() {
+	renderPlanFeatureRows = () => {
 		const longestFeatures = this.getLongestFeaturesList();
 		const classes = classNames( 'plan-features__row', {
 			'plan-features__hide': abtest( 'signupPlansPageSimplification' ) === 'modified' && this.state.hideFeatures,
@@ -389,7 +400,7 @@ class PlanFeatures extends Component {
 		} );
 	}
 
-	renderFeatureItem( feature, index ) {
+	renderFeatureItem = ( feature, index ) => {
 		const description = feature.getDescription
 					? feature.getDescription( abtest, this.props.domainName )
 					: null;
@@ -400,13 +411,13 @@ class PlanFeatures extends Component {
 				hideInfoPopover={ false }
 			>
 				<span className="plan-features__item-info">
-					<span className="plan-features__item-title">{ feature.getTitle() }</span>
+					<span className="plan-features__item-title">{ feature.getTitle( abtest ) }</span>
 				</span>
 			</PlanFeaturesItem>
 		);
 	}
 
-	renderPlanFeatureColumns( rowIndex ) {
+	renderPlanFeatureColumns = ( rowIndex ) => {
 		const {
 			planProperties,
 			selectedFeature
@@ -438,7 +449,7 @@ class PlanFeatures extends Component {
 		} );
 	}
 
-	renderBottomButtons() {
+	renderBottomButtons = () => {
 		const { canPurchase, planProperties, isInSignup, isLandingPage, site } = this.props;
 
 		return map( planProperties, ( properties ) => {
@@ -486,27 +497,6 @@ class PlanFeatures extends Component {
 		retargetViewPlans();
 	}
 }
-
-PlanFeatures.propTypes = {
-	canPurchase: PropTypes.bool.isRequired,
-	onUpgradeClick: PropTypes.func,
-	// either you specify the plans prop or isPlaceholder prop
-	plans: PropTypes.array,
-	planProperties: PropTypes.array,
-	isInSignup: PropTypes.bool,
-	basePlansPath: PropTypes.string,
-	selectedFeature: PropTypes.string,
-	intervalType: PropTypes.string,
-	site: PropTypes.object
-};
-
-PlanFeatures.defaultProps = {
-	onUpgradeClick: noop,
-	isInSignup: false,
-	basePlansPath: null,
-	intervalType: 'yearly',
-	site: {}
-};
 
 export default connect(
 	( state, ownProps ) => {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -427,3 +427,16 @@ $plan-features-sidebar-width: 272px;
 	display: inline-block;
 	margin-left: 10px;
  }
+
+/* For signupPlansPageSimplification a/b test */
+
+.plan-features__hide {
+	display: none;
+}
+
+.plan-features__toggle-container {
+	text-align: center;
+	margin-top: -0.5em;
+}
+
+/* End signupPlansPageSimplification a/b test */

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -430,13 +430,28 @@ $plan-features-sidebar-width: 272px;
 
 /* For signupPlansPageSimplification a/b test */
 
+.plan-features__description--test {
+	text-align: center;
+	margin-bottom: 24px;
+
+	strong {
+		display: block;
+		margin-bottom: 1em;
+	}
+}
+
 .plan-features__hide {
 	display: none;
 }
 
-.plan-features__toggle-container {
+.btn-toggle-features {
+	font-weight: normal;
+	font-size: 0.9em;
+}
+
+.toggle-container {
 	text-align: center;
-	margin-top: -0.5em;
+	margin-top: -20px;
 }
 
 /* End signupPlansPageSimplification a/b test */


### PR DESCRIPTION
I'd like to test some new copy on the plans page in signup. This PR is a work in progress. I've got the basic approach implemented but I'm still working on adding copy updates. 

The new design collapses the features and allows the user to toggle their visibility with a `Show features` button. This was done by binding the visibility to a variable in the state. There's also a lot of logic in the code to show different copy for the test. 

In order to see the variation, go through the signup flow till you reach the plans page (http://calypso.localhost:3000/start). Then make sure you have `signupPlansPageSimplification_20170504` set to `modified` in your local storage. 

@markryall can you take a look through the code and let me know if you have any feedback?