### PR TITLE
WooCommerce: Fix "All Variations" by making it a bulk editor

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -66,8 +66,7 @@ class ProductFormVariationsModal extends React.Component {
 		const { selectedVariation } = this.state;
 		const variation = this.selectedVariation();
 
-		const navVariations = ( variations && variations.filter( v => v.attributes.length > 0 ) ) || [];
-		const navItems = navVariations.map( function( v, i ) {
+		const navItems = variations && variations.map( function( v, i ) {
 			return (
 				<ModalNavItem key={ i } variation={ v } selected={ selectedVariation } />
 			);

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -7,12 +7,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormTextInput from 'components/forms/form-text-input';
-import FormCurrencyInput from 'components/forms/form-currency-input';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
-import FormDimensionsInput from '../../components/form-dimensions-input';
 import formattedVariationName from '../../lib/formatted-variation-name';
+import FormCurrencyInput from 'components/forms/form-currency-input';
+import FormDimensionsInput from '../../components/form-dimensions-input';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 
 const ProductFormVariationsRow = ( {
 	product,
@@ -37,43 +36,30 @@ const ProductFormVariationsRow = ( {
 	};
 
 	const setStockQuantity = ( e ) => {
-		editProductVariation( product, variation, { stock_quantity: e.target.value } );
-	};
-
-	const toggleStock = () => {
-		editProductVariation( product, variation, { manage_stock: ! variation.manage_stock } );
+		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
+		editProductVariation( product, variation, { stock_quantity } );
 	};
 
 	const showDialog = () => {
 		onShowDialog( variation.id );
 	};
 
-	// A variation with empty attributes is a 'fallback variation'.
-	// We use this for the "All variations" row in the table, as defaults for the other variations.
-	const fallbackRow = ! variation.attributes.length;
-	const rowClassName = 'products__product-form-variation-' + ( fallbackRow && 'all-row' || 'row' );
-
 	return (
-		<tr className={ rowClassName }>
+		<tr className="products__product-form-variation-row">
 			<td className="products__product-id">
-				{ ! fallbackRow && (
-					<div className="products__product-name-thumb">
-						<div className="products__product-form-variation-image"></div>
-						<span className="products__product-name products__variation-settings-link" onClick={ showDialog }>
-							{ formattedVariationName( variation ) }
-						</span>
-					</div>
-				) || (
-					<div className="products__product-name">
-						{ translate( 'All variations' ) }
-					</div>
-				) }
+				<div className="products__product-name-thumb">
+					<div className="products__product-form-variation-image"></div>
+					<span className="products__product-name products__variation-settings-link" onClick={ showDialog }>
+						{ formattedVariationName( variation ) }
+					</span>
+				</div>
 			</td>
 			<td>
 				<FormCurrencyInput noWrap
 					currencySymbolPrefix="$"
 					name="price"
 					value={ variation.regular_price || '' }
+					placeholder="0.00"
 					onChange={ setPrice }
 					size="4"
 				/>
@@ -102,20 +88,13 @@ const ProductFormVariationsRow = ( {
 			</td>
 			<td>
 				<div className="products__product-manage-stock">
-					{ fallbackRow && (
-						<div className="products__product-manage-stock-checkbox">
-							<FormCheckbox checked={ Boolean( variation.manage_stock ) } onChange={ toggleStock } />
-						</div>
-					) }
-					{ manageStock && (
-						<FormTextInput
-							name="stock_quantity"
-							value={ variation.stock_quantity || '' }
-							type="number"
-							onChange={ setStockQuantity }
-							placeholder={ translate( 'Quantity' ) }
-						/>
-					) }
+					{ manageStock && ( <FormTextInput
+						name="stock_quantity"
+						value={ variation.stock_quantity || '' }
+						type="number"
+						onChange={ setStockQuantity }
+						placeholder={ translate( 'Quantity' ) }
+					/> ) }
 				</div>
 			</td>
 		</tr>

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -110,6 +110,10 @@
 
 	.products__product-form-variation-all-row {
 		background: lighten( $gray, 30% );
+
+		.products__product-manage-stock-toggle {
+			display: inline;
+		}
 	}
 
 	.products__product-form-variation-row {
@@ -428,7 +432,11 @@
 	}
 
 	.products__product-manage-stock {
-		width: 150px;
+		width: 200px;
+
+		.form-text-input {
+			width: 110px;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -122,11 +122,7 @@ function editProductAttributeAction( edits, action ) {
 
 // TODO Check against a product's existing variations (retrieved from the API) and deal with those in the checks below.
 function editProductVariations( productEdits, variations ) {
-	// Adds the default "all variations" variation, which expects an empty attributes array.
-	const creates = productEdits && productEdits.creates || [ {
-		id: { index: Number( uniqueId() ) },
-		attributes: [],
-	} ];
+	const creates = productEdits && productEdits.creates || [];
 
 	// Add new variations that do not exist yet.
 	variations.forEach( ( variation ) => {

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -151,19 +151,7 @@ describe( 'edits-reducer', () => {
 				variation: true
 			} ) );
 
-			expect( edits1[ 0 ].creates[ 1 ].attributes ).to.eql( attributes );
-		} );
-
-		it( 'should add "all variations" variation to "creates"', () => {
-			const product = { id: 48 };
-
-			const edits1 = reducer( undefined, editProductAttribute( product, null, {
-				name: 'Color',
-				options: [ 'Blue' ],
-				variation: true
-			} ) );
-
-			expect( edits1[ 0 ].creates[ 0 ].attributes ).to.eql( [] );
+			expect( edits1[ 0 ].creates[ 0 ].attributes ).to.eql( attributes );
 		} );
 
 		it( 'should remove invalid variations from "creates"', () => {
@@ -176,7 +164,7 @@ describe( 'edits-reducer', () => {
 				variation: true
 			} ) );
 
-			expect( edits1[ 0 ].creates[ 1 ].attributes ).to.eql( attributes );
+			expect( edits1[ 0 ].creates[ 0 ].attributes ).to.eql( attributes );
 
 			const smallAttributes = [ { name: 'Color', option: 'Blue' }, { name: 'Size', option: 'Small' } ];
 			const mediumAttributes = [ { name: 'Color', option: 'Blue' }, { name: 'Size', option: 'Medium' } ];
@@ -194,9 +182,9 @@ describe( 'edits-reducer', () => {
 				variation: true
 			} ) );
 
-			expect( edits2[ 0 ].creates.length ).to.eql( 3 );
-			expect( edits2[ 0 ].creates[ 1 ].attributes ).to.eql( smallAttributes );
-			expect( edits2[ 0 ].creates[ 2 ].attributes ).to.eql( mediumAttributes );
+			expect( edits2[ 0 ].creates.length ).to.eql( 2 );
+			expect( edits2[ 0 ].creates[ 0 ].attributes ).to.eql( smallAttributes );
+			expect( edits2[ 0 ].creates[ 1 ].attributes ).to.eql( mediumAttributes );
 		} );
 
 		it( 'should preserve variations that are still valid', () => {
@@ -228,15 +216,15 @@ describe( 'edits-reducer', () => {
 				uid: 'edit_1'
 			} );
 
-			const blueMediumVariation = edits2[ 0 ].creates[ 2 ];
+			const blueMediumVariation = edits2[ 0 ].creates[ 1 ];
 			const edits3 = reducer( edits2, editProductVariation( product, blueMediumVariation, { regular_price: '2.99' } ) );
 
 			const blueMediumAttributes = [ { name: 'Color', option: 'Blue' }, { name: 'Size', option: 'Medium' } ];
 
 			const edits4 = reducer( edits3, editProductAttribute( product, product.attributes[ 0 ], { options: [ 'Blue', 'Red' ] } ) );
-			expect( edits4[ 0 ].creates.length ).to.eql( 5 );
-			expect( edits4[ 0 ].creates[ 2 ].attributes ).to.eql( blueMediumAttributes );
-			expect( edits4[ 0 ].creates[ 2 ].regular_price ).to.equal( '2.99' );
+			expect( edits4[ 0 ].creates.length ).to.eql( 4 );
+			expect( edits4[ 0 ].creates[ 1 ].attributes ).to.eql( blueMediumAttributes );
+			expect( edits4[ 0 ].creates[ 1 ].regular_price ).to.equal( '2.99' );
 		} );
 	} );
 } );


### PR DESCRIPTION
The original intended behavior of the "all variations" row was to act as a bulk editor, so that users could quickly enter a value in the top row and have all values in that column update to the new value.

This PR implements that behavior.

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`.
* Toggle "This product has variations".
* Enter a few types/values so that variations are created and the table is displayed.
* Enter values in the "All Variations" row, and see the values update in the rows below.
* Toggle stock to enable inputs for all the rows, to make sure that works.
* Run `make test` to make sure all tests pass, since I backed out some changes there.