### PR TITLE
Reader Following Intro: banner should be dismissed when user clicks Manage Following link

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -33,16 +33,11 @@ class FollowingIntro extends React.Component {
 		}
 	};
 
-	handleManageLinkClick = () => {
-		this.props.dismiss();
-		recordTrack( 'calypso_reader_following_intro_link_clicked' );
-	};
-
 	render() {
 		const { isNewReader, translate, dismiss } = this.props;
 		const linkElement = config.isEnabled( 'reader/following-manage-refresh' )
-			? <a onClick={ this.handleManageLinkClick } href="/following/manage" />
-			: <a onClick={ this.handleManageLinkClick } href="/following/edit" />;
+			? <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />
+			: <a onClick={ this.props.handleManageLinkClick } href="/following/edit" />;
 
 		if ( ! isNewReader ) {
 			return null;
@@ -99,6 +94,10 @@ export default connect(
 			{
 				dismiss: () => {
 					recordTrack( 'calypso_reader_following_intro_dismiss' );
+					return savePreference( 'is_new_reader', false );
+				},
+				handleManageLinkClick: () => {
+					recordTrack( 'calypso_reader_following_intro_link_clicked' );
 					return savePreference( 'is_new_reader', false );
 				},
 			},

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -33,15 +33,16 @@ class FollowingIntro extends React.Component {
 		}
 	};
 
-	recordManageLinkTrack = () => {
+	handleManageLinkClick = () => {
+		this.props.dismiss();
 		recordTrack( 'calypso_reader_following_intro_link_clicked' );
 	};
 
 	render() {
 		const { isNewReader, translate, dismiss } = this.props;
 		const linkElement = config.isEnabled( 'reader/following-manage-refresh' )
-			? <a onClick={ this.recordManageLinkTrack } href="/following/manage" />
-			: <a onClick={ this.recordManageLinkTrack } href="/following/edit" />;
+			? <a onClick={ this.handleManageLinkClick } href="/following/manage" />
+			: <a onClick={ this.handleManageLinkClick } href="/following/edit" />;
 
 		if ( ! isNewReader ) {
 			return null;


### PR DESCRIPTION
As requested by @fraying, the Following Intro banner should be dismissed if the user interacts with the Manage Following link, as well as if they click the dismiss button.

<img width="865" alt="screen shot 2017-05-10 at 18 00 42" src="https://cloud.githubusercontent.com/assets/17325/25965512/81887e20-3688-11e7-953d-1eaf61bd0181.png">

### To test

Create a brand new WordPress.com user and go to the Reader. Try clicking the link in the banner. The banner should be dismissed when you return and you shouldn't see it again.