### PR TITLE
Reader: Fix Follow and Settings touch targets

### DIFF
--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -64,7 +64,11 @@ function ReaderSubscriptionListItem( {
 	}
 
 	return (
-		<div className={ classnames( 'reader-subscription-list-item', className ) }>
+		<div
+			className={ classnames( 'reader-subscription-list-item', className, {
+				'has-email-settings': showEmailSettings && isFollowing,
+			} ) }
+		>
 			<div className="reader-subscription-list-item__avatar">
 				<ReaderAvatar
 					siteIcon={ siteIcon }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -1,6 +1,12 @@
 .reader-subscription-list-item {
 	display: flex;
 	flex-direction: row;
+
+	&.has-email-settings {
+		@include breakpoint( "<660px" ) {
+			min-height: 56px;
+		}
+	}
 }
 
 .reader-subscription-list-item__byline {

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -180,10 +180,11 @@
 	height: 18px;
 	position: relative;
 		left: 0;
-		top: 4px;
+		top: 19px;
 
 	@include breakpoint( ">660px" ) {
 		left: -4px;
+		top: 4px;
 	}
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/14168

**Before:**
![screenshot 2017-05-22 10 49 43](https://cloud.githubusercontent.com/assets/4924246/26323156/9e091016-3ee2-11e7-8b3d-43ff2e120423.png)

**After:**
![screenshot 2017-05-22 11 35 00](https://cloud.githubusercontent.com/assets/4924246/26323325/4283170e-3ee3-11e7-897b-192cf82808ef.png)

@samouri For sites that don't have a description/author, is there any way to make their container a bit taller to accommodate this change? 

The cog is almost touching the divider. Example:

![screenshot 2017-05-22 11 40 02](https://cloud.githubusercontent.com/assets/4924246/26323406/9add23ea-3ee3-11e7-9017-71802f7b7d13.png)
![screenshot 2017-05-22 11 41 41](https://cloud.githubusercontent.com/assets/4924246/26323414/a0e81c0e-3ee3-11e7-8342-cb1f4fac00ba.png)

