### PR TITLE
Signup: Add A/B test for domains step's CTA during signup

### DIFF
--- a/client/components/domains/domain-mapping-suggestion/index.jsx
+++ b/client/components/domains/domain-mapping-suggestion/index.jsx
@@ -1,16 +1,18 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var DomainSuggestion = require( 'components/domains/domain-suggestion' ),
-	{ shouldBundleDomainWithPlan, getDomainPriceRule } = require( 'lib/cart-values/cart-items' );
+import DomainSuggestion from 'components/domains/domain-suggestion';
+import { shouldBundleDomainWithPlan, getDomainPriceRule } from 'lib/cart-values/cart-items';
+import { abtest } from 'lib/abtest';
 
 var DomainMappingSuggestion = React.createClass( {
 	propTypes: {
+		isSignupStep: React.PropTypes.bool,
 		cart: React.PropTypes.object,
 		products: React.PropTypes.object.isRequired,
 		onButtonClick: React.PropTypes.func.isRequired,
@@ -22,18 +24,20 @@ var DomainMappingSuggestion = React.createClass( {
 				product_slug: this.props.products.domain_map.product_slug,
 				cost: this.props.products.domain_map.cost_display
 			},
-			buttonContent = shouldBundleDomainWithPlan( this.props.domainsWithPlansOnly, this.props.selectedSite, this.props.cart, suggestion )
+			{ cart, domainsWithPlansOnly, isSignupStep, selectedSite } = this.props,
+			allowUpgradeCta = ! isSignupStep || abtest( 'selectCtaInDomainsSignup' ) === 'original',
+			buttonContent = allowUpgradeCta && shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
 				? this.translate( 'Upgrade', { context: 'Domain mapping suggestion button with plan upgrade' } )
 				: this.translate( 'Map it', { context: 'Domain mapping suggestion button' } );
 		return (
 				<DomainSuggestion
-					priceRule={ getDomainPriceRule( this.props.domainsWithPlansOnly, this.props.selectedSite, this.props.cart, suggestion ) }
+					priceRule={ getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion ) }
 					price={ this.props.products.domain_map && this.props.products.domain_map.cost_display }
 					extraClasses="is-visible domain-mapping-suggestion"
 					buttonClasses="map"
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					domainsWithPlansOnly={ domainsWithPlansOnly }
 					buttonContent={ buttonContent }
-					cart={ this.props.cart }
+					cart={ cart }
 					onButtonClick={ this.props.onButtonClick }>
 				<div className="domain-mapping-suggestion__domain-description">
 					<h3>

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -12,9 +12,11 @@ import DomainSuggestion from 'components/domains/domain-suggestion';
 import Gridicon from 'gridicons';
 import DomainSuggestionFlag from 'components/domains/domain-suggestion-flag';
 import { shouldBundleDomainWithPlan, getDomainPriceRule, hasDomainInCart } from 'lib/cart-values/cart-items';
+import { abtest } from 'lib/abtest';
 
 const DomainRegistrationSuggestion = React.createClass( {
 	propTypes: {
+		isSignupStep: React.PropTypes.bool,
 		cart: React.PropTypes.object,
 		suggestion: React.PropTypes.shape( {
 			domain_name: React.PropTypes.string.isRequired,
@@ -27,9 +29,9 @@ const DomainRegistrationSuggestion = React.createClass( {
 	},
 
 	render() {
-		const { suggestion, translate } = this.props,
+		const { cart, domainsWithPlansOnly, isSignupStep, selectedSite, suggestion, translate } = this.props,
 			domain = suggestion.domain_name,
-			isAdded = hasDomainInCart( this.props.cart, domain ),
+			isAdded = hasDomainInCart( cart, domain ),
 			domainFlags = [];
 
 		let buttonClasses, buttonContent;
@@ -87,20 +89,21 @@ const DomainRegistrationSuggestion = React.createClass( {
 			buttonContent = <Gridicon icon="checkmark" />;
 		} else {
 			buttonClasses = 'add is-primary';
-			buttonContent = shouldBundleDomainWithPlan( this.props.domainsWithPlansOnly, this.props.selectedSite, this.props.cart, suggestion )
+			const allowUpgradeCta = ! isSignupStep || abtest( 'selectCtaInDomainsSignup' ) === 'original';
+			buttonContent = allowUpgradeCta && shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
 				? translate( 'Upgrade', { context: 'Domain mapping suggestion button with plan upgrade' } )
 				: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
 
 		return (
 			<DomainSuggestion
-					priceRule={ getDomainPriceRule( this.props.domainsWithPlansOnly, this.props.selectedSite, this.props.cart, suggestion ) }
+					priceRule={ getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion ) }
 					price={ suggestion.product_slug && suggestion.cost }
 					domain={ domain }
 					buttonClasses={ buttonClasses }
 					buttonContent={ buttonContent }
-					cart={ this.props.cart }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					cart={ cart }
+					domainsWithPlansOnly={ domainsWithPlansOnly }
 					onButtonClick={ this.props.onButtonClick }>
 				<h3>
 					{ domain }

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -42,7 +42,8 @@ var DomainSearchResults = React.createClass( {
 		offerMappingOption: React.PropTypes.bool,
 		onClickResult: React.PropTypes.func.isRequired,
 		onAddMapping: React.PropTypes.func,
-		onClickMapping: React.PropTypes.func
+		onClickMapping: React.PropTypes.func,
+		isSignupStep: React.PropTypes.bool,
 	},
 
 	renderDomainAvailability: function() {
@@ -75,6 +76,7 @@ var DomainSearchResults = React.createClass( {
 					buttonContent={ this.props.buttonContent }
 					selectedSite={ this.props.selectedSite }
 					cart={ this.props.cart }
+					isSignupStep={ this.props.isSignupStep }
 					onButtonClick={ this.props.onClickResult.bind( null, availableDomain ) } />
 				);
 		} else if ( suggestions.length !== 0 && includes( [ MAPPABLE, UNKNOWN ], lastDomainStatus ) && this.props.products.domain_map ) {
@@ -139,6 +141,7 @@ var DomainSearchResults = React.createClass( {
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }
+						isSignupStep={ this.props.isSignupStep }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 						onButtonClick={ this.props.onClickResult.bind( null, suggestion ) } />
@@ -152,6 +155,7 @@ var DomainSearchResults = React.createClass( {
 						products={ this.props.products }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						isSignupStep={ this.props.isSignupStep }
 						cart={ this.props.cart } />
 				);
 			}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -443,6 +443,7 @@ const RegisterDomainStep = React.createClass( {
 			domainRegistrationSuggestions = suggestions.map( function( suggestion ) {
 				return (
 					<DomainRegistrationSuggestion
+						isSignupStep={ this.props.isSignupStep }
 						suggestion={ suggestion }
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }
@@ -454,6 +455,7 @@ const RegisterDomainStep = React.createClass( {
 
 			domainMappingSuggestion = (
 				<DomainMappingSuggestion
+					isSignupStep={ this.props.isSignupStep }
 					onButtonClick={ this.goToMapDomainStep }
 					selectedSite={ this.props.selectedSite }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
@@ -510,6 +512,7 @@ const RegisterDomainStep = React.createClass( {
 				selectedSite={ this.props.selectedSite }
 				offerMappingOption={ this.props.offerMappingOption }
 				placeholderQuantity={ SUGGESTION_QUANTITY }
+				isSignupStep={ this.props.isSignupStep }
 				cart={ this.props.cart } />
 		);
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,5 +91,13 @@ module.exports = {
 			modified: 50,
 		},
 		defaultVariation: 'original',
-	}
+	},
+	selectCtaInDomainsSignup: {
+		datestamp: '20170529',
+		variations: {
+			original: 50,
+			select: 50,
+		},
+		defaultVariation: 'original',
+	},
 };


### PR DESCRIPTION
This PR adds a simple A/B test, inspired by how the Plans step was improved in https://github.com/Automattic/wp-calypso/pull/12963 with a simple CTA change.

For the domains step, we're changing the `Upgrade` CTA to `Select`. Test's name is `selectCtaInDomainsSignup`.
This change should only apply to new users in the signup - all other flows should stay the same.

### Testing
Verify that the `original` variation looks like this:
<img width="987" alt="screen shot 2017-05-24 at 04 09 13" src="https://cloud.githubusercontent.com/assets/3392497/26384764/b02c31f6-403b-11e7-8959-740e67f21537.png">

Verify that the `select` variation looks like this:
<img width="980" alt="screen shot 2017-05-24 at 04 09 49" src="https://cloud.githubusercontent.com/assets/3392497/26384772/bedeb64c-403b-11e7-9bfd-85d340d88a49.png">

(the misaligned text is a known issue: https://github.com/Automattic/wp-calypso/issues/11521)

Verify that other flows stayed the same - and still obey the DWPO rules, etc.