### PR TITLE
Fix "an other" -> "another" typo

### DIFF
--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -118,7 +118,7 @@ class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case 'retryingAuth':
-				noticeValues.text = translate( 'Error authorizing. Page is refreshing for an other attempt.' );
+				noticeValues.text = translate( 'Error authorizing. Page is refreshing for another attempt.' );
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
 				return noticeValues;


### PR DESCRIPTION
Fix the typo.

This has been around since #13142 but was blocked by linting errors that required additional changes. Lint errors are fixed and the typo can be corrected now.