### PR TITLE
Add Array.includes to wrapped warned es6 functions

### DIFF
--- a/client/lib/wrap-es6-functions/index.js
+++ b/client/lib/wrap-es6-functions/index.js
@@ -22,7 +22,7 @@ function wrapObjectFn( obj, objectName, key ) {
 }
 
 export default function() {
-	[ 'keys', 'entries', 'values', 'findIndex', 'fill', 'find' ]
+	[ 'keys', 'entries', 'values', 'findIndex', 'fill', 'find', 'includes' ]
 		.map( partial( wrapObjectFn, Array.prototype, 'Array#' ) );
 
 	[ 'codePointAt', 'normalize', 'repeat', 'startsWith', 'endsWith', 'includes' ]

--- a/client/lib/wrap-es6-functions/test/index.js
+++ b/client/lib/wrap-es6-functions/test/index.js
@@ -23,7 +23,7 @@ describe( 'wrap-es6-functions', () => {
 		sandbox.stub( console, 'error' );
 
 		fromPairs( [
-			[ Array, [ 'keys', 'entries', 'values', 'findIndex', 'fill', 'find' ] ],
+			[ Array, [ 'keys', 'entries', 'values', 'findIndex', 'fill', 'find', 'includes' ] ],
 			[ String, [ 'codePointAt', 'normalize', 'repeat', 'startsWith', 'endsWith', 'includes' ] ],
 		], ( object, keys ) => {
 			keys.forEach( ( key ) => {
@@ -37,7 +37,7 @@ describe( 'wrap-es6-functions', () => {
 	} );
 
 	describe( 'Array', () => {
-		[ 'keys', 'entries', 'values' ].forEach( partial( assertCall, Array.prototype, [] ) );
+		[ 'keys', 'entries', 'values', 'includes' ].forEach( partial( assertCall, Array.prototype, [] ) );
 		[ 'findIndex', 'find' ].forEach( partial( assertCall, Array.prototype, [ () => true ] ) );
 		[ 'fill' ].forEach( partial( assertCall, Array.prototype, [ 1 ] ) );
 	} );


### PR DESCRIPTION
`Array.prototype.includes` is [not supported in all browsers](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Browser_compatibility).

Add it to wrapped warned functions to discourage its use.

Via p1495116722955459-slack-calypso-framework

Testing:
* Ensure tests pass
* Try using Array.prototype.includes while on this branch. It should continue to work, but you will see a console warning.