### PR TITLE
Extensions: WPSC - Remove redundant `isBusy` local state in EasyTab component

### DIFF
--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -45,7 +45,6 @@ class EasyTab extends Component {
 
 	state = {
 		httpOnly: true,
-		isBusy: false,
 		isDeleting: false,
 		isDeletingAll: false,
 	}
@@ -56,15 +55,6 @@ class EasyTab extends Component {
 				isDeleting: false,
 				isDeletingAll: false,
 			} );
-		}
-
-		if ( ! this.props.isTesting && nextProps.isTesting ) {
-			this.setState( { isBusy: true } );
-			return;
-		}
-
-		if ( this.props.isTesting && ! nextProps.isTesting ) {
-			this.setState( { isBusy: false } );
 		}
 	}
 
@@ -152,7 +142,7 @@ class EasyTab extends Component {
 
 							<Button
 								compact
-								busy={ this.state.isBusy }
+								busy={ isTesting }
 								disabled={ isTesting }
 								onClick={ this.testCache }>
 								{ translate( 'Test Cache' ) }


### PR DESCRIPTION
Local state is not needed to track the value of the _Test Cache_ button’s `busy` prop on the _Easy_ tab. We can just use the `isTesting` prop for that, which comes from the `isTestingCache` selector.

## Testing

To test, click the _Test Cache_ button on the _Easy_ tab and ensure that the button changes to its busy state:

![cache-tester-progress-updated](https://cloud.githubusercontent.com/assets/1190420/25526163/5f109d12-2be0-11e7-9d14-dcdc5cbddf7d.jpg)