### PR TITLE
Framework: use exact version for chrono-node

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -821,7 +821,7 @@
       "version": "1.0.1"
     },
     "chrono-node": {
-      "version": "1.3.2"
+      "version": "1.3.1"
     },
     "ci-info": {
       "version": "1.0.0",
@@ -3598,7 +3598,7 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.6.3"
+      "version": "1.7.0"
     },
     "node-gyp": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bounding-client-rect": "1.0.5",
     "browser-filesaver": "1.1.0",
     "chalk": "1.0.0",
-    "chrono-node": "^1.0.6",
+    "chrono-node": "1.3.1",
     "classnames": "1.1.1",
     "click-outside": "2.0.1",
     "clipboard": "1.5.3",


### PR DESCRIPTION
This PR fixes an issue where the datepicker was appearing in French. This fixes #14380
![screen shot 2017-05-23 at 9 44 17 am](https://cloud.githubusercontent.com/assets/1270189/26366326/8b444de8-3f9f-11e7-9a99-0a817365e941.png)
