### PR TITLE
Reader: Fix site recs not dismissible in Safari

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -90,6 +90,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		justify-content: flex-end;
 
 		.button.is-borderless {
+			position: relative;
 			z-index: 0;
 		}
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/14077

In a previous PR https://github.com/Automattic/wp-calypso/pull/14056, `z-index` was added to the dismiss buttons in Site Recs to be clickable. This somehow broke it in Safari, I think because it needed `position` to be set for z-indexing to work.

Reported by: @alisterscott 