### PR TITLE
Reader: Remove fade from site description

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -116,14 +116,24 @@
 	.reader-feed-header__details {
 		align-self: stretch;
 		font-size: 14px;
-		max-height: 16px * 4;
 		overflow: hidden;
 		text-align: center;
 		position: relative;
 
 		.reader-feed-header__description {
+			display: block;
+			position: relative;
 
+			@include breakpoint ( "<660px" ) {
+				max-height: 16px * 4;
+				overflow: hidden;
 
+				&::after {
+					@include long-content-fade( $size: 15% );
+					height: 16px * 1.3;
+					top: auto;
+				}
+			}
 		}
 	}
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -123,11 +123,7 @@
 
 		.reader-feed-header__description {
 
-				&::after {
-					@include long-content-fade( $size: 15% );
-					height: 16px * 1.3;
-					top: auto;
-			}
+
 		}
 	}
 


### PR DESCRIPTION
before
<img width="845" alt="screenshot 2017-05-23 16 09 07" src="https://cloud.githubusercontent.com/assets/14350/26374127/2b3b3e9c-3fd2-11e7-90b9-d51f5aebb84c.png">

after
<img width="874" alt="screenshot 2017-05-23 16 08 46" src="https://cloud.githubusercontent.com/assets/14350/26374111/205e8b82-3fd2-11e7-84cc-ffe05f6de40d.png">
