### PR TITLE
Extensions: Send user to Calypso settings page for Calypso extensions

### DIFF
--- a/client/extensions/wp-super-cache/package.json
+++ b/client/extensions/wp-super-cache/package.json
@@ -7,6 +7,7 @@
 	"section": {
 		"name": "wp-super-cache",
 		"paths": [ "/extensions/wp-super-cache" ],
+		"settings_path": "/extensions/wp-super-cache",
 		"module": "wp-super-cache",
 		"group": "sites",
 		"secondary": true

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -5,11 +5,12 @@ import React from 'react';
 import i18n from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
-
+import Button from 'components/button';
 import ExternalLink from 'components/external-link';
 import Version from 'components/version';
 import PluginRatings from 'my-sites/plugins/plugin-ratings/';
@@ -147,6 +148,19 @@ export default React.createClass( {
 		return {};
 	},
 
+	getDefaultActionLinks( plugin ) {
+		let adminUrl = get( this.props, 'selectedSite.options.admin_url' );
+		const pluginSlug = get( plugin, 'slug' );
+
+		if ( pluginSlug === 'vaultpress' ) {
+			adminUrl += '/admin.php?page=vaultpress';
+		}
+
+		return adminUrl
+			? { [ i18n.translate( 'WP Admin' ) ]: adminUrl }
+			: null;
+	},
+
 	renderPlaceholder() {
 		const classes = classNames( { 'plugin-information': true, 'is-placeholder': true } );
 		return (
@@ -195,6 +209,13 @@ export default React.createClass( {
 			'is-singlesite': !! this.props.siteVersion
 		} );
 
+		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
+		let actionLinks = get( plugin, 'action_links' );
+
+		if ( get( plugin, 'active' ) && isEmpty( actionLinks ) ) {
+			actionLinks = this.getDefaultActionLinks( plugin );
+		}
+
 		return (
 			<div className="plugin-information">
 				<div className="plugin-information__wrapper">
@@ -208,6 +229,21 @@ export default React.createClass( {
 							{ this.renderLimits() }
 						</div>
 					</div>
+
+					{ ! isEmpty( actionLinks ) &&
+					<div className="plugin-information__action-links">
+						{ Object.keys( actionLinks ).map( ( linkTitle, index ) => (
+							<Button compact icon
+								href={ actionLinks[ linkTitle ] }
+								target="_blank"
+								key={ 'action-link-' + index }
+								rel="noopener noreferrer">
+									{ linkTitle } <Gridicon icon="external" />
+							</Button>
+						) ) }
+					</div>
+					}
+
 					<div className="plugin-information__links">
 						{ this.renderWporgLink() }
 						{ this.renderHomepageLink() }

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -149,11 +149,11 @@ export default React.createClass( {
 	},
 
 	getDefaultActionLinks( plugin ) {
-		let adminUrl = get( this.props, 'selectedSite.options.admin_url' );
+		let adminUrl = get( this.props, 'site.options.admin_url' );
 		const pluginSlug = get( plugin, 'slug' );
 
 		if ( pluginSlug === 'vaultpress' ) {
-			adminUrl += '/admin.php?page=vaultpress';
+			adminUrl += 'admin.php?page=vaultpress'; // adminUrl has a trailing slash
 		}
 
 		return adminUrl
@@ -209,7 +209,7 @@ export default React.createClass( {
 			'is-singlesite': !! this.props.siteVersion
 		} );
 
-		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
+		const { plugin } = this.props;
 		let actionLinks = get( plugin, 'action_links' );
 
 		if ( get( plugin, 'active' ) && isEmpty( actionLinks ) ) {

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -1,16 +1,8 @@
 .plugin-information {
 	display: flex;
 	flex-wrap: wrap;
-	border-top: 1px solid lighten( $gray, 30% );
-	margin-top: 16px;
-	padding-top: 16px;
 	position: relative;
 	overflow: hidden;
-
-	@include breakpoint( '>480px' ) {
-		margin-top: 24px;
-		padding-top: 24px;
-	}
 }
 
 .plugin-information__description {
@@ -29,6 +21,18 @@
 .plugin-information__version-shell .version{
 	float: left;
 	margin: 0 16px 8px 0;
+}
+
+.plugin-information__action-links {
+	display: flex;
+	flex-wrap: wrap;
+	clear: both;
+
+	.button {
+		margin-top: 16px;
+		flex-shrink: 0;
+		margin-right: 10px;
+	}
 }
 
 .plugin-information__last-updated {

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import some from 'lodash/some';
 import get from 'lodash/get';
-import { findIndex, has, includes } from 'lodash';
+import { findIndex, includes } from 'lodash';
 import { isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
@@ -438,7 +438,7 @@ class PluginMeta extends Component {
 		}
 
 		return get( sections[ index ], 'paths', [] )[ 0 ];
-	},
+	}
 
 	render() {
 		const cardClasses = classNames( 'plugin-meta__information', {
@@ -446,7 +446,6 @@ class PluginMeta extends Component {
 			'has-site': !! this.props.selectedSite,
 			'is-placeholder': !! this.props.isPlaceholder
 		} );
-		let target = '_blank';
 
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
 		let actionLinks = get( plugin, 'action_links' );
@@ -455,11 +454,6 @@ class PluginMeta extends Component {
 		}
 
 		const path = this.getExtensionPath( plugin );
-
-		if ( path && has( actionLinks, 'Settings' ) ) {
-			actionLinks.Settings = `${ path }/${ this.props.slug }`;
-			target = '_self';
-		}
 
 		return (
 			<div className="plugin-meta">
@@ -475,12 +469,22 @@ class PluginMeta extends Component {
 							<div className="plugin-meta__meta">
 								{ this.renderAuthorUrl() }
 							</div>
+
+							{ path &&
+								<div className="plugin-meta__settings-link">
+									<Button primary
+										href={ `${ path }/${ this.props.slug }` }>
+										{ this.props.translate( 'Settings' ) }
+									</Button>
+								</div>
+							}
+
 							{ ! isEmpty( actionLinks ) &&
 								<div className="plugin-meta__action-links">
 									{ Object.keys( actionLinks ).map( ( linkTitle, index ) => (
 										<Button compact icon
 											href={ actionLinks[ linkTitle ] }
-											target={ target }
+											target="_blank"
 											key={ 'action-link-' + index }
 											rel="noopener noreferrer">
 												{ linkTitle } <Gridicon icon="external" />

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import some from 'lodash/some';
 import get from 'lodash/get';
-import { findIndex, includes } from 'lodash';
+import { find, includes } from 'lodash';
 import { isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
@@ -428,16 +428,12 @@ class PluginMeta extends Component {
 		analytics.ga.recordEvent( 'Plugins', 'Clicked Update All Sites Plugin', 'Plugin Name', this.props.pluginSlug );
 	}
 
-	getExtensionPath( plugin ) {
-		const pluginSlug = get( plugin, 'slug' );
+	getExtensionSettingsPath( plugin ) {
+		const pluginSlug = get( plugin, 'slug', '' );
 		const sections = sectionsModule.get();
-		const index = findIndex( sections, { name: pluginSlug } );
+		const section = find( sections, ( value => value.name === pluginSlug ) );
 
-		if ( ( index === -1 ) || ! includes( sections[ index ].envId, config( 'env_id' ) ) ) {
-			return '';
-		}
-
-		return get( sections[ index ], 'paths', [] )[ 0 ];
+		return get( section, 'settings_path' );
 	}
 
 	render() {
@@ -453,7 +449,7 @@ class PluginMeta extends Component {
 			actionLinks = this.getDefaultActionLinks( plugin );
 		}
 
-		const path = this.getExtensionPath( plugin );
+		const path = this.getExtensionSettingsPath( plugin );
 
 		return (
 			<div className="plugin-meta">

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -8,7 +8,6 @@ import i18n from 'i18n-calypso';
 import some from 'lodash/some';
 import get from 'lodash/get';
 import { find, includes } from 'lodash';
-import { isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
 import sectionsModule from 'sections';
@@ -19,6 +18,7 @@ import sectionsModule from 'sections';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import Count from 'components/count';
 import NoticeAction from 'components/notice/notice-action';
 import ExternalLink from 'components/external-link';
@@ -296,19 +296,6 @@ class PluginMeta extends Component {
 		}
 	}
 
-	getDefaultActionLinks( plugin ) {
-		let adminUrl = get( this.props, 'selectedSite.options.admin_url' );
-		const pluginSlug = get( plugin, 'slug' );
-
-		if ( pluginSlug === 'vaultpress' ) {
-			adminUrl += '/admin.php?page=vaultpress';
-		}
-
-		return adminUrl
-			? { [ i18n.translate( 'WP Admin' ) ]: adminUrl }
-			: null;
-	}
-
 	getUpdateWarning() {
 		const newVersions = this.getAvailableNewVersions();
 		if ( newVersions.length > 0 ) {
@@ -444,11 +431,6 @@ class PluginMeta extends Component {
 		} );
 
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
-		let actionLinks = get( plugin, 'action_links' );
-		if ( get( plugin, 'active' ) && isEmpty( actionLinks ) ) {
-			actionLinks = this.getDefaultActionLinks( plugin );
-		}
-
 		const path = this.getExtensionSettingsPath( plugin );
 
 		return (
@@ -465,43 +447,30 @@ class PluginMeta extends Component {
 							<div className="plugin-meta__meta">
 								{ this.renderAuthorUrl() }
 							</div>
-
-							{ path &&
-								<div className="plugin-meta__settings-link">
-									<Button primary
-										href={ `${ path }/${ this.props.slug }` }>
-										{ this.props.translate( 'Settings' ) }
-									</Button>
-								</div>
-							}
-
-							{ ! isEmpty( actionLinks ) &&
-								<div className="plugin-meta__action-links">
-									{ Object.keys( actionLinks ).map( ( linkTitle, index ) => (
-										<Button compact icon
-											href={ actionLinks[ linkTitle ] }
-											target="_blank"
-											key={ 'action-link-' + index }
-											rel="noopener noreferrer">
-												{ linkTitle } <Gridicon icon="external" />
-										</Button>
-									) ) }
-								</div>
-							}
 						</div>
 						{ this.renderActions() }
 					</div>
-					{ ! this.props.isMock && get( this.props.selectedSite, 'jetpack' ) &&
-						<PluginInformation
-							plugin={ this.props.plugin }
-							isPlaceholder={ this.props.isPlaceholder }
-							site={ this.props.selectedSite }
-							pluginVersion={ plugin && plugin.version }
-							siteVersion={ this.props.selectedSite && this.props.selectedSite.options.software_version }
-							hasUpdate={ this.getAvailableNewVersions().length > 0 }
-						/>
-					}
 				</Card>
+
+				{ path &&
+					<CompactCard
+						href={ `${ path }/${ this.props.slug }` }>
+						{ this.props.translate( 'Edit plugin settings' ) }
+					</CompactCard>
+				}
+
+				{ ! this.props.isMock && get( this.props.selectedSite, 'jetpack' ) &&
+				<Card className="plugin-meta__plugin-information-wrapper">
+					<PluginInformation
+						plugin={ this.props.plugin }
+						isPlaceholder={ this.props.isPlaceholder }
+						site={ this.props.selectedSite }
+						pluginVersion={ plugin && plugin.version }
+						siteVersion={ this.props.selectedSite && this.props.selectedSite.options.software_version }
+						hasUpdate={ this.getAvailableNewVersions().length > 0 }
+					/>
+				</Card>
+				}
 
 				{ this.props.atEnabled &&
 					this.maybeDisplayUnsupportedNotice()

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -152,6 +152,12 @@
 	color: $alert-green;
 }
 
+.plugin-meta__settings-link {
+	clear: both;
+	padding-top: 24px;
+	text-transform: uppercase;
+}
+
 .plugin-meta__action-links {
 	display: flex;
 	flex-wrap: wrap;

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -152,23 +152,8 @@
 	color: $alert-green;
 }
 
-.plugin-meta__settings-link {
-	clear: both;
-	padding-top: 24px;
-	text-transform: uppercase;
-}
-
-.plugin-meta__action-links {
-	display: flex;
-	flex-wrap: wrap;
-	clear: both;
-	padding-top: 12px;
-
-	.button {
-		margin-top: 12px;
-		flex-shrink: 0;
-		margin-right: 10px;
-	}
+.card.plugin-meta__plugin-information-wrapper {
+	margin-top: 16px;
 }
 
 a.plugin-meta__settings-link {


### PR DESCRIPTION
This PR sends a user to the Calypso settings page rather than opening the settings page of WP Admin in a new tab when the _Settings_ button is clicked on the plugin details page:

![plugin-details](https://cloud.githubusercontent.com/assets/1190420/26412986/84a2d0f2-4078-11e7-8630-49b1de9eb26d.jpg)

The buttons displayed on the above page come from the plugin itself:

![wp-super-cache](https://cloud.githubusercontent.com/assets/1190420/26413091/dd9c693e-4078-11e7-8446-3f47c8a08507.jpg)

The URL that the user is directed to comes from the `path` property in the extension's [`package.json`](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/wp-super-cache/package.json#L9). It is appended with the site slug.

This functionality is only enabled in certain environments, as determined by the `env_id` property in the extension's [`package.json`](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/wp-super-cache/package.json#L6).

For greater certainty, if a plugin does not exist as a section with a valid `path` property, or does not have a _Settings_ button, or the current environment does not match one of the environments listed in `env_id`, then the URL for the button remains unchanged.

## Testing

- Navigate to the _Plugins_ page
- Select _WP Super Cache_
- Click the _Settings_ button
- You should be taken to the WPSC settings page
- Repeat for other plugins as well (e.g. WooCommerce should navigate to `/store/siteId`, while other plugins should be unaffected)

_Questions_

- Is the reliance on a button named _Settings_ (i.e. `actionLinks.Settings`) too brittle?
- Why is the `paths` property in `package.json` an array? Under what circumstances would there be more than one value?