### PR TITLE
Domains: Allow transferring domains and contact and DNS updates during renewal grace period

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -122,25 +122,21 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	getVerticalNav() {
-		if ( this.props.domain.expired ) {
-			return null;
-		}
+		const { expirationMoment, expired, pendingTransfer } = this.props.domain;
+		const inNormalState = ! pendingTransfer && ! expired;
+		const inGracePeriod = this.moment().subtract( 18, 'days' ) <= expirationMoment;
 
 		return (
 			<VerticalNav>
-				{ this.emailNavItem() }
-				{ this.nameServersNavItem() }
-				{ this.contactsPrivacyNavItem() }
-				{ this.transferNavItem() }
+				{ inNormalState && this.emailNavItem() }
+				{ ( inNormalState || inGracePeriod ) && this.nameServersNavItem() }
+				{ ( inNormalState || inGracePeriod ) && this.contactsPrivacyNavItem() }
+				{ ( ! expired || inGracePeriod ) && this.transferNavItem() }
 			</VerticalNav>
 		);
 	},
 
 	emailNavItem() {
-		if ( this.props.domain.pendingTransfer ) {
-			return null;
-		}
-
 		const path = paths.domainManagementEmail(
 			this.props.selectedSite.slug,
 			this.props.domain.name
@@ -154,10 +150,6 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	nameServersNavItem() {
-		if ( this.props.domain.pendingTransfer ) {
-			return null;
-		}
-
 		const path = paths.domainManagementNameServers(
 			this.props.selectedSite.slug,
 			this.props.domain.name
@@ -171,10 +163,6 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	contactsPrivacyNavItem() {
-		if ( this.props.domain.pendingTransfer ) {
-			return null;
-		}
-
 		const path = paths.domainManagementContactsPrivacy(
 			this.props.selectedSite.slug,
 			this.props.domain.name


### PR DESCRIPTION
ICANN mandates us to allow transferring domains that have expired, but are in the grace period. It also makes sense to allow contact updates during that period, since that might be required for the transfer to succeed. And since I'm here, I've also enabled DNS updates during that period as well - users might want to point the domain to the new registrar/host while the domain is in progress, etc.

## Testing
Get an expired domain and verify that you can transfer it and update its contact info and DNS records.
Verify that there are no changes for domains in normal state and ones pending transfer.

Domain in normal state:
<img width="752" alt="screen shot 2017-05-18 at 22 13 19" src="https://cloud.githubusercontent.com/assets/3392497/26221607/67c97fd6-3c17-11e7-8a3e-97208f0843fa.png">


Expired domain (basically, the `Email` link is hidden):
<img width="748" alt="screen shot 2017-05-18 at 22 14 27" src="https://cloud.githubusercontent.com/assets/3392497/26221616/7416eae4-3c17-11e7-87b4-2863d25f00d1.png">
