### PR TITLE
PostShare: add `busy` state to Share buttons

### DIFF
--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -126,7 +126,7 @@ class PostShare extends Component {
 		this.props.sharePost( this.props.siteId, this.props.postId, this.state.skipped, this.state.message );
 	};
 
-	isButtonDisabled() {
+	isSharingPost() {
 		if ( this.props.requesting ) {
 			return true;
 		}
@@ -167,7 +167,7 @@ class PostShare extends Component {
 			className="post-share__button"
 			primary
 			onClick={ this.sharePost }
-			disabled={ this.isButtonDisabled() }
+			disabled={ this.isSharingPost() }
 		>
 			{ translate( 'Share post' ) }
 		</Button>;
@@ -191,13 +191,17 @@ class PostShare extends Component {
 					</Button>
 				}
 
-				<ButtonGroup className="post-share__share-combo">
+				<ButtonGroup
+					className="post-share__share-combo"
+					primary
+					busy={ this.isSharingPost() }
+				>
 					{ shareButton }
 
 					<CalendarButton
 						primary
 						className="post-share__schedule-button"
-						disabled={ this.isButtonDisabled() }
+						disabled={ this.isSharingPost() }
 						title={ translate( 'Set date and time' ) }
 						tabIndex={ 3 }
 						siteId={ siteId }


### PR DESCRIPTION
This PR adds `busy` state to the sharing buttons group when the post is being republished in a similar way that the Editor does when a post is being published.

### Testing

Publish a post from `http://calypso.localhost:3000/posts/my/<paid-site>`

You should see the `busy` animation in both Share and Calendar buttons.

<img src="https://cloud.githubusercontent.com/assets/77539/26424186/b90b00ca-40a6-11e7-89f3-22c43f31f59f.gif" width="400px" />