### PR TITLE
Post: load PostShare asynchronously.

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -28,8 +28,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 import Comments from 'blocks/comments';
-import PostShare from 'blocks/post-share';
-
+import AsyncLoad from 'components/async-load';
 import PostActions from 'blocks/post-actions';
 
 function recordEvent( eventAction ) {
@@ -340,8 +339,13 @@ const Post = React.createClass( {
 						onFilterChange={ commentsFilter => this.setState( { commentsFilter } ) }
 						onCommentsUpdate={ () => {} } />
 				}
-				{ this.state.showShare && config.isEnabled( 'republicize' ) &&
-					<PostShare post={ this.props.post } siteId={ this.props.post.site_ID } />
+				{
+					this.state.showShare &&
+					config.isEnabled( 'republicize' ) &&
+					<AsyncLoad
+						require="blocks/post-share"
+						post={ this.props.post }
+						siteId={ this.props.post.site_ID } />
 				}
 			</Card>
 		);


### PR DESCRIPTION
This PR implements async loading when the `<PostShare />` component should be shown

### Testing

In order to test this change, you will need a site connected with some social media account, a paid plan, and some posts on your site.

1. Go to Posts list page: `http://calypso.localhost:3000/posts/<your-site>`
2. Pick up some post and clicks in `Share` tab

<img src="https://cloud.githubusercontent.com/assets/77539/26070888/a25cdff0-397c-11e7-834d-f3ebd9a6a99a.png" width="600px" />

3. You should see the share sections as usual.

<img src="https://cloud.githubusercontent.com/assets/77539/26071089/4e5fe9aa-397d-11e7-80f7-aa17c7a43283.png" width="500px">


You'd take a look at the React tab from dev tools:
<img src="https://cloud.githubusercontent.com/assets/77539/26070999/019b3ad4-397d-11e7-9f98-497c2986d89c.png" width="500px">

^^^ `<PostShare />` component is being loaded through of `<AsyncLoad />` component.

