### PR TITLE
Jetpack plans: fix SEO preview offering a dotcom plan

### DIFF
--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -6,12 +6,10 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import Gridicon from 'gridicons';
-import { compact } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import QueryPlans from 'components/data/query-plans';
 import FeatureExample from 'components/feature-example';
 import FeatureComparison from 'my-sites/feature-comparison';
@@ -25,63 +23,12 @@ import { isFreePlan, isFreeJetpackPlan } from 'lib/products-values';
 import { isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getPlanBySlug } from 'state/plans/selectors';
+import { getPlan } from 'lib/plans';
 import {
 	PLAN_BUSINESS,
 	PLAN_JETPACK_BUSINESS,
-	FEATURE_ADVANCED_SEO,
-	FEATURE_CUSTOM_DOMAIN,
-	FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
-	FEATURE_ADVANCED_DESIGN,
-	FEATURE_UNLIMITED_STORAGE,
-	FEATURE_NO_ADS,
-	FEATURE_WORDADS_INSTANT,
-	FEATURE_VIDEO_UPLOADS,
-	FEATURE_GOOGLE_ANALYTICS,
-	FEATURE_NO_BRANDING,
-	FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-	FEATURE_BACKUP_ARCHIVE_UNLIMITED,
-	FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-	FEATURE_AUTOMATED_RESTORES,
-	FEATURE_SPAM_AKISMET_PLUS,
-	FEATURE_EASY_SITE_MIGRATION,
-	FEATURE_PREMIUM_SUPPORT,
-	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-	FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
-	FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-	FEATURE_REPUBLICIZE,
-	FEATURE_REPUBLICIZE_SCHEDULING
+	FEATURE_ADVANCED_SEO
 } from 'lib/plans/constants';
-
-const businessPlanFeatures = [
-	FEATURE_CUSTOM_DOMAIN,
-	FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
-	FEATURE_UNLIMITED_PREMIUM_THEMES,
-	FEATURE_ADVANCED_DESIGN,
-	FEATURE_UNLIMITED_STORAGE,
-	FEATURE_NO_ADS,
-	FEATURE_WORDADS_INSTANT,
-	FEATURE_VIDEO_UPLOADS,
-	FEATURE_GOOGLE_ANALYTICS,
-	FEATURE_NO_BRANDING
-];
-
-const jetpackBusinessPlanFeatures = compact( [
-	FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-	FEATURE_BACKUP_ARCHIVE_UNLIMITED,
-	FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
-	FEATURE_AUTOMATED_RESTORES,
-	FEATURE_SPAM_AKISMET_PLUS,
-	FEATURE_EASY_SITE_MIGRATION,
-	FEATURE_PREMIUM_SUPPORT,
-	FEATURE_WORDADS_INSTANT,
-	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-	FEATURE_MALWARE_SCANNING_DAILY_AND_ON_DEMAND,
-	FEATURE_ONE_CLICK_THREAT_RESOLUTION,
-	FEATURE_GOOGLE_ANALYTICS,
-	isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-	isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING
-] );
 
 const SeoPreviewNudge = ( { translate, domain, plan = {}, businessPlan = {}, isJetpack = false, planFeatures = [] } ) => {
 	let planPrice = translate( 'Free for life' );
@@ -105,7 +52,11 @@ const SeoPreviewNudge = ( { translate, domain, plan = {}, businessPlan = {}, isJ
 		? translate( '%(price)s per year', { args: { price: businessPlanPrice } } )
 		: translate( '%(price)s per month, billed yearly', { args: { price: businessPlanPrice } } );
 
-	const featuresToShow = planFeatures.filter( feature => ! planHasFeature( plan.product_slug, feature ) );
+	const featuresToShow = planFeatures.filter(
+		feature =>
+			! planHasFeature( plan.product_slug, feature ) &&
+			feature !== FEATURE_ADVANCED_SEO
+	);
 	return (
 		<div className="preview-upgrade-nudge">
 			<QueryPlans />
@@ -193,12 +144,13 @@ SeoPreviewNudge.propTypes = {
 const mapStateToProps = ( state, ownProps ) => {
 	const { site } = ownProps;
 	const isJetpack = isJetpackSite( state, site.ID );
+
 	return {
 		domain: site.domain,
 		plan: getPlanBySlug( state, site.plan.product_slug ),
 		businessPlan: getPlanBySlug( state, isJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS ),
 		isJetpack,
-		planFeatures: isJetpack ? jetpackBusinessPlanFeatures : businessPlanFeatures
+		planFeatures: getPlan( isJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS ).getFeatures()
 	};
 };
 

--- a/client/my-sites/plan-compare-card/item.jsx
+++ b/client/my-sites/plan-compare-card/item.jsx
@@ -29,7 +29,7 @@ export default React.createClass( {
 		const showCheckmark = this.props.highlight || ! this.props.unavailable;
 		return (
 			<li className={ classes }>
-				{ showCheckmark && <Gridicon className="plan-compare-card-item__checkmark" size={ 18 } icon="checkmark" /> }
+				{ showCheckmark && <span className="plan-compare-card__item-checkmark"><Gridicon size={ 18 } icon="checkmark" /></span> }
 				{ this.props.children }
 			</li>
 		);

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -60,6 +60,7 @@
 }
 
 .plan-compare-card-item {
+	display: flex;
 	list-style-type: none;
 }
 
@@ -73,10 +74,10 @@
 	margin-left: 24px;
 }
 
-.plan-compare-card-item__checkmark {
+.plan-compare-card__item-checkmark {
 	margin-right: 6px;
 	vertical-align: middle;
-	margin-top: -4px;
+	line-height: 16px;
 }
 
 .plan-compare-card__button-checkmark {


### PR DESCRIPTION
Right now, if you are in your plans page with a jetpack site that doesn't have a business plan, we are offering to purchase a dotcom business plan, instead of a jetpack one:

![image](https://cloud.githubusercontent.com/assets/1554855/26256713/21b5e500-3cbe-11e7-9a14-c5aed3832ab1.png)

This PR fixes this so the SEO upgrade nudge has into account if the selected site is a jetpack one or not:

![image](https://cloud.githubusercontent.com/assets/1554855/26256770/4c5e23b2-3cbe-11e7-9b7f-726865e2c8bf.png)

How to test
=====
1. Go to http://calypso.localhost:3000/plans and select a jetpack site (that doesn't have a business plan)
2. On the sidebar, click on site preview
3. Click on the SEO tab
4. You should see jetpack plans features and if you click 'upgrade' you should end in the checkout step with a business plan in your cart

ping @richardmuscat @seear @oskosk @rodrigoi 