### PR TITLE
Login: Fix redirect not working after succesfull 2FA push notification

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -9,6 +9,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import LoginForm from './login-form';
 import {
 	getTwoFactorAuthNonce,
@@ -120,6 +121,8 @@ class Login extends Component {
 
 		return (
 			<div>
+				<DocumentHead title={ translate( 'Log In', { textOnly: true } ) } />
+
 				<div className="login__form-header">
 					{ twoStepNonce ? translate( 'Two-Step Authentication' ) : translate( 'Log in to your account.' ) }
 				</div>

--- a/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
+++ b/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
@@ -40,8 +40,6 @@ class WaitingTwoFactorNotificationApproval extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! this.props.pushSuccess && nextProps.pushSuccess ) {
-			const { translate } = this.props;
-			this.props.successNotice( translate( 'Logging In…' ) );
 			this.props.onSuccess();
 		}
 	}
@@ -53,12 +51,14 @@ class WaitingTwoFactorNotificationApproval extends Component {
 			<form>
 				<Card className="two-factor-authentication__push-notification-screen is-compact">
 					<p>
-						{ translate( 'We sent a push notification to your {{strong}}WordPress mobile app{{/strong}}. ' +
+						{ translate(
+							'We sent a push notification to your {{strong}}WordPress mobile app{{/strong}}. ' +
 							'Once you get it and swipe or tap to confirm, this page will update.', {
 								components: {
 									strong: <strong />
 								}
-							} ) }
+							} )
+						}
 					</p>
 					<div>
 						<img className="two-factor-authentication__auth-code-preview"

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -173,7 +173,7 @@ export const sendSmsCode = ( userId, twoStepNonce ) => dispatch => {
 			const message = translate( 'A text message with the verification code was just sent to your ' +
 				'phone number ending in %(phoneNumber)s', {
 					args: {
-						phoneNumber: phoneNumber
+						phoneNumber
 					}
 				}
 			);


### PR DESCRIPTION
This pull request fixes #14210 in order to redirect the user to the `Reader` page after a successful login with 2FA and push notification. It also adds a page title to the `Login` pages.
  
#### Testing instructions
 
1. Run `git checkout fix/login-with-2fa-push` and start your server, or open a [live branch](https://calypso.live/?branch=fix/login-with-2fa-push)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in) in an incognito window
3. Check that the title of the page is now `Log In`
4. Enter credentials of a 2FA account that has push notifications enabled
5. Check that you are redirected to the [`Reader` page](http://calypso.localhost:3000/) once you have allowed the login request

#### Reviews
 
- [x] Code
- [x] Product