### PR TITLE
Publicize: add linkedin preview

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -161,6 +161,7 @@
 @import 'components/share/facebook-share-preview/style';
 @import 'components/share/google-plus-share-preview/style';
 @import 'components/share/tumblr-share-preview/style';
+@import 'components/share/linkedin-share-preview/style';
 @import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -12,6 +12,7 @@ import { get, find } from 'lodash';
 import { getPostImage, getExcerptForPost } from './utils';
 import FacebookSharePreview from 'components/share/facebook-share-preview';
 import GooglePlusSharePreview from 'components/share/google-plus-share-preview';
+import LinkedinSharePreview from 'components/share/linkedin-share-preview';
 import TwitterSharePreview from 'components/share/twitter-share-preview';
 import TumblrSharePreview from 'components/share/tumblr-share-preview';
 import VerticalMenu from 'components/vertical-menu';
@@ -39,6 +40,7 @@ class SharingPreviewPane extends PureComponent {
 		services: [
 			'facebook',
 			'google_plus',
+			'linkedin',
 			'twitter',
 			'tumblr',
 		]
@@ -89,6 +91,8 @@ class SharingPreviewPane extends PureComponent {
 				return <GooglePlusSharePreview { ...previewProps } />;
 			case 'tumblr':
 				return <TumblrSharePreview { ...previewProps } />;
+			case 'linkedin':
+				return <LinkedinSharePreview { ...previewProps } />;
 			case 'twitter':
 				return <TwitterSharePreview
 					{ ...previewProps }

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -55,7 +55,7 @@ class SharingPreviewPane extends PureComponent {
 	};
 
 	renderPreview() {
-		const { post, message, connections } = this.props;
+		const { post, site, message, connections } = this.props;
 		const { selectedService } = this.state;
 		const connection = find( connections, { service: selectedService } );
 		if ( ! connection ) {
@@ -65,6 +65,7 @@ class SharingPreviewPane extends PureComponent {
 		const articleUrl = get( post, 'URL', '' );
 		const articleTitle = get( post, 'title', '' );
 		const articleContent = getExcerptForPost( post );
+		const siteDomain = get( site, 'domain', '' );
 		const imageUrl = getPostImage( post );
 		const {
 			external_name: externalName,
@@ -77,11 +78,13 @@ class SharingPreviewPane extends PureComponent {
 			articleUrl,
 			articleTitle,
 			articleContent,
+			externalDisplay,
 			externalName,
 			externalProfileURL,
 			externalProfilePicture,
 			message,
 			imageUrl,
+			siteDomain,
 		};
 
 		switch ( selectedService ) {

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -22,8 +22,7 @@ export class LinkedinSharePreview extends PureComponent {
 			externalProfileUrl,
 			externalName,
 			imageUrl,
-			message,
-			translate
+			message
 		} = this.props;
 		return (
 			<div className="linkedin-share-preview">
@@ -40,41 +39,33 @@ export class LinkedinSharePreview extends PureComponent {
 								<a className="linkedin-share-preview__profile-name" href={ externalProfileUrl }>
 									{ externalName }
 								</a>
-								<span>
-									{
-										translate( 'published an article on {{a}}WordPress{{/a}}', {
-											components: {
-												a: <a href="#" />
-											}
-										} )
-									}
-								</span>
 							</div>
 							<div className="linkedin-share-preview__meta-line">
-								<a href="https://wordpress.com">
-									{ translate( 'WordPress' ) }
-								</a>
+								companyName
 							</div>
 						</div>
 					</div>
 					<div className="linkedin-share-preview__body">
-						<div className="linkedin-share-preview__message">
-							{ message }
-						</div>
-						<div className="linkedin-share-preview__article-url-line">
-							<a className="linkedin-share-preview__article-url"
-								href={ articleUrl }>
-								{ articleUrl }
-							</a>
-						</div>
 						{ imageUrl &&
 							<div className="linkedin-share-preview__image-wrapper">
-								<img
-									className="linkedin-share-preview__image"
-									src={ imageUrl }
-								/>
+								<a href={ articleUrl }>
+									<img
+										className="linkedin-share-preview__image"
+										src={ imageUrl }
+									/>
+								</a>
 							</div>
 						}
+						<div className="linkedin-share-preview__message-part">
+							<a href={ articleUrl }>
+								<div className="linkedin-share-preview__message">
+									{ message }
+								</div>
+								<div className="linkedin-share-preview__site-url">
+									siteUrl
+								</div>
+							</a>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+export class LinkedinSharePreview extends PureComponent {
+
+	static PropTypes = {
+		articleUrl: PropTypes.string,
+		externalProfilePicture: PropTypes.string,
+		externalProfileUrl: PropTypes.string,
+		externalName: PropTypes.string,
+		imageUrl: PropTypes.string,
+		message: PropTypes.string,
+	};
+
+	render() {
+		const {
+			articleUrl,
+			externalProfilePicture,
+			externalProfileUrl,
+			externalName,
+			imageUrl,
+			message,
+			translate
+		} = this.props;
+		return (
+			<div className="linkedin-share-preview">
+				<div className="linkedin-share-preview__content">
+					<div className="linkedin-share-preview__header">
+						<div className="linkedin-share-preview__profile-picture-part">
+							<img
+								className="linkedin-share-preview__profile-picture"
+								src={ externalProfilePicture }
+							/>
+						</div>
+						<div className="linkedin-share-preview__profile-line-part">
+							<div className="linkedin-share-preview__profile-line">
+								<a className="linkedin-share-preview__profile-name" href={ externalProfileUrl }>
+									{ externalName }
+								</a>
+								<span>
+									{
+										translate( 'published an article on {{a}}WordPress{{/a}}', {
+											components: {
+												a: <a href="#" />
+											}
+										} )
+									}
+								</span>
+							</div>
+							<div className="linkedin-share-preview__meta-line">
+								<a href="https://wordpress.com">
+									{ translate( 'WordPress' ) }
+								</a>
+							</div>
+						</div>
+					</div>
+					<div className="linkedin-share-preview__body">
+						<div className="linkedin-share-preview__message">
+							{ message }
+						</div>
+						<div className="linkedin-share-preview__article-url-line">
+							<a className="linkedin-share-preview__article-url"
+								href={ articleUrl }>
+								{ articleUrl }
+							</a>
+						</div>
+						{ imageUrl &&
+							<div className="linkedin-share-preview__image-wrapper">
+								<img
+									className="linkedin-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( LinkedinSharePreview );

--- a/client/components/share/linkedin-share-preview/index.jsx
+++ b/client/components/share/linkedin-share-preview/index.jsx
@@ -10,19 +10,21 @@ export class LinkedinSharePreview extends PureComponent {
 		articleUrl: PropTypes.string,
 		externalProfilePicture: PropTypes.string,
 		externalProfileUrl: PropTypes.string,
-		externalName: PropTypes.string,
 		imageUrl: PropTypes.string,
 		message: PropTypes.string,
+		name: PropTypes.string,
+		siteDomain: PropTypes.string,
 	};
 
 	render() {
 		const {
 			articleUrl,
+			externalDisplay,
 			externalProfilePicture,
 			externalProfileUrl,
-			externalName,
 			imageUrl,
-			message
+			message,
+			siteDomain,
 		} = this.props;
 		return (
 			<div className="linkedin-share-preview">
@@ -37,11 +39,8 @@ export class LinkedinSharePreview extends PureComponent {
 						<div className="linkedin-share-preview__profile-line-part">
 							<div className="linkedin-share-preview__profile-line">
 								<a className="linkedin-share-preview__profile-name" href={ externalProfileUrl }>
-									{ externalName }
+									{ externalDisplay }
 								</a>
-							</div>
-							<div className="linkedin-share-preview__meta-line">
-								companyName
 							</div>
 						</div>
 					</div>
@@ -57,12 +56,12 @@ export class LinkedinSharePreview extends PureComponent {
 							</div>
 						}
 						<div className="linkedin-share-preview__message-part">
-							<a href={ articleUrl }>
+							<a className="linkedin-share-preview__message-link" href={ articleUrl }>
 								<div className="linkedin-share-preview__message">
 									{ message }
 								</div>
 								<div className="linkedin-share-preview__site-url">
-									siteUrl
+									{ siteDomain }
 								</div>
 							</a>
 						</div>

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -1,0 +1,90 @@
+.linkedin-share-preview {
+	background: $white;
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 3px rgba(0, 0, 0, 0.2);
+	font-family: Source Sans Pro,Helvetica,Arial,sans-serif,Hiragino Kaku Gothic Pro,Meiryo,Hiragino Sans GB W3,Noto Naskh Arabic,Droid Arabic Naskh,Geeza Pro,Simplified Arabic,Noto Sans Thai,Thonburi,Dokchampa,Droid Sans Thai,Droid Sans Fallback,-apple-system,'.SFNSDisplay-Regular',Heiti SC,Microsoft Yahei,Segoe UI;
+	margin: 0 auto;
+	max-width: 552px;
+	padding: 16px;
+}
+
+.linkedin-share-preview__header {
+	display: flex;
+}
+
+.linkedin-share-preview__profile-picture-part {
+	flex: 0 0 48px;
+}
+
+.linkedin-share-preview__profile-picture {
+	border-radius: 50%;
+	display: block;
+	height: 48px;
+	width: 48px;
+}
+
+.linkedin-share-preview__profile-line-part {
+	margin-left: 8px;
+}
+
+.linkedin-share-preview__profile-line {
+	font-size: 15px;
+	line-height: 20px;
+}
+
+.linkedin-share-preview__profile-name {
+	color: rgba(0, 0, 0, 0.85);
+	font-weight: 600;
+}
+
+.linkedin-share-preview__meta-line {
+	color: rgba(0, 0, 0, 0.55);
+    font-size: 13px;
+    line-height: 16px;
+}
+
+.linkedin-share-preview__body {
+	align-items: center;
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+	display: flex;
+	margin-top: 16px;
+	padding: 8px;
+}
+
+.linkedin-share-preview__image-wrapper {
+	flex: 0 0 138px;
+	height: 72px;
+	margin-right: 8px;
+	max-width: 138px;
+	overflow: hidden;
+	position: relative;
+}
+
+.linkedin-share-preview__image {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+}
+
+.linkedin-share-preview__message {
+	color: rgba(0, 0, 0, 0.85);
+	display: -webkit-box;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 16px;
+	max-height: 40px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+.linkedin-share-preview__site-url {
+	color: rgba(0, 0, 0, 0.55);
+	font-size: 13px;
+	font-weight: 400;
+	line-height: 16px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	word-wrap: break-word;
+}

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -66,6 +66,9 @@
 	transform: translateY(-50%);
 }
 
+.linkedin-share-preview__message-link {
+	text-decoration: none;
+}
 .linkedin-share-preview__message {
 	color: rgba(0, 0, 0, 0.85);
 	display: -webkit-box;


### PR DESCRIPTION
This adds Linkedin to publicize preview.
**Testing**
- Enable publicize sharing on `calypso.localhost:3000` : `ENABLE_FEATURES=publicize-scheduling make run`
- Authorize Linkedin on a premium site
- Open the sharing tab on a published post
- Click 'Preview'
- Linkedin should be available for previewing
- Clicking "Linkedin share" on the left should show the correct linkedin share preview

_breaks up #12644_