### PR TITLE
Jetpack connect: Refactor authorize-form

### DIFF
--- a/client/signup/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-in-form.jsx
@@ -65,7 +65,6 @@ class LoggedInForm extends Component {
 			} ).isRequired,
 			siteReceived: PropTypes.bool,
 		} ).isRequired,
-		plansFirst: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		requestHasExpiredSecretError: PropTypes.func.isRequired,
 		requestHasXmlrpcError: PropTypes.func.isRequired,
@@ -110,14 +109,6 @@ class LoggedInForm extends Component {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}
-		} else if (
-			props.plansFirst &&
-			props.selectedPlan &&
-			! this.state.haveAuthorized &&
-			! this.isAuthorizing()
-		) {
-			this.setState( { haveAuthorized: true } );
-			this.props.authorize( queryObject );
 		} else if ( siteReceived ) {
 			return this.redirect();
 		} else if ( props.isAlreadyOnSitesList && queryObject.already_authorized ) {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
 import cookie from 'cookie';
 
 /**
@@ -68,10 +69,10 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 			<Main className="jetpack-connect__main-error">
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-whoops.svg"
-					title={ this.translate(
+					title={ this.props.translate(
 						'Oops, this URL should not be accessed directly'
 					) }
-					action={ this.translate( 'Get back to Jetpack Connect screen' ) }
+					action={ this.props.translate( 'Get back to Jetpack Connect screen' ) }
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
@@ -162,4 +163,4 @@ export default connect(
 		retryAuth,
 		goToXmlrpcErrorFallbackUrl
 	}, dispatch )
-)( JetpackConnectAuthorizeForm );
+)( localize( JetpackConnectAuthorizeForm ) );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -127,12 +127,8 @@ export default connect(
 	state => {
 		const remoteSiteUrl = getAuthorizationRemoteSite( state );
 		const siteSlug = urlToSlug( remoteSiteUrl );
-		const requestHasXmlrpcError = () => {
-			return hasXmlrpcError( state );
-		};
-		const requestHasExpiredSecretError = () => {
-			return hasExpiredSecretError( state );
-		};
+		const requestHasExpiredSecretError = () => hasExpiredSecretError( state );
+		const requestHasXmlrpcError = () => hasXmlrpcError( state );
 		const selectedPlan = getSiteSelectedPlan( state, siteSlug ) || getGlobalSelectedPlan( state );
 		const siteId = getSiteIdFromQueryObject( state );
 

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import cookie from 'cookie';
 
@@ -172,7 +171,7 @@ export default connect(
 			jetpackSSOSessions: getSSOSessions( state ),
 		};
 	},
-	dispatch => bindActionCreators( {
+	{
 		authorize,
 		createAccount,
 		goBackToWpAdmin,
@@ -180,5 +179,5 @@ export default connect(
 		recordTracksEvent,
 		requestSites,
 		retryAuth,
-	}, dispatch )
+	}
 )( localize( JetpackConnectAuthorizeForm ) );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -137,28 +137,30 @@ export default connect(
 		const siteId = getSiteIdFromQueryObject( state );
 
 		return {
-			siteSlug,
-			selectedPlan,
+			authAttempts: getAuthAttempts( state, siteSlug ),
+			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
+			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
+			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
+			isFetchingSites: isRequestingSites( state ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			plansFirst: false,
-			jetpackSSOSessions: getSSOSessions( state ),
-			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
-			isFetchingSites: isRequestingSites( state ),
-			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
-			requestHasXmlrpcError,
 			requestHasExpiredSecretError,
-			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
-			authAttempts: getAuthAttempts( state, siteSlug ),
+			requestHasXmlrpcError,
+			selectedPlan,
+			siteSlug,
 			user: getCurrentUser( state ),
+
+			// FIXME: Is this prop used? Can it be removed completely?
+			jetpackSSOSessions: getSSOSessions( state ),
 		};
 	},
 	dispatch => bindActionCreators( {
-		requestSites,
-		recordTracksEvent,
 		authorize,
 		createAccount,
 		goBackToWpAdmin,
+		goToXmlrpcErrorFallbackUrl,
+		recordTracksEvent,
+		requestSites,
 		retryAuth,
-		goToXmlrpcErrorFallbackUrl
 	}, dispatch )
 )( localize( JetpackConnectAuthorizeForm ) );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -31,7 +31,7 @@ import {
 	getAuthAttempts,
 	getSiteIdFromQueryObject
 } from 'state/jetpack-connect/selectors';
-import observe from 'lib/mixins/data-observe';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
 import { requestSites } from 'state/sites/actions';
@@ -46,7 +46,6 @@ import LoggedOutForm from './auth-logged-out-form';
 
 const JetpackConnectAuthorizeForm = React.createClass( {
 	displayName: 'JetpackConnectAuthorizeForm',
-	mixins: [ observe( 'userModule' ) ],
 
 	componentWillMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
@@ -93,16 +92,10 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 	},
 
 	renderForm() {
-		const { userModule } = this.props;
-		const user = userModule.get();
-		const props = Object.assign( {}, this.props, {
-			user: user
-		} );
-
 		return (
-			( user )
-				? <LoggedInForm { ...props } isSSO={ this.isSSO() } />
-				: <LoggedOutForm { ...props } isSSO={ this.isSSO() } />
+			( this.props.user )
+				? <LoggedInForm { ...this.props } isSSO={ this.isSSO() } />
+				: <LoggedOutForm { ...this.props } isSSO={ this.isSSO() } />
 		);
 	},
 
@@ -157,6 +150,7 @@ export default connect(
 			requestHasExpiredSecretError,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),
 			authAttempts: getAuthAttempts( state, siteSlug ),
+			user: getCurrentUser( state ),
 		};
 	},
 	dispatch => bindActionCreators( {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -38,8 +38,6 @@ import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
 import { urlToSlug } from 'lib/url';
-import Plans from './plans';
-import CheckoutData from 'components/data/checkout';
 import LoggedInForm from './auth-logged-in-form';
 import LoggedOutForm from './auth-logged-out-form';
 
@@ -100,19 +98,6 @@ class JetpackConnectAuthorizeForm extends Component {
 					<HelpButton onClick={ this.clickHelpButton } />
 				</LoggedOutFormLinks>
 			</Main>
-		);
-	}
-
-	renderPlansSelector() {
-		return (
-			<div>
-				<CheckoutData>
-					<Plans
-						{ ...this.props }
-						showFirst={ true }
-					/>
-				</CheckoutData>
-			</div>
 		);
 	}
 

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -112,7 +112,10 @@ class JetpackConnectAuthorizeForm extends Component {
 		return (
 			<div>
 				<CheckoutData>
-					<Plans { ...this.props } showFirst={ true } />
+					<Plans
+						{ ...this.props }
+						showFirst={ true }
+					/>
 				</CheckoutData>
 			</div>
 		);
@@ -121,8 +124,14 @@ class JetpackConnectAuthorizeForm extends Component {
 	renderForm() {
 		return (
 			( this.props.user )
-				? <LoggedInForm { ...this.props } isSSO={ this.isSSO() } />
-				: <LoggedOutForm { ...this.props } isSSO={ this.isSSO() } />
+				? <LoggedInForm
+					{ ...this.props }
+					isSSO={ this.isSSO() }
+				/>
+				: <LoggedOutForm
+					{ ...this.props }
+					isSSO={ this.isSSO() }
+				/>
 		);
 	}
 

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -47,7 +47,11 @@ import LoggedOutForm from './auth-logged-out-form';
 class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
 		authAttempts: PropTypes.number,
+		authorize: PropTypes.func,
 		calypsoStartedConnection: PropTypes.bool,
+		createAccount: PropTypes.func,
+		goBackToWpAdmin: PropTypes.func,
+		goToXmlrpcErrorFallbackUrl: PropTypes.func,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
@@ -57,8 +61,11 @@ class JetpackConnectAuthorizeForm extends Component {
 			} ).isRequired,
 		} ).isRequired,
 		plansFirst: PropTypes.bool,
+		recordTracksEvent: PropTypes.func,
 		requestHasExpiredSecretError: PropTypes.func,
 		requestHasXmlrpcError: PropTypes.func,
+		requestSites: PropTypes.func,
+		retryAuth: PropTypes.func,
 		selectedPlan: PropTypes.string,
 		siteSlug: PropTypes.string,
 		user: PropTypes.object,

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
@@ -46,6 +46,28 @@ import LoggedInForm from './auth-logged-in-form';
 import LoggedOutForm from './auth-logged-out-form';
 
 class JetpackConnectAuthorizeForm extends Component {
+	static propTypes = {
+		authAttempts: PropTypes.number,
+		calypsoStartedConnection: PropTypes.bool,
+		isAlreadyOnSitesList: PropTypes.bool,
+		isFetchingSites: PropTypes.bool,
+		jetpackConnectAuthorize: PropTypes.shape( {
+			queryObject: PropTypes.shape( {
+				client_id: PropTypes.string,
+				from: PropTypes.string,
+			} ).isRequired,
+		} ).isRequired,
+		plansFirst: PropTypes.bool,
+		requestHasExpiredSecretError: PropTypes.func,
+		requestHasXmlrpcError: PropTypes.func,
+		selectedPlan: PropTypes.string,
+		siteSlug: PropTypes.string,
+		user: PropTypes.object,
+
+		// FIXME: Is this prop used? Can it be removed completely?
+		jetpackSSOSessions: PropTypes.any,
+	}
+
 	componentWillMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
 	}

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -60,7 +60,6 @@ class JetpackConnectAuthorizeForm extends Component {
 				from: PropTypes.string,
 			} ).isRequired,
 		} ).isRequired,
-		plansFirst: PropTypes.bool,
 		recordTracksEvent: PropTypes.func,
 		requestHasExpiredSecretError: PropTypes.func,
 		requestHasXmlrpcError: PropTypes.func,
@@ -146,10 +145,6 @@ class JetpackConnectAuthorizeForm extends Component {
 			this.renderForm();
 		}
 
-		if ( this.props.plansFirst && ! this.props.selectedPlan ) {
-			return this.renderPlansSelector();
-		}
-
 		return (
 			<MainWrapper>
 				<div className="jetpack-connect__authorize-form">
@@ -176,7 +171,6 @@ export default connect(
 			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
 			isFetchingSites: isRequestingSites( state ),
 			jetpackConnectAuthorize: getAuthorizationData( state ),
-			plansFirst: false,
 			requestHasExpiredSecretError,
 			requestHasXmlrpcError,
 			selectedPlan,

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
@@ -45,12 +45,10 @@ import CheckoutData from 'components/data/checkout';
 import LoggedInForm from './auth-logged-in-form';
 import LoggedOutForm from './auth-logged-out-form';
 
-const JetpackConnectAuthorizeForm = React.createClass( {
-	displayName: 'JetpackConnectAuthorizeForm',
-
+class JetpackConnectAuthorizeForm extends Component {
 	componentWillMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
-	},
+	}
 
 	isSSO() {
 		const cookies = cookie.parse( document.cookie );
@@ -62,7 +60,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 			query.client_id &&
 			query.client_id === cookies.jetpack_sso_approved
 		);
-	},
+	}
 
 	renderNoQueryArgsError() {
 		return (
@@ -80,7 +78,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 				</LoggedOutFormLinks>
 			</Main>
 		);
-	},
+	}
 
 	renderPlansSelector() {
 		return (
@@ -90,7 +88,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 				</CheckoutData>
 			</div>
 		);
-	},
+	}
 
 	renderForm() {
 		return (
@@ -98,7 +96,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 				? <LoggedInForm { ...this.props } isSSO={ this.isSSO() } />
 				: <LoggedOutForm { ...this.props } isSSO={ this.isSSO() } />
 		);
-	},
+	}
 
 	render() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
@@ -123,7 +121,7 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 			</MainWrapper>
 		);
 	}
-} );
+}
 
 export default connect(
 	state => {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -50,6 +50,7 @@ class JetpackConnectAuthorizeForm extends Component {
 		goBackToWpAdmin: PropTypes.func,
 		goToXmlrpcErrorFallbackUrl: PropTypes.func,
 		isAlreadyOnSitesList: PropTypes.bool,
+		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			queryObject: PropTypes.shape( {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -21,7 +21,6 @@ import {
 import {
 	getAuthorizationData,
 	getAuthorizationRemoteSite,
-	getSSOSessions,
 	isCalypsoStartedConnection,
 	hasXmlrpcError,
 	hasExpiredSecretError,
@@ -68,9 +67,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		selectedPlan: PropTypes.string,
 		siteSlug: PropTypes.string,
 		user: PropTypes.object,
-
-		// FIXME: Is this prop used? Can it be removed completely?
-		jetpackSSOSessions: PropTypes.any,
 	}
 
 	componentWillMount() {
@@ -176,9 +172,6 @@ export default connect(
 			selectedPlan,
 			siteSlug,
 			user: getCurrentUser( state ),
-
-			// FIXME: Is this prop used? Can it be removed completely?
-			jetpackSSOSessions: getSSOSessions( state ),
 		};
 	},
 	{

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -178,8 +178,6 @@ export default {
 
 		removeSidebar( context );
 
-		userModule.fetch();
-
 		let intervalType = context.params.intervalType;
 		let locale = context.params.locale;
 		if ( context.params.localeOrInterval ) {
@@ -196,7 +194,7 @@ export default {
 				path={ context.path }
 				intervalType={ intervalType }
 				locale={ locale }
-				userModule={ userModule } />,
+			/>,
 			document.getElementById( 'primary' ),
 			context.store
 		);

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -54,10 +54,6 @@ const getSessions = ( state ) => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectSessions' ] );
 };
 
-const getSSOSessions = ( state ) => {
-	return get( state, [ 'jetpackConnect', 'jetpackSSOSessions' ] );
-};
-
 const getSSO = ( state ) => {
 	return get( state, [ 'jetpackConnect', 'jetpackSSO' ] );
 };
@@ -165,7 +161,6 @@ export default {
 	getAuthorizationRemoteQueryData,
 	getAuthorizationRemoteSite,
 	getSessions,
-	getSSOSessions,
 	getSSO,
 	isCalypsoStartedConnection,
 	isRedirectingToWpAdmin,

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -12,7 +12,6 @@ import {
 	getAuthorizationRemoteQueryData,
 	getAuthorizationRemoteSite,
 	getSessions,
-	getSSOSessions,
 	getSSO,
 	isCalypsoStartedConnection,
 	isRedirectingToWpAdmin,
@@ -241,36 +240,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getSessions( state ) ).to.eql( jetpackConnectSessions );
-		} );
-	} );
-
-	describe( '#getSSOSessions()', () => {
-		it( 'should return undefined if user has not started any single sign-on sessions', () => {
-			const state = {
-				jetpackConnect: {}
-			};
-
-			expect( getSSOSessions( state ) ).to.be.undefined;
-		} );
-
-		it( 'should return all of the user\'s single sign-on sessions', () => {
-			const jetpackSSOSessions = {
-				'wordpress.com': {
-					timestamp: 1234567890,
-					flowType: 'premium'
-				},
-				'jetpack.me': {
-					timestamp: 2345678901,
-					flowType: 'pro'
-				}
-			};
-			const state = {
-				jetpackConnect: {
-					jetpackSSOSessions
-				}
-			};
-
-			expect( getSSOSessions( state ) ).to.eql( jetpackSSOSessions );
 		} );
 	} );
 


### PR DESCRIPTION
Refactor `JetpackAuthorizeForm` component. Required by linter to separate jetpack-connect from signup #12991 

To test:

* Verify that there are no regressions in the authorize step (`/jetpack/connect/authorize`)
  * logged in
  * logged out
* Ensure jetpack-connect selector tests pass:
   ```
   npm run test-client client/state/jetpack-connect/test/selectors.js
   ```

Simple connection test flow instructions: P7rd6c-Me-p2