### PR TITLE
Site Settings: Cleanup old field values when switching site

### DIFF
--- a/client/lib/track-form/index.jsx
+++ b/client/lib/track-form/index.jsx
@@ -22,9 +22,10 @@ export const trackForm = WrappedComponent => class TrackFormComponent extends Co
 		this.setState( newState, callback );
 	};
 
-	replaceFields = ( fields, callback ) => {
+	replaceFields = ( fields, callback, keepOldFields = true ) => {
+		const oldFields = keepOldFields ? this.state.fields : {};
 		const newFields = {
-			...this.state.fields,
+			...oldFields,
 			...fields
 		};
 

--- a/client/lib/track-form/index.jsx
+++ b/client/lib/track-form/index.jsx
@@ -22,10 +22,10 @@ export const trackForm = WrappedComponent => class TrackFormComponent extends Co
 		this.setState( newState, callback );
 	};
 
-	replaceFields = ( fields, callback, keepOldFields = true ) => {
-		const oldFields = keepOldFields ? this.state.fields : {};
+	replaceFields = ( fields, callback, keepPrevFields = true ) => {
+		const prevFields = keepPrevFields ? this.state.fields : {};
 		const newFields = {
-			...oldFields,
+			...prevFields,
 			...fields
 		};
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -48,7 +48,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			if ( prevProps.siteId !== this.props.siteId ) {
 				this.props.clearDirtyFields();
 				const newSiteFields = getFormSettings( this.props.settings );
-				this.props.replaceFields( newSiteFields );
+				this.props.replaceFields( newSiteFields, undefined, false );
 			} else if (
 				! isEqual( prevProps.settings, this.props.settings ) ||
 				! isEqual( prevProps.fields, this.props.fields )


### PR DESCRIPTION
This PR fixes a nasty bug with settings being carried over when switching sites. 

To reproduce:
* Go to `http://calypso.localhost:3000/settings/writing/$site` where `$site` is one of your Jetpack sites.
* Load React Developer Tools.
* Click on the `<SiteSettingsFormWriting>` and explore its `fields` prop.
* Notice you have all of the AfterTheDeadline settings there (`Bias Language`, `Cliches`, etc.)
* Switch to a WordPress.com site.
* Click on the `<SiteSettingsFormWriting>` and explore its `fields` prop.
* Notice you still have all of the AfterTheDeadline settings there (`Bias Language`, `Cliches`, etc.), but they should not be there for a WP.com site 😱 

This PR fixes the issue by doing 2 things:

* Adding an option to the `replaceFields` utility to NOT keep the old fields.
* Using that new option to clean up the old fields when switching the site.

To test:

* Checkout this branch.
* Go through all test steps above.
* In the last step, verify you no longer see the ATD settings in the .com site `fields`.