### PR TITLE
Add expire/renewal information to plan page

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -78,6 +78,7 @@ class PlanFeaturesHeader extends Component {
 					<h4 className="plan-features__header-title">{ title }</h4>
 					{ this.getPlanFeaturesPrices() }
 					{ this.getBillingTimeframe() }
+					{ this.getRenewOrExpiry() }
 				</div>
 			</header>
 		);
@@ -115,6 +116,31 @@ class PlanFeaturesHeader extends Component {
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
 				</div>
+			</div>
+		);
+	}
+
+	getRenewOrExpiry() {
+		const {
+			currentSitePlan,
+			translate,
+		} = this.props;
+
+		if ( ! this.isPlanCurrent() ) {
+			return null;
+		}
+
+		// &nbsp;
+		let renewOrExpiryText = ' ';
+		if ( currentSitePlan && currentSitePlan.autoRenew && currentSitePlan.autoRenewDateMoment ) {
+			renewOrExpiryText = translate( 'Renews on' ) + ' ' + currentSitePlan.autoRenewDateMoment.format( 'LL' );
+		} else if ( currentSitePlan && currentSitePlan.userFacingExpiryMoment ) {
+			renewOrExpiryText = translate( 'Expires on' ) + ' ' + currentSitePlan.userFacingExpiryMoment.format( 'LL' );
+		}
+
+		return (
+			<div className="plan-features__renew-or-expiry">
+				{ renewOrExpiryText }
 			</div>
 		);
 	}
@@ -178,6 +204,10 @@ class PlanFeaturesHeader extends Component {
 			hideMonthly,
 			currentSitePlan,
 		} = this.props;
+
+		if ( this.isPlanCurrent() ) {
+			return null;
+		}
 
 		if ( hideMonthly ||
 			! rawPrice ||

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -312,6 +312,14 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plan-features__renew-or-expiry {
+	margin-bottom: 1.4em;
+
+	@include breakpoint( ">660px" ) {
+		height: 28px;
+	}
+}
+
 .plan-features__header-banner {
 	box-sizing: border-box;
 	position: absolute;


### PR DESCRIPTION
This expire/renew logic is naive and does not follow the more robust logic used on the purchases page which gives "real" renewal/expiration which accounts for a number of things including payment type and credit card expiration.

Partial implementation of #7228