### PR TITLE
Desktop: cherrypick notification fixes (#13960)

### DIFF
--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -33,13 +33,18 @@ class MasterbarItemNotifications extends Component {
 		animationState: 0,
 	};
 
+	componentWillMount() {
+		this.user = this.props.user.get();
+		this.setState( {
+			newNote: this.user && this.user.has_unseen_notes,
+		} );
+	}
+
 	componentWillReceiveProps( nextProps ) {
 		const {
 			isNotificationsOpen: isOpen,
 			recordOpening,
 		} = nextProps;
-
-		this.user = this.props.user.get();
 
 		if ( ! this.props.isNotificationsOpen && isOpen ) {
 			recordOpening( {
@@ -53,10 +58,6 @@ class MasterbarItemNotifications extends Component {
 			this.getNotificationLinkDomNode().blur();
 			window.focus();
 		}
-
-		this.setState( {
-			newNote: this.user && this.user.has_unseen_notes,
-		} );
 	}
 
 	checkToggleNotes = ( event, forceToggle ) => {

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -70,7 +70,7 @@
 		"reader/search": true,
 		"resume-editing": true,
 		"republicize": false,
-		"rubberband-scroll-disable": true,
+		"rubberband-scroll-disable": false,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3026,7 +3026,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.1.6"
+      "version": "1.1.9"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.1.6",
+    "notifications-panel": "1.1.9",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",


### PR DESCRIPTION
I'm merging fixes from `release/desktop/2.5.0` into `master`. @gwwar I'm not super familiar with the PR process for Calypso - I think only you need to review?

# Included in this:

* Notes: fix notification bell
* Notes: turn off rubberband-scroll-disable (#13848)
* Bump notifications panel to 1.1.8
* Bump notifications panel to 1.1.9