### PR TITLE
Ads: Remove Optimized Ads Checkbox

### DIFF
--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -438,7 +438,6 @@ class AdsFormSettings extends Component {
 					</FormButtonsBar>
 
 					{ ! this.props.siteIsJetpack ? this.showAdsToOptions() : null }
-					{ ! this.props.siteIsJetpack ? this.additionalAdsOption() : null }
 
 					<FormSectionHeading>{ translate( 'Site Owner Information' ) }</FormSectionHeading>
 					{ this.siteOwnerOptions() }


### PR DESCRIPTION
We’ve turned on optimized ads by default and therefore no longer need
the checkbox.

**To Test**
1. Go to a WP.com site with WordAds activated.
2. Switch over to `Settings` tab.
3. See that `Optimized Ads` checkbox no longer exists.
4. Update some settings and save them, verifying any changes live on the site.

<img width="749" alt="screen shot 2017-05-20 at 6 14 49 pm" src="https://cloud.githubusercontent.com/assets/273708/26277475/790ad746-3d88-11e7-8209-e255093a4e89.png">
