### PR TITLE
Reader: Remove follows that are under the wrong keys

### DIFF
--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -99,7 +99,11 @@ export const items = createReducer(
 			let urlKey = prepareComparableUrl( action.payload.feedUrl );
 			const newValues = { is_following: true };
 
-			const actualFeedUrl = get( action.payload, [ 'follow', 'feed_URL' ], action.payload.feedUrl );
+			const actualFeedUrl = get(
+				action.payload,
+				[ 'follow', 'feed_URL' ],
+				action.payload.feedUrl
+			);
 
 			const newState = { ...state };
 			// for the case where a user entered an exact url to follow something, sometimes the
@@ -177,7 +181,12 @@ export const items = createReducer(
 			// Only check items with an ID (the subscription ID) because those are what
 			// we show on the manage listing. Items without an ID are either inflight follows
 			// or follows that we picked up from a feed, site, or post object.
-			return omitBy( state, follow => follow.ID && ! seenSubscriptions.has( follow.feed_URL ) );
+			return omitBy(
+				state,
+				( follow, key ) =>
+					key !== prepareComparableUrl( follow.feed_URL ) ||
+					( follow.ID && ! seenSubscriptions.has( follow.feed_URL ) )
+			);
 		},
 		[ SERIALIZE ]: state => pickBy( state, item => item.is_following ),
 	},

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -483,7 +483,10 @@ describe( 'reducer', () => {
 			} );
 			const state = items( original, {
 				type: READER_FOLLOW_ERROR,
-				payload: { feedUrl: 'http://discoverinvalid.wordpress.com', error: 'invalid_feed' },
+				payload: {
+					feedUrl: 'http://discoverinvalid.wordpress.com',
+					error: 'invalid_feed',
+				},
 			} );
 			expect( state[ 'discoverinvalid.wordpress.com' ] ).to.eql( {
 				is_following: true,
@@ -637,6 +640,42 @@ describe( 'reducer', () => {
 			} );
 			const state = items( original, syncComplete( [ 'http://example2.com' ] ) );
 			expect( state ).to.eql( {
+				'example2.com': {
+					feed_URL: 'http://example2.com',
+					ID: 2,
+					is_following: true,
+				},
+			} );
+		} );
+
+		it( 'should remove sites under the wrong key', () => {
+			const original = deepFreeze( {
+				'example.com/feed': {
+					feed_URL: 'http://example.com',
+					ID: 1,
+					is_following: true,
+				},
+				'example.com': {
+					feed_URL: 'http://example.com',
+					ID: 1,
+					is_following: true,
+				},
+				'example2.com': {
+					feed_URL: 'http://example2.com',
+					ID: 2,
+					is_following: true,
+				},
+			} );
+			const state = items(
+				original,
+				syncComplete( [ 'http://example.com', 'http://example2.com' ] )
+			);
+			expect( state ).to.eql( {
+				'example.com': {
+					feed_URL: 'http://example.com',
+					ID: 1,
+					is_following: true,
+				},
 				'example2.com': {
 					feed_URL: 'http://example2.com',
 					ID: 2,


### PR DESCRIPTION
Not quite sure how this happens, but jan's seen it. This should clean it up when sync completes.