### PR TITLE
Framework: add eslint rule to avoid combineReducers import from redux

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
 		'wpcalypso/jsx-classname-namespace': [ 2, {
 			rootFiles: [ 'index.js', 'index.jsx', 'main.js', 'main.jsx' ],
 		} ],
+		'wpcalypso/import-no-redux-combine-reducers': 2
 	}
 };

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -3,7 +3,7 @@
  */
 import validator from 'is-my-json-valid';
 import { merge, flow, partialRight, reduce, isEqual, omit } from 'lodash';
-import { combineReducers as combine } from 'redux';
+import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
 
 /**
  * Internal dependencies

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1726,7 +1726,7 @@
       }
     },
     "eslint-plugin-wpcalypso": {
-      "version": "3.2.0",
+      "version": "3.3.0",
       "dev": true
     },
     "esmangle-evaluator": {

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "eslint": "3.8.1",
     "eslint-config-wpcalypso": "0.8.0",
     "eslint-plugin-react": "6.4.1",
-    "eslint-plugin-wpcalypso": "3.2.0",
+    "eslint-plugin-wpcalypso": "3.3.0",
     "glob": "7.0.3",
     "husky": "0.13.3",
     "jscodeshift": "0.3.30",


### PR DESCRIPTION
This PR adds a new eslint rule to disallow `combineReducers` imports from `redux`. This is a follow up to #14436 and #13542 to avoid accidental redux imports, since our new combining function makes it easier to persist state. If we allow mixed usage of `combineReducers` from `state/utils` and `redux`, persistence behavior may become unpredictable and confusing for folks.

### Testing Instructions
- Locally in your editor, we see an eslint error when adding `import { combineReducers } from 'redux';`
- No functional changes