### PR TITLE
Reader: always turn off email settings for recommended sites block

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -59,7 +59,7 @@ export class RecommendedSites extends React.PureComponent {
 											<Gridicon icon="cross" size={ 18 } />
 										</Button>
 									</div>
-									<ConnectedSubscriptionListItem siteId={ siteId } />
+									<ConnectedSubscriptionListItem siteId={ siteId } showEmailSettings={ false } />
 								</li> );
 							}
 						)

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -42,7 +42,7 @@ function ReaderSubscriptionListItem( {
 	className = '',
 	translate,
 	followSource,
-	isEmailBlocked,
+	showEmailSettings,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -104,7 +104,7 @@ function ReaderSubscriptionListItem( {
 					feedId={ feedId }
 					siteId={ siteId }
 				/>
-				{ isFollowing && ! isEmailBlocked && <EmailSettings siteId={ siteId } /> }
+				{ isFollowing && showEmailSettings && <EmailSettings siteId={ siteId } /> }
 			</div>
 		</div>
 	);

--- a/client/reader/following-manage/connected-subscription-list-item.jsx
+++ b/client/reader/following-manage/connected-subscription-list-item.jsx
@@ -20,10 +20,12 @@ class ConnectedSubscriptionListItem extends React.Component {
 		feedId: PropTypes.number,
 		siteId: PropTypes.number,
 		onLoad: PropTypes.func,
+		showEmailSettings: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		onLoad: noop,
+		showEmailSettings: true,
 	};
 
 	componentDidMount() {
@@ -37,7 +39,8 @@ class ConnectedSubscriptionListItem extends React.Component {
 	}
 
 	render() {
-		const { feed, site, translate, url, feedId, siteId } = this.props;
+		const { feed, site, translate, url, feedId, siteId, showEmailSettings } = this.props;
+		const isEmailBlocked = userSettings.getSetting( 'subscription_delivery_email_blocked' );
 
 		return (
 			<SubscriptionListItem
@@ -47,7 +50,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 				site={ site }
 				feed={ feed }
 				url={ url }
-				isEmailBlocked={ userSettings.getSetting( 'subscription_delivery_email_blocked' ) }
+				showEmailSettings={ showEmailSettings && ! isEmailBlocked }
 			/>
 		);
 	}


### PR DESCRIPTION
If you're already following a site that appears in a recommended sites block (notably in devdocs), the email settings appear:

<img width="621" alt="screen shot 2017-05-11 at 15 58 20" src="https://cloud.githubusercontent.com/assets/17325/25953584/23d72200-3664-11e7-823f-742bb86066e3.png">

This PR ensures that email settings are always off in the recommended sites block.

### To test

Visit the devdocs page:

https://wpcalypso.wordpress.com/devdocs/blocks/reader-recommended-sites