### PR TITLE
Posts list: Post Preview button shows the front page of the site, instead of the post itself

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -356,8 +356,19 @@ export default connect(
 			editUrl: getEditorPath( state, post.site_ID, post.ID, 'post' ),
 			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
-			previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
-			selectedSiteId
+			selectedSiteId,
+
+			/**
+			 * getPostPreviewUrl() relies on the post to be in Redux.
+			 *
+			 * There is an out of sync issue, because the posts list is fetched through Flux and the Redux store is
+			 * not filled with the proper Posts data.
+			 *
+			 * This is a hack to work around that issue for the moment. It must be removed when the posts list is
+			 * updated to fetch the posts through the newer QueryPosts component.
+			 */
+			//previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
+			previewUrl: getPostPreviewUrl( state, null, null, post )
 		};
 	},
 	{ setPreviewUrl, setLayoutFocus }

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -358,16 +358,20 @@ export default connect(
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
 			selectedSiteId,
 
-			/**
+			/*
 			 * getPostPreviewUrl() relies on the post to be in Redux.
 			 *
-			 * There is an out of sync issue, because the posts list is fetched through Flux and the Redux store is
-			 * not filled with the proper Posts data.
+			 * There is an out of sync issue, because the posts list is fetched
+			 * through Flux and the Redux store is not filled with the proper
+			 * Posts data.
 			 *
-			 * This is a hack to work around that issue for the moment. It must be removed when the posts list is
-			 * updated to fetch the posts through the newer QueryPosts component.
+			 * This is a hack to work around that issue for the moment. It must
+			 * be removed when the posts list is updated to fetch the posts
+			 * through the newer QueryPosts component.
+			 *
+			 * FIXME(biskobe,mcsf): undo hack
+			 * //previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
 			 */
-			//previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
 			previewUrl: getPostPreviewUrl( state, null, null, post )
 		};
 	},

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -421,15 +421,22 @@ export function getEditedPostSlug( state, siteId, postId ) {
  * Returns the most reliable preview URL for the post by site ID, post ID pair,
  * or null if a preview URL cannot be determined.
  *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @param  {Number}  postId Post ID
- * @return {?String}        Post preview URL
+ * @param  {Object}  state   Global state tree
+ * @param  {Number}  siteId  Site ID
+ * @param  {Number}  postId  Post ID
+ * @param  {Object}	 rawPost Raw post object. See my-sites/posts/post.jsx:361 ( export default connect() ) comment.
+ * @return {?String}         Post preview URL
  */
-export function getPostPreviewUrl( state, siteId, postId ) {
-	const post = getSitePost( state, siteId, postId );
-	if ( ! post ) {
-		return null;
+export function getPostPreviewUrl( state, siteId, postId, rawPost = null ) {
+	let post = null;
+
+	if ( siteId === null && postId === null && rawPost !== null ) {
+		post = rawPost;
+	} else {
+		post = getSitePost( state, siteId, postId );
+		if ( ! post ) {
+			return null;
+		}
 	}
 
 	const { URL: url, status } = post;

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -424,7 +424,7 @@ export function getEditedPostSlug( state, siteId, postId ) {
  * @param  {Object}  state   Global state tree
  * @param  {Number}  siteId  Site ID
  * @param  {Number}  postId  Post ID
- * @param  {Object}	 rawPost Raw post object. See my-sites/posts/post.jsx:361 ( export default connect() ) comment.
+ * @param  {Object}  rawPost Raw post object. See my-sites/posts/post.jsx:361 ( export default connect() ) comment.
  * @return {?String}         Post preview URL
  */
 export function getPostPreviewUrl( state, siteId, postId, rawPost = null ) {

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -428,15 +428,16 @@ export function getEditedPostSlug( state, siteId, postId ) {
  * @return {?String}           Post preview URL
  */
 export function getPostPreviewUrl( state, siteId, postId, rawPost = null ) {
-	let post = null;
+	const shouldUseRawPost = siteId === null &&
+		postId === null &&
+		rawPost !== null;
 
-	if ( siteId === null && postId === null && rawPost !== null ) {
-		post = rawPost;
-	} else {
-		post = getSitePost( state, siteId, postId );
-		if ( ! post ) {
-			return null;
-		}
+	const post = shouldUseRawPost
+		? rawPost
+		: getSitePost( state, siteId, postId );
+
+	if ( ! post ) {
+		return null;
 	}
 
 	const { URL: url, status } = post;

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -421,11 +421,11 @@ export function getEditedPostSlug( state, siteId, postId ) {
  * Returns the most reliable preview URL for the post by site ID, post ID pair,
  * or null if a preview URL cannot be determined.
  *
- * @param  {Object}  state   Global state tree
- * @param  {Number}  siteId  Site ID
- * @param  {Number}  postId  Post ID
- * @param  {Object}  rawPost Raw post object. See my-sites/posts/post.jsx:361 ( export default connect() ) comment.
- * @return {?String}         Post preview URL
+ * @param  {Object}  state     Global state tree
+ * @param  {Number}  siteId    Site ID
+ * @param  {Number}  postId    Post ID
+ * @param  {Object}  [rawPost] Raw post object. See wp-calypso#14456
+ * @return {?String}           Post preview URL
  */
 export function getPostPreviewUrl( state, siteId, postId, rawPost = null ) {
 	let post = null;


### PR DESCRIPTION
If you go to the posts list (Posts from the sidebar) and click on Preview on any of the posts, the preview popup will show the frontend of the site, instead of the post you chose to preview. 

The issue is that the `getPostPreviewUrl` selector relies on the post to be in the Redux state tree, but in my tests the state was populated only by the drafts posts I have. I suspect the problem lies in that the posts lists are fetched through a Flux query component ( `PostListFetcher` ) , instead of a Redux one ( `QueryPosts` ). This causes an out-of-sync issue for the posts list and where the code expects the data to be.

I noticed that the behavior for generating the Preview link changed in #11459, but it's possible something changed in the way posts are fetched and stored after the PR got merged. 

Props to @mcsf who reported the problem.

To test:

1. Checkout branch or use Calypso.live link
2. Go to Posts in the sidebar
3. Click Preview on any of the published posts
4. Verify the preview popup shows the post you chose
5. Verify there are no JS errors in the console
6. Verify the same is valid if you go to Pages and preview a page.