### PR TITLE
Banner: Account for Jetpack plans in component

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -5,6 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import {
+	includes,
 	noop,
 	size,
 } from 'lodash';
@@ -17,6 +18,12 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
 } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
@@ -204,9 +211,26 @@ class Banner extends Component {
 			'banner',
 			className,
 			{ 'has-call-to-action': callToAction },
-			{ 'is-upgrade-personal': PLAN_PERSONAL === plan },
-			{ 'is-upgrade-premium': PLAN_PREMIUM === plan },
-			{ 'is-upgrade-business': PLAN_BUSINESS === plan },
+			{ 'is-upgrade-personal':
+				includes( [
+					PLAN_PERSONAL,
+					PLAN_JETPACK_PERSONAL,
+					PLAN_JETPACK_PERSONAL_MONTHLY,
+				], plan )
+			},
+			{ 'is-upgrade-premium':
+				includes( [
+					PLAN_PREMIUM,
+					PLAN_JETPACK_PREMIUM,
+					PLAN_JETPACK_PREMIUM_MONTHLY,
+				], plan ) },
+			{ 'is-upgrade-business':
+				includes( [
+					PLAN_BUSINESS,
+					PLAN_JETPACK_BUSINESS,
+					PLAN_JETPACK_BUSINESS_MONTHLY,
+				], plan )
+			},
 			{ 'is-dismissible': dismissPreferenceName }
 		);
 


### PR DESCRIPTION
The `Banner` component did not account for Jetpack plans correctly. This PR updates the component to correctly support Jetpack plans.

To test:
* Use this branch
* Visit a page with a Banner displayed for Jetpack. It may be helpful to use the following links
  * [Create Jetpack sandboxed site pointing to calypso.localhost](poopy.life/create?src=homely-
otter&key=PHjCsw94ZfbK9q5t)
  * Ensure you have a Free/Personal plan
  * Visit http://calypso.localhost:3000/settings/writing/:site for your new site.
* Check the video `Banner`, ensure it is styled and working correctly

You can fiddle with component via react dev tools. By default it will display the `Banner` for a Jetpack Premium plan.

### Jetpack Premium (`jetpack_premium` / `jetpack_premium_monthly`)

![premium](https://cloud.githubusercontent.com/assets/841763/26303274/6f835b2a-3ee7-11e7-9410-5233d5955595.png)

### Jetpack Personal (`jetpack_personal` / `jetpack_personal_monthly`)

![personal](https://cloud.githubusercontent.com/assets/841763/26303289/8288af36-3ee7-11e7-90a7-dab8f433432d.png)

### Jetpack Professional (`jetpack_business`/`jetpack_business_monthly`)

![pro](https://cloud.githubusercontent.com/assets/841763/26303293/84d1a248-3ee7-11e7-9413-024758e0976d.png)

_selected text in screenshots mine, not part of component styling_

Via @drw158 in https://github.com/Automattic/wp-calypso/pull/14229#issuecomment-302748951