### PR TITLE
Themes: Prevent download link showing for premium themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -293,7 +293,7 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderOverviewTab() {
-		const { download, isWpcomTheme, siteSlug, taxonomies } = this.props;
+		const { download, isWpcomTheme, siteSlug, taxonomies, isPremium } = this.props;
 
 		return (
 			<div>
@@ -303,7 +303,7 @@ const ThemeSheet = React.createClass( {
 				<ThemeFeaturesCard taxonomies={ taxonomies }
 					siteSlug={ siteSlug }
 					isWpcomTheme={ isWpcomTheme } />
-				{ download && <ThemeDownloadCard href={ download } /> }
+				{ download && ! isPremium && <ThemeDownloadCard href={ download } /> }
 				{ isWpcomTheme && this.renderRelatedThemes() }
 				{ isWpcomTheme && this.renderNextTheme() }
 			</div>


### PR DESCRIPTION
**Before**
<img width="672" alt="screen shot 2017-05-18 at 15 07 33" src="https://cloud.githubusercontent.com/assets/7767559/26206228/2065461a-3bdc-11e7-8362-fd429123d875.png">

**After**
<img width="799" alt="screen shot 2017-05-18 at 15 07 50" src="https://cloud.githubusercontent.com/assets/7767559/26206236/259969cc-3bdc-11e7-8a80-7507190cc6aa.png">


#12375 moved most of the download link logic to the theme details API endpoint. As a result, any theme with a zip is showing a download link in Calypso, including premium themes.

Add a check to prevent the download card showing for premiums.

**To Test**
* Check that the download link is not showing for premium themes, for example:   https://calypso.live/theme/little-story?branch=fix/premium-theme-download-showing
* The download link should show for all free themes
