### PR TITLE
Jetpack connect: Implement plan interval routes

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -30,12 +30,12 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import PlansLanding from './plans-landing';
 import {
-	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
 } from 'lib/plans/constants';
 
 /**
@@ -51,26 +51,26 @@ const analyticsPageTitleByType = {
 };
 
 /**
- * Calculate plan based on type and interval.
+ * Calculate plan based on flow type and interval.
  *
- * @param   {String?} type     Flow type: personal | premium | pro
- * @param   {String?} interval Interval: yearly | monthly
+ * @param   {String?} flowType personal | premium | pro
+ * @param   {String?} interval yearly | monthly
  * @returns {String?}          Jetpack plan slug
  */
-const calculatePlan = ( type, interval ) => {
-	if ( type === 'personal' ) {
+const calculatePlan = ( flowType, interval ) => {
+	if ( flowType === 'personal' ) {
 		if ( interval === 'monthly' ) {
 			return PLAN_JETPACK_PERSONAL_MONTHLY;
 		}
 		return PLAN_JETPACK_PERSONAL;
 	}
-	if ( type === 'premium' ) {
+	if ( flowType === 'premium' ) {
 		if ( interval === 'monthly' ) {
 			return PLAN_JETPACK_PREMIUM_MONTHLY;
 		}
 		return PLAN_JETPACK_PREMIUM;
 	}
-	if ( type === 'pro' ) {
+	if ( flowType === 'pro' ) {
 		if ( interval === 'monthly' ) {
 			return PLAN_JETPACK_BUSINESS_MONTHLY;
 		}

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -103,6 +103,19 @@ export default {
 
 		debug( 'entered connect flow with params %o', params );
 
+		let jpc_from = 'direct';
+		switch ( type ) {
+			case 'install':
+				jpc_from = 'jpdotcom';
+				break;
+			case 'pro':
+			case 'premium':
+			case 'personal':
+				jpc_from = 'ad';
+				break;
+		}
+		analytics.tracks.recordEvent( 'calypso_jpc_url_view', { jpc_from } );
+
 		analytics.pageView.record( pathname, analyticsPageTitle );
 
 		removeSidebar( context );

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -29,6 +29,14 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import PlansLanding from './plans-landing';
+import {
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+} from 'lib/plans/constants';
 
 /**
  * Module variables
@@ -40,6 +48,34 @@ const analyticsPageTitleByType = {
 	personal: 'Jetpack Connect Personal',
 	premium: 'Jetpack Connect Premium',
 	pro: 'Jetpack Install Pro',
+};
+
+/**
+ * Calculate plan based on type and interval.
+ *
+ * @param   {String?} type     Flow type: personal | premium | pro
+ * @param   {String?} interval Interval: yearly | monthly
+ * @returns {String?}          Jetpack plan slug
+ */
+const calculatePlan = ( type, interval ) => {
+	if ( type === 'personal' ) {
+		if ( interval === 'monthly' ) {
+			return PLAN_JETPACK_PERSONAL_MONTHLY;
+		}
+		return PLAN_JETPACK_PERSONAL;
+	}
+	if ( type === 'premium' ) {
+		if ( interval === 'monthly' ) {
+			return PLAN_JETPACK_PREMIUM_MONTHLY;
+		}
+		return PLAN_JETPACK_PREMIUM;
+	}
+	if ( type === 'pro' ) {
+		if ( interval === 'monthly' ) {
+			return PLAN_JETPACK_BUSINESS_MONTHLY;
+		}
+		return PLAN_JETPACK_BUSINESS;
+	}
 };
 
 const removeSidebar = ( context ) => {
@@ -98,10 +134,15 @@ export default {
 			pathname,
 			params
 		} = context;
-		const { type = false } = params;
+		const {
+			interval,
+			locale,
+			type = false,
+		} = params;
 		const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
+		const selectedPlan = calculatePlan( type, interval );
 
-		debug( 'entered connect flow with params %o', params );
+		debug( 'enter connect with params %o, selectedPlan %o', params, selectedPlan );
 
 		let jpc_from = 'direct';
 		switch ( type ) {
@@ -125,8 +166,9 @@ export default {
 		renderWithReduxStore(
 			React.createElement( JetpackConnect, {
 				context,
-				locale: context.params.locale,
+				locale,
 				path,
+				selectedPlan,
 				type,
 				url: context.query.url,
 				userModule,

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -53,9 +53,9 @@ const analyticsPageTitleByType = {
 /**
  * Calculate plan based on flow type and interval.
  *
- * @param   {String?} flowType personal | premium | pro
- * @param   {String?} interval yearly | monthly
- * @returns {String?}          Jetpack plan slug
+ * @param   {?String} flowType personal | premium | pro
+ * @param   {?String} interval yearly | monthly
+ * @returns {?String}          Jetpack plan slug
  */
 const calculatePlan = ( flowType, interval ) => {
 	if ( flowType === 'personal' ) {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -29,14 +29,7 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import PlansLanding from './plans-landing';
-import {
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-} from 'lib/plans/constants';
+import { calculatePlan } from './utils';
 
 /**
  * Module variables
@@ -48,34 +41,6 @@ const analyticsPageTitleByType = {
 	personal: 'Jetpack Connect Personal',
 	premium: 'Jetpack Connect Premium',
 	pro: 'Jetpack Install Pro',
-};
-
-/**
- * Calculate plan based on flow type and interval.
- *
- * @param   {?String} flowType personal | premium | pro
- * @param   {?String} interval yearly | monthly
- * @returns {?String}          Jetpack plan slug
- */
-const calculatePlan = ( flowType, interval ) => {
-	if ( flowType === 'personal' ) {
-		if ( interval === 'monthly' ) {
-			return PLAN_JETPACK_PERSONAL_MONTHLY;
-		}
-		return PLAN_JETPACK_PERSONAL;
-	}
-	if ( flowType === 'premium' ) {
-		if ( interval === 'monthly' ) {
-			return PLAN_JETPACK_PREMIUM_MONTHLY;
-		}
-		return PLAN_JETPACK_PREMIUM;
-	}
-	if ( flowType === 'pro' ) {
-		if ( interval === 'monthly' ) {
-			return PLAN_JETPACK_BUSINESS_MONTHLY;
-		}
-		return PLAN_JETPACK_BUSINESS;
-	}
 };
 
 const removeSidebar = ( context ) => {
@@ -135,7 +100,7 @@ export default {
 			params
 		} = context;
 		const {
-			interval,
+			interval = 'yearly',
 			locale,
 			type = false,
 		} = params;

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -40,6 +40,15 @@ import {
 	goToPluginActivation,
 	checkUrl
 } from 'state/jetpack-connect/actions';
+import {
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+} from 'lib/plans/constants';
 
 /**
  * Constants
@@ -58,6 +67,15 @@ class JetpackConnectMain extends Component {
 			false,
 		] ),
 		url: PropTypes.string,
+		selectedPlan: PropTypes.oneOf( [
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+		] ),
 	};
 
 	state = this.props.url
@@ -472,11 +490,11 @@ class JetpackConnectMain extends Component {
 }
 
 const connectComponent = connect(
-	state => ( {
+	( state, ownProps ) => ( {
 		jetpackConnectSite: getConnectingSite( state ),
 		getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
 		isRequestingSites: isRequestingSites( state ),
-		selectedPlan: getGlobalSelectedPlan( state )
+		selectedPlan: ownProps.selectedPlan || getGlobalSelectedPlan( state ),
 	} ),
 	{
 		confirmJetpackInstallStatus,

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -149,7 +149,7 @@ class JetpackConnectMain extends Component {
 		return this.props.checkUrl(
 			url,
 			!! this.props.getJetpackSiteByUrl( url ),
-			this.props.type
+			this.props.selectedPlan
 		);
 	}
 

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -95,25 +95,6 @@ class JetpackConnectMain extends Component {
 		}
 	}
 
-	componentDidMount() {
-		let from = 'direct';
-		if ( this.props.type === 'install' ) {
-			from = 'jpdotcom';
-		}
-		if ( this.props.type === 'pro' ) {
-			from = 'ad';
-		}
-		if ( this.props.type === 'premium' ) {
-			from = 'ad';
-		}
-		if ( this.props.type === 'personal' ) {
-			from = 'ad';
-		}
-		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
-			jpc_from: from
-		} );
-	}
-
 	componentDidUpdate() {
 		if ( this.getStatus() === 'notConnectedJetpack' &&
 			this.isCurrentUrlFetched() &&

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -31,7 +31,10 @@ import { addItem } from 'lib/upgrades/actions';
 import { selectPlanInAdvance, goBackToWpAdmin, completeFlow } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { isRequestingPlans, getPlanBySlugSelector } from 'state/plans/selectors';
+import {
+	getPlanBySlug as getPlanBySlugSelector,
+	isRequestingPlans,
+} from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { canCurrentUser } from 'state/selectors';
 import {

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ import { addItem } from 'lib/upgrades/actions';
 import { selectPlanInAdvance, goBackToWpAdmin, completeFlow } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
+import { isRequestingPlans, getPlanBySlugSelector } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { canCurrentUser } from 'state/selectors';
 import {
@@ -153,57 +154,29 @@ class Plans extends Component {
 
 	autoselectPlan() {
 		const {
+			getPlanBySlug,
 			preSelectedPlan,
 			selectedPlan,
 		} = this.props;
 		if ( ! this.props.showFirst ) {
-			if ( preSelectedPlan === PLAN_JETPACK_PERSONAL || selectedPlan === PLAN_JETPACK_PERSONAL ) {
-				const plan = this.props.getPlanBySlug( PLAN_JETPACK_PERSONAL );
+			const checkPlan = preSelectedPlan || selectedPlan;
+			if ( includes( [
+				PLAN_JETPACK_BUSINESS,
+				PLAN_JETPACK_BUSINESS_MONTHLY,
+				PLAN_JETPACK_PERSONAL,
+				PLAN_JETPACK_PERSONAL_MONTHLY,
+				PLAN_JETPACK_PREMIUM,
+				PLAN_JETPACK_PREMIUM_MONTHLY,
+			], checkPlan ) ) {
+				const plan = getPlanBySlug( checkPlan );
 				if ( plan ) {
 					this.selectPlan( plan );
 					return;
 				}
-			}
-			if ( preSelectedPlan === PLAN_JETPACK_PERSONAL_MONTHLY || selectedPlan === PLAN_JETPACK_PERSONAL_MONTHLY ) {
-				const plan = this.props.getPlanBySlug( PLAN_JETPACK_PERSONAL_MONTHLY );
-				if ( plan ) {
-					this.selectPlan( plan );
-					return;
-				}
-			}
-			if ( preSelectedPlan === PLAN_JETPACK_BUSINESS || selectedPlan === PLAN_JETPACK_BUSINESS ) {
-				const plan = this.props.getPlanBySlug( PLAN_JETPACK_BUSINESS );
-				if ( plan ) {
-					this.selectPlan( plan );
-					return;
-				}
-			}
-			if ( preSelectedPlan === PLAN_JETPACK_BUSINESS_MONTHLY || selectedPlan === PLAN_JETPACK_BUSINESS_MONTHLY ) {
-				const plan = this.props.getPlanBySlug( PLAN_JETPACK_BUSINESS_MONTHLY );
-				if ( plan ) {
-					this.selectPlan( plan );
-					return;
-				}
-			}
-			if ( preSelectedPlan === PLAN_JETPACK_PREMIUM || selectedPlan === PLAN_JETPACK_PREMIUM ) {
-				const plan = this.props.getPlanBySlug( PLAN_JETPACK_PREMIUM );
-				if ( plan ) {
-					this.selectPlan( plan );
-					return;
-				}
-			}
-			if ( preSelectedPlan === PLAN_JETPACK_PREMIUM_MONTHLY || selectedPlan === PLAN_JETPACK_PREMIUM_MONTHLY ) {
-				const plan = this.props.getPlanBySlug( PLAN_JETPACK_PREMIUM_MONTHLY );
-				if ( plan ) {
-					this.selectPlan( plan );
-					return;
-				}
-			}
-			if (
-				preSelectedPlan === PLAN_JETPACK_FREE ||
-				selectedPlan === 'free' ||
-				selectedPlan === PLAN_JETPACK_FREE
-			) {
+			} else if ( includes( [
+				'free',
+				PLAN_JETPACK_FREE,
+			], checkPlan ) ) {
 				this.selectFreeJetpackPlan();
 			}
 		}
@@ -317,9 +290,6 @@ export default connect(
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '*';
 
 		const selectedPlan = getSiteSelectedPlan( state, selectedSiteSlug ) || getGlobalSelectedPlan( state );
-		const searchPlanBySlug = ( planSlug ) => {
-			return getPlanBySlug( state, planSlug );
-		};
 
 		return {
 			selectedSite,
@@ -332,7 +302,7 @@ export default connect(
 			canPurchasePlans: selectedSite ? canCurrentUser( state, selectedSite.ID, 'manage_options' ) : true,
 			preSelectedPlan: getPreSelectedPlan( state, selectedSiteSlug ),
 			isRequestingPlans: isRequestingPlans( state ),
-			getPlanBySlug: searchPlanBySlug,
+			getPlanBySlug: ( planSlug ) => getPlanBySlugSelector( state, planSlug ),
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSiteSlug ),
 			redirectingToWpAdmin: isRedirectingToWpAdmin( state ),
 		};

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -5,7 +5,10 @@ import { connect } from 'react-redux';
 import page from 'page';
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import {
+	get,
+	includes,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -142,14 +145,14 @@ class Plans extends Component {
 	}
 
 	hasPlan( site ) {
-		return site &&
-			site.plan &&
-			( site.plan.product_slug === PLAN_JETPACK_BUSINESS ||
-				site.plan.product_slug === PLAN_JETPACK_BUSINESS_MONTHLY ||
-				site.plan.product_slug === PLAN_JETPACK_PREMIUM ||
-				site.plan.product_slug === PLAN_JETPACK_PREMIUM_MONTHLY ||
-				site.plan.product_slug === PLAN_JETPACK_PERSONAL ||
-				site.plan.product_slug === PLAN_JETPACK_PERSONAL_MONTHLY );
+		return includes( [
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+		], get( site, 'plan.product_slug' ) );
 	}
 
 	autoselectPlan() {

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { calculatePlan } from '../utils' ;
+import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+} from 'lib/plans/constants';
+
+describe( 'utils', () => {
+	describe( 'calculatePlan', () => {
+		it( 'should return null for unknown flow types', () => {
+			expect( calculatePlan( 'not a flow type', 'yearly' ) ).to.be.null;
+		} );
+		it( 'should return null for unknown intervals', () => {
+			expect( calculatePlan( 'pro', 'not an interval' ) ).to.be.null;
+		} );
+		it( 'should return the correct slug for flowType and interval', () => {
+			const argsExpect = [
+				[ [ 'personal', 'monthly' ], PLAN_JETPACK_PERSONAL_MONTHLY ],
+				[ [ 'personal', 'yearly' ], PLAN_JETPACK_PERSONAL ],
+				[ [ 'premium', 'monthly' ], PLAN_JETPACK_PREMIUM_MONTHLY ],
+				[ [ 'premium', 'yearly' ], PLAN_JETPACK_PREMIUM ],
+				[ [ 'pro', 'monthly' ], PLAN_JETPACK_BUSINESS_MONTHLY ],
+				[ [ 'pro', 'yearly' ], PLAN_JETPACK_BUSINESS ],
+			];
+			argsExpect
+				.forEach( ( [ [ flowType, interval ], expectedPlan ] ) =>
+					expect( calculatePlan( flowType, interval ) ).to.equal( expectedPlan )
+				);
+		} );
+	} );
+} );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+} from 'lib/plans/constants';
+
+/**
+ * Module constants
+ */
+const flowIntervalPlanMapping = {
+	personal: {
+		monthly: PLAN_JETPACK_PERSONAL_MONTHLY,
+		yearly: PLAN_JETPACK_PERSONAL,
+	},
+	premium: {
+		monthly: PLAN_JETPACK_PREMIUM_MONTHLY,
+		yearly: PLAN_JETPACK_PREMIUM,
+	},
+	pro: {
+		monthly: PLAN_JETPACK_BUSINESS_MONTHLY,
+		yearly: PLAN_JETPACK_BUSINESS,
+	},
+};
+
+/**
+ * Calculate plan based on flow type and interval.
+ *
+ * @param   {String}  flowType personal | premium | pro
+ * @param   {String}  interval yearly | monthly
+ * @returns {?String}          Jetpack plan slug
+ */
+export function calculatePlan( flowType, interval ) {
+	return get( flowIntervalPlanMapping, [ flowType, interval ], null );
+}

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -76,17 +76,19 @@ export default {
 		};
 	},
 
-	checkUrl( url, isUrlOnSites, flowType ) {
+	checkUrl( url, isUrlOnSites, selectedPlan ) {
 		return ( dispatch ) => {
 			if ( _fetching[ url ] ) {
 				return;
 			}
+			const action = {
+				type: JETPACK_CONNECT_CHECK_URL,
+				selectedPlan,
+				url,
+			};
+
 			if ( isUrlOnSites ) {
-				dispatch( {
-					type: JETPACK_CONNECT_CHECK_URL,
-					url: url,
-					flowType: flowType
-				} );
+				dispatch( action );
 				setTimeout( () => {
 					dispatch( {
 						type: JETPACK_CONNECT_CHECK_URL_RECEIVE,
@@ -106,13 +108,8 @@ export default {
 				return;
 			}
 			_fetching[ url ] = true;
-			setTimeout( () => {
-				dispatch( {
-					type: JETPACK_CONNECT_CHECK_URL,
-					url: url,
-					flowType: flowType
-				} );
-			}, 1 );
+			setTimeout( () => dispatch( action ), 1 );
+
 			Promise.all( [
 				wpcom.undocumented().getSiteConnectInfo( url, 'exists' ),
 				wpcom.undocumented().getSiteConnectInfo( url, 'isWordPress' ),

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -53,11 +53,11 @@ function buildDefaultAuthorizeState() {
 	};
 }
 
-function buildUrlSessionObj( url, flowType ) {
+function buildUrlSessionObj( url, selectedPlan = '' ) {
 	const slug = urlToSlug( url );
 	const sessionValue = {
 		timestamp: Date.now(),
-		flowType: flowType || ''
+		selectedPlan,
 	};
 	return { [ slug ]: sessionValue };
 }
@@ -65,7 +65,7 @@ function buildUrlSessionObj( url, flowType ) {
 export function jetpackConnectSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_CHECK_URL:
-			return Object.assign( {}, state, buildUrlSessionObj( action.url, action.flowType ) );
+			return Object.assign( {}, state, buildUrlSessionObj( action.url, action.selectedPlan ) );
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, jetpackConnectSessionsSchema ) ) {
 				return pickBy( state, ( session ) => {

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -7,7 +7,7 @@ export const jetpackConnectSessionsSchema = {
 			required: [ 'timestamp' ],
 			properties: {
 				timestamp: { type: 'number' },
-				flowType: { type: 'string' }
+				selectedPlan: { type: 'string' }
 			},
 			additionalProperties: false
 		}

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -77,12 +77,12 @@ const isRedirectingToWpAdmin = function( state ) {
 	return !! authorizationData.isRedirectingToWpAdmin;
 };
 
-const getFlowType = function( state, siteSlug ) {
+const getPreSelectedPlan = function( state, siteSlug ) {
 	const sessions = getSessions( state );
 	siteSlug = urlToSlug( siteSlug );
 
 	if ( siteSlug && sessions[ siteSlug ] ) {
-		return sessions[ siteSlug ].flowType;
+		return sessions[ siteSlug ].selectedPlan;
 	}
 	return false;
 };
@@ -165,7 +165,7 @@ export default {
 	isCalypsoStartedConnection,
 	isRedirectingToWpAdmin,
 	isRemoteSiteOnSitesList,
-	getFlowType,
+	getPreSelectedPlan,
 	getJetpackSiteByUrl,
 	hasXmlrpcError,
 	hasExpiredSecretError,

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -84,7 +84,7 @@ const getPreSelectedPlan = function( state, siteSlug ) {
 	if ( siteSlug && sessions[ siteSlug ] ) {
 		return sessions[ siteSlug ].selectedPlan;
 	}
-	return false;
+	return null;
 };
 
 const getAuthAttempts = ( state, slug ) => {

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -6,9 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import {
-	PLAN_JETPACK_PREMIUM,
-} from 'lib/plans/constants';
+import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 import {
 	getConnectingSite,
 	getAuthorizationData,

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -422,14 +422,14 @@ describe( 'selectors', () => {
 			expect( getPreSelectedPlan( state, 'example.com/example123' ) ).to.eql( PLAN_JETPACK_PREMIUM );
 		} );
 
-		it( 'should return false if there\'s no session for a site', () => {
+		it( 'should return null if there\'s no session for a site', () => {
 			const state = {
 				jetpackConnect: {
 					jetpackConnectSessions: {}
 				}
 			};
 
-			expect( getPreSelectedPlan( state, 'sitetest' ) ).to.be.false;
+			expect( getPreSelectedPlan( state, 'sitetest' ) ).to.be.null;
 		} );
 	} );
 

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -7,6 +7,9 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	PLAN_JETPACK_PREMIUM,
+} from 'lib/plans/constants';
+import {
 	getConnectingSite,
 	getAuthorizationData,
 	getAuthorizationRemoteQueryData,
@@ -16,7 +19,7 @@ import {
 	isCalypsoStartedConnection,
 	isRedirectingToWpAdmin,
 	isRemoteSiteOnSitesList,
-	getFlowType,
+	getPreSelectedPlan,
 	getJetpackSiteByUrl,
 	hasXmlrpcError,
 	getAuthAttempts,
@@ -226,11 +229,11 @@ describe( 'selectors', () => {
 			const jetpackConnectSessions = {
 				'wordpress.com': {
 					timestamp: 1234567890,
-					flowType: 'premium'
+					selectedPlan: PLAN_JETPACK_PREMIUM
 				},
 				'jetpack.me': {
 					timestamp: 2345678901,
-					flowType: 'pro'
+					selectedPlan: PLAN_JETPACK_PREMIUM
 				}
 			};
 			const state = {
@@ -300,7 +303,7 @@ describe( 'selectors', () => {
 					jetpackConnectSessions: {
 						sitetest: {
 							timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
-							flowType: ''
+							selectedPlan: PLAN_JETPACK_PREMIUM
 						}
 					}
 				}
@@ -388,35 +391,35 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getFlowType()', () => {
-		it( 'should return the flow of the session for a site', () => {
+	describe( '#getPreSelectedPlan()', () => {
+		it( 'should return the preselected plan of the session for a site', () => {
 			const state = {
 				jetpackConnect: {
 					jetpackConnectSessions: {
 						sitetest: {
 							timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
-							flowType: 'pro'
+							selectedPlan: PLAN_JETPACK_PREMIUM
 						}
 					}
 				}
 			};
 
-			expect( getFlowType( state, 'sitetest' ) ).to.eql( 'pro' );
+			expect( getPreSelectedPlan( state, 'sitetest' ) ).to.eql( PLAN_JETPACK_PREMIUM );
 		} );
 
-		it( 'should return the flow of the session for a site with slash in the site slug', () => {
+		it( 'should return the preselected plan of the session for a site with slash in the site slug', () => {
 			const state = {
 				jetpackConnect: {
 					jetpackConnectSessions: {
 						'example.com::example123': {
 							timestamp: new Date( Date.now() - 59 * 60 * 1000 ).getTime(),
-							flowType: 'pro'
+							selectedPlan: PLAN_JETPACK_PREMIUM
 						}
 					}
 				}
 			};
 
-			expect( getFlowType( state, 'example.com/example123' ) ).to.eql( 'pro' );
+			expect( getPreSelectedPlan( state, 'example.com/example123' ) ).to.eql( PLAN_JETPACK_PREMIUM );
 		} );
 
 		it( 'should return false if there\'s no session for a site', () => {
@@ -426,7 +429,7 @@ describe( 'selectors', () => {
 				}
 			};
 
-			expect( getFlowType( state, 'sitetest' ) ).to.be.false;
+			expect( getPreSelectedPlan( state, 'sitetest' ) ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
Supersedes #14408
Contains #14416 
Fixes #12497

To test:

The goal of this PR is to unify the handlers so that plan type and interval logic can happen in one place.

I'm happy to discuss whether this is a move in the right direction, I've had a few false starts trying to simplify and clarify this part of the flow.

Combine several similar route handlers into one handler.
Explicitly match valid intervals `monthly` or `yearly`.

**To test:**
* It's a good idea to set the following for relevant debug information:
   ```js
   localStorage.setItem('debug', [
     'calypso:jetpack-connect:actions',
     'calypso:jetpack-connect:controller',
   ] )
   ```
* Test the following urls. You can append `?url=$site` to test a url directly, be sure to this functionality:
  * http://calypso.localhost:3000/jetpack/connect/install
  * http://calypso.localhost:3000/jetpack/connect/personal
  * http://calypso.localhost:3000/jetpack/connect/personal/yearly
  * http://calypso.localhost:3000/jetpack/connect/personal/monthly
  * http://calypso.localhost:3000/jetpack/connect/premium
  * http://calypso.localhost:3000/jetpack/connect/premium/yearly
  * http://calypso.localhost:3000/jetpack/connect/premium/monthly
  * http://calypso.localhost:3000/jetpack/connect/pro
  * http://calypso.localhost:3000/jetpack/connect/pro/yearly
  * http://calypso.localhost:3000/jetpack/connect/pro/monthly
* There should be no warnings/errors in the console
* When using a `(pro|premium|personal)/(monthly|yearly)` entry point, after connection you should be redirected to checkout with the expected plan (no plans page).
* Ensure tests pass:
   ```
   npm run test-client client/state/jetpack-connect/
   ```

The `/pro`, `/premium`, and `/personal` routes should complete the flow up at a checkout screen for the selected plan, _not_ the plans screen.


Preparation for #14408