### PR TITLE
Reader: Emojify post and reader excerpts

### DIFF
--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -12,6 +12,7 @@ import classnames from 'classnames';
  * Internal Dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderVisitLink from 'blocks/reader-visit-link';
 import ReaderAuthorLink from 'blocks/reader-author-link';
@@ -122,7 +123,9 @@ class ReaderCombinedCardPost extends React.Component {
 					<AutoDirection>
 						<h1 className="reader-combined-card__post-title">
 							<a className="reader-combined-card__post-title-link" href={ post.URL }>
-								{ post.title }
+								<Emojify>
+									{ post.title }
+								</Emojify>
 							</a>
 						</h1>
 					</AutoDirection>

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal Dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 
 const ReaderExcerpt = ( { post, isDiscover } ) => {
 	let excerpt = post.better_excerpt || post.excerpt;
@@ -18,10 +19,12 @@ const ReaderExcerpt = ( { post, isDiscover } ) => {
 
 	return (
 		<AutoDirection>
-			<div
-				className="reader-excerpt"
-				dangerouslySetInnerHTML={ { __html: excerpt } } // eslint-disable-line react/no-danger
-			/>
+			<Emojify>
+				<div
+					className="reader-excerpt__content reader-excerpt"
+					dangerouslySetInnerHTML={ { __html: excerpt } } // eslint-disable-line react/no-danger
+				/>
+			</Emojify>
 		</AutoDirection>
 	);
 };

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -8,6 +8,7 @@ import { map, take, filter } from 'lodash';
  * Internal Dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 import { imageIsBigEnoughForGallery } from 'state/reader/posts/normalization-rules';
 import resizeImageUrl from 'lib/resize-image-url';
 import cssSafeUrl from 'lib/css-safe-url';
@@ -54,7 +55,11 @@ const PostGallery = ( { post, children, isDiscover } ) => {
 			<div className="reader-post-card__post-details">
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
-						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
+						<a className="reader-post-card__title-link" href={ post.URL }>
+							<Emojify>
+								{ post.title }
+							</Emojify>
+						</a>
 					</h1>
 				</AutoDirection>
 				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />

--- a/client/blocks/reader-post-card/photo.jsx
+++ b/client/blocks/reader-post-card/photo.jsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  * Internal Dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 import cssSafeUrl from 'lib/css-safe-url';
 
 class PostPhoto extends React.Component {
@@ -115,7 +116,9 @@ class PostPhoto extends React.Component {
 							href={ post.URL }
 							onClick={ this.props.onClick }
 						>
-							{ linkTitle }
+							<Emojify>
+								{ linkTitle }
+							</Emojify>
 						</a>
 					</h1>
 				</AutoDirection>

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -8,6 +8,7 @@ import { partial } from 'lodash';
  * Internal Dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
@@ -36,7 +37,11 @@ const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpa
 			<div className="reader-post-card__post-details">
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
-						<a className="reader-post-card__title-link" href={ post.URL }>{ post.title }</a>
+						<a className="reader-post-card__title-link" href={ post.URL }>
+							<Emojify>
+								{ post.title }
+							</Emojify>
+						</a>
 					</h1>
 				</AutoDirection>
 				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -7,7 +7,11 @@ import config from 'config';
 
 export default class Emojify extends PureComponent {
 	static propTypes = {
-		children: PropTypes.string.isRequired,
+		children: PropTypes.oneOfType( [
+			PropTypes.array.isRequired,
+			PropTypes.object.isRequired,
+			PropTypes.string.isRequired,
+		] ),
 		className: PropTypes.string
 	}
 

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -45,7 +45,7 @@ export default class Emojify extends PureComponent {
 		}
 
 		return (
-			<div ref="emojified">{ this.props.children }</div>
+			<div className="emojify" ref="emojified">{ this.props.children }</div>
 		);
 	}
 }

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -38,8 +38,14 @@ export default class Emojify extends PureComponent {
 	}
 
 	render() {
+		if ( 'string' === typeof this.props.children ) {
+			return (
+				<span ref="emojified">{ this.props.children }</span>
+			);
+		}
+
 		return (
-			<span ref="emojified">{ this.props.children }</span>
+			<div ref="emojified">{ this.props.children }</div>
 		);
 	}
 }

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -38,12 +38,6 @@ export default class Emojify extends PureComponent {
 	}
 
 	render() {
-		if ( 'string' === typeof this.props.children ) {
-			return (
-				<span ref="emojified">{ this.props.children }</span>
-			);
-		}
-
 		return (
 			<div className="emojify" ref="emojified">{ this.props.children }</div>
 		);

--- a/client/components/emojify/style.scss
+++ b/client/components/emojify/style.scss
@@ -1,3 +1,7 @@
+.emojify {
+	display: inline;
+}
+
 // Styles recommended by twemoji
 // https://github.com/twitter/twemoji#inline-styles
 .emojify__emoji {

--- a/client/components/emojify/test/emojify.jsx
+++ b/client/components/emojify/test/emojify.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import Emojify from '..';
+
+describe( 'Emojify', function() {
+	useFakeDom();
+
+	context( 'component rendering', () => {
+		it( 'wraps a string in a span', () => {
+			const wrapper = shallow(
+				<Emojify>Foo</Emojify>
+			);
+			expect( wrapper.find( 'span' ).node.ref ).to.equal( 'emojified' );
+		} );
+
+		it( 'wraps a block in a div', () => {
+			const wrapper = shallow(
+				<Emojify><p>Bar</p></Emojify>
+			);
+			expect( wrapper.find( 'div' ).node.ref ).to.equal( 'emojified' );
+		} );
+
+		it( 'replaces emoji in a string', () => {
+			global.Image = window.Image;
+
+			const wrapper = mount(
+				<Emojify>🙂</Emojify>
+			);
+
+			delete global.Image;
+
+			expect( wrapper.html() ).to.equal(
+				'<span><img draggable="false" class="emojify__emoji" alt="🙂" ' +
+				'src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/72x72/1f642.png"></span>'
+			);
+		} );
+
+		it( 'replaces emoji in a block', () => {
+			global.Image = window.Image;
+
+			const wrapper = mount(
+				<Emojify><p>🧔🏻</p></Emojify>
+			);
+
+			delete global.Image;
+
+			expect( wrapper.html() ).to.equal(
+				'<div class="emojify"><p><img draggable="false" class="emojify__emoji" alt="🧔🏻" ' +
+				'src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/72x72/1f9d4-1f3fb.png"></p></div>'
+			);
+		} );
+	} );
+} );

--- a/client/components/emojify/test/emojify.jsx
+++ b/client/components/emojify/test/emojify.jsx
@@ -15,11 +15,11 @@ describe( 'Emojify', function() {
 	useFakeDom();
 
 	context( 'component rendering', () => {
-		it( 'wraps a string in a span', () => {
+		it( 'wraps a string in a div', () => {
 			const wrapper = shallow(
 				<Emojify>Foo</Emojify>
 			);
-			expect( wrapper.find( 'span' ).node.ref ).to.equal( 'emojified' );
+			expect( wrapper.find( 'div' ).node.ref ).to.equal( 'emojified' );
 		} );
 
 		it( 'wraps a block in a div', () => {
@@ -39,8 +39,8 @@ describe( 'Emojify', function() {
 			delete global.Image;
 
 			expect( wrapper.html() ).to.equal(
-				'<span><img draggable="false" class="emojify__emoji" alt="🙂" ' +
-				'src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/72x72/1f642.png"></span>'
+				'<div class="emojify"><img draggable="false" class="emojify__emoji" alt="🙂" ' +
+				'src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/72x72/1f642.png"></div>'
 			);
 		} );
 

--- a/client/components/post-excerpt/index.jsx
+++ b/client/components/post-excerpt/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
 
 const PostExcerpt = React.createClass( {
 
@@ -29,10 +30,12 @@ const PostExcerpt = React.createClass( {
 
 		return (
 			<AutoDirection>
-				<div className={ classes }
+				<Emojify>
+				<div
+					className={ classes }
 					dangerouslySetInnerHTML={ { __html: this.props.content } } // eslint-disable-line react/no-danger
-				>
-				</div>
+				/>
+				</Emojify>
 			</AutoDirection>
 		);
 	}


### PR DESCRIPTION
This pull request fixes #1887 by adding the `Emojify` component to post and reader excerpts:

<img width="223" alt="screen shot 2017-05-26 at 2 54 09 pm" src="https://cloud.githubusercontent.com/assets/352291/26481283/4dea935e-4223-11e7-9d7d-13bb994dba73.png">

This is particularly useful in browsers that don't support modern emoji standards - the emoji are often rendered as ugly blocks, which frequently detracts from the meaning of the text.

#### Testing instructions

1. Run `git checkout add/1887-emojify-post-excerpts` and start your server, or open a [live branch](https://calypso.live/?branch=add/1887-emojify-post-excerpts).
3. Publish a post on a blog that you follow with emoji in the title/early content.
2. Open the [`Home` page](http://calypso.localhost:3000/).
3. Observe that the emoji are converted into image versions.

