### PR TITLE
Boot: Restore device's last location if opened at /

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -149,6 +149,7 @@ export function createReduxStore( initialState = {} ) {
 		isBrowser && require( './analytics/middleware.js' ).analyticsMiddleware,
 		require( './data-layer/wpcom-api-middleware.js' ).default,
 		isBrowser && require( './lib/middleware.js' ).default,
+		isBrowser && config.isEnabled( 'restore-last-location' ) && require( './routing/middleware.js' ).default,
 		isBrowser && require( './data-layer/extensions-middleware.js' ).default,
 		isAudioSupported && require( './audio/middleware.js' ).default,
 		isBrowser && config.isEnabled( 'automated-transfer' ) && require( './automated-transfer/middleware.js' ).default,

--- a/client/state/routing/README.md
+++ b/client/state/routing/README.md
@@ -1,0 +1,17 @@
+Routing Middleware
+==================
+
+_As it stands, this piece of middleware does very little. It is unrelated to any potential future work on middleware-level routing in Calypso, but this module could be the place for it._
+
+
+`restore-last-location`
+-----------------------
+
+This middleware implements the behavior — first seen in the WordPress.com desktop app — whereby a user starting a new session at `/` will be shown their last route recorded on that device, _e.g._ `/posts/my` or `/pages/example.wordpress.com`.
+
+The implementation hinges on listening to `ROUTE_SET` actions and:
+
+- Saving the action's path to localStorage
+- If this is the middleware's first run and the application is being loaded at `/`, attempt to redirect to the path value found in localStorage.
+
+Behavior will probably change or be fine-tuned in the future.

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import page from 'page';
+import store from 'store';
+
+/**
+ * Internal dependencies
+ */
+import { ROUTE_SET } from 'state/action-types';
+
+const debug = debugFactory( 'calypso:restore-last-location' );
+
+let hasInitialized = false;
+
+export const restoreLastLocation = () => ( next ) => ( action ) => {
+	if ( action.type === ROUTE_SET && action.path ) {
+		const lastPath = store.get( 'last_path' );
+
+		if ( ! hasInitialized && lastPath && action.path === '/' ) {
+			debug( 'redir to', action.path );
+			page( lastPath );
+		} else {
+			debug( 'saving', action.path );
+			store.set( 'last_path', action.path );
+		}
+
+		if ( ! hasInitialized ) {
+			hasInitialized = true;
+		}
+	}
+
+	return next( action );
+};
+
+export default restoreLastLocation;

--- a/config/development.json
+++ b/config/development.json
@@ -132,6 +132,7 @@
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
+		"restore-last-location": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -97,6 +97,7 @@
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
+		"restore-last-location": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
See #11755

# Gist

- If the initial path is `/`, look for the last known path and start from there. The path is intentionally not persisted server-side, as this is a per-device behavior. See Desktop app for a precedent.
- Done as a lightning experiment at ∆'s meetup; let's try to merge it quickly.
- Enabled in `development` and `wpcalypso`.

![remember-location](https://cloud.githubusercontent.com/assets/150562/26084821/251ca1c0-39ad-11e7-9393-199f6ed8e076.gif)


# Open questions

- [x] ~`route-intercept` is not the greatest name~ `restore-last-location` adopted
- [ ] specific objections to use of `store`?