### PR TITLE
Maintain image selection in post after updateMedia

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -145,6 +145,7 @@ function mediaButton( editor ) {
 	} )();
 
 	updateMedia = debounce( function() {
+		const originalSelectedNode = editor.selection.getNode();
 		let isTransientDetected = false,
 			transients = 0,
 			content, images;
@@ -390,6 +391,21 @@ function mediaButton( editor ) {
 			// We also need to reset the counter of post/page images to update so if another image is
 			// edited and marked dirty, we can set the counter to correct number.
 			numOfImagesToUpdate = null;
+		}
+
+		// Re-select image node if one was selected.
+		if ( 'IMG' === originalSelectedNode.nodeName ) {
+			let replacement = editor.selection.getStart();
+			if ( 'IMG' !== replacement.nodeName ) {
+				replacement = replacement.querySelector( 'img' );
+			}
+
+			if ( replacement ) {
+				editor.selection.select( replacement );
+				editor.selection.controlSelection.showResizeRect( replacement );
+			}
+
+			editor.nodeChanged();
 		}
 	} );
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -378,6 +378,11 @@ function mediaButton( editor ) {
 				editor.fire( 'SetTextAreaContent', { content } );
 			}
 
+			// Re-select image node if one was selected.
+			if ( 'IMG' === originalSelectedNode.nodeName ) {
+				reselectImage();
+			}
+
 			// Trigger an editor change so that dirty detection and
 			// autosave take effect
 			editor.fire( 'change' );
@@ -391,11 +396,6 @@ function mediaButton( editor ) {
 			// We also need to reset the counter of post/page images to update so if another image is
 			// edited and marked dirty, we can set the counter to correct number.
 			numOfImagesToUpdate = null;
-		}
-
-		// Re-select image node if one was selected.
-		if ( 'IMG' === originalSelectedNode.nodeName ) {
-			reselectImage();
 		}
 	} );
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -395,19 +395,22 @@ function mediaButton( editor ) {
 
 		// Re-select image node if one was selected.
 		if ( 'IMG' === originalSelectedNode.nodeName ) {
-			let replacement = editor.selection.getStart();
-			if ( 'IMG' !== replacement.nodeName ) {
-				replacement = replacement.querySelector( 'img' );
-			}
-
-			if ( replacement ) {
-				editor.selection.select( replacement );
-				editor.selection.controlSelection.showResizeRect( replacement );
-			}
-
-			editor.nodeChanged();
+			reselectImage();
 		}
 	} );
+
+	function reselectImage() {
+		// Re-select image node
+		let replacement = editor.selection.getStart();
+		if ( 'IMG' !== replacement.nodeName ) {
+			replacement = replacement.querySelector( 'img' );
+		}
+
+		if ( replacement ) {
+			editor.selection.select( replacement );
+			editor.selection.controlSelection.showResizeRect( replacement );
+		}
+	}
 
 	function hideDropZoneOnDrag( event ) {
 		renderDropZone( { visible: event.type === 'dragend' } );
@@ -609,16 +612,7 @@ function mediaButton( editor ) {
 		// Replace selected content
 		editor.selection.setContent( markup );
 
-		// Re-select image node
-		let replacement = editor.selection.getStart();
-		if ( 'IMG' !== replacement.nodeName ) {
-			replacement = replacement.querySelector( 'img' );
-		}
-
-		if ( replacement ) {
-			editor.selection.select( replacement );
-			editor.selection.controlSelection.showResizeRect( replacement );
-		}
+		reselectImage();
 
 		editor.nodeChanged();
 	}

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -378,7 +378,8 @@ function mediaButton( editor ) {
 				editor.fire( 'SetTextAreaContent', { content } );
 			}
 
-			// Re-select image node if one was selected.
+			// We have just replaced some image nodes, potentially losing selection/focus.
+			// So if an image node was selected and one isn't now, re-select it.
 			if ( 'IMG' === originalSelectedNode.nodeName ) {
 				reselectImage();
 			}


### PR DESCRIPTION
This addresses https://github.com/Automattic/wp-calypso/issues/14233

When an edited image didn't have a caption and was updated, it created a duplicate image in the post. This was because updateMedia would sometimes lose the current selection. This change fixes this issue.