### PR TITLE
Checkout: No submit button when transaction is declined

### DIFF
--- a/client/my-sites/upgrades/checkout/cart-toggle.jsx
+++ b/client/my-sites/upgrades/checkout/cart-toggle.jsx
@@ -15,12 +15,6 @@ class CartToggle extends Component {
 		this.state = { isShowingCartOnMobile: false };
 	}
 
-	componentWillMount() {
-		setTimeout( () => {
-			showCartOnMobile( this.state.isShowingCartOnMobile );
-		}, 0 );
-	}
-
 	toggleCartOnMobile = ( event ) => {
 		event.preventDefault();
 

--- a/client/my-sites/upgrades/checkout/cart-toggle.jsx
+++ b/client/my-sites/upgrades/checkout/cart-toggle.jsx
@@ -16,7 +16,9 @@ class CartToggle extends Component {
 	}
 
 	componentWillMount() {
-		showCartOnMobile( this.state.isShowingCartOnMobile );
+		setTimeout( () => {
+			showCartOnMobile( this.state.isShowingCartOnMobile );
+		}, 0 );
 	}
 
 	toggleCartOnMobile = ( event ) => {


### PR DESCRIPTION
Steps to reproduce:

1. Add a product to cart (e.g. plan from /plans), continue to checkout
2. Use payment card that would get declined (e.g. 4000000000000002 in payments sandboxed mode) or random card in production mode
3. Submit checkout form

The progress bar stays displayed and there is no submit button.

![image](https://cloud.githubusercontent.com/assets/203105/26248128/514cd37c-3ca1-11e7-908d-9eaab9ce4e77.png)

Caused by this error: `Uncaught Error: Invariant Violation: Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.`

<Details>
Uncaught Error: Invariant Violation: Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.
    at invariant (invariant.js:39)
    at Dispatcher.dispatch (Dispatcher.js:167)
    at Dispatcher.handleViewAction (index.js:15)
    at showCartOnMobile (cart.js:52)
    at CartToggle.componentWillMount (cart-toggle.jsx:60)
    at eval (ReactCompositeComponent.js:348)
    at measureLifeCyclePerf (ReactCompositeComponent.js:75)
    at ReactCompositeComponentWrapper.performInitialMount (ReactCompositeComponent.js:347)
    at ReactCompositeComponentWrapper.mountComponent (ReactCompositeComponent.js:258)
    at Object.mountComponent (ReactReconciler.js:46)
</Details>
