### PR TITLE
Reader: Fix overlapping rec sites in IE

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -54,7 +54,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-recommended-sites__site-list-item {
 	display: flex;
-	flex: 1;
+	flex: 1 1 0;
 	flex-direction: column;
 	list-style-type: none;
 	margin-top: -40px;
@@ -81,7 +81,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	> :nth-child(2) {
-		flex: 1;
+		flex: 1 1 0;
 	}
 
 	.reader-recommended-sites__recommended-site-dismiss {

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -54,7 +54,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-recommended-sites__site-list-item {
 	display: flex;
-	flex: 1 1 0%;
+	flex: 1 1 auto;
 	flex-direction: column;
 	list-style-type: none;
 	margin-top: -40px;
@@ -62,7 +62,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		flex-direction: row;
-		flex: 0;
+		flex: 0 1 auto;
 		margin-top: 0;
 
 		& + & {
@@ -72,7 +72,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex-direction: row;
-		flex: 0;
+		flex: 0 1 auto;
 		margin-top: 0;
 
 		& + & {
@@ -81,7 +81,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	> :nth-child(2) {
-		flex: 1 1 0;
+		flex: 1 1 auto;
 	}
 
 	.reader-recommended-sites__recommended-site-dismiss {

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -54,7 +54,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-recommended-sites__site-list-item {
 	display: flex;
-	flex: 1 1 0;
+	flex: 1 1 0%;
 	flex-direction: column;
 	list-style-type: none;
 	margin-top: -40px;

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -54,7 +54,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-recommended-sites__site-list-item {
 	display: flex;
-	flex: 1 1 auto;
+	flex: 1 1 0%;
 	flex-direction: column;
 	list-style-type: none;
 	margin-top: -40px;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -6,7 +6,7 @@
 .reader-subscription-list-item__byline {
 	color: darken( $gray, 30% );
 	margin-right: 16px;
-	flex: 1;
+	flex: 1 0 0%;
 }
 
 .following-manage__subscriptions-list .reader-subscription-list-item__options {


### PR DESCRIPTION
This was due to `flex` written in shorthand which IE isn't able to interpret well.

**Before:**
<img width="1013" alt="screenshot 2017-05-15 16 40 19" src="https://cloud.githubusercontent.com/assets/4924246/26083911/4d12cb2a-398d-11e7-9ffe-02a3885e70ec.png">

**After:**
<img width="1013" alt="screenshot 2017-05-15 16 38 09" src="https://cloud.githubusercontent.com/assets/4924246/26083914/51934b5c-398d-11e7-8103-ee380d6e95f8.png">
