### PR TITLE
Media: add media library thumbnail test

### DIFF
--- a/client/my-sites/media-library/test/fixtures/index.js
+++ b/client/my-sites/media-library/test/fixtures/index.js
@@ -42,10 +42,15 @@ module.exports = {
 	media: [
 		{
 			ID: 1009,
-			guid: 'http://example.files.wordpress.com/2015/05/g1009.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1009.gif',
+			URL: 'http://example.files.wordpress.com/2015/05/g1009.gif',
 		}, {
 			ID: 1008,
-			guid: 'http://example.files.wordpress.com/2015/05/g1008.gif'
+			guid: 'http://example.files.wordpress.com/2015/05/g1008.gif',
+			URL: 'http://example.files.wordpress.com/2015/05/g1009.gif',
+			thumbnails: {
+				fmt_hd: 'http://example.files.wordpress.com/2015/05/g1009-hd.gif'
+			}
 		}, {
 			ID: 1007,
 			guid: 'http://example.files.wordpress.com/2015/05/g1007.gif'

--- a/client/my-sites/media-library/test/list-item-image.jsx
+++ b/client/my-sites/media-library/test/list-item-image.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+import photon from 'photon';
+import resize from 'lib/resize-image-url';
+import ListItemImage from 'my-sites/media-library/list-item-image';
+
+const WIDTH = 450;
+
+describe( 'MediaLibraryListItem image', function() {
+	let shallow, wrapper, fixtures;
+
+	useFakeDom();
+	useMockery();
+
+	before( function() {
+		shallow = require( 'enzyme' ).shallow;
+		fixtures = require( './fixtures' );
+	} );
+
+	beforeEach( function() {
+		if ( wrapper ) {
+			wrapper.unmount();
+		}
+	} );
+
+	const getPhotonUrl = () => photon( fixtures.media[ 0 ].URL, { width: WIDTH } );
+	const getResizedUrl = () => resize( fixtures.media[ 0 ].URL, { w: WIDTH } );
+	const getItem = usePhoton => <ListItemImage media={ fixtures.media[ 0 ] } scale={ 1 } photon={ usePhoton } maxImageWidth={ WIDTH } />;
+
+	context( 'thumbnail display mode', function() {
+		it( 'defaults to photon when no photon parameter is passed', function() {
+			wrapper = shallow( getItem() );
+
+			expect( wrapper.props().src ).to.be.equal( getPhotonUrl() );
+		} );
+
+		it( 'returns a photon thumbnail for a public image', function() {
+			wrapper = shallow( getItem( true ) );
+
+			expect( wrapper.props().src ).to.be.equal( getPhotonUrl() );
+		} );
+
+		it( 'returns a resized thumbnail for a private image', function() {
+			wrapper = shallow( getItem( false ) );
+
+			expect( wrapper.props().src ).to.be.equal( getResizedUrl() );
+		} );
+	} );
+} );

--- a/client/my-sites/media-library/test/list-item-video.jsx
+++ b/client/my-sites/media-library/test/list-item-video.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+import photon from 'photon';
+import ListItemVideo from 'my-sites/media-library/list-item-video';
+
+const WIDTH = 450;
+
+const styleUrl = url => `url(${ url })`;
+
+describe( 'MediaLibraryListItem video', function() {
+	let shallow, wrapper, fixtures;
+
+	useFakeDom();
+	useMockery();
+
+	before( function() {
+		shallow = require( 'enzyme' ).shallow;
+		fixtures = require( './fixtures' );
+	} );
+
+	beforeEach( function() {
+		if ( wrapper ) {
+			wrapper.unmount();
+		}
+	} );
+
+	const expectedBackground = () => styleUrl( photon( fixtures.media[ 1 ].thumbnails.fmt_hd, { width: WIDTH } ) );
+	const getItem = () => <ListItemVideo media={ fixtures.media[ 1 ] } scale={ 1 } maxImageWidth={ WIDTH } />;
+
+	context( 'thumbnail display mode', function() {
+		it( 'returns a photon thumbnail for a video', function() {
+			wrapper = shallow( getItem() );
+
+			expect( wrapper.props().style.backgroundImage ).to.be.equal( expectedBackground() );
+		} );
+	} );
+} );


### PR DESCRIPTION
This adds some basic tests to media library thumbnails, and will be used as the base for future modifications to thumbnails.

Tests:
- Public images return a photon URL (`photon` flag is `true`)
- Private images return a resized URL (`photon` flag is `false`)
- Any video returns a photonized thumbnail URL

Note this PR is a minimal set of tests for the things I intend to modify - it may or may not be a complete unit test!