### PR TITLE
Reader: Fix broken padding on dismiss button on recs

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -89,6 +89,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		height: 30px;
 		justify-content: flex-end;
 
+		.button.is-borderless {
+			z-index: 0;
+		}
+
 		.button.is-borderless .gridicon,
 		.gridicon,
 		.gridicons-cross {


### PR DESCRIPTION
For some reason, we need a z-index on the button to get the padding to be clickable on Chrome.