### PR TITLE
Reader: hide recommendations header in Following Manage if we don't have any recs to show

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { map, partial } from 'lodash';
+import { map, partial, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
@@ -39,6 +39,11 @@ export class RecommendedSites extends React.PureComponent {
 
 	render() {
 		const { sites } = this.props;
+
+		if ( isEmpty( sites ) ) {
+			return null;
+		}
+
 		return (
 			<div className="reader-recommended-sites">
 				<h1 className="reader-recommended-sites__header">


### PR DESCRIPTION
I noticed that in cases where we don't have any recommendations to show (particularly in non-English languages), we still show the header 'RECOMMENDED SITES'.

This PR hides the header unless we have recs to show.
