### PR TITLE
State: do not wait a tick if libs only need a site id

### DIFF
--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -20,7 +20,7 @@ import {
 import analytics from 'lib/analytics';
 import cartStore from 'lib/cart/store';
 import { isNotificationsOpen } from 'state/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import keyboardShortcuts from 'lib/keyboard-shortcuts';
 
@@ -53,10 +53,14 @@ if ( desktopEnabled ) {
  */
 let sitesListeners = [];
 
-const updateSelectedSiteForSitesList = ( dispatch, action, getState ) => {
-	const state = getState();
-	const selectedSiteId = getSelectedSiteId( state );
-	sites.select( selectedSiteId );
+/**
+ * Sets the selected site id for SitesList
+ *
+ * @param {function} dispatch - redux dispatch function
+ * @param {number} siteId     - the selected site id
+ */
+const updateSelectedSiteIdForSitesList = ( dispatch, { siteId } ) => {
+	sites.select( siteId );
 };
 
 /**
@@ -80,13 +84,10 @@ const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
  * Sets the selectedSiteId for lib/cart/store
  *
  * @param {function} dispatch - redux dispatch function
- * @param {object}   action   - the dispatched action
- * @param {function} getState - redux getState function
+ * @param {number}   siteId   - the selected siteId
  */
-const updateSelectedSiteForCart = ( dispatch, action, getState ) => {
-	const state = getState();
-	const selectedSiteId = getSelectedSiteId( state );
-	cartStore.setSelectedSiteId( selectedSiteId );
+const updateSelectedSiteForCart = ( dispatch, { siteId } ) => {
+	cartStore.setSelectedSiteId( siteId );
 };
 
 /**
@@ -159,13 +160,15 @@ const handler = ( dispatch, action, getState ) => {
 			return updateNotificationsOpenForKeyboardShortcuts( dispatch, action, getState );
 
 		case SELECTED_SITE_SET:
+			//let this fall through
+			updateSelectedSiteIdForSitesList( dispatch, action );
+			updateSelectedSiteForCart( dispatch, action );
+
 		case SITE_RECEIVE:
 		case SITES_RECEIVE:
 		case SITES_UPDATE:
 			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
-				updateSelectedSiteForSitesList( dispatch, action, getState );
-				updateSelectedSiteForCart( dispatch, action, getState );
 				if ( action.type === SITES_RECEIVE ) {
 					fireChangeListeners();
 				}


### PR DESCRIPTION
This PR updates `updateSelectedSiteIdForSitesList` and `updateSelectedSiteForCart` to only listen for `SELECTED_SITE_SET` and uses the `siteId` provided in the action versus current global state. This allows us to use this information more quickly. Certain utils use `site.getSelectedSite()` in render checks. If the data is off by a tick, this may cause flickers, or incorrect views to be rendered.

### Testing Instructions
- All purchase flows still work.
- As a non site admin attempt to view http://calypso.localhost:3000/plugins/browse/:site. We should see the "not available" drake, instead of a flash of the plugins page.

Since this touches the cart lib, could we run e2e tests against this branch?
cc @hoverduck @alisterscott 

As a side note does anyone know why we're firing off `SELECTED_SITE_SET` twice for a page load/site switch using the sites picker?

![screen shot 2017-05-11 at 2 08 02 pm](https://cloud.githubusercontent.com/assets/1270189/25973335/85d6769c-3658-11e7-9a1c-f1436252cc4a.png)
The above shows some logs from inside setTimeout (`tick`) vs outside (`current`) when we switch sites using the picker. The second item is the action, and the last item is the current selected site id in redux state.
