### PR TITLE
Post Editor: Fix post attributes reverting after a post copy

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -9,7 +9,7 @@ import page from 'page';
 import { Provider as ReduxProvider } from 'react-redux';
 import qs from 'querystring';
 import { isWebUri as isValidUrl } from 'valid-url';
-import { map, pick, startsWith } from 'lodash';
+import { map, pick, reduce, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -125,7 +125,6 @@ function startEditingPostCopy( siteId, postToCopyId, context ) {
 			'excerpt',
 			'featured_image',
 			'format',
-			'metadata',
 			'post_thumbnail',
 			'terms',
 			'title',
@@ -135,13 +134,24 @@ function startEditingPostCopy( siteId, postToCopyId, context ) {
 		postAttributes.title = decodeEntities( postAttributes.title );
 		postAttributes.featured_image = getFeaturedImageId( postToCopy );
 
+		const reduxPostAttributes = {
+			terms: postAttributes.terms,
+			title: postAttributes.title,
+		};
+
 		actions.startEditingNew( siteId, {
 			content: postToCopy.content,
 			title: postToCopy.title,
 			type: postToCopy.type,
 		} );
-		context.store.dispatch( editPost( siteId, null, postAttributes ) );
+		context.store.dispatch( editPost( siteId, null, reduxPostAttributes ) );
 		actions.edit( postAttributes );
+		actions.updateMetadata(
+			reduce( postToCopy.metadata, ( newMetadata, { key, value } ) => {
+				newMetadata[ key ] = value;
+				return newMetadata;
+			}, {} )
+		);
 	} ).catch( error => {
 		Dispatcher.handleServerAction( {
 			type: 'SET_POST_LOADING_ERROR',

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -134,6 +134,15 @@ function startEditingPostCopy( siteId, postToCopyId, context ) {
 		postAttributes.title = decodeEntities( postAttributes.title );
 		postAttributes.featured_image = getFeaturedImageId( postToCopy );
 
+		/**
+		 * A post attributes whitelist for Redux's `editPost()` action.
+		 *
+		 * This is needed because blindly passing all post attributes to `editPost()`
+		 * caused some of them (notably the featured image) to revert to their original value
+		 * when modified right after the copy.
+		 *
+		 * @see https://github.com/Automattic/wp-calypso/pull/13933
+		 */
 		const reduxPostAttributes = {
 			terms: postAttributes.terms,
 			title: postAttributes.title,


### PR DESCRIPTION
Fixes #12536

Follow up #12506

This PR fixes a Copy Post zero-day bug: when changing some attributes on a freshly copied post, their values would revert to their original (copied) values at post save.
The only workaround was to copy the post, save it or let it autosave, and reload the page. Once reloaded, the post would behave as expected.

It took me quite some time to identify this issue as the Post Editor consists of a heavily intertwined tangle of Flux and Redux. Some attributes are managed by Flux, some others by Redux; some look managed by both but in fact they respond to only one's actions (the post title!).

Now though, the PR was written to fix two attributes reverts in particular: the featured image and the sharing message (which is a metadata).

## Fixing the Metadata

Turns out it's not enough to send them to the dispatcher as-is (array of objects):
```js
[
  { key: 'foo', value: 'bar' },
  { key: 'baz', value: 'qux' },
]
```
But [they must be submitted as a single object](https://github.com/Automattic/wp-calypso/blob/master/client/lib/posts/actions.js#L25-L75) such as:
```js
{
  foo: 'bar',
  baz: 'qux',
}
```
Enough said, I guess.
Once reduced the array into an object, the sharing message (and for that matters every other metadata) gets copied correctly.

## Fixing the Featured Image

There's not much to be said here.
The debugging consisted of an endless amount of commenting stuff out until at some point I realized that there was only one thing I've never ever commented out: the Redux `editPost()` action.
Once commented it, the featured image worked smoothly.
Unfortunately I couldn't completely get rid of it, as title and categories (note: not all terms but only categories; tags are managed without issues by Flux only) are only managed via Redux.
Though, I went on the conservative side, with a Redux-managed attributes whitelist replacing the previous, too optimistic, "blanket" list (basically, I passed the same attributes list to both Flux and Redux).

Currently, the Redux-whitelisted attributes are only `title` and `terms`. Though I expect this list to grow over time, as we gradually Reduxify the entire Post Editor.

## Testing Instructions

- Create and save a new post complete of the following attributes:
  - title
  - content
  - featured image
  - categories
  - tags
  - sharing message (found in *Post Drawer → Sharing*, after connecting a social media to the site)
- Go back to the posts list, locate the newly created post and *Copy* it (copy button is in the *More* part of the post controls).
- Check that all those attributes show up as inserted and expected.
- Modify every single one of those attributes.
- Manually save the draft (or wait for an autosave).
- Check that the attributes values are still filled as expected and **that not a single one of them reverted to its original (copied) value**.
Especially check the featured image (which should be quite obvious) and the sharing message.