### PR TITLE
Reader: Use static 'Streams' title for mobile header

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -169,7 +169,7 @@ class FollowingManage extends Component {
 			<ReaderMain className="following-manage">
 				<DocumentHead title={ 'Manage Following' } />
 				<MobileBackToSidebar>
-					<h1>{ translate( 'Manage Followed Sites' ) }</h1>
+					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
 				{ ! searchResults && ! isSitesQueryUrl && <QueryReaderFeedsSearch query={ sitesQuery } /> }
 				{ hasFollows &&

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -177,7 +177,7 @@ class SearchStream extends Component {
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<DocumentHead title={ documentTitle } />
 					<MobileBackToSidebar>
-						<h1>{ translate( 'Search' ) }</h1>
+						<h1>{ translate( 'Streams' ) }</h1>
 					</MobileBackToSidebar>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -134,15 +134,18 @@ class SearchStream extends Component {
 		}
 
 		const suggestionList = initial(
-			flatMap( suggestions, suggestion => [
-				<Suggestion
-					suggestion={ suggestion.text }
-					source="search"
-					sort={ sortOrder === 'date' ? sortOrder : undefined }
-					railcar={ suggestion.railcar }
-				/>,
-				', ',
-			] )
+			flatMap(
+				suggestions,
+				suggestion => [
+					<Suggestion
+						suggestion={ suggestion.text }
+						source="search"
+						sort={ sortOrder === 'date' ? sortOrder : undefined }
+						railcar={ suggestion.railcar }
+					/>,
+					', ',
+				]
+			)
 		);
 
 		const documentTitle = this.props.translate( '%s ‹ Reader', {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -465,7 +465,7 @@ class ReaderStream extends React.Component {
 			<ReaderMain className={ classnames( 'following', this.props.className ) }>
 				{ this.props.showMobileBackToSidebar &&
 					<MobileBackToSidebar>
-						<h1>{ this.props.listName }</h1>
+						<h1>{ this.props.translate( 'Streams' ) }</h1>
 					</MobileBackToSidebar> }
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.showUpdates } />


### PR DESCRIPTION
Fixes #14079

before
![screenshot 2017-05-19 12 22 31](https://cloud.githubusercontent.com/assets/14350/26257252/d8e99c0c-3c8d-11e7-81a6-ff7f8d40e55f.png)

after
![screenshot 2017-05-19 12 21 58](https://cloud.githubusercontent.com/assets/14350/26257227/c9d78ee0-3c8d-11e7-976d-404c958dbf7f.png)
