### PR TITLE
Selectors: getSites sorts by primary site

### DIFF
--- a/client/state/selectors/get-sites.js
+++ b/client/state/selectors/get-sites.js
@@ -1,8 +1,14 @@
 /**
+ * External dependencies
+ */
+import { concat, partition, map } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
 import { getSite } from 'state/sites/selectors';
+import { getPrimarySiteId } from 'state/selectors';
 
 /**
  * Get all sites
@@ -11,9 +17,10 @@ import { getSite } from 'state/sites/selectors';
  * @return {Array}        Sites objects
  */
 export default createSelector(
-	( state ) => (
-		Object.values( state.sites.items )
-			.map( site => getSite( state, site.ID ) )
-	),
+	( state ) => {
+		const primarySiteId = getPrimarySiteId( state );
+		const [ primarySite, sites ] = partition( state.sites.items, site => site.ID === primarySiteId );
+		return map( concat( primarySite, sites ), site => getSite( state, site.ID ) );
+	},
 	( state ) => state.sites.items
 );

--- a/client/state/selectors/get-sites.js
+++ b/client/state/selectors/get-sites.js
@@ -19,7 +19,7 @@ import { getPrimarySiteId } from 'state/selectors';
 export default createSelector(
 	( state ) => {
 		const primarySiteId = getPrimarySiteId( state );
-		const [ primarySite, sites ] = partition( state.sites.items, site => site.ID === primarySiteId );
+		const [ primarySite, sites ] = partition( state.sites.items, { ID: primarySiteId } );
 		return map( concat( primarySite, sites ), site => getSite( state, site.ID ) );
 	},
 	( state ) => state.sites.items

--- a/client/state/selectors/test/get-sites.js
+++ b/client/state/selectors/test/get-sites.js
@@ -8,9 +8,23 @@ import { expect } from 'chai';
  */
 import { getSites } from '../';
 
+const currentUserState = {
+	currentUser: {
+		id: 12345678
+	},
+	users: {
+		items: {
+			12345678: {
+				primary_blog: 2916288
+			}
+		}
+	}
+};
+
 describe( 'getSites()', () => {
 	it( 'should return an empty array if no sites in state', () => {
 		const state = {
+			...currentUserState,
 			sites: {
 				items: {}
 			}
@@ -21,6 +35,7 @@ describe( 'getSites()', () => {
 
 	it( 'should return all the sites in state', () => {
 		const state = {
+			...currentUserState,
 			sites: {
 				items: {
 					2916284: {
@@ -51,5 +66,36 @@ describe( 'getSites()', () => {
 		expect( sites ).to.have.length( 2 );
 		expect( sites[ 0 ] ).to.have.property( 'name', 'WordPress.com Example Blog' );
 		expect( sites[ 1 ] ).to.have.property( 'name', 'WordPress.com Way Better Example Blog' );
+	} );
+
+	it( 'should return the primary site as the first element of the list', () => {
+		const state = {
+			...currentUserState,
+			sites: {
+				items: {
+					2916287: {
+						ID: 2916287,
+						name: 'WordPress.com Example Blog',
+					},
+					2916288: {
+						ID: 2916288,
+						name: 'WordPress.com Way Better Example Blog',
+					},
+					2916289: {
+						ID: 2916289,
+						name: 'WordPress.com Another Example Blog',
+					}
+				}
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getSites( state );
+
+		expect( sites ).to.have.length( 3 );
+		expect( sites[ 0 ] ).to.have.property( 'ID', 2916288 );
+		expect( sites[ 1 ] ).to.have.property( 'ID', 2916287 );
+		expect( sites[ 2 ] ).to.have.property( 'ID', 2916289 );
 	} );
 } );


### PR DESCRIPTION
This PR modifies the `getSites` selector to preserve `site-lists` order of sites, that always pushed the users' primary site to the top of the list.

Fixes #14023

cc: @tyxla @mtias 