### PR TITLE
Components: Add event to banner onClick

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -71,7 +71,7 @@ class Banner extends Component {
 		return href;
 	}
 
-	handleClick = () => {
+	handleClick = ( e ) => {
 		const {
 			event,
 			feature,
@@ -87,7 +87,7 @@ class Banner extends Component {
 				} );
 		}
 
-		onClick();
+		onClick( e );
 	}
 
 	getIcon() {


### PR DESCRIPTION
This PR improves the `Banner` component to call the `onClick` callback with the `event` argument. Previously, it did not take it into consideration, and we might want to use it for something. 

To test: 

* Checkout #14108 which includes this PR.
* Go to `/settings/traffic/$site` where `$site` is one of your Jetpack sites.
* Make sure the Stats module is disabled.
* Click the "Enable" button below the "Site Stats" card.
* Verify module gets enabled and you're NOT redirected to the plans page.