### PR TITLE
Reader: use keyedReducer for feed-searches

### DIFF
--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -6,7 +6,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
 import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
@@ -24,17 +24,12 @@ import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
  * @param  {Object} action Action payload
  * @return {Array}        Updated state
  */
-export const items = createReducer(
-	{},
-	{
-		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => {
-			const current = state[ action.query ] || [];
-			return {
-				...state,
-				[ action.query ]: uniqBy( current.concat( action.payload.feeds ), 'feed_URL' ),
-			};
-		},
-	}
+export const items = keyedReducer(
+	'query',
+	createReducer( null, {
+		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) =>
+			uniqBy( ( state || [] ).concat( action.payload.feeds ), 'feed_URL' ),
+	} )
 );
 
 /**
@@ -53,14 +48,11 @@ export const items = createReducer(
  * @param  {Object} action Action payload
  * @return {Array}         Updated state
  */
-export const total = createReducer(
-	{},
-	{
-		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => ( {
-			...state,
-			[ action.query ]: action.payload.total,
-		} ),
-	}
+export const total = keyedReducer(
+	'query',
+	createReducer( null, {
+		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => action.payload.total,
+	} )
 );
 
 export default combineReducers( {


### PR DESCRIPTION
We had moved away from keyedReducer because it was difficult to not-persist things.
Now that opt-in persistence has landed, we can switch back.

Is this worth the time? Not at all.

To test:
 - search for feeds on /following/manage.  everything should work
 - refresh the page and ensure that the state did not persist the feed search results