### PR TITLE
Reader: Fix follow button alignment site search

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -13,7 +13,8 @@
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes aliasing in Safari
 }
 
-.reader-subscription-list-item__options {
+.following-manage__subscriptions-list .reader-subscription-list-item__options,
+.following-manage__search-results .reader-subscription-list-item__options {
 	display: flex;
 	flex-direction: column;
 	min-width: 24px;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -13,7 +13,7 @@
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes aliasing in Safari
 }
 
-.following-manage__subscriptions-list .reader-subscription-list-item__options {
+.reader-subscription-list-item__options {
 	display: flex;
 	flex-direction: column;
 	min-width: 24px;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -13,8 +13,7 @@
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes aliasing in Safari
 }
 
-.following-manage__subscriptions-list .reader-subscription-list-item__options,
-.following-manage__search-results .reader-subscription-list-item__options {
+.following-manage__subscriptions-list .reader-subscription-list-item__options {
 	display: flex;
 	flex-direction: column;
 	min-width: 24px;

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -206,6 +206,23 @@
 	color: darken( $gray, 10% );
 }
 
+.following-manage__search-results .reader-subscription-list-item__options {
+	display: flex;
+	flex-direction: column;
+	min-width: 24px;
+
+	@include breakpoint( ">660px" ) {
+		min-width: 90px;
+	}
+
+	.button.follow-button {
+
+		@include breakpoint( ">660px" ) {
+			display: flex;
+		}
+	}
+}
+
 .following-manage__search-results.is-empty {
 	margin-top: 10px;
 }


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/issues/13433 and https://github.com/Automattic/wp-calypso/pull/13787.

Follow button alignment in Site Search needs to match that of Following.

**Before:**
![screenshot 2017-05-17 12 41 16](https://cloud.githubusercontent.com/assets/4924246/26172746/50378e18-3afe-11e7-983c-5da7ee24b853.png)

**After:**
![screenshot 2017-05-17 12 41 48](https://cloud.githubusercontent.com/assets/4924246/26172750/558d939e-3afe-11e7-9885-62cebf219e83.png)

