### PR TITLE
Sites: request only the fields we are consuming.

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -81,7 +81,7 @@ SitesList.prototype.fetch = function() {
 	wpcom.me().sites( {
 		site_visibility: 'all',
 		include_domain_only: true,
-		fields: 'ID,URL,name,capabilities,jetpack,visible,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
+		fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
 		options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
 	}, function( error, data ) {
 		if ( error ) {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -81,8 +81,8 @@ SitesList.prototype.fetch = function() {
 	wpcom.me().sites( {
 		site_visibility: 'all',
 		include_domain_only: true,
-		fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
-		options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
+		fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
+		options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only' //eslint-disable-line max-len
 	}, function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching SitesList from api', error );

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -78,7 +78,12 @@ SitesList.prototype.fetch = function() {
 
 	debug( 'getting SitesList from api' );
 
-	wpcom.me().sites( { site_visibility: 'all', include_domain_only: true }, function( error, data ) {
+	wpcom.me().sites( {
+		site_visibility: 'all',
+		include_domain_only: true,
+		fields: 'ID,URL,name,capabilities,jetpack,visible,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
+		options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
+	}, function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching SitesList from api', error );
 			this.fetching = false;

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -356,7 +356,12 @@ export default {
 				} );
 				// Update the user now that we are fully connected.
 				userFactory().fetch();
-				return wpcom.me().sites( { site_visibility: 'all', include_domain_only: true } );
+				return wpcom.me().sites( {
+					site_visibility: 'all',
+					include_domain_only: true,
+					fields: 'ID,URL,name,capabilities,jetpack,visible,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
+					options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
+				} );
 			} )
 			.then( ( data ) => {
 				tracksEvent( dispatch, 'calypso_jpc_auth_sitesrefresh', {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -359,8 +359,8 @@ export default {
 				return wpcom.me().sites( {
 					site_visibility: 'all',
 					include_domain_only: true,
-					fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
-					options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
+					fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
+					options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only' //eslint-disable-line max-len
 				} );
 			} )
 			.then( ( data ) => {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -359,7 +359,7 @@ export default {
 				return wpcom.me().sites( {
 					site_visibility: 'all',
 					include_domain_only: true,
-					fields: 'ID,URL,name,capabilities,jetpack,visible,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
+					fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
 					options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
 				} );
 			} )

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -32,6 +32,7 @@ import path from 'lib/route/path';
 
 describe( 'actions', () => {
 	let actions, sandbox, spy;
+	const mySitesPath = '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active';
 
 	useFakeDom();
 
@@ -209,11 +210,8 @@ describe( 'actions', () => {
 
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/me/sites' )
-					.query( {
-						site_visibility: 'all',
-						include_domain_only: true
-					} )
+					.filteringPath( () => mySitesPath )
+					.get( mySitesPath )
 					.reply( 200, {
 						sites: [ client_id ]
 					}, {

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -88,7 +88,14 @@ export function requestSites() {
 		dispatch( {
 			type: SITES_REQUEST
 		} );
-		return wpcom.me().sites( { site_visibility: 'all', include_domain_only: true, site_activity: 'active' } ).then( ( response ) => {
+
+		return wpcom.me().sites( {
+			site_visibility: 'all',
+			include_domain_only: true,
+			site_activity: 'active',
+			fields: 'ID,URL,name,capabilities,jetpack,visible,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
+			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
+		} ).then( ( response ) => {
 			dispatch( receiveSites( response.sites ) );
 			dispatch( {
 				type: SITES_REQUEST_SUCCESS

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -93,8 +93,8 @@ export function requestSites() {
 			site_visibility: 'all',
 			include_domain_only: true,
 			site_activity: 'active',
-			fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
-			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only' //eslint-disable-line
+			fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
+			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only' //eslint-disable-line max-len
 		} ).then( ( response ) => {
 			dispatch( receiveSites( response.sites ) );
 			dispatch( {

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -93,7 +93,7 @@ export function requestSites() {
 			site_visibility: 'all',
 			include_domain_only: true,
 			site_activity: 'active',
-			fields: 'ID,URL,name,capabilities,jetpack,visible,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
+			fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
 			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
 		} ).then( ( response ) => {
 			dispatch( receiveSites( response.sites ) );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -94,7 +94,7 @@ export function requestSites() {
 			include_domain_only: true,
 			site_activity: 'active',
 			fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,icon,plan,jetpack_modules,single_user_site,is_multisite,options',
-			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only'
+			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only' //eslint-disable-line
 		} ).then( ( response ) => {
 			dispatch( receiveSites( response.sites ) );
 			dispatch( {

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -20,6 +20,7 @@ export const sitesSchema = {
 				},
 				visible: { type: 'boolean' },
 				is_private: { type: 'boolean' },
+				is_vip: { type: 'boolean' },
 				options: { type: 'object' },
 				meta: { type: 'object' },
 				is_multisite: { type: 'boolean' },

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -8,12 +8,8 @@ export const sitesSchema = {
 			properties: {
 				ID: { type: 'number' },
 				name: { type: 'string' },
-				description: { type: 'string' },
 				URL: { type: 'string' },
 				jetpack: { type: 'boolean' },
-				post_count: { type: 'number' },
-				subscribers_count: { type: 'number' },
-				lang: { type: 'string' },
 				icon: {
 					type: 'object',
 					properties: {
@@ -22,21 +18,10 @@ export const sitesSchema = {
 						media_id: { type: 'number' }
 					}
 				},
-				logo: {
-					type: 'object',
-					properties: {
-						id: { type: 'number' },
-						sizes: { type: [ 'array', 'object' ] },
-						url: { type: 'string' }
-					}
-				},
 				visible: { type: 'boolean' },
 				is_private: { type: 'boolean' },
-				is_following: { type: 'boolean' },
 				options: { type: 'object' },
 				meta: { type: 'object' },
-				user_can_manage: { type: 'boolean' },
-				is_vip: { type: 'boolean' },
 				is_multisite: { type: 'boolean' },
 				capabilities: {
 					type: 'object',
@@ -58,7 +43,6 @@ export const sitesSchema = {
 					}
 				},
 				single_user_site: { type: 'boolean' },
-				updates: { type: 'object' },
 			}
 		}
 	},

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -35,6 +35,7 @@ import {
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'actions', () => {
+	const mySitesPath = '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active';
 	let sandbox, spy;
 
 	useSandbox( newSandbox => {
@@ -85,7 +86,8 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active' )
+					.filteringPath( () => mySitesPath )
+					.get( mySitesPath )
 					.reply( 200, {
 						sites: [
 							{ ID: 2916284, name: 'WordPress.com Example Blog' },
@@ -123,7 +125,8 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active' )
+					.filteringPath( () => mySitesPath )
+					.get( mySitesPath )
 					.reply( 403, {
 						error: 'authorization_required',
 						message: 'An active access token must be used to access sites.'


### PR DESCRIPTION
This reduces the processing time of `/me/sites` significantly as well as reducing the overall data weight we incur and store.

### Needs further testing as it's very likely missing other attributes we rely on.

Also, we should take a deeper look at things we added for convenience that only affect an individual section or feature of Calypso. What we load with `/me/sites` should be only the critical bits for structural navigation and site handling.

- Can we clean up the `seo` related attributes and request them on demand? @dmsnell 
- Can we reduce the `plan` object to its barest minimum? @artpi @gwwar 
- Can we request `allowed_file_types` on demand for media need? @aduth @rralian 
- Can we have a single object for Jetpack modules? @lezama @johnHackworth 
- Can we move `software_version` check to a specific settings request in "plugins"? @oskosk @johnHackworth 
- Can we request `default_post_format` and friends separately for the editor? @aduth @timmyc 
- Do we need `publicize_permanently_disabled`?
- Can we move `podcasting_archive` elsewhere? @youknowriad