### PR TITLE
Stats: Fix Map Display For zh-tw

### DIFF
--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -88,14 +88,19 @@ class StatsGeochart extends Component {
 		}
 
 		const mapData = map( data, ( country ) => {
-			return [ country.label, country.value ];
+			return [
+				{
+					v: country.countryCode,
+					f: country.label
+				},
+				country.value
+			];
 		} );
-		mapData.unshift( [
-			translate( 'Country' ).toString(),
-			translate( 'Views' ).toString()
-		] );
 
-		const chartData = window.google.visualization.arrayToDataTable( mapData );
+		const chartData = new window.google.visualization.DataTable();
+		chartData.addColumn( 'string', translate( 'Country' ).toString() );
+		chartData.addColumn( 'number', translate( 'Views' ).toString() );
+		chartData.addRows( mapData );
 		const node = this.refs.chart;
 		const width = node.clientWidth;
 

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -522,6 +522,7 @@ describe( 'utils', () => {
 				expect( parsedData ).to.eql( [
 					{
 						label: 'United States',
+						countryCode: 'US',
 						value: 1,
 						region: '021',
 						backgroundImage: '/calypso/images/flags/us.svg'
@@ -558,6 +559,7 @@ describe( 'utils', () => {
 				expect( parsedData ).to.eql( [
 					{
 						label: 'United States',
+						countryCode: 'US',
 						value: 10,
 						region: '021',
 						backgroundImage: '/calypso/images/flags/us.svg'
@@ -593,6 +595,7 @@ describe( 'utils', () => {
 				expect( parsedData ).to.eql( [
 					{
 						label: 'United States',
+						countryCode: 'US',
 						value: 100,
 						region: '021',
 						backgroundImage: '/calypso/images/flags/us.svg'
@@ -629,6 +632,7 @@ describe( 'utils', () => {
 				expect( parsedData ).to.eql( [
 					{
 						label: 'United States',
+						countryCode: 'US',
 						value: 100,
 						region: '021',
 						backgroundImage: '/calypso/images/flags/us.svg'
@@ -665,6 +669,7 @@ describe( 'utils', () => {
 				expect( parsedData ).to.eql( [
 					{
 						label: 'US\'A',
+						countryCode: 'US',
 						value: 100,
 						region: '021',
 						backgroundImage: '/calypso/images/flags/us.svg'
@@ -704,6 +709,7 @@ describe( 'utils', () => {
 				expect( parsedData ).to.eql( [
 					{
 						label: 'United States',
+						countryCode: 'US',
 						value: 100,
 						region: '021',
 						backgroundImage: '/calypso/images/flags/us.svg'

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -232,6 +232,7 @@ export const normalizers = {
 			// ’ in country names causes google's geo viz to break
 			return {
 				label: country.country_full.replace( /’/, "'" ),
+				countryCode: viewData.country_code,
 				value: viewData.views,
 				region: country.map_region,
 				backgroundImage: icon


### PR DESCRIPTION
From a user report at p56BUd-gP-p2 an issue was noted where Taiwan was not being highlighted on the stats country map when the interface language was set to `zh-tw`, but the map was being shown properly when viewing the stats page in English.

The reason for this was the `<Geochart />` logic was passing in the country `label` from the state tree - the same data that is shown in the table view, which when viewing the site in `zh-tw` was set to `台灣`, which the Google Viz did not know how to display.

The fix here is to pass in an object for the country which contains a Google cryptic syntax of `v`/value for the Country Code to highlight on the map and a `f`/format attribute for the text to show in the tooltip.

__Before__
![_ _ _-_your_own_manila_guide_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/26319509/298b8e34-3ed4-11e7-9a9f-2361cbb3a772.png)

__After__
![stats_ _ _-_your_own_manila_guide_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/26319528/3e5a82a2-3ed4-11e7-90fe-37193a082872.png)

__To Test__
- Open a site stats page and verify the map viz is displaying the same way it looks in production/staging.  Hover over a tooltip and verify 
- Bonus points testing, login to the site in the p2 post above and test out with the reporter's account via SSP