### PR TITLE
Include description in suggestions.

### DIFF
--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -302,14 +302,16 @@ class Suggestions extends React.Component {
 				</div>
 			);
 			//Add values
+			const { terms } = this.props;
 			rendered.push( suggestions[ key ].map( ( value, i ) => {
-				const taxonomyName = this.props.terms[ key ][ value ].name;
+				const taxonomyName = terms[ key ][ value ].name + ' - ';
 				const hasHighlight = ( noOfSuggestions + i ) === this.state.suggestionPosition;
 				const className = classNames( 'suggestions__value', { 'has-highlight': hasHighlight } );
 				return (
 					<span className={ className } onMouseDown={ this.onMouseDown } onMouseOver={ this.onMouseOver } key={ key + '_' + i }>
 						<span className="suggestions__value-category">{ key + ':' + value + ' '}</span>
 						{ this.createTextWithHighlight( taxonomyName, this.state.filterTerm ) }
+						<span className="suggestions__value-description">{ terms[ key ][ value ].description }</span>
 					</span>
 				);
 			} ) );

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -254,7 +254,7 @@ class Suggestions extends React.Component {
 			if ( lowercasePart === highlightedText ) {
 				return <span key={ key } className="suggestions__value-emphasis" >{ part }</span>;
 			}
-			return <span key={ key }className="suggestions__value-normal" >{ part }</span>;
+			return <span key={ key } className="suggestions__value-normal" >{ part }</span>;
 		} );
 
 		return token;
@@ -304,14 +304,18 @@ class Suggestions extends React.Component {
 			//Add values
 			const { terms } = this.props;
 			rendered.push( suggestions[ key ].map( ( value, i ) => {
-				const taxonomyName = terms[ key ][ value ].name + ' - ';
+				const taxonomyName = terms[ key ][ value ].name;
 				const hasHighlight = ( noOfSuggestions + i ) === this.state.suggestionPosition;
 				const className = classNames( 'suggestions__value', { 'has-highlight': hasHighlight } );
 				return (
 					<span className={ className } onMouseDown={ this.onMouseDown } onMouseOver={ this.onMouseOver } key={ key + '_' + i }>
 						<span className="suggestions__value-category">{ key + ':' + value + ' '}</span>
-						{ this.createTextWithHighlight( taxonomyName, this.state.filterTerm ) }
-						<span className="suggestions__value-description">{ terms[ key ][ value ].description }</span>
+						<span className="suggestions__value-label-wigh-highlight">
+							{ this.createTextWithHighlight( taxonomyName, this.state.filterTerm ) }
+						</span>
+						{ terms[ key ][ value ].description !== '' &&
+							<span className="suggestions__value-description">{ terms[ key ][ value ].description }</span>
+						}
 					</span>
 				);
 			} ) );

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -73,3 +73,10 @@
 		color: $white;
 	}
 }
+
+.suggestions__value-description {
+	pointer-events: none;
+	text-indent: 10px;
+	color: gray-text-min;
+	font-size: 14px;
+}

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -90,7 +90,7 @@
 	padding-top: 3px;
 	color: $gray-text-min;
 	font-size: 13px;
-	height: 16px;
+	height: 19px; /* font-size + 2*padding */
 	overflow: hidden;
 
 	&:before {

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -19,10 +19,6 @@
 .suggestions__suggestions {
 	display: flex;
 	flex-direction: column;
-
-	.suggestions__value-category {
-		display: none;
-	}
 }
 
 .suggestions__category {
@@ -50,33 +46,58 @@
 }
 
 .suggestions__value {
+	display: flex;
 	padding: 10px 10px;
 	background: $white;
 	border: 1px solid darken( $gray-light, 10% );
 	border-top: 0px;
-	font-size: 16px;
+	font-size: 15px;
 	cursor: pointer;
+
+	&.has-highlight {
+		background-color: $blue-medium;
+		color: $white;
+
+		.suggestions__value-description {
+			color: $white;
+		}
+	}
+}
+
+.suggestions__value-category {
+	display: none;
+}
+
+.suggestions__value-label-wigh-highlight {
+	flex: 0 0 auto;
 
 	.suggestions__value-emphasis,
 	.suggestions__value-normal {
-		/* Required to allow clicks pass-through */
-		pointer-events: none;
+		pointer-events: none; /* Required to allow clicks pass-through */
 	}
 
 	.suggestions__value-emphasis {
 		font-weight: bold;
 		color: inherit;
 	}
-
-	&.has-highlight {
-		background-color: $blue-medium;
-		color: $white;
-	}
 }
 
 .suggestions__value-description {
-	pointer-events: none;
-	text-indent: 10px;
-	color: gray-text-min;
-	font-size: 14px;
+	position: relative; /* Required to allow :before positioning to work */
+	pointer-events: none; /* Required to allow clicks pass-through */
+	flex: 1 1 auto;
+	margin-left: 0.5em;
+	padding-top: 3px;
+	color: $gray-text-min;
+	font-size: 13px;
+	height: 16px;
+	overflow: hidden;
+
+	&:before {
+		@include long-content-fade( $color : $white );
+
+		.has-highlight & {
+			@include long-content-fade( $color : $blue-medium );
+		}
+	}
 }


### PR DESCRIPTION
### Info 
This implements: #13004 

In some cases the descriptions looks nice:
![image](https://cloud.githubusercontent.com/assets/17271089/25994769/861b9bd4-370f-11e7-944a-0b9caf768ca3.png)

In some cases it does not: 
![image](https://cloud.githubusercontent.com/assets/17271089/25994932/4a77203e-3710-11e7-8aed-0b36828031dd.png)

In some cases there is nothing at all:
![image](https://cloud.githubusercontent.com/assets/17271089/25994980/74029fa0-3710-11e7-86ff-e1d6c5cd9c12.png)

This will require also mobile view design - where there is no space for the description.