### PR TITLE
Domains: Ensure full list of admins is fetched when attempting to transfer a domain

### DIFF
--- a/client/components/data/domain-management/transfer/index.jsx
+++ b/client/components/data/domain-management/transfer/index.jsx
@@ -57,7 +57,7 @@ class TransferData extends Component {
 
 		if ( this.prevSelectedSite !== selectedSite ) {
 			fetchDomains( selectedSite.ID );
-			fetchUsers( { siteId: selectedSite.ID } );
+			fetchUsers( { siteId: selectedSite.ID, number: 1000 } );
 
 			this.prevSelectedSite = selectedSite;
 		}


### PR DESCRIPTION
As reported by @simplysaru in `p2MSmN-60t-p2`, in some cases, the list of admins on the `Transfer to another user` view is not complete.

<img width="676" alt="screen shot 2017-05-11 at 18 11 32" src="https://cloud.githubusercontent.com/assets/3392497/25959824/49a62632-3675-11e7-917e-d61bf8d9573a.png">

Turns out, the reason for this is that the default `number` parameter that controls the number of users to fetch is... `20` - which might be too little for large-ish sites. I've set it to the maximum allowed value, `1000`, just to be sure ;) (we're then picking only admins from that list).

I've checked other cases, but is seems that they're either using an alternate approach (`SiteUsersFetcher` - which has a default `number` of 100) or are using pagination and thus are not affected by this.

## Testing
You need a site with >20 users (or hack the backend to lower the thresholds) and at least two admins (preferably, spread out "alphabetically" ;)).

* Navigate to the `Transfer to another user` (`/domains/manage/:domain/transfer/other-user/:site`).
* Verify in the Network that of the Developer Tools that all users for the site were fetched (before the patch, the number of users would be capped at 20).
* Verify that all the admins (and no other roles) are in the list on that view.

#user-report