### PR TITLE
Publicize: update preview feature flag

### DIFF
--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -182,7 +182,7 @@ class PostShare extends Component {
 
 		return (
 			<div className="post-share__button-actions">
-				{ ( isEnabled( 'publicize-scheduling' ) || isEnabled( 'publicize/preview' ) ) &&
+				{ ( isEnabled( 'publicize-preview' ) ) &&
 					<Button
 						className="post-share__preview-button"
 						onClick={ this.toggleSharingPreview }

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,7 @@
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
 		"press-this": true,
-		"publicize/preview": false,
+		"publicize-preview": false,
 		"publicize-scheduling": false,
 		"push-notifications": true,
 		"reader": true,


### PR DESCRIPTION
This updates the publicize preview feature flag. It decouples flagging the preview feature from publicize scheduling.

**Testing**

Enabling the feature flag, `ENABLE_FEATURES=publicize-preview  make run` should render the 'Preview' button on in the sharing tab of a post:
![screen shot 2017-05-23 at 12 07 38 pm](https://cloud.githubusercontent.com/assets/744755/26371740/7b2a829a-3fb0-11e7-81d5-b0c118d3f8a1.png)

Disabling the feature flag should hide the 'Preview' button.
