### PR TITLE
Support: Pass along automated transfer value to Tracks

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -138,7 +138,8 @@ const HelpContact = React.createClass( {
 		this.props.sendHappychatMessage( message );
 
 		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin', {
-			site_plan_product_id: ( site ? site.plan.product_id : null )
+			site_plan_product_id: ( site ? site.plan.product_id : null ),
+			is_automated_transfer: ( site ? site.options.is_automated_transfer : null )
 		} );
 
 		page( '/help' );
@@ -158,7 +159,8 @@ const HelpContact = React.createClass( {
 		notifications.forEach( olarkActions.sendNotificationToOperator );
 
 		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin', {
-			site_plan_product_id: ( site ? site.plan.product_id : null )
+			site_plan_product_id: ( site ? site.plan.product_id : null ),
+			is_automated_transfer: ( site ? site.options.is_automated_transfer : null )
 		} );
 
 		this.sendMessageToOperator( message );
@@ -227,7 +229,8 @@ const HelpContact = React.createClass( {
 
 			analytics.tracks.recordEvent( 'calypso_help_contact_submit', {
 				ticket_type: 'kayako',
-				site_plan_product_id: ( site ? site.plan.product_id : null )
+				site_plan_product_id: ( site ? site.plan.product_id : null ),
+				is_automated_transfer: ( site ? site.options.is_automated_transfer : null )
 			} );
 		} );
 


### PR DESCRIPTION
This introduces a new value alongside the information we send to Tracks when someone creates a new ticket or chat. The new value records whether or not the site is an automated transfer site. The result is that we'll be able to segment our two main support events - `calypso_help_contact_submit` and `calypso_help_live_chat_begin` - by AT Business customers vs non-AT Business customers.

Instead of using the [`isSiteAutomatedTransfer` selector](https://github.com/Automattic/wp-calypso/blob/master/client/state/selectors/is-site-automated-transfer.js), this just uses the site options and creates a new value for `is_automated_transfer` to pass alongside the site plan.

## To test
1. Load this branch and use `localStorage.setItem('debug', 'calypso:analytics*');` to log Tracks events to your console.
2. Fake submitting both a ticket and a chat from calypso.localhost:3000/help/contact from a variety of sites. To make this easy, you can just comment out necessary lines under `submitKayakoTicket()` and `startHappychat()` under `help-contact/index.jsx` to prevent from actually creating support interactions.

You should see the appropriate Tracks event with `is_automated_transfer` set to:
- False for normal WP.com sites and Business sites without AT
- True for WP.com Business sites with AT
- False for JP sites

Requesting a peek @lamosty just in case it's preferred to use the selector instead of the site options.