### PR TITLE
Woo-Connect Insights: Build Main Chart

### DIFF
--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { find } from 'lodash';
+import { find, noop } from 'lodash';
 
 /**
  * Module variables
@@ -44,10 +44,19 @@ const Legend = React.createClass( {
 
 	propTypes: {
 		activeTab: React.PropTypes.object.isRequired,
-		tabs: React.PropTypes.array.isRequired,
-		activeCharts: React.PropTypes.array.isRequired,
-		availableCharts: React.PropTypes.array.isRequired,
-		clickHandler: React.PropTypes.func.isRequired
+		tabs: React.PropTypes.array,
+		activeCharts: React.PropTypes.array,
+		availableCharts: React.PropTypes.array,
+		clickHandler: React.PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			tabs: [],
+			availableCharts: [],
+			activeCharts: [],
+			clickHandler: noop,
+		};
 	},
 
 	onFilterChange: function( chartItem ) {

--- a/client/extensions/woocommerce/app/stats/controller.js
+++ b/client/extensions/woocommerce/app/stats/controller.js
@@ -29,7 +29,8 @@ export default function StatsController( context ) {
 	const props = {
 		type: context.params.type,
 		unit: context.params.unit,
-		startDate: context.query.start_date,
+		path: context.pathname,
+		startDate: context.query.startDate,
 	};
 	renderWithReduxStore(
 		<AsyncLoad

--- a/client/extensions/woocommerce/app/stats/index.js
+++ b/client/extensions/woocommerce/app/stats/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -14,17 +14,31 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import StatsChart from './stats-chart';
 
 class Stats extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		unit: PropTypes.string.isRequired,
+		startDate: PropTypes.string,
+		path: PropTypes.string.isRequired,
+	};
+
 	render() {
-		const { siteId, unit } = this.props;
-		const chartQuery = {
+		const { siteId, unit, startDate, path } = this.props;
+		const today = this.props.moment().format( 'YYYY-MM-DD' );
+		const selectedDate = startDate || today;
+		const ordersQuery = {
 			unit,
-			date: this.props.moment().format( 'YYYY-MM-DD' ),
+			date: today,
 			quantity: '30'
 		};
 		return (
 			<Main className="woocommerce stats" wideLayout={ true }>
 				<StatsNavigation unit={ unit } type="orders" />
-				<StatsChart siteId={ siteId } query={ chartQuery } />
+				<StatsChart
+					path={ path }
+					query={ ordersQuery }
+					selectedDate={ selectedDate }
+					siteId={ siteId }
+				/>
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/stats/stats-chart/index.js
+++ b/client/extensions/woocommerce/app/stats/stats-chart/index.js
@@ -1,26 +1,97 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import classnames from 'classnames';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import QuerySiteStats from 'components/data/query-site-stats';
 import { getSiteStatsNormalizedData, isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
+import ElementChart from 'components/chart';
+import Legend from 'components/chart/legend';
 
-const StatsChart = ( { siteId, query } ) => {
-	return (
-		<div>
-			{ siteId && <QuerySiteStats
-				siteId={ siteId }
-				statType="statsOrders"
-				query={ query }
-			/> }
-		</div>
-	);
-};
+class StatsChart extends Component {
+	static propTypes = {
+		data: PropTypes.array.isRequired,
+		isRequesting: PropTypes.bool.isRequired,
+		path: PropTypes.string.isRequired,
+		query: PropTypes.object.isRequired,
+		selectedDate: PropTypes.string.isRequired,
+		siteId: PropTypes.number,
+	};
+
+	state = {
+		selectedTabIndex: 0
+	};
+
+	barClick = bar => {
+		page.redirect( `${ this.props.path }?startDate=${ bar.data.period }` );
+	};
+
+	buildChartData = ( item, selectedTab ) => {
+		const { selectedDate } = this.props;
+		const className = classnames( item.classNames.join( ' ' ), {
+			'is-selected': item.period === selectedDate,
+		} );
+		let value;
+		switch ( selectedTab.attr ) {
+			case 'total_sales':
+				value = item.total_sales;
+				break;
+			case 'net_sales':
+				value = Number( item.total_sales ) - Number( item.total_tax );
+				break;
+			case 'orders':
+				value = item.orders;
+				break;
+			case 'order_average':
+				value = item.orders === '0' ? 0 : Number( item.total_sales ) / Number( item.orders );
+				break;
+			default:
+				value = 0;
+		}
+		return {
+			label: item.labelDay,
+			value,
+			nestedValue: null,
+			data: item,
+			tooltipData: [],
+			className,
+		};
+	};
+
+	render() {
+		const { siteId, query, data } = this.props;
+		const { selectedTabIndex } = this.state;
+		const tabs = [
+			{ label: 'Gross Sales', attr: 'total_sales' },
+			{ label: 'Net Sales', attr: 'net_sales' },
+			{ label: 'Orders', attr: 'orders' },
+			{ label: 'Average Order Value', attr: 'order_average' },
+		];
+		const selectedTab = tabs[ selectedTabIndex ];
+		const isLoading = ! ! data.length;
+		const chartData = data.map( item => this.buildChartData( item, selectedTab ) );
+		return (
+			<Card className="stats-chart stats-module">
+				{ siteId && <QuerySiteStats
+					query={ query }
+					siteId={ siteId }
+					statType="statsOrders"
+				/> }
+				<Legend
+					activeTab={ selectedTab }
+				/>
+				<ElementChart loading={ isLoading } data={ chartData } barClick={ this.barClick } />
+			</Card>
+		);
+	}
+}
 
 export default connect(
 	( state, { query, siteId } ) => {


### PR DESCRIPTION
Create the main chart for Woo Stats Orders page

![screen shot 2017-05-22 at 1 12 04 pm](https://cloud.githubusercontent.com/assets/1922453/26289061/5473507a-3ef0-11e7-96b7-a6a1c430b614.png)

This PR is built on top of https://github.com/Automattic/wp-calypso/pull/14313. ~Until thats merged, the diff is going to be noisy.~ merged

### Test
```
ENABLE_FEATURES=woocommerce/extension-stats make run
```
```
http://calypso.localhost:3000/store/stats/orders/day/my-cool-site
```

Fixes https://github.com/Automattic/wp-calypso/issues/14311