### PR TITLE
Reader: Remove indent from site recs

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -169,6 +169,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-right: 0;
 	}
 
+	.reader-subscription-list-item__avatar {
+		min-width: 0;
+	}
+
 	.reader-subscription-list-item__byline {
 		margin-right: 0;
 		padding-right: 0;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -309,4 +309,3 @@
 .reader-subscription-list-item__avatar {
 	min-width: 44px;
 }
-


### PR DESCRIPTION
In a previous PR https://github.com/Automattic/wp-calypso/pull/14261, we added a consistent indent to subscription list items. This caused site recs without avatars to also be indented and that shouldn't be the case.

**Before:**
![screenshot 2017-05-22 11 59 01](https://cloud.githubusercontent.com/assets/4924246/26324131/66ff31c8-3ee6-11e7-96f6-a1325b5cb55e.png)

![screenshot 2017-05-22 11 58 56](https://cloud.githubusercontent.com/assets/4924246/26324135/6943d592-3ee6-11e7-971d-cc9355ab9acf.png)

**After:**
![screenshot 2017-05-22 11 59 09](https://cloud.githubusercontent.com/assets/4924246/26324145/72bca630-3ee6-11e7-8f52-ebdfcde1bf32.png)

![screenshot 2017-05-22 11 59 18](https://cloud.githubusercontent.com/assets/4924246/26324150/74837624-3ee6-11e7-91e9-07867b71bb80.png)

