### PR TITLE
WooCommerce: Add selectors for last wcApi error.

### DIFF
--- a/client/extensions/woocommerce/state/site/reducer.js
+++ b/client/extensions/woocommerce/state/site/reducer.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import { combineReducers } from 'state/utils';
-
-/**
  * Internal dependencies
  */
-import { keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import status from './status/reducer';
 
 const siteReducer = combineReducers( {

--- a/client/extensions/woocommerce/state/site/status/reducer.js
+++ b/client/extensions/woocommerce/state/site/status/reducer.js
@@ -2,10 +2,6 @@
  * Internal dependencies
  */
 import { combineReducers } from 'state/utils';
-
-/**
- * Internal dependencies
- */
 import wcApi from './wc-api/reducer';
 
 export default combineReducers( {

--- a/client/extensions/woocommerce/state/site/status/wc-api/selectors.js
+++ b/client/extensions/woocommerce/state/site/status/wc-api/selectors.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export function getLastApiError( rootState, siteId ) {
+	const woocommerce = rootState.extensions.woocommerce;
+	return get( woocommerce, [ 'site', siteId, 'status', 'wcApi', 'error', 'data' ] );
+}
+
+export function getLastApiErrorCode( rootState, siteId ) {
+	const err = getLastApiError( rootState, siteId );
+	return ( err ? err.code : undefined );
+}
+
+export function getLastApiErrorMessage( rootState, siteId ) {
+	const err = getLastApiError( rootState, siteId );
+	return ( err ? err.message : undefined );
+}
+

--- a/client/extensions/woocommerce/state/site/status/wc-api/test/selectors.js
+++ b/client/extensions/woocommerce/state/site/status/wc-api/test/selectors.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getLastApiError,
+	getLastApiErrorCode,
+	getLastApiErrorMessage,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	let stateWithoutError;
+	let stateWithError;
+
+	beforeEach( () => {
+		stateWithoutError = {
+			extensions: {
+				woocommerce: {
+					site: {
+						1337: {
+							status: {
+								wcApi: {
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+
+		stateWithError = {
+			extensions: {
+				woocommerce: {
+					site: {
+						1337: {
+							status: {
+								wcApi: {
+									error: {
+										data: {
+											code: 404,
+											message: 'Not found',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+	} );
+
+	describe( 'getLastApiError', () => {
+		it( 'should not provide an error if none is logged.', () => {
+			expect( getLastApiError( stateWithoutError, 1337 ) ).to.not.exist;
+		} );
+
+		it( 'should not provide an error if no site data exists.', () => {
+			expect( getLastApiError( stateWithoutError, 1338 ) ).to.not.exist;
+		} );
+
+		it( 'should provide last error if it exists.', () => {
+			const err = getLastApiError( stateWithError, 1337 );
+			expect( err ).to.exist;
+			expect( err.code ).to.equal( 404 );
+			expect( err.message ).to.equal( 'Not found' );
+		} );
+	} );
+
+	describe( 'getLastApiErrorCode', () => {
+		it( 'should not provide an error code if none is logged.', () => {
+			expect( getLastApiErrorCode( stateWithoutError, 1337 ) ).to.not.exist;
+		} );
+
+		it( 'should not provide an error code if no site data exists.', () => {
+			expect( getLastApiErrorCode( stateWithoutError, 1338 ) ).to.not.exist;
+		} );
+
+		it( 'should match output from getLastApiError.', () => {
+			expect( getLastApiErrorCode( stateWithError, 1337 ) ).to.equal( 404 );
+		} );
+	} );
+
+	describe( 'getLastApiErrorMessage', () => {
+		it( 'should not provide an error message if none is logged.', () => {
+			expect( getLastApiErrorCode( stateWithoutError, 1337 ) ).to.not.exist;
+		} );
+
+		it( 'should not provide an error message if no site data exists.', () => {
+			expect( getLastApiErrorCode( stateWithoutError, 1338 ) ).to.not.exist;
+		} );
+
+		it( 'should match output from getLastApiError.', () => {
+			expect( getLastApiErrorMessage( stateWithError, 1337 ) ).to.equal( 'Not found' );
+		} );
+	} );
+} );
+


### PR DESCRIPTION
This adds selectors for the error object, the code, and the message (if
available).

To Test:

`make test` and ensure tests run successfully.
