### PR TITLE
Reader: Use a more robust key for search results

### DIFF
--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -39,7 +39,7 @@ const FollowingManageSearchFeedsResults = ( {
 				url={ site.URL }
 				feedId={ +site.feed_ID }
 				siteId={ +site.blog_ID }
-				key={ `search-result-site-id-${ site.feed_ID }` }
+				key={ `search-result-site-id-${ site.feed_ID || 0 }-${ site.blog_ID || 0 }` }
 			/>
 		) );
 


### PR DESCRIPTION
Not all results have a feed ID (if we can't match a feed with the result, it won't have a feed ID) so default it to 0 and also include the blog ID, which has to be set if there's no feed ID.