### PR TITLE
AT: Add/at plugins nudge

### DIFF
--- a/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/jetpack-plugins-panel.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {
 	find,
@@ -30,8 +29,6 @@ import NavItem from 'components/section-nav/item';
 import Search from 'components/search';
 import jetpackPlugins from './jetpack-plugins';
 import Tooltip from 'components/tooltip';
-import { isATEnabled } from 'lib/automated-transfer';
-import { getSelectedSite } from 'state/ui/selectors';
 
 const filterGroup = category => group => {
 	if ( category && category !== 'all' ) {
@@ -176,26 +173,24 @@ class JetpackPluginsPanel extends Component {
 				</SectionNav>
 
 				<SectionHeader label={ translate( 'Plugins' ) }>
-					{ this.props.atEnabled &&
-						<ButtonGroup key="plugin-list-header__buttons-browser">
-							<Button
-								compact
-								href={ browserUrl }
-								onMouseEnter={ this.showPluginTooltip }
-								onMouseLeave={ this.hidePluginTooltip }
-								ref="addPluginButton"
-								aria-label={ translate( 'Browse all plugins', { context: 'button label' } ) }>
-								<Gridicon key="plus-icon" icon="plus-small" size={ 18 } />
-								<Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
-								<Tooltip
-									isVisible={ this.state.addPluginTooltip }
-									context={ this.refs && this.refs.addPluginButton }
-									position="bottom">
-									{ translate( 'Browse all plugins' ) }
-								</Tooltip>
-							</Button>
-						</ButtonGroup>
-					}
+					<ButtonGroup key="plugin-list-header__buttons-browser">
+						<Button
+							compact
+							href={ browserUrl }
+							onMouseEnter={ this.showPluginTooltip }
+							onMouseLeave={ this.hidePluginTooltip }
+							ref="addPluginButton"
+							aria-label={ translate( 'Browse all plugins', { context: 'button label' } ) }>
+							<Gridicon key="plus-icon" icon="plus-small" size={ 18 } />
+							<Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
+							<Tooltip
+								isVisible={ this.state.addPluginTooltip }
+								context={ this.refs && this.refs.addPluginButton }
+								position="bottom">
+								{ translate( 'Browse all plugins' ) }
+							</Tooltip>
+						</Button>
+					</ButtonGroup>
 				</SectionHeader>
 
 				<CompactCard className="plugins-wpcom__jetpack-main-plugin plugins-wpcom__jetpack-plugin-item">
@@ -253,11 +248,4 @@ class JetpackPluginsPanel extends Component {
 	}
 }
 
-export default connect(
-	( state ) => {
-		const selectedSite = getSelectedSite( state );
-		return {
-			atEnabled: isATEnabled( selectedSite )
-		};
-	}
-)( localize( urlSearch( JetpackPluginsPanel ) ) );
+export default localize( urlSearch( JetpackPluginsPanel ) );

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -14,16 +14,18 @@ import {
 	getSelectedSiteId
 } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import { canCurrentUser } from 'state/selectors';
 import {
 	isPremium,
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
-import { canCurrentUser } from 'state/selectors';
 import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import Banner from 'components/banner';
+import MainComponent from 'components/main';
+import EmptyContent from 'components/empty-content';
 
 export const PluginPanel = ( {
 	plan,
@@ -36,12 +38,26 @@ export const PluginPanel = ( {
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 	const hasPremium = hasBusiness || isPremium( plan );
 
+	if ( ! canUserManageOptions ) {
+		const accessError = {
+			title: translate( 'Not Available' ),
+			line: translate( 'The page you requested could not be found' ),
+			illustration: '/calypso/images/drake/drake-404.svg',
+			fullWidth: true
+		};
+		return (
+			<MainComponent>
+				<EmptyContent { ...accessError } />
+			</MainComponent>
+		);
+	}
+
 	return (
 		<div className="plugins-wpcom__panel">
 
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
 
-			{ ! hasBusiness && canUserManageOptions &&
+			{ ! hasBusiness &&
 				<Banner
 					feature={ FEATURE_UPLOAD_PLUGINS }
 					event={ 'calypso_plugins_page_upgrade_nudge' }

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -23,7 +23,6 @@ import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import Banner from 'components/banner';
-import { isATEnabled } from 'lib/automated-transfer';
 
 export const PluginPanel = ( {
 	plan,
@@ -31,7 +30,6 @@ export const PluginPanel = ( {
 	category,
 	search,
 	translate,
-	atEnabled
 } ) => {
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 	const hasPremium = hasBusiness || isPremium( plan );
@@ -41,7 +39,7 @@ export const PluginPanel = ( {
 
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
 
-			{ atEnabled && ! hasBusiness &&
+			{ ! hasBusiness &&
 				<Banner
 					feature={ FEATURE_UPLOAD_PLUGINS }
 					plan={ PLAN_BUSINESS }
@@ -64,7 +62,6 @@ export const PluginPanel = ( {
 const mapStateToProps = state => {
 	const selectedSite = getSelectedSite( state );
 	return {
-		atEnabled: isATEnabled( selectedSite ),
 		plan: get( selectedSite, 'plan', {} ),
 		siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
 	};

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -19,6 +19,7 @@ import {
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
+import { canCurrentUser } from 'state/selectors';
 import JetpackPluginsPanel from './jetpack-plugins-panel';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
@@ -30,6 +31,7 @@ export const PluginPanel = ( {
 	category,
 	search,
 	translate,
+	canUserManageOptions,
 } ) => {
 	const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 	const hasPremium = hasBusiness || isPremium( plan );
@@ -39,7 +41,7 @@ export const PluginPanel = ( {
 
 			<PageViewTracker path="/plugins/:site" title="Plugins > WPCOM Site" />
 
-			{ ! hasBusiness &&
+			{ ! hasBusiness && canUserManageOptions &&
 				<Banner
 					feature={ FEATURE_UPLOAD_PLUGINS }
 					event={ 'calypso_plugins_page_upgrade_nudge' }
@@ -62,9 +64,11 @@ export const PluginPanel = ( {
 
 const mapStateToProps = state => {
 	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		plan: get( selectedSite, 'plan', {} ),
-		siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
+		siteSlug: getSiteSlug( state, selectedSiteId ),
+		canUserManageOptions: canCurrentUser( state, selectedSiteId, 'manage_options' ),
 	};
 };
 

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -42,6 +42,7 @@ export const PluginPanel = ( {
 			{ ! hasBusiness &&
 				<Banner
 					feature={ FEATURE_UPLOAD_PLUGINS }
+					event={ 'calypso_plugins_page_upgrade_nudge' }
 					plan={ PLAN_BUSINESS }
 					title={ translate( 'Upgrade to the Business plan to install plugins.' ) }
 				/>

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -20,14 +20,6 @@ const hasErrorCondition = ( site, type ) => {
 	return errorConditions[ type ];
 };
 
-const getWpcomPluginPageError = () => {
-	return {
-		title: i18n.translate( 'Oops! Not supported' ),
-		line: i18n.translate( 'This site doesn\'t support installing plugins. Switch to a self-hosted site to install and manage plugins' ),
-		illustration: '/calypso/images/drake/drake-whoops.svg'
-	};
-};
-
 const hasRestrictedAccess = ( site ) => {
 	site = site || sites.getSelectedSite();
 
@@ -53,10 +45,6 @@ const hasRestrictedAccess = ( site ) => {
 				dismissID: 'allSitesNotOnMinJetpackVersion' + config( 'jetpack_min_version' ) + '-' + site.ID
 			}
 		);
-	}
-
-	if ( ! sites.hasSiteWithPlugins() ) {
-		return getWpcomPluginPageError();
 	}
 };
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -34,8 +34,8 @@ import PluginInformation from 'my-sites/plugins/plugin-information';
 import WpcomPluginInstallButton from 'my-sites/plugins-wpcom/plugin-install-button';
 import PluginAutomatedTransfer from 'my-sites/plugins/plugin-automated-transfer';
 import { userCan } from 'lib/site/utils';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
-import { FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import Banner from 'components/banner';
+import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import {
 	isBusiness,
 	isEnterprise
@@ -492,11 +492,11 @@ const PluginMeta = React.createClass( {
 
 				{ ! get( this.props.selectedSite, 'jetpack' ) && ! this.hasBusinessPlan() && ! this.isWpcomPreinstalled() &&
 					<div className="plugin-meta__upgrade_nudge">
-						<UpgradeNudge
+						<Banner
 							feature={ FEATURE_UPLOAD_PLUGINS }
+							event={ 'calypso_plugin_detail_page_upgrade_nudge' }
+							plan={ PLAN_BUSINESS }
 							title={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
-							message={ this.props.translate( 'Upgrade to the Business plan to install plugins.' ) }
-							event={ 'calypso_plugins_page_upgrade_nudge' }
 						/>
 					</div>
 				}

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -27,13 +27,11 @@ import pluginsAccessControl from 'my-sites/plugins/access-control';
 import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example';
 import DocumentHead from 'components/data/document-head';
-import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, canJetpackSiteManage, getRawSite } from 'state/sites/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import QuerySites from 'components/data/query-sites';
-import { isATEnabled } from 'lib/automated-transfer';
 
 const SinglePlugin = React.createClass( {
 	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
@@ -321,20 +319,6 @@ const SinglePlugin = React.createClass( {
 		const { selectedSite } = this.props;
 
 		if (
-			selectedSite &&
-			! this.props.isJetpackSite( selectedSite.ID ) &&
-			! this.props.atEnabled
-		) {
-			return (
-				<MainComponent>
-					{ this.renderDocumentHead() }
-					<SidebarNavigation />
-					<WpcomPluginsList />
-				</MainComponent>
-			);
-		}
-
-		if (
 			this.state.accessError &&
 			( ! selectedSite || selectedSite.jetpack )
 		) {
@@ -433,7 +417,6 @@ export default connect(
 			selectedSite: selectedSite,
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
-			atEnabled: isATEnabled( site ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
 		};
 	},

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -318,10 +318,7 @@ const SinglePlugin = React.createClass( {
 	render() {
 		const { selectedSite } = this.props;
 
-		if (
-			this.state.accessError &&
-			( ! selectedSite || selectedSite.jetpack )
-		) {
+		if ( this.state.accessError ) {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -318,7 +318,7 @@ const PluginsBrowser = React.createClass( {
 		);
 
 		if (
-			( this.state.accessError || cantManage ) && selectedSite && selectedSite.jetpack
+			( this.state.accessError || cantManage ) && selectedSite
 		)
 		{
 			return this.renderAccessError( selectedSite );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -29,7 +29,6 @@ import { hasTouch } from 'lib/touch-detect';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
-import { isATEnabled } from 'lib/automated-transfer';
 
 const PluginsBrowser = React.createClass( {
 	_SHORT_LIST_LENGTH: 6,
@@ -319,15 +318,9 @@ const PluginsBrowser = React.createClass( {
 		);
 
 		if (
-			( this.state.accessError || cantManage ) &&
-			(
-				// If automated transfer is _off_ then behave
-				// as normal. If it's on, then only show if we
-				// are getting an error on a Jetpack site
-				! this.props.atEnabled ||
-				( selectedSite && selectedSite.jetpack )
-			)
-		) {
+			( this.state.accessError || cantManage ) && selectedSite && selectedSite.jetpack
+		)
+		{
 			return this.renderAccessError( selectedSite );
 		}
 
@@ -347,7 +340,6 @@ export default connect(
 		const selectedSite = getSelectedSite( state );
 		return {
 			selectedSite,
-			atEnabled: isATEnabled( selectedSite ),
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
 		};

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -317,10 +317,7 @@ const PluginsBrowser = React.createClass( {
 			! this.props.canJetpackSiteManage( selectedSite.ID )
 		);
 
-		if (
-			( this.state.accessError || cantManage ) && selectedSite
-		)
-		{
+		if ( ( this.state.accessError || cantManage ) && selectedSite ) {
 			return this.renderAccessError( selectedSite );
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -202,9 +202,10 @@ export class MySitesSidebar extends Component {
 
 	plugins() {
 		const { site } = this.props;
+		const addPluginsLink = '/plugins/browse' + this.props.siteSuffix;
 		let pluginsLink = '/plugins' + this.props.siteSuffix;
-		let addPluginsLink;
 
+		// TODO: we can probably rip this out
 		if ( ! config.isEnabled( 'manage/plugins' ) ) {
 			if ( ! site ) {
 				return null;
@@ -215,12 +216,14 @@ export class MySitesSidebar extends Component {
 			}
 		}
 
+		// checks for manage plugins capability across all sites
 		if ( ! this.props.canManagePlugins ) {
 			return null;
 		}
 
-		if ( this.props.siteId || ( ! this.props.siteId && this.props.hasJetpackSites ) ) {
-			addPluginsLink = '/plugins/browse' + this.props.siteSuffix;
+		// if selectedSite and cannot manage, skip plugins section
+		if ( this.props.siteId && ! this.props.canUserManageOptions ) {
+			return null;
 		}
 
 		return (
@@ -589,6 +592,7 @@ function mapStateToProps( state ) {
 	const canManagePlugins = !! getSites( state ).some( ( s ) => (
 		( s.capabilities && s.capabilities.manage_options )
 	) );
+
 	// FIXME: Turn into dedicated selector
 	const hasJetpackSites = getSites( state ).some( s => s.jetpack );
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -46,7 +46,6 @@ import {
 	isJetpackSite
 } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
-import { isATEnabled } from 'lib/automated-transfer';
 import { abtest } from 'lib/abtest';
 
 /**
@@ -206,10 +205,6 @@ export class MySitesSidebar extends Component {
 		let pluginsLink = '/plugins' + this.props.siteSuffix;
 		let addPluginsLink;
 
-		if ( this.props.atEnabled ) {
-			addPluginsLink = '/plugins/browse' + this.props.siteSuffix;
-		}
-
 		if ( ! config.isEnabled( 'manage/plugins' ) ) {
 			if ( ! site ) {
 				return null;
@@ -224,7 +219,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( ( this.props.siteId && this.props.isJetpack ) || ( ! this.props.siteId && this.props.hasJetpackSites ) ) {
+		if ( this.props.siteId || ( ! this.props.siteId && this.props.hasJetpackSites ) ) {
 			addPluginsLink = '/plugins/browse' + this.props.siteSuffix;
 		}
 
@@ -257,7 +252,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( this.props.isJetpack && ! this.props.atEnabled ) {
+		if ( this.props.isJetpack && ! this.props.isSiteAutomatedTransfer ) {
 			return null;
 		}
 
@@ -600,7 +595,6 @@ function mapStateToProps( state ) {
 	const isPreviewShowing = getCurrentLayoutFocus( state ) === 'preview';
 
 	return {
-		atEnabled: isATEnabled( site ),
 		canManagePlugins,
 		canUserEditThemeOptions: canCurrentUser( state, siteId, 'edit_theme_options' ),
 		canUserListUsers: canCurrentUser( state, siteId, 'list_users' ),


### PR DESCRIPTION
## Purpose
This PR enables the plugins interface for users with a less-than-business-plan on their WPCOM site, showing the user an "add" button in the plugins sidebar, allowing them to review the wpcom plugins view (where an upgrade nudge will be shown), browse for a new plugin, and view the plugin details. On that plugin details page the user is presented with a nudge to upgrade to the business plan for the ability to install plugins.

## Changes For Non-Business WPCOM Site

#### Display "Add" Button in Sidebar
![sidebar add button](http://cld.wthms.co/Hilej+)

#### Display Upgrade Banner and "Add" Button
![upgrade banner and add button](http://cld.wthms.co/tMTsu+)

#### Disable Install and Show Upgrade Nudge on Plugin Detail Page
![browse page upgrade nudge](http://cld.wthms.co/7NDpn+)

## Related Change
While reviewing our plugins section I noticed that non-Admin users who should not have ability to manage plugins were still shown the plugins section in the sidebar. I've removed the sidebar option for these non-Admin users and we now display a "Not Available" message if users somehow navigate to these pages anyway.

![non-admin no access to plugins](http://cld.wthms.co/kBW0i+)

## Testing
- Make sure that a non-Admin user does not see plugins link in the sidebar, whether the site is Jetpack, AT, or WPCOM. If they navigate to a site-specific plugin page (e.g., via switching sites while viewing a plugin page), they should see the "Not Available" drake page.
- Make sure the everyone else see the plugin link along with the "Add" button in the sidebar.
- Make sure we show the upgrade notices to Admin users on WPCOM sites without the business plan.
- Check for general regressions in Jetpack and AT. Admin users for Jetpack and AT sites should be able to view the plugins pages, have the ability to add/install plugins, and should not see the upgrade banner.

## TODOs
I noticed a few things I think we should clean up, but that should be tackled in separate PRs.
- We check for the `manage_options` capability as a heuristic for the `Admin` role, and enable plugins in Calypso based on this. We should instead check plugin-specific capability before allowing access to the plugins UX to account for potentially custom roles in AT sites. This needs to be added to the REST-API and should be added separately.
- The [plugins/access-control.js](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/plugins/access-control.js) utility should be rewritten as a selector and stop using `sites-list`.
- There is a framework issue where pages will sometimes show a flash of content for the "all sites" view of a page before re-rendering with the site-specific view. This is due to the site-selection happening in a ["next tick" operation here](https://github.com/Automattic/wp-calypso/blob/737a1f1e4a65df14f77a8c216803f67cf015fdd0/client/state/lib/middleware.js#L167). It happens on some of these plugins pages, and I suspect in other pages as well. @gwwar is working on a separate PR to address this.
- Consider a more specific Drake message than just "Not Available". In these cases we could tell the user they don't have the permission to edit plugins on this site. But we're already using this message for access errors in plugins, so I'm not changing it here.