### PR TITLE
Domain Connect now requires both the providerId and the serviceId

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -68,9 +68,18 @@ const domainAvailability = {
 };
 
 const dnsTemplates = {
-	G_SUITE: 'g-suite',
-	MICROSOFT_OFFICE365: 'microsoft-office365',
-	ZOHO_MAIL: 'zoho-mail',
+	G_SUITE: {
+		PROVIDER: 'g-suite',
+		SERVICE: 'G-Suite'
+	},
+	MICROSOFT_OFFICE365: {
+		PROVIDER: 'microsoft-office365',
+		SERVICE: 'O365'
+	},
+	ZOHO_MAIL: {
+		PROVIDER: 'zoho-mail',
+		SERVICE: 'Zoho'
+	}
 };
 
 export default {

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -283,8 +283,8 @@ function deleteDns( domainName, record, onComplete ) {
 	} );
 }
 
-function applyDnsTemplate( domainName, template, variables, onComplete ) {
-	wpcom.applyDnsTemplate( domainName, template, variables, ( error, data ) => {
+function applyDnsTemplate( domainName, provider, service, variables, onComplete ) {
+	wpcom.applyDnsTemplate( domainName, provider, service, variables, ( error, data ) => {
 		if ( ! error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.DNS_APPLY_TEMPLATE_COMPLETED,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1788,8 +1788,8 @@ Undocumented.prototype.updateDns = function( domain, records, fn ) {
 	return this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
 };
 
-Undocumented.prototype.applyDnsTemplate = function( domain, template, variables, callback ) {
-	return this.wpcom.req.post( '/domains/' + domain + '/dns/template/' + template, { variables }, callback );
+Undocumented.prototype.applyDnsTemplate = function( domain, provider, service, variables, callback ) {
+	return this.wpcom.req.post( '/domains/' + domain + '/dns/providers/' + provider + '/services/' + service, { variables }, callback );
 };
 
 Undocumented.prototype.fetchWapiDomainInfo = function( domainName, fn ) {

--- a/client/my-sites/upgrades/domain-management/dns/email-provider.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/email-provider.jsx
@@ -42,7 +42,7 @@ class EmailProvider extends Component {
 			variables = template.modifyVariables( variables );
 		}
 
-		upgradesActions.applyDnsTemplate( domain, template.dnsTemplate, variables, ( error ) => {
+		upgradesActions.applyDnsTemplate( domain, template.dnsTemplateProvider, template.dnsTemplateService, variables, ( error ) => {
 			if ( error ) {
 				notices.error( error.message || translate( 'We weren\'t able to add DNS records for this service. Please try again.' ) );
 			} else {

--- a/client/my-sites/upgrades/domain-management/name-servers/dns-template-selector.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/dns-template-selector.jsx
@@ -21,7 +21,7 @@ class DnsTemplateSelector extends Component {
 				options={
 					templates.map( ( template ) => {
 						return {
-							value: template.dnsTemplate,
+							value: template.dnsTemplateService,
 							label: template.name
 						};
 					} )

--- a/client/my-sites/upgrades/domain-management/name-servers/dns-templates.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/dns-templates.jsx
@@ -32,7 +32,8 @@ class DnsTemplates extends Component {
 						} ),
 					placeholder: 'google-site-verification=...',
 					validationPattern: /^google-site-verification=\w{43}$/,
-					dnsTemplate: dnsTemplates.G_SUITE
+					dnsTemplateProvider: dnsTemplates.G_SUITE.PROVIDER,
+					dnsTemplateService: dnsTemplates.G_SUITE.SERVICE
 				},
 				{
 					name: 'Office 365',
@@ -44,7 +45,8 @@ class DnsTemplates extends Component {
 						} ),
 					placeholder: 'MS=ms...',
 					validationPattern: /^MS=ms\d{8}$/,
-					dnsTemplate: dnsTemplates.MICROSOFT_OFFICE365,
+					dnsTemplateProvider: dnsTemplates.MICROSOFT_OFFICE365.PROVIDER,
+					dnsTemplateService: dnsTemplates.MICROSOFT_OFFICE365.SERVICE,
 					modifyVariables: ( variables ) => Object.assign(
 						{},
 						variables,
@@ -56,7 +58,8 @@ class DnsTemplates extends Component {
 					label: translate( 'Zoho Mail CNAME zb code' ),
 					placeholder: 'zb...',
 					validationPattern: /^zb\w{1,100}$/,
-					dnsTemplate: dnsTemplates.ZOHO_MAIL
+					dnsTemplateProvider: dnsTemplates.ZOHO_MAIL.PROVIDER,
+					dnsTemplateService: dnsTemplates.ZOHO_MAIL.SERVICE
 				}
 			]
 		};


### PR DESCRIPTION
This PR updates the parts of Calypso that currently use Domain Connect to use both the providerId and the serviceId as required by the Domain Connect specification and the Domain Connect endpoints. This PR is dependent on D5744-code.