### PR TITLE
ButtonGroup: Add busy styles

### DIFF
--- a/client/components/button-group/docs/example.jsx
+++ b/client/components/button-group/docs/example.jsx
@@ -34,20 +34,20 @@ var Buttons = React.createClass( {
 					{ this.state.compact ? 'Normal Buttons' : 'Compact Buttons' }
 				</a>
 				<Card>
-					<div className="docs__design-button-row">
+					<div className="docs__design-button-group-row">
 						<ButtonGroup>
 							<Button compact={ this.state.compact }>Do thing</Button>
 							<Button compact={ this.state.compact }>Do another thing</Button>
 						</ButtonGroup>
 					</div>
-					<div className="docs__design-button-row">
+					<div className="docs__design-button-group-row">
 						<ButtonGroup>
 							<Button compact={ this.state.compact }>Button one</Button>
 							<Button compact={ this.state.compact }>Button two</Button>
 							<Button compact={ this.state.compact } scary>Button Three</Button>
 						</ButtonGroup>
 					</div>
-					<div className="docs__design-button-row">
+					<div className="docs__design-button-group-row">
 						<ButtonGroup>
 							<Button compact={ this.state.compact }><Gridicon icon="add-image" /></Button>
 							<Button compact={ this.state.compact }><Gridicon icon="heart" /></Button>
@@ -55,9 +55,21 @@ var Buttons = React.createClass( {
 							<Button compact={ this.state.compact }><Gridicon icon="history" /></Button>
 						</ButtonGroup>
 					</div>
-					<div className="docs__design-button-row">
+					<div className="docs__design-button-group-row">
 						<ButtonGroup>
 							<Button primary compact={ this.state.compact }>Publish</Button>
+							<Button primary compact={ this.state.compact }><Gridicon icon="calendar" /></Button>
+						</ButtonGroup>
+					</div>
+
+					<div className="docs__design-button-group-row">
+						<ButtonGroup busy>
+							<Button compact={ this.state.compact }>Busy</Button>
+							<Button compact={ this.state.compact }><Gridicon icon="calendar" /></Button>
+						</ButtonGroup>
+
+						<ButtonGroup busy primary>
+							<Button primary compact={ this.state.compact }>Primary Busy</Button>
 							<Button primary compact={ this.state.compact }><Gridicon icon="calendar" /></Button>
 						</ButtonGroup>
 					</div>

--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -22,7 +22,10 @@ class ButtonGroup extends PureComponent {
 		const buttonGroupClasses = classNames(
 			'button-group',
 			this.props.className,
-			{ 'is-busy': this.props.busy },
+			{
+				'is-busy': this.props.busy,
+				'is-primary': this.props.primary
+			},
 		);
 
 		return (

--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -1,14 +1,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
+
 import classNames from 'classnames';
 
-export default React.createClass( {
-
-	displayName: 'ButtonGroup',
-
-	propTypes: {
+class ButtonGroup extends PureComponent {
+	static propTypes = {
 		children( props ) {
 			let error = null;
 			React.Children.forEach( props.children, ( child ) => {
@@ -18,13 +16,19 @@ export default React.createClass( {
 			} );
 			return error;
 		}
-	},
+	};
 
 	render() {
-		const buttonGroupClasses = classNames( 'button-group', this.props.className );
+		const buttonGroupClasses = classNames(
+			'button-group',
+			this.props.className,
+			{ 'is-busy': this.props.busy },
+		);
 
 		return (
 			<span className={ buttonGroupClasses }>{ this.props.children }</span>
 		);
 	}
-} );
+}
+
+export default ButtonGroup;

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -9,18 +9,23 @@
 			z-index: z-index( 'button-group-parent', '.button-group .button:focus' );
 			box-shadow: inset 1px 0 0 $blue-medium, 0 0 0 2px $blue-light;
 		}
+
 		&.is-primary:focus {
 			box-shadow: inset 1px 0 0 $blue-dark, 0 0 0 2px $blue-light;
 		}
+
 		&.is-scary:focus {
 			box-shadow: inset 1px 0 0 $alert-red, 0 0 0 2px lighten( $alert-red, 20% );
 		}
+
 		&.is-primary.is-scary:focus {
 			box-shadow: inset 1px 0 0 darken( $alert-red, 30% ), 0 0 0 2px lighten( $alert-red, 20% );
 		}
+
 		&:first-child:focus {
 			box-shadow: 0 0 0 2px $blue-light;
 		}
+
 		&.is-scary:first-child:focus {
 			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
 		}
@@ -40,4 +45,29 @@
 	.section-header & .button {
 		margin-right: 0;
 	}
+
+	&.is-primary {
+		&.is-busy {
+			background-size: 120px 100%;
+			background-image: linear-gradient( -45deg, $blue-medium 28%, darken( $blue-medium, 5% ) 28%, darken( $blue-medium, 5% ) 72%, $blue-medium 72%);
+		}
+	}
+
+	&.is-busy {
+		animation: button__busy-animation 3000ms infinite linear;
+		background-size: 120px 100%;
+		background-image: linear-gradient( -45deg, lighten( $gray, 30% ) 28%, $white 28%, $white 72%, lighten( $gray, 30% ) 72%);
+		display: inline-block;
+		border-radius: 4px;
+
+		.button {
+			background-color: transparent;
+		}
+	}
+
+}
+
+
+@keyframes button__busy-animation {
+  0%   { background-position: 240px 0; }
 }

--- a/client/components/button-group/test/index.js
+++ b/client/components/button-group/test/index.js
@@ -32,6 +32,11 @@ describe( 'ButtonGroup', function() {
 		assert.equal( 2, buttonGroup.find( Button ).length );
 	} );
 
+	it( 'should get the busy `is-busy` class when passed the `busy` prop', function() {
+		const buttonGroup = shallow( <ButtonGroup busy /> );
+		assert.equal( 1, buttonGroup.find( '.is-busy' ).length );
+	} );
+
 	it( 'should throw an error if any of the children is not a <Button>', function() {
 		shallow( <ButtonGroup><div id="test">test</div></ButtonGroup> );
 

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -55,12 +55,16 @@
 
 .docs__design-button-row,
 .design__button-row {
-	&:first-child {
-		margin-top: -16px;
-	}
+	margin-bottom: 20px;
 	.button {
-		margin-top: 16px !important;
 		margin-right: 16px !important;
+	}
+}
+
+.docs__design-button-group-row {
+	margin-bottom: 20px;
+	.button-group {
+		margin-right: 16px;
 	}
 }
 


### PR DESCRIPTION
This PR adds `busy` styles top `<ButtonGroup />` instead of adding the styles to each child button.

The primary reason to this is because if we apply the busy property to each button it produces a weird background animation since it's not phased among the buttons:

<img src="https://cloud.githubusercontent.com/assets/77539/26124610/7adef934-3a55-11e7-8935-64aef4c5f51d.gif" width="400px" />

This patch adds `busy` and `primary` properties to `<ButtonGroup />` component in order to achieve a better animation of the busy state:

<img src="https://cloud.githubusercontent.com/assets/77539/26124264/36caf87a-3a54-11e7-8728-35ec07922926.gif" width="400px" />

### Testing

After applying this patch, go to the button group devdocs page http://calypso.localhost:3000/devdocs/design/button-group and take a look to the `busy` instances.
