### PR TITLE
Signup: Add a/b test for reduced theme choices in signup.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,4 +92,12 @@ module.exports = {
 		},
 		defaultVariation: 'hide',
 	},
+	reduceThemesInSignupTest: {
+		datestamp: '20170518',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+	},
 };

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -11,6 +11,7 @@ import { identity } from 'lodash';
  */
 import getThemes from 'lib/signup/themes';
 import ThemesList from 'components/themes-list';
+import { abtest } from 'lib/abtest';
 
 class SignupThemesList extends Component {
 
@@ -33,6 +34,10 @@ class SignupThemesList extends Component {
 	}
 
 	getComputedThemes() {
+		if ( abtest( 'reduceThemesInSignupTest' ) === 'modified' ) {
+			return getThemes( this.props.surveyQuestion, this.props.designType, 3 );
+		}
+
 		return getThemes( this.props.surveyQuestion, this.props.designType );
 	}
 


### PR DESCRIPTION
This test will reduce the number of theme choices in the signup flow from 9 to 3. We'll see if people make a choice better with the decreased number.

See p7EOS0-1iO-p2 for the detail.