### PR TITLE
Show "Your Plan" if plan matches yearly/monthly

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -40,7 +40,6 @@ class PlanFeaturesHeader extends Component {
 
 	render() {
 		const {
-			current,
 			planType,
 			popular,
 			newPlan,
@@ -58,7 +57,7 @@ class PlanFeaturesHeader extends Component {
 					newPlan && <Ribbon>{ translate( 'New' ) }</Ribbon>
 				}
 				{
-					current && <Ribbon>{ translate( 'Your Plan' ) }</Ribbon>
+					this.isPlanCurrent() && <Ribbon>{ translate( 'Your Plan' ) }</Ribbon>
 				}
 				<div className="plan-features__header-figure" >
 					<PlanIcon plan={ planType } />


### PR DESCRIPTION
Show "Your plan" regardless of monthly/yearly interval

To test:
* Use this branch
* Visit `/plans/jonsurrell.wpsandbox.me` for a Jetpack site with a plan.
* Ensure that the "Your plan" ribbon appears when toggling between monthly and yearly plans.
* Ensure nothing has changed for WordPress.com plans.

Partially implements #7228 changes