### PR TITLE
Add sympathy by randomly skipping initial state restore

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -55,6 +55,13 @@ function addSympathy( initialStateLoader ) {
 
 	console.log( 'Skipping initial state load to recreate first-load experience.' ); // eslint-disable-line no-console
 
+	try {
+		localStorage.clear();
+		indexedDB.deleteDatabase( 'calypso' );
+	} catch ( e ) {
+		// no big deal
+	}
+
 	return initialState => createReduxStore( initialState );
 }
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -48,7 +48,17 @@ function deserialize( state ) {
 	return reducer( state, { type: DESERIALIZE } );
 }
 
-function loadInitialState( initialState ) {
+function addSympathy( initialStateLoader ) {
+	if ( 'development' !== process.env.NODE_ENV || ( Math.random() > 0.5 ) ) {
+		return initialStateLoader;
+	}
+
+	console.log( 'Skipping initial state load to recreate first-load experience.' ); // eslint-disable-line no-console
+
+	return initialState => createReduxStore( initialState );
+}
+
+const loadInitialState = addSympathy( initialState => {
 	debug( 'loading initial state', initialState );
 	if ( initialState === null ) {
 		debug( 'no initial state found in localforage' );
@@ -62,7 +72,7 @@ function loadInitialState( initialState ) {
 	const serverState = getInitialServerState();
 	const mergedState = Object.assign( {}, localforageState, serverState );
 	return createReduxStore( mergedState );
-}
+} );
 
 function loadInitialStateFailed( error ) {
 	debug( 'failed to load initial redux-store state', error );

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -60,16 +60,16 @@ function deserialize( state ) {
  * @returns {Function} augmented initial state loader
  */
 function addSympathy( initialStateLoader ) {
-	if (
+	const shouldAdd = (
+		'development' === process.env.NODE_ENV && // only work in local dev mode
 		(
-			'development' !== process.env.NODE_ENV ||
-			( Math.random() > 0.75 ) ||
-			config.isEnabled( 'force-no-sympathy' )
+			Math.random() > 0.75 || // clear 75% of the time
+			config.isEnabled( 'force-sympathy' ) // or whenever the flag is set
 		) &&
-		(
-			! config.isEnabled( 'force-sympathy' )
-		)
-	) {
+		! config.isEnabled( 'no-force-sympathy' ) // unless purposefully disabled
+	);
+	
+	if ( ! shouldAdd ) {
 		return initialStateLoader;
 	}
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -68,7 +68,7 @@ function addSympathy( initialStateLoader ) {
 		) &&
 		! config.isEnabled( 'no-force-sympathy' ) // unless purposefully disabled
 	);
-	
+
 	if ( ! shouldAdd ) {
 		return initialStateLoader;
 	}

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -78,12 +78,7 @@ function addSympathy( initialStateLoader ) {
 		'font-size: 14px; color: red;'
 	);
 
-	try {
-		localforage.clear();
-	} catch ( e ) {
-		// no big deal
-	}
-
+	localforage.clear();
 	return () => createReduxStore( getInitialServerState() );
 }
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -63,7 +63,7 @@ function addSympathy( initialStateLoader ) {
 	const shouldAdd = (
 		'development' === process.env.NODE_ENV && // only work in local dev mode
 		(
-			Math.random() > 0.75 || // clear 75% of the time
+			Math.random() < 0.25 || // clear 25% of the time
 			config.isEnabled( 'force-sympathy' ) // or whenever the flag is set
 		) &&
 		! config.isEnabled( 'no-force-sympathy' ) // unless purposefully disabled


### PR DESCRIPTION
The initial load of Calypso takes a long time for all the API requests
to channel in and often times we developers don't experience that wait
because our state is fully hydrated in local storage or in indexedDB.

Although we have the ability to clear that out we often don't and this
change adds a nudge by skipping that approximately <del>half the time</del> one out of every four times which will help us better understand initial loads (which happen quite
frequently in reality).

**Testing**
Load the insights page. Reload if necessary. Look in the console.

https://calypso.localhost:3000/stats/insight

**Note** this can _only_ be tested in local dev