### PR TITLE
PostShare: sort actions list 

### DIFF
--- a/client/state/selectors/get-post-share-published-actions.js
+++ b/client/state/selectors/get-post-share-published-actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -9,11 +9,11 @@ import { get } from 'lodash';
 import { enrichPublicizeActionsWithConnections } from 'state/selectors/utils/';
 import createSelector from 'lib/create-selector';
 
-const getPublishedActions = ( state, siteId, postId ) => get(
+const getPublishedActions = ( state, siteId, postId ) => ( orderBy( get(
 	state,
 	[ 'sharing', 'publicize', 'sharePostActions', 'published', siteId, postId ],
 	[],
-);
+), [ 'ID' ], [ 'desc' ] ) );
 
 /**
  * Return a share-published-actions array propagaring data from publicize connections.

--- a/client/state/selectors/get-post-share-scheduled-actions.js
+++ b/client/state/selectors/get-post-share-scheduled-actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -9,11 +9,11 @@ import { get } from 'lodash';
 import { enrichPublicizeActionsWithConnections } from 'state/selectors/utils/';
 import createSelector from 'lib/create-selector';
 
-const getScheduledActions = ( state, siteId, postId ) => get(
+const getScheduledActions = ( state, siteId, postId ) => ( orderBy( get(
 	state,
 	[ 'sharing', 'publicize', 'sharePostActions', 'scheduled', siteId, postId ],
 	[],
-);
+), [ 'ID' ], [ 'desc' ] ) );
 
 /**
  * Return a share-scheduled-actions array propagaring data from publicize connections.


### PR DESCRIPTION
This PR sort the actions list array straight from the selectors.

### Testing

Confirm that the actions are not sorted chronologically in descending order.

<img src="https://cloud.githubusercontent.com/assets/77539/26402992/db3178e4-4062-11e7-9842-e4cb984af076.png" width="400px" />


After applying the patch the sort order should be as expected.

<img src="https://cloud.githubusercontent.com/assets/77539/26401020/2d5c6e20-405a-11e7-9b0a-37105f1dbfd6.png" width="400px" />

