### PR TITLE
Domains: fix binding in the domains renew button

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -120,7 +120,7 @@ class ManagePurchase extends Component {
 		return Boolean( getPurchase( props ) );
 	}
 
-	handleRenew() {
+	handleRenew = () => {
 		const purchase = getPurchase( this.props ),
 			renewItem = cartItems.getRenewalItemFromProduct( purchase, {
 				domain: purchase.meta


### PR DESCRIPTION
The Renew button does not work because of a javascript error - wrong binding.

To reproduce the problem, just expire a domain and visit /me/purchases. The renew notice would not work. Now it does.

![domain-renew](https://cloud.githubusercontent.com/assets/82778/25988401/80a4cac2-3700-11e7-8d3a-43102cc20e65.gif)
