### PR TITLE
JPC: Monthly plans (tracking PR)

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -54,6 +54,7 @@ const jetpackNewSiteSelector = ( context ) => {
 };
 
 const jetpackConnectFirstStep = ( context, type ) => {
+	debug( 'jetpackConnectFirstStep context', context );
 	removeSidebar( context );
 
 	userModule.fetch();

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -443,6 +443,7 @@ export default {
 	},
 	selectPlanInAdvance( planSlug, site ) {
 		return ( dispatch ) => {
+			debug( 'selectPlanInAdvance', planSlug );
 			dispatch( {
 				type: JETPACK_CONNECT_SELECT_PLAN_IN_ADVANCE,
 				plan: planSlug,


### PR DESCRIPTION
This is a main PR for tracking #12497 progress

To do:
- [ ] #14416 Unify entry points (`controller.pro` et al are very redundant) ~#14415~ 
- [ ] #14451 Ensure monthly plan types are propagated correctly
- [ ] Ensure monthly `flowType`s are correctly handled by store/checkout.