### PR TITLE
restoreLastLocation: use localforage, don't redir outside Calypso

### DIFF
--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -22,25 +22,28 @@ export const restoreLastLocation = () => {
 			return next( action );
 		}
 
-		localforage.getItem( LAST_PATH ).then( ( lastPath ) => {
-			if ( ! hasInitialized &&
-					lastPath && lastPath !== '/' &&
-					action.path === '/' &&
-					! isOutsideCalypso( lastPath ) ) {
-				debug( 'redir to', lastPath );
-				page( lastPath );
-			} else if ( action.path !== lastPath &&
-					! isOutsideCalypso( action.path ) ) {
-				debug( 'saving', action.path );
-				localforage.setItem( LAST_PATH, action.path );
-			}
+		localforage.getItem( LAST_PATH ).then(
+			( lastPath ) => {
+				if ( ! hasInitialized &&
+						lastPath && lastPath !== '/' &&
+						action.path === '/' &&
+						! isOutsideCalypso( lastPath ) ) {
+					debug( 'redir to', lastPath );
+					page( lastPath );
+				} else if ( action.path !== lastPath &&
+						! isOutsideCalypso( action.path ) ) {
+					debug( 'saving', action.path );
+					localforage.setItem( LAST_PATH, action.path );
+				}
 
-			if ( ! hasInitialized ) {
-				hasInitialized = true;
-			}
+				if ( ! hasInitialized ) {
+					hasInitialized = true;
+				}
 
-			return next( action );
-		} );
+				return next( action );
+			},
+			() => next( action )
+		);
 	};
 };
 

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -3,32 +3,33 @@
  */
 import debugFactory from 'debug';
 import page from 'page';
-import store from 'store';
 
 /**
  * Internal dependencies
  */
+import localforage from 'lib/localforage';
 import { ROUTE_SET } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:restore-last-location' );
+const key = 'last_path';
 
 let hasInitialized = false;
 
 export const restoreLastLocation = () => ( next ) => ( action ) => {
 	if ( action.type === ROUTE_SET && action.path ) {
-		const lastPath = store.get( 'last_path' );
+		localforage.getItem( key ).then( ( lastPath ) => {
+			if ( ! hasInitialized && lastPath && lastPath !== '/' && action.path === '/' ) {
+				debug( 'redir to', lastPath );
+				page( lastPath );
+			} else if ( action.path !== lastPath ) {
+				debug( 'saving', action.path );
+				localforage.setItem( key, action.path );
+			}
 
-		if ( ! hasInitialized && lastPath && lastPath !== '/' && action.path === '/' ) {
-			debug( 'redir to', action.path );
-			page( lastPath );
-		} else {
-			debug( 'saving', action.path );
-			store.set( 'last_path', action.path );
-		}
-
-		if ( ! hasInitialized ) {
-			hasInitialized = true;
-		}
+			if ( ! hasInitialized ) {
+				hasInitialized = true;
+			}
+		} );
 	}
 
 	return next( action );


### PR DESCRIPTION
Refinement of #14070 as suggested by @gwwar ([#](https://github.com/Automattic/wp-calypso/pull/14070#discussion_r116893106))

# Testing

Same instructions as #14070; behavior preserved, save for the improvement that the a user should never be redirected from `/` to somewhere external to Calypso.