### PR TITLE
UrlPreview: Fix support of Jetpack sites in subdirectories, take 2

### DIFF
--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
 import { closePreview } from 'state/ui/preview/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getPreviewUrl } from 'state/ui/preview/selectors';
-import { getSiteOption } from 'state/sites/selectors';
+import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 
@@ -97,11 +97,12 @@ export default function urlPreview( WebPreview ) {
 
 	function mapStateToProps( state ) {
 		const selectedSiteId = getSelectedSiteId( state );
-		const selectedSite = getSelectedSite( state );
+		const siteUrl = 'https://' + getSiteSlug( state, selectedSiteId );
+
 		return {
-			selectedSite,
+			selectedSite: getSelectedSite( state ),
 			selectedSiteId,
-			selectedSiteUrl: selectedSite && selectedSite.URL,
+			selectedSiteUrl: siteUrl.replace( /::/g, '/' ),
 			selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
 			previewUrl: getPreviewUrl( state ),
 			isDomainOnlySite: isDomainOnlySite( state, selectedSiteId ),

--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -97,6 +97,7 @@ export default function urlPreview( WebPreview ) {
 
 	function mapStateToProps( state ) {
 		const selectedSiteId = getSelectedSiteId( state );
+		// Force https to prevent mixed content errors in the iframe
 		const siteUrl = 'https://' + getSiteSlug( state, selectedSiteId );
 
 		return {


### PR DESCRIPTION
Yesterday I fixed a bug with previewing Jetpack sites that are installed in subdirectories in #13805, but by doing so, I removed the https forcing that we were doing. This basically broke the preview for all sites that were mapped as http but support https as well. This PR reverts #13805 while taking care of the Jetpack subdirectory issue in an alternative way. FIxes #13913.

To test:
* Click on the "Site Preview" in the sidebar and verify it loads correctly for:
  * WP.com Site that is mapped with HTTP, but supports HTTPS and is previewable.
  * WP.com Site that is mapped with HTTPS and supports it
  * WP.com site with the default *.wordpress.com domain.
  * A Jetpack site, installed in the root.
  * A Jetpack site, installed in a subdirectory.
  * A Jetpack multisite, main site
  * A Jetpack multisite, subsite

cc @jerrysarcastic who caught and reported the issue in #13913