### PR TITLE
Comments: fetch post comments using the data-layer

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -14,7 +14,6 @@ import {
 	getPostCommentsTree,
 	getPostTotalCommentsCount,
 	haveMoreCommentsToFetch,
-	getPostOldestCommentDate,
 } from 'state/comments/selectors';
 import {
 	requestPostComments
@@ -49,7 +48,7 @@ class PostCommentList extends React.Component {
 			post: { ID: postId, site_ID: siteId }
 		} = this.props;
 
-		this.props.requestPostComments( siteId, postId, this.props.commentsFilter, this.props.before );
+		this.props.requestPostComments( siteId, postId, this.props.commentsFilter );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -66,7 +65,7 @@ class PostCommentList extends React.Component {
 				this.props.post.ID !== nextPostId ||
 				this.props.commentsFilter !== nextCommentsFilter )
 			) {
-			this.props.requestPostComments( nextSiteId, nextPostId, this.props.commentsFilter, this.props.before );
+			this.props.requestPostComments( nextSiteId, nextPostId, this.props.commentsFilter );
 		}
 	}
 
@@ -200,7 +199,7 @@ class PostCommentList extends React.Component {
 		} );
 
 		if ( this.props.haveMoreCommentsToFetch ) {
-			this.props.requestPostComments( siteId, postId, this.props.commentsFilter, this.props.before );
+			this.props.requestPostComments( siteId, postId, this.props.commentsFilter );
 		}
 	}
 
@@ -312,7 +311,6 @@ export default connect(
 			commentsTree: getPostCommentsTree( state, ownProps.post.site_ID, ownProps.post.ID, ownProps.commentsFilter ),
 			totalCommentsCount: getPostTotalCommentsCount( state, ownProps.post.site_ID, ownProps.post.ID ),
 			haveMoreCommentsToFetch: haveMoreCommentsToFetch( state, ownProps.post.site_ID, ownProps.post.ID ),
-			before: getPostOldestCommentDate( state, ownProps.post.site_ID, ownProps.post.ID )
 		}
 	),
 	( dispatch ) => bindActionCreators( {

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -13,7 +13,8 @@ import { get, size, takeRight } from 'lodash';
 import {
 	getPostCommentsTree,
 	getPostTotalCommentsCount,
-	haveMoreCommentsToFetch
+	haveMoreCommentsToFetch,
+	getPostOldestCommentDate,
 } from 'state/comments/selectors';
 import {
 	requestPostComments
@@ -48,7 +49,7 @@ class PostCommentList extends React.Component {
 			post: { ID: postId, site_ID: siteId }
 		} = this.props;
 
-		this.props.requestPostComments( siteId, postId, this.props.commentsFilter );
+		this.props.requestPostComments( siteId, postId, this.props.commentsFilter, this.props.before );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -65,7 +66,7 @@ class PostCommentList extends React.Component {
 				this.props.post.ID !== nextPostId ||
 				this.props.commentsFilter !== nextCommentsFilter )
 			) {
-			this.props.requestPostComments( nextSiteId, nextPostId, this.props.commentsFilter );
+			this.props.requestPostComments( nextSiteId, nextPostId, this.props.commentsFilter, this.props.before );
 		}
 	}
 
@@ -199,7 +200,7 @@ class PostCommentList extends React.Component {
 		} );
 
 		if ( this.props.haveMoreCommentsToFetch ) {
-			this.props.requestPostComments( siteId, postId, this.props.commentsFilter );
+			this.props.requestPostComments( siteId, postId, this.props.commentsFilter, this.props.before );
 		}
 	}
 
@@ -310,7 +311,8 @@ export default connect(
 		{
 			commentsTree: getPostCommentsTree( state, ownProps.post.site_ID, ownProps.post.ID, ownProps.commentsFilter ),
 			totalCommentsCount: getPostTotalCommentsCount( state, ownProps.post.site_ID, ownProps.post.ID ),
-			haveMoreCommentsToFetch: haveMoreCommentsToFetch( state, ownProps.post.site_ID, ownProps.post.ID )
+			haveMoreCommentsToFetch: haveMoreCommentsToFetch( state, ownProps.post.site_ID, ownProps.post.ID ),
+			before: getPostOldestCommentDate( state, ownProps.post.site_ID, ownProps.post.ID )
 		}
 	),
 	( dispatch ) => bindActionCreators( {

--- a/client/state/comments/README.md
+++ b/client/state/comments/README.md
@@ -36,7 +36,6 @@ getPostCommentsTree - returns a memoized comments tree of the form:
 
 ### Simple selectors:
 getPostCommentItems - gets items of siteId, postId;
-getPostCommentRequests - gets requests of siteId, postId
 getPostTotalCommentsCount - gets totalCommentsCount of siteId, postId
 
 ### Compute selectors:

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -18,6 +18,7 @@ import {
 	COMMENTS_RECEIVE,
 	COMMENTS_COUNT_RECEIVE,
 	COMMENTS_REQUEST,
+	COMMENTS_REQUEST_FAILURE,
 	COMMENTS_LIKE,
 	COMMENTS_LIKE_UPDATE,
 	COMMENTS_UNLIKE,
@@ -31,6 +32,24 @@ import {
 	NUMBER_OF_COMMENTS_PER_FETCH,
 	PLACEHOLDER_STATE
 } from './constants';
+
+/***
+ * Internal handler for comments request failure
+ * @param {Function} dispatch redux dispatch function
+ * @param {String} siteId site identifier
+ * @param {String} postId post identifier
+ * @param {String} requestId request identifier
+ * @param {Object} err error object
+ */
+function commentsRequestFailure( dispatch, siteId, postId, requestId, err ) {
+	dispatch( {
+		type: COMMENTS_REQUEST_FAILURE,
+		siteId,
+		postId,
+		requestId,
+		error: err
+	} );
+}
 
 /***
  * Creates a thunk that requests comments for a given post

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isDate } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
@@ -56,29 +51,22 @@ function commentsRequestFailure( dispatch, siteId, postId, requestId, err ) {
  * @param {Number} siteId site identifier
  * @param {Number} postId post identifier
  * @param {String} status status filter. Defaults to approved posts
- * @param {Date}   before will retrieve comments before this date
  * @returns {Function} thunk that requests comments for a given post
  */
-export function requestPostComments( siteId, postId, status = 'approved', before ) {
+export function requestPostComments( siteId, postId, status = 'approved' ) {
 	if ( ! isEnabled( 'comments/filters-in-posts' ) ) {
 		status = 'approved';
-	}
-
-	const query = {
-		order: 'DESC',
-		number: NUMBER_OF_COMMENTS_PER_FETCH,
-		status
-	};
-
-	if ( before && isDate( before ) && before.toISOString ) {
-		query.before = before.toISOString();
 	}
 
 	return {
 		type: COMMENTS_REQUEST,
 		siteId,
 		postId,
-		query
+		query: {
+			order: 'DESC',
+			number: NUMBER_OF_COMMENTS_PER_FETCH,
+			status
+		}
 	};
 }
 

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -16,9 +16,6 @@ import {
 	COMMENTS_LIKE,
 	COMMENTS_LIKE_UPDATE,
 	COMMENTS_UNLIKE,
-	COMMENTS_REQUEST,
-	COMMENTS_REQUEST_SUCCESS,
-	COMMENTS_REQUEST_FAILURE,
 } from '../action-types';
 import { combineReducers } from 'state/utils';
 import {
@@ -110,31 +107,6 @@ export function items( state = {}, action ) {
 }
 
 /***
- * Stores information regarding requests status per requestId
- * @param {Object} state redux state
- * @param {Object} action redux action
- * @returns {Object} new redux state
- */
-export function requests( state = {}, action ) {
-	switch ( action.type ) {
-		case COMMENTS_REQUEST:
-		case COMMENTS_REQUEST_SUCCESS:
-		case COMMENTS_REQUEST_FAILURE:
-			const { siteId, postId, requestId, type } = action;
-			const stateKey = getStateKey( siteId, postId );
-			return {
-				...state,
-				[ stateKey ]: {
-					...state[ stateKey ],
-					[ requestId ]: type
-				}
-			};
-	}
-
-	return state;
-}
-
-/***
  * Stores latest comments count for post we've seen from the server
  * @param {Object} state redux state, prev totalCommentsCount
  * @param {Object} action redux action
@@ -156,6 +128,5 @@ export function totalCommentsCount( state = {}, action ) {
 
 export default combineReducers( {
 	items,
-	requests,
 	totalCommentsCount
 } );

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -18,15 +18,6 @@ import createSelector from 'lib/create-selector';
 export const getPostCommentItems = ( state, siteId, postId ) => get( state.comments.items, `${ siteId }-${ postId }` );
 
 /***
- * Get requests status map for post
- * @param {Object} state redux state
- * @param {Number} siteId site identification
- * @param {Number} postId site identification
- * @return {Object} requestIds
- */
-export const getPostCommentRequests = ( state, siteId, postId ) => get( state.comments.requests, `${ siteId }-${ postId }` );
-
-/***
  * Get total number of comments on the server for a given post
  * @param {Object} state redux state
  * @param {Number} siteId site identification

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -44,7 +44,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should return a comment request action', function() {
-			const action = requestPostComments( SITE_ID, POST_ID, 'trash', new Date( '2017-05-25T21:41:25.841Z' ) );
+			const action = requestPostComments( SITE_ID, POST_ID, 'trash' );
 
 			expect( action ).to.eql( {
 				type: COMMENTS_REQUEST,
@@ -53,14 +53,13 @@ describe( 'actions', () => {
 				query: {
 					order: 'DESC',
 					number: NUMBER_OF_COMMENTS_PER_FETCH,
-					status: 'trash',
-					before: '2017-05-25T21:41:25.841Z'
+					status: 'trash'
 				}
 			} );
 		} );
 
 		it( 'should return a comment request action with a default status of approved', function() {
-			const action = requestPostComments( SITE_ID, POST_ID, undefined, new Date( '2017-05-25T21:41:25.841Z' ) );
+			const action = requestPostComments( SITE_ID, POST_ID, undefined );
 
 			expect( action ).to.eql( {
 				type: COMMENTS_REQUEST,
@@ -69,23 +68,7 @@ describe( 'actions', () => {
 				query: {
 					order: 'DESC',
 					number: NUMBER_OF_COMMENTS_PER_FETCH,
-					status: 'approved',
-					before: '2017-05-25T21:41:25.841Z'
-				}
-			} );
-		} );
-
-		it( 'should return a comment request action with no before filter if none provided', function() {
-			const action = requestPostComments( SITE_ID, POST_ID, undefined, null );
-
-			expect( action ).to.eql( {
-				type: COMMENTS_REQUEST,
-				siteId: SITE_ID,
-				postId: POST_ID,
-				query: {
-					order: 'DESC',
-					number: NUMBER_OF_COMMENTS_PER_FETCH,
-					status: 'approved',
+					status: 'approved'
 				}
 			} );
 		} );

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -10,7 +10,6 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	items,
-	requests,
 	totalCommentsCount,
 } from '../reducer';
 import {
@@ -21,12 +20,7 @@ import {
 	COMMENTS_COUNT_RECEIVE,
 	COMMENTS_RECEIVE,
 	COMMENTS_REMOVE,
-	COMMENTS_REQUEST,
-	COMMENTS_REQUEST_FAILURE
 } from '../../action-types';
-import {
-	createRequestId
-} from '../utils';
 import {
 	PLACEHOLDER_STATE
 } from '../constants';
@@ -155,29 +149,6 @@ describe( 'reducer', () => {
 			expect( result[ '1-1' ][ 0 ].placeholderError ).to.equal( 'error_message' );
 		} );
 	} ); // end of items
-
-	describe( '#requests', () => {
-		it( 'should set state of query according to the action', () => {
-			const postId = 1;
-			const siteId = 1;
-			const requestId = createRequestId( siteId, postId, { after: new Date(), order: 'DESC', number: 10 } );
-
-			const action = {
-				type: COMMENTS_REQUEST,
-				siteId,
-				postId,
-				requestId: requestId
-			};
-
-			const response = requests( undefined, action );
-			expect( response[ '1-1' ][ requestId ] ).to.be.eql( COMMENTS_REQUEST );
-
-			action.type = COMMENTS_REQUEST_FAILURE;
-			const failureResponse = requests( deepFreeze( response ), action );
-
-			expect( failureResponse[ '1-1' ][ requestId ] ).to.be.eql( COMMENTS_REQUEST_FAILURE );
-		} );
-	} ); // end of requests
 
 	describe( '#totalCommentsCount()', () => {
 		it( 'should update post comments count', () => {

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -16,7 +16,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/replies/
-const fetchPostComments = ( { dispatch }, action ) => {
+export const fetchPostComments = ( { dispatch }, action ) => {
 	const { siteId, postId, query } = action;
 
 	dispatch( http( {
@@ -27,7 +27,7 @@ const fetchPostComments = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-const addComments = ( { dispatch }, { siteId, postId }, next, { comments, found } ) => {
+export const addComments = ( { dispatch }, { siteId, postId }, next, { comments, found } ) => {
 	dispatch( {
 		type: COMMENTS_RECEIVE,
 		siteId,
@@ -49,7 +49,7 @@ const addComments = ( { dispatch }, { siteId, postId }, next, { comments, found 
 	}
 };
 
-const announceFailure = ( { dispatch } ) => dispatch( errorNotice( translate( 'Could not retrieve post of comments' ) ) );
+export const announceFailure = ( { dispatch } ) => dispatch( errorNotice( translate( 'Could not retrieve post of comments' ) ) );
 
 export default {
 	[ COMMENTS_REQUEST ]: [ dispatchRequest( fetchPostComments, addComments, announceFailure ) ]

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -14,6 +14,7 @@ import {
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
+import { getSitePost } from 'state/posts/selectors';
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/replies/
 export const fetchPostComments = ( { dispatch }, action ) => {
@@ -49,7 +50,15 @@ export const addComments = ( { dispatch }, { siteId, postId }, next, { comments,
 	}
 };
 
-export const announceFailure = ( { dispatch } ) => dispatch( errorNotice( translate( 'Could not retrieve post of comments' ) ) );
+export const announceFailure = ( { dispatch, getState }, { siteId, postId } ) => {
+	const post = getSitePost( getState(), siteId, postId );
+	const postTitle = post && post.title && post.title.trim().slice( 0, 20 ).trim().concat( '…' );
+	const error = postTitle
+		? translate( 'Could not retrieve comments for “%(postTitle)s”', { args: { postTitle } } )
+		: translate( 'Could not retrieve comments for requested post' );
+
+	dispatch( errorNotice( error ) );
+};
 
 export default {
 	[ COMMENTS_REQUEST ]: [ dispatchRequest( fetchPostComments, addComments, announceFailure ) ]

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	COMMENTS_REQUEST,
+	COMMENTS_RECEIVE,
+	COMMENTS_COUNT_RECEIVE
+} from 'state/action-types';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { errorNotice } from 'state/notices/actions';
+
+// @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/replies/
+const fetchPostComments = ( { dispatch }, action ) => {
+	const { siteId, postId, query } = action;
+
+	dispatch( http( {
+		method: 'GET',
+		path: `/sites/${ siteId }/posts/${ postId }/replies`,
+		apiVersion: '1.1',
+		query
+	}, action ) );
+};
+
+const addComments = ( { dispatch }, { siteId, postId }, next, { comments, found } ) => {
+	dispatch( {
+		type: COMMENTS_RECEIVE,
+		siteId,
+		postId,
+		comments
+	} );
+
+	// if the api have returned comments count, dispatch it
+	// the api will produce a count only when the request has no
+	// query modifiers such as 'before', 'after', 'type' and more.
+	// in our case it'll be only on the first request
+	if ( found > -1 ) {
+		dispatch( {
+			type: COMMENTS_COUNT_RECEIVE,
+			siteId,
+			postId,
+			totalCommentsCount: found
+		} );
+	}
+};
+
+const announceFailure = ( { dispatch } ) => dispatch( errorNotice( translate( 'Could not retrieve post of comments' ) ) );
+
+export default {
+	[ COMMENTS_REQUEST ]: [ dispatchRequest( fetchPostComments, addComments, announceFailure ) ]
+};

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -29,8 +29,7 @@ describe( 'wpcom-api', () => {
 				const query = {
 					order: 'DESC',
 					number: NUMBER_OF_COMMENTS_PER_FETCH,
-					status: 'trash',
-					before: '2017-05-25T21:41:25.841Z'
+					status: 'trash'
 				};
 				const action = {
 					type: 'DUMMY_ACTION',
@@ -39,8 +38,15 @@ describe( 'wpcom-api', () => {
 					query
 				};
 				const dispatch = spy();
+				const getState = () => ( {
+					comments: {
+						items: {
+							'101010-1010': []
+						}
+					}
+				} );
 
-				fetchPostComments( { dispatch }, action );
+				fetchPostComments( { dispatch, getState }, action );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith( http( {
@@ -48,6 +54,45 @@ describe( 'wpcom-api', () => {
 					method: 'GET',
 					path: '/sites/101010/posts/1010/replies',
 					query
+				}, action ) );
+			} );
+
+			it( 'should dispatch an HTTP request to the post replies endpoint, before the oldest comment in state', () => {
+				const query = {
+					order: 'DESC',
+					number: NUMBER_OF_COMMENTS_PER_FETCH,
+					status: 'trash',
+				};
+				const action = {
+					type: 'DUMMY_ACTION',
+					siteId: '101010',
+					postId: '1010',
+					query
+				};
+				const dispatch = spy();
+				const getState = () => ( {
+					comments: {
+						items: {
+							'101010-1010': [
+								{ id: 1, date: '2017-05-25T21:41:25.841Z' },
+								{ id: 2, date: '2017-05-25T20:41:25.841Z' },
+								{ id: 3, date: '2017-05-25T19:41:25.841Z' }
+							]
+						}
+					}
+				} );
+
+				fetchPostComments( { dispatch, getState }, action );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'GET',
+					path: '/sites/101010/posts/1010/replies',
+					query: {
+						...query,
+						before: '2017-05-25T19:41:25.841Z'
+					}
 				}, action ) );
 			} );
 		} );

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	COMMENTS_RECEIVE,
+	COMMENTS_COUNT_RECEIVE,
+	NOTICE_CREATE
+} from 'state/action-types';
+import {
+	fetchPostComments,
+	addComments,
+	announceFailure,
+} from '../';
+import {
+	NUMBER_OF_COMMENTS_PER_FETCH
+} from 'state/comments/constants';
+
+describe( 'wpcom-api', () => {
+	describe( 'post comments request', () => {
+		describe( '#fetchPostComments()', () => {
+			it( 'should dispatch an HTTP request to the post replies endpoint', () => {
+				const query = {
+					order: 'DESC',
+					number: NUMBER_OF_COMMENTS_PER_FETCH,
+					status: 'trash',
+					before: '2017-05-25T21:41:25.841Z'
+				};
+				const action = {
+					type: 'DUMMY_ACTION',
+					siteId: '101010',
+					postId: '1010',
+					query
+				};
+				const dispatch = spy();
+
+				fetchPostComments( { dispatch }, action );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'GET',
+					path: '/sites/101010/posts/1010/replies',
+					query
+				}, action ) );
+			} );
+		} );
+
+		describe( '#addComments', () => {
+			it( 'should dispatch a comments receive action', () => {
+				const dispatch = spy();
+				const action = {
+					siteId: 101010,
+					postId: 1010
+				};
+				const data = {
+					comments: [],
+					found: -1
+				};
+
+				addComments( { dispatch }, action, null, data );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( {
+					type: COMMENTS_RECEIVE,
+					siteId: 101010,
+					postId: 1010,
+					comments: []
+				} );
+			} );
+
+			it( 'should dispatch a comments receive action and a count receive action when comments found', () => {
+				const dispatch = spy();
+				const action = {
+					siteId: 101010,
+					postId: 1010
+				};
+				const data = {
+					comments: [ {}, {} ],
+					found: 2
+				};
+
+				addComments( { dispatch }, action, null, data );
+
+				expect( dispatch ).to.have.been.calledTwice;
+				expect( dispatch ).to.have.been.calledWith( {
+					type: COMMENTS_RECEIVE,
+					siteId: 101010,
+					postId: 1010,
+					comments: [ {}, {} ]
+				} );
+
+				expect( dispatch ).to.have.been.calledWith( {
+					type: COMMENTS_COUNT_RECEIVE,
+					siteId: 101010,
+					postId: 1010,
+					totalCommentsCount: 2
+				} );
+			} );
+		} );
+
+		describe( '#announceFailure', () => {
+			it( 'should dispatch an error notice', () => {
+				const dispatch = spy();
+
+				announceFailure( { dispatch } );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWithMatch( {
+					type: NOTICE_CREATE,
+					notice: {
+						status: 'is-error'
+					}
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -108,14 +108,20 @@ describe( 'wpcom-api', () => {
 		describe( '#announceFailure', () => {
 			it( 'should dispatch an error notice', () => {
 				const dispatch = spy();
+				const getState = () => ( {
+					posts: {
+						queries: {}
+					}
+				} );
 
-				announceFailure( { dispatch } );
+				announceFailure( { dispatch, getState }, { siteId: 101010, postId: 1010 } );
 
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWithMatch( {
 					type: NOTICE_CREATE,
 					notice: {
-						status: 'is-error'
+						status: 'is-error',
+						text: 'Could not retrieve comments for requested post'
 					}
 				} );
 			} );

--- a/client/state/data-layer/wpcom/index.js
+++ b/client/state/data-layer/wpcom/index.js
@@ -3,6 +3,7 @@
  */
 import { mergeHandlers } from 'state/action-watchers/utils';
 import accountRecovery from './account-recovery';
+import comments from './comments';
 import me from './me';
 import plans from './plans';
 import posts from './posts';
@@ -15,6 +16,7 @@ import login2fa from './login-2fa';
 
 export const handlers = mergeHandlers(
 	accountRecovery,
+	comments,
 	me,
 	plans,
 	posts,


### PR DESCRIPTION
This PR introduces a new `comments` data layer and updates the `requestPostComments` action to dispatch a plain action object instead of a thunk.
It also removes request tracking from the reducer, since that responsibility now falls on the HTTP data layer.

Depends on #14437.

To test:

Use the _Posts_ and _Reader_ comments section as normal. There should be no regressions.

```sh
npm run test-client client/state/comments/test/actions.js
```

```sh
npm run test-client client/state/data-layer/wpcom/comments
```

cc: @Automattic/lannister @Automattic/reader 