### PR TITLE
Extensions: WPSC - Add / remove notices

### DIFF
--- a/client/extensions/wp-super-cache/advanced-tab.jsx
+++ b/client/extensions/wp-super-cache/advanced-tab.jsx
@@ -34,7 +34,7 @@ const AdvancedTab = ( {
 	return (
 		<div>
 			<QueryNotices siteId={ siteId } />
-			<Caching />
+			<Caching notices={ notices } />
 			<Miscellaneous notices={ notices } />
 			<Advanced />
 			<CacheLocation />

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -30,6 +30,7 @@ const Caching = ( {
 	isSaving,
 	notices: {
 		htaccess_ro,
+		mod_rewrite_missing,
 	},
 	translate,
 } ) => {
@@ -54,6 +55,13 @@ const Caching = ( {
 						showDismiss={ false }
 						status="is-warning"
 						text={ htaccess_ro.message } />
+					}
+
+					{ mod_rewrite_missing && mod_rewrite_missing.message &&
+					<Notice
+						showDismiss={ false }
+						status="is-warning"
+						text={ mod_rewrite_missing.message } />
 					}
 					<FormFieldset>
 						<FormToggle

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +34,9 @@ const Caching = ( {
 	},
 	translate,
 } ) => {
+	const htaccessMessage = get( htaccess_ro, 'message' );
+	const modRewriteMessage = get( mod_rewrite_missing, 'message' );
+
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Caching' ) }>
@@ -50,18 +53,18 @@ const Caching = ( {
 			</SectionHeader>
 			<Card>
 				<form>
-					{ htaccess_ro && htaccess_ro.message &&
+					{ htaccessMessage &&
 					<Notice
 						showDismiss={ false }
 						status="is-warning"
-						text={ htaccess_ro.message } />
+						text={ htaccessMessage } />
 					}
 
-					{ mod_rewrite_missing && mod_rewrite_missing.message &&
+					{ modRewriteMessage &&
 					<Notice
 						showDismiss={ false }
 						status="is-warning"
-						text={ mod_rewrite_missing.message } />
+						text={ modRewriteMessage } />
 					}
 					<FormFieldset>
 						<FormToggle

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -14,6 +14,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormToggle from 'components/forms/form-toggle/compact';
+import Notice from 'components/notice';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 
@@ -27,6 +28,9 @@ const Caching = ( {
 	handleSubmitForm,
 	isRequesting,
 	isSaving,
+	notices: {
+		htaccess_ro,
+	},
 	translate,
 } ) => {
 	return (
@@ -45,6 +49,12 @@ const Caching = ( {
 			</SectionHeader>
 			<Card>
 				<form>
+					{ htaccess_ro && htaccess_ro.message &&
+					<Notice
+						showDismiss={ false }
+						status="is-warning"
+						text={ htaccess_ro.message } />
+					}
 					<FormFieldset>
 						<FormToggle
 							checked={ !! is_cache_enabled }

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -13,7 +13,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
-import Notice from 'components/notice';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 
@@ -46,7 +45,6 @@ class DirectlyCachedFiles extends Component {
 		} = this.props;
 		const cache_direct_pages = fields.cache_direct_pages || [];
 		const cache_path = fields.cache_path || '';
-		const notices = pick( this.props.notices, 'cache_readonly' );
 
 		return (
 			<div>
@@ -63,13 +61,6 @@ class DirectlyCachedFiles extends Component {
 					</Button>
 				</SectionHeader>
 				<Card className="wp-super-cache__directly-cached-files">
-					{ notices && notices.cache_readonly && notices.cache_readonly.message &&
-					<Notice
-						showDismiss={ false }
-						status={ notices.cache_readonly.type ? `is-${ notices.cache_readonly.type }` : 'is-info' }
-						text={ notices.cache_readonly.message || '' } />
-					}
-
 					<p>
 						{ translate(
 							'Directly cached files are files created directly off %(cache_path)s where your blog lives. This ' +
@@ -79,57 +70,55 @@ class DirectlyCachedFiles extends Component {
 							}
 						) }
 					</p>
-						{ notices && ! notices.cache_readonly &&
-						<div>
-							<p>
+					<div>
+						<p>
+							{ translate(
+								'For example: to cache {{em}}%(url)s/about/{{/em}}, you would enter %(url)s/about/ or /about/. ' +
+								'The cached file will be generated the next time an anonymous user visits that page.',
+								{
+									args: { url: site && site.URL },
+									components: { em: <em /> },
+								}
+							) }
+						</p>
+						<form>
+							<FormFieldset>
+								<FormTextInput
+									disabled={ isRequesting || isSaving }
+									onChange={ handleChange( 'new_direct_page' ) }
+									onKeyDown={ this.onKeyDown }
+									ref="newDirectPage" />
+							</FormFieldset>
+
+							{ cache_direct_pages.length > 0 &&
+							<FormLabel>
 								{ translate(
-									'For example: to cache {{em}}%(url)s/about/{{/em}}, you would enter %(url)s/about/ or /about/. ' +
-									'The cached file will be generated the next time an anonymous user visits that page.',
-									{
-										args: { url: site && site.URL },
-										components: { em: <em /> },
-									}
+									'Existing Direct Page',
+									'Existing Direct Pages',
+									{ count: cache_direct_pages.length }
 								) }
-							</p>
-							<form>
-								<FormFieldset>
+							</FormLabel>
+							}
+
+							{ cache_direct_pages.map( ( page, index ) => (
+								<FormFieldset key={ index }>
 									<FormTextInput
 										disabled={ isRequesting || isSaving }
-										onChange={ handleChange( 'new_direct_page' ) }
-										onKeyDown={ this.onKeyDown }
-										ref="newDirectPage" />
+										key={ index }
+										onChange={ setFieldArrayValue( 'cache_direct_pages', index ) }
+										value={ page || '' } />
 								</FormFieldset>
+							) ) }
 
-								{ cache_direct_pages.length > 0 &&
-								<FormLabel>
-									{ translate(
-										'Existing Direct Page',
-										'Existing Direct Pages',
-										{ count: cache_direct_pages.length }
-									) }
-								</FormLabel>
-								}
-
-								{ cache_direct_pages.map( ( page, index ) => (
-									<FormFieldset key={ index }>
-										<FormTextInput
-											disabled={ isRequesting || isSaving }
-											key={ index }
-											onChange={ setFieldArrayValue( 'cache_direct_pages', index ) }
-											value={ page || '' } />
-									</FormFieldset>
-								) ) }
-
-								{ cache_direct_pages.length > 0 &&
-								<FormSettingExplanation>
-									{ translate(
-										'Make the textbox blank to remove it from the list of direct pages and delete the cached file.'
-									) }
-								</FormSettingExplanation>
-								}
-							</form>
-						</div>
-						}
+							{ cache_direct_pages.length > 0 &&
+							<FormSettingExplanation>
+								{ translate(
+									'Make the textbox blank to remove it from the list of direct pages and delete the cached file.'
+								) }
+							</FormSettingExplanation>
+							}
+						</form>
+					</div>
 				</Card>
 			</div>
 		);

--- a/client/extensions/wp-super-cache/directly-cached-files.jsx
+++ b/client/extensions/wp-super-cache/directly-cached-files.jsx
@@ -46,10 +46,7 @@ class DirectlyCachedFiles extends Component {
 		} = this.props;
 		const cache_direct_pages = fields.cache_direct_pages || [];
 		const cache_path = fields.cache_path || '';
-		const notices = pick( this.props.notices, [
-			'cache_readonly',
-			'cache_writable',
-		] );
+		const notices = pick( this.props.notices, 'cache_readonly' );
 
 		return (
 			<div>
@@ -71,13 +68,6 @@ class DirectlyCachedFiles extends Component {
 						showDismiss={ false }
 						status={ notices.cache_readonly.type ? `is-${ notices.cache_readonly.type }` : 'is-info' }
 						text={ notices.cache_readonly.message || '' } />
-					}
-
-					{ notices && notices.cache_writable && notices.cache_writable.message &&
-					<Notice
-						showDismiss={ false }
-						status={ notices.cache_writable.type ? `is-${ notices.cache_writable.type }` : 'is-info' }
-						text={ notices.cache_writable.message || '' } />
 					}
 
 					<p>

--- a/client/extensions/wp-super-cache/state/notices/selectors.js
+++ b/client/extensions/wp-super-cache/state/notices/selectors.js
@@ -22,5 +22,5 @@ export function isRequestingNotices( state, siteId ) {
  * @return {Object} Notices
  */
 export function getNotices( state, siteId ) {
-	return get( state, [ 'extensions', 'wpSuperCache', 'notices', 'items', siteId ], null );
+	return get( state, [ 'extensions', 'wpSuperCache', 'notices', 'items', siteId ], {} );
 }

--- a/client/extensions/wp-super-cache/state/notices/test/selectors.js
+++ b/client/extensions/wp-super-cache/state/notices/test/selectors.js
@@ -87,7 +87,7 @@ describe( 'selectors', () => {
 			}
 		};
 
-		it( 'should return null if no state exists', () => {
+		it( 'should return empty object if no state exists', () => {
 			const state = {
 				extensions: {
 					wpSuperCache: undefined,
@@ -95,10 +95,10 @@ describe( 'selectors', () => {
 			};
 			const notices = getNotices( state, primarySiteId );
 
-			expect( notices ).to.be.null;
+			expect( notices ).to.be.empty;
 		} );
 
-		it( 'should return null if the site is not attached', () => {
+		it( 'should return empty object if the site is not attached', () => {
 			const state = {
 				extensions: {
 					wpSuperCache: {
@@ -112,7 +112,7 @@ describe( 'selectors', () => {
 			};
 			const notices = getNotices( state, secondarySiteId );
 
-			expect( notices ).to.be.null;
+			expect( notices ).to.be.empty;
 		} );
 
 		it( 'should return the notices for a siteId', () => {

--- a/client/extensions/wp-super-cache/state/settings/actions.js
+++ b/client/extensions/wp-super-cache/state/settings/actions.js
@@ -21,6 +21,7 @@ import {
 	WP_SUPER_CACHE_UPDATE_SETTINGS,
 } from '../action-types';
 import { normalizeSettings, sanitizeSettings } from './utils';
+import { requestNotices } from '../notices/actions';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { getSiteTitle } from 'state/sites/selectors';
 
@@ -91,6 +92,7 @@ export const saveSettings = ( siteId, settings ) => {
 			{ path: `/jetpack-blogs/${ siteId }/rest-api/` },
 			{ path: '/wp-super-cache/v1/settings', body: JSON.stringify( sanitizeSettings( settings ) ), json: true } )
 			.then( () => {
+				dispatch( requestNotices( siteId ) );
 				dispatch( updateSettings( siteId, settings ) );
 				dispatch( {
 					type: WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,

--- a/client/extensions/wp-super-cache/state/settings/actions.js
+++ b/client/extensions/wp-super-cache/state/settings/actions.js
@@ -83,28 +83,18 @@ export const updateSettings = ( siteId, settings ) => ( { type: WP_SUPER_CACHE_U
  */
 export const saveSettings = ( siteId, settings ) => {
 	return ( dispatch ) => {
-		dispatch( {
-			type: WP_SUPER_CACHE_SAVE_SETTINGS,
-			siteId,
-		} );
+		dispatch( { type: WP_SUPER_CACHE_SAVE_SETTINGS, siteId } );
 
 		return wp.req.post(
 			{ path: `/jetpack-blogs/${ siteId }/rest-api/` },
 			{ path: '/wp-super-cache/v1/settings', body: JSON.stringify( sanitizeSettings( settings ) ), json: true } )
 			.then( () => {
-				dispatch( requestNotices( siteId ) );
 				dispatch( updateSettings( siteId, settings ) );
-				dispatch( {
-					type: WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS,
-					siteId,
-				} );
+				dispatch( { type: WP_SUPER_CACHE_SAVE_SETTINGS_SUCCESS, siteId } );
+				dispatch( requestNotices( siteId ) );
 			} )
 			.catch( error => {
-				dispatch( {
-					type: WP_SUPER_CACHE_SAVE_SETTINGS_FAILURE,
-					siteId,
-					error,
-				} );
+				dispatch( { type: WP_SUPER_CACHE_SAVE_SETTINGS_FAILURE, siteId, error } );
 			} );
 	};
 };

--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -41,15 +41,11 @@ export const sanitizeSettings = settings => {
 			case 'cache_mobile_prefixes':
 			case 'cache_mod_rewrite':
 			case 'cache_next_gc':
-			case 'cache_readonly':
-			case 'generated':
 			case 'is_preload_enabled':
 			case 'is_preloading':
 			case 'minimum_preload_interval':
 			case 'post_count':
 			case 'preload_refresh':
-			case 'supercache':
-			case 'wpcache':
 				return undefined;
 			default:
 				return setting;

--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -42,7 +42,6 @@ export const sanitizeSettings = settings => {
 			case 'cache_mod_rewrite':
 			case 'cache_next_gc':
 			case 'cache_readonly':
-			case 'cache_writable':
 			case 'generated':
 			case 'is_preload_enabled':
 			case 'is_preloading':


### PR DESCRIPTION
This PR changes (adds/removes) notices that Calypso shows, and also re-fetches notices after saving since new notices could have been generated. This PR requires [this branch](https://github.com/Automattic/wp-super-cache/pull/238) of WP Super Cache in order to test.

## Added

The following notice is now displayed on the _Advanced_ tab if .htaccess does not have write permissions set:

![caching-notice](https://cloud.githubusercontent.com/assets/1190420/26462043/3603ff72-414d-11e7-8e66-a27beb5f6d93.jpg)

The following notice is displayed on the _Advanced_ tab if the mod_rewrite module hasn't been loaded:

![missing-mod_rewrite-notice](https://cloud.githubusercontent.com/assets/1190420/26464168/d3e72690-4154-11e7-92ac-fa4af6be3c46.jpg)

## Removed

The `cache_writable` notice that used to show in the _Directly Cached Files_ section of the _Advanced_ tab has been removed as it is no longer returned by the API:

![directly-cached-files-notice](https://cloud.githubusercontent.com/assets/1190420/25443056/bc583024-2a74-11e7-8e27-a9002156ce51.jpg)