### PR TITLE
Extensions: WPSC - Remove use of HOC in FixConfig component

### DIFF
--- a/client/extensions/wp-super-cache/fix-config.jsx
+++ b/client/extensions/wp-super-cache/fix-config.jsx
@@ -11,23 +11,19 @@ import Button from 'components/button';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-const FixConfig = ( { translate } ) => {
-	return (
-		<div>
-			<SectionHeader label={ translate( 'Fix Configuration' ) } />
-			<Card>
-				<form>
-					<div>
-						<Button
-							compact
-							type="submit">
-							{ translate( 'Restore Default Configuration' ) }
-						</Button>
-					</div>
-				</form>
-			</Card>
-		</div>
-	);
-};
+const FixConfig = ( { translate } ) =>
+	<div>
+		<SectionHeader label={ translate( 'Fix Configuration' ) } />
+		<Card>
+			<form>
+				<div>
+					<Button
+						compact>
+						{ translate( 'Restore Default Configuration' ) }
+					</Button>
+				</div>
+			</form>
+		</Card>
+	</div>;
 
 export default localize( FixConfig );

--- a/client/extensions/wp-super-cache/fix-config.jsx
+++ b/client/extensions/wp-super-cache/fix-config.jsx
@@ -15,14 +15,9 @@ const FixConfig = ( { translate } ) =>
 	<div>
 		<SectionHeader label={ translate( 'Fix Configuration' ) } />
 		<Card>
-			<form>
-				<div>
-					<Button
-						compact>
-						{ translate( 'Restore Default Configuration' ) }
-					</Button>
-				</div>
-			</form>
+			<Button compact>
+				{ translate( 'Restore Default Configuration' ) }
+			</Button>
 		</Card>
 	</div>;
 

--- a/client/extensions/wp-super-cache/fix-config.jsx
+++ b/client/extensions/wp-super-cache/fix-config.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -9,7 +10,6 @@ import React from 'react';
 import Button from 'components/button';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-import WrapSettingsForm from './wrap-settings-form';
 
 const FixConfig = ( { translate } ) => {
 	return (
@@ -30,8 +30,4 @@ const FixConfig = ( { translate } ) => {
 	);
 };
 
-const getFormSettings = () => {
-	return {};
-};
-
-export default WrapSettingsForm( getFormSettings )( FixConfig );
+export default localize( FixConfig );


### PR DESCRIPTION
The `FixConfig` component doesn’t display or save any settings, so there's no need to wrap it in the `WrapSettingsForm` higher order component.