### PR TITLE
Add/site comments query component

### DIFF
--- a/client/components/data/query-site-comments/README.md
+++ b/client/components/data/query-site-comments/README.md
@@ -1,0 +1,32 @@
+Query Site Comments
+================
+
+`<QuerySiteComments />` requests that recent comments for a given site be loaded into Calypso.
+It should be used when we need comments but don't have a specific associated post.
+In many cases, for instance, we are looking for comment replies to a specific post, but in this case we are working with comments for any and all posts across an entire site.
+
+## Usage
+
+There is planned support for additional features not yet implemented:
+ - paging and limiting
+ - specifying type of comments (pingbacks, trackbacks, etc…)
+ - ordering
+ - Pinghub connection
+
+```js
+import QuerySiteComments from 'components/data/query-site-comments'
+
+const CommentList = ( { comments, siteId } ) => (
+	<div>
+		<QuerySiteComments siteId={ siteId } />
+		{ comments.map( … ) }
+	</div>
+)
+```
+
+## Props
+
+| Name | Type | Required? | Default | Description |
+| --- | --- | --- | --- | --- |
+| `siteId` | Number | Yes | | Site for whose recent comments to retrieve |
+| `status` | String | No | `unapproved` | Which comments to retrieve<br /> <ul><li>`all`</li><li>`approved`</li><li>`unapproved`</li><li>`spam`</li><li>`trash`</li></ul> |

--- a/client/components/data/query-site-comments/index.jsx
+++ b/client/components/data/query-site-comments/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestCommentsList } from 'state/comments/actions';
+
+const requestComments = ( { requestSiteComments, siteId, status } ) => requestSiteComments( { siteId, status } );
+
+export class QuerySiteComments extends Component {
+	componentDidMount() {
+		requestComments( this.props );
+	}
+
+	componentDidUpdate( { siteId } ) {
+		if ( siteId !== this.props.siteId ) {
+			requestComments( this.props );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+const mapDispatchToProps = dispatch => ( {
+	requestSiteComments: ( { siteId, status = 'unapproved' } ) => dispatch( requestCommentsList( {
+		listType: 'site',
+		siteId,
+		status,
+		type: 'comment',
+	} ) ),
+} );
+
+export default connect( null, mapDispatchToProps )( QuerySiteComments );

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -15,6 +15,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import CommentDetail from 'blocks/comment-detail';
 import CommentNavigation from './comment-navigation';
+import QuerySiteComments from 'components/data/query-site-comments';
 import { mockComments } from 'blocks/comment-detail/docs/mock-data';
 
 export class CommentsManagement extends Component {
@@ -46,6 +47,7 @@ export class CommentsManagement extends Component {
 		return (
 			<Main className="comments" wideLayout>
 				<PageViewTracker path={ basePath } title="Manage Comments" />
+				<QuerySiteComments siteId={ this.props.siteId } />
 				<DocumentHead title={ translate( 'Manage Comments' ) } />
 				<div className="comments__primary">
 					<CommentNavigation { ...{


### PR DESCRIPTION
Creates query component and adds it to the new comment management page for the currently-selected site.

Can pair with #14435 to load in stored comments for same site.

Depends on #14431 - **wait on this to merge**