### PR TITLE
Convert the addToCartAndRedirect event handler to class property in CartPlanAd

### DIFF
--- a/client/my-sites/upgrades/cart/cart-plan-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-ad.jsx
@@ -18,7 +18,7 @@ import * as upgradesActions from 'lib/upgrades/actions';
 import { PLAN_PREMIUM } from 'lib/plans/constants';
 
 class CartPlanAd extends Component {
-	addToCartAndRedirect( event ) {
+	addToCartAndRedirect = ( event ) => {
 		event.preventDefault();
 		upgradesActions.addItem( cartItems.premiumPlan( PLAN_PREMIUM, { isFreeTrial: false } ) );
 		page( '/checkout/' + this.props.selectedSite.slug );


### PR DESCRIPTION
If the handler is defined as a class method, it has a wrong `this` binding when called as an `onClick` handler. Converted to a class property with arrow fn value -- avoids a `ReferenceError`.

I don't know how to make the `CartPlanAd` component to appear and how to test the fix -- I discovered it by running an automated code-analysis script. @aidvu, can you please help me with testing?

I discovered this with an automated `codemod` script that checks React event handlers. @markryall  and @dzver might be interested, as they found and fixed a similar bug recently.