### PR TITLE
Reader: fix gravatar alignment/spacing on Manage Following

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -60,7 +60,7 @@
 
 .reader-subscription-list-item .gravatar {
 	float: left;
-	margin: 2px 8px 0 0;
+	margin: 4px 12px 0 0;
 	height: 32px;
 	min-height: 32px;
 	min-width: 32px;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/13941 and https://github.com/Automattic/wp-calypso/issues/13975.

**Before:**
<img width="192" alt="screenshot 2017-05-12 11 16 36" src="https://cloud.githubusercontent.com/assets/4924246/26011131/a3e00912-3704-11e7-8477-d2bf57812367.png">

**After:**
<img width="203" alt="screenshot 2017-05-12 11 17 13" src="https://cloud.githubusercontent.com/assets/4924246/26011133/a9a217d2-3704-11e7-8120-2f67dbd75d67.png">
