### PR TITLE
Tests: add simple hook for integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,8 @@ test:
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/ && find . -type f -regex  "./test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;:
         parallel: true
+    - >
+      if [[ "$RUN_ARGS" == "--nightly" ]]; then npm run test-integration; fi
 notify:
   webhooks:
     - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh


### PR DESCRIPTION
This PR adds a hook in circle ci so we can run integration tests on a given interval.

![screen shot 2017-05-16 at 1 06 04 pm](https://cloud.githubusercontent.com/assets/1270189/26125909/7f1bf096-3a38-11e7-83f0-157946ca0d83.png)

This is a follow up to #13618

After I merge, I should update the cron to point at master.