### PR TITLE
Publicize: google plus preview

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -159,6 +159,7 @@
 @import 'components/select-dropdown/style';
 @import 'components/seo/style';
 @import 'components/share/facebook-share-preview/style';
+@import 'components/share/google-plus-share-preview/style';
 @import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -11,6 +11,7 @@ import { get, find } from 'lodash';
  */
 import { getPostImage } from './utils';
 import FacebookSharePreview from 'components/share/facebook-share-preview';
+import GooglePlusSharePreview from 'components/share/google-plus-share-preview';
 import TwitterSharePreview from 'components/share/twitter-share-preview';
 import VerticalMenu from 'components/vertical-menu';
 import { SocialItem } from 'components/vertical-menu/items';
@@ -34,7 +35,10 @@ class SharingPreviewPane extends PureComponent {
 	};
 
 	static defaultProps = {
-		services: [ 'facebook', 'twitter' ]
+		services: [
+			'facebook',
+			'google_plus',
+			'twitter' ]
 	};
 
 	state = {
@@ -74,6 +78,8 @@ class SharingPreviewPane extends PureComponent {
 		switch ( selectedService ) {
 			case 'facebook':
 				return <FacebookSharePreview { ...previewProps } />;
+			case 'google_plus':
+				return <GooglePlusSharePreview { ...previewProps } />;
 			case 'twitter':
 				return <TwitterSharePreview
 					{ ...previewProps }

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -9,7 +9,7 @@ import { get, find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getPostImage } from './utils';
+import { getPostImage, getExcerptForPost } from './utils';
 import FacebookSharePreview from 'components/share/facebook-share-preview';
 import GooglePlusSharePreview from 'components/share/google-plus-share-preview';
 import TwitterSharePreview from 'components/share/twitter-share-preview';
@@ -58,6 +58,8 @@ class SharingPreviewPane extends PureComponent {
 		}
 
 		const articleUrl = get( post, 'URL', '' );
+		const articleTitle = get( post, 'title', '' );
+		const articleContent = getExcerptForPost( post );
 		const imageUrl = getPostImage( post );
 		const {
 			external_name: externalName,
@@ -68,6 +70,8 @@ class SharingPreviewPane extends PureComponent {
 
 		const previewProps = {
 			articleUrl,
+			articleTitle,
+			articleContent,
 			externalName,
 			externalProfileURL,
 			externalProfilePicture,

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -38,7 +38,8 @@ class SharingPreviewPane extends PureComponent {
 		services: [
 			'facebook',
 			'google_plus',
-			'twitter' ]
+			'twitter',
+		]
 	};
 
 	state = {

--- a/client/components/share/google-plus-share-preview/index.js
+++ b/client/components/share/google-plus-share-preview/index.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+export class GooglePlusSharePreview extends PureComponent {
+
+	static PropTypes = {
+		articleUrl: PropTypes.string,
+		externalProfilePicture: PropTypes.string,
+		externalProfileUrl: PropTypes.string,
+		externalName: PropTypes.string,
+		imageUrl: PropTypes.string,
+		message: PropTypes.string,
+	};
+
+	render() {
+		const {
+			articleUrl,
+			externalProfilePicture,
+			externalProfileUrl,
+			externalName,
+			imageUrl,
+			message,
+			translate
+		} = this.props;
+
+		return (
+			<div className="google-plus-share-preview">
+				<div className="google-plus-share-preview__content">
+					<div className="google-plus-share-preview__header">
+						<div className="google-plus-share-preview__profile-picture-part">
+							<img
+								className="google-plus-share-preview__profile-picture"
+								src={ externalProfilePicture }
+							/>
+						</div>
+						<div className="google-plus-share-preview__profile-line-part">
+							<div className="google-plus-share-preview__profile-line">
+								<a className="google-plus-share-preview__profile-name" href={ externalProfileUrl }>
+									{ externalName }
+								</a>
+								<span>
+									{
+										translate( 'published an article on {{a}}WordPress{{/a}}', {
+											components: {
+												a: <a href="#" />
+											}
+										} )
+									}
+								</span>
+							</div>
+							<div className="google-plus-share-preview__meta-line">
+								<a href="https://wordpress.com">
+									{ translate( 'WordPress' ) }
+								</a>
+							</div>
+						</div>
+					</div>
+					<div className="google-plus-share-preview__body">
+						<div className="google-plus-share-preview__message">
+							{ message }
+						</div>
+						<div className="google-plus-share-preview__article-url-line">
+							<a className="google-plus-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
+						</div>
+						{ imageUrl &&
+							<div className="google-plus-share-preview__image-wrapper">
+								<img
+									className="google-plus-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( GooglePlusSharePreview );

--- a/client/components/share/google-plus-share-preview/index.js
+++ b/client/components/share/google-plus-share-preview/index.js
@@ -22,8 +22,7 @@ export class GooglePlusSharePreview extends PureComponent {
 			externalProfileUrl,
 			externalName,
 			imageUrl,
-			message,
-			translate
+			message
 		} = this.props;
 
 		return (
@@ -41,20 +40,6 @@ export class GooglePlusSharePreview extends PureComponent {
 								<a className="google-plus-share-preview__profile-name" href={ externalProfileUrl }>
 									{ externalName }
 								</a>
-								<span>
-									{
-										translate( 'published an article on {{a}}WordPress{{/a}}', {
-											components: {
-												a: <a href="#" />
-											}
-										} )
-									}
-								</span>
-							</div>
-							<div className="google-plus-share-preview__meta-line">
-								<a href="https://wordpress.com">
-									{ translate( 'WordPress' ) }
-								</a>
 							</div>
 						</div>
 					</div>
@@ -62,18 +47,22 @@ export class GooglePlusSharePreview extends PureComponent {
 						<div className="google-plus-share-preview__message">
 							{ message }
 						</div>
-						<div className="google-plus-share-preview__article-url-line">
-							<a className="google-plus-share-preview__article-url"
-								href={ articleUrl }>
-								{ articleUrl }
+						<div className="google-plus-share-preview__article-summary">
+							Summury of the post goes here.
+						</div>
+						<div className="google-plus-share-preview__article-title">
+							<a className="google-plus-share-preview__article-url" href={ articleUrl }>
+							Title of the post goes here.
 							</a>
 						</div>
 						{ imageUrl &&
 							<div className="google-plus-share-preview__image-wrapper">
+								<a href={ articleUrl }>
 								<img
 									className="google-plus-share-preview__image"
 									src={ imageUrl }
 								/>
+								</a>
 							</div>
 						}
 					</div>

--- a/client/components/share/google-plus-share-preview/index.js
+++ b/client/components/share/google-plus-share-preview/index.js
@@ -3,6 +3,7 @@
  */
 import React, { PureComponent, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { truncatedAtSpace } from '../helpers';
 
 export class GooglePlusSharePreview extends PureComponent {
 
@@ -18,12 +19,17 @@ export class GooglePlusSharePreview extends PureComponent {
 	render() {
 		const {
 			articleUrl,
+			articleTitle,
+			articleContent,
 			externalProfilePicture,
 			externalProfileUrl,
 			externalName,
 			imageUrl,
 			message
 		} = this.props;
+
+		const summarizeContent = truncatedAtSpace( 0, 255 );
+		const summary = summarizeContent( articleContent );
 
 		return (
 			<div className="google-plus-share-preview">
@@ -48,11 +54,11 @@ export class GooglePlusSharePreview extends PureComponent {
 							{ message }
 						</div>
 						<div className="google-plus-share-preview__article-summary">
-							Summury of the post goes here.
+						{ summary }
 						</div>
 						<div className="google-plus-share-preview__article-title">
 							<a className="google-plus-share-preview__article-url" href={ articleUrl }>
-							Title of the post goes here.
+							{ articleTitle }
 							</a>
 						</div>
 						{ imageUrl &&

--- a/client/components/share/google-plus-share-preview/index.js
+++ b/client/components/share/google-plus-share-preview/index.js
@@ -3,7 +3,7 @@
  */
 import React, { PureComponent, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { truncatedAtSpace } from '../helpers';
+import { truncateArticleContent } from '../helpers';
 
 export class GooglePlusSharePreview extends PureComponent {
 
@@ -28,8 +28,7 @@ export class GooglePlusSharePreview extends PureComponent {
 			message
 		} = this.props;
 
-		const summarizeContent = truncatedAtSpace( 0, 255 );
-		const summary = summarizeContent( articleContent );
+		const summary = truncateArticleContent( 255, articleContent );
 
 		return (
 			<div className="google-plus-share-preview">

--- a/client/components/share/google-plus-share-preview/style.scss
+++ b/client/components/share/google-plus-share-preview/style.scss
@@ -1,0 +1,78 @@
+.google-plus-share-preview {
+	background-color: #fefefe;
+	border-radius: 2px;
+	box-shadow: 0 1px 4px 0 rgba(0,0,0,0.14);
+	color: rgba(0, 0, 0, 0.87);
+	font-family: Roboto, RobotoDraft, Helvetica, Arial, sans-serif;
+	margin: 0 auto;
+	max-width: 530px;
+	width: 100%;
+	
+	// Nesting to win main.scss
+	.google-plus-share-preview__profile-name {
+		color: rgba(0, 0, 0, 0.87);
+
+		&:hover {
+			color: rgba(0, 0, 0, 0.87);
+		}
+	}
+
+	.google-plus-share-preview__article-url {
+		color: rgba(0, 0, 0, 0.87);
+
+		&:hover {
+			color: rgba(0, 0, 0, 0.87);
+		}
+	}
+}
+
+
+.google-plus-share-preview__header {
+	align-items: center;
+	display: flex;
+	padding: 16px;
+}
+
+.google-plus-share-preview__profile-picture-part {
+	flex: 0 0 36px;
+}
+.google-plus-share-preview__profile-picture {
+	border-radius: 50%;
+	display: block;
+	height: 36px;
+	width: 36px;
+}
+
+.google-plus-share-preview__profile-line {
+	font-size: 14px;
+	font-weight: 500;
+	line-height: 1.285714286;
+	margin-left: 6px;
+}
+
+.google-plus-share-preview__message,
+.google-plus-share-preview__article-summary {
+	font-size: 14px;
+	line-height: 20px;
+	margin: 0 16px 16px;
+	word-break: break-word;
+}
+
+.google-plus-share-preview__article-title {
+	border-top: 1px solid #ebebeb;
+	display: -webkit-box;
+	font-size: 20px;
+	font-weight: 300;
+	line-height: 1.4;
+	margin: 16px;
+	max-height: 56px;
+	overflow: hidden;
+	padding-top: 16px;
+	text-overflow: ellipsis;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+.google-plus-share-preview__image {
+	display: block;
+}

--- a/client/components/share/helpers.js
+++ b/client/components/share/helpers.js
@@ -20,3 +20,20 @@ export const hardTruncation = limit => title => title.slice( 0, limit ).concat( 
 
 export const firstValid = ( ...predicates ) => a =>
 	find( predicates, ( p => false !== p( a ) ) )( a );
+
+export const truncateArticleContent = ( maxCharacters, content ) => {
+	if ( content.length <= maxCharacters ) {
+		return content;
+	}
+
+	const truncated = content.slice( 0, maxCharacters );
+
+	// don't trim off the last word if we truncated at
+	// the end of the word
+	if ( content[ maxCharacters + 1 ] === ' ' ) {
+		return `${ content }…`;
+	}
+
+	const lastSpace = truncated.lastIndexOf( ' ' );
+	return truncated.slice( 0, lastSpace ).concat( '…' );
+};

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -13,6 +13,7 @@ import SocialLogo from 'social-logos';
 const services = translate => ( {
 	facebook: { icon: 'facebook', label: translate( 'Facebook feed' ) },
 	google: { icon: 'google', label: translate( 'Google search' ) },
+	google_plus: { icon: 'google-plus', label: translate( 'Google+ ' ) },
 	linkedin: { icon: 'linkedin', label: translate( 'LinkedIn share' ) },
 	twitter: { icon: 'twitter', label: translate( 'Twitter card' ) },
 	wordpress: { icon: 'wordpress', label: translate( 'WordPress.com Reader' ) }

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -406,7 +406,6 @@ class PostShare extends Component {
 		}
 
 		const {
-			message,
 			hasRepublicizeFeature,
 			hasRepublicizeSchedulingFeature,
 			postId,
@@ -456,7 +455,7 @@ class PostShare extends Component {
 				<SharingPreviewModal
 					siteId={ siteId }
 					postId={ postId }
-					message={ message }
+					message={ this.state.message }
 					isVisible={ this.state.showSharingPreview }
 					onClose={ this.toggleSharingPreview }
 				/>


### PR DESCRIPTION
This adds google plus to the publicize preview

![screen shot 2017-05-17 at 12 36 06 pm](https://cloud.githubusercontent.com/assets/744755/26172473/76267f54-3afd-11e7-9b54-1a8fdaebd123.png)

**Testing**
- Enable publicize sharing on `calypso.localhost:3000` : `ENABLE_FEATURES=publicize-scheduling make run`
- Authorize google plus on a premium site
- Open the sharing tab on a published post
- Click 'Preview'
- Google+  should be available for previewing
- The Google+ should display the post title, excerpt, and featured image ( if present ) and the google user account info

_breaks up #12644_