### PR TITLE
Site Stats: Update Legend

### DIFF
--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -1,69 +1,63 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes, PureComponent, Component } from 'react';
 import { find, noop } from 'lodash';
 
 /**
  * Module variables
  */
-// TODO: remove and extend from PureComponent after porting the component to ES6
-const PureRenderMixin = require( 'react-pure-render/mixin' );
 
-const LegendItem = React.createClass( {
-	displayName: 'ModuleChartLegendItem',
+class LegendItem extends PureComponent {
+	static propTypes = {
+		attr: PropTypes.string.isRequired,
+		changeHandler: PropTypes.func.isRequired,
+		checked: PropTypes.bool.isRequired,
+		label: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
+	};
 
-	mixins: [ PureRenderMixin ],
-
-	propTypes: {
-		checked: React.PropTypes.bool.isRequired,
-		label: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.string ] ),
-		attr: React.PropTypes.string.isRequired,
-		changeHandler: React.PropTypes.func.isRequired
-	},
-
-	clickHandler: function() {
+	clickHandler = () => {
 		this.props.changeHandler( this.props.attr );
-	},
+	};
 
-	render: function() {
+	render() {
 		return (
 			<li className="chart__legend-option">
-				<label htmlFor="checkbox" className="chart__legend-label is-selectable" onClick={ this.clickHandler } >
-					<input type="checkbox" className="chart__legend-checkbox" checked={ this.props.checked } onChange={ function() {} } />
+				<label className="chart__legend-label is-selectable">
+					<input
+						checked={ this.props.checked }
+						className="chart__legend-checkbox"
+						onChange={ this.clickHandler }
+						type="checkbox"
+					/>
 					<span className={ this.props.className }></span>{ this.props.label }
 				</label>
 			</li>
 		);
 	}
+}
 
-} );
+class Legend extends Component {
+	static propTypes = {
+		activeCharts: PropTypes.array,
+		activeTab: PropTypes.object.isRequired,
+		availableCharts: PropTypes.array,
+		clickHandler: PropTypes.func,
+		tabs: PropTypes.array,
+	};
 
-const Legend = React.createClass( {
-	displayName: 'ModuleChartLegend',
+	static defaultProps = {
+		activeCharts: [],
+		availableCharts: [],
+		clickHandler: noop,
+		tabs: [],
+	};
 
-	propTypes: {
-		activeTab: React.PropTypes.object.isRequired,
-		tabs: React.PropTypes.array,
-		activeCharts: React.PropTypes.array,
-		availableCharts: React.PropTypes.array,
-		clickHandler: React.PropTypes.func
-	},
-
-	getDefaultProps() {
-		return {
-			tabs: [],
-			availableCharts: [],
-			activeCharts: [],
-			clickHandler: noop,
-		};
-	},
-
-	onFilterChange: function( chartItem ) {
+	onFilterChange = chartItem => {
 		this.props.clickHandler( chartItem );
-	},
+	};
 
-	render: function() {
+	render() {
 		const legendColors = [ 'chart__legend-color is-dark-blue' ],
 			activeTab = this.props.activeTab;
 
@@ -96,6 +90,6 @@ const Legend = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 
-module.exports = Legend;
+export default Legend;


### PR DESCRIPTION
### Motivation
I'd like to reuse the legend component for a simple use case. In order to do so, I wanted to simplify the API with use of default props. At the same time, I did some janitorial work in es6-ifying the component.

### Before
All sorts of props were needed to render a simple legend item
![screen shot 2017-05-26 at 1 23 20 pm](https://cloud.githubusercontent.com/assets/1922453/26477006/95e011e6-4216-11e7-8806-f203d3d1d192.png)
![screen shot 2017-05-26 at 1 19 32 pm](https://cloud.githubusercontent.com/assets/1922453/26477008/98e4a82a-4216-11e7-9038-7b44c2bc63c3.png)

### After
A simpler surface, if need be
```js
<Legend
    activeTab={ selectedTab }
/>
```