### PR TITLE
WooCommerce: Add Additional Details Form & Preview

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -88,7 +88,7 @@ class ProductFormAdditionalDetailsCard extends React.Component {
 					onChange={ this.updateNameHandler }
 				/>
 				<TokenField
-					placeholder={ translate( 'Comma separate these' ) }
+					placeholder={ translate( 'Cotton' ) }
 					value={ attribute.options }
 					name="values"
 					/* eslint-disable react/jsx-no-bind */
@@ -127,8 +127,9 @@ class ProductFormAdditionalDetailsCard extends React.Component {
 				onClick={ this.cardToggle }
 			>
 				<FormSettingExplanation>
-					{ translate( 'Display additional details in a formatted list. This will also allow customers ' +
-					'to filter your store to find the products they want based on the info you put here.' ) }
+					{ translate( 'Display additional details in a formatted list. ' +
+					'Examples when selling apparal include Material, Type, and Cut. ' +
+					'This will also allow customers to filter your store to find Women cut Hoodies in Cotton.' ) }
 				</FormSettingExplanation>
 
 				<div className="products__additional-details-container">
@@ -142,7 +143,7 @@ class ProductFormAdditionalDetailsCard extends React.Component {
 							{inputs}
 						</div>
 
-						<Button onClick={ this.addType }>{ translate( 'Add another' ) }</Button>
+						<Button compact onClick={ this.addType }>{ translate( 'Add another' ) }</Button>
 					</div>
 
 					<div className="products__additional-details-preview-container">

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { find, debounce } from 'lodash';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -82,15 +83,14 @@ class ProductFormAdditionalDetailsCard extends React.Component {
 		editProductAttribute( product, attribute, { name } );
 	}
 
-	renderInput( attribute ) {
+	renderInput( attribute, index ) {
 		const { translate } = this.props;
 		const { attributeNames } = this.state;
 		const attributeName = attributeNames && attributeNames[ attribute.uid ] || attribute.name;
 		const updateValues = ( values ) => {
 			this.updateValues( values, attribute );
 		};
-		const attributes = this.getAttributes();
-		const removeButton = attributes && attributes.length > 1 && (
+		const removeButton = index !== 0 && (
 			<Button
 				borderless
 				onClick={ this.removeAttribute }
@@ -100,8 +100,13 @@ class ProductFormAdditionalDetailsCard extends React.Component {
 			</Button>
 		);
 
+		const classes = classNames( {
+			'products__additional-details-form-fieldset': true,
+			'products__additional-details-form-first-row': index === 0,
+		} );
+
 		return (
-			<div key={ attribute.uid } className="products__additional-details-form-fieldset">
+			<div key={ attribute.uid } className={ classes }>
 				<FormTextInput
 					placeholder={ translate( 'Material' ) }
 					value={ attributeName }
@@ -115,7 +120,9 @@ class ProductFormAdditionalDetailsCard extends React.Component {
 					name="values"
 					onChange={ updateValues }
 				/>
-				{removeButton}
+				<div className="products__additional-details-form-remove">
+					{removeButton}
+				</div>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FoldableCard from 'components/foldable-card';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import TokenField from 'components/token-field';
+
+const ProductFormAdditionalDetailsCard = ( { product, translate, editProductAttribute } ) => {
+	const getAttributes = () => {
+		return product.attributes && product.attributes.filter( attribute => ! attribute.variation ) || [];
+	};
+
+	const addType = () => {
+		editProductAttribute( product, null, { name: '', options: [] } );
+	};
+
+	const cardToggle = () => {
+		const attributes = getAttributes();
+		if ( ! attributes.length ) {
+			addType();
+		}
+	};
+
+	const updateName = ( e ) => {
+		const attribute = product.attributes && find( product.attributes, function( a ) {
+			return a.uid === e.target.id;
+		} );
+		editProductAttribute( product, attribute, { name: e.target.value } );
+	};
+
+	const updateValues = ( values, attribute ) => {
+		editProductAttribute( product, attribute, { options: values } );
+	};
+
+	const renderInput = ( attribute ) => {
+		return (
+			<div key={ attribute.uid } className="products__additional-details-form-fieldset">
+				<FormTextInput
+					placeholder={ translate( 'Material' ) }
+					value={ attribute.name }
+					id={ attribute.uid }
+					name="type"
+					onChange={ updateName }
+				/>
+				<TokenField
+					placeholder={ translate( 'Comma separate these' ) }
+					value={ attribute.options }
+					name="values"
+					/* eslint-disable react/jsx-no-bind */
+					onChange={ values => updateValues( values, attribute ) }
+				/>
+			</div>
+		);
+	};
+
+	const renderPreview = ( attribute ) => {
+		if ( ! attribute.name && ! attribute.options.length ) {
+			return ( <div key={ attribute.uid }></div> );
+		}
+
+		return (
+			<div key={ attribute.uid } className="products__additional-details-preview-row">
+				<div className="products__additional-details-preview-type">{ attribute.name }</div>
+				<div>{ attribute.options.join( ', ' ) }</div>
+			</div>
+		);
+	};
+
+	const attributes = getAttributes();
+	const inputs = attributes && attributes.map( renderInput );
+	const previews = attributes && attributes.map( renderPreview );
+
+	return (
+		<FoldableCard
+			className="products__additional-details-card"
+			header={ translate( 'Add additional details' ) }
+			onClick={ cardToggle }
+		>
+			<FormSettingExplanation>
+				{ translate( 'Display additional details in a formatted list. This will also allow customers ' +
+				'to filter your store to find the products they want based on the info you put here.' ) }
+			</FormSettingExplanation>
+
+			<div className="products__additional-details-container">
+				<div className="products__additional-details-form-group">
+					<div className="products__additional-details-form-labels">
+						<FormLabel>{ translate( 'Type' ) }</FormLabel>
+						<FormLabel>{ translate( 'Value' ) }</FormLabel>
+					</div>
+
+					<div className="products__additional-details-form-inputs">
+						{inputs}
+					</div>
+
+					<Button onClick={ addType }>{ translate( 'Add another' ) }</Button>
+				</div>
+
+				<div className="products__additional-details-preview-container">
+					<span className="products__additional-details-preview-label">
+						{ translate( 'Preview' ) }
+					</span>
+
+					<div className="products__additional-details-preview">
+						<div className="products__additional-details-preview-title">
+							{ translate( 'Product details' ) }
+						</div>
+						{previews}
+					</div>
+				</div>
+			</div>
+		</FoldableCard>
+	);
+};
+
+ProductFormAdditionalDetailsCard.propTypes = {
+	product: PropTypes.object.isRequired,
+	editProductAttribute: PropTypes.func.isRequired,
+};
+
+export default localize( ProductFormAdditionalDetailsCard );

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -24,8 +24,8 @@ const ProductFormVariationsCard = ( {
 		if ( 'variable' !== product.type ) {
 			editProduct( product, { type: 'variable', dimensions: {} } );
 		} else {
-			// TODO: Don't clear out all attributes when implementing "additional details" (non variation attributes).
-			editProduct( product, { type: 'simple', attributes: null } );
+			const attributes = ( product.attributes && product.attributes.filter( attribute => ! attribute.variation ) ) || null;
+			editProduct( product, { type: 'simple', attributes } );
 		}
 	};
 

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import ProductFormAdditionalDetailsCard from './product-form-additional-details-card';
 import ProductFormCategoriesCard from './product-form-categories-card';
 import ProductFormDetailsCard from './product-form-details-card';
 import ProductFormVariationsCard from './product-form-variations-card';
@@ -43,7 +44,11 @@ export default class ProductForm extends Component {
 					productCategories={ productCategories }
 					editProduct={ editProduct }
 				/>
-
+				<ProductFormAdditionalDetailsCard
+					product={ product }
+					editProduct={ this.props.editProduct }
+					editProductAttribute={ this.props.editProductAttribute }
+				/>
 				<ProductFormVariationsCard
 					product={ product }
 					variations={ variations }

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -38,16 +38,15 @@ export default class ProductForm extends Component {
 					product={ product }
 					editProduct={ editProduct }
 				/>
-
-				<ProductFormCategoriesCard
-					product={ product }
-					productCategories={ productCategories }
-					editProduct={ editProduct }
-				/>
 				<ProductFormAdditionalDetailsCard
 					product={ product }
 					editProduct={ this.props.editProduct }
 					editProductAttribute={ this.props.editProductAttribute }
+				/>
+				<ProductFormCategoriesCard
+					product={ product }
+					productCategories={ productCategories }
+					editProduct={ editProduct }
 				/>
 				<ProductFormVariationsCard
 					product={ product }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -421,7 +421,4 @@
 		margin-right: 16px;
 	}
 
-	.button, .button:hover, .button:focus {
-		color: $gray-dark;
-	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -30,7 +30,7 @@
 .products__product-form-details-wrapper {
 	display: flex;
 	flex-direction: column;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( ">960px" ) {
 		flex-direction: row;
 	}
 }
@@ -39,7 +39,7 @@
 	background: $gray-light;
 	height: 200px;
 	margin-bottom: 16px;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( ">960px" ) {
 		margin-bottom: 0;
 	}
 }
@@ -47,7 +47,7 @@
 .products__product-form-details-images,
 .products__product-form-details-basic {
 	flex: 1;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( ">960px" ) {
 		margin-right: 32px;
 	}
 
@@ -319,7 +319,7 @@
 	label:first-child {
 		width: 37%;
 		padding-left: 16px;
-		@include breakpoint( '>660px' ) {
+		@include breakpoint( ">660px" ) {
 			width: 33%;
 		}
 
@@ -330,7 +330,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-wrap: wrap;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( ">660px" ) {
 		margin-top: 1em;
 		flex-direction: row;
 	}
@@ -339,7 +339,7 @@
 .products__additional-details-form-group {
 		width: 100%;
 		padding: 16px 0;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( ">660px" ) {
 		width: 60%;
 		margin-right: 1.5em;
 		padding: 0;
@@ -352,7 +352,7 @@
 	border: 1px solid lighten( $gray, 30% );
 	padding: 16px 16px 4px 16px;
 	margin-bottom: 8px;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( ">660px" ) {
 		margin-right: 24px;
 		margin-bottom: 16px;
 	}
@@ -360,7 +360,7 @@
 
 .products__additional-details-preview-container {
 	width: 100%;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( ">660px" ) {
 		width: 30%;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -420,5 +420,11 @@
 		width: 50%;
 		margin-right: 16px;
 	}
+}
 
+.products__additional-details-form-first-row {
+	.products__additional-details-form-remove {
+		width: 24px;
+		height: 24px;
+	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -317,10 +317,10 @@
 	display: flex;
 
 	label:first-child {
-		width: 37%;
+		width: 44%;
 		padding-left: 16px;
 		@include breakpoint( ">660px" ) {
-			width: 33%;
+			width: 42%;
 		}
 
 	}
@@ -355,6 +355,11 @@
 	@include breakpoint( ">660px" ) {
 		margin-right: 24px;
 		margin-bottom: 16px;
+	}
+
+	.form-setting-explanation {
+		padding: 10px;
+		padding-top: 0;
 	}
 }
 
@@ -403,10 +408,20 @@
 .products__additional-details-form-fieldset {
 	display: flex;
 	flex-direction: row;
+	align-items: center;
 	margin-bottom: 16px;
 
 	.form-text-input {
 		width: 40%;
 		margin-right: 24px;
+	}
+
+	.token-field {
+		width: 50%;
+		margin-right: 16px;
+	}
+
+	.button, .button:hover, .button:focus {
+		color: $gray-dark;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -307,6 +307,10 @@
 .products__additional-details-card {
 	margin-top: -1em;
 	border-top: 0;
+
+	&.is-expanded {
+		margin-bottom: 16px;
+	}
 }
 
 .products__additional-details-form-labels {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -295,3 +295,81 @@
 		margin-left: 8px;
 	}
 }
+
+.products__additional-details-card {
+	margin-top: -1em;
+	border-top: 0;
+}
+
+.products__additional-details-form-labels {
+	display: flex;
+
+	label:first-child {
+		width: 35%;
+	}
+}
+
+.products__additional-details-container {
+	margin-top: 1em;
+	display: flex;
+}
+
+.products__additional-details-form-group {
+	width: 60%;
+	margin-right: 1.5em;
+}
+
+.products__additional-details-form-inputs {
+	background: $gray-light;
+	padding: 5px;
+	border: 1px solid lighten( $gray, 30% );
+	border-radius: 4px;
+	margin-right: 1em;
+	margin-bottom: 1em;
+}
+
+.products__additional-details-preview-container {
+	width: 30%;
+}
+
+.products__additional-details-preview-label {
+	text-transform: uppercase;
+	font-size: 12px;
+}
+
+.products__additional-details-preview-title {
+	border-bottom: 1px solid lighten( $gray, 30% );
+	padding-bottom: 10px;
+	margin-bottom: 1em;
+}
+
+.products__additional-details-preview {
+	border: 1px solid lighten( $gray, 20% );
+	padding: 10px;
+}
+
+.products__additional-details-preview-row {
+	display: flex;
+	flex-direction: row;
+	border-bottom: 1px solid lighten( $gray, 30% );
+	padding-bottom: 10px;
+	margin-bottom: 1em;
+}
+
+.products__additional-details-preview-type {
+	width: 40%;
+	margin-right: 1em;
+	font-weight: bold;
+	overflow-wrap: break-word;
+}
+
+.products__additional-details-form-fieldset {
+	display: flex;
+	flex-direction: row;
+	margin-bottom: 1em;
+
+	.form-text-input {
+		width: 40%;
+		margin-right: 1.5em;
+	}
+}

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -6,9 +6,17 @@
 	margin-bottom: 5px;
 }
 
+.foldable-card.products__variation-card {
+	margin-bottom: 16px;
+}
+
 .foldable-card.products__variation-card .foldable-card__content {
 	padding: 0;
 	border: 0;
+}
+
+.foldable-card.products__variation-card .foldable-card__main {
+	flex: inherit;
 }
 
 .products__product-form-details-featured {
@@ -305,36 +313,58 @@
 	display: flex;
 
 	label:first-child {
-		width: 35%;
+		width: 37%;
+		padding-left: 16px;
+		@include breakpoint( ">660px" ) {
+			width: 33%;
+		}
+
 	}
 }
 
 .products__additional-details-container {
-	margin-top: 1em;
 	display: flex;
+	flex-direction: column;
+	flex-wrap: wrap;
+	@include breakpoint( ">660px" ) {
+		margin-top: 1em;
+		flex-direction: row;
+	}
 }
 
 .products__additional-details-form-group {
-	width: 60%;
-	margin-right: 1.5em;
+		width: 100%;
+		padding: 16px 0;
+	@include breakpoint( ">660px" ) {
+		width: 60%;
+		margin-right: 1.5em;
+		padding: 0;
+	}
 }
 
 .products__additional-details-form-inputs {
 	background: $gray-light;
-	padding: 5px;
+	padding: 8px;
 	border: 1px solid lighten( $gray, 30% );
-	border-radius: 4px;
-	margin-right: 1em;
-	margin-bottom: 1em;
+	padding: 16px 16px 4px 16px;
+	margin-bottom: 8px;
+	@include breakpoint( ">660px" ) {
+		margin-right: 24px;
+		margin-bottom: 16px;
+	}
 }
 
 .products__additional-details-preview-container {
-	width: 30%;
+	width: 100%;
+	@include breakpoint( ">660px" ) {
+		width: 30%;
+	}
 }
 
 .products__additional-details-preview-label {
 	text-transform: uppercase;
-	font-size: 12px;
+	font-size: 11px;
+	color: $gray;
 }
 
 .products__additional-details-preview-title {
@@ -345,7 +375,10 @@
 
 .products__additional-details-preview {
 	border: 1px solid lighten( $gray, 20% );
-	padding: 10px;
+	padding: 16px 16px 4px 16px;
+	margin-top: 2px;
+	font-size: 13px;
+	color: darken( $gray, 10% );
 }
 
 .products__additional-details-preview-row {
@@ -366,10 +399,10 @@
 .products__additional-details-form-fieldset {
 	display: flex;
 	flex-direction: row;
-	margin-bottom: 1em;
+	margin-bottom: 16px;
 
 	.form-text-input {
 		width: 40%;
-		margin-right: 1.5em;
+		margin-right: 24px;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -399,10 +399,14 @@
 }
 
 .products__additional-details-preview-type {
-	width: 40%;
+	width: 35%;
 	margin-right: 1em;
 	font-weight: bold;
 	overflow-wrap: break-word;
+
+	& + div {
+		width: 60%;
+	}
 }
 
 .products__additional-details-form-fieldset {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -330,7 +330,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-wrap: wrap;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( ">960px" ) {
 		margin-top: 1em;
 		flex-direction: row;
 	}
@@ -339,7 +339,7 @@
 .products__additional-details-form-group {
 		width: 100%;
 		padding: 16px 0;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( ">960px" ) {
 		width: 60%;
 		margin-right: 1.5em;
 		padding: 0;
@@ -352,7 +352,7 @@
 	border: 1px solid lighten( $gray, 30% );
 	padding: 16px 16px 4px 16px;
 	margin-bottom: 8px;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( ">960px" ) {
 		margin-right: 24px;
 		margin-bottom: 16px;
 	}
@@ -365,7 +365,7 @@
 
 .products__additional-details-preview-container {
 	width: 100%;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( ">960px" ) {
 		width: 30%;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -30,7 +30,7 @@
 .products__product-form-details-wrapper {
 	display: flex;
 	flex-direction: column;
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -39,7 +39,7 @@
 	background: $gray-light;
 	height: 200px;
 	margin-bottom: 16px;
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		margin-bottom: 0;
 	}
 }
@@ -47,7 +47,7 @@
 .products__product-form-details-images,
 .products__product-form-details-basic {
 	flex: 1;
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		margin-right: 32px;
 	}
 
@@ -319,7 +319,7 @@
 	label:first-child {
 		width: 37%;
 		padding-left: 16px;
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			width: 33%;
 		}
 
@@ -330,7 +330,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-wrap: wrap;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-top: 1em;
 		flex-direction: row;
 	}
@@ -339,7 +339,7 @@
 .products__additional-details-form-group {
 		width: 100%;
 		padding: 16px 0;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		width: 60%;
 		margin-right: 1.5em;
 		padding: 0;
@@ -352,7 +352,7 @@
 	border: 1px solid lighten( $gray, 30% );
 	padding: 16px 16px 4px 16px;
 	margin-bottom: 8px;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin-right: 24px;
 		margin-bottom: 16px;
 	}
@@ -360,7 +360,7 @@
 
 .products__additional-details-preview-container {
 	width: 100%;
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		width: 30%;
 	}
 }

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -32,7 +32,8 @@ export default class ProductVariationTypesForm extends Component {
 	componentWillMount() {
 		const { product } = this.props;
 
-		if ( ! product.attributes ) {
+		const attributes = ( product.attributes && product.attributes.filter( attribute => attribute.variation ) ) || [];
+		if ( ! attributes.length ) {
 			this.addType();
 		}
 


### PR DESCRIPTION
This adds an "additional details" card to the product form. This allows users to type in details about their product that are stored as (non-variable) product attributes. It includes a preview area for seeing how these would be displayed on the product page.

Closes #13652.

To test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Toggle the additional details card.
* Start typing in types and values, and see them display in the preview area to the right.

<img width="1086" alt="screen shot 2017-05-10 at 12 54 06 pm" src="https://cloud.githubusercontent.com/assets/689165/25920279/49c26b7a-3586-11e7-8b0a-52887df13560.png">

cc @kellychoffman @jameskoster this PR contains UI elements.
