### PR TITLE
Reader: Treat feeds and sites with no fetch time as stale

### DIFF
--- a/client/state/reader/feeds/selectors.js
+++ b/client/state/reader/feeds/selectors.js
@@ -17,7 +17,7 @@ export function shouldFeedBeFetched( state, feedId ) {
 function isStale( state, feedId ) {
 	const lastFetched = state.reader.feeds.lastFetched[ feedId ];
 	if ( ! lastFetched ) {
-		return false;
+		return true;
 	}
 	return lastFetched <= Date.now() - DAY_IN_MILLIS;
 }

--- a/client/state/reader/feeds/test/selectors.js
+++ b/client/state/reader/feeds/test/selectors.js
@@ -11,76 +11,120 @@ import { shouldFeedBeFetched } from '../selectors';
 describe( 'selectors', () => {
 	describe( 'shouldFeedBeFetched', () => {
 		it( 'should return false if the fetch is queued', () => {
-			expect( shouldFeedBeFetched( {
-				reader: {
-					feeds: {
-						queuedRequests: {
-							1: true
+			expect(
+				shouldFeedBeFetched(
+					{
+						reader: {
+							feeds: {
+								queuedRequests: {
+									1: true,
+								},
+								items: {},
+							},
 						},
-						items: {}
-					}
-				}
-			}, 1 ) ).to.be.false;
+					},
+					1
+				)
+			).to.be.false;
 		} );
 
 		it( 'should return false if the feed is loaded and recent', () => {
-			expect( shouldFeedBeFetched( {
-				reader: {
-					feeds: {
-						queuedRequests: {},
-						items: {
-							1: {}
+			expect(
+				shouldFeedBeFetched(
+					{
+						reader: {
+							feeds: {
+								queuedRequests: {},
+								items: {
+									1: {},
+								},
+								lastFetched: {
+									1: Date.now(),
+								},
+							},
 						},
-						lastFetched: {
-							1: Date.now()
-						}
-					}
-				}
-			}, 1 ) ).to.be.false;
+					},
+					1
+				)
+			).to.be.false;
+		} );
+
+		it( 'should return true if the feed is loaded, but no fetch time exists', () => {
+			expect(
+				shouldFeedBeFetched(
+					{
+						reader: {
+							feeds: {
+								queuedRequests: {},
+								items: {
+									1: {},
+								},
+								lastFetched: {},
+							},
+						},
+					},
+					1
+				)
+			).to.be.true;
 		} );
 
 		it( 'should return true if the feed is loaded, but old', () => {
-			expect( shouldFeedBeFetched( {
-				reader: {
-					feeds: {
-						queuedRequests: {},
-						items: {
-							1: {}
+			expect(
+				shouldFeedBeFetched(
+					{
+						reader: {
+							feeds: {
+								queuedRequests: {},
+								items: {
+									1: {},
+								},
+								lastFetched: {
+									1: 100,
+								},
+							},
 						},
-						lastFetched: {
-							1: 100
-						}
-					}
-				}
-			}, 1 ) ).to.be.true;
+					},
+					1
+				)
+			).to.be.true;
 		} );
 
 		it( 'should return true if the feed is not queued and not loaded', () => {
-			expect( shouldFeedBeFetched( {
-				reader: {
-					feeds: {
-						queuedRequests: {},
-						items: {},
-						lastFetched: {}
-					}
-				}
-			}, 1 ) ).to.be.true;
+			expect(
+				shouldFeedBeFetched(
+					{
+						reader: {
+							feeds: {
+								queuedRequests: {},
+								items: {},
+								lastFetched: {},
+							},
+						},
+					},
+					1
+				)
+			).to.be.true;
 		} );
 
 		it( 'should still return true if another feed is queued or loaded', () => {
-			expect( shouldFeedBeFetched( {
-				reader: {
-					feeds: {
-						queuedRequests: {
-							2: true
+			expect(
+				shouldFeedBeFetched(
+					{
+						reader: {
+							feeds: {
+								queuedRequests: {
+									2: true,
+								},
+								items: {
+									2: {},
+								},
+								lastFetched: {},
+							},
 						},
-						items: {
-							2: {}
-						},
-						lastFetched: {}
-					}
-				}
-			}, 1 ) ).to.be.true;
+					},
+					1
+				)
+			).to.be.true;
 		} );
 	} );
 } );

--- a/client/state/reader/sites/selectors.js
+++ b/client/state/reader/sites/selectors.js
@@ -17,7 +17,7 @@ export function shouldSiteBeFetched( state, siteId ) {
 function isStale( state, siteId ) {
 	const lastFetched = state.reader.sites.lastFetched[ siteId ];
 	if ( ! lastFetched ) {
-		return false;
+		return true;
 	}
 	return lastFetched <= Date.now() - DAY_IN_MILLIS;
 }

--- a/client/state/reader/sites/test/selectors.js
+++ b/client/state/reader/sites/test/selectors.js
@@ -11,77 +11,121 @@ import { shouldSiteBeFetched } from '../selectors';
 describe( 'selectors', () => {
 	describe( 'shouldSiteBeFetched', () => {
 		it( 'should return false if the fetch is queued', () => {
-			expect( shouldSiteBeFetched( {
-				reader: {
-					sites: {
-						queuedRequests: {
-							1: true
+			expect(
+				shouldSiteBeFetched(
+					{
+						reader: {
+							sites: {
+								queuedRequests: {
+									1: true,
+								},
+								items: {},
+								lastFetched: {},
+							},
 						},
-						items: {},
-						lastFetched: {},
-					}
-				}
-			}, 1 ) ).to.be.false;
+					},
+					1
+				)
+			).to.be.false;
 		} );
 
 		it( 'should return false if the site is loaded and recent', () => {
-			expect( shouldSiteBeFetched( {
-				reader: {
-					sites: {
-						queuedRequests: {},
-						items: {
-							1: {}
+			expect(
+				shouldSiteBeFetched(
+					{
+						reader: {
+							sites: {
+								queuedRequests: {},
+								items: {
+									1: {},
+								},
+								lastFetched: {
+									1: Date.now(),
+								},
+							},
 						},
-						lastFetched: {
-							1: Date.now()
-						}
-					}
-				}
-			}, 1 ) ).to.be.false;
+					},
+					1
+				)
+			).to.be.false;
+		} );
+
+		it( 'should return true if the site is loaded and has no last fetch time', () => {
+			expect(
+				shouldSiteBeFetched(
+					{
+						reader: {
+							sites: {
+								queuedRequests: {},
+								items: {
+									1: {},
+								},
+								lastFetched: {},
+							},
+						},
+					},
+					1
+				)
+			).to.be.true;
 		} );
 
 		it( 'should return true if the site is loaded and was not updated recently', () => {
-			expect( shouldSiteBeFetched( {
-				reader: {
-					sites: {
-						queuedRequests: {},
-						items: {
-							1: {}
+			expect(
+				shouldSiteBeFetched(
+					{
+						reader: {
+							sites: {
+								queuedRequests: {},
+								items: {
+									1: {},
+								},
+								lastFetched: {
+									1: 100,
+								},
+							},
 						},
-						lastFetched: {
-							1: 100
-						}
-					}
-				}
-			}, 1 ) ).to.be.true;
+					},
+					1
+				)
+			).to.be.true;
 		} );
 
 		it( 'should return true if the site is not queued and not loaded', () => {
-			expect( shouldSiteBeFetched( {
-				reader: {
-					sites: {
-						queuedRequests: {},
-						items: {},
-						lastFetched: {},
-					}
-				}
-			}, 1 ) ).to.be.true;
+			expect(
+				shouldSiteBeFetched(
+					{
+						reader: {
+							sites: {
+								queuedRequests: {},
+								items: {},
+								lastFetched: {},
+							},
+						},
+					},
+					1
+				)
+			).to.be.true;
 		} );
 
 		it( 'should still return true if another site is queued or loaded', () => {
-			expect( shouldSiteBeFetched( {
-				reader: {
-					sites: {
-						queuedRequests: {
-							2: true
+			expect(
+				shouldSiteBeFetched(
+					{
+						reader: {
+							sites: {
+								queuedRequests: {
+									2: true,
+								},
+								items: {
+									2: {},
+								},
+								lastFetched: {},
+							},
 						},
-						items: {
-							2: {}
-						},
-						lastFetched: {}
-					}
-				}
-			}, 1 ) ).to.be.true;
+					},
+					1
+				)
+			).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
This will refetch feeds and sites that have no fetch time. Since we don't cache fetch time, this will refresh feeds and sites in state on a window reload.