### PR TITLE
Ads: ES6ify ads settings form

### DIFF
--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -115,7 +115,7 @@ class AdsFormSettings extends Component {
 		} );
 	}
 
-	submitForm = ( event ) => {
+	handleSubmit = ( event ) => {
 		const { site } = this.props;
 		event.preventDefault();
 
@@ -430,7 +430,7 @@ class AdsFormSettings extends Component {
 
 		return (
 			<Card>
-				<form id="wordads-settings" onSubmit={ this.submitForm } onChange={ this.props.markChanged }>
+				<form id="wordads-settings" onSubmit={ this.handleSubmit } onChange={ this.props.markChanged }>
 					<FormButtonsBar>
 						<FormButton disabled={ this.state.isLoading || this.state.isSubmitting }>
 							{ this.state.isSubmitting ? translate( 'Saving…' ) : translate( 'Save Settings' ) }

--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -49,7 +49,7 @@ class AdsFormSettings extends Component {
 
 	componentWillMount() {
 		SettingsStore.on( 'change', this.updateSettings );
-		this._fetchIfEmpty();
+		this.fetchIfEmpty();
 	}
 
 	componentWillUnmount() {
@@ -68,7 +68,7 @@ class AdsFormSettings extends Component {
 		}
 
 		if ( site.ID !== nextProps.site.ID ) {
-			this._fetchIfEmpty( nextProps.site );
+			this.fetchIfEmpty( nextProps.site );
 			this.setState( this.getSettingsFromStore( nextProps.site ) );
 		}
 	}
@@ -181,7 +181,7 @@ class AdsFormSettings extends Component {
 		};
 	}
 
-	_fetchIfEmpty( site ) {
+	fetchIfEmpty( site ) {
 		site = site || this.props.site;
 		if ( ! site || ! site.ID ) {
 			return;

--- a/client/my-sites/ads/style.scss
+++ b/client/my-sites/ads/style.scss
@@ -118,7 +118,7 @@
 	}
 }
 @include breakpoint( "<480px" ) {
-	.settings__state{
+	.ads__settings-state {
 		max-width: 75%;
 	}
 }


### PR DESCRIPTION
This PR ES6ifies the ads settings form and removes all ESLint warnings from it. This will help us do any further modifications without much changes while working on the upcoming ads changes - https://github.com/Automattic/wp-calypso/milestone/169

There should be no functional, visual or behavioral changes.

To test:
* Checkout this branch
* Go to `/ads/settings/$site` where `$site` is a Jetpack site with a Premium or Professional plan.
* Play with all of the settings and verify there are no regressions or changes to the previous behavior.
* Verify saving and retrieving settings works properly.
* Try requesting approval for ads for a site that previously wasn't approved and verify it works as expected.
* Test all of the above with a WordPress.com site and verify there are no regressions.