### PR TITLE
Login: Move magic link into its own component and route

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -7,11 +7,19 @@ import React from 'react';
  * Internal dependencies
  */
 import WPLogin from './wp-login';
+import MagicLogin from './magic-login';
 
 export default {
 	login( context, next ) {
 		context.renderCacheKey = 'login';
 		context.primary = <WPLogin twoFactorAuthType={ context.params.twoFactorAuthType } />;
+
+		next();
+	},
+
+	magicLogin( context, next ) {
+		context.renderCacheKey = 'magiclogin';
+		context.primary = <MagicLogin />;
 
 		next();
 	}

--- a/client/login/index.js
+++ b/client/login/index.js
@@ -2,10 +2,14 @@
  * Internal dependencies
  */
 import config from 'config';
-import { login } from './controller';
+import { login, magicLogin } from './controller';
 import { makeLayout, redirectLoggedIn } from 'controller';
 
 export default router => {
+	if ( config.isEnabled( 'magic-login' ) ) {
+		router( '/login/link', redirectLoggedIn, magicLogin, makeLayout );
+	}
+
 	if ( config.isEnabled( 'wp-login' ) ) {
 		router( '/login/:twoFactorAuthType?', redirectLoggedIn, login, makeLayout );
 	}

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { compact } from 'lodash';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CHECK_YOUR_EMAIL_PAGE,
+	INTERSTITIAL_PAGE,
+	LINK_EXPIRED_PAGE,
+} from 'state/login/magic-login/constants';
+import config, { isEnabled } from 'config';
+import EmailedLoginLinkSuccessfully from '../magic-login/emailed-login-link-successfully';
+import EmailedLoginLinkExpired from '../magic-login/emailed-login-link-expired';
+import {
+	getMagicLoginEmailAddressFormInput,
+	getMagicLoginCurrentView,
+} from 'state/selectors';
+import { getCurrentQueryArguments } from 'state/ui/selectors';
+import HandleEmailedLinkForm from '../magic-login/handle-emailed-link-form';
+import {
+	hideMagicLoginRequestForm,
+	showMagicLoginInterstitialPage,
+	showMagicLoginRequestForm,
+} from 'state/login/magic-login/actions';
+import Main from 'components/main';
+import RequestLoginEmailForm from '../magic-login/request-login-email-form';
+import { recordTracksEvent } from 'state/analytics/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import GlobalNotices from 'components/global-notices';
+import notices from 'notices';
+import { login } from 'lib/paths';
+
+class MagicLogin extends React.Component {
+	static propTypes = {
+		hideMagicLoginRequestForm: PropTypes.func.isRequired,
+		magicLoginEmailAddress: PropTypes.string,
+		magicLoginEnabled: PropTypes.bool,
+		magicLoginView: PropTypes.string,
+		recordTracksEvent: PropTypes.func.isRequired,
+		showMagicLoginInterstitialPage: PropTypes.func.isRequired,
+		showMagicLoginRequestForm: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	onClickEnterPasswordInstead = event => {
+		event.preventDefault();
+		this.props.recordTracksEvent( 'calypso_login_enter_password_instead_click' );
+
+		page( login() );
+	};
+
+	magicLoginMainContent() {
+		const {
+			magicLoginView,
+			magicLoginEmailAddress,
+		} = this.props;
+
+		switch ( magicLoginView ) {
+			case LINK_EXPIRED_PAGE:
+				this.props.recordTracksEvent( 'calypso_login_magic_link_expired_link_view' );
+				return <EmailedLoginLinkExpired />;
+			case CHECK_YOUR_EMAIL_PAGE:
+				this.props.recordTracksEvent( 'calypso_login_magic_link_link_sent_view' );
+				return <EmailedLoginLinkSuccessfully emailAddress={ magicLoginEmailAddress } />;
+			case INTERSTITIAL_PAGE:
+				this.props.recordTracksEvent( 'calypso_login_magic_link_interstitial_view' );
+				return <HandleEmailedLinkForm />;
+		}
+	}
+
+	componentWillMount() {
+		const {
+			magicLoginEnabled,
+			queryArguments,
+		} = this.props;
+
+		if ( magicLoginEnabled && queryArguments && queryArguments.action === 'handleLoginEmail' ) {
+			this.props.showMagicLoginInterstitialPage();
+		}
+	}
+
+	render() {
+		const {
+			translate,
+		} = this.props;
+
+		return (
+			<Main className="wp-login">
+				<PageViewTracker path="/login" title="Login" />
+
+				<GlobalNotices id="notices" notices={ notices.list } />
+
+				{ this.magicLoginMainContent() || (
+					<div>
+						<div className="wp-login__container">
+							<RequestLoginEmailForm />
+						</div>
+						<div className="wp-login__footer">
+							<a href="#"
+								key="enter-password-link"
+								onClick={ this.onClickEnterPasswordInstead }>
+								{ translate( 'Enter a password instead' ) }
+							</a>
+						</div>
+					</div>
+				) }
+			</Main>
+		);
+	}
+}
+
+const mapState = state => {
+	const magicLoginEnabled = isEnabled( 'magic-login' );
+	return {
+		magicLoginEnabled,
+		magicLoginEmailAddress: getMagicLoginEmailAddressFormInput( state ),
+		magicLoginView: magicLoginEnabled ? getMagicLoginCurrentView( state ) : null,
+		queryArguments: getCurrentQueryArguments( state ),
+	};
+};
+
+const mapDispatch = {
+	hideMagicLoginRequestForm,
+	showMagicLoginInterstitialPage,
+	showMagicLoginRequestForm,
+	recordTracksEvent,
+};
+
+export default connect( mapState, mapDispatch )( localize( MagicLogin ) );


### PR DESCRIPTION
This pull request is an example of how the logic for displaying the magic login pages can be extracted from the existing `Login` component. The idea is to reduce the size of the latter and better separate concerns, as well as introducing a specific route for the magic login pages.

This is mostly for @jblz, let me know what you think of this approach :).
 
#### Testing instructions
 
1. Run `git checkout try/decouple-login` and start your server, or open a [live branch](https://calypso.live/?branch=try/decouple-login)
2. Open the [`Magic Login` page](http://calypso.localhost:3000/login/link)
3. Check that everything works as before