### PR TITLE
Editor: Fix confirmation sidebar appearing to the right of editor

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -24,9 +24,12 @@ class EditorConfirmationSidebar extends React.Component {
 	render() {
 		return (
 			<RootChild>
-				<div>
-					<div className={ classnames( {
+				<div className={ classnames( {
 						'editor-confirmation-sidebar': true,
+						'is-active': this.props.isActive,
+				} ) } >
+					<div className={ classnames( {
+						'editor-confirmation-sidebar__overlay': true,
 						'is-active': this.props.isActive,
 					} ) } onClick={ this.props.hideSidebar }></div>
 					<div className={ classnames( {

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -1,4 +1,12 @@
 .editor-confirmation-sidebar {
+	display: none;
+
+	&.is-active {
+		display: block;
+	}
+}
+
+.editor-confirmation-sidebar__overlay {
 	position: fixed;
 		top: 0;
 		right: 0;


### PR DESCRIPTION
This PR fixes a bug introduced in #14382 that caused the confirmation sidebar to appear when scrolling right of the editor.

BUG:
![bug](https://cloud.githubusercontent.com/assets/363749/26375757/c1799a8c-3fcf-11e7-959e-78a4ba0ccadd.gif)

To test:

* Checkout branch, `make run`. Visit the editor and verify that scrolling right doesn't show confirmation bar.