### PR TITLE
Reader: Remove margin around single site rec

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -164,6 +164,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 	}
 
+	&:only-child {
+		margin-left: 0;
+		margin-right: 0;
+	}
+
 	.reader-subscription-list-item__byline {
 		margin-right: 0;
 		padding-right: 0;


### PR DESCRIPTION
We add left/right margins for standard, two-site recs, but after dismissing them all and ending up with a single rec, the margins are still intact. This PR removes margins around single-site recs.

**Before:**
![screenshot 2017-05-17 11 02 18](https://cloud.githubusercontent.com/assets/4924246/26168933/c31021a6-3af0-11e7-993e-289ed67c382c.png)

**After:**
![screenshot 2017-05-17 11 02 31](https://cloud.githubusercontent.com/assets/4924246/26168936/c6f0511a-3af0-11e7-9cf5-5ccff294b498.png)
