### PR TITLE
Reader: only show following intro to users with an odd user ID

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -15,6 +15,9 @@ import QueryPreferences from 'components/data/query-preferences';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import { recordTrack } from 'reader/stats';
+import { getCurrentUserId } from 'state/current-user/selectors';
+
+const isEven = number => number % 2 === 0;
 
 class FollowingIntro extends React.Component {
 	componentDidMount() {
@@ -34,12 +37,13 @@ class FollowingIntro extends React.Component {
 	};
 
 	render() {
-		const { isNewReader, translate, dismiss } = this.props;
+		const { isNewReader, translate, dismiss, userId } = this.props;
 		const linkElement = config.isEnabled( 'reader/following-manage-refresh' )
 			? <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />
 			: <a onClick={ this.props.handleManageLinkClick } href="/following/edit" />;
 
-		if ( ! isNewReader ) {
+		// Only show the banner to new Readers with an odd user ID (simple A/B test)
+		if ( ! isNewReader || ! userId || ! isEven( userId ) ) {
 			return null;
 		}
 
@@ -87,6 +91,7 @@ export default connect(
 	state => {
 		return {
 			isNewReader: getPreference( state, 'is_new_reader' ),
+			userId: getCurrentUserId( state ),
 		};
 	},
 	dispatch =>

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -43,7 +43,7 @@ class FollowingIntro extends React.Component {
 			: <a onClick={ this.props.handleManageLinkClick } href="/following/edit" />;
 
 		// Only show the banner to new Readers with an odd user ID (simple A/B test)
-		if ( ! isNewReader || ! userId || ! isEven( userId ) ) {
+		if ( ! isNewReader || ! userId || isEven( userId ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
As discussed with @aaronyan and @fraying, this PR shows the following intro banner only to users with an odd user ID. Users with an even user ID will never see the banner.

<img width="865" alt="screen shot 2017-05-12 at 20 51 01" src="https://cloud.githubusercontent.com/assets/17325/26012463/d36e9fea-3754-11e7-9ecd-a8cf31f57244.png">

The aim here is to provide a simple A/B test where we can measure a user's behaviour across platforms and browsers after seeing the banner.

### To test

Create a brand new user account, and make sure you are only shown the banner if your user ID is odd. You might like to set a breakpoint on the following line, to see what your user ID is:

<img width="674" alt="screen shot 2017-05-12 at 20 53 09" src="https://cloud.githubusercontent.com/assets/17325/26012689/ad8deafa-3755-11e7-8fb4-10a2d69b9d59.png">

