### PR TITLE
Settings: Add 'Site Tools' header to delete-site-options

### DIFF
--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -96,7 +96,7 @@ class SiteTools extends Component {
 					onClick={ this.checkForSubscriptions }
 					className="delete-site-options__link">
 					<div className="delete-site-options__content">
-						<p className="delete-site-options__section-title is-destructive">
+						<p className="delete-site-options__section-title is-warning">
 							{ strings.deleteSite }
 						</p>
 						<p className="delete-site-options__section-desc">

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -12,6 +12,7 @@ import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-
 import config from 'config';
 import { tracks } from 'lib/analytics';
 import { localize } from 'i18n-calypso';
+import SectionHeader from 'components/section-header';
 
 const trackDeleteSiteOption = ( option ) => {
 	tracks.recordEvent( 'calypso_settings_delete_site_options', {
@@ -54,25 +55,19 @@ class SiteTools extends React.Component {
 		}
 
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
-			changeAddressLinkText = translate( 'Change your site\'s address.' );
+			changeAddressLinkText = translate( 'Change your site address.' );
 		}
 
 		return (
 			<div className="delete-site-options">
+				<SectionHeader label={ translate( 'Site Tools' ) } />
 				<CompactCard
 					href={ changeAddressLink }
 					onClick={ this.trackChangeAddress }
 					className="delete-site-options__link">
 					<div className="delete-site-options__content">
-						<h2 className="delete-site-options__section-title">{ strings.changeSiteAddress }</h2>
+						<p className="delete-site-options__section-title">{ strings.changeSiteAddress }</p>
 						<p className="delete-site-options__section-desc">{ changeAddressLinkText }</p>
-						<p className="delete-site-options__section-footnote">
-							{ translate( 'Your current site address is "%(siteAddress)s."', {
-								args: {
-									siteAddress: selectedSite.slug
-								}
-							} ) }
-						</p>
 					</div>
 				</CompactCard>
 				{ config.isEnabled( 'settings/theme-setup' ) &&
@@ -81,7 +76,7 @@ class SiteTools extends React.Component {
 						onClick={ this.trackThemeSetup }
 						className="delete-site-options__link">
 						<div className="delete-site-options__content">
-							<h2 className="delete-site-options__section-title">{ strings.themeSetup }</h2>
+							<p className="delete-site-options__section-title">{ strings.themeSetup }</p>
 							<p className="delete-site-options__section-desc">{ themeSetupLinkText }</p>
 						</div>
 					</CompactCard>
@@ -91,7 +86,7 @@ class SiteTools extends React.Component {
 					onClick={ this.trackStartOver }
 					className="delete-site-options__link">
 					<div className="delete-site-options__content">
-						<h2 className="delete-site-options__section-title">{ strings.startOver }</h2>
+						<p className="delete-site-options__section-title">{ strings.startOver }</p>
 						<p className="delete-site-options__section-desc">
 							{ translate( 'Keep your URL and site active, but remove the content.' ) }
 						</p>
@@ -102,25 +97,12 @@ class SiteTools extends React.Component {
 					onClick={ this.checkForSubscriptions }
 					className="delete-site-options__link">
 					<div className="delete-site-options__content">
-						<h2 className="delete-site-options__section-title">{ strings.deleteSite }</h2>
+						<p className="delete-site-options__section-title">{ strings.deleteSite }</p>
 						<p className="delete-site-options__section-desc">
 							{ translate(
 								'All your posts, images, and data will be deleted. ' +
-								'And this site’s address ({{siteAddress /}}) will be lost.',
-								{
-									components: {
-										siteAddress: <strong>{ selectedSite.wpcom_url || selectedSite.slug }</strong>
-									}
-								}
+								'And this site’s address will be lost.'
 							) }
-						</p>
-						<p className="delete-site-options__section-footnote">
-							{
-								translate(
-									'Be careful! Once a site is deleted, it cannot be recovered. ' +
-									'Please be sure before you proceed.'
-								)
-							}
 						</p>
 					</div>
 				</CompactCard>

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { some } from 'lodash';
 
 /**
@@ -20,12 +20,11 @@ const trackDeleteSiteOption = ( option ) => {
 	} );
 };
 
-class SiteTools extends React.Component {
-
+class SiteTools extends Component {
 	static propTypes = {
-		sitePurchases: React.PropTypes.array.isRequired,
-		hasLoadedSitePurchasesFromServer: React.PropTypes.bool.isRequired,
-		site: React.PropTypes.object.isRequired
+		sitePurchases: PropTypes.array.isRequired,
+		hasLoadedSitePurchasesFromServer: PropTypes.bool.isRequired,
+		site: PropTypes.object.isRequired
 	}
 
 	state = {

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -41,11 +41,11 @@ class SiteTools extends Component {
 		const startOverLink = `/settings/start-over/${ selectedSite.slug }`;
 		const deleteSiteLink = `/settings/delete-site/${ selectedSite.slug }`;
 		let changeAddressLinkText = translate( 'Register a new domain or change your site\'s address.' );
-		const themeSetupLinkText = translate( 'Make your site look like your theme\'s demo.' );
+		const themeSetupLinkText = translate( 'Automatically make your site look like your theme\'s demo.' );
 		const strings = {
 			changeSiteAddress: translate( 'Change your site address' ),
 			themeSetup: translate( 'Theme setup' ),
-			startOver: translate( 'Empty your content' ),
+			startOver: translate( 'Delete your content' ),
 			deleteSite: translate( 'Delete your site' )
 		};
 
@@ -87,7 +87,10 @@ class SiteTools extends Component {
 					<div className="delete-site-options__content">
 						<p className="delete-site-options__section-title">{ strings.startOver }</p>
 						<p className="delete-site-options__section-desc">
-							{ translate( 'Keep your site address and site active, but remove all of your posts, pages, media, etc.' ) }
+							{ translate(
+								'Keep your site\'s address and current theme, but remove all posts, ' +
+								'pages, and media so you can start fresh.'
+							) }
 						</p>
 					</div>
 				</CompactCard>
@@ -101,8 +104,8 @@ class SiteTools extends Component {
 						</p>
 						<p className="delete-site-options__section-desc">
 							{ translate(
-								'All your posts, images, and data will be deleted. ' +
-								'And this site’s address will be lost.'
+								'Delete all your posts, pages, media and data, ' +
+								'and give up your site\'s address'
 							) }
 						</p>
 					</div>

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -97,7 +97,9 @@ class SiteTools extends React.Component {
 					onClick={ this.checkForSubscriptions }
 					className="delete-site-options__link">
 					<div className="delete-site-options__content">
-						<p className="delete-site-options__section-title">{ strings.deleteSite }</p>
+						<p className="delete-site-options__section-title is-destructive">
+							{ strings.deleteSite }
+						</p>
 						<p className="delete-site-options__section-desc">
 							{ translate(
 								'All your posts, images, and data will be deleted. ' +

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -11,6 +11,7 @@ import CompactCard from 'components/card/compact';
 import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-dialog';
 import config from 'config';
 import { tracks } from 'lib/analytics';
+import { localize } from 'i18n-calypso';
 
 const trackDeleteSiteOption = ( option ) => {
 	tracks.recordEvent( 'calypso_settings_delete_site_options', {
@@ -18,35 +19,34 @@ const trackDeleteSiteOption = ( option ) => {
 	} );
 };
 
-module.exports = React.createClass( {
-	displayName: 'DeleteSite',
+class SiteTools extends React.Component {
 
-	propTypes: {
+	static propTypes = {
 		sitePurchases: React.PropTypes.array.isRequired,
 		hasLoadedSitePurchasesFromServer: React.PropTypes.bool.isRequired,
 		site: React.PropTypes.object.isRequired
-	},
+	}
 
-	getInitialState() {
-		return {
-			showDialog: false,
-			showStartOverDialog: false
-		};
-	},
+	state = {
+		showDialog: false,
+		showStartOverDialog: false,
+	}
 
 	render() {
+		const { translate } = this.props;
+
 		const selectedSite = this.props.site;
 		const changeAddressLink = `/domains/manage/${ selectedSite.slug }`;
 		const themeSetupLink = `/settings/theme-setup/${ selectedSite.slug }`;
 		const startOverLink = `/settings/start-over/${ selectedSite.slug }`;
 		const deleteSiteLink = `/settings/delete-site/${ selectedSite.slug }`;
-		let changeAddressLinkText = this.translate( 'Register a new domain or change your site\'s address.' );
-		const themeSetupLinkText = this.translate( 'Make your site look like your theme\'s demo.' );
+		let changeAddressLinkText = translate( 'Register a new domain or change your site\'s address.' );
+		const themeSetupLinkText = translate( 'Make your site look like your theme\'s demo.' );
 		const strings = {
-			changeSiteAddress: this.translate( 'Change Site Address' ),
-			themeSetup: this.translate( 'Theme Setup' ),
-			startOver: this.translate( 'Start Over' ),
-			deleteSite: this.translate( 'Delete Site' )
+			changeSiteAddress: translate( 'Change Site Address' ),
+			themeSetup: translate( 'Theme Setup' ),
+			startOver: translate( 'Start Over' ),
+			deleteSite: translate( 'Delete Site' )
 		};
 
 		if ( ! this.props.hasLoadedSitePurchasesFromServer ) {
@@ -54,7 +54,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
-			changeAddressLinkText = this.translate( 'Change your site\'s address.' );
+			changeAddressLinkText = translate( 'Change your site\'s address.' );
 		}
 
 		return (
@@ -67,7 +67,7 @@ module.exports = React.createClass( {
 						<h2 className="delete-site-options__section-title">{ strings.changeSiteAddress }</h2>
 						<p className="delete-site-options__section-desc">{ changeAddressLinkText }</p>
 						<p className="delete-site-options__section-footnote">
-							{ this.translate( 'Your current site address is "%(siteAddress)s."', {
+							{ translate( 'Your current site address is "%(siteAddress)s."', {
 								args: {
 									siteAddress: selectedSite.slug
 								}
@@ -93,7 +93,7 @@ module.exports = React.createClass( {
 					<div className="delete-site-options__content">
 						<h2 className="delete-site-options__section-title">{ strings.startOver }</h2>
 						<p className="delete-site-options__section-desc">
-							{ this.translate( 'Keep your URL and site active, but remove the content.' ) }
+							{ translate( 'Keep your URL and site active, but remove the content.' ) }
 						</p>
 					</div>
 				</CompactCard>
@@ -104,7 +104,7 @@ module.exports = React.createClass( {
 					<div className="delete-site-options__content">
 						<h2 className="delete-site-options__section-title">{ strings.deleteSite }</h2>
 						<p className="delete-site-options__section-desc">
-							{ this.translate(
+							{ translate(
 								'All your posts, images, and data will be deleted. ' +
 								'And this site’s address ({{siteAddress /}}) will be lost.',
 								{
@@ -116,7 +116,10 @@ module.exports = React.createClass( {
 						</p>
 						<p className="delete-site-options__section-footnote">
 							{
-								this.translate( 'Be careful! Once a site is deleted, it cannot be recovered. Please be sure before you proceed.' )
+								translate(
+									'Be careful! Once a site is deleted, it cannot be recovered. ' +
+									'Please be sure before you proceed.'
+								)
 							}
 						</p>
 					</div>
@@ -126,21 +129,21 @@ module.exports = React.createClass( {
 					onClose={ this.closeDialog } />
 			</div>
 		);
-	},
+	}
 
 	trackChangeAddress() {
 		trackDeleteSiteOption( 'change-address' );
-	},
+	}
 
 	trackThemeSetup() {
 		trackDeleteSiteOption( 'theme-setup' );
-	},
+	}
 
 	trackStartOver() {
 		trackDeleteSiteOption( 'start-over' );
-	},
+	}
 
-	checkForSubscriptions( event ) {
+	checkForSubscriptions = ( event ) => {
 		trackDeleteSiteOption( 'delete-site' );
 
 		if ( ! some( this.props.sitePurchases, 'active' ) ) {
@@ -149,9 +152,11 @@ module.exports = React.createClass( {
 
 		event.preventDefault();
 		this.setState( { showDialog: true } );
-	},
+	}
 
-	closeDialog() {
+	closeDialog = () => {
 		this.setState( { showDialog: false } );
 	}
-} );
+}
+
+export default localize( SiteTools );

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -44,8 +44,8 @@ class SiteTools extends React.Component {
 		let changeAddressLinkText = translate( 'Register a new domain or change your site\'s address.' );
 		const themeSetupLinkText = translate( 'Make your site look like your theme\'s demo.' );
 		const strings = {
-			changeSiteAddress: translate( 'Change Site Address' ),
-			themeSetup: translate( 'Theme Setup' ),
+			changeSiteAddress: translate( 'Change your site address' ),
+			themeSetup: translate( 'Theme setup' ),
 			startOver: translate( 'Empty your content' ),
 			deleteSite: translate( 'Delete your site' )
 		};

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -46,8 +46,8 @@ class SiteTools extends React.Component {
 		const strings = {
 			changeSiteAddress: translate( 'Change Site Address' ),
 			themeSetup: translate( 'Theme Setup' ),
-			startOver: translate( 'Start Over' ),
-			deleteSite: translate( 'Delete Site' )
+			startOver: translate( 'Empty your content' ),
+			deleteSite: translate( 'Delete your site' )
 		};
 
 		if ( ! this.props.hasLoadedSitePurchasesFromServer ) {
@@ -88,7 +88,7 @@ class SiteTools extends React.Component {
 					<div className="delete-site-options__content">
 						<p className="delete-site-options__section-title">{ strings.startOver }</p>
 						<p className="delete-site-options__section-desc">
-							{ translate( 'Keep your URL and site active, but remove the content.' ) }
+							{ translate( 'Keep your site address and site active, but remove all of your posts, pages, media, etc.' ) }
 						</p>
 					</div>
 				</CompactCard>

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -46,7 +46,7 @@ class SiteTools extends Component {
 			changeSiteAddress: translate( 'Change your site address' ),
 			themeSetup: translate( 'Theme setup' ),
 			startOver: translate( 'Delete your content' ),
-			deleteSite: translate( 'Delete your site' )
+			deleteSite: translate( 'Delete your site permanently' )
 		};
 
 		if ( ! this.props.hasLoadedSitePurchasesFromServer ) {

--- a/client/my-sites/site-settings/delete-site-options/style.scss
+++ b/client/my-sites/site-settings/delete-site-options/style.scss
@@ -3,21 +3,13 @@
  */
 
 .delete-site-options__section-title {
-	margin-bottom: 16px;
-	font-size: 21px;
-	font-weight: 300;
-	line-height: 24px;
-	color: $gray-dark;
-}
-
-.delete-site-options__section-desc {
 	margin-bottom: 4px;
 	font-size: 14px;
 	line-height: 18px;
 	color: $gray-dark;
 }
 
-.delete-site-options__section-footnote {
+.delete-site-options__section-desc {
 	margin-bottom: 0;
 	font-size: 13px;
 	color: $gray-text-min;
@@ -43,10 +35,6 @@
 
 .delete-site-options__content {
 	flex: 0 1 auto;
-
-	@include breakpoint( ">480px" ) {
-		max-width: 460px;
-	}
 }
 
 .delete-site-options__link,

--- a/client/my-sites/site-settings/delete-site-options/style.scss
+++ b/client/my-sites/site-settings/delete-site-options/style.scss
@@ -7,6 +7,10 @@
 	font-size: 14px;
 	line-height: 18px;
 	color: $gray-dark;
+
+	&.is-destructive {
+		color: $alert-red;
+	}
 }
 
 .delete-site-options__section-desc {

--- a/client/my-sites/site-settings/delete-site-options/style.scss
+++ b/client/my-sites/site-settings/delete-site-options/style.scss
@@ -8,7 +8,7 @@
 	line-height: 18px;
 	color: $gray-dark;
 
-	&.is-destructive {
+	&.is-warning {
 		color: $alert-red;
 	}
 }


### PR DESCRIPTION
First step of #12169.

Adds a header and updates the text and styling of the various existing settings at the bottom of _General_ (currently known as delete-site-options).

**Before**
<img width="739" alt="screen shot 2017-05-19 at 12 48 30" src="https://cloud.githubusercontent.com/assets/7767559/26246529/94a8f890-3c91-11e7-8e74-198e9d2c1c27.png">

**After**
<img width="739" alt="screen shot 2017-05-22 at 16 40 54" src="https://cloud.githubusercontent.com/assets/7767559/26316850/7bb011e2-3f0d-11e7-920e-18999e3949c5.png">

**Mobile**
<img width="393" alt="screen shot 2017-05-22 at 16 41 38" src="https://cloud.githubusercontent.com/assets/7767559/26316872/965cb48c-3f0d-11e7-9062-ab0a7f3985b6.png">


**Next steps for #12169** (in separate PRs)
* Rename `<DeleteSiteOptions/>` component to `<SiteOptions>`
* Bring _Import_ & _Export_ settings into the component


**To Test**
* The settings at http://calypso.localhost:3000/settings/general/{site} should work exactly as before 