### PR TITLE
Add UI indicator of Webpack build status

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -202,6 +202,7 @@
 @import 'components/vertical-nav/item/style';
 @import 'components/vertical-menu/style';
 @import 'components/web-preview/style';
+@import 'components/webpack-build-monitor/style';
 @import 'blocks/credit-card-form/style';
 @import 'devdocs/docs-example/style';
 @import 'devdocs/docs-selectors/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -155,6 +155,7 @@ $z-layers: (
 		'.guided-tours__overlay': 200050,
 		'.guided-tours__step': 201000,
 		'.wpcom-site__global-noscript': 300000, // JS off always visible
+		'.webpack-build-monitor': 99999999,
 		'#habla_window_div.habla_window_div_base': 99999999 //olark
 	),
 	'.ribbon': (

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -1,0 +1,112 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Spinner from 'components/spinner';
+
+const CONNECTED = 'CONNECTED';
+const DISCONNECTED = 'DISCONNECTED';
+const STATUS_BUILDING = 'STATUS_BUILDING';
+const STATUS_ERROR = 'STATUS_ERROR';
+const STATUS_IDLE = 'STATUS_IDLE';
+
+// Reducer for the CSS build status
+const cssStatus = ( state = STATUS_IDLE, message ) => {
+	switch ( message ) {
+		case 'Building CSS…':
+			return STATUS_BUILDING;
+		case 'Reloading CSS: ':
+			return STATUS_IDLE;
+	}
+	return state;
+};
+
+// Reducer for the JS build status
+const jsStatus = ( state = STATUS_IDLE, message ) => {
+	switch ( message ) {
+		case '[WDS] App updated. Recompiling...':
+			return STATUS_BUILDING;
+		case '[HMR] App is up to date.':
+		case '[WDS] Nothing changed.':
+			// Once completed, set the status to idle unless there's an error
+			return state === STATUS_ERROR ? state : STATUS_IDLE;
+		case '[WDS] Errors while compiling.':
+			return STATUS_ERROR;
+	}
+	return state;
+};
+
+// Reducer for the Webpack Dev Server status
+const wdsStatus = ( state = CONNECTED, message ) => {
+	switch ( message ) {
+		case '[WDS] Disconnected!':
+			return DISCONNECTED;
+	}
+	return state;
+};
+
+// Reducer for the component state
+const getState = ( state = {}, message ) => {
+	return {
+		cssStatus: cssStatus( state.cssStatus, message ),
+		jsStatus: jsStatus( state.jsStatus, message ),
+		wdsStatus: wdsStatus( state.wdsStatus, message ),
+	};
+};
+
+class WebpackBuildMonitor extends React.Component {
+	constructor() {
+		super();
+		this.state = getState();
+
+		// Spy on console to watch for messages from Webpack Dev Server
+		console.error = this.wrapConsoleFn( console.error );
+		console.log = this.wrapConsoleFn( console.log );
+	}
+
+	wrapConsoleFn = ( fn ) => ( message ) => {
+		this.setState( getState( this.state, message ) );
+		fn.call( this, message );
+	}
+
+	render() {
+		if ( this.state.wdsStatus === DISCONNECTED ) {
+			return (
+				<div className="webpack-build-monitor is-error">
+					Dev server disconnected
+				</div>
+			);
+		}
+
+		if ( this.state.cssStatus === STATUS_ERROR || this.state.jsStatus === STATUS_ERROR ) {
+			return (
+				<div className="webpack-build-monitor is-error">
+					Build error
+				</div>
+			);
+		}
+
+		if ( this.state.cssStatus === STATUS_BUILDING || this.state.jsStatus === STATUS_BUILDING ) {
+			return (
+				<div className="webpack-build-monitor ">
+					<Spinner size={ 11 } className="webpack-build-monitor__spinner" />
+					Rebuilding
+				</div>
+			);
+		}
+
+		return null;
+	}
+}
+
+// QUESTIONS:
+// - Worth saying whether it's JS or CSS that's loading/errored?
+// - Worth adding a "dirty" state, or a fading message to confirm when HMR works?
+
+export default WebpackBuildMonitor;

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -1,0 +1,36 @@
+.webpack-build-monitor {
+	position: fixed;
+	bottom: 20px;
+	right: 83px;
+	z-index: z-index( 'root', '.webpack-build-monitor' );
+	font-size: 9px;
+	padding: 4px 6px;
+	background: $alert-green;
+	color: $white;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	border-radius: 3px;
+	display: flex;
+	align-items: center;
+	line-height: 11px;
+	&.is-error {
+		background: $alert-red;
+	}
+}
+
+.webpack-build-monitor__spinner {
+	margin-right: 6px;
+}
+
+.webpack-build-monitor__text {
+	margin-left: 6px;
+	display: block;
+}
+
+.webpack-build-monitor .spinner__progress {
+	fill: currentColor;
+}
+
+.webpack-build-monitor .spinner__border {
+	fill: lighten( $alert-green, 30% );
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -167,6 +167,7 @@ Layout = React.createClass( {
 					isActive={ translator.isActivated() } />
 				{ this.renderPreview() }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
+				{ 'development' === config( 'env' ) && <AsyncLoad require="components/webpack-build-monitor" /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
**REQUESTING FEEDBACK!**

There's been some discussion about making Webpack build status more visible, but most of the ideas involved some level of individual setup. I wanted to try making a no-install build monitor for Calypso, so this PR adds a badge that appears when Webpack is building or has errors. Example:

![webpack build monitor](https://cloud.githubusercontent.com/assets/518059/25972846/5031b9ac-3667-11e7-933d-32dbf9e85648.gif)

It works by hijacking `console.log` and `console.error` to change state based on messages from the Webpack Dev Server. It is `AsyncLoad`ed in `development` env only, so it shouldn't bleed into other environments.

Currently it reports:
- When a JS or CSS build starts
- When a JS or CSS build completes ("reported" by disappearing)
- When there's a build error
- When the dev server disconnects

Open questions:
- Is it useful to say whether it's currently building JS or CSS, or is a generic "BUILDING" message good enough?
- Is it worth notifying when there's "dirty" changes (e.g. updated code that couldn't be hot-reloaded)?

#### Feedback requested
If this idea seems worth pursuing, I'll clean up the code a bit and open a new PR for formal code and design feedback. But helpful thoughts include:
- Would this help your day-to-day Calypso dev experience?
- Are there any obvious things this element could break that I'm missing?
- Any other features we could add to this build monitor?