### PR TITLE
Reader: Fix Combined Cards narrow in Search

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -15,7 +15,8 @@
 	background: lighten( $gray, 20% );
 }
 
-.is-reader-page .search-stream .reader-post-card.card {
+.is-reader-page .search-stream .reader-post-card.card,
+.is-reader-page .search-stream .reader-combined-card.card {
 	width: 100%;
 }
 
@@ -47,15 +48,11 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
-.is-reader-page .search-stream__input-card.card {
-	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
- }
-
- .is-reader-page .search-stream__blank-suggestions {
+.is-reader-page .search-stream__blank-suggestions {
 	 margin-bottom: -15px;
- }
+}
 
- .is-reader-page .search-stream__recommendation-list-item {
+.is-reader-page .search-stream__recommendation-list-item {
 	box-sizing: border-box;
 	border-bottom: 1px solid lighten( $gray, 20% );
 	display: flex;
@@ -170,9 +167,10 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			margin: 4px 8px 0 0;
 		}
 	}
- }
+}
 
 .search-stream__input-card.card {
+	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
 	margin-bottom: 16px;
 	padding: 0;
 	z-index: z-index( 'root', '.search-stream__input-card' );


### PR DESCRIPTION
This is caused by the `flex` property assigned to `reader__content` which needed is for recommended posts in Search.

Example: http://calypso.dev:3000/read/search?q=chrisboulasblog

Before:
<img width="821" alt="screenshot 2017-05-26 15 05 02" src="https://cloud.githubusercontent.com/assets/4924246/26514214/47647e62-4225-11e7-82ca-e19903631bde.png">
<img width="821" alt="screenshot 2017-05-26 15 05 07" src="https://cloud.githubusercontent.com/assets/4924246/26514213/47643362-4225-11e7-8e5e-d7a4c015eae8.png">

After:
<img width="816" alt="screenshot 2017-05-26 15 09 28" src="https://cloud.githubusercontent.com/assets/4924246/26514224/6074bf02-4225-11e7-8a71-ac5461f8c2c8.png">
<img width="657" alt="screenshot 2017-05-26 15 09 39" src="https://cloud.githubusercontent.com/assets/4924246/26514225/60801ea6-4225-11e7-8e3e-fd6b3de23bcc.png">