### PR TITLE
Reader: add additional generic WordPress site descriptions to blacklist

### DIFF
--- a/client/reader/lib/site-description-blacklist/index.js
+++ b/client/reader/lib/site-description-blacklist/index.js
@@ -1,7 +1,13 @@
-const siteDescriptionBlacklist = new Set( [
-	'Just another WordPress.com site',
-	'Just another WordPress site',
-] );
+const siteDescriptionBlacklist = new Set(
+	[
+		'Just another WordPress.com site',
+		'Just another WordPress site',
+		"This WordPress.com site is the bee's knees",
+		"This WordPress site is the bee's knees",
+		'A topnotch WordPress.com site',
+		'A topnotch WordPress site',
+	]
+);
 
 /**
  * Is the provided site description name blacklisted?


### PR DESCRIPTION
We currently don't show "Just another WordPress(.com) site" as a site description in Reader. This PR adds two more default site descriptions to ignore:

"This WordPress(.com) site is the bee's knees"
"A topnotch WordPress(.com) site"

