### PR TITLE
Reader: avoid unnecessary rerenders in following/manage/index.js

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -41,7 +41,7 @@ import { resemblesUrl, addSchemeIfMissing, withoutHttp } from 'lib/url';
 import { getReaderFollowsCount } from 'state/selectors';
 
 const PAGE_SIZE = 4;
-let RECS_SEED = random( 0, 10000 );
+let recommendationsSeed = random( 0, 10000 );
 
 class FollowingManage extends Component {
 	static propTypes = {
@@ -64,7 +64,7 @@ class FollowingManage extends Component {
 	};
 
 	componentWillUnmount() {
-		RECS_SEED = random( 0, 1000 );
+		recommendationsSeed = random( 0, 1000 );
 	}
 
 	// TODO make this common between our different search pages?
@@ -175,7 +175,7 @@ class FollowingManage extends Component {
 				{ ! searchResults && <QueryReaderFeedsSearch query={ sitesQuery } /> }
 				{ this.shouldRequestMoreRecs() &&
 					<QueryReaderRecommendedSites
-						seed={ RECS_SEED }
+						seed={ recommendationsSeed }
 						offset={ recommendedSitesPagingOffset + PAGE_SIZE || 0 }
 					/> }
 				<h2 className="following-manage__header">{ translate( 'Follow Something New' ) }</h2>
@@ -252,8 +252,11 @@ export default connect(
 	( state, ownProps ) => ( {
 		searchResults: getReaderFeedsForQuery( state, ownProps.sitesQuery ),
 		searchResultsCount: getReaderFeedsCountForQuery( state, ownProps.sitesQuery ),
-		recommendedSites: getReaderRecommendedSites( state, RECS_SEED ),
-		recommendedSitesPagingOffset: getReaderRecommendedSitesPagingOffset( state, RECS_SEED ),
+		recommendedSites: getReaderRecommendedSites( state, recommendationsSeed ),
+		recommendedSitesPagingOffset: getReaderRecommendedSitesPagingOffset(
+			state,
+			recommendationsSeed
+		),
 		blockedSites: getBlockedSites( state ),
 		readerAliasedFollowFeedUrl: getReaderAliasedFollowFeedUrl(
 			state,

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -207,9 +207,7 @@ class FollowingManage extends Component {
 							<FollowButton
 								followLabel={ translate( 'Follow %s', { args: sitesQueryWithoutProtocol } ) }
 								followingLabel={ translate( 'Following %s', { args: sitesQueryWithoutProtocol } ) }
-								siteUrl={ this.props.getReaderAliasedFollowFeedUrl(
-									addSchemeIfMissing( sitesQuery, 'http' )
-								) }
+								siteUrl={ this.props.readerAliasedFollowFeedUrl }
 								followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
 							/>
 						</div> }
@@ -252,7 +250,10 @@ export default connect(
 		getRecommendedSites: seed => getReaderRecommendedSites( state, seed ),
 		getRecommendedSitesPagingOffset: seed => getReaderRecommendedSitesPagingOffset( state, seed ),
 		isSiteBlocked: site => isSiteBlockedSelector( state, site.blogId ),
-		getReaderAliasedFollowFeedUrl: url => getReaderAliasedFollowFeedUrl( state, url ),
+		readerAliasedFollowFeedUrl: getReaderAliasedFollowFeedUrl(
+			state,
+			addSchemeIfMissing( ownProps.sitesQuery, 'http' )
+		),
 		followsCount: getReaderFollowsCount( state ),
 	} ),
 	{ requestFeedSearch }

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -127,7 +127,7 @@ class FollowingManage extends Component {
 	shouldRequestMoreRecs = () => {
 		const { recommendedSites, blockedSites } = this.props;
 
-		return reject( recommendedSites, site => includes( blockedSites, site ) ).length <= 4;
+		return reject( recommendedSites, site => includes( blockedSites, site.blogId ) ).length <= 4;
 	};
 
 	fetchNextPage = offset => this.props.requestFeedSearch( this.props.sitesQuery, offset );
@@ -162,7 +162,7 @@ class FollowingManage extends Component {
 		}
 		const filteredRecommendedSites = reject(
 			recommendedSites,
-			site => includes( blockedSites, site )
+			site => includes( blockedSites, site.blogId )
 		);
 		const isFollowByUrlWithNoSearchResults = isSitesQueryUrl && searchResultsCount === 0;
 
@@ -255,7 +255,7 @@ export default connect(
 		recommendedSites: getReaderRecommendedSites( state, RECS_SEED ),
 		recommendedSitesPagingOffset: getReaderRecommendedSitesPagingOffset( state, RECS_SEED ),
 		blockedSites: getBlockedSites( state ),
-		readerAliasedFollowFeedUrl: ownProps.sitesQuery && getReaderAliasedFollowFeedUrl(
+		readerAliasedFollowFeedUrl: getReaderAliasedFollowFeedUrl(
 			state,
 			addSchemeIfMissing( ownProps.sitesQuery, 'http' )
 		),

--- a/client/state/selectors/get-blocked-sites.js
+++ b/client/state/selectors/get-blocked-sites.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { map, pickBy } from 'lodash';
+import createSelector from 'lib/create-selector';
 
 /**
  * Returns a list of site IDs blocked by the user
@@ -9,6 +10,7 @@ import { map, pickBy } from 'lodash';
  * @param  {Object}  state  Global state tree
  * @return {Array}        Blocked site IDs
  */
-export default function getBlockedSites( state ) {
-	return map( Object.keys( pickBy( state.reader.siteBlocks.items ) ), Number );
-}
+export default createSelector(
+	state => map( Object.keys( pickBy( state.reader.siteBlocks.items ) ), Number ),
+	state => [ state.reader.siteBlocks.items ],
+);


### PR DESCRIPTION
Piece of the pie in preventing a re-render on every state change for following manage.