### PR TITLE
Reader: Hide close icon if Following filter is empty

### DIFF
--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -24,7 +24,6 @@ class FollowingManageSearchFollowed extends Component {
 		return (
 			<SearchCard
 				compact={ true }
-				isOpen={ true }
 				pinned={ false }
 				autoFocus={ false }
 				className="following-manage__search-followed"


### PR DESCRIPTION
**Before**:
<img width="737" alt="screenshot 2017-05-11 21 51 58" src="https://cloud.githubusercontent.com/assets/4924246/25982765/24f382f2-3694-11e7-9115-40a057f4a806.png">

**After:**
<img width="739" alt="screenshot 2017-05-11 21 52 06" src="https://cloud.githubusercontent.com/assets/4924246/25982767/29599a66-3694-11e7-85f7-854fd84a0551.png">

<img width="727" alt="screenshot 2017-05-11 21 53 26" src="https://cloud.githubusercontent.com/assets/4924246/25982788/547b2b92-3694-11e7-8efe-dbe4efc3f0d1.png">


