### PR TITLE
Data layer: Automatically call `next( action )` once for all handlers

### DIFF
--- a/client/state/data-layer/README.md
+++ b/client/state/data-layer/README.md
@@ -135,11 +135,6 @@ const syncChanges = ( { dispatch, getState }, action, next ) => {
 			// next() instead of dispatch()
 			next( reticulateSpline( oldSpline ) );
 		} );
-
-	// pass along action to reducers
-	// and bypass all further
-	// data-layer middleware
-	next( action );
 };
 
 export default {

--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -100,7 +100,6 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		config.middleware( store )( next )( action );
 
-		expect( next ).to.not.have.been.calledWith( action );
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -117,7 +116,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		config.middleware( store )( next )( action );
 
-		expect( next ).to.have.been.calledOnce;
+		expect( next ).to.have.been.calledTwice;
 		expect( next ).to.have.been.calledWith( local( action ) );
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -85,7 +85,8 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.been.calledWith( action );
+		expect( next ).to.have.been.calledOnce;
+		expect( next ).to.have.been.calledWith( action );
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -98,7 +99,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.have.been.calledOnce;
+		expect( next ).to.have.been.calledTwice;
 		expect( next ).to.have.been.calledWith( local( action ) );
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );

--- a/client/state/data-layer/third-party/directly/index.js
+++ b/client/state/data-layer/third-party/directly/index.js
@@ -15,16 +15,12 @@ import {
 } from 'state/help/directly/actions';
 import * as directly from 'lib/directly';
 
-export function askQuestion( { dispatch }, action, next ) {
-	next( action );
-
+export function askQuestion( { dispatch }, action ) {
 	return directly.askQuestion( action.questionText, action.name, action.email )
 		.then( () => dispatch( recordTracksEvent( 'calypso_directly_ask_question' ) ) );
 }
 
-export function initialize( { dispatch, getState }, action, next ) {
-	next( action );
-
+export function initialize( { dispatch } ) {
 	dispatch( recordTracksEvent( 'calypso_directly_initialization_start' ) );
 
 	return directly.initialize()

--- a/client/state/data-layer/third-party/directly/test/index.js
+++ b/client/state/data-layer/third-party/directly/test/index.js
@@ -64,11 +64,6 @@ describe( 'Directly data layer', () => {
 			expect( directly.askQuestion ).to.have.been.calledWith( questionText, name, email );
 		} );
 
-		it( 'should pass the action through', () => {
-			askQuestion( store, action, next );
-			expect( next ).to.have.been.calledWith( action );
-		} );
-
 		it( 'should dispatch an analytics event', () => (
 			askQuestion( store, action, next )
 				.then( () => expect( analytics.recordTracksEvent ).to.have.been.calledWith( 'calypso_directly_ask_question' ) )
@@ -81,11 +76,6 @@ describe( 'Directly data layer', () => {
 		it( 'should invoke the corresponding Directly function', () => {
 			initialize( store, action, next );
 			expect( directly.initialize ).to.have.been.calledOnce;
-		} );
-
-		it( 'should pass the action through', () => {
-			initialize( store, action, next );
-			expect( next ).to.have.been.calledWith( action );
 		} );
 
 		it( 'should dispatch an analytics event once initialization starts', () => {

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -68,7 +68,9 @@ export const middleware = handlers => store => next => {
 			}
 		}
 
-		return handlerChain.forEach( handler => handler( store, action, localNext ) );
+		handlerChain.forEach( handler => handler( store, action, localNext ) );
+
+		return next( action );
 	};
 };
 

--- a/client/state/data-layer/wpcom-http/README.md
+++ b/client/state/data-layer/wpcom-http/README.md
@@ -123,7 +123,7 @@ Notice how we can store that information inside of the responder actions just li
 ```js
 const missileMiddleware = ( store, action, next ) => {
 	if ( FIRE_ZE_MISSILES !== action.type ) {
-		return next( action );
+		return;
 	}
 
 	dispatch( http( {
@@ -142,7 +142,7 @@ import { getProgress } from 'state/data-layer/wpcom-http/utils';
 
 const packageMiddleware = ( store, action, next ) => {
 	if ( CREATE_PACKAGE !== action.type ) {
-		return next;
+		return;
 	}
 
 	const progress = getProgress( action );
@@ -227,10 +227,6 @@ const likePost = ( { dispatch }, action, next ) => {
 		// (not implemented yet)
 		whenOffline: QUEUE_REQUEST,
 	}, action ) );
-	
-	// feed LIKE_POST action along to reducers
-	// and skip additional data-layer middleware
-	next( action );
 }
 
 /**

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -32,11 +32,11 @@ export const successMeta = data => ( { meta: { dataLayer: { data } } } );
 export const failureMeta = error => ( { meta: { dataLayer: { error } } } );
 export const progressMeta = ( { total, loaded } ) => ( { meta: { dataLayer: { progress: { total, loaded } } } } );
 
-export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch }, rawAction, next ) => {
+export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch }, rawAction ) => {
 	const action = processOutbound( rawAction, dispatch );
 
 	if ( null === action ) {
-		return next( rawAction );
+		return;
 	}
 
 	const {
@@ -76,8 +76,6 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 	if ( 'POST' === method && onProgress ) {
 		request.upload.onprogress = event => dispatch( extendAction( onProgress, progressMeta( event ) ) );
 	}
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom-http/test/index.js
+++ b/client/state/data-layer/wpcom-http/test/index.js
@@ -53,8 +53,6 @@ describe( '#queueRequest', () => {
 
 		http( { dispatch }, getMe, next );
 
-		expect( next ).to.have.been.calledWith( getMe );
-
 		setTimeout( () => {
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith( extendAction( succeeder, successMeta( data ) ) );
@@ -67,8 +65,6 @@ describe( '#queueRequest', () => {
 		nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/me' ).replyWithError( error );
 
 		http( { dispatch }, getMe, next );
-
-		expect( next ).to.have.been.calledWith( getMe );
 
 		setTimeout( () => {
 			expect( dispatch ).to.have.been.calledOnce;

--- a/client/state/data-layer/wpcom/account-recovery/lookup/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/index.js
@@ -33,7 +33,7 @@ export const validate = ( { primary_email, primary_sms, secondary_email, seconda
 	}
 };
 
-export const handleRequestResetOptions = ( { dispatch }, action, next ) => {
+export const handleRequestResetOptions = ( { dispatch }, action ) => {
 	const { userData } = action;
 
 	wpcom.req.get( {
@@ -45,8 +45,6 @@ export const handleRequestResetOptions = ( { dispatch }, action, next ) => {
 		dispatch( updatePasswordResetUserData( userData ) );
 	} )
 	.catch( error => dispatch( fetchResetOptionsError( error ) ) );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
@@ -9,7 +9,7 @@ import {
 	setResetMethod,
 } from 'state/account-recovery/reset/actions';
 
-export const handleRequestReset = ( { dispatch }, action, next ) => {
+export const handleRequestReset = ( { dispatch }, action ) => {
 	const {
 		userData,
 		method,
@@ -27,8 +27,6 @@ export const handleRequestReset = ( { dispatch }, action, next ) => {
 		dispatch( setResetMethod( method ) );
 	} )
 	.catch( ( error ) => dispatch( requestResetError( error ) ) );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/account-recovery/validate/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/index.js
@@ -9,7 +9,7 @@ import {
 	setValidationKey,
 } from 'state/account-recovery/reset/actions';
 
-export const handleValidateRequest = ( { dispatch }, action, next ) => {
+export const handleValidateRequest = ( { dispatch }, action ) => {
 	const { userData, method, key } = action;
 	wpcom.req.post( {
 		body: {
@@ -24,8 +24,6 @@ export const handleValidateRequest = ( { dispatch }, action, next ) => {
 		dispatch( setValidationKey( key ) );
 	} )
 	.catch( ( error ) => dispatch( validateRequestError( error ) ) );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -79,10 +79,9 @@ const doAppPushPolling = store => {
 	}
 };
 
-const handleTwoFactorPushPoll = ( store, action, next ) => {
+const handleTwoFactorPushPoll = store => {
 	// this is deferred to allow reducer respond to TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START
 	defer( () => doAppPushPolling( store ) );
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -35,14 +35,12 @@ function fromApi( apiResponse ) {
 /*
  * Fetch settings from the WordPress.com API at /me/settings endpoint
  */
-export const requestUserSettings = ( { dispatch }, action, next ) => {
+export const requestUserSettings = ( { dispatch }, action ) => {
 	dispatch( http( {
 		apiVersion: '1.1',
 		method: 'GET',
 		path: '/me/settings',
 	}, action ) );
-
-	return next( action );
 };
 
 /*
@@ -55,7 +53,7 @@ export const storeFetchedUserSettings = ( { dispatch }, action, next, data ) => 
 /*
  * Post settings to WordPress.com API at /me/settings endpoint
  */
-export function saveUserSettings( { dispatch, getState }, action, next ) {
+export function saveUserSettings( { dispatch, getState }, action ) {
 	const { settingsOverride } = action;
 	const settings = settingsOverride || getUnsavedUserSettings( getState() );
 
@@ -67,8 +65,6 @@ export function saveUserSettings( { dispatch, getState }, action, next ) {
 			body: settings,
 		}, action ) );
 	}
-
-	return next( action );
 }
 
 /*

--- a/client/state/data-layer/wpcom/me/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/settings/test/index.js
@@ -44,14 +44,6 @@ describe( 'wpcom-api', () => {
 					path: '/me/settings',
 				}, action ) );
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = { type: 'DUMMY' };
-
-				settingsModule.requestUserSettings( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#storeFetchedUserSettings', () => {
@@ -106,7 +98,6 @@ describe( 'wpcom-api', () => {
 					path: '/me/settings',
 					body: { foo: 'baz' }
 				}, action ) );
-				expect( next ).to.have.been.calledWith( action );
 			} );
 
 			it( 'should dispatch POST request to me/settings using explicit settingsOverride', () => {
@@ -125,7 +116,6 @@ describe( 'wpcom-api', () => {
 					path: '/me/settings',
 					body: { foo: 'baz' }
 				}, action ) );
-				expect( next ).to.have.been.calledWith( action );
 			} );
 
 			it( 'should not dispatch any HTTP request when there are no unsaved settings', () => {
@@ -140,7 +130,6 @@ describe( 'wpcom-api', () => {
 				settingsModule.saveUserSettings( { dispatch, getState }, action, next );
 
 				expect( dispatch ).to.not.have.been.called;
-				expect( next ).to.have.been.calledWith( action );
 			} );
 		} );
 

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -22,7 +22,7 @@ import {
  * @param {Function} next data-layer-bypassing dispatcher
  * @returns {Object} original action
  */
-export const requestPlans = ( { dispatch }, action, next ) => {
+export const requestPlans = ( { dispatch }, action ) => {
 	dispatch( http( {
 		apiVersion: '1.4',
 		method: 'GET',
@@ -30,8 +30,6 @@ export const requestPlans = ( { dispatch }, action, next ) => {
 		onSuccess: action,
 		onFailure: action,
 	} ) );
-
-	return next( action );
 };
 
 /**

--- a/client/state/data-layer/wpcom/plans/test/index.js
+++ b/client/state/data-layer/wpcom/plans/test/index.js
@@ -40,16 +40,6 @@ describe( 'wpcom-api', () => {
 					onFailure: action,
 				} ) );
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = { type: 'DUMMY' };
-				const dispatch = spy();
-				const next = spy();
-
-				requestPlans( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#receivePlans', () => {

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -13,7 +13,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
-export function initiateFeedSearch( store, action, next ) {
+export function initiateFeedSearch( store, action ) {
 	if ( ! ( action.payload && action.payload.query ) ) {
 		return;
 	}
@@ -29,8 +29,6 @@ export function initiateFeedSearch( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 export function receiveFeeds( store, action, next, apiResponse ) {

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -39,16 +39,6 @@ describe( 'wpcom-api', () => {
 					} )
 				);
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = requestFeedSearch( query );
-				const dispatch = sinon.spy();
-				const next = sinon.spy();
-
-				initiateFeedSearch( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#receiveFeeds', () => {

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -13,7 +13,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { follow } from 'state/reader/follows/actions';
 
-export function requestUnfollow( { dispatch, getState }, action, next ) {
+export function requestUnfollow( { dispatch }, action ) {
 	const { payload: { feedUrl } } = action;
 	dispatch(
 		http( {
@@ -28,15 +28,14 @@ export function requestUnfollow( { dispatch, getState }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveUnfollow( store, action, next, response ) {
 	if ( response && ! response.subscribed ) {
-		next( action );
-	} else {
-		unfollowError( store, action, next );
+		return;
 	}
+
+	unfollowError( store, action, next );
 }
 
 export function unfollowError( { dispatch }, action, next ) {

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -31,7 +31,6 @@ describe( 'requestUnfollow', () => {
 				onFailure: action,
 			} )
 		);
-		expect( next ).to.have.been.calledWith( action );
 	} );
 } );
 
@@ -44,7 +43,6 @@ describe( 'receiveUnfollow', () => {
 			subscribed: false,
 		};
 		receiveUnfollow( { dispatch }, action, next, response );
-		expect( next ).to.be.calledWith( action );
 	} );
 
 	it( 'should dispatch an error notice and refollow when subscribed is true', () => {

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -63,7 +63,7 @@ let seenSubscriptions = null;
 export const isSyncingFollows = () => syncingFollows;
 export const resetSyncingFollows = () => syncingFollows = false;
 
-export function syncReaderFollows( store, action, next ) {
+export function syncReaderFollows( store ) {
 	if ( isSyncingFollows() ) {
 		return;
 	}
@@ -72,11 +72,9 @@ export function syncReaderFollows( store, action, next ) {
 	seenSubscriptions = new Set();
 
 	store.dispatch( requestPageAction( 1 ) );
-
-	next( action );
 }
 
-export function requestPage( store, action, next ) {
+export function requestPage( store, action ) {
 	store.dispatch(
 		http( {
 			method: 'GET',
@@ -91,8 +89,6 @@ export function requestPage( store, action, next ) {
 			onError: action,
 		} )
 	);
-
-	next( action );
 }
 
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
@@ -128,11 +124,10 @@ export function receivePage( store, action, next, apiResponse ) {
 	syncingFollows = false;
 }
 
-export function updateSeenOnFollow( store, action, next ) {
+export function updateSeenOnFollow( store, action ) {
 	if ( seenSubscriptions ) {
 		seenSubscriptions.add( action.payload.feedUrl );
 	}
-	next( action );
 }
 
 export function receiveError( store ) {

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -14,7 +14,7 @@ import { errorNotice } from 'state/notices/actions';
 import { follow, unfollow, recordFollowError } from 'state/reader/follows/actions';
 import { subscriptionFromApi } from 'state/data-layer/wpcom/read/following/mine';
 
-export function requestFollow( { dispatch }, action, next ) {
+export function requestFollow( { dispatch }, action ) {
 	const { payload: { feedUrl } } = action;
 
 	dispatch(
@@ -30,7 +30,6 @@ export function requestFollow( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveFollow( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -31,7 +31,6 @@ describe( 'requestFollow', () => {
 				onFailure: action,
 			} )
 		);
-		expect( next ).to.have.been.calledWith( action );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -88,16 +88,6 @@ describe( 'get follow subscriptions', () => {
 				} )
 			);
 		} );
-
-		it( 'should pass the original action along the middleware chain', () => {
-			const action = requestPageAction();
-			const dispatch = sinon.spy();
-			const next = sinon.spy();
-
-			requestPage( { dispatch }, action, next );
-
-			expect( next ).to.have.been.calledWith( action );
-		} );
 	} );
 
 	describe( '#receivePageSuccess', () => {

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { map } from 'lodash';
+import { map, noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { receiveRecommendedSites } from 'state/reader/recommended-sites/actions';
 import { decodeEntities } from 'lib/formatting';
 
-export const requestRecommendedSites = ( { dispatch }, action, next ) => {
+export const requestRecommendedSites = ( { dispatch }, action ) => {
 	const { seed = 1, number = 10, offset = 0 } = action.payload;
 	dispatch(
 		http( {
@@ -24,7 +24,6 @@ export const requestRecommendedSites = ( { dispatch }, action, next ) => {
 			onFailure: action,
 		} )
 	);
-	next( action );
 };
 
 export const fromApi = response => {
@@ -55,13 +54,8 @@ export const receiveRecommendedSitesResponse = ( store, action, next, response )
 	);
 };
 
-export const receiveError = ( store, action, next ) => {
-	// no-op
-	next( action );
-};
-
 export default {
 	[ READER_RECOMMENDED_SITES_REQUEST ]: [
-		dispatchRequest( requestRecommendedSites, receiveRecommendedSitesResponse, receiveError ),
+		dispatchRequest( requestRecommendedSites, receiveRecommendedSitesResponse, noop ),
 	],
 };

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -60,8 +60,6 @@ describe( 'recommended sites', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestCommentEmailUnsubscription( { dispatch }, action, next ) {
+export function requestCommentEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -23,7 +23,6 @@ export function requestCommentEmailUnsubscription( { dispatch }, action, next ) 
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveCommentEmailUnsubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -35,8 +35,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestCommentEmailSubscription( { dispatch }, action, next ) {
+export function requestCommentEmailSubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -23,7 +23,6 @@ export function requestCommentEmailSubscription( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveCommentEmailSubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -35,8 +35,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestPostEmailUnsubscription( { dispatch }, action, next ) {
+export function requestPostEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -23,7 +23,6 @@ export function requestPostEmailUnsubscription( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receivePostEmailUnsubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -32,8 +32,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -17,7 +17,7 @@ import {
 import { errorNotice } from 'state/notices/actions';
 import { buildBody } from '../utils';
 
-export function requestPostEmailSubscription( { dispatch }, action, next ) {
+export function requestPostEmailSubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -28,7 +28,6 @@ export function requestPostEmailSubscription( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receivePostEmailSubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -36,8 +36,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -15,7 +15,7 @@ import { errorNotice } from 'state/notices/actions';
 import { getReaderFollowForBlog } from 'state/selectors';
 import { buildBody } from '../utils';
 
-export function requestUpdatePostEmailSubscription( { dispatch, getState }, action, next ) {
+export function requestUpdatePostEmailSubscription( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
 			previousState: get( getReaderFollowForBlog( getState(), action.payload.blogId ), [
@@ -35,7 +35,6 @@ export function requestUpdatePostEmailSubscription( { dispatch, getState }, acti
 			onFailure: actionWithRevert,
 		} )
 	);
-	next( action );
 }
 
 export function receiveUpdatePostEmailSubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -17,7 +17,7 @@ import { mergeHandlers } from 'state/data-layer/utils';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestTags( store, action, next ) {
+export function requestTags( store, action ) {
 	const path = action.payload && action.payload.slug
 		? `/read/tags/${ action.payload.slug }`
 		: '/read/tags';
@@ -31,8 +31,6 @@ export function requestTags( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 export function receiveTagsSuccess( store, action, next, apiResponse ) {

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -13,7 +13,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
-export function requestUnfollow( store, action, next ) {
+export function requestUnfollow( store, action ) {
 	store.dispatch(
 		http( {
 			path: `/read/tags/${ action.payload.slug }/mine/delete`,
@@ -23,8 +23,6 @@ export function requestUnfollow( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 /**

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
@@ -63,16 +63,6 @@ describe( 'unfollow tag request', () => {
 				} )
 			);
 		} );
-
-		it( 'should pass the original action along the middleware chain', () => {
-			const action = requestUnfollowAction( slug );
-			const dispatch = sinon.spy();
-			const next = sinon.spy();
-
-			requestUnfollow( { dispatch }, action, next );
-
-			expect( next ).to.have.been.calledWith( action );
-		} );
 	} );
 
 	describe( '#receiveUnfollowSuccess', () => {

--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -15,7 +15,7 @@ import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
-export function requestFollowTag( store, action, next ) {
+export function requestFollowTag( store, action ) {
 	store.dispatch(
 		http( {
 			path: `/read/tags/${ action.payload.slug }/mine/new`,
@@ -25,8 +25,6 @@ export function requestFollowTag( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 export function receiveFollowTag( store, action, next, apiResponse ) {

--- a/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
@@ -66,16 +66,6 @@ describe( 'follow tag request', () => {
 				} )
 			);
 		} );
-
-		it( 'should pass the original action along the middleware chain', () => {
-			const action = requestFollowAction( slug );
-			const dispatch = sinon.spy();
-			const next = sinon.spy();
-
-			requestFollowTag( { dispatch }, action, next );
-
-			expect( next ).to.have.been.calledWith( action );
-		} );
 	} );
 
 	describe( '#receiveFollowSuccess', () => {

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -89,16 +89,6 @@ describe( 'wpcom-api', () => {
 					} )
 				);
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = requestTagsAction( slug );
-				const dispatch = sinon.spy();
-				const next = sinon.spy();
-
-				requestTags( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#receiveTagsResponse', () => {

--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -4,7 +4,7 @@
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
 import wpcom from 'lib/wp';
 
-export function handleTeamsRequest( store, action, next ) {
+export function handleTeamsRequest( store ) {
 	wpcom.req.get( '/read/teams', { apiVersion: '1.2' } ).then(
 		payload => {
 			store.dispatch( {
@@ -20,7 +20,6 @@ export function handleTeamsRequest( store, action, next ) {
 			} );
 		}
 	);
-	next( action );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -32,18 +32,8 @@ describe( 'wpcom-api', () => {
 				.get( '/rest/v1.2/read/teams' )
 				.reply( 200, successfulResponse )
 				.get( '/rest/v1.2/read/teams' )
-				.reply( 200, successfulResponse )
-				.get( '/rest/v1.2/read/teams' )
 				.reply( 500, new Error() )
 		);
-
-		it( 'handleTeamsRequest should pass the action forward', () => {
-			const dispatch = sinon.spy();
-			const action = requestTeams();
-
-			handleTeamsRequest( { dispatch }, action, nextSpy );
-			expect( nextSpy ).calledWith( action );
-		} );
 
 		it( 'should dispatch RECEIVE action when request completes', done => {
 			const dispatch = sinon.spy( action => {

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -50,7 +50,7 @@ export const fromApi = ( { manual_utc_offsets, timezones, timezones_by_continent
 /*
  * Start a request to WordPress.com server to get the timezones data
  */
-export const fetchTimezones = ( { dispatch }, action, next ) => {
+export const fetchTimezones = ( { dispatch } ) => {
 	wpcom.req.get( '/timezones', { apiNamespace: 'wpcom/v2' } )
 		.then( data => {
 			dispatch( timezonesRequestSuccess() );
@@ -59,8 +59,6 @@ export const fetchTimezones = ( { dispatch }, action, next ) => {
 		.catch( error => {
 			dispatch( timezonesRequestFailure( error ) );
 		} );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -19,9 +19,9 @@ import {
  * @param {Function} next Dispatches to next middleware in chain
  * @returns {Object} original action
  */
-export const updatePoster = ( { dispatch }, action, next ) => {
+export const updatePoster = ( { dispatch }, action ) => {
 	if ( ! ( 'file' in action.params || 'atTime' in action.params ) ) {
-		return next( action );
+		return;
 	}
 
 	const { atTime, file } = action.params;
@@ -36,8 +36,6 @@ export const updatePoster = ( { dispatch }, action, next ) => {
 	);
 
 	dispatch( http( params, action ) );
-
-	return next( action );
 };
 
 export const receivePosterUrl = ( { dispatch }, action, next, { poster: posterUrl } ) => {


### PR DESCRIPTION
> **To all who are requested for review**
> This PR updates a fundamental design choice in the data layer and I request that you review any parts that you have worked on to make sure that I didn't accidentally break them. **Please directly commit to this PR if you think of any further required changes to the code you have written.**

When the data layer was originally designed it was intended that each
handler in the chain for any given action would manually pass the
originating action down with a call to `next( action )`.

This was a wrong decision and introduced confusion and risk: multiple
handlers might all pass the action down causing it to run multiple times
through the reducers or a handler might neglect to pass it along.

Now, the handlers are all seen as side-effecting operations and the
middleware itself makes sure that the original action is passed along to
the reducers.

`next()` still plays a role in passing down newly-created actions
through the middleware to the reducers, but should not be used with the
original action.

**Testing**

This requires smoke testing and full e2e testing on the parts affected by the data layer. Thankfully we can look at the file tree in the data layer to see which endpoints are affected then find those places in Calypso which use them.