### PR TITLE
WooCommerce: Switch to using narrow layout for the post form

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -59,7 +59,7 @@ class ProductCreate extends React.Component {
 		const { product, className, variations, productCategories } = this.props;
 
 		return (
-			<Main className={ className } wideLayout={ true }>
+			<Main className={ className }>
 				<ProductForm
 					product={ product || { type: 'simple' } }
 					variations={ variations }

--- a/client/extensions/woocommerce/app/products/product-form-delivery-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-delivery-details-card.js
@@ -21,6 +21,7 @@ const ProductFormDeliveryDetailsCard = ( { product, editProduct, translate } ) =
 	const { dimensions } = product;
 
 	// TODO Pull in dimensions unit from settings API.
+	// TODO Fix width of dimensions on narrow screens once weight input is in place.
 	return (
 		<Card className="products__product-form-delivery-details">
 			<FormFieldSet>

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -40,10 +40,6 @@ const ProductFormVariationsRow = ( {
 		editProductVariation( product, variation, { stock_quantity: e.target.value } );
 	};
 
-	const toggleVisible = () => {
-		editProductVariation( product, variation, { visible: ! variation.visible } );
-	};
-
 	const toggleStock = () => {
 		editProductVariation( product, variation, { manage_stock: ! variation.manage_stock } );
 	};
@@ -59,11 +55,6 @@ const ProductFormVariationsRow = ( {
 
 	return (
 		<tr className={ rowClassName }>
-			<td>
-				{ ! fallbackRow && (
-					<FormCheckbox checked={ variation.visible } onChange={ toggleVisible } />
-				) }
-			</td>
 			<td className="products__product-id">
 				{ ! fallbackRow && (
 					<div className="products__product-name-thumb">
@@ -120,6 +111,7 @@ const ProductFormVariationsRow = ( {
 							value={ variation.stock_quantity || '' }
 							type="number"
 							onChange={ setStockQuantity }
+							placeholder={ translate( 'Quantity' ) }
 						/>
 					) }
 				</div>

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -93,22 +93,23 @@ class ProductFormVariationsTable extends React.Component {
 	render() {
 		const { variations, translate } = this.props;
 		return (
-			<div className="products__product-form-variation-table-wrapper">
-				<table className="products__product-form-variation-table">
-					<thead>
-						<tr>
-							<th></th>
-							<th></th>
-							<th className="products__product-price">{ translate( 'Price' ) }</th>
-							<th>{ translate( 'Dimensions & weight' ) }</th>
-							<th>{ translate( 'Manage stock' ) }</th>
-						</tr>
-					</thead>
-					<tbody>
-						{ variations && variations.map( ( v ) => this.renderVariationRow( v ) ) }
-					</tbody>
-				</table>
-				{ this.renderModal() }
+			<div className="products__product-form-variation-table-shadow">
+				<div className="products__product-form-variation-table-wrapper">
+					<table className="products__product-form-variation-table">
+						<thead>
+							<tr>
+								<th></th>
+								<th className="products__product-price">{ translate( 'Price' ) }</th>
+								<th>{ translate( 'Dimensions & weight' ) }</th>
+								<th>{ translate( 'Manage stock' ) }</th>
+							</tr>
+						</thead>
+						<tbody>
+							{ variations && variations.map( ( v ) => this.renderVariationRow( v ) ) }
+						</tbody>
+					</table>
+					{ this.renderModal() }
+				</div>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -181,11 +181,6 @@
 	&.products__product-price {
 		width: 80px;
 	}
-
-	&:first-child,
-	&:last-child {
-		min-width: 0;
-	}
 }
 
 .products__product-dimensions-input {
@@ -209,8 +204,26 @@
 	overflow-x: auto;
 }
 
-.products__product-form-variation-table-wrapper .form-text-input-with-affixes .form-text-input {
-	min-width: 80px;
+.products__product-form-variation-table-shadow {
+	position: relative;
+	overflow: hidden;
+
+	&:after {
+		content: "";
+		display: block;
+		width: 24px;
+		height: 100%;
+		position: absolute;
+		right: -12px;
+		top: 0;
+		background: radial-gradient( ellipse at center, rgba( $gray-dark,.125 ) 0%, rgba( $white,0 ) 75%, rgba( $white,0 ) 90% );
+	}
+}
+
+.products__product-form-variation-table-wrapper .form-text-input-with-affixes .form-text-input,
+.form-dimensions-input__length,
+.form-dimensions-input__width {
+	min-width: 75px;
 }
 
 /* TODO: remove placeholder styles once implemented */
@@ -250,6 +263,10 @@
 .products__variation-settings-link {
 	text-decoration: underline;
 	cursor: pointer;
+	color: $blue-medium;
+	&:hover {
+		color: $blue-light;
+	}
 }
 
 .products__product-form-variation-dialog {


### PR DESCRIPTION
This PR reverts the wide-layout change we made previously, based on discussion with @kellychoffman and @jameskoster. It also removes the visible checkbox (since it is already under the modal) to make a bit more room in the variations table, and adds a subtle hint to show that the table can scroll horizontally.

To test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Add some variation types.

<img width="779" alt="screen shot 2017-05-12 at 11 25 15 am" src="https://cloud.githubusercontent.com/assets/689165/26011469/16b05e46-3706-11e7-945a-1b65466469be.png">
