### PR TITLE
JPC: remove selectedPlan prop from authorize flow

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -69,7 +69,6 @@ class LoggedInForm extends Component {
 		requestHasExpiredSecretError: PropTypes.func.isRequired,
 		requestHasXmlrpcError: PropTypes.func.isRequired,
 		retryAuth: PropTypes.func.isRequired,
-		selectedPlan: PropTypes.string,
 		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		user: PropTypes.object.isRequired,

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -24,9 +24,7 @@ import {
 	isCalypsoStartedConnection,
 	hasXmlrpcError,
 	hasExpiredSecretError,
-	getSiteSelectedPlan,
 	isRemoteSiteOnSitesList,
-	getGlobalSelectedPlan,
 	getAuthAttempts,
 	getSiteIdFromQueryObject
 } from 'state/jetpack-connect/selectors';
@@ -63,7 +61,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		requestHasXmlrpcError: PropTypes.func,
 		requestSites: PropTypes.func,
 		retryAuth: PropTypes.func,
-		selectedPlan: PropTypes.string,
 		siteSlug: PropTypes.string,
 		user: PropTypes.object,
 	}
@@ -143,7 +140,6 @@ export default connect(
 		const siteSlug = urlToSlug( remoteSiteUrl );
 		const requestHasExpiredSecretError = () => hasExpiredSecretError( state );
 		const requestHasXmlrpcError = () => hasXmlrpcError( state );
-		const selectedPlan = getSiteSelectedPlan( state, siteSlug ) || getGlobalSelectedPlan( state );
 		const siteId = getSiteIdFromQueryObject( state );
 
 		return {
@@ -155,7 +151,6 @@ export default connect(
 			jetpackConnectAuthorize: getAuthorizationData( state ),
 			requestHasExpiredSecretError,
 			requestHasXmlrpcError,
-			selectedPlan,
 			siteSlug,
 			user: getCurrentUser( state ),
 		};


### PR DESCRIPTION
This prop is apparently unused in this flow. Remove it and save selector calls and imports.