### PR TITLE
Comments: add feature flag for comment moderation and add route

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { renderWithReduxStore } from 'lib/react-helpers';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CommentsManagement from './main';
+
+export const comments = function( context ) {
+	renderWithReduxStore(
+		<CommentsManagement
+			basePath={ context.path } />,
+		'primary',
+		context.store
+	);
+};

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import controller from 'my-sites/controller';
+import { comments } from './controller';
+import config from 'config';
+
+export default function() {
+	if ( config.isEnabled( 'comments/management' ) ) {
+		page( '/comments',
+			controller.siteSelection,
+			controller.sites
+		);
+
+		page( '/comments/:site',
+			controller.siteSelection,
+			controller.navigation,
+			comments
+		);
+	}
+}

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import DocumentHead from 'components/data/document-head';
+
+export class CommentsManagement extends Component {
+
+	static propTypes = {
+		basePath: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	render() {
+		const { translate, basePath } = this.props;
+		return (
+			<Main className="comments">
+				<PageViewTracker path={ basePath } title="Manage Comments" />
+				<DocumentHead title={ translate( 'Manage Comments' ) } />
+				<div>Hello World!</div>
+			</Main>
+		);
+	}
+}
+
+export default localize( CommentsManagement );

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -346,4 +346,12 @@ sections.push( {
 	secondary: true
 } );
 
+sections.push( {
+	name: 'comments',
+	paths: [ '/comments' ],
+	module: 'my-sites/comments',
+	group: 'sites',
+	secondary: true
+} );
+
 module.exports = sections;

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
+		"comments/management": true,
 		"community-translator": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,


### PR DESCRIPTION
This PR adds a new feature flag `comments/management` and a `/comments` route. 

### Testing Instructions
- No functional changes to Calypso
- Navigate to http://calypso.localhost:3000/comments
- Select a site appears
- Selecting a site redirects to http://calypso.localhost:3000/comments/:site: