### PR TITLE
Make confirmation sidebar responsive.

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -27,8 +27,8 @@ class EditorConfirmationSidebar extends React.Component {
 		return (
 			<RootChild>
 				<div className={ classnames( {
-						'editor-confirmation-sidebar': true,
-						'is-active': this.props.isActive,
+					'editor-confirmation-sidebar': true,
+					'is-active': this.props.isActive,
 				} ) } >
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__overlay': true,
@@ -39,9 +39,11 @@ class EditorConfirmationSidebar extends React.Component {
 						'is-active': this.props.isActive,
 					} ) }>
 						<div className="editor-confirmation-sidebar__ground-control">
-							<div className="editor-confirmation-sidebar__cancel" onClick={ this.props.hideSidebar }>Cancel</div>
+							<div className="editor-confirmation-sidebar__cancel" onClick={ this.props.hideSidebar }>
+								{ this.props.translate( 'Cancel' ) }
+							</div>
 							<div className="editor-confirmation-sidebar__action">
-								Are you sure? <Button onClick={ this.closeAndPublish } compact>Yea, do it!</Button>
+								<Button onClick={ this.closeAndPublish } compact>{ this.props.translate( 'Publish' ) }</Button>
 							</div>
 						</div>
 					</div>

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -8,9 +8,9 @@
 	visibility: hidden;
 
 	&.is-active {
-		position: static;
-			top: auto;
-			left: auto;
+		position: absolute;
+			top: 0;
+			left: 0;
 			width: auto;
 			height: auto;
 		overflow: auto;
@@ -50,13 +50,30 @@
 	&.is-active {
 		transform: translateX( -374px );
 	}
+
+  @include breakpoint( "<660px" ) {
+	transition: none;
+	border-left: none;
+
+	&.is-active {
+		height: auto;
+		width: 100%;
+		position: fixed;
+			top: 47px;
+			right: auto;
+			left: 0;
+		transform: none;
+	}
+  }
 }
 
 .editor-confirmation-sidebar__ground-control {
 	@extend .card;
 	display: flex;
 	justify-content: space-between;
-	
+	flex-direction: row;
+	flex-wrap: wrap;
+
 	position: absolute;
 		top: 0;
 		left: 0;


### PR DESCRIPTION
This pull requests makes the confirmation sidebar responsive so that it is usable on smaller screens.

The feature is behind a feature flag (post-editor/delta-post-publish-flow) and the confirmation bar is intentionally blank. It will be populated in future PRs. This is part of a larger epic (See p3Ex-2ri-p2)

Some screenshots:

Galaxy S5:

![screen shot 2017-05-26 at 11 32 36 am](https://cloud.githubusercontent.com/assets/1017839/26489320/361d6a92-4207-11e7-9a5f-324177adfb8c.png)

iPhone 5:

![screen shot 2017-05-26 at 11 32 51 am](https://cloud.githubusercontent.com/assets/1017839/26489322/399ffc8e-4207-11e7-91a7-5f2d0743ec16.png)

iPhone 5 (landscape):

![screen shot 2017-05-26 at 11 33 03 am](https://cloud.githubusercontent.com/assets/1017839/26489329/3fd02e26-4207-11e7-98c0-3641ce0c5b98.png)

iPad:

![screen shot 2017-05-26 at 11 33 15 am](https://cloud.githubusercontent.com/assets/1017839/26489343/4bb037fe-4207-11e7-88c2-5796d492f674.png)

1024 x 768:

![screen shot 2017-05-26 at 11 33 26 am](https://cloud.githubusercontent.com/assets/1017839/26489340/490f70a0-4207-11e7-9528-46ff51d49428.png)

--------------

To test:

- Checkout branch
- ENABLE_FEATURES=post-editor/delta-post-publish-flow make run
- Click Publish for the sidebar to show up
- Resize the browser window to experiment with different window sizes
- Run the branch again without the feature flag enabled and make sure other components show up as usual (no regression)