### PR TITLE
Remove all createClass instances using codemods take 2

### DIFF
--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -12,26 +12,24 @@ import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
-const FeedError = React.createClass( {
-	getDefaultProps() {
-		return {
-			message: i18n.translate( "Sorry, we can't find that site." ),
-		};
-	},
+class FeedError extends React.Component {
+    static defaultProps = {
+        message: i18n.translate( "Sorry, we can't find that site." ),
+    };
 
-	recordAction() {
+    recordAction = () => {
 		recordAction( 'clicked_search_on_404' );
 		recordGaEvent( 'Clicked Search on 404' );
 		recordTrack( 'calypso_reader_search_on_feed_error_clicked' );
-	},
+	};
 
-	recordSecondaryAction() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_404' );
 		recordGaEvent( 'Clicked Discover on 404' );
 		recordTrack( 'calypso_reader_discover_on_feed_error_clicked' );
-	},
+	};
 
-	render() {
+    render() {
 		const action = (
 			<a
 				className="empty-content__action button is-primary"
@@ -66,8 +64,8 @@ const FeedError = React.createClass( {
 				/>
 			</ReaderMain>
 		);
-	},
-} );
+	}
+}
 
 FeedError.propTypes = {
 	sidebarTitle: React.PropTypes.string,

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -13,23 +13,23 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class FeedError extends React.Component {
-    static defaultProps = {
-        message: i18n.translate( "Sorry, we can't find that site." ),
-    };
+	static defaultProps = {
+		message: i18n.translate( "Sorry, we can't find that site." ),
+	};
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_search_on_404' );
 		recordGaEvent( 'Clicked Search on 404' );
 		recordTrack( 'calypso_reader_search_on_feed_error_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_404' );
 		recordGaEvent( 'Clicked Discover on 404' );
 		recordTrack( 'calypso_reader_discover_on_feed_error_clicked' );
 	};
 
-    render() {
+	render() {
 		const action = (
 			<a
 				className="empty-content__action button is-primary"

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -11,23 +11,23 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class FollowingEditEmptyContent extends React.Component {
-    componentDidMount() {
+	componentDidMount() {
 		recordTrack( 'calypso_reader_empty_manage_following_loaded' );
 	}
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_search_on_empty_manage_following' );
 		recordGaEvent( 'Clicked Search on EmptyContent in Manage Following' );
 		recordTrack( 'calypso_reader_search_on_empty_manage_following_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty_manage_following' );
 		recordGaEvent( 'Clicked Discover on EmptyContent in Manage Following' );
 		recordTrack( 'calypso_reader_discover_on_empty_manage_following_clicked' );
 	};
 
-    render() {
+	render() {
 		const action = (
 			<a
 				className="empty-content__action button is-primary"

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -10,24 +10,24 @@ import { localize } from 'i18n-calypso';
 import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
-const FollowingEditEmptyContent = React.createClass( {
-	componentDidMount() {
+class FollowingEditEmptyContent extends React.Component {
+    componentDidMount() {
 		recordTrack( 'calypso_reader_empty_manage_following_loaded' );
-	},
+	}
 
-	recordAction() {
+    recordAction = () => {
 		recordAction( 'clicked_search_on_empty_manage_following' );
 		recordGaEvent( 'Clicked Search on EmptyContent in Manage Following' );
 		recordTrack( 'calypso_reader_search_on_empty_manage_following_clicked' );
-	},
+	};
 
-	recordSecondaryAction() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty_manage_following' );
 		recordGaEvent( 'Clicked Discover on EmptyContent in Manage Following' );
 		recordTrack( 'calypso_reader_discover_on_empty_manage_following_clicked' );
-	},
+	};
 
-	render() {
+    render() {
 		const action = (
 			<a
 				className="empty-content__action button is-primary"
@@ -57,7 +57,7 @@ const FollowingEditEmptyContent = React.createClass( {
 				illustrationWidth={ 500 }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default localize( FollowingEditEmptyContent );

--- a/client/reader/following-edit/export-button.jsx
+++ b/client/reader/following-edit/export-button.jsx
@@ -13,35 +13,31 @@ import { saveAs } from 'browser-filesaver';
 import wpcom from 'lib/wp';
 import Button from 'components/button';
 
-const FollowingExportButton = React.createClass( {
-	propTypes: {
+class FollowingExportButton extends React.Component {
+    static propTypes = {
 		onError: React.PropTypes.func,
 		onExport: React.PropTypes.func,
 		saveAs: React.PropTypes.string,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			onError: noop,
-			onExport: noop,
-			saveAs: 'wpcom-subscriptions.opml',
-		};
-	},
+    static defaultProps = {
+        onError: noop,
+        onExport: noop,
+        saveAs: 'wpcom-subscriptions.opml',
+    };
 
-	getInitialState() {
-		return {
-			disabled: false,
-		};
-	},
+    state = {
+        disabled: false,
+    };
 
-	onClick() {
+    onClick = () => {
 		wpcom.undocumented().exportReaderFeed( this.onFeed );
 		this.setState( {
 			disabled: true,
 		} );
-	},
+	};
 
-	onFeed( err, data ) {
+    onFeed = (err, data) => {
 		this.setState( {
 			disabled: false,
 		} );
@@ -57,15 +53,15 @@ const FollowingExportButton = React.createClass( {
 			saveAs( blob, this.props.saveAs );
 			this.props.onExport( this.props.saveAs );
 		}
-	},
+	};
 
-	render() {
+    render() {
 		return (
 			<Button compact disabled={ this.state.disabled } onClick={ this.onClick }>
 				{ this.props.translate( 'Export' ) }
 			</Button>
 		);
-	},
-} );
+	}
+}
 
 export default localize( FollowingExportButton );

--- a/client/reader/following-edit/export-button.jsx
+++ b/client/reader/following-edit/export-button.jsx
@@ -14,30 +14,30 @@ import wpcom from 'lib/wp';
 import Button from 'components/button';
 
 class FollowingExportButton extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		onError: React.PropTypes.func,
 		onExport: React.PropTypes.func,
 		saveAs: React.PropTypes.string,
 	};
 
-    static defaultProps = {
-        onError: noop,
-        onExport: noop,
-        saveAs: 'wpcom-subscriptions.opml',
-    };
+	static defaultProps = {
+		onError: noop,
+		onExport: noop,
+		saveAs: 'wpcom-subscriptions.opml',
+	};
 
-    state = {
-        disabled: false,
-    };
+	state = {
+		disabled: false,
+	};
 
-    onClick = () => {
+	onClick = () => {
 		wpcom.undocumented().exportReaderFeed( this.onFeed );
 		this.setState( {
 			disabled: true,
 		} );
 	};
 
-    onFeed = (err, data) => {
+	onFeed = ( err, data ) => {
 		this.setState( {
 			disabled: false,
 		} );
@@ -55,7 +55,7 @@ class FollowingExportButton extends React.Component {
 		}
 	};
 
-    render() {
+	render() {
 		return (
 			<Button compact disabled={ this.state.disabled } onClick={ this.onClick }>
 				{ this.props.translate( 'Export' ) }

--- a/client/reader/following-edit/import-button.jsx
+++ b/client/reader/following-edit/import-button.jsx
@@ -13,23 +13,23 @@ import Button from 'components/button';
 import FilePicker from 'components/file-picker';
 
 class FollowingImportButton extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		onError: React.PropTypes.func,
 		onImport: React.PropTypes.func,
 		onProgress: React.PropTypes.func,
 	};
 
-    static defaultProps = {
-        onError: noop,
-        onImport: noop,
-        onProgress: noop,
-    };
+	static defaultProps = {
+		onError: noop,
+		onImport: noop,
+		onProgress: noop,
+	};
 
-    state = {
-        disabled: false,
-    };
+	state = {
+		disabled: false,
+	};
 
-    onPick = (files) => {
+	onPick = files => {
 		// we only care about the first file in the list
 		const file = files[ 0 ];
 		if ( ! file ) {
@@ -45,7 +45,7 @@ class FollowingImportButton extends React.Component {
 		} );
 	};
 
-    onImport = (err, data) => {
+	onImport = ( err, data ) => {
 		this.setState( {
 			disabled: false,
 		} );
@@ -59,11 +59,11 @@ class FollowingImportButton extends React.Component {
 		}
 	};
 
-    onImportProgress = (event) => {
+	onImportProgress = event => {
 		this.props.onProgress( event );
 	};
 
-    render() {
+	render() {
 		return (
 			<FilePicker accept=".xml,.opml" onPick={ this.onPick }>
 				<Button compact disabled={ this.state.disabled }>

--- a/client/reader/following-edit/import-button.jsx
+++ b/client/reader/following-edit/import-button.jsx
@@ -12,28 +12,24 @@ import wpcom from 'lib/wp';
 import Button from 'components/button';
 import FilePicker from 'components/file-picker';
 
-const FollowingImportButton = React.createClass( {
-	propTypes: {
+class FollowingImportButton extends React.Component {
+    static propTypes = {
 		onError: React.PropTypes.func,
 		onImport: React.PropTypes.func,
 		onProgress: React.PropTypes.func,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			onError: noop,
-			onImport: noop,
-			onProgress: noop,
-		};
-	},
+    static defaultProps = {
+        onError: noop,
+        onImport: noop,
+        onProgress: noop,
+    };
 
-	getInitialState() {
-		return {
-			disabled: false,
-		};
-	},
+    state = {
+        disabled: false,
+    };
 
-	onPick( files ) {
+    onPick = (files) => {
 		// we only care about the first file in the list
 		const file = files[ 0 ];
 		if ( ! file ) {
@@ -47,9 +43,9 @@ const FollowingImportButton = React.createClass( {
 		this.setState( {
 			disabled: true,
 		} );
-	},
+	};
 
-	onImport( err, data ) {
+    onImport = (err, data) => {
 		this.setState( {
 			disabled: false,
 		} );
@@ -61,13 +57,13 @@ const FollowingImportButton = React.createClass( {
 			data.fileName = this.fileName;
 			this.props.onImport( data );
 		}
-	},
+	};
 
-	onImportProgress( event ) {
+    onImportProgress = (event) => {
 		this.props.onProgress( event );
-	},
+	};
 
-	render() {
+    render() {
 		return (
 			<FilePicker accept=".xml,.opml" onPick={ this.onPick }>
 				<Button compact disabled={ this.state.disabled }>
@@ -75,7 +71,7 @@ const FollowingImportButton = React.createClass( {
 				</Button>
 			</FilePicker>
 		);
-	},
-} );
+	}
+}
 
 export default localize( FollowingImportButton );

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -1,5 +1,6 @@
 // External dependencies
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import times from 'lodash/times';
 import trimStart from 'lodash/trimStart';
@@ -39,16 +40,17 @@ import { recordAction, recordFollow, recordGaEvent, recordTrack } from 'reader/s
 
 const initialLoadFeedCount = 20;
 
-const FollowingEdit = React.createClass( {
-	mixins: [ URLSearch ],
+const FollowingEdit = createReactClass({
+    displayName: 'FollowingEdit',
+    mixins: [ URLSearch ],
 
-	propTypes: {
+    propTypes: {
 		initialFollowUrl: React.PropTypes.string,
 		search: React.PropTypes.string,
 		userSettings: React.PropTypes.object,
 	},
 
-	getInitialState: function() {
+    getInitialState: function() {
 		return Object.assign(
 			{
 				notices: [],
@@ -58,15 +60,15 @@ const FollowingEdit = React.createClass( {
 		);
 	},
 
-	getDefaultProps: function() {
+    getDefaultProps: function() {
 		return {
 			initialFollowUrl: '',
 		};
 	},
 
-	smartSetState: smartSetState,
+    smartSetState: smartSetState,
 
-	getStateFromStores: function( props = this.props ) {
+    getStateFromStores: function( props = this.props ) {
 		const newState = {
 			subscriptions: FeedSubscriptionStore.getSubscriptions().list,
 			currentPage: FeedSubscriptionStore.getCurrentPage(),
@@ -91,16 +93,16 @@ const FollowingEdit = React.createClass( {
 		return newState;
 	},
 
-	// Add change listeners to stores
-	componentDidMount: function() {
+    // Add change listeners to stores
+    componentDidMount: function() {
 		FeedSubscriptionStore.on( 'add', this.handleAdd );
 		FeedSubscriptionStore.on( 'change', this.handleChange );
 		FeedSubscriptionStore.on( 'remove', this.handleRemove );
 		window.addEventListener( 'resize', this.handleResize );
 	},
 
-	// Remove change listers from stores
-	componentWillUnmount: function() {
+    // Remove change listers from stores
+    componentWillUnmount: function() {
 		FeedSubscriptionStore.clearErrors();
 		FeedSubscriptionStore.off( 'add', this.handleAdd );
 		FeedSubscriptionStore.off( 'change', this.handleChange );
@@ -108,11 +110,11 @@ const FollowingEdit = React.createClass( {
 		window.removeEventListener( 'resize', this.handleResize );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+    componentWillReceiveProps: function( nextProps ) {
 		this.smartSetState( this.getStateFromStores( nextProps ) );
 	},
 
-	searchSubscriptions: function( subscriptions, phrase ) {
+    searchSubscriptions: function( subscriptions, phrase ) {
 		return subscriptions.filter( function( item ) {
 			const feed = FeedStore.get( item.get( 'feed_ID' ) ),
 				site = SiteStore.get( item.get( 'blog_ID' ) ),
@@ -128,7 +130,7 @@ const FollowingEdit = React.createClass( {
 		}, this );
 	},
 
-	sortSubscriptions: function( subscriptions, sortOrder ) {
+    sortSubscriptions: function( subscriptions, sortOrder ) {
 		if ( ! subscriptions ) {
 			return;
 		}
@@ -149,7 +151,7 @@ const FollowingEdit = React.createClass( {
 			.reverse();
 	},
 
-	handleAdd: function( newSubscription ) {
+    handleAdd: function( newSubscription ) {
 		let newState = {
 			isAttemptingFollow: false,
 			isAddingOpen: false,
@@ -164,26 +166,26 @@ const FollowingEdit = React.createClass( {
 		this.setState( newState );
 	},
 
-	handleChange: function() {
+    handleChange: function() {
 		this.smartSetState( this.getStateFromStores() );
 	},
 
-	handleRemove: function( url ) {
+    handleRemove: function( url ) {
 		this.setState( { lastUnfollow: url } );
 	},
 
-	handleResize: debounce( function() {
+    handleResize: debounce( function() {
 		this.setState( { windowWidth: this.getWindowWidth() } );
 	}, 500 ),
 
-	handleSortOrderChange: function( newSortOrder ) {
+    handleSortOrderChange: function( newSortOrder ) {
 		this.setState( {
 			sortOrder: newSortOrder,
 			subscriptions: this.sortSubscriptions( this.state.subscriptions, newSortOrder ),
 		} );
 	},
 
-	handleNotificationSettingsOpen: function( cardKey ) {
+    handleNotificationSettingsOpen: function( cardKey ) {
 		let openCards = this.state.openCards;
 		if ( ! openCards ) {
 			openCards = Immutable.List(); // eslint-disable-line new-cap
@@ -193,7 +195,7 @@ const FollowingEdit = React.createClass( {
 		this.setState( { openCards: newOpenCards } );
 	},
 
-	handleNotificationSettingsClose: function( cardKey ) {
+    handleNotificationSettingsClose: function( cardKey ) {
 		const openCards = this.state.openCards;
 		if ( ! openCards ) {
 			return;
@@ -205,7 +207,7 @@ const FollowingEdit = React.createClass( {
 		this.setState( { openCards: newOpenCards } );
 	},
 
-	handleFeedExport( fileName ) {
+    handleFeedExport( fileName ) {
 		this.dismissFeedExportNotice();
 		if ( this.state.feedExportError ) {
 			this.dismissFeedImportExportError();
@@ -220,7 +222,7 @@ const FollowingEdit = React.createClass( {
 		} );
 	},
 
-	handleFeedExportError( error ) {
+    handleFeedExportError( error ) {
 		this.dismissFeedImportExportError();
 		if ( this.state.feedExport ) {
 			this.dismissFeedExportNotice();
@@ -235,7 +237,7 @@ const FollowingEdit = React.createClass( {
 		} );
 	},
 
-	handleFeedImport( data ) {
+    handleFeedImport( data ) {
 		this.dismissFeedImportNotice();
 		if ( this.state.feedImportError ) {
 			this.dismissFeedImportExportError();
@@ -250,7 +252,7 @@ const FollowingEdit = React.createClass( {
 		} );
 	},
 
-	handleFeedImportError( error ) {
+    handleFeedImportError( error ) {
 		this.dismissFeedImportExportError();
 		if ( this.state.feedImport ) {
 			this.dismissFeedImportNotice();
@@ -265,7 +267,7 @@ const FollowingEdit = React.createClass( {
 		} );
 	},
 
-	fetchNextPage: function() {
+    fetchNextPage: function() {
 		if ( this.state.isLastPage ) {
 			return;
 		}
@@ -273,15 +275,15 @@ const FollowingEdit = React.createClass( {
 		FeedSubscriptionActions.fetchNextPage();
 	},
 
-	getSubscriptionRef: function( subscription ) {
+    getSubscriptionRef: function( subscription ) {
 		return 'subscription-' + subscription.get( 'ID' );
 	},
 
-	getWindowWidth: function() {
+    getWindowWidth: function() {
 		return typeof window !== 'undefined' && window.innerWidth;
 	},
 
-	renderSubscription: function( subscription ) {
+    renderSubscription: function( subscription ) {
 		const subscriptionKey = this.getSubscriptionRef( subscription );
 		const isEmailBlocked = this.props.userSettings.getSetting(
 			'subscription_delivery_email_blocked'
@@ -300,14 +302,14 @@ const FollowingEdit = React.createClass( {
 		);
 	},
 
-	renderLoadingPlaceholders: function() {
+    renderLoadingPlaceholders: function() {
 		var count = this.state.subscriptions.size ? 10 : initialLoadFeedCount;
 		return times( count, function( i ) {
 			return <SubscriptionPlaceholder key={ 'placeholder-' + i } />;
 		} );
 	},
 
-	dismissError: function( event ) {
+    dismissError: function( event ) {
 		event.preventDefault();
 
 		// Call originating store and mark error as dismissed
@@ -318,7 +320,7 @@ const FollowingEdit = React.createClass( {
 		recordTrack( 'calypso_reader_follow_error_dismissed' );
 	},
 
-	handleNewSubscriptionSearch: function( searchString ) {
+    handleNewSubscriptionSearch: function( searchString ) {
 		// Clear the last follow error if the search box is empty
 		if ( this.state.lastError ) {
 			this.setState( { isAttemptingFollow: false } );
@@ -332,7 +334,7 @@ const FollowingEdit = React.createClass( {
 		}
 	},
 
-	dismissFeedExportNotice() {
+    dismissFeedExportNotice() {
 		const notices = this.state.notices;
 		remove( notices, f => f === 'renderFeedExportNotice' );
 		this.setState( {
@@ -341,7 +343,7 @@ const FollowingEdit = React.createClass( {
 		} );
 	},
 
-	dismissFeedImportNotice() {
+    dismissFeedImportNotice() {
 		const notices = this.state.notices;
 		remove( notices, f => f === 'renderFeedImportNotice' );
 		this.setState( {
@@ -350,7 +352,7 @@ const FollowingEdit = React.createClass( {
 		} );
 	},
 
-	dismissFeedImportExportError() {
+    dismissFeedImportExportError() {
 		const notices = this.state.notices;
 		remove( notices, f => f === 'renderFeedImportExportError' );
 		this.setState( {
@@ -360,7 +362,7 @@ const FollowingEdit = React.createClass( {
 		} );
 	},
 
-	handleNewSubscriptionSearchClose: function() {
+    handleNewSubscriptionSearchClose: function() {
 		this.toggleAddSite();
 
 		if (
@@ -372,13 +374,13 @@ const FollowingEdit = React.createClass( {
 		}
 	},
 
-	handleFollow: function( newUrl ) {
+    handleFollow: function( newUrl ) {
 		this.toggleAddSite();
 		this.setState( { isAttemptingFollow: true } );
 		recordFollow( newUrl );
 	},
 
-	renderUnfollowError: function() {
+    renderUnfollowError: function() {
 		if (
 			! this.state.lastError ||
 			this.state.lastError.errorType !== FeedSubscriptionErrorTypes.UNABLE_TO_UNFOLLOW
@@ -401,7 +403,7 @@ const FollowingEdit = React.createClass( {
 		);
 	},
 
-	renderFollowError: function() {
+    renderFollowError: function() {
 		if (
 			! this.state.lastError ||
 			this.state.lastError.errorType !== FeedSubscriptionErrorTypes.UNABLE_TO_FOLLOW
@@ -431,7 +433,7 @@ const FollowingEdit = React.createClass( {
 		);
 	},
 
-	renderFeedExportNotice() {
+    renderFeedExportNotice() {
 		const feedExport = this.state.feedExport;
 		if ( ! feedExport ) {
 			return null;
@@ -449,7 +451,7 @@ const FollowingEdit = React.createClass( {
 		);
 	},
 
-	renderFeedImportNotice() {
+    renderFeedImportNotice() {
 		const feedImport = this.state.feedImport;
 		if ( ! feedImport ) {
 			return null;
@@ -477,7 +479,7 @@ const FollowingEdit = React.createClass( {
 		);
 	},
 
-	renderFeedImportExportError() {
+    renderFeedImportExportError() {
 		const error = this.state.feedImportError || this.state.feedExportError;
 		if ( ! error ) {
 			return null;
@@ -500,15 +502,15 @@ const FollowingEdit = React.createClass( {
 		);
 	},
 
-	refresh() {
+    refresh() {
 		location.reload();
 	},
 
-	toggleAddSite: function() {
+    toggleAddSite: function() {
 		this.refs[ 'feed-search' ].focus();
 	},
 
-	toggleSearching() {
+    toggleSearching() {
 		var isSearching = ! this.state.isSearching;
 		this.setState( {
 			isSearching: isSearching,
@@ -518,11 +520,11 @@ const FollowingEdit = React.createClass( {
 		}
 	},
 
-	renderNotices() {
+    renderNotices() {
 		return this.state.notices.map( funcName => this[ funcName ]() );
 	},
 
-	render: function() {
+    render: function() {
 		let subscriptions = this.state.subscriptions,
 			subscriptionsToDisplay = [],
 			searchPlaceholder = '',
@@ -645,6 +647,6 @@ const FollowingEdit = React.createClass( {
 			</ReaderMain>
 		);
 	},
-} );
+});
 
 export default localize( FollowingEdit );

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -40,17 +40,17 @@ import { recordAction, recordFollow, recordGaEvent, recordTrack } from 'reader/s
 
 const initialLoadFeedCount = 20;
 
-const FollowingEdit = createReactClass({
-    displayName: 'FollowingEdit',
-    mixins: [ URLSearch ],
+const FollowingEdit = createReactClass( {
+	displayName: 'FollowingEdit',
+	mixins: [ URLSearch ],
 
-    propTypes: {
+	propTypes: {
 		initialFollowUrl: React.PropTypes.string,
 		search: React.PropTypes.string,
 		userSettings: React.PropTypes.object,
 	},
 
-    getInitialState: function() {
+	getInitialState: function() {
 		return Object.assign(
 			{
 				notices: [],
@@ -60,15 +60,15 @@ const FollowingEdit = createReactClass({
 		);
 	},
 
-    getDefaultProps: function() {
+	getDefaultProps: function() {
 		return {
 			initialFollowUrl: '',
 		};
 	},
 
-    smartSetState: smartSetState,
+	smartSetState: smartSetState,
 
-    getStateFromStores: function( props = this.props ) {
+	getStateFromStores: function( props = this.props ) {
 		const newState = {
 			subscriptions: FeedSubscriptionStore.getSubscriptions().list,
 			currentPage: FeedSubscriptionStore.getCurrentPage(),
@@ -93,16 +93,16 @@ const FollowingEdit = createReactClass({
 		return newState;
 	},
 
-    // Add change listeners to stores
-    componentDidMount: function() {
+	// Add change listeners to stores
+	componentDidMount: function() {
 		FeedSubscriptionStore.on( 'add', this.handleAdd );
 		FeedSubscriptionStore.on( 'change', this.handleChange );
 		FeedSubscriptionStore.on( 'remove', this.handleRemove );
 		window.addEventListener( 'resize', this.handleResize );
 	},
 
-    // Remove change listers from stores
-    componentWillUnmount: function() {
+	// Remove change listers from stores
+	componentWillUnmount: function() {
 		FeedSubscriptionStore.clearErrors();
 		FeedSubscriptionStore.off( 'add', this.handleAdd );
 		FeedSubscriptionStore.off( 'change', this.handleChange );
@@ -110,11 +110,11 @@ const FollowingEdit = createReactClass({
 		window.removeEventListener( 'resize', this.handleResize );
 	},
 
-    componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps: function( nextProps ) {
 		this.smartSetState( this.getStateFromStores( nextProps ) );
 	},
 
-    searchSubscriptions: function( subscriptions, phrase ) {
+	searchSubscriptions: function( subscriptions, phrase ) {
 		return subscriptions.filter( function( item ) {
 			const feed = FeedStore.get( item.get( 'feed_ID' ) ),
 				site = SiteStore.get( item.get( 'blog_ID' ) ),
@@ -130,7 +130,7 @@ const FollowingEdit = createReactClass({
 		}, this );
 	},
 
-    sortSubscriptions: function( subscriptions, sortOrder ) {
+	sortSubscriptions: function( subscriptions, sortOrder ) {
 		if ( ! subscriptions ) {
 			return;
 		}
@@ -151,7 +151,7 @@ const FollowingEdit = createReactClass({
 			.reverse();
 	},
 
-    handleAdd: function( newSubscription ) {
+	handleAdd: function( newSubscription ) {
 		let newState = {
 			isAttemptingFollow: false,
 			isAddingOpen: false,
@@ -166,26 +166,26 @@ const FollowingEdit = createReactClass({
 		this.setState( newState );
 	},
 
-    handleChange: function() {
+	handleChange: function() {
 		this.smartSetState( this.getStateFromStores() );
 	},
 
-    handleRemove: function( url ) {
+	handleRemove: function( url ) {
 		this.setState( { lastUnfollow: url } );
 	},
 
-    handleResize: debounce( function() {
+	handleResize: debounce( function() {
 		this.setState( { windowWidth: this.getWindowWidth() } );
 	}, 500 ),
 
-    handleSortOrderChange: function( newSortOrder ) {
+	handleSortOrderChange: function( newSortOrder ) {
 		this.setState( {
 			sortOrder: newSortOrder,
 			subscriptions: this.sortSubscriptions( this.state.subscriptions, newSortOrder ),
 		} );
 	},
 
-    handleNotificationSettingsOpen: function( cardKey ) {
+	handleNotificationSettingsOpen: function( cardKey ) {
 		let openCards = this.state.openCards;
 		if ( ! openCards ) {
 			openCards = Immutable.List(); // eslint-disable-line new-cap
@@ -195,7 +195,7 @@ const FollowingEdit = createReactClass({
 		this.setState( { openCards: newOpenCards } );
 	},
 
-    handleNotificationSettingsClose: function( cardKey ) {
+	handleNotificationSettingsClose: function( cardKey ) {
 		const openCards = this.state.openCards;
 		if ( ! openCards ) {
 			return;
@@ -207,7 +207,7 @@ const FollowingEdit = createReactClass({
 		this.setState( { openCards: newOpenCards } );
 	},
 
-    handleFeedExport( fileName ) {
+	handleFeedExport( fileName ) {
 		this.dismissFeedExportNotice();
 		if ( this.state.feedExportError ) {
 			this.dismissFeedImportExportError();
@@ -222,7 +222,7 @@ const FollowingEdit = createReactClass({
 		} );
 	},
 
-    handleFeedExportError( error ) {
+	handleFeedExportError( error ) {
 		this.dismissFeedImportExportError();
 		if ( this.state.feedExport ) {
 			this.dismissFeedExportNotice();
@@ -237,7 +237,7 @@ const FollowingEdit = createReactClass({
 		} );
 	},
 
-    handleFeedImport( data ) {
+	handleFeedImport( data ) {
 		this.dismissFeedImportNotice();
 		if ( this.state.feedImportError ) {
 			this.dismissFeedImportExportError();
@@ -252,7 +252,7 @@ const FollowingEdit = createReactClass({
 		} );
 	},
 
-    handleFeedImportError( error ) {
+	handleFeedImportError( error ) {
 		this.dismissFeedImportExportError();
 		if ( this.state.feedImport ) {
 			this.dismissFeedImportNotice();
@@ -267,7 +267,7 @@ const FollowingEdit = createReactClass({
 		} );
 	},
 
-    fetchNextPage: function() {
+	fetchNextPage: function() {
 		if ( this.state.isLastPage ) {
 			return;
 		}
@@ -275,15 +275,15 @@ const FollowingEdit = createReactClass({
 		FeedSubscriptionActions.fetchNextPage();
 	},
 
-    getSubscriptionRef: function( subscription ) {
+	getSubscriptionRef: function( subscription ) {
 		return 'subscription-' + subscription.get( 'ID' );
 	},
 
-    getWindowWidth: function() {
+	getWindowWidth: function() {
 		return typeof window !== 'undefined' && window.innerWidth;
 	},
 
-    renderSubscription: function( subscription ) {
+	renderSubscription: function( subscription ) {
 		const subscriptionKey = this.getSubscriptionRef( subscription );
 		const isEmailBlocked = this.props.userSettings.getSetting(
 			'subscription_delivery_email_blocked'
@@ -302,14 +302,14 @@ const FollowingEdit = createReactClass({
 		);
 	},
 
-    renderLoadingPlaceholders: function() {
+	renderLoadingPlaceholders: function() {
 		var count = this.state.subscriptions.size ? 10 : initialLoadFeedCount;
 		return times( count, function( i ) {
 			return <SubscriptionPlaceholder key={ 'placeholder-' + i } />;
 		} );
 	},
 
-    dismissError: function( event ) {
+	dismissError: function( event ) {
 		event.preventDefault();
 
 		// Call originating store and mark error as dismissed
@@ -320,7 +320,7 @@ const FollowingEdit = createReactClass({
 		recordTrack( 'calypso_reader_follow_error_dismissed' );
 	},
 
-    handleNewSubscriptionSearch: function( searchString ) {
+	handleNewSubscriptionSearch: function( searchString ) {
 		// Clear the last follow error if the search box is empty
 		if ( this.state.lastError ) {
 			this.setState( { isAttemptingFollow: false } );
@@ -334,7 +334,7 @@ const FollowingEdit = createReactClass({
 		}
 	},
 
-    dismissFeedExportNotice() {
+	dismissFeedExportNotice() {
 		const notices = this.state.notices;
 		remove( notices, f => f === 'renderFeedExportNotice' );
 		this.setState( {
@@ -343,7 +343,7 @@ const FollowingEdit = createReactClass({
 		} );
 	},
 
-    dismissFeedImportNotice() {
+	dismissFeedImportNotice() {
 		const notices = this.state.notices;
 		remove( notices, f => f === 'renderFeedImportNotice' );
 		this.setState( {
@@ -352,7 +352,7 @@ const FollowingEdit = createReactClass({
 		} );
 	},
 
-    dismissFeedImportExportError() {
+	dismissFeedImportExportError() {
 		const notices = this.state.notices;
 		remove( notices, f => f === 'renderFeedImportExportError' );
 		this.setState( {
@@ -362,7 +362,7 @@ const FollowingEdit = createReactClass({
 		} );
 	},
 
-    handleNewSubscriptionSearchClose: function() {
+	handleNewSubscriptionSearchClose: function() {
 		this.toggleAddSite();
 
 		if (
@@ -374,13 +374,13 @@ const FollowingEdit = createReactClass({
 		}
 	},
 
-    handleFollow: function( newUrl ) {
+	handleFollow: function( newUrl ) {
 		this.toggleAddSite();
 		this.setState( { isAttemptingFollow: true } );
 		recordFollow( newUrl );
 	},
 
-    renderUnfollowError: function() {
+	renderUnfollowError: function() {
 		if (
 			! this.state.lastError ||
 			this.state.lastError.errorType !== FeedSubscriptionErrorTypes.UNABLE_TO_UNFOLLOW
@@ -403,7 +403,7 @@ const FollowingEdit = createReactClass({
 		);
 	},
 
-    renderFollowError: function() {
+	renderFollowError: function() {
 		if (
 			! this.state.lastError ||
 			this.state.lastError.errorType !== FeedSubscriptionErrorTypes.UNABLE_TO_FOLLOW
@@ -433,7 +433,7 @@ const FollowingEdit = createReactClass({
 		);
 	},
 
-    renderFeedExportNotice() {
+	renderFeedExportNotice() {
 		const feedExport = this.state.feedExport;
 		if ( ! feedExport ) {
 			return null;
@@ -451,7 +451,7 @@ const FollowingEdit = createReactClass({
 		);
 	},
 
-    renderFeedImportNotice() {
+	renderFeedImportNotice() {
 		const feedImport = this.state.feedImport;
 		if ( ! feedImport ) {
 			return null;
@@ -479,7 +479,7 @@ const FollowingEdit = createReactClass({
 		);
 	},
 
-    renderFeedImportExportError() {
+	renderFeedImportExportError() {
 		const error = this.state.feedImportError || this.state.feedExportError;
 		if ( ! error ) {
 			return null;
@@ -502,15 +502,15 @@ const FollowingEdit = createReactClass({
 		);
 	},
 
-    refresh() {
+	refresh() {
 		location.reload();
 	},
 
-    toggleAddSite: function() {
+	toggleAddSite: function() {
 		this.refs[ 'feed-search' ].focus();
 	},
 
-    toggleSearching() {
+	toggleSearching() {
 		var isSearching = ! this.state.isSearching;
 		this.setState( {
 			isSearching: isSearching,
@@ -520,11 +520,11 @@ const FollowingEdit = createReactClass({
 		}
 	},
 
-    renderNotices() {
+	renderNotices() {
 		return this.state.notices.map( funcName => this[ funcName ]() );
 	},
 
-    render: function() {
+	render: function() {
 		let subscriptions = this.state.subscriptions,
 			subscriptionsToDisplay = [],
 			searchPlaceholder = '',
@@ -647,6 +647,6 @@ const FollowingEdit = createReactClass({
 			</ReaderMain>
 		);
 	},
-});
+} );
 
 export default localize( FollowingEdit );

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -26,10 +26,10 @@ import smartSetState from 'lib/react-smart-set-state';
 
 import ExternalLink from 'components/external-link';
 
-const SubscriptionListItem = createReactClass({
-    displayName: 'SubscriptionListItem',
+const SubscriptionListItem = createReactClass( {
+	displayName: 'SubscriptionListItem',
 
-    propTypes: {
+	propTypes: {
 		subscription: React.PropTypes.object.isRequired,
 		classNames: React.PropTypes.string,
 		onNotificationSettingsOpen: React.PropTypes.func,
@@ -38,9 +38,9 @@ const SubscriptionListItem = createReactClass({
 		isEmailBlocked: React.PropTypes.bool,
 	},
 
-    mixins: [ PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
-    getDefaultProps() {
+	getDefaultProps() {
 		return {
 			classNames: '',
 			onNotificationSettingsOpen: noop,
@@ -48,11 +48,11 @@ const SubscriptionListItem = createReactClass({
 		};
 	},
 
-    getInitialState: function() {
+	getInitialState: function() {
 		return this.getStateFromStores();
 	},
 
-    getStateFromStores: function( props = this.props ) {
+	getStateFromStores: function( props = this.props ) {
 		const site = SiteStore.get( props.subscription.get( 'blog_ID' ) ),
 			feed = FeedStore.get( props.subscription.get( 'feed_ID' ) );
 
@@ -62,27 +62,27 @@ const SubscriptionListItem = createReactClass({
 		};
 	},
 
-    smartSetState: smartSetState,
+	smartSetState: smartSetState,
 
-    componentDidMount: function() {
+	componentDidMount: function() {
 		SiteStore.on( 'change', this.handleChange );
 		FeedStore.on( 'change', this.handleChange );
 	},
 
-    componentWillUnmount: function() {
+	componentWillUnmount: function() {
 		SiteStore.off( 'change', this.handleChange );
 		FeedStore.off( 'change', this.handleChange );
 	},
 
-    componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps: function( nextProps ) {
 		this.smartSetState( this.getStateFromStores( nextProps ) );
 	},
 
-    handleChange: function() {
+	handleChange: function() {
 		this.smartSetState( this.getStateFromStores() );
 	},
 
-    handleFollowToggle: function() {
+	handleFollowToggle: function() {
 		const action = this.isFollowing() ? 'unfollow' : 'follow';
 		FeedSubscriptionActions[ action ](
 			this.props.subscription.get( 'URL' ),
@@ -90,14 +90,14 @@ const SubscriptionListItem = createReactClass({
 		);
 	},
 
-    isFollowing: function() {
+	isFollowing: function() {
 		return (
 			!! this.props.subscription &&
 			this.props.subscription.get( 'state' ) === SubscriptionStates.SUBSCRIBED
 		);
 	},
 
-    render: function() {
+	render: function() {
 		var subscription = this.props.subscription,
 			siteData = this.state.site,
 			feedData = this.state.feed,
@@ -158,6 +158,6 @@ const SubscriptionListItem = createReactClass({
 			</FoldableCard>
 		);
 	},
-});
+} );
 
 export default SubscriptionListItem;

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PureRenderMixin from 'react-pure-render/mixin';
 import noop from 'lodash/noop';
 
@@ -25,8 +26,10 @@ import smartSetState from 'lib/react-smart-set-state';
 
 import ExternalLink from 'components/external-link';
 
-const SubscriptionListItem = React.createClass( {
-	propTypes: {
+const SubscriptionListItem = createReactClass({
+    displayName: 'SubscriptionListItem',
+
+    propTypes: {
 		subscription: React.PropTypes.object.isRequired,
 		classNames: React.PropTypes.string,
 		onNotificationSettingsOpen: React.PropTypes.func,
@@ -35,9 +38,9 @@ const SubscriptionListItem = React.createClass( {
 		isEmailBlocked: React.PropTypes.bool,
 	},
 
-	mixins: [ PureRenderMixin ],
+    mixins: [ PureRenderMixin ],
 
-	getDefaultProps() {
+    getDefaultProps() {
 		return {
 			classNames: '',
 			onNotificationSettingsOpen: noop,
@@ -45,11 +48,11 @@ const SubscriptionListItem = React.createClass( {
 		};
 	},
 
-	getInitialState: function() {
+    getInitialState: function() {
 		return this.getStateFromStores();
 	},
 
-	getStateFromStores: function( props = this.props ) {
+    getStateFromStores: function( props = this.props ) {
 		const site = SiteStore.get( props.subscription.get( 'blog_ID' ) ),
 			feed = FeedStore.get( props.subscription.get( 'feed_ID' ) );
 
@@ -59,27 +62,27 @@ const SubscriptionListItem = React.createClass( {
 		};
 	},
 
-	smartSetState: smartSetState,
+    smartSetState: smartSetState,
 
-	componentDidMount: function() {
+    componentDidMount: function() {
 		SiteStore.on( 'change', this.handleChange );
 		FeedStore.on( 'change', this.handleChange );
 	},
 
-	componentWillUnmount: function() {
+    componentWillUnmount: function() {
 		SiteStore.off( 'change', this.handleChange );
 		FeedStore.off( 'change', this.handleChange );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+    componentWillReceiveProps: function( nextProps ) {
 		this.smartSetState( this.getStateFromStores( nextProps ) );
 	},
 
-	handleChange: function() {
+    handleChange: function() {
 		this.smartSetState( this.getStateFromStores() );
 	},
 
-	handleFollowToggle: function() {
+    handleFollowToggle: function() {
 		const action = this.isFollowing() ? 'unfollow' : 'follow';
 		FeedSubscriptionActions[ action ](
 			this.props.subscription.get( 'URL' ),
@@ -87,14 +90,14 @@ const SubscriptionListItem = React.createClass( {
 		);
 	},
 
-	isFollowing: function() {
+    isFollowing: function() {
 		return (
 			!! this.props.subscription &&
 			this.props.subscription.get( 'state' ) === SubscriptionStates.SUBSCRIBED
 		);
 	},
 
-	render: function() {
+    render: function() {
 		var subscription = this.props.subscription,
 			siteData = this.state.site,
 			feedData = this.state.feed,
@@ -155,6 +158,6 @@ const SubscriptionListItem = React.createClass( {
 			</FoldableCard>
 		);
 	},
-} );
+});
 
 export default SubscriptionListItem;

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -4,10 +4,10 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
-var FollowingEditNavigation = React.createClass( {
-	propTypes: { totalSubscriptions: React.PropTypes.number },
+class FollowingEditNavigation extends React.Component {
+    static propTypes = { totalSubscriptions: React.PropTypes.number };
 
-	renderSiteCount: function() {
+    renderSiteCount = () => {
 		const totalSubscriptions = this.props.totalSubscriptions;
 		if ( ! totalSubscriptions ) {
 			return null;
@@ -17,15 +17,15 @@ var FollowingEditNavigation = React.createClass( {
 			count: totalSubscriptions,
 			args: { count: totalSubscriptions },
 		} );
-	},
+	};
 
-	render: function() {
+    render() {
 		return (
 			<div className="following-edit-navigation">
 				<span className="following-edit-navigation__site-count">{ this.renderSiteCount() }</span>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( FollowingEditNavigation );

--- a/client/reader/following-edit/navigation.jsx
+++ b/client/reader/following-edit/navigation.jsx
@@ -5,9 +5,9 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 
 class FollowingEditNavigation extends React.Component {
-    static propTypes = { totalSubscriptions: React.PropTypes.number };
+	static propTypes = { totalSubscriptions: React.PropTypes.number };
 
-    renderSiteCount = () => {
+	renderSiteCount = () => {
 		const totalSubscriptions = this.props.totalSubscriptions;
 		if ( ! totalSubscriptions ) {
 			return null;
@@ -19,7 +19,7 @@ class FollowingEditNavigation extends React.Component {
 		} );
 	};
 
-    render() {
+	render() {
 		return (
 			<div className="following-edit-navigation">
 				<span className="following-edit-navigation__site-count">{ this.renderSiteCount() }</span>

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -24,7 +24,7 @@ const DELIVERY_FREQUENCY_INSTANTLY = 'instantly',
 	DELIVERY_FREQUENCY_DAILY = 'daily',
 	DELIVERY_FREQUENCY_WEEKLY = 'weekly';
 
-var FollowingEditNotificationSettings = createReactClass( {
+const FollowingEditNotificationSettings = createReactClass( {
 	displayName: 'FollowingEditNotificationSettings',
 
 	propTypes: {

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
 
@@ -23,17 +24,19 @@ const DELIVERY_FREQUENCY_INSTANTLY = 'instantly',
 	DELIVERY_FREQUENCY_DAILY = 'daily',
 	DELIVERY_FREQUENCY_WEEKLY = 'weekly';
 
-var FollowingEditNotificationSettings = React.createClass( {
-	propTypes: {
+var FollowingEditNotificationSettings = createReactClass({
+    displayName: 'FollowingEditNotificationSettings',
+
+    propTypes: {
 		subscription: React.PropTypes.object.isRequired,
 		isEmailBlocked: React.PropTypes.bool,
 	},
 
-	getInitialState: function() {
+    getInitialState: function() {
 		return this.getStateFromStores();
 	},
 
-	getStateFromStores: function( props = this.props ) {
+    getStateFromStores: function( props = this.props ) {
 		const blogId = props.subscription.get( 'blog_ID' ),
 			postEmailSubscription = PostEmailSubscriptionStore.getSubscription( blogId ),
 			commentEmailSubscription = CommentEmailSubscriptionStore.getSubscription( blogId ),
@@ -55,29 +58,29 @@ var FollowingEditNotificationSettings = React.createClass( {
 		return newState;
 	},
 
-	componentDidMount: function() {
+    componentDidMount: function() {
 		PostEmailSubscriptionStore.on( 'change', this.handleChange );
 		CommentEmailSubscriptionStore.on( 'change', this.handleChange );
 	},
 
-	componentWillUnmount: function() {
+    componentWillUnmount: function() {
 		PostEmailSubscriptionStore.off( 'change', this.handleChange );
 		CommentEmailSubscriptionStore.off( 'change', this.handleChange );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+    componentWillReceiveProps: function( nextProps ) {
 		this.smartSetState( this.getStateFromStores( nextProps ) );
 	},
 
-	smartSetState: smartSetState,
+    smartSetState: smartSetState,
 
-	handleChange: function() {
+    handleChange: function() {
 		if ( this.isMounted() ) {
 			this.smartSetState( this.getStateFromStores() );
 		}
 	},
 
-	handleEmailFrequencyClick: function( newFrequency ) {
+    handleEmailFrequencyClick: function( newFrequency ) {
 		this.setState( { emailDeliveryFrequency: newFrequency } );
 		PostEmailSubscriptionActions.updateDeliveryFrequency(
 			this.props.subscription.get( 'blog_ID' ),
@@ -85,7 +88,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 		);
 	},
 
-	handlePostEmailToggle: function() {
+    handlePostEmailToggle: function() {
 		if ( this.state.postEmailSubscription ) {
 			PostEmailSubscriptionActions.unsubscribe( this.props.subscription.get( 'blog_ID' ) );
 		} else {
@@ -96,7 +99,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 		}
 	},
 
-	handleCommentEmailToggle: function() {
+    handleCommentEmailToggle: function() {
 		const subscription = this.props.subscription;
 		if ( this.state.commentEmailSubscription ) {
 			CommentEmailSubscriptionActions.unsubscribe( subscription.get( 'blog_ID' ) );
@@ -105,15 +108,15 @@ var FollowingEditNotificationSettings = React.createClass( {
 		}
 	},
 
-	renderPostEmailError: function() {
+    renderPostEmailError: function() {
 		return this.renderEmailError( 'post' );
 	},
 
-	renderCommentEmailError: function() {
+    renderCommentEmailError: function() {
 		return this.renderEmailError( 'comment' );
 	},
 
-	renderEmailError: function( subscriptionType ) {
+    renderEmailError: function( subscriptionType ) {
 		if ( subscriptionType !== 'post' && subscriptionType !== 'comment' ) {
 			return;
 		}
@@ -137,7 +140,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 		);
 	},
 
-	render: function() {
+    render: function() {
 		var subscription = this.props.subscription,
 			isExternal = ! subscription.get( 'blog_ID' ) || subscription.get( 'blog_ID' ) < 1,
 			emailDeliveryFrequency = this.state.emailDeliveryFrequency,
@@ -256,6 +259,6 @@ var FollowingEditNotificationSettings = React.createClass( {
 			</div>
 		);
 	},
-} );
+});
 
 export default localize( FollowingEditNotificationSettings );

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -24,19 +24,19 @@ const DELIVERY_FREQUENCY_INSTANTLY = 'instantly',
 	DELIVERY_FREQUENCY_DAILY = 'daily',
 	DELIVERY_FREQUENCY_WEEKLY = 'weekly';
 
-var FollowingEditNotificationSettings = createReactClass({
-    displayName: 'FollowingEditNotificationSettings',
+var FollowingEditNotificationSettings = createReactClass( {
+	displayName: 'FollowingEditNotificationSettings',
 
-    propTypes: {
+	propTypes: {
 		subscription: React.PropTypes.object.isRequired,
 		isEmailBlocked: React.PropTypes.bool,
 	},
 
-    getInitialState: function() {
+	getInitialState: function() {
 		return this.getStateFromStores();
 	},
 
-    getStateFromStores: function( props = this.props ) {
+	getStateFromStores: function( props = this.props ) {
 		const blogId = props.subscription.get( 'blog_ID' ),
 			postEmailSubscription = PostEmailSubscriptionStore.getSubscription( blogId ),
 			commentEmailSubscription = CommentEmailSubscriptionStore.getSubscription( blogId ),
@@ -58,29 +58,29 @@ var FollowingEditNotificationSettings = createReactClass({
 		return newState;
 	},
 
-    componentDidMount: function() {
+	componentDidMount: function() {
 		PostEmailSubscriptionStore.on( 'change', this.handleChange );
 		CommentEmailSubscriptionStore.on( 'change', this.handleChange );
 	},
 
-    componentWillUnmount: function() {
+	componentWillUnmount: function() {
 		PostEmailSubscriptionStore.off( 'change', this.handleChange );
 		CommentEmailSubscriptionStore.off( 'change', this.handleChange );
 	},
 
-    componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps: function( nextProps ) {
 		this.smartSetState( this.getStateFromStores( nextProps ) );
 	},
 
-    smartSetState: smartSetState,
+	smartSetState: smartSetState,
 
-    handleChange: function() {
+	handleChange: function() {
 		if ( this.isMounted() ) {
 			this.smartSetState( this.getStateFromStores() );
 		}
 	},
 
-    handleEmailFrequencyClick: function( newFrequency ) {
+	handleEmailFrequencyClick: function( newFrequency ) {
 		this.setState( { emailDeliveryFrequency: newFrequency } );
 		PostEmailSubscriptionActions.updateDeliveryFrequency(
 			this.props.subscription.get( 'blog_ID' ),
@@ -88,7 +88,7 @@ var FollowingEditNotificationSettings = createReactClass({
 		);
 	},
 
-    handlePostEmailToggle: function() {
+	handlePostEmailToggle: function() {
 		if ( this.state.postEmailSubscription ) {
 			PostEmailSubscriptionActions.unsubscribe( this.props.subscription.get( 'blog_ID' ) );
 		} else {
@@ -99,7 +99,7 @@ var FollowingEditNotificationSettings = createReactClass({
 		}
 	},
 
-    handleCommentEmailToggle: function() {
+	handleCommentEmailToggle: function() {
 		const subscription = this.props.subscription;
 		if ( this.state.commentEmailSubscription ) {
 			CommentEmailSubscriptionActions.unsubscribe( subscription.get( 'blog_ID' ) );
@@ -108,15 +108,15 @@ var FollowingEditNotificationSettings = createReactClass({
 		}
 	},
 
-    renderPostEmailError: function() {
+	renderPostEmailError: function() {
 		return this.renderEmailError( 'post' );
 	},
 
-    renderCommentEmailError: function() {
+	renderCommentEmailError: function() {
 		return this.renderEmailError( 'comment' );
 	},
 
-    renderEmailError: function( subscriptionType ) {
+	renderEmailError: function( subscriptionType ) {
 		if ( subscriptionType !== 'post' && subscriptionType !== 'comment' ) {
 			return;
 		}
@@ -140,7 +140,7 @@ var FollowingEditNotificationSettings = createReactClass({
 		);
 	},
 
-    render: function() {
+	render: function() {
 		var subscription = this.props.subscription,
 			isExternal = ! subscription.get( 'blog_ID' ) || subscription.get( 'blog_ID' ) < 1,
 			emailDeliveryFrequency = this.state.emailDeliveryFrequency,
@@ -259,6 +259,6 @@ var FollowingEditNotificationSettings = createReactClass({
 			</div>
 		);
 	},
-});
+} );
 
 export default localize( FollowingEditNotificationSettings );

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -9,23 +9,21 @@ import noop from 'lodash/noop';
  * Module variables
  */
 
-const FollowingEditSortControls = React.createClass( {
-	propTypes: {
+class FollowingEditSortControls extends React.Component {
+    static propTypes = {
 		onSelectChange: React.PropTypes.func,
 		sortOrder: React.PropTypes.string,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			onSelectChange: noop,
-		};
-	},
+    static defaultProps = {
+        onSelectChange: noop,
+    };
 
-	handleSelectChange( event ) {
+    handleSelectChange = (event) => {
 		this.props.onSelectChange( event.target.value );
-	},
+	};
 
-	render() {
+    render() {
 		const sortOrder = this.props.sortOrder;
 
 		return (
@@ -43,7 +41,7 @@ const FollowingEditSortControls = React.createClass( {
 				</select>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( FollowingEditSortControls );

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -10,20 +10,20 @@ import noop from 'lodash/noop';
  */
 
 class FollowingEditSortControls extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		onSelectChange: React.PropTypes.func,
 		sortOrder: React.PropTypes.string,
 	};
 
-    static defaultProps = {
-        onSelectChange: noop,
-    };
+	static defaultProps = {
+		onSelectChange: noop,
+	};
 
-    handleSelectChange = (event) => {
+	handleSelectChange = event => {
 		this.props.onSelectChange( event.target.value );
 	};
 
-    render() {
+	render() {
 		const sortOrder = this.props.sortOrder;
 
 		return (

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -16,7 +16,7 @@ import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
 const minSearchLength = 8; // includes protocol
 
 class FollowingEditSubscribeForm extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		onSearch: React.PropTypes.func,
 		onSearchClose: React.PropTypes.func,
 		onFollow: React.PropTypes.func,
@@ -24,25 +24,25 @@ class FollowingEditSubscribeForm extends React.Component {
 		isSearchOpen: React.PropTypes.bool,
 	};
 
-    static defaultProps = {
-        onSearch: noop,
-        onSearchClose: noop,
-        onFollow: noop,
-        initialSearchString: '',
-        isSearchOpen: false,
-    };
+	static defaultProps = {
+		onSearch: noop,
+		onSearchClose: noop,
+		onFollow: noop,
+		initialSearchString: '',
+		isSearchOpen: false,
+	};
 
-    state = { searchString: this.props.initialSearchString };
+	state = { searchString: this.props.initialSearchString };
 
-    componentWillMount() {
+	componentWillMount() {
 		this.verifySearchString( this.props.initialSearchString );
 	}
 
-    focus = () => {
+	focus = () => {
 		this.refs.followingEditSubscriptionSearch.focus();
 	};
 
-    handleFollowToggle = () => {
+	handleFollowToggle = () => {
 		FeedSubscriptionActions.follow( this.state.searchString, true );
 		this.setState( { previousSearchString: this.state.searchString } );
 
@@ -53,7 +53,7 @@ class FollowingEditSubscribeForm extends React.Component {
 		this.props.onFollow( this.state.searchString );
 	};
 
-    handleKeyDown = (event) => {
+	handleKeyDown = event => {
 		// Use Enter to submit
 		if (
 			event.keyCode === 13 &&
@@ -65,7 +65,7 @@ class FollowingEditSubscribeForm extends React.Component {
 		}
 	};
 
-    handleSearch = (searchString) => {
+	handleSearch = searchString => {
 		if ( searchString === this.state.searchString ) {
 			return;
 		}
@@ -74,11 +74,11 @@ class FollowingEditSubscribeForm extends React.Component {
 		this.props.onSearch( searchString );
 	};
 
-    handleSearchClose = () => {
+	handleSearchClose = () => {
 		this.props.onSearchClose();
 	};
 
-    verifySearchString = (searchString) => {
+	verifySearchString = searchString => {
 		let parsedUrl = url.parse( searchString );
 
 		// Make sure the feed URL has http:// protocol
@@ -100,7 +100,7 @@ class FollowingEditSubscribeForm extends React.Component {
 		} );
 	};
 
-    isWellFormedFeedUrl = (parsedUrl) => {
+	isWellFormedFeedUrl = parsedUrl => {
 		if ( ! parsedUrl.hostname || parsedUrl.hostname.indexOf( '.' ) === -1 ) {
 			return false;
 		}
@@ -119,7 +119,7 @@ class FollowingEditSubscribeForm extends React.Component {
 		return true;
 	};
 
-    render() {
+	render() {
 		var searchResult = null, handleFollowToggle = noop;
 
 		const searchString = this.state.searchString,

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -15,38 +15,34 @@ import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
 
 const minSearchLength = 8; // includes protocol
 
-var FollowingEditSubscribeForm = React.createClass( {
-	propTypes: {
+class FollowingEditSubscribeForm extends React.Component {
+    static propTypes = {
 		onSearch: React.PropTypes.func,
 		onSearchClose: React.PropTypes.func,
 		onFollow: React.PropTypes.func,
 		initialSearchString: React.PropTypes.string,
 		isSearchOpen: React.PropTypes.bool,
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			onSearch: noop,
-			onSearchClose: noop,
-			onFollow: noop,
-			initialSearchString: '',
-			isSearchOpen: false,
-		};
-	},
+    static defaultProps = {
+        onSearch: noop,
+        onSearchClose: noop,
+        onFollow: noop,
+        initialSearchString: '',
+        isSearchOpen: false,
+    };
 
-	getInitialState: function() {
-		return { searchString: this.props.initialSearchString };
-	},
+    state = { searchString: this.props.initialSearchString };
 
-	componentWillMount: function() {
+    componentWillMount() {
 		this.verifySearchString( this.props.initialSearchString );
-	},
+	}
 
-	focus: function() {
+    focus = () => {
 		this.refs.followingEditSubscriptionSearch.focus();
-	},
+	};
 
-	handleFollowToggle: function() {
+    handleFollowToggle = () => {
 		FeedSubscriptionActions.follow( this.state.searchString, true );
 		this.setState( { previousSearchString: this.state.searchString } );
 
@@ -55,9 +51,9 @@ var FollowingEditSubscribeForm = React.createClass( {
 
 		// Call onFollow method on the parent
 		this.props.onFollow( this.state.searchString );
-	},
+	};
 
-	handleKeyDown: function( event ) {
+    handleKeyDown = (event) => {
 		// Use Enter to submit
 		if (
 			event.keyCode === 13 &&
@@ -67,22 +63,22 @@ var FollowingEditSubscribeForm = React.createClass( {
 			event.preventDefault();
 			this.handleFollowToggle();
 		}
-	},
+	};
 
-	handleSearch: function( searchString ) {
+    handleSearch = (searchString) => {
 		if ( searchString === this.state.searchString ) {
 			return;
 		}
 
 		this.verifySearchString( searchString );
 		this.props.onSearch( searchString );
-	},
+	};
 
-	handleSearchClose: function() {
+    handleSearchClose = () => {
 		this.props.onSearchClose();
-	},
+	};
 
-	verifySearchString: function( searchString ) {
+    verifySearchString = (searchString) => {
 		let parsedUrl = url.parse( searchString );
 
 		// Make sure the feed URL has http:// protocol
@@ -102,9 +98,9 @@ var FollowingEditSubscribeForm = React.createClass( {
 			searchString: searchString,
 			isWellFormedFeedUrl: isWellFormedFeedUrl,
 		} );
-	},
+	};
 
-	isWellFormedFeedUrl: function( parsedUrl ) {
+    isWellFormedFeedUrl = (parsedUrl) => {
 		if ( ! parsedUrl.hostname || parsedUrl.hostname.indexOf( '.' ) === -1 ) {
 			return false;
 		}
@@ -121,9 +117,9 @@ var FollowingEditSubscribeForm = React.createClass( {
 		}
 
 		return true;
-	},
+	};
 
-	render: function() {
+    render() {
 		var searchResult = null, handleFollowToggle = noop;
 
 		const searchString = this.state.searchString,
@@ -165,7 +161,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 				{ searchResult }
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( FollowingEditSubscribeForm );

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -11,8 +11,8 @@ import LikeButtonContainer from 'blocks/like-button';
 import { markSeen } from 'lib/feed-post-store/actions';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
-const ReaderLikeButton = React.createClass( {
-	recordLikeToggle: function( liked ) {
+class ReaderLikeButton extends React.Component {
+    recordLikeToggle = (liked) => {
 		const post =
 			this.props.post ||
 			postStore.get( {
@@ -30,11 +30,11 @@ const ReaderLikeButton = React.createClass( {
 		if ( liked && ! this.props.fullPost && ! post._seen ) {
 			markSeen( post, this.props.site );
 		}
-	},
+	};
 
-	render: function() {
+    render() {
 		return <LikeButtonContainer { ...this.props } onLikeToggle={ this.recordLikeToggle } />;
-	},
-} );
+	}
+}
 
 export default ReaderLikeButton;

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -12,7 +12,7 @@ import { markSeen } from 'lib/feed-post-store/actions';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 
 class ReaderLikeButton extends React.Component {
-    recordLikeToggle = (liked) => {
+	recordLikeToggle = liked => {
 		const post =
 			this.props.post ||
 			postStore.get( {
@@ -32,7 +32,7 @@ class ReaderLikeButton extends React.Component {
 		}
 	};
 
-    render() {
+	render() {
 		return <LikeButtonContainer { ...this.props } onLikeToggle={ this.recordLikeToggle } />;
 	}
 }

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -12,23 +12,23 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class TagEmptyContent extends React.Component {
-    shouldComponentUpdate() {
+	shouldComponentUpdate() {
 		return false;
 	}
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_following_on_empty_likes' );
 		recordGaEvent( 'Clicked Following on Empty Like Stream' );
 		recordTrack( 'calypso_reader_following_on_empty_like_stream_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty_likes' );
 		recordGaEvent( 'Clicked Discover on Empty Like Stream' );
 		recordTrack( 'calypso_reader_discover_on_empty_like_stream_clicked' );
 	};
 
-    render() {
+	render() {
 		var action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -11,24 +11,24 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
-var TagEmptyContent = React.createClass( {
-	shouldComponentUpdate: function() {
+class TagEmptyContent extends React.Component {
+    shouldComponentUpdate() {
 		return false;
-	},
+	}
 
-	recordAction: function() {
+    recordAction = () => {
 		recordAction( 'clicked_following_on_empty_likes' );
 		recordGaEvent( 'Clicked Following on Empty Like Stream' );
 		recordTrack( 'calypso_reader_following_on_empty_like_stream_clicked' );
-	},
+	};
 
-	recordSecondaryAction: function() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty_likes' );
 		recordGaEvent( 'Clicked Discover on Empty Like Stream' );
 		recordTrack( 'calypso_reader_discover_on_empty_like_stream_clicked' );
-	},
+	};
 
-	render: function() {
+    render() {
 		var action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }
@@ -54,7 +54,7 @@ var TagEmptyContent = React.createClass( {
 				illustrationWidth={ 500 }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default localize( TagEmptyContent );

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -11,8 +11,8 @@ import Stream from 'reader/stream';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
 
-var LikedStream = React.createClass( {
-	render: function() {
+class LikedStream extends React.Component {
+    render() {
 		var title = this.props.translate( 'My Likes' ), emptyContent = <EmptyContent />;
 
 		return (
@@ -25,7 +25,7 @@ var LikedStream = React.createClass( {
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 			</Stream>
 		);
-	},
-} );
+	}
+}
 
 export default localize( LikedStream );

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -12,7 +12,7 @@ import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
 
 class LikedStream extends React.Component {
-    render() {
+	render() {
 		var title = this.props.translate( 'My Likes' ), emptyContent = <EmptyContent />;
 
 		return (

--- a/client/reader/list-item/actions.jsx
+++ b/client/reader/list-item/actions.jsx
@@ -2,14 +2,11 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
-const ListItemActions = React.createClass( {
-	mixins: [ PureRenderMixin ],
-
-	render() {
+class ListItemActions extends React.PureComponent {
+    render() {
 		return <div className="reader-list-item__actions">{ this.props.children }</div>;
-	},
-} );
+	}
+}
 
 export default ListItemActions;

--- a/client/reader/list-item/actions.jsx
+++ b/client/reader/list-item/actions.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 class ListItemActions extends React.PureComponent {
-    render() {
+	render() {
 		return <div className="reader-list-item__actions">{ this.props.children }</div>;
 	}
 }

--- a/client/reader/list-item/description.jsx
+++ b/client/reader/list-item/description.jsx
@@ -2,15 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
-const ListItemDescription = React.createClass( {
-	mixins: [ PureRenderMixin ],
-
-	render() {
+class ListItemDescription extends React.PureComponent {
+    render() {
 		// should this be a div instead of a p? p's have odd nesting rules that we can't enforce in code.
 		return <p className="reader-list-item__description">{ this.props.children }</p>;
-	},
-} );
+	}
+}
 
 export default ListItemDescription;

--- a/client/reader/list-item/description.jsx
+++ b/client/reader/list-item/description.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 class ListItemDescription extends React.PureComponent {
-    render() {
+	render() {
 		// should this be a div instead of a p? p's have odd nesting rules that we can't enforce in code.
 		return <p className="reader-list-item__description">{ this.props.children }</p>;
 	}

--- a/client/reader/list-item/icon.jsx
+++ b/client/reader/list-item/icon.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 import noop from 'lodash/noop';
 
 /**
@@ -12,20 +11,16 @@ import SiteIcon from 'blocks/site-icon';
 
 const genericFeedIcon = <SiteIcon size={ 48 } />;
 
-const ListItemDescription = React.createClass( {
-	mixins: [ PureRenderMixin ],
+class ListItemDescription extends React.PureComponent {
+    static defaultProps = { onClick: noop };
 
-	getDefaultProps() {
-		return { onClick: noop };
-	},
-
-	render() {
+    render() {
 		return (
 			<span className="reader-list-item__icon" onClick={ this.props.onClick }>
 				{ this.props.children || genericFeedIcon }
 			</span>
 		);
-	},
-} );
+	}
+}
 
 export default ListItemDescription;

--- a/client/reader/list-item/icon.jsx
+++ b/client/reader/list-item/icon.jsx
@@ -12,9 +12,9 @@ import SiteIcon from 'blocks/site-icon';
 const genericFeedIcon = <SiteIcon size={ 48 } />;
 
 class ListItemDescription extends React.PureComponent {
-    static defaultProps = { onClick: noop };
+	static defaultProps = { onClick: noop };
 
-    render() {
+	render() {
 		return (
 			<span className="reader-list-item__icon" onClick={ this.props.onClick }>
 				{ this.props.children || genericFeedIcon }

--- a/client/reader/list-item/index.jsx
+++ b/client/reader/list-item/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
 
 /**
@@ -10,17 +9,15 @@ import classnames from 'classnames';
  */
 import Card from 'components/card/compact';
 
-const ListItem = React.createClass( {
-	mixins: [ PureRenderMixin ],
-
-	render() {
+class ListItem extends React.PureComponent {
+    render() {
 		const classes = classnames( 'reader-list-item__card', this.props.className );
 		return (
 			<Card className={ classes }>
 				{ this.props.children }
 			</Card>
 		);
-	},
-} );
+	}
+}
 
 export default ListItem;

--- a/client/reader/list-item/index.jsx
+++ b/client/reader/list-item/index.jsx
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import Card from 'components/card/compact';
 
 class ListItem extends React.PureComponent {
-    render() {
+	render() {
 		const classes = classnames( 'reader-list-item__card', this.props.className );
 		return (
 			<Card className={ classes }>

--- a/client/reader/list-item/title.jsx
+++ b/client/reader/list-item/title.jsx
@@ -5,9 +5,9 @@ import React from 'react';
 import noop from 'lodash/noop';
 
 class ListItemTitle extends React.PureComponent {
-    static defaultProps = { onClick: noop };
+	static defaultProps = { onClick: noop };
 
-    render() {
+	render() {
 		return (
 			<h2 className="reader-list-item__title" onClick={ this.props.onClick }>
 				{ this.props.children }

--- a/client/reader/list-item/title.jsx
+++ b/client/reader/list-item/title.jsx
@@ -2,23 +2,18 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 import noop from 'lodash/noop';
 
-const ListItemTitle = React.createClass( {
-	mixins: [ PureRenderMixin ],
+class ListItemTitle extends React.PureComponent {
+    static defaultProps = { onClick: noop };
 
-	getDefaultProps() {
-		return { onClick: noop };
-	},
-
-	render() {
+    render() {
 		return (
 			<h2 className="reader-list-item__title" onClick={ this.props.onClick }>
 				{ this.props.children }
 			</h2>
 		);
-	},
-} );
+	}
+}
 
 export default ListItemTitle;

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -12,23 +12,23 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class ListEmptyContent extends React.Component {
-    shouldComponentUpdate() {
+	shouldComponentUpdate() {
 		return false;
 	}
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_empty_list_stream_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_empty_list_stream_clicked' );
 	};
 
-    render() {
+	render() {
 		var action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -11,24 +11,24 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
-var ListEmptyContent = React.createClass( {
-	shouldComponentUpdate: function() {
+class ListEmptyContent extends React.Component {
+    shouldComponentUpdate() {
 		return false;
-	},
+	}
 
-	recordAction: function() {
+    recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_empty_list_stream_clicked' );
-	},
+	};
 
-	recordSecondaryAction: function() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_empty_list_stream_clicked' );
-	},
+	};
 
-	render: function() {
+    render() {
 		var action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }
@@ -54,7 +54,7 @@ var ListEmptyContent = React.createClass( {
 				illustrationWidth={ 500 }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default localize( ListEmptyContent );

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -23,8 +23,8 @@ import {
 import QueryReaderList from 'components/data/query-reader-list';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
-const ListStream = React.createClass( {
-	toggleFollowing( isFollowRequested ) {
+class ListStream extends React.Component {
+    toggleFollowing = (isFollowRequested) => {
 		const list = this.props.list;
 
 		if ( isFollowRequested ) {
@@ -47,9 +47,9 @@ const ListStream = React.createClass( {
 				list_slug: list.slug,
 			}
 		);
-	},
+	};
 
-	render() {
+    render() {
 		const list = this.props.list,
 			shouldShowFollow = list && ! list.is_owner,
 			shouldShowEdit = ! shouldShowFollow,
@@ -101,8 +101,8 @@ const ListStream = React.createClass( {
 				/>
 			</Stream>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	( state, ownProps ) => {

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -24,7 +24,7 @@ import QueryReaderList from 'components/data/query-reader-list';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class ListStream extends React.Component {
-    toggleFollowing = (isFollowRequested) => {
+	toggleFollowing = isFollowRequested => {
 		const list = this.props.list;
 
 		if ( isFollowRequested ) {
@@ -49,7 +49,7 @@ class ListStream extends React.Component {
 		);
 	};
 
-    render() {
+	render() {
 		const list = this.props.list,
 			shouldShowFollow = list && ! list.is_owner,
 			shouldShowEdit = ! shouldShowFollow,

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -14,24 +14,24 @@ import QueryReaderList from 'components/data/query-reader-list';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 class ListMissing extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		owner: React.PropTypes.string.isRequired,
 		slug: React.PropTypes.string.isRequired,
 	};
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_missing_list_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_missing_list_clicked' );
 	};
 
-    render() {
+	render() {
 		const action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Followed Sites' ) }

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -13,25 +13,25 @@ import QueryReaderList from 'components/data/query-reader-list';
 
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
-const ListMissing = React.createClass( {
-	propTypes: {
+class ListMissing extends React.Component {
+    static propTypes = {
 		owner: React.PropTypes.string.isRequired,
 		slug: React.PropTypes.string.isRequired,
-	},
+	};
 
-	recordAction() {
+    recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_missing_list_clicked' );
-	},
+	};
 
-	recordSecondaryAction() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_missing_list_clicked' );
-	},
+	};
 
-	render() {
+    render() {
 		const action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Followed Sites' ) }
@@ -60,7 +60,7 @@ const ListMissing = React.createClass( {
 				/>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( ListMissing );

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -11,27 +11,27 @@ import classNames from 'classnames';
 import { recordPermalinkClick } from 'reader/stats';
 
 class PostExcerptLink extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		siteName: React.PropTypes.string,
 		postUrl: React.PropTypes.string,
 	};
 
-    state = {
-        isShowingNotice: false,
-    };
+	state = {
+		isShowingNotice: false,
+	};
 
-    toggleNotice = (event) => {
+	toggleNotice = event => {
 		event.preventDefault();
 		this.setState( {
 			isShowingNotice: ! this.state.isShowingNotice,
 		} );
 	};
 
-    recordClick = () => {
+	recordClick = () => {
 		recordPermalinkClick( 'summary_card_site_name' );
 	};
 
-    render() {
+	render() {
 		if ( ! this.props.siteName || ! this.props.postUrl ) {
 			return null;
 		}

--- a/client/reader/post-excerpt-link/index.jsx
+++ b/client/reader/post-excerpt-link/index.jsx
@@ -10,30 +10,28 @@ import classNames from 'classnames';
  */
 import { recordPermalinkClick } from 'reader/stats';
 
-const PostExcerptLink = React.createClass( {
-	propTypes: {
+class PostExcerptLink extends React.Component {
+    static propTypes = {
 		siteName: React.PropTypes.string,
 		postUrl: React.PropTypes.string,
-	},
+	};
 
-	getInitialState() {
-		return {
-			isShowingNotice: false,
-		};
-	},
+    state = {
+        isShowingNotice: false,
+    };
 
-	toggleNotice( event ) {
+    toggleNotice = (event) => {
 		event.preventDefault();
 		this.setState( {
 			isShowingNotice: ! this.state.isShowingNotice,
 		} );
-	},
+	};
 
-	recordClick() {
+    recordClick = () => {
 		recordPermalinkClick( 'summary_card_site_name' );
-	},
+	};
 
-	render() {
+    render() {
 		if ( ! this.props.siteName || ! this.props.postUrl ) {
 			return null;
 		}
@@ -74,7 +72,7 @@ const PostExcerptLink = React.createClass( {
 				</p>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default localize( PostExcerptLink );

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 
 class ReadingTime extends React.PureComponent {
-    render() {
+	render() {
 		var words = this.props.words || 0,
 			timeInMinutes = Math.round( this.props.readingTime / 60 ),
 			approxTime = null,

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -3,12 +3,9 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import PureRenderMixin from 'react-pure-render/mixin';
 
-var ReadingTime = React.createClass( {
-	mixins: [ PureRenderMixin ],
-
-	render: function() {
+class ReadingTime extends React.PureComponent {
+    render() {
 		var words = this.props.words || 0,
 			timeInMinutes = Math.round( this.props.readingTime / 60 ),
 			approxTime = null,
@@ -32,7 +29,7 @@ var ReadingTime = React.createClass( {
 		} );
 
 		return <span className="byline__reading-time reading-time">{ readingTime }</span>;
-	},
-} );
+	}
+}
 
 export default localize( ReadingTime );

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -22,23 +22,23 @@ import { getSiteUrl } from 'reader/route';
 import { decodeEntities } from 'lib/formatting';
 
 class RecommendedForYou extends React.Component {
-    constructor(props, context) {
-        super(props, context);
-        const recommendations = this.getRecommendations();
-        let fetching = false;
-        if ( recommendations.length === 0 ) {
+	constructor( props, context ) {
+		super( props, context );
+		const recommendations = this.getRecommendations();
+		let fetching = false;
+		if ( recommendations.length === 0 ) {
 			fetchMore();
 			fetching = true;
 		}
 
-        this.state = {
+		this.state = {
 			recommendations,
 			fetching,
 			page: 1,
 		};
-    }
+	}
 
-    getRecommendations = () => {
+	getRecommendations = () => {
 		const recs = RecommendedSites.get();
 		return recs.map( function( rec ) {
 			rec.site = SiteStore.get( rec.blog_id );
@@ -46,23 +46,23 @@ class RecommendedForYou extends React.Component {
 		} );
 	};
 
-    update = () => {
+	update = () => {
 		this.setState( { recommendations: this.getRecommendations() } );
 	};
 
-    componentDidMount() {
+	componentDidMount() {
 		SiteStore.on( 'change', this.update );
 		RecommendedSites.on( 'change', this.update );
 		RecommendedSites.on( 'change', this.stopFetching );
 	}
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		SiteStore.off( 'change', this.update );
 		RecommendedSites.off( 'change', this.update );
 		RecommendedSites.off( 'change', this.stopFetching );
 	}
 
-    loadMore = (options) => {
+	loadMore = options => {
 		fetchMore();
 		this.setState( { fetching: true } );
 		if ( options.triggeredByScroll ) {
@@ -70,14 +70,14 @@ class RecommendedForYou extends React.Component {
 		}
 	};
 
-    stopFetching = () => {
+	stopFetching = () => {
 		this.setState( {
 			fetching: false,
 			page: this.state.page + 1,
 		} );
 	};
 
-    renderPlaceholders = () => {
+	renderPlaceholders = () => {
 		const placeholders = [], number = this.state.recommendations.length ? 2 : 10;
 
 		times( number, i => {
@@ -93,11 +93,11 @@ class RecommendedForYou extends React.Component {
 		return placeholders;
 	};
 
-    getItemRef = (rec) => {
+	getItemRef = rec => {
 		return 'recommendation-' + rec.blog_id;
 	};
 
-    trackSiteClick = (event) => {
+	trackSiteClick = event => {
 		const clickedUrl = event.currentTarget.getAttribute( 'href' );
 		recordAction( 'click_site_on_recommended_for_you' );
 		recordGaEvent( 'Clicked Site on Recommended For You' );
@@ -107,7 +107,7 @@ class RecommendedForYou extends React.Component {
 		} );
 	};
 
-    renderItem = (rec) => {
+	renderItem = rec => {
 		const site = rec.site && rec.site.toJS(),
 			itemKey = this.getItemRef( rec ),
 			title = site.name || ( site.URL && url.parse( site.URL ).hostname ),
@@ -127,7 +127,7 @@ class RecommendedForYou extends React.Component {
 		);
 	};
 
-    render() {
+	render() {
 		return (
 			<Main className="recommended-for-you">
 				<MobileBackToSidebar>

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -21,61 +21,63 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { getSiteUrl } from 'reader/route';
 import { decodeEntities } from 'lib/formatting';
 
-const RecommendedForYou = React.createClass( {
-	getInitialState() {
-		const recommendations = this.getRecommendations();
-		let fetching = false;
-		if ( recommendations.length === 0 ) {
+class RecommendedForYou extends React.Component {
+    constructor(props, context) {
+        super(props, context);
+        const recommendations = this.getRecommendations();
+        let fetching = false;
+        if ( recommendations.length === 0 ) {
 			fetchMore();
 			fetching = true;
 		}
-		return {
+
+        this.state = {
 			recommendations,
 			fetching,
 			page: 1,
 		};
-	},
+    }
 
-	getRecommendations() {
+    getRecommendations = () => {
 		const recs = RecommendedSites.get();
 		return recs.map( function( rec ) {
 			rec.site = SiteStore.get( rec.blog_id );
 			return rec;
 		} );
-	},
+	};
 
-	update() {
+    update = () => {
 		this.setState( { recommendations: this.getRecommendations() } );
-	},
+	};
 
-	componentDidMount() {
+    componentDidMount() {
 		SiteStore.on( 'change', this.update );
 		RecommendedSites.on( 'change', this.update );
 		RecommendedSites.on( 'change', this.stopFetching );
-	},
+	}
 
-	componentWillUnmount() {
+    componentWillUnmount() {
 		SiteStore.off( 'change', this.update );
 		RecommendedSites.off( 'change', this.update );
 		RecommendedSites.off( 'change', this.stopFetching );
-	},
+	}
 
-	loadMore( options ) {
+    loadMore = (options) => {
 		fetchMore();
 		this.setState( { fetching: true } );
 		if ( options.triggeredByScroll ) {
 			this.props.trackScrollPage( RecommendedSites.getPage() );
 		}
-	},
+	};
 
-	stopFetching() {
+    stopFetching = () => {
 		this.setState( {
 			fetching: false,
 			page: this.state.page + 1,
 		} );
-	},
+	};
 
-	renderPlaceholders() {
+    renderPlaceholders = () => {
 		const placeholders = [], number = this.state.recommendations.length ? 2 : 10;
 
 		times( number, i => {
@@ -89,13 +91,13 @@ const RecommendedForYou = React.createClass( {
 		} );
 
 		return placeholders;
-	},
+	};
 
-	getItemRef( rec ) {
+    getItemRef = (rec) => {
 		return 'recommendation-' + rec.blog_id;
-	},
+	};
 
-	trackSiteClick( event ) {
+    trackSiteClick = (event) => {
 		const clickedUrl = event.currentTarget.getAttribute( 'href' );
 		recordAction( 'click_site_on_recommended_for_you' );
 		recordGaEvent( 'Clicked Site on Recommended For You' );
@@ -103,9 +105,9 @@ const RecommendedForYou = React.createClass( {
 			clicked_url: clickedUrl,
 			recommendation_source: 'recommendations-page',
 		} );
-	},
+	};
 
-	renderItem( rec ) {
+    renderItem = (rec) => {
 		const site = rec.site && rec.site.toJS(),
 			itemKey = this.getItemRef( rec ),
 			title = site.name || ( site.URL && url.parse( site.URL ).hostname ),
@@ -123,9 +125,9 @@ const RecommendedForYou = React.createClass( {
 				</Actions>
 			</ListItem>
 		);
-	},
+	};
 
-	render() {
+    render() {
 		return (
 			<Main className="recommended-for-you">
 				<MobileBackToSidebar>
@@ -147,7 +149,7 @@ const RecommendedForYou = React.createClass( {
 				/>
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default localize( RecommendedForYou );

--- a/client/reader/recommendations/global-tags/index.jsx
+++ b/client/reader/recommendations/global-tags/index.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import Main from 'components/main';
 import Navigation from 'reader/recommendations/navigation';
 
-const RecommendedTags = React.createClass( {
-	render() {
+class RecommendedTags extends React.Component {
+    render() {
 		return (
 			<Main>
 				<Navigation selected="tags" />
 				Trending tags
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default RecommendedTags;

--- a/client/reader/recommendations/global-tags/index.jsx
+++ b/client/reader/recommendations/global-tags/index.jsx
@@ -3,7 +3,7 @@ import Main from 'components/main';
 import Navigation from 'reader/recommendations/navigation';
 
 class RecommendedTags extends React.Component {
-    render() {
+	render() {
 		return (
 			<Main>
 				<Navigation selected="tags" />

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -5,9 +5,9 @@ import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 
 class RecommendedNavigation extends React.Component {
-    static propTypes = { selected: PropTypes.oneOf( [ 'for-you', 'sites', 'tags' ] ).isRequired };
+	static propTypes = { selected: PropTypes.oneOf( [ 'for-you', 'sites', 'tags' ] ).isRequired };
 
-    render() {
+	render() {
 		const current = this.props.selected;
 		const sectionNames = {
 			'for-you': this.props.translate( 'Recommendations: For You' ),

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -4,10 +4,10 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 
-const RecommendedNavigation = React.createClass( {
-	propTypes: { selected: PropTypes.oneOf( [ 'for-you', 'sites', 'tags' ] ).isRequired },
+class RecommendedNavigation extends React.Component {
+    static propTypes = { selected: PropTypes.oneOf( [ 'for-you', 'sites', 'tags' ] ).isRequired };
 
-	render() {
+    render() {
 		const current = this.props.selected;
 		const sectionNames = {
 			'for-you': this.props.translate( 'Recommendations: For You' ),
@@ -34,7 +34,7 @@ const RecommendedNavigation = React.createClass( {
 				</NavTabs>
 			</SectionNav>
 		);
-	},
-} );
+	}
+}
 
 export default localize( RecommendedNavigation );

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -12,23 +12,23 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class RecommendedPostsEmptyContent extends React.Component {
-    shouldComponentUpdate() {
+	shouldComponentUpdate() {
 		return false;
 	}
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_following_on_empty_recommended_posts' );
 		recordGaEvent( 'Clicked Following on Empty Recommended Posts Stream' );
 		recordTrack( 'calypso_reader_following_on_empty_Posts_stream_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty_recommended_posts' );
 		recordGaEvent( 'Clicked Discover on Empty Recommended Posts Stream' );
 		recordTrack( 'calypso_reader_discover_on_empty_Posts_stream_clicked' );
 	};
 
-    render() {
+	render() {
 		var action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -11,24 +11,24 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
-var RecommendedPostsEmptyContent = React.createClass( {
-	shouldComponentUpdate: function() {
+class RecommendedPostsEmptyContent extends React.Component {
+    shouldComponentUpdate() {
 		return false;
-	},
+	}
 
-	recordAction: function() {
+    recordAction = () => {
 		recordAction( 'clicked_following_on_empty_recommended_posts' );
 		recordGaEvent( 'Clicked Following on Empty Recommended Posts Stream' );
 		recordTrack( 'calypso_reader_following_on_empty_Posts_stream_clicked' );
-	},
+	};
 
-	recordSecondaryAction: function() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty_recommended_posts' );
 		recordGaEvent( 'Clicked Discover on Empty Recommended Posts Stream' );
 		recordTrack( 'calypso_reader_discover_on_empty_Posts_stream_clicked' );
-	},
+	};
 
-	render: function() {
+    render() {
 		var action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }
@@ -56,7 +56,7 @@ var RecommendedPostsEmptyContent = React.createClass( {
 				illustrationWidth={ 500 }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default localize( RecommendedPostsEmptyContent );

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -11,8 +11,8 @@ import Stream from 'reader/stream';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
 
-var RecommendationPostsStream = React.createClass( {
-	render: function() {
+class RecommendationPostsStream extends React.Component {
+    render() {
 		const title = this.props.translate( 'Recommended Posts' );
 		const emptyContent = <EmptyContent />;
 
@@ -26,7 +26,7 @@ var RecommendationPostsStream = React.createClass( {
 				<DocumentHead title={ this.props.translate( '%s ‹ Reader', { args: title } ) } />
 			</Stream>
 		);
-	},
-} );
+	}
+}
 
 export default localize( RecommendationPostsStream );

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -12,7 +12,7 @@ import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
 
 class RecommendationPostsStream extends React.Component {
-    render() {
+	render() {
 		const title = this.props.translate( 'Recommended Posts' );
 		const emptyContent = <EmptyContent />;
 

--- a/client/reader/recommendations/sites/index.jsx
+++ b/client/reader/recommendations/sites/index.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import Main from 'components/main';
 import Navigation from 'reader/recommendations/navigation';
 
-const RecommendedSites = React.createClass( {
-	render() {
+class RecommendedSites extends React.Component {
+    render() {
 		return (
 			<Main>
 				<Navigation selected="sites" />
 				Sites!
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default RecommendedSites;

--- a/client/reader/recommendations/sites/index.jsx
+++ b/client/reader/recommendations/sites/index.jsx
@@ -3,7 +3,7 @@ import Main from 'components/main';
 import Navigation from 'reader/recommendations/navigation';
 
 class RecommendedSites extends React.Component {
-    render() {
+	render() {
 		return (
 			<Main>
 				<Navigation selected="sites" />

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -11,28 +11,28 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
-const SearchEmptyContent = React.createClass( {
-	propTypes: {
+class SearchEmptyContent extends React.Component {
+    static propTypes = {
 		query: React.PropTypes.string,
-	},
+	};
 
-	shouldComponentUpdate: function() {
+    shouldComponentUpdate() {
 		return false;
-	},
+	}
 
-	recordAction: function() {
+    recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_empty_search_stream_clicked' );
-	},
+	};
 
-	recordSecondaryAction: function() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_empty_search_stream_clicked' );
-	},
+	};
 
-	render: function() {
+    render() {
 		const action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }
@@ -63,7 +63,7 @@ const SearchEmptyContent = React.createClass( {
 				illustrationWidth={ 500 }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default localize( SearchEmptyContent );

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -12,27 +12,27 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class SearchEmptyContent extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		query: React.PropTypes.string,
 	};
 
-    shouldComponentUpdate() {
+	shouldComponentUpdate() {
 		return false;
 	}
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_empty_search_stream_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_empty_search_stream_clicked' );
 	};
 
-    render() {
+	render() {
 		const action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -41,32 +41,32 @@ import viewport from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import { getTagStreamUrl } from 'reader/route';
 
-export const ReaderSidebar = createReactClass({
-    displayName: 'ReaderSidebar',
-    mixins: [ observe( 'userSettings' ) ],
+export const ReaderSidebar = createReactClass( {
+	displayName: 'ReaderSidebar',
+	mixins: [ observe( 'userSettings' ) ],
 
-    getInitialState() {
+	getInitialState() {
 		return {};
 	},
 
-    componentDidMount() {
+	componentDidMount() {
 		// If we're browsing a tag or list, open the sidebar menu
 		this.openExpandableMenuForCurrentTagOrList();
 	},
 
-    handleClick( event ) {
+	handleClick( event ) {
 		if ( ! event.isDefaultPrevented() && closest( event.target, 'a,span', true ) ) {
 			this.props.setNextLayoutFocus( 'content' );
 			window.scrollTo( 0, 0 );
 		}
 	},
 
-    highlightNewList( list ) {
+	highlightNewList( list ) {
 		list = ReaderListsStore.get( list.owner, list.slug );
 		window.location.href = url.resolve( 'https://wordpress.com', list.URL + '/edit' );
 	},
 
-    highlightNewTag( tagSlug ) {
+	highlightNewTag( tagSlug ) {
 		const tagStreamUrl = getTagStreamUrl( tagSlug );
 		if ( tagStreamUrl !== page.current ) {
 			defer( function() {
@@ -76,7 +76,7 @@ export const ReaderSidebar = createReactClass({
 		}
 	},
 
-    openExpandableMenuForCurrentTagOrList() {
+	openExpandableMenuForCurrentTagOrList() {
 		const pathParts = this.props.path.split( '/' );
 
 		if ( startsWith( this.props.path, '/tag/' ) ) {
@@ -103,7 +103,7 @@ export const ReaderSidebar = createReactClass({
 		}
 	},
 
-    render() {
+	render() {
 		return (
 			<Sidebar onClick={ this.handleClick }>
 				<SidebarRegion>
@@ -206,7 +206,7 @@ export const ReaderSidebar = createReactClass({
 			</Sidebar>
 		);
 	},
-});
+} );
 
 ReaderSidebar.defaultProps = {
 	translate: identity,

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import closest from 'component-closest';
 import page from 'page';
 import url from 'url';
@@ -40,31 +41,32 @@ import viewport from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import { getTagStreamUrl } from 'reader/route';
 
-export const ReaderSidebar = React.createClass( {
-	mixins: [ observe( 'userSettings' ) ],
+export const ReaderSidebar = createReactClass({
+    displayName: 'ReaderSidebar',
+    mixins: [ observe( 'userSettings' ) ],
 
-	getInitialState() {
+    getInitialState() {
 		return {};
 	},
 
-	componentDidMount() {
+    componentDidMount() {
 		// If we're browsing a tag or list, open the sidebar menu
 		this.openExpandableMenuForCurrentTagOrList();
 	},
 
-	handleClick( event ) {
+    handleClick( event ) {
 		if ( ! event.isDefaultPrevented() && closest( event.target, 'a,span', true ) ) {
 			this.props.setNextLayoutFocus( 'content' );
 			window.scrollTo( 0, 0 );
 		}
 	},
 
-	highlightNewList( list ) {
+    highlightNewList( list ) {
 		list = ReaderListsStore.get( list.owner, list.slug );
 		window.location.href = url.resolve( 'https://wordpress.com', list.URL + '/edit' );
 	},
 
-	highlightNewTag( tagSlug ) {
+    highlightNewTag( tagSlug ) {
 		const tagStreamUrl = getTagStreamUrl( tagSlug );
 		if ( tagStreamUrl !== page.current ) {
 			defer( function() {
@@ -74,7 +76,7 @@ export const ReaderSidebar = React.createClass( {
 		}
 	},
 
-	openExpandableMenuForCurrentTagOrList() {
+    openExpandableMenuForCurrentTagOrList() {
 		const pathParts = this.props.path.split( '/' );
 
 		if ( startsWith( this.props.path, '/tag/' ) ) {
@@ -101,7 +103,7 @@ export const ReaderSidebar = React.createClass( {
 		}
 	},
 
-	render() {
+    render() {
 		return (
 			<Sidebar onClick={ this.handleClick }>
 				<SidebarRegion>
@@ -204,7 +206,7 @@ export const ReaderSidebar = React.createClass( {
 			</Sidebar>
 		);
 	},
-} );
+});
 
 ReaderSidebar.defaultProps = {
 	translate: identity,

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -15,129 +15,131 @@ import { getSourceData as getDiscoverSourceData } from 'reader/discover/helper';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import cssSafeUrl from 'lib/css-safe-url';
 
-export default localize(class extends React.PureComponent {
-    static displayName = 'FeedFeatured';
+export default localize(
+	class extends React.PureComponent {
+		static displayName = 'FeedFeatured';
 
-    getStateFromStores = (store = this.props.store) => {
-        const posts = store.get().map( postKey => {
-            const post = FeedPostStore.get( postKey );
+		getStateFromStores = ( store = this.props.store ) => {
+			const posts = store.get().map( postKey => {
+				const post = FeedPostStore.get( postKey );
 
-            if ( this.shouldFetch( post ) ) {
-                FeedPostStoreActions.fetchPost( postKey );
-                return { post };
-            }
+				if ( this.shouldFetch( post ) ) {
+					FeedPostStoreActions.fetchPost( postKey );
+					return { post };
+				}
 
-            const source = this.getSourcePost( post ), url = this.getPostUrl( source || post );
+				const source = this.getSourcePost( post ), url = this.getPostUrl( source || post );
 
-            return {
-                post,
-                source,
-                url,
-            };
-        } );
+				return {
+					post,
+					source,
+					url,
+				};
+			} );
 
-        return {
-            posts,
-        };
-    };
+			return {
+				posts,
+			};
+		};
 
-    updateState = (store) => {
-        this.setState( this.getStateFromStores( store ) );
-    };
+		updateState = store => {
+			this.setState( this.getStateFromStores( store ) );
+		};
 
-    componentDidMount() {
-        this.props.store.on( 'change', this.updateState );
-        FeedPostStore.on( 'change', this.updateState );
-    }
+		componentDidMount() {
+			this.props.store.on( 'change', this.updateState );
+			FeedPostStore.on( 'change', this.updateState );
+		}
 
-    componentWillUnmount() {
-        this.props.store.off( 'change', this.updateState );
-        FeedPostStore.off( 'change', this.updateState );
-    }
+		componentWillUnmount() {
+			this.props.store.off( 'change', this.updateState );
+			FeedPostStore.off( 'change', this.updateState );
+		}
 
-    componentWillReceiveProps(nextProps) {
-        if ( nextProps.store !== this.props.store ) {
-            this.updateState();
-        }
-    }
+		componentWillReceiveProps( nextProps ) {
+			if ( nextProps.store !== this.props.store ) {
+				this.updateState();
+			}
+		}
 
-    shouldFetch = (post) => {
-        return ! post || post._state === 'minimal';
-    };
+		shouldFetch = post => {
+			return ! post || post._state === 'minimal';
+		};
 
-    getSourcePost = (post) => {
-        const data = getDiscoverSourceData( post );
+		getSourcePost = post => {
+			const data = getDiscoverSourceData( post );
 
-        if ( ! data ) {
-            return null;
-        }
+			if ( ! data ) {
+				return null;
+			}
 
-        return FeedPostStore.get( data );
-    };
+			return FeedPostStore.get( data );
+		};
 
-    getPostUrl = (post) => {
-        return '/read/blogs/' + post.site_ID + '/posts/' + post.ID;
-    };
+		getPostUrl = post => {
+			return '/read/blogs/' + post.site_ID + '/posts/' + post.ID;
+		};
 
-    handleClick = (postData) => {
-        const post = postData.post;
-        recordTrackForPost( 'calypso_reader_clicked_featured_post', post );
-        recordAction( 'clicked_featured_post' );
-        recordGaEvent( 'Clicked Featured Post' );
+		handleClick = postData => {
+			const post = postData.post;
+			recordTrackForPost( 'calypso_reader_clicked_featured_post', post );
+			recordAction( 'clicked_featured_post' );
+			recordGaEvent( 'Clicked Featured Post' );
 
-        page( postData.url );
-    };
+			page( postData.url );
+		};
 
-    renderPosts = () => {
-        return this.state.posts.map( postData => {
-            const post = postData.post, postState = post._state;
+		renderPosts = () => {
+			return this.state.posts.map( postData => {
+				const post = postData.post, postState = post._state;
 
-            switch ( postState ) {
-                case 'minimal':
-                case 'pending':
-                case 'error':
-                    break;
-                default:
-                    let style = {
-                        backgroundImage: post.canonical_image && post.canonical_image.uri
-                            ? 'url(' + cssSafeUrl( post.canonical_image.uri ) + ')'
-                            : null,
-                    };
+				switch ( postState ) {
+					case 'minimal':
+					case 'pending':
+					case 'error':
+						break;
+					default:
+						let style = {
+							backgroundImage: post.canonical_image && post.canonical_image.uri
+								? 'url(' + cssSafeUrl( post.canonical_image.uri ) + ')'
+								: null,
+						};
 
-                    return (
-                        <div
-                            key={ post.ID }
-                            className="reader__featured-post"
-                            onClick={ this.handleClick.bind( this, postData ) }
-                        >
-                            <div className="reader__featured-post-image" style={ style } />
-                            <h2 className="reader__featured-post-title">{ post.title }</h2>
-                        </div>
-                    );
-            }
-        } );
-    };
+						return (
+							<div
+								key={ post.ID }
+								className="reader__featured-post"
+								onClick={ this.handleClick.bind( this, postData ) }
+							>
+								<div className="reader__featured-post-image" style={ style } />
+								<h2 className="reader__featured-post-title">{ post.title }</h2>
+							</div>
+						);
+				}
+			} );
+		};
 
-    state = this.getStateFromStores();
+		state = this.getStateFromStores();
 
-    render() {
-        if ( ! this.state.posts ) {
-            return null;
-        }
+		render() {
+			if ( ! this.state.posts ) {
+				return null;
+			}
 
-        return (
-            <Card className="reader__featured-card">
-                <div className="reader__featured-header">
-                    <div className="reader__featured-title">{ this.props.translate( 'Highlights' ) }</div>
-                    <div className="reader__featured-description">
-                        { this.props.translate( 'What we’re reading this week.' ) }
-                    </div>
-                </div>
+			return (
+				<Card className="reader__featured-card">
+					<div className="reader__featured-header">
+						<div className="reader__featured-title">{ this.props.translate( 'Highlights' ) }</div>
+						<div className="reader__featured-description">
+							{ this.props.translate( 'What we’re reading this week.' ) }
+						</div>
+					</div>
 
-                <div className="reader__featured-posts">
-                    { this.renderPosts() }
-                </div>
-            </Card>
-        );
-    }
-});
+					<div className="reader__featured-posts">
+						{ this.renderPosts() }
+					</div>
+				</Card>
+			);
+		}
+	}
+);

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -12,17 +12,17 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class FollowingEmptyContent extends React.Component {
-    shouldComponentUpdate() {
+	shouldComponentUpdate() {
 		return false;
 	}
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_search_on_empty' );
 		recordGaEvent( 'Clicked Search on EmptyContent' );
 		recordTrack( 'calypso_reader_search_on_empty_stream_clicked' );
 	};
 
-    render() {
+	render() {
 		const action = isDiscoverEnabled()
 			? <a
 					className="empty-content__action button is-primary"

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -11,18 +11,18 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
-const FollowingEmptyContent = React.createClass( {
-	shouldComponentUpdate: function() {
+class FollowingEmptyContent extends React.Component {
+    shouldComponentUpdate() {
 		return false;
-	},
+	}
 
-	recordAction: function() {
+    recordAction = () => {
 		recordAction( 'clicked_search_on_empty' );
 		recordGaEvent( 'Clicked Search on EmptyContent' );
 		recordTrack( 'calypso_reader_search_on_empty_stream_clicked' );
-	},
+	};
 
-	render: function() {
+    render() {
 		const action = isDiscoverEnabled()
 			? <a
 					className="empty-content__action button is-primary"
@@ -44,7 +44,7 @@ const FollowingEmptyContent = React.createClass( {
 				illustrationWidth={ 500 }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default localize( FollowingEmptyContent );

--- a/client/reader/stream/post-placeholder.jsx
+++ b/client/reader/stream/post-placeholder.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import Card from 'components/card';
 
 class PostPlaceholder extends React.PureComponent {
-    render() {
+	render() {
 		return (
 			<Card tagName="article" className="reader__card is-placeholder">
 				<div className="reader__post-header">

--- a/client/reader/stream/post-placeholder.jsx
+++ b/client/reader/stream/post-placeholder.jsx
@@ -2,17 +2,14 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 
-const PostPlaceholder = React.createClass( {
-	mixins: [ PureRenderMixin ],
-
-	render() {
+class PostPlaceholder extends React.PureComponent {
+    render() {
 		return (
 			<Card tagName="article" className="reader__card is-placeholder">
 				<div className="reader__post-header">
@@ -47,7 +44,7 @@ const PostPlaceholder = React.createClass( {
 				</ul>
 			</Card>
 		);
-	},
-} );
+	}
+}
 
 export default PostPlaceholder;

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -11,7 +11,7 @@ import config from 'config';
 import Card from 'components/card';
 
 class PostUnavailable extends React.PureComponent {
-    componentWillMount() {
+	componentWillMount() {
 		this.errors = {
 			unauthorized: this.props.translate(
 				'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.'
@@ -20,7 +20,7 @@ class PostUnavailable extends React.PureComponent {
 		};
 	}
 
-    render() {
+	render() {
 		var errorMessage = this.errors[ this.props.post.errorCode || 'default' ] || this.errors.default;
 
 		if ( this.props.post.statusCode === 404 ) {

--- a/client/reader/stream/post-unavailable.jsx
+++ b/client/reader/stream/post-unavailable.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import PureRenderMixin from 'react-pure-render/mixin';
 import config from 'config';
 
 /**
@@ -11,19 +10,17 @@ import config from 'config';
  */
 import Card from 'components/card';
 
-var PostUnavailable = React.createClass( {
-	mixins: [ PureRenderMixin ],
-
-	componentWillMount: function() {
+class PostUnavailable extends React.PureComponent {
+    componentWillMount() {
 		this.errors = {
 			unauthorized: this.props.translate(
 				'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.'
 			),
 			default: this.props.translate( 'An error occurred loading this post.' ),
 		};
-	},
+	}
 
-	render: function() {
+    render() {
 		var errorMessage = this.errors[ this.props.post.errorCode || 'default' ] || this.errors.default;
 
 		if ( this.props.post.statusCode === 404 ) {
@@ -49,7 +46,7 @@ var PostUnavailable = React.createClass( {
 				</div>
 			</Card>
 		);
-	},
-} );
+	}
+}
 
 export default localize( PostUnavailable );

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -12,27 +12,27 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
 class TagEmptyContent extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		decodedTagSlug: React.PropTypes.string,
 	};
 
-    shouldComponentUpdate() {
+	shouldComponentUpdate() {
 		return false;
 	}
 
-    recordAction = () => {
+	recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_empty_tag_stream_clicked' );
 	};
 
-    recordSecondaryAction = () => {
+	recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
 	};
 
-    render() {
+	render() {
 		const action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -11,28 +11,28 @@ import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 
-const TagEmptyContent = React.createClass( {
-	propTypes: {
+class TagEmptyContent extends React.Component {
+    static propTypes = {
 		decodedTagSlug: React.PropTypes.string,
-	},
+	};
 
-	shouldComponentUpdate() {
+    shouldComponentUpdate() {
 		return false;
-	},
+	}
 
-	recordAction() {
+    recordAction = () => {
 		recordAction( 'clicked_following_on_empty' );
 		recordGaEvent( 'Clicked Following on EmptyContent' );
 		recordTrack( 'calypso_reader_following_on_empty_tag_stream_clicked' );
-	},
+	};
 
-	recordSecondaryAction() {
+    recordSecondaryAction = () => {
 		recordAction( 'clicked_discover_on_empty' );
 		recordGaEvent( 'Clicked Discover on EmptyContent' );
 		recordTrack( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
-	},
+	};
 
-	render() {
+    render() {
 		const action = (
 			<a className="empty-content__action button is-primary" onClick={ this.recordAction } href="/">
 				{ this.props.translate( 'Back to Following' ) }
@@ -64,7 +64,7 @@ const TagEmptyContent = React.createClass( {
 				illustrationWidth={ 500 }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default localize( TagEmptyContent );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -21,18 +21,18 @@ import QueryReaderTag from 'components/data/query-reader-tag';
 import { find } from 'lodash';
 
 class TagStream extends React.Component {
-    static propTypes = {
+	static propTypes = {
 		encodedTagSlug: React.PropTypes.string,
 		decodedTagSlug: React.PropTypes.string,
 	};
 
-    state = {
-        isEmojiTitle: false,
-    };
+	state = {
+		isEmojiTitle: false,
+	};
 
-    _isMounted = false;
+	_isMounted = false;
 
-    componentWillMount() {
+	componentWillMount() {
 		const self = this;
 		this._isMounted = true;
 		// can't use arrows with asyncRequire
@@ -52,29 +52,29 @@ class TagStream extends React.Component {
 		} );
 	}
 
-    componentWillUnmount() {
+	componentWillUnmount() {
 		this._isMounted = false;
 	}
 
-    componentWillReceiveProps(nextProps) {
+	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.encodedTagSlug !== this.props.encodedTagSlug ) {
 			this.checkForTwemoji( nextProps );
 		}
 	}
 
-    checkForTwemoji = () => {
+	checkForTwemoji = () => {
 		const title = this.getTitle();
 		this.setState( {
 			isEmojiTitle: title && this.state.twemoji && this.state.twemoji.test( title ),
 		} );
 	};
 
-    isSubscribed = () => {
+	isSubscribed = () => {
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
 		return !! ( tag && tag.isFollowing );
 	};
 
-    toggleFollowing = () => {
+	toggleFollowing = () => {
 		const { decodedTagSlug, unfollowTag, followTag } = this.props;
 		const isFollowing = this.isSubscribed(); // this is the current state, not the new state
 		const toggleAction = isFollowing ? unfollowTag : followTag;
@@ -92,7 +92,7 @@ class TagStream extends React.Component {
 		);
 	};
 
-    render() {
+	render() {
 		const emptyContent = <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
 		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -20,21 +20,19 @@ import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags'
 import QueryReaderTag from 'components/data/query-reader-tag';
 import { find } from 'lodash';
 
-const TagStream = React.createClass( {
-	_isMounted: false,
-
-	propTypes: {
+class TagStream extends React.Component {
+    static propTypes = {
 		encodedTagSlug: React.PropTypes.string,
 		decodedTagSlug: React.PropTypes.string,
-	},
+	};
 
-	getInitialState() {
-		return {
-			isEmojiTitle: false,
-		};
-	},
+    state = {
+        isEmojiTitle: false,
+    };
 
-	componentWillMount() {
+    _isMounted = false;
+
+    componentWillMount() {
 		const self = this;
 		this._isMounted = true;
 		// can't use arrows with asyncRequire
@@ -52,31 +50,31 @@ const TagStream = React.createClass( {
 				} );
 			}
 		} );
-	},
+	}
 
-	componentWillUnmount() {
+    componentWillUnmount() {
 		this._isMounted = false;
-	},
+	}
 
-	componentWillReceiveProps( nextProps ) {
+    componentWillReceiveProps(nextProps) {
 		if ( nextProps.encodedTagSlug !== this.props.encodedTagSlug ) {
 			this.checkForTwemoji( nextProps );
 		}
-	},
+	}
 
-	checkForTwemoji() {
+    checkForTwemoji = () => {
 		const title = this.getTitle();
 		this.setState( {
 			isEmojiTitle: title && this.state.twemoji && this.state.twemoji.test( title ),
 		} );
-	},
+	};
 
-	isSubscribed() {
+    isSubscribed = () => {
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
 		return !! ( tag && tag.isFollowing );
-	},
+	};
 
-	toggleFollowing() {
+    toggleFollowing = () => {
 		const { decodedTagSlug, unfollowTag, followTag } = this.props;
 		const isFollowing = this.isSubscribed(); // this is the current state, not the new state
 		const toggleAction = isFollowing ? unfollowTag : followTag;
@@ -92,9 +90,9 @@ const TagStream = React.createClass( {
 				tag: decodedTagSlug,
 			}
 		);
-	},
+	};
 
-	render() {
+    render() {
 		const emptyContent = <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
 		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
@@ -129,8 +127,8 @@ const TagStream = React.createClass( {
 				/>
 			</Stream>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	state => ( {

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -15,16 +15,16 @@ import DocumentHead from 'components/data/document-head';
 import { getDocumentHeadCappedUnreadCount } from 'state/document-head/selectors';
 
 class UpdateNotice extends React.PureComponent {
-    static propTypes = {
+	static propTypes = {
 		count: React.PropTypes.number.isRequired,
 		onClick: React.PropTypes.func,
 		// connected props
 		cappedUnreadCount: React.PropTypes.string,
 	};
 
-    static defaultProps = { onClick: noop };
+	static defaultProps = { onClick: noop };
 
-    render() {
+	render() {
 		const counterClasses = classnames( {
 			'reader-update-notice': true,
 			'is-active': this.props.count > 0,
@@ -42,7 +42,7 @@ class UpdateNotice extends React.PureComponent {
 		);
 	}
 
-    handleClick = (event) => {
+	handleClick = event => {
 		event.preventDefault();
 		this.props.onClick();
 	};

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import PureRenderMixin from 'react-pure-render/mixin';
 import { noop } from 'lodash';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
@@ -15,21 +14,17 @@ import Gridicon from 'gridicons';
 import DocumentHead from 'components/data/document-head';
 import { getDocumentHeadCappedUnreadCount } from 'state/document-head/selectors';
 
-const UpdateNotice = React.createClass( {
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
+class UpdateNotice extends React.PureComponent {
+    static propTypes = {
 		count: React.PropTypes.number.isRequired,
 		onClick: React.PropTypes.func,
 		// connected props
 		cappedUnreadCount: React.PropTypes.string,
-	},
+	};
 
-	getDefaultProps: function() {
-		return { onClick: noop };
-	},
+    static defaultProps = { onClick: noop };
 
-	render: function() {
+    render() {
 		const counterClasses = classnames( {
 			'reader-update-notice': true,
 			'is-active': this.props.count > 0,
@@ -45,13 +40,13 @@ const UpdateNotice = React.createClass( {
 				} ) }
 			</div>
 		);
-	},
+	}
 
-	handleClick: function( event ) {
+    handleClick = (event) => {
 		event.preventDefault();
 		this.props.onClick();
-	},
-} );
+	};
+}
 
 export default connect( state => ( {
 	cappedUnreadCount: getDocumentHeadCappedUnreadCount( state ),

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -578,7 +578,7 @@
       "version": "6.24.1"
     },
     "babylon": {
-      "version": "6.17.0"
+      "version": "6.17.1"
     },
     "backo2": {
       "version": "1.0.2"
@@ -757,7 +757,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000666"
+      "version": "1.0.30000667"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -835,7 +835,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.25",
+      "version": "3.4.26",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -1078,6 +1078,9 @@
     "crc32": {
       "version": "0.2.2"
     },
+    "create-react-class": {
+      "version": "15.5.3"
+    },
     "creditcards": {
       "version": "2.1.2"
     },
@@ -1172,7 +1175,7 @@
       "dev": true
     },
     "deep-extend": {
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     "deep-freeze": {
       "version": "0.0.1",
@@ -1475,7 +1478,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.15",
+      "version": "0.10.16",
       "dev": true
     },
     "es6-iterator": {
@@ -1941,7 +1944,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.45.0",
+      "version": "0.46.0",
       "dev": true
     },
     "flux": {
@@ -3107,7 +3110,7 @@
       }
     },
     "levelup": {
-      "version": "1.3.5"
+      "version": "1.3.6"
     },
     "leven": {
       "version": "1.0.2",
@@ -4488,7 +4491,7 @@
       "dev": true
     },
     "scss-tokenizer": {
-      "version": "0.2.1",
+      "version": "0.2.3",
       "dependencies": {
         "source-map": {
           "version": "0.4.4"
@@ -4966,7 +4969,7 @@
       "version": "1.15.2"
     },
     "tar-stream": {
-      "version": "1.5.2",
+      "version": "1.5.4",
       "dependencies": {
         "readable-stream": {
           "version": "2.2.9"
@@ -5597,7 +5600,7 @@
       "version": "2.0.3"
     },
     "whatwg-url": {
-      "version": "4.7.1",
+      "version": "4.8.0",
       "dev": true,
       "dependencies": {
         "webidl-conversions": {
@@ -5613,7 +5616,7 @@
       "version": "1.0.0"
     },
     "wide-align": {
-      "version": "1.1.0"
+      "version": "1.1.2"
     },
     "window-size": {
       "version": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",
     "copy-webpack-plugin": "3.0.1",
+    "create-react-class": "15.5.3",
     "creditcards": "2.1.2",
     "debug": "2.2.0",
     "doctrine": "2.0.0",


### PR DESCRIPTION
This PR seeks to remove all usages of the deprecated `createClass` from the reader codebase.
It does so by taking advantage of the `class` codeshift defined in [react-codemods](https://github.com/reactjs/react-codemod).

Notes:
- [wp-prettier](https://github.com/samouri/prettier) is a fork of prettier that keeps all of calypso's spacing. it means that there aren't any extraneous whitespace diffs in this PR
- I initially did it differently (see [take1](https://github.com/Automattic/wp-calypso/pull/13948)) but then learned it could all be done with a single smarter codemod that would even transform to PureComponent
- there are 4 createClass usages that couldn't be fixed automatically. I've added the `react-create-class` compat package as a dependency and we can remove those 4 in future PRs.

```
jscodeshift -t ../react-codemod/transforms/class.js --mixin-module-name=react-pure-render/mixin --remove-runtime-proptypes=false --extensions=js,jsx --pure-component=true client/reader
git commit -nam "run class codemod "
./../prettier/bin/prettier.js  --write client/reader/**.js* 
./../prettier/bin/prettier.js  --write client/reader/**/*.js* 
git commit -nam "run wp-prettier" 
npm i --save create-react-class 
make shrinkwrap
```