### PR TITLE
Extensions: WPSC - API now returns status field as a boolean instead of a string

### DIFF
--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -173,7 +173,7 @@ class EasyTab extends Component {
 											}
 											<Gridicon
 												className="wp-super-cache__cache-test-results-icon"
-												icon={ get( attempts[ key ], 'status' ) === 'OK' ? 'checkmark-circle' : 'cross-circle' }
+												icon={ get( attempts[ key ], 'status', false ) ? 'checkmark-circle' : 'cross-circle' }
 												size={ 24 } />
 										</li>
 									) ) }


### PR DESCRIPTION
The API was changed to return `true` or `false` for the `status` field of the `cache/test` endpoint. Prior to this PR, the icons in the cache test results were being displayed incorrectly:

![cache-test-error](https://cloud.githubusercontent.com/assets/1190420/26422623/92968cb0-4098-11e7-944b-401f328de273.jpg)

They now display correctly:

![cache-test-success](https://cloud.githubusercontent.com/assets/1190420/26422617/90346924-4098-11e7-941d-aee8081f63d1.jpg)

## Testing

On the _Easy_ tab, click the _Test Cache_ button and ensure that the correct icons are shown. (Unless of course the endpoint did actually return `false` for `status`, in which case the red X's would be shown).