### PR TITLE
Remove Notice.defaultProps.status="is-info"

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -15,7 +15,7 @@ export class Notice extends Component {
 		isCompact: false,
 		onDismissClick: noop,
 		showDismiss: true,
-		status: 'is-info',
+		status: null,
 		text: null,
 	};
 


### PR DESCRIPTION
Fixes #14418

To test:
* Vist https://calypso.live/devdocs/design/notices?branch=fix/14418-notice-no-default-status and ensure the regression in #14418 is fixed.