### PR TITLE
Reader: Fix follow button Tag and Site streams

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -20,6 +20,12 @@
 	}
 }
 
+.is-reader-page .follow-button {
+	border: 0;
+	border-radius: 0;
+	float: right;
+}
+
 .is-reader-page .reader-full-post__story-content {
 	margin-top: 0;
 }


### PR DESCRIPTION
This was a regression introduced after removing this block: https://github.com/Automattic/wp-calypso/pull/14465/files#diff-65904b7326b92b2aefdcc0fd21d30c7dL40

**Before:**
<img width="598" alt="screenshot 2017-05-25 08 15 03" src="https://cloud.githubusercontent.com/assets/4924246/26456746/dcb42322-4122-11e7-9a52-4c06495613ea.png">

<img width="820" alt="screenshot 2017-05-25 08 19 09" src="https://cloud.githubusercontent.com/assets/4924246/26456751/e22c4bcc-4122-11e7-8830-a9e6181bad90.png">

**After:**
<img width="548" alt="screenshot 2017-05-25 08 15 08" src="https://cloud.githubusercontent.com/assets/4924246/26456776/f65a3096-4122-11e7-984a-4bcd78625d1b.png">

<img width="833" alt="screenshot 2017-05-25 08 18 54" src="https://cloud.githubusercontent.com/assets/4924246/26456786/ffbe550e-4122-11e7-8063-b04319d8eda0.png">


