### PR TITLE
Reader: track the render of the follow by url button

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -144,7 +144,7 @@ class FollowingManage extends Component {
 
 	reportFollowByUrlRender = () => {
 		const siteUrl = this.props.readerAliasedFeedFollowUrl;
-		const showingFollowByUrlButton = this.props.showFollowByUrl();
+		const showingFollowByUrlButton = this.shouldShowFollowByUrl();
 
 		if ( siteUrl && showingFollowByUrlButton ) {
 			recordTrack( 'calypso_reader_following_manage_follow_by_url_render', {

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -242,7 +242,6 @@ class FollowingManage extends Component {
 								followingLabel={ translate( 'Following %s', { args: sitesQueryWithoutProtocol } ) }
 								siteUrl={ this.props.readerAliasedFollowFeedUrl }
 								followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
-								onPropChange={ this.reportFollowByUrlRender }
 							/>
 						</div> }
 				</div>

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -143,7 +143,7 @@ class FollowingManage extends Component {
 	};
 
 	reportFollowByUrlRender = () => {
-		const siteUrl = this.props.readerAliasedFeedFollowUrl;
+		const siteUrl = this.props.readerAliasedFollowFeedUrl;
 		const showingFollowByUrlButton = this.shouldShowFollowByUrl();
 
 		if ( siteUrl && showingFollowByUrlButton ) {
@@ -156,7 +156,7 @@ class FollowingManage extends Component {
 	shouldShowFollowByUrl = () => resemblesUrl( this.props.sitesQuery );
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.readerAliasedFeedFollowUrl !== prevProps.readerAliasedFeedFollowUrl ) {
+		if ( this.props.readerAliasedFollowFeedUrl !== prevProps.readerAliasedFollowFeedUrl ) {
 			this.reportFollowByUrlRender();
 		}
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -44,29 +44,6 @@ import { recordTrack } from 'reader/stats';
 const PAGE_SIZE = 4;
 let recommendationsSeed = random( 0, 10000 );
 
-function reportOnPropChange( Wrapped, prop ) {
-	return class ReportOnPropChange extends Component {
-		static defaultProps = {
-			onPropChange: noop,
-		};
-		componentDidMount() {
-			this.props.onPropChange( this.props[ prop ] );
-		}
-
-		componentDidUpdate( prevProps ) {
-			if ( this.props[ prop ] !== prevProps[ prop ] ) {
-				this.props.onPropChange( this.props[ prop ] );
-			}
-		}
-
-		render() {
-			return <Wrapped { ...this.props } />;
-		}
-	};
-}
-
-const ReportingFollowButton = reportOnPropChange( FollowButton, 'siteUrl' );
-
 class FollowingManage extends Component {
 	static propTypes = {
 		sitesQuery: PropTypes.string,
@@ -171,6 +148,16 @@ class FollowingManage extends Component {
 		}
 	};
 
+	shouldShowFollowByUrl = () => resemblesUrl( this.props.sitesQuery );
+	componentDidUpdate() {
+		if (
+			this.shouldShowFollowByUrl
+			//url changed
+		) {
+			this.reportFollowByUrlRender(); //url
+		}
+	}
+
 	render() {
 		const {
 			sitesQuery,
@@ -188,6 +175,7 @@ class FollowingManage extends Component {
 		const searchPlaceholderText = translate( 'Search or enter URL to follow…' );
 		const hasFollows = followsCount > 0;
 		const showExistingSubscriptions = hasFollows && ! showMoreResults;
+<<<<<<< HEAD
 		const isSitesQueryUrl = resemblesUrl( sitesQuery );
 		let sitesQueryWithoutProtocol;
 		if ( isSitesQueryUrl ) {
@@ -198,6 +186,13 @@ class FollowingManage extends Component {
 			site => includes( blockedSites, site.blogId )
 		);
 		const isFollowByUrlWithNoSearchResults = isSitesQueryUrl && searchResultsCount === 0;
+=======
+		const sitesQueryWithoutProtocol = withoutHttp( sitesQuery );
+		const offset = getRecommendedSitesPagingOffset( this.state.seed );
+		const recommendedSites = reject( getRecommendedSites( this.state.seed ), isSiteBlocked );
+		const showFollowByUrl = this.shouldShowFollowByUrl();
+		const isFollowByUrlWithNoSearchResults = showFollowByUrl && searchResultsCount === 0;
+>>>>>>> idea2
 
 		return (
 			<ReaderMain className="following-manage">
@@ -229,7 +224,7 @@ class FollowingManage extends Component {
 						/>
 					</CompactCard>
 
-					{ isSitesQueryUrl &&
+					{ showFollowByUrl &&
 						<div className="following-manage__url-follow">
 							{ isFollowByUrlWithNoSearchResults &&
 								<span className="following-manage__url-follow-no-search-results-message">
@@ -242,7 +237,7 @@ class FollowingManage extends Component {
 										}
 									) }
 								</span> }
-							<ReportingFollowButton
+							<FollowButton
 								followLabel={ translate( 'Follow %s', { args: sitesQueryWithoutProtocol } ) }
 								followingLabel={ translate( 'Following %s', { args: sitesQueryWithoutProtocol } ) }
 								siteUrl={ this.props.readerAliasedFollowFeedUrl }

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { trim, debounce, random, take, reject, includes } from 'lodash';
+import { trim, debounce, noop, random, take, reject, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import qs from 'qs';
@@ -43,6 +43,29 @@ import { recordTrack } from 'reader/stats';
 
 const PAGE_SIZE = 4;
 let recommendationsSeed = random( 0, 10000 );
+
+function reportOnPropChange( Wrapped, prop ) {
+	return class ReportOnPropChange extends Component {
+		static defaultProps = {
+			onPropChange: noop,
+		};
+		componentDidMount() {
+			this.props.onPropChange( this.props[ prop ] );
+		}
+
+		componentDidUpdate( prevProps ) {
+			if ( this.props[ prop ] !== prevProps[ prop ] ) {
+				this.props.onPropChange( this.props[ prop ] );
+			}
+		}
+
+		render() {
+			return <Wrapped { ...this.props } />;
+		}
+	};
+}
+
+const ReportingFollowButton = reportOnPropChange( FollowButton, 'siteUrl' );
 
 class FollowingManage extends Component {
 	static propTypes = {
@@ -140,6 +163,14 @@ class FollowingManage extends Component {
 		);
 	};
 
+	reportFollowByUrlRender = siteUrl => {
+		if ( siteUrl ) {
+			recordTrack( 'calypso_reader_following_manage_follow_by_url_render', {
+				url: siteUrl,
+			} );
+		}
+	};
+
 	render() {
 		const {
 			sitesQuery,
@@ -211,11 +242,12 @@ class FollowingManage extends Component {
 										}
 									) }
 								</span> }
-							<FollowButton
+							<ReportingFollowButton
 								followLabel={ translate( 'Follow %s', { args: sitesQueryWithoutProtocol } ) }
 								followingLabel={ translate( 'Following %s', { args: sitesQueryWithoutProtocol } ) }
 								siteUrl={ this.props.readerAliasedFollowFeedUrl }
 								followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
+								onPropChange={ this.reportFollowByUrlRender }
 							/>
 						</div> }
 				</div>

--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -15,7 +15,6 @@ import { debounce, noop, get } from 'lodash';
  * Internal Dependencies
  */
 import ConnectedSubscriptionListItem from './connected-subscription-list-item';
-import { READER_SUBSCRIPTIONS } from 'reader/follow-button/follow-sources';
 
 /*
  * SitesWindowScroller is a component that takes in a list of site/feed objects.

--- a/client/reader/following-manage/sites-window-scroller.jsx
+++ b/client/reader/following-manage/sites-window-scroller.jsx
@@ -15,6 +15,7 @@ import { debounce, noop, get } from 'lodash';
  * Internal Dependencies
  */
 import ConnectedSubscriptionListItem from './connected-subscription-list-item';
+import { READER_SUBSCRIPTIONS } from 'reader/follow-button/follow-sources';
 
 /*
  * SitesWindowScroller is a component that takes in a list of site/feed objects.


### PR DESCRIPTION
Adds render tracking for the follow by URL button in following manage.

Discussion: https://github.com/Automattic/wp-calypso/pull/14377#pullrequestreview-39791806