### PR TITLE
Jetpack Connect: handle empty state in reducer

### DIFF
--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -222,8 +222,11 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 				}
 			);
 		case SITE_REQUEST_FAILURE:
-			const { client_id } = state.queryObject;
-			if ( parseInt( client_id ) === action.siteId ) {
+			if (
+				state.queryObject &&
+				state.queryObject.client_id &&
+				parseInt( state.queryObject.client_id ) === action.siteId
+			) {
 				return Object.assign( {}, state, { clientNotResponding: true } );
 			}
 			return state;

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -554,6 +554,33 @@ describe( 'reducer', () => {
 				.to.be.true;
 		} );
 
+		it( 'should return the given state when a site request fails on a different site', () => {
+			const originalState = { queryObject: { client_id: '123' } };
+			const state = jetpackConnectAuthorize(
+				originalState,
+				{ type: SITE_REQUEST_FAILURE, siteId: 234 }
+			);
+			expect( state ).to.eql( originalState );
+		} );
+
+		it( 'should return the given state when a site request fails and no client id is set', () => {
+			const originalState = { queryObject: { jetpack_version: '4.0' } };
+			const state = jetpackConnectAuthorize(
+				originalState,
+				{ type: SITE_REQUEST_FAILURE, siteId: 123 }
+			);
+			expect( state ).to.eql( originalState );
+		} );
+
+		it( 'should return the given state when a site request fails and no query object is set', () => {
+			const originalState = { isAuthorizing: false };
+			const state = jetpackConnectAuthorize(
+				originalState,
+				{ type: SITE_REQUEST_FAILURE, siteId: 123 }
+			);
+			expect( state ).to.eql( originalState );
+		} );
+
 		it( 'should persist state when a site request to a different client fails', () => {
 			const state = jetpackConnectAuthorize(
 				{ queryObject: { client_id: '123' } },


### PR DESCRIPTION
We should handle an empty state properly in our reducers.
See: https://github.com/Automattic/wp-calypso/pull/14074#discussion_r117875832

Thanks @gwwar for catching the error early.

To test:
- Run `npm run test-client client/state/jetpack-connect` and verify the tests are passing.