### PR TITLE
Site Settings: Display activation banner when Stats module is disabled

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -4,12 +4,14 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
+import Banner from 'components/banner';
 import FoldableCard from 'components/foldable-card';
+import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -23,7 +25,9 @@ import QuerySiteRoles from 'components/data/query-site-roles';
 import { getStatsPathForTab } from 'lib/route/path';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
+import { activateModule } from 'state/jetpack/modules/actions';
 import {
+	isActivatingJetpackModule,
 	isJetpackModuleActive,
 	isJetpackModuleUnavailableInDevelopmentMode,
 	isJetpackSiteInDevelopmentMode
@@ -57,6 +61,14 @@ class JetpackSiteStats extends Component {
 
 			setFieldValue( groupName, groupFields, true );
 		};
+	};
+
+	handleStatsActivationButton = ( event ) => {
+		const { siteId } = this.props;
+
+		this.props.activateModule( siteId, 'stats' );
+
+		event.preventDefault();
 	};
 
 	getCurrentGroupFields( groupName ) {
@@ -98,9 +110,23 @@ class JetpackSiteStats extends Component {
 		);
 	}
 
-	render() {
+	renderModuleEnableBanner() {
+		const { translate } = this.props;
+
+		return (
+			<Banner
+				title={ translate( 'Site Stats module is disabled' ) }
+				description={ translate( 'Enable it to see detailed stats, likes, followers, subscribers and more!' ) }
+				callToAction={ translate( 'Enable' ) }
+				onClick={ this.handleStatsActivationButton }
+				event={ 'site_stats_module_enable_banner' }
+				icon="stats"
+			/>
+		);
+	}
+
+	renderCardSettings() {
 		const {
-			siteId,
 			siteRoles,
 			siteSlug,
 			translate
@@ -113,12 +139,7 @@ class JetpackSiteStats extends Component {
 		);
 
 		return (
-			<div className="site-settings__traffic-settings">
-				<QueryJetpackConnection siteId={ siteId } />
-				<QuerySiteRoles siteId={ siteId } />
-
-				<SectionHeader label={ translate( 'Site stats' ) } />
-
+			<div>
 				<FoldableCard
 					className="site-settings__foldable-card is-top-level"
 					header={ header }
@@ -181,6 +202,50 @@ class JetpackSiteStats extends Component {
 			</div>
 		);
 	}
+
+	renderPlaceholder() {
+		return (
+			<Card className="site-settings__card is-placeholder">
+				<div />
+			</Card>
+		);
+	}
+
+	renderCardContent() {
+		const {
+			activatingStatsModule,
+			statsModuleActive
+		} = this.props;
+
+		if ( activatingStatsModule ) {
+			return this.renderPlaceholder();
+		}
+
+		if ( statsModuleActive === true ) {
+			return this.renderCardSettings();
+		} else if ( statsModuleActive === false ) {
+			return this.renderModuleEnableBanner();
+		}
+		return this.renderPlaceholder();
+	}
+
+	render() {
+		const {
+			siteId,
+			translate
+		} = this.props;
+
+		return (
+			<div className="site-settings__traffic-settings">
+				<QueryJetpackConnection siteId={ siteId } />
+				<QuerySiteRoles siteId={ siteId } />
+
+				<SectionHeader label={ translate( 'Site stats' ) } />
+
+				{ this.renderCardContent() }
+			</div>
+		);
+	}
 }
 
 export default connect(
@@ -192,9 +257,13 @@ export default connect(
 		return {
 			siteId,
 			siteSlug: getSelectedSiteSlug( state, siteId ),
-			statsModuleActive: !! isJetpackModuleActive( state, siteId, 'stats' ),
+			activatingStatsModule: isActivatingJetpackModule( state, siteId, 'stats' ),
+			statsModuleActive: isJetpackModuleActive( state, siteId, 'stats' ),
 			moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			siteRoles: getSiteRoles( state, siteId ),
 		};
+	},
+	{
+		activateModule
 	}
 )( localize( JetpackSiteStats ) );

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -116,7 +116,9 @@ class JetpackSiteStats extends Component {
 		return (
 			<Banner
 				title={ translate( 'Site Stats module is disabled' ) }
-				description={ translate( 'Enable it to see detailed stats, likes, followers, subscribers and more!' ) }
+				description={
+					translate( 'Enable this to see detailed information about your traffic, likes, comments, and subscribers.' )
+				}
 				callToAction={ translate( 'Enable' ) }
 				onClick={ this.handleStatsActivationButton }
 				event={ 'site_stats_module_enable_banner' }

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -136,7 +136,7 @@ class JetpackSiteStats extends Component {
 		const header = (
 			<div>
 				<Gridicon icon="checkmark" />
-				{ translate( 'Collecting valuable traffic stats and insights' ) }
+				{ translate( 'Enabled! You\'re collecting valuable data and insights.' ) }
 			</div>
 		);
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -192,6 +192,12 @@
 			margin-bottom: 8px;
 		}
 	}
+
+	.card {
+		&.is-placeholder div {
+			@include placeholder;
+		}
+	}
 }
 
 .site-settings__general-settings,


### PR DESCRIPTION
Currently, when the Stats module is disabled, the Stats card under Traffic settings for Jetpack sites will incorrectly display that stats are enabled. Also, there isn't a way to enable the Stats module. 

This PR handles this case by displaying a banner with activation button when the module is disabled. It also improves the card by rendering a placeholder in two cases: while loading module data, and while activating the module. Fixes #13647.

This approach was suggested in p6TEKc-1ca-p2 by @MichaelArestad.

Preview - stats module enabled:
![](https://cldup.com/4R8iy4RrxH.png)

Preview - stats module disabled:
![](https://cldup.com/KTHy-zxt2x.png)

Preview - placeholder while data is loading or stats module being activated
![](https://cldup.com/YQM8cSEe4K.png)

This PR includes #14109 in it, as currently the `<Banner />` does not allow us to use the `event` in the `onClick` handlers, and it redirects to the plans page by default.

To test:
* Checkout this branch or get it going live.
* Go to `/settings/traffic/$site` where `$site` is one of your Jetpack sites.
* Verify you're seeing the placeholder while the data is loading.
* When Stats module is disabled, verify you see the activation banner.
* Verify the activation button works properly, and you are presented with the placeholder while the module is being activated.
* When the Stats module is enabled, verify you see the stats card.
* Verify there are no regressions with the Stats card.

**Hint:** Want to quickly disable the Stats module on your Jetpack site? Use the following WP CLI command: `wp jetpack module deactivate stats`

/cc @Automattic/jetpack as they'll be implementing this in Jetpack