### PR TITLE
Remove step[s] props from StepHeader

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -392,8 +392,6 @@ class JetpackConnectMain extends Component {
 					<FormattedHeader
 						headerText={ this.getTexts().headerTitle }
 						subHeaderText={ this.getTexts().headerSubtitle }
-						step={ 1 }
-						steps={ 3 }
 					/>
 
 					{ this.renderSiteInput( status ) }
@@ -433,8 +431,6 @@ class JetpackConnectMain extends Component {
 					<FormattedHeader
 						headerText={ instructionsData.headerTitle }
 						subHeaderText={ instructionsData.headerSubtitle }
-						step={ 1 }
-						steps={ instructionsData.steps.length }
 					/>
 					<div className="jetpack-connect__install-steps">
 						{

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -48,8 +48,7 @@ class JetpackPlansGrid extends Component {
 			<FormattedHeader
 				headerText={ headerText }
 				subHeaderText={ subheaderText }
-				step={ 1 }
-				steps={ 3 } />
+			/>
 		);
 	}
 


### PR DESCRIPTION
These props are outdated and should be removed. `StepHeader` ignores them.

To test:
* Use this branch
* Visit `/jetpack/connect/store`
* Visit `/jetpack/connect/` and try to connect a site that doesn't have Jetpack installed or activated
* The `step` and `steps` properties should not appear on the `StepHeader` component.

via p1495472727522844-slack-luna