### PR TITLE
Support: Direct AT sites to WordPress.com support

### DIFF
--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -47,7 +47,8 @@ class CurrentPlanHeader extends Component {
 		] ).isRequired,
 		currentPlan: PropTypes.object,
 		isExpiring: PropTypes.bool,
-		translate: PropTypes.func
+		translate: PropTypes.func,
+		isAutomatedTransfer: PropTypes.bool,
 	};
 
 	renderPurchaseInfo() {
@@ -93,6 +94,7 @@ class CurrentPlanHeader extends Component {
 	render() {
 		const {
 			currentPlanSlug,
+			isAutomatedTransfer,
 			isPlaceholder,
 			title,
 			tagLine,
@@ -133,7 +135,7 @@ class CurrentPlanHeader extends Component {
 				<div className="current-plan__header-item">
 					<div className="current-plan__header-item-content">
 						<HappinessSupport
-							isJetpack={ !! selectedSite.jetpack }
+							isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 							isPlaceholder={ isPlaceholder }
 						/>
 					</div>

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -43,6 +43,7 @@ class CurrentPlan extends Component {
 		isExpiring: PropTypes.bool,
 		shouldShowDomainWarnings: PropTypes.bool,
 		hasDomainsLoaded: PropTypes.bool,
+		isAutomatedTransfer: PropTypes.bool,
 	};
 
 	isLoading() {
@@ -85,6 +86,7 @@ class CurrentPlan extends Component {
 			shouldShowDomainWarnings,
 			hasDomainsLoaded,
 			translate,
+			isAutomatedTransfer,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
@@ -130,6 +132,7 @@ class CurrentPlan extends Component {
 						currentPlanSlug={ currentPlanSlug }
 						currentPlan={ currentPlan }
 						isExpiring={ isExpiring }
+						isAutomatedTransfer={ isAutomatedTransfer }
 					/>
 					<ProductPurchaseFeaturesList
 						plan={ currentPlanSlug }
@@ -156,6 +159,7 @@ export default connect(
 			selectedSite,
 			selectedSiteId,
 			domains,
+			isAutomatedTransfer,
 			context: ownProps.context,
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),


### PR DESCRIPTION
Currently, if a site is connected via Jetpack, we direct them to Jetpack queues for support. This includes AT sites that are still on WP.com but connected via Jetpack. In those cases, we should direct the users to WordPress.com support instead. This modifies the [`isJetpack` prop](https://github.com/Automattic/wp-calypso/blob/6712e13a350ae7fceee3ecd4fd60243fcbcbb2d1/client/my-sites/plans/current-plan/header.jsx#L140) passed to HappinessSupport so AT sites are treated like WordPress.com sites.

## To test
1. On an AT site, visit http://calypso.localhost:3000/plans/my-plan. The links under "Ask a Question" and "Search our support site" should direct to /help/contact and en.support.wordpress.com.
2. Switch sites to a Jetpack site and view the same page. The links should change to jetpack.com/contact-support and jetpack.com/support

Here are the buttons I'm referring to:

<img width="526" alt="screen shot 2017-05-23 at 6 24 24 am" src="https://cloud.githubusercontent.com/assets/7240478/26354172/c3cc9f18-3f80-11e7-8c9d-e8f91cfda50b.png">

Resolves: #14066 (See also 210-gh-automated-transfer)