### PR TITLE
Image Editor: Add Inline Edit Button

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -184,6 +184,14 @@ function mediaButton( editor ) {
 			let mediaHasCaption = false;
 			let captionNode = null;
 
+			// If image is deleted in image editor, we delete it in the post/page editor.
+			if ( media && media.status === 'deleted' ) {
+				captionNode = editor.dom.getParent( img, 'div.mceTemp' );
+				editor.$( captionNode || img ).remove();
+				editor.nodeChanged();
+				return;
+			}
+
 			// If image is edited in image editor, we mark it as dirty and update it in post/page editor.
 			if ( media && media.isDirty ) {
 				if (
@@ -412,6 +420,35 @@ function mediaButton( editor ) {
 					{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 				</button>
 			) );
+		}
+	} );
+
+	editor.addButton( 'wp_img_edit', {
+		tooltip: i18n.translate( 'Edit', { context: 'verb' } ),
+		icon: 'dashicon dashicons-edit',
+		onclick: function() {
+			const selectedSite = getSelectedSiteFromState();
+			if ( ! selectedSite ) {
+				return;
+			}
+
+			const siteId = selectedSite.ID;
+			const node = editor.selection.getNode();
+			const m = node.className.match( /wp-image-(\d+)/ );
+			const imageId = m && parseInt( m[ 1 ], 10 );
+			if ( ! imageId ) {
+				return;
+			}
+			const image = MediaStore.get( siteId, imageId );
+
+			MediaActions.clearValidationErrors( siteId );
+			renderModal( {
+				visible: true,
+				labels: {
+					confirm: i18n.translate( 'Update', { context: 'verb' } )
+				}
+			} );
+			MediaActions.setLibrarySelectedItems( siteId, [ image ] );
 		}
 	} );
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -443,12 +443,17 @@ function mediaButton( editor ) {
 			const image = MediaStore.get( siteId, imageId );
 
 			MediaActions.clearValidationErrors( siteId );
-			renderModal( {
-				visible: true,
-				labels: {
-					confirm: i18n.translate( 'Update', { context: 'verb' } )
+			renderModal(
+				{
+					visible: true,
+					labels: {
+						confirm: i18n.translate( 'Update', { context: 'verb' } )
+					}
+				},
+				{
+					view: ModalViews.DETAIL
 				}
-			} );
+			);
 			MediaActions.setLibrarySelectedItems( siteId, [ image ] );
 		}
 	} );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -409,7 +409,7 @@ function mediaButton( editor ) {
 	} );
 
 	editor.addButton( 'wpcom_add_media', {
-		classes: 'btn wpcom-icon-button media',
+		classes: 'btn wpcom-icon-button media toolbar-segment-start',
 		cmd: 'wpcomAddMedia',
 		title: i18n.translate( 'Add Media' ),
 		onPostRender: function() {

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -409,7 +409,7 @@ function mediaButton( editor ) {
 	} );
 
 	editor.addButton( 'wpcom_add_media', {
-		classes: 'btn wpcom-icon-button media toolbar-segment-start',
+		classes: 'btn wpcom-icon-button media',
 		cmd: 'wpcomAddMedia',
 		title: i18n.translate( 'Add Media' ),
 		onPostRender: function() {
@@ -425,6 +425,7 @@ function mediaButton( editor ) {
 
 	editor.addButton( 'wp_img_edit', {
 		tooltip: i18n.translate( 'Edit', { context: 'verb' } ),
+		classes: 'toolbar-segment-start',
 		icon: 'dashicon dashicons-edit',
 		onclick: function() {
 			const selectedSite = getSelectedSiteFromState();

--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -68,6 +68,7 @@ function wpEditImage( editor ) {
 			'wp_img_alignnone',
 			'wpcom_img_size_decrease',
 			'wpcom_img_size_increase',
+			'wp_img_edit', // See plugins/media
 			'wp_img_caption', // See plugins/media
 			'wp_img_advanced', // See plugins/media/advanced
 			'wp_img_remove'
@@ -602,6 +603,13 @@ function wpEditImage( editor ) {
 				p = dom.create( 'p' );
 				dom.insertAfter( p, captionParent );
 				editor.selection.setCursorLocation( p, 0 );
+
+				// If we were pasting into an img, remove it so it's replaced
+				// with the new one.
+				if ( node.nodeName === 'IMG' ) {
+					editor.$( captionParent ).remove();
+				}
+
 				editor.nodeChanged();
 			}
 		} else if ( cmd === 'JustifyLeft' || cmd === 'JustifyRight' || cmd === 'JustifyCenter' || cmd === 'wpAlignNone' ) {

--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -606,7 +606,7 @@ function wpEditImage( editor ) {
 
 				// If we were pasting into an img, remove it so it's replaced
 				// with the new one.
-				if ( node.nodeName === 'IMG' ) {
+				if ( node.nodeName === 'IMG' || node.nodeName === 'DT' ) {
 					editor.$( captionParent ).remove();
 				}
 

--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -68,9 +68,9 @@ function wpEditImage( editor ) {
 			'wp_img_alignnone',
 			'wpcom_img_size_decrease',
 			'wpcom_img_size_increase',
-			'wp_img_edit', // See plugins/media
 			'wp_img_caption', // See plugins/media
 			'wp_img_advanced', // See plugins/media/advanced
+			'wp_img_edit', // See plugins/media
 			'wp_img_remove'
 		] );
 	} );

--- a/client/lib/media/README.md
+++ b/client/lib/media/README.md
@@ -22,7 +22,7 @@ The stores are singleton objects, which offer `get` and `getAll` methods to retr
 ```js
 var MediaStore = require( 'lib/media/store' )(),
 	allMedia = MediaStore.getAll( siteId ),
-	singleMedia = Mediatore.get( siteId, postId );
+	singleMedia = MediaStore.get( siteId, postId );
 ```
 
 To interact with the store, use the actions made available in `actions.js`.

--- a/client/lib/media/library-selected-store.js
+++ b/client/lib/media/library-selected-store.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var map = require( 'lodash/map' );
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,9 +84,13 @@ MediaLibrarySelectedStore.getAll = function( siteId ) {
 		return [];
 	}
 
-	return MediaLibrarySelectedStore._media[ siteId ].map( function( itemId ) {
-		return MediaStore.get( siteId, itemId );
-	} );
+	// Avoid keeping invalid items in the selected list.
+	return (
+		MediaLibrarySelectedStore
+			._media[ siteId ]
+			.map( itemId => MediaStore.get( siteId, itemId ) )
+			.filter( ( item ) => ( item && ( item.guid || item.transient ) ) )
+	);
 };
 
 MediaLibrarySelectedStore.dispatchToken = Dispatcher.register( function( payload ) {

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -53,7 +53,10 @@ function removeSingle( siteId, item ) {
 		return;
 	}
 
-	delete MediaStore._media[ siteId ][ item.ID ];
+	// This mimics the behavior we get from the server.
+	// Deleted items return with only an ID.
+	// Status is also added to let any listeners distinguish deleted items.
+	MediaStore._media[ siteId ][ item.ID ] = { ID: item.ID, status: item.status };
 }
 
 function receivePage( siteId, items ) {

--- a/client/lib/media/test/library-selected-store.js
+++ b/client/lib/media/test/library-selected-store.js
@@ -13,9 +13,9 @@ import useMockery from 'test/helpers/use-mockery';
 
 var DUMMY_SITE_ID = 1,
 	DUMMY_OBJECTS = {
-		100: { ID: 100, title: 'Image' },
-		'media-1': { ID: 100, title: 'Image' },
-		200: { ID: 200, title: 'Video' }
+		100: { ID: 100, title: 'Image', guid: 'https://example.files.wordpress.com/2017/05/g1001.png' },
+		'media-1': { ID: 100, title: 'Image', guid: 'https://example.files.wordpress.com/2017/05/g1001.png' },
+		200: { ID: 200, title: 'Video', guid: 'https://example.files.wordpress.com/2017/05/g1002.mov' }
 	},
 	DUMMY_MEDIA_OBJECT = DUMMY_OBJECTS[ 100 ],
 	DUMMY_TRANSIENT_MEDIA_OBJECT = DUMMY_OBJECTS[ 'media-1' ];

--- a/client/lib/media/test/store.js
+++ b/client/lib/media/test/store.js
@@ -134,11 +134,11 @@ describe( 'MediaStore', function() {
 			dispatchReceiveMediaItems();
 		} );
 
-		it( 'should remove an item when REMOVE_MEDIA_ITEM is dispatched', function() {
+		it( 'should blank an item when REMOVE_MEDIA_ITEM is dispatched', function() {
 			dispatchReceiveMediaItems();
 			dispatchRemoveMediaItem();
 
-			expect( MediaStore.get( DUMMY_SITE_ID, DUMMY_MEDIA_ID ) ).to.be.undefined;
+			expect( MediaStore.get( DUMMY_SITE_ID, DUMMY_MEDIA_ID ) ).to.not.have.any.keys( 'guid', 'url' );
 		} );
 
 		it( 'should re-add an item when REMOVE_MEDIA_ITEM errors and includes data', function() {

--- a/client/my-sites/media-library/test/fixtures/index.js
+++ b/client/my-sites/media-library/test/fixtures/index.js
@@ -41,25 +41,35 @@
 module.exports = {
 	media: [
 		{
-			ID: 1009
+			ID: 1009,
+			guid: 'http://example.files.wordpress.com/2015/05/g1009.gif'
 		}, {
-			ID: 1008
+			ID: 1008,
+			guid: 'http://example.files.wordpress.com/2015/05/g1008.gif'
 		}, {
-			ID: 1007
+			ID: 1007,
+			guid: 'http://example.files.wordpress.com/2015/05/g1007.gif'
 		}, {
-			ID: 1006
+			ID: 1006,
+			guid: 'http://example.files.wordpress.com/2015/05/g1006.gif'
 		}, {
-			ID: 1005
+			ID: 1005,
+			guid: 'http://example.files.wordpress.com/2015/05/g1005.gif'
 		}, {
-			ID: 1004
+			ID: 1004,
+			guid: 'http://example.files.wordpress.com/2015/05/g1004.gif'
 		}, {
-			ID: 1003
+			ID: 1003,
+			guid: 'http://example.files.wordpress.com/2015/05/g1003.gif'
 		}, {
-			ID: 1002
+			ID: 1002,
+			guid: 'http://example.files.wordpress.com/2015/05/g1002.gif'
 		}, {
-			ID: 1001
+			ID: 1001,
+			guid: 'http://example.files.wordpress.com/2015/05/g1001.gif'
 		}, {
-			ID: 1000
+			ID: 1000,
+			guid: 'http://example.files.wordpress.com/2015/05/g1000.gif'
 		}
 	]
 };


### PR DESCRIPTION
Regarding issue https://github.com/Automattic/wp-calypso/issues/8306 .

Clicking on an image in the post editor brings up an in-context menu:
<img width="320" alt="screen shot 2017-04-27 at 3 44 28 pm" src="https://cloud.githubusercontent.com/assets/479813/25501353/7538ee8a-2b60-11e7-9d81-6534a1073178.png">


This PR adds an edit icon (the pencil) to the in-context menu:
<img width="385" alt="screen shot 2017-04-27 at 3 34 42 pm" src="https://cloud.githubusercontent.com/assets/479813/25501398/a46977e2-2b60-11e7-9dd3-79c75dbda16f.png">


When we click on that the inline edit button, it brings up the gallery with the clicked on image pre-selected. I found when testing out usability that being able to swap the image with others was desirable and less confusing.

This completes https://github.com/Automattic/wp-calypso/issues/8306 .

## To Test

1. Edit a post with an image.
2. Click on the image to see the in-context menu.
3. Click on the pencil icon to see the new behavior.