### PR TITLE
WooCommerce: Add product create save notifications

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -4,12 +4,14 @@
 import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { successNotice, errorNotice } from 'state/notices/actions';
 
 import { editProduct, editProductAttribute } from '../../state/ui/products/actions';
 import { getCurrentlyEditingProduct } from '../../state/ui/products/selectors';
@@ -62,8 +64,26 @@ class ProductCreate extends React.Component {
 	}
 
 	onSave = () => {
-		const { siteId, product } = this.props;
-		this.props.createProduct( siteId, product );
+		const { siteId, product, translate } = this.props;
+
+		const successAction = () => {
+			return successNotice(
+				translate( '%(product)s successfully created.', {
+					args: { product: product.name },
+				} ),
+				{ duration: 4000 }
+			);
+		};
+
+		const errorAction = () => {
+			return errorNotice(
+				translate( 'There was a problem saving %(product)s. Please try again.', {
+					args: { product: product.name },
+				} )
+			);
+		};
+
+		this.props.createProduct( siteId, product, successAction, errorAction );
 	}
 
 	render() {
@@ -115,4 +135,4 @@ function mapDispatchToProps( dispatch ) {
 	);
 }
 
-export default connect( mapStateToProps, mapDispatchToProps )( ProductCreate );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ProductCreate ) );

--- a/client/extensions/woocommerce/components/action-header.js
+++ b/client/extensions/woocommerce/components/action-header.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import StickyPanel from 'components/sticky-panel';
+
+const ActionHeader = ( { children } ) => {
+	// TODO: Implement breadcrumbs component.
+
+	return (
+		<StickyPanel>
+			<Card className="components__action-header">
+				<span>Breadcrumbs > go > here</span>
+				<div className="components__action-header-actions">
+					{ children }
+				</div>
+			</Card>
+		</StickyPanel>
+	);
+};
+
+export default ActionHeader;
+

--- a/client/extensions/woocommerce/state/wc-api/products/actions.js
+++ b/client/extensions/woocommerce/state/wc-api/products/actions.js
@@ -8,7 +8,16 @@ import {
 	WOOCOMMERCE_API_CREATE_PRODUCT_SUCCESS,
 } from '../../action-types';
 
-export function createProduct( siteId, product ) {
+/**
+ * API call to create a product within designated WooCommerce site.
+ *
+ * @param {Number} siteId The Jetpack Site ID for the WooCommerce WordPress site.
+ * @param {Object} product The product data to be created.
+ * @param {Function} successAction Action creator, runs upon success, format of `function( data )`
+ * @param {Function} failureAction Action creator, runs upon failure, format of `function( err )`
+ * @returns {Object|Function} Object or thunk to be dispatched
+ */
+export function createProduct( siteId, product, successAction = null, failureAction = null ) {
 	return ( dispatch ) => {
 		const createAction = {
 			type: WOOCOMMERCE_API_CREATE_PRODUCT,
@@ -21,11 +30,10 @@ export function createProduct( siteId, product ) {
 		const { id, ...productData } = product;
 
 		if ( typeof id === 'number' ) {
-			dispatch( error( siteId, createAction, {
+			return error( siteId, createAction, {
 				message: 'Attempting to create a product which already has a valid id.',
 				product,
-			} ) );
-			return;
+			} );
 		}
 
 		const jetpackProps = { path: `/jetpack-blogs/${ siteId }/rest-api/` };
@@ -39,9 +47,15 @@ export function createProduct( siteId, product ) {
 		return wp.req.post( jetpackProps, httpProps )
 			.then( ( { data } ) => {
 				dispatch( createProductSuccess( siteId, data ) );
+				if ( successAction ) {
+					dispatch( successAction( data ) );
+				}
 			} )
 			.catch( err => {
 				dispatch( error( siteId, createAction, err ) );
+				if ( failureAction ) {
+					dispatch( failureAction( err ) );
+				}
 			} );
 	};
 }


### PR DESCRIPTION
This adds notifications for when you save your newly created product.

Depends on #13733 

To Test (success):

1. `make run`
2. Visit http://calypso.localhost:3000/store/products/<your site url>/add
3. Add a name to the product, other stuff if you want (variations don't save yet)
4. Click Save.
5. A success notification should pop up and then go away after 4 seconds.

To Test (failure):

1. Go to your Jetpack-connected WooCommerce site and disable the WooCommerce plugin.
2. Try the instructions above.
3. An error notification should pop up and not go away until you dismiss it.
