### PR TITLE
Upgrades: the plans nudge should not be visible on plans-related pages

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -178,7 +178,7 @@ class CurrentSite extends Component {
 					: <AllSites />
 				}
 				{ ! isJetpack && this.getDomainWarnings() }
-				<SiteNotice site={ selectedSite } />
+				<SiteNotice site={ selectedSite } allSitesPath={ this.props.allSitesPath } />
 			</Card>
 		);
 	}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -83,7 +83,7 @@ const SiteNotice = React.createClass( {
 	},
 
 	freeToPaidPlanNotice() {
-		if ( ! this.props.isEligibleForFreeToPaidUpsell ) {
+		if ( ! this.props.isEligibleForFreeToPaidUpsell || '/plans' === this.props.allSitesPath ) {
 			return null;
 		}
 		const eventName = 'calypso_upgrade_nudge_impression';

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -583,6 +583,7 @@ export class MySitesSidebar extends Component {
 			<Sidebar>
 				<SidebarRegion>
 					<CurrentSite
+						allSitesPath={ this.props.allSitesPath }
 						isPreviewShowing={ this.props.isPreviewShowing }
 						onClick={ this.onPreviewSite }
 					/>


### PR DESCRIPTION
![screen shot 2017-05-25 at 12 41 12 pm](https://cloud.githubusercontent.com/assets/82778/26445135/b7096e46-4147-11e7-92fc-18f4f112839d.png)

This nudge is a very strong call to action and should not be visible when the real calls to action are the upgrades buttons.

To test:
1. With a test blog that has no plans, go to plans page
2. The green nudge should not be visible