### PR TITLE
Revert "Image Editor: Add Inline Edit Button"

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -184,14 +184,6 @@ function mediaButton( editor ) {
 			let mediaHasCaption = false;
 			let captionNode = null;
 
-			// If image is deleted in image editor, we delete it in the post/page editor.
-			if ( media && media.status === 'deleted' ) {
-				captionNode = editor.dom.getParent( img, 'div.mceTemp' );
-				editor.$( captionNode || img ).remove();
-				editor.nodeChanged();
-				return;
-			}
-
 			// If image is edited in image editor, we mark it as dirty and update it in post/page editor.
 			if ( media && media.isDirty ) {
 				if (
@@ -420,35 +412,6 @@ function mediaButton( editor ) {
 					{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 				</button>
 			) );
-		}
-	} );
-
-	editor.addButton( 'wp_img_edit', {
-		tooltip: i18n.translate( 'Edit', { context: 'verb' } ),
-		icon: 'dashicon dashicons-edit',
-		onclick: function() {
-			const selectedSite = getSelectedSiteFromState();
-			if ( ! selectedSite ) {
-				return;
-			}
-
-			const siteId = selectedSite.ID;
-			const node = editor.selection.getNode();
-			const m = node.className.match( /wp-image-(\d+)/ );
-			const imageId = m && parseInt( m[ 1 ], 10 );
-			if ( ! imageId ) {
-				return;
-			}
-			const image = MediaStore.get( siteId, imageId );
-
-			MediaActions.clearValidationErrors( siteId );
-			renderModal( {
-				visible: true,
-				labels: {
-					confirm: i18n.translate( 'Update', { context: 'verb' } )
-				}
-			} );
-			MediaActions.setLibrarySelectedItems( siteId, [ image ] );
 		}
 	} );
 

--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -68,7 +68,6 @@ function wpEditImage( editor ) {
 			'wp_img_alignnone',
 			'wpcom_img_size_decrease',
 			'wpcom_img_size_increase',
-			'wp_img_edit', // See plugins/media
 			'wp_img_caption', // See plugins/media
 			'wp_img_advanced', // See plugins/media/advanced
 			'wp_img_remove'
@@ -603,13 +602,6 @@ function wpEditImage( editor ) {
 				p = dom.create( 'p' );
 				dom.insertAfter( p, captionParent );
 				editor.selection.setCursorLocation( p, 0 );
-
-				// If we were pasting into an img, remove it so it's replaced
-				// with the new one.
-				if ( node.nodeName === 'IMG' ) {
-					editor.$( captionParent ).remove();
-				}
-
 				editor.nodeChanged();
 			}
 		} else if ( cmd === 'JustifyLeft' || cmd === 'JustifyRight' || cmd === 'JustifyCenter' || cmd === 'wpAlignNone' ) {

--- a/client/lib/media/README.md
+++ b/client/lib/media/README.md
@@ -22,7 +22,7 @@ The stores are singleton objects, which offer `get` and `getAll` methods to retr
 ```js
 var MediaStore = require( 'lib/media/store' )(),
 	allMedia = MediaStore.getAll( siteId ),
-	singleMedia = MediaStore.get( siteId, postId );
+	singleMedia = Mediatore.get( siteId, postId );
 ```
 
 To interact with the store, use the actions made available in `actions.js`.

--- a/client/lib/media/library-selected-store.js
+++ b/client/lib/media/library-selected-store.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+var map = require( 'lodash/map' );
 
 /**
  * Internal dependencies
@@ -84,13 +84,9 @@ MediaLibrarySelectedStore.getAll = function( siteId ) {
 		return [];
 	}
 
-	// Avoid keeping invalid items in the selected list.
-	return (
-		MediaLibrarySelectedStore
-			._media[ siteId ]
-			.map( itemId => MediaStore.get( siteId, itemId ) )
-			.filter( ( item ) => ( item && ( item.guid || item.transient ) ) )
-	);
+	return MediaLibrarySelectedStore._media[ siteId ].map( function( itemId ) {
+		return MediaStore.get( siteId, itemId );
+	} );
 };
 
 MediaLibrarySelectedStore.dispatchToken = Dispatcher.register( function( payload ) {

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -53,10 +53,7 @@ function removeSingle( siteId, item ) {
 		return;
 	}
 
-	// This mimics the behavior we get from the server.
-	// Deleted items return with only an ID.
-	// Status is also added to let any listeners distinguish deleted items.
-	MediaStore._media[ siteId ][ item.ID ] = { ID: item.ID, status: item.status };
+	delete MediaStore._media[ siteId ][ item.ID ];
 }
 
 function receivePage( siteId, items ) {

--- a/client/lib/media/test/library-selected-store.js
+++ b/client/lib/media/test/library-selected-store.js
@@ -13,9 +13,9 @@ import useMockery from 'test/helpers/use-mockery';
 
 var DUMMY_SITE_ID = 1,
 	DUMMY_OBJECTS = {
-		100: { ID: 100, title: 'Image', guid: 'https://example.files.wordpress.com/2017/05/g1001.png' },
-		'media-1': { ID: 100, title: 'Image', guid: 'https://example.files.wordpress.com/2017/05/g1001.png' },
-		200: { ID: 200, title: 'Video', guid: 'https://example.files.wordpress.com/2017/05/g1002.mov' }
+		100: { ID: 100, title: 'Image' },
+		'media-1': { ID: 100, title: 'Image' },
+		200: { ID: 200, title: 'Video' }
 	},
 	DUMMY_MEDIA_OBJECT = DUMMY_OBJECTS[ 100 ],
 	DUMMY_TRANSIENT_MEDIA_OBJECT = DUMMY_OBJECTS[ 'media-1' ];

--- a/client/lib/media/test/store.js
+++ b/client/lib/media/test/store.js
@@ -134,11 +134,11 @@ describe( 'MediaStore', function() {
 			dispatchReceiveMediaItems();
 		} );
 
-		it( 'should blank an item when REMOVE_MEDIA_ITEM is dispatched', function() {
+		it( 'should remove an item when REMOVE_MEDIA_ITEM is dispatched', function() {
 			dispatchReceiveMediaItems();
 			dispatchRemoveMediaItem();
 
-			expect( MediaStore.get( DUMMY_SITE_ID, DUMMY_MEDIA_ID ) ).to.not.have.any.keys( 'guid', 'url' );
+			expect( MediaStore.get( DUMMY_SITE_ID, DUMMY_MEDIA_ID ) ).to.be.undefined;
 		} );
 
 		it( 'should re-add an item when REMOVE_MEDIA_ITEM errors and includes data', function() {

--- a/client/my-sites/media-library/test/fixtures/index.js
+++ b/client/my-sites/media-library/test/fixtures/index.js
@@ -41,35 +41,25 @@
 module.exports = {
 	media: [
 		{
-			ID: 1009,
-			guid: 'http://example.files.wordpress.com/2015/05/g1009.gif'
+			ID: 1009
 		}, {
-			ID: 1008,
-			guid: 'http://example.files.wordpress.com/2015/05/g1008.gif'
+			ID: 1008
 		}, {
-			ID: 1007,
-			guid: 'http://example.files.wordpress.com/2015/05/g1007.gif'
+			ID: 1007
 		}, {
-			ID: 1006,
-			guid: 'http://example.files.wordpress.com/2015/05/g1006.gif'
+			ID: 1006
 		}, {
-			ID: 1005,
-			guid: 'http://example.files.wordpress.com/2015/05/g1005.gif'
+			ID: 1005
 		}, {
-			ID: 1004,
-			guid: 'http://example.files.wordpress.com/2015/05/g1004.gif'
+			ID: 1004
 		}, {
-			ID: 1003,
-			guid: 'http://example.files.wordpress.com/2015/05/g1003.gif'
+			ID: 1003
 		}, {
-			ID: 1002,
-			guid: 'http://example.files.wordpress.com/2015/05/g1002.gif'
+			ID: 1002
 		}, {
-			ID: 1001,
-			guid: 'http://example.files.wordpress.com/2015/05/g1001.gif'
+			ID: 1001
 		}, {
-			ID: 1000,
-			guid: 'http://example.files.wordpress.com/2015/05/g1000.gif'
+			ID: 1000
 		}
 	]
 };


### PR DESCRIPTION
Reverts Automattic/wp-calypso#13479

Found an issue in staging where cropped images were appending duplicates rather than properly replacing the inline originals.