### PR TITLE
Jetpack Connect: Use lodash includes instead of Array.includes

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { flowRight } from 'lodash';
+import { flowRight, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -296,12 +296,12 @@ class JetpackConnectMain extends Component {
 		 * I'm avoiding significantly changing this implementation
 		 * until propTypes have been around for a while.
 		 */
-		return [
+		return includes( [
 			'install',
 			'pro',
 			'premium',
 			'personal',
-		].includes( this.props.type );
+		], this.props.type );
 	}
 
 	getInstructionsData( status ) {
@@ -456,7 +456,7 @@ class JetpackConnectMain extends Component {
 	render() {
 		const status = this.getStatus();
 		if (
-			[ 'notJetpack', 'notActiveJetpack' ].includes( status ) &&
+			includes( [ 'notJetpack', 'notActiveJetpack' ], status ) &&
 			! this.props.jetpackConnectSite.isDismissed
 		) {
 			return this.renderInstructions( this.getInstructionsData( status ) );


### PR DESCRIPTION
#14227 recently introduced a warning when we use `Array.includes` because of [insufficient browser support](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Browser_compatibility), thanks for that @sirreal.

Seems we're using `Array.includes` in Jetpack Connect, so this PR aims to replace it with lodash's `includes`:

![](https://cldup.com/TL0mfVguYZ.png)

To test:
* Checkout this branch
* Test various connection flows and verify they work properly.
* Verify there are no `Array.includes` warnings shown anymore.