### PR TITLE
Locales: add es_MX locale definition

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -68,6 +68,7 @@
 		{ "value": 18, "langSlug": "eo", "name": "Esperanto", "wpLocale": "eo" },
 		{ "value": 19, "langSlug": "es", "name": "Español", "wpLocale": "es_ES", "popular": 2 },
 		{ "value": 484, "langSlug": "es-cl", "name": "Español de Chile", "wpLocale": "es_CL" },
+		{ "value": 902, "langSlug": "es-mx", "name": "Español de México", "wpLocale": "es_MX" },
 		{ "value": 20, "langSlug": "et", "name": "Eesti", "wpLocale": "et" },
 		{ "value": 429, "langSlug": "eu", "name": "Euskara", "wpLocale": "eu" },
 		{ "value": 21, "langSlug": "fa", "name": "فارسی", "wpLocale": "fa_IR", "rtl": true },


### PR DESCRIPTION
This locale has been added on WP.com but not synced to Calypso.

**Test:** make sure es-mx is available to choose in the language dropdown (user/blog settings) .