### PR TITLE
Login: Remove prompt to use the old login page if unproxied

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -9,7 +9,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import LoginForm from './login-form';
 import {
 	getTwoFactorAuthNonce,
@@ -68,30 +67,8 @@ class Login extends Component {
 			return null;
 		}
 
-		let message;
-
-		if ( requestError.message === 'proxy_required' ) {
-			// TODO: Remove once the proxy requirement is removed from the API
-
-			let redirectTo = '';
-
-			if ( typeof window !== 'undefined' && window.location.search.indexOf( '?redirect_to=' ) === 0 ) {
-				redirectTo = window.location.search;
-			}
-
-			message = (
-				<div>
-					This endpoint is restricted to proxied Automatticians for now. Please use
-					{ ' ' }
-					<a href={ config( 'login_url' ) + redirectTo }>the old login page</a>.
-				</div>
-			);
-		} else {
-			message = requestError.message;
-		}
-
 		return (
-			<Notice status={ 'is-error' } showDismiss={ false }>{ message }</Notice>
+			<Notice status={ 'is-error' } showDismiss={ false }>{ requestError.message }</Notice>
 		);
 	}
 

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -94,14 +94,8 @@ export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch =
 				data: response.body && response.body.data,
 			} );
 		} ).catch( ( error ) => {
-			let message = getMessageFromHTTPError( error );
-			let field = loginErrorFields[ get( error, 'response.body.data.errors', [] )[ 0 ] ];
-
-			if ( error.crossDomain ) {
-				// We use custom field/message values here as this case is handled with JSX in `LoginForm`
-				field = 'global';
-				message = 'proxy_required';
-			}
+			const message = getMessageFromHTTPError( error );
+			const field = loginErrorFields[ get( error, 'response.body.data.errors', [] )[ 0 ] ];
 
 			dispatch( {
 				type: LOGIN_REQUEST_FAILURE,


### PR DESCRIPTION
We updated new Login page to work also when unproxied. We no longer need changes introduced in #13782. This PR removed code that was added last week.

**Testing**
- Visit http://calypso.localhost:3000/log-in or https://calypso.live/log-in?branch=remove/login-proxy-error while unproxied.
- Submit the form.
- Assert that you are logged in when valid credentials were provided.

- [x] Code
- [x] Product