### PR TITLE
Automated transfer: Update eligibility plan check

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -13,7 +13,6 @@ import Gridicon from 'gridicons';
  */
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { PLAN_BUSINESS, FEATURE_UPLOAD_PLUGINS, FEATURE_UPLOAD_THEMES } from 'lib/plans/constants';
-import { isBusiness, isEnterprise } from 'lib/products-values';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getEligibility, isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -145,12 +144,12 @@ EligibilityWarnings.defaultProps = {
 const mapStateToProps = state => {
 	const {
 		ID: siteId,
-		plan,
 		slug: siteSlug,
 	} = getSelectedSite( state );
 	const eligibilityData = getEligibility( state, siteId );
 	const isEligible = isEligibleForAutomatedTransfer( state, siteId );
-	const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
+	const eligibilityHolds = get( eligibilityData, 'eligibilityHolds', [] );
+	const hasBusinessPlan = ! includes( eligibilityHolds, 'NO_BUSINESS_PLAN' );
 	const isJetpack = isJetpackSite( state, siteId );
 	const dataLoaded = !! eligibilityData.lastUpdate;
 


### PR DESCRIPTION
Ref: p8yzl4-6w-p2

In previous version we were querying the site's plan data to determine if it has a required plan. Sometimes that resulted in a mismatch with data returned from eligibility endpoint, in cases when blog stickers where not applied correctly to upgraded sites. Those sites were not allowed to initiate transfer, and no appropriate message about the missing business plan was shown.  

We are now altering this check in order to use the same data source, namely the data returned from eligibility endpoint.

### Testing instruction

* Everything should be working as before. We should check that sites with a business plan are allowed to proceed with transfer, and that correct warning is shown to sites that don't have a business plan (e.g. navigate directly to `plugins/buddypress/eligibility/{siteSlug}`).