### PR TITLE
[Login] Track login midflow in signup

### DIFF
--- a/client/components/forms/form-input-validation/index.jsx
+++ b/client/components/forms/form-input-validation/index.jsx
@@ -12,7 +12,7 @@ export default React.createClass( {
 	propTypes: {
 		isError: React.PropTypes.bool,
 		isWarning: React.PropTypes.bool,
-		text: React.PropTypes.string,
+		text: React.PropTypes.node,
 		icon: React.PropTypes.string
 	},
 

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { map, forEach, head, includes, keys } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
@@ -29,6 +30,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { mergeFormWithValue } from 'signup/utils';
 import SocialSignupForm from './social';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -292,7 +294,7 @@ class SignupForm extends Component {
 							{ message }&nbsp;
 							{ this.props.translate( 'If this is you {{a}}log in now{{/a}}.', {
 								components: {
-									a: <a href={ link } />
+									a: <a href={ link } onClick={ this.props.trackLoginMidFlow } />
 								}
 							} ) }
 						</p>
@@ -476,4 +478,9 @@ class SignupForm extends Component {
 	}
 }
 
-export default localize( SignupForm );
+export default connect(
+	null,
+	{
+		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' )
+	}
+)( localize( SignupForm ) );


### PR DESCRIPTION
This PR adds tracking to the link which is shown on the `user` step of every signup flows when the user enters an existing email address or username.
```
Choose a different email address. This one is not available. If this is you log in now.
```

This link redirects to the login page which should redirect back to the flow. However, because of a bug/missing feature the flow is not able to resume correctly as described in #10738.

### Testing Instructions
- Apply the patch locally and boot the server
- Use a private window and boot http://calypso.localhost:3000/start
- You should enter the main flow which has a `user` step at the end. Fill some data to get to it.
- Once you are on the user step, enter an email address for which you already have a WordPress.com account.
- The error message should appear.
- Open you dev tools, click on the network tab, check "Preserve logs" and click on the link
- You should be redirected to http://calypso.localhost:3000/login (plus some query string).
- Check the network requests, there should be one to http://pixel.wp.com/t.gif. Check that the event `calypso_signup_login_midflow` was sent to tracks as the `_en` query param.

### Reviews
- [x] Code
- [x] Product