### PR TITLE
Purchases: Add placeholders for product keys while details are loading

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -256,6 +256,7 @@
 @import 'me/purchases/purchase-item/style';
 @import 'me/purchases/purchases-site/style';
 @import 'me/purchases/manage-purchase/style';
+@import 'me/purchases/manage-purchase/plan-details/style';
 @import 'me/purchases/remove-purchase/style';
 @import 'me/reauth-required/style';
 @import 'me/security-2fa-backup-codes-list/style';

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -22,6 +22,18 @@ import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
 import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
 class PurchasePlanDetails extends Component {
+	renderPlaceholder() {
+		return (
+			<div className="plan-details__wrapper is-placeholder">
+				<SectionHeader />
+				<Card>
+					<div className="plan-details__plugin-key" />
+					<div className="plan-details__plugin-key" />
+				</Card>
+			</div>
+		);
+	}
+
 	renderPluginLabel( slug ) {
 		switch ( slug ) {
 			case 'vaultpress':
@@ -35,12 +47,13 @@ class PurchasePlanDetails extends Component {
 		const { selectedSite, pluginList, translate } = this.props;
 		const purchase = getPurchase( this.props );
 
-		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
+		// Short out as soon as we know it's not a Jetpack plan
+		if ( purchase && ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) ) {
 			return null;
 		}
 
-		if ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) {
-			return null;
+		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
+			return this.renderPlaceholder();
 		}
 
 		if ( isExpired( purchase ) ) {

--- a/client/me/purchases/manage-purchase/plan-details/style.scss
+++ b/client/me/purchases/manage-purchase/plan-details/style.scss
@@ -1,0 +1,20 @@
+.plan-details__wrapper.is-placeholder {
+	.section-header__label-text,
+	.plan-details__plugin-key {
+		@include placeholder( 23% );
+
+		display: block;
+	}
+
+	.section-header__label-text {
+		width: 30%;
+	}
+
+	.plan-details__plugin-key {
+		height: 40px;
+
+		& + .plan-details__plugin-key {
+			margin-top: 20px;
+		}
+	}
+}


### PR DESCRIPTION
A section for product keys was added to the purchase detail screen in #12247; this PR adds placeholders for while the request is loading.

<img width="787" alt="screen shot 2017-05-11 at 2 18 05 pm" src="https://cloud.githubusercontent.com/assets/541093/25965068/dadf22e6-3654-11e7-90c4-9b55aa321320.png">

To test:

1. Visit /me/purchases
2. Click on a Jetpack plan purchase (this is just to get a URL)
3. Reload the page (so it needs to re-fetch the data)
4. You should see 3 cards with placeholders, the middle looking like the screenshot above.
