### PR TITLE
Publicize: Semi-opaque avatars for disabled connections

### DIFF
--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -250,6 +250,11 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	border-radius: 50%;
 	position: relative;
 	flex: 0 0 32px;
+	opacity: 0.3;
+}
+
+.post-share__service.is-active .post-share__service-account-image {
+	opacity: 1;
 }
 
 .post-share__service-account-name {


### PR DESCRIPTION
Fixes #14175.

Before:
<img width="291" alt="screen shot 2017-05-17 at 16 51 19" src="https://cloud.githubusercontent.com/assets/908665/26163279/1d58be18-3b21-11e7-8287-86544689c802.png">

After:
<img width="291" alt="screen shot 2017-05-17 at 16 50 26" src="https://cloud.githubusercontent.com/assets/908665/26163298/236a1414-3b21-11e7-8132-49d30f10eb60.png">

