### PR TITLE
Framework: fixed WebPreview touching edge (width)

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -51,13 +51,13 @@
 	transition: transform 0.2s ease-out,
 		opacity 0.1s ease-in-out,
 		max-width 0.2s ease-out;
-	width: 100%;
 
 	.is-computer & {
 		max-width: 1200px;
 		@include breakpoint( ">960px" ) {
 			left: 24px;
 			right: 24px;
+			width: calc( 100% - 48px ); /* IE11 fix */
 		}
 	}
 


### PR DESCRIPTION
The fix introduced in #9296 for IE11 broke the width on every other browser between 1248px and 960px, making the preview to go 24px beyond the right edge.

This patch adjusts the fix to be accurately sized considering the margins.

Before:

![screen shot 2017-05-17 at 16 23 56](https://cloud.githubusercontent.com/assets/4389/26159206/3b0290cc-3b1e-11e7-9431-dbc1652ec420.png)


After:

![screen shot 2017-05-17 at 16 23 49](https://cloud.githubusercontent.com/assets/4389/26159210/3fbe93f4-3b1e-11e7-8441-6c550d5834f9.png)

### To test 

1. Open this patch on any My Sites page
2. Open the Web Preview ("Site Preview")
3. Check the margins at three different sizes:
    * Less than 960px
    * Between 960px and 1248px
    * Larger than 1248px
4. Check on IE11 as well as all the other supported browsers (Chrome, Firefox, Edge, Safari)
