### PR TITLE
Improves wording of success and error notices when applying DNS templates

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/email-provider.jsx
@@ -44,9 +44,9 @@ class EmailProvider extends Component {
 
 		upgradesActions.applyDnsTemplate( domain, template.dnsTemplate, variables, ( error ) => {
 			if ( error ) {
-				notices.error( error.message || translate( 'The DNS records were not able to be added.' ) );
+				notices.error( error.message || translate( 'We weren\'t able to add DNS records for this service. Please try again.' ) );
 			} else {
-				notices.success( translate( 'All DNS records for this service have been added.' ), {
+				notices.success( translate( 'Hooray! We\'ve successfully added DNS records for this service.' ), {
 					duration: 5000
 				} );
 			}


### PR DESCRIPTION
This PR improves the wording of the success and error messages when applying a DNS Template from the Name Servers and DNS page.

@yoavf pointed out that the wording may be awkward and the editorial team helpfully suggested these changes. (See p2JRYi-3bm-p2)

The new success message:
![image](https://cloud.githubusercontent.com/assets/1379730/26258825/5940eac6-3c94-11e7-85e6-0e13576656be.png)

The new generic error message:
![image](https://cloud.githubusercontent.com/assets/1379730/26258813/4d913564-3c94-11e7-80fe-07935babce1f.png)
