### PR TITLE
Jetpack: A/B test regarding headlines #2

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -75,7 +75,7 @@ module.exports = {
 		defaultVariation: 'skip',
 	},
 	jetpackPlansHeadlines: {
-		datestamp: '20170508',
+		datestamp: '20170516',
 		variations: {
 			headlineA: 25,
 			headlineB: 25,

--- a/client/signup/jetpack-connect/plans-grid.jsx
+++ b/client/signup/jetpack-connect/plans-grid.jsx
@@ -41,13 +41,13 @@ class JetpackPlansGrid extends Component {
 		let subheaderText = translate( 'Now pick a plan that\'s right for you.' );
 
 		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineB' ) {
-			headerText = translate( 'Simple, affordable pricing.' );
+			headerText = translate( 'Don\'t skimp on security.' );
 		}
 		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineC' ) {
 			headerText = translate( 'Protect your site from data loss.' );
 		}
 		if ( abtest( 'jetpackPlansHeadlines' ) === 'headlineD' ) {
-			headerText = translate( 'Protect your data from hackers.' );
+			headerText = translate( 'Full data backups and priority support.' );
 		}
 
 		if ( showFirst ) {


### PR DESCRIPTION
- change timestamp of test (stops this test: https://github.com/Automattic/wp-calypso/pull/13792/)
- change headlines B and D (keep top performers from i#1)