### PR TITLE
Extensions: WPSC - Move fetching notices to AdvancedTab component

### DIFF
--- a/client/extensions/wp-super-cache/advanced-tab.jsx
+++ b/client/extensions/wp-super-cache/advanced-tab.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { pick } from 'lodash';
+import { connect } from 'react-redux';
+import { flowRight, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,19 +17,25 @@ import ExpiryTime from './expiry-time';
 import FixConfig from './fix-config';
 import LockDown from './lock-down';
 import Miscellaneous from './miscellaneous';
+import QueryNotices from './data/query-notices';
 import RejectedUserAgents from './rejected-user-agents';
 import WrapSettingsForm from './wrap-settings-form';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getNotices } from './state/notices/selectors';
 
 const AdvancedTab = ( {
 	fields: {
 		is_cache_enabled,
 		is_super_cache_enabled,
 	},
+	notices,
+	siteId,
 } ) => {
 	return (
 		<div>
+			<QueryNotices siteId={ siteId } />
 			<Caching />
-			<Miscellaneous />
+			<Miscellaneous notices={ notices } />
 			<Advanced />
 			<CacheLocation />
 			<ExpiryTime />
@@ -36,12 +43,24 @@ const AdvancedTab = ( {
 			<RejectedUserAgents />
 			<LockDown />
 			{ is_cache_enabled && is_super_cache_enabled &&
-				<DirectlyCachedFiles />
+				<DirectlyCachedFiles notices={ notices } />
 			}
 			<FixConfig />
 		</div>
 	);
 };
+
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const notices = getNotices( state, siteId );
+
+		return {
+			notices,
+		};
+	}
+);
+
 const getFormSettings = settings => {
 	return pick( settings, [
 		'is_cache_enabled',
@@ -49,4 +68,7 @@ const getFormSettings = settings => {
 	] );
 };
 
-export default WrapSettingsForm( getFormSettings )( AdvancedTab );
+export default flowRight(
+	connectComponent,
+	WrapSettingsForm( getFormSettings )
+)( AdvancedTab );

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -18,7 +18,6 @@ import { localize } from 'i18n-calypso';
  */
 import { protectForm } from 'lib/protect-form';
 import trackForm from 'lib/track-form';
-import QueryNotices from './data/query-notices';
 import QuerySettings from './data/query-settings';
 import {
 	getSelectedSite,
@@ -41,7 +40,6 @@ import {
 	isDeletingCache,
 	isTestingCache,
 } from './state/cache/selectors';
-import { getNotices } from './state/notices/selectors';
 import {
 	getSettings,
 	isRequestingSettings,
@@ -258,7 +256,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 
 			return (
 				<div>
-					<QueryNotices siteId={ this.props.siteId } />
 					<QuerySettings siteId={ this.props.siteId } />
 					<SettingsForm { ...this.props } { ...utils } />
 				</div>
@@ -272,7 +269,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const siteId = getSelectedSiteId( state );
 			const isSaving = isSavingSettings( state, siteId );
 			const isSaveSuccessful = isSettingsSaveSuccessful( state, siteId );
-			const notices = getNotices( state, siteId );
 			const settings = getSettings( state, siteId );
 			const isRequesting = isRequestingSettings( state, siteId ) && ! settings;
 			// Don't include read-only fields when saving.
@@ -309,7 +305,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				isSaving,
 				isTesting,
 				isTestSuccessful,
-				notices,
 				settings,
 				settingsFields,
 				site,


### PR DESCRIPTION
Notices coming from the `notices` endpoint are only displayed on the _Advanced_ tab, so they should be fetched there and passed down to child components as necessary.

## Testing
To test, ensure that the `public_html` directory is writable. A notice should display in the _Directly Cached Files_ section of the _Advanced_ tab:

![directly-cached-files-notice](https://cloud.githubusercontent.com/assets/1190420/25443056/bc583024-2a74-11e7-8e27-a9002156ce51.jpg)

In the _Network_ tab, you should not see the `notices` endpoint being hit except when on the _Advanced_ tab:

![notices-endpoint](https://cloud.githubusercontent.com/assets/1190420/26000502/36b61fd2-36f7-11e7-87c2-ef1ea7c025e4.jpeg)