### PR TITLE
Reader Following Manage: render search placeholders earlier

### DIFF
--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -36,7 +36,7 @@ const FollowingManageSearchFeedsResults = ( {
 	if ( ! searchResults ) {
 		return (
 			<div className={ classNames }>
-				{ times( 5, i => <ReaderSubscriptionListItemPlaceholder key={ `placeholder-${ i }` } /> ) }
+				{ times( 10, i => <ReaderSubscriptionListItemPlaceholder key={ `placeholder-${ i }` } /> ) }
 			</div>
 		);
 	} else if ( isEmpty ) {

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { take, map } from 'lodash';
+import { take, map, times } from 'lodash';
 import Gridicon from 'gridicons';
 import classnames from 'classnames';
 
@@ -13,6 +13,8 @@ import classnames from 'classnames';
 import ConnectedSubscriptionListItem from './connected-subscription-list-item';
 import SitesWindowScroller from './sites-window-scroller';
 import Button from 'components/button';
+import ReaderSubscriptionListItemPlaceholder
+	from 'blocks/reader-subscription-list-item/placeholder';
 import { READER_FOLLOWING_MANAGE_SEARCH_RESULT } from 'reader/follow-button/follow-sources';
 
 const FollowingManageSearchFeedsResults = ( {
@@ -32,7 +34,11 @@ const FollowingManageSearchFeedsResults = ( {
 	} );
 
 	if ( ! searchResults ) {
-		return null; // todo: add placeholder
+		return (
+			<div className={ classNames }>
+				{ times( 5, i => <ReaderSubscriptionListItemPlaceholder key={ `placeholder-${ i }` } /> ) }
+			</div>
+		);
 	} else if ( isEmpty ) {
 		return (
 			<div className={ classNames }>


### PR DESCRIPTION
When searching in Following Manage, this PR renders result placeholders earlier so we don't get a flash of blank page on slow connections:

![2017-05-23 15_01_21](https://cloud.githubusercontent.com/assets/17325/26358777/dc7cbea0-3fd3-11e7-8646-0bd354ae5c5c.gif)

### To test

Visit http://calypso.localhost:3000/following/manage and enter a search term. Throttle your connection if possible.