### PR TITLE
Reader: add a consistent indent for subscription list avatars

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -65,7 +65,7 @@ function ReaderSubscriptionListItem( {
 
 	return (
 		<div className={ classnames( 'reader-subscription-list-item', className ) }>
-			<div>
+			<div className="reader-subscription-list-item__avatar">
 				<ReaderAvatar
 					siteIcon={ siteIcon }
 					feedIcon={ feedIcon }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -305,3 +305,8 @@
 		}
 	}
 }
+
+.reader-subscription-list-item__avatar {
+	min-width: 44px;
+}
+

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -25,7 +25,7 @@ const FollowingManageSearchFeedsResults = ( {
 	searchResultsCount,
 	query,
 } ) => {
-	const isEmpty = !! ( query && searchResults && searchResults.length === 0 );
+	const isEmpty = !! ( query && query.length > 0 && searchResults && searchResults.length === 0 );
 	const classNames = classnames( 'following-manage__search-results', {
 		'is-empty': isEmpty,
 	} );
@@ -44,15 +44,18 @@ const FollowingManageSearchFeedsResults = ( {
 	}
 
 	if ( ! showMoreResults ) {
-		const resultsToShow = map( take( searchResults, 10 ), site => (
-			<ConnectedSubscriptionListItem
-				showLastUpdatedDate={ false }
-				url={ site.feed_URL || site.URL }
-				feedId={ +site.feed_ID }
-				siteId={ +site.blog_ID }
-				key={ `search-result-site-id-${ site.feed_ID || 0 }-${ site.blog_ID || 0 }` }
-			/>
-		) );
+		const resultsToShow = map(
+			take( searchResults, 10 ),
+			site => (
+				<ConnectedSubscriptionListItem
+					showLastUpdatedDate={ false }
+					url={ site.feed_URL || site.URL }
+					feedId={ +site.feed_ID }
+					siteId={ +site.blog_ID }
+					key={ `search-result-site-id-${ site.feed_ID || 0 }-${ site.blog_ID || 0 }` }
+				/>
+			)
+		);
 
 		return (
 			<div className={ classNames }>


### PR DESCRIPTION
If a subscription list item is missing an avatar, indent it anyway. This makes scanning down the list much easier and potentially fixes https://github.com/Automattic/wp-calypso/issues/14083.

Before:

<img width="787" alt="screen shot 2017-05-19 at 16 04 14" src="https://cloud.githubusercontent.com/assets/17325/26251329/2c3b3ca2-3cad-11e7-8413-678c85445c14.png">

After:

<img width="772" alt="screen shot 2017-05-19 at 16 03 46" src="https://cloud.githubusercontent.com/assets/17325/26251318/27623366-3cad-11e7-807a-cefee603c115.png">