### PR TITLE
Convert the clickNoManageItem event handler to class property in PluginItem

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -206,7 +206,7 @@ class PluginItem extends Component {
 		return null;
 	}
 
-	clickNoManageItem() {
+	clickNoManageItem = () => {
 		this.setState( { clicked: true } );
 	}
 


### PR DESCRIPTION
If the handler is defined as a class method, it has a wrong `this` binding when called as an `onClick` handler. Converted to a class property with arrow fn value to prevent `ReferenceError`.

I don't know how to make the `Plugin` component to appear and how to test the fix -- I discovered it by running an automated code-analysis script. @enejb , can you please help me with testing?

I discovered this with an automated `codemod` script that checks React event handlers. @markryall  and @dzver might be interested, as they found and fixed a similar bug recently.