### PR TITLE
Remove unused method from SiteRedirect component

### DIFF
--- a/client/my-sites/upgrades/domain-search/site-redirect.jsx
+++ b/client/my-sites/upgrades/domain-search/site-redirect.jsx
@@ -46,10 +46,6 @@ class SiteRedirect extends Component {
 		}
 	}
 
-	handleBackToDomainSearch() {
-		page( '/domains/add/' + this.props.selectedSiteSlug );
-	}
-
 	render() {
 		const {
 			cart,


### PR DESCRIPTION
Removing the `handleBackToDomainSearch` method, as it's already defined as a class property. Probably an oversight when migrating to ES6 classes.

Discovered by automated `codemod` script that looks for suspicious React event handlers.