### PR TITLE
Publicize: add post query

### DIFF
--- a/client/components/data/query-posts/README.md
+++ b/client/components/data/query-posts/README.md
@@ -42,6 +42,16 @@ export default function MyPostsList( { posts } ) {
 
 The site ID for which posts should be queried.
 
+### `postId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td><code>null</code></td></tr>
+</table>
+
+The post ID to query for. If provided a single post query will be performed
+
 ### `query`
 
 <table>

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -12,6 +12,7 @@ import { isEnabled } from 'config';
  * Internal dependencies
  */
 import QueryPostTypes from 'components/data/query-post-types';
+import QueryPosts from 'components/data/query-posts';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
@@ -452,7 +453,7 @@ class PostShare extends Component {
 
 					{ this.renderPrimarySection() }
 				</div>
-
+				<QueryPosts { ...{ siteId, postId } } />
 				<SharingPreviewModal
 					siteId={ siteId }
 					postId={ postId }


### PR DESCRIPTION
This adds a posts query component to the `<PostShare />` in post lists. 

**Why**
The posts list view is currently loading posts from a [Flux based store](https://github.com/Automattic/wp-calypso/blob/master/client/components/post-list-fetcher/index.jsx). As a result we can not assume that the posts will be in the redux state tree. The post share uses a redux connected share preview component which assumes the post will be in the redux state tree. Adding the query component assures the post will be available.

**Testing**
- Enable the `publicize-scheduling` feature flag and connect either a Twitter or Facebook account for sharing
- Visit `http://calypso.localhost:3000/posts/` on a cold start : `localStorage.clear();
    indexedDB.deleteDatabase( 'calypso' );`
- Click on the Share button in the post controls of a post
- A `POST_REQUEST` action should fire for the post
- The post should be added to the state tree
- Click on Preview
- The sharing preview should display content from the post
 
Issue discovered in #14123
h/t @sirbrillig for finding this

