### PR TITLE
Settings: Remove delete-site feature flag

### DIFF
--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -1,34 +1,80 @@
 /**
  * External dependencies
  */
-var	page = require( 'page' );
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	controller = require( 'my-sites/controller' ),
-	settingsController = require( './controller' );
+import config from 'config';
+import controller from 'my-sites/controller';
+import settingsController from 'my-sites/site-settings/controller';
 
 module.exports = function() {
-	page( '/settings', controller.siteSelection, settingsController.redirectToGeneral );
-	page( '/settings/general/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
+	page(
+		'/settings',
+		controller.siteSelection,
+		settingsController.redirectToGeneral
+	);
+	page(
+		'/settings/general/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.siteSettings
+	);
 
-	page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
+	page(
+		'/settings/import/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.importSite
+	);
 
 	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
-		page( '/settings/export/guided/:host_slug?/:site_id', controller.siteSelection, controller.navigation, settingsController.guidedTransfer );
+		page(
+			'/settings/export/guided/:host_slug?/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.guidedTransfer
+		);
 	}
 
 	if ( config.isEnabled( 'manage/export' ) ) {
-		page( '/settings/export/:site_id', controller.siteSelection, controller.navigation, settingsController.exportSite );
+		page(
+			'/settings/export/:site_id',
+			controller.siteSelection,
+			controller.navigation,
+			settingsController.exportSite
+		);
 	}
 
-	if ( config.isEnabled( 'manage/site-settings/delete-site' ) ) {
-		page( '/settings/delete-site/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.deleteSite );
-		page( '/settings/start-over/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.startOver );
-		page( '/settings/theme-setup/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.themeSetup );
-	}
+	page(
+		'/settings/delete-site/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.deleteSite
+	);
+	page(
+		'/settings/start-over/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.startOver
+	);
+	page(
+		'/settings/theme-setup/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.themeSetup
+	);
 
-	page( '/settings/:section', settingsController.legacyRedirects, controller.siteSelection, controller.sites );
+	page(
+		'/settings/:section',
+		settingsController.legacyRedirects,
+		controller.siteSelection,
+		controller.sites
+	);
 };

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
  */
 import GeneralForm from 'my-sites/site-settings/form-general';
 import SiteTools from './site-tools';
-import config from 'config';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const SiteSettingsGeneral = ( {
@@ -21,7 +20,7 @@ const SiteSettingsGeneral = ( {
 		<div className="site-settings__main general-settings">
 			<GeneralForm site={ site } />
 
-			{ config.isEnabled( 'manage/site-settings/delete-site' ) && site && ! site.jetpack && ! site.is_vip &&
+			{ site && ! site.jetpack && ! site.is_vip &&
 				<SiteTools
 					site={ site }
 					sitePurchases={ sitePurchases }

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -42,7 +42,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/development.json
+++ b/config/development.json
@@ -81,7 +81,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -47,7 +47,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -45,7 +45,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -47,7 +47,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/test.json
+++ b/config/test.json
@@ -60,7 +60,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -55,7 +55,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
Flag has become redundant, and is now gating a whole section (Site Tools) rather that just the delete site option.

No visual differences.

**To Test**
* Make sure _Settings -> General -> Site Tools_ displays as usual for wpcom sites

<img width="737" alt="screen shot 2017-05-25 at 12 26 57" src="https://cloud.githubusercontent.com/assets/7767559/26449252/166f8c70-4149-11e7-8102-066e091e2cdb.png">
