### PR TITLE
Make animation of site preview more performant

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -34,6 +34,7 @@
 		right: 0;
 		bottom: 0;
 	display: block;
+	background: fade-out( $gray-light, .2 );
 }
 
 .web-preview__content {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -34,7 +34,7 @@
 		right: 0;
 		bottom: 0;
 	display: block;
-	background: fade-out( $gray-light, .2 );
+	background: rgba( $gray-light, 0.8 );
 }
 
 .web-preview__content {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -1,12 +1,3 @@
-.layout {
-	transition: all 0.4s ease-in-out;
-
-	.is-previewing & {
-		-webkit-filter: blur( 3px );
-		opacity: 0.2;
-	}
-}
-
 .layout__content {
 	@include clear-fix;
 	position: relative;


### PR DESCRIPTION
When you open a preview window, we animate it from the bottom of the screen and at the same time, we also animate ALL the content that is behind the modal (`.layout` element). We animate both `opacity` and `filter: blur` - the latter being the slowest thing we can do, applied to the biggest area of the screen that is possible. All that while we load a whole frontend of the site in an iframe. 

Unless you are in Safari on Mac, this will jank/jump/not-be-a-peformant-animation, regardless of your hardware. My Touchbar Macbook has trouble rendering the animation. The blurred background was also unprecedented, as no other modal does that.

This PR removes all transitions from `.layout` and adds a semi-transparent background color to modal backdrop (which was fully transparent before) to simulate the content "fadeout".

| Before | After |
| --- | --- |
| <img width="360" alt="screen shot 2017-05-17 at 15 05 29" src="https://cloud.githubusercontent.com/assets/156676/26172158/750d392e-3b15-11e7-92f7-47165d26a565.png"> | <img width="369" alt="screen shot 2017-05-17 at 15 08 47" src="https://cloud.githubusercontent.com/assets/156676/26172164/7a513eb2-3b15-11e7-9c87-8442139c7b75.png"> |