### PR TITLE
VSCode jsconfig: updates the target compiler option to ES6

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
 		"module": "commonjs",
-		"target": "es2017",
+		"target": "ES6",
 		"baseUrl": ".",
 		"paths": {
 			"*": [ "test/*", "server/*", "client/*" ]


### PR DESCRIPTION
Updates the `target` compiler option to `ES6`, one of the valid values according to https://code.visualstudio.com/docs/languages/jsconfig to enable language services.