### PR TITLE
Reader: Fix aliasing font in following list

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -9,6 +9,10 @@
 	flex: 1 0 0%;
 }
 
+.following-manage__subscriptions-list {
+	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
+}
+
 .following-manage__subscriptions-list .reader-subscription-list-item__options {
 	display: flex;
 	flex-direction: column;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -10,7 +10,7 @@
 }
 
 .following-manage__subscriptions-list {
-	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
+	-webkit-font-smoothing: subpixel-antialiased; // Fixes aliasing in Safari
 }
 
 .following-manage__subscriptions-list .reader-subscription-list-item__options {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/13943

**Before:**
<img width="674" alt="screenshot 2017-05-17 10 28 53" src="https://cloud.githubusercontent.com/assets/4924246/26167598/0645e316-3aec-11e7-8db4-50429437b2ea.png">

**After:**
<img width="680" alt="screenshot 2017-05-17 10 29 00" src="https://cloud.githubusercontent.com/assets/4924246/26167600/0935735c-3aec-11e7-906a-b6854545b51f.png">
