### PR TITLE
Add data attribute elements to contact form

### DIFF
--- a/client/components/tinymce/plugins/contact-form/dialog/index.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/index.jsx
@@ -42,6 +42,7 @@ const ContactFormDialog = React.createClass( {
 		const actionButtons = [
 			<FormButton
 				key="save"
+				data-e2e-button="save"
 				disabled={ ! isValidForm }
 				onClick={ this.props.onInsert } >
 				{ this.props.isEdit ? this.translate( 'Update' ) : this.translate( 'Insert' ) }
@@ -49,6 +50,7 @@ const ContactFormDialog = React.createClass( {
 			<FormButton
 				key="cancel"
 				isPrimary={ false }
+				data-e2e-button="cancel"
 				onClick={ this.props.onClose } >
 				{ this.translate( 'Cancel' ) }
 			</FormButton>

--- a/client/components/tinymce/plugins/contact-form/dialog/index.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/index.jsx
@@ -62,6 +62,7 @@ const ContactFormDialog = React.createClass( {
 					<FormButton
 						key="add"
 						isPrimary={ false }
+						data-e2e-button="add"
 						onClick={ this.props.onFieldAdd } >
 						{ this.translate( 'Add New Field' ) }
 					</FormButton>


### PR DESCRIPTION
This PR adds a data-attribute for the buttons on the Add Contact form. Specifically, this adds a new data-e2e-button attribute to the button tags. This is to help with improving the selectors used in our e2e tests.

For testing this change, we just need to make sure the attribute is properly added to the three button tags on the Add Contact Form Modal, and that it shows the correct name (e.g add, save, etc). A great way to test it would be to create a new page, click the caret and choose "Add Contact Form". In the modal that opens, inspect the button elements at the bottom of the modal.