### PR TITLE
Editor: animate confirmation sidebar

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -1,8 +1,20 @@
 .editor-confirmation-sidebar {
-	display: none;
+	position: absolute;
+		top: -100px;
+		left: -100px;
+		width: 0;
+		height: 0;
+	overflow: hidden;
+	visibility: hidden;
 
 	&.is-active {
-		display: block;
+		position: static;
+			top: auto;
+			left: auto;
+			width: auto;
+			height: auto;
+		overflow: auto;
+		visibility: visible;
 	}
 }
 
@@ -27,7 +39,7 @@
 	@extend .sidebar;
 	width: 374px;
 	background: $sidebar-bg-color;
-	position: absolute;
+	position: fixed;
 		left: auto;
 		right: -374px;
 	z-index: z-index( 'root', '.editor-confirmation-sidebar__sidebar' );


### PR DESCRIPTION
The fix in #14394 removed animations for the sidebar's appearance. This PR adds them back and sets the sidebar to fixed such-that it always lines up with the ground-control that it overlays when scrolling (the ground-control beneath is also fixed).

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p3Ex-2ri-p2.

![sidebar animation](https://cloud.githubusercontent.com/assets/363749/26413139/a0541584-4070-11e7-9c8d-36a575bee65b.gif)

To test:
* Checkout branch
* `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Verify that there is no regression of the fix in #14394 (attempt scrolling right when the confirmation sidebar is closed)
* Open the confirmation sidebar by clicking on publish; verify that the animation occurs
* Reduce your browser side vertically such that vertical scrolling is possible; verify that while scrolling vertically the sidebar remains fixed to the top and lines up with the underlying ground-control bar.