### PR TITLE
Login: Scroll to top on page change

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -28,7 +28,7 @@ class Login extends Component {
 	static propTypes = {
 		redirectLocation: PropTypes.string,
 		requestError: PropTypes.object,
-		getRequestNotice: PropTypes.object,
+		requestNotice: PropTypes.object,
 		twoFactorAuthType: PropTypes.string,
 		twoFactorEnabled: PropTypes.bool,
 		twoFactorNotificationSent: PropTypes.string,
@@ -39,10 +39,20 @@ class Login extends Component {
 		rememberMe: false,
 	};
 
-	componentWillMount = () => {
-		if ( ! this.props.twoStepNonce && this.props.twoFactorAuthType && typeof window !== 'undefined' ) {
+	componentDidMount = () => {
+		if ( ! this.props.twoStepNonce && this.props.twoFactorAuthType ) {
 			// Disallow access to the 2FA pages unless the user has received a nonce
 			page( login( { isNative: true } ) );
+		}
+	};
+
+	componentWillReceiveProps = ( nextProps ) => {
+		const hasError = this.props.requestError !== nextProps.requestError;
+		const hasNotice = this.props.requestNotice !== nextProps.requestNotice;
+		const isNewPage = this.props.twoFactorAuthType !== nextProps.twoFactorAuthType;
+
+		if ( isNewPage || hasError || hasNotice ) {
+			window.scrollTo( 0, 0 );
 		}
 	};
 
@@ -70,7 +80,9 @@ class Login extends Component {
 		}
 
 		return (
-			<Notice status={ 'is-error' } showDismiss={ false }>{ requestError.message }</Notice>
+			<Notice status={ 'is-error' } showDismiss={ false }>
+				{ requestError.message }
+			</Notice>
 		);
 	}
 
@@ -82,7 +94,9 @@ class Login extends Component {
 		}
 
 		return (
-			<Notice status={ requestNotice.status } showDismiss={ false }>{ requestNotice.message }</Notice>
+			<Notice status={ requestNotice.status } showDismiss={ false }>
+				{ requestNotice.message }
+			</Notice>
 		);
 	}
 

--- a/client/lib/scroll-to/README.md
+++ b/client/lib/scroll-to/README.md
@@ -1,8 +1,10 @@
 scroll-to
-=======
+=========
+
 A utility module to smoothly scroll to a window position.
 
 ## Usage
+
 ```es6
 import scrollTo from 'lib/scroll-to'; 
 

--- a/client/lib/scroll-to/index.js
+++ b/client/lib/scroll-to/index.js
@@ -57,7 +57,7 @@ function animate() {
  * @param {function} options.onComplete - callback when scroll is finished
  * @param {HTMLElement} options.container - the container to scroll instead of window, if any
  */
-function scrollTo( options ) {
+export default function scrollTo( options ) {
 	const currentScroll = getCurrentScroll( options.container ),
 		tween = new TWEEN.Tween( currentScroll )
 		.easing( options.easing || TWEEN.Easing.Circular.Out )
@@ -78,4 +78,3 @@ function scrollTo( options ) {
 	}
 }
 
-export default scrollTo;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -821,7 +821,7 @@
       "version": "1.0.1"
     },
     "chrono-node": {
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     "ci-info": {
       "version": "1.0.0",
@@ -1486,7 +1486,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.20",
+      "version": "0.10.21",
       "dev": true
     },
     "es6-iterator": {
@@ -2094,7 +2094,7 @@
       "version": "1.1.0",
       "dependencies": {
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.2"
         },
         "lodash": {
           "version": "4.16.6"
@@ -2173,7 +2173,7 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.8",
+      "version": "4.0.10",
       "dev": true,
       "dependencies": {
         "async": {
@@ -2326,7 +2326,7 @@
           "version": "2.9.0"
         },
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.2"
         },
         "minimatch": {
           "version": "3.0.4"
@@ -2604,7 +2604,7 @@
       "dev": true,
       "dependencies": {
         "async": {
-          "version": "2.4.0",
+          "version": "2.4.1",
           "dev": true
         }
       }
@@ -3724,7 +3724,7 @@
       "version": "2.0.4"
     },
     "nwmatcher": {
-      "version": "1.3.9",
+      "version": "1.4.0",
       "dev": true
     },
     "oauth-sign": {
@@ -4513,7 +4513,7 @@
       "version": "2.6.1",
       "dependencies": {
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.2"
         },
         "minimatch": {
           "version": "3.0.4"
@@ -4755,7 +4755,7 @@
       "dev": true
     },
     "sinon": {
-      "version": "1.17.6",
+      "version": "1.17.7",
       "dev": true
     },
     "sinon-chai": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "react-hot-loader": "1.3.0",
     "react-test-env": "0.2.0",
     "readline-sync": "1.4.5",
-    "sinon": "1.17.6",
+    "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "socket.io": "1.4.5",
     "stylelint": "^6.5.1",


### PR DESCRIPTION
This pull request fixes #14182 by scrolling the viewport to the top of the page when navigating any of the `Login` pages.
 
<img width="309" alt="screenshot" src="https://cloud.githubusercontent.com/assets/594356/26240073/07345d62-3c80-11e7-9a0d-608180d36d16.png">

  
#### Testing instructions
 
1. Run `git checkout add/scrolling-to-login-pages` and start your server, or open a [live branch](https://calypso.live/?branch=add/scrolling-to-login-pages)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Submit the form with credentials from an account that has 2FA with push notifications enabled
4. Narrow your browser's window to make the vertical scrollbar appears, and scroll down
5. Click the `Your Authenticator app` link
6. Assert that you are presented with the top of the new page
7. Scroll down again, and click the `Code via text message` link this time
8. Assert that you are presented with the top of the new page

#### Reviews
 
- [x] Code
- [x] Product