### PR TITLE
Site preview opens in new tab if it can't be previewed

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -143,6 +143,8 @@ class CurrentSite extends Component {
 							href={ selectedSite.URL }
 							onClick={ this.previewSite }
 							className={ `current-site__view-site${ this.props.isPreviewShowing ? ' selected' : '' }` }
+							target="_blank"
+							rel="noopener noreferrer"
 						>
 							<span className="current-site__view-site-text">
 								{ translate( 'Site Preview' ) }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -105,6 +106,39 @@ class CurrentSite extends Component {
 
 	previewSite = ( event ) => this.props.onClick && this.props.onClick( event );
 
+	renderViewLink() {
+		const {
+			isPreviewShowing,
+			selectedSite,
+			translate,
+		} = this.props;
+
+		const viewText = selectedSite.is_previewable
+			? translate( 'Site Preview' )
+			: translate( 'View site' );
+
+		const viewIcon = selectedSite.is_previewable
+			? 'computer'
+			: 'external';
+
+		return (
+			<a
+				href={ selectedSite.URL }
+				onClick={ this.previewSite }
+				className={ classNames( 'current-site__view-site', {
+					selected: isPreviewShowing,
+				} ) }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<span className="current-site__view-site-text">
+					{ viewText }
+				</span>
+				<Gridicon icon={ viewIcon } />
+			</a>
+		);
+	}
+
 	render() {
 		const { isJetpack, selectedSite, translate, anySiteSelected } = this.props;
 
@@ -139,18 +173,7 @@ class CurrentSite extends Component {
 				{ selectedSite
 					? <div>
 						<Site site={ selectedSite } />
-						<a
-							href={ selectedSite.URL }
-							onClick={ this.previewSite }
-							className={ `current-site__view-site${ this.props.isPreviewShowing ? ' selected' : '' }` }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							<span className="current-site__view-site-text">
-								{ translate( 'Site Preview' ) }
-							</span>
-							<Gridicon icon="computer" />
-						</a>
+						{ this.renderViewLink() }
 					</div>
 					: <AllSites />
 				}

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -106,7 +106,7 @@ class CurrentSite extends Component {
 
 	previewSite = ( event ) => this.props.onClick && this.props.onClick( event );
 
-	renderViewLink() {
+	renderSiteViewLink() {
 		const {
 			isPreviewShowing,
 			selectedSite,
@@ -173,7 +173,7 @@ class CurrentSite extends Component {
 				{ selectedSite
 					? <div>
 						<Site site={ selectedSite } />
-						{ this.renderViewLink() }
+						{ this.renderSiteViewLink() }
 					</div>
 					: <AllSites />
 				}


### PR DESCRIPTION
If the site is not previewable, it will fallback to normal link behaviour. This PR changes the behaviour of the "Site Preview" link to open in a new window.

* Add `target="_blank"` to ensure the link opens in a new tab.
* Adjust icon and text depending on _previewability_.

Previewable:

![previewable](https://cloud.githubusercontent.com/assets/841763/26215850/25b21136-3c02-11e7-8857-aa607c50744c.gif)

Not previewable:

![not-previewable](https://cloud.githubusercontent.com/assets/841763/26215871/39cc9876-3c02-11e7-9895-34c24f8f3bf5.gif)

via https://github.com/Automattic/wp-calypso/pull/13176#issuecomment-301776779