### PR TITLE
DevDocs: Add displayName to AllSites example

### DIFF
--- a/client/my-sites/all-sites/docs/example.jsx
+++ b/client/my-sites/all-sites/docs/example.jsx
@@ -15,4 +15,6 @@ const AllSitesExample = () => (
 	</Card>
 );
 
+AllSitesExample.displayName = 'AllSites';
+
 export default AllSitesExample;


### PR DESCRIPTION
This PR adds a `displayName` to the `AllSites` example, as that was missed in #14376. The `displayName` is necessary, as in some environments we mangle the component names (as @gwwar clarified in https://github.com/Automattic/wp-calypso/pull/14376#discussion_r118527726).