### PR TITLE
Reader: Avoid keyed reducer for now to stop serializing feed searches

### DIFF
--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -7,7 +7,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer, keyedReducer } from 'state/utils';
+import { createReducer } from 'state/utils';
 import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
 /**
@@ -24,12 +24,17 @@ import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
  * @param  {Object} action Action payload
  * @return {Array}        Updated state
  */
-export const items = keyedReducer(
-	'query',
-	createReducer( null, {
-		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) =>
-			uniqBy( ( state || [] ).concat( action.payload.feeds ), 'feed_URL' ),
-	} )
+export const items = createReducer(
+	{},
+	{
+		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => {
+			const current = state[ action.query ] || [];
+			return {
+				...state,
+				[ action.query ]: uniqBy( current.concat( action.payload.feeds ), 'feed_URL' ),
+			};
+		},
+	}
 );
 
 /**
@@ -48,11 +53,14 @@ export const items = keyedReducer(
  * @param  {Object} action Action payload
  * @return {Array}         Updated state
  */
-export const total = keyedReducer(
-	'query',
-	createReducer( null, {
-		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => action.payload.total,
-	} )
+export const total = createReducer(
+	{},
+	{
+		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => ( {
+			...state,
+			[ action.query ]: action.payload.total,
+		} ),
+	}
 );
 
 export default combineReducers( {


### PR DESCRIPTION
Problem:
`client/state/utils#keyedReducer` is returning `state` whenever handed the `SERIALIZE` action.  It doesn't pass it down to its children. This is a problem for parts of the tree that we didn't intend to get serialized like search results

solution in this pr: get off `keyedReducer`