### PR TITLE
Add follow sources for search results and recommendations

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import { recordAction, recordTrack } from 'reader/stats';
 import Button from 'components/button';
 import { requestSiteBlock } from 'state/reader/site-blocks/actions';
+// @todo move this out of following-manage
 import ConnectedSubscriptionListItem
 	from 'reader/following-manage/connected-subscription-list-item';
 
@@ -20,6 +21,7 @@ export class RecommendedSites extends React.PureComponent {
 	static propTypes = {
 		translate: PropTypes.func,
 		sites: PropTypes.array,
+		followSource: PropTypes.string,
 	};
 
 	handleSiteDismiss = ( siteId, uiIndex ) => {
@@ -39,7 +41,7 @@ export class RecommendedSites extends React.PureComponent {
 	};
 
 	render() {
-		const { sites } = this.props;
+		const { sites, followSource } = this.props;
 
 		if ( isEmpty( sites ) ) {
 			return null;
@@ -71,6 +73,7 @@ export class RecommendedSites extends React.PureComponent {
 									siteId={ siteId }
 									showEmailSettings={ false }
 									showLastUpdatedDate={ false }
+									followSource={ followSource }
 								/>
 							</li>
 						);

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -7,6 +7,8 @@ const exported = {
 	READER_FEED_SEARCH: 'reader-feed-search-result',
 	COMBINED_CARD: 'reader-combined-card',
 	READER_FOLLOWING_MANAGE_URL_INPUT: 'reader-following-manage-url-input',
+	READER_FOLLOWING_MANAGE_SEARCH_RESULT: 'reader-following-manage-search-result',
+	READER_FOLLOWING_MANAGE_RECOMMENDATION: 'reader-following-manage-recommendation',
 };
 
 export default exported;
@@ -19,4 +21,6 @@ export const {
 	READER_FEED_SEARCH,
 	COMBINED_CARD,
 	READER_FOLLOWING_MANAGE_URL_INPUT,
+	READER_FOLLOWING_MANAGE_SEARCH_RESULT,
+	READER_FOLLOWING_MANAGE_RECOMMENDATION,
 } = exported;

--- a/client/reader/following-manage/connected-subscription-list-item.jsx
+++ b/client/reader/following-manage/connected-subscription-list-item.jsx
@@ -25,6 +25,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 		showEmailSettings: PropTypes.bool,
 		showLastUpdatedDate: PropTypes.bool,
 		isFollowing: PropTypes.bool,
+		followSource: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -54,6 +55,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 			showEmailSettings,
 			showLastUpdatedDate,
 			isFollowing,
+			followSource,
 		} = this.props;
 		const isEmailBlocked = userSettings.getSetting( 'subscription_delivery_email_blocked' );
 
@@ -68,6 +70,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 				showEmailSettings={ showEmailSettings && ! isEmailBlocked }
 				showLastUpdatedDate={ showLastUpdatedDate }
 				isFollowing={ isFollowing }
+				followSource={ followSource }
 			/>
 		);
 	}

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -13,6 +13,7 @@ import classnames from 'classnames';
 import ConnectedSubscriptionListItem from './connected-subscription-list-item';
 import SitesWindowScroller from './sites-window-scroller';
 import Button from 'components/button';
+import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'reader/follow-button/follow-sources';
 
 const FollowingManageSearchFeedsResults = ( {
 	showMoreResults,
@@ -53,6 +54,7 @@ const FollowingManageSearchFeedsResults = ( {
 					feedId={ +site.feed_ID }
 					siteId={ +site.blog_ID }
 					key={ `search-result-site-id-${ site.feed_ID || 0 }-${ site.blog_ID || 0 }` }
+					followSource={ READER_FOLLOWING_MANAGE_SEARCH_RESULT }
 				/>
 			)
 		);

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -33,7 +33,10 @@ import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import { requestFeedSearch } from 'state/reader/feed-searches/actions';
 import { addQueryArgs } from 'lib/url';
 import FollowButton from 'reader/follow-button';
-import { READER_FOLLOWING_MANAGE_URL_INPUT } from 'reader/follow-button/follow-sources';
+import {
+	READER_FOLLOWING_MANAGE_URL_INPUT,
+	READER_FOLLOWING_MANAGE_RECOMMENDATION,
+} from 'reader/follow-button/follow-sources';
 import { resemblesUrl, addSchemeIfMissing, withoutHttp } from 'lib/url';
 import { getReaderFollowsCount } from 'state/selectors';
 
@@ -214,7 +217,10 @@ class FollowingManage extends Component {
 				</div>
 				{ hasFollows &&
 					! sitesQuery &&
-					<RecommendedSites sites={ take( recommendedSites, 2 ) } /> }
+					<RecommendedSites
+						sites={ take( recommendedSites, 2 ) }
+						followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
+					/> }
 				{ !! sitesQuery &&
 					! isFollowByUrlWithNoSearchResults &&
 					<FollowingManageSearchFeedsResults

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -72,6 +72,9 @@ function getLocation() {
 	if ( path.indexOf( '/following/edit' ) === 0 ) {
 		return 'following_edit';
 	}
+	if ( path.indexOf( '/following/manage' ) === 0 ) {
+		return 'following_manage';
+	}
 	if ( path.indexOf( '/discover' ) === 0 ) {
 		return 'discover';
 	}


### PR DESCRIPTION
Add a followSource to the follow button for search results and recs in Following Manage (URL input already has one).

Part of https://github.com/Automattic/wp-calypso/issues/13830.

### To test

Follow a site in http://calypso.localhost:3000/following/manage with analytics logging in your console. Make sure the follow button events have the correct follow source included.

<img width="1125" alt="screen shot 2017-05-22 at 12 10 57" src="https://cloud.githubusercontent.com/assets/17325/26303363/bf94383c-3ee7-11e7-95c4-e93e420c5bd6.png">
