### PR TITLE
Codemod to remove 'react-addons-linked-state-mixin' usages

### DIFF
--- a/bin/codemods/src/remove-linked-state-mixin.js
+++ b/bin/codemods/src/remove-linked-state-mixin.js
@@ -1,0 +1,183 @@
+/*
+ * This codemod removes instances of `react-addons-linked-state-mixin` and converts all
+ * usages of `valueLink={ this.linkState( 'x' ) }` to `value` and `onChange` props.
+ */
+
+const config = require( './config' );
+
+/* eslint-disable no-console */
+export default function transformer( file, api ) {
+	const j = api.jscodeshift;
+	const ReactUtils = require( 'react-codemod/transforms/utils/ReactUtils' )( j );
+	const root = j( file.source );
+
+	let changedSomething = false;
+
+	// Remove CommonJS requires of LinkedStateMixin
+	const commonJSImports = root.find( j.VariableDeclarator, {
+		id: { name: 'LinkedStateMixin' },
+		init: {
+			type: 'CallExpression',
+			callee: { name: 'require' },
+			arguments: [ { type: 'Literal', value: 'react-addons-linked-state-mixin' } ]
+		}
+	} );
+
+	if ( commonJSImports.size() > 0 ) {
+		commonJSImports.remove();
+		changedSomething = true;
+	}
+
+	// Remove ES6 imports of LinkedStateMixin
+	const es6Imports = root.find( j.ImportDeclaration, {
+		specifiers: [ {
+			type: 'ImportDefaultSpecifier',
+			local: { name: 'LinkedStateMixin' }
+		} ],
+		source: { type: 'Literal', value: 'react-addons-linked-state-mixin' }
+	} );
+
+	if ( es6Imports.size() > 0 ) {
+		es6Imports.remove();
+		changedSomething = true;
+	}
+
+	ReactUtils.findAllReactCreateClassCalls( root ).forEach( createClassCall => {
+		removeLinkedStateMixin( createClassCall );
+		const changeMethodsToAdd = transformLinkStateCalls( createClassCall );
+		addChangeMethods( createClassCall, changeMethodsToAdd );
+	} );
+
+	return changedSomething ? root.toSource( config.recastOptions ) : null;
+
+	// If a React component has property "mixins: [ LinkedStateMixin ]", remove it
+	function removeLinkedStateMixin( classPath ) {
+		const mixinProperties = j( classPath ).find( j.Property, { key: { name: 'mixins' } } );
+		if ( mixinProperties.size() === 0 ) {
+			return null;
+		}
+
+		const mixinElements = j( mixinProperties.get( 'value' ).get( 'elements' ) );
+		const linkedStateMixins = mixinElements.find( j.Identifier, { name: 'LinkedStateMixin' } );
+		if ( linkedStateMixins.size() > 0 ) {
+			// If it's the only remaining mixin, remove the whole 'mixin' property
+			if ( mixinElements.get().value.length === 1 ) {
+				mixinProperties.remove();
+			} else {
+				linkedStateMixins.remove();
+			}
+			changedSomething = true;
+		}
+	}
+
+	// Check if a JSX element has a 'name' attribute with an expected value. It's added
+	// when it's missing, or the value is changed if it's not the right one.
+	function fixNameAttribute( jsxNode, statePropName ) {
+		const nameAttr = jsxNode.attributes.find( a => a.name.name === 'name' );
+		if ( ! nameAttr ) {
+			// JSX element doesn't have a `name` attribute -- let's add it
+			jsxNode.attributes.push( j.jsxAttribute(
+				j.jsxIdentifier( 'name' ),
+				j.literal( statePropName )
+			) );
+			changedSomething = true;
+			return;
+		}
+
+		const name = nameAttr.value.value;
+		if ( name !== statePropName ) {
+			// JSX element has a `name` attribute with wrong value -- let's change it
+			nameAttr.value.value = statePropName;
+			changedSomething = true;
+		}
+	}
+
+	// Return the right property and handler names for `valueLink` and `checkedLink`
+	function linkPropInfo( linkPropName ) {
+		return linkPropName === 'valueLink'
+			? { valuePropName: 'value', changeHandlerName: 'handleInputValueChange' }
+			: { valuePropName: 'checked', changeHandlerName: 'handleInputCheckedChange' };
+	}
+
+	// Transform calls to `linkState` into `value` and `onChange` props
+	function transformLinkStateCalls( classPath ) {
+		const changeMethodsToAdd = new Set;
+
+		// Find all usages of 'this.linkState'
+		j( classPath ).find( j.MemberExpression, {
+			object: { type: 'ThisExpression' },
+			property: { type: 'Identifier', name: 'linkState' }
+		} ).forEach( ( linkStateCall ) => {
+			// Verify they are all function calls with one string arg: this.linkState( 'x' )
+			// We can't transform any other occurences.
+			const caller = linkStateCall.parentPath.value;
+			if ( ! j.match( caller, { type: 'CallExpression', arguments: [ { type: 'Literal' } ] } ) ) {
+				console.log( 'ERR: Not a method call with one arg!' );
+				return;
+			}
+
+			// Save the name of the state property that's the target of the link
+			const stateProp = caller.arguments[ 0 ].value;
+
+			// Is the 'this.linkState' call inside a JSX attribute?
+			// We can't transform it if it isn't.
+			const linkProps = j( linkStateCall ).closest( j.JSXAttribute );
+			if ( linkProps.size() === 0 ) {
+				console.log( 'ERR: Not a child of JSX attribute!' );
+				return;
+			}
+
+			const linkProp = linkProps.get();
+			const linkPropName = linkProp.value.name.name;
+			if ( ! [ 'valueLink', 'checkedLink' ].includes( linkPropName ) ) {
+				console.log( 'ERR: The JSX attribute is neither valueLink nor checkedLink!' );
+				return;
+			}
+
+			const openingEl = j( linkProp ).closest( j.JSXOpeningElement ).get();
+			fixNameAttribute( openingEl.value, stateProp );
+
+			changeMethodsToAdd.add( linkPropName );
+
+			const { valuePropName, changeHandlerName } = linkPropInfo( linkPropName );
+
+			openingEl.value.attributes.push( j.jsxAttribute(
+				j.jsxIdentifier( valuePropName ),
+				j.jsxExpressionContainer( j.template.expression`this.state.${ stateProp }` )
+			) );
+
+			openingEl.value.attributes.push( j.jsxAttribute(
+				j.jsxIdentifier( 'onChange' ),
+				j.jsxExpressionContainer( j.template.expression`this.${ changeHandlerName }` )
+			) );
+
+			linkProps.remove();
+			changedSomething = true;
+		} );
+
+		return changeMethodsToAdd;
+	}
+
+	// Add change handler methods (i.e., `handleInputValueChange`) to the class
+	function addChangeMethods( classPath, changeMethodsToAdd ) {
+		const objectExpr = classPath.value.arguments[ 0 ];
+
+		for ( const linkPropName of changeMethodsToAdd ) {
+			const { valuePropName, changeHandlerName } = linkPropInfo( linkPropName );
+			const property = j.property(
+				'init',
+				j.identifier( changeHandlerName ),
+				j.functionExpression(
+					null,
+					[ j.identifier( 'e' ) ],
+					j.blockStatement( [
+						j.template.statement`const { name, ${ valuePropName } } = e.currentTarget;\n`,
+						j.template.statement`this.setState( { [ name ]: ${ valuePropName } } );`,
+					] )
+				)
+			);
+			property.method = true;
+			objectExpr.properties.push( property );
+		}
+	}
+}


### PR DESCRIPTION
Codemod that removes usages of the `react-addons-linked-state-mixin`:
- [x] Remove the module import, both as CommonJS `require` and ES6 `import`
- [x] Remove `LinkedStateMixin` from the `mixins` list. Remove the whole `mixins` property if it became empty.
- [x] Transform `this.linkState` calls to `value` and `onChange` props

Note that the mixin is present in many components where it's not actually used. It's needed to call the `this.linkState` method, not needed to pass a `valueLink` prop to a subcomponent.

Running the codemod exposes some whitespace formatting bugs:
1. Multiple CommonJS imports that are part of one variable declarator are formatted as one line:
```js
var a = require( 'a' ),
    b = require( 'b' );
```
becomes
```js
var a = require( 'a' ), b = require( 'b' );
```
2. When the whole `mixin` property is removed, all other properties in the class are indented with spaces, not tabs, despite `useTabs=true`. There is a [PR](https://github.com/benjamn/recast/pull/404) in the `recast` repo that fixes this bug.