### PR TITLE
Editor: fix editor basics tour

### DIFF
--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -21,7 +21,6 @@ import {
 	Link,
 } from 'layout/guided-tours/config-elements';
 import {
-	isEnabled,
 	isNewUser,
 } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
@@ -31,7 +30,7 @@ export const EditorBasicsTour = makeTour(
 		name="editorBasicsTour"
 		version="20170503"
 		path="/post/"
-		when={ and( isEnabled( 'guided-tours/editor-basics-tour' ), isDesktop, isNewUser ) }
+		when={ and( isDesktop, isNewUser ) }
 	>
 		<Step
 			name="init"

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -51,7 +51,7 @@ export const EditorBasicsTour = makeTour(
 		<Step
 			name="write"
 			arrow="top-left"
-			target=".mce-toolbar-grp.mce-container"
+			target=".editor-html-toolbar__buttons, .mce-toolbar-grp.mce-container"
 			placement="below"
 			style={ { marginTop: '40px' } }
 		>
@@ -70,7 +70,7 @@ export const EditorBasicsTour = makeTour(
 		<Step
 			name="add-image"
 			arrow="top-left"
-			target=".mce-wpcom-insert-menu button"
+			target=".editor-html-toolbar__button-insert-media, .mce-wpcom-insert-menu button"
 			placement="below"
 			style={ { marginLeft: '-10px', zIndex: 'auto' } }
 		>

--- a/config/development.json
+++ b/config/development.json
@@ -48,7 +48,6 @@
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,
-		"guided-tours/editor-basics-tour": true,
 		"help": true,
 		"help/courses": true,
 		"jetpack/invites": true,


### PR DESCRIPTION
The guided tour introduced in #12351 didn't work when the editor's HTML mode was active (see: #13735 and below). This PR fixes that. 

More specifically, steps 2 and 3 did not find their targets, as those are in the editor's toolbar and we switch out the whole editor when changing modes. This is what it looks like when it doesn't work:

![82532d54-3256-11e7-8322-03253ac2da20](https://cloud.githubusercontent.com/assets/23619/25941111/84da0e68-3638-11e7-9a13-5a083d15c1f7.jpg)

To test:

- go to `http://calypso.localhost:3000/post/SOME_SITE?tour=editorBasicsTour`
- make sure the editor is in "Visual" mode
- make sure the tour works as shown below
- reload the page
- make sure the editor is in "HTML" mode
- make sure the tour works as shown below

GIF of how the tour is supposed to work:

![editorbasicstour-v3](https://cloud.githubusercontent.com/assets/23619/25941002/36d2055e-3638-11e7-8f1a-ada702aebc7c.gif)
