### PR TITLE
Ads: ES6ify earnings form

### DIFF
--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -155,7 +155,7 @@ class AdsFormEarnings extends Component {
 		const { translate } = this.props;
 		const owed = this.state.earnings && this.state.earnings.total_amount_owed ? this.state.earnings.total_amount_owed : '0.00',
 			notice = translate(
-				'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment.' +
+				'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment. ' +
 				'Payment will be made as soon as the total outstanding amount has reached $100.',
 				{
 					comment: 'Insufficient balance for payout.',
@@ -171,7 +171,7 @@ class AdsFormEarnings extends Component {
 			);
 
 		return (
-			<div className="module-content-text module-content-text-info">
+			<div className="ads__module-content-text module-content-text module-content-text-info">
 				<p>{ owed < 100 ? notice : payout }</p>
 			</div>
 		);
@@ -181,24 +181,24 @@ class AdsFormEarnings extends Component {
 		const { translate } = this.props;
 
 		return (
-			<div className="module-content-text module-content-text-info">
+			<div className="ads__module-content-text module-content-text module-content-text-info">
 				<p>{ translate( 'Payments can have the following statuses:' ) }</p>
-				<ul className="earnings_history__statuses-list">
-					<li className="earnings_history__status"><strong>{ translate( 'Unpaid:' ) } </strong>
+				<ul className="ads__earnings-history-statuses-list">
+					<li className="ads__earnings-history-status"><strong>{ translate( 'Unpaid:' ) } </strong>
 						{ translate( 'Payment is on hold until the end of the current month.' ) }
 					</li>
-					<li className="earnings_history__status"><strong>{ translate( 'Paid:' ) } </strong>
+					<li className="ads__earnings-history-status"><strong>{ translate( 'Paid:' ) } </strong>
 						{ translate( 'Payment has been processed through PayPal.' ) }
 					</li>
-					<li className="earnings_history__status"><strong>{ translate( 'Pending (Missing Tax Info):' ) } </strong>
+					<li className="ads__earnings-history-status"><strong>{ translate( 'Pending (Missing Tax Info):' ) } </strong>
 						{ translate(
-							'Payment is pending due to missing information.' +
+							'Payment is pending due to missing information. ' +
 							'You can provide tax information in the settings screen.'
 						) }
 					</li>
-					<li className="earnings_history__status"><strong>{ translate( 'Pending (Invalid PayPal):' ) } </strong>
+					<li className="ads__earnings-history-status"><strong>{ translate( 'Pending (Invalid PayPal):' ) } </strong>
 						{ translate(
-							'Payment processing has failed due to invalid PayPal address.' +
+							'Payment processing has failed due to invalid PayPal address. ' +
 							'You can correct the PayPal address in the settings screen.'
 						) }
 					</li>
@@ -216,24 +216,24 @@ class AdsFormEarnings extends Component {
 				: 0;
 
 		return (
-			<ul className="earnings_breakdown__list" >
-				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">
+			<ul className="ads__earnings-breakdown-list">
+				<li className="ads__earnings-breakdown-item">
+					<span className="ads__earnings-breakdown-label">
 						{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
 					</span>
-					<span className="earnings_breakdown__value">${ numberFormat( earnings, 2 ) }</span>
+					<span className="ads__earnings-breakdown-value">${ numberFormat( earnings, 2 ) }</span>
 				</li>
-				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">
+				<li className="ads__earnings-breakdown-item">
+					<span className="ads__earnings-breakdown-label">
 						{ translate( 'Total paid', { context: 'Sum of earnings that have been distributed' } ) }
 					</span>
-					<span className="earnings_breakdown__value">${ numberFormat( paid, 2 ) }</span>
+					<span className="ads__earnings-breakdown-value">${ numberFormat( paid, 2 ) }</span>
 				</li>
-				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">
+				<li className="ads__earnings-breakdown-item">
+					<span className="ads__earnings-breakdown-label">
 						{ translate( 'Outstanding amount', { context: 'Sum earnings left unpaid' } ) }
 					</span>
-					<span className="earnings_breakdown__value">${ numberFormat( owed, 2 ) }</span>
+					<span className="ads__earnings-breakdown-value">${ numberFormat( owed, 2 ) }</span>
 				</li>
 			</ul>
 		);
@@ -252,10 +252,10 @@ class AdsFormEarnings extends Component {
 			if ( earnings.hasOwnProperty( period ) ) {
 				rows.push(
 					<tr key={ type + '-' + period }>
-						<td className="earnings-history__value">{ this.swapYearMonth( period ) }</td>
-						<td className="earnings-history__value">${ numberFormat( earnings[ period ].amount, 2 ) }</td>
-						<td className="earnings-history__value">{ earnings[ period ].pageviews }</td>
-						<td className="earnings-history__value">{ this.getStatus( earnings[ period ].status ) }</td>
+						<td className="ads__earnings-history-value">{ this.swapYearMonth( period ) }</td>
+						<td className="ads__earnings-history-value">${ numberFormat( earnings[ period ].amount, 2 ) }</td>
+						<td className="ads__earnings-history-value">{ earnings[ period ].pageviews }</td>
+						<td className="ads__earnings-history-value">{ this.getStatus( earnings[ period ].status ) }</td>
 					</tr>
 				);
 			}
@@ -263,12 +263,12 @@ class AdsFormEarnings extends Component {
 
 		return (
 			<Card className={ classes }>
-				<div className="module-header">
-					<h1 className="module-header-title">{ header_text }</h1>
-					<ul className="module-header-actions">
-						<li className="module-header-action toggle-info">
+				<div className="ads__module-header module-header">
+					<h1 className="ads__module-header-title module-header-title">{ header_text }</h1>
+					<ul className="ads__module-header-actions module-header-actions">
+						<li className="ads__module-header-action module-header-action toggle-info">
 							<a href="#"
-								className="module-header-action-link"
+								className="ads__module-header-action-link module-header-action-link"
 								aria-label={ translate( 'Show or hide panel information' ) }
 								title={ translate( 'Show or hide panel information' ) }
 								onClick={ this.toggleInfo( type ) }>
@@ -277,15 +277,15 @@ class AdsFormEarnings extends Component {
 						</li>
 					</ul>
 				</div>
-				<div className="module-content">
+				<div className="ads__module-content module-content">
 					{ this.infoNotice() }
 					<table>
 						<thead>
 							<tr>
-								<th className="earnings-history__header">{ translate( 'Period' ) }</th>
-								<th className="earnings-history__header">{ translate( 'Earnings' ) }</th>
-								<th className="earnings-history__header">{ translate( 'Ad Impressions' ) }</th>
-								<th className="earnings-history__header">{ translate( 'Status' ) }</th>
+								<th className="ads__earnings-history-header">{ translate( 'Period' ) }</th>
+								<th className="ads__earnings-history-header">{ translate( 'Earnings' ) }</th>
+								<th className="ads__earnings-history-header">{ translate( 'Ad Impressions' ) }</th>
+								<th className="ads__earnings-history-header">{ translate( 'Status' ) }</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -307,12 +307,12 @@ class AdsFormEarnings extends Component {
 		return (
 			<div>
 				<Card className={ classes }>
-					<div className="module-header">
-						<h1 className="module-header-title">{ translate( 'Totals' ) }</h1>
-						<ul className="module-header-actions">
-							<li className="module-header-action toggle-info">
+					<div className="ads__module-header module-header">
+						<h1 className="ads__module-header-title module-header-title">{ translate( 'Totals' ) }</h1>
+						<ul className="ads__module-header-actions module-header-actions">
+							<li className="ads__module-header-action module-header-action toggle-info">
 								<a href="#"
-									className="module-header-action-link"
+									className="ads__module-header-action-link module-header-action-link"
 									aria-label={ translate( 'Show or hide panel information' ) }
 									title={ translate( 'Show or hide panel information' ) }
 									onClick={ this.toggleEarningsNotice } >
@@ -321,7 +321,7 @@ class AdsFormEarnings extends Component {
 							</li>
 						</ul>
 					</div>
-					<div className="module-content">
+					<div className="ads__module-content module-content">
 						{ this.payoutNotice() }
 						{ this.earningsBreakdown() }
 					</div>

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -30,10 +30,6 @@ class AdsFormEarnings extends Component {
 		EarningsStore.removeListener( 'change', this.updateSettings );
 	}
 
-	updateSettings() {
-		this.setState( this.getSettingsFromStore() );
-	}
-
 	componentDidUpdate() {
 		if ( this.state.error && this.state.error.message ) {
 			notices.error( this.state.error.message );
@@ -98,6 +94,10 @@ class AdsFormEarnings extends Component {
 			WordadsActions.fetchEarnings( site )
 		}, 0 );
 	}
+
+	updateSettings = () => {
+		this.setState( this.getSettingsFromStore() );
+	};
 
 	toggleEarningsNotice = ( event ) => {
 		event.preventDefault();

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import notices from 'notices';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -142,27 +143,29 @@ class AdsFormEarnings extends Component {
 	}
 
 	getStatus( status ) {
+		const { translate } = this.props;
 		var statuses = {
-			0: this.translate( 'Unpaid' ),
-			1: this.translate( 'Paid' ),
-			2: this.translate( 'a8c-only' ),
-			3: this.translate( 'Pending (Missing Tax Info)' ),
-			4: this.translate( 'Pending (Invalid PayPal)' )
+			0: translate( 'Unpaid' ),
+			1: translate( 'Paid' ),
+			2: translate( 'a8c-only' ),
+			3: translate( 'Pending (Missing Tax Info)' ),
+			4: translate( 'Pending (Invalid PayPal)' )
 		}
 
 		return statuses[ status ] ? statuses[ status ] : '?';
 	}
 
 	payoutNotice() {
+		const { translate } = this.props;
 		var owed = this.state.earnings && this.state.earnings.total_amount_owed ? this.state.earnings.total_amount_owed : '0.00',
-			notice = this.translate(
+			notice = translate(
 				'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment. Payment will be made as soon as the total outstanding amount has reached $100.',
 				{
 					comment: 'Insufficient balance for payout.',
 					args: { amountOwed: owed }
 				}
 			),
-			payout = this.translate(
+			payout = translate(
 				'Outstanding amount of $%(amountOwed)s will be paid by the last business day of the month.',
 				{
 					comment: 'Payout will proceed.',
@@ -178,21 +181,23 @@ class AdsFormEarnings extends Component {
 	}
 
 	infoNotice() {
+		const { translate } = this.props;
+
 		return (
 			<div className="module-content-text module-content-text-info">
-				<p>{ this.translate( 'Payments can have the following statuses:' ) }</p>
+				<p>{ translate( 'Payments can have the following statuses:' ) }</p>
 				<ul className="earnings_history__statuses-list">
-					<li className="earnings_history__status"><strong>{ this.translate( 'Unpaid:' ) } </strong>
-						{ this.translate( 'Payment is on hold until the end of the current month.' ) }
+					<li className="earnings_history__status"><strong>{ translate( 'Unpaid:' ) } </strong>
+						{ translate( 'Payment is on hold until the end of the current month.' ) }
 					</li>
-					<li className="earnings_history__status"><strong>{ this.translate( 'Paid:' ) } </strong>
-						{ this.translate( 'Payment has been processed through PayPal.' ) }
+					<li className="earnings_history__status"><strong>{ translate( 'Paid:' ) } </strong>
+						{ translate( 'Payment has been processed through PayPal.' ) }
 					</li>
-					<li className="earnings_history__status"><strong>{ this.translate( 'Pending (Missing Tax Info):' ) } </strong>
-						{ this.translate( 'Payment is pending due to missing information. You can provide tax information in the settings screen.' ) }
+					<li className="earnings_history__status"><strong>{ translate( 'Pending (Missing Tax Info):' ) } </strong>
+						{ translate( 'Payment is pending due to missing information. You can provide tax information in the settings screen.' ) }
 					</li>
-					<li className="earnings_history__status"><strong>{ this.translate( 'Pending (Invalid PayPal):' ) } </strong>
-						{ this.translate( 'Payment processing has failed due to invalid PayPal address. You can correct the PayPal address in the settings screen.' ) }
+					<li className="earnings_history__status"><strong>{ translate( 'Pending (Invalid PayPal):' ) } </strong>
+						{ translate( 'Payment processing has failed due to invalid PayPal address. You can correct the PayPal address in the settings screen.' ) }
 					</li>
 				</ul>
 			</div>
@@ -200,6 +205,7 @@ class AdsFormEarnings extends Component {
 	}
 
 	earningsBreakdown() {
+		const { numberFormat, translate } = this.props;
 		var earnings = this.state.earnings && this.state.earnings.total_earnings ? Number( this.state.earnings.total_earnings ) : 0,
 			owed = this.state.earnings && this.state.earnings.total_amount_owed ? Number( this.state.earnings.total_amount_owed ) : 0,
 			paid = this.state.earnings && this.state.earnings.total_earnings && this.state.earnings.total_amount_owed ?
@@ -208,22 +214,23 @@ class AdsFormEarnings extends Component {
 		return (
 			<ul className="earnings_breakdown__list" >
 				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">{ this.translate( 'Total earnings', { context: 'Sum of earnings' } ) }</span>
-					<span className="earnings_breakdown__value">${ this.numberFormat( earnings, 2 ) }</span>
+					<span className="earnings_breakdown__label">{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }</span>
+					<span className="earnings_breakdown__value">${ numberFormat( earnings, 2 ) }</span>
 				</li>
 				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">{ this.translate( 'Total paid', { context: 'Sum of earnings that have been distributed' } ) }</span>
-					<span className="earnings_breakdown__value">${ this.numberFormat( paid, 2 ) }</span>
+					<span className="earnings_breakdown__label">{ translate( 'Total paid', { context: 'Sum of earnings that have been distributed' } ) }</span>
+					<span className="earnings_breakdown__value">${ numberFormat( paid, 2 ) }</span>
 				</li>
 				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">{ this.translate( 'Outstanding amount', { context: 'Sum earnings left unpaid' } ) }</span>
-					<span className="earnings_breakdown__value">${ this.numberFormat( owed, 2 ) }</span>
+					<span className="earnings_breakdown__label">{ translate( 'Outstanding amount', { context: 'Sum earnings left unpaid' } ) }</span>
+					<span className="earnings_breakdown__value">${ numberFormat( owed, 2 ) }</span>
 				</li>
 			</ul>
 		);
 	}
 
 	earningsTable( earnings, header_text, type ) {
+		const { numberFormat, translate } = this.props;
 		var period,
 			rows = [],
 			infoIcon = this.getInfoToggle( type ) ? 'info' : 'info-outline',
@@ -236,7 +243,7 @@ class AdsFormEarnings extends Component {
 				rows.push(
 					<tr key={ type + '-' + period }>
 						<td className="earnings-history__value">{ this.swapYearMonth( period ) }</td>
-						<td className="earnings-history__value">${ this.numberFormat( earnings[ period ].amount, 2 ) }</td>
+						<td className="earnings-history__value">${ numberFormat( earnings[ period ].amount, 2 ) }</td>
 						<td className="earnings-history__value">{ earnings[ period ].pageviews }</td>
 						<td className="earnings-history__value">{ this.getStatus( earnings[ period ].status ) }</td>
 					</tr>
@@ -252,8 +259,8 @@ class AdsFormEarnings extends Component {
 						<li className="module-header-action toggle-info">
 							<a href="#"
 								className="module-header-action-link"
-								aria-label={ this.translate( 'Show or hide panel information' ) }
-								title={ this.translate( 'Show or hide panel information' ) }
+								aria-label={ translate( 'Show or hide panel information' ) }
+								title={ translate( 'Show or hide panel information' ) }
 								onClick={ this.toggleInfo.bind( this, type ) }>
 								<Gridicon icon={ infoIcon } />
 							</a>
@@ -265,10 +272,10 @@ class AdsFormEarnings extends Component {
 					<table>
 						<thead>
 							<tr>
-								<th className="earnings-history__header">{ this.translate( 'Period' ) }</th>
-								<th className="earnings-history__header">{ this.translate( 'Earnings' ) }</th>
-								<th className="earnings-history__header">{ this.translate( 'Ad Impressions' ) }</th>
-								<th className="earnings-history__header">{ this.translate( 'Status' ) }</th>
+								<th className="earnings-history__header">{ translate( 'Period' ) }</th>
+								<th className="earnings-history__header">{ translate( 'Earnings' ) }</th>
+								<th className="earnings-history__header">{ translate( 'Ad Impressions' ) }</th>
+								<th className="earnings-history__header">{ translate( 'Status' ) }</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -281,6 +288,7 @@ class AdsFormEarnings extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
 		var infoIcon = this.state.showEarningsNotice ? 'info' : 'info-outline',
 			classes = classNames( 'earnings_breakdown', {
 				'is-showing-info': this.state.showEarningsNotice
@@ -290,13 +298,13 @@ class AdsFormEarnings extends Component {
 			<div>
 				<Card className={ classes }>
 					<div className="module-header">
-						<h1 className="module-header-title">{ this.translate( 'Totals' ) }</h1>
+						<h1 className="module-header-title">{ translate( 'Totals' ) }</h1>
 						<ul className="module-header-actions">
 							<li className="module-header-action toggle-info">
 								<a href="#"
 									className="module-header-action-link"
-									aria-label={ this.translate( 'Show or hide panel information' ) }
-									title={ this.translate( 'Show or hide panel information' ) }
+									aria-label={ translate( 'Show or hide panel information' ) }
+									title={ translate( 'Show or hide panel information' ) }
 									onClick={ this.toggleEarningsNotice } >
 									<Gridicon icon={ infoIcon } />
 								</a>
@@ -309,15 +317,15 @@ class AdsFormEarnings extends Component {
 					</div>
 				</Card>
 				{ this.state.earnings && this.checkSize( this.state.earnings.wordads ) ?
-					this.earningsTable( this.state.earnings.wordads, this.translate( 'Earnings History' ), 'wordads' ) :
+					this.earningsTable( this.state.earnings.wordads, translate( 'Earnings History' ), 'wordads' ) :
 					null
 				}
 				{ this.state.earnings && this.checkSize( this.state.earnings.sponsored ) ?
-					this.earningsTable( this.state.earnings.sponsored, this.translate( 'Sponsored Content History' ), 'sponsored' ) :
+					this.earningsTable( this.state.earnings.sponsored, translate( 'Sponsored Content History' ), 'sponsored' ) :
 					null
 				}
 				{ this.state.earnings && this.checkSize( this.state.earnings.adjustment ) ?
-					this.earningsTable( this.state.earnings.adjustment, this.translate( 'Adjustments History' ), 'adjustment' ) :
+					this.earningsTable( this.state.earnings.adjustment, translate( 'Adjustments History' ), 'adjustment' ) :
 					null
 				}
 			</div>
@@ -325,4 +333,4 @@ class AdsFormEarnings extends Component {
 	}
 }
 
-export default AdsFormEarnings;
+export default localize( AdsFormEarnings );

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -58,7 +58,7 @@ class AdsFormEarnings extends Component {
 	}
 
 	resetState() {
-		this.replaceState( {
+		this.setState( {
 			earnings: {
 				adjustment: {},
 				sponsored: {},

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -19,7 +19,7 @@ class AdsFormEarnings extends Component {
 
 	componentWillMount() {
 		EarningsStore.on( 'change', this.updateSettings );
-		this._fetchIfEmpty();
+		this.fetchIfEmpty();
 	}
 
 	componentWillUnmount() {
@@ -40,7 +40,7 @@ class AdsFormEarnings extends Component {
 		}
 
 		if ( this.props.site.ID !== nextProps.site.ID ) {
-			this._fetchIfEmpty( nextProps.site );
+			this.fetchIfEmpty( nextProps.site );
 			this.setState( this.getSettingsFromStore( nextProps.site ) );
 		}
 	}
@@ -75,7 +75,7 @@ class AdsFormEarnings extends Component {
 		} );
 	}
 
-	_fetchIfEmpty( site ) {
+	fetchIfEmpty( site ) {
 		site = site || this.props.site;
 		if ( ! site || ! site.ID ) {
 			return;

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -252,9 +252,8 @@ class AdsFormEarnings extends Component {
 			classes = classNames( 'earnings_history', {
 				'is-showing-info': this.getInfoToggle( type )
 			} );
-		let period;
 
-		for ( period in earnings ) {
+		for ( const period in earnings ) {
 			if ( earnings.hasOwnProperty( period ) ) {
 				rows.push(
 					<tr key={ type + '-' + period }>

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -100,7 +100,7 @@ class AdsFormEarnings extends Component {
 		this.setState( { showEarningsNotice: ! this.state.showEarningsNotice } );
 	};
 
-	toggleInfo = ( type, event ) => {
+	toggleInfo = ( type ) => ( event ) => {
 		event.preventDefault();
 		switch ( type ) {
 			case 'wordads':
@@ -271,7 +271,7 @@ class AdsFormEarnings extends Component {
 								className="module-header-action-link"
 								aria-label={ translate( 'Show or hide panel information' ) }
 								title={ translate( 'Show or hide panel information' ) }
-								onClick={ this.toggleInfo.bind( this, type ) }>
+								onClick={ this.toggleInfo( type ) }>
 								<Gridicon icon={ infoIcon } />
 							</a>
 						</li>

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -95,12 +95,12 @@ class AdsFormEarnings extends Component {
 		this.setState( this.getSettingsFromStore() );
 	};
 
-	toggleEarningsNotice = ( event ) => {
+	handleEarningsNoticeToggle = ( event ) => {
 		event.preventDefault();
 		this.setState( { showEarningsNotice: ! this.state.showEarningsNotice } );
 	};
 
-	toggleInfo = ( type ) => ( event ) => {
+	handleInfoToggle = ( type ) => ( event ) => {
 		event.preventDefault();
 		switch ( type ) {
 			case 'wordads':
@@ -271,7 +271,7 @@ class AdsFormEarnings extends Component {
 								className="ads__module-header-action-link module-header-action-link"
 								aria-label={ translate( 'Show or hide panel information' ) }
 								title={ translate( 'Show or hide panel information' ) }
-								onClick={ this.toggleInfo( type ) }>
+								onClick={ this.handleInfoToggle( type ) }>
 								<Gridicon icon={ infoIcon } />
 							</a>
 						</li>
@@ -315,7 +315,7 @@ class AdsFormEarnings extends Component {
 									className="ads__module-header-action-link module-header-action-link"
 									aria-label={ translate( 'Show or hide panel information' ) }
 									title={ translate( 'Show or hide panel information' ) }
-									onClick={ this.toggleEarningsNotice } >
+									onClick={ this.handleEarningsNoticeToggle } >
 									<Gridicon icon={ infoIcon } />
 								</a>
 							</li>

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -17,20 +17,20 @@ module.exports = React.createClass( {
 
 	displayName: 'AdsFormEarnings',
 
-	componentWillMount: function() {
+	componentWillMount() {
 		EarningsStore.on( 'change', this.updateSettings );
 		this._fetchIfEmpty();
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		EarningsStore.removeListener( 'change', this.updateSettings );
 	},
 
-	updateSettings: function() {
+	updateSettings() {
 		this.setState( this.getSettingsFromStore() );
 	},
 
-	componentDidUpdate: function() {
+	componentDidUpdate() {
 		if ( this.state.error && this.state.error.message ) {
 			notices.error( this.state.error.message );
 		} else {
@@ -38,7 +38,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( ! EarningsStore.getById( nextProps.site.ID ).earnings ) {
 			this.resetState();
 		}
@@ -49,11 +49,11 @@ module.exports = React.createClass( {
 		}
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return this.getSettingsFromStore();
 	},
 
-	getSettingsFromStore: function( siteInstance ) {
+	getSettingsFromStore( siteInstance ) {
 		var site = siteInstance || this.props.site,
 			store = EarningsStore.getById( site.ID ) || {};
 
@@ -65,7 +65,7 @@ module.exports = React.createClass( {
 		return store;
 	},
 
-	resetState: function() {
+	resetState() {
 		this.replaceState( {
 			earnings: {
 				adjustment: {},
@@ -83,7 +83,7 @@ module.exports = React.createClass( {
 		} );
 	},
 
-	_fetchIfEmpty: function( site ) {
+	_fetchIfEmpty( site ) {
 		site = site || this.props.site;
 		if ( ! site || ! site.ID ) {
 			return;
@@ -94,17 +94,17 @@ module.exports = React.createClass( {
 		}
 
 		// defer fetch requests to avoid dispatcher conflicts
-		setTimeout( function() {
+		setTimeout( () => {
 			WordadsActions.fetchEarnings( site )
 		}, 0 );
 	},
 
-	toggleEarningsNotice: function( event ) {
+	toggleEarningsNotice( event ) {
 		event.preventDefault();
 		this.setState( { showEarningsNotice: ! this.state.showEarningsNotice } );
 	},
 
-	toggleInfo: function( type, event ) {
+	toggleInfo( type, event ) {
 		event.preventDefault();
 		switch ( type ) {
 			case 'wordads':
@@ -119,7 +119,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	getInfoToggle: function( type ) {
+	getInfoToggle( type ) {
 		var types = {
 			wordads: this.state.showWordadsInfo,
 			sponsored: this.state.showSponsoredInfo,
@@ -129,7 +129,7 @@ module.exports = React.createClass( {
 		return types[ type ] ? types[ type ] : false;
 	},
 
-	checkSize: function( obj ) {
+	checkSize( obj ) {
 		if ( ! obj ) {
 			return 0;
 		}
@@ -137,12 +137,12 @@ module.exports = React.createClass( {
 		return Object.keys( obj ).length;
 	},
 
-	swapYearMonth: function( date ) {
+	swapYearMonth( date ) {
 		var splits = date.split( '-' );
 		return splits[ 1 ] + '-' + splits[ 0 ];
 	},
 
-	getStatus: function( status ) {
+	getStatus( status ) {
 		var statuses = {
 			0: this.translate( 'Unpaid' ),
 			1: this.translate( 'Paid' ),
@@ -154,7 +154,7 @@ module.exports = React.createClass( {
 		return statuses[ status ] ? statuses[ status ] : '?';
 	},
 
-	payoutNotice: function() {
+	payoutNotice() {
 		var owed = this.state.earnings && this.state.earnings.total_amount_owed ? this.state.earnings.total_amount_owed : '0.00',
 			notice = this.translate(
 				'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment. Payment will be made as soon as the total outstanding amount has reached $100.',
@@ -178,7 +178,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	infoNotice: function() {
+	infoNotice() {
 		return (
 			<div className="module-content-text module-content-text-info">
 				<p>{ this.translate( 'Payments can have the following statuses:' ) }</p>
@@ -200,7 +200,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	earningsBreakdown: function() {
+	earningsBreakdown() {
 		var earnings = this.state.earnings && this.state.earnings.total_earnings ? Number( this.state.earnings.total_earnings ) : 0,
 			owed = this.state.earnings && this.state.earnings.total_amount_owed ? Number( this.state.earnings.total_amount_owed ) : 0,
 			paid = this.state.earnings && this.state.earnings.total_earnings && this.state.earnings.total_amount_owed ?
@@ -224,7 +224,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	earningsTable: function( earnings, header_text, type ) {
+	earningsTable( earnings, header_text, type ) {
 		var period,
 			rows = [],
 			infoIcon = this.getInfoToggle( type ) ? 'info' : 'info-outline',
@@ -281,7 +281,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		var infoIcon = this.state.showEarningsNotice ? 'info' : 'info-outline',
 			classes = classNames( 'earnings_breakdown', {
 				'is-showing-info': this.state.showEarningsNotice

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -15,11 +15,7 @@ import WordadsActions from 'lib/ads/actions';
 import EarningsStore from 'lib/ads/earnings-store';
 
 class AdsFormEarnings extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = this.getSettingsFromStore();
-	}
+	state = this.getSettingsFromStore();
 
 	componentWillMount() {
 		EarningsStore.on( 'change', this.updateSettings );

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -1,25 +1,23 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	notices = require( 'notices' ),
-	classNames = require( 'classnames' ),
-	debug = require( 'debug' )( 'calypso:my-sites:ads-earnings' );
+import React from 'react';
+import notices from 'notices';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Gridicon = require( 'gridicons' ),
-	WordadsActions = require( 'lib/ads/actions' ),
-	EarningsStore = require( 'lib/ads/earnings-store' );
+import Card from 'components/card';
+import Gridicon from 'gridicons';
+import WordadsActions from 'lib/ads/actions';
+import EarningsStore from 'lib/ads/earnings-store';
 
 module.exports = React.createClass( {
 
 	displayName: 'AdsFormEarnings',
 
 	componentWillMount: function() {
-		debug( 'Mounting ' + this.constructor.displayName + ' React component.' );
 		EarningsStore.on( 'change', this.updateSettings );
 		this._fetchIfEmpty();
 	},
@@ -92,7 +90,6 @@ module.exports = React.createClass( {
 		}
 
 		if ( EarningsStore.getById( site.ID ).earnings ) {
-			debug( 'initial fetch not necessary' );
 			return;
 		}
 

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -17,7 +17,7 @@ import EarningsStore from 'lib/ads/earnings-store';
 class AdsFormEarnings extends Component {
 	state = this.getSettingsFromStore();
 
-	componentWillMount() {
+	componentDidMount() {
 		EarningsStore.on( 'change', this.updateSettings );
 		this.fetchIfEmpty();
 	}

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import notices from 'notices';
 import classNames from 'classnames';
 
@@ -13,22 +13,25 @@ import Gridicon from 'gridicons';
 import WordadsActions from 'lib/ads/actions';
 import EarningsStore from 'lib/ads/earnings-store';
 
-module.exports = React.createClass( {
+class AdsFormEarnings extends Component {
+	constructor( props ) {
+		super( props );
 
-	displayName: 'AdsFormEarnings',
+		this.state = this.getSettingsFromStore();
+	}
 
 	componentWillMount() {
 		EarningsStore.on( 'change', this.updateSettings );
 		this._fetchIfEmpty();
-	},
+	}
 
 	componentWillUnmount() {
 		EarningsStore.removeListener( 'change', this.updateSettings );
-	},
+	}
 
 	updateSettings() {
 		this.setState( this.getSettingsFromStore() );
-	},
+	}
 
 	componentDidUpdate() {
 		if ( this.state.error && this.state.error.message ) {
@@ -36,7 +39,7 @@ module.exports = React.createClass( {
 		} else {
 			notices.clearNotices( 'notices' );
 		}
-	},
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! EarningsStore.getById( nextProps.site.ID ).earnings ) {
@@ -47,11 +50,7 @@ module.exports = React.createClass( {
 			this._fetchIfEmpty( nextProps.site );
 			this.setState( this.getSettingsFromStore( nextProps.site ) );
 		}
-	},
-
-	getInitialState() {
-		return this.getSettingsFromStore();
-	},
+	}
 
 	getSettingsFromStore( siteInstance ) {
 		var site = siteInstance || this.props.site,
@@ -63,7 +62,7 @@ module.exports = React.createClass( {
 		store.showAdjustmentInfo = false;
 
 		return store;
-	},
+	}
 
 	resetState() {
 		this.replaceState( {
@@ -81,7 +80,7 @@ module.exports = React.createClass( {
 			showSponsoredInfo: false,
 			showAdjustmentInfo: false
 		} );
-	},
+	}
 
 	_fetchIfEmpty( site ) {
 		site = site || this.props.site;
@@ -97,14 +96,14 @@ module.exports = React.createClass( {
 		setTimeout( () => {
 			WordadsActions.fetchEarnings( site )
 		}, 0 );
-	},
+	}
 
-	toggleEarningsNotice( event ) {
+	toggleEarningsNotice = ( event ) => {
 		event.preventDefault();
 		this.setState( { showEarningsNotice: ! this.state.showEarningsNotice } );
-	},
+	};
 
-	toggleInfo( type, event ) {
+	toggleInfo = ( type, event ) => {
 		event.preventDefault();
 		switch ( type ) {
 			case 'wordads':
@@ -117,7 +116,7 @@ module.exports = React.createClass( {
 				this.setState( { showAdjustmentInfo: ! this.state.showAdjustmentInfo } );
 				break;
 		}
-	},
+	};
 
 	getInfoToggle( type ) {
 		var types = {
@@ -127,7 +126,7 @@ module.exports = React.createClass( {
 		}
 
 		return types[ type ] ? types[ type ] : false;
-	},
+	}
 
 	checkSize( obj ) {
 		if ( ! obj ) {
@@ -135,12 +134,12 @@ module.exports = React.createClass( {
 		}
 
 		return Object.keys( obj ).length;
-	},
+	}
 
 	swapYearMonth( date ) {
 		var splits = date.split( '-' );
 		return splits[ 1 ] + '-' + splits[ 0 ];
-	},
+	}
 
 	getStatus( status ) {
 		var statuses = {
@@ -152,7 +151,7 @@ module.exports = React.createClass( {
 		}
 
 		return statuses[ status ] ? statuses[ status ] : '?';
-	},
+	}
 
 	payoutNotice() {
 		var owed = this.state.earnings && this.state.earnings.total_amount_owed ? this.state.earnings.total_amount_owed : '0.00',
@@ -176,7 +175,7 @@ module.exports = React.createClass( {
 				<p>{ owed < 100 ? notice : payout }</p>
 			</div>
 		);
-	},
+	}
 
 	infoNotice() {
 		return (
@@ -198,7 +197,7 @@ module.exports = React.createClass( {
 				</ul>
 			</div>
 		);
-	},
+	}
 
 	earningsBreakdown() {
 		var earnings = this.state.earnings && this.state.earnings.total_earnings ? Number( this.state.earnings.total_earnings ) : 0,
@@ -222,7 +221,7 @@ module.exports = React.createClass( {
 				</li>
 			</ul>
 		);
-	},
+	}
 
 	earningsTable( earnings, header_text, type ) {
 		var period,
@@ -279,7 +278,7 @@ module.exports = React.createClass( {
 				</div>
 			</Card>
 		);
-	},
+	}
 
 	render() {
 		var infoIcon = this.state.showEarningsNotice ? 'info' : 'info-outline',
@@ -324,4 +323,6 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default AdsFormEarnings;

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -86,9 +86,7 @@ class AdsFormEarnings extends Component {
 		}
 
 		// defer fetch requests to avoid dispatcher conflicts
-		setTimeout( () => {
-			WordadsActions.fetchEarnings( site );
-		}, 0 );
+		setTimeout( () => WordadsActions.fetchEarnings( site ), 0 );
 	}
 
 	updateSettings = () => {

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -71,7 +71,7 @@ class AdsFormEarnings extends Component {
 			showEarningsNotice: false,
 			showWordadsInfo: false,
 			showSponsoredInfo: false,
-			showAdjustmentInfo: false
+			showAdjustmentInfo: false,
 		} );
 	}
 
@@ -97,20 +97,28 @@ class AdsFormEarnings extends Component {
 
 	handleEarningsNoticeToggle = ( event ) => {
 		event.preventDefault();
-		this.setState( { showEarningsNotice: ! this.state.showEarningsNotice } );
+		this.setState( {
+			showEarningsNotice: ! this.state.showEarningsNotice
+		} );
 	};
 
 	handleInfoToggle = ( type ) => ( event ) => {
 		event.preventDefault();
 		switch ( type ) {
 			case 'wordads':
-				this.setState( { showWordadsInfo: ! this.state.showWordadsInfo } );
+				this.setState( {
+					showWordadsInfo: ! this.state.showWordadsInfo,
+				} );
 				break;
 			case 'sponsored':
-				this.setState( { showSponsoredInfo: ! this.state.showSponsoredInfo } );
+				this.setState( {
+					showSponsoredInfo: ! this.state.showSponsoredInfo,
+				} );
 				break;
 			case 'adjustment':
-				this.setState( { showAdjustmentInfo: ! this.state.showAdjustmentInfo } );
+				this.setState( {
+					showAdjustmentInfo: ! this.state.showAdjustmentInfo,
+				} );
 				break;
 		}
 	};
@@ -145,7 +153,7 @@ class AdsFormEarnings extends Component {
 			1: translate( 'Paid' ),
 			2: translate( 'a8c-only' ),
 			3: translate( 'Pending (Missing Tax Info)' ),
-			4: translate( 'Pending (Invalid PayPal)' )
+			4: translate( 'Pending (Invalid PayPal)' ),
 		};
 
 		return statuses[ status ] ? statuses[ status ] : '?';
@@ -159,14 +167,14 @@ class AdsFormEarnings extends Component {
 				'Payment will be made as soon as the total outstanding amount has reached $100.',
 				{
 					comment: 'Insufficient balance for payout.',
-					args: { amountOwed: owed }
+					args: { amountOwed: owed },
 				}
 			),
 			payout = translate(
 				'Outstanding amount of $%(amountOwed)s will be paid by the last business day of the month.',
 				{
 					comment: 'Payout will proceed.',
-					args: { amountOwed: owed }
+					args: { amountOwed: owed },
 				}
 			);
 

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -46,7 +46,7 @@ class AdsFormEarnings extends Component {
 	}
 
 	getSettingsFromStore( siteInstance ) {
-		var site = siteInstance || this.props.site,
+		const site = siteInstance || this.props.site,
 			store = EarningsStore.getById( site.ID ) || {};
 
 		store.showEarningsNotice = false;
@@ -87,7 +87,7 @@ class AdsFormEarnings extends Component {
 
 		// defer fetch requests to avoid dispatcher conflicts
 		setTimeout( () => {
-			WordadsActions.fetchEarnings( site )
+			WordadsActions.fetchEarnings( site );
 		}, 0 );
 	}
 
@@ -116,11 +116,11 @@ class AdsFormEarnings extends Component {
 	};
 
 	getInfoToggle( type ) {
-		var types = {
+		const types = {
 			wordads: this.state.showWordadsInfo,
 			sponsored: this.state.showSponsoredInfo,
 			adjustment: this.state.showAdjustmentInfo,
-		}
+		};
 
 		return types[ type ] ? types[ type ] : false;
 	}
@@ -134,28 +134,29 @@ class AdsFormEarnings extends Component {
 	}
 
 	swapYearMonth( date ) {
-		var splits = date.split( '-' );
+		const splits = date.split( '-' );
 		return splits[ 1 ] + '-' + splits[ 0 ];
 	}
 
 	getStatus( status ) {
 		const { translate } = this.props;
-		var statuses = {
+		const statuses = {
 			0: translate( 'Unpaid' ),
 			1: translate( 'Paid' ),
 			2: translate( 'a8c-only' ),
 			3: translate( 'Pending (Missing Tax Info)' ),
 			4: translate( 'Pending (Invalid PayPal)' )
-		}
+		};
 
 		return statuses[ status ] ? statuses[ status ] : '?';
 	}
 
 	payoutNotice() {
 		const { translate } = this.props;
-		var owed = this.state.earnings && this.state.earnings.total_amount_owed ? this.state.earnings.total_amount_owed : '0.00',
+		const owed = this.state.earnings && this.state.earnings.total_amount_owed ? this.state.earnings.total_amount_owed : '0.00',
 			notice = translate(
-				'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment. Payment will be made as soon as the total outstanding amount has reached $100.',
+				'Outstanding amount of $%(amountOwed)s does not exceed the minimum $100 needed to make the payment.' +
+				'Payment will be made as soon as the total outstanding amount has reached $100.',
 				{
 					comment: 'Insufficient balance for payout.',
 					args: { amountOwed: owed }
@@ -190,10 +191,16 @@ class AdsFormEarnings extends Component {
 						{ translate( 'Payment has been processed through PayPal.' ) }
 					</li>
 					<li className="earnings_history__status"><strong>{ translate( 'Pending (Missing Tax Info):' ) } </strong>
-						{ translate( 'Payment is pending due to missing information. You can provide tax information in the settings screen.' ) }
+						{ translate(
+							'Payment is pending due to missing information.' +
+							'You can provide tax information in the settings screen.'
+						) }
 					</li>
 					<li className="earnings_history__status"><strong>{ translate( 'Pending (Invalid PayPal):' ) } </strong>
-						{ translate( 'Payment processing has failed due to invalid PayPal address. You can correct the PayPal address in the settings screen.' ) }
+						{ translate(
+							'Payment processing has failed due to invalid PayPal address.' +
+							'You can correct the PayPal address in the settings screen.'
+						) }
 					</li>
 				</ul>
 			</div>
@@ -202,23 +209,30 @@ class AdsFormEarnings extends Component {
 
 	earningsBreakdown() {
 		const { numberFormat, translate } = this.props;
-		var earnings = this.state.earnings && this.state.earnings.total_earnings ? Number( this.state.earnings.total_earnings ) : 0,
+		const earnings = this.state.earnings && this.state.earnings.total_earnings ? Number( this.state.earnings.total_earnings ) : 0,
 			owed = this.state.earnings && this.state.earnings.total_amount_owed ? Number( this.state.earnings.total_amount_owed ) : 0,
-			paid = this.state.earnings && this.state.earnings.total_earnings && this.state.earnings.total_amount_owed ?
-				( this.state.earnings.total_earnings - this.state.earnings.total_amount_owed ) : 0;
+			paid = this.state.earnings && this.state.earnings.total_earnings && this.state.earnings.total_amount_owed
+				? this.state.earnings.total_earnings - this.state.earnings.total_amount_owed
+				: 0;
 
 		return (
 			<ul className="earnings_breakdown__list" >
 				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }</span>
+					<span className="earnings_breakdown__label">
+						{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
+					</span>
 					<span className="earnings_breakdown__value">${ numberFormat( earnings, 2 ) }</span>
 				</li>
 				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">{ translate( 'Total paid', { context: 'Sum of earnings that have been distributed' } ) }</span>
+					<span className="earnings_breakdown__label">
+						{ translate( 'Total paid', { context: 'Sum of earnings that have been distributed' } ) }
+					</span>
 					<span className="earnings_breakdown__value">${ numberFormat( paid, 2 ) }</span>
 				</li>
 				<li className="earnings_breakdown__item">
-					<span className="earnings_breakdown__label">{ translate( 'Outstanding amount', { context: 'Sum earnings left unpaid' } ) }</span>
+					<span className="earnings_breakdown__label">
+						{ translate( 'Outstanding amount', { context: 'Sum earnings left unpaid' } ) }
+					</span>
 					<span className="earnings_breakdown__value">${ numberFormat( owed, 2 ) }</span>
 				</li>
 			</ul>
@@ -227,12 +241,12 @@ class AdsFormEarnings extends Component {
 
 	earningsTable( earnings, header_text, type ) {
 		const { numberFormat, translate } = this.props;
-		var period,
-			rows = [],
+		const rows = [],
 			infoIcon = this.getInfoToggle( type ) ? 'info' : 'info-outline',
 			classes = classNames( 'earnings_history', {
 				'is-showing-info': this.getInfoToggle( type )
 			} );
+		let period;
 
 		for ( period in earnings ) {
 			if ( earnings.hasOwnProperty( period ) ) {
@@ -285,7 +299,7 @@ class AdsFormEarnings extends Component {
 
 	render() {
 		const { translate } = this.props;
-		var infoIcon = this.state.showEarningsNotice ? 'info' : 'info-outline',
+		const infoIcon = this.state.showEarningsNotice ? 'info' : 'info-outline',
 			classes = classNames( 'earnings_breakdown', {
 				'is-showing-info': this.state.showEarningsNotice
 			} );
@@ -312,17 +326,17 @@ class AdsFormEarnings extends Component {
 						{ this.earningsBreakdown() }
 					</div>
 				</Card>
-				{ this.state.earnings && this.checkSize( this.state.earnings.wordads ) ?
-					this.earningsTable( this.state.earnings.wordads, translate( 'Earnings History' ), 'wordads' ) :
-					null
+				{ this.state.earnings && this.checkSize( this.state.earnings.wordads )
+					? this.earningsTable( this.state.earnings.wordads, translate( 'Earnings History' ), 'wordads' )
+					: null
 				}
-				{ this.state.earnings && this.checkSize( this.state.earnings.sponsored ) ?
-					this.earningsTable( this.state.earnings.sponsored, translate( 'Sponsored Content History' ), 'sponsored' ) :
-					null
+				{ this.state.earnings && this.checkSize( this.state.earnings.sponsored )
+					? this.earningsTable( this.state.earnings.sponsored, translate( 'Sponsored Content History' ), 'sponsored' )
+					: null
 				}
-				{ this.state.earnings && this.checkSize( this.state.earnings.adjustment ) ?
-					this.earningsTable( this.state.earnings.adjustment, translate( 'Adjustments History' ), 'adjustment' ) :
-					null
+				{ this.state.earnings && this.checkSize( this.state.earnings.adjustment )
+					? this.earningsTable( this.state.earnings.adjustment, translate( 'Adjustments History' ), 'adjustment' )
+					: null
 				}
 			</div>
 		);

--- a/client/my-sites/ads/style.scss
+++ b/client/my-sites/ads/style.scss
@@ -19,12 +19,12 @@
 	}
 }
 
-.earnings_breakdown__list {
+.ads__earnings-breakdown-list {
 	margin: 0;
 	border-top: 1px solid lighten( $gray, 30% );
 }
 
-.earnings_breakdown__item {
+.ads__earnings-breakdown-item {
 	width: 33%;
 	float: left;
 	padding: 5px 0 10px;
@@ -46,7 +46,7 @@
 	}
 }
 
-.earnings_breakdown__label {
+.ads__earnings-breakdown-label {
 	color: darken( $gray, 30% );
 	font-size: 10px;
 	letter-spacing: 0.1em;
@@ -59,7 +59,7 @@
 	}
 }
 
-.earnings_breakdown__value {
+.ads__earnings-breakdown-value {
 	width: 100%;
 	display: block;
 	font-size: 25px;
@@ -86,16 +86,16 @@
 	}
 }
 
-.module-content-text ul.earnings_history__statuses-list {
+.module-content-text ul.ads__earnings-history-statuses-list {
 	margin: 1em 24px 1em 40px;
 }
 
-.earnings_history__status {
+.ads__earnings-history-status {
 	padding-bottom: 10px;
 	text-align: left;
 }
 
-.earnings-history__header {
+.ads__earnings-history-header {
 	color: $gray;
 	border: 1px solid $gray-light;
 	border-left: none;
@@ -107,7 +107,7 @@
 	text-align: center;
 }
 
-.earnings-history__value {
+.ads__earnings-history-value {
 	line-height: 40px;
 	text-align: center;
 


### PR DESCRIPTION
This PR ES6ifies the ads earnings form and removes all ESLint warnings from it. This will help us do any further modifications without much changes while working on the upcoming ads modifications - https://github.com/Automattic/wp-calypso/milestone/169

There should be no functional, visual or behavioral changes.

To test:
* Checkout this branch
* Go to `/ads/earnings/$site` where `$site` is a Jetpack site with a Premium or Professional plan.
* Verify the earnings are properly listed and there are no visual/behavioral changes.
* Play with the info toggles and verify they work like they did before.
* Switch tabs, change some earnings settings, go back and verify everything works properly.
* Test the above with a WordPress.com site and verify there are no regressions.