### PR TITLE
Notifications: Use notifications-panel 1.1.13

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3826,7 +3826,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.1.12"
+      "version": "1.1.13"
     },
     "npm-path": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "ms": "0.7.1",
     "node-sass": "3.7.0",
     "npm-run-all": "4.0.2",
-    "notifications-panel": "1.1.12",
+    "notifications-panel": "1.1.13",
     "numeral": "2.0.4",
     "page": "1.6.4",
     "percentage-regex": "3.0.0",


### PR DESCRIPTION
Bump to lastest notifications-panel that fixes missing placeholder messages.

**To test**
* Load notifications in Calypso, and click on the `Unread` filter and clear them all out by clicking on them. You should see:
<img width="411" alt="screen shot 2017-05-23 at 3 52 40 pm" src="https://cloud.githubusercontent.com/assets/789137/26415438/5ab5ebb4-4067-11e7-84c1-4ad28b5442de.png">

* Load the `All` filter, and scroll, scroll, scroll until you reach the bottom of notifications. You should see `The End` displayed in the footer.