### PR TITLE
Comments: Add selector - get a given site's comments

### DIFF
--- a/client/state/selectors/get-site-comments.js
+++ b/client/state/selectors/get-site-comments.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  * @param {Number} siteId site for whose comments to find
  * @returns {Array<Object>} available comments for site
  */
-export const getCommentsForSite = ( state, siteId ) => {
+export const getSiteComments = ( state, siteId ) => {
 	const comments = get( state, 'comments.items', {} );
 
 	return Object.keys( comments )
@@ -18,4 +18,4 @@ export const getCommentsForSite = ( state, siteId ) => {
 		.reduce( ( list, key ) => [ ...list, ...comments[ key ] ], [] );
 };
 
-export default getCommentsForSite;
+export default getSiteComments;

--- a/client/state/selectors/get-site-comments.js
+++ b/client/state/selectors/get-site-comments.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns list of loaded comments for a given site
+ *
+ * @param {Object} state Redux state
+ * @param {Number} siteId site for whose comments to find
+ * @returns {Array<Object>} available comments for site
+ */
+export const getCommentsForSite = ( state, siteId ) => {
+	const comments = get( state, 'comments.items', {} );
+
+	return Object.keys( comments )
+		.filter( key => parseInt( key.split( '-', 1 ), 10 ) === siteId )
+		.reduce( ( list, key ) => [ ...list, ...comments[ key ] ], [] );
+};
+
+export default getCommentsForSite;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -76,6 +76,7 @@ export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getSelectedOrAllSites from './get-selected-or-all-sites';
 export getSharingButtons from './get-sharing-buttons';
+export getSiteComments from './get-site-comments';
 export getSiteConnectionStatus from './get-site-connection-status';
 export getSiteDefaultPostFormat from './get-site-default-post-format';
 export getSiteGmtOffset from './get-site-gmt-offset';


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/projects/32
@see #14431

This new selector returns all comments from memory which belong to a
given site by numeric `siteId`.

This does not yet introduce any changes; it only provides a new selector.