### PR TITLE
Always display account selection on google's popup

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -69,7 +69,9 @@ class GoogleLoginButton extends Component {
 
 		// Handle click async if the library is not loaded yet
 		// the popup might be blocked by the browser in that case
-		this.initialize().then( gapi => gapi.auth2.getAuthInstance().signIn().then( responseHandler ) );
+		// options are documented here:
+		// https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2signinoptions
+		this.initialize().then( gapi => gapi.auth2.getAuthInstance().signIn( { prompt: 'select_account' } ).then( responseHandler ) );
 	}
 
 	render() {


### PR DESCRIPTION
This pull request fixes #13954 by forcing the account selection to be always displayed:
  
![screen shot 2017-05-21 at 8 55 15](https://cloud.githubusercontent.com/assets/326402/26281563/6c87c1fc-3e03-11e7-9d7a-152b9bf107ab.png)

  #### Testing instructions
  
1. Run `git checkout fix/always-display-account-selection` and start your server, or open a [live branch](https://calypso.live/?branch=fix/always-display-account-selection)
2. Open the [`Start social` flow](http://calypso.localhost:3000/start/social)
3. Check that when you try to sign up with an account if are presented with the account selection screen when you logged in to Google
  
 #### Reviews
  
- [x] Code
- [x] Product
