### PR TITLE
Framework: rename to combineReducers to make persistence less scary

### DIFF
--- a/bin/codemods/rename-combine-reducers
+++ b/bin/codemods/rename-combine-reducers
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/*
+	This codemod converts combineReducersWithPersistence imports to use combineReducers from 'state/utils'
+
+	How to use:
+	./bin/codemods/rename-combine-reducers path-to-transform/
+*/
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const child_process = require( 'child_process' );
+
+/**
+ * Internal dependencies
+ */
+const config = require( './config' );
+const helpers = require( './helpers' );
+
+const args = process.argv.slice( 2 );
+if ( args.length === 0 ) {
+	process.stdout.write( 'No files to transform\n' );
+	process.exit( 0 );
+}
+
+const binArgs = [
+	// jscodeshift options
+	'--transform=bin/codemods/src/rename-combine-reducers.js',
+	...config.jscodeshiftArgs,
+
+	// Transform target
+	args[ 0 ],
+];
+const binPath = path.join( '.', 'node_modules', '.bin', 'jscodeshift' );
+const jscodeshift = child_process.spawn( binPath, binArgs );
+helpers.bindEvents( jscodeshift );

--- a/bin/codemods/src/combine-reducer-with-persistence.js
+++ b/bin/codemods/src/combine-reducer-with-persistence.js
@@ -2,19 +2,7 @@
  This codemod updates
 
  import { combineReducers } from 'redux'; to
- import { combineReducersWithPersistence } from 'state/utils';
-
- and updates
-
- combineReducers( {
-    //...
- } )
-
- with
-
- combineReducersWithPersistence( {
-    //...
- } )
+ import { combineReducers } from 'state/utils';
  */
 
 module.exports = function ( file, api ) {
@@ -54,7 +42,7 @@ module.exports = function ( file, api ) {
 		return j.importDeclaration(
 			[
 				j.importSpecifier(
-					j.identifier( 'combineReducersWithPersistence' ),
+					j.identifier( 'combineReducers' ),
 				)
 			],
 			j.literal( 'state/utils' )
@@ -62,16 +50,6 @@ module.exports = function ( file, api ) {
 	};
 	//note the extra whitespace coming from https://github.com/benjamn/recast/issues/371
 	firstInternalImport.insertAfter( combineReducersImport );
-
-	//update combineReducers call
-	const renameIdentifier = ( newName ) => imported => {
-		j( imported ).replaceWith( () => j.identifier( newName ) );
-	};
-	const combineReducerIdentifier = root.find( j.CallExpression ).find( j.Identifier ).filter(
-		( identifier ) => identifier.value.name === 'combineReducers'
-	);
-
-	combineReducerIdentifier.forEach( renameIdentifier( 'combineReducersWithPersistence' ) );
 
 	// print
 	return root.toSource( { quote: 'single' } );

--- a/bin/codemods/src/rename-combine-reducers.js
+++ b/bin/codemods/src/rename-combine-reducers.js
@@ -1,0 +1,100 @@
+/*
+ This codemod updates
+
+ import { combineReducersWithPersistence } from 'state/utils'; to
+ import { combineReducers } from 'state/utils';
+ 
+ and updates
+ 
+ combineReducersWithPersistence( {
+    foo,
+    bar
+ } );
+ 
+ to
+ 
+ combineReducers( {
+   foo,
+   bar
+ } );
+ */
+
+module.exports = function ( file, api ) {
+	// alias the jscodeshift API
+	const j = api.jscodeshift;
+	// parse JS code into an AST
+	const root = j( file.source );
+
+
+	const importNames = [];
+
+	const combineReducerImport = root.find( j.ImportDeclaration, {
+		source: {
+			type: 'Literal',
+			value: 'state/utils',
+		},
+	} ).filter( ( importDeclaration ) => {
+		if ( importDeclaration.value.specifiers.length > 0 ) {
+			return importDeclaration.value.specifiers.filter( ( specifier ) => {
+					const importedName = specifier.imported.name;
+					const localName = specifier.local.name;
+					const shouldRename = importedName === 'combineReducersWithPersistence';
+					importNames.push( {
+						local: localName === 'combineReducersWithPersistence' ? 'combineReducers' : localName,
+						imported: shouldRename ? 'combineReducers' : importedName
+					} );
+					return shouldRename;
+				} ).length > 0;
+		}
+		return false;
+	} );
+
+	if ( ! combineReducerImport.length ) {
+		return;
+	}
+
+	//sort by imported name
+	importNames.sort( ( a, b ) => {
+		if ( a.imported < b.imported ) {
+			return - 1;
+		}
+		if ( a.imported > b.imported ) {
+			return 1;
+		}
+		return 0;
+	} );
+	
+	//save the comment if possible
+	const comments = combineReducerImport.at( 0 ).get().node.comments;
+	const addImport = ( importNames ) => {
+		const names = importNames.map( name => {
+			if ( name.local === name.imported ) {
+				return j.importSpecifier( j.identifier( name.local ) );
+			}
+			if ( name.local !== name.imported ) {
+				return j.importSpecifier( j.identifier( name.imported ), j.identifier( name.local ) );
+			}
+		} );
+		const combinedImport = j.importDeclaration(
+			names,
+			j.literal( 'state/utils' )
+		);
+		combinedImport.comments = comments;
+		return combinedImport;
+	};
+
+	combineReducerImport.replaceWith( addImport( importNames ) );
+
+	//update combineReducers call
+	const renameIdentifier = ( newName ) => imported => {
+		j( imported ).replaceWith( () => j.identifier( newName ) );
+	};
+	const combineReducerIdentifier = root.find( j.CallExpression ).find( j.Identifier ).filter(
+		( identifier ) => identifier.value.name === 'combineReducersWithPersistence'
+	);
+
+	combineReducerIdentifier.forEach( renameIdentifier( 'combineReducers' ) );
+
+	// print
+	return root.toSource( { quote: 'single' } );
+};

--- a/client/extensions/woocommerce/state/reducer.js
+++ b/client/extensions/woocommerce/state/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import ui from './ui/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import wcApi from './wc-api/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	ui,
 	wcApi,
 } );

--- a/client/extensions/woocommerce/state/ui/products/reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import edits from './edits-reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import variations from './variations/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	edits,
 	variations,
 } );

--- a/client/extensions/woocommerce/state/ui/products/variations/reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/reducer.js
@@ -2,8 +2,8 @@
  * Internal dependencies
  */
 import edits from './edits-reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	edits
 } );

--- a/client/extensions/woocommerce/state/ui/reducer.js
+++ b/client/extensions/woocommerce/state/ui/reducer.js
@@ -2,8 +2,8 @@
  * Internal dependencies
  */
 import products from './products/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	products
 } );

--- a/client/extensions/wp-super-cache/state/cache/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	WP_SUPER_CACHE_DELETE_CACHE,
@@ -69,7 +69,7 @@ const items = createReducer( {}, {
 	[ WP_SUPER_CACHE_TEST_CACHE_SUCCESS ]: ( state, { siteId, data } ) => ( { ...state, [ siteId ]: data } ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	deleteStatus,
 	items,
 	testing,

--- a/client/extensions/wp-super-cache/state/notices/reducer.js
+++ b/client/extensions/wp-super-cache/state/notices/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { itemsSchema } from './schema';
 import {
@@ -35,7 +35,7 @@ const items = createReducer( {}, {
 	[ WP_SUPER_CACHE_RECEIVE_NOTICES ]: ( state, action ) => ( { ...state, [ action.siteId ]: action.notices } ),
 }, itemsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 } );

--- a/client/extensions/wp-super-cache/state/reducer.js
+++ b/client/extensions/wp-super-cache/state/reducer.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import cache from './cache/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import notices from './notices/reducer';
 import settings from './settings/reducer';
 import stats from './stats/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	cache,
 	notices,
 	settings,

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { itemsSchema } from './schema';
 import {
@@ -82,7 +82,7 @@ const items = createReducer( {}, {
 	} ),
 }, itemsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	saveStatus,

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { statsSchema } from './schema';
 import {
@@ -96,7 +96,7 @@ const items = createReducer( {}, {
 	},
 }, statsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	deleting,
 	generateStatus,
 	items,

--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import reset from './reset/reducer';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import settings from './settings/reducer';
 
 import {
@@ -17,7 +17,7 @@ const isFetchingSettings = createReducer( false, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_FAILED ]: () => false,
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	settings,
 	reset,
 	isFetchingSettings,

--- a/client/state/account-recovery/reset/reducer.js
+++ b/client/state/account-recovery/reset/reducer.js
@@ -6,7 +6,7 @@ import { stubTrue, stubFalse } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	ACCOUNT_RECOVERY_RESET_OPTIONS_ERROR,
@@ -26,7 +26,7 @@ import {
 	ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_ERROR,
 } from 'state/action-types';
 
-const options = combineReducersWithPersistence( {
+const options = combineReducers( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_OPTIONS_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_OPTIONS_RECEIVE ]: stubFalse,
@@ -54,7 +54,7 @@ const method = createReducer( null, {
 	[ ACCOUNT_RECOVERY_RESET_SET_METHOD ]: ( state, action ) => action.method,
 } );
 
-const requestReset = combineReducersWithPersistence( {
+const requestReset = combineReducers( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_REQUEST_SUCCESS ]: stubFalse,
@@ -72,7 +72,7 @@ const key = createReducer( null, {
 	[ ACCOUNT_RECOVERY_RESET_SET_VALIDATION_KEY ]: ( state, action ) => action.key,
 } );
 
-const validate = combineReducersWithPersistence( {
+const validate = combineReducers( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_VALIDATE_REQUEST_SUCCESS ]: stubFalse,
@@ -86,7 +86,7 @@ const validate = combineReducersWithPersistence( {
 	} ),
 } );
 
-const resetPassword = combineReducersWithPersistence( {
+const resetPassword = combineReducers( {
 	isRequesting: createReducer( false, {
 		[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST ]: stubTrue,
 		[ ACCOUNT_RECOVERY_RESET_PASSWORD_REQUEST_SUCCESS ]: stubFalse,
@@ -104,7 +104,7 @@ const resetPassword = combineReducersWithPersistence( {
 	} ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	options,
 	userData,
 	method,

--- a/client/state/account-recovery/settings/reducer.js
+++ b/client/state/account-recovery/settings/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS,
@@ -123,8 +123,8 @@ const isReady = createReducer( false, {
 	[ ACCOUNT_RECOVERY_SETTINGS_FETCH_SUCCESS ]: () => true,
 } );
 
-export default combineReducersWithPersistence( {
-	data: combineReducersWithPersistence( {
+export default combineReducers( {
+	data: combineReducers( {
 		phone,
 		phoneValidated,
 		email,

--- a/client/state/application/reducer.js
+++ b/client/state/application/reducer.js
@@ -5,13 +5,13 @@ import {
 	CONNECTION_LOST,
 	CONNECTION_RESTORED
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 export const connectionState = createReducer( 'CHECKING', {
 	[ CONNECTION_LOST ]: () => 'OFFLINE',
 	[ CONNECTION_RESTORED ]: () => 'ONLINE'
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	connectionState
 } );

--- a/client/state/automated-transfer/eligibility/reducer.js
+++ b/client/state/automated-transfer/eligibility/reducer.js
@@ -9,7 +9,7 @@ import { property, sortBy } from 'lodash';
 import {
 	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as UPDATE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 export const eligibilityHolds = ( state = [], action ) =>
 	UPDATE === action.type
@@ -26,7 +26,7 @@ export const lastUpdate = ( state = 0, action ) =>
 		? action.lastUpdate
 		: state;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	eligibilityHolds,
 	eligibilityWarnings,
 	lastUpdate,

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import eligibility from './eligibility/reducer';
-import { combineReducersWithPersistence, keyedReducer, withSchemaValidation } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import { transferStates } from './constants';
 import { automatedTransfer as schema } from './schema';
 import {
@@ -26,7 +26,7 @@ export const status = ( state = null, action ) => get( {
 	[ TRANSFER_UPDATE ]: 'complete' === action.status ? transferStates.COMPLETE : state,
 }, action.type, state );
 
-export const siteReducer = combineReducersWithPersistence( {
+export const siteReducer = combineReducers( {
 	eligibility,
 	status,
 } );

--- a/client/state/billing-transactions/reducer.js
+++ b/client/state/billing-transactions/reducer.js
@@ -10,7 +10,7 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { billingTransactionsSchema } from './schema';
 
 /**
@@ -53,7 +53,7 @@ export const sendingReceiptEmail = createReducer( {}, {
 	[ BILLING_RECEIPT_EMAIL_SEND_SUCCESS ]: ( state, { receiptId } ) => ( { ...state, [ receiptId ]: false } ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	sendingReceiptEmail,

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -20,7 +20,7 @@ import {
 	COMMENTS_REQUEST_SUCCESS,
 	COMMENTS_REQUEST_FAILURE,
 } from '../action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	PLACEHOLDER_STATE
 } from './constants';
@@ -38,9 +38,9 @@ const updateComment = ( commentId, newProperties ) => comment => {
 	return {
 		...comment,
 		...newProperties,
-		...updateLikeCount && {
+		...( updateLikeCount && {
 			like_count: newProperties.i_like ? comment.like_count + 1 : comment.like_count - 1
-		}
+		} )
 	};
 };
 
@@ -154,7 +154,7 @@ export function totalCommentsCount( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requests,
 	totalCommentsCount

--- a/client/state/country-states/reducer.js
+++ b/client/state/country-states/reducer.js
@@ -7,7 +7,7 @@ import {
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Stores the complete list of states, indexed by locale key
@@ -22,7 +22,7 @@ export const isFetching = createReducer( {}, {
 	[ COUNTRY_STATES_REQUEST_FAILURE ]: ( state, { countryCode } ) => ( { ...state, [ countryCode ]: false } )
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isFetching,
 	items,
 } );

--- a/client/state/current-user/email-verification/reducer.js
+++ b/client/state/current-user/email-verification/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	EMAIL_VERIFY_REQUEST,
@@ -24,7 +24,7 @@ export const errorMessage = createReducer( '', {
 	[ EMAIL_VERIFY_STATE_RESET ]: () => '',
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	status,
 	errorMessage,
 } );

--- a/client/state/current-user/gravatar-status/reducer.js
+++ b/client/state/current-user/gravatar-status/reducer.js
@@ -7,7 +7,7 @@ import {
 	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
 	GRAVATAR_UPLOAD_REQUEST_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 export const isUploading = createReducer( false, {
 	[ GRAVATAR_UPLOAD_REQUEST ]: () => true,
@@ -23,7 +23,7 @@ export const tempImage = createReducer( {}, {
 	}
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isUploading,
 	tempImage
 } );

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -15,7 +15,7 @@ import {
 	SITES_UPDATE,
 	PLANS_RECEIVE
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
 import gravatarStatus from './gravatar-status/reducer';
 import emailVerification from './email-verification/reducer';
@@ -89,7 +89,7 @@ export function capabilities( state = {}, action ) {
 }
 capabilities.schema = capabilitiesSchema;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	id,
 	currencyCode,
 	capabilities,

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	DOCUMENT_HEAD_LINK_SET,
@@ -27,7 +27,7 @@ export const link = createReducer( [], {
 	[ DOCUMENT_HEAD_LINK_SET ]: ( state, action ) => ( action.link )
 }, linkSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	link,
 	meta,
 	title,

--- a/client/state/domains/reducer.js
+++ b/client/state/domains/reducer.js
@@ -2,8 +2,8 @@
  * Internal dependencies
  */
 import suggestions from './suggestions/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	suggestions
 } );

--- a/client/state/domains/suggestions/reducer.js
+++ b/client/state/domains/suggestions/reducer.js
@@ -7,7 +7,7 @@ import {
 	DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
 	DOMAINS_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 import { getSerializedDomainsSuggestionsQuery } from './utils';
 
@@ -85,7 +85,7 @@ export function errors( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	errors

--- a/client/state/followers/reducer.js
+++ b/client/state/followers/reducer.js
@@ -18,7 +18,7 @@ import {
 	FOLLOWER_REMOVE_REQUEST,
 	FOLLOWER_REMOVE_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { getSerializedQuery, normalizeFollower } from 'state/followers/utils';
 import { FOLLOWERS_PER_PAGE } from 'state/followers/constants';
 
@@ -92,7 +92,7 @@ export function removeFromSiteRequests( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	queries,
 	queryRequests,

--- a/client/state/geo/reducer.js
+++ b/client/state/geo/reducer.js
@@ -7,7 +7,7 @@ import {
 	GEO_REQUEST_FAILURE,
 	GEO_REQUEST_SUCCESS
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { geoSchema } from './schema';
 
 /**
@@ -36,7 +36,7 @@ export const geo = createReducer( null, {
 	[ GEO_RECEIVE ]: ( state, action ) => action.geo
 }, geoSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	geo
 } );

--- a/client/state/google-apps-users/reducer.js
+++ b/client/state/google-apps-users/reducer.js
@@ -6,7 +6,7 @@ import uniqBy from 'lodash/uniqBy';
 /**
  * Internal Dependencies
  */
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	GOOGLE_APPS_USERS_FETCH,
 	GOOGLE_APPS_USERS_FETCH_COMPLETED,
@@ -32,7 +32,7 @@ export function loaded( state = false, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	loaded
 } );

--- a/client/state/happiness-engineers/reducer.js
+++ b/client/state/happiness-engineers/reducer.js
@@ -6,7 +6,7 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { itemsSchema } from './schema';
 import {
@@ -45,7 +45,7 @@ export const items = createReducer( null, {
 	}
 }, itemsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/happychat/reducer.js
+++ b/client/state/happychat/reducer.js
@@ -32,7 +32,7 @@ import {
 	HAPPYCHAT_TRANSCRIPT_RECEIVE,
 	HAPPYCHAT_SET_GEO_LOCATION,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	HAPPYCHAT_CHAT_STATUS_DEFAULT,
 } from './selectors';
@@ -268,7 +268,7 @@ export const lostFocusAt = ( state = null, action ) => {
 };
 lastActivityTimestamp.hasCustomPersistence = true;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	chatStatus,
 	connectionError,
 	connectionStatus,

--- a/client/state/help/courses/reducer.js
+++ b/client/state/help/courses/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	HELP_COURSES_RECEIVE,
@@ -11,6 +11,6 @@ export const items = createReducer( null, {
 	[ HELP_COURSES_RECEIVE ]: ( state, { courses } ) => courses
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items
 } );

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	DIRECTLY_INITIALIZATION_START,
@@ -21,6 +21,6 @@ export const status = createReducer( STATUS_UNINITIALIZED, {
 	[ DIRECTLY_INITIALIZATION_ERROR ]: () => STATUS_ERROR,
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	status,
 } );

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -2,11 +2,11 @@
  * Internal dependencies
  */
 import courses from './courses/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import directly from './directly/reducer';
 import ticket from './ticket/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	courses,
 	directly,
 	ticket,

--- a/client/state/help/ticket/reducer.js
+++ b/client/state/help/ticket/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
@@ -31,7 +31,7 @@ const requestError = createReducer( null, {
 	[ HELP_TICKET_CONFIGURATION_DISMISS_ERROR ]: () => null,
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isReady,
 	isRequesting,
 	isUserEligible,

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -7,7 +7,7 @@ import { createStore, applyMiddleware, compose } from 'redux';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import analyticsTracking from './analytics/reducer';
 import sitesSync from './sites/enhancer';
 import noticesMiddleware from './notices/middleware';
@@ -71,7 +71,7 @@ import config from 'config';
  */
 
 // Consolidate the extension reducers under 'extensions' for namespacing.
-const extensions = combineReducersWithPersistence( extensionsModule.reducers() );
+const extensions = combineReducers( extensionsModule.reducers() );
 
 const reducers = {
 	analyticsTracking,
@@ -129,7 +129,7 @@ const reducers = {
 	wordads,
 };
 
-export const reducer = combineReducersWithPersistence( reducers );
+export const reducer = combineReducers( reducers );
 
 /**
  * @typedef {Object} ReduxStore

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -33,7 +33,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, isValidStateWithSchema } from 'state/utils';
 import {
 	jetpackConnectSessionsSchema,
 	jetpackAuthAttemptsSchema,
@@ -304,7 +304,7 @@ export function jetpackConnectSelectedPlans( state = {}, action ) {
 }
 jetpackConnectSelectedPlans.schema = jetpackConnectSelectedPlansSchema;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	jetpackConnectSite,
 	jetpackSSO,
 	jetpackConnectAuthorize,

--- a/client/state/jetpack-sync/reducer.js
+++ b/client/state/jetpack-sync/reducer.js
@@ -14,7 +14,7 @@ import {
 	JETPACK_SYNC_STATUS_SUCCESS,
 	JETPACK_SYNC_STATUS_ERROR,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { getExpectedResponseKeys } from './utils';
 
 export function fullSyncRequest( state = {}, action ) {
@@ -97,7 +97,7 @@ export function syncStatus( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	syncStatus,
 	fullSyncRequest
 } );

--- a/client/state/jetpack/connection/reducer.js
+++ b/client/state/jetpack/connection/reducer.js
@@ -10,7 +10,7 @@ import {
 	JETPACK_DISCONNECT_REQUEST_FAILURE,
 	JETPACK_DISCONNECT_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 const createRequestReducer = ( requesting ) => {
 	return ( state, { siteId } ) => ( {
@@ -51,7 +51,7 @@ export const disconnectRequests = createReducer( {}, {
 	[ JETPACK_DISCONNECT_REQUEST_SUCCESS ]: createRequestReducer( false )
 } );
 
-export const reducer = combineReducersWithPersistence( {
+export const reducer = combineReducers( {
 	items,
 	requests,
 	disconnectRequests

--- a/client/state/jetpack/jumpstart/reducer.js
+++ b/client/state/jetpack/jumpstart/reducer.js
@@ -18,7 +18,7 @@ import {
 	JETPACK_JUMPSTART_STATUS_REQUEST_SUCCESS,
 	JETPACK_JUMPSTART_STATUS_REQUEST_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 const createRequestReducer = ( data ) => {
 	return ( state, { siteId } ) => {
@@ -62,7 +62,7 @@ export const requests = createReducer( {}, {
 	[ JETPACK_JUMPSTART_STATUS_REQUEST_SUCCESS ]: createRequestReducer( { requesting: false } )
 } );
 
-export const reducer = combineReducersWithPersistence( {
+export const reducer = combineReducers( {
 	items,
 	requests
 } );

--- a/client/state/jetpack/modules/reducer.js
+++ b/client/state/jetpack/modules/reducer.js
@@ -20,7 +20,7 @@ import {
 	JETPACK_SETTINGS_RECEIVE,
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 const createItemsReducer = ( active ) => {
 	return ( state, { siteId, moduleSlug } ) => {
@@ -121,7 +121,7 @@ export const requests = createReducer( {}, {
 	[ JETPACK_MODULES_REQUEST_SUCCESS ]: createModuleListRequestReducer( false )
 } );
 
-export const reducer = combineReducersWithPersistence( {
+export const reducer = combineReducers( {
 	items,
 	requests
 } );

--- a/client/state/jetpack/reducer.js
+++ b/client/state/jetpack/reducer.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import { reducer as connection } from './connection/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { reducer as jumpstart } from './jumpstart/reducer';
 import { reducer as modules } from './modules/reducer';
 import { reducer as settings } from './settings/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	connection,
 	jumpstart,
 	modules,

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -21,7 +21,7 @@ import {
 	JETPACK_SETTINGS_UPDATE_SUCCESS,
 	JETPACK_SETTINGS_UPDATE_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { normalizeSettings } from './utils';
 
 const createRequestsReducer = ( data ) => {
@@ -133,7 +133,7 @@ export const saveRequests = createReducer( {}, {
 	} )
 } );
 
-export const reducer = combineReducersWithPersistence( {
+export const reducer = combineReducers( {
 	items,
 	requests,
 	saveRequests

--- a/client/state/login/magic-login/reducer.js
+++ b/client/state/login/magic-login/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	CHECK_YOUR_EMAIL_PAGE,
@@ -84,7 +84,7 @@ export const requestEmailSuccess = createReducer( false, {
 	[ MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS ]: () => true,
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	emailAddressFormInput,
 	isFetchingEmail,
 	requestAuthError,

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducersWithPersistence } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import magicLogin from './magic-login/reducer';
 import {
 	LOGIN_REQUEST,
@@ -77,7 +77,7 @@ export const twoFactorAuthPushPoll = createReducer( { inProgress: false, success
 	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED ]: state => ( { ...state, inProgress: false, success: true } ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isRequesting,
 	isRequestingTwoFactorAuth,
 	magicLogin,

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -15,7 +15,7 @@ import {
 	MEDIA_REQUEST_SUCCESS,
 	MEDIA_REQUESTING
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import MediaQueryManager from 'lib/query-manager/media';
 
 export const queries = ( () => {
@@ -110,7 +110,7 @@ export const mediaItemRequests = createReducer( {}, {
 	}
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	queries,
 	queryRequests,
 	mediaItemRequests

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -12,7 +12,7 @@ import {
 	NOTICE_REMOVE,
 	ROUTE_SET
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 export const items = createReducer( {}, {
 	[ NOTICE_CREATE ]: ( state, action ) => {
@@ -50,6 +50,6 @@ export const items = createReducer( {}, {
 	}
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items
 } );

--- a/client/state/nps-survey/reducer.js
+++ b/client/state/nps-survey/reducer.js
@@ -11,7 +11,7 @@ import {
 	NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_FAILURE,
 	NPS_SURVEY_SUBMIT_WITH_NO_SCORE_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	NOT_SUBMITTED,
 	SUBMITTING,
@@ -51,7 +51,7 @@ export const score = createReducer( null, {
 	},
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isSessionEligible,
 	wasShownThisSession,
 	surveyState,

--- a/client/state/page-templates/reducer.js
+++ b/client/state/page-templates/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { itemsSchema } from './schema';
 import {
@@ -46,7 +46,7 @@ export const items = createReducer( {}, {
 	}
 }, itemsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/plans/reducer.js
+++ b/client/state/plans/reducer.js
@@ -7,7 +7,7 @@ import {
 	PLANS_REQUEST_SUCCESS,
 	PLANS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -68,7 +68,7 @@ export const error = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	error

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -10,7 +10,7 @@ import {
  * Internal dependencies
  */
 import status from './status/reducer';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	PLUGINS_RECEIVE,
 	PLUGINS_REQUEST,
@@ -122,7 +122,7 @@ function plugin( state, action ) {
 	}
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isRequesting,
 	plugins,
 	status

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -17,7 +17,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, isValidStateWithSchema } from 'state/utils';
 import { pluginInstructionSchema } from './schema';
 
 /*
@@ -154,7 +154,7 @@ function pluginStatus( state, action ) {
 	}
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isRequesting,
 	hasRequested,
 	plugins

--- a/client/state/plugins/reducer.js
+++ b/client/state/plugins/reducer.js
@@ -2,11 +2,11 @@
  * Internal dependencies
  */
 import wporg from './wporg/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import premium from './premium/reducer';
 import installed from './installed/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	wporg,
 	premium,
 	installed

--- a/client/state/plugins/wporg/reducer.js
+++ b/client/state/plugins/wporg/reducer.js
@@ -5,7 +5,7 @@ import {
 	WPORG_PLUGIN_DATA_RECEIVE,
 	FETCH_WPORG_PLUGIN_DATA,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 function updatePluginState( state = {}, pluginSlug, attributes ) {
 	return Object.assign( {},
@@ -37,7 +37,7 @@ export function items( state = {}, action ) {
 	}
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	fetchingItems
 } );

--- a/client/state/post-formats/reducer.js
+++ b/client/state/post-formats/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { postFormatsItemsSchema } from './schema';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	POST_FORMATS_RECEIVE,
 	POST_FORMATS_REQUEST,
@@ -38,7 +38,7 @@ export const items = createReducer( {}, {
 	}
 }, postFormatsItemsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -6,7 +6,7 @@ import keyBy from 'lodash/keyBy';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, isValidStateWithSchema } from 'state/utils';
 
 import * as schema from './schema';
 import taxonomies from './taxonomies/reducer';
@@ -69,7 +69,7 @@ export function items( state = {}, action ) {
 }
 items.hasCustomPersistence = true;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items,
 	taxonomies

--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -15,7 +15,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, isValidStateWithSchema } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -72,7 +72,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/posts/counts/reducer.js
+++ b/client/state/posts/counts/reducer.js
@@ -20,7 +20,7 @@ import {
 	POST_SAVE,
 	POSTS_RECEIVE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { countsSchema } from './schema';
 
 /**
@@ -183,7 +183,7 @@ export const counts = ( () => {
 	}, countsSchema );
 } )();
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	counts
 } );

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -7,7 +7,7 @@ import { merge } from 'lodash';
  * Internal dependencies
  */
 import itemsSchema from './schema';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	POST_LIKES_RECEIVE,
 	POST_LIKES_REQUEST,
@@ -61,7 +61,7 @@ export const items = createReducer( {}, {
 	}
 }, itemsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -7,7 +7,7 @@ import { get, set, omit, omitBy, isEqual, reduce, merge, findKey, mapValues, map
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
-import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	EDITOR_START,
 	EDITOR_STOP,
@@ -295,7 +295,7 @@ export function edits( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	counts,
 	items,
 	siteRequests,

--- a/client/state/posts/revisions/reducer.js
+++ b/client/state/posts/revisions/reducer.js
@@ -12,7 +12,7 @@ import {
 	POST_REVISIONS_REQUEST_FAILURE,
 	POST_REVISIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 export function requesting( state = {}, action ) {
 	switch ( action.type ) {
@@ -44,7 +44,7 @@ export function revisions( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	revisions,
 } );

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -14,7 +14,7 @@ import {
 	PREFERENCES_FETCH_FAILURE,
 	PREFERENCES_SAVE_SUCCESS
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { remoteValuesSchema } from './schema';
 
 /**
@@ -63,7 +63,7 @@ const lastFetchedTimestamp = createReducer( false, {
 	[ PREFERENCES_FETCH_SUCCESS ]: () => Date.now(),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	localValues,
 	remoteValues,
 	fetching,

--- a/client/state/products-list/reducer.js
+++ b/client/state/products-list/reducer.js
@@ -6,7 +6,7 @@ import {
 	PRODUCTS_LIST_REQUEST,
 	PRODUCTS_LIST_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { productsListSchema } from './schema';
 
 // Stores the complete list of products, indexed by the product key
@@ -21,7 +21,7 @@ export const isFetching = createReducer( false, {
 	[ PRODUCTS_LIST_REQUEST_FAILURE ]: () => false
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isFetching,
 	items,
 } );

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -7,7 +7,7 @@ import omit from 'lodash/omit';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, isValidStateWithSchema } from 'state/utils';
 
 import {
 	settingsSchema,
@@ -170,7 +170,7 @@ function settings( state = {}, action ) {
 }
 settings.hasCustomPersistence = true;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	settings,
 	system
 } );

--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -6,7 +6,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
@@ -63,7 +63,7 @@ export const total = createReducer(
 	}
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	total,
 } );

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -14,7 +14,7 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import { decodeEntities } from 'lib/formatting';
 import { itemsSchema } from './schema';
 
@@ -121,7 +121,7 @@ export const lastFetched = createReducer(
 	}
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	lastFetched,
 	queuedRequests,

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -22,7 +22,7 @@ import {
 	READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { prepareComparableUrl } from './utils';
 import { items as itemsSchema } from './schema';
 
@@ -195,7 +195,7 @@ export const lastSyncTime = createReducer( null, {
 	},
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	itemsCount,
 	lastSyncTime,

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -28,7 +28,7 @@ import {
 	READER_LISTS_REQUEST_FAILURE,
 	READER_LISTS_UNFOLLOW_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } from './schema';
 
 /**
@@ -198,7 +198,7 @@ export function missingLists( state = [], action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	subscribedLists,
 	updatedLists,

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -7,7 +7,7 @@ import keyBy from 'lodash/keyBy';
  * Internal dependencies
  */
 import { READER_POSTS_RECEIVE } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -27,6 +27,6 @@ export function items( state = {}, action ) {
 }
 items.schema = itemsSchema;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 } );

--- a/client/state/reader/recommended-sites/reducer.js
+++ b/client/state/reader/recommended-sites/reducer.js
@@ -7,11 +7,7 @@ import { uniqBy } from 'lodash';
  * Internal dependencies
  */
 import { READER_RECOMMENDED_SITES_RECEIVE } from 'state/action-types';
-import {
-	createReducer,
-	keyedReducer,
-	combineReducersWithPersistence
-} from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
 /**
  * Tracks mappings between randomization seeds and site recs.
@@ -45,7 +41,7 @@ export const pagingOffset = keyedReducer(
 	} )
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	pagingOffset,
 } );

--- a/client/state/reader/reducer.js
+++ b/client/state/reader/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import lists from './lists/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import feeds from './feeds/reducer';
 import follows from './follows/reducer';
 import sites from './sites/reducer';
@@ -15,7 +15,7 @@ import teams from './teams/reducer';
 import feedSearches from './feed-searches/reducer';
 import recommendedSites from './recommended-sites/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	feeds,
 	follows,
 	lists,

--- a/client/state/reader/related-posts/reducer.js
+++ b/client/state/reader/related-posts/reducer.js
@@ -8,7 +8,7 @@ import map from 'lodash/map';
 /**
  * Internal Dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	READER_RELATED_POSTS_RECEIVE,
@@ -49,7 +49,7 @@ export const queuedRequests = createReducer(
 	}
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	queuedRequests,
 } );

--- a/client/state/reader/site-blocks/reducer.js
+++ b/client/state/reader/site-blocks/reducer.js
@@ -10,7 +10,7 @@ import {
 	READER_SITE_UNBLOCK_REQUEST_SUCCESS,
 } from 'state/action-types';
 
-import { combineReducersWithPersistence, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
 /**
  * Tracks all known site block statuses, indexed by site ID.
@@ -30,6 +30,6 @@ export const items = keyedReducer(
 	)
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 } );

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -14,7 +14,7 @@ import {
 	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
 import { decodeEntities } from 'lib/formatting';
@@ -139,7 +139,7 @@ export const lastFetched = createReducer(
 	}
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	queuedRequests,
 	lastFetched,

--- a/client/state/reader/tags/images/reducer.js
+++ b/client/state/reader/tags/images/reducer.js
@@ -7,7 +7,7 @@ import {
 	READER_TAG_IMAGES_REQUEST_SUCCESS,
 	READER_TAG_IMAGES_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 /**
  * Tracks all known image objects, indexed by tag name.
@@ -54,7 +54,7 @@ export function requesting( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 } );

--- a/client/state/reader/tags/reducer.js
+++ b/client/state/reader/tags/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import images from './images/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import items from './items/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	images,
 	items,
 } );

--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { itemsSchema } from './schema';
 
 export const items = createReducer(
@@ -18,7 +18,7 @@ export const isRequesting = createReducer( false, {
 	[ READER_TEAMS_RECEIVE ]: () => false,
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	isRequesting,
 } );

--- a/client/state/reader/thumbnails/reducer.js
+++ b/client/state/reader/thumbnails/reducer.js
@@ -7,7 +7,7 @@ import {
 	READER_THUMBNAIL_REQUEST_FAILURE,
 	READER_THUMBNAIL_RECEIVE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 /**
  * Tracks mappings between embedUrls (iframe.src) --> thumbnails
@@ -63,7 +63,7 @@ export function requesting( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 } );

--- a/client/state/receipts/reducer.js
+++ b/client/state/receipts/reducer.js
@@ -6,7 +6,7 @@ import {
 	RECEIPT_FETCH_COMPLETED,
 	RECEIPT_FETCH_FAILED,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 export const initialReceiptState = {
 	data: null,
@@ -52,6 +52,6 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items
 } );

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -15,7 +15,7 @@ import {
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Tracks fetching state for keyring connections
@@ -45,7 +45,7 @@ export const items = createReducer( {}, {
 	},
 }, itemSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isFetching,
 	items,
 } );

--- a/client/state/sharing/publicize/publicize-actions/reducer.js
+++ b/client/state/sharing/publicize/publicize-actions/reducer.js
@@ -20,7 +20,7 @@ import {
 	PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS,
 	PUBLICIZE_SHARE_ACTION_EDIT_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { publicizeActionsSchema } from './schema';
 
 function updateDataForPost( newValue, state, siteId, postId, actionId ) {
@@ -97,7 +97,7 @@ export const editingSharePostAction = createReducer( {}, {
 		( state, { siteId, postId, actionId } ) => updateDataForPost( true, state, siteId, postId, actionId ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	scheduled,
 	published,
 	fetchingSharePostActionsScheduled,

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -21,7 +21,7 @@ import {
 	PUBLICIZE_SHARE_FAILURE,
 	PUBLICIZE_SHARE_DISMISS
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { connectionsSchema } from './schema';
 import sharePostActions from './publicize-actions/reducer';
 
@@ -77,7 +77,7 @@ export const connections = createReducer( {}, {
 	[ PUBLICIZE_CONNECTION_UPDATE ]: ( state, { connection } ) => ( { ...state, [ connection.ID ]: connection } ),
 }, connectionsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	fetchingConnection,
 	fetchingConnections,
 	fetchedConnections,

--- a/client/state/sharing/reducer.js
+++ b/client/state/sharing/reducer.js
@@ -2,11 +2,11 @@
  * Internal dependencies
  */
 import keyring from './keyring/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import publicize from './publicize/reducer';
 import services from './services/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	keyring,
 	publicize,
 	services,

--- a/client/state/sharing/services/reducer.js
+++ b/client/state/sharing/services/reducer.js
@@ -7,7 +7,7 @@ import {
 	KEYRING_SERVICES_REQUEST_FAILURE,
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Stores the list of available keyring services
@@ -22,7 +22,7 @@ export const isFetching = createReducer( false, {
 	[ KEYRING_SERVICES_REQUEST_FAILURE ]: () => false
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isFetching,
 	items,
 } );

--- a/client/state/shortcodes/reducer.js
+++ b/client/state/shortcodes/reducer.js
@@ -7,7 +7,7 @@ import { merge } from 'lodash';
  * Internal dependencies
  */
 import { shortcodesSchema } from './schema';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	SHORTCODE_RECEIVE,
 	SHORTCODE_REQUEST,
@@ -58,7 +58,7 @@ export const items = createReducer( {}, {
 	}
 }, shortcodesSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/signup/optional-dependencies/reducer.js
+++ b/client/state/signup/optional-dependencies/reducer.js
@@ -4,7 +4,7 @@
 import {
 	SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { suggestedUsernameSchema } from './schema';
 
 const suggestedUsername = createReducer( '',
@@ -16,7 +16,7 @@ const suggestedUsername = createReducer( '',
 	suggestedUsernameSchema
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	suggestedUsername
 } );
 

--- a/client/state/signup/reducer.js
+++ b/client/state/signup/reducer.js
@@ -2,11 +2,11 @@
  * Internal dependencies
  */
 import dependencyStore from './dependency-store/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import optionalDependencies from './optional-dependencies/reducer';
 import steps from './steps/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	dependencyStore,
 	optionalDependencies,
 	steps,

--- a/client/state/signup/steps/reducer.js
+++ b/client/state/signup/steps/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import siteTitle from './site-title/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import survey from './survey/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	siteTitle,
 	survey,
 } );

--- a/client/state/site-roles/reducer.js
+++ b/client/state/site-roles/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { siteRolesSchema } from './schema';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	SITE_ROLES_RECEIVE,
 	SITE_ROLES_REQUEST,
@@ -37,7 +37,7 @@ export const items = createReducer( {}, {
 	[ SITE_ROLES_RECEIVE ]: ( state, { siteId, roles } ) => ( { ...state, [ siteId ]: roles } )
 }, siteRolesSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/site-settings/exporter/reducers.js
+++ b/client/state/site-settings/exporter/reducers.js
@@ -13,7 +13,7 @@ import {
 	EXPORT_STARTED,
 	EXPORT_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { States } from './constants';
 
 export function selectedPostType( state = null, action ) {
@@ -134,7 +134,7 @@ export function downloadURL( state = null, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	selectedPostType,
 	selectedAdvancedSettings,
 	exportingState,

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import exporter from './exporter/reducers';
 import { items as itemSchemas } from './schema';
@@ -86,7 +86,7 @@ export const items = createReducer( {}, {
 	}
 }, itemSchemas );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	exporter,
 	items,
 	requesting,

--- a/client/state/sites/connection/reducer.js
+++ b/client/state/sites/connection/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	SITE_CONNECTION_STATUS_RECEIVE,
@@ -23,7 +23,7 @@ export const requesting = createReducer( {}, {
 	[ SITE_CONNECTION_STATUS_REQUEST_SUCCESS ]: createRequestingReducer( false ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 } );

--- a/client/state/sites/domains/reducer.js
+++ b/client/state/sites/domains/reducer.js
@@ -7,7 +7,7 @@ import {
 	SITE_DOMAINS_REQUEST_SUCCESS,
 	SITE_DOMAINS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -79,7 +79,7 @@ export const errors = ( state = {}, action ) => {
 	return state;
 };
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	errors

--- a/client/state/sites/guided-transfer/reducer.js
+++ b/client/state/sites/guided-transfer/reducer.js
@@ -10,7 +10,7 @@ import {
 	GUIDED_TRANSFER_STATUS_REQUEST_FAILURE,
 	GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { guidedTransferStatusSchema } from './schema';
 
 // Stores the status of guided transfers per site
@@ -60,7 +60,7 @@ export const isSaving = createReducer( {}, {
 		( { ...state, [ action.siteId ]: false } ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	error,
 	isFetching,
 	isSaving,

--- a/client/state/sites/media-storage/reducer.js
+++ b/client/state/sites/media-storage/reducer.js
@@ -12,7 +12,7 @@ import {
 	SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
 	SITE_MEDIA_STORAGE_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -53,7 +53,7 @@ export function fetchingItems( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	fetchingItems
 } );

--- a/client/state/sites/monitor/reducer.js
+++ b/client/state/sites/monitor/reducer.js
@@ -6,7 +6,7 @@ import { stubFalse, stubTrue } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
 import {
 	SITE_MONITOR_SETTINGS_RECEIVE,
@@ -34,7 +34,7 @@ export const updating = keyedReducer( 'siteId', createReducer( {}, {
 	[ SITE_MONITOR_SETTINGS_UPDATE_FAILURE ]: stubFalse,
 } ) );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	updating,

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -37,7 +37,7 @@ import {
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 } from 'state/action-types';
 import { sitesSchema } from './schema';
-import { createReducer, keyedReducer, combineReducersWithPersistence } from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
 /**
  * Constants
@@ -255,7 +255,7 @@ export const deleting = keyedReducer( 'siteId', createReducer( {}, {
 	[ SITE_DELETE_SUCCESS ]: stubFalse
 } ) );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	connection,
 	deleting,
 	domains,

--- a/client/state/sites/sharing-buttons/reducer.js
+++ b/client/state/sites/sharing-buttons/reducer.js
@@ -6,7 +6,7 @@ import { uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { items as itemSchemas } from './schema';
 import {
@@ -64,7 +64,7 @@ export const items = createReducer( {}, {
 	} )
 }, itemSchemas );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	saveRequests

--- a/client/state/sites/updates/reducer.js
+++ b/client/state/sites/updates/reducer.js
@@ -6,7 +6,7 @@ import { isEmpty, merge, stubFalse, stubTrue } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
 import {
 	SITE_RECEIVE,
@@ -72,7 +72,7 @@ export const errors = keyedReducer( 'siteId', createReducer( undefined, {
 	[ SITE_UPDATES_REQUEST_FAILURE ]: stubTrue,
 } ) );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	wordpressUpdateStatus,

--- a/client/state/sites/vouchers/reducer.js
+++ b/client/state/sites/vouchers/reducer.js
@@ -11,7 +11,7 @@ import {
 	SITE_VOUCHERS_REQUEST_SUCCESS,
 	SITE_VOUCHERS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -117,7 +117,7 @@ export const errors = ( state = {}, { type, siteId, error } ) => {
 	return state;
 };
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	requesting,
 	errors

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -6,7 +6,7 @@ import { merge, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
@@ -90,7 +90,7 @@ export function items( state = {}, action ) {
 }
 items.schema = itemSchema;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requests,
 	items
 } );

--- a/client/state/stats/posts/reducer.js
+++ b/client/state/stats/posts/reducer.js
@@ -6,7 +6,7 @@ import { get, merge } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	POST_STATS_RECEIVE,
@@ -67,7 +67,7 @@ export function items( state = {}, action ) {
 }
 items.schema = itemSchemas;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items
 } );

--- a/client/state/stats/reducer.js
+++ b/client/state/stats/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import posts from './posts/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import lists from './lists/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	posts,
 	lists
 } );

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -10,7 +10,7 @@ import {
 	STORED_CARDS_DELETE_COMPLETED,
 	STORED_CARDS_DELETE_FAILED
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { storedCardsSchema } from './schema';
 
 /**
@@ -88,7 +88,7 @@ export const isDeleting = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	hasLoadedFromServer,
 	isDeleting,
 	isFetching,

--- a/client/state/support/reducer.js
+++ b/client/state/support/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	SUPPORT_USER_ACTIVATE,
 	SUPPORT_USER_TOKEN_FETCH,
@@ -63,7 +63,7 @@ export function username( state = null, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	errorMessage,
 	isSupportUser,
 	isTransitioning,

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -16,7 +16,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
@@ -111,7 +111,7 @@ export const queries = createReducer( {}, {
 	}
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	queries,
 	queryRequests
 } );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -27,7 +27,7 @@ describe( 'utils', () => {
 	let keyedReducer;
 	let reducer;
 	let withSchemaValidation;
-	let combineReducersWithPersistence;
+	let combineReducers;
 	let isValidStateWithSchema;
 	let withoutPersistence;
 
@@ -39,7 +39,7 @@ describe( 'utils', () => {
 			extendAction,
 			keyedReducer,
 			withSchemaValidation,
-			combineReducersWithPersistence,
+			combineReducers,
 			isValidStateWithSchema,
 			withoutPersistence,
 		} = require( 'state/utils' ) );
@@ -441,7 +441,7 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( '#combineReducersWithPersistence', () => {
+	describe( '#combineReducers', () => {
 		const load = { type: DESERIALIZE };
 		const write = { type: SERIALIZE };
 		const grow = { type: 'GROW' };
@@ -485,7 +485,7 @@ describe( 'utils', () => {
 		let reducers;
 
 		beforeEach( () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				age,
 				height
 			} );
@@ -522,12 +522,12 @@ describe( 'utils', () => {
 		} );
 
 		it( 'nested reducers work on load', () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				age,
 				height,
 				date
 			} );
-			const nested = combineReducersWithPersistence( {
+			const nested = combineReducers( {
 				person: reducers,
 				count
 			} );
@@ -539,12 +539,12 @@ describe( 'utils', () => {
 		} );
 
 		it( 'nested reducers work on persist', () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				age,
 				height,
 				date
 			} );
-			const nested = combineReducersWithPersistence( {
+			const nested = combineReducers( {
 				person: reducers,
 				count
 			} );
@@ -556,15 +556,15 @@ describe( 'utils', () => {
 		} );
 
 		it( 'deeply nested reducers work on load', () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				age,
 				height,
 				date
 			} );
-			const nested = combineReducersWithPersistence( {
+			const nested = combineReducers( {
 				person: reducers,
 			} );
-			const veryNested = combineReducersWithPersistence( {
+			const veryNested = combineReducers( {
 				bob: nested,
 				count
 			} );
@@ -576,15 +576,15 @@ describe( 'utils', () => {
 		} );
 
 		it( 'deeply nested reducers work on persist', () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				age,
 				height,
 				date
 			} );
-			const nested = combineReducersWithPersistence( {
+			const nested = combineReducers( {
 				person: reducers,
 			} );
-			const veryNested = combineReducersWithPersistence( {
+			const veryNested = combineReducers( {
 				bob: nested,
 				count
 			} );
@@ -596,14 +596,14 @@ describe( 'utils', () => {
 		} );
 
 		it( 'deeply nested reducers work with reducer with a custom handler', () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				height,
 				date
 			} );
-			const nested = combineReducersWithPersistence( {
+			const nested = combineReducers( {
 				person: reducers,
 			} );
-			const veryNested = combineReducersWithPersistence( {
+			const veryNested = combineReducers( {
 				bob: nested,
 				count
 			} );
@@ -615,7 +615,7 @@ describe( 'utils', () => {
 		} );
 
 		it( 'uses the provided validation from withSchemaValidation', () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				height: withSchemaValidation( schema, height ),
 				count
 			} );
@@ -628,7 +628,7 @@ describe( 'utils', () => {
 		} );
 
 		it( 'uses the provided validation from createReducer', () => {
-			reducers = combineReducersWithPersistence( {
+			reducers = combineReducers( {
 				height: createReducer( 160, {}, schema ),
 				count
 			} );

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -7,7 +7,7 @@ import { mapValues, omit } from 'lodash';
  * Internal dependencies
  */
 import ThemeQueryManager from 'lib/query-manager/theme';
-import { combineReducersWithPersistence, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -369,7 +369,7 @@ export const themeFilters = createReducer( {}, {
 	[ THEME_FILTERS_ADD ]: ( state, { filters } ) => ( filters )
 }, themeFiltersSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	queries,
 	queryRequests,
 	queryRequestErrors,

--- a/client/state/themes/themes-ui/reducer.js
+++ b/client/state/themes/themes-ui/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { THEME_BACK_PATH_SET } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 // Destination for 'back' button on theme sheet
 function backPath( state = '/themes', action ) {
@@ -13,4 +13,4 @@ function backPath( state = '/themes', action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( { backPath } );
+export default combineReducers( { backPath } );

--- a/client/state/themes/upload-theme/reducer.js
+++ b/client/state/themes/upload-theme/reducer.js
@@ -6,7 +6,7 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	THEME_UPLOAD_START,
@@ -116,7 +116,7 @@ export const inProgress = createReducer( {}, {
 	} ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	uploadedThemeId,
 	uploadError,
 	progressLoaded,

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	TIMEZONES_RECEIVE,
@@ -30,7 +30,7 @@ export const isRequesting = ( state = false, { type } ) => (
 	type === TIMEZONES_REQUEST
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	rawOffsets,
 	labels,
 	byContinents,

--- a/client/state/ui/drop-zone/reducer.js
+++ b/client/state/ui/drop-zone/reducer.js
@@ -6,7 +6,7 @@ import {
 	DROPZONE_HIDE
 } from 'state/action-types';
 
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 // TODO(biskobe) - Can be improved with `keyedReducer` instead of state spread.
 const isVisible = createReducer( {},
@@ -22,6 +22,6 @@ const isVisible = createReducer( {},
 	}
 );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isVisible,
 } );

--- a/client/state/ui/editor/image-editor/reducer.js
+++ b/client/state/ui/editor/image-editor/reducer.js
@@ -14,7 +14,7 @@ import {
 	IMAGE_EDITOR_STATE_RESET_ALL,
 	IMAGE_EDITOR_IMAGE_HAS_LOADED
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { AspectRatios } from './constants';
 
 export const defaultTransform = {
@@ -176,7 +176,7 @@ export function aspectRatio( state = AspectRatios.FREE, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	hasChanges,
 	fileInfo,
 	transform,

--- a/client/state/ui/editor/last-draft/reducer.js
+++ b/client/state/ui/editor/last-draft/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { EDITOR_LAST_DRAFT_SET } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 /**
  * Returns the updated editor last draft site ID state after an action has been
@@ -38,7 +38,7 @@ export function postId( state = null, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	siteId,
 	postId
 } );

--- a/client/state/ui/editor/reducer.js
+++ b/client/state/ui/editor/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { EDITOR_START, POST_SAVE_SUCCESS } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import imageEditor from './image-editor/reducer';
 import videoEditor from './video-editor/reducer';
 import lastDraft from './last-draft/reducer';
@@ -27,7 +27,7 @@ export function postId( state = null, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	postId,
 	imageEditor,
 	videoEditor,

--- a/client/state/ui/editor/video-editor/reducer.js
+++ b/client/state/ui/editor/video-editor/reducer.js
@@ -7,7 +7,7 @@ import {
 	VIDEO_EDITOR_SHOW_ERROR,
 	VIDEO_EDITOR_SHOW_UPLOAD_PROGRESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 /**
  * Tracks whether or not the modal should close.
@@ -58,7 +58,7 @@ export const uploadProgress = ( state = null, { type, percentage } ) => {
  */
 export const showError = ( state = false, { type } ) => type === VIDEO_EDITOR_SHOW_ERROR;
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	closeModal,
 	showError,
 	uploadProgress,

--- a/client/state/ui/happychat/reducer.js
+++ b/client/state/ui/happychat/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	HAPPYCHAT_OPEN,
 	HAPPYCHAT_MINIMIZING
@@ -34,4 +34,4 @@ const isMinimizing = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducersWithPersistence( { open, isMinimizing } );
+export default combineReducers( { open, isMinimizing } );

--- a/client/state/ui/media-modal/reducer.js
+++ b/client/state/ui/media-modal/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import { MEDIA_MODAL_VIEW_SET } from 'state/action-types';
 
@@ -9,6 +9,6 @@ export const view = createReducer( null, {
 	[ MEDIA_MODAL_VIEW_SET ]: ( state, action ) => action.view
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	view
 } );

--- a/client/state/ui/nps-survey-notice/reducer.js
+++ b/client/state/ui/nps-survey-notice/reducer.js
@@ -4,13 +4,13 @@
 import {
 	NPS_SURVEY_DIALOG_IS_SHOWING,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 export const isNpsSurveyDialogShowing = createReducer( false, {
 	[ NPS_SURVEY_DIALOG_IS_SHOWING ]: ( state, { isShowing } ) =>
 		isShowing !== undefined ? isShowing : state,
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isNpsSurveyDialogShowing,
 } );

--- a/client/state/ui/olark/reducer.js
+++ b/client/state/ui/olark/reducer.js
@@ -9,7 +9,7 @@ import {
 	OLARK_OPERATORS_AWAY,
 	OLARK_SET_AVAILABILITY,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	STATUS_READY,
 	STATUS_TIMEOUT,
@@ -86,7 +86,7 @@ export function requesting( state = false, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	operatorStatus,
 	availability,
 	requesting,

--- a/client/state/ui/preview/reducer.js
+++ b/client/state/ui/preview/reducer.js
@@ -8,7 +8,7 @@ import {
 	PREVIEW_TYPE_SET,
 	PREVIEW_TYPE_RESET,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 export function currentPreviewUrl( state = null, action ) {
 	switch ( action.type ) {
@@ -39,7 +39,7 @@ export function activeDesignTool( state = null, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	currentPreviewUrl,
 	currentPreviewType,
 	activeDesignTool,

--- a/client/state/ui/query-arguments/reducer.js
+++ b/client/state/ui/query-arguments/reducer.js
@@ -6,7 +6,7 @@ import { isEqual, omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 
 import {
 	ROUTE_SET,
@@ -34,7 +34,7 @@ const current = createReducer( {}, {
 			: state,
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	initial,
 	current,
 } );

--- a/client/state/ui/reader/reducer.js
+++ b/client/state/ui/reader/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import sidebar from './sidebar/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import cardExpansions from './card-expansions/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	sidebar,
 	cardExpansions,
 } );

--- a/client/state/ui/reader/sidebar/reducer.js
+++ b/client/state/ui/reader/sidebar/reducer.js
@@ -5,7 +5,7 @@ import {
 	READER_SIDEBAR_LISTS_TOGGLE,
 	READER_SIDEBAR_TAGS_TOGGLE
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 export function isListsOpen( state = false, action ) {
 	switch ( action.type ) {
@@ -25,7 +25,7 @@ export function isTagsOpen( state = false, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	isListsOpen,
 	isTagsOpen
 } );

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -9,7 +9,7 @@ import {
 	DESERIALIZE,
 	NOTIFICATIONS_PANEL_TOGGLE,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import editor from './editor/reducer';
 import dropZone from './drop-zone/reducer';
 import guidedTour from './guided-tours/reducer';
@@ -83,7 +83,7 @@ export const isNotificationsOpen = function( state = false, { type } ) {
 	return state;
 };
 
-const reducer = combineReducersWithPersistence( {
+const reducer = combineReducers( {
 	section,
 	isLoading,
 	layoutFocus,

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -12,7 +12,7 @@ import {
 	USER_SETTINGS_UNSAVED_SET,
 	USER_SETTINGS_UNSAVED_REMOVE,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 export const settings = ( state = null, { type, settingValues } ) =>
 	USER_SETTINGS_UPDATE === type
@@ -43,7 +43,7 @@ export const unsavedSettings = ( state = {}, action ) => {
 	}
 };
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	settings,
 	unsavedSettings,
 } );

--- a/client/state/users/reducer.js
+++ b/client/state/users/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import suggestions from './suggestions/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import {
 	USER_RECEIVE,
 } from 'state/action-types';
@@ -25,7 +25,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	suggestions,
 } );

--- a/client/state/users/suggestions/reducer.js
+++ b/client/state/users/suggestions/reducer.js
@@ -7,7 +7,7 @@ import {
 	USER_SUGGESTIONS_REQUEST_FAILURE,
 	USER_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -45,7 +45,7 @@ export const items = createReducer( {}, {
 	},
 }, itemsSchema );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	items,
 } );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -3,7 +3,7 @@
  */
 import validator from 'is-my-json-valid';
 import { merge, flow, partialRight, reduce, isEqual, omit } from 'lodash';
-import { combineReducers } from 'redux';
+import { combineReducers as combine } from 'redux';
 
 /**
  * Internal dependencies
@@ -322,7 +322,7 @@ export const withSchemaValidation = ( schema, reducer ) => {
  *
  * age.schema = schema;
  *
- * const combinedReducer = combineReducersWithPersistence( {
+ * const combinedReducer = combineReducers( {
  *     age,
  *     height
  * } );
@@ -354,7 +354,7 @@ export const withSchemaValidation = ( schema, reducer ) => {
  * };
  * date.hasCustomPersistence = true;
  *
- * const combinedReducer = combineReducersWithPersistence( {
+ * const combinedReducer = combineReducers( {
  *     date,
  *     height
  * } );
@@ -368,12 +368,12 @@ export const withSchemaValidation = ( schema, reducer ) => {
  * @param {object} reducers - object containing the reducers to merge
  * @returns {function} - Returns the combined reducer function
  */
-export function combineReducersWithPersistence( reducers ) {
+export function combineReducers( reducers ) {
 	const validatedReducers = reduce( reducers, ( validated, next, key ) => {
 		const { schema, hasCustomPersistence } = next;
 		return { ...validated, [ key ]: hasCustomPersistence ? next : withSchemaValidation( schema, next ) };
 	}, {} );
-	const combined = combineReducers( validatedReducers );
+	const combined = combine( validatedReducers );
 	combined.hasCustomPersistence = true;
 	return combined;
 }

--- a/client/state/wordads/approve/reducer.js
+++ b/client/state/wordads/approve/reducer.js
@@ -8,7 +8,7 @@ import {
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_ERROR,
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_SUCCESS,
 } from 'state/action-types';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 /**
  * Tracks all WordAds request status, indexed by site ID.
@@ -73,7 +73,7 @@ export function requestSuccess( state = {}, action ) {
 	return state;
 }
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	requesting,
 	requestSuccess,
 	requestErrors,

--- a/client/state/wordads/reducer.js
+++ b/client/state/wordads/reducer.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import approve from './approve/reducer';
-import { combineReducersWithPersistence } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import status from './status/reducer';
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	approve,
 	status
 } );

--- a/client/state/wordads/status/reducer.js
+++ b/client/state/wordads/status/reducer.js
@@ -6,7 +6,7 @@ import {
 	WORDADS_STATUS_REQUEST_SUCCESS,
 	WORDADS_STATUS_REQUEST_FAILURE
 } from 'state/action-types';
-import { combineReducersWithPersistence, createReducer } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { wordadsStatusSchema } from './schema';
 
 export const items = createReducer( {}, {
@@ -21,7 +21,7 @@ export const fetchingItems = createReducer( {}, {
 	[ WORDADS_STATUS_REQUEST_FAILURE ]: ( state, action ) => Object.assign( {}, state, { [ action.siteId ]: false } ),
 } );
 
-export default combineReducersWithPersistence( {
+export default combineReducers( {
 	items,
 	fetchingItems
 } );

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -395,14 +395,14 @@ handlers to avoid data shape errors.
 ### Opt-in to Persistence ( [#13542](https://github.com/Automattic/wp-calypso/pull/13542) )
 
 If we choose not to use `createReducer` we can opt-in to persistence by adding a schema as a property on the reducer. 
-We do this by combining all of our reducers using `combineReducersWithPersistence` at every level of the tree instead 
-of [combineReducers](http://redux.js.org/docs/api/combineReducers.html). Each reducer is then wrapped with 
+We do this by combining all of our reducers using `combineReducers` from `state/utils` at every level of the tree instead 
+of [combineReducers](http://redux.js.org/docs/api/combineReducers.html) from `redux`. Each reducer is then wrapped with 
 `withSchemaValidation` which returns a wrapped reducer that validates on `DESERIALZE` if a schema is present and 
 returns initial state on both `SERIALIZE` and `DESERIALZE` if a schema is not present.
 
 To opt-out of persistence we combine the reducers without any attached schema.
 ```javascript
-return combineReducersWithPersistence( {
+return combineReducers( {
     age,
     height,
 } );
@@ -411,7 +411,7 @@ return combineReducersWithPersistence( {
 To persist, we add the schema as a property on the reducer:
 ```javascript
 age.schema = ageSchema;
-return combineReducersWithPersistence( {
+return combineReducers( {
     age,
     height,
 } );
@@ -422,7 +422,7 @@ on `DESERIALIZE` so all we need to do is set a boolean bit on the reducer, to en
 incorrectly from the default handling provided by `withSchemaValidation`.
 ```javascript
 date.hasCustomPersistence = true;
-return combineReducersWithPersistence( {
+return combineReducers( {
     age,
     height,
     date,


### PR DESCRIPTION
This PR renames `combineReducersWithPersistence` to `combineReducers`. The original name was causing confusion on when it should be used (answer: always).

I'll need to follow up with a custom eslint rule to disallow importing `combineReducers` from `redux`

### Testing Instructions
- No functional changes
- No usages of combineReducersWithPersistence in code.