### PR TITLE
Reader: remove reader/combined-cards feature flag

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -37,7 +37,6 @@ import PostLifecycle from './post-lifecycle';
 import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 import { showSelectedPost } from 'reader/utils';
 import getBlockedSites from 'state/selectors/get-blocked-sites';
-import config from 'config';
 import { keysAreEqual } from 'lib/feed-stream-store/post-key';
 import { resetCardExpansions } from 'state/ui/reader/card-expansions/actions';
 import { combineCards, injectRecommendations, RECS_PER_BLOCK } from './utils';
@@ -101,7 +100,7 @@ class ReaderStream extends React.Component {
 		showPrimaryFollowButtonOnCards: true,
 		showMobileBackToSidebar: true,
 		isDiscoverStream: false,
-		shouldCombineCards: config.isEnabled( 'reader/combined-cards' ),
+		shouldCombineCards: true,
 		transformStreamItems: identity,
 	};
 

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -65,7 +65,6 @@
 		"press-this": false,
 		"preview-layout": true,
 		"reader": true,
-		"reader/combined-cards": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/search": true,

--- a/config/development.json
+++ b/config/development.json
@@ -120,7 +120,6 @@
 		"publicize-scheduling": false,
 		"push-notifications": true,
 		"reader": true,
-		"reader/combined-cards": true,
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -73,7 +73,6 @@
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,
-		"reader/combined-cards": true,
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/related-posts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -73,7 +73,6 @@
 		"preview-layout": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/combined-cards": true,
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -76,7 +76,6 @@
 		"preview-layout": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/combined-cards": true,
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,6 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
-		"reader/combined-cards": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -85,7 +85,6 @@
 		"press-this": true,
 		"preview-layout": true,
 		"reader": true,
-		"reader/combined-cards": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/following-manage-refresh": true,


### PR DESCRIPTION
Remove `reader/combined-cards` feature flag. The feature was launched some time ago, and we intend to keep it enabled in all environments.

### To test

Ensure that combined cards still appear in your stream.

<img width="835" alt="screen shot 2017-05-24 at 14 37 12" src="https://cloud.githubusercontent.com/assets/17325/26403429/88eba9c0-408e-11e7-9d87-491caf88f5f3.png">
