### PR TITLE
KeyedReducer: allow for setting of initialState

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -280,11 +280,16 @@ describe( 'utils', () => {
 
 	describe( '#keyedReducer', () => {
 		const grow = name => ( { type: 'GROW', name } );
+		const reset = name => ( { type: 'RESET', name } );
 
-		const age = ( state = 0, action ) =>
-			'GROW' === action.type
-				? state + 1
-				: state;
+		const age = ( state = 0, action ) => {
+			if ( 'GROW' === action.type ) {
+				return state + 1;
+			} else if ( 'RESET' === action.type ) {
+				return 0;
+			}
+			return state;
+		};
 
 		const prevState = deepFreeze( {
 			Bonobo: 13,
@@ -356,6 +361,11 @@ describe( 'utils', () => {
 		it( 'should not initialize a state if no changes and not keyed (simple state)', () => {
 			const keyed = keyedReducer( 'name', age );
 			expect( keyed( prevState, { type: 'STAY', name: 'Calypso' } ) ).to.equal( prevState );
+		} );
+
+		it( 'should remove keys if set back to initialState', () => {
+			const keyed = keyedReducer( 'name', age );
+			expect( keyed( { '10': 10 }, reset( '10' ) ) ).to.eql( { } );
 		} );
 	} );
 

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -365,7 +365,7 @@ describe( 'utils', () => {
 
 		it( 'should remove keys if set back to initialState', () => {
 			const keyed = keyedReducer( 'name', age );
-			expect( keyed( { '10': 10 }, reset( '10' ) ) ).to.eql( { } );
+			expect( keyed( { 10: 10 }, reset( '10' ) ) ).to.eql( { } );
 		} );
 	} );
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import validator from 'is-my-json-valid';
-import { merge, flow, partialRight, reduce } from 'lodash';
+import { merge, flow, partialRight, reduce, isEqual, omit } from 'lodash';
 import { combineReducers } from 'redux';
 
 /**
@@ -107,13 +107,21 @@ export const keyedReducer = ( keyName, reducer ) => {
 		// pass the old sub-state from that item into the reducer
 		// we need this to update state and also to compare if
 		// we had any changes, thus the initialState
-		const isInitialState = ! state.hasOwnProperty( itemKey );
+		const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
 		const oldItemState = state[ itemKey ];
 		const newItemState = reducer( oldItemState, action );
 
 		// and do nothing if the new sub-state matches the old sub-state
-		if ( ! isInitialState && newItemState === oldItemState ) {
+		if ( newItemState === oldItemState ) {
 			return state;
+		}
+
+		// remove key from state if setting back to initial state
+		// if it didn't exist anyway, then do nothing.
+		if ( isEqual( newItemState, initialState ) ) {
+			return state.hasOwnProperty( itemKey )
+				? omit( state, itemKey )
+				: state;
 		}
 
 		// otherwise immutably update the super-state

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -89,8 +89,6 @@ export const keyedReducer = ( keyName, reducer ) => {
 		throw new TypeError( `Reducer passed into ``keyedReducer`` must be a function but I detected a ${ typeof reducer }` );
 	}
 
-	const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
-
 	return ( state = {}, action ) => {
 		// don't allow coercion of key name: null => 0
 		if ( ! action.hasOwnProperty( keyName ) ) {
@@ -109,19 +107,12 @@ export const keyedReducer = ( keyName, reducer ) => {
 		// pass the old sub-state from that item into the reducer
 		// we need this to update state and also to compare if
 		// we had any changes, thus the initialState
-		const oldItemState = state.hasOwnProperty( itemKey )
-			? state[ itemKey ]
-			: initialState;
-
+		const isInitialState = ! state.hasOwnProperty( itemKey );
+		const oldItemState = state[ itemKey ];
 		const newItemState = reducer( oldItemState, action );
 
 		// and do nothing if the new sub-state matches the old sub-state
-		// or if it matches the default state for the reducer, in which
-		// case nothing happened and we don't need to store it
-		if (
-			newItemState === oldItemState ||
-			newItemState === initialState
-		) {
+		if ( ! isInitialState && newItemState === oldItemState ) {
 			return state;
 		}
 


### PR DESCRIPTION
I'm not sure why it makes sense to disallow explicitly setting the state to initialState within keyedReducer.

Example where this leads to counterintuitive behavior:

```js
const increment = site => ( { site, increment: true } );
const reset     = site => ( { site, reset: true })

// reducer that keeps count of how many actions have affected a site
const siteIncrement = keyedReducer( 'site',  createReducer( 
    0, 
    ( state, action ) => {
      if ( action.reset ) {
        return 0;
      } 
      return state + 1;
    }
  )
);

const prevState = {};
const nextState = siteIncrement( increment( 'yay_site' ) );
expect( nextState ).eql( { 'yay_site': 1  } ); // everything looking good so far

const nextNextState = siteIncrement( nextState, reset( 'yay_site' ) );
expect( nextNextState ).eql( { 'yay_site': 0  } ); // this won't work
```

This should not break anything --  just removes an optimization