### PR TITLE
Media library: add a display mode for library thumbnails

### DIFF
--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -195,3 +195,6 @@ export const MimeTypes = {
 	numbers: 'application/vnd.apple.numbers',
 	pages: 'application/vnd.apple.pages',
 };
+
+export const MEDIA_IMAGE_PHOTON = 'MEDIA_IMAGE_PHOTON';
+export const MEDIA_IMAGE_RESIZER = 'MEDIA_IMAGE_RESIZER';

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -20,7 +20,11 @@ import NoticeAction from 'components/notice/notice-action';
 import MediaListData from 'components/data/media-list-data';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaActions from 'lib/media/actions';
-import { ValidationErrors as MediaValidationErrors } from 'lib/media/constants';
+import {
+	ValidationErrors as MediaValidationErrors,
+	MEDIA_IMAGE_PHOTON,
+	MEDIA_IMAGE_RESIZER,
+} from 'lib/media/constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import MediaLibraryHeader from './header';
 import MediaLibraryList from './list';
@@ -160,6 +164,14 @@ const MediaLibraryContent = React.createClass( {
 		analytics.tracks.recordEvent( tracksEvent, tracksData );
 	},
 
+	getThumbnailType() {
+		if ( this.props.site.is_private ) {
+			return MEDIA_IMAGE_RESIZER;
+		}
+
+		return MEDIA_IMAGE_PHOTON;
+	},
+
 	renderMediaList: function() {
 		if ( ! this.props.site ) {
 			return <MediaLibraryList key="list-loading" />;
@@ -175,7 +187,7 @@ const MediaLibraryContent = React.createClass( {
 						filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
 						search={ this.props.search }
 						containerWidth={ this.props.containerWidth }
-						photon={ ! this.props.site.is_private }
+						thumbnailType={ this.getThumbnailType() }
 						single={ this.props.single }
 						scrollable={ this.props.scrollable }
 						onEditItem={ this.props.onEditItem } />

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -9,6 +9,8 @@ var React = require( 'react' );
 var MediaUtils = require( 'lib/media/utils' ),
 	MediaLibraryListItemFileDetails = require( './list-item-file-details' );
 
+import { MEDIA_IMAGE_PHOTON } from 'lib/media/constants';
+
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryListItemImage',
 
@@ -16,13 +18,13 @@ module.exports = React.createClass( {
 		media: React.PropTypes.object,
 		scale: React.PropTypes.number,
 		maxImageWidth: React.PropTypes.number,
-		photon: React.PropTypes.bool
+		thumbnailType: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
 		return {
 			maxImageWidth: 450,
-			photon: true
+			thumbnailType: MEDIA_IMAGE_PHOTON,
 		};
 	},
 
@@ -76,8 +78,8 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var url = MediaUtils.url( this.props.media, {
-			photon: this.props.photon,
-			maxWidth: this.props.maxImageWidth
+			photon: this.props.thumbnailType === MEDIA_IMAGE_PHOTON,
+			maxWidth: this.props.maxImageWidth,
 		} );
 
 		if ( ! url ) {

--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -15,7 +15,8 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		media: React.PropTypes.object,
-		maxImageWidth: React.PropTypes.number
+		maxImageWidth: React.PropTypes.number,
+		thumbnailType: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
@@ -33,13 +34,12 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var thumbnail = this.getHighestQualityThumbnail(),
-			url;
+		const thumbnail = this.getHighestQualityThumbnail();
 
 		if ( thumbnail ) {
 			// All thumbnails extracted from the media should be accessible via
 			// Photon, so we don't concern ourselves with the boolean prop
-			url = photon( thumbnail, { width: this.props.maxImageWidth } );
+			const url = photon( thumbnail, { width: this.props.maxImageWidth } );
 
 			return (
 				<div className="media-library__list-item-video" style={ { backgroundImage: 'url(' + url + ')' } }>

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -9,7 +9,7 @@ var React = require( 'react' ),
 	isEqual = require( 'lodash/isEqual' );
 
 /**
- * External dependencies
+ * Internal dependencies
  */
 var Spinner = require( 'components/spinner' ),
 	Gridicon = require( 'gridicons' ),
@@ -20,6 +20,7 @@ var Spinner = require( 'components/spinner' ),
 	MediaUtils = require( 'lib/media/utils' );
 
 import EditorMediaModalGalleryHelp from 'post-editor/media-modal/gallery-help';
+import { MEDIA_IMAGE_PHOTON } from 'lib/media/constants';
 
 export default React.createClass( {
 	displayName: 'MediaLibraryListItem',
@@ -28,7 +29,7 @@ export default React.createClass( {
 		media: React.PropTypes.object,
 		scale: React.PropTypes.number.isRequired,
 		maxImageWidth: React.PropTypes.number,
-		photon: React.PropTypes.bool,
+		thumbnailType: React.PropTypes.string,
 		showGalleryHelp: React.PropTypes.bool,
 		selectedIndex: React.PropTypes.number,
 		onToggle: React.PropTypes.func,
@@ -39,10 +40,10 @@ export default React.createClass( {
 	getDefaultProps: function() {
 		return {
 			maxImageWidth: 450,
-			photon: true,
+			thumbnailType: MEDIA_IMAGE_PHOTON,
 			selectedIndex: -1,
 			onToggle: noop,
-			onEditItem: noop
+			onEditItem: noop,
 		};
 	},
 
@@ -50,7 +51,7 @@ export default React.createClass( {
 		return ! ( nextProps.media === this.props.media &&
 			nextProps.scale === this.props.scale &&
 			nextProps.maxImageWidth === this.props.maxImageWidth &&
-			nextProps.photon === this.props.photon &&
+			nextProps.thumbnailType === this.props.thumbnailType &&
 			nextProps.selectedIndex === this.props.selectedIndex &&
 			isEqual( nextProps.style, this.props.style ) );
 	},
@@ -122,4 +123,3 @@ export default React.createClass( {
 		);
 	}
 } );
-

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -37,7 +37,7 @@ export const MediaLibraryList = React.createClass( {
 		containerWidth: React.PropTypes.number,
 		rowPadding: React.PropTypes.number,
 		mediaScale: React.PropTypes.number.isRequired,
-		photon: React.PropTypes.bool,
+		thumbnailType: React.PropTypes.string,
 		mediaHasNextPage: React.PropTypes.bool,
 		mediaFetchingNextPage: React.PropTypes.bool,
 		mediaOnFetchNextPage: React.PropTypes.func,
@@ -174,7 +174,7 @@ export const MediaLibraryList = React.createClass( {
 				style={ this.getMediaItemStyle( index ) }
 				media={ item }
 				scale={ this.props.mediaScale }
-				photon={ this.props.photon }
+				thumbnailType={ this.props.thumbnailType }
 				showGalleryHelp={ showGalleryHelp }
 				selectedIndex={ selectedIndex }
 				onToggle={ this.toggleItem }

--- a/client/my-sites/media-library/test/list-item-image.jsx
+++ b/client/my-sites/media-library/test/list-item-image.jsx
@@ -34,23 +34,28 @@ describe( 'MediaLibraryListItem image', function() {
 
 	const getPhotonUrl = () => photon( fixtures.media[ 0 ].URL, { width: WIDTH } );
 	const getResizedUrl = () => resize( fixtures.media[ 0 ].URL, { w: WIDTH } );
-	const getItem = usePhoton => <ListItemImage media={ fixtures.media[ 0 ] } scale={ 1 } photon={ usePhoton } maxImageWidth={ WIDTH } />;
+	const getItem = ( itemPos, type ) =>
+		<ListItemImage
+			media={ fixtures.media[ itemPos ] }
+			scale={ 1 }
+			maxImageWidth={ WIDTH }
+			thumbnailType={ type } />;
 
 	context( 'thumbnail display mode', function() {
-		it( 'defaults to photon when no photon parameter is passed', function() {
-			wrapper = shallow( getItem() );
+		it( 'defaults to photon when no thumbnail parameter is passed', function() {
+			wrapper = shallow( getItem( 0 ) );
 
 			expect( wrapper.props().src ).to.be.equal( getPhotonUrl() );
 		} );
 
-		it( 'returns a photon thumbnail for a public image', function() {
-			wrapper = shallow( getItem( true ) );
+		it( 'returns a photon thumbnail for type MEDIA_IMAGE_PHOTON', function() {
+			wrapper = shallow( getItem( 0, 'MEDIA_IMAGE_PHOTON' ) );
 
 			expect( wrapper.props().src ).to.be.equal( getPhotonUrl() );
 		} );
 
-		it( 'returns a resized thumbnail for a private image', function() {
-			wrapper = shallow( getItem( false ) );
+		it( 'returns a resized private thumbnail for type MEDIA_IMAGE_RESIZER', function() {
+			wrapper = shallow( getItem( 0, 'MEDIA_IMAGE_RESIZER' ) );
 
 			expect( wrapper.props().src ).to.be.equal( getResizedUrl() );
 		} );

--- a/client/my-sites/media-library/test/list-item-video.jsx
+++ b/client/my-sites/media-library/test/list-item-video.jsx
@@ -34,11 +34,23 @@ describe( 'MediaLibraryListItem video', function() {
 	} );
 
 	const expectedBackground = () => styleUrl( photon( fixtures.media[ 1 ].thumbnails.fmt_hd, { width: WIDTH } ) );
-	const getItem = () => <ListItemVideo media={ fixtures.media[ 1 ] } scale={ 1 } maxImageWidth={ WIDTH } />;
+	const getItem = type => <ListItemVideo media={ fixtures.media[ 1 ] } scale={ 1 } maxImageWidth={ WIDTH } thumbnailType={ type } />;
 
 	context( 'thumbnail display mode', function() {
-		it( 'returns a photon thumbnail for a video', function() {
+		it( 'defaults to photon', function() {
 			wrapper = shallow( getItem() );
+
+			expect( wrapper.props().style.backgroundImage ).to.be.equal( expectedBackground() );
+		} );
+
+		it( 'returns a photon thumbnail for type MEDIA_IMAGE_PHOTON', function() {
+			wrapper = shallow( getItem( 'MEDIA_IMAGE_PHOTON' ) );
+
+			expect( wrapper.props().style.backgroundImage ).to.be.equal( expectedBackground() );
+		} );
+
+		it( 'returns a photon thumbnail for type MEDIA_IMAGE_RESIZER', function() {
+			wrapper = shallow( getItem( 'MEDIA_IMAGE_RESIZER' ) );
 
 			expect( wrapper.props().style.backgroundImage ).to.be.equal( expectedBackground() );
 		} );


### PR DESCRIPTION
Change how thumbnails are generated for the media library by moving from a simple 'use/dont use photon' to a thumbnail type variable:

- `MEDIA_IMAGE_PHOTON` - uses Photon to resize original image on public blogs and video thumbnails (existing)
- `MEDIA_IMAGE_RESIZER` - uses WP.com resize URLs for private blogs (existing)

It doesn't change the appearance of thumbnails - they should look exactly the same to the user.

This will be extended in a future change to provide Google Photo thumbnails, which can't use Photon or the resizer.

## Testing:

The PR contains unit tests to verify that the different modes show expected thumbnails.

Also manually:

- Open up the media library on a public site and verify that thumbnails still appear for images and videos, and use Photon
- Open media library on a private site and verify that images don't use Photon and are resized, but that videos do use Photon.
