### PR TITLE
Social Signup: Handle the case where users block third-party cookies/data

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -48,7 +48,8 @@ button {
 		color: $gray-dark;
 	}
 	&[disabled],
-	&:disabled {
+	&:disabled,
+	&.disabled {
 		color: lighten( $gray, 30% );
 		background: $white;
 		border-color: lighten( $gray, 30% );

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -43,7 +43,9 @@ class SocialSignupForm extends Component {
 		return (
 			<div className="signup-form__social">
 				<p>
-					{ this.props.translate( "Or create account using social profile. We'll never post without your permission." ) }
+					{ this.props.translate(
+						"Or create an account using your existing social profile. We'll never post without your permission."
+					) }
 				</p>
 
 				<div className="signup-form__social-buttons">
@@ -55,10 +57,6 @@ class SocialSignupForm extends Component {
 						appId={ config( 'facebook_app_id' ) }
 						responseHandler={ this.handleFacebookResponse } />
 				</div>
-
-				<p>
-					{ this.props.translate( 'Connect to your existing social profile to get started faster.' ) }
-				</p>
 			</div>
 		);
 	}

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -43,7 +43,7 @@ class SocialSignupForm extends Component {
 		return (
 			<div className="signup-form__social">
 				<p>
-					{ this.props.translate( 'Or create account using social profile:' ) }
+					{ this.props.translate( "Or create account using social profile. We'll never post without your permission." ) }
 				</p>
 
 				<div className="signup-form__social-buttons">
@@ -57,9 +57,7 @@ class SocialSignupForm extends Component {
 				</div>
 
 				<p>
-					{ this.props.translate(
-						"Connect to your existing social profile to get started faster. We'll never post without your permission."
-					) }
+					{ this.props.translate( 'Connect to your existing social profile to get started faster.' ) }
 				</p>
 			</div>
 		);

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -43,9 +43,7 @@ class SocialSignupForm extends Component {
 		return (
 			<div className="signup-form__social">
 				<p>
-					{ this.props.translate(
-						"Or create an account using your existing social profile. We'll never post without your permission."
-					) }
+					{ this.props.translate( 'Or create an account using your existing social profile:' ) }
 				</p>
 
 				<div className="signup-form__social-buttons">
@@ -57,6 +55,12 @@ class SocialSignupForm extends Component {
 						appId={ config( 'facebook_app_id' ) }
 						responseHandler={ this.handleFacebookResponse } />
 				</div>
+
+        <p>
+					{ this.props.translate(
+            "Connect to your existing social profile to get started faster. We'll never post without your permission."
+          ) }
+				</p>
 			</div>
 		);
 	}

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -41,32 +41,8 @@
 		margin: 0 0 10px;
 		width: 100%;
 	}
-
-	svg {
-		margin-top: -2px;
-
-		&.disabled {
-			display: none;
-		}
-	}
-}
-
-.social-buttons__button:disabled {
-	svg.enabled {
-		display: none;
-	}
-
-	svg.disabled {
-		display: inline;
-	}
 }
 
 .signup-form__notice.notice {
 	margin-bottom: 10px;
-}
-
-.social-buttons__service-error {
-	color: $alert-red;
-	font-size: 11px;
-	margin: 0 10px 10px;
 }

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -50,3 +50,9 @@
 .signup-form__notice.notice {
 	margin-bottom: 10px;
 }
+
+.social-buttons__service-error {
+	color: red;
+	font-size: 11px;
+	margin: 0 10px 10px 10px;
+}

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -44,6 +44,20 @@
 
 	svg {
 		margin-top: -2px;
+
+		&.disabled {
+			display: none;
+		}
+	}
+}
+
+.social-buttons__button:disabled {
+	svg.enabled {
+		display: none;
+	}
+
+	svg.disabled {
+		display: inline;
 	}
 }
 
@@ -52,7 +66,7 @@
 }
 
 .social-buttons__service-error {
-	color: red;
+	color: $alert-red;
 	font-size: 11px;
-	margin: 0 10px 10px 10px;
+	margin: 0 10px 10px;
 }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -65,7 +65,6 @@ class GoogleLoginButton extends Component {
 				if ( 'idpiframe_initialization_failed' === error.error ) {
 					// This error is caused by 3rd party cookies being blocked.
 					this.setState( { error: translate( 'Please enable "third-party cookies" to connect your Google account.' ) } );
-					return null;
 				}
 
 				return Promise.reject( error );

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -65,7 +65,7 @@ class GoogleLoginButton extends Component {
 				if ( 'idpiframe_initialization_failed' === error.error ) {
 					// This error is caused by 3rd party cookies being blocked.
 					this.setState( { error: translate( 'Your privacy settings are blocking us from connecting to your Google account. ' +
-						'Please enable "third-party cookies" in your browser or operating system, or log in with an email address instead.'
+						'Please enable "third-party cookies" in your browser or operating system, or sign up with an email address instead.'
 					) } );
 					return null;
 				}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -64,9 +64,7 @@ class GoogleLoginButton extends Component {
 
 				if ( 'idpiframe_initialization_failed' === error.error ) {
 					// This error is caused by 3rd party cookies being blocked.
-					this.setState( { error: translate( 'Your privacy settings are blocking us from connecting to your Google account. ' +
-						'Please enable "third-party cookies" in your browser or operating system, or sign up with an email address instead.'
-					) } );
+					this.setState( { error: translate( 'Please enable "third-party cookies" to connect your Google account.' ) } );
 					return null;
 				}
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -96,16 +96,25 @@ class GoogleLoginButton extends Component {
 		return (
 			<div>
 				<button className="social-buttons__button button" onClick={ this.handleClick } disabled={ buttonDisabled }>
-					<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-						{ /* eslint-disable max-len */ }
+					{ /* eslint-disable max-len */ }
+					<svg className="social-buttons__logo enabled" width="20" height="20" viewBox="0 0 20 20"xmlns="http://www.w3.org/2000/svg">
 						<g fill="none" fillRule="evenodd">
 							<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />
 							<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#34A853" />
 							<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#FBBC05" />
 							<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#EA4335" />
-						{ /* eslint-enable max-len */ }
 						</g>
 					</svg>
+
+					<svg className="social-buttons__logo disabled" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+						<g fill="none" fillRule="evenodd">
+							<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#e9eff3" />
+							<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#e9eff3" />
+							<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#e9eff3" />
+							<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#e9eff3" />
+						</g>
+					</svg>
+					{ /* eslint-enable max-len */ }
 
 					<span className="social-buttons__service-name">
 						{ this.props.translate( 'Continue with %(service)s', {

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -122,7 +122,7 @@ class GoogleLoginButton extends Component {
 						} ) }
 					</span>
 				</button>
-				<div className="social-buttons__service-error">{ this.state.error }</div>
+				{ this.state.error && <div className="social-buttons__service-error">{ this.state.error }</div> }
 			</div>
 		);
 	}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -19,6 +19,8 @@ class GoogleLoginButton extends Component {
 		fetchBasicProfile: true,
 	};
 
+	state = { error: false };
+
 	constructor( props ) {
 		super( props );
 
@@ -45,6 +47,10 @@ class GoogleLoginButton extends Component {
 			return this.initialized;
 		}
 
+		this.setState( { error: '' } );
+
+		const { translate } = this.props;
+
 		this.initialized = this.loadDependency()
 			.then( gapi => new Promise( resolve => gapi.load( 'client:auth2', resolve ) ).then( () => gapi ) )
 			.then( gapi => gapi.client.init( {
@@ -56,6 +62,14 @@ class GoogleLoginButton extends Component {
 			).catch( error => {
 				this.initialized = null;
 
+				if ( 'idpiframe_initialization_failed' === error.error ) {
+					// This error is caused by 3rd party cookies being blocked.
+					this.setState( { error: translate( 'Your privacy settings are blocking us from connecting to your Google account. ' +
+						'Please enable "third-party cookies" in your browser or operating system, or log in with an email address instead.'
+					) } );
+					return null;
+				}
+
 				return Promise.reject( error );
 			} );
 
@@ -64,6 +78,10 @@ class GoogleLoginButton extends Component {
 
 	handleClick( event ) {
 		event.preventDefault();
+
+		if ( this.state.error ) {
+			return;
+		}
 
 		const { responseHandler } = this.props;
 
@@ -75,26 +93,33 @@ class GoogleLoginButton extends Component {
 	}
 
 	render() {
+		let buttonDisabled = false;
+		if ( this.state.error ) {
+			buttonDisabled = true;
+		}
 		return (
-			<button className="button" onClick={ this.handleClick }>
-				<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-					{ /* eslint-disable max-len */ }
-					<g fill="none" fillRule="evenodd">
-						<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />
-						<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#34A853" />
-						<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#FBBC05" />
-						<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#EA4335" />
-					{ /* eslint-enable max-len */ }
-					</g>
-				</svg>
+			<div>
+				<button className="social-buttons__button button" onClick={ this.handleClick } disabled={ buttonDisabled }>
+					<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+						{ /* eslint-disable max-len */ }
+						<g fill="none" fillRule="evenodd">
+							<path d="M19.6 10.227c0-.709-.064-1.39-.182-2.045H10v3.868h5.382a4.6 4.6 0 0 1-1.996 3.018v2.51h3.232c1.891-1.742 2.982-4.305 2.982-7.35z" fill="#4285F4" />
+							<path d="M10 20c2.7 0 4.964-.895 6.618-2.423l-3.232-2.509c-.895.6-2.04.955-3.386.955-2.605 0-4.81-1.76-5.595-4.123H1.064v2.59A9.996 9.996 0 0 0 10 20z" fill="#34A853" />
+							<path d="M4.405 11.9c-.2-.6-.314-1.24-.314-1.9 0-.66.114-1.3.314-1.9V5.51H1.064A9.996 9.996 0 0 0 0 10c0 1.614.386 3.14 1.064 4.49l3.34-2.59z" fill="#FBBC05" />
+							<path d="M10 3.977c1.468 0 2.786.505 3.823 1.496l2.868-2.868C14.959.99 12.695 0 10 0 6.09 0 2.71 2.24 1.064 5.51l3.34 2.59C5.192 5.736 7.396 3.977 10 3.977z" fill="#EA4335" />
+						{ /* eslint-enable max-len */ }
+						</g>
+					</svg>
 
-				<span className="social-buttons__service-name">
-					{ this.props.translate( 'Continue with %(service)s', {
-						args: { service: 'Google' },
-						comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
-					} ) }
-				</span>
-			</button>
+					<span className="social-buttons__service-name">
+						{ this.props.translate( 'Continue with %(service)s', {
+							args: { service: 'Google' },
+							comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
+						} ) }
+					</span>
+				</button>
+				<div className="social-buttons__service-error">{ this.state.error }</div>
+			</div>
 		);
 	}
 }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -19,7 +19,7 @@ class GoogleLoginButton extends Component {
 		fetchBasicProfile: true,
 	};
 
-	state = { error: false };
+	state = { error: '' };
 
 	constructor( props ) {
 		super( props );
@@ -93,10 +93,8 @@ class GoogleLoginButton extends Component {
 	}
 
 	render() {
-		let buttonDisabled = false;
-		if ( this.state.error ) {
-			buttonDisabled = true;
-		}
+		const buttonDisabled = Boolean( this.state.error );
+
 		return (
 			<div>
 				<button className="social-buttons__button button" onClick={ this.handleClick } disabled={ buttonDisabled }>

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -130,8 +130,7 @@ class GoogleLoginButton extends Component {
 
 		return (
 			<div>
-				<button
-					className={ classes } onMouseOver={ this.showError } onMouseOut={ this.hideError } onClick={ this.handleClick }>
+				<button className={ classes } onMouseOver={ this.showError } onMouseOut={ this.hideError } onClick={ this.handleClick }>
 					{ /* eslint-disable max-len */ }
 					<svg className="social-buttons__logo enabled" width="20" height="20" viewBox="0 0 20 20"xmlns="http://www.w3.org/2000/svg">
 						<g fill="none" fillRule="evenodd">

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
-import closest from 'component-closest';
 
 /**
  * Internal dependencies
@@ -93,7 +92,7 @@ class GoogleLoginButton extends Component {
 		if ( this.state.error ) {
 			this.setState( {
 				showError: ! this.state.showError,
-				errorRef: closest( event.target, '.social-buttons__button', true ),
+				errorRef: event.currentTarget,
 			} );
 
 			return;
@@ -115,7 +114,7 @@ class GoogleLoginButton extends Component {
 
 		this.setState( {
 			showError: true,
-			errorRef: closest( event.target, '.social-buttons__button', true ),
+			errorRef: event.currentTarget,
 		} );
 	}
 

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { loadScript } from 'lib/load-script';
 import { localize } from 'i18n-calypso';
+import closest from 'component-closest';
 
 /**
  * Internal dependencies
@@ -92,7 +93,7 @@ class GoogleLoginButton extends Component {
 		if ( this.state.error ) {
 			this.setState( {
 				showError: ! this.state.showError,
-				errorRef: event.target,
+				errorRef: closest( event.target, '.social-buttons__button', true ),
 			} );
 
 			return;
@@ -114,7 +115,7 @@ class GoogleLoginButton extends Component {
 
 		this.setState( {
 			showError: true,
-			errorRef: event.target,
+			errorRef: closest( event.target, '.social-buttons__button', true ),
 		} );
 	}
 

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,9 +1,36 @@
 /*rtl:ignore*/
 
+.social-buttons__button {
+	svg {
+		margin-top: -2px;
+
+		&.disabled {
+			display: none;
+		}
+	}
+}
+
+.social-buttons__button.disabled {
+	svg.enabled {
+		display: none;
+	}
+
+	svg.disabled {
+		display: inline;
+	}
+}
+
 .social-buttons__logo {
 	vertical-align: middle;
 }
 
 .social-buttons__service-name {
 	margin-left: 9px;
+}
+
+.social-buttons__error {
+	.popover__inner {
+		padding: 10px;
+		max-width: 200px;
+	}
 }

--- a/client/login/wp-login/test/test.jsx
+++ b/client/login/wp-login/test/test.jsx
@@ -9,11 +9,16 @@ import { identity } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { Login } from '../index.jsx';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
 describe( 'Login', () => {
+	let Login;
+
 	useFakeDom();
+
+	before( () => {
+		Login = require( '../index.jsx' ).Login;
+	} );
 
 	describe( 'footerLinks', () => {
 		context( 'when state is not loaded', () => {


### PR DESCRIPTION
This pull request addresses #13553 by disabling the Google signup button, and showing an error message, when 3rd party cookies are disabled:

<img width="427" alt="screen shot 2017-05-12 at 4 10 22 pm" src="https://cloud.githubusercontent.com/assets/352291/25985373/92018986-372d-11e7-8af7-bc41f99769b1.png">


#### Testing instructions

1. Run `git checkout fix/13553-signup-3rd-party-cookies` and start your server, or open a [live branch](https://calypso.live/?branch=fix/13553-signup-3rd-party-cookies)
2. Open the [`Social Signup` page](http://calypso.localhost:3000/start/social/user-social)
3. Check that the "Continue with Google" button is enabled, and there is no error message.
4. In your browser settings, enabled the "Block third-party cookies" setting.
5. Refresh the Social Signup page.
6. Check that the "Continue with Google" button is disabled, and there is an error message.

#### Reviews

- [x] Code
- [ ] Design
- [x] Product