### PR TITLE
Site Settings: Remove Photon copy from Media card

### DIFF
--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -115,14 +115,14 @@ class MediaSettings extends Component {
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
 								<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon" >
-									{ translate( 'Learn more about Photon.' ) }
+									{ translate( 'Learn more' ) }
 								</ExternalLink>
 							</InfoPopover>
 						</div>
 						<JetpackModuleToggle
 							siteId={ siteId }
 							moduleSlug="photon"
-							label={ translate( 'Speed up your images and photos with Photon' ) }
+							label={ translate( 'Speed up images and photos' ) }
 							description={ translate( 'Must be enabled to use tiled galleries.' ) }
 							disabled={ isRequestingOrSaving || photonModuleUnavailable }
 							/>


### PR DESCRIPTION
As discussed previously in Slack (p1495005647568060-slack-jetpack-settings-ui), to be consistent with Jetpack we need to update the Media card to not mention `Photon` at all. This PR removes the mention from the info popover and from the module toggle label.

Before:
![](https://cldup.com/CsvvoCOkh5.png)

After:
![](https://cldup.com/9Klui0RSzS.png)

Thanks to @eliorivero who noticed that for the dashboard item in Jetpack.