### PR TITLE
WooCommerce: Sidebar animation

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -12,8 +12,18 @@
 	@import 'components/form-dimensions-input/style';
 }
 
-.store-sidebar__sidebar {
+@keyframes slideInFromLeft {
+	0% {
+		transform: translateX(-273px);
+	}
+	100% {
+		transform: translateX(0);
+	}
+}
+
+.sidebar.store-sidebar__sidebar {
 	display: block;
+	animation: 1s ease-out 0s 1 slideInFromLeft;
 
 	.store-sidebar__ground-control {
 		align-items: center;

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -23,7 +23,7 @@
 
 .sidebar.store-sidebar__sidebar {
 	display: block;
-	animation: 1s ease-out 0s 1 slideInFromLeft;
+	animation: 0.15s cubic-bezier(0.075, 0.82, 0.165, 1) 0s 1 slideInFromLeft;
 
 	.store-sidebar__ground-control {
 		align-items: center;


### PR DESCRIPTION
This addresses https://github.com/Automattic/wp-calypso/pull/13837#issuecomment-300624125.

To test: 

- Navigate to http://calypso.localhost:3000/store/{site}
- Confirm that sidebar sliiiiides in

@jameskoster: What do you think? We might have to wait until the Store menu item is implemented to really see how it feels. 