### PR TITLE
Localize v2 api requests by default

### DIFF
--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -46,7 +46,8 @@ export function addLocaleQueryParam( params ) {
 	let localeQueryParam = {};
 	const query = qs.parse( params.query );
 
-	if ( 'wpcom/v2' === params.apiNamespace ) {
+	if ( params.apiNamespace ) {
+		// v2 api request
 		localeQueryParam = { _locale: locale };
 	} else {
 		localeQueryParam = { locale };

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -43,9 +43,17 @@ export function addLocaleQueryParam( params ) {
 		return params;
 	}
 
+	let localeQueryParam = {};
 	const query = qs.parse( params.query );
+
+	if ( params.hasOwnProperty( 'apiNamespace' ) && 'wpcom/v2' === params.apiNamespace ) {
+		localeQueryParam = { _locale: locale };
+	} else {
+		localeQueryParam = { locale };
+	}
+
 	return Object.assign( params, {
-		query: qs.stringify( Object.assign( query, { locale } ) )
+		query: qs.stringify( Object.assign( query, localeQueryParam ) )
 	} );
 }
 

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -43,7 +43,7 @@ export function addLocaleQueryParam( params ) {
 		return params;
 	}
 
-	let localeQueryParam = {};
+	let localeQueryParam;
 	const query = qs.parse( params.query );
 
 	if ( params.apiNamespace ) {

--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -46,7 +46,7 @@ export function addLocaleQueryParam( params ) {
 	let localeQueryParam = {};
 	const query = qs.parse( params.query );
 
-	if ( params.hasOwnProperty( 'apiNamespace' ) && 'wpcom/v2' === params.apiNamespace ) {
+	if ( 'wpcom/v2' === params.apiNamespace ) {
 		localeQueryParam = { _locale: locale };
 	} else {
 		localeQueryParam = { locale };


### PR DESCRIPTION
Follow-up to #12809

**Testing:**
With a UI language set to non-english, load the stats for a site. You should see a request to the v2 post-counts endpoind, with a `_locale` param instead of the regular `locale`, i.e.: https://public-api.wordpress.com/wpcom/v2/sites/XXX/post-counts/post?_envelope=1&_locale=XX