### PR TITLE
Enable updating Gravatars on Desktop

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -81,13 +81,15 @@ export class EditGravatar extends Component {
 
 			if ( extension ) {
 				errorMessage = translate(
-					'An image of filetype %s is not allowed',
+					'Sorry, %s files are not supported' +
+					' — please make sure your image is in JPG, GIF, or PNG format.',
 					{
 						args: extension
 					}
 				);
 			} else {
-				errorMessage = translate( 'An image of that filetype is not allowed' );
+				errorMessage = translate( 'Sorry, images of that filetype are not supported ' +
+				'— please make sure your image is in JPG, GIF, or PNG format.' );
 			}
 
 			receiveGravatarImageFailedAction( {
@@ -116,7 +118,7 @@ export class EditGravatar extends Component {
 
 		if ( error ) {
 			receiveGravatarImageFailedAction( {
-				errorMessage: translate( "We couldn't save that image, please try another one" ),
+				errorMessage: translate( "We couldn't save that image — please try another one." ),
 				statName: 'image_editor_error',
 			} );
 			return;
@@ -136,7 +138,7 @@ export class EditGravatar extends Component {
 			uploadGravatarAction( imageBlob, bearerToken, user.email );
 		} else {
 			receiveGravatarImageFailedAction( {
-				errorMessage: translate( "We can't save a new Gravatar now. Please try again later." ),
+				errorMessage: translate( "Hmm, we can't save a new Gravatar now. Please try again later." ),
 				statName: 'no_bearer_token',
 			} );
 		}
@@ -204,7 +206,7 @@ export class EditGravatar extends Component {
 		const icon = ( user.email_verified ? 'cloud-upload' : 'notice' );
 		const buttonText = ( user.email_verified
 			? translate( 'Click to change photo' )
-			: translate( 'Verify email first' )
+			: translate( 'Verify your email' )
 		);
 		return (
 			<div
@@ -256,9 +258,10 @@ export class EditGravatar extends Component {
 						className="edit-gravatar__pop-over"
 						position="left" >
 						{ translate( '{{p}}The avatar you use on WordPress.com comes ' +
-							'from {{ExternalLink}}Gravatar{{/ExternalLink}} - a universal avatar service.{{/p}}' +
-							'{{p}}Your photo may be displayed on other sites where ' +
-							'you use your email address %(email)s.{{/p}}',
+							'from {{ExternalLink}}Gravatar{{/ExternalLink}}, a universal avatar service ' +
+							'(it stands or "Global Avatar," get it?).{{/p}}' +
+							'{{p}}Your image may also appear on other sites using Gravatar ' +
+							"whenever you're logged in with your email address %(email)s.{{/p}}",
 							{
 								components: {
 									ExternalLink: <ExternalLink

--- a/client/components/email-verification/email-verification-dialog/index.jsx
+++ b/client/components/email-verification/email-verification-dialog/index.jsx
@@ -56,13 +56,17 @@ class VerifyEmailDialog extends Component {
 
 	render() {
 		const strings = {
-			confirmHeading: this.props.translate( 'Please confirm your email address' ),
+			confirmHeading: this.props.translate( 'Please verify your email address:' ),
 
-			confirmExplanation: this.props.translate( 'We sent you an email when you first signed up. ' +
-				'Please open the message and click the blue button.' ),
+			confirmExplanation: this.props.translate(
+				'When you first signed up for a WordPress.com account we sent you an email. ' +
+				'Please open it and click on the blue button to verify your email address.'
+			),
 
-			confirmReasoning: this.props.translate( 'Email confirmation allows us to assist when recovering ' +
-				'your account in the event you forget your password.' ),
+			confirmReasoning: this.props.translate(
+				'Verifying your email allows us to assist you if you ' +
+				'ever lose access to your account in the future.'
+			),
 
 			confirmEmail: this.props.translate(
 				'{{wrapper}}%(email)s{{/wrapper}} {{emailPreferences}}change{{/emailPreferences}}',

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -251,8 +251,12 @@ export const handlers = {
 	[ GRAVATAR_RECEIVE_IMAGE_FAILURE ]: ( dispatch, action ) => {
 		dispatch( errorNotice( action.errorMessage ) );
 	},
-	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: dispatchError( translate( 'New Gravatar was not saved.' ) ),
-	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: dispatchSuccess( translate( 'New Gravatar uploaded successfully!' ) ),
+	[ GRAVATAR_UPLOAD_REQUEST_FAILURE ]: dispatchError(
+		translate( 'Hmm, your new Gravatar was not saved. Please try uploading again.' )
+	),
+	[ GRAVATAR_UPLOAD_REQUEST_SUCCESS ]: dispatchSuccess(
+		translate( 'You successfully uploaded a new Gravatar — looking sharp!' )
+	),
 	[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: onJetpackModuleActivationActionMessage,
 	[ JETPACK_MODULE_DEACTIVATE_SUCCESS ]: onJetpackModuleActivationActionMessage,
 	[ JETPACK_MODULE_ACTIVATE_FAILURE ]: onJetpackModuleActivationActionMessage,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -49,6 +49,7 @@
 		"manage/themes/details/jetpack": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,


### PR DESCRIPTION
This PR enables the feature flag "me/edit-gravatar" on Desktop.

@designsimply, this is now ready for testing 🎉 thank you :) :)
@astralbodies - could you please let me know if there's anything else I need to do to get this in to the June desktop release? A: no, this is good to go.

# Testing Instructions

## Install the desktop app
1. Install the desktop app using [these instructions](https://github.com/Automattic/wp-desktop#getting-started--running-locally). The full instructions are also listed below:
`git clone git@github.com:Automattic/wp-desktop.git`
`git submodule init`
Create a `calypso/config/secrets.json` file and fill it with secrets. You can find the location of the secrets at PCYsg-6rI-p2, under "Build App"
2. While in `/calypso`, checkout this branch `update/edit-gravatar-on-desktop`
3. In `/wp-desktop` use `make run` to build and run the app

## Seeing the feature
You should be able to see the feature if you go to 'My Profile' by clicking your Gravatar in the top right corner:

<img width="1188" alt="screen shot 2017-05-27 at 10 30 27 am" src="https://cloud.githubusercontent.com/assets/11487924/26522143/c415e07a-42c7-11e7-8c93-e80c56d5d638.png">

## Things that should work

General
- responsive: resizing the screen should still allow you see and use the feature
- i18n: you should be able to see the feature translated (the 'Change My Photo' string is not yet translated)

Selecting an image
- clicking: click on the image to select a photo from your computer
- drag and drop: you should be able to drag an image onto the circle
- file type: you should see an error if you select an svg file or if your file has an image extension but isn't actually an image

Editing the image
- editing the image: you should be able to use the image editor that comes up after selecting the image to resize it. the dimensions should always be square - you should not be allowed to make a non-square selection
- you should be able to cancel the edit and the image won't get uploaded
- you should be able to click on 'Change My Photo' to save the new image

Uploading
- after clicking 'Change My Photo' you should see a spinner to indicate upload
- after the the upload succeeds, you should see a success notice
- if the upload fails, you should see a failure notice

Unverified users
- if you log in using an unverified user, you should not be able to upload an image, and instead you'll see a message letting you send another verification email
- note: there's a bug (#14538) with the 'Resend Email' button for now, which I'll work on fixing next week

Here's a video showing a bad image, and then a successful upload:

http://cld.wthms.co/eRmtOuw

## Strings

I wanted to make sure all the different strings make sense. Here's a list of all the possible ones and when they can happen:

- "**An image of filetype %s is not allowed**" and "**An image of that filetype is not allowed**" - when a user picks an image type that's not allowed (e.g. svn)
- "**We couldn't save that image, please try another one**" - when the image could not be shown edited in the image editor
- "**We can't save a new Gravatar now. Please try again later.**" - when there's an authentication problem. I expect this to never be shown
- "**Click to change photo**" - the text shown on the button
- "**Verify email first**" -  the text shown for users with an unverifeid email
- "**Drop to upload profile photo**" - the text shown when dragging an image 
- "**Your profile photo is public.**" - the text shown right below the button
- "**The avatar you use on WordPress.com comes from <a>Gravatar</a>  - a universal avatar service. Your photo may be displayed on other sites where you use your email address your@email.com**" - the explanation text shown in a tooltip if the user clicks the information button
- "**New Gravatar was not saved.**" - the error message shown if the Gravatar was not saved on Gravatar.com
- "**New Gravatar uploaded successfully!**" - success message shown when Gravatar is saved on Gravatar.com

Adding the 'Needs Copy Review' label for this.

## Instructions to see the new strings:
1. `export ENABLE_FEATURES=me/edit-gravatar && make run`
2. Log in to WordPress.com as an unverified user, go to `http://calypso.localhost:3000/me`
3. See the "Verify your email" string
4. Click on the Gravatar, see the new email verification strings:
>Please verify your email address:
>[email]
> When you first signed up for a WordPress.com account we sent you an email. Please open it and click on the blue button to verify your email address.
>Verifying your email allows us to assist you if you ever lose access to your account in the future.
5. Click the information button (i), see the new strings:
> The avatar you use on WordPress.com comes from Gravatar, a universal avatar service (it stands or "Global Avatar," get it?).
> Your image may also appear on other sites using Gravatar whenever you're logged in with your email address [email]
6. Log out, and log back in as a verified user. Go to `http://calypso.localhost:3000/me`
7. Click on the Gravatar and choose a new photo. See the error message "Hmm, we can't save a new Gravatar now. Please try again later, or contact our Happiness team."
8. Set your bearer token in the console using `localStorage.setItem('bearerToken', 'your_bearer_token');` You can [find your bearer token using these instructions](https://github.com/Automattic/wp-calypso/pull/13159#issuecomment-303583833), or ask me for a test username + bearer token.
9. Click on the Gravatar and try to upload a png photo, and see the string 'Change My Photo'
10. Click on 'Change My Photo', see the image upload, and see the string "You successfully uploaded a new Gravatar — looking sharp!" in the success message
11. Try to upload an svg photo and see the string "Sorry, svg files are not supported — please make sure your image is in JPG, GIF, or PNG format."
12. Try to upload this non-photo file, and see the error message "Sorry, images of that filetype are not supported — please make sure your image is in JPG, GIF, or PNG format."
13. Turn off networking before clicking 'Change My Photo', and see this error message "Hmm, your new Gravatar was not saved. Please try uploading again, or contact our Happiness team."
14. On line 116 of `/client/blocks/edit-gravatar/index.jsx` add `error = true`, refresh the page and try to upload an image. See the error message "We couldn't save that image — please try another one, or contact our Happiness team."