### PR TITLE
Update 5to6-codemod dependency to use upstream repository

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.17.0",
   "dependencies": {
     "5to6-codemod": {
-      "version": "1.8.0",
-      "from": "git://github.com/jsnmoon/5to6-codemod.git#34b2248a93cd491f4a7cd70249c8d5b56304d2c8",
-      "resolved": "git://github.com/jsnmoon/5to6-codemod.git#34b2248a93cd491f4a7cd70249c8d5b56304d2c8",
+      "version": "1.7.0",
+      "from": "git://github.com/5to6/5to6-codemod.git#60306b71d8dde341e4d4bb968e6fbaf6875e19ae",
+      "resolved": "git://github.com/5to6/5to6-codemod.git#60306b71d8dde341e4d4bb968e6fbaf6875e19ae",
       "dev": true,
       "dependencies": {
         "ast-types": {

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm install && npm shrinkwrap --dev"
   },
   "devDependencies": {
-    "5to6-codemod": "git://github.com/jsnmoon/5to6-codemod#v1.8.0",
+    "5to6-codemod": "5to6/5to6-codemod#v1.7.0",
     "babel-eslint": "6.1.2",
     "cash-touch": "0.2.0",
     "chai": "3.5.0",


### PR DESCRIPTION
We had originally been using my [personal fork](https://github.com/jsnmoon/5to6-codemod/) to take advantage of new transformations and bugfixes I had created for `5to6-codemod` . Now that these changes have landed upstream into the original repository, it's time to deprecate my personal fork. Two things of note:

1. The versions differ between my fork and the upstream project. However, the specified upstream version contains all the changes I'd made to my personal fork. (Upstream [changelog](https://github.com/5to6/5to6-codemod/blob/master/CHANGELOG.md) vs my fork's [changelog](https://github.com/jsnmoon/5to6-codemod/blob/master/CHANGELOG.md) for comparison)

2. While the upstream fork is published onto NPM, the published version is currently stale at `v1.6.0`. We require `v1.7.0` for Calypso for CommonJS import hoisting transformation.