### PR TITLE
Publicize: Move 'Add account' button to SectionHeader

### DIFF
--- a/client/my-sites/post-share/connections-list.jsx
+++ b/client/my-sites/post-share/connections-list.jsx
@@ -54,10 +54,15 @@ class ConnectionsList extends PureComponent {
 			return null;
 		}
 
+		const brokenConnections = connections.filter( connection => connection.status === 'broken' );
+
+		if ( ! brokenConnections || ! brokenConnections.length ) {
+			return null;
+		}
+
 		return (
 			<div>
-				{ connections
-					.filter( connection => connection.status === 'broken' )
+				{ brokenConnections
 					.map( connection => <Notice
 						key={ connection.keyring_connection_ID }
 						status="is-warning"
@@ -85,7 +90,7 @@ class ConnectionsList extends PureComponent {
 		}
 
 		return (
-			<div className="post-share__connections">
+			<div className="card post-share__connections">
 				{ this.renderWarnings() }
 
 				{ connections.map( connection =>

--- a/client/my-sites/post-share/connections-list.jsx
+++ b/client/my-sites/post-share/connections-list.jsx
@@ -90,7 +90,7 @@ class ConnectionsList extends PureComponent {
 		}
 
 		return (
-			<div className="card post-share__connections">
+			<div className="post-share__connections">
 				{ this.renderWarnings() }
 
 				{ connections.map( connection =>

--- a/client/my-sites/post-share/connections-list.jsx
+++ b/client/my-sites/post-share/connections-list.jsx
@@ -56,7 +56,7 @@ class ConnectionsList extends PureComponent {
 
 		const brokenConnections = connections.filter( connection => connection.status === 'broken' );
 
-		if ( ! brokenConnections || ! brokenConnections.length ) {
+		if ( ! brokenConnections.length ) {
 			return null;
 		}
 

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -355,13 +355,13 @@ class PostShare extends Component {
 						onMouseEnter={ this.showAddTooltip }
 						onMouseLeave={ this.hideAddTooltip }
 						ref="addAccountButton"
-						aria-label={ translate( 'Add account', { context: 'button label' } ) }>
+						aria-label={ translate( 'Add account' ) }>
 						<Gridicon icon="plus-small" size={ 18 } /><Gridicon icon="user" size={ 18 } />
 						<Tooltip
 							isVisible={ this.state.showAccountTooltip }
 							context={ this.refs && this.refs.addAccountButton }
 							position="bottom">
-							{ translate( 'Add account', { context: 'button tooltip' } ) }
+							{ translate( 'Add account' ) }
 						</Tooltip>
 					</Button>
 				</SectionHeader>

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -333,13 +333,9 @@ class PostShare extends Component {
 		}
 	}
 
-	showAddTooltip = () => {
-		this.setState( { showAccountTooltip: true } );
-	}
+	showAddTooltip = () => this.setState( { showAccountTooltip: true } );
 
-	hideAddTooltip = () => {
-		this.setState( { showAccountTooltip: false } );
-	}
+	hideAddTooltip = () => this.setState( { showAccountTooltip: false } );
 
 	renderConnectionsSection() {
 		const { hasFetchedConnections, siteId, siteSlug, translate } = this.props;

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { get, includes, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -55,6 +56,8 @@ import {
 	SCHEDULED,
 	PUBLISHED,
 } from './constants';
+import SectionHeader from 'components/section-header';
+import Tooltip from 'components/tooltip';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -89,6 +92,7 @@ class PostShare extends Component {
 		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title,
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
 		showSharingPreview: false,
+		showAccountTooltip: false,
 	};
 
 	setFooterSection = selectedShareTab => () => this.setState( { selectedShareTab } );
@@ -329,6 +333,14 @@ class PostShare extends Component {
 		}
 	}
 
+	showAddTooltip = () => {
+		this.setState( { showAccountTooltip: true } );
+	}
+
+	hideAddTooltip = () => {
+		this.setState( { showAccountTooltip: false } );
+	}
+
 	renderConnectionsSection() {
 		const { hasFetchedConnections, siteId, siteSlug, translate } = this.props;
 
@@ -339,9 +351,24 @@ class PostShare extends Component {
 
 		return (
 			<div className="post-share__services">
-				<h5 className="post-share__services-header">
-					{ translate( 'Connected services' ) }
-				</h5>
+				<SectionHeader className="post-share__services-header" label={ translate( 'Connected accounts' ) }>
+					<Button
+						compact
+						href={ '/sharing/' + siteId }
+						className="post-share__add-button"
+						onMouseEnter={ this.showAddTooltip }
+						onMouseLeave={ this.hideAddTooltip }
+						ref="addAccountButton"
+						aria-label={ translate( 'Add account', { context: 'button label' } ) }>
+						<Gridicon icon="plus-small" size={ 18 } /><Gridicon icon="user" size={ 18 } />
+						<Tooltip
+							isVisible={ this.state.showAccountTooltip }
+							context={ this.refs && this.refs.addAccountButton }
+							position="bottom">
+							{ translate( 'Add account', { context: 'button tooltip' } ) }
+						</Tooltip>
+					</Button>
+				</SectionHeader>
 
 				<ConnectionsList { ...{
 					connections,
@@ -351,14 +378,6 @@ class PostShare extends Component {
 				} }
 					onToggle={ this.toggleConnection }
 				/>
-
-				<Button
-					href={ '/sharing/' + siteId }
-					compact={ true }
-					className="post-share__services-add"
-				>
-					{ translate( 'Add account' ) }
-				</Button>
 			</div>
 		);
 	}

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -33,7 +33,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share__main {
-	border-top: $section-border;
 	display: flex;
 	flex-direction: column-reverse;
 
@@ -66,57 +65,20 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share__form {
-	flex: 3;
+	flex: 3 0 0;
 	padding-bottom: 16px;
-
-	@include breakpoint( ">480px" ) {
-		border-right: $section-border;
-	}
-
-	@include breakpoint( ">660px" ) {
-		border-right-width: 0;
-	}
-
-	@include breakpoint( ">960px" ) {
-		border-right-width: 1px;
-	}
 
 	.editor-sharing__publicize-message {
 			margin-top: 0;
 
-		@include breakpoint( ">480px" ) {
-			margin-top: 11px;
-		}
-
-		@include breakpoint( ">660px" ) {
-			margin-top: 0;
-		}
-
-		@include breakpoint( ">960px" ) {
-			margin-top: 11px;
-		}
-
 		.editor-sharing__message-heading {
-			border-top: $section-border;
-			border-bottom: $section-border;
-			line-height: 15px;
-			margin-bottom: 8px;
+			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 0 0 transparentize( lighten( $gray, 20% ), .5 );
+			line-height: 28px;
+			margin-bottom: 0;
 			padding: 11px 16px;
 
 			@include breakpoint( ">480px" ) {
-				border-top: 0;
-				padding: 0 24px 11px;
-			}
-
-			@include breakpoint( ">660px" ) {
-				border-top: $section-border;
-				line-height: 28px;
-				padding-top: 11px;
-			}
-
-			@include breakpoint( ">960px" ) {
-				border-top: 0;
-				padding-top: 0;
+				padding: 11px 24px;
 			}
 		}
 
@@ -124,8 +86,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 			margin: 16px 16px 8px;
 
 			@include breakpoint( ">480px" ) {
-				margin-right: 24px;
-				margin-left: 24px;
+				margin: 24px 24px 8px;
 			}
 
 			&.form-textarea {
@@ -142,44 +103,26 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share__services {
-	flex: 2;
-	flex-direction: column;
-	display: flex;
-	flex-wrap: wrap;
-	margin-top: 11px;
-	padding-bottom: 16px;
+	flex: 2 1 0;
 }
 
-.post-share__services-header {
-	border-bottom: $section-border;
-	font-size: 14px;
-	line-height: 15px;
-	margin-bottom: 16px;
-	padding: 0 16px 11px;
+.post-share__services .section-header__actions {
+	flex: 0 0 auto;
+}
 
-	@include breakpoint( ">480px" ) {
-		padding: 0 24px 11px;
-	}
-
-	@include breakpoint( ">660px" ) {
-		line-height: 28px;
-	}
+.post-share__connections {
+	margin-bottom: 0;
 }
 
 .post-share__service {
 	align-items: center;
 	cursor: pointer;
 	display: flex;
-	padding-bottom: 16px;
 	color: lighten( $gray, 20% );
-	margin: 0 16px;
-
-	@include breakpoint( ">480px" ) {
-		margin: 0 24px;
-	}
+	margin-top: 16px;
 
 	&:first-of-type {
-		margin-top: 8px;
+		margin-top: 0;
 	}
 
 	&.is-broken {

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -36,14 +36,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	display: flex;
 	flex-direction: column-reverse;
 
-	@include breakpoint( ">480px" ) {
-		flex-direction: row;
-	}
-
-	@include breakpoint( ">660px" ) {
-		flex-direction: column-reverse;
-	}
-
 	@include breakpoint( ">960px" ) {
 		flex-direction: row;
 	}
@@ -67,6 +59,10 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 .post-share__form {
 	flex: 3 0 0;
 	padding-bottom: 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding-bottom: 24px;
+	}
 
 	.editor-sharing__publicize-message {
 			margin-top: 0;
@@ -104,6 +100,10 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share__services {
 	flex: 2 1 0;
+
+	@include breakpoint( ">960px" ) {
+		border-left: $section-border;
+	}
 }
 
 .post-share__services .section-header__actions {
@@ -111,7 +111,11 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share__connections {
-	margin-bottom: 0;
+	padding: 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 24px;
+	}
 }
 
 .post-share__service {

--- a/client/my-sites/post-share/style.scss
+++ b/client/my-sites/post-share/style.scss
@@ -86,7 +86,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 			}
 
 			&.form-textarea {
-				margin-top: 8px;
 				padding: 8px;
 				width: calc(100% - 32px);
 


### PR DESCRIPTION
This PR intends to move "Add account" button to SectionHeader. Calypso has already established this pattern in many places such as People and Plugins. Also this makes the panel where we now have avatars. This also simplify some of unpleasant css around the fake SectionHeader with `<h5>`.

I've also changed the heading to say "Connected accounts" for a consistency, and it sounds a lot better to me when we can have more than one accounts from a same "service".
 
Props @retrofox for his advice.

Before:
<img width="299" alt="screen shot 2017-05-19 at 19 01 41" src="https://cloud.githubusercontent.com/assets/908665/26260584/a72d034c-3cc5-11e7-8c6f-0b7f75112842.png">

After:
<img width="301" alt="screen shot 2017-05-19 at 18 43 28" src="https://cloud.githubusercontent.com/assets/908665/26260445/2b7aa0ba-3cc5-11e7-9f32-0dd2acebc2b0.png">

