### PR TITLE
Reader: fix for paging through site-recs via blocks

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -120,7 +120,7 @@ class FollowingManage extends Component {
 		const { getRecommendedSites, isSiteBlocked } = this.props;
 		const { recommendedSites } = getRecommendedSites( this.state.seed );
 
-		return reject( recommendedSites, isSiteBlocked ).length <= 2;
+		return reject( recommendedSites, isSiteBlocked ).length <= 4;
 	};
 
 	fetchNextPage = offset => this.props.requestFeedSearch( this.props.sitesQuery, offset );
@@ -211,8 +211,6 @@ class FollowingManage extends Component {
 				</div>
 				{ hasFollows &&
 					! sitesQuery &&
-					<RecommendedSites sites={ take( reject( recommendedSites, isSiteBlocked ), 2 ) } /> }
-				{ ! sitesQuery &&
 					<RecommendedSites sites={ take( reject( recommendedSites, isSiteBlocked ), 2 ) } /> }
 				{ !! sitesQuery &&
 					! isFollowByUrlWithNoSearchResults &&

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -19,6 +19,7 @@ import {
 	getReaderFeedsForQuery,
 	getReaderFeedsCountForQuery,
 	getReaderRecommendedSites,
+	getReaderRecommendedSitesPagingOffset,
 	isSiteBlocked as isSiteBlockedSelector,
 	getReaderAliasedFollowFeedUrl,
 } from 'state/selectors';
@@ -118,7 +119,7 @@ class FollowingManage extends Component {
 
 	shouldRequestMoreRecs = () => {
 		const { getRecommendedSites, isSiteBlocked } = this.props;
-		const { recommendedSites } = getRecommendedSites( this.state.seed );
+		const recommendedSites = getRecommendedSites( this.state.seed );
 
 		return reject( recommendedSites, isSiteBlocked ).length <= 4;
 	};
@@ -141,6 +142,7 @@ class FollowingManage extends Component {
 			searchResultsCount,
 			showMoreResults,
 			getRecommendedSites,
+			getRecommendedSitesPagingOffsets,
 			isSiteBlocked,
 			followsCount,
 		} = this.props;
@@ -153,7 +155,8 @@ class FollowingManage extends Component {
 		if ( isSitesQueryUrl ) {
 			sitesQueryWithoutProtocol = withoutHttp( sitesQuery );
 		}
-		const { recommendedSites, offset } = getRecommendedSites( this.state.seed );
+		const offset = getRecommendedSitesPagingOffsets( this.state.seed );
+		const recommendedSites = reject( getRecommendedSites( this.state.seed ), isSiteBlocked );
 		const isFollowByUrlWithNoSearchResults = isSitesQueryUrl && searchResultsCount === 0;
 
 		return (
@@ -211,7 +214,7 @@ class FollowingManage extends Component {
 				</div>
 				{ hasFollows &&
 					! sitesQuery &&
-					<RecommendedSites sites={ take( reject( recommendedSites, isSiteBlocked ), 2 ) } /> }
+					<RecommendedSites sites={ take( recommendedSites, 2 ) } /> }
 				{ !! sitesQuery &&
 					! isFollowByUrlWithNoSearchResults &&
 					<FollowingManageSearchFeedsResults
@@ -242,6 +245,7 @@ export default connect(
 		searchResults: getReaderFeedsForQuery( state, ownProps.sitesQuery ),
 		searchResultsCount: getReaderFeedsCountForQuery( state, ownProps.sitesQuery ),
 		getRecommendedSites: seed => getReaderRecommendedSites( state, seed ),
+		getRecommendedSitesPagingOffsets: seed => getReaderRecommendedSitesPagingOffset( state, seed ),
 		isSiteBlocked: site => isSiteBlockedSelector( state, site.blogId ),
 		getReaderAliasedFollowFeedUrl: url => getReaderAliasedFollowFeedUrl( state, url ),
 		followsCount: getReaderFollowsCount( state ),

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -142,7 +142,7 @@ class FollowingManage extends Component {
 			searchResultsCount,
 			showMoreResults,
 			getRecommendedSites,
-			getRecommendedSitesPagingOffsets,
+			getRecommendedSitesPagingOffset,
 			isSiteBlocked,
 			followsCount,
 		} = this.props;
@@ -155,7 +155,7 @@ class FollowingManage extends Component {
 		if ( isSitesQueryUrl ) {
 			sitesQueryWithoutProtocol = withoutHttp( sitesQuery );
 		}
-		const offset = getRecommendedSitesPagingOffsets( this.state.seed );
+		const offset = getRecommendedSitesPagingOffset( this.state.seed );
 		const recommendedSites = reject( getRecommendedSites( this.state.seed ), isSiteBlocked );
 		const isFollowByUrlWithNoSearchResults = isSitesQueryUrl && searchResultsCount === 0;
 
@@ -245,7 +245,7 @@ export default connect(
 		searchResults: getReaderFeedsForQuery( state, ownProps.sitesQuery ),
 		searchResultsCount: getReaderFeedsCountForQuery( state, ownProps.sitesQuery ),
 		getRecommendedSites: seed => getReaderRecommendedSites( state, seed ),
-		getRecommendedSitesPagingOffsets: seed => getReaderRecommendedSitesPagingOffset( state, seed ),
+		getRecommendedSitesPagingOffset: seed => getReaderRecommendedSitesPagingOffset( state, seed ),
 		isSiteBlocked: site => isSiteBlockedSelector( state, site.blogId ),
 		getReaderAliasedFollowFeedUrl: url => getReaderAliasedFollowFeedUrl( state, url ),
 		followsCount: getReaderFollowsCount( state ),

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -51,6 +51,7 @@ export const receiveRecommendedSitesResponse = ( store, action, next, response )
 		receiveRecommendedSites( {
 			sites: fromApi( response ),
 			seed: action.payload.seed,
+			offset: action.payload.offset,
 		} )
 	);
 };

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -77,6 +77,7 @@ describe( 'recommended sites', () => {
 				receiveRecommendedSites( {
 					sites: fromApi( response ),
 					seed,
+					offset: 0,
 				} )
 			);
 		} );

--- a/client/state/reader/recommended-sites/actions.js
+++ b/client/state/reader/recommended-sites/actions.js
@@ -11,8 +11,8 @@ export const requestRecommendedSites = ( { offset = 0, number = 4, seed = 0 } ) 
 	payload: { offset, number, seed },
 } );
 
-export const receiveRecommendedSites = ( { seed, sites } ) => ( {
+export const receiveRecommendedSites = ( { seed, sites, offset = 0 } ) => ( {
 	type: READER_RECOMMENDED_SITES_RECEIVE,
-	payload: { sites },
+	payload: { sites, offset },
 	seed,
 } );

--- a/client/state/reader/recommended-sites/reducer.js
+++ b/client/state/reader/recommended-sites/reducer.js
@@ -36,7 +36,7 @@ export const items = keyedReducer(
  */
 export const pagingOffset = keyedReducer(
 	'seed',
-	createReducer( 0, {
+	createReducer( null, {
 		[ READER_RECOMMENDED_SITES_RECEIVE ]: ( state, action ) =>
 			Math.max( action.payload.offset, state ),
 	} )

--- a/client/state/reader/recommended-sites/reducer.js
+++ b/client/state/reader/recommended-sites/reducer.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { createReducer, keyedReducer } from 'state/utils';
 import { uniqBy } from 'lodash';
+import { combineReducers } from 'redux';
 
 /**
  * Internal dependencies
  */
 import { READER_RECOMMENDED_SITES_RECEIVE } from 'state/action-types';
+import { createReducer, keyedReducer } from 'state/utils';
 
 /**
  * Tracks mappings between randomization seeds and site recs.
@@ -25,4 +26,23 @@ export const items = keyedReducer(
 	} )
 );
 
-export default items;
+/**
+ * Tracks mappings between randomization seeds and current offset in the that seed's stream.
+ * this is for used whenrequesting the next page of site recs
+ *
+ * @param  {Array} state Current state
+ * @param  {Object} action Action payload
+ * @return {Array}        Updated state
+ */
+export const pagingOffset = keyedReducer(
+	'seed',
+	createReducer( 0, {
+		[ READER_RECOMMENDED_SITES_RECEIVE ]: ( state, action ) =>
+			Math.max( action.payload.offset, state ),
+	} )
+);
+
+export default combineReducers( {
+	items,
+	pagingOffset,
+} );

--- a/client/state/reader/recommended-sites/test/reducer.js
+++ b/client/state/reader/recommended-sites/test/reducer.js
@@ -8,7 +8,7 @@ import freeze from 'deep-freeze';
  * Internal dependencies
  */
 import { receiveRecommendedSites } from '../actions';
-import { items } from '../reducer';
+import { items, pagingOffset } from '../reducer';
 
 const seed = 0;
 const sites = freeze( [
@@ -48,6 +48,32 @@ describe( 'reducer', () => {
 			expect( nextState ).to.eql( {
 				...prevState,
 				[ seed ]: sites,
+			} );
+		} );
+	} );
+
+	describe( '#pagingOffset', () => {
+		it( 'should default to empty object', () => {
+			expect( pagingOffset( undefined, {} ) ).to.eql( {} );
+		} );
+
+		it( 'should set the offset of a seed to the specified number', () => {
+			const prevState = {};
+			const action = receiveRecommendedSites( { seed, offset: 20 } );
+			const nextState = pagingOffset( prevState, action );
+
+			expect( nextState ).to.eql( {
+				[ seed ]: 20,
+			} );
+		} );
+
+		it( 'should never let the offset for a seed get smaller', () => {
+			const prevState = { [ seed ]: 42 };
+			const action = receiveRecommendedSites( { seed, offset: 20 } );
+			const nextState = pagingOffset( prevState, action );
+
+			expect( nextState ).to.eql( {
+				[ seed ]: 42,
 			} );
 		} );
 	} );

--- a/client/state/selectors/get-reader-recommended-sites-paging-offset.js
+++ b/client/state/selectors/get-reader-recommended-sites-paging-offset.js
@@ -1,0 +1,8 @@
+/***
+ * Returns the recommended sites paging offset
+ *
+ * @param  {Object} state  Global state tree
+ * @param {Number} seed the elasticsearch seed for which to grab recs
+ * @return {Number} the paging offset
+ */
+export default ( state, seed ) => state.reader.recommendedSites.pagingOffset[ seed ];

--- a/client/state/selectors/get-reader-recommended-sites.js
+++ b/client/state/selectors/get-reader-recommended-sites.js
@@ -1,10 +1,12 @@
-/**
- * Returns the recommended sites for a given seed
+/***
+ * Returns the recommended sites for a given seed.
  *
  * @param  {Object} state  Global state tree
  * @param {Number} seed the elasticsearch seed for which to grab recs
- * @return {Array} Reader Sites
+ * @return {Object} { recommendedSites: [ Reader Sites ], offset:  Current paging offset }
  */
-export default function getReaderRecommendedSites( state, seed ) {
-	return state.reader.recommendedSites.items[ seed ];
-}
+const getReaderRecommendedSites = ( state, seed ) => ( {
+	recommendedSites: state.reader.recommendedSites.items[ seed ],
+	offset: state.reader.recommendedSites.pagingOffset[ seed ],
+} );
+export default getReaderRecommendedSites;

--- a/client/state/selectors/get-reader-recommended-sites.js
+++ b/client/state/selectors/get-reader-recommended-sites.js
@@ -6,5 +6,5 @@
  * @return {Array} Reader Sites
  */
 export default function getReaderRecommendedSites( state, seed ) {
-	return state.reader.recommendedSites[ seed ];
+	return state.reader.recommendedSites.items[ seed ];
 }

--- a/client/state/selectors/get-reader-recommended-sites.js
+++ b/client/state/selectors/get-reader-recommended-sites.js
@@ -3,10 +3,6 @@
  *
  * @param  {Object} state  Global state tree
  * @param {Number} seed the elasticsearch seed for which to grab recs
- * @return {Object} { recommendedSites: [ Reader Sites ], offset:  Current paging offset }
+ * @return {Array} array of recommended sites for a given seed
  */
-const getReaderRecommendedSites = ( state, seed ) => ( {
-	recommendedSites: state.reader.recommendedSites.items[ seed ],
-	offset: state.reader.recommendedSites.pagingOffset[ seed ],
-} );
-export default getReaderRecommendedSites;
+export default ( state, seed ) => state.reader.recommendedSites.items[ seed ];

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -71,6 +71,7 @@ export getReaderFollowForFeed from './get-reader-follow-for-feed';
 export getReaderFollows from './get-reader-follows';
 export getReaderFollowsCount from './get-reader-follows-count';
 export getReaderRecommendedSites from './get-reader-recommended-sites';
+export getReaderRecommendedSitesPagingOffset from './get-reader-recommended-sites-paging-offset';
 export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getSelectedOrAllSites from './get-selected-or-all-sites';


### PR DESCRIPTION
On the refreshed manage page, blocking a site should slide a new site into its place. There was an issue with the pagination logic / site filtering described in [here](https://github.com/Automattic/wp-calypso/issues/14084) that would result in emptying out recs without replacing them.

Behavior before:
- sometimes get less than 2 recs.
- wouldn't page 

Behavior now:
- should page till the end of time
- never have less than 2 recs


Note: setting the initialState of the new reducer to null because of https://github.com/Automattic/wp-calypso/pull/14245.


UX Note: its a bit strange that we don't expose site recs anywhere else.  The only way to page through site recommendations is to block them...
