### PR TITLE
Reader Following Manage: show email settings immediately on follow (attempt two)

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -44,6 +44,7 @@ function ReaderSubscriptionListItem( {
 	followSource,
 	showEmailSettings,
 	showLastUpdatedDate,
+	isFollowing,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -54,7 +55,6 @@ function ReaderSubscriptionListItem( {
 	const streamUrl = getStreamUrl( feedId, siteId );
 	const feedUrl = url || getFeedUrl( { feed, site } );
 	const siteUrl = getSiteUrl( { feed, site } );
-	const isFollowing = ( site && site.is_following ) || ( feed && feed.is_following );
 	const isMultiAuthor = get( site, 'is_multi_author', false );
 	const preferGravatar = ! isMultiAuthor;
 	const lastUpdatedDate = showLastUpdatedDate && moment( get( feed, 'last_update' ) ).fromNow();

--- a/client/reader/following-manage/connected-subscription-list-item.jsx
+++ b/client/reader/following-manage/connected-subscription-list-item.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -11,6 +12,7 @@ import { noop } from 'lodash';
 import connectSite from 'lib/reader-connect-site';
 import userSettings from 'lib/user-settings';
 import SubscriptionListItem from 'blocks/reader-subscription-list-item';
+import { isFollowing as isFollowingSelector } from 'state/selectors';
 
 class ConnectedSubscriptionListItem extends React.Component {
 	static propTypes = {
@@ -22,6 +24,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 		onLoad: PropTypes.func,
 		showEmailSettings: PropTypes.bool,
 		showLastUpdatedDate: PropTypes.bool,
+		isFollowing: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -50,6 +53,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 			siteId,
 			showEmailSettings,
 			showLastUpdatedDate,
+			isFollowing,
 		} = this.props;
 		const isEmailBlocked = userSettings.getSetting( 'subscription_delivery_email_blocked' );
 
@@ -63,9 +67,12 @@ class ConnectedSubscriptionListItem extends React.Component {
 				url={ url }
 				showEmailSettings={ showEmailSettings && ! isEmailBlocked }
 				showLastUpdatedDate={ showLastUpdatedDate }
+				isFollowing={ isFollowing }
 			/>
 		);
 	}
 }
 
-export default localize( connectSite( ConnectedSubscriptionListItem ) );
+export default connect( ( state, ownProps ) => ( {
+	isFollowing: isFollowingSelector( state, { feedId: ownProps.feedId, blogId: ownProps.siteId } ),
+} ) )( localize( connectSite( ConnectedSubscriptionListItem ) ) );


### PR DESCRIPTION
We currently don't show the 'Settings' link for a new follow until after a page reload.

Fixes #14069.

Todo:
- [x] correct following status so link is shown
- [x] show correct initial settings in settings dialog

Original PR was https://github.com/Automattic/wp-calypso/pull/14172, but something went awry with git history.