### PR TITLE
Framework: Move `client/my-sites` section out of boot file to Framework: Async load parts of My Sites sidebar

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -200,8 +200,6 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		} );
 	}
 
-	require( 'my-sites' )();
-
 	if ( config.isEnabled( 'olark' ) ) {
 		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );
 	}

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -200,8 +200,6 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		} );
 	}
 
-	require( 'my-sites/controller' );
-
 	if ( config.isEnabled( 'olark' ) ) {
 		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );
 	}

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -200,6 +200,8 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		} );
 	}
 
+	require( 'my-sites/controller' );
+
 	if ( config.isEnabled( 'olark' ) ) {
 		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );
 	}

--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -36,3 +36,12 @@ In general usage, this should be passed as a string of the module to be imported
 </table>
 
 A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown.
+
+### `noPlaceholder`
+
+<table>
+	<tr><td>Type</td><td>PropTypes.bool</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+A flag indicating if a placeholder should be hidden while the module is being asynchronously required. If omitted, the placeholder will be shown.

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -6,8 +6,13 @@ import { omit } from 'lodash';
 
 export default class AsyncLoad extends Component {
 	static propTypes = {
+		noPlaceholder: PropTypes.bool,
+		placeholder: PropTypes.node,
 		require: PropTypes.func.isRequired,
-		placeholder: PropTypes.node
+	};
+
+	static defaultProps = {
+		noPlaceholder: false,
 	};
 
 	constructor() {
@@ -48,8 +53,12 @@ export default class AsyncLoad extends Component {
 
 	render() {
 		if ( this.state.component ) {
-			const props = omit( this.props, [ 'require', 'placeholder' ] );
+			const props = omit( this.props, [ 'noPlaceholder', 'placeholder', 'require' ] );
 			return <this.state.component { ...props } />;
+		}
+
+		if ( this.props.noPlaceholder ) {
+			return null;
 		}
 
 		if ( this.props.placeholder ) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -41,6 +41,9 @@ import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
 
+// Load My Sites sidebar here to decrease the size of chunks
+require( 'my-sites/sidebar' );
+
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -15,11 +15,9 @@ import userFactory from 'lib/user';
 import { receiveSite, requestSites } from 'state/sites/actions';
 import {
 	getSite,
-	isJetpackModuleActive,
-	isJetpackSite,
 	isRequestingSites,
 } from 'state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import {
 	setSelectedSiteId,
 	setSection,
@@ -58,7 +56,6 @@ import {
 	domainManagementTransferToAnotherUser
 } from 'my-sites/upgrades/paths';
 import SitesComponent from 'my-sites/sites';
-import { isATEnabled } from 'lib/automated-transfer';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -369,28 +366,6 @@ module.exports = {
 		next();
 	},
 
-	jetpackModuleActive( moduleId, redirect ) {
-		return function( context, next ) {
-			const { getState } = getStore( context );
-			const siteId = getSelectedSiteId( getState() );
-			const isJetpack = isJetpackSite( getState(), siteId );
-			const isModuleActive = isJetpackModuleActive(
-					getState(),
-					siteId,
-					moduleId );
-
-			if ( ! isJetpack ) {
-				return next();
-			}
-
-			if ( isModuleActive || false === redirect ) {
-				next();
-			} else {
-				page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
-			}
-		};
-	},
-
 	makeNavigation: function( context, next ) {
 		context.secondary = createNavigation( context );
 		next();
@@ -404,29 +379,6 @@ module.exports = {
 			context.store
 		);
 		next();
-	},
-
-	jetPackWarning( context, next ) {
-		const { getState } = getStore( context );
-		const Main = require( 'components/main' );
-		const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
-		const basePath = route.sectionify( context.path );
-		const selectedSite = getSelectedSite( getState() );
-
-		if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
-			renderWithReduxStore( (
-				<Main>
-					<JetpackManageErrorPage
-						template="noDomainsOnJetpack"
-						siteId={ selectedSite.ID }
-					/>
-				</Main>
-			), document.getElementById( 'primary' ), context.store );
-
-			analytics.pageView.record( basePath, '> No Domains On Jetpack' );
-		} else {
-			next();
-		}
 	},
 
 	sites( context ) {

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
+import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import QuerySiteDomains from 'components/data/query-site-domains';
+
+const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSiteId, selectedSite } ) => {
+	if ( ! selectedSiteId || isJetpack ) {
+		return null;
+	}
+
+	if ( ! domains.length ) {
+		return <QuerySiteDomains siteId={ selectedSiteId } />;
+	}
+
+	return (
+		<DomainWarnings
+			isCompact
+			selectedSite={ selectedSite }
+			domains={ domains }
+			ruleWhiteList={ [
+				'unverifiedDomainsCanManage',
+				'unverifiedDomainsCannotManage',
+				'expiredDomainsCanManage',
+				'expiringDomainsCanManage',
+				'expiredDomainsCannotManage',
+				'expiringDomainsCannotManage',
+				'wrongNSMappedDomains',
+				'pendingGappsTosAcceptanceDomains',
+			] }
+		/>
+	);
+};
+
+CurrentSiteDomainWarnings.propTypes = {
+	domains: PropTypes.array,
+	isJetpack: PropTypes.bool,
+	selectedSite: PropTypes.object,
+	selectedSiteId: PropTypes.number,
+};
+
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			domains: getDecoratedSiteDomains( state, selectedSiteId ),
+			isJetpack: isJetpackSite( state, selectedSiteId ),
+			selectedSite: getSelectedSite( state ),
+			selectedSiteId,
+		};
+	}
+)( CurrentSiteDomainWarnings );

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -8,6 +8,11 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import {
+	isJetpackModuleActive,
+	isJetpackSite,
+} from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import notices from 'notices';
 import { pageView } from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
@@ -74,4 +79,26 @@ export const buttons = ( context, next ) => {
 	context.contentComponent = createElement( SharingButtons );
 
 	next();
+};
+
+export const jetpackModuleActive = ( moduleId, redirect ) => {
+	return function( context, next ) {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isModuleActive = isJetpackModuleActive(
+			state,
+			siteId,
+			moduleId );
+
+		if ( ! isJetpack ) {
+			return next();
+		}
+
+		if ( isModuleActive || false === redirect ) {
+			next();
+		} else {
+			page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
+		}
+	};
 };

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -6,8 +6,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { jetpackModuleActive, navigation, sites, siteSelection } from 'my-sites/controller';
-import { buttons, connections, layout } from './controller';
+import { navigation, sites, siteSelection } from 'my-sites/controller';
+import { jetpackModuleActive, buttons, connections, layout } from './controller';
 
 export default function() {
 	page( /^\/sharing(\/buttons)?$/, siteSelection, sites );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -26,6 +26,7 @@ import {
 	getSelectedSiteSlug
 } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { isATEnabled } from 'lib/automated-transfer';
 
 /**
  * Module variables
@@ -278,6 +279,27 @@ module.exports = {
 		);
 
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	},
+
+	jetPackWarning( context, next ) {
+		const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
+		const basePath = route.sectionify( context.path );
+		const selectedSite = getSelectedSite( context.store.getState() );
+
+		if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
+			renderWithReduxStore( (
+				<Main>
+					<JetpackManageErrorPage
+						template="noDomainsOnJetpack"
+						siteId={ selectedSite.ID }
+					/>
+				</Main>
+			), document.getElementById( 'primary' ), context.store );
+
+			analytics.pageView.record( basePath, '> No Domains On Jetpack' );
+		} else {
+			next();
+		}
 	},
 
 	redirectIfNoSite: function( redirectTo ) {

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -28,7 +28,7 @@ function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJ
 	}
 
 	if ( warnIfJetpack ) {
-		handlers.push( controller.jetPackWarning );
+		handlers.push( upgradesController.jetPackWarning );
 	}
 
 	return handlers;
@@ -155,7 +155,7 @@ module.exports = function() {
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
 			upgradesController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			controller.sites
 		);
 
@@ -163,7 +163,7 @@ module.exports = function() {
 			'/domains/add/mapping',
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			controller.sites
 		);
 
@@ -171,7 +171,7 @@ module.exports = function() {
 			'/domains/add/site-redirect',
 			controller.siteSelection,
 			upgradesController.domainsAddRedirectHeader,
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			controller.sites
 		);
 
@@ -180,7 +180,7 @@ module.exports = function() {
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
 			upgradesController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.domainSearch
 		);
 
@@ -189,7 +189,7 @@ module.exports = function() {
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
 			upgradesController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.domainSearch
 		);
 
@@ -197,7 +197,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.googleAppsWithRegistration
 		);
 
@@ -205,7 +205,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/mapping' ),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.mapDomain
 		);
 
@@ -213,7 +213,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/site-redirect' ),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.siteRedirect
 		);
 	}
@@ -228,7 +228,7 @@ module.exports = function() {
 		'/domains/:site',
 		controller.siteSelection,
 		controller.navigation,
-		controller.jetPackWarning,
+		upgradesController.jetPackWarning,
 		domainManagementController.domainManagementIndex
 	);
 

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -7,7 +7,7 @@ const sections = [
 		paths: [ '/sites' ],
 		module: 'my-sites',
 		group: 'sites',
-		secondary: true
+		secondary: false
 	},
 	{
 		name: 'customize',

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max_old_space_size=4096
 
 /**
  * External dependencies

--- a/server/bundler/bin/bundler.js
+++ b/server/bundler/bin/bundler.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --max_old_space_size=4096
+#!/usr/bin/env node
 
 /**
  * External dependencies


### PR DESCRIPTION
Reverts #14169, which reverted #12404 :) It was reverted because it broke Calypso deploy queue:
> specifically stuck in /usr/bin/env node --max_old_space_size=4096 /calypso/bin/bundler, called from make build in the dockerfile

Implements #12314: Async load sites section.

When thinking about sites section we refer to the code that is imported with this line of code: https://github.com/Automattic/wp-calypso/blob/5ec23905ced23ba7502f26ba270fce9ac2bc8623/client/boot/index.js#L361.

### Testing
1. Open Calypso using calypso.live branch or http://calypso.localhost:3000/.
2. Click My Sites button in the masterbar.
3. Make sure it works as before.
4. Navigate to a few subpages and make sure they still work.
5. Open /sites page and make sure it still works.
6. Navigate to http://calypso.localhost:3000/sharing.
7. Pick a site and make sure it still works.
8. Navigate to http://calypso.localhost:3000/domains/add.
9. Pick a site and make sure it loads properly.
10. Pick a Jetpack site and make sure you see the feature gate.
11. Execute `make analyze-bundles` and make sure it works.
12. Execute `make docker-build` and make sure it works.

This is how current site should look like with domain warnings enabled:

![screen shot 2017-05-16 at 14 20 53](https://cloud.githubusercontent.com/assets/699132/26105621/f4f93d8c-3a42-11e7-82ab-5fe265da9bf2.png)

## Stats

#### Before
```
build.b72e66e66ff31d71ad09.js (build) 4.98 MB
hello-dolly.430f9b1c35b211e6ef33.js (hello-dolly) 12.2 kB
stats.09c9876174b9fc4435d1.js (stats) 26.4 kB
```

![screen shot 2017-05-15 at 10 02 34](https://cloud.githubusercontent.com/assets/699132/26048071/ea43c878-3955-11e7-8462-26bd7a4aaf22.png)


#### After

build.e516d3036afd2f1e5df4.js (build) 4.76 MB
hello-dolly.febc9bb8ca71580a6e7b.js (hello-dolly) 42.3 kB
stats.05a4925bb603ef814214.js (stats) 56.4 kB

async-load-my-sites-current-site-domain-warnings.9c0302305e10bbd7d687.js (async-load-my-sites-current-site-domain-warnings) 87.4 kB 

![screen shot 2017-05-22 at 13 03 27](https://cloud.githubusercontent.com/assets/699132/26305317/1869df78-3eef-11e7-8626-ab7c9336256d.png)

![screen shot 2017-05-22 at 13 09 23](https://cloud.githubusercontent.com/assets/699132/26305513/e73c8918-3eef-11e7-99c2-a1b3f72f6b32.png)

#### Summary

I decided to take a different approach in this PR to avoid any further memory issues with production build. Therefore I decided to revert changes to the bundler file where I increased memory limit with the `--max_old_space_size=4096` flag. 

This time I tried to narrow down code that is always bundled into the main build file to the My Sites sidebar: `require( 'my-sites/sidebar' );`. I also moved it from the boot file to the logged in Layout. In reality this the only place where it really is needed. I did it to make it easier in the future to load those files only for logged in users and avoid loading it for logged out users.

I also added 2 more refactoring where I moved two Jetpack related middlewares to put them next to the code that consumes them.

This refactoring still allows to save a good amount of bytes for initial page load: 33 kb after minification and compression. 

### Review

* [ ] Code
* [ ] Product