### PR TITLE
Shrinkwrap: remove binary gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-npm-shrinkwrap.json binary


### PR DESCRIPTION
Remove `.gitattributes` which only served to mark `npm-shrinkwrap.json` as binary. The file is not binary, it is readable JSON.

In particular, tracking down the cause of #14380 was complicated by hidden diffs, the root of the problem was a version bump in `npm-shrinkwrap.json`.

More than trying to push this change through, I think it's a conversation worth having.