### PR TITLE
SiteSelector: Remove selector state binding

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -55,15 +55,15 @@ export default React.createClass( {
 	},
 
 	onSelect( event ) {
-		this.props.onSelect( event, this.props.site.slug );
+		this.props.onSelect( event, this.props.site.ID );
 	},
 
 	onMouseEnter( event ) {
-		this.props.onMouseEnter( event, this.props.site.slug );
+		this.props.onMouseEnter( event, this.props.site.ID );
 	},
 
 	onMouseLeave( event ) {
-		this.props.onMouseLeave( event, this.props.site.slug );
+		this.props.onMouseLeave( event, this.props.site.ID );
 	},
 
 	render() {

--- a/client/components/search-sites/index.js
+++ b/client/components/search-sites/index.js
@@ -28,8 +28,6 @@ export default function searchSites( WrappedComponent ) {
 		WrappedComponent.name || '';
 
 	class Searcher extends Component {
-		static displayName = `SearchSites(${ componentName })`;
-
 		state = { term: null };
 
 		setSearchTerm = ( term ) => this.setState( { term } );
@@ -50,5 +48,7 @@ export default function searchSites( WrappedComponent ) {
 		}
 	}
 
-	return connect( mapState )( Searcher );
+	const Connected = connect( mapState )( Searcher );
+	Connected.displayName = `SearchSites(${ componentName })`;
+	return Connected;
 }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -9,6 +9,7 @@ import page from 'page';
 import classNames from 'classnames';
 import {
 	filter,
+	flow,
 	get,
 	includes,
 	keyBy,
@@ -449,7 +450,7 @@ class SiteSelector extends Component {
 	}
 }
 
-export default connect( ( state ) => {
+const mapState = ( state ) => {
 	const user = getCurrentUser( state );
 	const visibleSiteCount = get( user, 'visible_site_count', 0 );
 
@@ -465,4 +466,10 @@ export default connect( ( state ) => {
 		allSitesSingleUser: areAllSitesSingleUser( state ),
 		isRequestingMissingSites: isRequestingMissingSites( state ),
 	};
-} )( searchSites( localize( SiteSelector ) ) );
+};
+
+export default flow(
+	localize,
+	searchSites,
+	connect( mapState )
+)( SiteSelector );


### PR DESCRIPTION
Part of #14024 

Also **fixes keyboard navigation** in SiteSelector, a feature knowingly broken in #13094 and introduced in #5808.

# Testing

Try to switch sites, select all sites, etc., in different Calypso sections. Try to switch sites with the mouse, the keyboard, both. Site switching should continue to work as expected; keyboard navigation should now be working properly, e.g.:
- open the site switcher
- hover the mouse over a site; the site should become highlighted
- without further moving the mouse, navigate up or down with the keyboard
- the highlighting should move up or down starting from the previously highlighted site