### PR TITLE
Extensions: WPSC: Controller: ES6ify, Simplify

### DIFF
--- a/client/extensions/wp-super-cache/controller.js
+++ b/client/extensions/wp-super-cache/controller.js
@@ -15,45 +15,40 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import WPSuperCache from './main';
 
-const controller = {
+export function settings( context ) {
+	const siteId = getSiteFragment( context.path );
+	const site = getSelectedSite( context.store.getState() );
+	let tab = context.params.tab;
 
-	settings: function( context ) {
-		const siteId = getSiteFragment( context.path );
-		const site = getSelectedSite( context.store.getState() );
-		let tab = context.params.tab;
+	tab = ( ! tab || tab === siteId ) ? '' : tab;
+	context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
 
-		tab = ( ! tab || tab === siteId ) ? '' : tab;
-		context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
+	const basePath = sectionify( context.path );
+	let baseAnalyticsPath;
 
-		const basePath = sectionify( context.path );
-		let baseAnalyticsPath;
-
-		if ( siteId ) {
-			baseAnalyticsPath = `${ basePath }/:site`;
-		} else {
-			baseAnalyticsPath = basePath;
-		}
-
-		let analyticsPageTitle = 'WP Super Cache';
-
-		if ( tab.length ) {
-			analyticsPageTitle += ` > ${ titlecase( tab ) }`;
-		} else {
-			analyticsPageTitle += ' > Easy';
-		}
-
-		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
-
-		renderWithReduxStore(
-			React.createElement( WPSuperCache, {
-				context,
-				site,
-				tab,
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	if ( siteId ) {
+		baseAnalyticsPath = `${ basePath }/:site`;
+	} else {
+		baseAnalyticsPath = basePath;
 	}
-};
 
-module.exports = controller;
+	let analyticsPageTitle = 'WP Super Cache';
+
+	if ( tab.length ) {
+		analyticsPageTitle += ` > ${ titlecase( tab ) }`;
+	} else {
+		analyticsPageTitle += ' > Easy';
+	}
+
+	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
+
+	renderWithReduxStore(
+		React.createElement( WPSuperCache, {
+			context,
+			site,
+			tab,
+		} ),
+		document.getElementById( 'primary' ),
+		context.store
+	);
+}

--- a/client/extensions/wp-super-cache/controller.js
+++ b/client/extensions/wp-super-cache/controller.js
@@ -18,9 +18,8 @@ import WPSuperCache from './main';
 export function settings( context ) {
 	const siteId = getSiteFragment( context.path );
 	const site = getSelectedSite( context.store.getState() );
-	let tab = context.params.tab;
+	const { tab = '' } = context.params;
 
-	tab = ( ! tab || tab === siteId ) ? '' : tab;
 	context.store.dispatch( setTitle( i18n.translate( 'WP Super Cache', { textOnly: true } ) ) );
 
 	const basePath = sectionify( context.path );

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -2,14 +2,16 @@
  * External dependencies
  */
 import page from 'page';
+import { values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { navigation, sites, siteSelection } from 'my-sites/controller';
 import { settings } from './controller';
+import { Tabs } from './constants';
 
 export default function() {
 	page( '/extensions/wp-super-cache', siteSelection, sites, navigation, settings );
-	page( '/extensions/wp-super-cache/:tab?/:site', siteSelection, navigation, settings );
+	page( `/extensions/wp-super-cache/:tab(${ values( Tabs ).join( '|' ) })?/:site`, siteSelection, navigation, settings );
 }

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -7,9 +7,9 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, sites, siteSelection } from 'my-sites/controller';
-import controller from './controller';
+import { settings } from './controller';
 
 export default function() {
-	page( '/extensions/wp-super-cache', siteSelection, sites, navigation, controller.settings );
-	page( '/extensions/wp-super-cache/:tab?/:site', siteSelection, navigation, controller.settings );
+	page( '/extensions/wp-super-cache', siteSelection, sites, navigation, settings );
+	page( '/extensions/wp-super-cache/:tab?/:site', siteSelection, navigation, settings );
 }

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -12,6 +12,6 @@ import { settings } from './controller';
 import { Tabs } from './constants';
 
 export default function() {
-	page( '/extensions/wp-super-cache', sites, navigation, settings );
+	page( '/extensions/wp-super-cache', sites );
 	page( `/extensions/wp-super-cache/:tab(${ values( Tabs ).join( '|' ) })?/:site`, siteSelection, navigation, settings );
 }

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -12,6 +12,6 @@ import { settings } from './controller';
 import { Tabs } from './constants';
 
 export default function() {
-	page( '/extensions/wp-super-cache', siteSelection, sites, navigation, settings );
+	page( '/extensions/wp-super-cache', sites, navigation, settings );
 	page( `/extensions/wp-super-cache/:tab(${ values( Tabs ).join( '|' ) })?/:site`, siteSelection, navigation, settings );
 }


### PR DESCRIPTION
Specifying allowed values for the `:tab` param in the route defs simplifies the controller a bit (and makes route params unambiguous).