### PR TITLE
Jetpack video: Add storage indicator

### DIFF
--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -11,6 +11,7 @@ import { includes } from 'lodash';
  */
 import Banner from 'components/banner';
 import Card from 'components/card';
+import filesize from 'filesize';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSelect from 'components/forms/form-select';
@@ -30,11 +31,16 @@ import {
 	isJetpackModuleUnavailableInDevelopmentMode,
 	isJetpackSiteInDevelopmentMode
 } from 'state/selectors';
+import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePlanSlug } from 'state/sites/selectors';
+import {
+	getSitePlanSlug,
+	getSiteSlug,
+} from 'state/sites/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
+import QueryMediaStorage from 'components/data/query-media-storage';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
-import PlanStorage from 'blocks/plan-storage';
+import PlanStorageBar from 'blocks/plan-storage/bar';
 
 class MediaSettings extends Component {
 	static propTypes = {
@@ -45,8 +51,19 @@ class MediaSettings extends Component {
 		isSavingSettings: PropTypes.bool,
 		isVideoPressActive: PropTypes.bool,
 		isVideoPressAvailable: PropTypes.bool,
+		mediaStorage: PropTypes.shape( {
+			max_storage_bytes: PropTypes.number.isRequired,
+			storage_used_bytes: PropTypes.number.isRequired,
+		} ).isRequired,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
+	};
+
+	static defaultProps = {
+		mediaStorage: {
+			max_storage_bytes: -1,
+			storage_used_bytes: -1,
+		},
 	};
 
 	renderVideoSettings() {
@@ -80,10 +97,43 @@ class MediaSettings extends Component {
 	}
 
 	renderVideoStorageIndicator() {
-		const { siteId } = this.props;
-		return <div className="site-settings__videopress-storage">
-			<PlanStorage siteId={ siteId } />
-		</div>;
+		const {
+			mediaStorage,
+			siteId,
+			sitePlanSlug,
+			siteSlug,
+			translate,
+		} = this.props;
+
+		// The API may use -1 for both values to indicate special cases
+		const isStorageDataValid = mediaStorage.storage_used_bytes > -1;
+		const isStorageUnlimited = mediaStorage.max_storage_bytes > -1;
+
+		const renderedStorageInfo = isStorageDataValid && (
+			isStorageUnlimited
+				? (
+					<PlanStorageBar
+						siteSlug={ siteSlug }
+						sitePlanSlug={ sitePlanSlug }
+						mediaStorage={ mediaStorage }
+					/>
+				) : (
+					<p className="site-settings__videopress-storage-used form-setting-explanation">{
+						translate( '%(size)s uploaded, unlimited storage available', {
+							args: {
+								size: filesize( mediaStorage.storage_used_bytes ),
+							}
+						} )
+					}</p>
+				)
+		);
+
+		return (
+			<div className="site-settings__videopress-storage">
+				<QueryMediaStorage siteId={ siteId } />
+				{ renderedStorageInfo }
+			</div>
+		);
 	}
 
 	renderVideoUpgradeNudge() {
@@ -203,8 +253,11 @@ export default connect(
 			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),
 			isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
 			isVideoPressAvailable,
+			mediaStorage: getMediaStorage( state, selectedSiteId ),
 			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			selectedSiteId,
+			sitePlanSlug,
+			siteSlug: getSiteSlug( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -34,6 +34,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePlanSlug } from 'state/sites/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+import PlanStorage from 'blocks/plan-storage';
 
 class MediaSettings extends Component {
 	static propTypes = {
@@ -42,6 +43,7 @@ class MediaSettings extends Component {
 		handleAutosavingToggle: PropTypes.func.isRequired,
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
+		isVideoPressActive: PropTypes.bool,
 		isVideoPressAvailable: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
@@ -72,7 +74,15 @@ class MediaSettings extends Component {
 					label={ translate( 'Enable fast, ad-free video hosting' ) }
 					disabled={ isRequestingOrSaving }
 				/>
+				{ this.props.isVideoPressActive && this.renderVideoStorageIndicator() }
 			</FormFieldset>
+		);
+	}
+
+	renderVideoStorageIndicator() {
+		const { siteId } = this.props;
+		return (
+			<PlanStorage siteId={ siteId } />
 		);
 	}
 
@@ -191,6 +201,7 @@ export default connect(
 
 		return {
 			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),
+			isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
 			isVideoPressAvailable,
 			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			selectedSiteId,

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -46,6 +46,16 @@ import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import PlanStorageBar from 'blocks/plan-storage/bar';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
+/**
+ * Module constants
+ */
+const plansIncludingVideoPress = [
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+];
+
 class MediaSettings extends Component {
 	static propTypes = {
 		fields: PropTypes.object,
@@ -250,12 +260,6 @@ export default connect(
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 		const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, selectedSiteId, 'photon' );
-		const plansIncludingVideoPress = [
-			PLAN_JETPACK_BUSINESS,
-			PLAN_JETPACK_BUSINESS_MONTHLY,
-			PLAN_JETPACK_PREMIUM,
-			PLAN_JETPACK_PREMIUM_MONTHLY,
-		];
 		const isVideoPressAvailable = includes( plansIncludingVideoPress, sitePlanSlug );
 
 		return {

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -81,9 +81,9 @@ class MediaSettings extends Component {
 
 	renderVideoStorageIndicator() {
 		const { siteId } = this.props;
-		return (
+		return <div className="site-settings__videopress-storage">
 			<PlanStorage siteId={ siteId } />
-		);
+		</div>;
 	}
 
 	renderVideoUpgradeNudge() {

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -44,19 +44,25 @@ import PlanStorageBar from 'blocks/plan-storage/bar';
 
 class MediaSettings extends Component {
 	static propTypes = {
-		carouselActive: PropTypes.bool.isRequired,
 		fields: PropTypes.object,
 		handleAutosavingToggle: PropTypes.func.isRequired,
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
+		onChangeField: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+
+		// connected props
+		carouselActive: PropTypes.bool.isRequired,
 		isVideoPressActive: PropTypes.bool,
 		isVideoPressAvailable: PropTypes.bool,
 		mediaStorage: PropTypes.shape( {
 			max_storage_bytes: PropTypes.number.isRequired,
 			storage_used_bytes: PropTypes.number.isRequired,
 		} ).isRequired,
-		onChangeField: PropTypes.func.isRequired,
-		siteId: PropTypes.number.isRequired,
+		photonModuleUnavailable: PropTypes.bool,
+		selectedSiteId: PropTypes.number,
+		sitePlanSlug: PropTypes.string,
+		siteSlug: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -41,6 +41,7 @@ import { updateSettings } from 'state/jetpack/settings/actions';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import PlanStorageBar from 'blocks/plan-storage/bar';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 class MediaSettings extends Component {
 	static propTypes = {
@@ -124,13 +125,13 @@ class MediaSettings extends Component {
 						mediaStorage={ mediaStorage }
 					/>
 				) : (
-					<p className="site-settings__videopress-storage-used form-setting-explanation">{
-						translate( '%(size)s uploaded, unlimited storage available', {
+					<FormSettingExplanation className="site-settings__videopress-storage-used">
+						{ translate( '%(size)s uploaded, unlimited storage available', {
 							args: {
 								size: filesize( mediaStorage.storage_used_bytes ),
 							}
-						} )
-					}</p>
+						} ) }
+					</FormSettingExplanation>
 				)
 		);
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -450,7 +450,9 @@
 	.plan-storage__bar {
 		margin-top: 24px;
 	}
-	p.site-settings__videopress-storage-used {
+
+	// Necessary additional specificity
+	.site-settings__videopress-storage-used.form-setting-explanation {
 		margin-left: 36px;
 	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -447,5 +447,10 @@
 }
 
 .site-settings__videopress-storage {
-	margin-top: 24px;
+	.plan-storage__bar {
+		margin-top: 24px;
+	}
+	p.site-settings__videopress-storage-used {
+		margin-left: 36px;
+	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -445,3 +445,7 @@
 .site-settings__jetpack-dev-mode-notice .notice {
 	animation: none;
 }
+
+.site-settings__videopress-storage {
+	margin-top: 24px;
+}

--- a/client/state/selectors/get-media-storage-limit.js
+++ b/client/state/selectors/get-media-storage-limit.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorage } from 'state/sites/media-storage/selectors';
+
+/**
+ * Returns a site's maximum storage in bytes or null if the site doesn't exist or the limit
+ * is unknown.
+ *
+ * Note that the API will return -1 to indicate unlimited storage.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Number}        Storage limit in bytes
+ */
+export default function getMediaStorageLimit( state, siteId ) {
+	return get( getMediaStorage( state, siteId ), 'max_storage_bytes', null );
+}

--- a/client/state/selectors/get-media-storage-used.js
+++ b/client/state/selectors/get-media-storage-used.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorage } from 'state/sites/media-storage/selectors';
+
+/**
+ * Returns a site's used storage in bytes or null if the site doesn't exist or the usage
+ * is unknown.
+ *
+ * Note that the API may return -1 in some cases rather than reporting usage.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Number}        Storage used in bytes
+ */
+export default function getMediaStorageUsed( state, siteId ) {
+	return get( getMediaStorage( state, siteId ), 'storage_used_bytes', null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -56,6 +56,7 @@ export getMagicLoginRequestEmailError from './get-magic-login-request-email-erro
 export getMedia from './get-media';
 export getMediaItem from './get-media-item';
 export getMediaStorageLimit from './get-media-storage-limit';
+export getMediaStorageUsed from './get-media-storage-used';
 export getMediaUrl from './get-media-url';
 export getMenuItemTypes from './get-menu-item-types';
 export getMenusUrl from './get-menus-url';

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -55,6 +55,7 @@ export getMagicLoginRequestedEmailSuccessfully from './get-magic-login-requested
 export getMagicLoginRequestEmailError from './get-magic-login-request-email-error';
 export getMedia from './get-media';
 export getMediaItem from './get-media-item';
+export getMediaStorageLimit from './get-media-storage-limit';
 export getMediaUrl from './get-media-url';
 export getMenuItemTypes from './get-menu-item-types';
 export getMenusUrl from './get-menus-url';

--- a/client/state/selectors/test/get-media-storage-limit.js
+++ b/client/state/selectors/test/get-media-storage-limit.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorageLimit } from '..';
+
+describe( 'getMediaStorageLimit()', () => {
+	it( 'should return null if the site is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						456: { max_storage_bytes: 12345 },
+					},
+				},
+			},
+		};
+
+		expect( getMediaStorageLimit( state ) ).to.be.null;
+		expect( getMediaStorageLimit( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return null if the limit is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {},
+						456: { max_storage_bytes: 12345 },
+					},
+				},
+			},
+		};
+		expect( getMediaStorageLimit( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return the limit for a site', () => {
+		const max_storage_bytes = 1029384756;
+		const result = getMediaStorageLimit( {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {
+							max_storage_bytes,
+						},
+					},
+				},
+			},
+		}, 123 );
+
+		expect( result ).to.equal( max_storage_bytes );
+	} );
+} );

--- a/client/state/selectors/test/get-media-storage-used.js
+++ b/client/state/selectors/test/get-media-storage-used.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getMediaStorageUsed } from '..';
+
+describe( 'getMediaStorageUsed()', () => {
+	it( 'should return null if the site is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						456: { storage_used_bytes: 12345 },
+					},
+				},
+			},
+		};
+
+		expect( getMediaStorageUsed( state ) ).to.be.null;
+		expect( getMediaStorageUsed( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return null if usage is unknown', () => {
+		const state = {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {},
+						456: { storage_used_bytes: 12345 },
+					},
+				},
+			},
+		};
+		expect( getMediaStorageUsed( state, 123 ) ).to.be.null;
+	} );
+
+	it( 'should return the storage used for a site', () => {
+		const storage_used_bytes = 1029384756;
+		const result = getMediaStorageUsed( {
+			sites: {
+				mediaStorage: {
+					items: {
+						123: {
+							storage_used_bytes,
+						},
+					},
+				},
+			},
+		}, 123 );
+
+		expect( result ).to.equal( storage_used_bytes );
+	} );
+} );


### PR DESCRIPTION
Add `PlanStorage` bar or storage text to VideoPress settings.

~Depends on D5652-code~ Landed 🎉 

Storage bar (Jetpack Premium):

![bar-premium](https://cloud.githubusercontent.com/assets/841763/26242620/5aa080bc-3c89-11e7-9f35-a7b7019b4e07.png)

Usage indicator (Jetpack Professional):

![storage-pro](https://cloud.githubusercontent.com/assets/841763/26246429/659879f6-3c99-11e7-8466-1be38ac57896.png)

Module disabled (Free and Personal plans, _unchanged by this PR_):

![upgrade-banner](https://cloud.githubusercontent.com/assets/841763/26246793/4581b6a8-3c9b-11e7-8c36-4d94d32d7823.png)


To test:
* ~Point public-api.wordpress.com at a sandbox and apply D5652-code~
* Use this branch
* Visit http://calypso.localhost:3000/settings/writing/:site for a Jetpack site to see the changes.
  * Free and Personal plans should see no differences (upgrade banner).
  * Premium plans should see the storage bar accurately reflecting their used and available VideoPress storage.
  * Ensure the `Upgrade` link works correctly.
  * Professional plans should see the text storage repor accurately reflecting their used storage.
* Ensure there are no regressions.
* Media storage queries should only be sent when on a relevant plan (Premium or Professional). Look for network activity for the `media-storage` endpoint.

Fixes #12507 