### PR TITLE
Login: Update url of new Login page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -19,7 +19,6 @@
 @import 'account-recovery/reset-code-validation/style';
 @import 'account-recovery/style';
 @import 'auth/style';
-@import 'login/wp-login/style';
 @import 'blocks/app-promo/style';
 @import 'blocks/author-compact-profile/style';
 @import 'blocks/author-selector/style';
@@ -214,6 +213,7 @@
 @import 'lib/directly/style';
 @import 'lib/keyboard-shortcuts/style';
 @import 'lib/abtest/test-helper/style';
+@import 'login/wp-login/style';
 @import 'mailing-lists/style';
 @import 'me/account-password/style';
 @import 'me/account/style';

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -31,7 +31,7 @@ class Login extends Component {
 	componentWillMount = () => {
 		if ( ! this.props.twoStepNonce && this.props.twoFactorAuthType && typeof window !== 'undefined' ) {
 			// Disallow access to the 2FA pages unless the user has received a nonce
-			page( login() );
+			page( login( { isNative: true } ) );
 		}
 	};
 
@@ -40,6 +40,7 @@ class Login extends Component {
 			this.rebootAfterLogin();
 		} else {
 			page( login( {
+				isNative: true,
 				// If no notification is sent, the user is using the authenticator for 2FA by default
 				twoFactorAuthType: this.props.twoFactorNotificationSent.replace( 'none', 'authenticator' )
 			} ) );

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -34,7 +34,7 @@ class TwoFactorActions extends Component {
 
 		const { userId, translate, twoStepNonce } = this.props;
 
-		page( login( { twoFactorAuthType: 'sms' } ) );
+		page( login( { isNative: true, twoFactorAuthType: 'sms' } ) );
 
 		this.props.sendSmsCode( userId, twoStepNonce ).then( ( phoneNumber ) => {
 			this.props.successNotice(
@@ -70,19 +70,25 @@ class TwoFactorActions extends Component {
 
 				{ isSmsSupported && twoFactorAuthType !== 'sms' && (
 					<p>
-						<a href="#" onClick={ this.sendSmsCode }>{ translate( 'Code via text message' ) }</a>
+						<a href="#" onClick={ this.sendSmsCode }>
+							{ translate( 'Code via text message' ) }
+						</a>
 					</p>
 				) }
 
 				{ isAuthenticatorSupported && twoFactorAuthType !== 'authenticator' && (
 					<p>
-						<a href={ login( { twoFactorAuthType: 'authenticator' } ) }>{ translate( 'An Authenticator application' ) }</a>
+						<a href={ login( { isNative: true, twoFactorAuthType: 'authenticator' } ) }>
+							{ translate( 'An Authenticator application' ) }
+						</a>
 					</p>
 				) }
 
 				{ isPushSupported && twoFactorAuthType !== 'push' && (
 					<p>
-						<a href={ login( { twoFactorAuthType: 'push' } ) }>{ translate( 'The WordPress mobile app' ) }</a>
+						<a href={ login( { isNative: true, twoFactorAuthType: 'push' } ) }>
+							{ translate( 'The WordPress mobile app' ) }
+						</a>
 					</p>
 				) }
 			</Card>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -284,7 +284,8 @@ class SignupForm extends Component {
 			return;
 		}
 
-		let link = login( { redirectTo: this.props.getRedirectToAfterLoginUrl } );
+		let link = login( { isNative: true, redirectTo: this.props.getRedirectToAfterLoginUrl } );
+
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
 				link += '&email_address=' + encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );
@@ -440,7 +441,9 @@ class SignupForm extends Component {
 			return;
 		}
 
-		const logInUrl = config.isEnabled( 'wp-login' ) ? login() : this.localizeUrlWithSubdomain( config( 'login_url' ) );
+		const logInUrl = config.isEnabled( 'wp-login' )
+			? login( { isNative: true } )
+			: this.localizeUrlWithSubdomain( config( 'login_url' ) );
 
 		return (
 			<LoggedOutFormLinks>

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -46,8 +46,7 @@ const devdocs = {
 	 */
 	devdocs: function( context ) {
 		function onSearchChange( searchTerm ) {
-			let query = context.query,
-				url = context.pathname;
+			const query = context.query;
 
 			if ( searchTerm ) {
 				query.term = searchTerm;
@@ -57,11 +56,13 @@ const devdocs = {
 
 			const queryString = qs.stringify( query ).replace( /%20/g, '+' ).trim();
 
+			let newUrl = context.pathname;
+
 			if ( queryString ) {
-				url += '?' + queryString;
+				newUrl += '?' + queryString;
 			}
 
-			page.replace( url,
+			page.replace( newUrl,
 				context.state,
 				false,
 				false );
@@ -154,7 +155,7 @@ const devdocs = {
 				title: 'Log In to start hacking',
 				line: 'Required to access the WordPress.com API',
 				action: 'Log In to WordPress.com',
-				actionURL: login( { redirectTo } ),
+				actionURL: login( { isNative: true, redirectTo } ),
 				secondaryAction: 'Register',
 				secondaryActionURL: '/start/developer',
 				illustration: '/calypso/images/drake/drake-nosites.svg'

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -10,7 +10,7 @@ export function login( { legacy, redirectTo, twoFactorAuthType } = {} ) {
 	let url = '';
 
 	if ( ! legacy && isEnabled( 'wp-login' ) ) {
-		url = '/login';
+		url = '/log-in';
 
 		if ( twoFactorAuthType ) {
 			url += '/' + twoFactorAuthType;

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -4,19 +4,15 @@
 import { addQueryArgs } from 'lib/url';
 import config, { isEnabled } from 'config';
 
-export function login( { legacy, redirectTo, twoFactorAuthType } = {} ) {
-	const legacyUrl = config( 'login_url' );
+export function login( { isNative, redirectTo, twoFactorAuthType } = {} ) {
+	let url = config( 'login_url' );
 
-	let url = '';
-
-	if ( ! legacy && isEnabled( 'wp-login' ) ) {
+	if ( isNative && isEnabled( 'wp-login' ) ) {
 		url = '/log-in';
 
 		if ( twoFactorAuthType ) {
 			url += '/' + twoFactorAuthType;
 		}
-	} else {
-		url = legacyUrl;
 	}
 
 	return redirectTo

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -28,7 +28,7 @@ describe( 'index', () => {
 			const url = login();
 
 			expect( url ).to.equal(
-				'/login'
+				'/log-in'
 			);
 		} );
 
@@ -36,7 +36,7 @@ describe( 'index', () => {
 			const url = login( { twoFactorAuthType: 'code' } );
 
 			expect( url ).to.equal(
-				'/login/code'
+				'/log-in/code'
 			);
 		} );
 
@@ -44,7 +44,7 @@ describe( 'index', () => {
 			const url = login( { redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
 
 			expect( url ).to.equal(
-				'/login?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
+				'/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
 			);
 		} );
 	} );

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -17,15 +17,23 @@ describe( 'index', () => {
 		} );
 
 		it( 'should return the legacy login url', () => {
-			const url = login( { legacy: true } );
+			const url = login();
 
 			expect( url ).to.equal(
 				'https://wordpress.com/wp-login.php'
 			);
 		} );
 
+		it( 'should return the legacy login url with encoded redirect url param', () => {
+			const url = login( { redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
+
+			expect( url ).to.equal(
+				'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'
+			);
+		} );
+
 		it( 'should return the login url', () => {
-			const url = login();
+			const url = login( { isNative: true } );
 
 			expect( url ).to.equal(
 				'/log-in'
@@ -33,7 +41,7 @@ describe( 'index', () => {
 		} );
 
 		it( 'should return the login url when the two factor auth page is supplied', () => {
-			const url = login( { twoFactorAuthType: 'code' } );
+			const url = login( { isNative: true, twoFactorAuthType: 'code' } );
 
 			expect( url ).to.equal(
 				'/log-in/code'
@@ -41,7 +49,7 @@ describe( 'index', () => {
 		} );
 
 		it( 'should return the login url with encoded redirect url param', () => {
-			const url = login( { redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
+			const url = login( { isNative: true, redirectTo: 'https://wordpress.com/?search=test&foo=bar' } );
 
 			expect( url ).to.equal(
 				'/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F%3Fsearch%3Dtest%26foo%3Dbar'

--- a/client/login/index.js
+++ b/client/login/index.js
@@ -7,6 +7,6 @@ import { makeLayout, redirectLoggedIn } from 'controller';
 
 export default router => {
 	if ( config.isEnabled( 'wp-login' ) ) {
-		router( '/login/:twoFactorAuthType?', redirectLoggedIn, login, makeLayout );
+		router( '/log-in/:twoFactorAuthType?', redirectLoggedIn, login, makeLayout );
 	}
 };

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -158,7 +158,7 @@ export class Login extends React.Component {
 
 		const lostPhoneLink = twoFactorAuthType && twoFactorAuthType !== 'backup' && (
 			<a
-				href={ login( { twoFactorAuthType: 'backup' } ) }
+				href={ login( { isNative: true, twoFactorAuthType: 'backup' } ) }
 				key="lost-phone-link">
 				{ this.props.translate( "I can't access my phone" ) }
 			</a>

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -97,7 +97,7 @@ let InviteAccept = React.createClass( {
 
 	signInLink() {
 		const invite = this.state.invite;
-		let loginUrl = login( { legacy: true, redirectTo: window.location.href } );
+		let loginUrl = login( { redirectTo: window.location.href } );
 
 		if ( invite && invite.sentTo ) {
 			let presetEmail = '&email_address=' + encodeURIComponent( invite.sentTo );
@@ -166,14 +166,14 @@ let InviteAccept = React.createClass( {
 						title: error.message, // "You are already a (follower|member) of this site"
 						line: this.translate( 'Would you like to accept the invite with a different account?' ),
 						action: this.translate( 'Switch Accounts' ),
-						actionURL: login( { legacy: true, redirectTo: window.location.href } ),
+						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
 				case 'unauthorized_created_by_self':
 					Object.assign( props, {
 						line: error.message, // "You can not use an invitation that you have created for someone else."
 						action: this.translate( 'Switch Accounts' ),
-						actionURL: login( { legacy: true, redirectTo: window.location.href } ),
+						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
 				default:

--- a/client/signup/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/signup/jetpack-connect/auth-logged-in-form.jsx
@@ -470,7 +470,7 @@ class LoggedInForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
-				<LoggedOutFormLinkItem href={ login( { legacy: true, redirectTo } ) }>
+				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
 					{ translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -132,7 +132,7 @@ class JetpackSsoForm extends Component {
 	}
 
 	getSignInLink() {
-		return login( { legacy: true, redirectTo: window.location.href } );
+		return login( { redirectTo: window.location.href } );
 	}
 
 	maybeValidateSSO( props = this.props ) {

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -186,7 +186,7 @@ module.exports = React.createClass( {
 	},
 
 	getErrorMessagesWithLogin( fieldName ) {
-		const link = login( { redirectTo: window.location.href } ),
+		const link = login( { isNative: true, redirectTo: window.location.href } ),
 			messages = formState.getFieldErrorMessages( this.state.form, fieldName );
 
 		if ( ! messages ) {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -315,7 +315,7 @@ sections.push( {
 
 sections.push( {
 	name: 'login',
-	paths: [ '/login' ],
+	paths: [ '/log-in' ],
 	module: 'login',
 	enableLoggedOut: true,
 	secondary: false,


### PR DESCRIPTION
This pull request is a follow-up of #14144 that updates the path of the new `Login` pages from `/login` to `/log-in`. The reason for such change is that moving these pages under `/me/login` has proven to be much more complicated than anticipated, and that https://wordpress.com/log-in is already server by Calypso and can be appropriated easily. Note this pull request also updates our code so the new `Login` pages are only linked from the signup flow and [devdocs](http://calypso.localhost:3000/devdocs/start): we will now have to whitelist every new link to target these pages.
 
#### Testing instructions
 
1. Run `git checkout update/login-url` and start your server, or open a [live branch](https://calypso.live/?branch=update/login-url)
2. Open the [`Home` page](http://calypso.localhost:3000/) in an incognito window
3. Check that `Log In` link in the top bar points to the legacy `Login` page
4. Check that `Log In to WordPress.com` button points to the new `Login` page
5. Click the `Sign Up` link in the top bar and proceed to the `User` step
6. Enter the username of an existing account
7. Click the link in the `Sorry, that username already exists! If this is you log in now.` error message
8. Assert that you are presented with the new `Login` page
9. Check that you can still log in using different authentication methods
 
#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests