### PR TITLE
Reader Manage Following: add a site description blacklist to hide the 'just another WordPress site' default tagline

### DIFF
--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -9,6 +9,7 @@ import { trim } from 'lodash';
  * Internal Dependencies
  */
 import { decodeEntities } from 'lib/formatting';
+import { isSiteDescriptionBlacklisted } from 'reader/lib/site-description-blacklist';
 
 /**
  * Given a feed, site, or post: return the site url. return false if one could not be found.
@@ -68,7 +69,13 @@ export const getSiteName = ( { feed, site, post } = {} ) => {
 };
 
 export const getSiteDescription = ( { site, feed } ) => {
-	return decodeEntities( ( site && site.description ) || ( feed && feed.description ) );
+	const description = decodeEntities(
+		( site && site.description ) || ( feed && feed.description )
+	);
+	if ( isSiteDescriptionBlacklisted( description ) ) {
+		return null;
+	}
+	return description;
 };
 
 export const getSiteAuthorName = site => {

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -69,9 +69,7 @@ export const getSiteName = ( { feed, site, post } = {} ) => {
 };
 
 export const getSiteDescription = ( { site, feed } ) => {
-	const description = decodeEntities(
-		( site && site.description ) || ( feed && feed.description )
-	);
+	const description = ( site && site.description ) || ( feed && feed.description );
 	if ( isSiteDescriptionBlacklisted( description ) ) {
 		return null;
 	}

--- a/client/reader/lib/site-description-blacklist/index.js
+++ b/client/reader/lib/site-description-blacklist/index.js
@@ -1,0 +1,19 @@
+/**
+ * External Dependencies
+ */
+import { includes } from 'lodash';
+
+const siteDescriptionBlacklist = [
+	'Just another WordPress.com site',
+	'Just another WordPress site',
+];
+
+/**
+ * Is the provided site description name blacklisted?
+ *
+ * @param {string} siteDescription Site description
+ * @returns {boolean} True if blacklisted
+ */
+export const isSiteDescriptionBlacklisted = siteDescription => {
+	return includes( siteDescriptionBlacklist, siteDescription );
+};

--- a/client/reader/lib/site-description-blacklist/index.js
+++ b/client/reader/lib/site-description-blacklist/index.js
@@ -1,12 +1,7 @@
-/**
- * External Dependencies
- */
-import { includes } from 'lodash';
-
-const siteDescriptionBlacklist = [
+const siteDescriptionBlacklist = new Set( [
 	'Just another WordPress.com site',
 	'Just another WordPress site',
-];
+] );
 
 /**
  * Is the provided site description name blacklisted?
@@ -15,5 +10,5 @@ const siteDescriptionBlacklist = [
  * @returns {boolean} True if blacklisted
  */
 export const isSiteDescriptionBlacklisted = siteDescription => {
-	return includes( siteDescriptionBlacklist, siteDescription );
+	return siteDescriptionBlacklist.has( siteDescription );
 };

--- a/client/reader/lib/site-description-blacklist/test/index.js
+++ b/client/reader/lib/site-description-blacklist/test/index.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isSiteDescriptionBlacklisted } from '../';
+
+describe( 'isSiteDescriptionBlacklisted', () => {
+	it( 'should return null if a site description is blacklisted', function() {
+		const blackListedDescription = 'Just another WordPress site';
+		const unBlackListedDescription = 'My site is marvellous';
+		expect( isSiteDescriptionBlacklisted( blackListedDescription ) ).to.equal( true );
+		expect( isSiteDescriptionBlacklisted( unBlackListedDescription ) ).to.equal( false );
+	} );
+} );

--- a/client/reader/lib/site-description-blacklist/test/index.js
+++ b/client/reader/lib/site-description-blacklist/test/index.js
@@ -9,10 +9,13 @@ import { expect } from 'chai';
 import { isSiteDescriptionBlacklisted } from '../';
 
 describe( 'isSiteDescriptionBlacklisted', () => {
-	it( 'should return null if a site description is blacklisted', function() {
+	it( 'should return true if a site description is blacklisted', function() {
 		const blackListedDescription = 'Just another WordPress site';
-		const unBlackListedDescription = 'My site is marvellous';
 		expect( isSiteDescriptionBlacklisted( blackListedDescription ) ).to.equal( true );
+	} );
+
+	it( 'should return false if a site description is not blacklisted', function() {
+		const unBlackListedDescription = 'My site is marvellous';
 		expect( isSiteDescriptionBlacklisted( unBlackListedDescription ) ).to.equal( false );
 	} );
 } );

--- a/client/reader/lib/site-description-blacklist/test/index.js
+++ b/client/reader/lib/site-description-blacklist/test/index.js
@@ -11,11 +11,11 @@ import { isSiteDescriptionBlacklisted } from '../';
 describe( 'isSiteDescriptionBlacklisted', () => {
 	it( 'should return true if a site description is blacklisted', function() {
 		const blackListedDescription = 'Just another WordPress site';
-		expect( isSiteDescriptionBlacklisted( blackListedDescription ) ).to.equal( true );
+		expect( isSiteDescriptionBlacklisted( blackListedDescription ) ).to.be.true;
 	} );
 
 	it( 'should return false if a site description is not blacklisted', function() {
 		const unBlackListedDescription = 'My site is marvellous';
-		expect( isSiteDescriptionBlacklisted( unBlackListedDescription ) ).to.equal( false );
+		expect( isSiteDescriptionBlacklisted( unBlackListedDescription ) ).to.be.false;
 	} );
 } );

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -19,6 +19,7 @@ import {
 import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
+import { decodeEntities } from 'lib/formatting';
 
 const actionMap = {
 	[ SERIALIZE ]: handleSerialize,
@@ -66,6 +67,10 @@ function adaptSite( attributes ) {
 		attributes.slug = attributes.domain.replace( /\//g, '::' );
 	}
 	attributes.title = trim( attributes.name ) || attributes.domain;
+
+	if ( attributes.description ) {
+		attributes.description = decodeEntities( attributes.description );
+	}
 
 	// If a WordPress.com site has a mapped domain create a `wpcom_url`
 	// attribute to allow site selection with either domain.

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -119,6 +119,23 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should decode entities in the site description', () => {
+			expect(
+				items(
+					{},
+					{
+						type: READER_SITE_REQUEST_SUCCESS,
+						payload: {
+							ID: 1,
+							description: 'Apples&amp;Pears',
+						},
+					}
+				)[ 1 ]
+			).to.have.a
+				.property( 'description' )
+				.that.equals( 'Apples&Pears' );
+		} );
+
 		it( 'should serialize site entries', () => {
 			const unvalidatedObject = deepFreeze( { hi: 'there' } );
 			expect( items( unvalidatedObject, { type: SERIALIZE } ) ).to.deep.equal( unvalidatedObject );


### PR DESCRIPTION
@designsimply suggested:

"Can sites with default site descriptions be de-emphasized?"

![screen-shot-2017-05-15-at-mon-may-15-11-45-57-am](https://cloud.githubusercontent.com/assets/17325/26110030/60954546-3a51-11e7-9531-72dc72341730.png)

This PR drops the 'Just another Wordpress[.com] site' default taglines.