### PR TITLE
Notes: unselect a note when the panel is closed

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3683,7 +3683,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.1.9"
+      "version": "Automattic/notifications-panel#fix\/keypress"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3683,7 +3683,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "Automattic/notifications-panel#fix\/keypress"
+      "version": "1.1.10"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.1.9",
+    "notifications-panel": "Automattic/notifications-panel#fix\/keypress",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "Automattic/notifications-panel#fix\/keypress",
+    "notifications-panel": "1.1.10",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",


### PR DESCRIPTION
This PR fixes an issue where the notifications panel would steal keystrokes if we closed the panel with a certain type of note selected.

### Testing Instructions

- Open the editor. http://calypso.localhost:3000/post
- Select a site if prompted
- Open the notifications panel.
- Open a notification for a post or comment.
- Click somewhere else on the page, closing the notification panel.
- Click in the Title box.
- Press ‘l’.

h/t @pento for repro steps

I'll update the branch to point at 1.1.10 instead of the branch before this is merged.