### PR TITLE
WooCommerce: Try using a FormToggle instead of a checkbox for "Manage Stock"

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -94,15 +94,14 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 	const renderStock = () => (
 		<Card className="products__product-form-stock">
 			<div className="products__product-manage-stock-wrapper">
+				<div className="products__product-manage-stock-toggle">
+					<FormToggle
+						checked={ Boolean( product.manage_stock ) }
+						name="manage_stock"
+						onChange={ toggleStock } />
+				</div>
 				<FormLabel>{ translate( 'Manage stock' ) }</FormLabel>
 				<div className="products__product-manage-stock">
-					<div className="products__product-manage-stock-checkbox">
-						<FormToggle
-							checked={ Boolean( product.manage_stock ) }
-							name="manage_stock"
-							onChange={ toggleStock } />
-					</div>
-
 					{ product.manage_stock && (
 						<FormTextInput
 							name="stock_quantity"

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -39,8 +39,7 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 	};
 
 	const setStockQuantity = ( e ) => {
-		const stock_quantity = e.target.value;
-		Number( stock_quantity ) >= 0 && editProduct( product, { stock_quantity } );
+		editProduct( product, { stock_quantity: e.target.value } );
 	};
 
 	const setBackorders = ( e ) => {
@@ -92,8 +91,7 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 		</Card>
 	);
 
-	const stockClasses = classNames( {
-		'products__product-form-stock': true,
+	const stockClasses = classNames( 'products__product-form-stock', {
 		'products__product-form-stock-disabled': ! product.manage_stock,
 	} );
 
@@ -112,7 +110,7 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 						<FormLabel>{ translate( 'Quantity' ) }</FormLabel>
 						<FormTextInput
 							name="stock_quantity"
-							value={ product.stock_quantity || 0 }
+							value={ product.stock_quantity || '' }
 							type="number"
 							min="0"
 							onChange={ setStockQuantity }

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import FormCheckbox from 'components/forms/form-checkbox';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from '../../components/form-dimensions-input';
 import FormFieldSet from 'components/forms/form-fieldset';
@@ -17,6 +16,7 @@ import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import FormToggle from 'components/forms/form-toggle';
 
 const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 	const setDimension = ( e ) => {
@@ -97,7 +97,7 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 				<FormLabel>{ translate( 'Manage stock' ) }</FormLabel>
 				<div className="products__product-manage-stock">
 					<div className="products__product-manage-stock-checkbox">
-						<FormCheckbox
+						<FormToggle
 							checked={ Boolean( product.manage_stock ) }
 							name="manage_stock"
 							onChange={ toggleStock } />

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -3,11 +3,13 @@
  */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from '../../components/form-dimensions-input';
 import FormFieldSet from 'components/forms/form-fieldset';
@@ -16,7 +18,6 @@ import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
-import FormToggle from 'components/forms/form-toggle';
 
 const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 	const setDimension = ( e ) => {
@@ -91,42 +92,48 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 		</Card>
 	);
 
+	const stockClasses = classNames( {
+		'products__product-form-stock': true,
+		'products__product-form-stock-disabled': ! product.manage_stock,
+	} );
+
 	const renderStock = () => (
-		<Card className="products__product-form-stock">
-			<div className="products__product-manage-stock-wrapper">
-				<div className="products__product-manage-stock-toggle">
-					<FormToggle
-						checked={ Boolean( product.manage_stock ) }
-						name="manage_stock"
-						onChange={ toggleStock } />
-				</div>
-				<FormLabel>{ translate( 'Manage stock' ) }</FormLabel>
-				<div className="products__product-manage-stock">
-					{ product.manage_stock && (
+		<Card className={ stockClasses }>
+			<div className="products__product-manage-stock-toggle">
+				<CompactFormToggle
+					checked={ Boolean( product.manage_stock ) }
+					name="manage_stock"
+					onChange={ toggleStock } />
+				<FormLabel onClick={ toggleStock }>{ translate( 'Manage stock' ) }</FormLabel>
+			</div>
+			<div className="products__product-stock-options-wrapper">
+				{ product.manage_stock && (
+					<div className="products__product-manage-stock">
+						<FormLabel>{ translate( 'Quantity' ) }</FormLabel>
 						<FormTextInput
 							name="stock_quantity"
-							value={ product.stock_quantity || '' }
+							value={ product.stock_quantity || 0 }
 							type="number"
 							min="0"
 							onChange={ setStockQuantity }
 							placeholder={ translate( 'Quantity' ) } />
-					) }
-				</div>
-			</div>
-			{ product.manage_stock && (
-				<div className="products__product-backorders-wrapper">
-					<FormLabel>{ translate( 'Backorders' ) }</FormLabel>
-					<FormSelect name="backorders" onChange={ setBackorders } value={ product.backorders || 'no' } >
-						<option value="no">{ translate( 'Do not allow' ) }</option>
-						<option value="notify">{ translate( 'Allow, but notify customer' ) }</option>
-						<option value="yes">{ translate( 'Allow' ) }</option>
-					</FormSelect>
+					</div>
+				) }
+				{ product.manage_stock && (
+					<div className="products__product-backorders-wrapper">
+						<FormLabel>{ translate( 'Backorders' ) }</FormLabel>
+						<FormSelect name="backorders" onChange={ setBackorders } value={ product.backorders || 'no' } >
+							<option value="no">{ translate( 'Do not allow' ) }</option>
+							<option value="notify">{ translate( 'Allow, but notify customer' ) }</option>
+							<option value="yes">{ translate( 'Allow' ) }</option>
+						</FormSelect>
 
-					<FormSettingExplanation>{ translate(
-						'Backorders allow customers to purchase products that are out of stock.'
-					) }</FormSettingExplanation>
-				</div>
-			) }
+						<FormSettingExplanation>{ translate(
+							'Backorders allow customers to purchase products that are out of stock.'
+						) }</FormSettingExplanation>
+					</div>
+				) }
+			</div>
 		</Card>
 	);
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -504,7 +504,7 @@
 	}
 
 	.products__product-backorders-wrapper label {
-		margin-bottom: 12px;
+		margin-bottom: 5px;
 	}
 
 	.products__product-backorders-wrapper select {
@@ -514,16 +514,12 @@
 	.products__product-stock-options-wrapper {
 		display: flex;
 		flex-direction: column;
-		margin-top: 16px;
+		margin-top: 6px;
 
 		.products__product-manage-stock {
-			width: 200px;
-			margin-right: 32px;
+			width: 150px;
+			margin-right: 24px;
 			margin-bottom: 12px;
-
-			.form-text-input {
-				margin-top: 8px;
-			}
 		}
 
 		.products__product-backorders-wrapper {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -422,14 +422,7 @@
 	.products__product-manage-stock-checkbox {
 		@include clear-fix();
 		padding: 12px;
-		background: $white;
-		border: 1px solid lighten( $gray, 20% );
 		display: flex;
-
-		input[type=checkbox] {
-			float: none;
-			margin: 0;
-		}
 
 		+ .form-text-input {
 			transform: translateX( -1px );
@@ -438,7 +431,17 @@
 
 	.form-text-input {
 		height: 42px;
+		width: 150px;
 	}
+
+	.form-toggle__switch {
+		vertical-align: middle;
+	}
+}
+
+.products__product-manage-stock-wrapper label,
+.products__product-backorders-wrapper label {
+	margin-bottom: 1em;
 }
 
 .products__product-form-variation-table {
@@ -524,7 +527,7 @@
 		flex-direction: column;
 
 		.products__product-manage-stock-wrapper {
-			width: 150px;
+			width: 200px;
 			margin-right: 32px;
 			margin-bottom: 12px;
 		}

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -414,49 +414,6 @@
 	}
 }
 
-.products__product-manage-stock {
-	display: inline-flex;
-	flex-direction: row;
-	width: 100%;
-
-	.products__product-manage-stock-toggle {
-		@include clear-fix();
-		padding: 12px;
-		display: inline-flex;
-
-		+ .form-text-input {
-			transform: translateX( -1px );
-		}
-	}
-
-	.form-text-input {
-		height: 42px;
-		width: 150px;
-	}
-
-	.form-toggle__switch {
-		vertical-align: middle;
-	}
-}
-
-.products__product-manage-stock-toggle,
-.products__product-manage-stock-wrapper .form-label {
-	display: inline-flex;
-}
-
-.products__product-manage-stock-wrapper .form-label {
-	font-weight: normal;
-	margin-bottom: 12px;
-}
-
-.products__product-backorders-wrapper label {
-	margin-bottom: 12px;
-}
-
-.products__product-backorders-wrapper select {
-	padding: 9px 32px 11px 14px;
-}
-
 .products__product-form-variation-table {
 	.products__product-dimensions-weight {
 		flex-direction: row;
@@ -531,18 +488,42 @@
 		width: 150px;
 	}
 
-	.products__product-manage-stock {
-		width: 150px;
+	.products__product-form-stock-disabled {
+		height: 70px;
 	}
 
-	.products__product-form-stock {
+	.products__product-manage-stock-toggle,
+	.products__product-manage-stock-wrapper .form-label {
+		display: inline-flex;
+		cursor: pointer;
+	}
+
+	.products__product-manage-stock-toggle .form-label {
+		font-weight: normal;
+		margin-bottom: 12px;
+	}
+
+	.products__product-backorders-wrapper label {
+		margin-bottom: 12px;
+	}
+
+	.products__product-backorders-wrapper select {
+		padding: 9px 32px 11px 14px;
+	}
+
+	.products__product-stock-options-wrapper {
 		display: flex;
 		flex-direction: column;
+		margin-top: 16px;
 
-		.products__product-manage-stock-wrapper {
+		.products__product-manage-stock {
 			width: 200px;
 			margin-right: 32px;
 			margin-bottom: 12px;
+
+			.form-text-input {
+				margin-top: 8px;
+			}
 		}
 
 		.products__product-backorders-wrapper {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -419,10 +419,10 @@
 	flex-direction: row;
 	width: 100%;
 
-	.products__product-manage-stock-checkbox {
+	.products__product-manage-stock-toggle {
 		@include clear-fix();
 		padding: 12px;
-		display: flex;
+		display: inline-flex;
 
 		+ .form-text-input {
 			transform: translateX( -1px );
@@ -439,9 +439,22 @@
 	}
 }
 
-.products__product-manage-stock-wrapper label,
+.products__product-manage-stock-toggle,
+.products__product-manage-stock-wrapper .form-label {
+	display: inline-flex;
+}
+
+.products__product-manage-stock-wrapper .form-label {
+	font-weight: normal;
+	margin-bottom: 12px;
+}
+
 .products__product-backorders-wrapper label {
-	margin-bottom: 1em;
+	margin-bottom: 12px;
+}
+
+.products__product-backorders-wrapper select {
+	padding: 9px 32px 11px 14px;
 }
 
 .products__product-form-variation-table {


### PR DESCRIPTION
This branch uses a `FormToggle` instead of a checkbox for the "manage stock" option.

From https://github.com/Automattic/wp-calypso/pull/14343#issuecomment-303388145

> What if we do another /try branch where, instead of a checkbox its a toggle? So, like it was before with the input and back order only being visible if toggled on. That is more inline with our other on/off interactions.

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`
* Click the toggle button under "manage stock".
* See the backorders and quantity input display.
* Click the toggle again and see the section go away.

cc @kellychoffman @jameskoster