### PR TITLE
Reader: release following manage refresh to production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -75,6 +75,7 @@
 		"reader": true,
 		"reader/combined-cards": true,
 		"reader/following-intro": true,
+		"reader/following-manage-refresh": true,
 		"reader/full-errors": false,
 		"reader/tags-with-elasticsearch": false,
 		"reader/related-posts": true,


### PR DESCRIPTION
Releases the new Manage Following refresh to production (https://github.com/Automattic/wp-calypso/milestone/160).