### PR TITLE
Reader: Properly handle feeds that come back with a new feed URL

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -20,6 +20,7 @@ import {
 	getReaderFeedsCountForQuery,
 	getReaderRecommendedSites,
 	isSiteBlocked as isSiteBlockedSelector,
+	getReaderAliasedFollowFeedUrl,
 } from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
 import QueryReaderRecommendedSites from 'components/data/query-reader-recommended-sites';
@@ -193,7 +194,9 @@ class FollowingManage extends Component {
 							<FollowButton
 								followLabel={ translate( 'Follow %s', { args: sitesQueryWithoutProtocol } ) }
 								followingLabel={ translate( 'Following %s', { args: sitesQueryWithoutProtocol } ) }
-								siteUrl={ addSchemeIfMissing( sitesQuery, 'http' ) }
+								siteUrl={ this.props.getReaderAliasedFollowFeedUrl(
+									addSchemeIfMissing( sitesQuery, 'http' )
+								) }
 								followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
 							/>
 						</div> }
@@ -228,6 +231,7 @@ export default connect(
 		searchResultsCount: getReaderFeedsCountForQuery( state, ownProps.sitesQuery ),
 		getRecommendedSites: seed => getReaderRecommendedSites( state, seed ),
 		isSiteBlocked: site => isSiteBlockedSelector( state, site.blogId ),
+		getReaderAliasedFollowFeedUrl: url => getReaderAliasedFollowFeedUrl( state, url ),
 	} ),
 	{ requestFeedSearch }
 )( localize( FollowingManage ) );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -49,7 +49,6 @@ class FollowingManage extends Component {
 		subsQuery: '',
 		sitesQuery: '',
 		showMoreResults: false,
-		forceRefresh: false,
 		subsSortOrder: 'date-followed',
 	};
 
@@ -57,7 +56,6 @@ class FollowingManage extends Component {
 		width: 800,
 		seed: random( 0, 10000 ),
 		offset: 0,
-		forceRefresh: false,
 	};
 
 	// TODO make this common between our different search pages?
@@ -118,8 +116,7 @@ class FollowingManage extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const forceRefresh = nextProps.sitesQuery !== this.props.sitesQuery;
-		const nextState = { forceRefresh };
+		const nextState = {};
 		const recommendedSites = nextProps.getRecommendedSites( this.state.seed );
 
 		const shouldRequestMoreRecs =
@@ -210,7 +207,7 @@ class FollowingManage extends Component {
 						showMoreResultsClicked={ this.handleShowMoreClicked }
 						width={ this.state.width }
 						fetchNextPage={ this.fetchNextPage }
-						forceRefresh={ this.state.forceRefresh }
+						forceRefresh={ this.props.sitesQuery }
 						searchResultsCount={ searchResultsCount }
 					/> }
 				{ showExistingSubscriptions &&

--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -27,7 +27,7 @@ class SitesWindowScroller extends Component {
 		sites: PropTypes.array.isRequired,
 		fetchNextPage: PropTypes.func,
 		remoteTotalCount: PropTypes.number.isRequired,
-		forceRefresh: PropTypes.bool,
+		forceRefresh: PropTypes.any, // forceRefresh can be anything. Whenever we want to force a refresh, it should change
 		windowScrollerRef: PropTypes.func,
 	};
 	defaultProps = { windowScrollerRef: noop };

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -17,7 +17,7 @@ import SitesWindowScroller from './sites-window-scroller';
 import SyncReaderFollows from 'components/data/sync-reader-follows';
 import FollowingManageSearchFollowed from './search-followed';
 import FollowingManageSortControls from './sort-controls';
-import { getFeed as getReaderFeed } from 'state/reader/feeds/selectors';
+import { getFeed as getReaderFeed, getFeeds } from 'state/reader/feeds/selectors';
 import { getSite as getReaderSite } from 'state/reader/sites/selectors';
 import { getReaderFollows, getReaderFollowsCount } from 'state/selectors';
 import UrlSearch from 'lib/url-search';
@@ -35,8 +35,6 @@ class FollowingManageSubscriptions extends Component {
 		sortOrder: PropTypes.oneOf( [ 'date-followed', 'alpha' ] ),
 		windowScrollerRef: PropTypes.func,
 	};
-
-	state = { forceRefresh: false };
 
 	filterFollowsByQuery( query ) {
 		const { getFeed, getSite, follows } = this.props;
@@ -77,14 +75,8 @@ class FollowingManageSubscriptions extends Component {
 		page.replace( addQueryArgs( { sort }, window.location.pathname + window.location.search ) );
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		const forceRefresh =
-			nextProps.query !== this.props.query || nextProps.sortOrder !== this.props.sortOrder;
-		this.setState( { forceRefresh } );
-	}
-
 	render() {
-		const { follows, width, translate, query, followsCount, sortOrder } = this.props;
+		const { follows, width, translate, query, followsCount, sortOrder, feeds } = this.props;
 		const filteredFollows = this.filterFollowsByQuery( query );
 		const sortedFollows = this.sortFollows( filteredFollows, sortOrder );
 
@@ -126,7 +118,7 @@ class FollowingManageSubscriptions extends Component {
 							sites={ sortedFollows }
 							width={ width }
 							remoteTotalCount={ sortedFollows.length }
-							forceRefresh={ this.state.forceRefresh }
+							forceRefresh={ [ feeds, sortedFollows ] }
 							windowScrollerRef={ this.props.windowScrollerRef }
 						/> }
 				</div>
@@ -138,10 +130,11 @@ class FollowingManageSubscriptions extends Component {
 const mapStateToProps = state => {
 	const follows = getReaderFollows( state );
 	const followsCount = getReaderFollowsCount( state );
+	const feeds = getFeeds( state );
 	const getFeed = feedId => getReaderFeed( state, feedId );
 	const getSite = siteId => getReaderSite( state, siteId );
 
-	return { follows, followsCount, getFeed, getSite };
+	return { follows, followsCount, getFeed, getSite, feeds };
 };
 
 export default connect( mapStateToProps )( localize( UrlSearch( FollowingManageSubscriptions ) ) );

--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -33,3 +33,7 @@ function isStale( state, feedId ) {
 export function getFeed( state, feedId ) {
 	return state.reader.feeds.items[ feedId ];
 }
+
+export function getFeeds( state ) {
+	return state.reader.feeds.items;
+}

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -96,23 +96,32 @@ export const items = createReducer(
 			};
 		},
 		[ READER_FOLLOW ]: ( state, action ) => {
-			const urlKey = prepareComparableUrl( action.payload.feedUrl );
+			let urlKey = prepareComparableUrl( action.payload.feedUrl );
 			const newValues = { is_following: true };
 
-			// Reset follow error state
-			if ( state[ urlKey ] && state[ urlKey ].error ) {
+			const actualFeedUrl = get(
+				action.payload,
+				[ 'follow', 'feed_URL' ],
+				action.payload.feedUrl
+			);
+
+			const newState = { ...state };
+			if ( actualFeedUrl !== action.payload.feedUrl ) {
+				delete newState[ urlKey ];
+				urlKey = prepareComparableUrl( actualFeedUrl );
+			} else if ( state[ urlKey ] && state[ urlKey ].error ) {
+				// Reset follow error state
 				newValues.error = null;
 			}
 
-			return {
-				...state,
+			return Object.assign( newState, {
 				[ urlKey ]: merge(
-					{ feed_URL: action.payload.feedUrl },
+					{ feed_URL: actualFeedUrl },
 					state[ urlKey ],
 					action.payload.follow,
 					newValues
 				),
-			};
+			} );
 		},
 		[ READER_UNFOLLOW ]: ( state, action ) => {
 			const urlKey = prepareComparableUrl( action.payload.feedUrl );

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -99,11 +99,7 @@ export const items = createReducer(
 			let urlKey = prepareComparableUrl( action.payload.feedUrl );
 			const newValues = { is_following: true };
 
-			const actualFeedUrl = get(
-				action.payload,
-				[ 'follow', 'feed_URL' ],
-				action.payload.feedUrl
-			);
+			const actualFeedUrl = get( action.payload, [ 'follow', 'feed_URL' ], action.payload.feedUrl );
 
 			const newState = { ...state };
 			// for the case where a user entered an exact url to follow something, sometimes the
@@ -111,7 +107,13 @@ export const items = createReducer(
 			// e.g. example.com --> example.com/rss.
 			// Since we are keying this reducer by url,
 			// we need delete the old key and move it to the new one.
+			// also keep what was typed in as an alias.  pretty edge casey but ideally we should retain aliases to
+			// display correct followByUrl follow button status
 			if ( actualFeedUrl !== action.payload.feedUrl ) {
+				newValues.alias_feed_URLs = [
+					...( state[ urlKey ].alias_feed_URLs || [] ),
+					prepareComparableUrl( action.payload.feedUrl ),
+				];
 				delete newState[ urlKey ];
 				urlKey = prepareComparableUrl( actualFeedUrl );
 			} else if ( state[ urlKey ] && state[ urlKey ].error ) {

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -106,6 +106,11 @@ export const items = createReducer(
 			);
 
 			const newState = { ...state };
+			// for the case where a user entered an exact url to follow something, sometimes the
+			// correct feed_URL is slightly different from what they typed in.
+			// e.g. example.com --> example.com/rss.
+			// Since we are keying this reducer by url,
+			// we need delete the old key and move it to the new one.
 			if ( actualFeedUrl !== action.payload.feedUrl ) {
 				delete newState[ urlKey ];
 				urlKey = prepareComparableUrl( actualFeedUrl );

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -570,6 +570,7 @@ describe( 'reducer', () => {
 				'example.com/feed': {
 					...subscriptionInfo,
 					is_following: true,
+					alias_feed_URLs: [ 'example.com' ],
 				},
 			} );
 		} );

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -528,7 +528,7 @@ describe( 'reducer', () => {
 				ID: 25,
 				blog_ID: 10,
 				feed_ID: 20,
-				feed_URL: 'http://example.com', // what should we do if the feed_URL doesn't match the feedUrl on the action??
+				feed_URL: 'http://example.com',
 				delivery_methods: {
 					email: {
 						send_posts: true
@@ -542,6 +542,35 @@ describe( 'reducer', () => {
 					...subscriptionInfo,
 					is_following: true,
 				}
+			} );
+		} );
+
+		it( 'should update the feed key when an existing subscription changes feed URL', () => {
+			const original = deepFreeze( {
+				'example.com': {
+					is_following: true,
+					feed_URL: 'http://example.com',
+				},
+			} );
+
+			const subscriptionInfo = {
+				ID: 25,
+				blog_ID: 10,
+				feed_ID: 20,
+				feed_URL: 'http://example.com/feed',
+				delivery_methods: {
+					email: {
+						send_posts: true,
+					},
+				},
+			};
+
+			const state = items( original, follow( 'http://example.com', subscriptionInfo ) );
+			expect( state ).to.eql( {
+				'example.com/feed': {
+					...subscriptionInfo,
+					is_following: true,
+				},
 			} );
 		} );
 	} );

--- a/client/state/selectors/get-reader-aliased-follow-feed-url.js
+++ b/client/state/selectors/get-reader-aliased-follow-feed-url.js
@@ -1,0 +1,34 @@
+/**
+ * External Dependencies
+ */
+import { find, includes } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { prepareComparableUrl } from 'state/reader/follows/utils';
+
+/**
+ * This selector will usually return the same feedUrl passed in.
+ * If the feedUrl passed in is not in the follows reducer AND we can find an alias for it,
+ * then return the feed_URL for the aliased feed.  This is specifically useful for cases where
+ * example.com --> example.com/rss when users follow directly by url
+ *
+ * @param {object} state - The Redux state tree
+ * @param {string} feedUrl - the url for which we are searching for a potential alias
+ * @returns {string} either the original feedUrl or an aliased one.
+ */
+export default function getReaderAliasedFollowFeedUrl( state, feedUrl ) {
+	const urlKey = prepareComparableUrl( feedUrl );
+
+	if ( state.reader.follows.items[ urlKey ] ) {
+		return urlKey;
+	}
+
+	const foundAlias = find( state.reader.follows.items, f => includes( f.alias_feed_URLs, urlKey ) );
+	if ( foundAlias ) {
+		return foundAlias.feed_URL;
+	}
+
+	return feedUrl;
+}

--- a/client/state/selectors/get-reader-followed-tags.js
+++ b/client/state/selectors/get-reader-followed-tags.js
@@ -11,7 +11,7 @@ import createSelector from 'lib/create-selector';
 /**
  * Selector for all of the reader tags a user is following. Sorted by tag slug
  */
-const getReaderFollowedtags = createSelector(
+const getReaderFollowedTags = createSelector(
 	state => {
 		return state.reader.tags.items
 			? sortBy( filter( state.reader.tags.items, tag => tag.isFollowing ), 'slug' )
@@ -20,4 +20,4 @@ const getReaderFollowedtags = createSelector(
 	state => [ state.reader.tags.items ]
 );
 
-export default getReaderFollowedtags;
+export default getReaderFollowedTags;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -61,6 +61,7 @@ export getPublicizeConnection from './get-publicize-connection';
 export getPostLikes from './get-post-likes';
 export getPrimarySiteId from './get-primary-site-id';
 export getRawOffsets from './get-raw-offsets';
+export getReaderAliasedFollowFeedUrl from './get-reader-aliased-follow-feed-url';
 export getReaderFeedsForQuery from './get-reader-feeds-for-query';
 export getReaderFeedsCountForQuery from './get-reader-feeds-count-for-query';
 export getReaderFollowedTags from './get-reader-followed-tags';

--- a/client/state/selectors/is-following.js
+++ b/client/state/selectors/is-following.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { find } from 'lodash';
+import { find, includes } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,6 +13,10 @@ export default function isFollowing( state, { feedUrl, feedId, blogId } ) {
 	if ( feedUrl ) {
 		const url = prepareComparableUrl( feedUrl );
 		follow = state.reader.follows.items[ url ];
+		// if follow by url make sure it hasn't been aliased
+		if ( ! follow ) {
+			follow = find( state.reader.follows.items, f => includes( f.alias_feed_URLs, url ) );
+		}
 	} else if ( feedId ) {
 		follow = find( state.reader.follows.items, { feed_ID: feedId } );
 	} else if ( blogId ) {

--- a/client/state/selectors/is-following.js
+++ b/client/state/selectors/is-following.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { find, includes } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,10 +13,6 @@ export default function isFollowing( state, { feedUrl, feedId, blogId } ) {
 	if ( feedUrl ) {
 		const url = prepareComparableUrl( feedUrl );
 		follow = state.reader.follows.items[ url ];
-		// if follow by url make sure it hasn't been aliased
-		if ( ! follow ) {
-			follow = find( state.reader.follows.items, f => includes( f.alias_feed_URLs, url ) );
-		}
 	} else if ( feedId ) {
 		follow = find( state.reader.follows.items, { feed_ID: feedId } );
 	} else if ( blogId ) {


### PR DESCRIPTION
When following some sites using direct URL entry, the returned feed URL will not match what the user entered. This can happen for a variety of reasons, including auto-discovery of feeds and protocol normalization.

Fixes #13934