### PR TITLE
WebPreview: Add analytics for the chosen device viewport in the preview 

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -19,6 +19,7 @@ import Spinner from 'components/spinner';
 import RootChild from 'components/root-child';
 import SeoPreviewPane from 'components/seo-preview-pane';
 import { setPreviewShowing } from 'state/ui/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const debug = debugModule( 'calypso:web-preview' );
 
@@ -151,6 +152,8 @@ export class WebPreview extends Component {
 
 	setDeviceViewport( device = 'computer' ) {
 		this.setState( { device } );
+
+		this.props.recordTracksEvent( 'calypso_web_preview_select_viewport_device', { device } );
 	}
 
 	setLoaded() {
@@ -269,4 +272,4 @@ WebPreview.defaultProps = {
 	hasSidebar: false,
 };
 
-export default connect( null, { setPreviewShowing } )( localize( WebPreview ) );
+export default connect( null, { recordTracksEvent, setPreviewShowing } )( localize( WebPreview ) );


### PR DESCRIPTION
This PR adds analytics functionality to the WebPreview component. This will help us understand user preferences for device previews.

To test the PR:
1. Checkout branch or use Calypso.live link
2. Open Site Preview
3. Click on a device in the toolbar
4. Verify an analytics action has been sent
5. Verify everything is working correctly and no JS errors in the console