### PR TITLE
Framework: Remove sites-list from PlanStorage block example

### DIFF
--- a/client/blocks/plan-storage/docs/example.jsx
+++ b/client/blocks/plan-storage/docs/example.jsx
@@ -2,86 +2,100 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PlanStorage from '../index';
 import PlanStorageBar from '../bar';
-import sitesList from 'lib/sites-list';
 import {
 	PLAN_BUSINESS,
 	PLAN_PREMIUM,
 	PLAN_PERSONAL,
 	PLAN_FREE,
 } from 'lib/plans/constants';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { getSite, getSiteSlug } from 'state/sites/selectors';
 
-const sites = sitesList();
+const PlanStorageExample = ( { site, siteId, siteSlug } ) => {
+	const mediaStorage = {
+		red: {
+			storage_used_bytes: 11362335981,
+			max_storage_bytes: 13958643712
+		},
+		yellow: {
+			storage_used_bytes: 1971389988,
+			max_storage_bytes: 3221225472
+		},
+		green: {
+			storage_used_bytes: 167503724,
+			max_storage_bytes: 3221225472
+		}
+	};
 
-export default React.createClass( {
-
-	displayName: 'PlanStorage',
-
-	mixins: [ PureRenderMixin ],
-
-	render() {
-		const mediaStorage = {
-			red: {
-				storage_used_bytes: 11362335981,
-				max_storage_bytes: 13958643712
-			},
-			yellow: {
-				storage_used_bytes: 1971389988,
-				max_storage_bytes: 3221225472
-			},
-			green: {
-				storage_used_bytes: 167503724,
-				max_storage_bytes: 3221225472
-			}
-		};
-		const primarySite = sites.initialized && sites.getPrimary();
-		const siteId = primarySite ? primarySite.ID : 0;
-		return (
-			<div>
-				<div style={ { marginBottom: 16 } }>
-					<PlanStorage siteId={ siteId } />
-				</div>
-
-				<div style={ { marginBottom: 16 } }>
-					<PlanStorageBar
-						siteSlug={ primarySite.slug }
-						sitePlanSlug={ PLAN_FREE }
-						mediaStorage={ mediaStorage.green }
-					/>
-				</div>
-				<div style={ { marginBottom: 16, maxWidth: '400px' } }>
-					<PlanStorageBar
-						siteSlug={ primarySite.slug }
-						sitePlanSlug={ PLAN_PERSONAL }
-						mediaStorage={ mediaStorage.yellow }
-					/>
-				</div>
-
-				<div style={ { marginBottom: 16, maxWidth: '300px' } }>
-					<PlanStorageBar
-						siteSlug={ primarySite.slug }
-						sitePlanSlug={ PLAN_PREMIUM }
-						mediaStorage={ mediaStorage.red }
-					/>
-				</div>
-
-				<div style={ { marginBottom: 16 } }>
-					<span style={ { fontSize: 12, color: 'grey' } }>
-						Business plans have unlimited storage, so PlanStorage will not be rendered.
-					</span>
-					<PlanStorageBar
-						siteSlug={ primarySite.slug }
-						sitePlanSlug={ PLAN_BUSINESS }
-						mediaStorage={ mediaStorage.red }
-					/>
-				</div>
-			</div>
-		);
+	if ( ! site ) {
+		return null;
 	}
-} );
+
+	return (
+		<div>
+			<div style={ { marginBottom: 16 } }>
+				<PlanStorage siteId={ siteId } />
+			</div>
+
+			<div style={ { marginBottom: 16 } }>
+				<PlanStorageBar
+					siteSlug={ siteSlug }
+					sitePlanSlug={ PLAN_FREE }
+					mediaStorage={ mediaStorage.green }
+				/>
+			</div>
+			<div style={ { marginBottom: 16, maxWidth: '400px' } }>
+				<PlanStorageBar
+					siteSlug={ siteSlug }
+					sitePlanSlug={ PLAN_PERSONAL }
+					mediaStorage={ mediaStorage.yellow }
+				/>
+			</div>
+
+			<div style={ { marginBottom: 16, maxWidth: '300px' } }>
+				<PlanStorageBar
+					siteSlug={ siteSlug }
+					sitePlanSlug={ PLAN_PREMIUM }
+					mediaStorage={ mediaStorage.red }
+				/>
+			</div>
+
+			<div style={ { marginBottom: 16 } }>
+				<span style={ { fontSize: 12, color: 'grey' } }>
+					Business plans have unlimited storage, so PlanStorage will not be rendered.
+				</span>
+				<PlanStorageBar
+					siteSlug={ siteSlug }
+					sitePlanSlug={ PLAN_BUSINESS }
+					mediaStorage={ mediaStorage.red }
+				/>
+			</div>
+		</div>
+	);
+};
+
+const ConnectedPlanStorageExample = connect(
+	( state ) => {
+		const siteId = get( getCurrentUser( state ), 'primary_blog', null );
+		const site = getSite( state, siteId );
+		const siteSlug = getSiteSlug( state, siteId );
+
+		return {
+			site,
+			siteId,
+			siteSlug,
+		};
+	}
+)( PlanStorageExample );
+
+ConnectedPlanStorageExample.displayName = 'PlanStorage';
+
+export default ConnectedPlanStorageExample;

--- a/client/blocks/plan-storage/docs/example.jsx
+++ b/client/blocks/plan-storage/docs/example.jsx
@@ -17,9 +17,9 @@ import {
 	PLAN_FREE,
 } from 'lib/plans/constants';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
-const PlanStorageExample = ( { site, siteId, siteSlug } ) => {
+const PlanStorageExample = ( { siteId, siteSlug } ) => {
 	const mediaStorage = {
 		red: {
 			storage_used_bytes: 11362335981,
@@ -35,7 +35,7 @@ const PlanStorageExample = ( { site, siteId, siteSlug } ) => {
 		}
 	};
 
-	if ( ! site ) {
+	if ( ! siteSlug ) {
 		return null;
 	}
 
@@ -85,11 +85,9 @@ const PlanStorageExample = ( { site, siteId, siteSlug } ) => {
 const ConnectedPlanStorageExample = connect(
 	( state ) => {
 		const siteId = get( getCurrentUser( state ), 'primary_blog', null );
-		const site = getSite( state, siteId );
 		const siteSlug = getSiteSlug( state, siteId );
 
 		return {
-			site,
 			siteId,
 			siteSlug,
 		};


### PR DESCRIPTION
This PR removes `sites-list` from the `PlanStorage` block example.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs/blocks and verify the `PlanStorage` example looks and works well.
* Go to http://calypso.localhost:3000/devdocs/blocks/plan-storage and verify the example looks and works well.