### PR TITLE
Components: PreviewCard

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -144,6 +144,7 @@
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';
 @import 'components/post-schedule/style';
+@import 'components/preview-card/style';
 @import 'components/progress-bar/style';
 @import 'components/progress-indicator/style';
 @import 'components/pulsing-dot/style';

--- a/client/components/preview-card/docs/example.jsx
+++ b/client/components/preview-card/docs/example.jsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PreviewCard from 'components/preview-card';
+import PreviewCardContent from 'components/preview-card/preview-card-content';
+import PreviewCardContentElement from 'components/preview-card/preview-card-content-element';
+import PreviewCardHeader from 'components/preview-card/preview-card-header';
+import PreviewCardHeaderElement from 'components/preview-card/preview-card-header-element';
+
+class PreviewCardExample extends Component {
+	state = {
+		isExpanded: false,
+	};
+
+	toggleExpanded = () => this.setState( { isExpanded: ! this.state.isExpanded } );
+
+	getActions = () => [
+		{
+			icon: 'star',
+			label: 'Like',
+			onClick: () => console.log( 'PreviewCardExample like' ),
+		},
+		{
+			icon: 'trash',
+			label: 'Trash',
+			onClick: () => console.log( 'PreviewCardExample trash' ),
+		},
+	];
+
+	getHeader = () =>
+		<PreviewCardHeader onClick={ this.toggleExpanded }>
+			<PreviewCardHeaderElement>
+				<img
+					src="https://secure.gravatar.com/blavatar/e6392390e3bcfadff3671c5a5653d95b?s=240"
+					style={ { height: '24px', verticalAlign: 'middle' } }
+				/>
+				<strong>Username</strong>
+			</PreviewCardHeaderElement>
+			<PreviewCardHeaderElement>
+				Preview content
+			</PreviewCardHeaderElement>
+		</PreviewCardHeader>;
+
+	render() {
+		const { isExpanded } = this.state;
+
+		return(
+			<PreviewCard
+				actions={ this.getActions() }
+				header={ this.getHeader() }
+				isExpanded={ isExpanded }
+				toggleExpanded={ this.toggleExpanded }
+			>
+				<PreviewCardContent>
+					<PreviewCardContentElement>
+						A PreviewCard Element
+					</PreviewCardContentElement>
+					<PreviewCardContentElement>
+						Another PreviewCard Element
+					</PreviewCardContentElement>
+				</PreviewCardContent>
+			</PreviewCard>
+		);
+	}
+}
+
+export const PreviewCardExampleList = () =>
+	<div>
+		<PreviewCardExample />
+		<PreviewCardExample />
+		<PreviewCardExample />
+	</div>;
+
+PreviewCardExampleList.displayName = 'PreviewCard';
+
+export default PreviewCardExampleList;

--- a/client/components/preview-card/index.jsx
+++ b/client/components/preview-card/index.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import PreviewCardAction from 'components/preview-card/preview-card-action';
+import PreviewCardHeader from 'components/preview-card/preview-card-header';
+import PreviewCardHeaderElement from 'components/preview-card/preview-card-header-element';
+
+export class PreviewCard extends Component {
+	static propTypes = {
+		actions: PropTypes.arrayOf( PropTypes.object ),
+		className: PropTypes.string,
+		header: PropTypes.element.isRequired,
+		isExpanded: PropTypes.bool,
+		toggleExpanded: PropTypes.func,
+	};
+
+	static defaultProps = {
+		isExpanded: false,
+	};
+
+	render() {
+		const {
+			actions,
+			className,
+			children,
+			header,
+			isExpanded,
+			toggleExpanded,
+		} = this.props;
+
+		const classes = classNames( 'preview-card', className, { 'is-expanded': isExpanded } );
+
+		return (
+			<Card is-compact className={ classes }>
+				{ isExpanded &&
+					<PreviewCardHeader className="preview-card__actions">
+						<PreviewCardHeaderElement>
+							<PreviewCardAction icon="cross" onClick={ toggleExpanded } />
+						</PreviewCardHeaderElement>
+						<PreviewCardHeaderElement>
+							{ map( actions, ( action, index ) =>
+								<PreviewCardAction { ...action } key={ index } />
+							) }
+						</PreviewCardHeaderElement>
+					</PreviewCardHeader>
+				}
+
+				{ ! isExpanded && header }
+
+				{ isExpanded && children }
+			</Card>
+		);
+	}
+}
+
+export default PreviewCard;

--- a/client/components/preview-card/preview-card-action.jsx
+++ b/client/components/preview-card/preview-card-action.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+import classNames from 'classnames';
+
+export const PreviewCardAction = ( {
+	className,
+	href,
+	icon,
+	label,
+	onClick,
+} ) =>
+	<a
+		className={ classNames( 'preview-card__action', className, { 'has-icon': icon } ) }
+		href={ href }
+		onClick={ onClick }
+	>
+		{ icon && <Gridicon icon={ icon } /> }
+		{ label && <span>{ label }</span> }
+	</a>;
+
+export default PreviewCardAction;

--- a/client/components/preview-card/preview-card-content-element.jsx
+++ b/client/components/preview-card/preview-card-content-element.jsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+export const PreviewCardContentElement = ( {
+	children,
+	className,
+} ) =>
+	<div className={ classNames(
+		'preview-card__content-element',
+		'preview-card__overflow-ellipsis',
+		className
+	) }>
+		{ children }
+	</div>;
+
+export default PreviewCardContentElement;

--- a/client/components/preview-card/preview-card-content.jsx
+++ b/client/components/preview-card/preview-card-content.jsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+export const PreviewCardContent = ( {
+	children,
+	className,
+} ) =>
+	<div className={ classNames( 'preview-card__content', className ) }>
+		{ children }
+	</div>;
+
+export default PreviewCardContent;

--- a/client/components/preview-card/preview-card-header-element.jsx
+++ b/client/components/preview-card/preview-card-header-element.jsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+export const PreviewCardHeaderElement = ( {
+	children,
+	className,
+} ) =>
+	<div className={ classNames(
+		'preview-card__header-element',
+		'preview-card__overflow-ellipsis',
+		className
+	) }>
+		{ children }
+	</div>;
+
+export default PreviewCardHeaderElement;

--- a/client/components/preview-card/preview-card-header.jsx
+++ b/client/components/preview-card/preview-card-header.jsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+export const PreviewCardHeader = ( {
+	children,
+	className,
+	onClick,
+} ) =>
+	<div className={ classNames( 'preview-card__header', className ) } onClick={ onClick }>
+		{ children }
+	</div>;
+
+export default PreviewCardHeader;

--- a/client/components/preview-card/style.scss
+++ b/client/components/preview-card/style.scss
@@ -1,0 +1,85 @@
+.preview-card.card {
+	font-size: 14px;
+	margin: 0 auto;
+	padding: 0;
+	transition: margin .15s linear;
+
+	&.is-expanded {
+		margin: 16px auto;
+
+		.preview-card__header {
+			border-bottom: 1px solid lighten( $gray, 30% );
+		}
+	}
+	&:not( .is-expanded ) {
+		&:hover {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
+			z-index: 1;
+		}
+
+		.preview-card__header {
+			cursor: pointer;
+		}
+	}
+
+	.gridicon {
+		margin-right: 4px;
+		vertical-align: middle;
+	}
+}
+
+.preview-card__header {
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: flex-start;
+	padding: 12px 8px;
+}
+
+.preview-card__header-element {
+	padding: 0px 8px;
+}
+
+.preview-card__actions {
+	justify-content: space-between;
+
+	.preview-card__header-element {
+		padding: 0;
+	}
+}
+
+.preview-card__action {
+	color: $gray;
+	cursor: pointer;
+	fill: $gray;
+	padding: 8px;
+	white-space: nowrap;
+	&:focus,
+	&:hover {
+		color: $blue-wordpress;
+		fill: $blue-wordpress;
+	}
+
+	&.has-icon span {
+		display: none;
+
+		@include breakpoint( ">960px" ) {
+			display: inline;
+		}
+	}
+}
+
+.preview-card__content-element {
+	border-bottom: 1px solid lighten( $gray, 30% );
+	padding: 16px;
+
+	&:last-child {
+		border-bottom: none;
+	}
+}
+
+// Utilities
+.preview-card__overflow-ellipsis {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -71,6 +71,7 @@ import VerticalMenu from 'components/vertical-menu/docs/example';
 import Banner from 'components/banner/docs/example';
 import EmojifyExample from 'components/emojify/docs/example';
 import LanguagePicker from 'components/language-picker/docs/example';
+import PreviewCard from 'components/preview-card/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -149,6 +150,7 @@ let DesignAssets = React.createClass( {
 					<Notices />
 					<PaymentLogo />
 					<Popovers />
+					<PreviewCard />
 					<ProgressBar />
 					<Ranges />
 					<Rating />


### PR DESCRIPTION
As part of the [Comment Management](https://github.com/Automattic/wp-calypso/projects/32) project, I've started iterating on the component asynchronously with the actual design iterations, in order to speed up both design and development and at the same time to have a working sandbox to test in.

During various design discussions (see: p3fqKv-4yC-p2), it emerged that the comment management behaviour is actually quite similar to other form of communications.

Now, I've sincerely think that the current comment management design iteration is ace (even though is by no mean complete yet!), and I'd personally love to see it used also on other management lists, if only to improve the UX consistency across Calypso.

A simple demo of the comment management list is available at https://wpcalypso.wordpress.com/devdocs/blocks/comment-detail.

![may-16-2017 19-34-50](https://cloud.githubusercontent.com/assets/2070010/26122307/eeefcfe2-3a6e-11e7-9956-7ceb2db28684.gif)

Unfortunately though, that completely fails to take advantage of React components composition and reusability. As it should be clear with a quick glance of its code, it's 100% tied to the comment management.

For this reason, I've thought of extracting everything that could be extracted from `CommentDetail` and I've placed it in a standalone and extremely flexible component, ineptly named **`PreviewCard`**.

![may-19-2017 16-05-15](https://cloud.githubusercontent.com/assets/2070010/26251275/07c6f582-3cad-11e7-9e04-b2d27596d133.gif)

(Testable at `/devdocs/design/preview-card`)

The idea behind `PreviewCard` is to offer to developer both a stylish component ready to be used with the least possible friction, and some optional framework utilities that can be used to improve the consistency.
To give you just a couple of examples, in this PR proof of concept we can see that:

- The card content is completely free (it uses the `children` prop), but can be filled with `PreviewCardContentElement`s, which right now are simple div with a bottom border and some padding, but in some future iterations could radically change, while still keeping a visual consistency everywhere.

- There's a `.preview-card__overflow-ellipsis` utility CSS class, that can be added everywhere, which might prove itself quite worthy in a "flexbox / row" situation, with divs prone to be resized to really small widths.

Now, I'm fairly sure that refactoring the current version of `CommentDetail` to use `PreviewCard` would require a quite limited amount of code, and the same goes for the CSS overrides needed (reason why I've kept the styling as bare bones as possible).

As you can see, in fact, most of the code of this PR is in the example component, but the look and feel is undeniably similar to the `CommentDetail` demo.

What do you think about this?
Is it something that in your opinion could make sense and be helpful to all our projects?

---

PS: I've named it "Preview Card" because it's inspired by `FoldableCard` and, when closed, it shows a preview of the entire content.
I don't like this name, but somehow "Inbox-Like Foldable Card" felt a bit off as well. 😄 