### PR TITLE
Correct position prop "left bottom" -> "bottom left"

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -101,7 +101,7 @@ class PlanFeaturesHeader extends Component {
 					{ isDiscounted && ! isPlaceholder &&
 						<InfoPopover
 							className="plan-features__header-tip-info"
-							position={ isMobile() ? 'top' : 'left bottom' }>
+							position={ isMobile() ? 'top' : 'bottom left' }>
 							{ translate( 'Discount for first year' ) }
 						</InfoPopover>
 					}


### PR DESCRIPTION
The canonical positions are vertical-first. Horizontal-first positions have unknown behaviour and are unsupported.

To test:
I was actually unable to find this occurrence reported in [here](https://github.com/Automattic/wp-calypso/pull/13600#discussion_r118021873), but hopefully @tyxla can confirm it is corrected 🙂 