### PR TITLE
Reader Manage Following: fix so that scrolling quickly won't bump you back to the top

### DIFF
--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -9,7 +9,7 @@ import {
 	CellMeasurer,
 	InfiniteLoader,
 } from 'react-virtualized';
-import { debounce, noop } from 'lodash';
+import { debounce, noop, get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -39,9 +39,9 @@ class SitesWindowScroller extends Component {
 
 	siteRowRenderer = ( { index, key, style, parent } ) => {
 		const site = this.props.sites[ index ];
-		if ( ! site ) {
-			return null;
-		}
+		const feedUrl = get( site, 'feed_URL' );
+		const feedId = +get( site, 'feed_ID' );
+		const siteId = +get( site, 'blog_ID' );
 
 		return (
 			<CellMeasurer
@@ -58,9 +58,9 @@ class SitesWindowScroller extends Component {
 						className="following-manage__sites-window-scroller-row-wrapper"
 					>
 						<ConnectedSubscriptionListItem
-							url={ site.feed_URL }
-							feedId={ +site.feed_ID }
-							siteId={ +site.blog_ID }
+							url={ feedUrl }
+							feedId={ feedId }
+							siteId={ siteId }
 							onLoad={ measure }
 						/>
 					</div>


### PR DESCRIPTION
Within the Search on Manage feed results, after clicking "ShowMore", if you scrolled even moderately quickly then you would be bounced back to the top.

Turns out that WindowScroller/List don't do well with null elements so removing the lines that return null in favor of placeholders resolves the issue.

To Test:
1. load up the branch
2. navigate to /following/manage
3. conduct search and click show more
4. scroll!