### PR TITLE
Purchases: Remove the v2 design feature flag

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -180,10 +180,6 @@ class ManagePurchase extends Component {
 	}
 
 	renderPlanDetails() {
-		if ( ! config.isEnabled( 'me/purchases-v2' ) ) {
-			return null;
-		}
-
 		return (
 			<PurchasePlanDetails
 				selectedSite={ this.props.selectedSite }

--- a/config/development.json
+++ b/config/development.json
@@ -95,7 +95,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/purchases-v2": true,
 		"me/trophies": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -70,7 +70,6 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
-		"me/purchases-v2": true,
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/12247/commits/457d97119c6a13ff7c20b7b9c50498d611ff6cfe, we added a feature flag to block loading of the product keys until the new purchases design was in place (see #12746). It is now, so we can get rid of this flag.

It was poorly named, so I'm just removing it rather than adding it to the other configs.

To test:

- Make sure the "Plan Details" card appears on Jetpack plan purchases