### PR TITLE
Use the new "withoutPersistence" helper on the wc-api reducer.

### DIFF
--- a/client/extensions/woocommerce/state/wc-api/reducer.js
+++ b/client/extensions/woocommerce/state/wc-api/reducer.js
@@ -3,10 +3,7 @@
  */
 import error from './error-reducer';
 import productCategories from './product-categories/reducer';
-import {
-	SERIALIZE,
-	DESERIALIZE,
-} from 'state/action-types';
+import { withoutPersistence } from 'state/utils';
 
 const initialState = {};
 
@@ -15,15 +12,10 @@ const handlers = {
 	...error,
 };
 
-export default function( state = initialState, action ) {
+export default withoutPersistence( ( state = initialState, action ) => {
 	const { type, payload } = action;
 	const { siteId } = payload || {};
 	const handler = handlers[ type ];
-
-	// Necessary to ensure this data is not persisted.
-	if ( type === SERIALIZE || type === DESERIALIZE ) {
-		return initialState;
-	}
 
 	if ( handler ) {
 		if ( ! siteId ) {
@@ -37,5 +29,4 @@ export default function( state = initialState, action ) {
 	}
 
 	return state;
-}
-
+} );

--- a/client/extensions/woocommerce/state/wc-api/test/reducer.js
+++ b/client/extensions/woocommerce/state/wc-api/test/reducer.js
@@ -16,7 +16,7 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should resist persisting', () => {
-		expect( reducer( undefined, { type: SERIALIZE } ) ).to.eql( {} );
+		expect( reducer( undefined, { type: SERIALIZE } ) ).to.eql( null );
 		expect( reducer( undefined, { type: DESERIALIZE } ) ).to.eql( {} );
 	} );
 


### PR DESCRIPTION
Small "cleanup" PR. https://github.com/Automattic/wp-calypso/pull/14289 introduced a `withoutPersistence` redux helper, I've modified the `wc-api` reducer to use it.

To test: Just run `make test` and check the tests pass.