### PR TITLE
Settings: Move display logic down into the site-tools component

### DIFF
--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -8,10 +8,8 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Main from 'components/main';
-import notices from 'notices';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
-import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import GeneralSettings from './section-general';
@@ -27,9 +25,6 @@ export class SiteSettingsComponent extends Component {
 	static propTypes = {
 		section: PropTypes.string,
 		// Connected props
-		sitePurchases: PropTypes.array.isRequired,
-		purchasesError: PropTypes.object,
-		hasLoadedSitePurchasesFromServer: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
 		jetpackSettingsUiSupported: PropTypes.bool
 	};
@@ -38,23 +33,12 @@ export class SiteSettingsComponent extends Component {
 		section: 'general'
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.purchasesError ) {
-			notices.error( nextProps.purchasesError );
-		}
-	}
-
 	getSection() {
 		const { section, hostSlug } = this.props;
 
 		switch ( section ) {
 			case 'general':
-				return (
-					<GeneralSettings
-						sitePurchases={ this.props.sitePurchases }
-						hasLoadedSitePurchasesFromServer={ this.props.hasLoadedSitePurchasesFromServer }
-					/>
-				);
+				return <GeneralSettings />;
 			case 'import':
 				return <ImportSettings />;
 			case 'export':
@@ -93,9 +77,6 @@ export default connect(
 
 		return {
 			siteId,
-			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
-			purchasesError: getPurchasesError( state ),
-			sitePurchases: getSitePurchases( state, siteId ),
 			jetpackSettingsUiSupported: jetpackSite && jetpackUiSupported,
 		};
 	}

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -11,22 +11,11 @@ import GeneralForm from 'my-sites/site-settings/form-general';
 import SiteTools from './site-tools';
 import { getSelectedSite } from 'state/ui/selectors';
 
-const SiteSettingsGeneral = ( {
-	hasLoadedSitePurchasesFromServer,
-	site,
-	sitePurchases
-} ) => {
+const SiteSettingsGeneral = ( { site } ) => {
 	return (
 		<div className="site-settings__main general-settings">
 			<GeneralForm site={ site } />
-
-			{ site &&
-				<SiteTools
-					site={ site }
-					sitePurchases={ sitePurchases }
-					hasLoadedSitePurchasesFromServer={ hasLoadedSitePurchasesFromServer }
-				/>
-			}
+			<SiteTools />
 		</div>
 	);
 };

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -20,7 +20,7 @@ const SiteSettingsGeneral = ( {
 		<div className="site-settings__main general-settings">
 			<GeneralForm site={ site } />
 
-			{ site && ! site.jetpack && ! site.is_vip &&
+			{ site &&
 				<SiteTools
 					site={ site }
 					sitePurchases={ sitePurchases }

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { some } from 'lodash';
+import { isEmpty, pickBy, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +33,21 @@ class SiteTools extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const {
+			translate,
+			site: { jetpack: isJetpack, is_vip: isVip },
+		} = this.props;
+
+		const showSection = {
+			changeAddress: ! isJetpack && ! isVip,
+			themeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
+			deleteContent: ! isJetpack && ! isVip,
+			deleteSite: ! isJetpack && ! isVip,
+		};
+
+		if ( isEmpty( pickBy( showSection ) ) ) {
+			return null;
+		}
 
 		const selectedSite = this.props.site;
 		const changeAddressLink = `/domains/manage/${ selectedSite.slug }`;
@@ -67,16 +81,18 @@ class SiteTools extends Component {
 		return (
 			<div className="site-tools">
 				<SectionHeader label={ translate( 'Site Tools' ) } />
-				<CompactCard
-					href={ changeAddressLink }
-					onClick={ this.trackChangeAddress }
-					className="site-tools__link">
-					<div className="site-tools__content">
-						<p className="site-tools__section-title">{ changeSiteAddress }</p>
-						<p className="site-tools__section-desc">{ changeAddressText }</p>
-					</div>
-				</CompactCard>
-				{ config.isEnabled( 'settings/theme-setup' ) &&
+				{ showSection.changeAddress &&
+					<CompactCard
+						href={ changeAddressLink }
+						onClick={ this.trackChangeAddress }
+						className="site-tools__link">
+						<div className="site-tools__content">
+							<p className="site-tools__section-title">{ changeSiteAddress }</p>
+							<p className="site-tools__section-desc">{ changeAddressText }</p>
+						</div>
+					</CompactCard>
+				}
+				{ showSection.themeSetup &&
 					<CompactCard
 						href={ themeSetupLink }
 						onClick={ this.trackThemeSetup }
@@ -87,26 +103,28 @@ class SiteTools extends Component {
 						</div>
 					</CompactCard>
 				}
-				<CompactCard
-					href={ startOverLink }
-					onClick={ this.trackStartOver }
-					className="site-tools__link">
-					<div className="site-tools__content">
-						<p className="site-tools__section-title">{ startOver }</p>
-						<p className="site-tools__section-desc">{ startOverText }</p>
-					</div>
-				</CompactCard>
-				<CompactCard
-					href={ deleteSiteLink }
-					onClick={ this.checkForSubscriptions }
-					className="site-tools__link">
-					<div className="site-tools__content">
-						<p className="site-tools__section-title is-warning">
-							{ deleteSite }
-						</p>
-						<p className="site-tools__section-desc">{ deleteSiteText }</p>
-					</div>
-				</CompactCard>
+				{ showSection.deleteContent &&
+					<CompactCard
+						href={ startOverLink }
+						onClick={ this.trackStartOver }
+						className="site-tools__link">
+						<div className="site-tools__content">
+							<p className="site-tools__section-title">{ startOver }</p>
+							<p className="site-tools__section-desc">{ startOverText }</p>
+						</div>
+					</CompactCard>
+				}
+				{ showSection.deleteSite &&
+					<CompactCard
+						href={ deleteSiteLink }
+						onClick={ this.checkForSubscriptions }
+						className="site-tools__link">
+						<div className="site-tools__content">
+							<p className="site-tools__section-title is-warning">{ deleteSite }</p>
+							<p className="site-tools__section-desc">{ deleteSiteText }</p>
+						</div>
+					</CompactCard>
+				}
 				<DeleteSiteWarningDialog
 					isVisible={ this.state.showDialog }
 					onClose={ this.closeDialog } />

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -55,14 +55,10 @@ class SiteTools extends Component {
 			changeAddress: ! isJetpack && ! isVip,
 			themeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
 			deleteContent: ! isJetpack && ! isVip,
-			deleteSite: ! isJetpack && ! isVip,
+			deleteSite: ! isJetpack && ! isVip && sitePurchasesLoaded,
 		};
 
 		if ( isEmpty( pickBy( showSection ) ) ) {
-			return null;
-		}
-
-		if ( ! sitePurchasesLoaded ) {
 			return null;
 		}
 


### PR DESCRIPTION
No visual differences. Part of  #12169.

Allow more granularity when choosing to display different links in the site-tools settings component by moving the display logic down into the component itself.

This will allow settings links to be enabled or disabled per site when we start displaying this component for jetpack sites in #14371.

**To Test**
In _Settings -> General_, the _Site Tools_ group at the bottom should behave exactly as before:
* Visible for wpcom sites
* Hidden for Jetpack sites

<img width="737" alt="screen shot 2017-05-25 at 12 26 57" src="https://cloud.githubusercontent.com/assets/7767559/26448540/b01b5f06-4145-11e7-947d-fbea4abddec9.png">
