### PR TITLE
Framework: Bump eslint-config-wpcalypso to 0.8.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -656,13 +656,13 @@
       "version": "2.11.0"
     },
     "body-parser": {
-      "version": "1.17.1",
+      "version": "1.17.2",
       "dependencies": {
         "debug": {
-          "version": "2.6.1"
+          "version": "2.6.7"
         },
         "ms": {
-          "version": "0.7.2"
+          "version": "2.0.0"
         },
         "qs": {
           "version": "6.4.0"
@@ -1486,7 +1486,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.18",
+      "version": "0.10.20",
       "dev": true
     },
     "es6-iterator": {
@@ -1675,7 +1675,7 @@
       }
     },
     "eslint-config-wpcalypso": {
-      "version": "0.6.0",
+      "version": "0.8.0",
       "dev": true
     },
     "eslint-plugin-react": {
@@ -2636,11 +2636,11 @@
       "dev": true,
       "dependencies": {
         "debug": {
-          "version": "2.6.6",
+          "version": "2.6.7",
           "dev": true
         },
         "ms": {
-          "version": "0.7.3",
+          "version": "2.0.0",
           "dev": true
         },
         "source-map": {
@@ -2742,6 +2742,10 @@
         },
         "yargs": {
           "version": "6.6.0",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
           "dev": true
         }
       }
@@ -2892,6 +2896,10 @@
         },
         "yargs": {
           "version": "6.6.0",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
           "dev": true
         }
       }
@@ -3137,7 +3145,7 @@
       "version": "1.6.2"
     },
     "kind-of": {
-      "version": "3.2.0"
+      "version": "3.2.2"
     },
     "klaw": {
       "version": "1.3.1"
@@ -3157,7 +3165,7 @@
       "dev": true
     },
     "level": {
-      "version": "1.6.0"
+      "version": "1.7.0"
     },
     "level-codec": {
       "version": "6.1.0"
@@ -3172,7 +3180,7 @@
       "version": "1.2.1"
     },
     "leveldown": {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.6.1"
@@ -3538,7 +3546,7 @@
       "dev": true
     },
     "nan": {
-      "version": "2.5.1"
+      "version": "2.6.2"
     },
     "natives": {
       "version": "1.1.0",
@@ -4593,7 +4601,7 @@
       "version": "1.11.1"
     },
     "sass-graph": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0"
@@ -4602,7 +4610,7 @@
           "version": "3.2.0"
         },
         "yargs": {
-          "version": "6.6.0"
+          "version": "7.1.0"
         }
       }
     },
@@ -5448,7 +5456,7 @@
           "dev": true
         },
         "debug": {
-          "version": "2.6.1",
+          "version": "2.6.7",
           "dev": true
         },
         "destroy": {
@@ -5464,7 +5472,7 @@
           "dev": true
         },
         "express": {
-          "version": "4.15.2",
+          "version": "4.15.3",
           "dev": true
         },
         "filesize": {
@@ -5472,18 +5480,8 @@
           "dev": true
         },
         "finalhandler": {
-          "version": "1.0.2",
-          "dev": true,
-          "dependencies": {
-            "debug": {
-              "version": "2.6.4",
-              "dev": true
-            },
-            "ms": {
-              "version": "0.7.3",
-              "dev": true
-            }
-          }
+          "version": "1.0.3",
+          "dev": true
         },
         "fresh": {
           "version": "0.5.0",
@@ -5502,7 +5500,7 @@
           "dev": true
         },
         "ms": {
-          "version": "0.7.2",
+          "version": "2.0.0",
           "dev": true
         },
         "negotiator": {
@@ -5522,11 +5520,11 @@
           "dev": true
         },
         "send": {
-          "version": "0.15.1",
+          "version": "0.15.3",
           "dev": true
         },
         "serve-static": {
-          "version": "1.12.1",
+          "version": "1.12.3",
           "dev": true
         },
         "supports-color": {
@@ -5863,7 +5861,7 @@
       "version": "3.10.0"
     },
     "yargs-parser": {
-      "version": "4.2.1",
+      "version": "5.0.0",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "esformatter-special-bangs": "1.0.1",
     "eslines": "0.0.13",
     "eslint": "3.8.1",
-    "eslint-config-wpcalypso": "0.6.0",
+    "eslint-config-wpcalypso": "0.8.0",
     "eslint-plugin-react": "6.4.1",
     "eslint-plugin-wpcalypso": "3.2.0",
     "glob": "7.0.3",


### PR DESCRIPTION
Which includes the `react/no-deprecated` rule, https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md

My specific motivation was #5951, which according to https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#breaking-2 should be covered by this rule, but funnily, I don't see any error in Atom. Am I missing something? (Try `client/auth/login.jsx` for example.)