### PR TITLE
Reader: Pass down the feed_URL if available instead of the site URL

### DIFF
--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -36,7 +36,7 @@ const FollowingManageSearchFeedsResults = ( {
 	if ( ! showMoreResults ) {
 		const resultsToShow = map( take( searchResults, 10 ), site => (
 			<ConnectedSubscriptionListItem
-				url={ site.URL }
+				url={ site.feed_URL || site.URL }
 				feedId={ +site.feed_ID }
 				siteId={ +site.blog_ID }
 				key={ `search-result-site-id-${ site.feed_ID }` }


### PR DESCRIPTION
This makes subs to things with a feed URL that's different from the site URL work as expected. Try Boing Boing.