### PR TITLE
Use last happychat activity timestamp when retrieving transcript

### DIFF
--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -52,7 +52,6 @@ import {
 	setGeoLocation,
 } from './actions';
 import {
-	getHappychatTranscriptTimestamp,
 	isHappychatConnectionUninitialized,
 	wasHappychatRecentlyActive,
 	isHappychatClientConnected,
@@ -134,10 +133,11 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 		.catch( e => debug( 'failed to start happychat session', e, e.stack ) );
 };
 
-export const requestTranscript = ( connection, { getState, dispatch } ) => {
-	const timestamp = getHappychatTranscriptTimestamp( getState() );
-	debug( 'requesting transcript', timestamp );
-	return connection.transcript( timestamp ).then(
+export const requestTranscript = ( connection, { dispatch } ) => {
+	debug( 'requesting current session transcript' );
+
+	// passing a null timestamp will request the latest session's transcript
+	return connection.transcript( null ).then(
 		result => dispatch( receiveChatTranscript( result.messages, result.timestamp ) ),
 		e => debug( 'failed to get transcript', e )
 	);

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -3,7 +3,6 @@
  */
 import {
 	get,
-	head,
 	includes,
 	last,
 	map,
@@ -42,8 +41,10 @@ export const getHappychatChatStatus = createSelector(
 	state => state.happychat.chatStatus
 );
 
+export const getHappychatLastActivityTimestamp = state => state.happychat.lastActivityTimestamp;
+
 export const getHappychatTranscriptTimestamp = state => (
-	state.happychat.transcript_timestamp || get( head( state.happychat.timeline ), 'timestamp' )
+	state.happychat.transcript_timestamp || getHappychatLastActivityTimestamp( state )
 );
 
 /**
@@ -111,8 +112,6 @@ export const canUserSendMessages = createSelector(
 	),
 	[ getHappychatConnectionStatus, getHappychatChatStatus ]
 );
-
-export const getHappychatLastActivityTimestamp = state => state.happychat.lastActivityTimestamp;
 
 export const wasHappychatRecentlyActive = state => {
 	const lastActive = getHappychatLastActivityTimestamp( state );

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -43,10 +43,6 @@ export const getHappychatChatStatus = createSelector(
 
 export const getHappychatLastActivityTimestamp = state => state.happychat.lastActivityTimestamp;
 
-export const getHappychatTranscriptTimestamp = state => (
-	state.happychat.transcript_timestamp || getHappychatLastActivityTimestamp( state )
-);
-
 /**
  * Gets the current happychat connection status
  * @param {Object} state - global redux state


### PR DESCRIPTION
This PR use the last activity timestamp when retrieving the transcript instead of the most recent timeline event, this approach will allow the retrieval of operators messages that were not directly sent to the client via websockets but are saved in the chat transcript  

Check 344-gh-happychat for more details and testing information.

Implementation description:
- Use `getHappychatLastActivityTimestamp` when retrieving the chat transcript instead of using the latest timeline entry which does not always reflect the latest messages from operators.