### PR TITLE
Action Watchers: Move `mergeHandlers` out of data layer

### DIFF
--- a/client/state/action-watchers/test/utils.js
+++ b/client/state/action-watchers/test/utils.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { mergeHandlers } from '../utils';
+
+describe( '#mergeHandlers', () => {
+	const inc = a => a + 1;
+	const triple = a => a * 3;
+	const action = 'DO_MATH';
+	const first = { [ action ]: [ inc ] };
+	const second = { [ action ]: [ triple ] };
+
+	it( 'should pass through a single handler', () => {
+		expect( mergeHandlers( first ) ).to.equal( first );
+	} );
+
+	it( 'should combine lists of handlers for different action types', () => {
+		const merged = mergeHandlers(
+			{ INCREMENT: [ inc ] },
+			{ TRIPLE: [ triple ] },
+		);
+
+		expect( merged ).to.eql( {
+			INCREMENT: [ inc ],
+			TRIPLE: [ triple ],
+		} );
+	} );
+
+	it( 'should combine lists of handlers for the same action type', () => {
+		const merged = mergeHandlers( first, second );
+
+		expect( merged[ action ] ).to.eql( [ inc, triple ] );
+	} );
+} );

--- a/client/state/action-watchers/utils.js
+++ b/client/state/action-watchers/utils.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import {
+	isArray,
+	mergeWith,
+} from 'lodash';
+
+/**
+ * Merge handler for lodash.mergeWith
+ *
+ * Note that a return value of `undefined`
+ * indicates to lodash that it should use
+ * its normal merge algorithm.
+ *
+ * In this case, we want to merge keys if
+ * they don't exists but when they do, we
+ * prefer to concatenate lists instead of
+ * overwriting them.
+ *
+ * @param {?Array<Function>} left existing handlers
+ * @param {Array<Function>} right new handlers to add
+ * @returns {Array<Function>} combined handlers
+ */
+const concatHandlers = ( left, right ) =>
+	isArray( left )
+		? left.concat( right )
+		: undefined;
+
+export const mergeHandlers = ( ...handlers ) =>
+	handlers.length > 1
+		? mergeWith( Object.create( null ), ...handlers, concatHandlers )
+		: handlers[ 0 ];

--- a/client/state/data-layer/extensions-middleware.js
+++ b/client/state/data-layer/extensions-middleware.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from './utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import { middleware } from './wpcom-api-middleware';
 
 const configuration = configureMiddleware( Object.create( null ), Object.create( null ) );

--- a/client/state/data-layer/test/utils.js
+++ b/client/state/data-layer/test/utils.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { local, mergeHandlers } from '../utils';
+import { local } from '../utils';
 
 describe( 'Data Layer', () => {
 	describe( '#local', () => {
@@ -31,36 +31,6 @@ describe( 'Data Layer', () => {
 
 			expect( localAction ).to.have.deep.property( 'meta.oceanName', 'ARCTIC' );
 			expect( localAction ).to.have.deep.property( 'meta.dataLayer.forceRefresh', true );
-		} );
-	} );
-
-	describe( '#mergeHandlers', () => {
-		const inc = a => a + 1;
-		const triple = a => a * 3;
-		const action = 'DO_MATH';
-		const first = { [ action ]: [ inc ] };
-		const second = { [ action ]: [ triple ] };
-
-		it( 'should pass through a single handler', () => {
-			expect( mergeHandlers( first ) ).to.equal( first );
-		} );
-
-		it( 'should combine lists of handlers for different action types', () => {
-			const merged = mergeHandlers(
-				{ INCREMENT: [ inc ] },
-				{ TRIPLE: [ triple ] },
-			);
-
-			expect( merged ).to.eql( {
-				INCREMENT: [ inc ],
-				TRIPLE: [ triple ],
-			} );
-		} );
-
-		it( 'should combine lists of handlers for the same action type', () => {
-			const merged = mergeHandlers( first, second );
-
-			expect( merged[ action ] ).to.eql( [ inc, triple ] );
 		} );
 	} );
 } );

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -8,7 +8,8 @@ import { spy, stub } from 'sinon';
  * Internal dependencies
  */
 import { middleware } from '../wpcom-api-middleware';
-import { local, mergeHandlers } from '../utils';
+import { local } from '../utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 
 describe( 'WordPress.com API Middleware', () => {
 	let next;

--- a/client/state/data-layer/third-party/index.js
+++ b/client/state/data-layer/third-party/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import directly from './directly';
 
 export const handlers = mergeHandlers(

--- a/client/state/data-layer/utils.js
+++ b/client/state/data-layer/utils.js
@@ -1,37 +1,7 @@
 /**
- * External dependencies
- */
-import {
-	isArray,
-	mergeWith,
-} from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { extendAction } from 'state/utils';
-
-/**
- * Merge handler for lodash.mergeWith
- *
- * Note that a return value of `undefined`
- * indicates to lodash that it should use
- * its normal merge algorithm.
- *
- * In this case, we want to merge keys if
- * they don't exists but when they do, we
- * prefer to concatenate lists instead of
- * overwriting them.
- */
-const concatHandlers = ( left, right ) =>
-	isArray( left )
-		? left.concat( right )
-		: undefined;
-
-export const mergeHandlers = ( ...handlers ) =>
-	handlers.length > 1
-		? mergeWith( Object.create( null ), ...handlers, concatHandlers )
-		: handlers[ 0 ];
 
 const doBypassDataLayer = {
 	meta: {

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { local, mergeHandlers } from './utils';
+import { local } from './utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 
 import httpHandlers from './wpcom-http';
 import thirdPartyHandlers from './third-party';

--- a/client/state/data-layer/wpcom/account-recovery/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import lookup from './lookup';
 import requestReset from './request-reset';
 import reset from './reset';

--- a/client/state/data-layer/wpcom/index.js
+++ b/client/state/data-layer/wpcom/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import accountRecovery from './account-recovery';
 import me from './me';
 import plans from './plans';

--- a/client/state/data-layer/wpcom/me/index.js
+++ b/client/state/data-layer/wpcom/me/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import settings from './settings';
 import sendVerificationEmail from './send-verification-email';
 

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -7,7 +7,7 @@ import { forEach, map, omitBy, isArray, isUndefined } from 'lodash';
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import followingNew from './new';
 import followingDelete from './delete';
 import {

--- a/client/state/data-layer/wpcom/read/index.js
+++ b/client/state/data-layer/wpcom/read/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import site from './site';
 import teams from './teams';
 import tags from './tags';

--- a/client/state/data-layer/wpcom/read/recommendations/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal Dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import sites from './sites';
 
 export default mergeHandlers( sites );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/index.js
@@ -5,7 +5,7 @@
 /**
  * Internal Dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import subscribe from './new';
 import unsubscribe from './delete';
 

--- a/client/state/data-layer/wpcom/read/site/index.js
+++ b/client/state/data-layer/wpcom/read/site/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal Dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import postEmailSubscriptions from './post-email-subscriptions';
 import commentEmailSubscriptions from './comment-email-subscriptions';
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal Dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import subscribe from './new';
 import update from './update';
 import unsubscribe from './delete';

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -13,7 +13,7 @@ import requestFollowHandler from 'state/data-layer/wpcom/read/tags/mine/new';
 import requestUnfollowHandler from 'state/data-layer/wpcom/read/tags/mine/delete';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import eligibility from './eligibility';
 
 export default mergeHandlers(

--- a/client/state/data-layer/wpcom/sites/index.js
+++ b/client/state/data-layer/wpcom/sites/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import automatedTransfer from './automated-transfer';
 import media from './media';
 

--- a/client/state/data-layer/wpcom/videos/index.js
+++ b/client/state/data-layer/wpcom/videos/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/data-layer/utils';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import poster from './poster';
 
 export default mergeHandlers(


### PR DESCRIPTION
@see #14299 

Previously the `mergeHandlers()` utility was hidden in the data layer
even though it was useful in a much more general context.

This PR is the first of many changes to generalize the action-based
handler middleware that the data-layer implements.

It is a small change to keep individual changes small and incremental.

**Testing**

Smoke test. Anything reliant on the data layer should fail terribly if something is wrong here.