### PR TITLE
Woo-Connect Insights: Query and Normalize Orders Data

### DIFF
--- a/client/extensions/woocommerce/app/stats/controller.js
+++ b/client/extensions/woocommerce/app/stats/controller.js
@@ -15,7 +15,7 @@ import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 function isValidParameters( context ) {
 	const validParameters = {
 		type: [ 'orders' ],
-		period: [ 'day', 'week', 'month', 'year' ],
+		unit: [ 'day', 'week', 'month', 'year' ],
 	};
 	return Object.keys( validParameters )
 		.every( param => includes( validParameters[ param ], context.params[ param ] ) );
@@ -28,9 +28,8 @@ export default function StatsController( context ) {
 
 	const props = {
 		type: context.params.type,
-		period: context.params.period,
+		unit: context.params.unit,
 		startDate: context.query.start_date,
-		endDate: context.query.end_date,
 	};
 	renderWithReduxStore(
 		<AsyncLoad

--- a/client/extensions/woocommerce/app/stats/index.js
+++ b/client/extensions/woocommerce/app/stats/index.js
@@ -2,19 +2,40 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
 import StatsNavigation from './stats-navigation';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import StatsChart from './stats-chart';
 
-export default class Stats extends Component {
+class Stats extends Component {
 	render() {
+		const { siteId, unit } = this.props;
+		const chartQuery = {
+			unit,
+			date: this.props.moment().format( 'YYYY-MM-DD' ),
+			quantity: '30'
+		};
 		return (
 			<Main className="woocommerce stats" wideLayout={ true }>
-				<StatsNavigation { ...this.props } />
+				<StatsNavigation unit={ unit } type="orders" />
+				<StatsChart siteId={ siteId } query={ chartQuery } />
 			</Main>
 		);
 	}
 }
+
+const localizedStats = localize( Stats );
+
+export default connect(
+	state => {
+		return {
+			siteId: getSelectedSiteId( state ),
+		};
+	}
+)( localizedStats );

--- a/client/extensions/woocommerce/app/stats/stats-chart/index.js
+++ b/client/extensions/woocommerce/app/stats/stats-chart/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSiteStatsNormalizedData, isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
+
+const StatsChart = ( { siteId, query } ) => {
+	return (
+		<div>
+			{ siteId && <QuerySiteStats
+				siteId={ siteId }
+				statType="statsOrders"
+				query={ query }
+			/> }
+		</div>
+	);
+};
+
+export default connect(
+	( state, { query, siteId } ) => {
+		return {
+			data: getSiteStatsNormalizedData( state, siteId, 'statsOrders', query ),
+			isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsOrders', query ),
+		};
+	}
+)( StatsChart );

--- a/client/extensions/woocommerce/app/stats/stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/stats/stats-navigation/index.js
@@ -16,23 +16,23 @@ import SegmentedControl from 'components/segmented-control';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const StatsNavigation = props => {
-	const { translate, slug, type, period } = props;
-	const periods = {
+	const { translate, slug, type, unit } = props;
+	const units = {
 		day: translate( 'Days' ),
 		week: translate( 'Weeks' ),
 		month: translate( 'Months' ),
 		year: translate( 'Years' ),
 	};
 	return (
-		<SectionNav selectedText={ periods[ period ] }>
+		<SectionNav selectedText={ units[ unit ] }>
 			<NavTabs label={ translate( 'Stats' ) }>
-				{ Object.keys( periods ).map( key => (
+				{ Object.keys( units ).map( key => (
 					<NavItem
 						key={ key }
 						path={ `/store/stats/${ type }/${ key }/${ slug }` }
-						selected={ period === key }
+						selected={ unit === key }
 					>
-						{ periods[ key ] }
+						{ units[ key ] }
 					</NavItem>
 				) ) }
 			</NavTabs>
@@ -40,7 +40,7 @@ const StatsNavigation = props => {
 				className="stats-navigation__control"
 				initialSelected="store"
 				options={ [
-					{ value: 'site', label: translate( 'Site' ), path: `/stats/${ period }/${ slug }` },
+					{ value: 'site', label: translate( 'Site' ), path: `/stats/${ unit }/${ slug }` },
 					{ value: 'store', label: translate( 'Store' ) },
 				] }
 			/>

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -182,6 +182,6 @@ export default function() {
 
 	// Add pages that use my-sites navigation instead
 	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
-		page( '/store/stats/:type/:period/:site', siteSelection, navigation, StatsController );
+		page( '/store/stats/:type/:unit/:site', siteSelection, navigation, StatsController );
 	}
 }

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -104,6 +104,61 @@ export function getSerializedStatsQuery( query = {} ) {
 	return JSON.stringify( sortBy( toPairs( query ), ( pair ) => pair[ 0 ] ) );
 }
 
+/**
+ * Return data in a format used by 'components/chart`. The fields array is matched to
+ * the data in a single object.
+ *
+ * @param {Object} payload - response
+ * @param {array} nullAttributes - properties on data objects to be initialized with
+ * a null value
+ * @return {array} - Array of data objects
+ */
+function parseChartData( payload, nullAttributes = [] ) {
+	if ( ! payload || ! payload.data ) {
+		return [];
+	}
+
+	return payload.data.map( function( record ) {
+		// Initialize data
+		const dataRecord = nullAttributes.reduce( ( memo, attribute ) => {
+			memo[ attribute ] = null;
+			return memo;
+		}, {} );
+
+		// Fill Field Values
+		record.forEach( function( value, i ) {
+			// Remove W from weeks
+			if ( 'period' === payload.fields[ i ] ) {
+				value = value.replace( /W/g, '-' );
+			}
+			dataRecord[ payload.fields[ i ] ] = value;
+		} );
+
+		dataRecord.labelDay = '';
+		dataRecord.labelWeek = '';
+		dataRecord.labelMonth = '';
+		dataRecord.labelYear = '';
+		dataRecord.classNames = [];
+
+		if ( dataRecord.period ) {
+			const date = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( 'en' );
+			const localizedDate = moment( dataRecord.period, 'YYYY-MM-DD' );
+			if ( date.isValid() ) {
+				const dayOfWeek = date.toDate().getDay();
+				if ( ( 'day' === payload.unit ) && ( ( 6 === dayOfWeek ) || ( 0 === dayOfWeek ) ) ) {
+					dataRecord.classNames.push( 'is-weekend' );
+				}
+				dataRecord.labelDay = localizedDate.format( 'MMM D' );
+				dataRecord.labelWeek = localizedDate.format( 'MMM D' );
+				dataRecord.labelMonth = localizedDate.format( 'MMM' );
+				dataRecord.labelYear = localizedDate.format( 'YYYY' );
+			}
+		}
+
+		return dataRecord;
+	} );
+}
+
 export const normalizers = {
 	/**
 	 * Returns a normalized payload from `/sites/{ site }/stats`
@@ -620,51 +675,11 @@ export const normalizers = {
 	},
 
 	statsVisits( payload ) {
-		if ( ! payload || ! payload.data ) {
-			return [];
-		}
+		return parseChartData( payload, [ 'visits', 'likes', 'visitors', 'comments', 'posts' ] );
+	},
 
-		const attributes = [ 'visits', 'likes', 'visitors', 'comments', 'posts' ];
-
-		return payload.data.map( function( record ) {
-			// Initialize data
-			const dataRecord = attributes.reduce( ( memo, attribute ) => {
-				memo[ attribute ] = null;
-				return memo;
-			}, {} );
-
-			// Fill Field Values
-			record.forEach( function( value, i ) {
-				// Remove W from weeks
-				if ( 'period' === payload.fields[ i ] ) {
-					value = value.replace( /W/g, '-' );
-				}
-				dataRecord[ payload.fields[ i ] ] = value;
-			} );
-
-			dataRecord.labelDay = '';
-			dataRecord.labelWeek = '';
-			dataRecord.labelMonth = '';
-			dataRecord.labelYear = '';
-			dataRecord.classNames = [];
-
-			if ( dataRecord.period ) {
-				const date = moment( dataRecord.period, 'YYYY-MM-DD' ).locale( 'en' );
-				const localizedDate = moment( dataRecord.period, 'YYYY-MM-DD' );
-				if ( date.isValid() ) {
-					const dayOfWeek = date.toDate().getDay();
-					if ( ( 'day' === payload.unit ) && ( ( 6 === dayOfWeek ) || ( 0 === dayOfWeek ) ) ) {
-						dataRecord.classNames.push( 'is-weekend' );
-					}
-					dataRecord.labelDay = localizedDate.format( 'MMM D' );
-					dataRecord.labelWeek = localizedDate.format( 'MMM D' );
-					dataRecord.labelMonth = localizedDate.format( 'MMM' );
-					dataRecord.labelYear = localizedDate.format( 'YYYY' );
-				}
-			}
-
-			return dataRecord;
-		} );
+	statsOrders( payload ) {
+		return parseChartData( payload );
 	},
 
 	/*


### PR DESCRIPTION
### Query and Normalize Orders Data
In order render the main chart, the data will need to be queried and normalized.

![screen shot 2017-05-22 at 1 12 04 pm](https://cloud.githubusercontent.com/assets/1922453/26291605/a0fb9d22-3f03-11e7-8487-42d31a5f1a44.png)

### Comments
Normalization is the exact same for `statsOrders` as it is for `statsVisits`. ~Until I figure out a better way to share that logic, I've hacked a solution.~ I pulled the logic into a function `parseChartData` so each normalizer can have access

~I've also printed out some data for now and will remove on a final clean up.~ Removed

### Also
I'm renaming `period` (days, weeks, months, years) to `unit` so that it matches the nomenclature of the API and backend.

Fixes https://github.com/Automattic/wp-calypso/issues/12984