### PR TITLE
Signup: Provide the signup flow name to the social signup endpoint

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -267,7 +267,7 @@ module.exports = {
 
 		if ( service ) {
 			// We're creating a new social account
-			wpcom.undocumented().usersSocialNew( service, token, ( error, response ) => {
+			wpcom.undocumented().usersSocialNew( service, token, flowName, ( error, response ) => {
 				const errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined;
 
 				if ( errors ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1401,8 +1401,13 @@ Undocumented.prototype.usersNew = function( query, fn ) {
  *
  * @return {Promise} A promise for the request
  */
-Undocumented.prototype.usersSocialNew = function( service, token, fn ) {
-	const body = { service, token, locale: i18n.getLocaleSlug() };
+Undocumented.prototype.usersSocialNew = function( service, token, flowName, fn ) {
+	const body = {
+		service,
+		token,
+		signup_flow_name: flowName,
+		locale: i18n.getLocaleSlug()
+	};
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( body );


### PR DESCRIPTION
Requires D5617-code.

This PR updates the social signup endpoint to provide the flow name to the API, which needs this information to determine which welcome email to send.

**Testing**
See D5617-code.