### PR TITLE
DevDocs: Add displayName to Login block example

### DIFF
--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -8,8 +8,10 @@ import React from 'react';
  */
 import LoginBlock from 'blocks/login';
 
-export default function Login() {
-	return (
-		<LoginBlock title={ 'Sign in to connect to WordPress.com' } />
-	)
-}
+const LoginExample = () => (
+	<LoginBlock title={ 'Sign in to connect to WordPress.com' } />
+);
+
+LoginExample.displayName = 'Login';
+
+export default LoginExample;


### PR DESCRIPTION
While I was working on #14480 I noticed that the `<Login />` block example also lacks a `displayName`. The `displayName` is necessary, as in some environments we mangle the component names.

This PR adds a `displayName` to the `<Login />` block example. 