### PR TITLE
WooCommerce: Preserves changes when toggling between simple & variable product type

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,69 +12,125 @@ import ProductVariationTypesForm from './product-variation-types-form';
 import ProductFormVariationsTable from './product-form-variations-table';
 import FormToggle from 'components/forms/form-toggle';
 
-const ProductFormVariationsCard = ( {
-	product,
-	variations,
-	editProduct,
-	translate,
-	editProductAttribute,
-	editProductVariation
-} ) => {
-	// TODO When toggling between types, don't destory a user's previous edits. Save to component state and restore on toggle.
-	const handleToggle = () => {
-		if ( 'variable' !== product.type ) {
-			editProduct( product, { type: 'variable' } );
-		} else {
-			const attributes = ( product.attributes && product.attributes.filter( attribute => ! attribute.variation ) ) || null;
-			editProduct( product, { type: 'simple', attributes } );
-		}
+class ProductFormVariationsCard extends Component {
+
+	state = {
+		simpleProduct: [],
+		variationAttributes: [],
 	};
 
-	const variationToggleDescription = translate(
-		'%(productName)s has variations, for example size and color.', {
-			args: {
-				productName: ( product && product.name ) || translate( 'This product' )
-			}
+	static propTypes = {
+		product: PropTypes.shape( {
+			type: PropTypes.string.isRequired,
+			name: PropTypes.string,
+			attributes: PropTypes.array,
+		} ),
+		variations: PropTypes.array,
+		editProduct: PropTypes.func.isRequired,
+		editProductAttribute: PropTypes.func.isRequired,
+		editProductVariation: PropTypes.func.isRequired,
+	};
+
+	simpleFields = [
+		'dimensions', 'weight', 'regular_price',
+		'manage_stock', 'stock_quantity', 'backorders',
+	];
+
+	/*
+	 * When switching between product types, we clean up the Redux state to drop fields or variation attributes
+	 * that are no longer valid, so we can keep API calls clean. This is done in setVariable and setSimple.
+	 * To preserve a users edits, we store these changes in component state, and restore them if they toggle back.
+	 * A user shouldn't lose work just because they locally toggled a card.
+	 */
+	handleToggle = () => {
+		if ( 'variable' !== this.props.product.type ) {
+			this.setProductTypeVariable();
+		} else {
+			this.setProductTypeSimple();
 		}
-	);
+	}
 
-	return (
-		<FoldableCard
-			icon=""
-			expanded
-			className="products__variation-card"
-			header={ ( <FormToggle onChange={ handleToggle } checked={ 'variable' === product.type }>
-				{ variationToggleDescription }
-			</FormToggle>
-			) }
-		>
-			{ 'variable' === product.type && (
-				<div>
-					<ProductVariationTypesForm
-						product={ product }
-						editProductAttribute={ editProductAttribute }
-					/>
-					<ProductFormVariationsTable
-						product={ product }
-						variations={ variations }
-						editProductVariation={ editProductVariation }
-					/>
-				</div>
-			) }
-		</FoldableCard>
-	);
-};
+	setProductTypeVariable() {
+		const { product, editProduct } = this.props;
+		const attributes = product.attributes && [ ...product.attributes ] || [];
+		const productData = { ...product };
+		const simpleProduct = [ ...this.state.simpleProduct ];
 
-ProductFormVariationsCard.propTypes = {
-	product: PropTypes.shape( {
-		id: PropTypes.isRequired,
-		type: PropTypes.string.isRequired,
-		name: PropTypes.string,
-	} ),
-	variations: PropTypes.array,
-	editProduct: PropTypes.func.isRequired,
-	editProductAttribute: PropTypes.func.isRequired,
-	editProductVariation: PropTypes.func.isRequired,
-};
+		this.simpleFields.forEach( function( field ) {
+			if ( product[ field ] ) {
+				simpleProduct[ field ] = product[ field ];
+				productData[ field ] = null;
+			}
+		} );
+		this.state.variationAttributes.forEach( function( attribute ) {
+			attributes.push( attribute );
+		} );
+
+		this.setState( { simpleProduct, variationAttributes: [] } );
+		editProduct( product, {
+			...productData,
+			type: 'variable',
+			attributes,
+		} );
+	}
+
+	setProductTypeSimple() {
+		const { product, editProduct } = this.props;
+		const productData = { ...product };
+		const simpleProduct = this.state.simpleProduct;
+
+		this.simpleFields.forEach( function( field ) {
+			if ( simpleProduct[ field ] ) {
+				productData[ field ] = simpleProduct[ field ];
+			}
+		} );
+		const variationAttributes = ( product.attributes && product.attributes.filter( attribute => attribute.variation ) ) || [];
+		const attributes = ( product.attributes && product.attributes.filter( attribute => ! attribute.variation ) ) || null;
+
+		this.setState( { variationAttributes, simpleProduct: [] } );
+		editProduct( product, {
+			...productData,
+			type: 'simple',
+			attributes,
+		} );
+	}
+
+	render() {
+		const { product, variations, translate, editProductAttribute, editProductVariation } = this.props;
+		const variationToggleDescription = translate(
+			'%(productName)s has variations, for example size and color.', {
+				args: {
+					productName: ( product && product.name ) || translate( 'This product' )
+				}
+			}
+		);
+
+		return (
+			<FoldableCard
+				icon=""
+				expanded
+				className="products__variation-card"
+				header={ ( <FormToggle onChange={ this.handleToggle } checked={ 'variable' === product.type }>
+					{ variationToggleDescription }
+				</FormToggle>
+				) }
+			>
+				{ 'variable' === product.type && (
+					<div>
+						<ProductVariationTypesForm
+							product={ product }
+							editProductAttribute={ editProductAttribute }
+						/>
+						<ProductFormVariationsTable
+							product={ product }
+							variations={ variations }
+							editProductVariation={ editProductVariation }
+						/>
+					</div>
+				) }
+			</FoldableCard>
+		);
+	}
+}
 
 export default localize( ProductFormVariationsCard );


### PR DESCRIPTION
This preserves a user's changes in component state when toggling the product type. 

We were clearing data that no longer applied to the new product type, so that the Redux state matched what we would send to state. We don't want to pass the fields for a simple product through for a variable product, and we don't want to pass variation attributes along with a simple product.

This PR keeps that behavior, but backs up fields to component state so we can reapply them if the user toggles back.

cc @allendav This is what we mentioned on #14186.

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Type in a price, weight, dimension, or something related to stock (or all of the above!)
* Click the `This product has variations, for example size and color.` toggle. If you have Redux dev tools installed, you should see these changes get removed.
* Toggle back, and see your changes still inside the input fields. They should get added back to the Redux state.
* Toggle again, and fill out a couple variation types.
* Toggle, and see the variation attributes dropped from Redux state.
* Toggle a final time and see your variation attributes still inside the input fields. They should get added back to state.