### PR TITLE
DevDocs: Fix wrong import in ReaderSubscriptionListItemExample

### DIFF
--- a/client/blocks/reader-subscription-list-item/docs/example.jsx
+++ b/client/blocks/reader-subscription-list-item/docs/example.jsx
@@ -7,7 +7,7 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import ConnectedSubscriptionListItem from 'blocks/reader-subscription-list-item/connected';
+import ConnectedReaderSubscriptionListItem from 'blocks/reader-subscription-list-item/connected';
 import ReaderSubscriptionListItemPlaceholder
 	from 'blocks/reader-subscription-list-item/placeholder';
 import Card from 'components/card';


### PR DESCRIPTION
It appears that in #14411 we renamed an import, which caused the Blocks page in DevDocs to break:

![](https://cldup.com/3cJB2lmlUg.png)

This PR fixes the import name so it will import correctly.

To test:
* Checkout this branch
* Verify http://calypso.localhost:3000/devdocs/blocks loads properly again.