### PR TITLE
SitesDropdown: Don't bind selectors to state

### DIFF
--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get, noop } from 'lodash';
+import { flow, get, noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -104,27 +104,28 @@ export class SitesDropdown extends PureComponent {
 	}
 }
 
-const Connected = connect(
-	( state, { selectedSiteId, selectedSiteSlug } ) => {
-		const initialSiteId = selectedSiteId ||
-			getPrimarySiteId( state );
+const mapState = ( state, { selectedSiteId, selectedSiteSlug } ) => {
+	const initialSiteId = selectedSiteId ||
+		getPrimarySiteId( state );
 
-		const selectedSite = selectedSiteSlug
-			? getSite( state, selectedSiteSlug )
-			: undefined;
+	const selectedSite = selectedSiteSlug
+		? getSite( state, selectedSiteSlug )
+		: undefined;
 
-		return {
-			initialSiteId,
-			selectedSite,
-		};
-	}
-)( SitesDropdown );
+	return {
+		initialSiteId,
+		selectedSite,
+	};
+};
 
 /*
  * A container for component state that can then be passed to SitesDropdown's
  * Redux-connected counterpart.
  */
-export default class SitesDropdownWrapper extends PureComponent {
+const withSelectedSiteSlug = ( Wrapped ) => class extends PureComponent {
+	static displayName = `WithSelectedSiteSlug(${
+		Wrapped.displayName || Wrapped.name } )`
+
 	state = { selectedSiteSlug: null }
 
 	setSelectedSiteSlug = ( slug ) => {
@@ -132,9 +133,14 @@ export default class SitesDropdownWrapper extends PureComponent {
 	}
 
 	render() {
-		return <Connected
+		return <Wrapped
 			selectedSiteSlug={ this.state.selectedSiteSlug }
 			setSelectedSiteSlug={ this.setSelectedSiteSlug }
 			{ ...this.props } />;
 	}
-}
+};
+
+export default flow(
+	connect( mapState ),
+	withSelectedSiteSlug
+)( SitesDropdown );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -27,7 +27,7 @@ export class SitesDropdown extends PureComponent {
 		filter: PropTypes.func,
 		isPlaceholder: PropTypes.bool,
 
-		// connected
+		// Redux-provided
 		initialSiteId: PropTypes.number.isRequired,
 		selectedSite: PropTypes.object,
 	}
@@ -39,6 +39,15 @@ export class SitesDropdown extends PureComponent {
 		isPlaceholder: false
 	}
 
+	constructor( props ) {
+		super( props );
+
+		// needed to be done in constructor b/c spy tests
+		this.selectSite = this.selectSite.bind( this );
+		this.toggleOpen = this.toggleOpen.bind( this );
+		this.onClose = this.onClose.bind( this );
+	}
+
 	state = { open: false }
 
 	componentDidMount() {
@@ -46,7 +55,7 @@ export class SitesDropdown extends PureComponent {
 		setSelectedSiteSlug( initialSiteId );
 	}
 
-	selectSite = ( siteSlug ) => {
+	selectSite( siteSlug ) {
 		this.props.onSiteSelect( siteSlug );
 		this.props.setSelectedSiteSlug( siteSlug );
 		this.setState( {
@@ -54,11 +63,11 @@ export class SitesDropdown extends PureComponent {
 		} );
 	}
 
-	toggleOpen = () => {
+	toggleOpen() {
 		this.setState( { open: ! this.state.open } );
 	}
 
-	onClose = ( e ) => {
+	onClose( e ) {
 		this.setState( { open: false } );
 		this.props.onClose && this.props.onClose( e );
 	}

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { flow, get, noop } from 'lodash';
+import { flow, get, identity, noop } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -27,16 +27,18 @@ export class SitesDropdown extends PureComponent {
 		filter: PropTypes.func,
 		isPlaceholder: PropTypes.bool,
 
-		// Redux-provided
+		// connected props
 		initialSiteId: PropTypes.number.isRequired,
 		selectedSite: PropTypes.object,
+		setLocallySelectedSiteId: PropTypes.func,
 	}
 
 	static defaultProps = {
 		showAllSites: false,
 		onClose: noop,
 		onSiteSelect: noop,
-		isPlaceholder: false
+		isPlaceholder: false,
+		setLocallySelectedSiteId: identity,
 	}
 
 	constructor( props ) {
@@ -51,13 +53,13 @@ export class SitesDropdown extends PureComponent {
 	state = { open: false }
 
 	componentDidMount() {
-		const { initialSiteId, setSelectedSiteSlug } = this.props;
-		setSelectedSiteSlug( initialSiteId );
+		const { initialSiteId, setLocallySelectedSiteId } = this.props;
+		setLocallySelectedSiteId( initialSiteId );
 	}
 
 	selectSite( siteSlug ) {
 		this.props.onSiteSelect( siteSlug );
-		this.props.setSelectedSiteSlug( siteSlug );
+		this.props.setLocallySelectedSiteId( siteSlug );
 		this.setState( {
 			open: false
 		} );
@@ -104,12 +106,12 @@ export class SitesDropdown extends PureComponent {
 	}
 }
 
-const mapState = ( state, { selectedSiteId, selectedSiteSlug } ) => {
+const mapState = ( state, { selectedSiteId, locallySelectedSiteId } ) => {
 	const initialSiteId = selectedSiteId ||
 		getPrimarySiteId( state );
 
-	const selectedSite = selectedSiteSlug
-		? getSite( state, selectedSiteSlug )
+	const selectedSite = locallySelectedSiteId
+		? getSite( state, locallySelectedSiteId )
 		: undefined;
 
 	return {
@@ -122,25 +124,25 @@ const mapState = ( state, { selectedSiteId, selectedSiteSlug } ) => {
  * A container for component state that can then be passed to SitesDropdown's
  * Redux-connected counterpart.
  */
-const withSelectedSiteSlug = ( Wrapped ) => class extends PureComponent {
-	static displayName = `WithSelectedSiteSlug(${
+const withSelectedSiteId = ( Wrapped ) => class extends PureComponent {
+	static displayName = `WithSelectedSiteId(${
 		Wrapped.displayName || Wrapped.name } )`
 
-	state = { selectedSiteSlug: null }
+	state = { locallySelectedSiteId: null }
 
-	setSelectedSiteSlug = ( slug ) => {
-		this.setState( { selectedSiteSlug: slug } );
+	setLocallySelectedSiteId = ( slug ) => {
+		this.setState( { locallySelectedSiteId: slug } );
 	}
 
 	render() {
 		return <Wrapped
-			selectedSiteSlug={ this.state.selectedSiteSlug }
-			setSelectedSiteSlug={ this.setSelectedSiteSlug }
+			locallySelectedSiteId={ this.state.locallySelectedSiteId }
+			setLocallySelectedSiteId={ this.setLocallySelectedSiteId }
 			{ ...this.props } />;
 	}
 };
 
 export default flow(
 	connect( mapState ),
-	withSelectedSiteSlug
+	withSelectedSiteId
 )( SitesDropdown );

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -26,7 +26,7 @@ describe( 'index', function() {
 	let SitesDropdown;
 
 	before( function() {
-		SitesDropdown = require( '../index.jsx' ).SitesDropdown;
+		SitesDropdown = require( '..' ).SitesDropdown;
 	} );
 
 	describe( 'component rendering', function() {
@@ -64,11 +64,13 @@ describe( 'index', function() {
 	describe( 'selectSite', function() {
 		it( 'should update the `selectedSiteSlug`, and `open` state properties', function() {
 			const setStateSpy = sinon.spy();
+			const setSelectedSiteSlugSpy = sinon.spy();
 			const siteSelectedSpy = sinon.spy();
 			const fakeContext = {
 				setState: setStateSpy,
 				props: {
-					onSiteSelect: siteSelectedSpy
+					onSiteSelect: siteSelectedSpy,
+					setSelectedSiteSlug: setSelectedSiteSlugSpy,
 				}
 			};
 
@@ -77,8 +79,11 @@ describe( 'index', function() {
 			sinon.assert.calledOnce( siteSelectedSpy );
 			sinon.assert.calledWith( siteSelectedSpy, 'foobar' );
 
+			sinon.assert.calledOnce( setSelectedSiteSlugSpy );
+			sinon.assert.calledWith( setSelectedSiteSlugSpy, 'foobar' );
+
 			sinon.assert.calledOnce( setStateSpy );
-			sinon.assert.calledWith( setStateSpy, { open: false, selectedSiteSlug: 'foobar' } );
+			sinon.assert.calledWith( setStateSpy, { open: false } );
 		} );
 	} );
 

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -64,13 +64,13 @@ describe( 'index', function() {
 	describe( 'selectSite', function() {
 		it( 'should update the `selectedSiteSlug`, and `open` state properties', function() {
 			const setStateSpy = sinon.spy();
-			const setSelectedSiteSlugSpy = sinon.spy();
+			const setLocallySelectedSiteIdSpy = sinon.spy();
 			const siteSelectedSpy = sinon.spy();
 			const fakeContext = {
 				setState: setStateSpy,
 				props: {
 					onSiteSelect: siteSelectedSpy,
-					setSelectedSiteSlug: setSelectedSiteSlugSpy,
+					setLocallySelectedSiteId: setLocallySelectedSiteIdSpy,
 				}
 			};
 
@@ -79,8 +79,8 @@ describe( 'index', function() {
 			sinon.assert.calledOnce( siteSelectedSpy );
 			sinon.assert.calledWith( siteSelectedSpy, 'foobar' );
 
-			sinon.assert.calledOnce( setSelectedSiteSlugSpy );
-			sinon.assert.calledWith( setSelectedSiteSlugSpy, 'foobar' );
+			sinon.assert.calledOnce( setLocallySelectedSiteIdSpy );
+			sinon.assert.calledWith( setLocallySelectedSiteIdSpy, 'foobar' );
 
 			sinon.assert.calledOnce( setStateSpy );
 			sinon.assert.calledWith( setStateSpy, { open: false } );


### PR DESCRIPTION
Part of #14024 

# Testing

`SitesDropdown` is used in `SiteSelectorModal` (via ellipsis actions at `/themes`), `/me/account`, `HelpContactForm`. Behaviors should remain unchanged.