### PR TITLE
Editor: fix navigation away from editor on clean cache

### DIFF
--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -80,6 +80,9 @@ export class EditorAuthor extends Component {
 
 	userCanAssignAuthor() {
 		const { post, site } = this.props;
+		if ( ! post ) {
+			return false;
+		}
 		const reassignCapability = 'edit_others_' + post.type + 's';
 
 		// if user cannot edit others posts


### PR DESCRIPTION
This PR fixes an issue where we cannot navigate away from the post editor on a clean cache.

![screen shot 2017-05-22 at 1 02 24 pm](https://cloud.githubusercontent.com/assets/1270189/26326159/eb6aac5a-3eee-11e7-8134-2ef420c9a90c.png)


### Testing Instructions
- Navigate to http://calypso.localhost:3000/post
- Select a site if prompted
- Clear Cache `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );`
- Refresh the page
- Then click on 'My Sites'
- In prod we would fail to navigate away.