### PR TITLE
JPC: Revert 'already connected' notice

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -8,8 +8,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import { urlToSlug } from 'lib/url';
 
 class JetpackConnectNotices extends Component {
 	static propTypes = {
@@ -42,7 +40,6 @@ class JetpackConnectNotices extends Component {
 			noticeType,
 			onDismissClick,
 			translate,
-			url,
 		} = this.props;
 
 		const noticeValues = {
@@ -96,19 +93,6 @@ class JetpackConnectNotices extends Component {
 				noticeValues.status = 'is-notice';
 				noticeValues.icon = 'status';
 				noticeValues.text = translate( 'Jetpack couldn\'t be found.' );
-				return noticeValues;
-
-			case 'alreadyConnected':
-			case 'alreadyOwned':
-				noticeValues.status = 'is-success';
-				noticeValues.icon = 'status';
-				noticeValues.text = translate( 'This site is already connected!' );
-				noticeValues.showDismiss = false;
-				noticeValues.children = (
-					<NoticeAction href={ '/plans/my-plan/' + urlToSlug( url ) }>
-						{ translate( 'Visit' ) }
-					</NoticeAction>
-				);
 				return noticeValues;
 
 			case 'wordpress.com':

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -103,6 +103,10 @@ class JetpackConnectMain extends Component {
 		) {
 			return this.props.goToRemoteAuth( this.state.currentUrl );
 		}
+		if ( this.getStatus() === 'alreadyOwned' &&
+			! this.props.jetpackConnectSite.isRedirecting ) {
+			return this.props.goToPlans( this.state.currentUrl );
+		}
 
 		if ( this.state.waitingForSites && ! this.props.isRequestingSites ) {
 			// eslint-disable-next-line react/no-did-update-set-state


### PR DESCRIPTION
We are reverting the change introduced by https://github.com/Automattic/wp-calypso/pull/13599/, because have been seeing a reduction in the conversion rates and we theorize that may be related with this change

how to test
======

1. You need a connected site that has not a plan
2. Go to http://calypso.localhost:3000/jetpack/connect/ and enter the url of your site
3. You should be redirected to the plans selection page
