### PR TITLE
Extensions: WPSC - Move read-only settings to data layer

### DIFF
--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -35,6 +35,23 @@ export const sanitizeSettings = settings => {
 			case 'cache_rejected_uri':
 			case 'cache_rejected_user_agent':
 				return setting.split( '\n' );
+			// Don't include read-only fields when saving.
+			case 'cache_direct_pages':
+			case 'cache_mobile_browsers':
+			case 'cache_mobile_prefixes':
+			case 'cache_mod_rewrite':
+			case 'cache_next_gc':
+			case 'cache_readonly':
+			case 'cache_writable':
+			case 'generated':
+			case 'is_preload_enabled':
+			case 'is_preloading':
+			case 'minimum_preload_interval':
+			case 'post_count':
+			case 'preload_refresh':
+			case 'supercache':
+			case 'wpcache':
+				return undefined;
 			default:
 				return setting;
 		}

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import {
 	flowRight,
 	isEqual,
-	keys,
 	omit,
 	pick,
 } from 'lodash';
@@ -182,13 +181,12 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 		submitForm = () => {
 			const {
 				fields,
-				settingsFields,
 				siteId,
 			} = this.props;
 
 			this.props.removeNotice( 'wpsc-cache-delete' );
 			this.props.removeNotice( 'wpsc-settings-save' );
-			this.props.saveSettings( siteId, pick( fields, settingsFields ) );
+			this.props.saveSettings( siteId, fields );
 		};
 
 		handleDeleteCache = ( deleteAll, deleteExpired ) => {
@@ -226,25 +224,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const isSaveSuccessful = isSettingsSaveSuccessful( state, siteId );
 			const settings = getSettings( state, siteId );
 			const isRequesting = isRequestingSettings( state, siteId ) && ! settings;
-			// Don't include read-only fields when saving.
-			const settingsFields = keys( omit( settings, [
-				'cache_direct_pages',
-				'cache_disable_locking',
-				'cache_mobile_browsers',
-				'cache_mobile_prefixes',
-				'cache_mod_rewrite',
-				'cache_next_gc',
-				'cache_readonly',
-				'cache_writable',
-				'generated',
-				'is_preload_enabled',
-				'is_preloading',
-				'minimum_preload_interval',
-				'post_count',
-				'preload_refresh',
-				'supercache',
-				'wpcache',
-			] ) );
 			const isDeleting = isDeletingCache( state, siteId );
 			const isDeleteSuccessful = isCacheDeleteSuccessful( state, siteId );
 
@@ -255,7 +234,6 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				isSaveSuccessful,
 				isSaving,
 				settings,
-				settingsFields,
 				site,
 				siteId,
 			};


### PR DESCRIPTION
Move the list of read-only field names from the HOC to the data layer for a better separation of concerns.

## Testing

Ensure that none of the read-only fields are passed to the settings endpoint when saving. The read-only settings are:

`cache_direct_pages`
`cache_mobile_browsers`	
`cache_mobile_prefixes`		
`cache_mod_rewrite`
`cache_next_gc`
`cache_readonly`	
`cache_writable`	
`generated`
`is_preload_enabled`	
`is_preloading`
`minimum_preload_interval`
`post_count`
`preload_refresh`
`supercache`
`wpcache`

For example, `cache_next_gc` is used in the _Expiry Time & Garbage Collection_ section of the _Advanced_ tab for displaying the next scheduled garbage collection time. As it's a read-only field, it shouldn't be passed back for saving.

![settings-save](https://cloud.githubusercontent.com/assets/1190420/26322228/f818a9d0-3ef7-11e7-85c0-8242f964050b.jpg)