### PR TITLE
Selectors: Add/update Theme Filter related Selectors

### DIFF
--- a/client/state/selectors/find-theme-filter-term.js
+++ b/client/state/selectors/find-theme-filter-term.js
@@ -6,6 +6,7 @@ import { filter, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import createSelector from 'lib/create-selector';
 import { getThemeFilters, getThemeFilterTerm } from './';
 
 /**
@@ -15,21 +16,24 @@ import { getThemeFilters, getThemeFilterTerm } from './';
  * @param  {String}  search The term to search for
  * @return {Object}         A filter term object
  */
-export default function findThemeFilterTerm( state, search ) {
-	const [ left, right ] = search.split( ':' );
-	if ( right ) {
-		return getThemeFilterTerm( state, left, right );
-	}
+export default createSelector(
+	( state, search ) => {
+		const [ left, right ] = search.split( ':' );
+		if ( right ) {
+			return getThemeFilterTerm( state, left, right );
+		}
 
-	const filters = getThemeFilters( state );
+		const filters = getThemeFilters( state );
 
-	const results = filter( filters, ( terms ) => (
-		!! get( terms, left )
-	) );
+		const results = filter( filters, ( terms ) => (
+			!! get( terms, left )
+		) );
 
-	if ( results.length !== 1 ) {
-		// No or ambiguous results
-		return null;
-	}
-	return results[ 0 ][ left ];
-}
+		if ( results.length !== 1 ) {
+			// No or ambiguous results
+			return null;
+		}
+		return results[ 0 ][ left ];
+	},
+	( state ) => [ getThemeFilters( state ) ]
+);

--- a/client/state/selectors/find-theme-filter-term.js
+++ b/client/state/selectors/find-theme-filter-term.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, some } from 'lodash';
+import { get, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export default function findThemeFilterTerm( state, search ) {
 
 	let ret;
 	some( filters, ( terms ) => {
-		ret = find( terms, ( value, term ) => ( term === left ) );
+		ret = get( terms, left );
 		return !! ret;
 	} );
 	return ret;

--- a/client/state/selectors/find-theme-filter-term.js
+++ b/client/state/selectors/find-theme-filter-term.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, some } from 'lodash';
+import { filter, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,10 +23,13 @@ export default function findThemeFilterTerm( state, search ) {
 
 	const filters = getThemeFilters( state );
 
-	let ret;
-	some( filters, ( terms ) => {
-		ret = get( terms, left );
-		return !! ret;
-	} );
-	return ret;
+	const results = filter( filters, ( terms ) => (
+		!! get( terms, left )
+	) );
+
+	if ( results.length !== 1 ) {
+		// No or ambiguous results
+		return null;
+	}
+	return results[ 0 ][ left ];
 }

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -162,6 +162,7 @@ export isSiteBlocked from './is-site-blocked';
 export isSiteOnFreePlan from './is-site-on-free-plan';
 export isSiteSupportingImageEditor from './is-site-supporting-image-editor';
 export isSiteUpgradeable from './is-site-upgradeable';
+export isValidThemeFilterTerm from './is-valid-theme-filter-term';
 export isVipSite from './is-vip-site';
 export isTransientMedia from './is-transient-media';
 export isTracking from './is-tracking';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -108,6 +108,7 @@ export isAccountRecoveryResetOptionsReady from './is-account-recovery-reset-opti
 export isAccountRecoveryUserDataReady from './is-account-recovery-user-data-ready';
 export isActivatingJetpackJumpstart from './is-activating-jetpack-jumpstart';
 export isActivatingJetpackModule from './is-activating-jetpack-module';
+export isAmbiguousThemeFilterTerm from './is-ambiguous-theme-filter-term';
 export isAutomatedTransferActive from './is-automated-transfer-active';
 export isAutomatedTransferFailed from './is-automated-transfer-failed';
 export isDeactivatingJetpackJumpstart from './is-deactivating-jetpack-jumpstart';

--- a/client/state/selectors/is-ambiguous-theme-filter-term.js
+++ b/client/state/selectors/is-ambiguous-theme-filter-term.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { filter, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getThemeFilters } from './';
+
+/**
+ * Whether a filter term slug is ambiguous
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  term   The term to check for ambiguity
+ * @return {Bool}           True if term is ambiguous
+ */
+export default createSelector(
+	( state, term ) => {
+		const filters = getThemeFilters( state );
+
+		const results = filter( filters, ( terms ) => (
+			!! get( terms, term )
+		) );
+
+		return results.length > 1;
+	},
+	( state ) => [ getThemeFilters( state ) ]
+);

--- a/client/state/selectors/is-ambiguous-theme-filter-term.js
+++ b/client/state/selectors/is-ambiguous-theme-filter-term.js
@@ -10,7 +10,8 @@ import createSelector from 'lib/create-selector';
 import { getThemeFilters } from './';
 
 /**
- * Whether a filter term slug is ambiguous
+ * Returns true if a theme filter term belongs to more
+ * than one taxonomy.
  *
  * @param  {Object}  state  Global state tree
  * @param  {String}  term   The term to check for ambiguity

--- a/client/state/selectors/is-valid-theme-filter-term.js
+++ b/client/state/selectors/is-valid-theme-filter-term.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { findThemeFilterTerm } from './';
+
+/**
+ * Whether a filter term slug is valid
+ *
+ * @param  {Object}  state Global state tree
+ * @param  {String}  term  The term to validate
+ * @return {Bool}          True if term is valid
+ */
+export default function isValidThemeFilterTerm( state, term ) {
+	return !! findThemeFilterTerm( state, term );
+}

--- a/client/state/selectors/test/find-theme-filter-term.js
+++ b/client/state/selectors/test/find-theme-filter-term.js
@@ -10,9 +10,9 @@ import { findThemeFilterTerm } from '../';
 import { state } from './fixtures/theme-filters';
 
 describe( 'findThemeFilterTerm()', () => {
-	it( 'should return undefined for an inexistent term slug', () => {
+	it( 'should return null for an inexistent term slug', () => {
 		const term = findThemeFilterTerm( state, 'blahg' );
-		expect( term ).to.be.undefined;
+		expect( term ).to.be.null;
 	} );
 
 	it( 'should return the filter term object for a given term slug', () => {

--- a/client/state/selectors/test/fixtures/theme-filters.js
+++ b/client/state/selectors/test/fixtures/theme-filters.js
@@ -14,6 +14,14 @@ export const state = {
 					name: 'Business',
 					description: 'WordPress business themes offer you a professional design for your company or organization. ...'
 				},
+				music: {
+					name: 'Music',
+					description: 'Here you\'ll find great WordPress music themes made with bands and musicians in mind, ...'
+				},
+				video: {
+					name: 'Video',
+					description: ''
+				}
 			},
 			style: {
 				artistic: {
@@ -32,6 +40,16 @@ export const state = {
 					name: 'Minimal',
 					description: 'Whether you\'re minimalist at heart, like keeping things clean, or just want to focus — ...'
 				},
+			},
+			feature: {
+				video: {
+					name: 'Video',
+					description: 'Displays video in the header, scrolling panel, featured-content, or other area for visual variety.'
+				},
+				wordads: {
+					name: 'WordAds',
+					description: 'If you’ve applied for our WordAds advertising program, any of these themes will play nicely with the ads.'
+				}
 			}
 		}
 	},

--- a/client/state/selectors/test/get-theme-filter-terms.js
+++ b/client/state/selectors/test/get-theme-filter-terms.js
@@ -17,19 +17,6 @@ describe( 'getThemeFilterTerms()', () => {
 
 	it( 'should return the filter terms for a given filter slug', () => {
 		const terms = getThemeFilterTerms( state, 'subject' );
-		expect( terms ).to.deep.equal( {
-			artwork: {
-				name: 'Artwork',
-				description: ''
-			},
-			blog: {
-				name: 'Blog',
-				description: 'Whether you\'re authoring a personal blog, professional blog, or a business blog — ...'
-			},
-			business: {
-				name: 'Business',
-				description: 'WordPress business themes offer you a professional design for your company or organization. ...'
-			},
-		} );
+		expect( terms ).to.deep.equal( state.themes.themeFilters.subject );
 	} );
 } );

--- a/client/state/selectors/test/is-ambiguous-theme-filter-term.js
+++ b/client/state/selectors/test/is-ambiguous-theme-filter-term.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isAmbiguousThemeFilterTerm } from '../';
+import { state } from './fixtures/theme-filters';
+
+describe( 'isAmbiguousThemeFilterTerm()', () => {
+	it( 'should return false for an unambiguous term', () => {
+		expect( isAmbiguousThemeFilterTerm( state, 'music' ) ).to.be.false;
+	} );
+
+	it( 'should return true for an ambiguous term', () => {
+		expect( isAmbiguousThemeFilterTerm( state, 'video' ) ).to.be.true;
+	} );
+} );

--- a/client/state/selectors/test/is-valid-theme-filter-term.js
+++ b/client/state/selectors/test/is-valid-theme-filter-term.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isValidThemeFilterTerm } from '../';
+import { state } from './fixtures/theme-filters';
+
+describe( 'isValidThemeFilterTerm()', () => {
+	it( 'should return true for a valid term string', () => {
+		expect( isValidThemeFilterTerm( state, 'music' ) ).to.be.true;
+		expect( isValidThemeFilterTerm( state, 'feature:video' ) ).to.be.true;
+	} );
+
+	it( 'should return false for an invalid filter string', () => {
+		expect( isValidThemeFilterTerm( state, 'video' ) ).to.be.false;
+		expect( isValidThemeFilterTerm( state, '' ) ).to.be.false;
+		expect( isValidThemeFilterTerm( state, ':video' ) ).to.be.false;
+		expect( isValidThemeFilterTerm( state, ':' ) ).to.be.false;
+	} );
+} );


### PR DESCRIPTION
* `findThemeFilterTerm`: Return null for ambiguous results; memoize
* Add `isValidThemeFilterTerm`, `isAmbiguousThemeFilterTerm` (both unused for now, needed for #13867)

Verify that unit tests pass.