### PR TITLE
Domains: fix contact form i18n

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -35,8 +35,26 @@ const wpcom = require( 'lib/wp' ).undocumented(),
 	countriesList = countriesListForDomainRegistrations();
 
 class DomainDetailsForm extends Component {
-	getInitialState() {
-		return {
+
+	constructor( props, context ) {
+		super( props, context );
+
+		this.fieldNames = [
+			'firstName',
+			'lastName',
+			'organization',
+			'email',
+			'phone',
+			'address1',
+			'address2',
+			'city',
+			'state',
+			'postalCode',
+			'countryCode',
+			'fax'
+		];
+
+		this.state = {
 			form: null,
 			isDialogVisible: false,
 			submissionCount: 0,
@@ -431,19 +449,5 @@ class DomainDetailsForm extends Component {
 }
 
 DomainDetailsForm.displayName = 'DomainDetailsForm';
-DomainDetailsForm.fieldNames = [
-	'firstName',
-	'lastName',
-	'organization',
-	'email',
-	'phone',
-	'address1',
-	'address2',
-	'city',
-	'state',
-	'postalCode',
-	'countryCode',
-	'fax'
-];
 
 export default localize( DomainDetailsForm );

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import {
 	camelCase,
@@ -33,24 +34,7 @@ import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 const wpcom = require( 'lib/wp' ).undocumented(),
 	countriesList = countriesListForDomainRegistrations();
 
-export default React.createClass( {
-	displayName: 'DomainDetailsForm',
-
-	fieldNames: [
-		'firstName',
-		'lastName',
-		'organization',
-		'email',
-		'phone',
-		'address1',
-		'address2',
-		'city',
-		'state',
-		'postalCode',
-		'countryCode',
-		'fax'
-	],
-
+class DomainDetailsForm extends Component {
 	getInitialState() {
 		return {
 			form: null,
@@ -58,7 +42,7 @@ export default React.createClass( {
 			submissionCount: 0,
 			phoneCountryCode: 'US'
 		};
-	},
+	}
 
 	componentWillMount() {
 		this.formStateController = formState.Controller( {
@@ -71,11 +55,11 @@ export default React.createClass( {
 		} );
 
 		this.setState( { form: this.formStateController.getInitialState() } );
-	},
+	}
 
 	componentDidMount() {
 		analytics.pageView.record( '/checkout/domain-contact-information', 'Checkout > Domain Contact Information' );
-	},
+	}
 
 	sanitize( fieldValues, onComplete ) {
 		const sanitizedFieldValues = Object.assign( {}, fieldValues );
@@ -89,7 +73,7 @@ export default React.createClass( {
 		} );
 
 		onComplete( sanitizedFieldValues );
-	},
+	}
 
 	validate( fieldValues, onComplete ) {
 		if ( this.needsOnlyGoogleAppsDetails() ) {
@@ -101,14 +85,14 @@ export default React.createClass( {
 		allFieldValues.phone = toIcannFormat( allFieldValues.phone, countries[ this.state.phoneCountryCode ] );
 		const domainNames = map( cartItems.getDomainRegistrations( this.props.cart ), 'meta' );
 		wpcom.validateDomainContactInformation( allFieldValues, domainNames, this.generateValidationHandler( onComplete ) );
-	},
+	}
 
 	generateValidationHandler( onComplete ) {
 		return ( error, data ) => {
 			const messages = data && data.messages || {};
 			onComplete( error, messages );
 		};
-	},
+	}
 
 	setFormState( form ) {
 		if ( ! this.isMounted() ) {
@@ -120,15 +104,15 @@ export default React.createClass( {
 		}
 
 		this.setState( { form } );
-	},
+	}
 
 	needsOnlyGoogleAppsDetails() {
 		return cartItems.hasGoogleApps( this.props.cart ) && ! cartItems.hasDomainRegistration( this.props.cart );
-	},
+	}
 
 	handleFormControllerError( error ) {
 		throw error;
-	},
+	}
 
 	handleChangeEvent( event ) {
 		// Resets the state field every time the user selects a different country
@@ -150,7 +134,7 @@ export default React.createClass( {
 			name: event.target.name,
 			value: event.target.value
 		} );
-	},
+	}
 
 	handlePhoneChange( { value, countryCode } ) {
 		this.formStateController.handleFieldChange( {
@@ -161,11 +145,11 @@ export default React.createClass( {
 		this.setState( {
 			phoneCountryCode: countryCode
 		} );
-	},
+	}
 
 	getNumberOfDomainRegistrations() {
 		return cartItems.getDomainRegistrations( this.props.cart ).length;
-	},
+	}
 
 	getFieldProps( name ) {
 		return {
@@ -182,23 +166,23 @@ export default React.createClass( {
 			errorMessage: ( formState.getFieldErrorMessages( this.state.form, camelCase( name ) ) || [] ).join( '\n' ),
 			eventFormName: 'Checkout Form'
 		};
-	},
+	}
 
 	needsFax() {
 		return formState.getFieldValue( this.state.form, 'countryCode' ) === 'NL' && cartItems.hasTld( this.props.cart, 'nl' );
-	},
+	}
 
 	allDomainRegistrationsHavePrivacy() {
 		return cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0;
-	},
+	}
 
 	renderSubmitButton() {
 		return (
 			<FormButton className="checkout__domain-details-form-submit-button" onClick={ this.handleSubmitButtonClick }>
-				{ this.translate( 'Continue to Checkout' ) }
+				{ this.props.translate( 'Continue to Checkout' ) }
 			</FormButton>
 		);
-	},
+	}
 
 	renderPrivacySection() {
 		return (
@@ -215,25 +199,25 @@ export default React.createClass( {
 				isDialogVisible={ this.state.isDialogVisible }
 				productsList={ this.props.productsList }/>
 		);
-	},
+	}
 
 	renderNameFields() {
 		return (
 			<div>
 				<Input
 					autoFocus
-					label={ this.translate( 'First Name') }
+					label={ this.props.translate( 'First Name' ) }
 					{ ...this.getFieldProps( 'first-name' ) } />
 
-				<Input label={ this.translate( 'Last Name' ) } { ...this.getFieldProps( 'last-name' ) } />
+				<Input label={ this.props.translate( 'Last Name' ) } { ...this.getFieldProps( 'last-name' ) } />
 			</div>
 		);
-	},
+	}
 
 	renderOrganizationField() {
 		return <HiddenInput
-			label={ this.translate( 'Organization' ) }
-			text={ this.translate(
+			label={ this.props.translate( 'Organization' ) }
+			text={ this.props.translate(
 				'Registering this domain for a company? + Add Organization Name',
 				'Registering these domains for a company? + Add Organization Name',
 				{
@@ -241,31 +225,31 @@ export default React.createClass( {
 				}
 			) }
 			{ ...this.getFieldProps( 'organization' ) } />;
-	},
+	}
 
 	renderEmailField() {
 		return (
-			<Input label={ this.translate( 'Email' ) } { ...this.getFieldProps( 'email' ) } />
+			<Input label={ this.props.translate( 'Email' ) } { ...this.getFieldProps( 'email' ) } />
 		);
-	},
+	}
 
 	renderCountryField() {
 		return (
 			<CountrySelect
-				label={ this.translate( 'Country' ) }
+				label={ this.props.translate( 'Country' ) }
 				countriesList={ countriesList }
 				{ ...this.getFieldProps( 'country-code' ) } />
 		);
-	},
+	}
 
 	renderFaxField() {
 		return (
-			<Input label={ this.translate( 'Fax' ) } { ...this.getFieldProps( 'fax' ) } />
+			<Input label={ this.props.translate( 'Fax' ) } { ...this.getFieldProps( 'fax' ) } />
 		);
-	},
+	}
 
 	renderPhoneField() {
-		const label = this.translate( 'Phone' );
+		const label = this.props.translate( 'Phone' );
 
 		return (
 			<FormPhoneMediaInput
@@ -275,42 +259,42 @@ export default React.createClass( {
 				onChange={ this.handlePhoneChange }
 				{ ...omit( this.getFieldProps( 'phone' ), 'onChange' ) } />
 		);
-	},
+	}
 
 	renderAddressFields() {
 		return (
 			<div>
-				<Input label={ this.translate( 'Address' ) } maxLength={ 40 } { ...this.getFieldProps( 'address-1' ) }/>
+				<Input label={ this.props.translate( 'Address' ) } maxLength={ 40 } { ...this.getFieldProps( 'address-1' ) } />
 
 				<HiddenInput
-					label={ this.translate( 'Address Line 2' ) }
-					text={ this.translate( '+ Add Address Line 2' ) }
+					label={ this.props.translate( 'Address Line 2' ) }
+					text={ this.props.translate( '+ Add Address Line 2' ) }
 					maxLength={ 40 }
 					{ ...this.getFieldProps( 'address-2' ) } />
 			</div>
 		);
-	},
+	}
 
 	renderCityField() {
 		return (
-			<Input label={ this.translate( 'City' ) } { ...this.getFieldProps( 'city' ) } />
+			<Input label={ this.props.translate( 'City' ) } { ...this.getFieldProps( 'city' ) } />
 		);
-	},
+	}
 
 	renderStateField() {
 		const countryCode = formState.getFieldValue( this.state.form, 'countryCode' );
 
 		return <StateSelect
-			label={ this.translate( 'State' ) }
+			label={ this.props.translate( 'State' ) }
 			countryCode={ countryCode }
 			{ ...this.getFieldProps( 'state' ) } />;
-	},
+	}
 
 	renderPostalCodeField() {
 		return (
-			<Input label={ this.translate( 'Postal Code' ) } { ...this.getFieldProps( 'postal-code' ) } />
+			<Input label={ this.props.translate( 'Postal Code' ) } { ...this.getFieldProps( 'postal-code' ) } />
 		);
-	},
+	}
 
 	renderDetailsForm() {
 		const needsOnlyGoogleAppsDetails = this.needsOnlyGoogleAppsDetails();
@@ -331,23 +315,23 @@ export default React.createClass( {
 				{ this.renderSubmitButton() }
 			</form>
 		);
-	},
+	}
 
 	handleCheckboxChange() {
 		this.setPrivacyProtectionSubscriptions( ! this.allDomainRegistrationsHavePrivacy() );
-	},
+	}
 
 	closeDialog() {
 		this.setState( { isDialogVisible: false } );
-	},
+	}
 
 	openDialog() {
 		this.setState( { isDialogVisible: true } );
-	},
+	}
 
 	focusFirstError() {
 		this.refs[ kebabCase( head( map( formState.getInvalidFields( this.state.form ), 'name' ) ) ) ].focus();
-	},
+	}
 
 	handleSubmitButtonClick( event ) {
 		event.preventDefault();
@@ -367,7 +351,7 @@ export default React.createClass( {
 
 			this.finish();
 		} );
-	},
+	}
 
 	recordSubmit() {
 		const errors = formState.getErrorMessages( this.state.form ),
@@ -385,7 +369,7 @@ export default React.createClass( {
 
 		analytics.tracks.recordEvent( 'calypso_contact_information_form_submit', tracksEventObject );
 		this.setState( { submissionCount: this.state.submissionCount + 1 } );
-	},
+	}
 
 	handlePrivacyDialogSelect( options ) {
 		this.formStateController.handleSubmit( ( hasErrors ) => {
@@ -399,7 +383,7 @@ export default React.createClass( {
 
 			this.finish( options );
 		} );
-	},
+	}
 
 	finish( options = {} ) {
 		this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
@@ -408,7 +392,7 @@ export default React.createClass( {
 		allFieldValues.phone = toIcannFormat( allFieldValues.phone, countries[ this.state.phoneCountryCode ] );
 		setDomainDetails( allFieldValues );
 		addGoogleAppsRegistrationData( allFieldValues );
-	},
+	}
 
 	setPrivacyProtectionSubscriptions( enable ) {
 		if ( enable ) {
@@ -416,7 +400,7 @@ export default React.createClass( {
 		} else {
 			removePrivacyFromAllDomains();
 		}
-	},
+	}
 
 	render() {
 		const needsOnlyGoogleAppsDetails = this.needsOnlyGoogleAppsDetails(),
@@ -428,9 +412,9 @@ export default React.createClass( {
 
 		let title;
 		if ( needsOnlyGoogleAppsDetails ) {
-			title = this.translate( 'G Suite Account Information' );
+			title = this.props.translate( 'G Suite Account Information' );
 		} else {
-			title = this.translate( 'Domain Contact Information' );
+			title = this.props.translate( 'Domain Contact Information' );
 		}
 
 		return (
@@ -444,4 +428,22 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+DomainDetailsForm.displayName = 'DomainDetailsForm';
+DomainDetailsForm.fieldNames = [
+	'firstName',
+	'lastName',
+	'organization',
+	'email',
+	'phone',
+	'address1',
+	'address2',
+	'city',
+	'state',
+	'postalCode',
+	'countryCode',
+	'fax'
+];
+
+export default localize( DomainDetailsForm );

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -424,16 +424,13 @@ export default React.createClass( {
 				'domain-details': true,
 				selected: true,
 				'only-google-apps-details': needsOnlyGoogleAppsDetails
-			} ),
-			titleOptions = {
-				context: 'Domain contact information page'
-			};
+			} );
 
 		let title;
 		if ( needsOnlyGoogleAppsDetails ) {
-			title = this.translate( 'G Suite Account Information', titleOptions );
+			title = this.translate( 'G Suite Account Information' );
 		} else {
-			title = this.translate( 'Domain Contact Information', titleOptions );
+			title = this.translate( 'Domain Contact Information' );
 		}
 
 		return (

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -237,8 +237,6 @@ export default React.createClass( {
 				'Registering this domain for a company? + Add Organization Name',
 				'Registering these domains for a company? + Add Organization Name',
 				{
-					context: 'Domain contact information page',
-					comment: 'Count specifies the number of domain registrations',
 					count: this.getNumberOfDomainRegistrations()
 				}
 			) }

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -29,13 +29,12 @@ import FormButton from 'components/forms/form-button';
 import { countries } from 'components/phone-input/data';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
+import wp from 'lib/wp';
 
-// Cannot convert to ES6 import
-const wpcom = require( 'lib/wp' ).undocumented(),
+const wpcom = wp.undocumented(),
 	countriesList = countriesListForDomainRegistrations();
 
 class DomainDetailsForm extends Component {
-
 	constructor( props, context ) {
 		super( props, context );
 
@@ -79,7 +78,7 @@ class DomainDetailsForm extends Component {
 		analytics.pageView.record( '/checkout/domain-contact-information', 'Checkout > Domain Contact Information' );
 	}
 
-	sanitize( fieldValues, onComplete ) {
+	sanitize = ( fieldValues, onComplete ) => {
 		const sanitizedFieldValues = Object.assign( {}, fieldValues );
 		this.fieldNames.forEach( ( fieldName ) => {
 			if ( typeof fieldValues[ fieldName ] === 'string' ) {
@@ -93,7 +92,7 @@ class DomainDetailsForm extends Component {
 		onComplete( sanitizedFieldValues );
 	}
 
-	validate( fieldValues, onComplete ) {
+	validate = ( fieldValues, onComplete ) => {
 		if ( this.needsOnlyGoogleAppsDetails() ) {
 			wpcom.validateGoogleAppsContactInformation( fieldValues, this.generateValidationHandler( onComplete ) );
 			return;
@@ -112,11 +111,7 @@ class DomainDetailsForm extends Component {
 		};
 	}
 
-	setFormState( form ) {
-		if ( ! this.isMounted() ) {
-			return;
-		}
-
+	setFormState = ( form ) => {
 		if ( ! this.needsFax() ) {
 			delete form.fax;
 		}
@@ -128,11 +123,11 @@ class DomainDetailsForm extends Component {
 		return cartItems.hasGoogleApps( this.props.cart ) && ! cartItems.hasDomainRegistration( this.props.cart );
 	}
 
-	handleFormControllerError( error ) {
+	handleFormControllerError = ( error ) => {
 		throw error;
 	}
 
-	handleChangeEvent( event ) {
+	handleChangeEvent = ( event ) => {
 		// Resets the state field every time the user selects a different country
 		if ( event.target.name === 'country-code' ) {
 			this.formStateController.handleFieldChange( {
@@ -154,7 +149,7 @@ class DomainDetailsForm extends Component {
 		} );
 	}
 
-	handlePhoneChange( { value, countryCode } ) {
+	handlePhoneChange = ( { value, countryCode } ) => {
 		this.formStateController.handleFieldChange( {
 			name: 'phone',
 			value
@@ -215,7 +210,7 @@ class DomainDetailsForm extends Component {
 				onDialogOpen={ this.openDialog }
 				onDialogSelect={ this.handlePrivacyDialogSelect }
 				isDialogVisible={ this.state.isDialogVisible }
-				productsList={ this.props.productsList }/>
+				productsList={ this.props.productsList } />
 		);
 	}
 
@@ -335,15 +330,15 @@ class DomainDetailsForm extends Component {
 		);
 	}
 
-	handleCheckboxChange() {
+	handleCheckboxChange = () => {
 		this.setPrivacyProtectionSubscriptions( ! this.allDomainRegistrationsHavePrivacy() );
 	}
 
-	closeDialog() {
+	closeDialog = () => {
 		this.setState( { isDialogVisible: false } );
 	}
 
-	openDialog() {
+	openDialog = () => {
 		this.setState( { isDialogVisible: true } );
 	}
 
@@ -351,7 +346,7 @@ class DomainDetailsForm extends Component {
 		this.refs[ kebabCase( head( map( formState.getInvalidFields( this.state.form ), 'name' ) ) ) ].focus();
 	}
 
-	handleSubmitButtonClick( event ) {
+	handleSubmitButtonClick = ( event ) => {
 		event.preventDefault();
 
 		this.formStateController.handleSubmit( ( hasErrors ) => {
@@ -389,7 +384,7 @@ class DomainDetailsForm extends Component {
 		this.setState( { submissionCount: this.state.submissionCount + 1 } );
 	}
 
-	handlePrivacyDialogSelect( options ) {
+	handlePrivacyDialogSelect = ( options ) => {
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			this.recordSubmit();
 
@@ -447,7 +442,5 @@ class DomainDetailsForm extends Component {
 		);
 	}
 }
-
-DomainDetailsForm.displayName = 'DomainDetailsForm';
 
 export default localize( DomainDetailsForm );


### PR DESCRIPTION
Two strings aren't currently translated in that screen:
- The title, because it uses a dynamic context, which i18n-calypso cannot parse (so the string exists in the language file without a context)
- The "Registering for a company..." - because the context is skipped due to a bug in i18n-calypso. See https://github.com/Automattic/i18n-calypso/pull/37

see #13854

In both cases, the context is not very helpful, so we can just drop it.

Testing: switch to French, make sure the strings are translated, like this:
<img width="614" alt="screen shot 2017-05-11 at 13 02 43" src="https://cloud.githubusercontent.com/assets/844866/25944283/68b5b5a8-364b-11e7-8a23-332b7bb08505.png">
