### PR TITLE
Reader: Add the feed description into the feed object

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -14,6 +14,7 @@ import ReaderFollowButton from 'reader/follow-button';
 import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 import Site from 'blocks/site';
 import HeaderBack from 'reader/header-back';
+import { getSiteDescription } from 'reader/get-helpers';
 
 class FeedHeader extends Component {
 	static propTypes = {
@@ -55,7 +56,7 @@ class FeedHeader extends Component {
 		const ownerDisplayName =
 			site && ! site.is_multi_author && site.owner && site.owner.name;
 		const siteish = this.buildSiteish( site, feed );
-		const description = site && site.description;
+		const description = getSiteDescription( { site, feed } );
 
 		const classes = classnames( {
 			'reader-feed-header': true,

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -67,6 +67,7 @@ function adaptFeed( feed ) {
 		feed_URL: feed.feed_URL,
 		is_following: feed.is_following,
 		subscribers_count: feed.subscribers_count,
+		description: feed.description && decodeEntities( feed.description ),
 	};
 }
 

--- a/client/state/reader/feeds/schema.js
+++ b/client/state/reader/feeds/schema.js
@@ -13,6 +13,7 @@ export const itemsSchema = {
 				feed_URL: { type: [ 'string', 'null' ] },
 				is_following: { type: [ 'boolean', 'null' ] },
 				subscribers_count: { type: [ 'integer', 'null' ] },
+				description: { type: [ 'string', 'null' ] },
 			},
 		},
 	},

--- a/client/state/reader/feeds/test/reducer.js
+++ b/client/state/reader/feeds/test/reducer.js
@@ -47,10 +47,11 @@ describe( 'reducer', () => {
 				is_following: true,
 				name: undefined,
 				subscribers_count: undefined,
+				description: undefined,
 			} );
 		} );
 
-		it( 'should decode entities in the name', () => {
+		it( 'should decode entities in the name and description', () => {
 			expect(
 				items(
 					{},
@@ -60,6 +61,7 @@ describe( 'reducer', () => {
 							feed_ID: 1,
 							blog_ID: 2,
 							name: 'ben &amp; jerries',
+							description: 'peaches &amp; cream',
 						},
 					}
 				)[ 1 ]
@@ -67,6 +69,7 @@ describe( 'reducer', () => {
 				feed_ID: 1,
 				blog_ID: 2,
 				name: 'ben & jerries',
+				description: 'peaches & cream',
 				URL: undefined,
 				feed_URL: undefined,
 				is_following: undefined,
@@ -150,6 +153,7 @@ describe( 'reducer', () => {
 					feed_URL: undefined,
 					URL: undefined,
 					is_following: undefined,
+					description: undefined,
 				},
 			} );
 		} );
@@ -185,6 +189,7 @@ describe( 'reducer', () => {
 					feed_URL: undefined,
 					is_following: true,
 					subscribers_count: undefined,
+					description: undefined,
 				},
 				1: {
 					feed_ID: 1,
@@ -194,6 +199,7 @@ describe( 'reducer', () => {
 					feed_URL: undefined,
 					is_following: true,
 					subscribers_count: undefined,
+					description: undefined,
 				},
 				2: {
 					feed_ID: 2,
@@ -203,6 +209,7 @@ describe( 'reducer', () => {
 					feed_URL: undefined,
 					is_following: true,
 					subscribers_count: undefined,
+					description: undefined,
 				},
 			} );
 		} );


### PR DESCRIPTION
Currently passed by the API, but we're ignoring it. This allows us to use it properly.

Also update the feed header to look for it.