### PR TITLE
Jetpack Connect: Add `jp_version` to authorization requests

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -312,10 +312,10 @@ Undocumented.prototype.jetpackLogin = function( siteId, _wp_nonce, redirect_uri,
 	return this.wpcom.req.get( { path: endpointUrl }, params );
 };
 
-Undocumented.prototype.jetpackAuthorize = function( siteId, code, state, redirect_uri, secret ) {
+Undocumented.prototype.jetpackAuthorize = function( siteId, code, state, redirect_uri, secret, jp_version ) {
 	debug( '/jetpack-blogs/:site_id:/authorize query' );
 	const endpointUrl = '/jetpack-blogs/' + siteId + '/authorize';
-	const params = { code, state, redirect_uri, secret };
+	const params = { code, state, redirect_uri, secret, jp_version };
 	return this.wpcom.req.post( { path: endpointUrl }, params );
 };
 

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -318,7 +318,7 @@ export default {
 	},
 	authorize( queryObject ) {
 		return ( dispatch ) => {
-			const { _wp_nonce, client_id, redirect_uri, scope, secret, state } = queryObject;
+			const { _wp_nonce, client_id, redirect_uri, scope, secret, state, jp_version } = queryObject;
 			debug( 'Trying Jetpack login.', _wp_nonce, redirect_uri, scope, state );
 			tracksEvent( dispatch, 'calypso_jpc_authorize' );
 			dispatch( {
@@ -332,7 +332,14 @@ export default {
 					type: JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE,
 					data
 				} );
-				return wpcom.undocumented().jetpackAuthorize( client_id, data.code, state, redirect_uri, secret );
+				return wpcom.undocumented().jetpackAuthorize(
+					client_id,
+					data.code,
+					state,
+					redirect_uri,
+					secret,
+					jp_version
+				);
 			} )
 			.then( ( data ) => {
 				tracksEvent( dispatch, 'calypso_jpc_authorize_success', {


### PR DESCRIPTION
This PR simply adds the version of Jetpack on external site ( jp_version ) to the main authorization request when connecting a site.

This will allow us to save the version on the server immediately, and not have to wait for a sync to occur.

Fixes #14395 

Requires D5597-code.

Testing instructions coming soon.