### PR TITLE
Include existing users in ATPromptOnCancel and ATUpgradeOnCancel a/b tests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -57,6 +57,7 @@ module.exports = {
 			show: 80,
 		},
 		defaultVariation: 'hide',
+		allowExistingUsers: true,
 	},
 	ATUpgradeOnCancel: {
 		datestamp: '20170515',
@@ -65,6 +66,7 @@ module.exports = {
 			show: 80,
 		},
 		defaultVariation: 'hide',
+		allowExistingUsers: true,
 	},
 	reduceThemesInSignupTest: {
 		datestamp: '20170518',


### PR DESCRIPTION
The AT prompt in cancellation a/b test should have included existing users.