### PR TITLE
Editor: Show confirmation sidebar on publish

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -416,6 +416,7 @@
 @import 'post-editor/editor-action-bar/style';
 @import 'post-editor/editor-author/style';
 @import 'post-editor/editor-categories-tags/style';
+@import 'post-editor/editor-confirmation-sidebar/style';
 @import 'post-editor/editor-delete-post/style';
 @import 'post-editor/editor-discussion/style';
 @import 'post-editor/editor-drawer/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -113,6 +113,8 @@ $z-layers: (
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
 		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,
 		'.first-view': 175,
+		'.editor-confirmation-sidebar__overlay': 176,
+		'.editor-confirmation-sidebar__sidebar': 177,
 		'.popover.editor-visibility__popover': 179,
 		'.feature-example__gradient': 179,
 		'.global-notices': 179,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import RootChild from 'components/root-child';
+import Button from 'components/button';
+
+class EditorConfirmationSidebar extends React.Component {
+	static propTypes = {
+		hideSidebar: React.PropTypes.func,
+		isActive: React.PropTypes.bool,
+	};
+
+	stopPropagation( event ) {
+		event.stopPropagation();
+	}
+
+	render() {
+		return (
+			<RootChild>
+				<div>
+					<div className={ classnames( {
+						'editor-confirmation-sidebar': true,
+						'is-active': this.props.isActive,
+					} ) } onClick={ this.props.hideSidebar }></div>
+					<div className={ classnames( {
+						'editor-confirmation-sidebar__sidebar': true,
+						'is-active': this.props.isActive,
+					} ) } onClick={ this.stopPropagation }>
+						<div className="editor-confirmation-sidebar__ground-control">
+							<div className="editor-confirmation-sidebar__cancel" onClick={ this.props.hideSidebar }>Cancel</div>
+							<div className="editor-confirmation-sidebar__action">
+								Are you sure? <Button compact>Yea, do it!</Button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</RootChild>
+		);
+	}
+}
+
+export default localize( EditorConfirmationSidebar );

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -1,0 +1,70 @@
+.editor-confirmation-sidebar {
+	position: fixed;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+
+	z-index: z-index( 'root', '.editor-confirmation-sidebar__overlay' );
+	background: rgba( $white, 0.8 );
+
+	display: none;
+
+	&.is-active {
+		display: block;
+	}
+}
+
+.editor-confirmation-sidebar__sidebar {
+	@extend .sidebar;
+	width: 374px;
+	background: $sidebar-bg-color;
+	position: absolute;
+		left: auto;
+		right: -374px;
+	z-index: z-index( 'root', '.editor-confirmation-sidebar__sidebar' );
+	border-left: 1px solid darken( $sidebar-bg-color, 5% );
+	border-right: none;
+	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
+
+	&.is-active {
+		transform: translateX( -374px );
+	}
+}
+
+.editor-confirmation-sidebar__ground-control {
+	@extend .card;
+	display: flex;
+	justify-content: space-between;
+	
+	position: absolute;
+		top: -2px; // @todo investigate
+		left: 0;
+		right: 0;
+	padding: 10px 24px;
+}
+
+.editor-confirmation-sidebar__cancel {
+	flex-grow: 1;
+	color: $alert-red;
+}
+
+.editor-confirmation-sidebar__action .button {
+	background: $alert-green;
+	border-color: darken( $alert-green, 20% );
+	color: $white;
+
+	text-transform: none;
+	padding: 7px 22px;
+	margin-left: 12px;
+
+	&:hover,
+	&:focus {
+		border-color: darken( $alert-green, 40% );
+	}
+	&[disabled],
+	&:disabled {
+		background: lighten( $alert-green, 20% );
+		border-color: tint( $alert-green, 30% );
+	}
+}

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -38,10 +38,10 @@
 	justify-content: space-between;
 	
 	position: absolute;
-		top: -2px; // @todo investigate
+		top: 0;
 		left: 0;
 		right: 0;
-	padding: 10px 24px;
+	padding: 9px 24px;
 }
 
 .editor-confirmation-sidebar__cancel {

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -98,6 +98,12 @@ export class EditorPublishButton extends Component {
 	onClick() {
 		this.trackClick();
 
+		// @TODO: Check feature flag for publish confirmation
+		if ( true ) {
+			
+			return;
+		}
+
 		if ( postUtils.isPublished( this.props.savedPost ) &&
 			! postUtils.isBackDatedPublished( this.props.savedPost )
 		) {

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -98,12 +98,6 @@ export class EditorPublishButton extends Component {
 	onClick() {
 		this.trackClick();
 
-		// @TODO: Check feature flag for publish confirmation
-		if ( true ) {
-			
-			return;
-		}
-
 		if ( postUtils.isPublished( this.props.savedPost ) &&
 			! postUtils.isBackDatedPublished( this.props.savedPost )
 		) {


### PR DESCRIPTION
This PR creates a confirmation sidebar that is shown when the publish button is pressed in the editor. The feature is behind a feature flag (`post-editor/delta-post-publish-flow`) and the confirmation bar is intentionally blank. It will be populated in future PRs.

Strings are also intentionally not-wrapped until the language is finalized.

![publish-sidebar](https://cloud.githubusercontent.com/assets/363749/26364448/f9f7fe24-3fa9-11e7-9555-7f54700b8e61.gif)

This is part of a larger epic (See p3Ex-2ri-p2)

To test:

* Checkout branch
* `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure the sidebar shows up when you click `Publish`
* Run the branch again without the feature flag enabled and make sure publish works as normal