### PR TITLE
Reader: try forcing users to insert http for a direct site match

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -55,8 +55,12 @@ function isExternal( url ) {
 	return hostname !== config( 'hostname' );
 }
 
-function isHttps( url ) {
-	return url && startsWith( url, 'https://' );
+function isHttps( uri ) {
+	return url && startsWith( uri, 'https://' );
+}
+
+function isHttp( uri ) {
+	return url && startsWith( uri, 'http://' );
 }
 
 const schemeRegex = /^\w+:\/\//;
@@ -147,6 +151,7 @@ export default {
 	isOutsideCalypso,
 	isExternal,
 	isHttps,
+	isHttp,
 	withoutHttp,
 	addSchemeIfMissing,
 	setUrlScheme,

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -29,10 +29,9 @@ import FollowingManageSubscriptions from './subscriptions';
 import FollowingManageSearchFeedsResults from './feed-search-results';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import { requestFeedSearch } from 'state/reader/feed-searches/actions';
-import { addQueryArgs } from 'lib/url';
+import { addQueryArgs, isHttps, isHttp, addSchemeIfMissing, withoutHttp } from 'lib/url';
 import FollowButton from 'reader/follow-button';
 import { READER_FOLLOWING_MANAGE_URL_INPUT } from 'reader/follow-button/follow-sources';
-import { resemblesUrl, addSchemeIfMissing, withoutHttp } from 'lib/url';
 
 const PAGE_SIZE = 4;
 
@@ -153,7 +152,7 @@ class FollowingManage extends Component {
 		} = this.props;
 		const searchPlaceholderText = translate( 'Search or enter URL to follow…' );
 		const showExistingSubscriptions = ! ( !! sitesQuery && showMoreResults );
-		const isSitesQueryUrl = resemblesUrl( sitesQuery );
+		const isSitesQueryUrl = isHttp( sitesQuery ) || isHttps( sitesQuery );
 		let sitesQueryWithoutProtocol;
 		if ( isSitesQueryUrl ) {
 			sitesQueryWithoutProtocol = withoutHttp( sitesQuery );


### PR DESCRIPTION
require "http" or "https" to show the URL state (instead of X.XX). That way we can test search results when you put in a domain (whatever.com without the "http") and see how they are.
