### PR TITLE
Use `withoutPersistence()` wrapper in comment state

### DIFF
--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -20,9 +20,8 @@ import {
 	COMMENTS_REQUEST,
 	COMMENTS_REQUEST_SUCCESS,
 	COMMENTS_REQUEST_FAILURE,
-	DESERIALIZE,
-	SERIALIZE,
 } from '../action-types';
+import { withoutPersistence } from 'state/utils';
 import {
 	getCommentParentKey,
 	updateExistingIn
@@ -139,10 +138,6 @@ export function items( state = Immutable.Map(), action ) {
 										.set( 'placeholderError', action.error )
 				)
 			);
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return Immutable.Map();
 	}
 
 	return state;
@@ -164,10 +159,6 @@ export function requests( state = Immutable.Map(), action ) {
 				action,
 				( requestStatuses = Immutable.Map() ) => requestStatuses.set( action.requestId, action.type )
 			);
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return Immutable.Map();
 	}
 
 	return state;
@@ -183,17 +174,13 @@ export function totalCommentsCount( state = Immutable.Map(), action ) {
 	switch ( action.type ) {
 		case COMMENTS_COUNT_RECEIVE:
 			return updateSpecificState( state, action, action.totalCommentsCount );
-		case SERIALIZE:
-			return {};
-		case DESERIALIZE:
-			return Immutable.Map();
 	}
 
 	return state;
 }
 
-export default combineReducers( {
+export default withoutPersistence( combineReducers( {
 	items,
 	requests,
 	totalCommentsCount
-} );
+} ) );

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -264,13 +264,9 @@ describe( 'reducer', () => {
 				postId: 1
 			} );
 
-			const serialized = comments( state, { type: SERIALIZE } );
+			expect( comments( state, { type: SERIALIZE } ) ).to.be.null;
 
-			expect( Object.getOwnPropertyNames( serialized.items ).length ).to.equal( 0 );
-			expect( Object.getOwnPropertyNames( serialized.requests ).length ).to.equal( 0 );
-			expect( Object.getOwnPropertyNames( serialized.totalCommentsCount ).length ).to.equal( 0 );
-
-			const deserialized = comments( serialized, { type: DESERIALIZE } );
+			const deserialized = comments( {}, { type: DESERIALIZE } );
 
 			expect( Immutable.Map.isMap( deserialized.items ) ).to.equal( true );
 			expect( deserialized.items.size ).to.equal( 0 );


### PR DESCRIPTION
Removes individual reducer extensions with a composition of the base
reducers and the `withoutPersistence()` wrapper.

@rodrigoi feel free to use to lose this. It shouldn't be a big merge conflict. I wanted to create the PR as a demonstration of the new wrapper and how we can start using it to cut down on existing code.