### PR TITLE
WooCommerce: Try connecting stock quantity and manage stock inputs

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -34,12 +34,19 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 	};
 
 	const toggleStock = () => {
-		editProduct( product, { manage_stock: ! product.manage_stock } );
+		let manage_stock = ! product.manage_stock;
+		let stock_quantity = product.stock_quantity;
+		if ( product.stock_quantity >= 0 && product.manage_stock ) {
+			manage_stock = false;
+			stock_quantity = '';
+		}
+		editProduct( product, { manage_stock, stock_quantity } );
 	};
 
 	const setStockQuantity = ( e ) => {
-		const stock_quantity = e.target.value;
-		Number( stock_quantity ) >= 0 && editProduct( product, { stock_quantity } );
+		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
+		const manage_stock = ( stock_quantity !== '' );
+		editProduct( product, { manage_stock, stock_quantity } );
 	};
 
 	const setBackorders = ( e ) => {
@@ -102,16 +109,13 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 							name="manage_stock"
 							onChange={ toggleStock } />
 					</div>
-
-					{ product.manage_stock && (
-						<FormTextInput
-							name="stock_quantity"
-							value={ product.stock_quantity || '' }
-							type="number"
-							min="0"
-							onChange={ setStockQuantity }
-							placeholder={ translate( 'Quantity' ) } />
-					) }
+					<FormTextInput
+						name="stock_quantity"
+						value={ product.stock_quantity || '' }
+						type="number"
+						min="0"
+						onChange={ setStockQuantity }
+						placeholder={ translate( 'Quantity' ) } />
 				</div>
 			</div>
 			{ product.manage_stock && (


### PR DESCRIPTION
This branch ties the stock quantity and manage stock input boxes together, so if you enter a quantity, the checkbox is checked. If you uncheck the box, quantity is removed. The quantity box will always be displayed now.

This is from a request on #14186:

> I think the quantity field should always be visible. If you enter a quantity, the checkbox is checked.

It looks like we were not 100% sure if this is the behavior we want to go with (per @jameskoster's reply), and I'm not 100% sure if I am a fan of this  yet -- so here is a try branch.

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Type a number in the stock quantity box. 
* See the checkbox get checked.
* Clear the quantity box (backspace) and see the checkbox uncheck.
* Type another quantity to have the box re-check itself.
* Uncheck the box and watch the quantity clear.

cc @kellychoffman @jameskoster 