### PR TITLE
Login: Show the phone number when we successfully send an SMS

### DIFF
--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -32,10 +32,18 @@ class TwoFactorActions extends Component {
 	sendSmsCode = ( event ) => {
 		event.preventDefault();
 
-		const { userId, twoStepNonce } = this.props;
+		const { userId, translate, twoStepNonce } = this.props;
 
-		this.props.sendSmsCode( userId, twoStepNonce ).then( () => {
-			page( login( { twoFactorAuthType: 'sms' } ) );
+		page( login( { twoFactorAuthType: 'sms' } ) );
+
+		this.props.sendSmsCode( userId, twoStepNonce ).then( ( phoneNumber ) => {
+			this.props.successNotice(
+				translate( 'A text message with the verification code was just sent to your phone number ending in %(phoneNumber)s', {
+					args: {
+						phoneNumber: phoneNumber
+					}
+				} )
+			);
 		} ).catch( ( errorMesssage ) => {
 			this.props.errorNotice( errorMesssage );
 		} );

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -174,6 +174,8 @@ export const sendSmsCode = ( userId, twoStepNonce ) => dispatch => {
 				type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
 				twoStepNonce: get( response, 'body.data.two_step_nonce' ),
 			} );
+
+			return Promise.resolve( get( response, 'body.data.phone_number' ) );
 		} ).catch( ( error ) => {
 			const errorMessage = getMessageFromHTTPError( error );
 


### PR DESCRIPTION
This pull request fixes #14092 by showing the phone number that an SMS was sent to:

<img width="682" alt="screen shot 2017-05-16 at 14 48 40" src="https://cloud.githubusercontent.com/assets/275961/26109243/d2e0e214-3a46-11e7-8675-dfbe4576b2d3.png">
  
This also shows the SMS screen whenever the user clicks on that link, even if an SMS can't be sent, to allow users to enter code sent previously by SMS.

#### Testing instructions
  
1. Run `git checkout update/2fa-sms` and start your server, or open a [live branch](https://delphin.live/?branch=update/2fa-sms)
2. Apply the patch D5622-code
2. Open the [`Login` page](http://calypso.localhost:3000/)
3. Log in to an account with 2FA
4. Send a recovery code via SMS
5. Check that the last four digit of your phone number show in the success notice.
 
#### Reviews
  
- [x] Code
- [x] Product
   
cc @ranh for a copy review.