### PR TITLE
Site Settings: Move Posts per Page to Writing section

### DIFF
--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -7,31 +7,31 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import AfterTheDeadline from './after-the-deadline';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import PostsPerPage from './posts-per-page';
-import DefaultPostFormat from './default-post-format';
-import AfterTheDeadline from './after-the-deadline';
 import DateTimeFormat from '../date-time-format';
+import DefaultPostFormat from './default-post-format';
+import PostsPerPage from './posts-per-page';
 import {
-	isJetpackSite,
 	isJetpackMinimumVersion,
+	isJetpackSite,
 	siteSupportsJetpackSettingsUi,
 } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 const Composing = ( {
-	fields,
-	handleToggle,
-	handleSelect,
-	onChangeField,
-	setFieldValue,
 	eventTracker,
-	uniqueEventTracker,
+	fields,
+	handleSelect,
+	handleToggle,
 	hasDateTimeFormats,
 	isRequestingSettings,
 	isSavingSettings,
 	jetpackSettingsUISupported,
+	onChangeField,
+	setFieldValue,
+	uniqueEventTracker,
 	updateFields,
 } ) => {
 	const CardComponent = jetpackSettingsUISupported ? CompactCard : Card;
@@ -40,30 +40,30 @@ const Composing = ( {
 		<div>
 			<CardComponent className="composing__card site-settings">
 				<PostsPerPage
-					onChangeField={ onChangeField }
 					eventTracker={ eventTracker }
-					uniqueEventTracker={ uniqueEventTracker }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					onChangeField={ onChangeField }
+					uniqueEventTracker={ uniqueEventTracker }
 				/>
 
 				<DefaultPostFormat
-					onChangeField={ onChangeField }
 					eventTracker={ eventTracker }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					onChangeField={ onChangeField }
 				/>
 			</CardComponent>
 
 			{ jetpackSettingsUISupported &&
 				<AfterTheDeadline
-					handleToggle={ handleToggle }
-					setFieldValue={ setFieldValue }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
+					handleToggle={ handleToggle }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					setFieldValue={ setFieldValue }
 				/>
 			}
 			{ hasDateTimeFormats &&
@@ -80,22 +80,22 @@ const Composing = ( {
 };
 
 Composing.defaultProps = {
-	isSavingSettings: false,
-	isRequestingSettings: true,
 	fields: {},
+	isRequestingSettings: true,
+	isSavingSettings: false,
 };
 
 Composing.propTypes = {
+	eventTracker: PropTypes.func.isRequired,
+	fields: PropTypes.object,
 	handleSelect: PropTypes.func.isRequired,
 	handleToggle: PropTypes.func.isRequired,
+	isRequestingSettings: PropTypes.bool,
+	isSavingSettings: PropTypes.bool,
 	onChangeField: PropTypes.func.isRequired,
 	setFieldValue: PropTypes.func.isRequired,
-	eventTracker: PropTypes.func.isRequired,
 	uniqueEventTracker: PropTypes.func.isRequired,
 	updateFields: PropTypes.func.isRequired,
-	isSavingSettings: PropTypes.bool,
-	isRequestingSettings: PropTypes.bool,
-	fields: PropTypes.object,
 };
 
 export default connect(
@@ -104,8 +104,8 @@ export default connect(
 		const siteIsJetpack = isJetpackSite( state, siteId );
 
 		return {
-			jetpackSettingsUISupported: siteIsJetpack && siteSupportsJetpackSettingsUi( state, siteId ),
 			hasDateTimeFormats: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.7' ),
+			jetpackSettingsUISupported: siteIsJetpack && siteSupportsJetpackSettingsUi( state, siteId ),
 		};
 	}
 )( Composing );

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
+import PostsPerPage from './posts-per-page';
 import DefaultPostFormat from './default-post-format';
 import AfterTheDeadline from './after-the-deadline';
 import DateTimeFormat from '../date-time-format';
@@ -26,6 +27,7 @@ const Composing = ( {
 	onChangeField,
 	setFieldValue,
 	eventTracker,
+	uniqueEventTracker,
 	hasDateTimeFormats,
 	isRequestingSettings,
 	isSavingSettings,
@@ -37,6 +39,15 @@ const Composing = ( {
 	return (
 		<div>
 			<CardComponent className="composing__card site-settings">
+				<PostsPerPage
+					onChangeField={ onChangeField }
+					eventTracker={ eventTracker }
+					uniqueEventTracker={ uniqueEventTracker }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+
 				<DefaultPostFormat
 					onChangeField={ onChangeField }
 					eventTracker={ eventTracker }
@@ -80,6 +91,7 @@ Composing.propTypes = {
 	onChangeField: PropTypes.func.isRequired,
 	setFieldValue: PropTypes.func.isRequired,
 	eventTracker: PropTypes.func.isRequired,
+	uniqueEventTracker: PropTypes.func.isRequired,
 	updateFields: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -82,7 +82,7 @@ const Composing = ( {
 Composing.defaultProps = {
 	isSavingSettings: false,
 	isRequestingSettings: true,
-	fields: {}
+	fields: {},
 };
 
 Composing.propTypes = {

--- a/client/my-sites/site-settings/composing/posts-per-page.jsx
+++ b/client/my-sites/site-settings/composing/posts-per-page.jsx
@@ -21,7 +21,7 @@ const PostsPerPage = ( {
 	isSavingSettings,
 	translate
 } ) => {
-	if ( 'undefined' === typeof fields.posts_per_page ) {
+	if ( ! fields.hasOwnProperty( 'posts_per_page' ) ) {
 		return null;
 	}
 

--- a/client/my-sites/site-settings/composing/posts-per-page.jsx
+++ b/client/my-sites/site-settings/composing/posts-per-page.jsx
@@ -8,18 +8,18 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
 import FormInput from 'components/forms/form-text-input';
+import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const PostsPerPage = ( {
-	fields,
-	onChangeField,
 	eventTracker,
-	uniqueEventTracker,
+	fields,
 	isRequestingSettings,
 	isSavingSettings,
-	translate
+	onChangeField,
+	translate,
+	uniqueEventTracker,
 } ) => {
 	if ( ! fields.hasOwnProperty( 'posts_per_page' ) ) {
 		return null;
@@ -48,18 +48,18 @@ const PostsPerPage = ( {
 };
 
 PostsPerPage.defaultProps = {
-	isSavingSettings: false,
+	fields: {},
 	isRequestingSettings: true,
-	fields: {}
+	isSavingSettings: false,
 };
 
 PostsPerPage.propTypes = {
-	onChangeField: PropTypes.func.isRequired,
 	eventTracker: PropTypes.func.isRequired,
-	uniqueEventTracker: PropTypes.func.isRequired,
-	isSavingSettings: PropTypes.bool,
-	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,
+	isRequestingSettings: PropTypes.bool,
+	isSavingSettings: PropTypes.bool,
+	onChangeField: PropTypes.func.isRequired,
+	uniqueEventTracker: PropTypes.func.isRequired,
 };
 
 export default localize( PostsPerPage );

--- a/client/my-sites/site-settings/composing/posts-per-page.jsx
+++ b/client/my-sites/site-settings/composing/posts-per-page.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormInput from 'components/forms/form-text-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const PostsPerPage = ( {
+	fields,
+	onChangeField,
+	eventTracker,
+	uniqueEventTracker,
+	isRequestingSettings,
+	isSavingSettings,
+	translate
+} ) => {
+	if ( 'undefined' === typeof fields.posts_per_page ) {
+		return null;
+	}
+
+	return (
+		<FormFieldset>
+			<FormLabel htmlFor="posts_per_page">{ translate( 'Posts Per Page' ) }</FormLabel>
+			<FormInput
+				name="posts_per_page"
+				type="number"
+				step="1"
+				min="1"
+				id="posts_per_page"
+				value={ fields.posts_per_page || 10 }
+				onChange={ onChangeField( 'posts_per_page' ) }
+				disabled={ isRequestingSettings || isSavingSettings }
+				onClick={ eventTracker( 'Clicked Posts Per Page Field' ) }
+				onKeyPress={ uniqueEventTracker( 'Typed in Posts Per Page Field' ) }
+			/>
+			<FormSettingExplanation>
+				{ translate( 'On blog pages, the number of posts to show per page.' ) }
+			</FormSettingExplanation>
+		</FormFieldset>
+	);
+};
+
+PostsPerPage.defaultProps = {
+	isSavingSettings: false,
+	isRequestingSettings: true,
+	fields: {}
+};
+
+PostsPerPage.propTypes = {
+	onChangeField: PropTypes.func.isRequired,
+	eventTracker: PropTypes.func.isRequired,
+	uniqueEventTracker: PropTypes.func.isRequired,
+	isSavingSettings: PropTypes.bool,
+	isRequestingSettings: PropTypes.bool,
+	fields: PropTypes.object,
+};
+
+export default localize( PostsPerPage );

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -329,35 +329,6 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	postsPerPageOption() {
-		const { eventTracker, fields, isRequestingSettings, onChangeField, translate, uniqueEventTracker } = this.props;
-		const showPostsPerPage = ( 'undefined' !== typeof fields.posts_per_page );
-
-		return showPostsPerPage && (
-			<FormFieldset className="site-settings__has-divider is-top-only">
-				<FormLabel htmlFor="posts_per_page">{ translate( 'Posts Per Page' ) }</FormLabel>
-				<ul>
-					<li>
-						<FormInput
-							name="posts_per_page"
-							type="number"
-							step="1"
-							min="1"
-							id="posts_per_page"
-							value={ fields.posts_per_page || 10 }
-							onChange={ onChangeField( 'posts_per_page' ) }
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Posts Per Page Field' ) }
-							onKeyPress={ uniqueEventTracker( 'Typed in Posts Per Page Field' ) } />
-							<FormSettingExplanation>
-								{ translate( 'On blog pages, the number of posts to show per page.' ) }
-							</FormSettingExplanation>
-					</li>
-				</ul>
-			</FormFieldset>
-		);
-	}
-
 	Timezone() {
 		const { fields, isRequestingSettings, siteIsJetpack, translate } = this.props;
 		if ( siteIsJetpack ) {
@@ -472,7 +443,6 @@ class SiteSettingsFormGeneral extends Component {
 						{ this.languageOptions() }
 						{ this.Timezone() }
 						{ this.holidaySnowOption() }
-						{ this.postsPerPageOption() }
 					</form>
 				</Card>
 
@@ -603,7 +573,6 @@ const getFormSettings = settings => {
 		jetpack_sync_non_public_post_stati: false,
 		holidaysnow: false,
 		api_cache: false,
-		posts_per_page: '',
 	};
 
 	if ( ! settings ) {
@@ -622,8 +591,6 @@ const getFormSettings = settings => {
 		holidaysnow: !! settings.holidaysnow,
 
 		api_cache: settings.api_cache,
-
-		posts_per_page: settings.posts_per_page,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -51,6 +51,7 @@ class SiteSettingsFormWriting extends Component {
 	render() {
 		const {
 			eventTracker,
+			uniqueEventTracker,
 			fields,
 			handleSelect,
 			handleToggle,
@@ -101,6 +102,7 @@ class SiteSettingsFormWriting extends Component {
 					onChangeField={ onChangeField }
 					setFieldValue={ setFieldValue }
 					eventTracker={ eventTracker }
+					uniqueEventTracker={ uniqueEventTracker }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
@@ -190,6 +192,7 @@ const connectComponent = connect(
 
 const getFormSettings = settings => {
 	const formSettings = pick( settings, [
+		'posts_per_page',
 		'default_post_format',
 		'custom-content-types',
 		'jetpack_testimonial',


### PR DESCRIPTION
This PR moves the newly added Posts per Page setting from the General to the Writing section. To achieve this:

* It moves the functionality to a separate `PostsPerPage` component.
* Embeds that component in the `Composing` card under the `Writing` section.
* Removes the old option from the General tab.

Fixes #13868. 

Before:
![](https://cldup.com/zvypMP4tu3.png)

After:
![](https://cldup.com/ebJmawDBwu.png)

There is currently a bug with old data persisting after switching sites, but this is being handled separately in #13915. **Update** This has been merged and the bug is corrected.

To test:
* Checkout this branch or get it going on calypso.live.
* Go to `/settings/writing/$site` and verify you see the new setting there for a WordPress.com site.
* Go to `/settings/writing/$site` and verify you don't see the new setting there for a Jetpack site (we don't sync that setting right now, see #7154 for details).
* Verify the setting works properly (stores and retrieves value correctly). 