### PR TITLE
Trim URLs provided to Jetpack connect

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -137,7 +137,7 @@ class JetpackConnectMain extends Component {
 	}
 
 	getCurrentUrl() {
-		let url = this.refs.siteUrlInputRef.state.value.toLowerCase();
+		let url = this.refs.siteUrlInputRef.state.value.trim().toLowerCase();
 		if ( url && url.substr( 0, 4 ) !== 'http' ) {
 			url = 'http://' + url;
 		}


### PR DESCRIPTION
It's easy to get whitespace in a copied URL, but valid URLs shouldn't have any initial or trailing whitespace. Trimming should allow more URL's without breakage.

To test:

* Use this branch
* Visit `http://calypso.localhost:3000/jetpack/connect`
* Enter a variety of URLs. Ensure that you are allowed to type in valid URLs
* Try to copy/paste a URL with initial or trailing whitespace. It should be corrected and the connection continue without problems due to the initial or trailing whitespace.