### PR TITLE
Activity Log: Add new tab & page in stats navigation

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import StatsFirstView from '../stats-first-view';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import StatsNavigation from '../stats-navigation';
+
+class ActivityLog extends Component {
+	componentDidMount() {
+		window.scrollTo( 0, 0 );
+	}
+
+	render() {
+		const { slug, isJetpack } = this.props;
+
+		return (
+			<Main wideLayout={ true }>
+				<StatsFirstView />
+				<SidebarNavigation />
+				<StatsNavigation
+					isJetpack={ isJetpack }
+					slug={ slug }
+					section="activity"
+				/>
+                Hi
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		return {
+			isJetpack,
+			slug: getSiteSlug( state, siteId )
+		};
+	}
+)( localize( ActivityLog ) );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -18,6 +18,7 @@ import { savePreference } from 'state/preferences/actions';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 const analyticsPageTitle = 'Stats';
@@ -381,14 +382,12 @@ module.exports = {
 	},
 
 	activity_log: function( context ) {
-		let siteId = context.params.site_id;
-		const site = getSite( context.store.getState(), siteId );
-		siteId = site ? ( site.ID || 0 ) : 0;
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
 
-		const isJetpack = isJetpackSite( context.store.getState(), siteId );
-
-		if ( 0 === siteId || ! isJetpack ) {
-			window.location = '/stats';
+		if ( siteId && ! isJetpack ) {
+			page.redirect( '/stats' );
 		} else {
 			analytics.pageView.record( '/stats/activity/:site', analyticsPageTitle + ' > Activity ' );
 

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -15,7 +15,7 @@ import titlecase from 'to-title-case';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { savePreference } from 'state/preferences/actions';
-import { getSite } from 'state/sites/selectors';
+import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import AsyncLoad from 'components/async-load';
@@ -374,6 +374,31 @@ module.exports = {
 			};
 			renderWithReduxStore(
 				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/comment-follows" { ...props } />,
+				document.getElementById( 'primary' ),
+				context.store
+			);
+		}
+	},
+
+	activity_log: function( context ) {
+		let siteId = context.params.site_id;
+		const site = getSite( context.store.getState(), siteId );
+		siteId = site ? ( site.ID || 0 ) : 0;
+
+		const isJetpack = isJetpackSite( context.store.getState(), siteId );
+
+		if ( 0 === siteId || ! isJetpack ) {
+			window.location = '/stats';
+		} else {
+			analytics.pageView.record( '/stats/activity/:site', analyticsPageTitle + ' > Activity ' );
+
+			const props = {
+				path: context.path,
+				siteId,
+				context,
+			};
+			renderWithReduxStore(
+				<AsyncLoad placeholder={ <StatsPagePlaceholder /> } require="my-sites/stats/activity-log" { ...props } />,
 				document.getElementById( 'primary' ),
 				context.store
 			);

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -381,7 +381,7 @@ module.exports = {
 		}
 	},
 
-	activity_log: function( context ) {
+	activityLog: function( context ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -11,6 +11,9 @@ var controller = require( 'my-sites/controller' ),
 	config = require( 'config' );
 
 module.exports = function() {
+	if ( config.isEnabled( 'jetpack/activity-log' ) ) {
+		page( '/stats/activity/:site_id', controller.siteSelection, controller.navigation, statsController.activity_log );
+	}
 	if ( config.isEnabled( 'manage/stats' ) ) {
 		// Stat Overview Page
 		page( '/stats', controller.siteSelection, controller.navigation, statsController.overview );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -12,7 +12,7 @@ var controller = require( 'my-sites/controller' ),
 
 module.exports = function() {
 	if ( config.isEnabled( 'jetpack/activity-log' ) ) {
-		page( '/stats/activity/:site_id', controller.siteSelection, controller.navigation, statsController.activity_log );
+		page( '/stats/activity/:site_id', controller.siteSelection, controller.navigation, statsController.activityLog );
 	}
 	if ( config.isEnabled( 'manage/stats' ) ) {
 		// Stat Overview Page

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -23,8 +23,10 @@ const StatsNavigation = ( props ) => {
 		day: translate( 'Days' ),
 		week: translate( 'Weeks' ),
 		month: translate( 'Months' ),
-		year: translate( 'Years' )
+		year: translate( 'Years' ),
+		activity: translate( 'Activity' ),
 	};
+
 	let statsControl;
 
 	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
@@ -49,6 +51,12 @@ const StatsNavigation = ( props ) => {
 		}
 	}
 
+	const ActivityTab = config.isEnabled( 'jetpack/activity-log' ) && isJetpack
+		? <NavItem path={ '/stats/activity' + siteFragment } selected={ section === 'activity' }>
+				{ sectionTitles.activity }
+			</NavItem>
+		: null;
+
 	return (
 		<SectionNav selectedText={ sectionTitles[ section ] }>
 			{ isJetpack && <QueryJetpackPlugins siteIds={ [ siteId ] } /> }
@@ -68,6 +76,7 @@ const StatsNavigation = ( props ) => {
 				<NavItem path={ '/stats/year' + siteFragment } selected={ section === 'year' }>
 					{ sectionTitles.year }
 				</NavItem>
+				{ ActivityTab }
 			</NavTabs>
 			{ statsControl }
 			<FollowersCount />

--- a/config/development.json
+++ b/config/development.json
@@ -55,6 +55,7 @@
 		"jetpack/invites": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/api-cache": true,
+		"jetpack/activity-log": true,
 		"keyboard-shortcuts": true,
 		"happychat": true,
 		"magic-login": true,


### PR DESCRIPTION
This registers a new page for the Jetpack activity log. It lives in `/stats/activity/:site_id`. 

The tab and page are only registered for Jetpack sites, and are feature flagged in development.  This is the first of many PRs to come, which is why there is no UI in this one.  

I'm seeking to merge the project (see #10862 for ongoing work) in smallish chunks as an attempt to make reviewing easier.  

See p6TEKc-DQ-p2 for project info and background.  