### PR TITLE
Editor Publish Confirmation: Implement action button

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -15,11 +15,13 @@ class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
 		hideSidebar: React.PropTypes.func,
 		isActive: React.PropTypes.bool,
+		onPublish: React.PropTypes.func,
 	};
 
-	stopPropagation( event ) {
-		event.stopPropagation();
-	}
+	closeAndPublish = () => {
+		this.props.hideSidebar();
+		this.props.onPublish( true );
+	};
 
 	render() {
 		return (
@@ -35,11 +37,11 @@ class EditorConfirmationSidebar extends React.Component {
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__sidebar': true,
 						'is-active': this.props.isActive,
-					} ) } onClick={ this.stopPropagation }>
+					} ) }>
 						<div className="editor-confirmation-sidebar__ground-control">
 							<div className="editor-confirmation-sidebar__cancel" onClick={ this.props.hideSidebar }>Cancel</div>
 							<div className="editor-confirmation-sidebar__action">
-								Are you sure? <Button compact>Yea, do it!</Button>
+								Are you sure? <Button onClick={ this.closeAndPublish } compact>Yea, do it!</Button>
 							</div>
 						</div>
 					</div>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -230,7 +230,11 @@ export const PostEditor = React.createClass( {
 		return (
 			<div className={ classes }>
 				<QueryPreferences />
-				<EditorConfirmationSidebar hideSidebar={ this.hideConfirmationSidebar } isActive={ this.state.showConfirmationSidebar } />
+				<EditorConfirmationSidebar
+					hideSidebar={ this.hideConfirmationSidebar }
+					isActive={ this.state.showConfirmationSidebar }
+					onPublish={ this.onPublish }
+				/>
 				<EditorDocumentHead />
 				<EditorPostTypeUnsupported />
 				<EditorForbidden />
@@ -653,13 +657,13 @@ export const PostEditor = React.createClass( {
 		}
 	},
 
-	onPublish: function() {
+	onPublish: function( isConfirmed = false ) {
 		const edits = {
 			...this.props.edits,
 			status: 'publish'
 		};
 
-		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) && false === isConfirmed ) {
 			this.showConfirmationSidebar();
 			return;
 		}


### PR DESCRIPTION
This PR implements the "Yea, do it!" button in the publish confirmation sidebar, which closes the sidebar and publishes the post. The sidebar remains intentionally blank and will be populated in a future PR.

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p3Ex-2ri-p2.

![yeadoit](https://cloud.githubusercontent.com/assets/363749/26422698/7f4f4f3c-4090-11e7-81fc-3217d05c9e48.gif)


To test:
* `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Draft a post and hit publish, you should see the confirmation sidebar
* Press `Yea, do it!`, the sidebar should close and your post should be published