### PR TITLE
Reader: remove fetching of subscriptions on load

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -5,7 +5,6 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
-import config from 'config';
 
 /**
  * Internal Dependencies
@@ -22,7 +21,6 @@ import {
 	setPageTitle,
 } from './controller-helper';
 import FeedError from 'reader/feed-error';
-import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
 import StreamComponent from 'reader/following/main';
 import { getPrettyFeedUrl, getPrettySiteUrl } from 'reader/route';
 import { recordTrack } from 'reader/stats';
@@ -124,13 +122,6 @@ const exported = {
 
 	preloadReaderBundle( context, next ) {
 		preload( 'reader' );
-		next();
-	},
-
-	loadSubscriptions( context, next ) {
-		if ( ! config.isEnabled( 'reader/following-manage-refresh' ) ) {
-			FeedSubscriptionActions.fetchAll();
-		}
 		next();
 	},
 
@@ -315,7 +306,6 @@ export const {
 	updateLastRoute,
 	incompleteUrlRedirects,
 	preloadReaderBundle,
-	loadSubscriptions,
 	sidebar,
 	unmountSidebar,
 	following,

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -7,22 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { discover } from './controller';
-import {
-	initAbTests,
-	loadSubscriptions,
-	preloadReaderBundle,
-	sidebar,
-	updateLastRoute,
-} from 'reader/controller';
+import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 
 export default function() {
-	page(
-		'/discover',
-		preloadReaderBundle,
-		updateLastRoute,
-		loadSubscriptions,
-		initAbTests,
-		sidebar,
-		discover
-	);
+	page( '/discover', preloadReaderBundle, updateLastRoute, initAbTests, sidebar, discover );
 }

--- a/client/reader/following/index.js
+++ b/client/reader/following/index.js
@@ -7,11 +7,11 @@ import page from 'page';
  * Internal dependencies
  */
 import { followingEdit, followingManage } from './controller';
-import { loadSubscriptions, initAbTests, updateLastRoute, sidebar } from 'reader/controller';
+import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
 import config from 'config';
 
 export default function() {
-	page( '/following/*', loadSubscriptions, initAbTests );
+	page( '/following/*', initAbTests );
 	if ( config.isEnabled( 'reader/following-manage-refresh' ) ) {
 		page( '/following/manage', updateLastRoute, sidebar, followingManage );
 		page.redirect( '/following/edit*', '/following/manage' );

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -14,7 +14,6 @@ import {
 	incompleteUrlRedirects,
 	initAbTests,
 	legacyRedirects,
-	loadSubscriptions,
 	preloadReaderBundle,
 	prettyRedirects,
 	readA8C,
@@ -30,15 +29,7 @@ function forceTeamA8C( context, next ) {
 
 export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
-		page(
-			'/',
-			preloadReaderBundle,
-			loadSubscriptions,
-			initAbTests,
-			updateLastRoute,
-			sidebar,
-			following
-		);
+		page( '/', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/' );
@@ -50,7 +41,7 @@ export default function() {
 		page( '/read/feed', '/' );
 
 		// Feed stream
-		page( '/read/*', preloadReaderBundle, loadSubscriptions, initAbTests );
+		page( '/read/*', preloadReaderBundle, initAbTests );
 		page( '/read/blog/feed/:feed_id', legacyRedirects );
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page(

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -7,22 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { likes } from './controller';
-import {
-	preloadReaderBundle,
-	loadSubscriptions,
-	initAbTests,
-	updateLastRoute,
-	sidebar,
-} from 'reader/controller';
+import { preloadReaderBundle, initAbTests, updateLastRoute, sidebar } from 'reader/controller';
 
 export default function() {
-	page(
-		'/activities/likes',
-		preloadReaderBundle,
-		loadSubscriptions,
-		initAbTests,
-		updateLastRoute,
-		sidebar,
-		likes
-	);
+	page( '/activities/likes', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, likes );
 }

--- a/client/reader/recommendations/index.js
+++ b/client/reader/recommendations/index.js
@@ -8,13 +8,7 @@ import { forEach } from 'lodash';
  * Internal dependencies
  */
 import { recommendedForYou, recommendedPosts } from './controller';
-import {
-	initAbTests,
-	loadSubscriptions,
-	preloadReaderBundle,
-	sidebar,
-	updateLastRoute,
-} from 'reader/controller';
+import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 import config from 'config';
 
 export default function() {
@@ -25,7 +19,6 @@ export default function() {
 	page(
 		'/recommendations',
 		preloadReaderBundle,
-		loadSubscriptions,
 		initAbTests,
 		updateLastRoute,
 		sidebar,
@@ -44,14 +37,10 @@ export default function() {
 				'/recommendations/coldtopics',
 			],
 			path => {
-				page.apply( page, [
-					path,
-					preloadReaderBundle,
-					loadSubscriptions,
-					updateLastRoute,
-					sidebar,
-					recommendedPosts,
-				] );
+				page.apply(
+					page,
+					[ path, preloadReaderBundle, updateLastRoute, sidebar, recommendedPosts ]
+				);
 			}
 		);
 	}

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -7,17 +7,11 @@ import page from 'page';
  * Internal dependencies
  */
 import { recommendedTags, tagListing } from './controller';
-import {
-	initAbTests,
-	loadSubscriptions,
-	preloadReaderBundle,
-	sidebar,
-	updateLastRoute,
-} from 'reader/controller';
+import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 
 export default function() {
-	page( '/tag/*', preloadReaderBundle, loadSubscriptions, initAbTests );
+	page( '/tag/*', preloadReaderBundle, initAbTests );
 	page( '/tag/:tag', updateLastRoute, sidebar, tagListing );
 
-	page( '/tags', loadSubscriptions, initAbTests, updateLastRoute, sidebar, recommendedTags );
+	page( '/tags', initAbTests, updateLastRoute, sidebar, recommendedTags );
 }


### PR DESCRIPTION
Since Calypso launch, we've fetched the user's full subscription list into Flux when the Reader starts. The recent move to Redux for the Following Manage Refresh has made this unnecessary 🎉 

The fetch itself is already turned off via the feature flag `reader/manage-following-refresh` (active in all environments). This PR removes the associated `loadSubscriptions` call throughout Reader.