### PR TITLE
Boot: restoreLastLocation: only redirect if remembered path is not root

### DIFF
--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -18,7 +18,7 @@ export const restoreLastLocation = () => ( next ) => ( action ) => {
 	if ( action.type === ROUTE_SET && action.path ) {
 		const lastPath = store.get( 'last_path' );
 
-		if ( ! hasInitialized && lastPath && action.path === '/' ) {
+		if ( ! hasInitialized && lastPath && lastPath !== '/' && action.path === '/' ) {
 			debug( 'redir to', action.path );
 			page( lastPath );
 		} else {


### PR DESCRIPTION
Fixes breakage in wpcalypso introduced in #14070 