### PR TITLE
State: Add sites receive test case for JPC authorize

### DIFF
--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -23,6 +23,7 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 	JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
 	JETPACK_CONNECT_SSO_VALIDATION_ERROR,
+	SITES_RECEIVE,
 } from 'state/action-types';
 import useNock from 'test/helpers/use-nock';
 import useFakeDom from 'test/helpers/use-fake-dom';
@@ -256,6 +257,17 @@ describe( 'actions', () => {
 							plans_url: '/plans/example.com'
 						},
 						error: null
+					} );
+				} );
+			} );
+
+			it( 'should dispatch sites receive action when request completes', () => {
+				const { authorize } = actions;
+
+				return authorize( queryObject )( spy ).then( () => {
+					expect( spy ).to.have.been.calledWith( {
+						type: SITES_RECEIVE,
+						sites: [ client_id ]
 					} );
 				} );
 			} );


### PR DESCRIPTION
This PR adds a test for the `SITES_RECEIVE` action that the JPC `authorize` action creator dispatches (it was added in #13879).

To test:
* Checkout this branch
* Verify the JPC action tests pass:

```
npm run test-client client/state/jetpack-connect/test/actions.js
```