### PR TITLE
Adds a component to display address

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -7,10 +7,24 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import AddressView from '../../../components/address-view';
 import Card from 'components/card';
 import ExtendedHeader from '../../../components/extended-header';
 
 class SettingsPaymentsLocationCurrency extends Component {
+	constructor( props ) {
+		super( props );
+
+		//TODO: use redux state and real data
+		this.state = {
+			address: {
+				name: 'Octopus Outlet Emporium',
+				street: '27 Main Street',
+				city: 'Ellington, CT 06029',
+				country: 'United States'
+			},
+		};
+	}
 
 	render() {
 		const { translate } = this.props;
@@ -24,7 +38,10 @@ class SettingsPaymentsLocationCurrency extends Component {
 							'location and currency.'
 						)
 					} />
-				<Card></Card>
+				<Card>
+					<AddressView
+						address={ this.state.address } />
+				</Card>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+class AddressView extends Component {
+
+	static propTypes = {
+		address: PropTypes.shape( {
+			name: PropTypes.string.isRequired,
+			street: PropTypes.string.isRequired,
+			city: PropTypes.string.isRequired,
+			country: PropTypes.string.isRequired,
+		} ),
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.edit = this.edit.bind( this );
+	}
+
+	edit() {
+		//TODO: Add edit functionality
+		return false;
+	}
+
+	render() {
+		const __ = i18n.translate;
+
+		return (
+			<div>
+				<div className="address-view__address">
+					<p className="address-view__address-name">
+						{ this.props.address.name }
+					</p>
+					<p>{ this.props.address.street }</p>
+					<p>{ this.props.address.city }</p>
+					<p>{ this.props.address.country }</p>
+				</div>
+				<a>{ __( 'Edit address' ) }</a>
+			</div>
+		);
+	}
+}
+
+export default AddressView;

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -1,0 +1,11 @@
+.address-view__address {
+	margin-bottom: 24px;
+
+	p {
+		margin-bottom: 0;
+
+		&.address-view__address-name {
+			font-weight: bold;
+		}
+	}
+}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -9,6 +9,7 @@
 	flex-grow: 1;
 
 	@import 'app/products/product-form';
+	@import 'components/address-view/style';
 	@import 'components/extended-header/style';
 	@import 'components/form-dimensions-input/style';
 }


### PR DESCRIPTION
This PR steals the address styling from the shipping commit and implements it within the settings/payments page. Once the settings PR is merged I will switch out the component to use this one.

You can test this by going here: http://calypso.localhost:3000/store/settings/{slug}/payments

https://calypso.live/store/settings/{slug}/payments?branch=add/woocommerce-address-view

<img width="268" alt="screen shot 2017-05-11 at 9 10 25 am" src="https://cloud.githubusercontent.com/assets/6817400/25950683/b7181532-3629-11e7-8ba5-d85eb61c49db.png">
