### PR TITLE
Editor: Don't strip the `markdown="1"` HTML attribute.

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -45,6 +45,7 @@ import insertMenuPlugin from './plugins/insert-menu/plugin';
 import embedReversalPlugin from './plugins/embed-reversal/plugin';
 import EditorHtmlToolbar from 'post-editor/editor-html-toolbar';
 import mentionsPlugin from './plugins/mentions/plugin';
+import markdownPlugin from './plugins/markdown/plugin';
 
 [
 	wpcomPlugin,
@@ -68,6 +69,7 @@ import mentionsPlugin from './plugins/mentions/plugin';
 	wptextpatternPlugin,
 	toolbarPinPlugin,
 	embedReversalPlugin,
+	markdownPlugin,
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
@@ -136,6 +138,7 @@ const PLUGINS = [
 	'wpcom/embedreversal',
 	'wpcom/trackpaste',
 	'wpcom/insertmenu',
+	'wpcom/markdown',
 ];
 
 mentionsPlugin();

--- a/client/components/tinymce/plugins/markdown/plugin.js
+++ b/client/components/tinymce/plugins/markdown/plugin.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+
+/**
+ * TinyMCE plugin tweaking Markdown behaviour.
+ *
+ * @param {Object} editor TinyMCE editor instance
+ */
+function markdown( editor ) {
+	function allowMarkdownAttribute( event ) {
+		const ed = event.target;
+		Object.keys( ed.schema.elements ).forEach( function( key ) {
+			if ( typeof ed.schema.elements[ key ].attributes.markdown === 'undefined' ) {
+				ed.schema.elements[ key ].attributes.markdown = {};
+				ed.schema.elements[ key ].attributesOrder.push( 'markdown' );
+			}
+		} );
+	}
+
+	editor.on( 'BeforeSetContent', allowMarkdownAttribute );
+}
+
+export default function() {
+	tinymce.PluginManager.add( 'wpcom/markdown', markdown );
+}

--- a/client/components/tinymce/plugins/markdown/plugin.js
+++ b/client/components/tinymce/plugins/markdown/plugin.js
@@ -12,14 +12,12 @@ function markdown( editor ) {
 	function allowMarkdownAttribute( event ) {
 		const ed = event.target;
 		Object.keys( ed.schema.elements ).forEach( function( key ) {
-			if ( typeof ed.schema.elements[ key ].attributes.markdown === 'undefined' ) {
-				ed.schema.elements[ key ].attributes.markdown = {};
-				ed.schema.elements[ key ].attributesOrder.push( 'markdown' );
-			}
+			ed.schema.elements[ key ].attributes.markdown = {};
+			ed.schema.elements[ key ].attributesOrder.push( 'markdown' );
 		} );
 	}
 
-	editor.on( 'BeforeSetContent', allowMarkdownAttribute );
+	editor.on( 'preinit', allowMarkdownAttribute );
 }
 
 export default function() {


### PR DESCRIPTION
The Markdown parser uses the `markdown="1"` HTML attribute to note HTML that Markdown can be parsed inside of.

Naturally, TinyMCE doesn't recognise that attribute by default, so needs to be told not to strip it out when cleaning up the post HTML.

#### Testing instructions
 
1. Run `git checkout fix/13978-markdown-attribute` and start your server, or open a [live branch](https://calypso.live/?branch=fix/13978-markdown-attribute)
2. Create a new post.
3. Switch to HTML view.
4. Insert the HTML: `<div markdown="1">foo</div>`.
5. Switch to Visual view.
6. Switch back to HTML view.

The `markdown="1"` attribute should not have been touched.