### PR TITLE
Publicize: display proper share counts

### DIFF
--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -360,10 +360,12 @@ class PostShare extends Component {
 				</div>
 
 				{ this.renderUpgradeToGetSchedulingNudge() }
-				<ActionsList
-					siteId={ siteId }
-					postId={ postId }
-				/>
+				{ this.props.hasRepublicizeSchedulingFeature &&
+					<ActionsList
+						siteId={ siteId }
+						postId={ postId }
+					/>
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -44,19 +44,13 @@ import {
 	PLAN_BUSINESS,
 } from 'lib/plans/constants';
 
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
 import Banner from 'components/banner';
 import SharingPreviewModal from './sharing-preview-modal';
 import ConnectionsList, { NoConnectionsNotice } from './connections-list';
 import ActionsList from './publicize-actions-list';
 import CalendarButton from 'blocks/calendar-button';
 import formatCurrency from 'lib/format-currency';
-import {
-	SCHEDULED,
-	PUBLISHED,
-} from './constants';
+
 import SectionHeader from 'components/section-header';
 import Tooltip from 'components/tooltip';
 
@@ -89,14 +83,11 @@ class PostShare extends Component {
 	};
 
 	state = {
-		selectedShareTab: SCHEDULED,
 		message: PostMetadata.publicizeMessage( this.props.post ) || this.props.post.title,
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
 		showSharingPreview: false,
 		showAccountTooltip: false,
 	};
-
-	setFooterSection = selectedShareTab => () => this.setState( { selectedShareTab } );
 
 	hasConnections() {
 		return !! get( this.props, 'connections.length' );
@@ -263,44 +254,6 @@ class PostShare extends Component {
 		);
 	}
 
-	renderActionsSection() {
-		if ( ! this.props.hasRepublicizeSchedulingFeature ) {
-			return null;
-		}
-
-		const { postId, siteId, } = this.props;
-		const { selectedShareTab } = this.state;
-
-		return (
-			<div className="post-share__footer">
-				<SectionNav className="post-share__footer-nav" selectedText={ 'some text' }>
-					<NavTabs label="Status" selectedText="Published">
-						<NavItem
-							selected={ selectedShareTab === SCHEDULED }
-							count={ 4 }
-							onClick={ this.setFooterSection( SCHEDULED ) }
-						>
-							Scheduled
-						</NavItem>
-						<NavItem
-							selected={ selectedShareTab === PUBLISHED }
-							count={ 2 }
-							onClick={ this.setFooterSection( PUBLISHED ) }
-						>
-							Published
-						</NavItem>
-					</NavTabs>
-				</SectionNav>
-
-				<ActionsList
-					section={ selectedShareTab }
-					postId={ postId }
-					siteId={ siteId }
-				/>
-			</div>
-		);
-	}
-
 	renderRequestSharingNotice() {
 		const {
 			failure,
@@ -380,7 +333,7 @@ class PostShare extends Component {
 	}
 
 	renderPrimarySection() {
-		const { hasFetchedConnections, siteSlug, translate } = this.props;
+		const { hasFetchedConnections, siteSlug, translate, siteId, postId } = this.props;
 
 		if ( ! hasFetchedConnections ) {
 			return null;
@@ -407,7 +360,10 @@ class PostShare extends Component {
 				</div>
 
 				{ this.renderUpgradeToGetSchedulingNudge() }
-				{ this.renderActionsSection() }
+				<ActionsList
+					siteId={ siteId }
+					postId={ postId }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/post-share/publicize-actions-list.jsx
+++ b/client/my-sites/post-share/publicize-actions-list.jsx
@@ -22,18 +22,20 @@ import {
 	SCHEDULED,
 	PUBLISHED,
 } from './constants';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {
-		section: PropTypes.string,
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 	};
 
-	static defaultProps = {
-		section: SCHEDULED,
+	state = {
+		selectedShareTab: SCHEDULED,
 	};
-
+	setFooterSection = selectedShareTab => () => this.setState( { selectedShareTab } );
 	renderFooterSectionItem( {
 		connectionName,
 		message,
@@ -76,37 +78,51 @@ class PublicizeActionsList extends PureComponent {
 		);
 	}
 
-	renderActionsList( status = SCHEDULED ) {
-		if ( this.props.section !== status ) {
-			return null;
-		}
-
+	renderActionsList = ( actions ) => (
+		<div>
+			{ actions.map( ( item, index ) => this.renderFooterSectionItem( item, index ) ) }
+		</div>
+	);
+	render() {
 		const {
 			postId,
+			siteId,
 			scheduledActions,
 			publishedActions,
-			siteId,
 		} = this.props;
-
-		const actions = status === SCHEDULED ? scheduledActions : publishedActions;
-
 		return (
 			<div>
-				<QuerySharePostActions siteId={ siteId } postId={ postId } status={ status } />
-				{ actions.map( ( item, index ) => this.renderFooterSectionItem( item, index ) ) }
-			</div>
-		);
-	}
-
-	render() {
-		return (
-			<div className="post-share__actions-list">
-				<div className="post-share__scheduled-list">
-					{ this.renderActionsList( SCHEDULED ) }
-				</div>
-
-				<div className="post-share__published-list">
-					{ this.renderActionsList( PUBLISHED ) }
+				<SectionNav className="post-share__footer-nav" selectedText={ 'some text' }>
+					<NavTabs label="Status" selectedText="Published">
+						<NavItem
+							selected={ this.state.selectedShareTab === SCHEDULED }
+							count={ this.props.scheduledActions.length }
+							onClick={ this.setFooterSection( SCHEDULED ) }
+						>
+							Scheduled
+						</NavItem>
+						<NavItem
+							selected={ this.state.selectedShareTab === PUBLISHED }
+							count={ this.props.publishedActions.length }
+							onClick={ this.setFooterSection( PUBLISHED ) }
+						>
+							Published
+						</NavItem>
+					</NavTabs>
+				</SectionNav>
+				<div className="post-share__actions-list">
+					<QuerySharePostActions siteId={ siteId } postId={ postId } status={ SCHEDULED } />
+					<QuerySharePostActions siteId={ siteId } postId={ postId } status={ PUBLISHED } />
+					{ this.state.selectedShareTab === SCHEDULED &&
+						<div className="post-share__scheduled-list">
+							{ this.renderActionsList( scheduledActions ) }
+						</div>
+					}
+					{ this.state.selectedShareTab === PUBLISHED &&
+						<div className="post-share__published-list">
+							{ this.renderActionsList( publishedActions ) }
+						</div>
+					}
 				</div>
 			</div>
 		);

--- a/client/my-sites/post-share/publicize-actions-list.jsx
+++ b/client/my-sites/post-share/publicize-actions-list.jsx
@@ -30,6 +30,8 @@ class PublicizeActionsList extends PureComponent {
 	static propTypes = {
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
+		scheduledActions: PropTypes.array,
+		publishedActions: PropTypes.array,
 	};
 
 	state = {


### PR DESCRIPTION
This displays proper share counts for publicize share actions
![zrzut ekranu 2017-05-22 o 17 59 36](https://cloud.githubusercontent.com/assets/3775068/26317639/7667519a-3f18-11e7-8e06-304aab2c1fe7.png)

Also moves the tabs to  puklicize-action-list component

## Testing

1. Enable scheduling in development.js
2. Navigate to sharing section
3. Use republicize
4. Refresh to see new share in publisheid section and proper count

