### PR TITLE
Publicize: add tumblr preview

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -160,6 +160,7 @@
 @import 'components/seo/style';
 @import 'components/share/facebook-share-preview/style';
 @import 'components/share/google-plus-share-preview/style';
+@import 'components/share/tumblr-share-preview/style';
 @import 'components/share/twitter-share-preview/style';
 @import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/seo/preview-upgrade-nudge/style';

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -13,6 +13,7 @@ import { getPostImage, getExcerptForPost } from './utils';
 import FacebookSharePreview from 'components/share/facebook-share-preview';
 import GooglePlusSharePreview from 'components/share/google-plus-share-preview';
 import TwitterSharePreview from 'components/share/twitter-share-preview';
+import TumblrSharePreview from 'components/share/tumblr-share-preview';
 import VerticalMenu from 'components/vertical-menu';
 import { SocialItem } from 'components/vertical-menu/items';
 import { getSitePost } from 'state/posts/selectors';
@@ -39,6 +40,7 @@ class SharingPreviewPane extends PureComponent {
 			'facebook',
 			'google_plus',
 			'twitter',
+			'tumblr',
 		]
 	};
 
@@ -85,6 +87,8 @@ class SharingPreviewPane extends PureComponent {
 				return <FacebookSharePreview { ...previewProps } />;
 			case 'google_plus':
 				return <GooglePlusSharePreview { ...previewProps } />;
+			case 'tumblr':
+				return <TumblrSharePreview { ...previewProps } />;
 			case 'twitter':
 				return <TwitterSharePreview
 					{ ...previewProps }

--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+
+/* Internal dependecies */
+import { localize } from 'i18n-calypso';
+
+export class TumblrSharePreview extends PureComponent {
+	render() {
+		const {
+			externalProfilePicture,
+			externalProfileUrl,
+			externalDisplay,
+			externalName,
+			message,
+			articleUrl,
+			imageUrl,
+			postTitle,
+			translate,
+		} = this.props;
+
+		return (
+			<div className="tumblr-share-preview">
+				<div className="tumblr-share-preview__content">
+					<div className="tumblr-share-preview__profile-picture-part">
+						<img
+							className="tumblr-share-preview__profile-picture"
+							src={ externalProfilePicture }
+						/>
+					</div>
+					<div className="tumblr-share-preview__content-part">
+						<div className="tumblr-share-preview__profile-line">
+							<a
+								className="tumblr-share-preview__profile-name"
+								href={ externalProfileUrl }
+							>
+								{ externalDisplay }
+							</a>
+							<a
+								className="tumblr-share-preview__profile-handle"
+								href={ externalProfileUrl }
+							>
+								{ externalName }
+							</a>
+						</div>
+						<div className="tumblr-share-preview__post-title">
+							<h1> { postTitle } </h1>
+						</div>
+						{ imageUrl &&
+							<div className="tumblr-share-preview__image-wrapper">
+								<img
+									className="tumblr-share-preview__image"
+									src={ imageUrl }
+								/>
+							</div>
+						}
+						<div className="tumblr-share-preview__message">
+							<blockquote>
+								{ message }
+							</blockquote>
+						</div>
+						<div className="tumblr-share-preview__article-url-line">
+							<a className="tumblr-share-preview__article-url"
+								href={ articleUrl }>
+								{ translate( 'View On WordPress' ) }
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( TumblrSharePreview );
+

--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -11,7 +11,6 @@ export class TumblrSharePreview extends PureComponent {
 		const {
 			externalProfilePicture,
 			externalProfileUrl,
-			externalDisplay,
 			externalName,
 			message,
 			articleUrl,
@@ -35,17 +34,20 @@ export class TumblrSharePreview extends PureComponent {
 								className="tumblr-share-preview__profile-name"
 								href={ externalProfileUrl }
 							>
-								{ externalDisplay }
-							</a>
-							<a
-								className="tumblr-share-preview__profile-handle"
-								href={ externalProfileUrl }
-							>
 								{ externalName }
 							</a>
+							<span className="tumblr-share-preview__profile-wp">
+								{ translate( 'WordPress' ) }
+							</span>
 						</div>
-						<div className="tumblr-share-preview__post-title">
-							<h1> { postTitle } </h1>
+						<div className="tumblr-share-preview__post-title-part">
+							<h1 className="tumblr-share-preview__post-title">{ postTitle }</h1>
+						</div>
+						<div className="tumblr-share-preview__message">
+							<a className="tumblr-share-preview__message-link"
+								href={ articleUrl }>
+								{ message }
+							</a>
 						</div>
 						{ imageUrl &&
 							<div className="tumblr-share-preview__image-wrapper">
@@ -55,13 +57,13 @@ export class TumblrSharePreview extends PureComponent {
 								/>
 							</div>
 						}
-						<div className="tumblr-share-preview__message">
-							<blockquote>
-								{ message }
+						<div className="tumblr-share-preview__summery-part">
+							<blockquote className="tumblr-share-preview__summery">
+								Post contents goes here.
 							</blockquote>
 						</div>
-						<div className="tumblr-share-preview__article-url-line">
-							<a className="tumblr-share-preview__article-url"
+						<div className="tumblr-share-preview__article-link-line">
+							<a className="tumblr-share-preview__article-link"
 								href={ articleUrl }>
 								{ translate( 'View On WordPress' ) }
 							</a>

--- a/client/components/share/tumblr-share-preview/index.jsx
+++ b/client/components/share/tumblr-share-preview/index.jsx
@@ -5,6 +5,7 @@ import React, { PureComponent } from 'react';
 
 /* Internal dependecies */
 import { localize } from 'i18n-calypso';
+import { truncateArticleContent } from '../helpers';
 
 export class TumblrSharePreview extends PureComponent {
 	render() {
@@ -14,11 +15,13 @@ export class TumblrSharePreview extends PureComponent {
 			externalName,
 			message,
 			articleUrl,
+			articleTitle,
+			articleContent,
 			imageUrl,
-			postTitle,
 			translate,
 		} = this.props;
 
+		const summary = truncateArticleContent( 396, articleContent );
 		return (
 			<div className="tumblr-share-preview">
 				<div className="tumblr-share-preview__content">
@@ -41,7 +44,7 @@ export class TumblrSharePreview extends PureComponent {
 							</span>
 						</div>
 						<div className="tumblr-share-preview__post-title-part">
-							<h1 className="tumblr-share-preview__post-title">{ postTitle }</h1>
+							<div className="tumblr-share-preview__post-title">{ articleTitle }</div>
 						</div>
 						<div className="tumblr-share-preview__message">
 							<a className="tumblr-share-preview__message-link"
@@ -59,7 +62,7 @@ export class TumblrSharePreview extends PureComponent {
 						}
 						<div className="tumblr-share-preview__summery-part">
 							<blockquote className="tumblr-share-preview__summery">
-								Post contents goes here.
+								{ summary }
 							</blockquote>
 						</div>
 						<div className="tumblr-share-preview__article-link-line">

--- a/client/components/share/tumblr-share-preview/style.scss
+++ b/client/components/share/tumblr-share-preview/style.scss
@@ -1,0 +1,89 @@
+.tumblr-share-preview {
+	color: #444;
+	font-family: Helvetica Neue, HelveticaNeue, Helvetica, Arial, sans-serif;
+	margin: 0 auto;
+	max-width: 624px;
+
+	.tumblr-share-preview__profile-name,
+	.tumblr-share-preview__message-link,
+	.tumblr-share-preview__article-link {
+		color: #444;
+		text-decoration: none;
+
+		&:hover {
+			color: #444;
+		}
+	}
+}
+
+.tumblr-share-preview__content {
+	display: flex;
+}
+
+.tumblr-share-preview__profile-picture-part {
+	flex: 0 0 10%;
+	margin-right: 20px;
+}
+
+.tumblr-share-preview__content-part {
+	background-color: $white;
+	border-radius: 3px;
+	flex: 1 1 auto;
+	padding: 15px 20px;
+}
+
+.tumblr-share-preview__profile-line {
+	display: flex;
+	font-size: 13px;
+	justify-content: space-between;
+	line-height: 20px;
+	margin-bottom: 13px;
+}
+
+.tumblr-share-preview__profile-name {
+	font-weight: bold;
+}
+
+.tumblr-share-preview__profile-wp {
+	color: #8f8f8f;
+}
+
+.tumblr-share-preview__post-title {
+    font-family: Gibson, Helvetica Neue, HelveticaNeue, Helvetica, Arial, sans-serif;
+    font-weight: 400;
+    font-size: 36px;
+    line-height: 47px;
+    margin-bottom: 10px;
+}
+
+.tumblr-share-preview__image-wrapper {
+	margin: 15px 0;
+}
+
+.tumblr-share-preview__image {
+	width: 300px;
+}
+
+.tumblr-share-preview__message,
+.tumblr-share-preview__summery,
+.tumblr-share-preview__article-link-line {
+	font-size: 14px;
+	line-height: 21px;
+}
+
+.tumblr-share-preview__message {
+	margin-bottom: 15px;
+}
+
+.tumblr-share-preview__message-link,
+.tumblr-share-preview__article-link {
+	border-bottom: 1px solid #d1d1d1;
+}
+
+.tumblr-share-preview__summery {
+	background: transparent;
+	border-left: 2px solid #e7e7e7;
+	margin-top: 15px;
+	margin-bottom: 15px;
+	padding: 0 0 0 18px;
+}

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -15,6 +15,7 @@ const services = translate => ( {
 	google: { icon: 'google', label: translate( 'Google search' ) },
 	google_plus: { icon: 'google-plus', label: translate( 'Google+ ' ) },
 	linkedin: { icon: 'linkedin', label: translate( 'LinkedIn share' ) },
+	tumblr: { icon: 'tumblr', label: translate( 'Tumblr post' ) },
 	twitter: { icon: 'twitter', label: translate( 'Twitter card' ) },
 	wordpress: { icon: 'wordpress', label: translate( 'WordPress.com Reader' ) }
 } );


### PR DESCRIPTION
This adds Tumblr to publicize preview.
![screen shot 2017-05-22 at 6 09 28 pm](https://cloud.githubusercontent.com/assets/744755/26334424/d7aba964-3f19-11e7-8711-d03b3cb1e6fa.png)

**Testing**
- Enable publicize sharing on `calypso.localhost:3000` : `ENABLE_FEATURES=publicize-scheduling make run`
- Authorize Tumblr on a premium site
- Open the sharing tab on a published post
- Click 'Preview'
- Tumblr should be available for previewing
- Clicking "Tumblr post" on the left should show the correct tumblr post preview

_breaks up #12644_