### PR TITLE
Framework: Remove sites-list usage from DomainTip example

### DIFF
--- a/client/my-sites/domain-tip/docs/example.jsx
+++ b/client/my-sites/domain-tip/docs/example.jsx
@@ -2,26 +2,25 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import DomainTip from '../index';
-import sitesList from 'lib/sites-list';
+import { getCurrentUser } from 'state/current-user/selectors';
 
-const sites = sitesList();
+const DomainTipExample = ( { siteId } ) => (
+	<DomainTip siteId={ siteId } event="domain_app_example" />
+);
 
-export default React.createClass( {
+const ConnectedDomainTipExample = connect(
+	( state ) => ( {
+		siteId: get( getCurrentUser( state ), 'primary_blog', null )
+	} )
+)( DomainTipExample );
 
-	displayName: 'DomainTip',
+ConnectedDomainTipExample.displayName = 'DomainTip';
 
-	mixins: [ PureRenderMixin ],
-
-	render() {
-		const primarySite = sites.initialized && sites.getPrimary();
-		const siteId = primarySite ? primarySite.ID : 0;
-
-		return <DomainTip siteId={ siteId } event="domain_app_example" />;
-	}
-} );
+export default ConnectedDomainTipExample;


### PR DESCRIPTION
This PR removes `sites-list` from the `DomainTip` example.

To test:
* Checkout this branch.
* Make sure to set a WordPress.com site without a custom domain and with a free plan as a primary site.
* Go to http://calypso.localhost:3000/devdocs/blocks and verify the `PlanStorage` example looks and works well.
* Go to http://calypso.localhost:3000/devdocs/blocks/domain-tip and verify the example looks and works well.

If your primary site is eligible for that domain tip, it should look something like this:

![](https://cldup.com/oz-EBH0t60.png)

