### PR TITLE
Editor: update EditorVisibility component.

### DIFF
--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -6,6 +6,51 @@
 	margin: 0;
 }
 
+.editor-visibility__dropdown{
+	text-align: left;
+	width: 100%;
+
+	.select-dropdown {
+		max-width: 100%;
+		width: 100%;
+	}
+
+	.form-text-input {
+		font-size: 13px;
+		margin-top: 8px;
+	}
+
+	.form-input-validation {
+		padding-bottom: 0;
+	}
+
+	.form-setting-explanation {
+		margin: -4px 0 8px 24px;
+
+		&.password {
+			margin-bottom: 0;
+		}
+	}
+
+	.gridicon {
+		cursor: pointer;
+		vertical-align: middle;
+		margin-right: 4px;
+
+		&:hover {
+			color: $gray-dark;
+		}
+	}
+
+	.gridicon.is_active {
+		color: $gray-dark;
+
+		&:hover {
+			color: lighten( $gray, 15% );
+		}
+	}
+}
+
 .editor-visibility .button {
 	&.is-dialog-open,
 	&.is-touch,


### PR DESCRIPTION
This updates the Post Editor's visibility component from a popover with radio buttons to a `SelectDropdown` with new icons. Currently only available behind 'post-editor/delta-post-publish-flow' flag.

**Before:**
<img width="391" alt="editor-visibility-dialog" src="https://cloud.githubusercontent.com/assets/942359/26508398/929ff774-4222-11e7-8ce4-f4bb1546ca30.png">

**After:**
<img width="402" alt="editor-visibility-dropdown" src="https://cloud.githubusercontent.com/assets/942359/26508334/5fef12c4-4222-11e7-911d-52a644dc2103.png">

This is part of a larger epic (See p3Ex-2ri-p2)

**To test:**
- Checkout branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Make sure that the updated `EditorVisibility` component is used in the post editor 'Status' section.
- Change the post visibility to verify functionality:
 - 'Password Protected' should show/hide a password field under the dropdown
 - 'Members Only' should show the privacy confirmation modal to publish the post privately
- Run the branch again without the feature flag enabled and make sure the `EditorVisibility` component works as normal