### PR TITLE
Save more recent sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -222,7 +222,7 @@ function onSelectedSiteAvailable( context ) {
 			context.store.dispatch( savePreference( 'recentSites', uniq( [
 				selectedSite.ID,
 				...recentSites
-			] ).slice( 0, 3 ) ) );
+			] ).slice( 0, 5 ) ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #13632 

This PR bumps a number of recent sites stored from 3 to 5. 

*To test:*

1. Have more than 11 sites
2. Go to My Sites and switch to a different site multiple times
3. There should now be 5 sites in the recent section