### PR TITLE
Extensions: WPSC: Accept files object from stats endpoint instead of array

### DIFF
--- a/client/extensions/wp-super-cache/cache-stats.jsx
+++ b/client/extensions/wp-super-cache/cache-stats.jsx
@@ -57,7 +57,7 @@ class CacheStats extends Component {
 					</thead>
 					<tbody>
 						{ map( files, ( file, dir ) => (
-							<tr className="wp-super-cache__stat" key={ file.lower_age }>
+							<tr className="wp-super-cache__stat" key={ dir }>
 								<td className="wp-super-cache__stat-dir">{ dir }</td>
 								<td>{ file.files }</td>
 								<td className="wp-super-cache__stat-age">{ getAge( file ) }</td>

--- a/client/extensions/wp-super-cache/cache-stats.jsx
+++ b/client/extensions/wp-super-cache/cache-stats.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +25,7 @@ function getAge( { lower_age, upper_age } ) {
 
 class CacheStats extends Component {
 	static propTypes = {
-		files: PropTypes.array,
+		files: PropTypes.object,
 		header: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
@@ -55,18 +56,18 @@ class CacheStats extends Component {
 						</tr>
 					</thead>
 					<tbody>
-						{ files.map( ( file, index ) =>
-						<tr className="wp-super-cache__stat" key={ index }>
-							<td className="wp-super-cache__stat-dir">{ file.dir }</td>
-							<td>{ file.files }</td>
-							<td className="wp-super-cache__stat-age">{ getAge( file ) }</td>
-							<td className="wp-super-cache__stat-action">
-								<Button compact>
-									{ translate( 'Delete' ) }
-								</Button>
-							</td>
-						</tr>
-					) }
+						{ map( files, ( file, dir ) => (
+							<tr className="wp-super-cache__stat" key={ file.lower_age }>
+								<td className="wp-super-cache__stat-dir">{ dir }</td>
+								<td>{ file.files }</td>
+								<td className="wp-super-cache__stat-age">{ getAge( file ) }</td>
+								<td className="wp-super-cache__stat-action">
+									<Button compact>
+										{ translate( 'Delete' ) }
+									</Button>
+								</td>
+							</tr>
+						) ) }
 					</tbody>
 				</table>
 			</FoldableCard>


### PR DESCRIPTION
To be used with https://github.com/Automattic/wp-super-cache/commit/907ec9a909d3de27963ed9de4df0a2dd398d7086.

Purports to simplify https://github.com/Automattic/wp-calypso/pull/13818/files#diff-597825fe096a64181e9fcfb31718b3fbR96.

To test -- verify that the 'Stale WP-Cached Files'/'Stale Super Cached Files' Cards in the 'Contents' tab still work.