### PR TITLE
Sites List: Update the query parameters so that we remove any inactive jetpack sites

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -88,7 +88,11 @@ export function requestSites() {
 		dispatch( {
 			type: SITES_REQUEST
 		} );
-		return wpcom.me().sites( { site_visibility: 'all', include_domain_only: true } ).then( ( response ) => {
+		return wpcom.me().sites( {
+			site_visibility: 'all',
+			include_domain_only: true,
+			remove_inactive_jetpack: true
+		} ).then( ( response ) => {
 			dispatch( receiveSites( response.sites ) );
 			dispatch( {
 				type: SITES_REQUEST_SUCCESS


### PR DESCRIPTION
Currently if a user has not correctly disconnected a Jetpack site they still show up on calypso and add confusion. This PR would help by just removing them since they can add a lot of confusion. 

**To test**
Apply the following to you sandbox D5765-code and make sure your browser is talking to your sandbox api. 

Then any site that is marked as disconnected will not be visible any more in calypso.

