### PR TITLE
Data Layer: Save response headers in the action `meta` when redispatching

### DIFF
--- a/client/state/data-layer/wpcom-http/pipeline/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/index.js
@@ -17,8 +17,10 @@ import { applyDuplicatesHandlers, removeDuplicateGets } from './remove-duplicate
  * @property {ReduxStore} store Redux store
  * @property {*} originalData response data from returned network request
  * @property {*} originalError response error from returned network request
+ * @property {*} originalHeaders response headers from returned network request
  * @property {*} nextData transformed response data
  * @property {*} nextError transformed response error
+ * @property {*} nextHeaders transformed repsonse headers
  * @property {Object[]} failures list of `onFailure` actions to dispatch
  * @property {Object[]} successes list of `onSuccess` actions to dispatch
  * @property {Boolean} [shouldAbort] whether or not no further processing should occur for request
@@ -63,19 +65,21 @@ const applyOutboundProcessor = ( outboundData, nextProcessor ) =>
 		? nextProcessor( outboundData )
 		: outboundData;
 
-export const processInboundChain = chain => ( originalRequest, store, originalData, originalError ) =>
+export const processInboundChain = chain => ( originalRequest, store, originalData, originalError, originalHeaders ) =>
 	pick(
 		chain.reduce( applyInboundProcessor, {
 			originalRequest,
 			store,
 			originalData,
 			originalError,
+			originalHeaders,
 			nextData: originalData,
 			nextError: originalError,
+			nextHeaders: originalHeaders,
 			failures: compact( [ originalRequest.onFailure ] ),
 			successes: compact( [ originalRequest.onSuccess ] ),
 		} ),
-		[ 'failures', 'nextData', 'nextError', 'successes', 'shouldAbort' ],
+		[ 'failures', 'nextData', 'nextError', 'nextHeaders', 'successes', 'shouldAbort' ],
 	);
 
 export const processOutboundChain = chain => ( originalRequest, store ) =>

--- a/client/state/data-layer/wpcom-http/pipeline/test/test.js
+++ b/client/state/data-layer/wpcom-http/pipeline/test/test.js
@@ -35,44 +35,48 @@ describe( '#processInboundChain', () => {
 
 	it( 'should pass through data given an empty chain', () => {
 		expect(
-			processInboundChain( [] )( getSites, {}, { value: 1 }, { error: 'bad' } )
+			processInboundChain( [] )( getSites, {}, { value: 1 }, { error: 'bad' }, {} )
 		).to.eql( {
 			failures: [ getSites.onFailure ],
 			nextData: { value: 1 },
 			nextError: { error: 'bad' },
+			nextHeaders: {},
 			successes: [ getSites.onSuccess ],
 		} );
 	} );
 
 	it( 'should sequence a single processor', () => {
 		expect(
-			processInboundChain( [ responderDoubler ] )( getSites, {}, {}, {} )
+			processInboundChain( [ responderDoubler ] )( getSites, {}, {}, {}, {} )
 		).to.eql( {
 			failures: [ getSites.onFailure, getSites.onFailure ],
 			nextData: {},
 			nextError: {},
+			nextHeaders: {},
 			successes: [ getSites.onSuccess, getSites.onSuccess ],
 		} );
 	} );
 
 	it( 'should sequence multiple processors', () => {
 		expect(
-			processInboundChain( [ responderDoubler, responderDoubler ] )( getSites, {}, {}, {} )
+			processInboundChain( [ responderDoubler, responderDoubler ] )( getSites, {}, {}, {}, {} )
 		).to.eql( {
 			failures: ( new Array( 4 ) ).fill( getSites.onFailure ),
 			nextData: {},
 			nextError: {},
+			nextHeaders: {},
 			successes: ( new Array( 4 ) ).fill( getSites.onSuccess ),
 		} );
 	} );
 
 	it( 'should abort the chain as soon as `shouldAbort` is set', () => {
 		expect(
-			processInboundChain( [ aborter, responderDoubler ] )( getSites, {}, {}, {} )
+			processInboundChain( [ aborter, responderDoubler ] )( getSites, {}, {}, {}, {} )
 		).to.eql( {
 			failures: [],
 			nextData: {},
 			nextError: {},
+			nextHeaders: {},
 			successes: [],
 			shouldAbort: true,
 		} );

--- a/client/state/data-layer/wpcom-http/pipeline/test/test.js
+++ b/client/state/data-layer/wpcom-http/pipeline/test/test.js
@@ -35,12 +35,12 @@ describe( '#processInboundChain', () => {
 
 	it( 'should pass through data given an empty chain', () => {
 		expect(
-			processInboundChain( [] )( getSites, {}, { value: 1 }, { error: 'bad' }, {} )
+			processInboundChain( [] )( getSites, {}, { value: 1 }, { error: 'bad' }, { header: 'foobar' } )
 		).to.eql( {
 			failures: [ getSites.onFailure ],
 			nextData: { value: 1 },
 			nextError: { error: 'bad' },
-			nextHeaders: {},
+			nextHeaders: { header: 'foobar' },
 			successes: [ getSites.onSuccess ],
 		} );
 	} );

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -20,6 +20,14 @@ export const getData = action => get( action, 'meta.dataLayer.data', null );
 export const getError = action => get( action, 'meta.dataLayer.error', null );
 
 /**
+ * Returns (response) headers data from an HTTP request action if available
+ *
+ * @param {Object} action may contain HTTP response headers data
+ * @returns {?*} headers data if available
+ */
+export const getHeaders = action => get( action, 'meta.dataLayer.headers', null );
+
+/**
  * @typedef {Object} ProgressData
  * @property {number} loaded number of bytes already transferred
  * @property {number} total total number of bytes to transfer

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5753,7 +5753,7 @@
       "version": "1.3.0"
     },
     "wpcom": {
-      "version": "5.3.0",
+      "version": "5.4.0",
       "dependencies": {
         "wpcom-xhr-request": {
           "version": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "walk": "2.3.4",
     "webpack": "1.13.1",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "5.3.0",
+    "wpcom": "5.4.0",
     "wpcom-oauth": "0.3.3",
     "wpcom-proxy-request": "3.0.0",
     "wpcom-xhr-request": "1.1.0"


### PR DESCRIPTION
This is an attempt at giving easy access - in the data layer - to response headers, now available through [wpcom.js 5.4.0](https://github.com/Automattic/wpcom.js/pull/213).

The main use case right now is to access the [REST API pagination headers](https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/): `X-WP-Total` and `X-WP-TotalPages`.

I didn't update `dispatchRequest` success / error handlers signatures with a last parameter containing the `headers` to limit as much as possible the impact of this change. Essentially, all it does is add another key in the action's `meta.dataLayer` object. In the success / error handlers, we can use the util function `getHeaders` to extract them from the action as demonstrated in the updated #13828.

This is the last PR to unblock #13828.

In the shrinkmap, nothing really worrisome:
- time-stamp has gotten a minor refactor but [nothing big](https://github.com/jonschlinkert/time-stamp/commit/14b0ed1c7d1723ade46d33266cc361359ef05443)
- node-abi changed a few supported targets
- es5-ext gets a couple of new shims: `safeToString`, `ensurePromise` and `isPromise`.