### PR TITLE
Comments: data-layer

### DIFF
--- a/client/state/data-layer/wpcom/comments/content/index.js
+++ b/client/state/data-layer/wpcom/comments/content/index.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { DISCUSSIONS_ITEM_CONTENT_UPDATE_REQUEST } from 'state/action-types';
+import {
+	successCommentContentUpdateRequest,
+	failCommentContentUpdateRequest,
+} from 'state/discussions/actions';
+
+/**
+* Dispatches a request update the content of a comment
+*
+* @param   {Function} dispatch Redux dispatcher
+* @param   {Object}   action   Redux action
+* @param   {Function} next     data-layer-bypassing dispatcher
+* @returns {Promise}           Promise
+*/
+export const requestCommentContentUpdate = ( { dispatch }, action, next ) => {
+	const {
+		siteId,
+		commentId,
+		content
+	} = action;
+
+	dispatch( http( {
+		apiVersion: '1.1',
+		method: 'POST',
+		path: `/sites/${ siteId }/comments/${ commentId }`,
+		body: { content },
+	} ) );
+
+	return next( action );
+};
+
+/**
+ * Dispatches returned WordPress.com comment update
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {String}   content  updated comment content
+ */
+export const receiveContentUpdate = ( { dispatch }, action, next, { content } ) => {
+	const {
+		siteId,
+		commentId
+	} = action;
+
+	dispatch( successCommentContentUpdateRequest( siteId, commentId, content ) );
+};
+
+/**
+ * Dispatches returned error from comment update request
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {Object}   rawError raw error from HTTP request
+ */
+export const receiveError = ( { dispatch }, action, next, rawError ) => {
+	const error = rawError instanceof Error
+		? rawError.message
+		: rawError;
+	const {
+		siteId,
+		commentId,
+		content
+	} = action;
+
+	dispatch( failCommentContentUpdateRequest( siteId, commentId, content, error ) );
+};
+
+export const dispatchContentUpdateRequest = dispatchRequest( requestCommentContentUpdate, receiveContentUpdate, receiveError );
+
+export default {
+	[ DISCUSSIONS_ITEM_CONTENT_UPDATE_REQUEST ]: [ dispatchContentUpdateRequest ]
+};

--- a/client/state/data-layer/wpcom/comments/content/test/index.js
+++ b/client/state/data-layer/wpcom/comments/content/test/index.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	successCommentContentUpdateRequest,
+	failCommentContentUpdateRequest,
+} from 'state/discussions/actions';
+import {
+	requestCommentContentUpdate,
+	receiveContentUpdate,
+	receiveError
+} from '../';
+
+describe( 'wpcom-api', () => {
+	describe( 'comment content update', () => {
+		describe( '#requestCommentContentUpdate()', () => {
+			it( 'should not dispatch any action if a request for the specified site and post is in flight' );
+
+			it( 'should dispatch HTTP request to comments endpoint', () => {
+				const action = {
+					type: 'DUMMY',
+					siteId: 101010,
+					commentId: 20,
+					content: 'lorem ipsum'
+				};
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentContentUpdate( { dispatch }, action, next );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'POST',
+					path: '/sites/101010/comments/20',
+					body: { content: action.content }
+				} ) );
+			} );
+
+			it( 'should pass the original action along the middleware chain', () => {
+				const action = { type: 'DUMMY' };
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentContentUpdate( { dispatch }, action, next );
+
+				expect( next ).to.have.been.calledOnce;
+				expect( next ).to.have.been.calledWith( action );
+			} );
+		} );
+
+		describe( '#receiveContentUpdate()', () => {
+			it( 'should dispatch a success request action', () => {
+				const response = { content: 'lorem ipsum' };
+				const action = successCommentContentUpdateRequest( 101010, 20, 'lorem ipsum' );
+				const dispatch = spy();
+				const next = spy();
+
+				receiveContentUpdate( { dispatch }, action, next, response );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( successCommentContentUpdateRequest( 101010, 20, 'lorem ipsum' ) );
+			} );
+		} );
+
+		describe( '#receiveError', () => {
+			it( 'should dispatch error', () => {
+				const error = 'could not update content for comment';
+				const action = failCommentContentUpdateRequest( 101010, 20, 'lorem ipsum', error );
+				const dispatch = spy();
+				const next = spy();
+
+				receiveError( { dispatch }, action, next, error );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( failCommentContentUpdateRequest( 101010, 20, 'lorem ipsum', error ) );
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { mergeHandlers } from 'state/data-layer/utils';
+
+import content from './content';
+import likes from './likes';
+import postComments from './post-comments';
+import status from './status';
+
+export default mergeHandlers(
+	content,
+	postComments,
+	likes,
+	status,
+);

--- a/client/state/data-layer/wpcom/comments/likes/index.js
+++ b/client/state/data-layer/wpcom/comments/likes/index.js
@@ -1,0 +1,114 @@
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import {
+	DISCUSSIONS_ITEM_LIKE_REQUEST,
+	DISCUSSIONS_ITEM_UNLIKE_REQUEST
+} from 'state/action-types';
+import {
+	sucessCommentLikeRequest,
+	failCommentLikeRequest,
+} from 'state/discussions/actions';
+
+ /**
+  * Dispatches a request to like a comment
+  *
+	* @param   {Function} dispatch Redux dispatcher
+  * @param   {Object}   action   Redux action
+	* @param   {Function} next     data-layer-bypassing dispatcher
+  * @returns {Promise}           Promise
+  */
+export const requestCommentLike = ( { dispatch }, action, next ) => {
+	const {
+		siteId,
+		commentId,
+		source
+	} = action;
+
+	dispatch( http( {
+		apiVersion: '1.1',
+		method: 'POST',
+		path: `/sites/${ siteId }/comments/${ commentId }/likes/new`,
+		body: { source }
+	} ) );
+
+	return next( action );
+};
+
+/**
+ * Dispatches a request to unlike a comment
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @param   {Function} next     data-layer-bypassing dispatcher
+ * @returns {Promise}           Promise
+ */
+export const requestCommentUnLike = ( { dispatch }, action, next ) => {
+	const {
+		siteId,
+		commentId,
+		source
+	} = action;
+
+	dispatch( http( {
+		apiVersion: '1.1',
+		method: 'POST',
+		path: `/sites/${ siteId }/comments/${ commentId }/likes/mine/delete`,
+		body: { source }
+	} ) );
+
+	return next( action );
+};
+
+/**
+ * Dispatches returned WordPress.com comment status
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {String}   result   request result
+ */
+export const receiveLikeUpdate = ( { dispatch }, action, next, result ) => {
+	const {
+		siteId,
+		commentId,
+		source
+	} = action;
+	const {
+		i_like,
+		like_count
+	} = result;
+
+	dispatch( sucessCommentLikeRequest( siteId, commentId, source, i_like, like_count ) );
+};
+
+/**
+ * Dispatches returned error from comment like/unlike request
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {Object}   rawError raw error from HTTP request
+ */
+export const receiveError = ( { dispatch }, action, next, rawError ) => {
+	const error = rawError instanceof Error
+		? rawError.message
+		: rawError;
+	const {
+		siteId,
+		commentId,
+		source
+	} = action;
+
+	dispatch( failCommentLikeRequest( siteId, commentId, source, error ) );
+};
+
+export const dispatchLikeUpdateRequest = dispatchRequest( requestCommentLike, receiveLikeUpdate, receiveError );
+export const dispatchUnLikeUpdateRequest = dispatchRequest( requestCommentUnLike, receiveLikeUpdate, receiveError );
+
+export default {
+	[ DISCUSSIONS_ITEM_LIKE_REQUEST ]: [ dispatchLikeUpdateRequest ],
+	[ DISCUSSIONS_ITEM_UNLIKE_REQUEST ]: [ dispatchUnLikeUpdateRequest ]
+};

--- a/client/state/data-layer/wpcom/comments/likes/test/index.js
+++ b/client/state/data-layer/wpcom/comments/likes/test/index.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	sucessCommentLikeRequest,
+	failCommentLikeRequest,
+} from 'state/discussions/actions';
+import {
+	requestCommentLike,
+	requestCommentUnLike,
+	receiveLikeUpdate,
+	receiveError
+} from '../';
+
+describe( 'wpcom-api', () => {
+	describe( 'comment like/unlike', () => {
+		describe( '#requestCommentLike()', () => {
+			it( 'should not dispatch any action if a request for the specified site and post is in flight' );
+
+			it( 'should dispatch HTTP request to comments endpoint', () => {
+				const action = {
+					type: 'DUMMY',
+					siteId: 101010,
+					commentId: 20,
+					source: 'reader'
+				};
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentLike( { dispatch }, action, next );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'POST',
+					path: '/sites/101010/comments/20/likes/new',
+					body: { source: action.source }
+				} ) );
+			} );
+
+			it( 'should pass the original action along the middleware chain', () => {
+				const action = { type: 'DUMMY' };
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentLike( { dispatch }, action, next );
+
+				expect( next ).to.have.been.calledOnce;
+				expect( next ).to.have.been.calledWith( action );
+			} );
+		} );
+
+		describe( '#requestCommentUnLike()', () => {
+			it( 'should not dispatch any action if a request for the specified site and post is in flight' );
+
+			it( 'should dispatch HTTP request to comments endpoint', () => {
+				const action = {
+					type: 'DUMMY',
+					siteId: 101010,
+					commentId: 20,
+					source: 'reader'
+				};
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentUnLike( { dispatch }, action, next );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'POST',
+					path: '/sites/101010/comments/20/likes/mine/delete',
+					body: { source: action.source }
+				} ) );
+			} );
+
+			it( 'should pass the original action along the middleware chain', () => {
+				const action = { type: 'DUMMY' };
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentUnLike( { dispatch }, action, next );
+
+				expect( next ).to.have.been.calledOnce;
+				expect( next ).to.have.been.calledWith( action );
+			} );
+		} );
+
+		describe( '#receiveLikeUpdate()', () => {
+			it( 'should dispatch a success request action', () => {
+				const response = { i_like: true, like_count: 5 };
+				const action = sucessCommentLikeRequest( 101010, 20, 'reader', true, 5 );
+				const dispatch = spy();
+				const next = spy();
+
+				receiveLikeUpdate( { dispatch }, action, next, response );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( sucessCommentLikeRequest( 101010, 20, 'reader', true, 5 ) );
+			} );
+		} );
+
+		describe( '#receiveError', () => {
+			it( 'should dispatch error', () => {
+				const error = 'could not like comment';
+				const action = failCommentLikeRequest( 101010, 20, 'reader', error );
+				const dispatch = spy();
+				const next = spy();
+
+				receiveError( { dispatch }, action, next, error );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( failCommentLikeRequest( 101010, 20, 'reader', error ) );
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/comments/post-comments/index.js
+++ b/client/state/data-layer/wpcom/comments/post-comments/index.js
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import {
+	DISCUSSIONS_REQUEST,
+} from 'state/action-types';
+import {
+	successPostCommentsRequest,
+	failPostCommentsRequest,
+	receivePostCommentsCount,
+} from 'state/discussions/actions';
+
+ /**
+  * Dispatches a request to fetch all available discussions for a post with query options
+  *
+	* @param   {Function} dispatch Redux dispatcher
+  * @param   {Object}   action   Redux action
+  * @param   {Function} next     data-layer-bypassing dispatcher
+  * @returns {Promise}           Promise
+  */
+export const requestPostComments = ( { dispatch }, action, next ) => {
+	const {
+		siteId,
+		postId,
+		status
+	} = action;
+
+	dispatch( http( {
+		apiVersion: '1.1',
+		method: 'GET',
+		path: `/sites/${ siteId }/posts/${ postId }/replies`,
+		query: { status }
+	} ) );
+
+	return next( action );
+};
+
+/**
+ * Dispatches returned WordPress.com comments
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {Array}    comments list of comments
+ * @param {Number}   found    total number of comments for the post
+ */
+export const receivePostComments = ( { dispatch }, action, next, { comments, found } ) => {
+	const {
+		siteId,
+		postId,
+		status
+	} = action;
+
+	dispatch( successPostCommentsRequest( siteId, postId, status, comments ) );
+	dispatch( receivePostCommentsCount( siteId, postId, found ) );
+};
+
+/**
+ * Dispatches returned error from comments request
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {Object}   rawError raw error from HTTP request
+ */
+export const receiveError = ( { dispatch }, action, next, rawError ) => {
+	const error = rawError instanceof Error
+		? rawError.message
+		: rawError;
+	const {
+		siteId,
+		postId,
+		status
+	} = action;
+
+	dispatch( failPostCommentsRequest( siteId, postId, status, error ) );
+};
+
+export const dispatchPostCommentsRequest = dispatchRequest( requestPostComments, receivePostComments, receiveError );
+
+export default {
+	[ DISCUSSIONS_REQUEST ]: [ dispatchPostCommentsRequest ],
+};

--- a/client/state/data-layer/wpcom/comments/post-comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/post-comments/test/index.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	// receivePostComments,
+	successPostCommentsRequest,
+	receivePostCommentsCount,
+	failPostCommentsRequest
+} from 'state/discussions/actions';
+import {
+	requestPostComments,
+	receivePostComments,
+	receiveError,
+} from '../';
+
+describe( 'wpcom-api', () => {
+	describe( 'post comments request', () => {
+		describe( '#requestPostComments()', () => {
+			it( 'should not dispatch any action if a request for the specified site and post is in flight' );
+
+			it( 'should dispatch HTTP request to comments endpoint', () => {
+				const action = {
+					type: 'DUMMY',
+					siteId: 101010,
+					postId: 10,
+					status: 'all'
+				};
+				const dispatch = spy();
+				const next = spy();
+
+				requestPostComments( { dispatch }, action, next );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'GET',
+					path: '/sites/101010/posts/10/replies',
+					query: { status: action.status }
+				} ) );
+			} );
+
+			it( 'should pass the original action along the middleware chain', () => {
+				const action = { type: 'DUMMY' };
+				const dispatch = spy();
+				const next = spy();
+
+				requestPostComments( { dispatch }, action, next );
+
+				expect( next ).to.have.been.calledOnce;
+				expect( next ).to.have.been.calledWith( action );
+			} );
+		} );
+
+		describe( '#receiveLikeUpdate()', () => {
+			it( 'should dispatch a success request action', () => {
+				const response = { comments: [], found: 5 };
+				const action = {
+					type: 'DUMMY',
+					siteId: 101010,
+					postId: 10,
+					status: 'all',
+					comments: []
+				};
+				const dispatch = spy();
+				const next = spy();
+
+				receivePostComments( { dispatch }, action, next, response );
+
+				expect( dispatch ).to.have.been.calledTwice;
+				expect( dispatch ).to.have.been.calledWith( successPostCommentsRequest( 101010, 10, 'all', [] ) );
+				expect( dispatch ).to.have.been.calledWith( receivePostCommentsCount( 101010, 10, 5 ) );
+			} );
+		} );
+
+		describe( '#receiveError', () => {
+			it( 'should dispatch error', () => {
+				const error = 'could not retrieve comments';
+				const action = failPostCommentsRequest( 101010, 10, 'all', error );
+				const dispatch = spy();
+				const next = spy();
+
+				receiveError( { dispatch }, action, next, error );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( failPostCommentsRequest( 101010, 10, 'all', error ) );
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/comments/status/index.js
+++ b/client/state/data-layer/wpcom/comments/status/index.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { DISCUSSIONS_ITEM_STATUS_UPDATE_REQUEST } from 'state/action-types';
+import {
+	successCommentStatusUpdateRequest,
+	failCommentStatusUpdateRequest,
+} from 'state/discussions/actions';
+
+ /**
+  * Dispatches a request to update the status of a comment
+  *
+  * @param   {Function} dispatch Redux dispatcher
+  * @param   {Object}   action   Redux action
+	* @param   {Function} next     data-layer-bypassing dispatcher
+  * @returns {Promise}           Promise
+  */
+export const requestCommentStatusUpdate = ( { dispatch }, action, next ) => {
+	const {
+		siteId,
+		commentId,
+		status
+	} = action;
+
+	dispatch( http( {
+		apiVersion: '1.1',
+		method: 'POST',
+		path: `/sites/${ siteId }/comments/${ commentId }`,
+		body: { status }
+	} ) );
+
+	return next( action );
+};
+
+/**
+ * Dispatches returned WordPress.com comment status
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {String}   content  updated comment content
+ */
+export const receiveStatusUpdate = ( { dispatch }, action, next, { status } ) => {
+	const {
+		siteId,
+		commentId
+	} = action;
+
+	dispatch( successCommentStatusUpdateRequest( siteId, commentId, status ) );
+};
+
+/**
+ * Dispatches returned error from comment status update request
+ *
+ * @param {Function} dispatch Redux dispatcher
+ * @param {Object}   action   Redux action
+ * @param {Function} next     dispatches to next middleware in chain
+ * @param {Object}   rawError raw error from HTTP request
+ */
+export const receiveError = ( { dispatch }, action, next, rawError ) => {
+	const error = rawError instanceof Error
+		? rawError.message
+		: rawError;
+	const {
+		siteId,
+		commentId,
+		status
+	} = action;
+
+	dispatch( failCommentStatusUpdateRequest( siteId, commentId, status, error ) );
+};
+
+export const dispatchStatusUpdateRequest = dispatchRequest( requestCommentStatusUpdate, receiveStatusUpdate, receiveError );
+
+export default {
+	[ DISCUSSIONS_ITEM_STATUS_UPDATE_REQUEST ]: [ dispatchStatusUpdateRequest ]
+};

--- a/client/state/data-layer/wpcom/comments/status/test/index.js
+++ b/client/state/data-layer/wpcom/comments/status/test/index.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	successCommentStatusUpdateRequest,
+	failCommentStatusUpdateRequest,
+} from 'state/discussions/actions';
+import {
+	requestCommentStatusUpdate,
+	receiveStatusUpdate,
+	receiveError
+} from '../';
+
+describe( 'wpcom-api', () => {
+	describe( 'content update', () => {
+		describe( '#requestCommentStatusUpdate()', () => {
+			it( 'should not dispatch any action if a request for the specified site and post is in flight' );
+
+			it( 'should dispatch HTTP request to comments endpoint', () => {
+				const action = {
+					type: 'DUMMY',
+					siteId: 101010,
+					commentId: 20,
+					status: 'approved'
+				};
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentStatusUpdate( { dispatch }, action, next );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'POST',
+					path: '/sites/101010/comments/20',
+					body: { status: action.status }
+				} ) );
+			} );
+
+			it( 'should pass the original action along the middleware chain', () => {
+				const action = { type: 'DUMMY' };
+				const dispatch = spy();
+				const next = spy();
+
+				requestCommentStatusUpdate( { dispatch }, action, next );
+
+				expect( next ).to.have.been.calledOnce;
+				expect( next ).to.have.been.calledWith( action );
+			} );
+		} );
+
+		describe( '#receiveContentUpdate()', () => {
+			it( 'should dispatch a success request action', () => {
+				const response = { status: 'approved' };
+				const action = successCommentStatusUpdateRequest( 101010, 20, 'approved' );
+				const dispatch = spy();
+				const next = spy();
+
+				receiveStatusUpdate( { dispatch }, action, next, response );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( successCommentStatusUpdateRequest( 101010, 20, 'approved' ) );
+			} );
+		} );
+
+		describe( '#receiveError', () => {
+			it( 'should dispatch error', () => {
+				const error = 'could not update content for comment';
+				const action = failCommentStatusUpdateRequest( 101010, 20, 'approved', error );
+				const dispatch = spy();
+				const next = spy();
+
+				receiveError( { dispatch }, action, next, error );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( failCommentStatusUpdateRequest( 101010, 20, 'approved', error ) );
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/index.js
+++ b/client/state/data-layer/wpcom/index.js
@@ -3,6 +3,7 @@
  */
 import { mergeHandlers } from 'state/data-layer/utils';
 import accountRecovery from './account-recovery';
+import comments from './comments';
 import me from './me';
 import plans from './plans';
 import posts from './posts';
@@ -15,6 +16,7 @@ import login2fa from './login-2fa';
 
 export const handlers = mergeHandlers(
 	accountRecovery,
+	comments,
 	me,
 	plans,
 	posts,


### PR DESCRIPTION
This PR introduces a new data-layer to handle all comment related network activities.

Originally a part of #13534, took life on it's own. Size mostly because of test.

Depends on #14019. Tests will fail.

cc: @Automattic/lannister 