### PR TITLE
Sites: Don't bind selectors to state

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -13,7 +13,7 @@ import Main from 'components/main';
 import observe from 'lib/mixins/data-observe';
 import SiteSelector from 'components/site-selector';
 import { addSiteFragment } from 'lib/route';
-import { getSites, isSiteUpgradeable } from 'state/selectors';
+import { getSites } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
 export const Sites = React.createClass( {
@@ -47,7 +47,7 @@ export const Sites = React.createClass( {
 
 		// Filter out sites with no upgrades on particular routes
 		if ( /^\/domains/.test( path ) || /^\/plans/.test( this.props.sourcePath ) ) {
-			return this.props.isSiteUpgradeable( site.ID );
+			return site.isSiteUpgradeable;
 		}
 
 		return site;
@@ -103,7 +103,6 @@ export default connect(
 		return {
 			selectedSite: getSelectedSite( state ),
 			sites: getSites( state ),
-			isSiteUpgradeable: isSiteUpgradeable.bind( null, state ),
 		};
 	}
 )( Sites );

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -47,7 +47,7 @@ export const Sites = React.createClass( {
 
 		// Filter out sites with no upgrades on particular routes
 		if ( /^\/domains/.test( path ) || /^\/plans/.test( this.props.sourcePath ) ) {
-			return site.isSiteUpgradeable;
+			return site.isSiteUpgradeable !== false;
 		}
 
 		return site;

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -47,7 +47,7 @@ export const Sites = React.createClass( {
 
 		// Filter out sites with no upgrades on particular routes
 		if ( /^\/domains/.test( path ) || /^\/plans/.test( this.props.sourcePath ) ) {
-			return site.isSiteUpgradeable !== false;
+			return ! site.isJetpack || site.isSiteUpgradable;
 		}
 
 		return site;

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -32,6 +32,7 @@ import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/map
 import versionCompare from 'lib/version-compare';
 import getComputedAttributes from 'lib/site/computed-attributes';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
+import { isSiteUpgradeable } from 'state/selectors';
 
 /**
  * Returns a raw site object by its ID.
@@ -102,6 +103,7 @@ export function getJetpackComputedAttributes( state, siteId ) {
 		canManage: canJetpackSiteManage( state, siteId ),
 		isMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
 		isSecondaryNetworkSite: isJetpackSiteSecondaryNetworkSite( state, siteId ),
+		isSiteUpgradeable: isSiteUpgradeable( state, siteId ),
 	};
 }
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3276,6 +3276,14 @@ describe( 'selectors', () => {
 	describe( 'getJetpackComputedAttributes()', () => {
 		it( 'should return undefined attributes if a site is not Jetpack', () => {
 			const state = {
+				currentUser: {
+					id: 73705554,
+					capabilities: {
+						77203074: {
+							manage_options: false
+						}
+					}
+				},
 				sites: {
 					items: {
 						77203074: {
@@ -3293,10 +3301,19 @@ describe( 'selectors', () => {
 			expect( noNewAttributes.canManage ).to.equal( undefined );
 			expect( noNewAttributes.isMainNetworkSite ).to.equal( undefined );
 			expect( noNewAttributes.isSecondaryNetworkSite ).to.equal( undefined );
+			expect( noNewAttributes.isSiteUpgradeable ).to.equal( undefined );
 		} );
 
 		it( 'should return exists for attributes if a site is Jetpack', () => {
 			const state = {
+				currentUser: {
+					id: 73705554,
+					capabilities: {
+						77203074: {
+							manage_options: false
+						}
+					}
+				},
 				sites: {
 					items: {
 						77203074: {
@@ -3313,6 +3330,7 @@ describe( 'selectors', () => {
 			expect( noNewAttributes.canManage ).to.have.property;
 			expect( noNewAttributes.isMainNetworkSite ).to.have.property;
 			expect( noNewAttributes.isSecondaryNetworkSite ).to.have.property;
+			expect( noNewAttributes.isSiteUpgradeable ).to.have.property;
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of #14024 

This PR seeks to remove

```js
export default connect(
  ( state ) => ( {
    isSiteUpgradeable: isSiteUpgradeable.bind( null, state ),
  } )
)( Sites );
```

from `my-sites/sites`. @tyxla: You've been working a lot with Jetpack and capabilities, do you have recommendations on how to approach this? `Sites` passes a `filter` function prop to `SiteSelector`, which calls it to filter all site objects. How _wrong_ would it be to inspect the site objects instead of calling the selector?