### PR TITLE
Run the remove-linked-state-mixin codemod

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import Gridicon from 'gridicons';
 
 /**
@@ -29,8 +28,7 @@ import LostPassword from './lost-password';
 
 export const Login = createReactClass( {
 	displayName: 'Auth',
-
-	mixins: [ LinkedStateMixin, eventRecorder ],
+	mixins: [ eventRecorder ],
 
 	componentDidMount: function() {
 		AuthStore.on( 'change', this.refreshData );
@@ -113,7 +111,8 @@ export const Login = createReactClass( {
 									disabled={ requires2fa || inProgress }
 									placeholder={ translate( 'Username or email address' ) }
 									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
-									valueLink={ this.linkState( 'login' ) }
+									value={ this.state.login }
+									onChange={ this.handleChange }
 								/>
 							</div>
 							<div className="auth__input-wrapper">
@@ -125,7 +124,8 @@ export const Login = createReactClass( {
 									onFocus={ this.recordFocusEvent( 'Password' ) }
 									hideToggle={ requires2fa }
 									submitting={ inProgress }
-									valueLink={ this.linkState( 'password' ) }
+									value={ this.state.password }
+									onChange={ this.handleChange }
 								/>
 							</div>
 							{ requires2fa && (
@@ -137,7 +137,8 @@ export const Login = createReactClass( {
 										disabled={ inProgress }
 										placeholder={ translate( 'Verification code' ) }
 										onFocus={ this.recordFocusEvent( 'Verification code' ) }
-										valueLink={ this.linkState( 'auth_code' ) }
+										value={ this.state.auth_code }
+										onChange={ this.handleChange }
 									/>
 								</FormFieldset>
 							) }
@@ -179,6 +180,11 @@ export const Login = createReactClass( {
 				</div>
 			</Main>
 		);
+	},
+
+	handleChange( e ) {
+		const { name, value } = e.currentTarget;
+		this.setState( { [ name ]: value } );
 	},
 } );
 

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:application-passwords' );
 import { bindActionCreators } from 'redux';
@@ -36,8 +35,7 @@ import { errorNotice } from 'state/notices/actions';
 
 const ApplicationPasswords = React.createClass( {
 	displayName: 'ApplicationPasswords',
-
-	mixins: [ observe( 'appPasswordsData' ), LinkedStateMixin, eventRecorder ],
+	mixins: [ observe( 'appPasswordsData' ), eventRecorder ],
 
 	componentDidMount: function() {
 		debug( this.displayName + ' React component is mounted.' );
@@ -110,9 +108,10 @@ const ApplicationPasswords = React.createClass( {
 							className="application-passwords__add-new-field"
 							disabled={ this.state.submittingForm }
 							id="application-name"
-							name="application-name"
+							name="applicationName"
 							onFocus={ this.recordFocusEvent( 'Application Name Field' ) }
-							valueLink={ this.linkState( 'applicationName' ) }
+							value={ this.state.applicationName }
+							onChange={ this.handleChange }
 						/>
 					</FormFieldset>
 
@@ -237,6 +236,11 @@ const ApplicationPasswords = React.createClass( {
 				</Card>
 			</div>
 		);
+	},
+
+	handleChange( e ) {
+		const { name, value } = e.currentTarget;
+		this.setState( { [ name ]: value } );
 	},
 } );
 

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -6,7 +6,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { debounce, isEqual, find } from 'lodash';
 import { connect } from 'react-redux';
@@ -51,7 +50,7 @@ const trackSupportAfterSibylClick = () =>
 	composeAnalytics( recordTracksEvent( 'calypso_sibyl_support_after_question_click' ) );
 
 export const HelpContactForm = React.createClass( {
-	mixins: [ LinkedStateMixin, PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		formDescription: PropTypes.node,
@@ -337,14 +336,20 @@ export const HelpContactForm = React.createClass( {
 				{ showSubjectField && (
 					<div className="help-contact-form__subject">
 						<FormLabel>{ translate( 'Subject' ) }</FormLabel>
-						<FormTextInput valueLink={ this.linkState( 'subject' ) } />
+						<FormTextInput
+							name="subject"
+							value={ this.state.subject }
+							onChange={ this.handleChange }
+						/>
 					</div>
 				) }
 
 				<FormLabel>{ translate( 'What are you trying to do?' ) }</FormLabel>
 				<FormTextarea
-					valueLink={ this.linkState( 'message' ) }
 					placeholder={ translate( 'Please be descriptive' ) }
+					name="message"
+					value={ this.state.message }
+					onChange={ this.handleChange }
 				/>
 
 				{ showHelpLanguagePrompt && (
@@ -365,6 +370,11 @@ export const HelpContactForm = React.createClass( {
 				</FormButton>
 			</div>
 		);
+	},
+
+	handleChange( e ) {
+		const { name, value } = e.currentTarget;
+		this.setState( { [ name ]: value } );
 	},
 } );
 

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 
 /**
  * Internal dependencies
@@ -20,8 +19,7 @@ import Notice from 'components/notice';
 export default localize(
 	React.createClass( {
 		displayName: 'ProfileLinksAddOther',
-
-		mixins: [ LinkedStateMixin, eventRecorder ],
+		mixins: [ eventRecorder ],
 
 		getInitialState() {
 			return {
@@ -144,15 +142,19 @@ export default localize(
 					<FormFieldset>
 						<FormTextInput
 							className="profile-links-add-other__value"
-							valueLink={ this.linkState( 'value' ) }
 							placeholder={ this.props.translate( 'Enter a URL' ) }
 							onFocus={ this.recordFocusEvent( 'Add Other Site URL Field' ) }
+							name="value"
+							value={ this.state.value }
+							onChange={ this.handleChange }
 						/>
 						<FormTextInput
 							className="profile-links-add-other__title"
-							valueLink={ this.linkState( 'title' ) }
 							placeholder={ this.props.translate( 'Enter a description' ) }
 							onFocus={ this.recordFocusEvent( 'Add Other Site Description Field' ) }
+							name="title"
+							value={ this.state.title }
+							onChange={ this.handleChange }
 						/>
 						<FormButton
 							className="profile-links-add-other__add"
@@ -171,6 +173,11 @@ export default localize(
 					</FormFieldset>
 				</form>
 			);
+		},
+
+		handleChange( e ) {
+			const { name, value } = e.currentTarget;
+			this.setState( { [ name ]: value } );
 		},
 	} )
 );

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:reauth-required' );
 
@@ -32,8 +31,7 @@ import Notice from 'components/notice';
 export default localize(
 	React.createClass( {
 		displayName: 'ReauthRequired',
-
-		mixins: [ LinkedStateMixin, observe( 'twoStepAuthorization' ), eventRecorder ],
+		mixins: [ observe( 'twoStepAuthorization' ), eventRecorder ],
 
 		getInitialState: function() {
 			return {
@@ -214,7 +212,8 @@ export default localize(
 								name="code"
 								placeholder={ codePlaceholder }
 								onFocus={ this.recordFocusEvent( 'Reauth Required Verification Code Field' ) }
-								valueLink={ this.linkState( 'code' ) }
+								value={ this.state.code }
+								onChange={ this.handleChange }
 							/>
 
 							{ this.renderFailedValidationMsg() }
@@ -223,10 +222,11 @@ export default localize(
 						<FormFieldset>
 							<FormLabel>
 								<FormCheckbox
-									checkedLink={ this.linkState( 'remember2fa' ) }
 									id="remember2fa"
 									name="remember2fa"
 									onClick={ this.recordCheckboxEvent( 'Remember 2fa' ) }
+									checked={ this.state.remember2fa }
+									onChange={ this.handleCheckedChange }
 								/>
 								<span>{ this.props.translate( 'Remember for 30 days.' ) }</span>
 							</FormLabel>
@@ -247,6 +247,16 @@ export default localize(
 					</form>
 				</Dialog>
 			);
+		},
+
+		handleChange( e ) {
+			const { name, value } = e.currentTarget;
+			this.setState( { [ name ]: value } );
+		},
+
+		handleCheckedChange( e ) {
+			const { name, checked } = e.currentTarget;
+			this.setState( { [ name ]: checked } );
 		},
 	} )
 );

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-backup-codes-prompt' );
 
@@ -26,8 +25,6 @@ import Notice from 'components/notice';
 export default localize(
 	React.createClass( {
 		displayName: 'Security2faBackupCodesPrompt',
-
-		mixins: [ LinkedStateMixin ],
 
 		propTypes: {
 			onPrintAgain: PropTypes.func,
@@ -144,17 +141,18 @@ export default localize(
 						</FormLabel>
 						<FormTelInput
 							disabled={ this.state.submittingCode }
-							name="backup-code-entry"
+							name="backupCodeEntry"
 							autoComplete="off"
 							maxLength="8"
 							placeholder={ constants.eightDigitBackupCodePlaceholder }
-							valueLink={ this.linkState( 'backupCodeEntry' ) }
 							onFocus={ function() {
 								analytics.ga.recordEvent(
 									'Me',
 									'Focused On 2fa Backup Codes Confirm Printed Backup Codes Input'
 								);
 							} }
+							value={ this.state.backupCodeEntry }
+							onChange={ this.handleChange }
 						/>
 					</FormFieldset>
 
@@ -177,6 +175,11 @@ export default localize(
 					</FormButton>
 				</form>
 			);
+		},
+
+		handleChange( e ) {
+			const { name, value } = e.currentTarget;
+			this.setState( { [ name ]: value } );
 		},
 	} )
 );

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-code-prompt' );
 
@@ -28,8 +27,6 @@ import Notice from 'components/notice';
 export default localize(
 	React.createClass( {
 		displayName: 'Security2faCodePrompt',
-
-		mixins: [ LinkedStateMixin ],
 
 		codeRequestTimer: false,
 
@@ -217,13 +214,14 @@ export default localize(
 							autoFocus
 							className="security-2fa-code-prompt__verification-code"
 							disabled={ this.state.submittingForm }
-							name="verification-code"
+							name="verificationCode"
 							placeholder={ codePlaceholder }
 							autoComplete="off"
-							valueLink={ this.linkState( 'verificationCode' ) }
 							onFocus={ function() {
 								analytics.ga.recordEvent( 'Me', 'Focused On 2fa Disable Code Verification Input' );
 							} }
+							value={ this.state.verificationCode }
+							onChange={ this.handleChange }
 						/>
 						{ this.state.codeRequestPerformed ? (
 							<FormSettingExplanation>
@@ -282,6 +280,11 @@ export default localize(
 					</FormButtonsBar>
 				</form>
 			);
+		},
+
+		handleChange( e ) {
+			const { name, value } = e.currentTarget;
+			this.setState( { [ name ]: value } );
 		},
 	} )
 );

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-enable' );
 import QRCode from 'qrcode.react';
@@ -30,8 +29,6 @@ import Notice from 'components/notice';
 export default localize(
 	React.createClass( {
 		displayName: 'Security2faEnable',
-
-		mixins: [ LinkedStateMixin ],
 
 		codeRequestTimer: false,
 
@@ -344,7 +341,7 @@ export default localize(
 						autoComplete="off"
 						autoFocus
 						disabled={ this.state.submittingForm }
-						name="verification-code"
+						name="verificationCode"
 						placeholder={
 							'sms' === this.state.method ? (
 								constants.sevenDigit2faPlaceholder
@@ -352,10 +349,11 @@ export default localize(
 								constants.sixDigit2faPlaceholder
 							)
 						}
-						valueLink={ this.linkState( 'verificationCode' ) }
 						onFocus={ function() {
 							analytics.ga.recordEvent( 'Me', 'Focused On 2fa Enable Verification Code Input' );
 						} }
+						value={ this.state.verificationCode }
+						onChange={ this.handleChange }
 					/>
 					{ 'sms' === this.state.method && this.state.smsRequestPerformed ? (
 						<FormSettingExplanation>
@@ -456,6 +454,11 @@ export default localize(
 					</form>
 				</div>
 			);
+		},
+
+		handleChange( e ) {
+			const { name, value } = e.currentTarget;
+			this.setState( { [ name ]: value } );
 		},
 	} )
 );

--- a/client/me/security-account-recovery/edit-email.jsx
+++ b/client/me/security-account-recovery/edit-email.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import ReactDom from 'react-dom';
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import emailValidator from 'email-validator';
 
 /**
@@ -23,8 +22,6 @@ import Buttons from './buttons';
 export default localize(
 	React.createClass( {
 		displayName: 'SecurityAccountRecoveryRecoveryEmailEdit',
-
-		mixins: [ LinkedStateMixin ],
 
 		propTypes: {
 			storedEmail: PropTypes.string,
@@ -78,11 +75,12 @@ export default localize(
 				<div className={ this.props.className }>
 					<FormFieldset>
 						<FormTextInput
-							valueLink={ this.linkState( 'email' ) }
 							isError={ this.state.isInvalid }
 							onKeyUp={ this.onKeyUp }
-							name="recovery-email"
+							name="email"
 							ref="email"
+							value={ this.state.email }
+							onChange={ this.handleChange }
 						/>
 
 						{ this.renderValidation() }
@@ -156,6 +154,11 @@ export default localize(
 
 		onDelete: function() {
 			this.props.onDelete();
+		},
+
+		handleChange( e ) {
+			const { name, value } = e.currentTarget;
+			this.setState( { [ name ]: value } );
 		},
 	} )
 );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1718,7 +1718,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.31"
+      "version": "0.10.35"
     },
     "es6-error": {
       "version": "4.0.2"
@@ -2209,7 +2209,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.56.0",
+      "version": "0.57.3",
       "dev": true
     },
     "flux": {
@@ -3191,7 +3191,7 @@
       "version": "1.0.5"
     },
     "irregular-plurals": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dev": true
     },
     "is-arrayish": {
@@ -4366,6 +4366,17 @@
     "levn": {
       "version": "0.3.0",
       "dev": true
+    },
+    "libphonenumber-js": {
+      "version": "0.4.27",
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1"
+        },
+        "minimist": {
+          "version": "1.2.0"
+        }
+      }
     },
     "lie": {
       "version": "3.0.2"
@@ -5558,7 +5569,7 @@
       }
     },
     "private": {
-      "version": "0.1.7"
+      "version": "0.1.8"
     },
     "process": {
       "version": "0.11.10"
@@ -5652,7 +5663,7 @@
       "version": "2.2.0"
     },
     "rc": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -5663,9 +5674,6 @@
       "version": "15.4.0"
     },
     "react-addons-create-fragment": {
-      "version": "15.4.0"
-    },
-    "react-addons-linked-state-mixin": {
       "version": "15.4.0"
     },
     "react-addons-test-utils": {
@@ -6334,8 +6342,7 @@
       }
     },
     "sax": {
-      "version": "1.2.4",
-      "dev": true
+      "version": "1.2.4"
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -7780,6 +7787,12 @@
     "xml-name-validator": {
       "version": "2.0.1",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19"
+    },
+    "xmlbuilder": {
+      "version": "9.0.4"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1"

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "qs": "4.0.0",
     "react": "15.4.0",
     "react-addons-create-fragment": "15.4.0",
-    "react-addons-linked-state-mixin": "15.4.0",
     "react-click-outside": "2.1.0",
     "react-day-picker": "6.0.2",
     "react-docgen": "2.13.0",


### PR DESCRIPTION
This runs the remove-linked-state-mixin codemod that landed in #13925.

The second commit removes the `react-addons-linked-state-mixin` from `package.json` and reshrinkwraps.


**To test:**
Go through the forms in the affected files and check that they work:
```
client/auth/login.jsx
client/me/application-passwords/index.jsx
client/me/help/help-contact-form/index.jsx
client/me/profile-links-add-other/index.jsx
client/me/reauth-required/index.jsx
client/me/security-2fa-backup-codes-prompt/index.jsx
client/me/security-2fa-code-prompt/index.jsx
client/me/security-2fa-enable/index.jsx
client/me/security-account-recovery/edit-email.jsx
```
