### PR TITLE
Ads: ES6ify main component

### DIFF
--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -35,12 +35,12 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 
 class AdsMain extends Component {
 	static propTypes = {
-		site: PropTypes.object.isRequired,
-		requestingWordAdsApproval: PropTypes.bool.isRequired,
-		requestWordAdsApproval: PropTypes.func.isRequired,
 		isRequestingWordadsStatus: PropTypes.bool.isRequired,
 		isUnsafe: PropTypes.oneOf( wordadsUnsafeValues ),
+		requestingWordAdsApproval: PropTypes.bool.isRequired,
+		requestWordAdsApproval: PropTypes.func.isRequired,
 		section: PropTypes.string.isRequired,
+		site: PropTypes.object.isRequired,
 		wordAdsError: PropTypes.string,
 		wordAdsSuccess: PropTypes.bool,
 	};

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { find } from 'lodash';
 import { connect } from 'react-redux';
 
@@ -32,31 +32,28 @@ import { isSiteWordadsUnsafe, isRequestingWordadsStatus } from 'state/wordads/st
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
-const AdsMain = React.createClass( {
+class AdsMain extends Component {
+	static propTypes = {
+		site: PropTypes.object.isRequired,
+		requestingWordAdsApproval: PropTypes.bool.isRequired,
+		requestWordAdsApproval: PropTypes.func.isRequired,
+		isRequestingWordadsStatus: PropTypes.bool.isRequired,
+		isUnsafe: PropTypes.oneOf( wordadsUnsafeValues ),
+		section: PropTypes.string.isRequired,
+		wordAdsError: PropTypes.string,
+		wordAdsSuccess: PropTypes.bool,
+	};
 
-	displayName: 'AdsMain',
-
-	PropTypes: {
-		site: React.PropTypes.object.isRequired,
-		requestingWordAdsApproval: React.PropTypes.bool.isRequired,
-		requestWordAdsApproval: React.PropTypes.func.isRequired,
-		wordAdsError: React.PropTypes.string.isRequired,
-		isRequestingWordadsStatus: React.PropTypes.bool.isRequired,
-		isUnsafe: React.PropTypes.oneOf( wordadsUnsafeValues ),
-		section: React.PropTypes.string.isRequired,
-		wordAdsSuccess: React.PropTypes.bool.isRequired
-	},
-
-	getSelectedText: function() {
+	getSelectedText() {
 		var selected = find( this.getFilters(), { path: this.props.path } );
 		if ( selected ) {
 			return selected.title;
 		}
 
 		return '';
-	},
+	}
 
-	getFilters: function() {
+	getFilters() {
 		const { site, siteSlug } = this.props,
 			pathSuffix = siteSlug ? '/' + siteSlug : '',
 			filters = [];
@@ -76,9 +73,9 @@ const AdsMain = React.createClass( {
 		}
 
 		return filters;
-	},
+	}
 
-	getComponent: function( section ) {
+	getComponent( section ) {
 		switch ( section ) {
 			case 'earnings':
 				return <AdsEarnings site={ this.props.site } />;
@@ -87,14 +84,14 @@ const AdsMain = React.createClass( {
 			default:
 				return null;
 		}
-	},
+	}
 
-	dismissWordAdsError() {
+	dismissWordAdsError = () => {
 		const { siteId } = this.props;
 		this.props.dismissWordAdsError( siteId );
-	},
+	};
 
-	renderInstantActivationToggle: function( component ) {
+	renderInstantActivationToggle( component ) {
 		const { siteId } = this.props;
 		return ( <div>
 			<QueryWordadsStatus siteId={ siteId } />
@@ -175,9 +172,9 @@ const AdsMain = React.createClass( {
 				{ component }
 			</FeatureExample>
 		</div> );
-	},
+	}
 
-	render: function() {
+	render() {
 		let component = this.getComponent( this.props.section );
 		let notice = null;
 
@@ -196,7 +193,7 @@ const AdsMain = React.createClass( {
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>
-						{ this.getFilters().map( function( filterItem ) {
+						{ this.getFilters().map( ( filterItem ) => {
 							return (
 								<NavItem
 									key={ filterItem.id }
@@ -206,7 +203,7 @@ const AdsMain = React.createClass( {
 									{ filterItem.title }
 								</NavItem>
 							);
-						}, this ) }
+						} ) }
 					</NavTabs>
 				</SectionNav>
 				{ notice }
@@ -214,7 +211,7 @@ const AdsMain = React.createClass( {
 			</Main>
 		);
 	}
-} );
+}
 
 const mapStateToProps = ( state ) => {
 	const site = getSelectedSite( state );

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -61,23 +61,21 @@ class AdsMain extends Component {
 			translate
 		} = this.props;
 		const pathSuffix = siteSlug ? '/' + siteSlug : '';
-		const filters = [];
 
-		if ( canAccessWordads( site ) ) {
-			filters.push( {
-				title: translate( 'Earnings' ),
-				path: '/ads/earnings' + pathSuffix,
-				id: 'ads-earnings'
-			} );
-
-			filters.push( {
-				title: translate( 'Settings' ),
-				path: '/ads/settings' + pathSuffix,
-				id: 'ads-settings'
-			} );
-		}
-
-		return filters;
+		return canAccessWordads( site )
+			? [
+				{
+					title: translate( 'Earnings' ),
+					path: '/ads/earnings' + pathSuffix,
+					id: 'ads-earnings'
+				},
+				{
+					title: translate( 'Settings' ),
+					path: '/ads/settings' + pathSuffix,
+					id: 'ads-settings'
+				}
+			]
+			: [];
 	}
 
 	getComponent( section ) {

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { find } from 'lodash';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -54,19 +55,19 @@ class AdsMain extends Component {
 	}
 
 	getFilters() {
-		const { site, siteSlug } = this.props,
+		const { site, siteSlug, translate } = this.props,
 			pathSuffix = siteSlug ? '/' + siteSlug : '',
 			filters = [];
 
 		if ( canAccessWordads( site ) ) {
 			filters.push( {
-				title: this.translate( 'Earnings' ),
+				title: translate( 'Earnings' ),
 				path: '/ads/earnings' + pathSuffix,
 				id: 'ads-earnings'
 			} );
 
 			filters.push( {
-				title: this.translate( 'Settings' ),
+				title: translate( 'Settings' ),
 				path: '/ads/settings' + pathSuffix,
 				id: 'ads-settings'
 			} );
@@ -92,12 +93,12 @@ class AdsMain extends Component {
 	};
 
 	renderInstantActivationToggle( component ) {
-		const { siteId } = this.props;
+		const { siteId, translate } = this.props;
 		return ( <div>
 			<QueryWordadsStatus siteId={ siteId } />
 			<Card className="rads__activate-wrapper">
 				<div className="rads__activate-header">
-					<h2 className="rads__activate-header-title">{ this.translate( 'WordAds Disabled' ) }</h2>
+					<h2 className="rads__activate-header-title">{ translate( 'WordAds Disabled' ) }</h2>
 					<div className="rads__activate-header-toggle">
 						<FormButton
 							disabled={
@@ -108,7 +109,7 @@ class AdsMain extends Component {
 							}
 							onClick={ this.props.requestWordAdsApproval }
 						>
-							{ this.translate( 'Join WordAds' ) }
+							{ translate( 'Join WordAds' ) }
 						</FormButton>
 					</div>
 				</div>
@@ -121,10 +122,10 @@ class AdsMain extends Component {
 					<Notice
 						status="is-warning rads__activate-notice"
 						showDismiss={ false }
-						text={ this.translate( 'Your site has been identified as serving mature content. Our advertisers would like to include only family-friendly sites in the program.' ) }
+						text={ translate( 'Your site has been identified as serving mature content. Our advertisers would like to include only family-friendly sites in the program.' ) }
 					>
 						<NoticeAction href="https://wordads.co/2012/09/06/wordads-is-for-family-safe-sites/" external={ true }>
-							{ this.translate( 'Learn more' ) }
+							{ translate( 'Learn more' ) }
 						</NoticeAction>
 					</Notice>
 				}
@@ -132,7 +133,7 @@ class AdsMain extends Component {
 					<Notice
 						status="is-warning rads__activate-notice"
 						showDismiss={ false }
-						text={ this.translate( 'Your site has been identified as serving automatically created or copied content. We cannot serve WordAds on these kind of sites.' ) }
+						text={ translate( 'Your site has been identified as serving automatically created or copied content. We cannot serve WordAds on these kind of sites.' ) }
 					>
 					</Notice>
 				}
@@ -140,10 +141,10 @@ class AdsMain extends Component {
 					<Notice
 						status="is-warning rads__activate-notice"
 						showDismiss={ false }
-						text={ this.translate( 'Your site is marked as private. It needs to be public so that visitors can see the ads.' ) }
+						text={ translate( 'Your site is marked as private. It needs to be public so that visitors can see the ads.' ) }
 					>
 						<NoticeAction href={ '/settings/general/' + this.props.siteSlug }>
-							{ this.translate( 'Change privacy settings' ) }
+							{ translate( 'Change privacy settings' ) }
 						</NoticeAction>
 					</Notice>
 				}
@@ -151,12 +152,12 @@ class AdsMain extends Component {
 					<Notice
 						status="is-warning rads__activate-notice"
 						showDismiss={ false }
-						text={ this.translate( 'Your site cannot participate in WordAds program.' ) }
+						text={ translate( 'Your site cannot participate in WordAds program.' ) }
 					>
 					</Notice>
 				}
 				<p className="rads__activate-description">
-					{ this.translate(
+					{ translate(
 						'WordAds allows you to make money from advertising that runs on your site. ' +
 						'Because you have a WordPress.com Premium plan, you can skip the review process and activate WordAds instantly. ' +
 						'{{a}}Learn more about the program.{{/a}}', {
@@ -175,13 +176,14 @@ class AdsMain extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
 		let component = this.getComponent( this.props.section );
 		let notice = null;
 
 		if ( this.props.requestingWordAdsApproval || this.props.wordAdsSuccess ) {
 			notice = (
 				<Notice status="is-success" showDismiss={ false }>
-					{ this.translate( 'You have joined the WordAds program. Please review these settings:' ) }
+					{ translate( 'You have joined the WordAds program. Please review these settings:' ) }
 				</Notice>
 			);
 		} else if ( ! this.props.site.options.wordads && isWordadsInstantActivationEligible( this.props.site ) ) {
@@ -243,4 +245,8 @@ const mergeProps = ( stateProps, dispatchProps, parentProps ) => ( {
 	...stateProps
 } );
 
-export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( AdsMain );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+	mergeProps
+)( localize( AdsMain ) );

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:ads-settings' ),
-	find = require( 'lodash/find' );
+import React from 'react';
+import { find } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -46,10 +45,6 @@ const AdsMain = React.createClass( {
 		isUnsafe: React.PropTypes.oneOf( wordadsUnsafeValues ),
 		section: React.PropTypes.string.isRequired,
 		wordAdsSuccess: React.PropTypes.bool.isRequired
-	},
-
-	componentWillMount: function() {
-		debug( 'Mounting AdsMain React component.' );
 	},
 
 	getSelectedText: function() {

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -55,9 +55,13 @@ class AdsMain extends Component {
 	}
 
 	getFilters() {
-		const { site, siteSlug, translate } = this.props,
-			pathSuffix = siteSlug ? '/' + siteSlug : '',
-			filters = [];
+		const {
+			site,
+			siteSlug,
+			translate
+		} = this.props;
+		const pathSuffix = siteSlug ? '/' + siteSlug : '';
+		const filters = [];
 
 		if ( canAccessWordads( site ) ) {
 			filters.push( {
@@ -93,7 +97,11 @@ class AdsMain extends Component {
 	};
 
 	renderInstantActivationToggle( component ) {
-		const { siteId, translate } = this.props;
+		const {
+			siteId,
+			translate
+		} = this.props;
+
 		return ( <div>
 			<QueryWordadsStatus siteId={ siteId } />
 			<Card className="ads__activate-wrapper">

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -87,7 +87,7 @@ class AdsMain extends Component {
 		}
 	}
 
-	dismissWordAdsError = () => {
+	handleDismissWordAdsError = () => {
 		const { siteId } = this.props;
 		this.props.dismissWordAdsError( siteId );
 	};
@@ -114,7 +114,7 @@ class AdsMain extends Component {
 					</div>
 				</div>
 				{ this.props.wordAdsError &&
-					<Notice status="is-error ads__activate-notice" onDismissClick={ this.dismissWordAdsError }>
+					<Notice status="is-error ads__activate-notice" onDismissClick={ this.handleDismissWordAdsError }>
 						{ this.props.wordAdsError }
 					</Notice>
 				}

--- a/client/my-sites/ads/main.jsx
+++ b/client/my-sites/ads/main.jsx
@@ -46,7 +46,7 @@ class AdsMain extends Component {
 	};
 
 	getSelectedText() {
-		var selected = find( this.getFilters(), { path: this.props.path } );
+		const selected = find( this.getFilters(), { path: this.props.path } );
 		if ( selected ) {
 			return selected.title;
 		}
@@ -96,10 +96,10 @@ class AdsMain extends Component {
 		const { siteId, translate } = this.props;
 		return ( <div>
 			<QueryWordadsStatus siteId={ siteId } />
-			<Card className="rads__activate-wrapper">
-				<div className="rads__activate-header">
-					<h2 className="rads__activate-header-title">{ translate( 'WordAds Disabled' ) }</h2>
-					<div className="rads__activate-header-toggle">
+			<Card className="ads__activate-wrapper">
+				<div className="ads__activate-header">
+					<h2 className="ads__activate-header-title">{ translate( 'WordAds Disabled' ) }</h2>
+					<div className="ads__activate-header-toggle">
 						<FormButton
 							disabled={
 								this.props.site.options.wordads ||
@@ -114,15 +114,18 @@ class AdsMain extends Component {
 					</div>
 				</div>
 				{ this.props.wordAdsError &&
-					<Notice status="is-error rads__activate-notice" onDismissClick={ this.dismissWordAdsError }>
+					<Notice status="is-error ads__activate-notice" onDismissClick={ this.dismissWordAdsError }>
 						{ this.props.wordAdsError }
 					</Notice>
 				}
 				{ this.props.isUnsafe === 'mature' &&
 					<Notice
-						status="is-warning rads__activate-notice"
+						status="is-warning ads__activate-notice"
 						showDismiss={ false }
-						text={ translate( 'Your site has been identified as serving mature content. Our advertisers would like to include only family-friendly sites in the program.' ) }
+						text={ translate(
+							'Your site has been identified as serving mature content. ' +
+							'Our advertisers would like to include only family-friendly sites in the program.'
+						) }
 					>
 						<NoticeAction href="https://wordads.co/2012/09/06/wordads-is-for-family-safe-sites/" external={ true }>
 							{ translate( 'Learn more' ) }
@@ -131,15 +134,18 @@ class AdsMain extends Component {
 				}
 				{ this.props.isUnsafe === 'spam' &&
 					<Notice
-						status="is-warning rads__activate-notice"
+						status="is-warning ads__activate-notice"
 						showDismiss={ false }
-						text={ translate( 'Your site has been identified as serving automatically created or copied content. We cannot serve WordAds on these kind of sites.' ) }
+						text={ translate(
+							'Your site has been identified as serving automatically created or copied content. ' +
+							'We cannot serve WordAds on these kind of sites.'
+						) }
 					>
 					</Notice>
 				}
 				{ this.props.isUnsafe === 'private' &&
 					<Notice
-						status="is-warning rads__activate-notice"
+						status="is-warning ads__activate-notice"
 						showDismiss={ false }
 						text={ translate( 'Your site is marked as private. It needs to be public so that visitors can see the ads.' ) }
 					>
@@ -150,13 +156,13 @@ class AdsMain extends Component {
 				}
 				{ this.props.isUnsafe === 'other' &&
 					<Notice
-						status="is-warning rads__activate-notice"
+						status="is-warning ads__activate-notice"
 						showDismiss={ false }
 						text={ translate( 'Your site cannot participate in WordAds program.' ) }
 					>
 					</Notice>
 				}
-				<p className="rads__activate-description">
+				<p className="ads__activate-description">
 					{ translate(
 						'WordAds allows you to make money from advertising that runs on your site. ' +
 						'Because you have a WordPress.com Premium plan, you can skip the review process and activate WordAds instantly. ' +
@@ -191,7 +197,7 @@ class AdsMain extends Component {
 		}
 
 		return (
-			<Main className="rads">
+			<Main className="ads">
 				<SidebarNavigation />
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>

--- a/client/my-sites/ads/style.scss
+++ b/client/my-sites/ads/style.scss
@@ -123,28 +123,28 @@
 	}
 }
 
-.rads__activate-header-title {
+.ads__activate-header-title {
 	font-weight: 600;
 }
 
-.rads__activate-notice {
+.ads__activate-notice {
 	margin: 0;
 }
 
-.rads__activate-header-toggle, .rads__activate-header-title {
+.ads__activate-header-toggle, .ads__activate-header-title {
 	margin: auto 0 auto 0;
 }
-.rads__activate-wrapper {
+.ads__activate-wrapper {
 	padding: 0;
 }
-.rads__activate-header {
+.ads__activate-header {
 	padding: 24px;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 }
 
-.rads__activate-description {
+.ads__activate-description {
 	border-top: 1px solid #e9eff3;
 	padding: 24px;
 }


### PR DESCRIPTION
This PR ES6ifies the main ads component and removes all ESLint warnings from it. This will help us do any further modifications without much changes while working on the upcoming ads modifications - https://github.com/Automattic/wp-calypso/milestone/169

There should be no functional, visual or behavioral changes.

To test:
* Checkout this branch
* Let `$site` is a Jetpack site with a Premium or Professional plan.
* Go to `/ads/earnings/$site` where `$site` is a Jetpack site with a Premium or Professional plan.
* Verify the earnings are properly listed and there are no visual/behavioral changes.
* Play with the info toggles and verify they work like they did before.
* Switch tabs, change some earnings settings, go back and verify everything works properly.
* Go to `/ads/settings/$site` where `$site` is a Jetpack site with a Premium or Professional plan.
* Play with all of the settings and verify there are no regressions or changes to the previous behavior.
* Verify saving and retrieving settings works properly.
* Try requesting approval for ads for a site that previously wasn't approved and verify it works as expected.
* Test the above with a WordPress.com site and verify there are no regressions.