### PR TITLE
Reader: Suppress owner name on multi-author sites

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -16,9 +16,8 @@ import Site from 'blocks/site';
 import HeaderBack from 'reader/header-back';
 
 class FeedHeader extends Component {
-
 	static propTypes = {
-		showBack: React.PropTypes.bool
+		showBack: React.PropTypes.bool,
 	};
 
 	buildSiteish = ( site, feed ) => {
@@ -32,11 +31,11 @@ class FeedHeader extends Component {
 					( feed.feed_URL && url.parse( feed.feed_URL ).hostname ),
 				domain: ( feed.URL && url.parse( feed.URL ).hostname ) ||
 					( feed.feed_URL && url.parse( feed.feed_URL ).hostname ),
-				URL: feed.URL || feed.feed_URL
+				URL: feed.URL || feed.feed_URL,
 			};
 		}
 		return siteish;
-	}
+	};
 
 	getFollowerCount = ( feed, site ) => {
 		if ( site && site.subscribers_count ) {
@@ -48,7 +47,7 @@ class FeedHeader extends Component {
 		}
 
 		return null;
-	}
+	};
 
 	render() {
 		const { site, feed } = this.props;
@@ -68,15 +67,23 @@ class FeedHeader extends Component {
 				<div className="reader-feed-header__back-and-follow">
 					{ this.props.showBack && <HeaderBack /> }
 					<div className="reader-feed-header__follow">
-						{ followerCount ? <span className="reader-feed-header__follow-count"> {
-						this.props.translate( '%s follower', '%s followers',
-						{ count: followerCount, args: [ this.props.numberFormat( followerCount ) ] } ) }
-						</span> : null }
-						{ this.props.feed && ! this.props.feed.is_error &&
+						{ followerCount
+							? <span className="reader-feed-header__follow-count">
+									{' '}
+									{ this.props.translate( '%s follower', '%s followers', {
+										count: followerCount,
+										args: [ this.props.numberFormat( followerCount ) ],
+									} ) }
+								</span>
+							: null }
+						{ this.props.feed &&
+							! this.props.feed.is_error &&
 							<div className="reader-feed-header__follow-button">
-								<ReaderFollowButton siteUrl={ this.props.feed.feed_URL } iconSize={ 24 } />
-							</div>
-						}
+								<ReaderFollowButton
+									siteUrl={ this.props.feed.feed_URL }
+									iconSize={ 24 }
+								/>
+							</div> }
 					</div>
 				</div>
 				<Card className="reader-feed-header__site">
@@ -86,21 +93,19 @@ class FeedHeader extends Component {
 							homeLink={ true }
 							showHomeIcon={ false }
 							href={ siteish.URL }
-							indicator={ false } />
-					}
+							indicator={ false }
+						/> }
 					<div className="reader-feed-header__details">
 						<span className="reader-feed-header__description">{ description }</span>
-						{ ownerDisplayName && ! isAuthorNameBlacklisted( ownerDisplayName ) && <span className="reader-feed-header__byline">
-							{ this.props.translate(
-								'by %(author)s',
-								{
+						{ ownerDisplayName &&
+							! isAuthorNameBlacklisted( ownerDisplayName ) &&
+							<span className="reader-feed-header__byline">
+								{ this.props.translate( 'by %(author)s', {
 									args: {
-										author: ownerDisplayName
-									}
-								}
-							)
-						}
-						</span> }
+										author: ownerDisplayName,
+									},
+								} ) }
+							</span> }
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -52,7 +52,8 @@ class FeedHeader extends Component {
 	render() {
 		const { site, feed } = this.props;
 		const followerCount = this.getFollowerCount( feed, site );
-		const ownerDisplayName = site && site.owner && site.owner.name;
+		const ownerDisplayName =
+			site && ! site.is_multi_author && site.owner && site.owner.name;
 		const siteish = this.buildSiteish( site, feed );
 		const description = site && site.description;
 
@@ -69,7 +70,7 @@ class FeedHeader extends Component {
 					<div className="reader-feed-header__follow">
 						{ followerCount
 							? <span className="reader-feed-header__follow-count">
-									{' '}
+									{ ' ' }
 									{ this.props.translate( '%s follower', '%s followers', {
 										count: followerCount,
 										args: [ this.props.numberFormat( followerCount ) ],

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -54,8 +54,8 @@ function ReaderSubscriptionListItem( {
 	const feedUrl = url || getFeedUrl( { feed, site } );
 	const siteUrl = getSiteUrl( { feed, site } );
 	const isFollowing = ( site && site.is_following ) || ( feed && feed.is_following );
-	const preferBlavatar = get( site, 'is_multi_author', false );
-	const preferGravatar = ! preferBlavatar;
+	const isMultiAuthor = get( site, 'is_multi_author', false );
+	const preferGravatar = ! isMultiAuthor;
 
 	if ( ! site && ! feed ) {
 		return <ReaderSubscriptionListItemPlaceholder />;
@@ -68,7 +68,7 @@ function ReaderSubscriptionListItem( {
 					siteIcon={ siteIcon }
 					feedIcon={ feedIcon }
 					author={ siteAuthor }
-					preferBlavatar={ preferBlavatar }
+					preferBlavatar={ isMultiAuthor }
 					preferGravatar={ preferGravatar }
 					siteUrl={ streamUrl }
 					isCompact={ true }
@@ -78,18 +78,19 @@ function ReaderSubscriptionListItem( {
 				<span className="reader-subscription-list-item__site-title">
 					{
 						<a href={ streamUrl } className="reader-subscription-list-item__link">
-							{' '}{ siteTitle }{' '}
+							{ ' ' }{ siteTitle }{ ' ' }
 						</a>
 					}
 				</span>
 				<div className="reader-subscription-list-item__site-excerpt">{ siteExcerpt }</div>
-				{ ! isEmpty( authorName ) &&
+				{ ! isMultiAuthor &&
+					! isEmpty( authorName ) &&
 					<span className="reader-subscription-list-item__by-text">
 						{ translate( 'by {{author/}}', {
 							components: {
 								author: (
 									<a href={ streamUrl } className="reader-subscription-list-item__link">
-										{' '}{ authorName }{' '}
+										{ ' ' }{ authorName }{ ' ' }
 									</a>
 								),
 							},

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -21,7 +21,8 @@ import {
 	getSiteUrl,
 } from 'reader/get-helpers';
 import untrailingslashit from 'lib/route/untrailingslashit';
-import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
+import ReaderSubscriptionListItemPlaceholder
+	from 'blocks/reader-subscription-list-item/placeholder';
 
 /**
  * Takes in a string and removes the starting https, www., and removes a trailing slash
@@ -29,9 +30,8 @@ import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-li
  * @param {String} url - the url to format
  * @returns {String} - the formatted url.  e.g. "https://www.wordpress.com/" --> "wordpress.com"
  */
-const formatUrlForDisplay = url => untrailingslashit(
-	url.replace( /^https?:\/\/(www\.)?/, '' )
-);
+const formatUrlForDisplay = url =>
+	untrailingslashit( url.replace( /^https?:\/\/(www\.)?/, '' ) );
 
 function ReaderSubscriptionListItem( {
 	url,
@@ -76,30 +76,34 @@ function ReaderSubscriptionListItem( {
 			</div>
 			<div className="reader-subscription-list-item__byline">
 				<span className="reader-subscription-list-item__site-title">
-					{ <a href={ streamUrl } className="reader-subscription-list-item__link"> { siteTitle } </a> }
+					{
+						<a href={ streamUrl } className="reader-subscription-list-item__link">
+							{' '}{ siteTitle }{' '}
+						</a>
+					}
 				</span>
 				<div className="reader-subscription-list-item__site-excerpt">{ siteExcerpt }</div>
 				{ ! isEmpty( authorName ) &&
 					<span className="reader-subscription-list-item__by-text">
-						{
-							translate( 'by {{author/}}', {
-								components: {
-									author: <a href={ streamUrl } className="reader-subscription-list-item__link"> { authorName } </a>
-								}
-							} )
-						}
-					</span>
-				}
-			{ siteUrl && (
-				<a
-					href={ siteUrl }
-					target="_blank"
-					rel="noopener noreferrer"
-					className="reader-subscription-list-item__site-url"
-				>
-					{ formatUrlForDisplay( siteUrl ) }
-				</a>
-			) }
+						{ translate( 'by {{author/}}', {
+							components: {
+								author: (
+									<a href={ streamUrl } className="reader-subscription-list-item__link">
+										{' '}{ authorName }{' '}
+									</a>
+								),
+							},
+						} ) }
+					</span> }
+				{ siteUrl &&
+					<a
+						href={ siteUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+						className="reader-subscription-list-item__site-url"
+					>
+						{ formatUrlForDisplay( siteUrl ) }
+					</a> }
 			</div>
 			<div className="reader-subscription-list-item__options">
 				<FollowButton


### PR DESCRIPTION
Suppress both in site search results and on the site / feed stream.

To test, try searching for boing or lost art press. Both are multi-author sites.