### PR TITLE
Plugins Meta: Only display the Banner on single site plugin single plugin view

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -488,11 +488,15 @@ class PluginMeta extends Component {
 					<PluginAutomatedTransfer plugin={ this.props.plugin } />
 				}
 
-				{ ( get( this.props.selectedSite, 'jetpack' ) || this.hasBusinessPlan() || this.isWpcomPreinstalled() ) &&
+				{ ( this.props.selectedSite &&
+					get( this.props.selectedSite, 'jetpack' ) || this.hasBusinessPlan() || this.isWpcomPreinstalled() ) &&
 					<div style={ { marginBottom: 16 } } />
 				}
 
-				{ ! get( this.props.selectedSite, 'jetpack' ) && ! this.hasBusinessPlan() && ! this.isWpcomPreinstalled() &&
+				{ ! this.props.selectedSite &&
+					get( this.props.selectedSite, 'jetpack' ) &&
+					! this.hasBusinessPlan() &&
+					! this.isWpcomPreinstalled() &&
 					<div className="plugin-meta__upgrade_nudge">
 						<Banner
 							feature={ FEATURE_UPLOAD_PLUGINS }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -493,8 +493,7 @@ class PluginMeta extends Component {
 					<div style={ { marginBottom: 16 } } />
 				}
 
-				{ ! this.props.selectedSite &&
-					get( this.props.selectedSite, 'jetpack' ) &&
+				{ this.props.selectedSite && ! get( this.props.selectedSite, 'jetpack' ) &&
 					! this.hasBusinessPlan() &&
 					! this.isWpcomPreinstalled() &&
 					<div className="plugin-meta__upgrade_nudge">


### PR DESCRIPTION
Currently you see this

![screen shot 2017-05-26 at 12 51 18](https://cloud.githubusercontent.com/assets/115071/26510438/3618509c-4212-11e7-99d5-c787c0958171.png)

This PR updated it to this
![screen shot 2017-05-26 at 12 51 24](https://cloud.githubusercontent.com/assets/115071/26510436/32741dcc-4212-11e7-96bd-58da7fa17338.png)

This is change will also not display the banner for users that do not have any .com site so the banner in that case doesn't make sense to them. 

**To test**
Visit a plugin on the single plugin multisite view
http://calypso.localhost:3000/plugins/oembed-gist/

Notice that the banner doesn't show up any more. 
