### PR TITLE
Login: Disable magic-login

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -34,7 +34,6 @@
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
-		"magic-login": true,
 		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,


### PR DESCRIPTION
Disable magic login in wp-calypso, so when we test /log-in we get a more realistic experience.
  
#### Testing instructions
  
1. Run `git checkout [branch]` and start your server, or open a [live branch](https://delphin.live/?branch=[branch])
2. Run Calypso with the wpcalypso environment: `NODE_ENV=wpcalypso make run`
2. Open the [`Login` page](http://calypso.localhost:3000/login)
3. Check that the `Email me a login link` link is not shown
  
#### Reviews
  
- [x] Code
- [x] Product



