### PR TITLE
Analytics: added Quora ad-tracking

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -46,6 +46,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	DCM_FLOODLIGHT_IFRAME_URL = 'https://6355556.fls.doubleclick.net/activityi',
 	LINKED_IN_SCRIPT_URL = 'https://snap.licdn.com/li.lms-analytics/insight.min.js',
 	MEDIA_WALLAH_URL = 'https://d3ir0rz7vxwgq5.cloudfront.net/mwData.min.js',
+	QUORA_URL = 'https://a.quora.com/qevents.js',
 	TRACKING_IDS = {
 		bingInit: '4074038',
 		facebookInit: '823166884443641',
@@ -58,7 +59,8 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		yahooPixelId: '10014088',
 		twitterPixelId: 'nvzbs',
 		dcmFloodlightAdvertiserId: '6355556',
-		linkedInPartnerId: '36622'
+		linkedInPartnerId: '36622',
+		quoraPixelId: '420845cb70e444938cf0728887a74ca1'
 	},
 
 	// This name is something we created to store a session id for DCM Floodlight session tracking
@@ -104,6 +106,10 @@ if ( ! window._linkedin_data_partner_id ) {
 	window._linkedin_data_partner_id = TRACKING_IDS.linkedInPartnerId;
 }
 
+if ( ! window.qp ) {
+	setupQuoraGlobal();
+}
+
 /**
  * Initializes Media Wallah tracking.
  * This is a rework of the obfuscated tracking code provided by Media Wallah.
@@ -132,6 +138,17 @@ function initMediaWallah() {
 	};
 
 	window.addEventListener ? window.addEventListener( 'load', init, false ) : window.attachEvent( 'onload', init );
+}
+
+/**
+ * Initializes Quora tracking.
+ * This is a rework of the obfuscated tracking code provided by Quora.
+ */
+function setupQuoraGlobal() {
+	const quoraPixel = window.qp = function() {
+		quoraPixel.qp ? quoraPixel.qp.apply( quoraPixel, arguments ) : quoraPixel.queue.push( arguments );
+	};
+	quoraPixel.queue = [];
 }
 
 /**
@@ -199,6 +216,9 @@ function loadTrackingScripts( callback ) {
 		},
 		function( onComplete ) {
 			loadScript.loadScript( MEDIA_WALLAH_URL, onComplete );
+		},
+		function( onComplete ) {
+			loadScript.loadScript( QUORA_URL, onComplete );
 		}
 	], function( errors ) {
 		if ( ! some( errors ) ) {
@@ -216,6 +236,9 @@ function loadTrackingScripts( callback ) {
 
 			// init Media Wallah tracking
 			initMediaWallah();
+
+			// init Quora tracking
+			window.qp( 'init', TRACKING_IDS.quoraPixelId );
 
 			if ( typeof UET !== 'undefined' ) {
 				// bing's script creates the UET global for us
@@ -294,6 +317,9 @@ function retarget() {
 
 	// One by AOL
 	new Image().src = ONE_BY_AOL_AUDIENCE_BUILDING_PIXEL_URL;
+
+	// Quora
+	window.qp( 'track', 'ViewContent' );
 }
 
 /**
@@ -409,6 +435,7 @@ function recordOrder( cart, orderId ) {
 	// 3. Fire a single tracking event without any details about what was purchased
 	new Image().src = ONE_BY_AOL_CONVERSION_PIXEL_URL;
 	new Image().src = PANDORA_CONVERSION_PIXEL_URL;
+	window.qp( 'track', 'Generic' );
 }
 
 /**


### PR DESCRIPTION
Add Quora retargeting pixel tracking to Calypso.

- On page view fires `qp('track', 'ViewContent')`.
- On order completion fires `qp('track', 'Generic')`.

At the moment Quora does not provide specialized events for purchase so we have to use the "Generic" one which we fire once per order (as opposed to once per product).

This code is an adaptation of the obfuscated original code provided by Quora:
```
<!-- DO NOT MODIFY -->
<!-- Quora Pixel Code (JS Helper) -->
<script>
!function(q,e,v,n,t,s){if(q.qp) return; n=q.qp=function(){n.qp?n.qp.apply(n,arguments):n.queue.push(arguments);}; n.queue=[];t=document.createElement(e);t.async=!0;t.src=v; s=document.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t,s);}(window, 'script', 'https://a.quora.com/qevents.js');
qp('init', '420845cb70e444938cf0728887a74ca1');
qp('track', 'ViewContent');
</script>
<noscript><img height="1" width="1" style="display:none" src="https://q.quora.com/_/ad/420845cb70e444938cf0728887a74ca1/pixel?tag=ViewContent&noscript=1"/></noscript>
<!-- End of Quora Pixel Code -->
```

# Testing Page Views

- In `config/development.json` enable `ad-tracking`.
- Open Chrome's Network tab from the developer's tools
- Reload Calypso
- Searching for `a.quora.com/qevents.js` should yield one result confirming the JS code has been loaded.
- Searching for "ViewContent" should yield a pair of results for every page view generated (the first is a 302 redirect), similar to:

https://q.quora.com/_/ad/420845cb70e444938cf0728887a74ca1/pixel?j=1&u=http%3A%2F%2Fcalypso.localhost%3A3000%2Fthemes%2Fmicbosi.wordpress.com&tag=ViewContent

https://www.quora.com/_/ad/420845cb70e444938cf0728887a74ca1/pixel?j=1&u=http%3A%2F%2Fcalypso.localhost%3A3000%2Fthemes%2Fmicbosi.wordpress.com&tag=ViewContent

# Testing Purchases
- Keep the Network tab open
- Purchase something, for example purchase an upgrade on a test site using free credits (Store Admin ► Credit Balance ► Free Credits)
-  Searching for "tag=Generic" in the dev tools you should see something similar to:

https://q.quora.com/_/ad/420845cb70e444938cf0728887a74ca1/pixel?j=1&u=http%3A%2F%2Fcalypso.localhost%3A3000%2Fcheckout%2Fmicbositest02.wordpress.com%2Fpersonal&tag=Generic

https://www.quora.com/_/ad/420845cb70e444938cf0728887a74ca1/pixel?j=1&u=http%3A%2F%2Fcalypso.localhost%3A3000%2Fcheckout%2Fmicbositest02.wordpress.com%2Fpersonal&tag=Generic

which confirms your purchase has been tracked.

Thank you! :)
