### PR TITLE
Ensure jetpack_version exists when validating version

### DIFF
--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -50,7 +50,7 @@ const PostsMain = React.createClass( {
 	},
 
 	showDrafts() {
-		const { isJetpack } = this.props;
+		const { isJetpack } = this.props;
 
 		// Jetpack sites can have malformed counts
 		if ( isJetpack && ! this.props.loadingDrafts && this.props.drafts && this.props.drafts.length === 0 ) {
@@ -69,7 +69,7 @@ const PostsMain = React.createClass( {
 	},
 
 	mostRecentDrafts() {
-		const { siteId, siteSlug } = this.props;
+		const { siteId, siteSlug } = this.props;
 
 		if ( ! siteId || ! this.showDrafts() ) {
 			return null;
@@ -122,8 +122,12 @@ const PostsMain = React.createClass( {
 		);
 	},
 
-	setWarning( { adminUrl, hasMinimumJetpackVersion, isJetpack, siteId } ) {
-		if ( siteId && isJetpack && ! hasMinimumJetpackVersion ) {
+	setWarning( { adminUrl, hasMinimumJetpackVersion, isJetpack, siteId } ) {
+		if (
+			siteId &&
+			isJetpack &&
+			false === hasMinimumJetpackVersion
+		) {
 			this.props.warningNotice(
 				this.props.translate( 'Jetpack %(version)s is required to take full advantage of all post editing features.', {
 					args: { version: config( 'jetpack_min_version' ) }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -939,6 +939,13 @@ export function siteHasMinimumJetpackVersion( state, siteId ) {
 	}
 
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
+
+	// FIXME: Recently connected Jetpack sites have jetpack_version = false
+	// When this is corrected, drop this condition
+	if ( ! siteJetpackVersion ) {
+		return null;
+	}
+
 	const jetpackMinVersion = config( 'jetpack_min_version' );
 
 	return versionCompare( siteJetpackVersion, jetpackMinVersion ) >= 0;

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -939,9 +939,6 @@ export function siteHasMinimumJetpackVersion( state, siteId ) {
 	}
 
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
-
-	// FIXME: Recently connected Jetpack sites have jetpack_version = false
-	// When this is corrected, drop this condition
 	if ( ! siteJetpackVersion ) {
 		return null;
 	}


### PR DESCRIPTION
Immediately after connecting a new Jetpack site, the `jetpack_version` option is `false`. This make version checking impossible, and in at least one place we display incorrect error messages.

This fix changes the selector so that if the `jetpack_version` option is falsy, `null` is returned.
That way `false === siteHasMinimumJetpackVersion` can be used to create the errors, and avoid the current issues.

Avoids raising incorrect errors on recently connected sites which initially have `jetpack_version = false`.

To test:

1. Use this branch
1. Create new Jetpack site
1. Connect the site
1. Immediately visit http://calypso.localhost:3000/posts/:site
1. You should not see errors
1. Verify that `jetpack_version === false`:
   1. Select provider from React devtools
   1. `s = $r.store.getState()`
   1. `s.sites.items[ SITE_ID ].options.jetpack_version` should be `false`

The wall of errors we're trying to avoid:

![errors](https://cloud.githubusercontent.com/assets/841763/26006604/548a92fe-373d-11e7-929b-7e1e35be93da.png)
