### PR TITLE
Add/tld/fr extra fields dialog

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -89,6 +89,7 @@
 @import 'components/domains/example-domain-suggestions/style';
 @import 'components/domains/map-domain-step/style';
 @import 'components/domains/register-domain-step/style';
+@import 'components/domains/registrant-extra-info/style';
 @import 'components/drop-zone/style';
 @import 'components/ellipsis-menu/style';
 @import 'components/email-verification/style';

--- a/client/components/domains/README.md
+++ b/client/components/domains/README.md
@@ -40,3 +40,7 @@ Enables users to select a domain to map
 register-domain-step
 --------------------
 Enables users to select a domain to register
+
+registrant-extra-info
+---------------------
+Forms to collect additional tld-specific user information

--- a/client/components/domains/registrant-extra-info/README.md
+++ b/client/components/domains/registrant-extra-info/README.md
@@ -1,0 +1,11 @@
+Registrant Extra Info Forms
+===========================
+
+This module provides forms to support TLD-specific requirements.
+
+These forms aim to be extremely thin, returning a component that only does 3
+things:
+
+1. Presents just the form elements required for a given TLD
+2. Expose a single onChange event that returns the state of it's fields when any of them change
+3. Accept errors & warnings through props and display them with the appropriate fields

--- a/client/components/domains/registrant-extra-info/docs/example.jsx
+++ b/client/components/domains/registrant-extra-info/docs/example.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import ExtraInfoFrForm from 'components/domains/registrant-extra-info/fr-form';
+import { forDomainRegistrations as getCountries } from 'lib/countries-list';
+const countriesList = getCountries();
+
+class ExtraInfoFrFormExample extends PureComponent {
+	state = {
+		registrantExtraInfo: {},
+	}
+
+	handleExtraChange = ( registrantExtraInfo ) => {
+		this.setState( { registrantExtraInfo } );
+	}
+
+	render() {
+		return (
+			<div>
+				<p>
+					The Fr Extra Registrant Information form collects the extra data
+					required by AFNIC.
+				</p>
+
+				<Card>
+					<ExtraInfoFrForm
+						values={ this.state.registrantExtraInfo }
+						countriesList={ countriesList }
+						onStateChange={ this.handleExtraChange } >
+					</ExtraInfoFrForm>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default ExtraInfoFrFormExample;

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -1,0 +1,352 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { isEqual, noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+import moment from 'moment';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormRadio from 'components/forms/form-radio';
+import FormCountrySelect from 'components/forms/form-country-select';
+import FormTextInput from 'components/forms/form-text-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const debug = debugFactory( 'calypso:domains:registrant-extra-info' );
+
+// If we set a field to null, react decides it's uncontrolled and complains
+// and we don't particularly want to make the parent remember all our fields
+// so we use these values to plug missing.
+const emptyValues = {
+	countryOfBirth: '',
+	dobDays: '',
+	dobMonths: '',
+	dobYears: '',
+	placeOfBirth: '',
+	postalCodeOfBirth: '',
+	registrantVatId: '',
+	sirenSiret: '',
+	trademarkNumber: '',
+};
+
+class RegistrantExtraInfoForm extends React.PureComponent {
+	static propTypes = {
+		countriesList: PropTypes.object.isRequired,
+		isVisible: PropTypes.bool,
+		onSubmit: PropTypes.func,
+		onStateChanged: PropTypes.func, // Just until we can reduxify the contact details
+		countryCode: PropTypes.string,
+		isProbablyOrganization: PropTypes.bool,
+	}
+
+	static defaultProps = {
+		countriesList: { data: [] },
+		isVisible: true,
+		isProbablyOrganization: false,
+		values: {},
+		onSubmit: noop,
+		onStateChanged: noop,
+	}
+
+	componentWillMount() {
+		const defaults = {
+			registrantType: this.props.isProbablyOrganization
+				? 'organization' : 'individual',
+			countryOfBirth: this.props.countryCode || 'FR',
+		};
+
+		const values = {
+			...defaults,
+			...this.props.values,
+		};
+
+		// It's possible for the parent to pass in null and still have a form
+		// that the user is happy with, so we pass one state out
+		// immediatly to to make sure there's something valid in the parent
+		this.props.onStateChange( values );
+	}
+
+	handleDobChangeEvent = ( event ) => {
+		// TODO FIXME: Sanitize and validate individual fields and resulting
+		// date
+
+		// setState() is not syncronous :(
+		const newState = this.newStateFromEvent( event );
+		const { dobYears, dobMonths, dobDays } = newState;
+
+		const dateOfBirth = ( dobYears && dobMonths && dobDays ) &&
+			[ dobYears, dobMonths, dobDays ].join( '-' );
+
+		if ( dateOfBirth ) {
+			debug( 'Setting dateOfBirth to ' + dateOfBirth +
+				( moment( dateOfBirth, 'YYYY-MM-DD' ).isValid() ? '' : ' (invalid)' ) );
+		}
+
+		this.props.onStateChange( {
+			...newState,
+			...( dateOfBirth ? { dateOfBirth } : {} )
+		} );
+	}
+
+	newStateFromEvent( event ) {
+		return {
+			...this.props.values,
+			[ event.target.id ]: event.target.value,
+		};
+	}
+
+	handleChangeEvent = ( event ) => {
+		this.props.onStateChange( this.newStateFromEvent( event ) );
+	}
+
+	// We need a deep comparison to check inside props.values
+	shouldComponentUpdate( nextProps ) {
+		return ! isEqual( this.props, nextProps );
+	}
+
+	render() {
+		const translate = this.props.translate;
+		const {
+			registrantType
+		} = { ...emptyValues, ...this.props.values };
+
+		return (
+			<form className="registrant-extra-info__form">
+				<h1 className="registrant-extra-info__form-title">
+					{ translate(
+						'Registering a .FR domain'
+					) }
+				</h1>
+				<p className="registrant-extra-info__form-desciption">
+					{ translate(
+						'Almost done! We need some extra details to register domains ending in ".fr".'
+					) }
+				</p>
+				<FormFieldset>
+					<FormLegend>
+						{ translate( "Who's this domain for?" ) }
+					</FormLegend>
+					<FormLabel>
+						<FormRadio value="individual"
+							id="registrantType"
+							checked={ 'individual' === registrantType }
+							onChange={ this.handleChangeEvent } />
+						<span>{ translate( 'An individual' ) }</span>
+					</FormLabel>
+
+					<FormLabel>
+						<FormRadio value="organization"
+							id="registrantType"
+							checked={ 'organization' === registrantType }
+							onChange={ this.handleChangeEvent } />
+						<span>{ translate( 'A company or organization' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+
+				{ 'individual' === registrantType
+					? this.renderPersonalFields()
+					: this.renderOrganizationFields() }
+
+				{ this.props.children }
+			</form>
+		);
+	}
+
+	renderPersonalFields() {
+		const translate = this.props.translate;
+		const screenReaderText = 'screen-reader-text';
+		const {
+			countryOfBirth,
+			dobDays,
+			dobMonths,
+			dobYears,
+			placeOfBirth,
+			postalCodeOfBirth,
+		} = { ...emptyValues, ...this.props.values };
+
+		return (
+			<div>
+				<FormFieldset>
+					<FormLabel htmlFor="countryOfBirth">
+						{ translate( 'Country of Birth' ) }
+					</FormLabel>
+					<FormCountrySelect
+						id="countryOfBirth"
+						value={ countryOfBirth }
+						countriesList={ this.props.countriesList }
+						className="registrant-extra-info__form-country-select"
+						onChange={ this.handleChangeEvent } />
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLegend>
+						{ translate( 'Date of Birth' ) }
+					</FormLegend>
+					<div className="registrant-extra-info__dob-inputs">
+						<div className="registrant-extra-info__dob-column">
+							<FormLabel htmlFor="dobYears" className={ screenReaderText }>
+								{ translate( 'Year' ) }
+							</FormLabel>
+							<FormTextInput className="registrant-extra-info__dob-year"
+								id="dobYears"
+								value={ dobYears }
+								type="number"
+								placeholder={ translate( 'YYYY', {
+									comment: 'Placeholder text for the year part of a date input. Indicates that the user should enter a year as a 4 digit value', // eslint-disable-line max-len
+								} ) }
+								onChange={ this.handleDobChangeEvent } />
+						</div>
+						<div className="registrant-extra-info__dob-column">
+							<FormLabel htmlFor="dobMonths" className={ screenReaderText }>
+								{ translate( 'Month' ) }
+							</FormLabel>
+							<FormTextInput className="registrant-extra-info__dob-month"
+								id="dobMonths"
+								value={ dobMonths }
+								max="2"
+								type="number"
+								placeholder={ translate( 'MM', {
+									comment: 'Placeholder text for the month part of a date input. Indicates that the user should enter a month as a 2 digit value', // eslint-disable-line max-len
+								} ) }
+								onChange={ this.handleDobChangeEvent } />
+						</div>
+						<div className="registrant-extra-info__dob-column">
+							<FormLabel htmlFor="dobDays" className={ screenReaderText }>
+								{ translate( 'Day' ) }
+							</FormLabel>
+							<FormTextInput className="registrant-extra-info__dob-day"
+								id="dobDays"
+								value={ dobDays }
+								max="2"
+								type="number"
+								placeholder={ translate( 'DD', {
+									comment: 'Placeholder text for the day part of a date input. Indicates that the user should enter a day as a 2 digit value', // eslint-disable-line max-len
+								} ) }
+								onChange={ this.handleDobChangeEvent } />
+						</div>
+					</div>
+					<FormSettingExplanation>{
+						translate( 'Year/Month/Day - e.g. 1970/12/31', {
+							comment: 'This is describing a date format with fixed fields, so please do not ' +
+								'alter the numbers (Year, Month, Day). Please translate e.g("For example") if appropriate and also ' +
+								'the words, Year, Month, Day, individually.'
+						} )
+					}</FormSettingExplanation>
+				</FormFieldset>
+
+				{ countryOfBirth === 'FR' && (
+					<FormFieldset>
+						<FormLabel htmlFor="placeOfBirth">
+							{ translate( 'City of Birth' ) }
+						</FormLabel>
+						<FormTextInput
+							id="placeOfBirth"
+							value={ placeOfBirth }
+							placeholder={ translate( 'City of birth' ) }
+							onChange={ this.handleChangeEvent } />
+					</FormFieldset>
+				) }
+
+				{ countryOfBirth === 'FR' && (
+					<FormFieldset>
+						<FormLabel htmlFor="postalCodeOfBirth">
+							{ translate( 'Postal Code of Birth' ) }
+						</FormLabel>
+						<FormTextInput
+							id="postalCodeOfBirth"
+							value={ postalCodeOfBirth }
+							type="number"
+							autoCapitalize="off"
+							autoComplete="off"
+							autoCorrect="off"
+							placeholder={ translate( 'ex. 75008' ) }
+							onChange={ this.handleChangeEvent } />
+					</FormFieldset>
+				) }
+			</div>
+		);
+	}
+
+	renderOrganizationFields() {
+		const translate = this.props.translate;
+		const {
+			registrantVatId,
+			sirenSiret,
+			trademarkNumber
+		} = { ...emptyValues, ...this.props.values };
+		return (
+			<div>
+				<FormFieldset>
+					<FormLabel className="registrant-extra-info__optional"
+						htmlFor="registrantVatId">
+						{ translate( 'VAT Number' ) }
+						{ this.renderOptional() }
+					</FormLabel>
+					<FormTextInput
+						id="registrantVatId"
+						value={ registrantVatId }
+						autoCapitalize="off"
+						autoComplete="off"
+						autoCorrect="off"
+						placeholder={ translate( 'ex. XX123456789' ) }
+						onChange={ this.handleChangeEvent } />
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel className="registrant-extra-info__optional"
+						htmlFor="sirenSiret">
+						{ translate( 'SIREN or SIRET Number' ) }
+						{ this.renderOptional() }
+					</FormLabel>
+					<FormTextInput
+						id="sirenSiret"
+						value={ sirenSiret }
+						placeholder={
+							translate( 'ex. 123 456 789 or 123 456 789 01234',
+								{ comment: 'ex is short for "example". The numbers are examples of the EU VAT format' }
+							)
+						}
+						autoCapitalize="off"
+						autoComplete="off"
+						autoCorrect="off"
+						onChange={ this.handleChangeEvent } />
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel className="registrant-extra-info__optional"
+						htmlFor="trademarkNumber">
+						{ translate( 'EU Trademark Number' ) }
+						{ this.renderOptional() }
+					</FormLabel>
+					<FormTextInput
+						id="trademarkNumber"
+						value={ trademarkNumber }
+						type="number"
+						autoCapitalize="off"
+						autoComplete="off"
+						autoCorrect="off"
+						placeholder={
+							translate( 'ex. 123456789',
+								{ comment: 'ex is short for example. The number is the EU trademark number format.' }
+							)
+						}
+						onChange={ this.handleChangeEvent } />
+				</FormFieldset>
+			</div>
+		);
+	}
+
+	renderOptional() {
+		return (
+			<span className="registrant-extra-info__optional-label">{ this.props.translate( 'Optional' ) }</span>
+		);
+	}
+}
+
+export default localize( RegistrantExtraInfoForm );

--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -1,0 +1,70 @@
+.registrant-extra-info__form-title {
+	font-size: 16px;
+	font-weight: bold;
+	margin: 0 0 5px;
+}
+
+.registrant-extra-info__form-desciption {
+	font-weight: 16px;
+	margin: 0 0 1.7em;
+}
+
+// We need .form-label for specificity
+.form-label.registrant-extra-info__optional {
+	display: flex;
+
+	.registrant-extra-info__optional-label {
+		color: darken( $gray, 20% );
+		font-weight: 200;
+		margin-left: 5px;
+	}
+}
+
+// Turn off number spinners
+.registrant-extra-info__form {
+	input[type=number] {
+		-moz-appearance: textfield;
+
+		&::-webkit-inner-spin-button,
+		&::-webkit-outer-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+	}
+}
+
+.registrant-extra-info__form-country-select {
+	width: 100%;
+}
+
+.registrant-extra-info__dob-inputs {
+	flex-direction: row;
+	display: flex;
+
+	.registrant-extra-info__dob-year {
+		box-sizing: content-box;
+		width: 42px;
+	}
+
+	.registrant-extra-info__dob-month,
+	.registrant-extra-info__dob-day {
+		box-sizing: content-box;
+		width: 28px;
+	}
+}
+
+
+.registrant-extra-info__dob-column {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin: 0 5px;
+
+	&:first-child {
+		margin-left: 0;
+	}
+}
+
+.registrant-extra-info__title-card {
+	margin-bottom: 0;
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -73,6 +73,7 @@ import EmojifyExample from 'components/emojify/docs/example';
 import LanguagePicker from 'components/language-picker/docs/example';
 import FormattedHeader from 'components/formatted-header/docs/example';
 import EmptyContent from 'components/empty-content/docs/example';
+import ExtraInfoFrForm from 'components/domains/registrant-extra-info/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -136,6 +137,7 @@ let DesignAssets = React.createClass( {
 					<FoldableCard />
 					<FormattedHeader />
 					<FormFields searchKeywords="input textbox textarea radio" />
+					{ config.isEnabled( 'domains/cctlds' ) && <ExtraInfoFrForm /> }
 					<Gauge />
 					<GlobalNotices />
 					<Gravatar />

--- a/client/my-sites/upgrades/checkout/payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/payment-box.jsx
@@ -1,29 +1,43 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	Card = require( 'components/card' ),
-	classNames = require( 'classnames' );
+import React, { PureComponent } from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
-module.exports = React.createClass( {
-	displayName: 'PaymentBox',
+export default class PaymentBox extends PureComponent {
+	static displayName = 'PaymentBox';
 
-	render: function() {
-		var cardClass = classNames( 'payment-box', this.props.classSet ),
+	render() {
+		const cardClass = classNames( 'payment-box', this.props.classSet ),
 			contentClass = classNames( 'payment-box__content', this.props.contentClassSet );
 		return (
-			<div className="checkout__payment-box-container">
-				<SectionHeader label={ this.props.title } />
-				<Card className={ cardClass }>
-					<div className="checkout__box-padding">
-						<div className={ contentClass }>
-							{ this.props.children }
+			<ReactCSSTransitionGroup
+				transitionName={ 'checkout__payment-box-container' }
+				transitionAppear={ true }
+				transitionAppearTimeout={ 400 }
+				transitionEnter={ true }
+				transitionEnterTimeout={ 400 }
+				transitionLeave={ false } >
+
+				<div className="checkout__payment-box-container"
+					key={ this.props.currentPage } >
+					<SectionHeader label={ this.props.title } />
+					<Card className={ cardClass }>
+						<div className="checkout__box-padding">
+							<div className={ contentClass }>
+								{ this.props.children }
+							</div>
 						</div>
-					</div>
-				</Card>
-			</div>
+					</Card>
+				</div>
+			</ReactCSSTransitionGroup>
 		);
 	}
-} );
+}

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -7,14 +7,21 @@
 		width: 100%;
 		overflow: hidden;
 
-		opacity: 0;
-		visibility: hidden;
-		transform: translateZ(0) scale(.8); // Zoom out effect
+		&-appear,
+		&-enter {
+			height: 0;
+			opacity: 0.01;
+			transform: translateZ(0) scale(.8);
+		}
 
-		animation-delay: 0.3s;
-		animation-fill-mode: forwards;
-		animation-duration: 0.4s;
-		animation-name: increase;
+		&-appear-active,
+		&-enter-active {
+			height: auto;
+			opacity: 1;
+			transform: translateZ(0) scale(1);
+			transition-property: height, opacity, transform;
+			transition-duration: 400ms;
+		}
 
 		&:not(.domain-details) {
 			@include breakpoint( "<660px" ) {
@@ -184,7 +191,10 @@
 		}
 	}
 
+	// Turn off number spinners
 	input[type=number] {
+		-moz-appearance: textfield;
+
 		&::-webkit-outer-spin-button,
 		&::-webkit-inner-spin-button {
 			-webkit-appearance: none;
@@ -928,22 +938,6 @@
 .checkout__privacy-protection-free-text {
 	color: $alert-green;
 	padding-left: 8px;
-}
-
-@keyframes increase {
-	from {
-		height: 0;
-		opacity: 0;
-		visibility: hidden;
-		transform: translateZ(0) scale(.8);
-	}
-
-	to {
-		height: auto;
-		opacity: 1;
-		visibility: visible;
-		transform: translateZ(0) scale(1);
-	}
 }
 
 .credit-card-payment-box__progress-bar {

--- a/config/client.json
+++ b/config/client.json
@@ -7,6 +7,7 @@
   "directly_rtm_widget_ids",
   "discover_blog_id",
   "discover_feed_id",
+  "domains/cctlds",
   "env",
   "env_id",
   "facebook_api_key",

--- a/config/development.json
+++ b/config/development.json
@@ -47,6 +47,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
+		"domains/cctlds": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,


### PR DESCRIPTION
This PR adds a form to support .FR extra fields for the for the domains checkout flow and contact detail editing flow as per #13890.

I've added the `domains/cctlds` feature flag, and the .FR form is behind that, so the most critical testing is that we don't break calypso with the flag off:
`DISABLE_FEATURES=domains/cctlds make run`

*Note*: that the back-end will only offer .FR domains to proxied a12s, or sandboxes with the store sandbox enabled, so this is not a very community friendly PR, sorry :( 

After that, we want to see:
- the checkout flow works: contact details -> .fr details (for .fr domains) -> maybe privacy dialog -> checkout
- The appropriate fields being visible for registrant type and country of birth
- the (token) tests run (and don't break the entire suite anymore): ` npm run test-client client/components/domains/registrant-extra-info` (or even better  `npm run test-client`)
- the extra fields are passed to the server

Things that are not in this PR:
- no sanitation or validation at the moment ( we'll do that after we reduxify)
- no registration success (we need to fix the backend)
- no remembered data on the .fr form ( needs backend + redux )
- domain management integration (after redux)
- more testing (after redux)

Video:
![fr extra 2](https://cloud.githubusercontent.com/assets/5952255/26438436/637bbea4-4166-11e7-97fe-7180638f779d.gif)

And passing that data to the server:
![thank_you_ _wordpress_com_and_licecap_v1_25__stopped__and_calypso_ _-bash_ _86x85](https://cloud.githubusercontent.com/assets/5952255/26438439/668bd0b6-4166-11e7-9835-d34c188ded79.jpg)