### PR TITLE
Login: Reset the code input value when switching between methods in `VerificationCodeForm`

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -41,6 +41,13 @@ class VerificationCodeForm extends Component {
 		twoStepCode: ''
 	};
 
+	componentWillReceiveProps = ( nextProps ) => {
+		if ( this.props.twoFactorAuthType !== nextProps.twoFactorAuthType ) {
+			// reset the code input value when changing pages
+			this.setState( { twoStepCode: '' } );
+		}
+	};
+
 	onChangeField = ( event ) => {
 		this.setState( {
 			[ event.target.name ]: event.target.value,
@@ -102,6 +109,7 @@ class VerificationCodeForm extends Component {
 						</FormLabel>
 
 						<FormTextInput
+							value={ this.state.twoStepCode }
 							onChange={ this.onChangeField }
 							className={ classNames( { 'is-error': isError } ) }
 							name="twoStepCode" />


### PR DESCRIPTION
Fixes #14160.

![gif](https://cloud.githubusercontent.com/assets/1130674/26178368/89005554-3b12-11e7-8d37-ffb588c97609.gif)

**Testing**
- Visit `/log-in`.
- Submit credentials for an account with SMS or Authenticator as its 2FA method.
- Assert that the code is cleared when you switch between different 2FA methods.

- [x] Code
- [x] Product