### PR TITLE
Reader: fix follow from feed-search + site-recs while on manage page

### DIFF
--- a/client/blocks/follow-button/redux.jsx
+++ b/client/blocks/follow-button/redux.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React, { Component } from 'react';
-import { noop } from 'lodash';
+import { noop, omitBy, isUndefined } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -18,16 +18,22 @@ class FollowButtonContainer extends Component {
 		iconSize: React.PropTypes.number,
 		onFollowToggle: React.PropTypes.func,
 		followLabel: React.PropTypes.string,
-		followingLabel: React.PropTypes.string
+		followingLabel: React.PropTypes.string,
+		feedId: React.PropTypes.number,
+		siteId: React.PropTypes.number,
 	}
 
 	static defaultProps = {
 		onFollowToggle: noop
 	}
-
 	handleFollowToggle = ( following ) => {
 		if ( following ) {
-			this.props.follow( this.props.siteUrl );
+			const followData = omitBy( {
+				feed_ID: this.props.feedId,
+				blog_ID: this.props.siteId,
+			}, isUndefined );
+
+			this.props.follow( this.props.siteUrl, followData );
 		} else {
 			this.props.unfollow( this.props.siteUrl );
 		}

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -98,7 +98,12 @@ function ReaderSubscriptionListItem( {
 			) }
 			</div>
 			<div className="reader-subscription-list-item__options">
-				<FollowButton siteUrl={ feedUrl } followSource={ followSource } />
+				<FollowButton
+					siteUrl={ feedUrl }
+					followSource={ followSource }
+					feedId={ feedId }
+					siteId={ siteId }
+				/>
 				{ isFollowing && ! isEmailBlocked && <EmailSettings siteId={ siteId } /> }
 			</div>
 		</div>


### PR DESCRIPTION
This PR seeks to address a bug that existed while on the `following/manage` page where following a site from either the site-recs or from feed searching (aka anything powered by the ReaderSubscriptionListItem) would trigger odd behavior in list of current subs. Essentially it wouldn't appear properly in your subscription list until a refresh.

This PR solves the problem by teaching follow buttons about `feed_ID` and `blog_ID`.

To Test:
1. load up the calypso.live branch and follow new sites from both site-recs and from feed searches. both should be instant and correct.