### PR TITLE
Fix: Swap HTTP pipeline chains (fix stupid)

### DIFF
--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -52,7 +52,7 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 
 	const request = fetcherMap( method )( ...compact( [
 		{ path, formData },
-		query,
+		{ ...query }, // wpcom mutates the query so hand it a copy
 		method === 'POST' && body,
 		( error, data ) => {
 			const {

--- a/client/state/data-layer/wpcom-http/pipeline/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/index.js
@@ -83,6 +83,6 @@ export const processOutboundChain = chain => ( originalRequest, store ) =>
 		.reduce( applyOutboundProcessor, { originalRequest, store, nextRequest: originalRequest } )
 		.nextRequest;
 
-export const processInbound = processInboundChain( outboundChain );
+export const processInbound = processInboundChain( inboundChain );
 
-export const processOutbound = processOutboundChain( inboundChain );
+export const processOutbound = processOutboundChain( outboundChain );

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -10,6 +10,8 @@ import {
 	toPairs,
 	unionWith,
 } from 'lodash';
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:data-layer:remove-duplicate-gets' );
 
 /**
  * Prevent sending multiple identical GET requests
@@ -122,6 +124,11 @@ export const applyDuplicatesHandlers = inboundData => {
 	const queued = requestQueue.get( key );
 
 	if ( ! queued ) {
+		debug(
+			'applyDuplicatesHandler has entered an impossible state!' +
+			'A HTTP request is exiting the http pipeline without having entered it.' +
+			'There must be a bug somewhere'
+		);
 		return inboundData;
 	}
 


### PR DESCRIPTION
Early on I renamed the terms but forgot to swap these processors. Who
knows why it hasn't blown up in production `¯\_(ツ)_/¯`