### PR TITLE
Login: Add/update login events

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -19,6 +19,7 @@ import {
 	getTwoFactorNotificationSent,
 	isTwoFactorEnabled
 } from 'state/login/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
 import { login } from 'lib/paths';
@@ -26,6 +27,7 @@ import Notice from 'components/notice';
 
 class Login extends Component {
 	static propTypes = {
+		recordTracksEvent: PropTypes.func.isRequired,
 		redirectLocation: PropTypes.string,
 		requestError: PropTypes.object,
 		requestNotice: PropTypes.object,
@@ -69,6 +71,10 @@ class Login extends Component {
 	};
 
 	rebootAfterLogin = () => {
+		this.props.recordTracksEvent( 'calypso_login_success', {
+			two_factor_enabled: this.props.twoFactorEnabled
+		} );
+
 		window.location.href = this.props.redirectLocation || window.location.origin;
 	};
 
@@ -159,5 +165,7 @@ export default connect(
 		twoFactorEnabled: isTwoFactorEnabled( state ),
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 		twoStepNonce: getTwoFactorAuthNonce( state ),
-	} ),
+	} ), {
+		recordTracksEvent,
+	}
 )( localize( Login ) );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -53,13 +53,13 @@ export class LoginForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
-		this.props.recordTracksEvent( 'calypso_login_block_login_submit' );
+		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
 		this.props.loginUser( this.state.usernameOrEmail, this.state.password, this.state.rememberMe ).then( () => {
-			this.props.recordTracksEvent( 'calypso_login_block_login_success' );
+			this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 			this.props.onSuccess( this.state );
 		} ).catch( error => {
-			this.props.recordTracksEvent( 'calypso_login_block_login_failure', {
+			this.props.recordTracksEvent( 'calypso_login_block_login_form_failure', {
 				error_message: error.message
 			} );
 		} );


### PR DESCRIPTION
This PR:

- Renames the `calypso_login_block_login` prefixed events to use `calypso_login_block_login_form` to indicate that they are events for `LoginForm` and do not (necessarily) represent a successful login if 2FA is enabled.
- Adds a `calypso_login_success` event.

**Testing**
- Visit `/log-in`.
- Open the Developer Tools in Chrome.
- Open the Network pane.
- Ensure that the checkbox by "Preserve log" is checked.
- Log in to an account.
- Type `calypso_login_success` in the filter input.
- Assert that you see one request that matches this filter.

- [x] Code
- [x] Product