### PR TITLE
Add privacy component to the editor confirmation sidebar

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,9 +47,9 @@ class EditorConfirmationSidebar extends React.Component {
 		}
 
 		const { password, type, status } = this.props.post || {};
-		const isPrivateSite = this.props.site && this.props.site.is_private;
-		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
-		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
+		const isPrivateSite = get( this.props, 'site.is_private' );
+		const savedStatus = get( this.props, 'savedPost.status' );
+		const savedPassword = get( this.props, 'savedPost.password' );
 		const props = {
 			onPrivatePublish: this.props.onPrivatePublish,
 			isPrivateSite,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,11 +12,17 @@ import { localize } from 'i18n-calypso';
 import RootChild from 'components/root-child';
 import Button from 'components/button';
 import EditorVisibility from 'post-editor/editor-visibility';
+import { editPost } from 'state/posts/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPost } from 'state/posts/selectors';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
-		hideSidebar: React.PropTypes.func,
-		isActive: React.PropTypes.bool,
+		closeOverlay: React.PropTypes.func,
+		closeSidebar: React.PropTypes.func,
+		isOverlayActive: React.PropTypes.bool,
+		isSidebarActive: React.PropTypes.bool,
 		onPublish: React.PropTypes.func,
 		post: React.PropTypes.object,
 		site: React.PropTypes.object,
@@ -23,8 +30,13 @@ class EditorConfirmationSidebar extends React.Component {
 		onPrivatePublish: React.PropTypes.func,
 	};
 
+	closeOverlayAndSidebar = () => {
+		this.props.closeSidebar();
+		this.props.closeOverlay();
+	};
+
 	closeAndPublish = () => {
-		this.props.hideSidebar();
+		this.closeOverlayAndSidebar();
 		this.props.onPublish( true );
 	};
 
@@ -57,18 +69,18 @@ class EditorConfirmationSidebar extends React.Component {
 			<RootChild>
 				<div className={ classnames( {
 					'editor-confirmation-sidebar': true,
-					'is-active': this.props.isActive,
+					'is-active': this.props.isOverlayActive || this.props.isSidebarActive,
 				} ) } >
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__overlay': true,
-						'is-active': this.props.isActive,
-					} ) } onClick={ this.props.hideSidebar } />
+						'is-active': this.props.isOverlayActive,
+					} ) } onClick={ this.closeOverlayAndSidebar } />
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__sidebar': true,
-						'is-active': this.props.isActive,
+						'is-active': this.props.isSidebarActive,
 					} ) }>
 						<div className="editor-confirmation-sidebar__ground-control">
-							<div className="editor-confirmation-sidebar__cancel" onClick={ this.props.hideSidebar }>
+							<div className="editor-confirmation-sidebar__cancel" onClick={ this.closeOverlayAndSidebar }>
 								{ this.props.translate( 'Cancel' ) }
 							</div>
 							<div className="editor-confirmation-sidebar__action">
@@ -87,4 +99,17 @@ class EditorConfirmationSidebar extends React.Component {
 	}
 }
 
-export default localize( EditorConfirmationSidebar );
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		const post = getEditedPost( state, siteId, postId );
+
+		return {
+			siteId,
+			postId,
+			post
+		};
+	},
+	{ editPost }
+)( localize( EditorConfirmationSidebar ) );

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -10,18 +10,47 @@ import { localize } from 'i18n-calypso';
  */
 import RootChild from 'components/root-child';
 import Button from 'components/button';
+import EditorVisibility from 'post-editor/editor-visibility';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
 		hideSidebar: React.PropTypes.func,
 		isActive: React.PropTypes.bool,
 		onPublish: React.PropTypes.func,
+		post: React.PropTypes.object,
+		site: React.PropTypes.object,
+		savedPost: React.PropTypes.object,
+		onPrivatePublish: React.PropTypes.func,
 	};
 
 	closeAndPublish = () => {
 		this.props.hideSidebar();
 		this.props.onPublish( true );
 	};
+
+	renderPrivacyControl() {
+		if ( ! this.props.post ) {
+			return;
+		}
+
+		const { password, type, status } = this.props.post || {};
+		const isPrivateSite = this.props.site && this.props.site.is_private;
+		const savedStatus = this.props.savedPost ? this.props.savedPost.status : null;
+		const savedPassword = this.props.savedPost ? this.props.savedPost.password : null;
+		const props = {
+			onPrivatePublish: this.props.onPrivatePublish,
+			isPrivateSite,
+			type,
+			password,
+			status,
+			savedStatus,
+			savedPassword
+		};
+
+		return (
+			<EditorVisibility { ...props } />
+		);
+	}
 
 	render() {
 		return (
@@ -33,7 +62,7 @@ class EditorConfirmationSidebar extends React.Component {
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__overlay': true,
 						'is-active': this.props.isActive,
-					} ) } onClick={ this.props.hideSidebar }></div>
+					} ) } onClick={ this.props.hideSidebar } />
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__sidebar': true,
 						'is-active': this.props.isActive,
@@ -45,6 +74,9 @@ class EditorConfirmationSidebar extends React.Component {
 							<div className="editor-confirmation-sidebar__action">
 								<Button onClick={ this.closeAndPublish } compact>{ this.props.translate( 'Publish' ) }</Button>
 							</div>
+						</div>
+						<div className="editor-confirmation-sidebar__privacy-control">
+							{ this.renderPrivacyControl() }
 						</div>
 					</div>
 				</div>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -75,8 +75,10 @@ class EditorConfirmationSidebar extends React.Component {
 								<Button onClick={ this.closeAndPublish } compact>{ this.props.translate( 'Publish' ) }</Button>
 							</div>
 						</div>
-						<div className="editor-confirmation-sidebar__privacy-control">
-							{ this.renderPrivacyControl() }
+						<div className="editor-confirmation-sidebar__content-wrap">
+							<div className="editor-confirmation-sidebar__privacy-control">
+								{ this.renderPrivacyControl() }
+							</div>
 						</div>
 					</div>
 				</div>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -20,24 +20,21 @@ import { getEditedPost } from 'state/posts/selectors';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
-		closeOverlay: React.PropTypes.func,
-		closeSidebar: React.PropTypes.func,
-		isOverlayActive: React.PropTypes.bool,
-		isSidebarActive: React.PropTypes.bool,
+		onPrivatePublish: React.PropTypes.func,
 		onPublish: React.PropTypes.func,
 		post: React.PropTypes.object,
-		site: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
-		onPrivatePublish: React.PropTypes.func,
+		setState: React.PropTypes.func,
+		site: React.PropTypes.object,
+		state: React.PropTypes.string,
 	};
 
-	closeOverlayAndSidebar = () => {
-		this.props.closeSidebar();
-		this.props.closeOverlay();
+	closeOverlay = () => {
+		this.props.setState( 'closed' );
 	};
 
 	closeAndPublish = () => {
-		this.closeOverlayAndSidebar();
+		this.closeOverlay();
 		this.props.onPublish( true );
 	};
 
@@ -66,22 +63,25 @@ class EditorConfirmationSidebar extends React.Component {
 	}
 
 	render() {
+		const isSidebarActive = this.props.state === 'open';
+		const isOverlayActive = this.props.state !== 'closed';
+
 		return (
 			<RootChild>
 				<div className={ classnames( {
 					'editor-confirmation-sidebar': true,
-					'is-active': this.props.isOverlayActive || this.props.isSidebarActive,
+					'is-active': isOverlayActive,
 				} ) } >
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__overlay': true,
-						'is-active': this.props.isOverlayActive,
-					} ) } onClick={ this.closeOverlayAndSidebar } />
+						'is-active': isOverlayActive,
+					} ) } onClick={ this.closeOverlay } />
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__sidebar': true,
-						'is-active': this.props.isSidebarActive,
+						'is-active': isSidebarActive,
 					} ) }>
 						<div className="editor-confirmation-sidebar__ground-control">
-							<div className="editor-confirmation-sidebar__cancel" onClick={ this.closeOverlayAndSidebar }>
+							<div className="editor-confirmation-sidebar__cancel" onClick={ this.closeOverlay }>
 								{ this.props.translate( 'Cancel' ) }
 							</div>
 							<div className="editor-confirmation-sidebar__action">

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -54,6 +54,7 @@
   @include breakpoint( "<660px" ) {
 	transition: none;
 	border-left: none;
+	pointer-events: auto;
 
 	&.is-active {
 		height: auto;

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -73,12 +73,12 @@
 	justify-content: space-between;
 	flex-direction: row;
 	flex-wrap: wrap;
-
-	position: absolute;
+	position: relative;
 		top: 0;
 		left: 0;
 		right: 0;
 	padding: 9px 24px;
+	width: 100%;
 }
 
 .editor-confirmation-sidebar__cancel {
@@ -104,4 +104,8 @@
 		background: lighten( $alert-green, 20% );
 		border-color: tint( $alert-green, 30% );
 	}
+}
+
+.editor-confirmation-sidebar__content-wrap {
+	padding: 0 24px 24px 24px
 }

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -245,7 +245,7 @@ const EditorVisibility = React.createClass( {
 		this.setState( {
 			showPopover: false
 		} );
-		setTimeout( () => this.props.onPrivatePublish(), 0 );
+		setTimeout( () => this.props.onPrivatePublish( true ), 0 );
 	},
 
 	onSetToPrivate() {

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -32,12 +32,6 @@ import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 
-/**
- * Debug
- */
-import debugModule from 'debug';
-const debug = debugModule( 'calypso:editor-visibility' );
-
 const EditorVisibility = React.createClass( {
 	showingAcceptDialog: false,
 
@@ -193,7 +187,6 @@ const EditorVisibility = React.createClass( {
 	},
 
 	updateDropdownVisibility( newVisibility ) {
-		debug( 'updateDropdownVisibility', newVisibility );
 		const { siteId, postId } = this.props;
 		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
 		const postEdits = { status: defaultVisibility };
@@ -294,7 +287,6 @@ const EditorVisibility = React.createClass( {
 	},
 
 	renderPasswordInput() {
-		debug( 'renderPasswordInput' );
 		const value = this.props.password ? this.props.password.trim() : null;
 		const isError = ! this.state.passwordIsValid;
 		const errorMessage = this.props.translate( 'Password is empty.', { context: 'Editor: Error shown when password is empty.' } );

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -32,6 +32,12 @@ import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 
+/**
+ * Debug
+ */
+import debugModule from 'debug';
+const debug = debugModule( 'calypso:editor-visibility' );
+
 const EditorVisibility = React.createClass( {
 	showingAcceptDialog: false,
 
@@ -187,6 +193,7 @@ const EditorVisibility = React.createClass( {
 	},
 
 	updateDropdownVisibility( newVisibility ) {
+		debug( 'updateDropdownVisibility', newVisibility );
 		const { siteId, postId } = this.props;
 		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
 		const postEdits = { status: defaultVisibility };
@@ -287,6 +294,7 @@ const EditorVisibility = React.createClass( {
 	},
 
 	renderPasswordInput() {
+		debug( 'renderPasswordInput' );
 		const value = this.props.password ? this.props.password.trim() : null;
 		const isError = ! this.state.passwordIsValid;
 		const errorMessage = this.props.translate( 'Password is empty.', { context: 'Editor: Error shown when password is empty.' } );

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -10,7 +10,8 @@
 	text-align: left;
 	width: 100%;
 
-	.select-dropdown {
+	.select-dropdown,
+	.select-dropdown__container {
 		max-width: 100%;
 		width: 100%;
 	}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -86,6 +86,7 @@ export const PostEditor = React.createClass( {
 			isPublishing: false,
 			notice: null,
 			showConfirmationSidebar: false,
+			showConfirmationSidebarOverlay: false,
 			showVerifyEmailDialog: false,
 			showAutosaveDialog: true,
 			isLoadingAutosave: false,
@@ -192,8 +193,16 @@ export const PostEditor = React.createClass( {
 		this.setState( { showConfirmationSidebar: true } );
 	},
 
-	hideConfirmationSidebar: function() {
+	closeConfirmationSidebar: function() {
 		this.setState( { showConfirmationSidebar: false } );
+	},
+
+	showConfirmationSidebarOverlay: function() {
+		this.setState( { showConfirmationSidebarOverlay: true } );
+	},
+
+	closeConfirmationSidebarOverlay: function() {
+		this.setState( { showConfirmationSidebarOverlay: false } );
 	},
 
 	toggleSidebar: function() {
@@ -231,8 +240,10 @@ export const PostEditor = React.createClass( {
 			<div className={ classes }>
 				<QueryPreferences />
 				<EditorConfirmationSidebar
-					hideSidebar={ this.hideConfirmationSidebar }
-					isActive={ this.state.showConfirmationSidebar }
+					closeOverlay={ this.closeConfirmationSidebarOverlay }
+					closeSidebar={ this.closeConfirmationSidebar }
+					isOverlayActive={ this.state.showConfirmationSidebarOverlay }
+					isSidebarActive={ this.state.showConfirmationSidebar }
 					onPublish={ this.onPublish }
 					post={ this.state.post }
 					site={ site }
@@ -668,8 +679,14 @@ export const PostEditor = React.createClass( {
 		};
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) && false === isConfirmed ) {
+			this.showConfirmationSidebarOverlay();
 			this.showConfirmationSidebar();
 			return;
+		}
+
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+			this.closeConfirmationSidebarOverlay();
+			this.closeConfirmationSidebar();
 		}
 
 		// determine if this is a private publish

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -234,6 +234,10 @@ export const PostEditor = React.createClass( {
 					hideSidebar={ this.hideConfirmationSidebar }
 					isActive={ this.state.showConfirmationSidebar }
 					onPublish={ this.onPublish }
+					post={ this.state.post }
+					site={ site }
+					savedPost={ this.state.savedPost }
+					onPrivatePublish={ this.onPublish }
 				/>
 				<EditorDocumentHead />
 				<EditorPostTypeUnsupported />

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -82,11 +82,10 @@ export const PostEditor = React.createClass( {
 	getInitialState() {
 		return {
 			...this.getPostEditState(),
+			confirmationSidebar: 'closed',
 			isSaving: false,
 			isPublishing: false,
 			notice: null,
-			showConfirmationSidebar: false,
-			showConfirmationSidebarOverlay: false,
 			showVerifyEmailDialog: false,
 			showAutosaveDialog: true,
 			isLoadingAutosave: false,
@@ -189,20 +188,10 @@ export const PostEditor = React.createClass( {
 		return this.props.setLayoutFocus( 'content' );
 	},
 
-	showConfirmationSidebar: function() {
-		this.setState( { showConfirmationSidebar: true } );
-	},
-
-	closeConfirmationSidebar: function() {
-		this.setState( { showConfirmationSidebar: false } );
-	},
-
-	showConfirmationSidebarOverlay: function() {
-		this.setState( { showConfirmationSidebarOverlay: true } );
-	},
-
-	closeConfirmationSidebarOverlay: function() {
-		this.setState( { showConfirmationSidebarOverlay: false } );
+	setConfirmationSidebar: function( state ) {
+		const allowedStates = [ 'closed', 'open', 'publishing' ];
+		const confirmationSidebar = allowedStates.indexOf( state ) > -1 ? state : 'closed';
+		this.setState( { confirmationSidebar } );
 	},
 
 	toggleSidebar: function() {
@@ -240,15 +229,13 @@ export const PostEditor = React.createClass( {
 			<div className={ classes }>
 				<QueryPreferences />
 				<EditorConfirmationSidebar
-					closeOverlay={ this.closeConfirmationSidebarOverlay }
-					closeSidebar={ this.closeConfirmationSidebar }
-					isOverlayActive={ this.state.showConfirmationSidebarOverlay }
-					isSidebarActive={ this.state.showConfirmationSidebar }
+					onPrivatePublish={ this.onPublish }
 					onPublish={ this.onPublish }
 					post={ this.state.post }
-					site={ site }
 					savedPost={ this.state.savedPost }
-					onPrivatePublish={ this.onPublish }
+					setState={ this.setConfirmationSidebar }
+					site={ site }
+					state={ this.state.confirmationSidebar }
 				/>
 				<EditorDocumentHead />
 				<EditorPostTypeUnsupported />
@@ -270,7 +257,6 @@ export const PostEditor = React.createClass( {
 						site={ site }
 						user={ this.props.user }
 						userUtils={ this.props.userUtils }
-						showConfirmationSidebar={ this.showConfirmationSidebar }
 						toggleSidebar={ this.toggleSidebar }
 						type={ this.props.type }
 						onMoreInfoAboutEmailVerify={ this.onMoreInfoAboutEmailVerify }
@@ -679,14 +665,12 @@ export const PostEditor = React.createClass( {
 		};
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) && false === isConfirmed ) {
-			this.showConfirmationSidebarOverlay();
-			this.showConfirmationSidebar();
+			this.setConfirmationSidebar( 'open' );
 			return;
 		}
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.closeConfirmationSidebarOverlay();
-			this.closeConfirmationSidebar();
+			this.setConfirmationSidebar( 'closed' );
 		}
 
 		// determine if this is a private publish


### PR DESCRIPTION
This PR add the privacy setting component to the confirmation sidebar in the editor.

![sidebar-privacy](https://cloud.githubusercontent.com/assets/363749/26686190/d9112ad2-46b1-11e7-86bf-2368a797bc65.gif)

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p3Ex-2ri-p2.

To test:

- ENABLE_FEATURES=post-editor/delta-post-publish-flow make run
- Draft a post and hit publish, you should see the confirmation sidebar
- Select each privacy setting and make sure they behave as expected
  - Selecting "Private" should prompt you to immediately publish the post
    - Selecting "Yes" should close the confirmation sidebar and immediately publish the post
    - Selecting "No" should close the prompt and return you to the sidebar with your previously selected privacy setting restored.
  - Selecting "Public" or "Password Protected" should cause the component in "Post Settings" to stay in sync.
    - The password you type for "Password Protected" should also remain in sync.