### PR TITLE
Jetpack Connect: query single site pre-connection

### DIFF
--- a/client/signup/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-in-form.jsx
@@ -47,6 +47,7 @@ class LoggedInForm extends Component {
 		goBackToWpAdmin: PropTypes.func.isRequired,
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
+		isFetchingAuthorizationSite: PropTypes.bool,
 		isSSO: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			authorizeError: PropTypes.oneOfType( [
@@ -347,7 +348,7 @@ class LoggedInForm extends Component {
 			return translate( 'Try again' );
 		}
 
-		if ( this.props.isFetchingSites ) {
+		if ( this.props.isFetchingAuthorizationSite ) {
 			return translate( 'Preparing authorization' );
 		}
 
@@ -484,7 +485,7 @@ class LoggedInForm extends Component {
 	renderStateAction() {
 		const { authorizeSuccess, siteReceived } = this.props.jetpackConnectAuthorize;
 		if (
-			this.props.isFetchingSites ||
+			this.props.isFetchingAuthorizationSite ||
 			this.isAuthorizing() ||
 			this.retryingAuth ||
 			( authorizeSuccess && ! siteReceived )

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -34,7 +34,7 @@ import observe from 'lib/mixins/data-observe';
 import { recordTracksEvent } from 'state/analytics/actions';
 import EmptyContent from 'components/empty-content';
 import { requestSites } from 'state/sites/actions';
-import { isRequestingSites } from 'state/sites/selectors';
+import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
 import MainWrapper from './main-wrapper';
 import HelpButton from './help-button';
 import { urlToSlug } from 'lib/url';
@@ -83,11 +83,11 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 	renderPlansSelector() {
 		return (
-				<div>
-					<CheckoutData>
-						<Plans { ...this.props } showFirst={ true } />
-					</CheckoutData>
-				</div>
+			<div>
+				<CheckoutData>
+					<Plans { ...this.props } showFirst={ true } />
+				</CheckoutData>
+			</div>
 		);
 	},
 
@@ -150,6 +150,7 @@ export default connect(
 			jetpackSSOSessions: getSSOSessions( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingSites: isRequestingSites( state ),
+			isFetchingAuthorizationSite: isRequestingSite( state ),
 			requestHasXmlrpcError,
 			requestHasExpiredSecretError,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -28,7 +28,8 @@ import {
 	getSiteSelectedPlan,
 	isRemoteSiteOnSitesList,
 	getGlobalSelectedPlan,
-	getAuthAttempts
+	getAuthAttempts,
+	getSiteIdFromQueryObject
 } from 'state/jetpack-connect/selectors';
 import observe from 'lib/mixins/data-observe';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -141,6 +142,7 @@ export default connect(
 			return hasExpiredSecretError( state );
 		};
 		const selectedPlan = getSiteSelectedPlan( state, siteSlug ) || getGlobalSelectedPlan( state );
+		const siteId = getSiteIdFromQueryObject( state );
 
 		return {
 			siteSlug,
@@ -150,7 +152,7 @@ export default connect(
 			jetpackSSOSessions: getSSOSessions( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 			isFetchingSites: isRequestingSites( state ),
-			isFetchingAuthorizationSite: isRequestingSite( state ),
+			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
 			requestHasXmlrpcError,
 			requestHasExpiredSecretError,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, remoteSiteUrl ),

--- a/client/signup/jetpack-connect/site-card.jsx
+++ b/client/signup/jetpack-connect/site-card.jsx
@@ -20,6 +20,7 @@ class SiteCard extends Component {
 			blogname: PropTypes.string.isRequired,
 			home_url: PropTypes.string.isRequired,
 			site_url: PropTypes.string.isRequired,
+			client_id: PropTypes.string.isRequired
 		} ).isRequired,
 	};
 
@@ -29,6 +30,7 @@ class SiteCard extends Component {
 			blogname,
 			home_url,
 			site_url,
+			client_id
 		} = this.props.queryObject;
 		const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
 		const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
@@ -47,7 +49,7 @@ class SiteCard extends Component {
 
 		return (
 			<CompactCard className="jetpack-connect__site">
-				<QuerySites allSites />
+				<QuerySites siteId={ parseInt( client_id ) } />
 				<Site site={ site } />
 			</CompactCard>
 		);

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -31,6 +31,7 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 	JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
 	JETPACK_CONNECT_SSO_VALIDATION_ERROR,
+	SITE_REQUEST_FAILURE,
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
@@ -221,6 +222,12 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 					bearerToken: action.data.bearer_token
 				}
 			);
+		case SITE_REQUEST_FAILURE:
+			const { client_id } = state.queryObject;
+			if ( parseInt( client_id ) === action.siteId ) {
+				return Object.assign( {}, state, { clientNotResponding: true } );
+			}
+			return state;
 		case JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -36,9 +36,14 @@ const getAuthorizationRemoteSite = ( state ) => {
 };
 
 const isRemoteSiteOnSitesList = ( state ) => {
-	const remoteUrl = getAuthorizationRemoteSite( state );
+	const remoteUrl = getAuthorizationRemoteSite( state ),
+		authorizationData = getAuthorizationData( state );
 
 	if ( ! remoteUrl ) {
+		return false;
+	}
+
+	if ( authorizationData.clientNotResponding ) {
 		return false;
 	}
 

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -151,6 +151,14 @@ const getGlobalSelectedPlan = function( state ) {
 	return state.jetpackConnect.jetpackConnectSelectedPlans && state.jetpackConnect.jetpackConnectSelectedPlans[ '*' ];
 };
 
+const getSiteIdFromQueryObject = function( state ) {
+	const authorizationData = getAuthorizationData( state );
+	if ( authorizationData.queryObject && authorizationData.queryObject.client_id ) {
+		return parseInt( authorizationData.queryObject.client_id );
+	}
+	return null;
+};
+
 export default {
 	getConnectingSite,
 	getAuthorizationData,
@@ -169,5 +177,6 @@ export default {
 	getJetpackPlanSelected,
 	getSiteSelectedPlan,
 	getGlobalSelectedPlan,
-	getAuthAttempts
+	getAuthAttempts,
+	getSiteIdFromQueryObject
 };

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -31,6 +31,7 @@ import {
 	JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL,
 	JETPACK_CONNECT_REDIRECT_WP_ADMIN,
 	JETPACK_CONNECT_RETRY_AUTH,
+	SITE_REQUEST_FAILURE,
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
@@ -564,6 +565,23 @@ describe( 'reducer', () => {
 
 			expect( state ).to.have.property( 'isRedirectingToWpAdmin' )
 				.to.be.true;
+		} );
+
+		it( 'should set clientNotResponding when a site request to current client fails', () => {
+			const state = jetpackConnectAuthorize(
+				{ queryObject: { client_id: '123' } },
+				{ type: SITE_REQUEST_FAILURE, siteId: 123 }
+			);
+			expect( state ).to.have.property( 'clientNotResponding' )
+				.to.be.true;
+		} );
+
+		it( 'should persist state when a site request to a different client fails', () => {
+			const state = jetpackConnectAuthorize(
+				{ queryObject: { client_id: '123' } },
+				{ type: SITE_REQUEST_FAILURE, siteId: 456 }
+			);
+			expect( state ).to.eql( { queryObject: { client_id: '123' } } );
 		} );
 
 		it( 'should persist state', () => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -21,7 +21,8 @@ import {
 	getJetpackSiteByUrl,
 	hasXmlrpcError,
 	getAuthAttempts,
-	hasExpiredSecretError
+	hasExpiredSecretError,
+	getSiteIdFromQueryObject
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -156,6 +157,30 @@ describe( 'selectors', () => {
 			};
 
 			expect( isRemoteSiteOnSitesList( state ) ).to.be.true;
+		} );
+
+		it( 'should return false if the site is in the sites list, but is not responding', () => {
+			const state = {
+				sites: {
+					items: {
+						12345678: {
+							ID: 12345678,
+							jetpack: true,
+							URL: 'https://wordpress.com/'
+						}
+					}
+				},
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						queryObject: {
+							client_id: '12345678',
+						},
+						clientNotResponding: true
+					}
+				}
+			};
+
+			expect( isRemoteSiteOnSitesList( state ) ).to.be.false;
 		} );
 	} );
 
@@ -660,6 +685,41 @@ describe( 'selectors', () => {
 			};
 
 			expect( getAuthAttempts( state, 'sitetest.com' ) ).to.equals( 2 );
+		} );
+	} );
+
+	describe( '#getSiteIdFromQueryObject()', () => {
+		it( 'should return an integer', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						queryObject: {
+							client_id: '123'
+						}
+					}
+				}
+			};
+			expect( getSiteIdFromQueryObject( state ) ).to.equals( 123 );
+		} );
+
+		it( 'should return null if there is no query object', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {}
+				}
+			};
+			expect( getSiteIdFromQueryObject( state ) ).to.be.null;
+		} );
+
+		it( 'should return null if there is no client id', () => {
+			const state = {
+				jetpackConnect: {
+					jetpackConnectAuthorize: {
+						queryObject: {}
+					}
+				}
+			};
+			expect( getSiteIdFromQueryObject( state ) ).to.be.null;
 		} );
 	} );
 } );


### PR DESCRIPTION
Currently, when connecting a Jetpack site we wait for the query to `me/sites` to finish before allowing folks to start the process. We wait to ensure that the site we are connecting is not already on the site's list, or in the case of re-connection, that the site is removed before proceeding.

We can speed up the wait time by only querying the site in question.

To test reconnections:

- Disconnect a connected Jetpack site via the site's wp-admin
- Ensure that you can reconnect

Try the Jetpack Connect flows, and ensure there are no regressions. Ensure there is no long wait time when you land on the authorization screen.
