### PR TITLE
DataLayer: Start transition to implicit `next( action )` in handlers

### DIFF
--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -68,7 +68,22 @@ export const middleware = handlers => store => next => {
 			}
 		}
 
-		return handlerChain.forEach( handler => handler( store, action, localNext ) );
+		// as we transition to making next() implicit we want
+		// to limit the extent of our changes so make this new
+		// function which gives us the ability to incrementally
+		// remove the uses of `next( action )` inside the handlers
+		//
+		// this guarantees that we don't double-dispatch
+		const nextActions = new Set();
+		const safeNext = a => nextActions.add( a );
+
+		handlerChain.forEach( handler => handler( store, action, safeNext ) );
+
+		// make sure we pass along this action
+		// eventually this will return to the
+		// simpler `return next( action )`
+		nextActions.add( action );
+		nextActions.forEach( localNext );
 	};
 };
 

--- a/client/state/data-layer/wpcom/account-recovery/lookup/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/index.js
@@ -33,7 +33,7 @@ export const validate = ( { primary_email, primary_sms, secondary_email, seconda
 	}
 };
 
-export const handleRequestResetOptions = ( { dispatch }, action, next ) => {
+export const handleRequestResetOptions = ( { dispatch }, action ) => {
 	const { userData } = action;
 
 	wpcom.req.get( {
@@ -45,8 +45,6 @@ export const handleRequestResetOptions = ( { dispatch }, action, next ) => {
 		dispatch( updatePasswordResetUserData( userData ) );
 	} )
 	.catch( error => dispatch( fetchResetOptionsError( error ) ) );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/account-recovery/lookup/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/lookup/test/index.js
@@ -3,7 +3,6 @@
  */
 import { assert } from 'chai';
 import sinon from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -78,7 +77,7 @@ describe( 'handleRequestResetOptions()', () => {
 				}
 			} );
 
-			handleRequestResetOptions( { dispatch }, { userData }, noop );
+			handleRequestResetOptions( { dispatch }, { userData } );
 		} );
 
 		it( 'should dispatch UPDATE_USER_DATA action on success', ( done ) => {
@@ -93,7 +92,7 @@ describe( 'handleRequestResetOptions()', () => {
 				}
 			} );
 
-			handleRequestResetOptions( { dispatch }, { userData }, noop );
+			handleRequestResetOptions( { dispatch }, { userData } );
 		} );
 	} );
 
@@ -119,7 +118,7 @@ describe( 'handleRequestResetOptions()', () => {
 				done();
 			} );
 
-			handleRequestResetOptions( { dispatch }, { userData }, noop );
+			handleRequestResetOptions( { dispatch }, { userData } );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/request-reset/index.js
@@ -9,7 +9,7 @@ import {
 	setResetMethod,
 } from 'state/account-recovery/reset/actions';
 
-export const handleRequestReset = ( { dispatch }, action, next ) => {
+export const handleRequestReset = ( { dispatch }, action ) => {
 	const {
 		userData,
 		method,
@@ -27,8 +27,6 @@ export const handleRequestReset = ( { dispatch }, action, next ) => {
 		dispatch( setResetMethod( method ) );
 	} )
 	.catch( ( error ) => dispatch( requestResetError( error ) ) );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/account-recovery/request-reset/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/request-reset/test/index.js
@@ -3,7 +3,6 @@
  */
 import { assert } from 'chai';
 import sinon from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,7 +43,7 @@ describe( 'handleRequestReset()', () => {
 				}
 			} );
 
-			handleRequestReset( { dispatch }, { userData, method }, noop );
+			handleRequestReset( { dispatch }, { userData, method } );
 		} );
 
 		it( 'should dispatch SET_METHOD action on success', ( done ) => {
@@ -59,7 +58,7 @@ describe( 'handleRequestReset()', () => {
 				}
 			} );
 
-			handleRequestReset( { dispatch }, { userData, method }, noop );
+			handleRequestReset( { dispatch }, { userData, method } );
 		} );
 	} );
 
@@ -83,7 +82,7 @@ describe( 'handleRequestReset()', () => {
 				} ) )
 			} );
 
-			handleRequestReset( { dispatch }, { userData, method }, noop );
+			handleRequestReset( { dispatch }, { userData, method } );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/account-recovery/reset/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/index.js
@@ -8,7 +8,7 @@ import {
 	requestResetPasswordError,
 } from 'state/account-recovery/reset/actions';
 
-export const handleResetPasswordRequest = ( { dispatch }, action, next ) => {
+export const handleResetPasswordRequest = ( { dispatch }, action ) => {
 	const {
 		userData, // userData can be either { user } or { firstname, lastname, url }
 		method,
@@ -27,8 +27,6 @@ export const handleResetPasswordRequest = ( { dispatch }, action, next ) => {
 		path: '/account-recovery/reset'
 	} ).then( () => dispatch( requestResetPasswordSuccess() ) )
 	.catch( ( error ) => dispatch( requestResetPasswordError( error ) ) );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/reset/test/index.js
@@ -3,7 +3,6 @@
  */
 import { assert } from 'chai';
 import sinon from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,7 +45,7 @@ describe( 'handleResetPasswordRequest()', () => {
 				done();
 			} );
 
-			handleResetPasswordRequest( { dispatch }, params, noop );
+			handleResetPasswordRequest( { dispatch }, params );
 		} );
 	} );
 
@@ -72,7 +71,7 @@ describe( 'handleResetPasswordRequest()', () => {
 				done();
 			} );
 
-			handleResetPasswordRequest( { dispatch }, params, noop );
+			handleResetPasswordRequest( { dispatch }, params );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/account-recovery/validate/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/index.js
@@ -9,7 +9,7 @@ import {
 	setValidationKey,
 } from 'state/account-recovery/reset/actions';
 
-export const handleValidateRequest = ( { dispatch }, action, next ) => {
+export const handleValidateRequest = ( { dispatch }, action ) => {
 	const { userData, method, key } = action;
 	wpcom.req.post( {
 		body: {
@@ -24,8 +24,6 @@ export const handleValidateRequest = ( { dispatch }, action, next ) => {
 		dispatch( setValidationKey( key ) );
 	} )
 	.catch( ( error ) => dispatch( validateRequestError( error ) ) );
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
+++ b/client/state/data-layer/wpcom/account-recovery/validate/test/index.js
@@ -3,7 +3,6 @@
  */
 import { assert } from 'chai';
 import sinon from 'sinon';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,7 +44,7 @@ describe( 'handleValidateRequest()', () => {
 				}
 			} );
 
-			handleValidateRequest( { dispatch }, { userData, method, key }, noop );
+			handleValidateRequest( { dispatch }, { userData, method, key } );
 		} );
 
 		it( 'should dispatch SET_VALIDATION_KEY action on success', ( done ) => {
@@ -60,7 +59,7 @@ describe( 'handleValidateRequest()', () => {
 				}
 			} );
 
-			handleValidateRequest( { dispatch }, { userData, method, key }, noop );
+			handleValidateRequest( { dispatch }, { userData, method, key } );
 		} );
 	} );
 
@@ -86,7 +85,7 @@ describe( 'handleValidateRequest()', () => {
 				done();
 			} );
 
-			handleValidateRequest( { dispatch }, { userData, method, key }, noop );
+			handleValidateRequest( { dispatch }, { userData, method, key } );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -79,10 +79,9 @@ const doAppPushPolling = store => {
 	}
 };
 
-const handleTwoFactorPushPoll = ( store, action, next ) => {
+const handleTwoFactorPushPoll = ( store ) => {
 	// this is deferred to allow reducer respond to TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START
 	defer( () => doAppPushPolling( store ) );
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/me/send-verification-email/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/index.js
@@ -9,14 +9,12 @@ import {
 	EMAIL_VERIFY_REQUEST_FAILURE,
 } from 'state/action-types';
 
-export const requestEmailVerification = function( { dispatch }, action, next ) {
+export const requestEmailVerification = function( { dispatch }, action ) {
 	dispatch( http( {
 		apiVersion: '1.1',
 		method: 'POST',
 		path: '/me/send-verification-email',
 	}, action ) );
-
-	return next( action );
 };
 
 export const handleError = ( { dispatch }, action, next, rawError ) => {

--- a/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
@@ -21,10 +21,9 @@ import {
 describe( 'send-email-verification', () => {
 	describe( '#requestEmailVerification', () => {
 		const dispatchSpy = spy();
-		const nextSpy = spy();
 		const dummyAction = { type: 'DUMMY' };
 
-		requestEmailVerification( { dispatch: dispatchSpy }, dummyAction, nextSpy );
+		requestEmailVerification( { dispatch: dispatchSpy }, dummyAction );
 
 		it( 'should dispatch HTTP request to plans endpoint', () => {
 			expect( dispatchSpy ).to.have.been.calledOnce;
@@ -33,11 +32,6 @@ describe( 'send-email-verification', () => {
 				method: 'POST',
 				path: '/me/send-verification-email',
 			}, dummyAction ) );
-		} );
-
-		it( 'should pass the original action along the middleware chain', () => {
-			expect( nextSpy ).to.have.been.calledOnce;
-			expect( nextSpy ).to.have.been.calledWith( dummyAction );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -35,15 +35,11 @@ function fromApi( apiResponse ) {
 /*
  * Fetch settings from the WordPress.com API at /me/settings endpoint
  */
-export const requestUserSettings = ( { dispatch }, action, next ) => {
-	dispatch( http( {
-		apiVersion: '1.1',
-		method: 'GET',
-		path: '/me/settings',
-	}, action ) );
-
-	return next( action );
-};
+export const requestUserSettings = ( { dispatch }, action ) => dispatch( http( {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: '/me/settings',
+}, action ) );
 
 /*
  * Store the fetched user settings to Redux state
@@ -55,7 +51,7 @@ export const storeFetchedUserSettings = ( { dispatch }, action, next, data ) => 
 /*
  * Post settings to WordPress.com API at /me/settings endpoint
  */
-export function saveUserSettings( { dispatch, getState }, action, next ) {
+export function saveUserSettings( { dispatch, getState }, action ) {
 	const { settingsOverride } = action;
 	const settings = settingsOverride || getUnsavedUserSettings( getState() );
 
@@ -67,8 +63,6 @@ export function saveUserSettings( { dispatch, getState }, action, next ) {
 			body: settings,
 		}, action ) );
 	}
-
-	return next( action );
 }
 
 /*

--- a/client/state/data-layer/wpcom/me/settings/test/index.js
+++ b/client/state/data-layer/wpcom/me/settings/test/index.js
@@ -16,11 +16,10 @@ import {
 } from 'state/user-settings/actions';
 
 describe( 'wpcom-api', () => {
-	let dispatch, next, settingsModule;
+	let dispatch, settingsModule;
 
 	useSandbox( sandbox => {
 		dispatch = sandbox.spy();
-		next = sandbox.spy();
 	} );
 
 	useMockery( () => {
@@ -35,7 +34,7 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch HTTP GET request to me/settings endpoint', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.requestUserSettings( { dispatch }, action, next );
+				settingsModule.requestUserSettings( { dispatch }, action );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( http( {
@@ -44,21 +43,13 @@ describe( 'wpcom-api', () => {
 					path: '/me/settings',
 				}, action ) );
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = { type: 'DUMMY' };
-
-				settingsModule.requestUserSettings( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#storeFetchedUserSettings', () => {
 			it( 'should dispatch user settings update', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.storeFetchedUserSettings( { dispatch }, action, next, {
+				settingsModule.storeFetchedUserSettings( { dispatch }, action, null, {
 					language: 'qix',
 				} );
 
@@ -71,7 +62,7 @@ describe( 'wpcom-api', () => {
 			it( 'should decode HTML entities returned in some fields of HTTP response', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.storeFetchedUserSettings( { dispatch }, action, next, {
+				settingsModule.storeFetchedUserSettings( { dispatch }, action, null, {
 					display_name: 'baz &amp; qix',
 					description: 'foo &amp; bar',
 					user_URL: 'http://example.com?a=b&amp;c=d',
@@ -97,7 +88,7 @@ describe( 'wpcom-api', () => {
 				} );
 				const action = { type: 'DUMMY' };
 
-				settingsModule.saveUserSettings( { dispatch, getState }, action, next );
+				settingsModule.saveUserSettings( { dispatch, getState }, action, null );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( http( {
@@ -106,7 +97,6 @@ describe( 'wpcom-api', () => {
 					path: '/me/settings',
 					body: { foo: 'baz' }
 				}, action ) );
-				expect( next ).to.have.been.calledWith( action );
 			} );
 
 			it( 'should dispatch POST request to me/settings using explicit settingsOverride', () => {
@@ -116,7 +106,7 @@ describe( 'wpcom-api', () => {
 					settingsOverride: { foo: 'baz' }
 				};
 
-				settingsModule.saveUserSettings( { dispatch, getState }, action, next );
+				settingsModule.saveUserSettings( { dispatch, getState }, action, null );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( http( {
@@ -125,7 +115,6 @@ describe( 'wpcom-api', () => {
 					path: '/me/settings',
 					body: { foo: 'baz' }
 				}, action ) );
-				expect( next ).to.have.been.calledWith( action );
 			} );
 
 			it( 'should not dispatch any HTTP request when there are no unsaved settings', () => {
@@ -137,10 +126,9 @@ describe( 'wpcom-api', () => {
 				} );
 				const action = { type: 'DUMMY' };
 
-				settingsModule.saveUserSettings( { dispatch, getState }, action, next );
+				settingsModule.saveUserSettings( { dispatch, getState }, action, null );
 
 				expect( dispatch ).to.not.have.been.called;
-				expect( next ).to.have.been.calledWith( action );
 			} );
 		} );
 
@@ -148,7 +136,7 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch user settings update and clear all unsaved settings on full save', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.finishUserSettingsSave( { dispatch }, action, next, {
+				settingsModule.finishUserSettingsSave( { dispatch }, action, null, {
 					language: 'qix',
 				} );
 
@@ -165,7 +153,7 @@ describe( 'wpcom-api', () => {
 				};
 				const action = { type: 'DUMMY', settingsOverride: data };
 
-				settingsModule.finishUserSettingsSave( { dispatch }, action, next, data );
+				settingsModule.finishUserSettingsSave( { dispatch }, action, null, data );
 
 				expect( dispatch ).to.have.been.calledTwice;
 				expect( dispatch ).to.have.been.calledWith( updateUserSettings( {
@@ -179,7 +167,7 @@ describe( 'wpcom-api', () => {
 			it( 'should decode HTML entities returned in some fields of HTTP response', () => {
 				const action = { type: 'DUMMY' };
 
-				settingsModule.finishUserSettingsSave( { dispatch }, action, next, {
+				settingsModule.finishUserSettingsSave( { dispatch }, action, null, {
 					display_name: 'baz &amp; qix',
 					description: 'foo &amp; bar',
 					user_URL: 'http://example.com?a=b&amp;c=d',

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -22,17 +22,13 @@ import {
  * @param {Function} next data-layer-bypassing dispatcher
  * @returns {Object} original action
  */
-export const requestPlans = ( { dispatch }, action, next ) => {
-	dispatch( http( {
-		apiVersion: '1.4',
-		method: 'GET',
-		path: '/plans',
-		onSuccess: action,
-		onFailure: action,
-	} ) );
-
-	return next( action );
-};
+export const requestPlans = ( { dispatch }, action ) => dispatch( http( {
+	apiVersion: '1.4',
+	method: 'GET',
+	path: '/plans',
+	onSuccess: action,
+	onFailure: action,
+} ) );
 
 /**
  * Dispatches returned WordPress.com plan data

--- a/client/state/data-layer/wpcom/plans/test/index.js
+++ b/client/state/data-layer/wpcom/plans/test/index.js
@@ -27,9 +27,8 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch HTTP request to plans endpoint', () => {
 				const action = { type: 'DUMMY' };
 				const dispatch = spy();
-				const next = spy();
 
-				requestPlans( { dispatch }, action, next );
+				requestPlans( { dispatch }, action );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( http( {
@@ -40,16 +39,6 @@ describe( 'wpcom-api', () => {
 					onFailure: action,
 				} ) );
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = { type: 'DUMMY' };
-				const dispatch = spy();
-				const next = spy();
-
-				requestPlans( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#receivePlans', () => {
@@ -57,9 +46,8 @@ describe( 'wpcom-api', () => {
 				const plans = WPCOM_RESPONSE;
 				const action = plansReceiveAction( plans );
 				const dispatch = spy();
-				const next = spy();
 
-				receivePlans( { dispatch }, action, next, plans );
+				receivePlans( { dispatch }, action, null, plans );
 
 				expect( dispatch ).to.have.been.calledTwice;
 				expect( dispatch ).to.have.been.calledWith( plansRequestSuccessAction() );
@@ -72,9 +60,8 @@ describe( 'wpcom-api', () => {
 				const error = 'could not find plans';
 				const action = plansRequestFailureAction( error );
 				const dispatch = spy();
-				const next = spy();
 
-				receiveError( { dispatch }, action, next, error );
+				receiveError( { dispatch }, action, null, error );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( plansRequestFailureAction( error ) );

--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -70,9 +70,8 @@ describe( '#fetchPostRevisions', () => {
 	it( 'should dispatch HTTP request to tag endpoint', () => {
 		const action = requestPostRevisions( 12345678, 10 );
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 
-		fetchPostRevisions( { dispatch }, action, next );
+		fetchPostRevisions( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( http( {
@@ -89,9 +88,8 @@ describe( '#receiveSuccess', () => {
 	it( 'should normalize the revisions and dispatch `receivePostRevisions` and `receivePostRevisionsSuccess`', () => {
 		const action = requestPostRevisions( 12345678, 10 );
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 
-		receiveSuccess( { dispatch }, action, next, successfulPostRevisionsResponse );
+		receiveSuccess( { dispatch }, action, null, successfulPostRevisionsResponse );
 
 		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch ).to.have.been.calledWith( receivePostRevisionsSuccess( 12345678, 10 ) );
@@ -103,10 +101,9 @@ describe( '#receiveError', () => {
 	it( 'should dispatch `receivePostRevisionsFailure`', () => {
 		const action = requestPostRevisions( 12345678, 10 );
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 		const rawError = new Error( 'Foo Bar' );
 
-		receiveError( { dispatch }, action, next, rawError );
+		receiveError( { dispatch }, action, null, rawError );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( receivePostRevisionsFailure( 12345678, 10, rawError ) );

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -13,7 +13,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
-export function initiateFeedSearch( store, action, next ) {
+export function initiateFeedSearch( store, action ) {
 	if ( ! ( action.payload && action.payload.query ) ) {
 		return;
 	}
@@ -29,8 +29,6 @@ export function initiateFeedSearch( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 export function receiveFeeds( store, action, next, apiResponse ) {

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -23,9 +23,8 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch http request for feed search', () => {
 				const action = requestFeedSearch( query );
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 
-				initiateFeedSearch( { dispatch }, action, next );
+				initiateFeedSearch( { dispatch }, action );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
@@ -39,26 +38,15 @@ describe( 'wpcom-api', () => {
 					} )
 				);
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = requestFeedSearch( query );
-				const dispatch = sinon.spy();
-				const next = sinon.spy();
-
-				initiateFeedSearch( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#receiveFeeds', () => {
 			it( 'should dispatch an action with the feed results', () => {
 				const action = requestFeedSearch( query );
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 				const apiResponse = { feeds, total: 500 };
 
-				receiveFeeds( { dispatch }, action, next, apiResponse );
+				receiveFeeds( { dispatch }, action, null, apiResponse );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
@@ -81,14 +69,12 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch error notice', () => {
 				const action = requestFeedSearch( query );
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 
-				receiveError( { dispatch }, action, next );
+				receiveError( { dispatch }, action );
 
 				expect( dispatch ).to.have.been.calledWithMatch( {
 					type: NOTICE_CREATE,
 				} );
-				expect( next ).callCount( 0 );
 			} );
 		} );
 	} );

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -13,7 +13,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { follow } from 'state/reader/follows/actions';
 
-export function requestUnfollow( { dispatch, getState }, action, next ) {
+export function requestUnfollow( { dispatch }, action ) {
 	const { payload: { feedUrl } } = action;
 	dispatch(
 		http( {
@@ -28,7 +28,6 @@ export function requestUnfollow( { dispatch, getState }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveUnfollow( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -15,9 +15,8 @@ import { requestUnfollow, receiveUnfollow, unfollowError } from '../';
 describe( 'requestUnfollow', () => {
 	it( 'should dispatch a http request', () => {
 		const dispatch = spy();
-		const next = spy();
 		const action = unfollow( 'http://example.com' );
-		requestUnfollow( { dispatch }, action, next );
+		requestUnfollow( { dispatch }, action );
 		expect( dispatch ).to.have.been.calledWith(
 			http( {
 				method: 'POST',
@@ -31,7 +30,6 @@ describe( 'requestUnfollow', () => {
 				onFailure: action,
 			} )
 		);
-		expect( next ).to.have.been.calledWith( action );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -63,7 +63,7 @@ let seenSubscriptions = null;
 export const isSyncingFollows = () => syncingFollows;
 export const resetSyncingFollows = () => syncingFollows = false;
 
-export function syncReaderFollows( store, action, next ) {
+export function syncReaderFollows( store ) {
 	if ( isSyncingFollows() ) {
 		return;
 	}
@@ -72,11 +72,9 @@ export function syncReaderFollows( store, action, next ) {
 	seenSubscriptions = new Set();
 
 	store.dispatch( requestPageAction( 1 ) );
-
-	next( action );
 }
 
-export function requestPage( store, action, next ) {
+export function requestPage( store, action ) {
 	store.dispatch(
 		http( {
 			method: 'GET',
@@ -91,8 +89,6 @@ export function requestPage( store, action, next ) {
 			onError: action,
 		} )
 	);
-
-	next( action );
 }
 
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
@@ -128,11 +124,10 @@ export function receivePage( store, action, next, apiResponse ) {
 	syncingFollows = false;
 }
 
-export function updateSeenOnFollow( store, action, next ) {
+export function updateSeenOnFollow( store, action ) {
 	if ( seenSubscriptions ) {
 		seenSubscriptions.add( action.payload.feedUrl );
 	}
-	next( action );
 }
 
 export function receiveError( store ) {

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -14,7 +14,7 @@ import { errorNotice } from 'state/notices/actions';
 import { follow, unfollow, recordFollowError } from 'state/reader/follows/actions';
 import { subscriptionFromApi } from 'state/data-layer/wpcom/read/following/mine';
 
-export function requestFollow( { dispatch }, action, next ) {
+export function requestFollow( { dispatch }, action ) {
 	const { payload: { feedUrl } } = action;
 
 	dispatch(
@@ -30,7 +30,6 @@ export function requestFollow( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveFollow( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -15,9 +15,8 @@ import { requestFollow, receiveFollow, followError } from '../';
 describe( 'requestFollow', () => {
 	it( 'should dispatch a http request', () => {
 		const dispatch = spy();
-		const next = spy();
 		const action = follow( 'http://example.com' );
-		requestFollow( { dispatch }, action, next );
+		requestFollow( { dispatch }, action );
 		expect( dispatch ).to.have.been.calledWith(
 			http( {
 				method: 'POST',
@@ -31,7 +30,6 @@ describe( 'requestFollow', () => {
 				onFailure: action,
 			} )
 		);
-		expect( next ).to.have.been.calledWith( action );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/read/following/mine/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/test/index.js
@@ -59,9 +59,8 @@ describe( 'get follow subscriptions', () => {
 		it( 'should request first page + set syncing to true', () => {
 			const action = { type: READER_FOLLOWS_SYNC_START };
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			syncReaderFollows( { dispatch }, action, next );
+			syncReaderFollows( { dispatch }, action );
 
 			expect( isSyncingFollows() ).ok;
 			expect( dispatch ).calledWith( requestPageAction() );
@@ -72,9 +71,8 @@ describe( 'get follow subscriptions', () => {
 		it( 'should dispatch HTTP request to following/mine endpoint', () => {
 			const action = requestPageAction();
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			requestPage( { dispatch }, action, next );
+			requestPage( { dispatch }, action );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith(
@@ -88,16 +86,6 @@ describe( 'get follow subscriptions', () => {
 				} )
 			);
 		} );
-
-		it( 'should pass the original action along the middleware chain', () => {
-			const action = requestPageAction();
-			const dispatch = sinon.spy();
-			const next = sinon.spy();
-
-			requestPage( { dispatch }, action, next );
-
-			expect( next ).to.have.been.calledWith( action );
-		} );
 	} );
 
 	describe( '#receivePageSuccess', () => {
@@ -105,10 +93,9 @@ describe( 'get follow subscriptions', () => {
 			const startSyncAction = { type: READER_FOLLOWS_SYNC_START };
 			const action = requestPageAction(); // no feeds
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			syncReaderFollows( { dispatch }, startSyncAction, next );
-			receivePage( { dispatch }, action, next, successfulApiResponse );
+			syncReaderFollows( { dispatch }, startSyncAction );
+			receivePage( { dispatch }, action, null, successfulApiResponse );
 
 			expect( dispatch ).to.have.been.calledThrice;
 			expect( dispatch ).to.have.been.calledWith( requestPageAction( 1 ) );
@@ -126,7 +113,6 @@ describe( 'get follow subscriptions', () => {
 			const action = requestPageAction(); // no feeds
 			const ignoredDispatch = noop;
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
 			const getState = () => ( {
 				reader: {
@@ -142,9 +128,9 @@ describe( 'get follow subscriptions', () => {
 				},
 			} );
 
-			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction, next );
-			receivePage( { dispatch: ignoredDispatch }, action, next, successfulApiResponse );
-			receivePage( { dispatch, getState }, action, next, {
+			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );
+			receivePage( { dispatch: ignoredDispatch }, action, null, successfulApiResponse );
+			receivePage( { dispatch, getState }, action, null, {
 				number: 0,
 				page: 2,
 				total_subscriptions: 10,
@@ -168,7 +154,6 @@ describe( 'get follow subscriptions', () => {
 			const action = requestPageAction(); // no feeds
 			const ignoredDispatch = noop;
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
 			const getState = () => ( {
 				reader: {
@@ -184,16 +169,15 @@ describe( 'get follow subscriptions', () => {
 				},
 			} );
 
-			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction, next );
-			receivePage( { dispatch: ignoredDispatch }, action, next, successfulApiResponse );
+			syncReaderFollows( { dispatch: ignoredDispatch }, startSyncAction );
+			receivePage( { dispatch: ignoredDispatch }, action, null, successfulApiResponse );
 
 			updateSeenOnFollow(
 				{ dispatch: ignoredDispatch },
 				follow( 'http://feed.example.com' ),
-				next
 			);
 
-			receivePage( { dispatch, getState }, action, next, {
+			receivePage( { dispatch, getState }, action, null, {
 				number: 0,
 				page: 2,
 				total_subscriptions: 10,
@@ -222,9 +206,8 @@ describe( 'get follow subscriptions', () => {
 		it( 'should dispatch an error notice', () => {
 			const action = requestPageAction();
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			receiveError( { dispatch }, action, next );
+			receiveError( { dispatch }, action );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWithMatch( {

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { map } from 'lodash';
+import { map, noop } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { receiveRecommendedSites } from 'state/reader/recommended-sites/actions';
 import { decodeEntities } from 'lib/formatting';
 
-export const requestRecommendedSites = ( { dispatch }, action, next ) => {
+export const requestRecommendedSites = ( { dispatch }, action ) => {
 	const { seed = 1, number = 10, offset = 0 } = action.payload;
 	dispatch(
 		http( {
@@ -24,7 +24,6 @@ export const requestRecommendedSites = ( { dispatch }, action, next ) => {
 			onFailure: action,
 		} )
 	);
-	next( action );
 };
 
 export const fromApi = response => {
@@ -56,13 +55,8 @@ export const receiveRecommendedSitesResponse = ( store, action, next, response )
 	);
 };
 
-export const receiveError = ( store, action, next ) => {
-	// no-op
-	next( action );
-};
-
 export default {
 	[ READER_RECOMMENDED_SITES_REQUEST ]: [
-		dispatchRequest( requestRecommendedSites, receiveRecommendedSitesResponse, receiveError ),
+		dispatchRequest( requestRecommendedSites, receiveRecommendedSitesResponse, noop ),
 	],
 };

--- a/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/test/index.js
@@ -47,9 +47,8 @@ describe( 'recommended sites', () => {
 	describe( '#requestRecommendedSites', () => {
 		it( 'should dispatch an http request and call through next', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = requestRecommendedSitesAction( { seed } );
-			requestRecommendedSites( { dispatch }, action, next );
+			requestRecommendedSites( { dispatch }, action );
 			expect( dispatch ).to.have.been.calledWith(
 				http( {
 					method: 'GET',
@@ -60,8 +59,6 @@ describe( 'recommended sites', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 
@@ -69,10 +66,8 @@ describe( 'recommended sites', () => {
 		it( 'should dispatch action with sites if successful', () => {
 			const dispatch = spy();
 			const action = requestRecommendedSitesAction( { seed } );
-			const next = spy();
 
-			receiveRecommendedSitesResponse( { dispatch }, action, next, response );
-			expect( next ).to.not.have.been.called;
+			receiveRecommendedSitesResponse( { dispatch }, action, null, response );
 			expect( dispatch ).calledWith(
 				receiveRecommendedSites( {
 					sites: fromApi( response ),

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestCommentEmailUnsubscription( { dispatch }, action, next ) {
+export function requestCommentEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -23,7 +23,6 @@ export function requestCommentEmailUnsubscription( { dispatch }, action, next ) 
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveCommentEmailUnsubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -22,9 +22,8 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'requestCommentEmailUnsubscription', () => {
 		it( 'should dispatch an http request and call through next', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = unsubscribeToNewCommentEmail( 1234 );
-			requestCommentEmailUnsubscription( { dispatch }, action, next );
+			requestCommentEmailUnsubscription( { dispatch }, action );
 			expect( dispatch ).to.have.been.calledWith(
 				http( {
 					method: 'POST',
@@ -35,8 +34,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestCommentEmailSubscription( { dispatch }, action, next ) {
+export function requestCommentEmailSubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -23,7 +23,6 @@ export function requestCommentEmailSubscription( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receiveCommentEmailSubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -22,9 +22,8 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'requestCommentEmailSubscription', () => {
 		it( 'should dispatch an http request and call through next', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = subscribeToNewCommentEmail( 1234 );
-			requestCommentEmailSubscription( { dispatch }, action, next );
+			requestCommentEmailSubscription( { dispatch }, action );
 			expect( dispatch ).to.have.been.calledWith(
 				http( {
 					method: 'POST',
@@ -35,8 +34,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -12,7 +12,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestPostEmailUnsubscription( { dispatch }, action, next ) {
+export function requestPostEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -23,7 +23,6 @@ export function requestPostEmailUnsubscription( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receivePostEmailUnsubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -19,9 +19,8 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'requestPostEmailUnsubscription', () => {
 		it( 'should dispatch an http request and call through next', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = unsubscribeToNewPostEmail( 1234 );
-			requestPostEmailUnsubscription( { dispatch }, action, next );
+			requestPostEmailUnsubscription( { dispatch }, action );
 			expect( dispatch ).to.have.been.calledWith(
 				http( {
 					method: 'POST',
@@ -32,8 +31,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -17,7 +17,7 @@ import {
 import { errorNotice } from 'state/notices/actions';
 import { buildBody } from '../utils';
 
-export function requestPostEmailSubscription( { dispatch }, action, next ) {
+export function requestPostEmailSubscription( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
@@ -28,7 +28,6 @@ export function requestPostEmailSubscription( { dispatch }, action, next ) {
 			onFailure: action,
 		} )
 	);
-	next( action );
 }
 
 export function receivePostEmailSubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -23,9 +23,8 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'requestPostEmailSubscription', () => {
 		it( 'should dispatch an http request and call through next', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = subscribeToNewPostEmail( 1234 );
-			requestPostEmailSubscription( { dispatch }, action, next );
+			requestPostEmailSubscription( { dispatch }, action );
 			expect( dispatch ).to.have.been.calledWith(
 				http( {
 					method: 'POST',
@@ -36,8 +35,6 @@ describe( 'comment-email-subscriptions', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( next ).to.have.been.calledWith( action );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -15,7 +15,7 @@ import { errorNotice } from 'state/notices/actions';
 import { getReaderFollowForBlog } from 'state/selectors';
 import { buildBody } from '../utils';
 
-export function requestUpdatePostEmailSubscription( { dispatch, getState }, action, next ) {
+export function requestUpdatePostEmailSubscription( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
 		meta: {
 			previousState: get( getReaderFollowForBlog( getState(), action.payload.blogId ), [
@@ -35,7 +35,6 @@ export function requestUpdatePostEmailSubscription( { dispatch, getState }, acti
 			onFailure: actionWithRevert,
 		} )
 	);
-	next( action );
 }
 
 export function receiveUpdatePostEmailSubscription( store, action, next, response ) {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -20,7 +20,6 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'requestUpdatePostEmailSubscription', () => {
 		it( 'should dispatch an http request with revert info on the success and failure actions', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
 			const getState = () => {
 				return {
 					reader: {
@@ -45,7 +44,7 @@ describe( 'comment-email-subscriptions', () => {
 					previousState: 'instantly',
 				},
 			} );
-			requestUpdatePostEmailSubscription( { dispatch, getState }, action, nextSpy );
+			requestUpdatePostEmailSubscription( { dispatch, getState }, action );
 
 			expect( dispatch ).to.have.been.calledWith(
 				http( {

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -17,7 +17,7 @@ import { mergeHandlers } from 'state/data-layer/utils';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestTags( store, action, next ) {
+export function requestTags( store, action ) {
 	const path = action.payload && action.payload.slug
 		? `/read/tags/${ action.payload.slug }`
 		: '/read/tags';
@@ -31,14 +31,12 @@ export function requestTags( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 export function receiveTagsSuccess( store, action, next, apiResponse ) {
 	let tags = fromApi( apiResponse );
 	if ( ! apiResponse || ( ! apiResponse.tag && ! apiResponse.tags ) ) {
-		receiveTagsError( store, action, next );
+		receiveTagsError( store, action );
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -13,7 +13,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
-export function requestUnfollow( store, action, next ) {
+export function requestUnfollow( store, action ) {
 	store.dispatch(
 		http( {
 			path: `/read/tags/${ action.payload.slug }/mine/delete`,
@@ -23,8 +23,6 @@ export function requestUnfollow( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 /**
@@ -37,7 +35,7 @@ export const fromApi = apiResponse => apiResponse.removed_tag;
 
 export function receiveUnfollowTag( store, action, next, apiResponse ) {
 	if ( apiResponse.subscribed ) {
-		receiveError( store, action, next );
+		receiveError( store, action );
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
@@ -48,9 +48,8 @@ describe( 'unfollow tag request', () => {
 		it( 'should dispatch HTTP request to unfollow tag endpoint', () => {
 			const action = requestUnfollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			requestUnfollow( { dispatch }, action, next );
+			requestUnfollow( { dispatch }, action );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith(
@@ -63,25 +62,14 @@ describe( 'unfollow tag request', () => {
 				} )
 			);
 		} );
-
-		it( 'should pass the original action along the middleware chain', () => {
-			const action = requestUnfollowAction( slug );
-			const dispatch = sinon.spy();
-			const next = sinon.spy();
-
-			requestUnfollow( { dispatch }, action, next );
-
-			expect( next ).to.have.been.calledWith( action );
-		} );
 	} );
 
 	describe( '#receiveUnfollowSuccess', () => {
 		it( 'should dispatch the id of the unfollowed tag', () => {
 			const action = requestUnfollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			receiveUnfollowTag( { dispatch }, action, next, successfulUnfollowResponse );
+			receiveUnfollowTag( { dispatch }, action, null, successfulUnfollowResponse );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith(
@@ -94,9 +82,8 @@ describe( 'unfollow tag request', () => {
 		it( 'if api reports error then should create an error notice', () => {
 			const action = requestUnfollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			receiveUnfollowTag( { dispatch }, action, next, unsuccessfulResponse );
+			receiveUnfollowTag( { dispatch }, action, null, unsuccessfulResponse );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWithMatch( {
@@ -109,10 +96,9 @@ describe( 'unfollow tag request', () => {
 		it( 'should dispatch an error notice', () => {
 			const action = requestUnfollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 			const error = 'could not find tag';
 
-			receiveError( { dispatch }, action, next, error );
+			receiveError( { dispatch }, action, null, error );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWithMatch( {

--- a/client/state/data-layer/wpcom/read/tags/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/index.js
@@ -15,7 +15,7 @@ import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
-export function requestFollowTag( store, action, next ) {
+export function requestFollowTag( store, action ) {
 	store.dispatch(
 		http( {
 			path: `/read/tags/${ action.payload.slug }/mine/new`,
@@ -25,13 +25,11 @@ export function requestFollowTag( store, action, next ) {
 			onFailure: action,
 		} )
 	);
-
-	next( action );
 }
 
 export function receiveFollowTag( store, action, next, apiResponse ) {
 	if ( apiResponse.subscribed === false ) {
-		receiveError( store, action, next );
+		receiveError( store, action );
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
@@ -51,9 +51,8 @@ describe( 'follow tag request', () => {
 		it( 'should dispatch HTTP request to tag endpoint', () => {
 			const action = requestFollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			requestFollowTag( { dispatch }, action, next );
+			requestFollowTag( { dispatch }, action );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWith(
@@ -66,25 +65,14 @@ describe( 'follow tag request', () => {
 				} )
 			);
 		} );
-
-		it( 'should pass the original action along the middleware chain', () => {
-			const action = requestFollowAction( slug );
-			const dispatch = sinon.spy();
-			const next = sinon.spy();
-
-			requestFollowTag( { dispatch }, action, next );
-
-			expect( next ).to.have.been.calledWith( action );
-		} );
 	} );
 
 	describe( '#receiveFollowSuccess', () => {
 		it( 'should dispatch the followed tag with isFollowing=true', () => {
 			const action = requestFollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			receiveFollowTag( { dispatch }, action, next, successfulFollowResponse );
+			receiveFollowTag( { dispatch }, action, null, successfulFollowResponse );
 
 			const followedTagId = successfulFollowResponse.added_tag;
 			const followedTag = find( successfulFollowResponse.tags, { ID: followedTagId } );
@@ -104,9 +92,8 @@ describe( 'follow tag request', () => {
 		it( 'if api reports error then create an error notice', () => {
 			const action = requestFollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 
-			receiveFollowTag( { dispatch }, action, next, unsuccessfulResponse );
+			receiveFollowTag( { dispatch }, action, null, unsuccessfulResponse );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				type: NOTICE_CREATE,
 			} );
@@ -117,10 +104,9 @@ describe( 'follow tag request', () => {
 		it( 'should dispatch an error notice', () => {
 			const action = requestFollowAction( slug );
 			const dispatch = sinon.spy();
-			const next = sinon.spy();
 			const error = 'could not find tag';
 
-			receiveError( { dispatch }, action, next, error );
+			receiveError( { dispatch }, action, null, error );
 
 			expect( dispatch ).to.have.been.calledOnce;
 			expect( dispatch ).to.have.been.calledWithMatch( {

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -55,9 +55,8 @@ describe( 'wpcom-api', () => {
 			it( 'single tag: should dispatch HTTP request to tag endpoint', () => {
 				const action = requestTagsAction( slug );
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 
-				requestTags( { dispatch }, action, next );
+				requestTags( { dispatch }, action );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
@@ -74,9 +73,8 @@ describe( 'wpcom-api', () => {
 			it( 'multiple tags: should dispatch HTTP request to tags endpoint', () => {
 				const action = requestTagsAction();
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 
-				requestTags( { dispatch }, action, next );
+				requestTags( { dispatch }, action );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
@@ -89,25 +87,14 @@ describe( 'wpcom-api', () => {
 					} )
 				);
 			} );
-
-			it( 'should pass the original action along the middleware chain', () => {
-				const action = requestTagsAction( slug );
-				const dispatch = sinon.spy();
-				const next = sinon.spy();
-
-				requestTags( { dispatch }, action, next );
-
-				expect( next ).to.have.been.calledWith( action );
-			} );
 		} );
 
 		describe( '#receiveTagsResponse', () => {
 			it( 'single tag: should normalize + dispatch', () => {
 				const action = requestTagsAction( slug );
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 
-				receiveTagsSuccess( { dispatch }, action, next, successfulSingleTagResponse );
+				receiveTagsSuccess( { dispatch }, action, null, successfulSingleTagResponse );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
@@ -121,9 +108,8 @@ describe( 'wpcom-api', () => {
 			it( 'multiple tags: should dispatch the tags', () => {
 				const action = requestTagsAction();
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 
-				receiveTagsSuccess( { dispatch }, action, next, successfulFollowedTagsResponse );
+				receiveTagsSuccess( { dispatch }, action, null, successfulFollowedTagsResponse );
 
 				const transformedResponse = map( fromApi( successfulFollowedTagsResponse ), tag => ( {
 					...tag,
@@ -144,10 +130,9 @@ describe( 'wpcom-api', () => {
 			it( 'should dispatch an error notice', () => {
 				const action = requestTagsAction( slug );
 				const dispatch = sinon.spy();
-				const next = sinon.spy();
 				const error = 'could not find tag(s)';
 
-				receiveTagsError( { dispatch }, action, next, error );
+				receiveTagsError( { dispatch }, action, null, error );
 
 				expect( dispatch ).to.have.been.calledTwice;
 				expect( dispatch ).to.have.been.calledWithMatch( {

--- a/client/state/data-layer/wpcom/read/teams/index.js
+++ b/client/state/data-layer/wpcom/read/teams/index.js
@@ -4,7 +4,7 @@
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
 import wpcom from 'lib/wp';
 
-export function handleTeamsRequest( store, action, next ) {
+export function handleTeamsRequest( store ) {
 	wpcom.req.get( '/read/teams', { apiVersion: '1.2' } ).then(
 		payload => {
 			store.dispatch( {
@@ -20,7 +20,6 @@ export function handleTeamsRequest( store, action, next ) {
 			} );
 		}
 	);
-	next( action );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -24,8 +24,6 @@ export const successfulResponse = {
 };
 
 describe( 'wpcom-api', () => {
-	const nextSpy = sinon.spy();
-
 	describe( 'teams request', () => {
 		useNock( nock =>
 			nock( 'https://public-api.wordpress.com:443' )
@@ -36,14 +34,6 @@ describe( 'wpcom-api', () => {
 				.get( '/rest/v1.2/read/teams' )
 				.reply( 500, new Error() )
 		);
-
-		it( 'handleTeamsRequest should pass the action forward', () => {
-			const dispatch = sinon.spy();
-			const action = requestTeams();
-
-			handleTeamsRequest( { dispatch }, action, nextSpy );
-			expect( nextSpy ).calledWith( action );
-		} );
 
 		it( 'should dispatch RECEIVE action when request completes', done => {
 			const dispatch = sinon.spy( action => {
@@ -56,7 +46,7 @@ describe( 'wpcom-api', () => {
 				}
 			} );
 
-			handleTeamsRequest( { dispatch }, requestTeams(), nextSpy );
+			handleTeamsRequest( { dispatch }, requestTeams() );
 		} );
 
 		it( 'should dispatch RECEIVE action with error when request errors', done => {
@@ -71,7 +61,7 @@ describe( 'wpcom-api', () => {
 				}
 			} );
 
-			handleTeamsRequest( { dispatch }, requestTeams(), nextSpy );
+			handleTeamsRequest( { dispatch }, requestTeams() );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/teams/test/index.js
+++ b/client/state/data-layer/wpcom/read/teams/test/index.js
@@ -30,8 +30,6 @@ describe( 'wpcom-api', () => {
 				.get( '/rest/v1.2/read/teams' )
 				.reply( 200, successfulResponse )
 				.get( '/rest/v1.2/read/teams' )
-				.reply( 200, successfulResponse )
-				.get( '/rest/v1.2/read/teams' )
 				.reply( 500, new Error() )
 		);
 

--- a/client/state/data-layer/wpcom/timezones/index.js
+++ b/client/state/data-layer/wpcom/timezones/index.js
@@ -50,7 +50,7 @@ export const fromApi = ( { manual_utc_offsets, timezones, timezones_by_continent
 /*
  * Start a request to WordPress.com server to get the timezones data
  */
-export const fetchTimezones = ( { dispatch }, action, next ) => {
+export const fetchTimezones = ( { dispatch } ) =>
 	wpcom.req.get( '/timezones', { apiNamespace: 'wpcom/v2' } )
 		.then( data => {
 			dispatch( timezonesRequestSuccess() );
@@ -59,9 +59,6 @@ export const fetchTimezones = ( { dispatch }, action, next ) => {
 		.catch( error => {
 			dispatch( timezonesRequestFailure( error ) );
 		} );
-
-	return next( action );
-};
 
 export default {
 	[ TIMEZONES_REQUEST ]: [ fetchTimezones ],

--- a/client/state/data-layer/wpcom/timezones/test/index.js
+++ b/client/state/data-layer/wpcom/timezones/test/index.js
@@ -13,8 +13,6 @@ import {
 	TIMEZONES_REQUEST_SUCCESS,
 } from 'state/action-types';
 
-import { requestTimezones } from 'state/timezones/actions';
-
 const WP_REST_API = {
 	hostname: 'https://public-api.wordpress.com',
 	namespace: '/wpcom/v2',
@@ -27,8 +25,6 @@ const WP_REST_API = {
 import { fetchTimezones } from '../';
 
 describe( 'request', () => {
-	const nextSpy = sinon.spy();
-
 	describe( 'successful requests', () => {
 		useNock( ( nock ) => {
 			nock( WP_REST_API.hostname )
@@ -71,7 +67,7 @@ describe( 'request', () => {
 				}
 			} );
 
-			fetchTimezones( { dispatch }, requestTimezones(), nextSpy, );
+			fetchTimezones( { dispatch } );
 		} );
 
 		it( 'should dispatch RECEIVE action when request completes', done => {
@@ -111,7 +107,7 @@ describe( 'request', () => {
 				}
 			} );
 
-			fetchTimezones( { dispatch }, requestTimezones(), nextSpy, );
+			fetchTimezones( { dispatch } );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/videos/poster/index.js
+++ b/client/state/data-layer/wpcom/videos/poster/index.js
@@ -17,11 +17,10 @@ import {
  * @param  {Object} store Redux store
  * @param  {Object} action Action object
  * @param {Function} next Dispatches to next middleware in chain
- * @returns {Object} original action
  */
-export const updatePoster = ( { dispatch }, action, next ) => {
+export const updatePoster = ( { dispatch }, action ) => {
 	if ( ! ( 'file' in action.params || 'atTime' in action.params ) ) {
-		return next( action );
+		return;
 	}
 
 	const { atTime, file } = action.params;
@@ -36,8 +35,6 @@ export const updatePoster = ( { dispatch }, action, next ) => {
 	);
 
 	dispatch( http( params, action ) );
-
-	return next( action );
 };
 
 export const receivePosterUrl = ( { dispatch }, action, next, { poster: posterUrl } ) => {


### PR DESCRIPTION
@see #14025

As we have decided that it is best to call `next( action )` at the
middleware level and not even pass `next` in to the action handlers,
this allows us to start removing those calls incrementally instead of
pushing out a single huge PR.

The "safe" `next()` queues up unique actions and at the end passes them
all along. Since we are mostly calling `next( action )` in the handlers
reference equality will be good enough for now to prevent
double-dispatch. Some handlers actually call `next()` on new actions and
this is why we need this safe helper for now.

**Testing**

Smoke test anything relying on the data layer. Check for multiple dispatch of the actions. Make sure that email subscriptions work appropriate as they are what uses `next()` with new actions.

**Complicated refactorings**
 - `read/site/post-email-subscriptions`
 - `read/site/comment-email-subscriptions`
 - `read/following/mine`