### PR TITLE
Login: Fix inability to log in with Internet Explorer

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 
@@ -94,7 +95,7 @@ class Login extends Component {
 			rememberMe,
 		} = this.state;
 
-		if ( twoStepNonce && [ 'authenticator', 'sms', 'backup' ].includes( twoFactorAuthType ) ) {
+		if ( twoStepNonce && includes( [ 'authenticator', 'sms', 'backup' ], twoFactorAuthType ) ) {
 			return (
 				<VerificationCodeForm
 					rememberMe={ rememberMe }


### PR DESCRIPTION
This pull request fixes #14213 in order to allow users to log in again with Internet Explorer from the new `Login` page. To be more specific, it actually fixes an `Object doesn't support property or method 'includes'` error that was triggered upon submitting credentials (unfortunately this error wouldn't appear in the browser's console) because we don't polyfill `Array.includes()`.
  
#### Testing instructions
 
1. Run `git checkout fix/login-with-ie` and start your server, or open a [live branch](https://calypso.live/?branch=fix/login-with-ie)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in) in an incognito window on Internet Explorer
3. Check that you can log in and that you are redirected to the [`Reader` page](http://calypso.localhost:3000)
 
#### Reviews
 
- [x] Code
- [ ] Product