### PR TITLE
Reader: fix empty state illustrations on streams

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -366,10 +366,10 @@
 	}
 
 	&.is-drake {
-		margin-top: -90px;
+		margin-top: -72px;
 
-		@include breakpoint( "<480px" ) {
-			margin-top: -72px;
+		@include breakpoint( ">480px" ) {
+			margin-top: -90px;
 		}
 
 		.empty-content__title {

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -359,19 +359,22 @@
 
 .is-group-reader .main .empty-content,
 .is-reader-page .main .empty-content {
-	margin-top: -90px;
 	padding-top: 0;
 
-	img {
-		min-height: 150px;
+	.empty-content__title {
+		margin-top: -10px;
 	}
 
-	@include breakpoint( "<480px" ) {
-		margin-top: -72px;
-	}
+	&.drake {
+		margin-top: -90px;
 
-	.empty-content__illustration {
-		min-height: 100px;
+		@include breakpoint( "<480px" ) {
+			margin-top: -72px;
+		}
+
+		.empty-content__title {
+			margin-top: 0;
+		}
 	}
 }
 

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -365,7 +365,7 @@
 		margin-top: -10px;
 	}
 
-	&.drake {
+	&.is-drake {
 		margin-top: -90px;
 
 		@include breakpoint( "<480px" ) {

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -387,7 +387,7 @@
 
 // No Results in new Search
 .is-reader-page .search-stream .empty-content {
-	margin-top: 0;
+	margin-top: 135px;
 }
 
 /* = Infinite scroll end (shown at end of streams)

--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -32,10 +32,10 @@ class FollowingManageEmptyContent extends React.Component {
 				{ this.props.translate( 'Explore Discover' ) }
 			</a>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 		return (
 			<EmptyContent
+				className="is-drake"
 				action={ action }
 				title={ this.props.translate( "You haven't followed any sites yet" ) }
 				line={ this.props.translate( 'Search for a site above or explore Discover.' ) }
@@ -43,6 +43,7 @@ class FollowingManageEmptyContent extends React.Component {
 				illustrationWidth={ 500 }
 			/>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -51,7 +51,7 @@ class TagEmptyContent extends React.Component {
 				action={ action }
 				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-				illustrationWidth={ 500 }
+				illustrationWidth={ 400 }
 			/>
 		);
 	}

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -51,7 +51,7 @@ class ListEmptyContent extends React.Component {
 				action={ action }
 				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-				illustrationWidth={ 500 }
+				illustrationWidth={ 400 }
 			/>
 		);
 	}

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -60,7 +60,7 @@ class SearchEmptyContent extends React.Component {
 				action={ action }
 				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-				illustrationWidth={ 500 }
+				illustrationWidth={ 400 }
 			/>
 		);
 	}

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -34,8 +34,10 @@ class FollowingEmptyContent extends React.Component {
 			: null,
 			secondaryAction = null;
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<EmptyContent
+				className="is-drake"
 				title={ this.props.translate( 'Welcome to Reader' ) }
 				line={ this.props.translate( 'Recent posts from sites you follow will appear here.' ) }
 				action={ action }
@@ -44,6 +46,7 @@ class FollowingEmptyContent extends React.Component {
 				illustrationWidth={ 500 }
 			/>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -61,7 +61,7 @@ class TagEmptyContent extends React.Component {
 				action={ action }
 				secondaryAction={ secondaryAction }
 				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-				illustrationWidth={ 500 }
+				illustrationWidth={ 400 }
 			/>
 		);
 	}

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -56,6 +56,7 @@ class TagEmptyContent extends React.Component {
 
 		return (
 			<EmptyContent
+				className="tag-stream__empty-content"
 				title={ this.props.translate( 'No recent posts' ) }
 				line={ message }
 				action={ action }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -135,3 +135,7 @@
 		padding: 0;
 	}
 }
+
+.is-reader-page .main .tag-stream__empty-content {
+	margin-top: 15px;
+}


### PR DESCRIPTION
The recent change from a Drake empty illustration to the new style in #14479 have led to display regressions in the Reader:

<img width="851" alt="screen shot 2017-05-26 at 15 38 12" src="https://cloud.githubusercontent.com/assets/17325/26496838/5c7bf2ea-4229-11e7-90ad-520d929b753d.png">

This PR fixes them to look like this:

<img width="861" alt="screen shot 2017-05-26 at 15 30 40" src="https://cloud.githubusercontent.com/assets/17325/26496849/625bc640-4229-11e7-8715-000900408915.png">

To check:
- [x] list stream
- [x] tag stream
- [x] My Likes
- [x] feed stream
- [x] site stream
- [x] following stream

cc @jancavan 
