### PR TITLE
Jetpack connect: Remove unused paths

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -25,6 +25,7 @@ import route from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import PlansLanding from './plans-landing';
 
 /**
  * Module variables
@@ -197,10 +198,9 @@ export default {
 	},
 
 	plansLanding( context ) {
-		const PlansLanding = require( './plans-landing' ),
-			analyticsPageTitle = 'Plans',
-			basePath = route.sectionify( context.path ),
-			analyticsBasePath = basePath + '/:site';
+		const analyticsPageTitle = 'Plans';
+		const basePath = route.sectionify( context.path );
+		const analyticsBasePath = basePath + '/:site';
 
 		removeSidebar( context );
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -72,33 +72,6 @@ const jetpackConnectFirstStep = ( context, type ) => {
 	);
 };
 
-const getPlansLandingPage = ( context, hideFreePlan, path, landingType ) => {
-	const PlansLanding = require( './plans-landing' ),
-		analyticsPageTitle = 'Plans',
-		basePath = route.sectionify( context.path ),
-		analyticsBasePath = basePath + '/:site';
-
-	removeSidebar( context );
-
-	context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
-
-	analytics.tracks.recordEvent( 'calypso_plans_view' );
-	analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-
-	renderWithReduxStore(
-		<PlansLanding
-			context={ context }
-			destinationType={ context.params.destinationType }
-			intervalType={ context.params.intervalType }
-			isLanding={ true }
-			landingType={ landingType }
-			basePlansPath={ path }
-			hideFreePlan={ hideFreePlan } />,
-		document.getElementById( 'primary' ),
-		context.store
-	);
-};
-
 export default {
 	redirectWithoutLocaleifLoggedIn( context, next ) {
 		if ( userModule.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
@@ -224,7 +197,31 @@ export default {
 	},
 
 	plansLanding( context ) {
-		getPlansLandingPage( context, false, '/jetpack/connect/store', 'jetpack' );
+		const PlansLanding = require( './plans-landing' ),
+			analyticsPageTitle = 'Plans',
+			basePath = route.sectionify( context.path ),
+			analyticsBasePath = basePath + '/:site';
+
+		removeSidebar( context );
+
+		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
+
+		analytics.tracks.recordEvent( 'calypso_plans_view' );
+		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
+
+		renderWithReduxStore(
+			<PlansLanding
+				context={ context }
+				destinationType={ context.params.destinationType }
+				intervalType={ context.params.intervalType }
+				isLanding={ true }
+				landingType={ 'jetpack' }
+				basePlansPath={ '/jetpack/connect/store' }
+				hideFreePlan={ false }
+			/>,
+			document.getElementById( 'primary' ),
+			context.store
+		);
 	},
 
 	plansSelection( context ) {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -223,14 +223,6 @@ export default {
 		);
 	},
 
-	vaultpressLanding( context ) {
-		getPlansLandingPage( context, true, '/jetpack/connect/vaultpress', 'vaultpress' );
-	},
-
-	akismetLanding( context ) {
-		getPlansLandingPage( context, true, '/jetpack/connect/akismet', 'akismet' );
-	},
-
 	plansLanding( context ) {
 		getPlansLandingPage( context, false, '/jetpack/connect/store', 'jetpack' );
 	},

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -6,7 +6,7 @@ import React from 'react';
 import isEmpty from 'lodash/isEmpty';
 import page from 'page';
 import Debug from 'debug';
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -204,7 +204,7 @@ export default {
 
 		removeSidebar( context );
 
-		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
+		context.store.dispatch( setTitle( translate( 'Plans', { textOnly: true } ) ) );
 
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
@@ -238,7 +238,7 @@ export default {
 		removeSidebar( context );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Plans', { textOnly: true } ) ) );
+		context.store.dispatch( setTitle( translate( 'Plans', { textOnly: true } ) ) );
 
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -214,10 +214,7 @@ export default {
 				context={ context }
 				destinationType={ context.params.destinationType }
 				intervalType={ context.params.intervalType }
-				isLanding={ true }
-				landingType={ 'jetpack' }
 				basePlansPath={ '/jetpack/connect/store' }
-				hideFreePlan={ false }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -9,6 +9,13 @@ import page from 'page';
 import controller from './controller';
 import sitesController from 'my-sites/controller';
 
+const redirectToStoreWithInterval = context => {
+	const intervalType = context && context.params && context.params.intervalType
+		? context.params.intervalType
+		: '';
+	page.redirect( `/jetpack/connect/store/${ intervalType }` );
+};
+
 export default function() {
 	page( '/jetpack/connect/install', controller.install );
 
@@ -49,20 +56,10 @@ export default function() {
 	page( '/jetpack/connect/store/:intervalType', controller.plansLanding );
 
 	page( '/jetpack/connect/vaultpress', '/jetpack/connect/store' );
-	page( '/jetpack/connect/vaultpress/:intervalType', context => {
-		const intervalType = context && context.params && context.params.intervalType
-			? context.params.intervalType
-			: '';
-		page.redirect( `/jetpack/connect/store/${ intervalType }` );
-	} );
+	page( '/jetpack/connect/vaultpress/:intervalType', redirectToStoreWithInterval );
 
 	page( '/jetpack/connect/akismet', '/jetpack/connect/store' );
-	page( '/jetpack/connect/akismet/:intervalType', context => {
-		const intervalType = context && context.params && context.params.intervalType
-			? context.params.intervalType
-			: '';
-		page.redirect( `/jetpack/connect/store/${ intervalType }` );
-	} );
+	page( '/jetpack/connect/akismet/:intervalType', redirectToStoreWithInterval );
 
 	page(
 		'/jetpack/connect/:locale?',

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -48,11 +48,21 @@ export default function() {
 	page( '/jetpack/connect/store', controller.plansLanding );
 	page( '/jetpack/connect/store/:intervalType', controller.plansLanding );
 
-	page( '/jetpack/connect/vaultpress', controller.vaultpressLanding );
-	page( '/jetpack/connect/vaultpress/:intervalType', controller.vaultpressLanding );
+	page( '/jetpack/connect/vaultpress', '/jetpack/connect/store' );
+	page( '/jetpack/connect/vaultpress/:intervalType', context => {
+		const intervalType = context && context.params && context.params.intervalType
+			? context.params.intervalType
+			: '';
+		page.redirect( `/jetpack/connect/store/${ intervalType }` );
+	} );
 
-	page( '/jetpack/connect/akismet', controller.akismetLanding );
-	page( '/jetpack/connect/akismet/:intervalType', controller.akismetLanding );
+	page( '/jetpack/connect/akismet', '/jetpack/connect/store' );
+	page( '/jetpack/connect/akismet/:intervalType', context => {
+		const intervalType = context && context.params && context.params.intervalType
+			? context.params.intervalType
+			: '';
+		page.redirect( `/jetpack/connect/store/${ intervalType }` );
+	} );
 
 	page(
 		'/jetpack/connect/:locale?',

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -22,7 +22,6 @@ class JetpackPlansGrid extends Component {
 		hideFreePlan: PropTypes.bool,
 		intervalType: PropTypes.string,
 		isLanding: PropTypes.bool,
-		landingType: PropTypes.string,
 		onSelect: PropTypes.func,
 		selectedSite: PropTypes.object,
 		showFirst: PropTypes.bool,
@@ -31,7 +30,6 @@ class JetpackPlansGrid extends Component {
 	renderConnectHeader() {
 		const {
 			isLanding,
-			landingType,
 			showFirst,
 			translate,
 		} = this.props;
@@ -45,11 +43,6 @@ class JetpackPlansGrid extends Component {
 		if ( isLanding ) {
 			headerText = translate( 'Pick a plan that\'s right for you.' );
 			subheaderText = '';
-
-			if ( landingType === 'vaultpress' ) {
-				headerText = translate( 'Select your VaultPress plan.' );
-				subheaderText = translate( 'VaultPress backup and security plans are now cheaper as part of Jetpack.' );
-			}
 		}
 		return (
 			<StepHeader

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -53,7 +53,6 @@ class PlansLanding extends Component {
 					hideFreePlan={ false }
 					intervalType={ intervalType }
 					isLanding={ true }
-					landingType={ 'jetpack' }
 					onSelect={ this.storeSelectedPlan }
 				/>
 			</div>

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -18,15 +18,12 @@ const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 class PlansLanding extends Component {
 	static propTypes = {
 		basePlansPath: PropTypes.string,
-		hideFreePlan: PropTypes.bool,
 		intervalType: PropTypes.string,
-		isLanding: PropTypes.bool,
-		landingType: PropTypes.string,
 	};
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_landing_view', {
-			jpc_from: this.props.landingType
+			jpc_from: 'jetpack',
 		} );
 	}
 
@@ -44,10 +41,7 @@ class PlansLanding extends Component {
 	render() {
 		const {
 			basePlansPath,
-			hideFreePlan,
 			intervalType,
-			isLanding,
-			landingType,
 		} = this.props;
 		return (
 			<div>
@@ -56,10 +50,10 @@ class PlansLanding extends Component {
 				<PlansGrid
 					basePlansPath={ basePlansPath }
 					calypsoStartedConnection={ true }
-					hideFreePlan={ hideFreePlan }
+					hideFreePlan={ false }
 					intervalType={ intervalType }
-					isLanding={ isLanding }
-					landingType={ landingType }
+					isLanding={ true }
+					landingType={ 'jetpack' }
 					onSelect={ this.storeSelectedPlan }
 				/>
 			</div>


### PR DESCRIPTION
These paths are no longer in use and we no longer need to maintain them.

The following paths have been removed:
* ~`/jetpack/connect/store`~ **in use**
* `/jetpack/connect/akismet` -> `/jetpack/connect/store`
* `/jetpack/connect/vaultpress` -> `/jetpack/connect/store`

Code that was used to handle these different routes has been removed where possible.

To test:

* Use this branch
* Follow various jetpack connect flows and ensure we don't hit broken paths, console warnings/errors, and everything renders and works correctly.
  * http://calypso.localhost:3000/jetpack/connect/store
  * http://calypso.localhost:3000/jetpack/connect/store/monthly
  * Redirections:
    * http://calypso.localhost:3000/jetpack/connect/vaultpress
    * http://calypso.localhost:3000/jetpack/connect/vaultpress/monthly
    * http://calypso.localhost:3000/jetpack/connect/akismet
    * http://calypso.localhost:3000/jetpack/connect/akismet/monthly

via p1494952155196176-slack-luna