### PR TITLE
Remove Jetpack restriction on plan-storage block

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -35,10 +35,20 @@ const UNLIMITED_STORAGE_PLANS = [
 class PlanStorage extends Component {
 	static propTypes = {
 		className: PropTypes.string,
-		mediaStorage: PropTypes.object,
-		siteId: PropTypes.number,
+		mediaStorage: PropTypes.shape( {
+			max_storage_bytes: PropTypes.number.isRequired,
+			storage_used_bytes: PropTypes.number.isRequired,
+		} ).isRequired,
+		siteId: PropTypes.number.isRequired,
 		sitePlanSlug: PropTypes.string,
 		siteSlug: PropTypes.string,
+	};
+
+	static defaultProps = {
+		mediaStorage: {
+			max_storage_bytes: -1,
+			storage_used_bytes: -1,
+		},
 	};
 
 	render() {

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -4,6 +4,7 @@
 import classNames from 'classnames';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,11 +14,23 @@ import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import {
 	getSitePlanSlug,
 	getSiteSlug,
-	isJetpackSite
 } from 'state/sites/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import {
+	PLAN_BUSINESS,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
 
 import PlanStorageBar from './bar';
+
+/**
+ * Constants
+ */
+const UNLIMITED_STORAGE_PLANS = [
+	PLAN_BUSINESS,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+];
 
 class PlanStorage extends Component {
 	static propTypes = {
@@ -31,17 +44,17 @@ class PlanStorage extends Component {
 	render() {
 		const {
 			className,
-			jetpackSite,
+			mediaStorage,
 			siteId,
 			sitePlanSlug,
 			siteSlug,
 		} = this.props;
 
-		if ( jetpackSite || ! sitePlanSlug ) {
+		if ( ! sitePlanSlug ) {
 			return null;
 		}
 
-		if ( sitePlanSlug === PLAN_BUSINESS ) {
+		if ( includes( UNLIMITED_STORAGE_PLANS, sitePlanSlug ) ) {
 			return null;
 		}
 
@@ -51,7 +64,7 @@ class PlanStorage extends Component {
 				<PlanStorageBar
 					siteSlug={ siteSlug }
 					sitePlanSlug={ sitePlanSlug }
-					mediaStorage={ this.props.mediaStorage }
+					mediaStorage={ mediaStorage }
 				>
 					{ this.props.children }
 				</PlanStorageBar>
@@ -64,7 +77,6 @@ export default connect( ( state, ownProps ) => {
 	const { siteId } = ownProps;
 	return {
 		mediaStorage: getMediaStorage( state, siteId ),
-		jetpackSite: isJetpackSite( state, siteId ),
 		sitePlanSlug: getSitePlanSlug( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	};


### PR DESCRIPTION
`PlanStorage` currently renders `null` for Jetpack sites. However, Jetpack sites may use storage and storage usage reporting will be added (see #12507 for an example).

* Remove Jetpack restriction to render this block for Jetpack sites. We should be able to continue to rely on the API to tell us how much storage a site has, whether Jetpack or not.
* Expand `PLAN_BUSINESS` check to include unlimited Jetpack plans (don't render the bar for plans with no maximum).
* Improve `propTypes`.

See D5652-code which handles reporting Jetpack storage from the API.

To test:
* Point public-api.wordpress.com to sandbox and apply D5652-code.
* ...
* Ensure the storage bar continue to function correctly in other contexts.