### PR TITLE
Added data-e2e-button attribute for dialog buttons

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -63,7 +63,8 @@ class DialogBase extends Component {
 			clickHandler = this._onButtonClick.bind( this, button );
 
 		return (
-			<button key={ button.action } className={ classes } data-e2e-button={ button.label } onClick={ clickHandler } disabled={ !! button.disabled }>
+			<button key={ button.action } className={ classes }
+					data-e2e-button={ button.action } onClick={ clickHandler } disabled={ !! button.disabled }>
 				<span className={ this.props.baseClassName + '__button-label' }>{ button.label }</span>
 			</button>
 		);

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -63,7 +63,7 @@ class DialogBase extends Component {
 			clickHandler = this._onButtonClick.bind( this, button );
 
 		return (
-			<button key={ button.action } className={ classes } onClick={ clickHandler } disabled={ !! button.disabled }>
+			<button key={ button.action } className={ classes } data-e2e-button={ button.label } onClick={ clickHandler } disabled={ !! button.disabled }>
 				<span className={ this.props.baseClassName + '__button-label' }>{ button.label }</span>
 			</button>
 		);


### PR DESCRIPTION
This PR adds a data-attribute for the dialog buttons. Specifically, this adds a new data-e2e-button attribute to the button tag. This is to help with improving the selectors used in our e2e tests.

For testing this change, we just need to make sure the attribute is properly added to the button tag, and that it shows the correct name (e.g Cancel, Insert, etc). A great way to test it would be to create a new post, click the "+" to open the media modal, and inspect the button elements at the bottom right of the modal.