### PR TITLE
Add extended headers component

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import SectionHeader from 'components/section-header';
+import ExtendedHeader from '../../../components/extended-header';
 
 class SettingsPaymentsLocationCurrency extends Component {
 
@@ -16,14 +16,15 @@ class SettingsPaymentsLocationCurrency extends Component {
 		const { translate } = this.props;
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Store location and currency' ) } />
-				<Card>
-					{
+				<ExtendedHeader
+					label={ translate( 'Store location and currency' ) }
+					description={
 						translate(
-							'Different payment methods may be available based on your store location and currency.'
+							'Different payment methods may be available based on your store' +
+							'location and currency.'
 						)
-					}
-				</Card>
+					} />
+				<Card></Card>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/settings/payments/payments-off-site.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-off-site.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import SectionHeader from 'components/section-header';
+import ExtendedHeader from '../../../components/extended-header';
 
 class SettingsPaymentsOffSite extends Component {
 
@@ -16,16 +16,16 @@ class SettingsPaymentsOffSite extends Component {
 		const { translate } = this.props;
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Off-site credit card payment methods' ) } />
-				<Card>
-					{
+				<ExtendedHeader
+					label={ translate( 'Off-site credit card payment methods' ) }
+					description={
 						translate(
 							'Off-site payment methods involve sending the customer to a ' +
 							'third party web site to complete payment, like PayPal. More ' +
 							'information'
 						)
-					}
-				</Card>
+					} />
+				<Card></Card>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/settings/payments/payments-offline.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-offline.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import SectionHeader from 'components/section-header';
+import ExtendedHeader from '../../../components/extended-header';
 
 class SettingsPaymentsOffline extends Component {
 
@@ -16,15 +16,15 @@ class SettingsPaymentsOffline extends Component {
 		const { translate } = this.props;
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Offline payment methods' ) } />
-				<Card>
-					{
+				<ExtendedHeader
+					label={ translate( 'Offline payment methods' ) }
+					description={
 						translate(
 							'Allow customers to pay you manually using methods like bank ' +
 							'transfer, check or cash on delivery.'
 						)
-					}
-				</Card>
+					} />
+				<Card></Card>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/settings/payments/payments-on-site.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-on-site.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import SectionHeader from 'components/section-header';
+import ExtendedHeader from '../../../components/extended-header';
 
 class SettingsPaymentsOnSite extends Component {
 
@@ -16,16 +16,16 @@ class SettingsPaymentsOnSite extends Component {
 		const { translate } = this.props;
 		return (
 			<div>
-				<SectionHeader label={ translate( 'On-site credit card payment methods' ) } />
-				<Card>
-					{
+				<ExtendedHeader
+					label={ translate( 'On-site credit card payment methods' ) }
+					description={
 						translate(
 							'On-site methods provide a seamless experience by keeping the ' +
 							'customer on your site to enter their credit card details and ' +
 							'complete checkout. More information'
 						)
-					}
-				</Card>
+					} />
+				<Card></Card>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/components/extended-header/index.js
+++ b/client/extensions/woocommerce/components/extended-header/index.js
@@ -13,10 +13,10 @@ class ExtendedHeader extends Component {
 		const { label, description, children } = this.props;
 
 		const labelContent = (
-			<span>
+			<div>
 				<div className="extended-header__header">{ label }</div>
 				<div className="extended-header__header-description">{ description }</div>
-			</span>
+			</div>
 		);
 
 		return (

--- a/client/extensions/woocommerce/components/extended-header/index.js
+++ b/client/extensions/woocommerce/components/extended-header/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'components/section-header';
+
+class ExtendedHeader extends Component {
+	render() {
+		const { label, description, children } = this.props;
+
+		const labelContent = (
+			<span>
+				<div className="extended-header__header">{ label }</div>
+				<div className="extended-header__header-description">{ description }</div>
+			</span>
+		);
+
+		return (
+			<SectionHeader label={ labelContent }>
+				{ children }
+			</SectionHeader>
+		);
+	}
+}
+
+export default ExtendedHeader;

--- a/client/extensions/woocommerce/components/extended-header/style.scss
+++ b/client/extensions/woocommerce/components/extended-header/style.scss
@@ -1,0 +1,12 @@
+.extended-header__header {
+	font-size: 18px;
+	margin-bottom: 0;
+	padding-top: 8px;
+}
+
+.extended-header__header-description {
+	color: $gray;
+	font-size: 12px;
+	line-height: 18px;
+	padding-bottom: 8px;
+}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -9,6 +9,7 @@
 	flex-grow: 1;
 
 	@import 'app/products/product-form';
+	@import 'components/extended-header/style';
 	@import 'components/form-dimensions-input/style';
 }
 


### PR DESCRIPTION
This PR steals the header from the shipping commit and implements it within the settings/payments page.  Once the settings PR is merged I will switch out the component to use this one.

You can test this by going here:  http://calypso.localhost:3000/store/settings/{slug}/payments

https://calypso.live/store/settings/{slug}/payments?branch=add/woocommerce-extended-header

<img width="493" alt="screen shot 2017-05-11 at 8 45 31 am" src="https://cloud.githubusercontent.com/assets/6817400/25949660/3e512ad8-3626-11e7-8a62-76c611849932.png">
