### PR TITLE
Unify Jetpack Connect route handling

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -63,25 +63,6 @@ const jetpackNewSiteSelector = ( context ) => {
 	);
 };
 
-const jetpackConnectFirstStep = ( context, type ) => {
-	removeSidebar( context );
-
-	userModule.fetch();
-
-	renderWithReduxStore(
-		React.createElement( JetpackConnect, {
-			path: context.path,
-			context: context,
-			type: type,
-			userModule: userModule,
-			locale: context.params.locale,
-			url: context.query.url
-		} ),
-		document.getElementById( 'primary' ),
-		context.store
-	);
-};
-
 export default {
 	redirectWithoutLocaleifLoggedIn( context, next ) {
 		if ( userModule.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
@@ -111,13 +92,31 @@ export default {
 	},
 
 	connect( context, options = {} ) {
-		const { pathname } = context;
+		const {
+			path,
+			pathname,
+		} = context;
 		const { type = false } = options;
 		const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
 
 		analytics.pageView.record( pathname, analyticsPageTitle );
 
-		jetpackConnectFirstStep( context, type );
+		removeSidebar( context );
+
+		userModule.fetch();
+
+		renderWithReduxStore(
+			React.createElement( JetpackConnect, {
+				context,
+				locale: context.params.locale,
+				path,
+				type,
+				url: context.query.url,
+				userModule,
+			} ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
 	},
 
 	authorizeForm( context ) {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -3,10 +3,13 @@
  */
 import ReactDom from 'react-dom';
 import React from 'react';
-import isEmpty from 'lodash/isEmpty';
 import page from 'page';
 import Debug from 'debug';
 import { translate } from 'i18n-calypso';
+import {
+	get,
+	isEmpty,
+} from 'lodash';
 
 /**
  * Internal Dependencies
@@ -32,6 +35,12 @@ import PlansLanding from './plans-landing';
  */
 const debug = new Debug( 'calypso:jetpack-connect:controller' );
 const userModule = userFactory();
+const analyticsPageTitleByType = {
+	install: 'Jetpack Install',
+	personal: 'Jetpack Connect Personal',
+	premium: 'Jetpack Connect Premium',
+	pro: 'Jetpack Install Pro',
+};
 
 const removeSidebar = ( context ) => {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
@@ -96,54 +105,19 @@ export default {
 		next();
 	},
 
-	personal( context ) {
-		const analyticsBasePath = '/jetpack/connect/personal',
-			analyticsPageTitle = 'Jetpack Connect Personal';
-
-		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-
-		jetpackConnectFirstStep( context, 'personal' );
-	},
-
-	premium( context ) {
-		const analyticsBasePath = '/jetpack/connect/premium',
-			analyticsPageTitle = 'Jetpack Connect Premium';
-
-		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-
-		jetpackConnectFirstStep( context, 'premium' );
-	},
-
 	newSite( context ) {
 		analytics.pageView.record( '/jetpack/new', 'Add a new site (Jetpack)' );
 		jetpackNewSiteSelector( context );
 	},
 
-	pro( context ) {
-		const analyticsBasePath = '/jetpack/connect/pro',
-			analyticsPageTitle = 'Jetpack Install Pro';
+	connect( context, options = {} ) {
+		const { pathname } = context;
+		const { type = false } = options;
+		const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
 
-		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
+		analytics.pageView.record( pathname, analyticsPageTitle );
 
-		jetpackConnectFirstStep( context, 'pro' );
-	},
-
-	install( context ) {
-		const analyticsBasePath = '/jetpack/connect/install',
-			analyticsPageTitle = 'Jetpack Install';
-
-		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-
-		jetpackConnectFirstStep( context, 'install' );
-	},
-
-	connect( context ) {
-		const analyticsBasePath = '/jetpack/connect',
-			analyticsPageTitle = 'Jetpack Connect';
-
-		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
-
-		jetpackConnectFirstStep( context, false );
+		jetpackConnectFirstStep( context, type );
 	},
 
 	authorizeForm( context ) {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -67,6 +67,7 @@ export default {
 	redirectWithoutLocaleifLoggedIn( context, next ) {
 		if ( userModule.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
 			const urlWithoutLocale = i18nUtils.removeLocaleFromPath( context.path );
+			debug( 'redirectWithoutLocaleifLoggedIn to %s', urlWithoutLocale );
 			return page.redirect( urlWithoutLocale );
 		}
 
@@ -91,13 +92,16 @@ export default {
 		jetpackNewSiteSelector( context );
 	},
 
-	connect( context, options = {} ) {
+	connect( context ) {
 		const {
 			path,
 			pathname,
+			params
 		} = context;
-		const { type = false } = options;
+		const { type = false } = params;
 		const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
+
+		debug( 'entered connect flow with params %o', params );
 
 		analytics.pageView.record( pathname, analyticsPageTitle );
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -129,11 +129,11 @@ export default {
 
 		removeSidebar( context );
 
-		let intervalType = context.params.intervalType;
+		let interval = context.params.interval;
 		let locale = context.params.locale;
 		if ( context.params.localeOrInterval ) {
 			if ( [ 'monthly', 'yearly' ].indexOf( context.params.localeOrInterval ) >= 0 ) {
-				intervalType = context.params.localeOrInterval;
+				interval = context.params.localeOrInterval;
 			} else {
 				locale = context.params.localeOrInterval;
 			}
@@ -143,7 +143,7 @@ export default {
 		renderWithReduxStore(
 			<JetpackConnectAuthorizeForm
 				path={ context.path }
-				intervalType={ intervalType }
+				interval={ interval }
 				locale={ locale }
 			/>,
 			document.getElementById( 'primary' ),
@@ -190,7 +190,7 @@ export default {
 			<PlansLanding
 				context={ context }
 				destinationType={ context.params.destinationType }
-				intervalType={ context.params.intervalType }
+				interval={ context.params.interval }
 				basePlansPath={ '/jetpack/connect/store' }
 			/>,
 			document.getElementById( 'primary' ),
@@ -226,7 +226,7 @@ export default {
 					context={ context }
 					destinationType={ context.params.destinationType }
 					basePlansPath={ '/jetpack/connect/plans' }
-					intervalType={ context.params.intervalType } />
+					interval={ context.params.interval } />
 			</CheckoutData>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -10,10 +10,10 @@ import controller from './controller';
 import sitesController from 'my-sites/controller';
 
 const redirectToStoreWithInterval = context => {
-	const intervalType = context && context.params && context.params.intervalType
-		? context.params.intervalType
+	const interval = context && context.params && context.params.interval
+		? context.params.interval
 		: '';
-	page.redirect( `/jetpack/connect/store/${ intervalType }` );
+	page.redirect( `/jetpack/connect/store/${ interval }` );
 };
 
 export default function() {
@@ -36,20 +36,20 @@ export default function() {
 	);
 
 	page(
-		'/jetpack/connect/authorize/:intervalType/:locale',
+		'/jetpack/connect/authorize/:interval/:locale',
 		controller.redirectWithoutLocaleifLoggedIn,
 		controller.saveQueryObject,
 		controller.authorizeForm
 	);
 
 	page( '/jetpack/connect/store', controller.plansLanding );
-	page( '/jetpack/connect/store/:intervalType', controller.plansLanding );
+	page( '/jetpack/connect/store/:interval', controller.plansLanding );
 
 	page( '/jetpack/connect/vaultpress', '/jetpack/connect/store' );
-	page( '/jetpack/connect/vaultpress/:intervalType', redirectToStoreWithInterval );
+	page( '/jetpack/connect/vaultpress/:interval', redirectToStoreWithInterval );
 
 	page( '/jetpack/connect/akismet', '/jetpack/connect/store' );
-	page( '/jetpack/connect/akismet/:intervalType', redirectToStoreWithInterval );
+	page( '/jetpack/connect/akismet/:interval', redirectToStoreWithInterval );
 
 	page(
 		'/jetpack/connect/:locale?',
@@ -64,7 +64,7 @@ export default function() {
 	);
 
 	page(
-		'/jetpack/connect/plans/:intervalType/:site',
+		'/jetpack/connect/plans/:interval/:site',
 		sitesController.siteSelection,
 		controller.plansSelection
 	);

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -16,26 +16,15 @@ const redirectToStoreWithInterval = context => {
 	page.redirect( `/jetpack/connect/store/${ intervalType }` );
 };
 
-// Wrap controller.connect so we can pre-load known route options
-const getJetpackConnectHandler = ( options ) =>
-	( context ) => controller.connect( context, options );
-
 export default function() {
-	page( '/jetpack/connect/install', getJetpackConnectHandler( { type: 'install' } ) );
+	page( '/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?', controller.connect );
 
-	page( '/jetpack/connect/personal', getJetpackConnectHandler( { type: 'personal' } ) );
-	page( '/jetpack/connect/personal/yearly', getJetpackConnectHandler( { type: 'personal' } ) );
-	page( '/jetpack/connect/personal/monthly', getJetpackConnectHandler( { type: 'personal', interval: 'monthly' } ) );
+	page( '/jetpack/connect/:type(install)/:locale?',
+		controller.redirectWithoutLocaleifLoggedIn,
+		controller.connect
+	);
 
-	page( '/jetpack/connect/premium', getJetpackConnectHandler( { type: 'premium' } ) );
-	page( '/jetpack/connect/premium/yearly', getJetpackConnectHandler( { type: 'premium' } ) );
-	page( '/jetpack/connect/premium/monthly', getJetpackConnectHandler( { type: 'premium', interval: 'monthly' } ) );
-
-	page( '/jetpack/connect/pro', getJetpackConnectHandler( { type: 'pro' } ) );
-	page( '/jetpack/connect/pro/yearly', getJetpackConnectHandler( { type: 'pro' } ) );
-	page( '/jetpack/connect/pro/monthly', getJetpackConnectHandler( { type: 'pro', interval: 'monthly' } ) );
-
-	page( '/jetpack/connect', getJetpackConnectHandler() );
+	page( '/jetpack/connect', controller.connect );
 
 	page( '/jetpack/connect/choose/:site', controller.plansPreSelection );
 
@@ -51,12 +40,6 @@ export default function() {
 		controller.redirectWithoutLocaleifLoggedIn,
 		controller.saveQueryObject,
 		controller.authorizeForm
-	);
-
-	page(
-		'/jetpack/connect/install/:locale?',
-		controller.redirectWithoutLocaleifLoggedIn,
-		getJetpackConnectHandler( { type: 'install' } )
 	);
 
 	page( '/jetpack/connect/store', controller.plansLanding );

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -16,19 +16,26 @@ const redirectToStoreWithInterval = context => {
 	page.redirect( `/jetpack/connect/store/${ intervalType }` );
 };
 
+// Wrap controller.connect so we can pre-load known route options
+const getJetpackConnectHandler = ( options ) =>
+	( context ) => controller.connect( context, options );
+
 export default function() {
-	page( '/jetpack/connect/install', controller.install );
+	page( '/jetpack/connect/install', getJetpackConnectHandler( { type: 'install' } ) );
 
-	page( '/jetpack/connect/personal', controller.personal );
-	page( '/jetpack/connect/personal/:intervalType', controller.personal );
+	page( '/jetpack/connect/personal', getJetpackConnectHandler( { type: 'personal' } ) );
+	page( '/jetpack/connect/personal/yearly', getJetpackConnectHandler( { type: 'personal' } ) );
+	page( '/jetpack/connect/personal/monthly', getJetpackConnectHandler( { type: 'personal', interval: 'monthly' } ) );
 
-	page( '/jetpack/connect/premium', controller.premium );
-	page( '/jetpack/connect/premium/:intervalType', controller.premium );
+	page( '/jetpack/connect/premium', getJetpackConnectHandler( { type: 'premium' } ) );
+	page( '/jetpack/connect/premium/yearly', getJetpackConnectHandler( { type: 'premium' } ) );
+	page( '/jetpack/connect/premium/monthly', getJetpackConnectHandler( { type: 'premium', interval: 'monthly' } ) );
 
-	page( '/jetpack/connect/pro', controller.pro );
-	page( '/jetpack/connect/pro/:intervalType', controller.pro );
+	page( '/jetpack/connect/pro', getJetpackConnectHandler( { type: 'pro' } ) );
+	page( '/jetpack/connect/pro/yearly', getJetpackConnectHandler( { type: 'pro' } ) );
+	page( '/jetpack/connect/pro/monthly', getJetpackConnectHandler( { type: 'pro', interval: 'monthly' } ) );
 
-	page( '/jetpack/connect', controller.connect );
+	page( '/jetpack/connect', getJetpackConnectHandler() );
 
 	page( '/jetpack/connect/choose/:site', controller.plansPreSelection );
 
@@ -49,7 +56,7 @@ export default function() {
 	page(
 		'/jetpack/connect/install/:locale?',
 		controller.redirectWithoutLocaleifLoggedIn,
-		controller.install
+		getJetpackConnectHandler( { type: 'install' } )
 	);
 
 	page( '/jetpack/connect/store', controller.plansLanding );

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -20,7 +20,7 @@ class JetpackPlansGrid extends Component {
 	static propTypes = {
 		basePlansPath: PropTypes.string,
 		hideFreePlan: PropTypes.bool,
-		intervalType: PropTypes.string,
+		interval: PropTypes.string,
 		isLanding: PropTypes.bool,
 		onSelect: PropTypes.func,
 		selectedSite: PropTypes.object,
@@ -65,7 +65,7 @@ class JetpackPlansGrid extends Component {
 							isLandingPage={ ! this.props.selectedSite }
 							basePlansPath={ this.props.basePlansPath }
 							onUpgradeClick={ this.props.onSelect }
-							intervalType={ this.props.intervalType }
+							interval={ this.props.interval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true } />
 					</div>

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -18,7 +18,7 @@ const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 class PlansLanding extends Component {
 	static propTypes = {
 		basePlansPath: PropTypes.string,
-		intervalType: PropTypes.string,
+		interval: PropTypes.string,
 	};
 
 	componentDidMount() {
@@ -41,7 +41,7 @@ class PlansLanding extends Component {
 	render() {
 		const {
 			basePlansPath,
-			intervalType,
+			interval,
 		} = this.props;
 		return (
 			<div>
@@ -51,7 +51,7 @@ class PlansLanding extends Component {
 					basePlansPath={ basePlansPath }
 					calypsoStartedConnection={ true }
 					hideFreePlan={ false }
-					intervalType={ intervalType }
+					interval={ interval }
 					isLanding={ true }
 					onSelect={ this.storeSelectedPlan }
 				/>


### PR DESCRIPTION
The goal of this PR is to unify the handlers so that plan type and interval logic can happen in one place.

I'm happy to discuss whether this is a move in the right direction, I've had a few false starts trying to simplify and clarify this part of the flow.

Combine several similar route handlers into one handler.
Explicitly match valid intervals `monthly` or `yearly`.

**To test:**
* It's a good idea to set the following for relevant debug:
   ```js
   localStorage.setItem('debug', [
     'calypso:jetpack-connect:actions',
     'calypso:jetpack-connect:controller',
     'calypso:analytics:tracks',
   ] )
   ```
* the analytics reporting should be the same as before.
* Test the following urls. You can append `?url=$site` to test a url directly, be sure to this functionality:
  * http://calypso.localhost:3000/jetpack/connect/install
  * http://calypso.localhost:3000/jetpack/connect/personal
  * http://calypso.localhost:3000/jetpack/connect/personal/yearly
  * http://calypso.localhost:3000/jetpack/connect/personal/monthly
  * http://calypso.localhost:3000/jetpack/connect/premium
  * http://calypso.localhost:3000/jetpack/connect/premium/yearly
  * http://calypso.localhost:3000/jetpack/connect/premium/monthly
  * http://calypso.localhost:3000/jetpack/connect/pro
  * http://calypso.localhost:3000/jetpack/connect/pro/yearly
  * http://calypso.localhost:3000/jetpack/connect/pro/monthly
  * Specifically when logged out (locale = 'es', for example):
    * http://calypso.localhost:3000/jetpack/connect/$locale
    * http://calypso.localhost:3000/jetpack/connect/install/$locale

The `/pro`, `/premium`, and `/personal` routes should complete the flow up at a checkout screen for the selected plan, _not_ the plans screen.


Included in #14451