### PR TITLE
Purchases: Prettify all files with prettier!

### DIFF
--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -15,14 +15,14 @@ import { concatTitle } from 'lib/react-helpers';
 import { createPaygateToken } from 'lib/store-transactions';
 import CreditCardForm from 'blocks/credit-card-form';
 import DocumentHead from 'components/data/document-head';
-import HeaderCake from 'components/header-cake' ;
+import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import titles from 'me/purchases/titles';
 import purchasesPaths from 'me/purchases/paths';
 
 class AddCreditCard extends Component {
 	static propTypes = {
-		addStoredCard: PropTypes.func.isRequired
+		addStoredCard: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {
@@ -58,7 +58,7 @@ class AddCreditCard extends Component {
 }
 
 const mapDispatchToProps = {
-	addStoredCard
+	addStoredCard,
 };
 
 export default connect( null, mapDispatchToProps )( AddCreditCard );

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -13,7 +13,11 @@ import Button from 'components/button';
 import { cancelPrivacyProtection } from 'state/purchases/actions';
 import Card from 'components/card';
 import HeaderCake from 'components/header-cake';
-import { getByPurchaseId, getPurchasesError, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import {
+	getByPurchaseId,
+	getPurchasesError,
+	hasLoadedUserPurchasesFromServer,
+} from 'state/purchases/selectors';
 import { getPurchase, isDataLoading, goToManagePurchase, recordPageView } from '../utils';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { hasPrivacyProtection, isRefundable } from 'lib/purchases';
@@ -34,16 +38,13 @@ const CancelPrivacyProtection = React.createClass( {
 		hasLoadedSites: React.PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
 		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.bool,
-			React.PropTypes.object
-		] )
+		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.bool, React.PropTypes.object ] ),
 	},
 
 	getInitialState() {
 		return {
 			disabled: false,
-			cancelling: false
+			cancelling: false,
 		};
 	},
 
@@ -70,8 +71,7 @@ const CancelPrivacyProtection = React.createClass( {
 			return true;
 		}
 
-		const { selectedSite } = props,
-			purchase = getPurchase( props );
+		const { selectedSite } = props, purchase = getPurchase( props );
 
 		return selectedSite && purchase && hasPrivacyProtection( purchase );
 	},
@@ -84,20 +84,26 @@ const CancelPrivacyProtection = React.createClass( {
 
 		this.setState( {
 			disabled: true,
-			cancelling: true
+			cancelling: true,
 		} );
 
-		this.props.cancelPrivacyProtection( id ).then( () => {
-			this.resetState();
+		this.props
+			.cancelPrivacyProtection( id )
+			.then( () => {
+				this.resetState();
 
-			notices.success( this.translate( 'You have successfully canceled privacy protection for %(domain)s.', {
-				args: { domain }
-			} ), { persistent: true } );
+				notices.success(
+					this.translate( 'You have successfully canceled privacy protection for %(domain)s.', {
+						args: { domain },
+					} ),
+					{ persistent: true }
+				);
 
-			page( paths.managePurchase( this.props.selectedSite.slug, id ) );
-		} ).catch( () => {
-			this.resetState();
-		} );
+				page( paths.managePurchase( this.props.selectedSite.slug, id ) );
+			} )
+			.catch( () => {
+				this.resetState();
+			} );
 	},
 
 	resetState() {
@@ -109,17 +115,15 @@ const CancelPrivacyProtection = React.createClass( {
 
 		return (
 			<p>
-				{
-					this.translate(
-						'You are about to cancel the privacy protection upgrade for {{strong}}%(domain)s{{/strong}}. ' +
+				{ this.translate(
+					'You are about to cancel the privacy protection upgrade for {{strong}}%(domain)s{{/strong}}. ' +
 						'{{br/}}' +
 						'This will make your personal details public.',
-						{
-							components: { strong: <strong />, br: <br /> },
-							args: { domain: purchase.meta }
-						}
-					)
-				}
+					{
+						components: { strong: <strong />, br: <br /> },
+						args: { domain: purchase.meta },
+					}
+				) }
 			</p>
 		);
 	},
@@ -129,11 +133,9 @@ const CancelPrivacyProtection = React.createClass( {
 
 		return (
 			<strong>
-				{
-					isRefundable( purchase )
+				{ isRefundable( purchase )
 					? this.translate( 'You will receive a refund when the upgrade is cancelled.' )
-					: this.translate( 'You will not receive a refund when the upgrade is cancelled.' )
-				}
+					: this.translate( 'You will not receive a refund when the upgrade is cancelled.' ) }
 			</strong>
 		);
 	},
@@ -143,11 +145,11 @@ const CancelPrivacyProtection = React.createClass( {
 			<Button
 				onClick={ this.cancel }
 				className="cancel-privacy-protection__cancel-button"
-				disabled={ this.state.disabled }>
-				{
-					this.state.cancelling
-						? this.translate( 'Processing…' )
-						: this.translate( 'Cancel Privacy Protection' ) }
+				disabled={ this.state.disabled }
+			>
+				{ this.state.cancelling
+					? this.translate( 'Processing…' )
+					: this.translate( 'Cancel Privacy Protection' ) }
 			</Button>
 		);
 	},
@@ -156,13 +158,15 @@ const CancelPrivacyProtection = React.createClass( {
 		const { error } = this.props;
 
 		if ( error ) {
-			return <Notice status="is-error" showDismiss={ false }>
-				{ error }
-				{ ' ' }
-				{ this.translate( 'Please try again later or {{a}}contact support.{{/a}}', {
-					components: { a: <a href={ CALYPSO_CONTACT } /> }
-				} ) }
-			</Notice>;
+			return (
+				<Notice status="is-error" showDismiss={ false }>
+					{ error }
+					{ ' ' }
+					{ this.translate( 'Please try again later or {{a}}contact support.{{/a}}', {
+						components: { a: <a href={ CALYPSO_CONTACT } /> },
+					} ) }
+				</Notice>
+			);
 		}
 
 		return null;
@@ -170,7 +174,7 @@ const CancelPrivacyProtection = React.createClass( {
 
 	render() {
 		const classes = classNames( 'cancel-privacy-protection__card', {
-			'is-placeholder': isDataLoading( this.props )
+			'is-placeholder': isDataLoading( this.props ),
 		} );
 
 		let notice,
@@ -195,7 +199,6 @@ const CancelPrivacyProtection = React.createClass( {
 		}
 
 		return (
-
 			<Main>
 				<QueryUserPurchases userId={ user.get().ID } />
 				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
@@ -214,7 +217,7 @@ const CancelPrivacyProtection = React.createClass( {
 				</Card>
 			</Main>
 		);
-	}
+	},
 } );
 
 export default connect(
@@ -223,7 +226,7 @@ export default connect(
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
-		selectedSite: getSelectedSiteSelector( state )
+		selectedSite: getSelectedSiteSelector( state ),
 	} ),
 	{ cancelPrivacyProtection }
 )( CancelPrivacyProtection );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -14,24 +14,27 @@ import config from 'config';
 import Button from 'components/button';
 import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
-import {
-	isHappychatAvailable,
-	isHappychatChatActive,
-} from 'state/happychat/selectors';
+import { isHappychatAvailable, isHappychatChatActive } from 'state/happychat/selectors';
 import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
-import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enrichedSurveyData';
-import initialSurveyState from 'components/marketing-survey/cancel-purchase-form/initialSurveyState';
+import enrichedSurveyData
+	from 'components/marketing-survey/cancel-purchase-form/enrichedSurveyData';
+import initialSurveyState
+	from 'components/marketing-survey/cancel-purchase-form/initialSurveyState';
 import isSurveyFilledIn from 'components/marketing-survey/cancel-purchase-form/isSurveyFilledIn';
-import stepsForProductAndSurvey from 'components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey';
+import stepsForProductAndSurvey
+	from 'components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey';
 import nextStep from 'components/marketing-survey/cancel-purchase-form/nextStep';
 import previousStep from 'components/marketing-survey/cancel-purchase-form/previousStep';
+import { INITIAL_STEP, FINAL_STEP } from 'components/marketing-survey/cancel-purchase-form/steps';
 import {
-	INITIAL_STEP,
-	FINAL_STEP,
-} from 'components/marketing-survey/cancel-purchase-form/steps';
-import { getName, getSubscriptionEndDate, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
+	getName,
+	getSubscriptionEndDate,
+	isOneTimePurchase,
+	isRefundable,
+	isSubscription,
+} from 'lib/purchases';
 import { isDomainRegistration, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
@@ -42,16 +45,16 @@ import { cancellationEffectDetail, cancellationEffectHeadline } from './cancella
 class CancelPurchaseButton extends Component {
 	static propTypes = {
 		purchase: PropTypes.object.isRequired,
-		selectedSite: PropTypes.object.isRequired
-	}
+		selectedSite: PropTypes.object.isRequired,
+	};
 
 	state = {
 		disabled: false,
 		showDialog: false,
 		isRemoving: false,
 		surveyStep: INITIAL_STEP,
-		survey: initialSurveyState()
-	}
+		survey: initialSurveyState(),
+	};
 
 	recordEvent = ( name, properties = {} ) => {
 		const { purchase } = this.props;
@@ -61,7 +64,7 @@ class CancelPurchaseButton extends Component {
 			name,
 			Object.assign( { cancellation_flow, product_slug }, properties )
 		);
-	}
+	};
 
 	handleCancelPurchaseClick = () => {
 		if ( isDomainRegistration( this.props.purchase ) ) {
@@ -71,9 +74,9 @@ class CancelPurchaseButton extends Component {
 		this.recordEvent( 'calypso_purchases_cancel_form_start' );
 
 		this.setState( {
-			showDialog: true
+			showDialog: true,
 		} );
-	}
+	};
 
 	closeDialog = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_close' );
@@ -81,70 +84,70 @@ class CancelPurchaseButton extends Component {
 		this.setState( {
 			showDialog: false,
 			surveyStep: INITIAL_STEP,
-			survey: initialSurveyState()
+			survey: initialSurveyState(),
 		} );
-	}
+	};
 
 	chatInitiated = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_chat_initiated' );
 		this.closeDialog();
-	}
+	};
 
-	changeSurveyStep = ( stepFunction ) => {
+	changeSurveyStep = stepFunction => {
 		const { purchase, isChatAvailable, isChatActive } = this.props;
 		const { surveyStep, survey } = this.state;
 		const steps = stepsForProductAndSurvey( survey, purchase, isChatAvailable || isChatActive );
 		const newStep = stepFunction( surveyStep, steps );
 		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
 		this.setState( { surveyStep: newStep } );
-	}
+	};
 
 	clickNext = () => {
 		if ( this.state.isRemoving || ! isSurveyFilledIn( this.state.survey ) ) {
 			return;
 		}
 		this.changeSurveyStep( nextStep );
-	}
+	};
 
 	clickPrevious = () => {
 		if ( this.state.isRemoving ) {
 			return;
 		}
 		this.changeSurveyStep( previousStep );
-	}
+	};
 
-	onSurveyChange = ( update ) => {
+	onSurveyChange = update => {
 		this.setState( {
 			survey: update,
 		} );
-	}
+	};
 
 	renderCancelConfirmationDialog = () => {
 		const { purchase, translate } = this.props;
 		const buttons = {
 			close: {
 				action: 'close',
-				label: translate( "I'll Keep It" )
+				label: translate( "I'll Keep It" ),
 			},
 			next: {
 				action: 'next',
 				disabled: this.state.isRemoving || ! isSurveyFilledIn( this.state.survey ),
 				label: translate( 'Next Step' ),
-				onClick: this.clickNext
+				onClick: this.clickNext,
 			},
 			prev: {
 				action: 'prev',
 				disabled: this.state.isRemoving,
 				label: translate( 'Previous Step' ),
-				onClick: this.clickPrevious
+				onClick: this.clickPrevious,
 			},
 			cancel: {
 				action: 'cancel',
 				label: translate( 'Cancel Now' ),
 				isPrimary: true,
 				disabled: this.state.submitting,
-				onClick: this.submitCancelAndRefundPurchase
-			}
+				onClick: this.submitCancelAndRefundPurchase,
+			},
 		};
 
 		let buttonsArr;
@@ -163,7 +166,8 @@ class CancelPurchaseButton extends Component {
 				isVisible={ this.state.showDialog }
 				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
-				className="cancel-purchase__button-warning-dialog">
+				className="cancel-purchase__button-warning-dialog"
+			>
 				<CancelPurchaseForm
 					chatInitiated={ this.chatInitiated }
 					productName={ getName( purchase ) }
@@ -175,21 +179,20 @@ class CancelPurchaseButton extends Component {
 				/>
 			</Dialog>
 		);
-	}
+	};
 
 	goToCancelConfirmation = () => {
-		const { id } = this.props.purchase,
-			{ slug } = this.props.selectedSite;
+		const { id } = this.props.purchase, { slug } = this.props.selectedSite;
 
 		page( paths.confirmCancelDomain( slug, id ) );
-	}
+	};
 
 	cancelPurchase = () => {
 		const { purchase, translate } = this.props;
 
 		this.toggleDisabled();
 
-		cancelPurchase( purchase.id, ( success ) => {
+		cancelPurchase( purchase.id, success => {
 			const purchaseName = getName( purchase ),
 				subscriptionEndDate = getSubscriptionEndDate( purchase );
 
@@ -198,44 +201,49 @@ class CancelPurchaseButton extends Component {
 			this.props.clearPurchases();
 
 			if ( success ) {
-				notices.success( translate(
-					'%(purchaseName)s was successfully cancelled. It will be available ' +
-					'for use until it expires on %(subscriptionEndDate)s.',
-					{
-						args: {
-							purchaseName,
-							subscriptionEndDate
+				notices.success(
+					translate(
+						'%(purchaseName)s was successfully cancelled. It will be available ' +
+							'for use until it expires on %(subscriptionEndDate)s.',
+						{
+							args: {
+								purchaseName,
+								subscriptionEndDate,
+							},
 						}
-					}
-				), { persistent: true } );
+					),
+					{ persistent: true }
+				);
 
 				page( paths.purchasesRoot() );
 			} else {
-				notices.error( translate(
-					'There was a problem canceling %(purchaseName)s. ' +
-					'Please try again later or contact support.',
-					{
-						args: { purchaseName }
-					}
-				) );
+				notices.error(
+					translate(
+						'There was a problem canceling %(purchaseName)s. ' +
+							'Please try again later or contact support.',
+						{
+							args: { purchaseName },
+						}
+					)
+				);
 				this.cancellationFailed();
 			}
 		} );
-	}
+	};
 
 	cancellationFailed = () => {
 		this.closeDialog();
 
 		this.setState( {
-			submitting: false
+			submitting: false,
 		} );
-	}
+	};
 
 	toggleDisabled = () => {
 		this.setState( {
-			disabled: ! this.state.disabled
+			disabled: ! this.state.disabled,
 		} );
-	}
+	};
 
 	handleSubmit = ( error, response ) => {
 		if ( error ) {
@@ -255,28 +263,28 @@ class CancelPurchaseButton extends Component {
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
 		page.redirect( paths.purchasesRoot() );
-	}
+	};
 
 	submitCancelAndRefundPurchase = () => {
 		const { purchase, selectedSite } = this.props;
 		const refundable = isRefundable( purchase );
 
 		this.setState( {
-			submitting: true
+			submitting: true,
 		} );
 
 		if ( config.isEnabled( 'upgrades/removal-survey' ) ) {
 			const surveyData = {
 				'why-cancel': {
 					response: this.state.survey.questionOneRadio,
-					text: this.state.survey.questionOneText
+					text: this.state.survey.questionOneText,
 				},
 				'next-adventure': {
 					response: this.state.survey.questionTwoRadio,
-					text: this.state.survey.questionTwoText
+					text: this.state.survey.questionTwoText,
 				},
 				'what-better': { text: this.state.survey.questionThreeText },
-				type: refundable ? 'refund' : 'cancel-autorenew'
+				type: refundable ? 'refund' : 'cancel-autorenew',
 			};
 
 			submitSurvey(
@@ -291,7 +299,7 @@ class CancelPurchaseButton extends Component {
 		} else {
 			this.cancelPurchase();
 		}
-	}
+	};
 
 	renderCancellationEffect = () => {
 		const { purchase, translate } = this.props;
@@ -302,7 +310,7 @@ class CancelPurchaseButton extends Component {
 				{ cancellationEffectDetail( purchase, translate ) }
 			</p>
 		);
-	}
+	};
 
 	render() {
 		const { purchase, translate } = this.props;
@@ -342,12 +350,12 @@ class CancelPurchaseButton extends Component {
 					className="cancel-purchase__button"
 					disabled={ this.state.disabled }
 					onClick={ onClick }
-					primary>
+					primary
+				>
 					{ text }
 				</Button>
 				{ this.renderCancelConfirmationDialog() }
 			</div>
-
 		);
 	}
 }

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -11,31 +11,33 @@ import { isDomainMapping, isGoogleApps, isJetpackPlan, isTheme } from 'lib/produ
 
 export function cancellationEffectHeadline( purchase, translate ) {
 	const { domain } = purchase;
-	const	purchaseName = getName( purchase );
+	const purchaseName = getName( purchase );
 
 	if ( isRefundable( purchase ) ) {
 		return translate(
-			'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ', {
+			'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ',
+			{
 				args: {
 					purchaseName,
-					domain
+					domain,
 				},
 				components: {
-					em: <em />
-				}
+					em: <em />,
+				},
 			}
 		);
 	}
 
 	return translate(
-		'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? ', {
+		'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? ',
+		{
 			args: {
 				purchaseName,
-				domain
+				domain,
 			},
 			components: {
-				em: <em />
-			}
+				em: <em />,
+			},
 		}
 	);
 }
@@ -45,10 +47,11 @@ function refundableCancellationEffectDetail( purchase, translate ) {
 
 	if ( isTheme( purchase ) ) {
 		return translate(
-			'Your site\'s appearance will revert to its previously selected theme and you will be refunded %(cost)s.', {
+			"Your site's appearance will revert to its previously selected theme and you will be refunded %(cost)s.",
+			{
 				args: {
-					cost: refundText
-				}
+					cost: refundText,
+				},
 			}
 		);
 	}
@@ -56,10 +59,11 @@ function refundableCancellationEffectDetail( purchase, translate ) {
 	if ( isGoogleApps( purchase ) ) {
 		return translate(
 			'You will be refunded %(cost)s, but your G Suite account will continue working without interruption. ' +
-			'You will be able to manage your G Suite billing directly through Google.', {
+				'You will be able to manage your G Suite billing directly through Google.',
+			{
 				args: {
-					cost: refundText
-				}
+					cost: refundText,
+				},
 			}
 		);
 	}
@@ -67,19 +71,21 @@ function refundableCancellationEffectDetail( purchase, translate ) {
 	if ( isJetpackPlan( purchase ) ) {
 		return translate(
 			'All plan features - spam filtering, backups, and security screening - will be removed from your site ' +
-			'and you will be refunded %(cost)s.', {
+				'and you will be refunded %(cost)s.',
+			{
 				args: {
-					cost: refundText
-				}
+					cost: refundText,
+				},
 			}
 		);
 	}
 
 	return translate(
-		'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.', {
+		'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.',
+		{
 			args: {
-				cost: refundText
-			}
+				cost: refundText,
+			},
 		}
 	);
 }
@@ -89,29 +95,32 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 
 	if ( isGoogleApps( purchase ) ) {
 		return translate(
-			'Your G Suite account remains active until it expires on %(subscriptionEndDate)s.', {
+			'Your G Suite account remains active until it expires on %(subscriptionEndDate)s.',
+			{
 				args: {
-					subscriptionEndDate
-				}
+					subscriptionEndDate,
+				},
 			}
 		);
 	}
 
 	if ( isDomainMapping( purchase ) ) {
 		return translate(
-			'Your domain mapping remains active until it expires on %(subscriptionEndDate)s.', {
+			'Your domain mapping remains active until it expires on %(subscriptionEndDate)s.',
+			{
 				args: {
-					subscriptionEndDate
-				}
+					subscriptionEndDate,
+				},
 			}
 		);
 	}
 
 	return translate(
-		"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s.", {
+		"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s.",
+		{
 			args: {
-				subscriptionEndDate
-			}
+				subscriptionEndDate,
+			},
 		}
 	);
 }

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -13,8 +13,19 @@ import CancelPurchaseButton from './button';
 import CancelPurchaseLoadingPlaceholder from 'me/purchases/cancel-purchase/loading-placeholder';
 import CancelPurchaseRefundInformation from './refund-information';
 import CompactCard from 'components/card/compact';
-import { getName, isCancelable, isOneTimePurchase, isRefundable, isSubscription } from 'lib/purchases';
-import { getPurchase, getSelectedSite, goToManagePurchase, recordPageView } from 'me/purchases/utils';
+import {
+	getName,
+	isCancelable,
+	isOneTimePurchase,
+	isRefundable,
+	isSubscription,
+} from 'lib/purchases';
+import {
+	getPurchase,
+	getSelectedSite,
+	goToManagePurchase,
+	recordPageView,
+} from 'me/purchases/utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
@@ -35,10 +46,7 @@ const CancelPurchase = React.createClass( {
 		hasLoadedSites: React.PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
 		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.bool,
-			React.PropTypes.object
-		] )
+		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.bool, React.PropTypes.object ] ),
 	},
 
 	componentWillMount() {
@@ -64,15 +72,13 @@ const CancelPurchase = React.createClass( {
 			return true;
 		}
 
-		const purchase = getPurchase( props ),
-			selectedSite = getSelectedSite( props );
+		const purchase = getPurchase( props ), selectedSite = getSelectedSite( props );
 
 		return selectedSite && purchase && isCancelable( purchase );
 	},
 
 	redirect( props ) {
-		const purchase = getPurchase( props ),
-			selectedSite = getSelectedSite( props );
+		const purchase = getPurchase( props ), selectedSite = getSelectedSite( props );
 		let redirectPath = paths.purchasesRoot();
 
 		if ( selectedSite && purchase && ! isCancelable( purchase ) ) {
@@ -83,13 +89,12 @@ const CancelPurchase = React.createClass( {
 	},
 
 	renderFooterText() {
-		const purchase = getPurchase( this.props ),
-			{ refundText, renewDate } = purchase;
+		const purchase = getPurchase( this.props ), { refundText, renewDate } = purchase;
 
 		if ( isRefundable( purchase ) ) {
 			return this.translate( '%(refundText)s to be refunded', {
 				args: { refundText },
-				context: 'refundText is of the form "[currency-symbol][amount]" i.e. "$20"'
+				context: 'refundText is of the form "[currency-symbol][amount]" i.e. "$20"',
 			} );
 		}
 
@@ -97,12 +102,12 @@ const CancelPurchase = React.createClass( {
 
 		if ( isDomainRegistration( purchase ) ) {
 			return this.translate( 'Domain will be removed on %(renewalDate)s', {
-				args: { renewalDate }
+				args: { renewalDate },
 			} );
 		}
 
 		return this.translate( 'Subscription will be removed on %(renewalDate)s', {
-			args: { renewalDate }
+			args: { renewalDate },
 		} );
 	},
 
@@ -131,13 +136,13 @@ const CancelPurchase = React.createClass( {
 
 		if ( isDomainRegistration( purchase ) || isOneTimePurchase( purchase ) ) {
 			heading = this.translate( 'Cancel %(purchaseName)s', {
-				args: { purchaseName }
+				args: { purchaseName },
 			} );
 		}
 
 		if ( isSubscription( purchase ) ) {
 			heading = this.translate( 'Cancel Your %(purchaseName)s Subscription', {
-				args: { purchaseName }
+				args: { purchaseName },
 			} );
 		}
 
@@ -158,28 +163,22 @@ const CancelPurchase = React.createClass( {
 				<CompactCard className="cancel-purchase__product-information">
 					<div className="cancel-purchase__purchase-name">{ purchaseName }</div>
 					<div className="cancel-purchase__site-title">{ siteName || siteDomain }</div>
-					<ProductLink
-						selectedPurchase={ purchase }
-						selectedSite={ this.props.selectedSite } />
+					<ProductLink selectedPurchase={ purchase } selectedSite={ this.props.selectedSite } />
 				</CompactCard>
 				<CompactCard className="cancel-purchase__footer">
 					<div className="cancel-purchase__refund-amount">
 						{ this.renderFooterText( this.props ) }
 					</div>
-					<CancelPurchaseButton
-						purchase={ purchase }
-						selectedSite={ this.props.selectedSite } />
+					<CancelPurchaseButton purchase={ purchase } selectedSite={ this.props.selectedSite } />
 				</CompactCard>
 			</Main>
 		);
-	}
+	},
 } );
 
-export default connect(
-	( state, props ) => ( {
-		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
-		selectedSite: getSelectedSiteSelector( state )
-	} )
-)( CancelPurchase );
+export default connect( ( state, props ) => ( {
+	hasLoadedSites: ! isRequestingSites( state ),
+	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+	selectedPurchase: getByPurchaseId( state, props.purchaseId ),
+	selectedSite: getSelectedSiteSelector( state ),
+} ) )( CancelPurchase );

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -21,9 +21,7 @@ const CancelPurchaseLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {
 	}
 
 	return (
-		<LoadingPlaceholder
-			title={ titles.cancelPurchase }
-			path={ path }>
+		<LoadingPlaceholder title={ titles.cancelPurchase } path={ path }>
 			<Card className="cancel-purchase-loading-placeholder__card">
 				<h2 className="loading-placeholder__content cancel-purchase-loading-placeholder__header" />
 				<div className="loading-placeholder__content cancel-purchase-loading-placeholder__subheader" />
@@ -40,10 +38,7 @@ const CancelPurchaseLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {
 
 CancelPurchaseLoadingPlaceholder.propTypes = {
 	purchaseId: React.PropTypes.number.isRequired,
-	selectedSite: React.PropTypes.oneOfType( [
-		React.PropTypes.bool,
-		React.PropTypes.object
-	] )
+	selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.bool, React.PropTypes.object ] ),
 };
 
 export default CancelPurchaseLoadingPlaceholder;

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -22,9 +22,9 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 		if ( isDomainRegistration( purchase ) ) {
 			text = i18n.translate(
 				'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
-				"you'll receive a refund and it will be removed from your site immediately.",
+					"you'll receive a refund and it will be removed from your site immediately.",
 				{
-					args: { refundPeriodInDays }
+					args: { refundPeriodInDays },
 				}
 			);
 		}
@@ -34,29 +34,29 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 				text = [
 					i18n.translate(
 						'This plan includes the custom domain mapping for %(mappedDomain)s, normally a %(mappingCost)s purchase. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
 						{
 							args: {
 								mappedDomain: includedDomainPurchase.meta,
-								mappingCost: includedDomainPurchase.priceText
-							}
+								mappingCost: includedDomainPurchase.priceText,
+							},
 						}
 					),
 					i18n.translate(
 						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus ' +
-						'%(mappingCost)s for the domain mapping. To cancel the domain mapping with the ' +
-						'plan and ask for a full refund, please {{contactLink}}contact support{{/contactLink}}.',
+							'%(mappingCost)s for the domain mapping. To cancel the domain mapping with the ' +
+							'plan and ask for a full refund, please {{contactLink}}contact support{{/contactLink}}.',
 						{
 							args: {
 								planCost: purchase.priceText,
 								mappingCost: includedDomainPurchase.priceText,
-								refundAmount: purchase.refundText
+								refundAmount: purchase.refundText,
 							},
 							components: {
-								contactLink: <a href={ support.CALYPSO_CONTACT } />
-							}
+								contactLink: <a href={ support.CALYPSO_CONTACT } />,
+							},
 						}
-					)
+					),
 				];
 
 				showSupportLink = false;
@@ -64,36 +64,36 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 				text = [
 					i18n.translate(
 						'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
-						'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
 						{
 							args: {
 								domain: includedDomainPurchase.meta,
 								domainCost: includedDomainPurchase.priceText,
-							}
+							},
 						}
 					),
 					i18n.translate(
 						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-						'minus %(domainCost)s for the domain.',
+							'minus %(domainCost)s for the domain.',
 						{
 							args: {
 								domainCost: includedDomainPurchase.priceText,
 								planCost: purchase.priceText,
-								refundAmount: purchase.refundText
-							}
+								refundAmount: purchase.refundText,
+							},
 						}
-					)
+					),
 				];
 
 				if ( isRefundable( includedDomainPurchase ) ) {
 					text.push(
 						i18n.translate(
 							'To cancel the domain with the plan and ask for a full refund, ' +
-							'please {{contactLink}}contact support{{/contactLink}}.',
+								'please {{contactLink}}contact support{{/contactLink}}.',
 							{
 								components: {
-									contactLink: <a href={ support.CALYPSO_CONTACT } />
-								}
+									contactLink: <a href={ support.CALYPSO_CONTACT } />,
+								},
 							}
 						)
 					);
@@ -103,9 +103,9 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 			} else {
 				text = i18n.translate(
 					'When you cancel your subscription within %(refundPeriodInDays)d days of purchasing, ' +
-					"you'll receive a refund and it will be removed from your site immediately.",
+						"you'll receive a refund and it will be removed from your site immediately.",
 					{
-						args: { refundPeriodInDays }
+						args: { refundPeriodInDays },
 					}
 				);
 			}
@@ -114,47 +114,55 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 		if ( isOneTimePurchase( purchase ) ) {
 			text = i18n.translate(
 				'When you cancel this purchase within %(refundPeriodInDays)d days of purchasing, ' +
-				"you'll receive a refund and it will be removed from your site immediately.",
+					"you'll receive a refund and it will be removed from your site immediately.",
 				{
-					args: { refundPeriodInDays }
+					args: { refundPeriodInDays },
 				}
 			);
 		}
 	} else if ( isDomainRegistration( purchase ) ) {
 		text = i18n.translate(
 			'When you cancel your domain, it will remain registered and active until the registration expires, ' +
-			'at which point it will be automatically removed from your site.'
+				'at which point it will be automatically removed from your site.'
 		);
-	} else if ( isSubscription( purchase ) && includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
+	} else if (
+		isSubscription( purchase ) &&
+		includedDomainPurchase &&
+		isDomainMapping( includedDomainPurchase )
+	) {
 		text = i18n.translate(
 			'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
-			'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+				'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
 			{
 				args: {
 					mappedDomain: includedDomainPurchase.meta,
-					mappingCost: includedDomainPurchase.priceText
-				}
+					mappingCost: includedDomainPurchase.priceText,
+				},
 			}
 		);
-	} else if ( isSubscription( purchase ) && includedDomainPurchase && isDomainRegistration( includedDomainPurchase ) ) {
+	} else if (
+		isSubscription( purchase ) &&
+		includedDomainPurchase &&
+		isDomainRegistration( includedDomainPurchase )
+	) {
 		text = i18n.translate(
 			'This plan includes the custom domain, %(domain)s. ' +
-			'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+				'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
 			{
 				args: {
 					domain: includedDomainPurchase.meta,
 					domainCost: includedDomainPurchase.priceText,
-				}
+				},
 			}
 		);
 	} else {
 		text = i18n.translate(
 			"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
-			'Once it expires, it will be automatically removed from your site.',
+				'Once it expires, it will be automatically removed from your site.',
 			{
 				args: {
-					productName: getName( purchase )
-				}
+					productName: getName( purchase ),
+				},
 			}
 		);
 	}
@@ -162,39 +170,36 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 	return (
 		<div className="cancel-purchase__info">
 			{ Array.isArray( text )
-				? text.map( ( paragraph, index ) =>
-					<p key={ purchase.id + '_refund_p_' + index } className="cancel-purchase__refund-information">
-						{ paragraph }
-					</p>
-					)
-				: <p className="cancel-purchase__refund-information">{ text }</p>
-			}
+				? text.map( ( paragraph, index ) => (
+						<p
+							key={ purchase.id + '_refund_p_' + index }
+							className="cancel-purchase__refund-information"
+						>
+							{ paragraph }
+						</p>
+					) )
+				: <p className="cancel-purchase__refund-information">{ text }</p> }
 
-			{ showSupportLink && (
+			{ showSupportLink &&
 				<strong className="cancel-purchase__support-information">
-				{
-					i18n.translate(
+					{ i18n.translate(
 						'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
 						{
 							components: {
-								contactLink: <a href={ support.CALYPSO_CONTACT } />
-							}
+								contactLink: <a href={ support.CALYPSO_CONTACT } />,
+							},
 						}
-					)
-				}
-				</strong> )
-			}
+					) }
+				</strong> }
 		</div>
 	);
 };
 
 CancelPurchaseRefundInformation.propTypes = {
 	purchase: React.PropTypes.object.isRequired,
-	includedDomainPurchase: React.PropTypes.object
+	includedDomainPurchase: React.PropTypes.object,
 };
 
-export default connect(
-	( state, props ) => ( {
-		includedDomainPurchase: getIncludedDomainPurchase( state, props.purchase )
-	} )
-)( CancelPurchaseRefundInformation );
+export default connect( ( state, props ) => ( {
+	includedDomainPurchase: getIncludedDomainPurchase( state, props.purchase ),
+} ) )( CancelPurchaseRefundInformation );

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -35,7 +35,7 @@ describe( 'cancellation-effect', function() {
 			it( 'should return translation of cancel and return', function() {
 				const headline = cancellationEffect.cancellationEffectHeadline( purchase, translate );
 				expect( headline.text ).to.equal(
-					'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? ',
+					'Are you sure you want to cancel and remove %(purchaseName)s from {{em}}%(domain)s{{/em}}? '
 				);
 			} );
 		} );
@@ -48,7 +48,7 @@ describe( 'cancellation-effect', function() {
 			it( 'should return translation of cancel', function() {
 				const headline = cancellationEffect.cancellationEffectHeadline( purchase, translate );
 				expect( headline.text ).to.equal(
-					'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? ',
+					'Are you sure you want to cancel %(purchaseName)s for {{em}}%(domain)s{{/em}}? '
 				);
 			} );
 		} );
@@ -74,7 +74,7 @@ describe( 'cancellation-effect', function() {
 				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
 				expect( headline.text ).to.equal(
 					'You will be refunded %(cost)s, but your G Suite account will continue working without interruption. ' +
-					'You will be able to manage your G Suite billing directly through Google.'
+						'You will be able to manage your G Suite billing directly through Google.'
 				);
 			} );
 
@@ -85,7 +85,7 @@ describe( 'cancellation-effect', function() {
 				const headline = cancellationEffect.cancellationEffectDetail( purchase, translate );
 				expect( headline.text ).to.equal(
 					'All plan features - spam filtering, backups, and security screening ' +
-					'- will be removed from your site and you will be refunded %(cost)s.'
+						'- will be removed from your site and you will be refunded %(cost)s.'
 				);
 			} );
 

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -13,7 +13,7 @@ import Main from 'components/main';
 const LoadingPlaceholder = React.createClass( {
 	propTypes: {
 		path: React.PropTypes.string,
-		title: React.PropTypes.string.isRequired
+		title: React.PropTypes.string.isRequired,
 	},
 
 	goBack() {
@@ -30,7 +30,7 @@ const LoadingPlaceholder = React.createClass( {
 				{ this.props.children }
 			</Main>
 		);
-	}
+	},
 } );
 
 export default LoadingPlaceholder;

--- a/client/me/purchases/components/purchase-card-details/index.jsx
+++ b/client/me/purchases/components/purchase-card-details/index.jsx
@@ -33,15 +33,14 @@ class PurchaseCardDetails extends Component {
 	}
 
 	isDataValid( props = this.props ) {
-		const purchase = getPurchase( props ),
-			{ selectedSite } = props;
+		const purchase = getPurchase( props ), { selectedSite } = props;
 
 		return purchase && selectedSite;
 	}
 
 	getApiParams() {
 		return {
-			purchaseId: getPurchase( this.props ).id
+			purchaseId: getPurchase( this.props ).id,
 		};
 	}
 
@@ -50,10 +49,9 @@ class PurchaseCardDetails extends Component {
 	}
 
 	recordFormSubmitEvent() {
-		analytics.tracks.recordEvent(
-			'calypso_purchases_credit_card_form_submit',
-			{ product_slug: getPurchase( this.props ).productSlug }
-		);
+		analytics.tracks.recordEvent( 'calypso_purchases_credit_card_form_submit', {
+			product_slug: getPurchase( this.props ).productSlug,
+		} );
 	}
 
 	successCallback() {

--- a/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
+++ b/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
@@ -15,50 +15,60 @@ export default [
 		label: i18n.translate( 'I misspelled the domain' ),
 		helpMessage: i18n.translate(
 			'If you misspelled the domain name you were attempting to purchase, it’s likely that others will as well, ' +
-			'and you might want to consider keeping the misspelled domain.'
-		)
+				'and you might want to consider keeping the misspelled domain.'
+		),
 	},
 	{
 		value: 'other_host',
 		label: i18n.translate( 'I want to use the domain with another service or host' ),
 		helpMessage: i18n.translate(
 			'Canceling a domain name causes the domain to become unavailable for a brief period. ' +
-			'Afterward, anyone can repurchase. If you wish to use the domain with another service, ' +
-			'you’ll want to {{a}}update your name servers{{/a}} instead.', {
-				components: { a: <a href={ support.UPDATE_NAMESERVERS } target="_blank" rel="noopener noreferrer" /> }
+				'Afterward, anyone can repurchase. If you wish to use the domain with another service, ' +
+				'you’ll want to {{a}}update your name servers{{/a}} instead.',
+			{
+				components: {
+					a: <a href={ support.UPDATE_NAMESERVERS } target="_blank" rel="noopener noreferrer" />,
+				},
 			}
-		)
+		),
 	},
 	{
 		value: 'transfer',
 		label: i18n.translate( 'I want to transfer my domain to another registrar' ),
 		helpMessage: i18n.translate(
 			'You may not transfer a domain name for 60 days after its purchase, renewal, name server change, ' +
-			'or any contact information change. This is a rule set by the Internet Corporation for ' +
-			'Assigned Names and Numbers (ICANN) and standard across all registrars. ' +
-			'You will need to {{a}}update your name servers{{/a}} instead.', {
-				components: { a: <a href={ support.UPDATE_NAMESERVERS } target="_blank" rel="noopener noreferrer" /> }
+				'or any contact information change. This is a rule set by the Internet Corporation for ' +
+				'Assigned Names and Numbers (ICANN) and standard across all registrars. ' +
+				'You will need to {{a}}update your name servers{{/a}} instead.',
+			{
+				components: {
+					a: <a href={ support.UPDATE_NAMESERVERS } target="_blank" rel="noopener noreferrer" />,
+				},
 			}
-		)
+		),
 	},
 	{
 		value: 'expectations',
 		label: i18n.translate( 'The service isn’t what I expected' ),
 		helpMessage: i18n.translate(
 			'If you misspelled the domain name you were attempting to purchase, it’s likely that others will as well, ' +
-			'and you might want to consider keeping the misspelled domain.'
-		)
+				'and you might want to consider keeping the misspelled domain.'
+		),
 	},
 	{
 		value: 'wanted_free',
 		label: i18n.translate( 'I meant to get a free blog' ),
-		helpMessage: i18n.translate( 'Please provide a brief description of your reasons for canceling:' ),
-		showTextarea: true
+		helpMessage: i18n.translate(
+			'Please provide a brief description of your reasons for canceling:'
+		),
+		showTextarea: true,
 	},
 	{
 		value: 'other',
 		label: i18n.translate( 'Something not listed here' ),
-		helpMessage: i18n.translate( 'Please provide a brief description of your reasons for canceling:' ),
-		showTextarea: true
-	}
+		helpMessage: i18n.translate(
+			'Please provide a brief description of your reasons for canceling:'
+		),
+		showTextarea: true,
+	},
 ];

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -48,10 +48,7 @@ const ConfirmCancelDomain = React.createClass( {
 		purchaseId: React.PropTypes.number.isRequired,
 		receiveDeletedSite: React.PropTypes.func.isRequired,
 		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.bool,
-			React.PropTypes.object
-		] ),
+		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.bool, React.PropTypes.object ] ),
 		setAllSitesSelected: React.PropTypes.func.isRequired,
 	},
 
@@ -60,7 +57,7 @@ const ConfirmCancelDomain = React.createClass( {
 			selectedReason: null,
 			message: '',
 			confirmed: false,
-			submitting: false
+			submitting: false,
 		};
 	},
 
@@ -105,8 +102,7 @@ const ConfirmCancelDomain = React.createClass( {
 	onSubmit( event ) {
 		event.preventDefault();
 
-		const purchase = getPurchase( this.props ),
-			purchaseName = getDomainName( purchase );
+		const purchase = getPurchase( this.props ), purchaseName = getDomainName( purchase );
 
 		const data = {
 			domain_cancel_reason: this.state.selectedReason.value,
@@ -114,18 +110,15 @@ const ConfirmCancelDomain = React.createClass( {
 			confirm: true,
 			product_id: purchase.productId,
 			blog_id: purchase.siteId,
-			domain: purchaseName
+			domain: purchaseName,
 		};
 
 		this.setState( { submitting: true } );
 
-		cancelAndRefundPurchase( purchase.id, data, ( error ) => {
+		cancelAndRefundPurchase( purchase.id, data, error => {
 			this.setState( { submitting: false } );
 
-			const {
-				isDomainOnlySite,
-				selectedSite,
-			} = this.props;
+			const { isDomainOnlySite, selectedSite } = this.props;
 
 			if ( isDomainOnlySite ) {
 				// Removing the domain from a domain-only site results
@@ -138,14 +131,19 @@ const ConfirmCancelDomain = React.createClass( {
 			}
 
 			if ( error ) {
-				notices.error( error.message || this.translate( 'Unable to cancel your purchase. Please try again later or contact support.' ) );
+				notices.error(
+					error.message ||
+						this.translate(
+							'Unable to cancel your purchase. Please try again later or contact support.'
+						)
+				);
 
 				return;
 			}
 
 			notices.success(
 				this.translate( '%(purchaseName)s was successfully cancelled and refunded.', {
-					args: { purchaseName }
+					args: { purchaseName },
 				} ),
 				{ persistent: true }
 			);
@@ -154,10 +152,9 @@ const ConfirmCancelDomain = React.createClass( {
 
 			this.props.clearPurchases();
 
-			analytics.tracks.recordEvent(
-				'calypso_domain_cancel_form_submit',
-				{ product_slug: purchase.productSlug }
-			);
+			analytics.tracks.recordEvent( 'calypso_domain_cancel_form_submit', {
+				product_slug: purchase.productSlug,
+			} );
 
 			page.redirect( paths.purchasesRoot() );
 		} );
@@ -173,7 +170,7 @@ const ConfirmCancelDomain = React.createClass( {
 
 	onMessageChange( event ) {
 		this.setState( {
-			message: event.target.value
+			message: event.target.value,
 		} );
 	},
 
@@ -190,7 +187,10 @@ const ConfirmCancelDomain = React.createClass( {
 					{ selectedReason.helpMessage }
 				</p>
 				{ selectedReason.showTextarea &&
-				<FormTextarea className="confirm-cancel-domain__reason-details" onChange={ this.onMessageChange } /> }
+					<FormTextarea
+						className="confirm-cancel-domain__reason-details"
+						onChange={ this.onMessageChange }
+					/> }
 			</div>
 		);
 	},
@@ -206,10 +206,11 @@ const ConfirmCancelDomain = React.createClass( {
 					<FormCheckbox checked={ this.state.confirmed } onChange={ this.onConfirmationChange } />
 					<span>
 						{ this.translate(
-							'I understand that canceling means that I may {{strong}}lose this domain forever{{/strong}}.', {
+							'I understand that canceling means that I may {{strong}}lose this domain forever{{/strong}}.',
+							{
 								components: {
-									strong: <strong />
-								}
+									strong: <strong />,
+								},
 							}
 						) }
 					</span>
@@ -225,25 +226,24 @@ const ConfirmCancelDomain = React.createClass( {
 
 		if ( this.state.submitting ) {
 			return (
-				<FormButton isPrimary={ true } disabled={ true } >
+				<FormButton isPrimary={ true } disabled={ true }>
 					{ this.translate( 'Cancelling Domain…' ) }
 				</FormButton>
 			);
 		}
 
-		const selectedReason = this.state.selectedReason,
-			confirmed = this.state.confirmed;
+		const selectedReason = this.state.selectedReason, confirmed = this.state.confirmed;
 
 		if ( selectedReason && 'misspelled' === selectedReason.value ) {
 			return (
-				<FormButton isPrimary={ true } onClick={ this.onSubmit } disabled={ ! confirmed } >
+				<FormButton isPrimary={ true } onClick={ this.onSubmit } disabled={ ! confirmed }>
 					{ this.translate( 'Cancel Anyway' ) }
 				</FormButton>
 			);
 		}
 
 		return (
-			<FormButton isPrimary={ true } onClick={ this.onSubmit } disabled={ ! confirmed } >
+			<FormButton isPrimary={ true } onClick={ this.onSubmit } disabled={ ! confirmed }>
 				{ this.translate( 'Cancel Domain' ) }
 			</FormButton>
 		);
@@ -256,7 +256,9 @@ const ConfirmCancelDomain = React.createClass( {
 					<QueryUserPurchases userId={ user.get().ID } />
 					<ConfirmCancelDomainLoadingPlaceholder
 						purchaseId={ this.props.purchaseId }
-						selectedSite={ this.props.selectedSite } />;
+						selectedSite={ this.props.selectedSite }
+					/>
+					;
 				</div>
 			);
 		}
@@ -277,26 +279,28 @@ const ConfirmCancelDomain = React.createClass( {
 					<p>
 						{ this.translate(
 							'Since domain cancellation can cause your site to stop working, ' +
-							'we’d like to make sure we help you take the right action. ' +
-							'Please select the best option below.'
+								'we’d like to make sure we help you take the right action. ' +
+								'Please select the best option below.'
 						) }
 					</p>
 					<SelectDropdown
-							className="confirm-cancel-domain__reasons-dropdown"
-							key="confirm-cancel-domain__reasons-dropdown"
-							selectedText={ selectedReason
-											? selectedReason.label
-											: this.translate( 'Please let us know why you wish to cancel.' ) }
-							options={ cancellationReasons }
-							onSelect={ this.onReasonChange } >
-					</SelectDropdown>
+						className="confirm-cancel-domain__reasons-dropdown"
+						key="confirm-cancel-domain__reasons-dropdown"
+						selectedText={
+							selectedReason
+								? selectedReason.label
+								: this.translate( 'Please let us know why you wish to cancel.' )
+						}
+						options={ cancellationReasons }
+						onSelect={ this.onReasonChange }
+					/>
 					{ this.renderHelpMessage() }
 					{ this.renderConfirmationCheckbox() }
 					{ this.renderSubmitButton() }
 				</Card>
 			</Main>
 		);
-	}
+	},
 } );
 
 export default connect(

--- a/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
@@ -37,10 +37,7 @@ const ConfirmCancelDomainLoadingPlaceholder = ( { purchaseId, selectedSite } ) =
 
 ConfirmCancelDomainLoadingPlaceholder.propTypes = {
 	purchaseId: React.PropTypes.number.isRequired,
-	selectedSite: React.PropTypes.oneOfType( [
-		React.PropTypes.bool,
-		React.PropTypes.object
-	] )
+	selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.bool, React.PropTypes.object ] ),
 };
 
 export default ConfirmCancelDomainLoadingPlaceholder;

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -29,141 +29,86 @@ const user = userFactory();
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {
-	context.store.dispatch( setDocumentHeadTitle(
-		concatTitle( titles.purchases, ...title )
-	) );
+	context.store.dispatch( setDocumentHeadTitle( concatTitle( titles.purchases, ...title ) ) );
 }
 
 export default {
 	addCardDetails( context ) {
-		setTitle(
-			context,
-			titles.addCardDetails
-		);
+		setTitle( context, titles.addCardDetails );
 
-		recordPurchasesPageView(
-			paths.addCardDetails(),
-			'Add Card Details'
-		);
+		recordPurchasesPageView( paths.addCardDetails(), 'Add Card Details' );
 
 		renderPage(
 			context,
-			<AddCardDetails
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+			<AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);
 	},
 
 	addCreditCard( context ) {
-		recordPurchasesPageView(
-			paths.addCreditCard(),
-			'Add Credit Card'
-		);
+		recordPurchasesPageView( paths.addCreditCard(), 'Add Credit Card' );
 
-		renderPage(
-			context,
-			<AddCreditCard />
-		);
+		renderPage( context, <AddCreditCard /> );
 	},
 
 	cancelPrivacyProtection( context ) {
-		setTitle(
-			context,
-			titles.cancelPrivacyProtection
-		);
+		setTitle( context, titles.cancelPrivacyProtection );
 
-		recordPurchasesPageView(
-			paths.cancelPrivacyProtection(),
-			'Cancel Privacy Protection'
-		);
+		recordPurchasesPageView( paths.cancelPrivacyProtection(), 'Cancel Privacy Protection' );
 
 		renderPage(
 			context,
-			<CancelPrivacyProtection
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			/>
+			<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);
 	},
 
 	cancelPurchase( context ) {
-		setTitle(
-			context,
-			titles.cancelPurchase
-		);
+		setTitle( context, titles.cancelPurchase );
 
-		recordPurchasesPageView(
-			paths.cancelPurchase(),
-			'Cancel Purchase'
-		);
+		recordPurchasesPageView( paths.cancelPurchase(), 'Cancel Purchase' );
 
 		renderPage(
 			context,
-			<CancelPurchase
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			/>
+			<CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);
 	},
 
 	confirmCancelDomain( context ) {
-		setTitle(
-			context,
-			titles.confirmCancelDomain
-		);
+		setTitle( context, titles.confirmCancelDomain );
 
-		recordPurchasesPageView(
-			paths.confirmCancelDomain(),
-			'Confirm Cancel Domain'
-		);
+		recordPurchasesPageView( paths.confirmCancelDomain(), 'Confirm Cancel Domain' );
 
 		renderPage(
 			context,
-			<ConfirmCancelDomain
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			/>
+			<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
 		);
 	},
 
 	editCardDetails( context ) {
-		setTitle(
-			context,
-			titles.editCardDetails
-		);
+		setTitle( context, titles.editCardDetails );
 
-		recordPurchasesPageView(
-			paths.editCardDetails(),
-			'Edit Card Details'
-		);
+		recordPurchasesPageView( paths.editCardDetails(), 'Edit Card Details' );
 
 		renderPage(
 			context,
 			<EditCardDetails
 				cardId={ context.params.cardId }
-				purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+			/>
 		);
 	},
 
 	list( context ) {
 		setTitle( context );
 
-		recordPurchasesPageView(
-			paths.purchasesRoot()
-		);
+		recordPurchasesPageView( paths.purchasesRoot() );
 
-		renderPage(
-			context,
-			<PurchasesList noticeType={ context.params.noticeType } />
-		);
+		renderPage( context, <PurchasesList noticeType={ context.params.noticeType } /> );
 	},
 
 	managePurchase( context ) {
-		setTitle(
-			context,
-			titles.managePurchase
-		);
+		setTitle( context, titles.managePurchase );
 
-		recordPurchasesPageView(
-			paths.managePurchase(),
-			'Manage Purchase'
-		);
+		recordPurchasesPageView( paths.managePurchase(), 'Manage Purchase' );
 
 		renderPage(
 			context,
@@ -181,10 +126,7 @@ export default {
 
 		setTitle( context );
 
-		recordPurchasesPageView(
-			context.path,
-			'No Sites'
-		);
+		recordPurchasesPageView( context.path, 'No Sites' );
 
 		renderPage(
 			context,
@@ -193,5 +135,5 @@ export default {
 				<NoSitesMessage />
 			</Main>
 		);
-	}
+	},
 };

--- a/client/me/purchases/credit-cards/credit-card-delete.jsx
+++ b/client/me/purchases/credit-cards/credit-card-delete.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ), connect = require( 'react-redux' ).connect;
+import { connect } from 'react-redux';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var StoredCard = require( 'my-sites/upgrades/checkout/stored-card' ),
-	successNotice = require( 'state/notices/actions' ).successNotice,
-	errorNotice = require( 'state/notices/actions' ).errorNotice,
-	deleteStoredCard = require( 'state/stored-cards/actions' ).deleteStoredCard;
+import { deleteStoredCard } from 'state/stored-cards/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
 import { isDeletingStoredCard } from 'state/stored-cards/selectors';
+import StoredCard from 'my-sites/upgrades/checkout/stored-card';
 
 const CreditCardDelete = React.createClass( {
 	handleClick: function() {
@@ -25,11 +25,7 @@ const CreditCardDelete = React.createClass( {
 	},
 
 	renderDeleteButton: function() {
-		var text = this.translate( 'Delete' );
-
-		if ( this.props.isDeleting ) {
-			text = this.translate( 'Deleting ' );
-		}
+		const text = this.props.isDeleting ? this.translate( 'Deleting ' ) : this.translate( 'Delete' );
 
 		return (
 			<button

--- a/client/me/purchases/credit-cards/credit-card-delete.jsx
+++ b/client/me/purchases/credit-cards/credit-card-delete.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	connect = require( 'react-redux' ).connect;
+var React = require( 'react' ), connect = require( 'react-redux' ).connect;
 
 /**
  * Internal dependencies
@@ -15,11 +14,14 @@ import { isDeletingStoredCard } from 'state/stored-cards/selectors';
 
 const CreditCardDelete = React.createClass( {
 	handleClick: function() {
-		this.props.deleteStoredCard( this.props.card ).then( () => {
-			this.props.successNotice( this.translate( 'Card deleted successfully' ) );
-		} ).catch( error => {
-			this.props.errorNotice( error.message );
-		} )
+		this.props
+			.deleteStoredCard( this.props.card )
+			.then( () => {
+				this.props.successNotice( this.translate( 'Card deleted successfully' ) );
+			} )
+			.catch( error => {
+				this.props.errorNotice( error.message );
+			} );
 	},
 
 	renderDeleteButton: function() {
@@ -33,7 +35,8 @@ const CreditCardDelete = React.createClass( {
 			<button
 				className="button credit-card-delete__button"
 				disabled={ this.props.isDeleting }
-				onClick={ this.handleClick }>
+				onClick={ this.handleClick }
+			>
 				{ text }
 			</button>
 		);
@@ -47,18 +50,18 @@ const CreditCardDelete = React.createClass( {
 				{ this.renderDeleteButton() }
 			</div>
 		);
-	}
+	},
 } );
 
 export default connect(
 	state => {
 		return {
-			isDeleting: isDeletingStoredCard( state )
+			isDeleting: isDeletingStoredCard( state ),
 		};
 	},
 	{
 		deleteStoredCard,
 		errorNotice,
-		successNotice
+		successNotice,
 	}
 )( CreditCardDelete );

--- a/client/me/purchases/credit-cards/index.jsx
+++ b/client/me/purchases/credit-cards/index.jsx
@@ -16,7 +16,7 @@ import CreditCardDelete from './credit-card-delete';
 import {
 	getStoredCards,
 	hasLoadedStoredCardsFromServer,
-	isFetchingStoredCards
+	isFetchingStoredCards,
 } from 'state/stored-cards/selectors';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import { addCreditCard } from 'me/purchases/paths';
@@ -59,11 +59,7 @@ class CreditCards extends Component {
 		}
 
 		return (
-			<Button
-				primary
-				compact
-				className="credit-cards__add"
-				onClick={ this.goToAddCreditCard }>
+			<Button primary compact className="credit-cards__add" onClick={ this.goToAddCreditCard }>
 				{ this.props.translate( 'Add Credit Card' ) }
 			</Button>
 		);
@@ -88,10 +84,8 @@ class CreditCards extends Component {
 	}
 }
 
-export default connect(
-	state => ( {
-		cards: getStoredCards( state ),
-		hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),
-		isFetching: isFetchingStoredCards( state )
-	} )
-)( localize( CreditCards ) );
+export default connect( state => ( {
+	cards: getStoredCards( state ),
+	hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),
+	isFetching: isFetchingStoredCards( state ),
+} ) )( localize( CreditCards ) );

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -15,37 +15,17 @@ import paths from './paths';
 
 export default function() {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
-		page(
-			paths.addCreditCard(),
-			meController.sidebar,
-			controller.addCreditCard
-		);
+		page( paths.addCreditCard(), meController.sidebar, controller.addCreditCard );
 
 		// redirect legacy urls
-		page(
-			'/payment-methods/add-credit-card',
-			() => page.redirect( paths.addCreditCard() )
-		);
+		page( '/payment-methods/add-credit-card', () => page.redirect( paths.addCreditCard() ) );
 	}
 
-	page(
-		paths.billingHistory(),
-		meController.sidebar,
-		billingController.billingHistory
-	);
+	page( paths.billingHistory(), meController.sidebar, billingController.billingHistory );
 
-	page(
-		paths.billingHistoryReceipt(),
-		meController.sidebar,
-		billingController.transaction
-	);
+	page( paths.billingHistoryReceipt(), meController.sidebar, billingController.transaction );
 
-	page(
-		paths.purchasesRoot(),
-		meController.sidebar,
-		controller.noSitesMessage,
-		controller.list
-	);
+	page( paths.purchasesRoot(), meController.sidebar, controller.noSitesMessage, controller.list );
 
 	page(
 		paths.managePurchase(),
@@ -96,38 +76,38 @@ export default function() {
 	);
 
 	// redirect legacy urls
-	page(
-		'/purchases',
-		() => page.redirect( paths.purchasesRoot() )
-	);
+	page( '/purchases', () => page.redirect( paths.purchasesRoot() ) );
 	page(
 		'/purchases/:siteName/:purchaseId',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.managePurchase( siteName, purchaseId ) )
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect( paths.managePurchase( siteName, purchaseId ) )
 	);
 	page(
 		'/purchases/:siteName/:purchaseId/cancel',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.cancelPurchase( siteName, purchaseId ) )
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect( paths.cancelPurchase( siteName, purchaseId ) )
 	);
 	page(
 		'/purchases/:siteName/:purchaseId/cancel-private-registration',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.cancelPrivacyProtection( siteName, purchaseId ) )
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect( paths.cancelPrivacyProtection( siteName, purchaseId ) )
 	);
 	page(
 		'/purchases/:siteName/:purchaseId/confirm-cancel-domain',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.confirmCancelDomain( siteName, purchaseId ) )
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect( paths.confirmCancelDomain( siteName, purchaseId ) )
 	);
 	page(
 		'/purchases/:siteName/:purchaseId/payment/add',
-		( { params: { siteName, purchaseId } } ) => page.redirect( paths.addCardDetails( siteName, purchaseId ) )
+		( { params: { siteName, purchaseId } } ) =>
+			page.redirect( paths.addCardDetails( siteName, purchaseId ) )
 	);
 	page(
 		'/purchases/:siteName/:purchaseId/payment/edit/:cardId',
-		( { params: { siteName, purchaseId, cardId } } ) => page.redirect( paths.editCardDetails( siteName, purchaseId, cardId ) )
+		( { params: { siteName, purchaseId, cardId } } ) =>
+			page.redirect( paths.editCardDetails( siteName, purchaseId, cardId ) )
 	);
-	page(
-		'/me/billing',
-		() => page.redirect( paths.billingHistory() )
-	);
+	page( '/me/billing', () => page.redirect( paths.billingHistory() ) );
 	page(
 		'/me/billing/:receiptId',
 		( { params: { receiptId } } ) => page.redirect( paths.billingHistoryReceipt( receiptId ) )

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -40,14 +40,11 @@ import {
 	getPurchase,
 	getSelectedSite,
 	goToList,
-	recordPageView
+	recordPageView,
 } from '../utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getCanonicalTheme } from 'state/themes/selectors';
-import {
-	getSelectedSite as getSelectedSiteSelector,
-	getSelectedSiteId,
-} from 'state/ui/selectors';
+import { getSelectedSite as getSelectedSiteSelector, getSelectedSiteId } from 'state/ui/selectors';
 import Gridicon from 'gridicons';
 import HeaderCake from 'components/header-cake';
 import {
@@ -87,12 +84,10 @@ class ManagePurchase extends Component {
 		hasLoadedSites: React.PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
 		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool,
-			React.PropTypes.undefined
-		] )
-	}
+		selectedSite: React.PropTypes.oneOfType(
+			[ React.PropTypes.object, React.PropTypes.bool, React.PropTypes.undefined ]
+		),
+	};
 
 	componentWillMount() {
 		if ( ! this.isDataValid() ) {
@@ -123,34 +118,39 @@ class ManagePurchase extends Component {
 	handleRenew = () => {
 		const purchase = getPurchase( this.props ),
 			renewItem = cartItems.getRenewalItemFromProduct( purchase, {
-				domain: purchase.meta
+				domain: purchase.meta,
 			} ),
 			renewItems = [ renewItem ];
 
 		// Track the renew now submit
-		analytics.tracks.recordEvent(
-			'calypso_purchases_renew_now_click',
-			{ product_slug: purchase.productSlug }
-		);
+		analytics.tracks.recordEvent( 'calypso_purchases_renew_now_click', {
+			product_slug: purchase.productSlug,
+		} );
 
 		if ( hasPrivacyProtection( purchase ) ) {
-			const privacyItem = cartItems.getRenewalItemFromCartItem( cartItems.domainPrivacyProtection( {
-				domain: purchase.meta
-			} ), {
-				id: purchase.id,
-				domain: purchase.domain
-			} );
+			const privacyItem = cartItems.getRenewalItemFromCartItem(
+				cartItems.domainPrivacyProtection( {
+					domain: purchase.meta,
+				} ),
+				{
+					id: purchase.id,
+					domain: purchase.domain,
+				}
+			);
 
 			renewItems.push( privacyItem );
 		}
 
 		if ( isRedeemable( purchase ) ) {
-			const redemptionItem = cartItems.getRenewalItemFromCartItem( cartItems.domainRedemption( {
-				domain: purchase.meta
-			} ), {
-				id: purchase.id,
-				domain: purchase.domain
-			} );
+			const redemptionItem = cartItems.getRenewalItemFromCartItem(
+				cartItems.domainRedemption( {
+					domain: purchase.meta,
+				} ),
+				{
+					id: purchase.id,
+					domain: purchase.domain,
+				}
+			);
 
 			renewItems.push( redemptionItem );
 		}
@@ -158,7 +158,7 @@ class ManagePurchase extends Component {
 		upgradesActions.addItems( renewItems );
 
 		page( '/checkout/' + this.props.selectedSite.slug );
-	}
+	};
 
 	renderRenewButton() {
 		const purchase = getPurchase( this.props );
@@ -168,7 +168,12 @@ class ManagePurchase extends Component {
 			return null;
 		}
 
-		if ( ! isRenewable( purchase ) || isExpired( purchase ) || isExpiring( purchase ) || ! getSelectedSite( this.props ) ) {
+		if (
+			! isRenewable( purchase ) ||
+			isExpired( purchase ) ||
+			isExpiring( purchase ) ||
+			! getSelectedSite( this.props )
+		) {
 			return null;
 		}
 
@@ -207,17 +212,14 @@ class ManagePurchase extends Component {
 				? translate( 'Edit Payment Method' )
 				: translate( 'Add Credit Card' );
 
-			return (
-				<CompactCard href={ path }>{ text }</CompactCard>
-			);
+			return <CompactCard href={ path }>{ text }</CompactCard>;
 		}
 
 		return null;
 	}
 
 	renderCancelPurchaseNavItem() {
-		const purchase = getPurchase( this.props ),
-			{ id } = purchase;
+		const purchase = getPurchase( this.props ), { id } = purchase;
 		const { translate } = this.props;
 
 		if ( ! isCancelable( purchase ) || ! getSelectedSite( this.props ) ) {
@@ -261,11 +263,14 @@ class ManagePurchase extends Component {
 	}
 
 	renderCancelPrivacyProtection() {
-		const purchase = getPurchase( this.props ),
-			{ id } = purchase;
+		const purchase = getPurchase( this.props ), { id } = purchase;
 		const { translate } = this.props;
 
-		if ( isExpired( purchase ) || ! hasPrivacyProtection( purchase ) || ! getSelectedSite( this.props ) ) {
+		if (
+			isExpired( purchase ) ||
+			! hasPrivacyProtection( purchase ) ||
+			! getSelectedSite( this.props )
+		) {
 			return null;
 		}
 
@@ -316,12 +321,12 @@ class ManagePurchase extends Component {
 			description = theme.description;
 		} else if ( isDomainMapping( purchase ) || isDomainRegistration( purchase ) ) {
 			description = translate(
-				'Replaces your site\'s free address with the domain %(domain)s, ' +
-				'making it easier to remember and easier to share.',
+				"Replaces your site's free address with the domain %(domain)s, " +
+					'making it easier to remember and easier to share.',
 				{
 					args: {
 						domain: selectedSite.domain,
-					}
+					},
 				}
 			);
 		}
@@ -382,10 +387,7 @@ class ManagePurchase extends Component {
 
 		return (
 			<div>
-				<PurchaseSiteHeader
-					siteId={ selectedSiteId }
-					name={ siteName }
-					domain={ siteDomain } />
+				<PurchaseSiteHeader siteId={ selectedSiteId } name={ siteName } domain={ siteDomain } />
 				<Card className={ classes }>
 					<header className="manage-purchase__header">
 						{ this.renderPlanIcon() }
@@ -430,14 +432,17 @@ class ManagePurchase extends Component {
 		const classes = 'manage-purchase';
 
 		let editCardDetailsPath = false;
-		if ( ! isDataLoading( this.props ) && selectedSite && canEditPaymentDetails( selectedPurchase ) ) {
+		if (
+			! isDataLoading( this.props ) && selectedSite && canEditPaymentDetails( selectedPurchase )
+		) {
 			editCardDetailsPath = getEditCardDetailsPath( selectedSite, selectedPurchase );
 		}
 
 		return (
 			<span>
 				<QueryUserPurchases userId={ user.get().ID } />
-				{ isPurchaseTheme && <QueryCanonicalTheme siteId={ selectedSiteId } themeId={ selectedPurchase.meta } /> }
+				{ isPurchaseTheme &&
+					<QueryCanonicalTheme siteId={ selectedSiteId } themeId={ selectedPurchase.meta } /> }
 				<Main className={ classes }>
 					<HeaderCake onClick={ goToList }>
 						{ titles.managePurchase }
@@ -447,7 +452,8 @@ class ManagePurchase extends Component {
 						handleRenew={ this.handleRenew }
 						selectedSite={ selectedSite }
 						selectedPurchase={ selectedPurchase }
-						editCardDetailsPath={ editCardDetailsPath } />
+						editCardDetailsPath={ editCardDetailsPath }
+					/>
 					{ this.renderPurchaseDetail() }
 				</Main>
 			</span>
@@ -455,21 +461,19 @@ class ManagePurchase extends Component {
 	}
 }
 
-export default connect(
-	( state, props ) => {
-		const selectedPurchase = getByPurchaseId( state, props.purchaseId );
-		const selectedSiteId = getSelectedSiteId( state );
-		const isPurchasePlan = selectedPurchase && isPlan( selectedPurchase );
-		const isPurchaseTheme = selectedPurchase && isTheme( selectedPurchase );
-		return {
-			hasLoadedSites: ! isRequestingSites( state ),
-			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-			selectedPurchase,
-			selectedSiteId,
-			selectedSite: getSelectedSiteSelector( state ),
-			plan: isPurchasePlan && applyTestFiltersToPlansList( selectedPurchase.productSlug, abtest ),
-			isPurchaseTheme,
-			theme: isPurchaseTheme && getCanonicalTheme( state, selectedSiteId, selectedPurchase.meta ),
-		};
-	}
-)( localize( ManagePurchase ) );
+export default connect( ( state, props ) => {
+	const selectedPurchase = getByPurchaseId( state, props.purchaseId );
+	const selectedSiteId = getSelectedSiteId( state );
+	const isPurchasePlan = selectedPurchase && isPlan( selectedPurchase );
+	const isPurchaseTheme = selectedPurchase && isTheme( selectedPurchase );
+	return {
+		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		selectedPurchase,
+		selectedSiteId,
+		selectedSite: getSelectedSiteSelector( state ),
+		plan: isPurchasePlan && applyTestFiltersToPlansList( selectedPurchase.productSlug, abtest ),
+		isPurchaseTheme,
+		theme: isPurchaseTheme && getCanonicalTheme( state, selectedSiteId, selectedPurchase.meta ),
+	};
+} )( localize( ManagePurchase ) );

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -17,7 +17,7 @@ import {
 	isOneTimePurchase,
 	isRedeemable,
 	isRenewable,
-	showCreditCardExpiringWarning
+	showCreditCardExpiringWarning,
 } from 'lib/purchases';
 import { getPurchase, getSelectedSite } from '../utils';
 import Notice from 'components/notice';
@@ -29,27 +29,25 @@ class PurchaseNotice extends Component {
 		isDataLoading: React.PropTypes.bool,
 		handleRenew: React.PropTypes.func,
 		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool,
-			React.PropTypes.undefined
-		] ),
-		editCardDetailsPath: React.PropTypes.oneOfType( [
-			React.PropTypes.string,
-			React.PropTypes.bool
-		] )
-	}
+		selectedSite: React.PropTypes.oneOfType(
+			[ React.PropTypes.object, React.PropTypes.bool, React.PropTypes.undefined ]
+		),
+		editCardDetailsPath: React.PropTypes.oneOfType(
+			[ React.PropTypes.string, React.PropTypes.bool ]
+		),
+	};
 
 	getExpiringText( purchase ) {
 		const { translate, moment, selectedSite } = this.props;
 		if ( selectedSite && purchase.expiryStatus === 'manualRenew' ) {
-			return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
-				'Please, add a credit card if you want it to autorenew. ',
+			return translate(
+				'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
+					'Please, add a credit card if you want it to autorenew. ',
 				{
 					args: {
 						purchaseName: getName( purchase ),
-						expiry: moment( purchase.expiryMoment ).fromNow()
-					}
+						expiry: moment( purchase.expiryMoment ).fromNow(),
+					},
 				}
 			);
 		}
@@ -57,24 +55,23 @@ class PurchaseNotice extends Component {
 			const expiryMoment = moment( purchase.expiryMoment );
 			const daysToExpiry = moment( expiryMoment.diff( moment() ) ).format( 'D' );
 
-			return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
+			return translate(
+				'%(purchaseName)s will expire and be removed from your site %(expiry)s days. ',
 				{
 					args: {
 						purchaseName: getName( purchase ),
-						expiry: daysToExpiry
-					}
+						expiry: daysToExpiry,
+					},
 				}
 			);
 		}
 
-		return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.',
-			{
-				args: {
-					purchaseName: getName( purchase ),
-					expiry: moment( purchase.expiryMoment ).fromNow()
-				}
-			}
-		);
+		return translate( '%(purchaseName)s will expire and be removed from your site %(expiry)s.', {
+			args: {
+				purchaseName: getName( purchase ),
+				expiry: moment( purchase.expiryMoment ).fromNow(),
+			},
+		} );
 	}
 
 	renderRenewNoticeAction() {
@@ -107,7 +104,8 @@ class PurchaseNotice extends Component {
 				className="manage-purchase__purchase-expiring-notice"
 				showDismiss={ false }
 				status={ noticeStatus }
-				text={ this.getExpiringText( purchase ) }>
+				text={ this.getExpiringText( purchase ) }
+			>
 				{ this.renderRenewNoticeAction() }
 			</Notice>
 		);
@@ -115,10 +113,14 @@ class PurchaseNotice extends Component {
 
 	renderCreditCardExpiringNotice() {
 		const { translate, editCardDetailsPath } = this.props;
-		const purchase = getPurchase( this.props ),
-			{ payment: { creditCard } } = purchase;
+		const purchase = getPurchase( this.props ), { payment: { creditCard } } = purchase;
 
-		if ( isExpired( purchase ) || isOneTimePurchase( purchase ) || isIncludedWithPlan( purchase ) || ! getSelectedSite( this.props ) ) {
+		if (
+			isExpired( purchase ) ||
+			isOneTimePurchase( purchase ) ||
+			isIncludedWithPlan( purchase ) ||
+			! getSelectedSite( this.props )
+		) {
 			return null;
 		}
 
@@ -127,23 +129,22 @@ class PurchaseNotice extends Component {
 				<Notice
 					className="manage-purchase__expiring-credit-card-notice"
 					showDismiss={ false }
-					status={ showCreditCardExpiringWarning( purchase ) ? 'is-error' : 'is-info' }>
-					{
-						translate( 'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s ' +
-							'– before the next renewal. Please {{a}}update your payment information{{/a}}.', {
-								args: {
-									cardType: creditCard.type.toUpperCase(),
-									cardNumber: creditCard.number,
-									cardExpiry: creditCard.expiryMoment.format( 'MMMM YYYY' )
-								},
-								components: {
-									a: editCardDetailsPath
-										? <a href={ editCardDetailsPath } />
-										: <span />
-								}
-							}
-						)
-					}
+					status={ showCreditCardExpiringWarning( purchase ) ? 'is-error' : 'is-info' }
+				>
+					{ translate(
+						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s ' +
+							'– before the next renewal. Please {{a}}update your payment information{{/a}}.',
+						{
+							args: {
+								cardType: creditCard.type.toUpperCase(),
+								cardNumber: creditCard.number,
+								cardExpiry: creditCard.expiryMoment.format( 'MMMM YYYY' ),
+							},
+							components: {
+								a: editCardDetailsPath ? <a href={ editCardDetailsPath } /> : <span />,
+							},
+						}
+					) }
 				</Notice>
 			);
 		}
@@ -165,7 +166,8 @@ class PurchaseNotice extends Component {
 			<Notice
 				showDismiss={ false }
 				status="is-error"
-				text={ translate( 'This purchase has expired and is no longer in use.' ) }>
+				text={ translate( 'This purchase has expired and is no longer in use.' ) }
+			>
 				{ this.renderRenewNoticeAction() }
 			</Notice>
 		);

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -62,8 +62,8 @@ class PurchasePlanDetails extends Component {
 
 		const headerText = translate( '%(planName)s Plan', {
 			args: {
-				planName: getName( purchase )
-			}
+				planName: getName( purchase ),
+			},
 		} );
 
 		return (
@@ -74,7 +74,9 @@ class PurchasePlanDetails extends Component {
 					{ pluginList.map( ( plugin, i ) => {
 						return (
 							<FormFieldset key={ i }>
-								<FormLabel htmlFor={ `plugin-${ plugin.slug }` }>{ this.renderPluginLabel( plugin.slug ) }</FormLabel>
+								<FormLabel htmlFor={ `plugin-${ plugin.slug }` }>
+									{ this.renderPluginLabel( plugin.slug ) }
+								</FormLabel>
 								<ClipboardButtonInput id={ `plugin-${ plugin.slug }` } value={ plugin.key } />
 							</FormFieldset>
 						);
@@ -87,11 +89,9 @@ class PurchasePlanDetails extends Component {
 
 // hasLoadedSites & hasLoadedUserPurchasesFromServer are used in isDataLoading,
 // selectedPurchase is used in getPurchase
-export default connect(
-	( state, props ) => ( {
-		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
-		pluginList: props.selectedSite ? getPluginsForSite( state, props.selectedSite.ID ) : [],
-	} )
-)( localize( PurchasePlanDetails ) );
+export default connect( ( state, props ) => ( {
+	hasLoadedSites: ! isRequestingSites( state ),
+	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+	selectedPurchase: getByPurchaseId( state, props.purchaseId ),
+	pluginList: props.selectedSite ? getPluginsForSite( state, props.selectedSite.ID ) : [],
+} ) )( localize( PurchasePlanDetails ) );

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -38,61 +38,65 @@ import {
 	isDataLoading,
 	getEditCardDetailsPath,
 	getPurchase,
-	getSelectedSite
+	getSelectedSite,
 } from '../utils';
 
 class PurchaseMeta extends Component {
 	static propTypes = {
 		hasLoadedSites: React.PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: React.PropTypes.bool.isRequired,
-		purchaseId: React.PropTypes.oneOfType( [
-			React.PropTypes.number,
-			React.PropTypes.bool
-		] ).isRequired,
+		purchaseId: React.PropTypes.oneOfType( [ React.PropTypes.number, React.PropTypes.bool ] )
+			.isRequired,
 		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool,
-			React.PropTypes.undefined
-		] )
-	}
+		selectedSite: React.PropTypes.oneOfType(
+			[ React.PropTypes.object, React.PropTypes.bool, React.PropTypes.undefined ]
+		),
+	};
 
 	static defaultProps = {
 		hasLoadedSites: false,
 		hasLoadedUserPurchasesFromServer: false,
 		purchaseId: false,
-	}
+	};
 
 	renderPrice() {
 		const { translate } = this.props;
 		const purchase = getPurchase( this.props );
 		const { amount, currencyCode, currencySymbol, productSlug } = purchase;
-		const period = productSlug && isMonthly( productSlug ) ? translate( 'month' ) : translate( 'year' );
+		const period = productSlug && isMonthly( productSlug )
+			? translate( 'month' )
+			: translate( 'year' );
 
 		if ( isOneTimePurchase( purchase ) ) {
-			return translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}(one-time){{/period}}', {
-				args: { amount, currencyCode, currencySymbol },
-				components: {
-					period: <span className="manage-purchase__time-period" />
+			return translate(
+				'%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}(one-time){{/period}}',
+				{
+					args: { amount, currencyCode, currencySymbol },
+					components: {
+						period: <span className="manage-purchase__time-period" />,
+					},
 				}
-			} );
+			);
 		}
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			return translate( 'Free with Plan' );
 		}
 
-		return translate( '%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}/ %(period)s{{/period}}', {
-			args: {
-				amount,
-				currencyCode,
-				currencySymbol,
-				period
-			},
-			components: {
-				period: <span className="manage-purchase__time-period" />
+		return translate(
+			'%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}/ %(period)s{{/period}}',
+			{
+				args: {
+					amount,
+					currencyCode,
+					currencySymbol,
+					period,
+				},
+				components: {
+					period: <span className="manage-purchase__time-period" />,
+				},
 			}
-		} );
+		);
 	}
 
 	renderRenewsOrExpiresOnLabel() {
@@ -161,7 +165,11 @@ class PurchaseMeta extends Component {
 			);
 		}
 
-		if ( isExpiring( purchase ) || isExpired( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
+		if (
+			isExpiring( purchase ) ||
+			isExpired( purchase ) ||
+			creditCardExpiresBeforeSubscription( purchase )
+		) {
 			return moment( purchase.expiryDate ).format( 'LL' );
 		}
 
@@ -194,7 +202,7 @@ class PurchaseMeta extends Component {
 			} else if ( isPaidWithPayPalDirect( purchase ) ) {
 				paymentInfo = translate( 'expiring %(cardExpiry)s', {
 					args: {
-						cardExpiry: purchase.payment.expiryMoment.format( 'MMMM YYYY' )
+						cardExpiry: purchase.payment.expiryMoment.format( 'MMMM YYYY' ),
 					},
 				} );
 			}
@@ -229,7 +237,11 @@ class PurchaseMeta extends Component {
 			</span>
 		);
 
-		if ( ! canEditPaymentDetails( purchase ) || ! isPaidWithCreditCard( purchase ) || ! getSelectedSite( this.props ) ) {
+		if (
+			! canEditPaymentDetails( purchase ) ||
+			! isPaidWithCreditCard( purchase ) ||
+			! getSelectedSite( this.props )
+		) {
 			return (
 				<li>
 					{ paymentDetails }
@@ -256,18 +268,20 @@ class PurchaseMeta extends Component {
 
 		return (
 			<div className="manage-purchase__contact-support">
-				{ translate( 'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
-				'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
-				'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
+				{ translate(
+					'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
+						'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
+						'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
 					{
 						args: {
 							purchaseName: getName( purchase ),
-							siteSlug: this.props.selectedPurchase.domain
+							siteSlug: this.props.selectedPurchase.domain,
 						},
 						components: {
-							contactSupportLink: <a href={ support.CALYPSO_CONTACT } />
-						}
-					} ) }
+							contactSupportLink: <a href={ support.CALYPSO_CONTACT } />,
+						},
+					}
+				) }
 			</div>
 		);
 	}
@@ -291,14 +305,12 @@ class PurchaseMeta extends Component {
 	renderPlaceholder() {
 		return (
 			<ul className="manage-purchase__meta">
-				{
-					times( 4, ( i ) => (
-						<li key={ i }>
-							<em className="manage-purchase__detail-label" />
-							<span className="manage-purchase__detail" />
-						</li>
-					) )
-				}
+				{ times( 4, i => (
+					<li key={ i }>
+						<em className="manage-purchase__detail-label" />
+						<span className="manage-purchase__detail" />
+					</li>
+				) ) }
 			</ul>
 		);
 	}
@@ -319,7 +331,9 @@ class PurchaseMeta extends Component {
 						<span className="manage-purchase__detail">{ this.renderPrice() }</span>
 					</li>
 					<li>
-						<em className="manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
+						<em className="manage-purchase__detail-label">
+							{ this.renderRenewsOrExpiresOnLabel() }
+						</em>
 						<span className="manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
 					</li>
 					{ this.renderPaymentDetails() }
@@ -330,16 +344,14 @@ class PurchaseMeta extends Component {
 	}
 }
 
-export default connect(
-	( state, props ) => {
-		const purchase = getByPurchaseId( state, props.purchaseId );
+export default connect( ( state, props ) => {
+	const purchase = getByPurchaseId( state, props.purchaseId );
 
-		return {
-			hasLoadedSites: ! isRequestingSites( state ),
-			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-			selectedPurchase: purchase,
-			selectedSite: getSelectedSiteSelector( state ),
-			owner: purchase ? getUser( state, purchase.userId ) : null,
-		};
-	}
-)( localize( PurchaseMeta ) );
+	return {
+		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		selectedPurchase: purchase,
+		selectedSite: getSelectedSiteSelector( state ),
+		owner: purchase ? getUser( state, purchase.userId ) : null,
+	};
+} )( localize( PurchaseMeta ) );

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -48,5 +48,5 @@ export default {
 	confirmCancelDomain,
 	editCardDetails,
 	managePurchase,
-	purchasesRoot
+	purchasesRoot,
 };

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -12,7 +12,7 @@ import CreditCardForm from 'blocks/credit-card-form';
 import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
-import HeaderCake from 'components/header-cake' ;
+import HeaderCake from 'components/header-cake';
 import { isDataLoading, recordPageView } from 'me/purchases/utils';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
@@ -29,10 +29,7 @@ class AddCardDetails extends PurchaseCardDetails {
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		selectedPurchase: PropTypes.object,
-		selectedSite: PropTypes.oneOfType( [
-			PropTypes.object,
-			PropTypes.bool
-		] )
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 	};
 
 	componentWillMount() {
@@ -66,7 +63,8 @@ class AddCardDetails extends PurchaseCardDetails {
 					apiParams={ this.getApiParams() }
 					createPaygateToken={ this.createPaygateToken }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
-					successCallback={ this.successCallback } />
+					successCallback={ this.successCallback }
+				/>
 			</Main>
 		);
 	}
@@ -77,12 +75,12 @@ const mapStateToProps = ( state, { purchaseId } ) => {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
-		selectedSite: getSelectedSiteSelector( state )
+		selectedSite: getSelectedSiteSelector( state ),
 	};
 };
 
 const mapDispatchToProps = {
-	clearPurchases
+	clearPurchases,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( AddCardDetails );

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -13,7 +13,7 @@ import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-pl
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-cards/selectors';
-import HeaderCake from 'components/header-cake' ;
+import HeaderCake from 'components/header-cake';
 import { isDataLoading, recordPageView } from 'me/purchases/utils';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
@@ -33,10 +33,7 @@ class EditCardDetails extends PurchaseCardDetails {
 		hasLoadedStoredCardsFromServer: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		selectedPurchase: PropTypes.object,
-		selectedSite: PropTypes.oneOfType( [
-			PropTypes.object,
-			PropTypes.bool
-		] )
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 	};
 
 	componentWillMount() {
@@ -73,7 +70,8 @@ class EditCardDetails extends PurchaseCardDetails {
 					createPaygateToken={ this.createPaygateToken }
 					initialValues={ this.props.card }
 					recordFormSubmitEvent={ this.recordFormSubmitEvent }
-					successCallback={ this.successCallback } />
+					successCallback={ this.successCallback }
+				/>
 			</Main>
 		);
 	}
@@ -86,12 +84,12 @@ const mapStateToProps = ( state, { cardId, purchaseId } ) => {
 		hasLoadedStoredCardsFromServer: hasLoadedStoredCardsFromServer( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		selectedPurchase: getByPurchaseId( state, purchaseId ),
-		selectedSite: getSelectedSiteSelector( state )
+		selectedSite: getSelectedSiteSelector( state ),
 	};
 };
 
 const mapDispatchToProps = {
-	clearPurchases
+	clearPurchases,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( EditCardDetails );

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from 'react-redux';
 import i18n from 'i18n-calypso';
 
 /**
@@ -12,12 +12,16 @@ import config from 'config';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
 import { getThemeDetailsUrl } from 'state/themes/selectors';
 import { googleAppsSettingsUrl } from 'lib/google-apps';
-import { isDomainProduct, isGoogleApps, isPlan, isSiteRedirect, isTheme } from 'lib/products-values';
+import {
+	isDomainProduct,
+	isGoogleApps,
+	isPlan,
+	isSiteRedirect,
+	isTheme,
+} from 'lib/products-values';
 
 const ProductLink = ( { selectedPurchase, selectedSite, productUrl } ) => {
-	let props = {},
-		url,
-		text;
+	let props = {}, url, text;
 
 	if ( ! selectedSite ) {
 		return <span />;
@@ -60,20 +64,15 @@ const ProductLink = ( { selectedPurchase, selectedSite, productUrl } ) => {
 
 ProductLink.propTypes = {
 	selectedPurchase: React.PropTypes.object.isRequired,
-	selectedSite: React.PropTypes.oneOfType( [
-		React.PropTypes.bool,
-		React.PropTypes.object
-	] )
+	selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.bool, React.PropTypes.object ] ),
 };
 
-export default connect(
-	( state, { selectedPurchase } ) => {
-		if ( isTheme( selectedPurchase ) ) {
-			return {
-				// No <QueryTheme /> component needed, since getThemeDetailsUrl() only needs the themeId which we pass here.
-				productUrl: getThemeDetailsUrl( state, selectedPurchase.meta, selectedPurchase.siteId )
-			};
-		}
-		return {};
+export default connect( ( state, { selectedPurchase } ) => {
+	if ( isTheme( selectedPurchase ) ) {
+		return {
+			// No <QueryTheme /> component needed, since getThemeDetailsUrl() only needs the themeId which we pass here.
+			productUrl: getThemeDetailsUrl( state, selectedPurchase.meta, selectedPurchase.siteId ),
+		};
 	}
-)( ProductLink );
+	return {};
+} )( ProductLink );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -17,7 +17,7 @@ import {
 	isOneTimePurchase,
 	isRenewing,
 	purchaseType,
-	showCreditCardExpiringWarning
+	showCreditCardExpiringWarning,
 } from 'lib/purchases';
 import { isPlan, isDomainProduct, isTheme } from 'lib/products-values';
 import Notice from 'components/notice';
@@ -39,7 +39,7 @@ class PurchaseItem extends Component {
 
 		if ( isRenewing( purchase ) ) {
 			return translate( 'Renews on %s', {
-				args: purchase.renewMoment.format( 'LL' )
+				args: purchase.renewMoment.format( 'LL' ),
 			} );
 		}
 
@@ -49,16 +49,16 @@ class PurchaseItem extends Component {
 					<Notice isCompact status="is-error" icon="notice">
 						{ translate( 'Expires %(timeUntilExpiry)s', {
 							args: {
-								timeUntilExpiry: purchase.expiryMoment.fromNow()
+								timeUntilExpiry: purchase.expiryMoment.fromNow(),
 							},
-							context: 'timeUntilExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"'
+							context: 'timeUntilExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 						} ) }
 					</Notice>
 				);
 			}
 
 			return translate( 'Expires on %s', {
-				args: purchase.expiryMoment.format( 'LL' )
+				args: purchase.expiryMoment.format( 'LL' ),
 			} );
 		}
 
@@ -67,9 +67,9 @@ class PurchaseItem extends Component {
 				<Notice isCompact status="is-error" icon="notice">
 					{ translate( 'Expired %(timeSinceExpiry)s', {
 						args: {
-							timeSinceExpiry: purchase.expiryMoment.fromNow()
+							timeSinceExpiry: purchase.expiryMoment.fromNow(),
 						},
-						context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"'
+						context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 					} ) }
 				</Notice>
 			);
@@ -105,7 +105,8 @@ class PurchaseItem extends Component {
 
 	render() {
 		const { isPlaceholder, isDisconnectedSite, purchase } = this.props;
-		const classes = classNames( 'purchase-item',
+		const classes = classNames(
+			'purchase-item',
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
 			{ 'is-placeholder': isPlaceholder },
 			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) }
@@ -143,7 +144,9 @@ class PurchaseItem extends Component {
 						<div className="purchase-item__title">
 							{ getName( this.props.purchase ) }
 						</div>
-						<div className="purchase-item__purchase-type">{ purchaseType( this.props.purchase ) }</div>
+						<div className="purchase-item__purchase-type">
+							{ purchaseType( this.props.purchase ) }
+						</div>
 						<div className="purchase-item__purchase-date">
 							{ this.renewsOrExpiresOn() }
 						</div>
@@ -155,7 +158,7 @@ class PurchaseItem extends Component {
 		let props;
 		if ( ! isPlaceholder ) {
 			props = {
-				onClick: this.scrollToTop
+				onClick: this.scrollToTop,
 			};
 
 			if ( ! isDisconnectedSite ) {
@@ -175,7 +178,7 @@ PurchaseItem.propTypes = {
 	isPlaceholder: React.PropTypes.bool,
 	isDisconnectedSite: React.PropTypes.bool,
 	purchase: React.PropTypes.object,
-	slug: React.PropTypes.string
+	slug: React.PropTypes.string,
 };
 
 export default localize( PurchaseItem );

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -35,7 +35,7 @@ const PurchasesHeader = ( { section } ) => {
 };
 
 PurchasesHeader.propTypes = {
-	section: React.PropTypes.string.isRequired
+	section: React.PropTypes.string.isRequired,
 };
 
 export default PurchasesHeader;

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -13,7 +13,7 @@ import EmptyContent from 'components/empty-content';
 import {
 	getUserPurchases,
 	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases
+	isFetchingUserPurchases,
 } from 'state/purchases/selectors';
 import { getSites } from 'state/selectors';
 import { getPurchasesBySite } from 'lib/purchases';
@@ -50,7 +50,8 @@ class PurchasesList extends Component {
 						name={ site.name }
 						domain={ site.domain }
 						slug={ site.slug }
-						purchases={ site.purchases } />
+						purchases={ site.purchases }
+					/>
 				)
 			);
 		}
@@ -60,12 +61,15 @@ class PurchasesList extends Component {
 				<CompactCard className="purchases-list__no-content">
 					<EmptyContent
 						title={ this.props.translate( 'Looking to upgrade?' ) }
-						line={ this.props.translate( 'Our plans give your site the power to thrive. ' +
-								'Find the plan that works for you.' ) }
+						line={ this.props.translate(
+							'Our plans give your site the power to thrive. ' +
+								'Find the plan that works for you.'
+						) }
 						action={ this.props.translate( 'Upgrade Now' ) }
 						actionURL={ '/plans' }
 						illustration={ '/calypso/images/drake/drake-whoops.svg' }
-						isCompact />
+						isCompact
+					/>
 				</CompactCard>
 			);
 		}
@@ -83,11 +87,8 @@ class PurchasesList extends Component {
 
 PurchasesList.propTypes = {
 	noticeType: React.PropTypes.string,
-	purchases: React.PropTypes.oneOfType( [
-		React.PropTypes.array,
-		React.PropTypes.bool
-	] ),
-	sites: React.PropTypes.array.isRequired
+	purchases: React.PropTypes.oneOfType( [ React.PropTypes.array, React.PropTypes.bool ] ),
+	sites: React.PropTypes.array.isRequired,
 };
 
 export default connect(

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -20,7 +20,7 @@ class PurchaseSiteHeader extends Component {
 		siteId: React.PropTypes.number,
 		name: React.PropTypes.string,
 		domain: React.PropTypes.string,
-	}
+	};
 
 	// Disconnected sites can't render the `Site` component, but there can be
 	// purchases from disconnected sites. Here we spoof the Site header.
@@ -49,13 +49,9 @@ class PurchaseSiteHeader extends Component {
 		let header;
 
 		if ( isPlaceholder ) {
-			header = (
-				<SitePlaceholder />
-			);
+			header = <SitePlaceholder />;
 		} else if ( site ) {
-			header = (
-				<Site isCompact site={ site } indicator={ false } />
-			);
+			header = <Site isCompact site={ site } indicator={ false } />;
 		} else {
 			header = this.renderFauxSite( name, domain );
 		}
@@ -69,8 +65,6 @@ class PurchaseSiteHeader extends Component {
 	}
 }
 
-export default connect(
-	( state, { siteId } ) => ( {
-		site: getSite( state, siteId )
-	} )
-)( PurchaseSiteHeader );
+export default connect( ( state, { siteId } ) => ( {
+	site: getSite( state, siteId ),
+} ) )( PurchaseSiteHeader );

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -17,21 +17,31 @@ import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
 import PurchaseReconnectNotice from './reconnect-notice';
 
-const PurchasesSite = ( { hasLoadedSite, isPlaceholder, site, siteId, purchases, name, domain, slug } ) => {
+const PurchasesSite = ( {
+	hasLoadedSite,
+	isPlaceholder,
+	site,
+	siteId,
+	purchases,
+	name,
+	domain,
+	slug,
+} ) => {
 	let items;
 
 	if ( isPlaceholder ) {
-		items = times( 2, index => (
-			<PurchaseItem isPlaceholder key={ index } />
-		) );
+		items = times( 2, index => <PurchaseItem isPlaceholder key={ index } /> );
 	} else {
-		items = purchases.map( purchase => (
-			<PurchaseItem
-				key={ purchase.id }
-				slug={ slug }
-				isDisconnectedSite={ ! site }
-				purchase={ purchase } />
-		) );
+		items = purchases.map(
+			purchase => (
+				<PurchaseItem
+					key={ purchase.id }
+					slug={ slug }
+					isDisconnectedSite={ ! site }
+					purchase={ purchase }
+				/>
+			)
+		);
 	}
 
 	const isJetpack = some( purchases, purchase => isJetpackPlan( purchase ) );
@@ -43,17 +53,14 @@ const PurchasesSite = ( { hasLoadedSite, isPlaceholder, site, siteId, purchases,
 				siteId={ siteId }
 				name={ name }
 				domain={ domain }
-				isPlaceholder={ isPlaceholder } />
+				isPlaceholder={ isPlaceholder }
+			/>
 
 			{ items }
 
-			{ ( ! isPlaceholder && hasLoadedSite && ! site )
-				? <PurchaseReconnectNotice
-					isJetpack={ isJetpack }
-					name={ name }
-					domain={ domain } />
-				: null
-			}
+			{ ! isPlaceholder && hasLoadedSite && ! site
+				? <PurchaseReconnectNotice isJetpack={ isJetpack } name={ name } domain={ domain } />
+				: null }
 		</div>
 	);
 };
@@ -67,9 +74,7 @@ PurchasesSite.propTypes = {
 	slug: React.PropTypes.string,
 };
 
-export default connect(
-	( state, { siteId } ) => ( {
-		site: getSite( state, siteId ),
-		hasLoadedSite: ! isRequestingSite( state, siteId ),
-	} )
-)( PurchasesSite );
+export default connect( ( state, { siteId } ) => ( {
+	site: getSite( state, siteId ),
+	hasLoadedSite: ! isRequestingSite( state, siteId ),
+} ) )( PurchasesSite );

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -15,29 +15,28 @@ class PurchaseReconnectNotice extends Component {
 	static propTypes = {
 		name: React.PropTypes.string,
 		domain: React.PropTypes.string,
-	}
+	};
 
 	render() {
 		const { translate, name, isJetpack } = this.props;
 		let text = translate( 'You are no longer a user on %(site)s and cannot manage this purchase.', {
 			args: {
 				site: name,
-			}
+			},
 		} );
 		if ( isJetpack ) {
 			text = translate( '%(site)s has been disconnected from WordPress.com.', {
 				args: {
 					site: name,
-				}
+				},
 			} );
 		}
 
 		return (
-			<Notice
-				showDismiss={ false }
-				status="is-error"
-				text={ text }>
-				<NoticeAction href={ isJetpack ? support.JETPACK_CONTACT_SUPPORT : support.CALYPSO_CONTACT }>
+			<Notice showDismiss={ false } status="is-error" text={ text }>
+				<NoticeAction
+					href={ isJetpack ? support.JETPACK_CONTACT_SUPPORT : support.CALYPSO_CONTACT }
+				>
 					{ translate( 'Contact Support' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -268,8 +268,8 @@ class RemovePurchase extends Component {
 				label: translate( 'Remove Now' ),
 				onClick: this.removePurchase,
 			},
-		],
-			productName = getName( getPurchase( this.props ) );
+		];
+		const productName = getName( getPurchase( this.props ) );
 
 		if ( config.isEnabled( 'upgrades/precancellation-chat' ) ) {
 			buttons.unshift( this.getChatButton() );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -16,26 +16,23 @@ import config from 'config';
 import CompactCard from 'components/card/compact';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
-import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enrichedSurveyData';
-import initialSurveyState from 'components/marketing-survey/cancel-purchase-form/initialSurveyState';
+import enrichedSurveyData
+	from 'components/marketing-survey/cancel-purchase-form/enrichedSurveyData';
+import initialSurveyState
+	from 'components/marketing-survey/cancel-purchase-form/initialSurveyState';
 import isSurveyFilledIn from 'components/marketing-survey/cancel-purchase-form/isSurveyFilledIn';
-import stepsForProductAndSurvey from 'components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey';
+import stepsForProductAndSurvey
+	from 'components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey';
 import nextStep from 'components/marketing-survey/cancel-purchase-form/nextStep';
 import previousStep from 'components/marketing-survey/cancel-purchase-form/previousStep';
-import {
-	INITIAL_STEP,
-	FINAL_STEP,
-} from 'components/marketing-survey/cancel-purchase-form/steps';
+import { INITIAL_STEP, FINAL_STEP } from 'components/marketing-survey/cancel-purchase-form/steps';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { getPurchase, isDataLoading } from '../utils';
 import { isDomainRegistration, isPlan, isGoogleApps, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
 import purchasePaths from '../paths';
 import { removePurchase } from 'state/purchases/actions';
-import {
-	isHappychatAvailable,
-	isHappychatChatActive,
-} from 'state/happychat/selectors';
+import { isHappychatAvailable, isHappychatChatActive } from 'state/happychat/selectors';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import userFactory from 'lib/user';
 import { isDomainOnlySite as isDomainOnly } from 'state/selectors';
@@ -60,20 +57,16 @@ class RemovePurchase extends Component {
 		receiveDeletedSite: PropTypes.func.isRequired,
 		removePurchase: PropTypes.func.isRequired,
 		selectedPurchase: PropTypes.object,
-		selectedSite: PropTypes.oneOfType( [
-			PropTypes.object,
-			PropTypes.bool,
-			PropTypes.undefined
-		] ),
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool, PropTypes.undefined ] ),
 		setAllSitesSelected: PropTypes.func.isRequired,
-	}
+	};
 
 	state = {
 		isDialogVisible: false,
 		isRemoving: false,
 		surveyStep: INITIAL_STEP,
-		survey: initialSurveyState()
-	}
+		survey: initialSurveyState(),
+	};
 
 	recordChatEvent( eventAction ) {
 		const purchase = this.props.selectedPurchase;
@@ -93,66 +86,70 @@ class RemovePurchase extends Component {
 			name,
 			Object.assign( { cancellation_flow, product_slug }, properties )
 		);
-	}
+	};
 
 	closeDialog = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_close' );
 		this.setState( {
 			isDialogVisible: false,
 			surveyStep: INITIAL_STEP,
-			survey: initialSurveyState()
+			survey: initialSurveyState(),
 		} );
-	}
+	};
 
 	chatInitiated = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_chat_initiated' );
 		this.closeDialog();
-	}
+	};
 
-	openDialog = ( event ) => {
+	openDialog = event => {
 		this.recordEvent( 'calypso_purchases_cancel_form_start' );
 		event.preventDefault();
 
 		this.setState( { isDialogVisible: true } );
-	}
+	};
 
-	chatButtonClicked = ( event ) => {
+	chatButtonClicked = event => {
 		this.recordChatEvent( 'calypso_precancellation_chat_click' );
 		event.preventDefault();
 
 		this.setState( { isDialogVisible: false } );
-	}
+	};
 
-	changeSurveyStep = ( stepFunction ) => {
+	changeSurveyStep = stepFunction => {
 		const { selectedPurchase, isChatAvailable, isChatActive } = this.props;
 		const { surveyStep, survey } = this.state;
-		const steps = stepsForProductAndSurvey( survey, selectedPurchase, isChatAvailable || isChatActive );
+		const steps = stepsForProductAndSurvey(
+			survey,
+			selectedPurchase,
+			isChatAvailable || isChatActive
+		);
 		const newStep = stepFunction( surveyStep, steps );
 		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
 		this.setState( { surveyStep: newStep } );
-	}
+	};
 
 	clickNext = () => {
 		if ( this.state.isRemoving || ! isSurveyFilledIn( this.state.survey ) ) {
 			return;
 		}
 		this.changeSurveyStep( nextStep );
-	}
+	};
 
 	clickPrevious = () => {
 		if ( this.state.isRemoving ) {
 			return;
 		}
 		this.changeSurveyStep( previousStep );
-	}
+	};
 
-	onSurveyChange = ( update ) => {
+	onSurveyChange = update => {
 		this.setState( {
 			survey: update,
 		} );
-	}
+	};
 
-	removePurchase = ( closeDialog ) => {
+	removePurchase = closeDialog => {
 		this.setState( { isRemoving: true } );
 
 		const purchase = getPurchase( this.props );
@@ -161,24 +158,27 @@ class RemovePurchase extends Component {
 		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
 			this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
-			const survey = wpcom.marketing().survey( 'calypso-remove-purchase', this.props.selectedSite.ID );
+			const survey = wpcom
+				.marketing()
+				.survey( 'calypso-remove-purchase', this.props.selectedSite.ID );
 			const surveyData = {
 				'why-cancel': {
 					response: this.state.survey.questionOneRadio,
-					text: this.state.survey.questionOneText
+					text: this.state.survey.questionOneText,
 				},
 				'next-adventure': {
 					response: this.state.survey.questionTwoRadio,
-					text: this.state.survey.questionTwoText
+					text: this.state.survey.questionTwoText,
 				},
 				'what-better': { text: this.state.survey.questionThreeText },
-				type: 'remove'
+				type: 'remove',
 			};
 
 			survey.addResponses( enrichedSurveyData( surveyData, moment(), selectedSite, purchase ) );
 
 			debug( 'Survey responses', survey );
-			survey.submit()
+			survey
+				.submit()
 				.then( res => {
 					debug( 'Survey submit response', res );
 					if ( ! res.success ) {
@@ -188,7 +188,8 @@ class RemovePurchase extends Component {
 				.catch( err => debug( err ) ); // shouldn't get here
 		}
 
-		this.props.removePurchase( purchase.id, user.get().ID )
+		this.props
+			.removePurchase( purchase.id, user.get().ID )
 			.then( () => {
 				const productName = getName( purchase );
 
@@ -205,7 +206,7 @@ class RemovePurchase extends Component {
 
 					notices.success(
 						translate( 'The domain {{domain/}} was removed from your account.', {
-							components: { domain: <em>{ productName }</em> }
+							components: { domain: <em>{ productName }</em> },
 						} ),
 						{ persistent: true }
 					);
@@ -213,7 +214,7 @@ class RemovePurchase extends Component {
 					notices.success(
 						translate( '%(productName)s was removed from {{siteName/}}.', {
 							args: { productName },
-							components: { siteName: <em>{ selectedSite.domain }</em> }
+							components: { siteName: <em>{ selectedSite.domain }</em> },
 						} ),
 						{ persistent: true }
 					);
@@ -228,7 +229,7 @@ class RemovePurchase extends Component {
 
 				notices.error( this.props.selectedPurchase.error );
 			} );
-	}
+	};
 
 	renderCard = () => {
 		const { translate } = this.props;
@@ -242,32 +243,32 @@ class RemovePurchase extends Component {
 				</a>
 			</CompactCard>
 		);
-	}
+	};
 
 	getChatButton = () => {
 		return (
-			<HappychatButton
-				className="remove-purchase__chat-button"
-				onClick={ this.chatButtonClicked }>
+			<HappychatButton className="remove-purchase__chat-button" onClick={ this.chatButtonClicked }>
 				{ this.props.translate( 'Need help? Chat with us' ) }
 			</HappychatButton>
 		);
-	}
+	};
 
 	renderDomainDialog = () => {
 		const { translate } = this.props;
-		const buttons = [ {
+		const buttons = [
+			{
 				action: 'cancel',
 				disabled: this.state.isRemoving,
-				label: translate( 'Cancel' )
+				label: translate( 'Cancel' ),
 			},
 			{
 				action: 'remove',
 				disabled: this.state.isRemoving,
 				isPrimary: true,
 				label: translate( 'Remove Now' ),
-				onClick: this.removePurchase
-			} ],
+				onClick: this.removePurchase,
+			},
+		],
 			productName = getName( getPurchase( this.props ) );
 
 		if ( config.isEnabled( 'upgrades/precancellation-chat' ) ) {
@@ -279,31 +280,31 @@ class RemovePurchase extends Component {
 				buttons={ buttons }
 				className="remove-purchase__dialog"
 				isVisible={ this.state.isDialogVisible }
-				onClose={ this.closeDialog }>
-				<FormSectionHeading>{ translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
+				onClose={ this.closeDialog }
+			>
+				<FormSectionHeading>
+					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
+				</FormSectionHeading>
 				{ this.renderDomainDialogText() }
 			</Dialog>
 		);
-	}
+	};
 
 	renderDomainDialogText = () => {
 		const { translate } = this.props;
-		const purchase = getPurchase( this.props ),
-			productName = getName( purchase );
+		const purchase = getPurchase( this.props ), productName = getName( purchase );
 
 		return (
 			<p>
-				{
-					translate(
-						'This will remove %(domain)s from your account. By removing, ' +
-							'you are canceling the domain registration. This may stop ' +
-							'you from using it again, even with another service.',
-						{ args: { domain: productName } }
-					)
-				}
+				{ translate(
+					'This will remove %(domain)s from your account. By removing, ' +
+						'you are canceling the domain registration. This may stop ' +
+						'you from using it again, even with another service.',
+					{ args: { domain: productName } }
+				) }
 			</p>
 		);
-	}
+	};
 
 	renderPlanDialogs = () => {
 		const { selectedPurchase, translate } = this.props;
@@ -311,27 +312,27 @@ class RemovePurchase extends Component {
 			cancel: {
 				action: 'cancel',
 				disabled: this.state.isRemoving,
-				label: translate( "I'll Keep It" )
+				label: translate( "I'll Keep It" ),
 			},
 			next: {
 				action: 'next',
 				disabled: this.state.isRemoving || ! isSurveyFilledIn( this.state.survey ),
 				label: translate( 'Next Step' ),
-				onClick: this.clickNext
+				onClick: this.clickNext,
 			},
 			prev: {
 				action: 'prev',
 				disabled: this.state.isRemoving,
 				label: translate( 'Previous Step' ),
-				onClick: this.clickPrevious
+				onClick: this.clickPrevious,
 			},
 			remove: {
 				action: 'remove',
 				disabled: this.state.isRemoving,
 				isPrimary: true,
 				label: translate( 'Remove Now' ),
-				onClick: this.removePurchase
-			}
+				onClick: this.removePurchase,
+			},
 		};
 
 		let buttonsArr;
@@ -355,7 +356,8 @@ class RemovePurchase extends Component {
 					buttons={ buttonsArr }
 					className="remove-purchase__dialog"
 					isVisible={ this.state.isDialogVisible }
-					onClose={ this.closeDialog }>
+					onClose={ this.closeDialog }
+				>
 					<CancelPurchaseForm
 						chatInitiated={ this.chatInitiated }
 						productName={ getName( selectedPurchase ) }
@@ -368,7 +370,7 @@ class RemovePurchase extends Component {
 				</Dialog>
 			</div>
 		);
-	}
+	};
 
 	renderPlanDialogsText = () => {
 		const { translate } = this.props;
@@ -376,46 +378,38 @@ class RemovePurchase extends Component {
 			productName = getName( purchase ),
 			includedDomainText = (
 				<p>
-					{
-						translate(
-							'The domain associated with this plan, {{domain/}}, will not be removed. ' +
-								'It will remain active on your site, unless also removed.',
-							{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
-						)
-					}
+					{ translate(
+						'The domain associated with this plan, {{domain/}}, will not be removed. ' +
+							'It will remain active on your site, unless also removed.',
+						{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
+					) }
 				</p>
 			);
 
 		return (
 			<div>
 				<p>
-					{
-						translate(
-							'Are you sure you want to remove %(productName)s from {{siteName/}}?',
-							{
-								args: { productName },
-								components: { siteName: <em>{ this.props.selectedSite.domain }</em> }
-							}
-						)
-					}
+					{ translate( 'Are you sure you want to remove %(productName)s from {{siteName/}}?', {
+						args: { productName },
+						components: { siteName: <em>{ this.props.selectedSite.domain }</em> },
+					} ) }
 					{ ' ' }
 					{ isGoogleApps( purchase )
 						? translate(
-							'Your G Suite account will continue working without interruption. ' +
-								'You will be able to manage your G Suite billing directly through Google.'
-						)
+								'Your G Suite account will continue working without interruption. ' +
+									'You will be able to manage your G Suite billing directly through Google.'
+							)
 						: translate(
-							'You will not be able to reuse it again without purchasing a new subscription.',
-							{ comment: "'it' refers to a product purchased by a user" }
-						)
-					}
+								'You will not be able to reuse it again without purchasing a new subscription.',
+								{ comment: "'it' refers to a product purchased by a user" }
+							) }
 
 				</p>
 
-				{ ( isPlan( purchase ) && hasIncludedDomain( purchase ) ) && includedDomainText }
+				{ isPlan( purchase ) && hasIncludedDomain( purchase ) && includedDomainText }
 			</div>
 		);
-	}
+	};
 
 	render() {
 		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -12,5 +12,5 @@ export default {
 	addCardDetails: i18n.translate( 'Add Card Details', { comment: 'Credit card' } ),
 	editPaymentMethod: i18n.translate( 'Edit Payment Method' ),
 	managePurchase: i18n.translate( 'Manage Purchase' ),
-	purchases: i18n.translate( 'Purchases' )
+	purchases: i18n.translate( 'Purchases' ),
 };

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -13,7 +13,7 @@ import {
 	isExpired,
 	isIncludedWithPlan,
 	isOneTimePurchase,
-	isPaidWithCreditCard
+	isPaidWithCreditCard,
 } from 'lib/purchases';
 
 // TODO: Remove these property-masking functions in favor of accessing the props directly
@@ -26,8 +26,7 @@ function getSelectedSite( props ) {
 }
 
 function goToCancelPurchase( props ) {
-	const { id } = getPurchase( props ),
-		{ slug } = getSelectedSite( props );
+	const { id } = getPurchase( props ), { slug } = getSelectedSite( props );
 
 	page( paths.cancelPurchase( slug, id ) );
 }
@@ -37,8 +36,7 @@ function goToList() {
 }
 
 function goToManagePurchase( props ) {
-	const { id } = getPurchase( props ),
-		{ slug } = getSelectedSite( props );
+	const { id } = getPurchase( props ), { slug } = getSelectedSite( props );
 
 	page( paths.managePurchase( slug, id ) );
 }
@@ -52,8 +50,10 @@ function recordPageView( trackingSlug, props, nextProps = null ) {
 		return null;
 	}
 
-	if ( nextProps &&
-		( props.hasLoadedUserPurchasesFromServer || ! nextProps.hasLoadedUserPurchasesFromServer ) ) {
+	if (
+		nextProps &&
+		( props.hasLoadedUserPurchasesFromServer || ! nextProps.hasLoadedUserPurchasesFromServer )
+	) {
 		// only record the page view the first time the purchase loads from the server
 		return null;
 	}
@@ -66,14 +66,18 @@ function recordPageView( trackingSlug, props, nextProps = null ) {
 
 	const { productSlug } = purchase;
 
-	analytics.tracks.recordEvent( `calypso_${ trackingSlug }_purchase_view`, { product_slug: productSlug } );
+	analytics.tracks.recordEvent( `calypso_${ trackingSlug }_purchase_view`, {
+		product_slug: productSlug,
+	} );
 }
 
 function canEditPaymentDetails( purchase ) {
 	if ( ! config.isEnabled( 'upgrades/credit-cards' ) ) {
 		return false;
 	}
-	return ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase );
+	return (
+		! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase )
+	);
 }
 
 function getEditCardDetailsPath( site, purchase ) {


### PR DESCRIPTION
This is an experiment to validate `prettier` usage which was enabled with #14010. I would love to hear your feedback about this change. Reader team has already done that and they happily use `codemods` :)

Once we have all files styled with `prettier`, we should have much simplified flow when using `codemods`. Every time you execute `codemod`, you run prettier again to fix all spacing or new lines issues. See #13965 to find out how Reader team is taking advantage of `prettier`.

Prettier in action with PhpStorm:

![prettier](https://cloud.githubusercontent.com/assets/699132/26094165/1bfb960c-3a19-11e7-9815-cf10647b180a.gif)

More details how to setup with Jetbrains: https://github.com/prettier/prettier/tree/master/editors/jetbrains.

Pretttier from CLI:

```
./node_modules/.bin/prettier --write client/me/purchases/**/*.js*
```

There is no change in logic with this PR. It's mostly about introducing code style with prettier. I also fixed 2 linter issues.

Note: there are still errors triggered by Eslint on CircleCI, all of them related to missing `localize` usage. They will be relaxed to warnings on master, so we can leave them for another PR.

### Testing

1. Open  https://calypso.live/me/purchase?branch=update/prettify-me-purchases.
2. Make sure it works as before.
