### PR TITLE
SEO Tools: enable SEO settings on private sites

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -416,7 +416,7 @@ export const SeoForm = React.createClass( {
 		const activateVerificationServices = () => this.props.activateModule( siteId, 'verification-tools' );
 		const isSitePrivate = siteSettings && parseInt( siteSettings.blog_public, 10 ) !== 1;
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
-		const isDisabled = isSitePrivate || isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
+		const isDisabled = isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
 		const isSeoDisabled = isDisabled || isSeoToolsActive === false;
 		const isVerificationDisabled = isDisabled || isVerificationToolsActive === false;
 		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
@@ -471,12 +471,11 @@ export const SeoForm = React.createClass( {
 						status="is-warning"
 						showDismiss={ false }
 						text={ translate(
-							'SEO settings are disabled because the ' +
-							'site visibility is not set to Public.'
+							"SEO settings aren't recognized by search engines while your site is Private."
 						) }
 					>
 						<NoticeAction href={ generalTabUrl }>
-							{ translate( 'View Settings' ) }
+							{ translate( 'View privacy settings' ) }
 						</NoticeAction>
 					</Notice>
 				}

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -479,7 +479,7 @@ export const SeoForm = React.createClass( {
 						}
 					>
 						<NoticeAction href={ generalTabUrl }>
-							{ translate( 'View privacy settings' ) }
+							{ translate( 'Privacy Settings' ) }
 						</NoticeAction>
 					</Notice>
 				}

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -46,11 +46,14 @@ import {
 } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
-	getSiteSettings,
 	getSiteSettingsSaveError,
 } from 'state/site-settings/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackModuleActive } from 'state/selectors';
+import {
+	isJetpackModuleActive,
+	isHiddenSite,
+	isPrivateSite,
+} from 'state/selectors';
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
 import WebPreview from 'components/web-preview';
@@ -389,9 +392,10 @@ export const SeoForm = React.createClass( {
 			showAdvancedSeo,
 			showWebsiteMeta,
 			site,
-			siteSettings,
 			isFetchingSite,
 			isSeoToolsActive,
+			isSitePrivate,
+			isSiteHidden,
 			isVerificationToolsActive,
 			translate,
 		} = this.props;
@@ -414,7 +418,6 @@ export const SeoForm = React.createClass( {
 
 		const activateSeoTools = () => this.props.activateModule( siteId, 'seo-tools' );
 		const activateVerificationServices = () => this.props.activateModule( siteId, 'verification-tools' );
-		const isSitePrivate = siteSettings && parseInt( siteSettings.blog_public, 10 ) !== 1;
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
 		const isDisabled = isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
 		const isSeoDisabled = isDisabled || isSeoToolsActive === false;
@@ -466,13 +469,14 @@ export const SeoForm = React.createClass( {
 					path="/settings/seo/:site"
 					title="Site Settings > SEO"
 				/>
-				{ isSitePrivate && hasBusinessPlan( site.plan ) &&
+				{ ( isSitePrivate || isSiteHidden ) && hasBusinessPlan( site.plan ) &&
 					<Notice
 						status="is-warning"
 						showDismiss={ false }
-						text={ translate(
-							"SEO settings aren't recognized by search engines while your site is Private."
-						) }
+						text={ isSitePrivate
+							? translate( "SEO settings aren't recognized by search engines while your site is Private." )
+							: translate( "SEO settings aren't recognized by search engines while your site is Hidden." )
+						}
 					>
 						<NoticeAction href={ generalTabUrl }>
 							{ translate( 'View privacy settings' ) }
@@ -751,12 +755,13 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteIsJetpack,
 		selectedSite: getSelectedSite( state ),
 		storedTitleFormats: getSeoTitleFormatsForSite( getSelectedSite( state ) ),
-		siteSettings: getSiteSettings( state, siteId ),
 		showAdvancedSeo: isAdvancedSeoEligible && isAdvancedSeoSupported,
 		showWebsiteMeta: !! get( site, 'options.advanced_seo_front_page_description', '' ),
 		jetpackVersionSupportsSeo: jetpackVersionSupportsSeo,
 		isFetchingSite: isRequestingSite( state, siteId ),
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
+		isSiteHidden: isHiddenSite( state, siteId ),
+		isSitePrivate: isPrivateSite( state, siteId ),
 		isVerificationToolsActive: isJetpackModuleActive( state, siteId, 'verification-tools' ),
 		hasAdvancedSEOFeature: hasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -127,7 +127,7 @@
 	}
 
 	.seo-settings__seo-form .form-text-input-with-affixes__prefix {
-		min-width: 60px;
+		min-width: 80px;
 		text-align: center;
 	}
 

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -34,8 +34,7 @@ import {
 import config from 'config';
 import {
 	areSitePermalinksEditable,
-	isPrivateSite,
-	isHiddenSite
+	isHiddenSite,
 } from 'state/selectors';
 
 import EditorDrawerTaxonomies from './taxonomies';
@@ -259,9 +258,9 @@ const EditorDrawer = React.createClass( {
 
 		const { plan } = this.props.site;
 		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-		const { isPrivate, isHidden } = this.props;
+		const { isHidden } = this.props;
 
-		if ( ! hasBusinessPlan || isPrivate || isHidden ) {
+		if ( ! hasBusinessPlan || isHidden ) {
 			return;
 		}
 
@@ -374,7 +373,6 @@ export default connect(
 			isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
 			typeObject: getPostType( state, siteId, type ),
-			isPrivate: isPrivateSite( state, siteId ),
 			isHidden: isHiddenSite( state, siteId ),
 		};
 	},

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -32,10 +32,7 @@ import {
 	isJetpackSite,
 } from 'state/sites/selectors';
 import config from 'config';
-import {
-	areSitePermalinksEditable,
-	isHiddenSite,
-} from 'state/selectors';
+import { areSitePermalinksEditable } from 'state/selectors';
 
 import EditorDrawerTaxonomies from './taxonomies';
 import EditorDrawerPageOptions from './page-options';
@@ -258,9 +255,8 @@ const EditorDrawer = React.createClass( {
 
 		const { plan } = this.props.site;
 		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-		const { isHidden } = this.props;
 
-		if ( ! hasBusinessPlan || isHidden ) {
+		if ( ! hasBusinessPlan ) {
 			return;
 		}
 
@@ -373,7 +369,6 @@ export default connect(
 			isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
 			typeObject: getPostType( state, siteId, type ),
-			isHidden: isHiddenSite( state, siteId ),
 		};
 	},
 	null,


### PR DESCRIPTION
Resolves: #13049

Allows users to mange SEO settings of private and hidden sites.

### Testing instructions

1. Use a test site that has a business plan and set its privacy to `private` or `hidden`. 
2. Navigate to `settings/traffic/` and verify that SEO fields are enabled and that correct notice is shown.
3. Open the post editor and verify that `SEO Description` accordion is now visible.
4. Revert site's privacy back to `public` and verify that notice is no longer shown in traffic tab.