### PR TITLE
WooCommerce: Try moving variation weight and dimensions to modal.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -10,10 +10,12 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import formattedVariationName from '../../lib/formatted-variation-name';
+import FormDimensionsInput from '../../components/form-dimensions-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextArea from 'components/forms/form-textarea';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import FormToggle from 'components/forms/form-toggle';
 import VerticalMenu from 'components/vertical-menu';
 
@@ -47,6 +49,19 @@ class ProductFormVariationsModal extends React.Component {
 		const { product, editProductVariation } = this.props;
 		const variation = this.selectedVariation();
 		editProductVariation( product, variation, { description: e.target.value } );
+	}
+
+	setWeight = ( e ) => {
+		const { product, editProductVariation } = this.props;
+		const variation = this.selectedVariation();
+		editProductVariation( product, variation, { weight: e.target.value } );
+	}
+
+	setDimension = ( e ) => {
+		const { product, editProductVariation } = this.props;
+		const variation = this.selectedVariation();
+		const dimensions = { ...variation.dimensions, [ e.target.name ]: e.target.value };
+		editProductVariation( product, variation, { dimensions } );
 	}
 
 	toggleVisible() {
@@ -92,6 +107,32 @@ class ProductFormVariationsModal extends React.Component {
 								'This will be displayed in addition to the main product description when this variation is selected.'
 						) }</FormSettingExplanation>
 					</FormFieldSet>
+
+					<FormLabel>
+						{ translate( 'Dimensions & weight' ) }
+					</FormLabel>
+
+					<div className="products__product-dimensions-weight">
+						<div className="products__product-dimensions-wrapper">
+							<FormDimensionsInput
+								className="products__product-dimensions-input"
+								unit="in"
+								name="dimensions"
+								dimensions={ variation.dimensions }
+								onChange={ this.setDimension }
+							/>
+						</div>
+						<div className="products__product-weight-input">
+							<FormTextInputWithAffixes
+								name="weight"
+								type="number"
+								suffix="g"
+								value={ variation.weight || '' }
+								onChange={ this.setWeight }
+								size="4"
+							/>
+						</div>
+					</div>
 
 					<FormLabel>
 						{ translate( 'Visible' ) }

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -10,8 +10,6 @@ import { localize } from 'i18n-calypso';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormTextInput from 'components/forms/form-text-input';
 import FormCurrencyInput from 'components/forms/form-currency-input';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
-import FormDimensionsInput from '../../components/form-dimensions-input';
 import formattedVariationName from '../../lib/formatted-variation-name';
 
 const ProductFormVariationsRow = ( {
@@ -25,15 +23,6 @@ const ProductFormVariationsRow = ( {
 	// TODO: Consildate the following set/toggle functions with a helper (along with the form-details functions).
 	const setPrice = ( e ) => {
 		editProductVariation( product, variation, { regular_price: e.target.value } );
-	};
-
-	const setWeight = ( e ) => {
-		editProductVariation( product, variation, { weight: e.target.value } );
-	};
-
-	const setDimension = ( e ) => {
-		const dimensions = { ...variation.dimensions, [ e.target.name ]: e.target.value };
-		editProductVariation( product, variation, { dimensions } );
 	};
 
 	const setStockQuantity = ( e ) => {
@@ -69,7 +58,7 @@ const ProductFormVariationsRow = ( {
 					</div>
 				) }
 			</td>
-			<td>
+			<td className="products__product-price">
 				<FormCurrencyInput
 					currencySymbolPrefix="$"
 					name="price"
@@ -77,26 +66,6 @@ const ProductFormVariationsRow = ( {
 					onChange={ setPrice }
 					size="4"
 				/>
-			</td>
-			<td>
-				<div className="products__product-dimensions-weight">
-					<FormDimensionsInput
-						className="products__product-dimensions-input"
-						unit="in"
-						dimensions={ variation.dimensions }
-						onChange={ setDimension }
-					/>
-					<div className="products__product-weight-input">
-						<FormTextInputWithAffixes
-							name="weight"
-							type="number"
-							suffix="g"
-							value={ variation.weight || '' }
-							onChange={ setWeight }
-							size="4"
-						/>
-					</div>
-				</div>
 			</td>
 			<td>
 				<div className="products__product-manage-stock">

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -99,7 +99,6 @@ class ProductFormVariationsTable extends React.Component {
 						<tr>
 							<th></th>
 							<th className="products__product-price">{ translate( 'Price' ) }</th>
-							<th>{ translate( 'Dimensions & weight' ) }</th>
 							<th>{ translate( 'Manage stock' ) }</th>
 						</tr>
 					</thead>

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -97,15 +97,6 @@
 		background: lighten( $gray, 30% );
 	}
 
-	.products__product-dimensions-weight {
-		display: flex;
-		justify-content: flex-start;
-
-		.products__product-dimensions-input {
-			margin-right: 8px;
-		}
-	}
-
 	.products__product-manage-stock {
 		display: inline-flex;
 		flex-direction: row;
@@ -224,6 +215,10 @@
 	vertical-align: middle;
 }
 
+.products__product-price {
+	width: 35%;
+}
+
 .products__product-name-thumb {
 	display: inline-flex;
 	flex-direction: row;
@@ -293,5 +288,20 @@
 
 	.form-toggle__wrapper {
 		margin-left: 8px;
+	}
+
+	.products__product-dimensions-weight {
+		display: flex;
+		flex-direction: column;
+		margin-bottom: 16px;
+
+		.products__product-dimensions-wrapper {
+			width: 70%;
+		}
+
+		.products__product-weight-input {
+			margin-top: 16px;
+			width: 25%;
+		}
 	}
 }


### PR DESCRIPTION
This PR is try branch. It builds on #13950 and also moves the dimensions & weight inputs to the modal.

To test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Add some variation types.

<img width="880" alt="screen shot 2017-05-11 at 11 27 57 am" src="https://cloud.githubusercontent.com/assets/689165/25965468/ef0c6250-363c-11e7-8e47-2b0b65ac72ed.png">

cc @kellychoffman @jameskoster 