### PR TITLE
Remove reorder plans page signup test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,14 +16,6 @@ module.exports = {
 		},
 		defaultVariation: 'hideSurveyStep',
 	},
-	signupPlansReorderTest: {
-		datestamp: '20170410',
-		variations: {
-			original: 50,
-			modified: 50,
-		},
-		defaultVariation: 'original',
-	},
 	presaleChatButton: {
 		datestamp: '20170328',
 		variations: {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { filter, get, reverse } from 'lodash';
+import { filter, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,6 @@ import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import { isEnabled } from 'config';
 import purchasesPaths from 'me/purchases/paths';
-import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 	getPlanFeatures() {
@@ -100,15 +99,13 @@ class PlansFeaturesMain extends Component {
 			);
 		}
 
-		const signupPlans = [
-			hideFreePlan ? null : PLAN_FREE,
-			isPersonalPlanEnabled ? PLAN_PERSONAL : null,
-			PLAN_PREMIUM,
-			PLAN_BUSINESS
-		];
-
 		const plans = filter(
-			abtest( 'signupPlansReorderTest' ) === 'modified' ? reverse( signupPlans ) : signupPlans,
+			[
+				hideFreePlan ? null : PLAN_FREE,
+				isPersonalPlanEnabled ? PLAN_PERSONAL : null,
+				PLAN_PREMIUM,
+				PLAN_BUSINESS
+			],
 			value => !! value
 		);
 


### PR DESCRIPTION
We recently concluded [a test](https://github.com/Automattic/wp-calypso/pull/12965) with a variation that reversed the order of the plans in signup. The variation was out performed by the original. We will therefore be removing the variation. 

This PR removes the test from the code base. 

@markryall can you please review?