### PR TITLE
Re-enable upload button for all site types.

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -24,10 +24,8 @@ import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
-import { isATEnabled } from 'lib/automated-transfer';
 import { getThemeShowcaseDescription, getThemeShowcaseTitle } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite } from 'state/ui/selectors';
 import ThemesSearchCard from './themes-magic-search-card';
 import QueryThemeFilters from 'components/data/query-theme-filters';
 
@@ -135,13 +133,12 @@ const ThemeShowcase = React.createClass( {
 	},
 
 	showUploadButton() {
-		const { isMultisite, isJetpack, isLoggedIn } = this.props;
+		const { isMultisite, isLoggedIn } = this.props;
 
 		return (
 			config.isEnabled( 'manage/themes/upload' ) &&
 			isLoggedIn &&
-			! isMultisite &&
-			( isJetpack || this.props.atEnabled )
+			! isMultisite
 		);
 	},
 
@@ -255,7 +252,6 @@ const ThemeShowcase = React.createClass( {
 } );
 
 const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
-	atEnabled: isATEnabled( getSelectedSite( state ) ),
 	isLoggedIn: !! getCurrentUserId( state ),
 	siteSlug: getSiteSlug( state, siteId ),
 	isJetpack: isJetpackSite( state, siteId ),

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -20,7 +20,6 @@ import ProgressBar from 'components/progress-bar';
 import Button from 'components/button';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
-import { isATEnabled } from 'lib/automated-transfer';
 // Necessary for ThanksModal
 import QueryActiveTheme from 'components/data/query-active-theme';
 import { localize } from 'i18n-calypso';
@@ -296,18 +295,6 @@ class Upload extends React.Component {
 		);
 	}
 
-	renderNotAvailable() {
-		return (
-			<EmptyContent
-				title={ this.props.translate( 'Upload not available for this site' ) }
-				line={ this.props.translate( 'Please select a different site' ) }
-				action={ this.props.translate( 'Back to themes' ) }
-				actionURL={ this.props.backPath }
-				illustration={ '/calypso/images/drake/drake-whoops.svg' }
-			/>
-		);
-	}
-
 	render() {
 		const {
 			translate,
@@ -316,7 +303,6 @@ class Upload extends React.Component {
 			themeId,
 			upgradeJetpack,
 			backPath,
-			isJetpack,
 			isMultisite
 		} = this.props;
 
@@ -324,10 +310,6 @@ class Upload extends React.Component {
 
 		if ( isMultisite ) {
 			return this.renderNotAvailableForMultisite();
-		}
-
-		if ( ! isJetpack && ! this.props.atEnabled ) {
-			return this.renderNotAvailable();
 		}
 
 		return (
@@ -396,7 +378,6 @@ export default connect(
 			showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
-			atEnabled: isATEnabled( site )
 		};
 	},
 	{ uploadTheme, clearThemeUpload, initiateThemeTransfer },


### PR DESCRIPTION
### Info
Add upload button to all sites types ( except Jetpack multisite )

### Testing 
Go to `/themes` design and check on all-sites, single-site( all types), jetpack that the Upload Themes button is there and it forwards to a meaningful upload site.