### PR TITLE
Extensions: WPSC - Use cache_type setting for the value of cache type

### DIFF
--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -19,9 +19,8 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const Caching = ( {
 	fields: {
-		cache_mod_rewrite,
+		cache_type,
 		is_cache_enabled,
-		is_super_cache_enabled,
 	},
 	handleAutosavingToggle,
 	handleRadio,
@@ -60,11 +59,11 @@ const Caching = ( {
 					<FormFieldset className="wp-super-cache__cache-type-fieldset">
 						<FormLabel>
 							<FormRadio
-								checked={ !! is_super_cache_enabled && !! cache_mod_rewrite }
+								checked={ 'mod_rewrite' === cache_type }
 								disabled={ isRequesting || isSaving || ! is_cache_enabled }
-								name="is_super_cache_enabled"
+								name="cache_type"
 								onChange={ handleRadio }
-								value="1" />
+								value="mod_rewrite" />
 							<span>
 								{ translate( 'Use mod_rewrite to serve cache files.' ) }
 							</span>
@@ -72,11 +71,11 @@ const Caching = ( {
 
 						<FormLabel>
 							<FormRadio
-								checked={ ! cache_mod_rewrite }
+								checked={ 'PHP' === cache_type }
 								disabled={ isRequesting || isSaving || ! is_cache_enabled }
-								name="is_super_cache_enabled"
+								name="cache_type"
 								onChange={ handleRadio }
-								value="2" />
+								value="PHP" />
 							<span>
 								{ translate(
 									'Use PHP to serve cache files. {{em}}(Recommended){{/em}}',
@@ -89,11 +88,11 @@ const Caching = ( {
 
 						<FormLabel>
 							<FormRadio
-								checked={ ! is_super_cache_enabled }
+								checked={ 'wpcache' === cache_type }
 								disabled={ isRequesting || isSaving || ! is_cache_enabled }
-								name="is_super_cache_enabled"
+								name="cache_type"
 								onChange={ handleRadio }
-								value="0" />
+								value="wpcache" />
 							<span>
 								{ translate( 'Legacy page caching.' ) }
 							</span>
@@ -116,9 +115,8 @@ const Caching = ( {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'cache_mod_rewrite',
+		'cache_type',
 		'is_cache_enabled',
-		'is_super_cache_enabled',
 	] );
 };
 


### PR DESCRIPTION
A new setting was added to the API to use for cache type [here](https://github.com/Automattic/wp-super-cache/commit/a19767de54968d226d1403d11e39772314a8a8d7). This PR removes the conditional logic that was previously used (and that didn't work), and uses the `cache_type` setting instead.

_Note: Currently the REST API always returns a `cache_type` of `wpcache` from the settings endpoint, so validating that the cache type was successfully saved can't happen until the endpoint is fixed._

## Testing
On the _Advanced_ tab, ensure that the radio buttons in the _Caching_ section save successfully.

![caching](https://cloud.githubusercontent.com/assets/1190420/26307979/3cfce0da-3ec5-11e7-9b16-85b2075cccd8.jpg)