### PR TITLE
Add store to sidebar for admins on jetpack sites

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -318,6 +318,26 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	store() {
+		const { canUserManageOptions, isJetpack, site, siteSuffix, translate } = this.props;
+		const storeLink = '/store' + siteSuffix;
+		const showStoreLink = config.isEnabled( 'woocommerce/extension-dashboard' ) &&
+			site && isJetpack && canUserManageOptions;
+
+		return (
+			showStoreLink &&
+			<SidebarItem
+				label={ translate( 'Store' ) }
+				link={ storeLink }
+				onNavigate={ this.onNavigate }
+				icon="cart" >
+				<SidebarButton href={ storeLink }>
+					{ translate( 'Set up' ) }
+				</SidebarButton>
+			</SidebarItem>
+		);
+	}
+
 	trackUpgradeClick = () => {
 		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
 			cta_name: 'sidebar_upgrade_default'
@@ -517,6 +537,7 @@ export class MySitesSidebar extends Component {
 					<ul>
 						{ this.stats() }
 						{ this.plan() }
+						{ this.store() }
 					</ul>
 				</SidebarMenu>
 


### PR DESCRIPTION
See #13514 

To test:
* Add Jetpack to your site
* Make sure you are an admin on that site
* Make sure you can see the Store link on routes like http://calypso.localhost:3000/stats/day/{your-site-slug-here}
* Make sure clicking on the link takes you to /store/{your-site-slug-here}
* Repeat for a site without Jetpack
* Make sure you do *not* see the Store link

Note: Tied to woocommerce/extension-dashboard config flag, so this will only appear on local development and staging, not production.

Note: Does not include sidebar animation - that will be a separate PR

Note: Does not include toggling button text to "Manage" after setup is complete - that will be a separate PR.

cc @kellychoffman 
