### PR TITLE
Supply the browser language setting if the current user locale is not available.

### DIFF
--- a/client/lib/wp/localization/index.js
+++ b/client/lib/wp/localization/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import qs from 'querystring';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,7 +77,7 @@ export function injectLocalization( wpcom ) {
  */
 export function bindState( store ) {
 	function setLocaleFromState() {
-		setLocale( getCurrentUserLocale( store.getState() ) );
+		setLocale( getCurrentUserLocale( store.getState() ) || get( window, 'navigator.language', 'en' ) );
 	}
 
 	store.subscribe( setLocaleFromState );


### PR DESCRIPTION
## Summary

Currently, for all api requests initiated from a logged-out session, the locale parameter will be absent since there is no current user. This PR aims to supply the browser language setting in this case, so that these requests can carry proper localization info.

## Test Plan

From what I know, one easy way to initiate some logged-out api requests is through the account recovery process, so let's piggy-back on it.

### Logged-out session
1. Visit http://calypso.localhost:3000/account-recovery, enter a test account, and hit "Continue"
1. From there, a GET request to `/account-recovery/lookup` should be fired. On this branch, it should carry a `locale` query argument:

![image](https://cloud.githubusercontent.com/assets/1842898/26092703/fd340c50-3a44-11e7-89f0-f51496e79609.png)


