### PR TITLE
Notification Settings: drake showing on load.

### DIFF
--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -11,6 +11,7 @@ import Immutable from 'immutable';
  * Internal dependencies
  */
 import { getSites } from 'state/selectors';
+import { isRequestingSites } from 'state/sites/selectors';
 import EmptyContentComponent from 'components/empty-content';
 import Blog from './blog';
 import InfiniteList from 'components/infinite-list';
@@ -24,6 +25,7 @@ const getItemRef = ( { ID } ) => `blog-${ ID }`;
 class BlogsSettings extends Component {
 	static propTypes = {
 		sites: PropTypes.array.isRequired,
+		requestingSites: PropTypes.bool.isRequired,
 		devices: PropTypes.object.isRequired,
 		settings: PropTypes.instanceOf( Immutable.List ),
 		hasUnsavedChanges: PropTypes.bool.isRequired,
@@ -33,13 +35,13 @@ class BlogsSettings extends Component {
 	};
 
 	render() {
-		const { sites, translate } = this.props;
+		const { sites, requestingSites, translate } = this.props;
 
 		if ( ! sites || ! this.props.devices.initialized || ! this.props.settings ) {
 			return <Placeholder />;
 		}
 
-		if ( sites.length === 0 ) {
+		if ( sites.length === 0 && ! requestingSites ) {
 			return <EmptyContentComponent
 				title={ translate( 'You don\'t have any WordPress sites yet.' ) }
 				line={ translate( 'Would you like to start one?' ) }
@@ -85,7 +87,8 @@ class BlogsSettings extends Component {
 }
 
 const mapStateToProps = state => ( {
-	sites: getSites( state )
+	sites: getSites( state ),
+	requestingSites: isRequestingSites( state )
 } );
 
 export default connect( mapStateToProps )( localize( BlogsSettings ) );


### PR DESCRIPTION
Adds a check for `isRequesting` site so drake won't show on page load.

cc: @Automattic/lannister 