### PR TITLE
Site Settings: Replace usage of Array_includes for lodash's version in media-settings component

### DIFF
--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -170,7 +171,6 @@ class MediaSettings extends Component {
 				</Card>
 				{ this.renderVideoUpgradeNudge() }
 			</div>
-
 		);
 	}
 }
@@ -181,13 +181,13 @@ export default connect(
 		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 		const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
 		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode( state, selectedSiteId, 'photon' );
-
-		const isVideoPressAvailable = [
+		const plansIncludingVideoPress = [
 			PLAN_JETPACK_BUSINESS,
 			PLAN_JETPACK_BUSINESS_MONTHLY,
 			PLAN_JETPACK_PREMIUM,
 			PLAN_JETPACK_PREMIUM_MONTHLY,
-		].includes( sitePlanSlug );
+		];
+		const isVideoPressAvailable = includes( plansIncludingVideoPress, sitePlanSlug );
 
 		return {
 			carouselActive: !! isJetpackModuleActive( state, selectedSiteId, 'carousel' ),


### PR DESCRIPTION
Replaces usage of `Array.prototype.includes` for lodash includes.

A few message started appearing on the console when visiting the Writing Settings section after the changes in #14227 were introduced.


#### Testing instructions

1. Visit `/settings/writing` for a site with a Jetpack /Premium Professional Plan. Check that you see the Videopress toggle in the Media Settings Card.
1. Visit `/settings/writing` for a site with a Free Plan. Check that you see the upgrade banner.

