### PR TITLE
Plans: remove Google Voucher for AT sites

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-voucher/index.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import debounce from 'lodash/debounce';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -208,6 +209,15 @@ class GoogleVoucherDetails extends Component {
 		const { selectedSite, translate } = this.props;
 		const { step } = this.state;
 		let body;
+
+		if ( ! selectedSite ) {
+			return null;
+		}
+
+		// hide voucher for AT sites
+		if ( get( selectedSite, 'options.is_automated_transfer' ) ) {
+			return null;
+		}
 
 		switch ( step ) {
 			case INITIAL_STEP:


### PR DESCRIPTION
As a regular Jetpack site, an AT site does not have the capability to handle the workflow about the Google Voucher feature.
So for now, the little fix is hiding this feature. Keep in mind we are not showing this one for Jetpack either.

### Testing

1) Go to plans page for an AT site: `http://calypso.localhost:3000/plans/my-plan/<your-at-site>`
You shouldn't see the google voucher feature.

2) Select a non-AT site. Now you should see the feature.

<img src="https://cloud.githubusercontent.com/assets/77539/26248328/4c63d7c6-3c78-11e7-86f9-b2b3011e634e.png" width="400px" />