### PR TITLE
Notifications: Fix calypso notifications in laptops with touch screens

### DIFF
--- a/assets/stylesheets/sections/_notifications.scss
+++ b/assets/stylesheets/sections/_notifications.scss
@@ -57,6 +57,5 @@
 }
 
 html.touch #wpnc-panel {
-	overflow-y: scroll;
 	-webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
The notification panel is currently broken for laptops with touch screen capacity. The panel layout is misaligned and nothing happens when you click in a notification (Well, technically, it happens, but the detail panel for the notification is hidden all the time):
![may 24 2017 10-43 am](https://cloud.githubusercontent.com/assets/1554855/26394773/4d253f02-406e-11e7-98e0-113a7874b887.gif)

This PR removes the css style that is causing it. I'm not sure what was the point of that style originally, though (to me it works as expected without it)
![may 24 2017 10-44 am 1](https://cloud.githubusercontent.com/assets/1554855/26395177/939f104c-406f-11e7-869b-2c8ff9cf1b3d.gif)


How to test:
----

Well, you need a touch screen enabled laptop for testing this. I'm not sure how well it could be replicated with chrome developer tools, though. Once you have an environment where the `.touch` class is added to the notification bar, just test the before and after of this patch :) 