### PR TITLE
Editor: tweak Revisions so doesn't look like an accordion

### DIFF
--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -2,9 +2,9 @@
 	color: $gray-text;
 	display: block;
 	font-size: 13px;
-	margin: 16px -16px -16px;
-	padding: 16px;
-	border-top: 1px solid darken( $sidebar-bg-color, 5% );
+	margin: 0 0 -16px;
+	padding: 16px 0;
+	bxorder-top: 1px solid darken( $sidebar-bg-color, 5% );
 
 	&:visited {
 		color: $gray-text;

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -4,7 +4,6 @@
 	font-size: 13px;
 	margin: 0 0 -16px;
 	padding: 16px 0;
-	bxorder-top: 1px solid darken( $sidebar-bg-color, 5% );
 
 	&:visited {
 		color: $gray-text;


### PR DESCRIPTION
The "Revisions" button in the Status accordion looks too much like another accordion due to an odd visual hierarchy. This PR is a small tweak to fix it before the redesign is implemented (p4TIVU-6pW-p2).

Before:
![screen shot 2017-05-22 at 10 56 52](https://cloud.githubusercontent.com/assets/4389/26302814/61b128d8-3edd-11e7-86f0-bacf4f11b87b.png)


After:
![screen shot 2017-05-22 at 10 49 57](https://cloud.githubusercontent.com/assets/4389/26302733/2192397c-3edd-11e7-864c-230278506b58.png)

### To test

1. Open the Editor (edit or new post either way)
2. Open the status panel
3. Check the separator is gone
