### PR TITLE
Add two-level persistence to keyedReducer

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -278,7 +278,7 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe.only( '#keyedReducer', () => {
+	describe( '#keyedReducer', () => {
 		const grow = name => ( { type: 'GROW', name } );
 
 		const age = ( state = 0, action ) =>

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -373,6 +373,13 @@ describe( 'utils', () => {
 			expect( keyed( prevState, { type: SERIALIZE } ) ).to.eql( { Bonobo: 'age:13' } );
 		} );
 
+		it( 'should return initial state on DESERIALIZE if no deserializer given', () => {
+			const keyed = keyedReducer( 'name', age );
+
+			expect( keyed( undefined, { type: DESERIALIZE } ) ).to.eql( {} );
+			expect( keyed( prevState, { type: DESERIALIZE } ) ).to.eql( {} );
+		} );
+
 		it( 'should pass along DESERIALIZE actions to items in collection', () => {
 			const deserializing = ( state = 0, { type } ) => {
 				if ( DESERIALIZE === type ) {
@@ -384,7 +391,7 @@ describe( 'utils', () => {
 					? state + 1
 					: state;
 			};
-			const keyed = keyedReducer( 'name', deserializing );
+			const keyed = keyedReducer( 'name', deserializing, { deserializer: ( state, mapper ) => mapper( state ) } );
 
 			expect( keyed( { Bonobo: 'age:13' }, { type: DESERIALIZE } ) ).to.eql( { Bonobo: 13 } );
 		} );
@@ -421,9 +428,6 @@ describe( 'utils', () => {
 				DESERIALIZE === type
 					? state * 2
 					: state;
-
-			const deserialized = keyedReducer( 'name', deserializing );
-			expect( deserialized( { Bonobo: 13 }, { type: DESERIALIZE } ) ).to.eql( { Bonobo: 26 } );
 
 			const custom = keyedReducer( 'name', deserializing, { deserializer: state => state } );
 			expect( custom( prevState, { type: DESERIALIZE } ) ).to.equal( prevState );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -2,7 +2,14 @@
  * External dependencies
  */
 import validator from 'is-my-json-valid';
-import { merge, flow, partialRight, reduce } from 'lodash';
+import {
+	flow,
+	identity,
+	mapValues,
+	merge,
+	partialRight,
+	reduce,
+} from 'lodash';
 import { combineReducers } from 'redux';
 
 /**
@@ -73,9 +80,11 @@ export function isValidStateWithSchema( state, schema ) {
  *
  * @param {string} keyName name of key in action referencing item in state map
  * @param {function} reducer applied to referenced item in state map
+ * @param {function} deserializer takes entire state of collection and deserializes
+ * @param {function} serializer takes entire state of collection and serializes
  * @return {function} super-reducer applying reducer over map of keyed items
  */
-export const keyedReducer = ( keyName, reducer ) => {
+export const keyedReducer = ( keyName, reducer, { deserializer, serializer } = { deserializer: identity, serializer: identity } ) => {
 	// some keys are invalid
 	if ( 'string' !== typeof keyName ) {
 		throw new TypeError( `Key name passed into ``keyedReducer`` must be a string but I detected a ${ typeof keyName }` );
@@ -92,6 +101,14 @@ export const keyedReducer = ( keyName, reducer ) => {
 	const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
 
 	return ( state = {}, action ) => {
+		if ( DESERIALIZE === action.type ) {
+			return deserializer( state );
+		}
+
+		if ( SERIALIZE === action.type ) {
+			return serializer( mapValues( state, item => reducer( item, action ) ) );
+		}
+
 		// don't allow coercion of key name: null => 0
 		if ( ! action.hasOwnProperty( keyName ) ) {
 			return state;

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -86,7 +86,7 @@ const keyedMapper = ( state, collectionMapper ) => collectionMapper( state );
  * @param {function} serializer takes entire state of collection and serializes
  * @return {function} super-reducer applying reducer over map of keyed items
  */
-export const keyedReducer = ( keyName, reducer, { deserializer, serializer } = { deserializer: keyedMapper, serializer: keyedMapper } ) => {
+export const keyedReducer = ( keyName, reducer, { deserializer, serializer } = { serializer: keyedMapper } ) => {
 	// some keys are invalid
 	if ( 'string' !== typeof keyName ) {
 		throw new TypeError( `Key name passed into ``keyedReducer`` must be a string but I detected a ${ typeof keyName }` );
@@ -104,7 +104,9 @@ export const keyedReducer = ( keyName, reducer, { deserializer, serializer } = {
 
 	return ( state = {}, action ) => {
 		if ( DESERIALIZE === action.type ) {
-			return deserializer( state, next => mapValues( next, item => reducer( item, action ) ) );
+			return deserializer
+				? deserializer( state, next => mapValues( next, item => reducer( item, action ) ) )
+				: {};
 		}
 
 		if ( SERIALIZE === action.type ) {


### PR DESCRIPTION
Previously the `keyedReducer` was "eating" the SERIALIZE and DESERIALIZE
actions because they never had the attached `key` value. This meant that
the entire state was being persisted (I think)

Now they pass through those actions to each item in the collection on
SERIALIZE and return through an optional serializer and deserializer.

Tests to come