### PR TITLE
Publicize: only preview connected services

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, find } from 'lodash';
+import { get, find, map, intersection } from 'lodash';
 
 /**
  * Internal dependencies
@@ -95,7 +95,8 @@ class SharingPreviewPane extends PureComponent {
 	}
 
 	render() {
-		const { translate, services } = this.props;
+		const { translate, connections, services } = this.props;
+		const activeServices = intersection( services, map( connections, 'service' ) );
 
 		return (
 			<div className="sharing-preview-pane">
@@ -112,7 +113,7 @@ class SharingPreviewPane extends PureComponent {
 						</p>
 					</div>
 					<VerticalMenu onClick={ this.selectPreview }>
-						{ services.map( service => <SocialItem { ...{ key: service, service } } /> ) }
+						{ activeServices.map( service => <SocialItem { ...{ key: service, service } } /> ) }
 					</VerticalMenu>
 				</div>
 				<div className="sharing-preview-pane__preview-area">

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -42,9 +42,11 @@ class SharingPreviewPane extends PureComponent {
 		]
 	};
 
-	state = {
-		selectedService: 'facebook'
-	};
+	constructor( props ) {
+		super( props );
+		const selectedService = this.props.connectedServices[ 0 ];
+		this.state = { selectedService };
+	}
 
 	selectPreview = ( selectedService ) => {
 		this.setState( { selectedService } );
@@ -95,8 +97,8 @@ class SharingPreviewPane extends PureComponent {
 	}
 
 	render() {
-		const { translate, connections, services } = this.props;
-		const activeServices = intersection( services, map( connections, 'service' ) );
+		const { translate, services, connectedServices } = this.props;
+		const activeServices = intersection( services, connectedServices );
 
 		return (
 			<div className="sharing-preview-pane">
@@ -133,12 +135,14 @@ const mapStateToProps = ( state, ownProps ) => {
 	const seoTitle = getSeoTitle( state, 'posts', { site, post } );
 	const currentUserId = getCurrentUserId( state );
 	const connections = getSiteUserConnections( state, siteId, currentUserId );
+	const connectedServices = map( connections, 'service' );
 
 	return {
 		site,
 		post,
 		seoTitle,
 		connections,
+		connectedServices,
 	};
 };
 


### PR DESCRIPTION
This PR updates the publicize preview modal to only show connected services. Currently we show all available services[1] even if the user has does not have a connected account for a given service. Clicking on an unconnected service results in a blank preview.

**Before**
![preview](https://cloud.githubusercontent.com/assets/744755/26326618/cb2a52ea-3ef0-11e7-875a-632ebeadad65.gif)

**After**
![screen shot 2017-05-22 at 1 12 25 pm](https://cloud.githubusercontent.com/assets/744755/26326630/de695d10-3ef0-11e7-90f2-b0061fe4601c.png)


[1] As of opening this PR, the only available services are Facebook, Twitter, and Google+.
