### PR TITLE
Reader: Fix site tools spacing

### DIFF
--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -135,7 +135,7 @@
 
 		.search__input {
 			background: transparent;
-			height: 30px;
+			padding-bottom: 5px;
 		}
 	}
 

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -69,11 +69,9 @@
 	}
 
 	.following-manage__subscriptions-header {
-		align-items: center;
-		display: flex;
 		flex: 1;
 		font-weight: 600;
-		padding-bottom: 15px;
+		padding: 4px 0 15px;
 
 		@include breakpoint( "<960px" ) {
 			flex: 0 0 auto;
@@ -108,6 +106,7 @@
 		color: $gray;
 		font-size: 12px;
 		font-weight: normal;
+		padding-top: 8px;
 		width: 100%;
 
 		@include breakpoint( ">960px" ) {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/13946

**Before:**
<img width="737" alt="screenshot 2017-05-11 15 03 41" src="https://cloud.githubusercontent.com/assets/4924246/25973982/4a734e56-365b-11e7-8301-a77cd55bc584.png">

**After:**
<img width="730" alt="screenshot 2017-05-11 15 00 13" src="https://cloud.githubusercontent.com/assets/4924246/25973985/4f7c3c46-365b-11e7-952e-29ec717ffa53.png">
