### PR TITLE
Open post links from notes panel in Calypso instead of new tab

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -159,7 +159,9 @@ export class Notifications extends Component {
 			OPEN_POST: [ ( store, { siteId, postId, href } ) => {
 				if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
 					this.props.checkToggle();
-					page( `/read/blogs/${ siteId }/posts/${ postId }` );
+					const commentIdIndex = href.indexOf( '#comment-' );
+					const commentHash = commentIdIndex === -1 ? '' : href.substring( commentIdIndex );
+					page( `/read/blogs/${ siteId }/posts/${ postId }${ commentHash }` );
 				} else {
 					window.open( href, '_blank' );
 				}

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -159,9 +159,15 @@ export class Notifications extends Component {
 			OPEN_POST: [ ( store, { siteId, postId, href } ) => {
 				if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
 					this.props.checkToggle();
-					const commentIdIndex = href.indexOf( '#comment-' );
-					const commentHash = commentIdIndex === -1 ? '' : href.substring( commentIdIndex );
-					page( `/read/blogs/${ siteId }/posts/${ postId }${ commentHash }` );
+					page( `/read/blogs/${ siteId }/posts/${ postId }` );
+				} else {
+					window.open( href, '_blank' );
+				}
+			} ],
+			OPEN_COMMENT: [ ( store, { siteId, postId, href, commentId } ) => {
+				if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
+					this.props.checkToggle();
+					page( `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` );
 				} else {
 					window.open( href, '_blank' );
 				}

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -155,7 +155,10 @@ export class Notifications extends Component {
 		const customMiddleware = {
 			APP_RENDER_NOTES: [ ( store, { newNoteCount } ) => this.props.setIndicator( newNoteCount ) ],
 			OPEN_LINK: [ ( store, { href } ) => window.open( href, '_blank' ) ],
-			OPEN_POST: [ ( store, { href } ) => window.open( href, '_blank' ) ],
+			OPEN_POST: [ ( store, { siteId, postId } ) => {
+				this.props.checkToggle();
+				page( `/read/blogs/${ siteId }/posts/${ postId }` );
+			} ],
 			VIEW_SETTINGS: [ () => {
 				this.props.checkToggle();
 				page( '/me/notifications' );

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -18,6 +18,7 @@ import classNames from 'classnames';
 import page from 'page';
 import wpcom from 'lib/wp';
 import { get } from 'lodash';
+import 'config';
 
 /**
  * Internal dependencies
@@ -155,9 +156,13 @@ export class Notifications extends Component {
 		const customMiddleware = {
 			APP_RENDER_NOTES: [ ( store, { newNoteCount } ) => this.props.setIndicator( newNoteCount ) ],
 			OPEN_LINK: [ ( store, { href } ) => window.open( href, '_blank' ) ],
-			OPEN_POST: [ ( store, { siteId, postId } ) => {
-				this.props.checkToggle();
-				page( `/read/blogs/${ siteId }/posts/${ postId }` );
+			OPEN_POST: [ ( store, { siteId, postId, href } ) => {
+				if ( config.isEnabled( 'notifications/link-to-reader' ) ) {
+					this.props.checkToggle();
+					page( `/read/blogs/${ siteId }/posts/${ postId }` );
+				} else {
+					window.open( href, '_blank' );
+				}
 			} ],
 			VIEW_SETTINGS: [ () => {
 				this.props.checkToggle();

--- a/config/development.json
+++ b/config/development.json
@@ -111,6 +111,7 @@
 		"paladin": true,
 		"network-connection": true,
 		"notifications2beta": true,
+		"notifications/link-to-reader": true,
 		"oauth": false,
 		"olark": true,
 		"perfmon": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -64,6 +64,7 @@
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,
+		"notifications/link-to-reader": true,
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,6 +77,7 @@
 		"me/trophies": false,
 		"network-connection": true,
 		"notifications2beta": true,
+		"notifications/link-to-reader": true,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,


### PR DESCRIPTION
Work in Automattic/notifications-panel#114 is opening up a new integration path with Calypso. Instead of directly opening links when clicked we intercept and fire off a Redux action instead. This allows for a controllable modification of the link-click behavior. In the iframe we will leave the behavior the same but in Calypso if we have a post link we can open that post directly in the Reader view.

This PR modifies that link click behavior to allow deep-linking into Calypso from the notifications panel.

**Questions**
 - Should we also deep-link into Calypso from the iframe? That would take people to Calypso from the front end of whatever site they are on. (My take? Let people stay on their site; open links in a new tab to the direct URL)
 - Should we close the notifications panel once the link has been clicked or leave it open with the post behind it. (My take? Leave it open)

**Testing**

Test on the [live branch](https://calypso.live/?branch=update/integrate-notes-client-post-links). Click on post links inside of the header of the notification detail view. If linked to a post, that post should open in the Reader view and the notifications panel should close.

<del>**Do not merge** until automattic/notifications-panel#114 is deployed.</del>