### PR TITLE
run wp-prettier on reader data-layer

### DIFF
--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -19,14 +19,16 @@ export function initiateFeedSearch( store, action, next ) {
 	}
 
 	const path = '/read/feed';
-	store.dispatch( http( {
-		path,
-		method: 'GET',
-		apiVersion: '1.1',
-		query: { q: action.payload.query, offset: action.payload.offset },
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	store.dispatch(
+		http( {
+			path,
+			method: 'GET',
+			apiVersion: '1.1',
+			query: { q: action.payload.query, offset: action.payload.offset },
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 
 	next( action );
 }
@@ -38,9 +40,7 @@ export function receiveFeeds( store, action, next, apiResponse ) {
 	} ) );
 
 	const total = apiResponse.total > 200 ? 200 : apiResponse.total;
-	store.dispatch(
-		receiveFeedSearch( action.payload.query, feeds, total )
-	);
+	store.dispatch( receiveFeedSearch( action.payload.query, feeds, total ) );
 }
 
 export function receiveError( store, action, next, error ) {
@@ -49,16 +49,13 @@ export function receiveError( store, action, next, error ) {
 	}
 
 	const errorText = translate( 'Could not get results for query: %(query)s', {
-		args: { query: action.payload.query }
+		args: { query: action.payload.query },
 	} );
 	store.dispatch( errorNotice( errorText ) );
 }
 
 export default {
-	[ READER_FEED_SEARCH_REQUEST ]: [ dispatchRequest(
-			initiateFeedSearch,
-			receiveFeeds,
-			receiveError
-		) ],
+	[ READER_FEED_SEARCH_REQUEST ]: [
+		dispatchRequest( initiateFeedSearch, receiveFeeds, receiveError ),
+	],
 };
-

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -8,21 +8,12 @@ import freeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import {
-	requestFeedSearch,
-	receiveFeedSearch,
-} from 'state/reader/feed-searches/actions';
-import {
-	initiateFeedSearch,
-	receiveFeeds,
-	receiveError,
-} from '../';
+import { requestFeedSearch, receiveFeedSearch } from 'state/reader/feed-searches/actions';
+import { initiateFeedSearch, receiveFeeds, receiveError } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { NOTICE_CREATE } from 'state/action-types';
 
-const feeds = freeze( [
-	{ blog_ID: 'IM A BLOG', subscribe_URL: 'feedUrl' },
-] );
+const feeds = freeze( [ { blog_ID: 'IM A BLOG', subscribe_URL: 'feedUrl' } ] );
 
 const query = 'okapis r us';
 
@@ -37,14 +28,16 @@ describe( 'wpcom-api', () => {
 				initiateFeedSearch( { dispatch }, action, next );
 
 				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( http( {
-					method: 'GET',
-					path: '/read/feed',
-					apiVersion: '1.1',
-					query: { q: query, offset: 0 },
-					onSuccess: action,
-					onFailure: action,
-				} ) );
+				expect( dispatch ).to.have.been.calledWith(
+					http( {
+						method: 'GET',
+						path: '/read/feed',
+						apiVersion: '1.1',
+						query: { q: query, offset: 0 },
+						onSuccess: action,
+						onFailure: action,
+					} )
+				);
 			} );
 
 			it( 'should pass the original action along the middleware chain', () => {
@@ -69,16 +62,18 @@ describe( 'wpcom-api', () => {
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
-					receiveFeedSearch( query,
+					receiveFeedSearch(
+						query,
 						[
 							{
 								blog_ID: 'IM A BLOG',
 								feed_URL: 'feedUrl',
 								subscribe_URL: 'feedUrl',
-							}
+							},
 						],
-						200,
-					) );
+						200
+					)
+				);
 			} );
 		} );
 

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -15,17 +15,19 @@ import { follow } from 'state/reader/follows/actions';
 
 export function requestUnfollow( { dispatch, getState }, action, next ) {
 	const { payload: { feedUrl } } = action;
-	dispatch( http( {
-		method: 'POST',
-		path: '/read/following/mine/delete',
-		apiVersion: '1.1',
-		body: {
-			url: feedUrl,
-			source: config( 'readerFollowingSource' )
-		},
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	dispatch(
+		http( {
+			method: 'POST',
+			path: '/read/following/mine/delete',
+			apiVersion: '1.1',
+			body: {
+				url: feedUrl,
+				source: config( 'readerFollowingSource' ),
+			},
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 	next( action );
 }
 
@@ -47,5 +49,5 @@ export function unfollowError( { dispatch }, action, next ) {
 }
 
 export default {
-	[ READER_UNFOLLOW ]: [ dispatchRequest( requestUnfollow, receiveUnfollow, unfollowError ) ]
+	[ READER_UNFOLLOW ]: [ dispatchRequest( requestUnfollow, receiveUnfollow, unfollowError ) ],
 };

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -18,17 +18,19 @@ describe( 'requestUnfollow', () => {
 		const next = spy();
 		const action = unfollow( 'http://example.com' );
 		requestUnfollow( { dispatch }, action, next );
-		expect( dispatch ).to.have.been.calledWith( http( {
-			method: 'POST',
-			path: '/read/following/mine/delete',
-			apiVersion: '1.1',
-			body: {
-				url: 'http://example.com',
-				source: 'calypso',
-			},
-			onSuccess: action,
-			onFailure: action,
-		} ) );
+		expect( dispatch ).to.have.been.calledWith(
+			http( {
+				method: 'POST',
+				path: '/read/following/mine/delete',
+				apiVersion: '1.1',
+				body: {
+					url: 'http://example.com',
+					source: 'calypso',
+				},
+				onSuccess: action,
+				onFailure: action,
+			} )
+		);
 		expect( next ).to.have.been.calledWith( action );
 	} );
 } );
@@ -39,7 +41,7 @@ describe( 'receiveUnfollow', () => {
 		const next = spy();
 		const action = unfollow( 'http://example.com' );
 		const response = {
-			subscribed: false
+			subscribed: false,
 		};
 		receiveUnfollow( { dispatch }, action, next, response );
 		expect( next ).to.be.calledWith( action );
@@ -50,12 +52,12 @@ describe( 'receiveUnfollow', () => {
 		const next = spy();
 		const action = unfollow( 'http://example.com' );
 		const response = {
-			subscribed: true
+			subscribed: true,
 		};
 
 		receiveUnfollow( { dispatch }, action, next, response );
 		expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-		expect( next ) .to.be.calledWith( follow( 'http://example.com' ) );
+		expect( next ).to.be.calledWith( follow( 'http://example.com' ) );
 	} );
 } );
 
@@ -67,6 +69,6 @@ describe( 'followError', () => {
 
 		unfollowError( { dispatch }, action, next );
 		expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-		expect( next ) .to.be.calledWith( follow( 'http://example.com' ) );
+		expect( next ).to.be.calledWith( follow( 'http://example.com' ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -15,10 +15,7 @@ import {
 	READER_FOLLOWS_SYNC_START,
 	READER_FOLLOWS_SYNC_PAGE,
 } from 'state/action-types';
-import {
-	receiveFollows as receiveFollowsAction,
-	syncComplete,
-} from 'state/reader/follows/actions';
+import { receiveFollows as receiveFollowsAction, syncComplete } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
@@ -27,27 +24,32 @@ import { toValidId } from 'reader/id-helpers';
 const ITEMS_PER_PAGE = 200;
 const MAX_ITEMS = 2000;
 
-export const requestPageAction = ( page = 1, number = ITEMS_PER_PAGE, meta = '' )=> ( {
+export const requestPageAction = ( page = 1, number = ITEMS_PER_PAGE, meta = '' ) => ( {
 	type: READER_FOLLOWS_SYNC_PAGE,
-	payload: { page, meta, number, }
+	payload: { page, meta, number },
 } );
 
 export const isValidApiResponse = apiResponse => {
-	const hasSubscriptions = apiResponse && apiResponse.subscriptions &&
-		isArray( apiResponse.subscriptions );
+	const hasSubscriptions =
+		apiResponse && apiResponse.subscriptions && isArray( apiResponse.subscriptions );
 	return hasSubscriptions;
 };
 
-export const subscriptionFromApi = subscription => subscription && omitBy( {
-	ID: Number( subscription.ID ),
-	URL: subscription.URL,
-	feed_URL: subscription.URL,
-	blog_ID: toValidId( subscription.blog_ID ),
-	feed_ID: toValidId( subscription.feed_ID ),
-	date_subscribed: Date.parse( subscription.date_subscribed ),
-	delivery_methods: subscription.delivery_methods,
-	is_owner: subscription.is_owner,
-}, isUndefined );
+export const subscriptionFromApi = subscription =>
+	subscription &&
+	omitBy(
+		{
+			ID: Number( subscription.ID ),
+			URL: subscription.URL,
+			feed_URL: subscription.URL,
+			blog_ID: toValidId( subscription.blog_ID ),
+			feed_ID: toValidId( subscription.feed_ID ),
+			date_subscribed: Date.parse( subscription.date_subscribed ),
+			delivery_methods: subscription.delivery_methods,
+			is_owner: subscription.is_owner,
+		},
+		isUndefined
+	);
 
 export const subscriptionsFromApi = apiResponse => {
 	if ( ! isValidApiResponse( apiResponse ) ) {
@@ -75,18 +77,20 @@ export function syncReaderFollows( store, action, next ) {
 }
 
 export function requestPage( store, action, next ) {
-	store.dispatch( http( {
-		method: 'GET',
-		path: '/read/following/mine',
-		apiVersion: '1.2',
-		query: {
-			page: action.payload.page,
-			number: action.payload.number,
-			meta: action.payload.meta,
-		},
-		onSuccess: action,
-		onError: action,
-	} ) );
+	store.dispatch(
+		http( {
+			method: 'GET',
+			path: '/read/following/mine',
+			apiVersion: '1.2',
+			query: {
+				page: action.payload.page,
+				number: action.payload.number,
+				meta: action.payload.meta,
+			},
+			onSuccess: action,
+			onError: action,
+		} )
+	);
 
 	next( action );
 }
@@ -108,7 +112,7 @@ export function receivePage( store, action, next, apiResponse ) {
 		} )
 	);
 
-	forEach( follows, ( follow ) => {
+	forEach( follows, follow => {
 		seenSubscriptions.add( follow.feed_URL );
 	} );
 
@@ -141,11 +145,7 @@ export function receiveError( store ) {
 const followingMine = {
 	[ READER_FOLLOWS_SYNC_START ]: [ syncReaderFollows ],
 	[ READER_FOLLOWS_SYNC_PAGE ]: [ dispatchRequest( requestPage, receivePage, receiveError ) ],
-	[ READER_FOLLOW ]: [ updateSeenOnFollow ]
+	[ READER_FOLLOW ]: [ updateSeenOnFollow ],
 };
 
-export default mergeHandlers(
-	followingMine,
-	followingNew,
-	followingDelete,
-);
+export default mergeHandlers( followingMine, followingNew, followingDelete );

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -17,28 +17,25 @@ import { subscriptionFromApi } from 'state/data-layer/wpcom/read/following/mine'
 export function requestFollow( { dispatch }, action, next ) {
 	const { payload: { feedUrl } } = action;
 
-	dispatch( http( {
-		method: 'POST',
-		path: '/read/following/mine/new',
-		apiVersion: '1.1',
-		body: {
-			url: feedUrl,
-			source: config( 'readerFollowingSource' )
-		},
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	dispatch(
+		http( {
+			method: 'POST',
+			path: '/read/following/mine/new',
+			apiVersion: '1.1',
+			body: {
+				url: feedUrl,
+				source: config( 'readerFollowingSource' ),
+			},
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 	next( action );
 }
 
 export function receiveFollow( store, action, next, response ) {
 	if ( response && response.subscribed ) {
-		next(
-			follow(
-				action.payload.feedUrl,
-				subscriptionFromApi( response.subscription )
-			)
-		);
+		next( follow( action.payload.feedUrl, subscriptionFromApi( response.subscription ) ) );
 	} else {
 		followError( store, action, next, response );
 	}
@@ -46,9 +43,7 @@ export function receiveFollow( store, action, next, response ) {
 
 export function followError( { dispatch }, action, next, response ) {
 	dispatch(
-		errorNotice(
-			translate( 'Sorry, there was a problem following that site. Please try again.' )
-		)
+		errorNotice( translate( 'Sorry, there was a problem following that site. Please try again.' ) )
 	);
 
 	if ( response && response.info ) {
@@ -59,5 +54,5 @@ export function followError( { dispatch }, action, next, response ) {
 }
 
 export default {
-	[ READER_FOLLOW ]: [ dispatchRequest( requestFollow, receiveFollow, followError ) ]
+	[ READER_FOLLOW ]: [ dispatchRequest( requestFollow, receiveFollow, followError ) ],
 };

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -18,17 +18,19 @@ describe( 'requestFollow', () => {
 		const next = spy();
 		const action = follow( 'http://example.com' );
 		requestFollow( { dispatch }, action, next );
-		expect( dispatch ).to.have.been.calledWith( http( {
-			method: 'POST',
-			path: '/read/following/mine/new',
-			apiVersion: '1.1',
-			body: {
-				url: 'http://example.com',
-				source: 'calypso',
-			},
-			onSuccess: action,
-			onFailure: action,
-		} ) );
+		expect( dispatch ).to.have.been.calledWith(
+			http( {
+				method: 'POST',
+				path: '/read/following/mine/new',
+				apiVersion: '1.1',
+				body: {
+					url: 'http://example.com',
+					source: 'calypso',
+				},
+				onSuccess: action,
+				onFailure: action,
+			} )
+		);
 		expect( next ).to.have.been.calledWith( action );
 	} );
 } );
@@ -48,12 +50,11 @@ describe( 'receiveFollow', () => {
 				date_subscribed: '1976-09-15T12:00:00Z',
 				delivery_methods: {},
 				is_owner: false,
-			}
+			},
 		};
 		receiveFollow( { dispatch }, action, next, response );
-		expect( next ).to.be.calledWith( follow(
-			'http://example.com',
-			{
+		expect( next ).to.be.calledWith(
+			follow( 'http://example.com', {
 				ID: 1,
 				URL: 'http://example.com',
 				feed_URL: 'http://example.com',
@@ -61,9 +62,9 @@ describe( 'receiveFollow', () => {
 				feed_ID: 3,
 				date_subscribed: 211636800000,
 				delivery_methods: {},
-				is_owner: false
-			}
-		) );
+				is_owner: false,
+			} )
+		);
 	} );
 
 	it( 'should dispatch an error notice when subscribed is false', () => {
@@ -71,7 +72,7 @@ describe( 'receiveFollow', () => {
 		const next = spy();
 		const action = follow( 'http://example.com' );
 		const response = {
-			subscribed: false
+			subscribed: false,
 		};
 
 		receiveFollow( { dispatch }, action, next, response );
@@ -88,6 +89,6 @@ describe( 'followError', () => {
 
 		followError( { dispatch }, action, next );
 		expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-		expect( next ) .to.be.calledWith( unfollow( 'http://example.com' ) );
+		expect( next ).to.be.calledWith( unfollow( 'http://example.com' ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -22,7 +22,11 @@ import {
 	resetSyncingFollows,
 	updateSeenOnFollow,
 } from '../';
-import { receiveFollows as receiveFollowsAction, follow, syncComplete } from 'state/reader/follows/actions';
+import {
+	receiveFollows as receiveFollowsAction,
+	follow,
+	syncComplete,
+} from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { NOTICE_CREATE } from 'state/action-types';
 
@@ -42,8 +46,8 @@ const successfulApiResponse = freeze( {
 			blog_ID: '64146350',
 			URL: 'https://fivethirtyeight.com/',
 			date_subscribed: '2016-01-12T03:55:45+00:00',
-		}
-	]
+		},
+	],
 } );
 
 describe( 'get follow subscriptions', () => {
@@ -73,14 +77,16 @@ describe( 'get follow subscriptions', () => {
 			requestPage( { dispatch }, action, next );
 
 			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( http( {
-				method: 'GET',
-				path: '/read/following/mine',
-				apiVersion: '1.2',
-				query: { page: 1, number: 200, meta: '' },
-				onSuccess: action,
-				onError: action,
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					method: 'GET',
+					path: '/read/following/mine',
+					apiVersion: '1.2',
+					query: { page: 1, number: 200, meta: '' },
+					onSuccess: action,
+					onError: action,
+				} )
+			);
 		} );
 
 		it( 'should pass the original action along the middleware chain', () => {
@@ -130,10 +136,10 @@ describe( 'get follow subscriptions', () => {
 								ID: 5,
 								is_following: true,
 								feed_URL: 'http://example.com',
-							}
-						}
-					}
-				}
+							},
+						},
+					},
+				},
 			} );
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction, next );
@@ -146,14 +152,15 @@ describe( 'get follow subscriptions', () => {
 			} );
 
 			expect( dispatch ).to.have.been.calledTwice;
-			expect( dispatch ).to.have.been.calledWith( receiveFollowsAction( {
-				follows: [],
-				totalCount: 10
-			} ) );
-			expect( dispatch ).to.have.been.calledWith( syncComplete( [
-				'http://readerpostcards.wordpress.com',
-				'https://fivethirtyeight.com/',
-			] ) );
+			expect( dispatch ).to.have.been.calledWith(
+				receiveFollowsAction( {
+					follows: [],
+					totalCount: 10,
+				} )
+			);
+			expect( dispatch ).to.have.been.calledWith(
+				syncComplete( [ 'http://readerpostcards.wordpress.com', 'https://fivethirtyeight.com/' ] )
+			);
 		} );
 
 		it( 'should catch a feed followed during the sync', () => {
@@ -171,16 +178,20 @@ describe( 'get follow subscriptions', () => {
 								ID: 6,
 								is_following: true,
 								feed_URL: 'http://feed.example.com',
-							}
-						}
-					}
-				}
+							},
+						},
+					},
+				},
 			} );
 
 			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction, next );
 			receivePage( { dispatch: ignoredDispatch }, action, next, successfulApiResponse );
 
-			updateSeenOnFollow( { dispatch: ignoredDispatch }, follow( 'http://feed.example.com' ), next );
+			updateSeenOnFollow(
+				{ dispatch: ignoredDispatch },
+				follow( 'http://feed.example.com' ),
+				next
+			);
 
 			receivePage( { dispatch, getState }, action, next, {
 				number: 0,
@@ -190,16 +201,20 @@ describe( 'get follow subscriptions', () => {
 			} );
 
 			expect( dispatch ).to.have.been.calledTwice;
-			expect( dispatch ).to.have.been.calledWith( receiveFollowsAction( {
-				follows: [],
-				totalCount: 10
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				receiveFollowsAction( {
+					follows: [],
+					totalCount: 10,
+				} )
+			);
 
-			expect( dispatch ).to.have.been.calledWith( syncComplete( [
-				'http://readerpostcards.wordpress.com',
-				'https://fivethirtyeight.com/',
-				'http://feed.example.com',
-			] ) );
+			expect( dispatch ).to.have.been.calledWith(
+				syncComplete( [
+					'http://readerpostcards.wordpress.com',
+					'https://fivethirtyeight.com/',
+					'http://feed.example.com',
+				] )
+			);
 		} );
 	} );
 
@@ -248,7 +263,7 @@ describe( 'get follow subscriptions', () => {
 					URL: 'https://fivethirtyeight.com/',
 					feed_URL: 'https://fivethirtyeight.com/',
 					date_subscribed: Date.parse( '2016-01-12T03:55:45+00:00' ),
-				}
+				},
 			];
 			expect( subscriptionsFromApi( successfulApiResponse ) ).eql( transformedSubs );
 		} );

--- a/client/state/data-layer/wpcom/read/index.js
+++ b/client/state/data-layer/wpcom/read/index.js
@@ -9,11 +9,4 @@ import followingMine from './following/mine';
 import feed from './feed';
 import recommendations from './recommendations';
 
-export default mergeHandlers(
-	site,
-	teams,
-	tags,
-	followingMine,
-	feed,
-	recommendations,
-);
+export default mergeHandlers( site, teams, tags, followingMine, feed, recommendations );

--- a/client/state/data-layer/wpcom/read/recommendations/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/index.js
@@ -4,6 +4,4 @@
 import { mergeHandlers } from 'state/data-layer/utils';
 import sites from './sites';
 
-export default mergeHandlers(
-	sites,
-);
+export default mergeHandlers( sites );

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -1,4 +1,3 @@
-
 /**
  * External Dependencies
  */
@@ -7,9 +6,7 @@ import { map } from 'lodash';
 /**
  * Internal Dependencies
  */
-import {
-	READER_RECOMMENDED_SITES_REQUEST
-} from 'state/action-types';
+import { READER_RECOMMENDED_SITES_REQUEST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { receiveRecommendedSites } from 'state/reader/recommended-sites/actions';
@@ -17,14 +14,16 @@ import { decodeEntities } from 'lib/formatting';
 
 export const requestRecommendedSites = ( { dispatch }, action, next ) => {
 	const { seed = 1, number = 10, offset = 0 } = action.payload;
-	dispatch( http( {
-		method: 'GET',
-		path: '/read/recommendations/sites',
-		query: { number, offset, seed, posts_per_site: 0 },
-		apiVersion: '1.2',
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	dispatch(
+		http( {
+			method: 'GET',
+			path: '/read/recommendations/sites',
+			query: { number, offset, seed, posts_per_site: 0 },
+			apiVersion: '1.2',
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 	next( action );
 };
 
@@ -48,10 +47,12 @@ export const receiveRecommendedSitesResponse = ( store, action, next, response )
 		return;
 	}
 
-	store.dispatch( receiveRecommendedSites( {
-		sites: fromApi( response ),
-		seed: action.payload.seed,
-	} ) );
+	store.dispatch(
+		receiveRecommendedSites( {
+			sites: fromApi( response ),
+			seed: action.payload.seed,
+		} )
+	);
 };
 
 export const receiveError = ( store, action, next ) => {
@@ -61,10 +62,6 @@ export const receiveError = ( store, action, next ) => {
 
 export default {
 	[ READER_RECOMMENDED_SITES_REQUEST ]: [
-		dispatchRequest(
-			requestRecommendedSites,
-			receiveRecommendedSitesResponse,
-			receiveError
-		)
+		dispatchRequest( requestRecommendedSites, receiveRecommendedSitesResponse, receiveError ),
 	],
 };

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -73,10 +73,12 @@ describe( 'recommended sites', () => {
 
 			receiveRecommendedSitesResponse( { dispatch }, action, next, response );
 			expect( next ).to.not.have.been.called;
-			expect( dispatch ).calledWith( receiveRecommendedSites( {
-				sites: fromApi( response ),
-				seed
-			} ) );
+			expect( dispatch ).calledWith(
+				receiveRecommendedSites( {
+					sites: fromApi( response ),
+					seed,
+				} )
+			);
 		} );
 	} );
 
@@ -112,7 +114,7 @@ describe( 'recommended sites', () => {
 					feedId: 1098976,
 					title: 'Make Something Mondays!',
 					url: 'http:\/\/makesomethingmondays.wordpress.com',
-				}
+				},
 			];
 
 			expect( fromApi( response ) ).eql( expected );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -6,23 +6,23 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import {
-	READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL,
-} from 'state/action-types';
+import { READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
 export function requestCommentEmailUnsubscription( { dispatch }, action, next ) {
-	dispatch( http( {
-		method: 'POST',
-		path: `/read/site/${ action.payload.blogId }/comment_email_subscriptions/delete`,
-		apiVersion: '1.2',
-		body: {}, // have to have the empty body for now to make the middleware happy
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	dispatch(
+		http( {
+			method: 'POST',
+			path: `/read/site/${ action.payload.blogId }/comment_email_subscriptions/delete`,
+			apiVersion: '1.2',
+			body: {}, // have to have the empty body for now to make the middleware happy
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 	next( action );
 }
 
@@ -38,7 +38,9 @@ export function receiveCommentEmailUnsubscription( store, action, next, response
 }
 
 export function receiveCommentEmailUnsubscriptionError( { dispatch }, action, next ) {
-	dispatch( errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) ) );
+	dispatch(
+		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
+	);
 	next( subscribeToNewCommentEmail( action.payload.blogId ) );
 }
 
@@ -48,6 +50,6 @@ export default {
 			requestCommentEmailUnsubscription,
 			receiveCommentEmailUnsubscription,
 			receiveCommentEmailUnsubscriptionError
-		)
+		),
 	],
 };

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -14,7 +14,7 @@ import {
 } from '../';
 import {
 	subscribeToNewCommentEmail,
-	unsubscribeToNewCommentEmail
+	unsubscribeToNewCommentEmail,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
@@ -25,14 +25,16 @@ describe( 'comment-email-subscriptions', () => {
 			const next = spy();
 			const action = unsubscribeToNewCommentEmail( 1234 );
 			requestCommentEmailUnsubscription( { dispatch }, action, next );
-			expect( dispatch ).to.have.been.calledWith( http( {
-				method: 'POST',
-				path: '/read/site/1234/comment_email_subscriptions/delete',
-				body: {},
-				apiVersion: '1.2',
-				onSuccess: action,
-				onFailure: action
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					method: 'POST',
+					path: '/read/site/1234/comment_email_subscriptions/delete',
+					body: {},
+					apiVersion: '1.2',
+					onSuccess: action,
+					onFailure: action,
+				} )
+			);
 
 			expect( next ).to.have.been.calledWith( action );
 		} );
@@ -42,32 +44,22 @@ describe( 'comment-email-subscriptions', () => {
 		it( 'should do nothing if successful', () => {
 			const nextSpy = spy();
 
-			receiveCommentEmailUnsubscription(
-				null,
-				null,
-				nextSpy,
-				{ subscribed: false }
-			);
+			receiveCommentEmailUnsubscription( null, null, nextSpy, { subscribed: false } );
 			expect( nextSpy ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a subscribe if it fails using next', () => {
 			const nextSpy = spy();
 			const dispatch = spy();
-			receiveCommentEmailUnsubscription(
-				{ dispatch },
-				{ payload: { blogId: 1234 } },
-				nextSpy,
-				{ subscribed: true }
-			);
+			receiveCommentEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+				subscribed: true,
+			} );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem unsubscribing. Please try again.',
+				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith(
-				subscribeToNewCommentEmail( 1234 )
-			);
+			expect( nextSpy ).to.have.been.calledWith( subscribeToNewCommentEmail( 1234 ) );
 		} );
 	} );
 
@@ -82,12 +74,10 @@ describe( 'comment-email-subscriptions', () => {
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem unsubscribing. Please try again.',
+				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith(
-				subscribeToNewCommentEmail( 1234 )
-			);
+			expect( nextSpy ).to.have.been.calledWith( subscribeToNewCommentEmail( 1234 ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
@@ -9,7 +9,4 @@ import { mergeHandlers } from 'state/data-layer/utils';
 import subscribe from './new';
 import unsubscribe from './delete';
 
-export default mergeHandlers(
-	subscribe,
-	unsubscribe,
-);
+export default mergeHandlers( subscribe, unsubscribe );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -6,23 +6,23 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import {
-	READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL
-} from 'state/action-types';
+import { READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
 export function requestCommentEmailSubscription( { dispatch }, action, next ) {
-	dispatch( http( {
-		method: 'POST',
-		path: `/read/site/${ action.payload.blogId }/comment_email_subscriptions/new`,
-		body: {}, // have to have an empty body to make wpcom-http happy
-		apiVersion: '1.2',
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	dispatch(
+		http( {
+			method: 'POST',
+			path: `/read/site/${ action.payload.blogId }/comment_email_subscriptions/new`,
+			body: {}, // have to have an empty body to make wpcom-http happy
+			apiVersion: '1.2',
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 	next( action );
 }
 
@@ -46,6 +46,6 @@ export default {
 			requestCommentEmailSubscription,
 			receiveCommentEmailSubscription,
 			receiveCommentEmailSubscriptionError
-		)
-	]
+		),
+	],
 };

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -14,7 +14,7 @@ import {
 } from '../';
 import {
 	subscribeToNewCommentEmail,
-	unsubscribeToNewCommentEmail
+	unsubscribeToNewCommentEmail,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
@@ -25,14 +25,16 @@ describe( 'comment-email-subscriptions', () => {
 			const next = spy();
 			const action = subscribeToNewCommentEmail( 1234 );
 			requestCommentEmailSubscription( { dispatch }, action, next );
-			expect( dispatch ).to.have.been.calledWith( http( {
-				method: 'POST',
-				path: '/read/site/1234/comment_email_subscriptions/new',
-				body: {},
-				apiVersion: '1.2',
-				onSuccess: action,
-				onFailure: action
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					method: 'POST',
+					path: '/read/site/1234/comment_email_subscriptions/new',
+					body: {},
+					apiVersion: '1.2',
+					onSuccess: action,
+					onFailure: action,
+				} )
+			);
 
 			expect( next ).to.have.been.calledWith( action );
 		} );
@@ -41,31 +43,21 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receiveCommentEmailSubscription', () => {
 		it( 'should do nothing if successful', () => {
 			const nextSpy = spy();
-			receiveCommentEmailSubscription(
-				null,
-				null,
-				nextSpy,
-				{ subscribed: true }
-			);
+			receiveCommentEmailSubscription( null, null, nextSpy, { subscribed: true } );
 			expect( nextSpy ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch an unsubscribe if it fails using next', () => {
 			const nextSpy = spy();
 			const dispatch = spy();
-			receiveCommentEmailSubscription(
-				{ dispatch },
-				{ payload: { blogId: 1234 } },
-				nextSpy,
-				{ subscribed: false }
-			);
-			expect( nextSpy ).to.have.been.calledWith(
-				unsubscribeToNewCommentEmail( 1234 )
-			);
+			receiveCommentEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+				subscribed: false,
+			} );
+			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewCommentEmail( 1234 ) );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem subscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem subscribing. Please try again.',
+				},
 			} );
 		} );
 	} );
@@ -74,19 +66,13 @@ describe( 'comment-email-subscriptions', () => {
 		it( 'should dispatch an error notice and unsubscribe action using next', () => {
 			const dispatch = spy();
 			const nextSpy = spy();
-			receiveCommentEmailSubscriptionError(
-				{ dispatch },
-				{ payload: { blogId: 1234 } },
-				nextSpy
-			);
+			receiveCommentEmailSubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, nextSpy );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem subscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem subscribing. Please try again.',
+				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith(
-				unsubscribeToNewCommentEmail( 1234 )
-			);
+			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewCommentEmail( 1234 ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/index.js
+++ b/client/state/data-layer/wpcom/read/site/index.js
@@ -5,7 +5,4 @@ import { mergeHandlers } from 'state/data-layer/utils';
 import postEmailSubscriptions from './post-email-subscriptions';
 import commentEmailSubscriptions from './comment-email-subscriptions';
 
-export default mergeHandlers(
-	commentEmailSubscriptions,
-	postEmailSubscriptions,
-);
+export default mergeHandlers( commentEmailSubscriptions, postEmailSubscriptions );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -6,23 +6,23 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import {
-	READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL
-} from 'state/action-types';
+import { READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
 export function requestPostEmailUnsubscription( { dispatch }, action, next ) {
-	dispatch( http( {
-		method: 'POST',
-		path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/delete`,
-		apiVersion: '1.2',
-		body: {}, // have to have the empty body for now to make the middleware happy
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	dispatch(
+		http( {
+			method: 'POST',
+			path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/delete`,
+			apiVersion: '1.2',
+			body: {}, // have to have the empty body for now to make the middleware happy
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 	next( action );
 }
 
@@ -38,7 +38,9 @@ export function receivePostEmailUnsubscription( store, action, next, response ) 
 }
 
 export function receivePostEmailUnsubscriptionError( { dispatch }, action, next ) {
-	dispatch( errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) ) );
+	dispatch(
+		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
+	);
 	next( subscribeToNewPostEmail( action.payload.blogId ) );
 }
 
@@ -48,6 +50,6 @@ export default {
 			requestPostEmailUnsubscription,
 			receivePostEmailUnsubscription,
 			receivePostEmailUnsubscriptionError
-		)
+		),
 	],
 };

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -12,10 +12,7 @@ import {
 	receivePostEmailUnsubscription,
 	receivePostEmailUnsubscriptionError,
 } from '../';
-import {
-	subscribeToNewPostEmail,
-	unsubscribeToNewPostEmail,
-} from 'state/reader/follows/actions';
+import { subscribeToNewPostEmail, unsubscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'comment-email-subscriptions', () => {
@@ -25,14 +22,16 @@ describe( 'comment-email-subscriptions', () => {
 			const next = spy();
 			const action = unsubscribeToNewPostEmail( 1234 );
 			requestPostEmailUnsubscription( { dispatch }, action, next );
-			expect( dispatch ).to.have.been.calledWith( http( {
-				method: 'POST',
-				path: '/read/site/1234/post_email_subscriptions/delete',
-				body: {},
-				apiVersion: '1.2',
-				onSuccess: action,
-				onFailure: action
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					method: 'POST',
+					path: '/read/site/1234/post_email_subscriptions/delete',
+					body: {},
+					apiVersion: '1.2',
+					onSuccess: action,
+					onFailure: action,
+				} )
+			);
 
 			expect( next ).to.have.been.calledWith( action );
 		} );
@@ -41,33 +40,23 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receivePostEmailUnsubscription', () => {
 		it( 'should do nothing if successful', () => {
 			const nextSpy = spy();
-			receivePostEmailUnsubscription(
-				null,
-				null,
-				nextSpy,
-				{ subscribed: false }
-			);
+			receivePostEmailUnsubscription( null, null, nextSpy, { subscribed: false } );
 			expect( nextSpy ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a subscribe if it fails using next', () => {
 			const nextSpy = spy();
 			const dispatch = spy();
-			receivePostEmailUnsubscription(
-				{ dispatch },
-				{ payload: { blogId: 1234 } },
-				nextSpy,
-				{ subscribed: true }
-			);
+			receivePostEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+				subscribed: true,
+			} );
 
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem unsubscribing. Please try again.',
+				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith(
-				subscribeToNewPostEmail( 1234 )
-			);
+			expect( nextSpy ).to.have.been.calledWith( subscribeToNewPostEmail( 1234 ) );
 		} );
 	} );
 
@@ -75,19 +64,13 @@ describe( 'comment-email-subscriptions', () => {
 		it( 'should dispatch an error notice and subscribe action using next', () => {
 			const dispatch = spy();
 			const nextSpy = spy();
-			receivePostEmailUnsubscriptionError(
-				{ dispatch },
-				{ payload: { blogId: 1234 } },
-				nextSpy
-			);
+			receivePostEmailUnsubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, nextSpy );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem unsubscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem unsubscribing. Please try again.',
+				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith(
-				subscribeToNewPostEmail( 1234 )
-			);
+			expect( nextSpy ).to.have.been.calledWith( subscribeToNewPostEmail( 1234 ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
@@ -6,8 +6,4 @@ import subscribe from './new';
 import update from './update';
 import unsubscribe from './delete';
 
-export default mergeHandlers(
-	subscribe,
-	update,
-	unsubscribe,
-);
+export default mergeHandlers( subscribe, update, unsubscribe );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -7,24 +7,27 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import {
-	READER_SUBSCRIBE_TO_NEW_POST_EMAIL
-} from 'state/action-types';
+import { READER_SUBSCRIBE_TO_NEW_POST_EMAIL } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { unsubscribeToNewPostEmail, updateNewPostEmailSubscription } from 'state/reader/follows/actions';
+import {
+	unsubscribeToNewPostEmail,
+	updateNewPostEmailSubscription,
+} from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { buildBody } from '../utils';
 
 export function requestPostEmailSubscription( { dispatch }, action, next ) {
-	dispatch( http( {
-		method: 'POST',
-		path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/new`,
-		body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
-		apiVersion: '1.2',
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	dispatch(
+		http( {
+			method: 'POST',
+			path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/new`,
+			body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
+			apiVersion: '1.2',
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 	next( action );
 }
 
@@ -56,6 +59,6 @@ export default {
 			requestPostEmailSubscription,
 			receivePostEmailSubscription,
 			receivePostEmailSubscriptionError
-		)
-	]
+		),
+	],
 };

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -26,14 +26,16 @@ describe( 'comment-email-subscriptions', () => {
 			const next = spy();
 			const action = subscribeToNewPostEmail( 1234 );
 			requestPostEmailSubscription( { dispatch }, action, next );
-			expect( dispatch ).to.have.been.calledWith( http( {
-				method: 'POST',
-				path: '/read/site/1234/post_email_subscriptions/new',
-				body: {},
-				apiVersion: '1.2',
-				onSuccess: action,
-				onFailure: action
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					method: 'POST',
+					path: '/read/site/1234/post_email_subscriptions/new',
+					body: {},
+					apiVersion: '1.2',
+					onSuccess: action,
+					onFailure: action,
+				} )
+			);
 
 			expect( next ).to.have.been.calledWith( action );
 		} );
@@ -42,39 +44,27 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receivePostEmailSubscription', () => {
 		it( 'should call next to update the subscription with the delivery frequency from the response', () => {
 			const nextSpy = spy();
-			receivePostEmailSubscription(
-				null,
-				subscribeToNewPostEmail( 1234 ),
-				nextSpy,
-				{
-					subscribed: true,
-					subscription: {
-						delivery_frequency: 'daily'
-					}
-				}
-			);
-			expect( nextSpy ).to.have.been.calledWith(
-				updateNewPostEmailSubscription( 1234, 'daily' )
-			);
+			receivePostEmailSubscription( null, subscribeToNewPostEmail( 1234 ), nextSpy, {
+				subscribed: true,
+				subscription: {
+					delivery_frequency: 'daily',
+				},
+			} );
+			expect( nextSpy ).to.have.been.calledWith( updateNewPostEmailSubscription( 1234, 'daily' ) );
 		} );
 
 		it( 'should dispatch an unsubscribe if it fails using next', () => {
 			const nextSpy = spy();
 			const dispatch = spy();
-			receivePostEmailSubscription(
-				{ dispatch },
-				{ payload: { blogId: 1234 } },
-				nextSpy,
-				{ subscribed: false }
-			);
+			receivePostEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+				subscribed: false,
+			} );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem subscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem subscribing. Please try again.',
+				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith(
-				unsubscribeToNewPostEmail( 1234 )
-			);
+			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewPostEmail( 1234 ) );
 		} );
 	} );
 
@@ -82,19 +72,13 @@ describe( 'comment-email-subscriptions', () => {
 		it( 'should dispatch an error notice and unsubscribe action using next', () => {
 			const dispatch = spy();
 			const nextSpy = spy();
-			receivePostEmailSubscriptionError(
-				{ dispatch },
-				{ payload: { blogId: 1234 } },
-				nextSpy
-			);
+			receivePostEmailSubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, nextSpy );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem subscribing. Please try again.'
-				}
+					text: 'Sorry, we had a problem subscribing. Please try again.',
+				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith(
-				unsubscribeToNewPostEmail( 1234 )
-			);
+			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewPostEmail( 1234 ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -7,9 +7,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import {
-	READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION,
-} from 'state/action-types';
+import { READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
@@ -20,20 +18,23 @@ import { buildBody } from '../utils';
 export function requestUpdatePostEmailSubscription( { dispatch, getState }, action, next ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
-			previousState: get(
-				getReaderFollowForBlog( getState(), action.payload.blogId ),
-				[ 'delivery_frequency', 'email', 'post_delivery_frequency' ]
-			)
-		}
+			previousState: get( getReaderFollowForBlog( getState(), action.payload.blogId ), [
+				'delivery_frequency',
+				'email',
+				'post_delivery_frequency',
+			] ),
+		},
 	} );
-	dispatch( http( {
-		method: 'POST',
-		path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/update`,
-		apiVersion: '1.2',
-		body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
-		onSuccess: actionWithRevert,
-		onFailure: actionWithRevert,
-	} ) );
+	dispatch(
+		http( {
+			method: 'POST',
+			path: `/read/site/${ action.payload.blogId }/post_email_subscriptions/update`,
+			apiVersion: '1.2',
+			body: buildBody( get( action, [ 'payload', 'deliveryFrequency' ] ) ),
+			onSuccess: actionWithRevert,
+			onFailure: actionWithRevert,
+		} )
+	);
 	next( action );
 }
 
@@ -44,11 +45,17 @@ export function receiveUpdatePostEmailSubscription( store, action, next, respons
 	}
 }
 
-export function receiveUpdatePostEmailSubscriptionError( { dispatch }, { payload: { blogId }, meta: { previousState } }, next ) {
-	dispatch( errorNotice( translate( 'Sorry, we had a problem updating that subscription. Please try again.' ) ) );
-	next(
-		updateNewPostEmailSubscription( blogId, previousState )
+export function receiveUpdatePostEmailSubscriptionError(
+	{ dispatch },
+	{ payload: { blogId }, meta: { previousState } },
+	next
+ ) {
+	dispatch(
+		errorNotice(
+			translate( 'Sorry, we had a problem updating that subscription. Please try again.' )
+		)
 	);
+	next( updateNewPostEmailSubscription( blogId, previousState ) );
 }
 
 export default {
@@ -57,6 +64,6 @@ export default {
 			requestUpdatePostEmailSubscription,
 			receiveUpdatePostEmailSubscription,
 			receiveUpdatePostEmailSubscriptionError
-		)
-	]
+		),
+	],
 };

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -13,9 +13,7 @@ import {
 	receiveUpdatePostEmailSubscription,
 	receiveUpdatePostEmailSubscriptionError,
 } from '../';
-import {
-	updateNewPostEmailSubscription,
-} from 'state/reader/follows/actions';
+import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'comment-email-subscriptions', () => {
@@ -32,37 +30,35 @@ describe( 'comment-email-subscriptions', () => {
 									blog_ID: 1234,
 									delivery_frequency: {
 										email: {
-											post_delivery_frequency: 'instantly'
-										}
-									}
-								}
-							}
-						}
-					}
+											post_delivery_frequency: 'instantly',
+										},
+									},
+								},
+							},
+						},
+					},
 				};
 			};
 			const action = updateNewPostEmailSubscription( 1234, 'daily' );
 			const actionWithRevert = merge( {}, action, {
 				meta: {
-					previousState: 'instantly'
-				}
-			} );
-			requestUpdatePostEmailSubscription(
-				{ dispatch, getState },
-				action,
-				nextSpy
-			);
-
-			expect( dispatch ).to.have.been.calledWith( http( {
-				method: 'POST',
-				path: '/read/site/1234/post_email_subscriptions/update',
-				body: {
-					delivery_frequency: 'daily'
+					previousState: 'instantly',
 				},
-				apiVersion: '1.2',
-				onSuccess: actionWithRevert,
-				onFailure: actionWithRevert
-			} ) );
+			} );
+			requestUpdatePostEmailSubscription( { dispatch, getState }, action, nextSpy );
+
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					method: 'POST',
+					path: '/read/site/1234/post_email_subscriptions/update',
+					body: {
+						delivery_frequency: 'daily',
+					},
+					apiVersion: '1.2',
+					onSuccess: actionWithRevert,
+					onFailure: actionWithRevert,
+				} )
+			);
 		} );
 	} );
 
@@ -74,7 +70,7 @@ describe( 'comment-email-subscriptions', () => {
 				{ dispatch },
 				{
 					payload: { blogId: 1234 },
-					meta: { previousState: 'instantly' }
+					meta: { previousState: 'instantly' },
 				},
 				next,
 				{ success: true }
@@ -91,7 +87,7 @@ describe( 'comment-email-subscriptions', () => {
 				{ dispatch },
 				{
 					payload: { blogId: 1234 },
-					meta: { previousState }
+					meta: { previousState },
 				},
 				next,
 				null
@@ -109,7 +105,7 @@ describe( 'comment-email-subscriptions', () => {
 				{ dispatch },
 				{
 					payload: { blogId: 1234 },
-					meta: { previousState }
+					meta: { previousState },
 				},
 				next,
 				{ success: false }
@@ -129,7 +125,7 @@ describe( 'comment-email-subscriptions', () => {
 				{ dispatch },
 				{
 					payload: { blogId: 1234 },
-					meta: { previousState }
+					meta: { previousState },
 				},
 				next
 			);
@@ -137,7 +133,7 @@ describe( 'comment-email-subscriptions', () => {
 				updateNewPostEmailSubscription( 1234, previousState )
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
-				notice: { text: 'Sorry, we had a problem updating that subscription. Please try again.' }
+				notice: { text: 'Sorry, we had a problem updating that subscription. Please try again.' },
 			} );
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/utils.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/utils.js
@@ -8,14 +8,10 @@ import { includes } from 'lodash';
  */
 
 export function buildBody( frequency ) {
-	const validFrequencies = [
-		'instantly',
-		'daily',
-		'weekly',
-	];
+	const validFrequencies = [ 'instantly', 'daily', 'weekly' ];
 	if ( includes( validFrequencies, frequency ) ) {
 		return {
-			delivery_frequency: frequency
+			delivery_frequency: frequency,
 		};
 	}
 	return {};

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -7,10 +7,8 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import {
-	READER_TAGS_REQUEST,
-} from 'state/action-types';
-import { receiveTags, } from 'state/reader/tags/items/actions';
+import { READER_TAGS_REQUEST } from 'state/action-types';
+import { receiveTags } from 'state/reader/tags/items/actions';
 import requestFollowHandler from 'state/data-layer/wpcom/read/tags/mine/new';
 import requestUnfollowHandler from 'state/data-layer/wpcom/read/tags/mine/delete';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -24,20 +22,22 @@ export function requestTags( store, action, next ) {
 		? `/read/tags/${ action.payload.slug }`
 		: '/read/tags';
 
-	store.dispatch( http( {
-		path,
-		method: 'GET',
-		apiVersion: '1.2',
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	store.dispatch(
+		http( {
+			path,
+			method: 'GET',
+			apiVersion: '1.2',
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 
 	next( action );
 }
 
 export function receiveTagsSuccess( store, action, next, apiResponse ) {
 	let tags = fromApi( apiResponse );
-	if ( ! apiResponse || ! apiResponse.tag && ! apiResponse.tags ) {
+	if ( ! apiResponse || ( ! apiResponse.tag && ! apiResponse.tags ) ) {
 		receiveTagsError( store, action, next );
 		return;
 	}
@@ -47,10 +47,12 @@ export function receiveTagsSuccess( store, action, next, apiResponse ) {
 		tags = map( tags, tag => ( { ...tag, isFollowing: true } ) );
 	}
 
-	store.dispatch( receiveTags( {
-		payload: tags,
-		resetFollowingData: !! apiResponse.tags
-	} ) );
+	store.dispatch(
+		receiveTags( {
+			payload: tags,
+			resetFollowingData: !! apiResponse.tags,
+		} )
+	);
 }
 
 export function receiveTagsError( store, action, next, error ) {
@@ -68,12 +70,9 @@ export function receiveTagsError( store, action, next, error ) {
 }
 
 const readTagsHandler = {
-	[ READER_TAGS_REQUEST ]: [ dispatchRequest( requestTags, receiveTagsSuccess, receiveTagsSuccess ) ],
+	[ READER_TAGS_REQUEST ]: [
+		dispatchRequest( requestTags, receiveTagsSuccess, receiveTagsSuccess ),
+	],
 };
 
-export default mergeHandlers(
-	readTagsHandler,
-	requestFollowHandler,
-	requestUnfollowHandler,
-);
-
+export default mergeHandlers( readTagsHandler, requestFollowHandler, requestUnfollowHandler );

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -6,9 +6,7 @@
  * Internal dependencies
  */
 import { READER_UNFOLLOW_TAG_REQUEST } from 'state/action-types';
-import {
-	receiveUnfollowTag as receiveUnfollowTagAction,
-} from 'state/reader/tags/items/actions';
+import { receiveUnfollowTag as receiveUnfollowTagAction } from 'state/reader/tags/items/actions';
 
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
@@ -16,13 +14,15 @@ import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
 export function requestUnfollow( store, action, next ) {
-	store.dispatch( http( {
-		path: `/read/tags/${ action.payload.slug }/mine/delete`,
-		method: 'POST',
-		apiVersion: '1.1',
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	store.dispatch(
+		http( {
+			path: `/read/tags/${ action.payload.slug }/mine/delete`,
+			method: 'POST',
+			apiVersion: '1.1',
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 
 	next( action );
 }
@@ -41,14 +41,16 @@ export function receiveUnfollowTag( store, action, next, apiResponse ) {
 		return;
 	}
 
-	store.dispatch( receiveUnfollowTagAction( {
-		payload: fromApi( apiResponse ),
-	} ) );
+	store.dispatch(
+		receiveUnfollowTagAction( {
+			payload: fromApi( apiResponse ),
+		} )
+	);
 }
 
 export function receiveError( store, action, next, error ) {
 	const errorText = translate( 'Could not unfollow tag: %(tag)s', {
-		args: { tag: action.payload.slug }
+		args: { tag: action.payload.slug },
 	} );
 
 	store.dispatch( errorNotice( errorText ) );
@@ -58,5 +60,7 @@ export function receiveError( store, action, next, error ) {
 }
 
 export default {
-	[ READER_UNFOLLOW_TAG_REQUEST ]: [ dispatchRequest( requestUnfollow, receiveUnfollowTag, receiveError ) ],
+	[ READER_UNFOLLOW_TAG_REQUEST ]: [
+		dispatchRequest( requestUnfollow, receiveUnfollowTag, receiveError ),
+	],
 };

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
@@ -11,12 +11,7 @@ import {
 	requestUnfollowTag as requestUnfollowAction,
 	receiveUnfollowTag as receiveUnfollowAction,
 } from 'state/reader/tags/items/actions';
-import {
-	requestUnfollow,
-	receiveUnfollowTag,
-	receiveError,
-	fromApi,
-} from '../';
+import { requestUnfollow, receiveUnfollowTag, receiveError, fromApi } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { NOTICE_CREATE } from 'state/action-types';
 
@@ -29,14 +24,14 @@ const successfulUnfollowResponse = {
 			slug: 'poetry',
 			title: 'Poetry',
 			display_name: 'poetry',
-			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/poetry/posts'
+			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/poetry/posts',
 		},
 		{
 			ID: '69750',
 			slug: 'ship',
 			title: 'SHIP',
 			display_name: 'ship',
-			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/ship/posts'
+			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/ship/posts',
 		},
 	],
 };
@@ -58,13 +53,15 @@ describe( 'unfollow tag request', () => {
 			requestUnfollow( { dispatch }, action, next );
 
 			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( http( {
-				apiVersion: '1.1',
-				method: 'POST',
-				path: `/read/tags/${ slug }/mine/delete`,
-				onSuccess: action,
-				onFailure: action,
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					apiVersion: '1.1',
+					method: 'POST',
+					path: `/read/tags/${ slug }/mine/delete`,
+					onSuccess: action,
+					onFailure: action,
+				} )
+			);
 		} );
 
 		it( 'should pass the original action along the middleware chain', () => {

--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -7,9 +7,7 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import { READER_FOLLOW_TAG_REQUEST } from 'state/action-types';
-import {
-	receiveTags as receiveTagsAction,
-} from 'state/reader/tags/items/actions';
+import { receiveTags as receiveTagsAction } from 'state/reader/tags/items/actions';
 
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
@@ -18,13 +16,15 @@ import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
 export function requestFollowTag( store, action, next ) {
-	store.dispatch( http( {
-		path: `/read/tags/${ action.payload.slug }/mine/new`,
-		method: 'POST',
-		apiVersion: '1.1',
-		onSuccess: action,
-		onFailure: action,
-	} ) );
+	store.dispatch(
+		http( {
+			path: `/read/tags/${ action.payload.slug }/mine/new`,
+			method: 'POST',
+			apiVersion: '1.1',
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
 
 	next( action );
 }
@@ -41,9 +41,11 @@ export function receiveFollowTag( store, action, next, apiResponse ) {
 		isFollowing: true,
 	};
 
-	store.dispatch( receiveTagsAction( {
-		payload: [ followedTag ],
-	} ) );
+	store.dispatch(
+		receiveTagsAction( {
+			payload: [ followedTag ],
+		} )
+	);
 }
 
 export function receiveError( store, action, next, error ) {
@@ -53,7 +55,7 @@ export function receiveError( store, action, next, error ) {
 	}
 
 	const errorText = translate( 'Could not follow tag: %(tag)s', {
-		args: { tag: action.payload.slug }
+		args: { tag: action.payload.slug },
 	} );
 
 	store.dispatch( errorNotice( errorText ) );
@@ -63,5 +65,7 @@ export function receiveError( store, action, next, error ) {
 }
 
 export default {
-	[ READER_FOLLOW_TAG_REQUEST ]: [ dispatchRequest( requestFollowTag, receiveFollowTag, receiveError ) ],
+	[ READER_FOLLOW_TAG_REQUEST ]: [
+		dispatchRequest( requestFollowTag, receiveFollowTag, receiveError ),
+	],
 };

--- a/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
@@ -13,11 +13,7 @@ import {
 	requestFollowTag as requestFollowAction,
 	receiveTags as receiveTagsAction,
 } from 'state/reader/tags/items/actions';
-import {
-	requestFollowTag,
-	receiveFollowTag,
-	receiveError,
-} from '../';
+import { requestFollowTag, receiveFollowTag, receiveError } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { NOTICE_CREATE } from 'state/action-types';
@@ -31,14 +27,14 @@ export const successfulFollowResponse = freeze( {
 			slug: 'poetry',
 			title: 'Poetry',
 			display_name: 'poetry',
-			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/poetry/posts'
+			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/poetry/posts',
 		},
 		{
 			ID: '69750',
 			slug: 'ship',
 			title: 'SHIP',
 			display_name: 'ship',
-			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/ship/posts'
+			URL: 'https://public-api.wordpress.com/rest/v1/read/tags/ship/posts',
 		},
 	],
 } );
@@ -60,13 +56,15 @@ describe( 'follow tag request', () => {
 			requestFollowTag( { dispatch }, action, next );
 
 			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( http( {
-				apiVersion: '1.1',
-				method: 'POST',
-				path: `/read/tags/${ slug }/mine/new`,
-				onSuccess: action,
-				onFailure: action,
-			} ) );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					apiVersion: '1.1',
+					method: 'POST',
+					path: `/read/tags/${ slug }/mine/new`,
+					onSuccess: action,
+					onFailure: action,
+				} )
+			);
 		} );
 
 		it( 'should pass the original action along the middleware chain', () => {

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -13,11 +13,7 @@ import {
 	requestTags as requestTagsAction,
 	receiveTags as receiveTagsAction,
 } from 'state/reader/tags/items/actions';
-import {
-	requestTags,
-	receiveTagsSuccess,
-	receiveTagsError,
-} from '../';
+import { requestTags, receiveTagsSuccess, receiveTagsError } from '../';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { NOTICE_CREATE } from 'state/action-types';
@@ -38,7 +34,7 @@ const successfulFollowedTagsResponse = deepFreeze( {
 			display_name: 'design',
 			URL: 'https://public-api.wordpress.com/rest/v1.2/read/tags/design/posts',
 		},
-	]
+	],
 } );
 
 const successfulSingleTagResponse = deepFreeze( {
@@ -47,7 +43,7 @@ const successfulSingleTagResponse = deepFreeze( {
 		slug: 'chickens',
 		title: 'Chickens',
 		display_name: 'chickens',
-		URL: 'https://public-api.wordpress.com/rest/v1.2/read/tags/chickens/posts'
+		URL: 'https://public-api.wordpress.com/rest/v1.2/read/tags/chickens/posts',
 	},
 } );
 
@@ -64,13 +60,15 @@ describe( 'wpcom-api', () => {
 				requestTags( { dispatch }, action, next );
 
 				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( http( {
-					apiVersion: '1.2',
-					method: 'GET',
-					path: `/read/tags/${ slug }`,
-					onSuccess: action,
-					onFailure: action,
-				} ) );
+				expect( dispatch ).to.have.been.calledWith(
+					http( {
+						apiVersion: '1.2',
+						method: 'GET',
+						path: `/read/tags/${ slug }`,
+						onSuccess: action,
+						onFailure: action,
+					} )
+				);
 			} );
 
 			it( 'multiple tags: should dispatch HTTP request to tags endpoint', () => {
@@ -81,13 +79,15 @@ describe( 'wpcom-api', () => {
 				requestTags( { dispatch }, action, next );
 
 				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith( http( {
-					apiVersion: '1.2',
-					method: 'GET',
-					path: '/read/tags',
-					onSuccess: action,
-					onFailure: action,
-				} ) );
+				expect( dispatch ).to.have.been.calledWith(
+					http( {
+						apiVersion: '1.2',
+						method: 'GET',
+						path: '/read/tags',
+						onSuccess: action,
+						onFailure: action,
+					} )
+				);
 			} );
 
 			it( 'should pass the original action along the middleware chain', () => {
@@ -125,10 +125,10 @@ describe( 'wpcom-api', () => {
 
 				receiveTagsSuccess( { dispatch }, action, next, successfulFollowedTagsResponse );
 
-				const transformedResponse = map(
-					fromApi( successfulFollowedTagsResponse ),
-					tag => ( { ...tag, isFollowing: true } )
-				);
+				const transformedResponse = map( fromApi( successfulFollowedTagsResponse ), tag => ( {
+					...tag,
+					isFollowing: true,
+				} ) );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(

--- a/client/state/data-layer/wpcom/read/tags/test/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/test/utils.js
@@ -25,7 +25,7 @@ const successfulFollowedTagsResponse = deepFreeze( {
 			display_name: 'design',
 			URL: 'https://public-api.wordpress.com/rest/v1.2/read/tags/design/posts',
 		},
-	]
+	],
 } );
 
 const normalizedFollowedTagsResponse = deepFreeze( [
@@ -51,7 +51,7 @@ const successfulSingleTagResponse = deepFreeze( {
 		slug: 'chickens',
 		title: 'Chickens',
 		display_name: 'chickens',
-		URL: 'https://public-api.wordpress.com/rest/v1.2/read/tags/chickens/posts'
+		URL: 'https://public-api.wordpress.com/rest/v1.2/read/tags/chickens/posts',
 	},
 } );
 

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -22,11 +22,13 @@ export function fromApi( apiResponse ) {
 		return [];
 	}
 
-	const tags = compact( concat(
-		[],
-		isObject( apiResponse.tag ) && apiResponse.tag,
-		isArray( apiResponse.tags ) && apiResponse.tags,
-	) );
+	const tags = compact(
+		concat(
+			[],
+			isObject( apiResponse.tag ) && apiResponse.tag,
+			isArray( apiResponse.tags ) && apiResponse.tags
+		)
+	);
 
 	return map( tags, tag => ( {
 		id: tag.ID,

--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -5,26 +5,24 @@ import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
 import wpcom from 'lib/wp';
 
 export function handleTeamsRequest( store, action, next ) {
-	wpcom.req.get( '/read/teams', { apiVersion: '1.2' } )
-		.then(
-			payload => {
-				store.dispatch( {
-					type: READER_TEAMS_RECEIVE,
-					payload,
-				} );
-			},
-			error => {
-				store.dispatch( {
-					type: READER_TEAMS_RECEIVE,
-					payload: error,
-					error: true,
-				} );
-			}
-		);
+	wpcom.req.get( '/read/teams', { apiVersion: '1.2' } ).then(
+		payload => {
+			store.dispatch( {
+				type: READER_TEAMS_RECEIVE,
+				payload,
+			} );
+		},
+		error => {
+			store.dispatch( {
+				type: READER_TEAMS_RECEIVE,
+				payload: error,
+				error: true,
+			} );
+		}
+	);
 	next( action );
 }
 
 export default {
-	[ READER_TEAMS_REQUEST ]: [ handleTeamsRequest ]
+	[ READER_TEAMS_REQUEST ]: [ handleTeamsRequest ],
 };
-

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -17,17 +17,17 @@ export const successfulResponse = {
 	teams: [
 		{
 			title: 'Automattic',
-			slug: 'a8c'
-		}
+			slug: 'a8c',
+		},
 	],
-	number: 1
+	number: 1,
 };
 
 describe( 'wpcom-api', () => {
 	const nextSpy = sinon.spy();
 
 	describe( 'teams request', () => {
-		useNock( nock => (
+		useNock( nock =>
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.2/read/teams' )
 				.reply( 200, successfulResponse )
@@ -35,17 +35,17 @@ describe( 'wpcom-api', () => {
 				.reply( 200, successfulResponse )
 				.get( '/rest/v1.2/read/teams' )
 				.reply( 500, new Error() )
-		) );
+		);
 
 		it( 'handleTeamsRequest should pass the action forward', () => {
 			const dispatch = sinon.spy();
 			const action = requestTeams();
 
-			handleTeamsRequest( { dispatch }, action, nextSpy, );
+			handleTeamsRequest( { dispatch }, action, nextSpy );
 			expect( nextSpy ).calledWith( action );
 		} );
 
-		it( 'should dispatch RECEIVE action when request completes', ( done ) => {
+		it( 'should dispatch RECEIVE action when request completes', done => {
 			const dispatch = sinon.spy( action => {
 				if ( action.type === READER_TEAMS_RECEIVE ) {
 					expect( dispatch ).to.have.been.calledWith( {
@@ -56,10 +56,10 @@ describe( 'wpcom-api', () => {
 				}
 			} );
 
-			handleTeamsRequest( { dispatch }, requestTeams(), nextSpy, );
+			handleTeamsRequest( { dispatch }, requestTeams(), nextSpy );
 		} );
 
-		it( 'should dispatch RECEIVE action with error when request errors', ( done ) => {
+		it( 'should dispatch RECEIVE action with error when request errors', done => {
 			const dispatch = sinon.spy( action => {
 				if ( action.type === READER_TEAMS_RECEIVE ) {
 					expect( dispatch ).to.have.been.calledWith( {
@@ -71,7 +71,7 @@ describe( 'wpcom-api', () => {
 				}
 			} );
 
-			handleTeamsRequest( { dispatch }, requestTeams(), nextSpy, );
+			handleTeamsRequest( { dispatch }, requestTeams(), nextSpy );
 		} );
 	} );
 } );


### PR DESCRIPTION
result of running wp-prettier on `client/state/data-layer/read`. there should be no functional changes.

Examples where we've done this already:
- `client/state/reader`: https://github.com/Automattic/wp-calypso/pull/13993
- `client/reader`: https://github.com/Automattic/wp-calypso/pull/13878