### PR TITLE
Reader: follow by url guess aliases

### DIFF
--- a/client/state/selectors/get-reader-aliased-follow-feed-url.js
+++ b/client/state/selectors/get-reader-aliased-follow-feed-url.js
@@ -1,12 +1,14 @@
 /**
  * External Dependencies
  */
-import { find, includes } from 'lodash';
+import { find, includes, some } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import { prepareComparableUrl } from 'state/reader/follows/utils';
+
+export const commonExtensions = [ 'rss', 'rss.xml', 'feed', 'feed/atom', 'atom.xml', 'atom' ];
 
 /**
  * This selector will usually return the same feedUrl passed in.
@@ -21,11 +23,18 @@ import { prepareComparableUrl } from 'state/reader/follows/utils';
 export default function getReaderAliasedFollowFeedUrl( state, feedUrl ) {
 	const urlKey = prepareComparableUrl( feedUrl );
 
+	// first check for exact match
 	if ( state.reader.follows.items[ urlKey ] ) {
 		return urlKey;
 	}
 
-	const foundAlias = find( state.reader.follows.items, f => includes( f.alias_feed_URLs, urlKey ) );
+	// then check if any follows have saved aliases OR if there is a matching autodiscoverable alias
+	const foundAlias = find(
+		state.reader.follows.items,
+		( follow, key ) =>
+			includes( follow.alias_feed_URLs, urlKey ) ||
+			some( commonExtensions, ext => `${ urlKey }/${ ext }` === key )
+	);
 	if ( foundAlias ) {
 		return foundAlias.feed_URL;
 	}

--- a/client/state/selectors/test/get-reader-aliased-follow-feed-url.js
+++ b/client/state/selectors/test/get-reader-aliased-follow-feed-url.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getReaderAliasedFollowFeedUrl } from '../';
+
+const site1UrlKey = 'discover.wordpress.com';
+const site1Aliases = [ 'site1 alias!', 'site1 second alias!' ];
+
+const siteA = 'sitea/feed';
+const siteB = 'siteb/rss';
+const siteC = 'sitec/rss.xml';
+const siteD = 'sited/feed/atom';
+
+describe( 'getReaderAliasedFollowFeedUrl()', () => {
+	const state = {
+		reader: {
+			follows: {
+				items: {
+					[ site1UrlKey ]: {
+						feed_URL: site1UrlKey,
+						alias_feed_URLs: site1Aliases,
+					},
+					[ siteA ]: { feed_URL: siteA },
+					[ siteB ]: { feed_URL: siteB },
+					[ siteC ]: { feed_URL: siteC },
+					[ siteD ]: { feed_URL: siteD },
+				},
+			},
+		},
+	};
+
+	it( 'should return passed in url if it cannot find anything', () => {
+		const feedUrl = getReaderAliasedFollowFeedUrl( state, 'http://croissant.happy' );
+		expect( feedUrl ).eql( 'http://croissant.happy' );
+	} );
+
+	it( 'should return exact match when it exists in state', () => {
+		const feedUrl = getReaderAliasedFollowFeedUrl( state, site1UrlKey );
+		expect( feedUrl ).eql( site1UrlKey );
+	} );
+
+	it( 'should utilize aliases within follow object to figure out a feed_url', () => {
+		const feedUrl1 = getReaderAliasedFollowFeedUrl( state, site1Aliases[ 0 ] );
+		expect( feedUrl1 ).eql( site1UrlKey );
+
+		const feedUrl2 = getReaderAliasedFollowFeedUrl( state, site1Aliases[ 1 ] );
+		expect( feedUrl2 ).eql( site1UrlKey );
+	} );
+
+	it( 'should try to guess basic rss/feed extensions', () => {
+		const feedUrlA = getReaderAliasedFollowFeedUrl( state, 'siteA' );
+		const feedUrlB = getReaderAliasedFollowFeedUrl( state, 'siteB' );
+		const feedUrlC = getReaderAliasedFollowFeedUrl( state, 'siteC' );
+		const feedUrlD = getReaderAliasedFollowFeedUrl( state, 'siteD' );
+
+		expect( feedUrlA ).eql( siteA );
+		expect( feedUrlB ).eql( siteB );
+		expect( feedUrlC ).eql( siteC );
+		expect( feedUrlD ).eql( siteD );
+	} );
+} );


### PR DESCRIPTION
This PR makes it so that when you try to follow items by url, Reader will check common extensions to see if you are already following that item.


Thoughts? is this worth it?

> so the goal was to make it so that if someone types in the intuitive version of the site, lets say jancavan.com, it would guess the less intuitive urls like jancavan.com/feed /rss etc