### PR TITLE
Full names for suggestions.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -160,7 +160,7 @@ class Suggestions extends React.Component {
 	 * @return {Object}          filtered taxonomy:[ terms ] object
 	 */
 	narrowDownAndSort = ( input, showAll = '' ) => {
-		const termsTable = mapValues( this.props.terms, term => Object.keys( term ) );
+		const termsTable = mapValues( this.props.terms, Object.keys );
 		const [ taxonomy, filter ] = input.toLowerCase().split( ':' );
 		if ( taxonomy === '' ) {
 			// empty string or just ":" or ":filter" -

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
-import { debounce } from 'lodash';
+import { debounce, intersection, difference } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -23,6 +23,9 @@ import MagicSearchWelcome from './welcome';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getThemeFilters } from 'state/selectors';
+
+//We want those taxonomies if they are used to be presented in this order
+const preferredOrderOfTaxonomies = [ 'feature', 'layout', 'column', 'subject', 'style' ];
 
 class ThemesMagicSearchCard extends React.Component {
 	constructor( props ) {
@@ -228,7 +231,7 @@ class ThemesMagicSearchCard extends React.Component {
 	}
 
 	render() {
-		const { isJetpack, translate } = this.props;
+		const { isJetpack, translate, filters } = this.props;
 		const isPremiumThemesEnabled = config.isEnabled( 'upgrades/premium-themes' );
 
 		const tiers = [
@@ -237,7 +240,10 @@ class ThemesMagicSearchCard extends React.Component {
 			{ value: 'premium', label: translate( 'Premium' ) },
 		];
 
-		const filtersKeys = Object.keys( this.props.filters );
+		const filtersKeys = [
+			...intersection( preferredOrderOfTaxonomies, Object.keys( filters ) ),
+			...difference( Object.keys( filters ), preferredOrderOfTaxonomies )
+		];
 
 		const searchField = (
 			<Search

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -17,11 +17,12 @@ import Suggestions from 'components/suggestions';
 import StickyPanel from 'components/sticky-panel';
 import config from 'config';
 import { isMobile } from 'lib/viewport';
-import { filterIsValid, getTaxonomies, } from '../theme-filters.js';
+import { filterIsValid } from '../theme-filters.js';
 import { localize } from 'i18n-calypso';
 import MagicSearchWelcome from './welcome';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getThemeFilters } from 'state/selectors';
 
 class ThemesMagicSearchCard extends React.Component {
 	constructor( props ) {
@@ -236,8 +237,7 @@ class ThemesMagicSearchCard extends React.Component {
 			{ value: 'premium', label: translate( 'Premium' ) },
 		];
 
-		const taxonomies = getTaxonomies();
-		const taxonomiesKeys = Object.keys( taxonomies );
+		const filtersKeys = Object.keys( this.props.filters );
 
 		const searchField = (
 			<Search
@@ -303,7 +303,7 @@ class ThemesMagicSearchCard extends React.Component {
 					{ renderSuggestions &&
 						<Suggestions
 							ref="suggestions"
-							terms={ taxonomies }
+							terms={ this.props.filters }
 							input={ this.state.editedSearchElement }
 							suggest={ this.suggest }
 						/>
@@ -311,7 +311,7 @@ class ThemesMagicSearchCard extends React.Component {
 					{ ! renderSuggestions &&
 						<MagicSearchWelcome
 							ref="welcome"
-							taxonomies={ taxonomiesKeys }
+							taxonomies={ filtersKeys }
 							topSearches={ [] }
 							suggestionsCallback={ this.insertTextInInput }
 						/>
@@ -338,6 +338,7 @@ ThemesMagicSearchCard.defaultProps = {
 
 export default connect(
 	( state ) => ( {
-		isJetpack: isJetpackSite( state, getSelectedSiteId( state ) )
+		isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+		filters: getThemeFilters( state )
 	} )
 )( localize( wrapWithClickOutside( ThemesMagicSearchCard ) ) );


### PR DESCRIPTION
### Info 
This PR implements request from https://github.com/Automattic/wp-calypso/issues/13000

![image](https://cloud.githubusercontent.com/assets/17271089/25946767/d41066b2-364c-11e7-87ea-c9bfa4faa0e6.png)


### Testing 
Go to `/themes`. Suggestions should have full names displayed. Suggesting and suggestions interactions: mous + keyboard should work as previously.

This closes #13000