### PR TITLE
Notice component: es6 class refactor

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -8,8 +8,6 @@ import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
 class Notice extends Component {
-	dismissTimeout = null;
-
 	static defaultProps = {
 		duration: 0,
 		status: null,
@@ -35,6 +33,8 @@ class Notice extends Component {
 		icon: PropTypes.string,
 		className: PropTypes.string
 	};
+
+	dismissTimeout = null;
 
 	componentDidMount() {
 		if ( this.props.duration > 0 ) {

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -7,7 +7,7 @@ import noop from 'lodash/noop';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
-class Notice extends Component {
+export class Notice extends Component {
 	static defaultProps = {
 		className: '',
 		duration: 0,

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -9,29 +9,30 @@ import Gridicon from 'gridicons';
 
 class Notice extends Component {
 	static defaultProps = {
-		duration: 0,
-		status: null,
-		showDismiss: true,
 		className: '',
-		onDismissClick: noop
+		duration: 0,
+		onDismissClick: noop,
+		showDismiss: true,
+		status: null,
 	};
 
 	static propTypes = {
+		className: PropTypes.string,
+		duration: React.PropTypes.number,
+		icon: PropTypes.string,
+		isCompact: PropTypes.bool,
+		onDismissClick: PropTypes.func,
+		showDismiss: PropTypes.bool,
 		status: PropTypes.oneOf( [
+			'is-error',
 			'is-info',
 			'is-success',
-			'is-error',
 			'is-warning',
 		] ),
-		showDismiss: PropTypes.bool,
-		isCompact: PropTypes.bool,
-		duration: React.PropTypes.number,
 		text: PropTypes.oneOfType( [
+			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) ),
 			PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
-			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) )
 		] ),
-		icon: PropTypes.string,
-		className: PropTypes.string
 	};
 
 	dismissTimeout = null;

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -36,6 +36,7 @@ export class Notice extends Component {
 			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) ),
 			PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		] ),
+		translate: PropTypes.func.isRequired,
 	};
 
 	dismissTimeout = null;

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -1,26 +1,24 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import noop from 'lodash/noop';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
-export const Notice = React.createClass( {
-	dismissTimeout: null,
+class Notice extends Component {
+	dismissTimeout = null;
 
-	getDefaultProps() {
-		return {
-			duration: 0,
-			status: null,
-			showDismiss: true,
-			className: '',
-			onDismissClick: noop
-		};
-	},
+	static defaultProps = {
+		duration: 0,
+		status: null,
+		showDismiss: true,
+		className: '',
+		onDismissClick: noop
+	};
 
-	propTypes: {
+	static propTypes = {
 		status: PropTypes.oneOf( [
 			'is-info',
 			'is-success',
@@ -36,19 +34,19 @@ export const Notice = React.createClass( {
 		] ),
 		icon: PropTypes.string,
 		className: PropTypes.string
-	},
+	};
 
 	componentDidMount() {
 		if ( this.props.duration > 0 ) {
 			this.dismissTimeout = setTimeout( this.props.onDismissClick, this.props.duration );
 		}
-	},
+	}
 
 	componentWillUnmount() {
 		if ( this.dismissTimeout ) {
 			clearTimeout( this.dismissTimeout );
 		}
-	},
+	}
 
 	getIcon() {
 		let icon;
@@ -72,7 +70,7 @@ export const Notice = React.createClass( {
 		}
 
 		return icon;
-	},
+	}
 
 	render() {
 		const { status, className, isCompact, showDismiss } = this.props;
@@ -101,6 +99,6 @@ export const Notice = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
 export default localize( Notice );

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -73,13 +73,21 @@ class Notice extends Component {
 	}
 
 	render() {
-		const { status, className, isCompact, showDismiss } = this.props;
+		const {
+			children,
+			className,
+			icon,
+			isCompact,
+			onDismissClick,
+			showDismiss,
+			status,
+			text,
+			translate,
+		} = this.props;
 		const classes = classnames( 'notice', status, className, {
 			'is-compact': isCompact,
 			'is-dismissable': showDismiss
 		} );
-
-		const { icon, text, children, onDismissClick, translate } = this.props;
 
 		return (
 			<div className={ classes }>

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -11,9 +11,12 @@ class Notice extends Component {
 	static defaultProps = {
 		className: '',
 		duration: 0,
+		icon: null,
+		isCompact: false,
 		onDismissClick: noop,
 		showDismiss: true,
-		status: null,
+		status: 'is-info',
+		text: null,
 	};
 
 	static propTypes = {

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -105,7 +105,7 @@ class Notice extends Component {
 				{ showDismiss && (
 					<span tabIndex="0" className="notice__dismiss" onClick={ onDismissClick } >
 						<Gridicon icon="cross" size={ 24 } />
-						<span className="screen-reader-text">{ translate( 'Dismiss' ) }</span>
+						<span className="notice__screen-reader-text screen-reader-text">{ translate( 'Dismiss' ) }</span>
 					</span>
 				) }
 			</div>


### PR DESCRIPTION
* Update `Notice` to es6 class
* Order properties
* Add `defaultProps.status = 'is-info'` (suggested in https://github.com/Automattic/wp-calypso/pull/13501#issuecomment-301927752)
* Add `defaultProps.icon = null`
* Add `defaultProps.text = null`
* Add linter required `className`
* General cleanup

To test:
* Use this branch
* Ensure tests pass
* Test notices
  * A good place is http://calypso.localhost:3000/jetpack/connect/?url=wordpress.com
  * Pay with [these lines](https://github.com/Automattic/wp-calypso/blob/c56a81d1f44170c10e8599c770c8ebd80e611bcf/client/signup/jetpack-connect/jetpack-connect-notices.jsx#L79-L84)
* Test available props:
  * `className`
  * `duration`
  * `icon` - any valid Gridicon or omit
  * `isCompact`
  * `onDismissClick`
  * `showDismiss`
  * `status`
  * `text`
  * `children`
* Ensure all the behaviour is maintained and new regressions, warning or errors have been introduced.

This component should have no functional changes. This PR simply updates to es6 class and clarifies some internal workings.