### PR TITLE
Signup A/B Test: Use progress bar instead of # steps

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -202,6 +202,7 @@
 @import 'components/vertical-nav/item/style';
 @import 'components/vertical-menu/style';
 @import 'components/web-preview/style';
+@import 'components/wizard-bar/style';
 @import 'blocks/credit-card-form/style';
 @import 'devdocs/docs-example/style';
 @import 'devdocs/docs-selectors/style';

--- a/client/components/wizard-bar/README.md
+++ b/client/components/wizard-bar/README.md
@@ -8,7 +8,7 @@ with a % of the size of the background.
 #### How to use:
 
 ```js
-var WizardBar = require( 'components/wizard-bar' );
+import WizardBar from 'components/wizard-bar';
 
 render: function() {
 	return <WizardBar

--- a/client/components/wizard-bar/README.md
+++ b/client/components/wizard-bar/README.md
@@ -1,0 +1,26 @@
+Wizard Bar
+==============
+
+This component is used to display a single bar in a background color,
+and another bar on top of that filled, in a different color,
+with a % of the size of the background.
+
+#### How to use:
+
+```js
+var WizardBar = require( 'components/wizard-bar' );
+
+render: function() {
+	return <WizardBar
+		value={ amount }
+		total={ total }
+		color={ color }
+	/>;
+}
+```
+
+#### Props
+
+* `value`: a number representing the amount over the total to be represented in the bar (required).
+* `total`: a number representing the value corresponding to the 100% of the bar (optional, default == 100).
+* `color`: a string of a css color (optional).

--- a/client/components/wizard-bar/docs/example.jsx
+++ b/client/components/wizard-bar/docs/example.jsx
@@ -2,18 +2,13 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
 import WizardBar from 'components/wizard-bar';
 
-module.exports = React.createClass( {
-	displayName: 'WizardBar',
-
-	mixins: [ PureRenderMixin ],
-
+export default class WizardBarExample extends React.Component {
 	render() {
 		return (
 			<div>
@@ -23,4 +18,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/components/wizard-bar/docs/example.jsx
+++ b/client/components/wizard-bar/docs/example.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
+import WizardBar from 'components/wizard-bar';
+
+module.exports = React.createClass( {
+	displayName: 'WizardBar',
+
+	mixins: [ PureRenderMixin ],
+
+	render() {
+		return (
+			<div>
+				<WizardBar value={ 0 } />
+				<WizardBar value={ 55 } total={ 100 } />
+				<WizardBar value={ 100 } color="#1BABDA" />
+			</div>
+		);
+	}
+} );

--- a/client/components/wizard-bar/index.jsx
+++ b/client/components/wizard-bar/index.jsx
@@ -11,6 +11,7 @@ import ProgressIcon from './progress-icon';
 export default class WizardBar extends React.Component {
 	static defaultProps = {
 		total: 100,
+		color: '#006fb5',
 	};
 
 	static propTypes = {
@@ -28,19 +29,20 @@ export default class WizardBar extends React.Component {
 
 	renderBar() {
 		const completionPercentage = this.getCompletionPercentage();
-		const styles = { width: completionPercentage + '%' };
-		if ( this.props.color ) {
-			styles.backgroundColor = this.props.color;
-		}
+		const progressStyle = {
+			width: completionPercentage + '%',
+			backgroundColor: this.props.color,
+		};
+		const indicatorStyle = {
+			width: completionPercentage === 0 ? '7px' : `${ completionPercentage }%`,
+			marginLeft: completionPercentage === 0 ? '-4px' : 0,
+		};
 
 		return (
 			<div>
-				<div className="wizard-bar__progress" style={ styles } />
-				<div
-					className="wizard-bar__indicator"
-					style={ { width: ( completionPercentage + 1 ) + '%' } }
-				>
-					{ <ProgressIcon /> }
+				<div className="wizard-bar__progress" style={ progressStyle } />
+				<div className="wizard-bar__indicator" style={ indicatorStyle }>
+					{ <ProgressIcon color={ this.props.color } /> }
 				</div>
 			</div>
 		);

--- a/client/components/wizard-bar/index.jsx
+++ b/client/components/wizard-bar/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -48,9 +47,8 @@ export default class WizardBar extends React.Component {
 	}
 
 	render() {
-		const classes = classnames( this.props.className, 'wizard-bar' );
 		return (
-			<div className={ classes }>
+			<div className="wizard-bar">
 				{ this.renderBar() }
 			</div>
 		);

--- a/client/components/wizard-bar/index.jsx
+++ b/client/components/wizard-bar/index.jsx
@@ -28,8 +28,8 @@ export default class WizardBar extends React.Component {
 	}
 
 	renderBar() {
-		const completitionPercentage = this.getCompletionPercentage();
-		const styles = { width: completitionPercentage + '%' };
+		const completionPercentage = this.getCompletionPercentage();
+		const styles = { width: completionPercentage + '%' };
 		if ( this.props.color ) {
 			styles.backgroundColor = this.props.color;
 		}
@@ -39,7 +39,7 @@ export default class WizardBar extends React.Component {
 				<div className="wizard-bar__progress" style={ styles } />
 				<div
 					className="wizard-bar__indicator"
-					style={ { width: ( completitionPercentage + 1 ) + '%' } }
+					style={ { width: ( completionPercentage + 1 ) + '%' } }
 				>
 					{ <ProgressIcon /> }
 				</div>

--- a/client/components/wizard-bar/index.jsx
+++ b/client/components/wizard-bar/index.jsx
@@ -10,11 +10,9 @@ import classnames from 'classnames';
 import ProgressIcon from './progress-icon';
 
 export default class WizardBar extends React.Component {
-	getDefaultProps() {
-		return {
-			total: 100,
-		};
-	}
+	static defaultProps = {
+		total: 100,
+	};
 
 	static propTypes = {
 		value: React.PropTypes.number.isRequired,
@@ -30,7 +28,8 @@ export default class WizardBar extends React.Component {
 	}
 
 	renderBar() {
-		const styles = { width: this.getCompletionPercentage() + '%' };
+		const completitionPercentage = this.getCompletionPercentage();
+		const styles = { width: completitionPercentage + '%' };
 		if ( this.props.color ) {
 			styles.backgroundColor = this.props.color;
 		}
@@ -38,7 +37,12 @@ export default class WizardBar extends React.Component {
 		return (
 			<div>
 				<div className="wizard-bar__progress" style={ styles } />
-				<div className="wizard-bar__indicator" style={ styles }>{ <ProgressIcon /> }</div>
+				<div
+					className="wizard-bar__indicator"
+					style={ { width: ( completitionPercentage + 1 ) + '%' } }
+				>
+					{ <ProgressIcon /> }
+				</div>
 			</div>
 		);
 	}

--- a/client/components/wizard-bar/index.jsx
+++ b/client/components/wizard-bar/index.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import ProgressIcon from './progress-icon';
+
+export default class WizardBar extends React.Component {
+	getDefaultProps() {
+		return {
+			total: 100,
+		};
+	}
+
+	static propTypes = {
+		value: React.PropTypes.number.isRequired,
+		total: React.PropTypes.number,
+		color: React.PropTypes.string,
+	};
+
+	getCompletionPercentage() {
+		const percentage = Math.ceil( this.props.value / this.props.total * 100 );
+
+		// The percentage should not be allowed to be more than 100
+		return Math.min( percentage, 100 );
+	}
+
+	renderBar() {
+		const styles = { width: this.getCompletionPercentage() + '%' };
+		if ( this.props.color ) {
+			styles.backgroundColor = this.props.color;
+		}
+
+		return (
+			<div>
+				<div className="wizard-bar__progress" style={ styles } />
+				<div className="wizard-bar__indicator" style={ styles }>{ <ProgressIcon /> }</div>
+			</div>
+		);
+	}
+
+	render() {
+		const classes = classnames( this.props.className, 'wizard-bar' );
+		return (
+			<div className={ classes }>
+				{ this.renderBar() }
+			</div>
+		);
+	}
+}

--- a/client/components/wizard-bar/progress-icon.jsx
+++ b/client/components/wizard-bar/progress-icon.jsx
@@ -3,8 +3,10 @@
  */
 import React from 'react';
 
-export default () => (
+const ProgressIcon = () => (
 	<svg className="wizard-bar__indicator-icon" width="8px" height="8px" viewBox="0 0 8 8" version="1.1">
 		<path d="M 4,0 L 8,4 L 4,8 L 0,4 Z" />
 	</svg>
 );
+
+export default ProgressIcon;

--- a/client/components/wizard-bar/progress-icon.jsx
+++ b/client/components/wizard-bar/progress-icon.jsx
@@ -3,8 +3,13 @@
  */
 import React from 'react';
 
-const ProgressIcon = () => (
-	<svg className="wizard-bar__indicator-icon" width="8px" height="8px" viewBox="0 0 8 8" version="1.1">
+const ProgressIcon = ( { color } ) => (
+	<svg
+		className="wizard-bar__indicator-icon"
+		fill={ color }
+		width="8px" height="8px"
+		viewBox="0 0 8 8" version="1.1"
+	>
 		<path d="M 4,0 L 8,4 L 4,8 Z" />
 	</svg>
 );

--- a/client/components/wizard-bar/progress-icon.jsx
+++ b/client/components/wizard-bar/progress-icon.jsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => (
+	<svg width="8px" height="8px" viewBox="0 0 7 7" version="1.1"
+		xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+		<g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+			<g className="wizard-bar__indicator-icon" id="alt-7" transform="translate(-418.000000, -76.000000)">
+				<rect id="Rectangle-3"
+					transform="translate(421.500000, 79.500000) rotate(-315.000000) translate(-421.500000, -79.500000) "
+					x="419" y="77" width="5" height="5" />
+			</g>
+		</g>
+	</svg>
+);

--- a/client/components/wizard-bar/progress-icon.jsx
+++ b/client/components/wizard-bar/progress-icon.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 const ProgressIcon = () => (
 	<svg className="wizard-bar__indicator-icon" width="8px" height="8px" viewBox="0 0 8 8" version="1.1">
-		<path d="M 4,0 L 8,4 L 4,8 L 0,4 Z" />
+		<path d="M 4,0 L 8,4 L 4,8 Z" />
 	</svg>
 );
 

--- a/client/components/wizard-bar/progress-icon.jsx
+++ b/client/components/wizard-bar/progress-icon.jsx
@@ -4,14 +4,7 @@
 import React from 'react';
 
 export default () => (
-	<svg width="8px" height="8px" viewBox="0 0 7 7" version="1.1"
-		xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
-		<g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-			<g className="wizard-bar__indicator-icon" id="alt-7" transform="translate(-418.000000, -76.000000)">
-				<rect id="Rectangle-3"
-					transform="translate(421.500000, 79.500000) rotate(-315.000000) translate(-421.500000, -79.500000) "
-					x="419" y="77" width="5" height="5" />
-			</g>
-		</g>
+	<svg className="wizard-bar__indicator-icon" width="8px" height="8px" viewBox="0 0 8 8" version="1.1">
+		<path d="M 4,0 L 8,4 L 4,8 L 0,4 Z" />
 	</svg>
 );

--- a/client/components/wizard-bar/style.scss
+++ b/client/components/wizard-bar/style.scss
@@ -1,0 +1,39 @@
+.wizard-bar {
+	width: 100%;
+	display: inline-block;
+	position: relative;
+	height: 2px;
+	background-color: lighten( $gray, 20% );
+	border-radius: 4.5px;
+	border: 1px solid $white;
+}
+
+.wizard-bar__progress {
+	display: inline-block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 100%;
+	background-color: lighten( $blue-dark, 10% );
+	border-radius: 4.5px;
+	transition: width 200ms;
+}
+
+.wizard-bar__indicator {
+	position: absolute;
+	top: -10px;
+}
+
+.wizard-bar__indicator-icon {
+	fill: lighten( $blue-dark, 10% );
+}
+
+/* Percentage bar */
+.percentage-bar {
+	border-radius: 0;
+	height: 8px;
+	width: 150px;
+	.wizard-bar__progress {
+		border-radius: 0;
+	}
+}

--- a/client/components/wizard-bar/style.scss
+++ b/client/components/wizard-bar/style.scss
@@ -28,7 +28,6 @@
 }
 
 .wizard-bar__indicator-icon {
-	fill: lighten( $blue-dark, 10% );
 	height: 7px;
 	width: 7px;
 }

--- a/client/components/wizard-bar/style.scss
+++ b/client/components/wizard-bar/style.scss
@@ -2,7 +2,7 @@
 	width: 100%;
 	display: inline-block;
 	position: relative;
-	height: 2px;
+	height: 1px;
 	background-color: lighten( $gray, 20% );
 	border-radius: 4.5px;
 	border: 1px solid $white;
@@ -27,6 +27,8 @@
 
 .wizard-bar__indicator-icon {
 	fill: lighten( $blue-dark, 10% );
+	height: 7px;
+	width: 7px;
 }
 
 /* Percentage bar */

--- a/client/components/wizard-bar/style.scss
+++ b/client/components/wizard-bar/style.scss
@@ -20,8 +20,9 @@
 }
 
 .wizard-bar__indicator {
-	position: absolute;
-	top: -10px;
+	display: flex;
+	justify-content: flex-end;
+	margin-top: -3px;
 }
 
 .wizard-bar__indicator-icon {

--- a/client/components/wizard-bar/style.scss
+++ b/client/components/wizard-bar/style.scss
@@ -17,12 +17,14 @@
 	background-color: lighten( $blue-dark, 10% );
 	border-radius: 4.5px;
 	transition: width 200ms;
+	transition: all 500ms ease-in;
 }
 
 .wizard-bar__indicator {
 	display: flex;
 	justify-content: flex-end;
 	margin-top: -3px;
+	transition: all 500ms ease-in;
 }
 
 .wizard-bar__indicator-icon {

--- a/client/components/wizard-bar/test/index.jsx
+++ b/client/components/wizard-bar/test/index.jsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import useFakeDom from 'test/helpers/use-fake-dom';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import WizardBar from '../';
+
+describe( 'WizardBar', function() {
+	useFakeDom();
+
+	it( 'should properly calculate the width percentage', function() {
+		const wizardBar = shallow( <WizardBar value={ 20 } total={ 40 } /> );
+
+		expect( wizardBar.find( '.wizard-bar__progress' ).props().style.width ).to.be.equal( '50%' );
+	} );
+
+	it( 'should have the color provided by the color property', function() {
+		const wizardBar = shallow( <WizardBar value={ 20 } color="red" /> );
+
+		expect( wizardBar.find( '.wizard-bar__progress' ).props().style.backgroundColor ).to.be.equal( 'red' );
+	} );
+
+	it( 'should not be able to be more than 100% complete', () => {
+		const wizardBar = shallow( <WizardBar value={ 240 } /> );
+		expect( wizardBar.find( '.wizard-bar__progress' ).props().style.width ).to.be.equal( '100%' );
+	} );
+} );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -74,6 +74,7 @@ import LanguagePicker from 'components/language-picker/docs/example';
 import FormattedHeader from 'components/formatted-header/docs/example';
 import EmptyContent from 'components/empty-content/docs/example';
 import ExtraInfoFrForm from 'components/domains/registrant-extra-info/docs/example';
+import WizardBar from 'components/wizard-bar/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -168,6 +169,7 @@ let DesignAssets = React.createClass( {
 					<TokenFields />
 					<VerticalMenu />
 					<Version />
+					<WizardBar />
 				</Collection>
 			</Main>
 		);

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -101,7 +101,7 @@ module.exports = {
 		defaultVariation: 'original',
 	},
 	signupProgressIndicator: {
-		datestamp: '20170605',
+		datestamp: '20170612',
 		variations: {
 			original: 50,
 			wizardbar: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,4 +100,12 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
+	signupProgressIndicator: {
+		datestamp: '20170605',
+		variations: {
+			original: 50,
+			wizardbar: 50,
+		},
+		defaultVariation: 'original',
+	},
 };

--- a/client/signup/flow-progress-indicator/index.jsx
+++ b/client/signup/flow-progress-indicator/index.jsx
@@ -2,35 +2,28 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import flows from 'signup/config/flows';
+import ProgressBar from 'components/progress-bar';
 
-module.exports = React.createClass( {
-	displayName: 'FlowProgressIndicator',
+export default localize( ( { flowName, positionInFlow, translate } ) => {
+	const flow = flows.getFlow( flowName );
+	const flowLength = flow.steps.length;
 
-	getFlowLength: function() {
-		var flow = flows.getFlow( this.props.flowName );
-
-		return flow.steps.length;
-	},
-
-	render: function() {
-		if ( this.getFlowLength() > 1 ) {
-			return (
-				<div className="flow-progress-indicator">{
-					this.translate( 'Step %(stepNumber)d of %(stepTotal)d', {
-						args: {
-							stepNumber: this.props.positionInFlow + 1,
-							stepTotal: this.getFlowLength()
-						}
-					} )
-				}</div>
-			);
-		}
-
-		return null;
+	if ( flowLength > 1 ) {
+		return (
+			<div className="flow-progress-indicator__container">
+				<div className="flow-progress-indicator__progress-bar">
+					{ translate( 'Current progress:' ) }
+					<ProgressBar value={ positionInFlow } total={ flowLength } isPulsing />
+				</div>
+			</div>
+		);
 	}
+
+	return null;
 } );

--- a/client/signup/flow-progress-indicator/index.jsx
+++ b/client/signup/flow-progress-indicator/index.jsx
@@ -2,28 +2,26 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import flows from 'signup/config/flows';
-import ProgressBar from 'components/progress-bar';
+import WizardBar from 'components/wizard-bar';
 
-export default localize( ( { flowName, positionInFlow, translate } ) => {
+export default ( { flowName, positionInFlow } ) => {
 	const flow = flows.getFlow( flowName );
 	const flowLength = flow.steps.length;
 
 	if ( flowLength > 1 ) {
 		return (
-			<div className="flow-progress-indicator__container">
-				<div className="flow-progress-indicator__progress-bar">
-					{ translate( 'Current progress:' ) }
-					<ProgressBar value={ positionInFlow } total={ flowLength } isPulsing />
+			<div className="flow-progress-indicator">
+				<div className="flow-progress-indicator__wizard-bar">
+					<WizardBar value={ positionInFlow + 1 } total={ flowLength } isPulsing />
 				</div>
 			</div>
 		);
 	}
 
 	return null;
-} );
+};

--- a/client/signup/flow-progress-indicator/index.jsx
+++ b/client/signup/flow-progress-indicator/index.jsx
@@ -2,26 +2,45 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import flows from 'signup/config/flows';
 import WizardBar from 'components/wizard-bar';
 
-export default ( { flowName, positionInFlow } ) => {
+const FlowProgressIndicator = ( { flowName, positionInFlow, translate } ) => {
 	const flow = flows.getFlow( flowName );
 	const flowLength = flow.steps.length;
 
 	if ( flowLength > 1 ) {
+		if ( abtest( 'signupProgressIndicator' ) === 'wizardbar' ) {
+			return (
+				<div className="flow-progress-indicator">
+					<div className="flow-progress-indicator__wizard-bar">
+						<WizardBar value={ positionInFlow + 1 } total={ flowLength } />
+					</div>
+				</div>
+			);
+		}
+
 		return (
 			<div className="flow-progress-indicator">
-				<div className="flow-progress-indicator__wizard-bar">
-					<WizardBar value={ positionInFlow + 1 } total={ flowLength } isPulsing />
-				</div>
+				{
+					translate( 'Step %(stepNumber)d of %(stepTotal)d', {
+						args: {
+							stepNumber: positionInFlow + 1,
+							stepTotal: flowLength
+						}
+					} )
+				}
 			</div>
 		);
 	}
 
 	return null;
 };
+
+export default localize( FlowProgressIndicator );

--- a/client/signup/flow-progress-indicator/style.scss
+++ b/client/signup/flow-progress-indicator/style.scss
@@ -1,4 +1,4 @@
-.flow-progress-indicator__container {
+.flow-progress-indicator {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -14,6 +14,6 @@
 	}
 }
 
-.flow-progress-indicator__progress-bar {
-	width: 50%;
+.flow-progress-indicator__wizard-bar {
+	width: 20%;
 }

--- a/client/signup/flow-progress-indicator/style.scss
+++ b/client/signup/flow-progress-indicator/style.scss
@@ -1,11 +1,19 @@
-.flow-progress-indicator {
+.flow-progress-indicator__container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
 	color: darken( $gray, 20 );
 	font-size: 14px;
 	font-weight: 300;
 	margin-bottom: -10px;
 	text-align: center;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		padding-top: 10px;
 	}
+}
+
+.flow-progress-indicator__progress-bar {
+	width: 50%;
 }


### PR DESCRIPTION
Use a visual progress bar, instead of the step numbers.

It's both a better UX and users won't get confused when we skip steps so they go from 2 to 4.

Test existing flows. Make sure the progress bar makes sense and nothing is broken.

Before:
![steps](https://cloud.githubusercontent.com/assets/1103398/26429637/5655f790-40e8-11e7-8911-7c85d3848496.png)

After:
![progress bar](https://cloud.githubusercontent.com/assets/1103398/26429639/5b64d4a4-40e8-11e7-8569-0c919c5f7d0c.png)
