### PR TITLE
Connect sidebar to redux to receive site prop when available

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -9,7 +9,6 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getSelectedSite } from 'state/ui/selectors';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import ProductCreate from './app/products/product-create';
@@ -152,18 +151,12 @@ function addStorePage( storePage, storeNavigation ) {
 }
 
 function createStoreNavigation( context, next ) {
-	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
-
 	renderWithReduxStore(
-		React.createElement(
-			StoreSidebar, {
-				path: context.path,
-				site: selectedSite,
-				sidebarItems: getStoreSidebarItems(),
-				sidebarItemButtons: getStoreSidebarItemButtons(),
-			}
-		),
+		React.createElement( StoreSidebar, {
+			path: context.path,
+			sidebarItems: getStoreSidebarItems(),
+			sidebarItemButtons: getStoreSidebarItemButtons(),
+		} ),
 		document.getElementById( 'secondary' ),
 		context.store
 	);

--- a/client/extensions/woocommerce/state/sites/selectors.js
+++ b/client/extensions/woocommerce/state/sites/selectors.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserSiteCount } from 'state/current-user/selectors';
+import { getPrimarySiteId } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
+
+/**
+ * Gets currently selected site or, if that isn't available and the user has
+ * just one site, returns the user's primary site as a fallback
+ *
+ * @param {Object} state Global state tree
+ * @return {?Object} Site
+ */
+export function getSelectedSiteIdWithFallback( state ) {
+	let siteId = getSelectedSiteId( state );
+	if ( ! siteId && ( 1 === getCurrentUserSiteCount( state ) ) ) {
+		siteId = getPrimarySiteId( state );
+	}
+	return getSite( state, siteId );
+}

--- a/client/extensions/woocommerce/store-sidebar/store-ground-control.js
+++ b/client/extensions/woocommerce/store-sidebar/store-ground-control.js
@@ -12,13 +12,15 @@ import Gridicon from 'gridicons';
 import Site from 'blocks/site';
 
 const StoreGroundControl = ( { site, translate } ) => {
-	const backLink = '/stats/day/' + site.slug;
+	const isPlaceholder = ! site;
+	const backLink = isPlaceholder ? '' : '/stats/day/' + site.slug;
 
 	return (
 		<div className="store-sidebar__ground-control">
 			<Button
 				borderless
 				className="store-sidebar__ground-control-back"
+				disabled={ isPlaceholder }
 				href={ backLink }
 				aria-label={ translate( 'Go back' ) }
 			>
@@ -39,7 +41,7 @@ const StoreGroundControl = ( { site, translate } ) => {
 
 StoreGroundControl.propTypes = {
 	site: React.PropTypes.shape( {
-		slug: React.PropTypes.string.isRequired,
+		slug: React.PropTypes.string,
 	} ),
 };
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -437,3 +437,27 @@ form.sidebar__button {
 		-webkit-overflow-scrolling: touch;
 	}
 }
+
+.sidebar__menu {
+	.is-placeholder {
+		cursor: default;
+		pointer-events: none;
+
+		.gridicon, span, .sidebar__button {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			background-color: lighten( $gray, 25% );
+			color: transparent;
+		}
+
+		.gridicon {
+			fill: transparent;
+			stroke: transparent;
+		}
+
+		a {
+			&:after {
+				display: none;
+			}
+		}
+	}
+}

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -44,6 +44,21 @@ export function getCurrentUserLocale( state ) {
 }
 
 /**
+ * Returns the number of sites for the current user.
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {?Number}        Current user site count
+ */
+export function getCurrentUserSiteCount( state ) {
+	const user = getCurrentUser( state );
+	if ( ! user ) {
+		return null;
+	}
+
+	return user.site_count || 0;
+}
+
+/**
  * Returns the currency code for the current user.
  *
  * @param  {Object}  state  Global state tree


### PR DESCRIPTION
Fixes #14021 

To test, 

Starting at URL: calypso.localhost:3000/store/products/{site}/add
localStorage.clear();
indexedDB.deleteDatabase( 'calypso' );
refresh
store sidebar will fail to render initially
ensure sidebar does eventually render after a few seconds (when site id becomes available)

@kellychoffman - thoughts on what we should display while waiting for a site id?

cc @coderkevin 
