### PR TITLE
Extensions: WPSC - Handle disabling of cache preload

### DIFF
--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -56,9 +56,9 @@ class PreloadTab extends Component {
 			const { fields, setFieldValue } = this.props;
 
 			if ( this.state.preloadRefresh ) {
-				setFieldValue( 'preload_interval', get( fields, 'minimum_preload_interval', '0' ) );
+				setFieldValue( 'preload_interval', get( fields, 'minimum_preload_interval', '0' ), true );
 			} else {
-				setFieldValue( 'preload_interval', '0' );
+				setFieldValue( 'preload_interval', '0', true );
 			}
 		} );
 	}

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -31,7 +31,7 @@ import { isPreloadingCache } from './state/cache/selectors';
 const CachePreloadInterval = ( {
 	handleChange,
 	isDisabled,
-	preload_interval,
+	preload_interval = 0,
 } ) => (
 	<FormTextInput
 		className="wp-super-cache__preload-interval"
@@ -41,7 +41,7 @@ const CachePreloadInterval = ( {
 		onChange={ handleChange( 'preload_interval' ) }
 		step="1"
 		type="number"
-		value={ preload_interval || '0' } />
+		value={ preload_interval } />
 );
 
 class PreloadTab extends Component {
@@ -56,9 +56,9 @@ class PreloadTab extends Component {
 			const { fields, setFieldValue } = this.props;
 
 			if ( this.state.preloadRefresh ) {
-				setFieldValue( 'preload_interval', get( fields, 'minimum_preload_interval', '0' ), true );
+				setFieldValue( 'preload_interval', get( fields, 'minimum_preload_interval', 0 ), true );
 			} else {
-				setFieldValue( 'preload_interval', '0', true );
+				setFieldValue( 'preload_interval', 0, true );
 			}
 		} );
 	}

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -28,7 +28,7 @@ import { isPreloadingCache } from './state/cache/selectors';
  * Render cache preload interval number input
  * @returns { object } React element containing the preload interval number input
  */
-const renderCachePreloadInterval = ( {
+const CachePreloadInterval = ( {
 	handleChange,
 	isDisabled,
 	preload_interval,
@@ -173,7 +173,7 @@ class PreloadTab extends Component {
 										{
 											count: preload_interval || 0,
 											components: {
-												number: renderCachePreloadInterval( {
+												number: CachePreloadInterval( {
 													handleChange,
 													isDisabled: isRequesting || isSaving || ! this.state.preloadRefresh,
 													preload_interval,

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, pick } from 'lodash';
+import { flowRight, get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -53,11 +53,13 @@ class PreloadTab extends Component {
 
 	handlePreloadRefreshChange = () => {
 		this.setState( { preloadRefresh: ! this.state.preloadRefresh }, () => {
-			if ( this.state.preloadRefresh ) {
-				return;
-			}
+			const { fields, setFieldValue } = this.props;
 
-			this.props.setFieldValue( 'preload_interval', '0' );
+			if ( this.state.preloadRefresh ) {
+				setFieldValue( 'preload_interval', get( fields, 'minimum_preload_interval', '0' ) );
+			} else {
+				setFieldValue( 'preload_interval', '0' );
+			}
 		} );
 	}
 

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -58,7 +58,7 @@ class PreloadTab extends Component {
 			const { fields, setFieldValue } = this.props;
 
 			if ( this.state.preloadRefresh ) {
-				setFieldValue( 'preload_interval', get( fields, 'minimum_preload_interval', 0 ), true );
+				setFieldValue( 'preload_interval', get( fields, 'minimum_preload_interval', 30 ), true );
 			} else {
 				setFieldValue( 'preload_interval', 0, true );
 			}

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -50,7 +50,7 @@ class PreloadTab extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		this.setState( { preloadRefresh: parseInt( nextProps.fields.preload_interval, 10 ) === 0 ? false : true } );
+		this.setState( { preloadRefresh: parseInt( nextProps.fields.preload_interval, 10 ) !== 0 ? true : false } );
 	}
 
 	handlePreloadRefreshChange = () => {

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -45,10 +45,12 @@ const CachePreloadInterval = ( {
 );
 
 class PreloadTab extends Component {
+	state = {
+		preloadRefresh: true,
+	};
+
 	componentWillReceiveProps( nextProps ) {
-		this.state = {
-			preloadRefresh: parseInt( nextProps.fields.preload_interval, 10 ) === 0 ? false : true
-		};
+		this.setState( { preloadRefresh: parseInt( nextProps.fields.preload_interval, 10 ) === 0 ? false : true } );
 	}
 
 	handlePreloadRefreshChange = () => {

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -30,13 +30,12 @@ import { isPreloadingCache } from './state/cache/selectors';
  */
 const renderCachePreloadInterval = ( {
 	handleChange,
-	isRequesting,
-	isSaving,
+	isDisabled,
 	preload_interval,
 } ) => (
 	<FormTextInput
 		className="wp-super-cache__preload-interval"
-		disabled={ isRequesting || isSaving }
+		disabled={ isDisabled }
 		min="0"
 		name="preload_interval"
 		onChange={ handleChange( 'preload_interval' ) }
@@ -174,8 +173,7 @@ class PreloadTab extends Component {
 											components: {
 												number: renderCachePreloadInterval( {
 													handleChange,
-													isRequesting,
-													isSaving,
+													isDisabled: isRequesting || isSaving || ! this.state.preloadRefresh,
 													preload_interval,
 												} )
 											}

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -42,16 +42,24 @@ const renderCachePreloadInterval = ( {
 		onChange={ handleChange( 'preload_interval' ) }
 		step="1"
 		type="number"
-		value={ preload_interval || '' } />
+		value={ preload_interval || '0' } />
 );
 
 class PreloadTab extends Component {
-	state = {
-		preloadRefresh: true,
+	componentWillReceiveProps( nextProps ) {
+		this.state = {
+			preloadRefresh: parseInt( nextProps.fields.preload_interval, 10 ) === 0 ? false : true
+		};
 	}
 
 	handlePreloadRefreshChange = () => {
-		this.setState( { preloadRefresh: ! this.state.preloadRefresh } );
+		this.setState( { preloadRefresh: ! this.state.preloadRefresh }, () => {
+			if ( this.state.preloadRefresh ) {
+				return;
+			}
+
+			this.props.setFieldValue( 'preload_interval', '0' );
+		} );
 	}
 
 	getPreloadPostsOptions( post_count ) {

--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -50,7 +50,7 @@ class PreloadTab extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		this.setState( { preloadRefresh: parseInt( nextProps.fields.preload_interval, 10 ) !== 0 ? true : false } );
+		this.setState( { preloadRefresh: parseInt( nextProps.fields.preload_interval, 10 ) !== 0 } );
 	}
 
 	handlePreloadRefreshChange = () => {

--- a/client/extensions/wp-super-cache/wrap-settings-form.jsx
+++ b/client/extensions/wp-super-cache/wrap-settings-form.jsx
@@ -157,7 +157,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
 		};
 
-		setFieldValue = ( field, value ) => this.props.updateFields( { [ field ]: value } );
+		setFieldValue = ( field, value, autosave = false ) => {
+			this.props.updateFields( { [ field ]: value }, () => {
+				autosave && this.submitForm();
+			} );
+		};
 
 		// Update a field that is stored as an array element.
 		setFieldArrayValue = ( name, index ) => event => {


### PR DESCRIPTION
The UI for the setting that determines how often cached files are preloaded differs between the plugin and Calypso:

## Plugin

![plugin-refresh-preloaded-files](https://cloud.githubusercontent.com/assets/1190420/26501550/f7591800-4207-11e7-9932-d2a49d9ff4ae.jpg)

## Calypso

![calypso-refresh-preloaded-files](https://cloud.githubusercontent.com/assets/1190420/26501557/fbb26b68-4207-11e7-9dde-58e9fc701886.jpg)

Essentially, a `preload_interval` of 0 disables cache preloading. This is represented in the plugin by explicitly setting the field to 0. In Calypso, the switch is toggled off and `preload_interval`is automatically set to 0.

When toggling the refresh setting on, `preload_interval` is updated from 0 to the `minimum_preload_interval` value (in the screenshot above, that would be 30).

## Testing

Check to ensure that when the toggle is switched off, the preload interval is set to 0. When the toggle is switched on, the preload interval should update to the value of `minimum_preload_interval` that is returned by the `settings` endpoint. In either case, toggling the switch should fire off a request to the API to persist the change.

Also check to ensure that the toggles in the _Accepted Filenames & Rejected URIs_ section of the _Advanced_ tab do *not* auto-save when toggled.