### PR TITLE
Update signup/step-header to stateless functional component

### DIFF
--- a/client/signup/step-header/index.jsx
+++ b/client/signup/step-header/index.jsx
@@ -9,24 +9,26 @@ import classNames from 'classnames';
  */
 import { preventWidows } from 'lib/formatting';
 
-module.exports = React.createClass( {
-	displayName: 'StepHeader',
+function StepHeader( { headerText, subHeaderText } ) {
+	const classes = classNames( 'step-header', {
+		'is-without-subhead': ! subHeaderText
+	} );
 
-	propTypes: {
-		headerText: PropTypes.string,
-		subHeaderText: React.PropTypes.node
-	},
+	return (
+		<header className={ classes }>
+			<h1 className="step-header__title">{ preventWidows( headerText, 2 ) }</h1>
+			{ subHeaderText && (
+				<p className="step-header__subtitle">
+					{ preventWidows( subHeaderText, 2 ) }
+				</p>
+			) }
+		</header>
+	);
+}
 
-	render: function() {
-		const { headerText, subHeaderText } = this.props;
-		const classes = classNames( 'step-header', {
-			'is-without-subhead': ! subHeaderText
-		} );
-		return (
-			<header className={ classes }>
-				<h1 className="step-header__title">{ preventWidows( headerText, 2 ) }</h1>
-				{ subHeaderText && <p className="step-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p> }
-			</header>
-		);
-	}
-} );
+StepHeader.propTypes = {
+	headerText: PropTypes.string,
+	subHeaderText: React.PropTypes.node,
+};
+
+export default StepHeader;


### PR DESCRIPTION
Updates to stateless functional component in preparation for moving.

This PR should be functionally equivalent, the changes are to pass lint tests to allow future changes with ease.

To test:

* Use this branch
* Visit http://calypso.localhost:3000/start
* Follow the flow and ensure there are no regressions, no console errors/warnings, and everything continues to behave as before.
* If you like, keep an eye on the `StepHeader` component in React devtools. It will be rendered with and without subHeaderText.