### PR TITLE
Plans: Remove Jetpack auto-config from staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -69,7 +69,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans/jetpack-config-v2": true,
+		"plans/jetpack-config-v2": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"press-this": true,


### PR DESCRIPTION
We are noticing some issues with the auto config for Jetpack plans which is currently in staging. This PR removes that from staging so that we're not impacting testing efforts.

The auto-config for Jetpack plans will still be available in `wpcalypso`.