### PR TITLE
Settings: Add import/export to General -> Site tools

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -24,6 +24,8 @@ import titlecase from 'to-title-case';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser } from 'state/selectors';
+import ImportSettings from './section-import';
+import ExportSettings from './section-export';
 
 /**
  * Module vars
@@ -97,17 +99,11 @@ module.exports = {
 	},
 
 	importSite( context ) {
-		renderPage(
-			context,
-			<SiteSettingsComponent section="import" />
-		);
+		renderPage( context, <ImportSettings /> );
 	},
 
 	exportSite( context ) {
-		renderPage(
-			context,
-			<SiteSettingsComponent section="export" />
-		);
+		renderPage( context, <ExportSettings /> );
 	},
 
 	guidedTransfer( context ) {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -492,7 +492,7 @@ class SiteSettingsFormGeneral extends Component {
 				}
 
 				{ siteIsJetpack
-					? <div>
+					? <div className="site-settings__general-jetpack">
 						<SectionHeader label={ translate( 'Jetpack' ) }>
 							{ this.jetpackDisconnectOption() }
 							{ this.showPublicPostTypesCheckbox() || this.showApiCacheCheckbox()

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -13,8 +13,6 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import GeneralSettings from './section-general';
-import ImportSettings from './section-import';
-import ExportSettings from './section-export';
 import GuidedTransfer from 'my-sites/guided-transfer';
 import SiteSettingsNavigation from './navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -39,10 +37,6 @@ export class SiteSettingsComponent extends Component {
 		switch ( section ) {
 			case 'general':
 				return <GeneralSettings />;
-			case 'import':
-				return <ImportSettings />;
-			case 'export':
-				return <ExportSettings />;
 			case 'guidedTransfer':
 				return <GuidedTransfer hostSlug={ hostSlug } />;
 		}

--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -29,28 +29,8 @@ export class SiteSettingsNavigation extends Component {
 			discussion: translate( 'Discussion', { context: 'settings screen' } ),
 			traffic: translate( 'Traffic', { context: 'settings screen' } ),
 			security: translate( 'Security', { context: 'settings screen' } ),
-			'import': translate( 'Import', { context: 'settings screen' } ),
-			'export': translate( 'Export', { context: 'settings screen' } ),
 		};
 	}
-
-	getImportPath = () => {
-		const { site } = this.props,
-			path = '/settings/import';
-
-		if ( site.jetpack ) {
-			return `${ site.options.admin_url }import.php`;
-		}
-
-		return [ path, site.slug ].join( '/' );
-	};
-
-	getExportPath = () => {
-		const { site } = this.props;
-		return site.jetpack
-			? `${ site.options.admin_url }export.php`
-			: `/settings/export/${ site.slug }`;
-	};
 
 	render() {
 		const { section, site } = this.props;
@@ -104,23 +84,6 @@ export class SiteSettingsNavigation extends Component {
 							selected={ section === 'security' } >
 								{ strings.security }
 						</NavItem>
-					}
-
-					<NavItem
-						path={ this.getImportPath() }
-						selected={ section === 'import' }
-						isExternalLink={ !! site.jetpack } >
-							{ strings.import }
-					</NavItem>
-
-					{
-						config.isEnabled( 'manage/export' ) &&
-							<NavItem
-								path={ this.getExportPath() }
-								selected={ section === 'export' }
-								isExternalLink={ !! site.jetpack } >
-									{ strings.export }
-							</NavItem>
 					}
 				</NavTabs>
 			</SectionNav>

--- a/client/my-sites/site-settings/section-export.jsx
+++ b/client/my-sites/site-settings/section-export.jsx
@@ -33,7 +33,7 @@ const SiteSettingsExport = ( { isJetpack, site, siteSlug, translate } ) => {
 				actionURL={ site.options.admin_url + 'export.php' }
 				actionTarget="_blank"
 			/> }
-			{ ! isJetpack && <ExporterContainer /> }
+			{ isJetpack === false && <ExporterContainer /> }
 		</Main>
 	);
 };

--- a/client/my-sites/site-settings/section-export.jsx
+++ b/client/my-sites/site-settings/section-export.jsx
@@ -10,24 +10,32 @@ import { localize } from 'i18n-calypso';
  */
 import EmptyContent from 'components/empty-content';
 import ExporterContainer from 'my-sites/exporter';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import Main from 'components/main';
+import HeaderCake from 'components/header-cake';
 
-const SiteSettingsExport = ( { isJetpack, site, translate } ) => {
-	if ( isJetpack ) {
-		return (
-			<EmptyContent
+const SiteSettingsExport = ( { isJetpack, site, siteSlug, translate } ) => {
+	return (
+		<Main>
+			<HeaderCake backHref={ '/settings/general/' + siteSlug }>
+				<h1>{ translate( 'Import' ) }</h1>
+			</HeaderCake>
+			{ isJetpack && <EmptyContent
 				illustration="/calypso/images/drake/drake-jetpack.svg"
 				title={ translate( 'Want to export your site?' ) }
 				line={ translate( 'Visit your site\'s wp-admin for all your import and export needs.' ) }
 				action={ translate( 'Export %(siteTitle)s', { args: { siteTitle: site.title } } ) }
 				actionURL={ site.options.admin_url + 'export.php' }
 				actionTarget="_blank"
-			/>
-		);
-	}
-
-	return <ExporterContainer />;
+			/> }
+			{ ! isJetpack && <ExporterContainer /> }
+		</Main>
+	);
 };
 
 export default connect(
@@ -38,6 +46,7 @@ export default connect(
 		return {
 			isJetpack: selectedSiteId && isJetpackSite( state, selectedSiteId ),
 			site,
+			siteSlug: getSelectedSiteSlug( state ),
 		};
 	}
 )( localize( SiteSettingsExport ) );

--- a/client/my-sites/site-settings/section-export.jsx
+++ b/client/my-sites/site-settings/section-export.jsx
@@ -23,7 +23,7 @@ const SiteSettingsExport = ( { isJetpack, site, siteSlug, translate } ) => {
 	return (
 		<Main>
 			<HeaderCake backHref={ '/settings/general/' + siteSlug }>
-				<h1>{ translate( 'Import' ) }</h1>
+				<h1>{ translate( 'Export' ) }</h1>
 			</HeaderCake>
 			{ isJetpack && <EmptyContent
 				illustration="/calypso/images/drake/drake-jetpack.svg"

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -18,7 +18,9 @@ import MediumImporter from 'my-sites/importer/importer-medium';
 import { fetchState } from 'lib/importer/actions';
 import { appStates, WORDPRESS, MEDIUM } from 'state/imports/constants';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import Main from 'components/main';
+import HeaderCake from 'components/header-cake';
 
 class SiteSettingsImport extends Component {
 	static propTypes = {
@@ -73,7 +75,7 @@ class SiteSettingsImport extends Component {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { site, siteSlug, translate } = this.props;
 		if ( ! site ) {
 			return null;
 		}
@@ -94,22 +96,20 @@ class SiteSettingsImport extends Component {
 			}
 		);
 
-		if ( isJetpack ) {
-			return (
-				<EmptyContent
+		return (
+			<Main>
+				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
+					<h1>{ translate( 'Import' ) }</h1>
+				</HeaderCake>
+				{ isJetpack && <EmptyContent
 					illustration="/calypso/images/drake/drake-jetpack.svg"
 					title={ translate( 'Want to import into your site?' ) }
 					line={ translate( 'Visit your site\'s wp-admin for all your import and export needs.' ) }
 					action={ translate( 'Import into %(title)s', { args: { title } } ) }
 					actionURL={ adminUrl + 'import.php' }
 					actionTarget="_blank"
-				/>
-			);
-		}
-
-		return (
-			<div className="section-import">
-				<EmailVerificationGate>
+				/> }
+				{ ! isJetpack && <EmailVerificationGate>
 					<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
 					<CompactCard>
 						<header>
@@ -130,8 +130,8 @@ class SiteSettingsImport extends Component {
 					<CompactCard href={ adminUrl + 'import.php' } target="_blank" rel="noopener noreferrer">
 						{ translate( 'Other importers' ) }
 					</CompactCard>
-				</EmailVerificationGate>
-			</div>
+				</EmailVerificationGate> }
+			</Main>
 		);
 	}
 }
@@ -139,5 +139,6 @@ class SiteSettingsImport extends Component {
 export default connect(
 	( state ) => ( {
 		site: getSelectedSite( state ),
+		siteSlug: getSelectedSiteSlug( state ),
 	} )
 )( localize( SiteSettingsImport ) );

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -97,6 +97,22 @@ class SiteTools extends Component {
 						</div>
 					</CompactCard>
 				}
+				<CompactCard
+					href={ importUrl }
+					className="site-tools__link">
+					<div className="site-tools__content">
+						<p className="site-tools__section-title">{ importTitle }</p>
+						<p className="site-tools__section-desc">{ importText }</p>
+					</div>
+				</CompactCard>
+				<CompactCard
+					href={ exportUrl }
+					className="site-tools__link">
+					<div className="site-tools__content">
+						<p className="site-tools__section-title">{ exportTitle }</p>
+						<p className="site-tools__section-desc">{ exportText }</p>
+					</div>
+				</CompactCard>
 				{ showThemeSetup &&
 					<CompactCard
 						href={ themeSetupLink }
@@ -130,22 +146,6 @@ class SiteTools extends Component {
 						</div>
 					</CompactCard>
 				}
-				<CompactCard
-					href={ importUrl }
-					className="site-tools__link">
-					<div className="site-tools__content">
-						<p className="site-tools__section-title">{ importTitle }</p>
-						<p className="site-tools__section-desc">{ importText }</p>
-					</div>
-				</CompactCard>
-				<CompactCard
-					href={ exportUrl }
-					className="site-tools__link">
-					<div className="site-tools__content">
-						<p className="site-tools__section-title">{ exportTitle }</p>
-						<p className="site-tools__section-desc">{ exportText }</p>
-					</div>
-				</CompactCard>
 				<DeleteSiteWarningDialog
 					isVisible={ this.state.showDialog }
 					onClose={ this.closeDialog } />

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -81,6 +81,11 @@ class SiteTools extends Component {
 			'and give up your site\'s address'
 		);
 
+		const importTitle = translate( 'Import' );
+		const importText = translate( 'Import content from another WordPress or Medium site' );
+		const exportTitle = translate( 'Export' );
+		const exportText = translate( 'Export content from your site. You own your data' );
+
 		let changeAddressText = translate( 'Register a new domain or change your site\'s address.' );
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
 			changeAddressText = translate( 'Change your site address.' );
@@ -133,11 +138,49 @@ class SiteTools extends Component {
 						</div>
 					</CompactCard>
 				}
+				<CompactCard
+					href={ this.getImportLink() }
+					className="site-tools__link">
+					<div className="site-tools__content">
+						<p className="site-tools__section-title">
+							{ importTitle }
+						</p>
+						<p className="site-tools__section-desc">{ importText }</p>
+					</div>
+				</CompactCard>
+				<CompactCard
+					href={ this.getExportLink() }
+					className="site-tools__link">
+					<div className="site-tools__content">
+						<p className="site-tools__section-title">
+							{ exportTitle }
+						</p>
+						<p className="site-tools__section-desc">{ exportText }</p>
+					</div>
+				</CompactCard>
 				<DeleteSiteWarningDialog
 					isVisible={ this.state.showDialog }
 					onClose={ this.closeDialog } />
 			</div>
 		);
+	}
+
+	getImportLink() {
+		const { jetpack, slug, options: { admin_url } } = this.props.site;
+
+		if ( jetpack ) {
+			return admin_url + 'import.php';
+		}
+		return `/settings/import/${ slug }`;
+	}
+
+	getExportLink() {
+		const { jetpack, slug, options: { admin_url } } = this.props.site;
+
+		if ( jetpack ) {
+			return admin_url + 'export.php';
+		}
+		return `/settings/export/${ slug }`;
 	}
 
 	trackChangeAddress() {

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { isEmpty, pickBy, some } from 'lodash';
+import { some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,24 +45,14 @@ class SiteTools extends Component {
 	render() {
 		const {
 			translate,
-			sitePurchasesLoaded,
 			siteSlug,
-			isJetpack,
-			isVip,
 			importUrl,
 			exportUrl,
+			showChangeAddress,
+			showDeleteContent,
+			showDeleteSite,
+			showThemeSetup,
 		} = this.props;
-
-		const showSection = {
-			changeAddress: ! isJetpack && ! isVip,
-			themeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
-			deleteContent: ! isJetpack && ! isVip,
-			deleteSite: ! isJetpack && ! isVip && sitePurchasesLoaded,
-		};
-
-		if ( isEmpty( pickBy( showSection ) ) ) {
-			return null;
-		}
 
 		const changeAddressLink = `/domains/manage/${ siteSlug }`;
 		const themeSetupLink = `/settings/theme-setup/${ siteSlug }`;
@@ -96,7 +86,7 @@ class SiteTools extends Component {
 		return (
 			<div className="site-tools">
 				<SectionHeader label={ translate( 'Site Tools' ) } />
-				{ showSection.changeAddress &&
+				{ showChangeAddress &&
 					<CompactCard
 						href={ changeAddressLink }
 						onClick={ this.trackChangeAddress }
@@ -107,7 +97,7 @@ class SiteTools extends Component {
 						</div>
 					</CompactCard>
 				}
-				{ showSection.themeSetup &&
+				{ showThemeSetup &&
 					<CompactCard
 						href={ themeSetupLink }
 						onClick={ this.trackThemeSetup }
@@ -118,7 +108,7 @@ class SiteTools extends Component {
 						</div>
 					</CompactCard>
 				}
-				{ showSection.deleteContent &&
+				{ showDeleteContent &&
 					<CompactCard
 						href={ startOverLink }
 						onClick={ this.trackStartOver }
@@ -129,7 +119,7 @@ class SiteTools extends Component {
 						</div>
 					</CompactCard>
 				}
-				{ showSection.deleteSite &&
+				{ showDeleteSite &&
 					<CompactCard
 						href={ deleteSiteLink }
 						onClick={ this.checkForSubscriptions }
@@ -196,6 +186,8 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSelectedSiteSlug( state );
 		const isJetpack = isJetpackSite( state, siteId );
+		const isVip = isVipSite( state, siteId );
+		const sitePurchasesLoaded = hasLoadedSitePurchasesFromServer( state );
 
 		let importUrl = `/settings/import/${ siteSlug }`;
 		let exportUrl = `/settings/export/${ siteSlug }`;
@@ -206,13 +198,14 @@ export default connect(
 
 		return {
 			siteSlug,
-			isJetpack,
-			isVip: isVipSite( state, siteId ),
-			sitePurchasesLoaded: hasLoadedSitePurchasesFromServer( state ),
 			sitePurchases: getSitePurchases( state, siteId ),
 			purchasesError: getPurchasesError( state ),
 			importUrl,
 			exportUrl,
+			showChangeAddress: ! isJetpack && ! isVip,
+			showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
+			showDeleteContent: ! isJetpack && ! isVip,
+			showDeleteSite: ! isJetpack && ! isVip && sitePurchasesLoaded,
 		};
 	}
 )( localize( SiteTools ) );

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -70,13 +70,13 @@ class SiteTools extends Component {
 		const deleteSite = translate( 'Delete your site permanently' );
 		const deleteSiteText = translate(
 			'Delete all your posts, pages, media and data, ' +
-			'and give up your site\'s address'
+			'and give up your site\'s address.'
 		);
 
 		const importTitle = translate( 'Import' );
-		const importText = translate( 'Import content from another WordPress or Medium site' );
+		const importText = translate( 'Import content from another WordPress or Medium site.' );
 		const exportTitle = translate( 'Export' );
-		const exportText = translate( 'Export content from your site. You own your data' );
+		const exportText = translate( 'Export content from your site. You own your data.' );
 
 		let changeAddressText = translate( 'Register a new domain or change your site\'s address.' );
 		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -139,22 +139,18 @@ class SiteTools extends Component {
 					</CompactCard>
 				}
 				<CompactCard
-					href={ this.getImportLink() }
+					href={ this.getImportExportLink( 'import' ) }
 					className="site-tools__link">
 					<div className="site-tools__content">
-						<p className="site-tools__section-title">
-							{ importTitle }
-						</p>
+						<p className="site-tools__section-title">{ importTitle }</p>
 						<p className="site-tools__section-desc">{ importText }</p>
 					</div>
 				</CompactCard>
 				<CompactCard
-					href={ this.getExportLink() }
+					href={ this.getImportExportLink( 'export' ) }
 					className="site-tools__link">
 					<div className="site-tools__content">
-						<p className="site-tools__section-title">
-							{ exportTitle }
-						</p>
+						<p className="site-tools__section-title">{ exportTitle }</p>
 						<p className="site-tools__section-desc">{ exportText }</p>
 					</div>
 				</CompactCard>
@@ -165,22 +161,17 @@ class SiteTools extends Component {
 		);
 	}
 
-	getImportLink() {
+	getImportExportLink( direction ) {
+		if ( direction !== 'import' && direction !== 'export' ) {
+			return null;
+		}
+
 		const { jetpack, slug, options: { admin_url } } = this.props.site;
 
 		if ( jetpack ) {
-			return admin_url + 'import.php';
+			return `${ admin_url }${ direction }.php`;
 		}
-		return `/settings/import/${ slug }`;
-	}
-
-	getExportLink() {
-		const { jetpack, slug, options: { admin_url } } = this.props.site;
-
-		if ( jetpack ) {
-			return admin_url + 'export.php';
-		}
-		return `/settings/export/${ slug }`;
+		return `/settings/${ direction }/${ slug }`;
 	}
 
 	trackChangeAddress() {

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -15,7 +15,7 @@ import { tracks } from 'lib/analytics';
 import { localize } from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite, getSiteAdminUrl } from 'state/sites/selectors';
 import { isVipSite } from 'state/selectors';
 import {
 	getSitePurchases,
@@ -49,6 +49,8 @@ class SiteTools extends Component {
 			siteSlug,
 			isJetpack,
 			isVip,
+			importUrl,
+			exportUrl,
 		} = this.props;
 
 		const showSection = {
@@ -139,7 +141,7 @@ class SiteTools extends Component {
 					</CompactCard>
 				}
 				<CompactCard
-					href={ this.getImportExportLink( 'import' ) }
+					href={ importUrl }
 					className="site-tools__link">
 					<div className="site-tools__content">
 						<p className="site-tools__section-title">{ importTitle }</p>
@@ -147,7 +149,7 @@ class SiteTools extends Component {
 					</div>
 				</CompactCard>
 				<CompactCard
-					href={ this.getImportExportLink( 'export' ) }
+					href={ exportUrl }
 					className="site-tools__link">
 					<div className="site-tools__content">
 						<p className="site-tools__section-title">{ exportTitle }</p>
@@ -159,19 +161,6 @@ class SiteTools extends Component {
 					onClose={ this.closeDialog } />
 			</div>
 		);
-	}
-
-	getImportExportLink( direction ) {
-		if ( direction !== 'import' && direction !== 'export' ) {
-			return null;
-		}
-
-		const { jetpack, slug, options: { admin_url } } = this.props.site;
-
-		if ( jetpack ) {
-			return `${ admin_url }${ direction }.php`;
-		}
-		return `/settings/${ direction }/${ slug }`;
 	}
 
 	trackChangeAddress() {
@@ -205,13 +194,25 @@ class SiteTools extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
+		const siteSlug = getSelectedSiteSlug( state );
+		const isJetpack = isJetpackSite( state, siteId );
+
+		let importUrl = `/settings/import/${ siteSlug }`;
+		let exportUrl = `/settings/export/${ siteSlug }`;
+		if ( isJetpack ) {
+			importUrl = getSiteAdminUrl( state, siteId, 'import.php' );
+			exportUrl = getSiteAdminUrl( state, siteId, 'export.php' );
+		}
+
 		return {
-			siteSlug: getSelectedSiteSlug( state ),
-			isJetpack: isJetpackSite( state, siteId ),
+			siteSlug,
+			isJetpack,
 			isVip: isVipSite( state, siteId ),
 			sitePurchasesLoaded: hasLoadedSitePurchasesFromServer( state ),
 			sitePurchases: getSitePurchases( state, siteId ),
 			purchasesError: getPurchasesError( state ),
+			importUrl,
+			exportUrl,
 		};
 	}
 )( localize( SiteTools ) );

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -408,3 +408,7 @@
 .site-settings__media-settings > .banner {
 	margin-top: -16px;
 }
+
+.site-settings__general-jetpack {
+	margin-bottom: 16px;
+}


### PR DESCRIPTION
Addresses #12169

Removes the _Import_ and _Export_ tabs in site settings, instead adding links in the _Site Tools_ section in _General_.

_Import_ and _export_ now become their own pages for wpcom sites, similar to _start-over_ and _delete-site_. For Jetpack sites, the links are external, just like the old tabs.

**To Test**

_WPCOM sites_
* Check that the import / export links exist in Settings -> General -> Site Tools
* Links should take you to appropriate page

_Jetpack sites_
* The import / export links in Settings -> General -> Site Tools should point to wp-admin import / export respectively

Before and after screenshots below:

**Before**

<img width="745" alt="screen shot 2017-05-31 at 18 00 38" src="https://cloud.githubusercontent.com/assets/7767559/26644017/45a6fdde-462b-11e7-8dee-fe759a236e65.png">
<img width="738" alt="screen shot 2017-05-31 at 18 00 56" src="https://cloud.githubusercontent.com/assets/7767559/26644020/473ce4a6-462b-11e7-857e-ad6f3299807f.png">
<img width="740" alt="screen shot 2017-05-31 at 18 01 18" src="https://cloud.githubusercontent.com/assets/7767559/26644021/489187bc-462b-11e7-9133-55002311733b.png">
<img width="742" alt="screen shot 2017-05-31 at 18 01 41" src="https://cloud.githubusercontent.com/assets/7767559/26644023/4aebeb60-462b-11e7-96e7-8a463d2c1353.png">
<img width="733" alt="screen shot 2017-05-31 at 18 01 49" src="https://cloud.githubusercontent.com/assets/7767559/26644024/4caf253e-462b-11e7-80d0-efc1f1e5c8c0.png">

**After**
Tabs removed:
<img width="738" alt="screen shot 2017-05-31 at 18 03 31" src="https://cloud.githubusercontent.com/assets/7767559/26644211/e6d4e572-462b-11e7-8290-d2841cad04bf.png">
New links in _Site Tools_:
<img width="740" alt="screen shot 2017-05-31 at 18 03 40" src="https://cloud.githubusercontent.com/assets/7767559/26644215/e9a1cb44-462b-11e7-8ad1-86d13edd223d.png">
_Site Tools_ section now in Jetpack, with links:
<img width="738" alt="screen shot 2017-05-31 at 18 04 07" src="https://cloud.githubusercontent.com/assets/7767559/26644219/ed453f56-462b-11e7-9214-930a6955a6e5.png">
Standalone _Import_ page:
<img width="741" alt="screen shot 2017-05-31 at 18 04 34" src="https://cloud.githubusercontent.com/assets/7767559/26644228/ef0e7faa-462b-11e7-977a-42c5ab45e117.png">
Standalone _Export_ page:
<img width="738" alt="screen shot 2017-05-31 at 18 04 57" src="https://cloud.githubusercontent.com/assets/7767559/26644230/f1890ba6-462b-11e7-9514-305d6f443750.png">





