### PR TITLE
Reader: add manage following empty state

### DIFF
--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+
+class FollowingManageEmptyContent extends React.Component {
+	componentDidMount() {
+		recordTrack( 'calypso_reader_empty_manage_following_loaded' );
+	}
+
+	recordAction = () => {
+		recordAction( 'clicked_discover_on_empty_manage_following' );
+		recordGaEvent( 'Clicked Discover on EmptyContent in Manage Following' );
+		recordTrack( 'calypso_reader_discover_on_empty_manage_following_clicked' );
+	};
+
+	render() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		const action = (
+			<a
+				className="empty-content__action button is-primary"
+				onClick={ this.recordAction }
+				href="/discover"
+			>
+				{ this.props.translate( 'Explore Discover' ) }
+			</a>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+
+		return (
+			<EmptyContent
+				action={ action }
+				title={ this.props.translate( "You haven't followed any sites yet" ) }
+				line={ this.props.translate( 'Search for a site above or explore Discover.' ) }
+				illustration={ '/calypso/images/drake/drake-all-done.svg' }
+				illustrationWidth={ 500 }
+			/>
+		);
+	}
+}
+
+export default localize( FollowingManageEmptyContent );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -33,6 +33,7 @@ import { addQueryArgs } from 'lib/url';
 import FollowButton from 'reader/follow-button';
 import { READER_FOLLOWING_MANAGE_URL_INPUT } from 'reader/follow-button/follow-sources';
 import { resemblesUrl, addSchemeIfMissing, withoutHttp } from 'lib/url';
+import { getReaderFollowsCount } from 'state/selectors';
 
 const PAGE_SIZE = 4;
 
@@ -150,9 +151,12 @@ class FollowingManage extends Component {
 			showMoreResults,
 			getRecommendedSites,
 			isSiteBlocked,
+			followsCount,
 		} = this.props;
 		const searchPlaceholderText = translate( 'Search or enter URL to follow…' );
-		const showExistingSubscriptions = ! ( !! sitesQuery && showMoreResults );
+		const isSearching = !! sitesQuery;
+		const hasFollows = followsCount > 0;
+		const showExistingSubscriptions = ! isSearching && hasFollows;
 		const isSitesQueryUrl = resemblesUrl( sitesQuery );
 		let sitesQueryWithoutProtocol;
 		if ( isSitesQueryUrl ) {
@@ -167,7 +171,8 @@ class FollowingManage extends Component {
 					<h1>{ translate( 'Manage Followed Sites' ) }</h1>
 				</MobileBackToSidebar>
 				{ ! searchResults && ! isSitesQueryUrl && <QueryReaderFeedsSearch query={ sitesQuery } /> }
-				{ recommendedSites.length <= 2 &&
+				{ hasFollows &&
+					recommendedSites.length <= 2 &&
 					<QueryReaderRecommendedSites seed={ this.state.seed } offset={ this.state.offset } /> }
 				<h2 className="following-manage__header">{ translate( 'Follow Something New' ) }</h2>
 				<div ref={ this.handleStreamMounted } />
@@ -198,7 +203,7 @@ class FollowingManage extends Component {
 							/>
 						</div> }
 				</div>
-				{ ! sitesQuery && <RecommendedSites sites={ take( recommendedSites, 2 ) } /> }
+				{ hasFollows && ! sitesQuery && <RecommendedSites sites={ take( recommendedSites, 2 ) } /> }
 				{ !! sitesQuery &&
 					! isSitesQueryUrl &&
 					<FollowingManageSearchFeedsResults
@@ -211,13 +216,13 @@ class FollowingManage extends Component {
 						searchResultsCount={ searchResultsCount }
 						query={ sitesQuery }
 					/> }
-				{ showExistingSubscriptions && (
+				{ showExistingSubscriptions &&
 					<FollowingManageSubscriptions
 						width={ this.state.width }
 						query={ subsQuery }
 						sortOrder={ subsSortOrder }
 						windowScrollerRef={ this.handleWindowScrollerMounted }
-					/> ) }
+					/> }
 			</ReaderMain>
 		);
 	}
@@ -230,6 +235,7 @@ export default connect(
 		getRecommendedSites: seed => getReaderRecommendedSites( state, seed ),
 		isSiteBlocked: site => isSiteBlockedSelector( state, site.blogId ),
 		getReaderAliasedFollowFeedUrl: url => getReaderAliasedFollowFeedUrl( state, url ),
+		followsCount: getReaderFollowsCount( state ),
 	} ),
 	{ requestFeedSearch }
 )( localize( FollowingManage ) );

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -27,6 +27,7 @@ import QueryReaderRecommendedSites from 'components/data/query-reader-recommende
 import RecommendedSites from 'blocks/reader-recommended-sites';
 import FollowingManageSubscriptions from './subscriptions';
 import FollowingManageSearchFeedsResults from './feed-search-results';
+import FollowingManageEmptyContent from './empty';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import { requestFeedSearch } from 'state/reader/feed-searches/actions';
 import { addQueryArgs } from 'lib/url';
@@ -223,6 +224,7 @@ class FollowingManage extends Component {
 						sortOrder={ subsSortOrder }
 						windowScrollerRef={ this.handleWindowScrollerMounted }
 					/> }
+				{ ! hasFollows && <FollowingManageEmptyContent /> }
 			</ReaderMain>
 		);
 	}


### PR DESCRIPTION
As reported in https://github.com/Automattic/wp-calypso/issues/14189, users not following any feeds didn't see an empty state for Manage Following.

This PR adds one:

<img width="829" alt="screen shot 2017-05-19 at 15 35 01" src="https://cloud.githubusercontent.com/assets/17325/26249971/c008406a-3ca8-11e7-97c9-8fcc2e746447.png">

Fixes https://github.com/Automattic/wp-calypso/issues/14189.
