### PR TITLE
Editor: update EditorVisibility component

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -345,7 +345,11 @@ const EditorVisibility = React.createClass( {
 								<Gridicon
 									icon="info-outline"
 									size={ 18 }
-									className={ classNames( 'editor-visibility__dialog-info', { is_active: this.state.showVisibilityInfotips } ) }
+									className={
+										classNames(
+											'editor-visibility__dialog-info',
+											{ is_active: this.state.showVisibilityInfotips }
+										) }
 									onClick={ this.toggleVisibilityInfotips }
 								/>
 							</FormLegend>
@@ -452,6 +456,7 @@ const EditorVisibility = React.createClass( {
 							<DropdownItem
 								selected={ option.value === visibility }
 								key={ option.value }
+								value={ option.value }
 								onClick={ option.onClick }
 							>
 								<Gridicon icon={ option.icon } size={ 18 } />

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -7,6 +7,7 @@ import { includes, find } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -87,8 +88,6 @@ const EditorVisibility = React.createClass( {
 	},
 
 	closePopover( event ) {
-		var stateChanges = {};
-
 		if ( this.showingAcceptDialog && event ) {
 			event.preventDefault();
 			return;
@@ -100,6 +99,8 @@ const EditorVisibility = React.createClass( {
 			event.stopImmediatePropagation();
 		}
 
+		const stateChanges = {};
+
 		if ( this.isPasswordValid() ) {
 			stateChanges.showPopover = false;
 		} else {
@@ -110,42 +111,40 @@ const EditorVisibility = React.createClass( {
 	},
 
 	isPasswordValid() {
-		var password;
-
 		if ( 'password' !== this.getVisibility() ) {
 			return true;
 		}
 
-		password = ReactDom.findDOMNode( this.refs.postPassword ).value.trim();
+		const password = ReactDom.findDOMNode( this.refs.postPassword ).value.trim();
 
 		return password.length;
 	},
 
 	renderVisibilityTip( visibility ) {
-		var infotext;
-
 		if ( ! this.state.showVisibilityInfotips ) {
 			return null;
 		}
 
+		let infotext;
+
 		switch ( visibility ) {
 			case 'public':
-				infotext = this.translate( 'Visible to everyone.',
+				infotext = this.props.translate( 'Visible to everyone.',
 					{ context: 'Post visibility: info text shown when changing post visibility to public.' }
 				);
 				if ( this.props.isPrivateSite ) {
-					infotext = this.translate( 'Any member of the site can view this post.',
+					infotext = this.props.translate( 'Any member of the site can view this post.',
 						{ context: 'Post visibility: info text shown when changing post visibility to public on a members-only site.' }
 					);
 				}
 				break;
 			case 'private':
-				infotext = this.translate( 'Only visible to site admins and editors.',
+				infotext = this.props.translate( 'Only visible to site admins and editors.',
 					{ context: 'Post visibility: info text shown when changing post visibility to private.' }
 				);
 				break;
 			case 'password':
-				infotext = this.translate( 'Protected with a password you choose. Only those with the password can view this post.',
+				infotext = this.props.translate( 'Protected with a password you choose. Only those with the password can view this post.',
 					{ context: 'Post visibility: info text shown when changing post visibility to password protected.' }
 				);
 				break;
@@ -253,9 +252,9 @@ const EditorVisibility = React.createClass( {
 		let message;
 
 		if ( this.props.type === 'page' ) {
-			message = this.translate( 'Private pages are only visible to administrators and editors of this site. Would you like to privately publish this page now?' );
+			message = this.props.translate( 'Private pages are only visible to administrators and editors of this site. Would you like to privately publish this page now?' );
 		} else {
-			message = this.translate( 'Private posts are only visible to administrators and editors of this site. Would you like to privately publish this post now?' );
+			message = this.props.translate( 'Private posts are only visible to administrators and editors of this site. Would you like to privately publish this post now?' );
 		}
 
 		accept( message, ( accepted ) => {
@@ -263,7 +262,7 @@ const EditorVisibility = React.createClass( {
 			if ( accepted ) {
 				this.onPrivatePublish();
 			}
-		}, this.translate( 'Yes' ), this.translate( 'No' ) );
+		}, this.props.translate( 'Yes' ), this.props.translate( 'No' ) );
 	},
 
 	onPasswordChange( event ) {
@@ -282,11 +281,9 @@ const EditorVisibility = React.createClass( {
 	},
 
 	renderPasswordInput() {
-		var value, isError, errorMessage;
-
-		value = this.props.password ? this.props.password.trim() : null;
-		isError = ! this.state.passwordIsValid;
-		errorMessage = this.translate( 'Password is empty.', { context: 'Editor: Error shown when password is empty.' } );
+		const value = this.props.password ? this.props.password.trim() : null;
+		const isError = ! this.state.passwordIsValid;
+		const errorMessage = this.props.translate( 'Password is empty.', { context: 'Editor: Error shown when password is empty.' } );
 
 		return (
 			<div>
@@ -297,7 +294,7 @@ const EditorVisibility = React.createClass( {
 					isError={ isError }
 					ref="postPassword"
 					className={ this.state.showVisibilityInfotips ? 'is-info-open' : null }
-					placeholder={ this.translate( 'Create password', { context: 'Editor: Create password for post' } ) }
+					placeholder={ this.props.translate( 'Create password', { context: 'Editor: Create password for post' } ) }
 				/>
 
 				{ isError ? <FormInputValidation isError={ true } text={ errorMessage } /> : null }
@@ -344,7 +341,7 @@ const EditorVisibility = React.createClass( {
 					<div className="editor-visibility__dialog">
 						<FormFieldset className="editor-fieldset">
 							<FormLegend className="editor-fieldset__legend">
-								{ this.translate( 'Post Visibility' ) }
+								{ this.props.translate( 'Post Visibility' ) }
 								<Gridicon
 									icon="info-outline"
 									size={ 18 }
@@ -362,8 +359,14 @@ const EditorVisibility = React.createClass( {
 								<span>
 									{
 										this.props.isPrivateSite
-										? this.translate( 'Visible for members of the site', { context: 'Editor: Radio label to set post visibility' } )
-										: this.translate( 'Public', { context: 'Editor: Radio label to set post visible to public' } )
+										? this.props.translate(
+											'Visible for members of the site',
+											{ context: 'Editor: Radio label to set post visibility' }
+										)
+										: this.props.translate(
+											'Public',
+											{ context: 'Editor: Radio label to set post visible to public'
+										} )
 									}
 								</span>
 							</FormLabel>
@@ -376,7 +379,14 @@ const EditorVisibility = React.createClass( {
 									onChange={ this.onSetToPrivate }
 									checked={ 'private' === visibility }
 								/>
-								<span>{ this.translate( 'Private', { context: 'Editor: Radio label to set post to private' } ) }</span>
+								<span>
+								{
+									this.props.translate(
+										'Private',
+										{ context: 'Editor: Radio label to set post to private' }
+									)
+								}
+								</span>
 							</FormLabel>
 							{ this.renderVisibilityTip( 'private' ) }
 							<FormLabel>
@@ -386,7 +396,14 @@ const EditorVisibility = React.createClass( {
 									onChange={ this.updateVisibility }
 									checked={ 'password' === visibility }
 								/>
-								<span>{ this.translate( 'Password Protected', { context: 'Editor: Radio label to set post to password protected' } ) }</span>
+								<span>
+								{
+									this.props.translate(
+										'Password Protected',
+										{ context: 'Editor: Radio label to set post to password protected' }
+									)
+								}
+								</span>
 							</FormLabel>
 							{ this.renderVisibilityTip( 'password' ) }
 							{ visibility === 'password' ? this.renderPasswordInput() : null }
@@ -400,7 +417,7 @@ const EditorVisibility = React.createClass( {
 	renderPrivacyDropdown( visibility ) {
 		const dropdownItems = [
 			{
-				label: this.translate( 'Public', { context: 'Editor: Radio label to set post visible to public' } ),
+				label: this.props.translate( 'Public', { context: 'Editor: Radio label to set post visible to public' } ),
 				icon: 'visible',
 				value: 'public',
 				onClick: () => {
@@ -408,13 +425,13 @@ const EditorVisibility = React.createClass( {
 				}
 			},
 			{
-				label: this.translate( 'Private', { context: 'Editor: Radio label to set post to private' } ),
+				label: this.props.translate( 'Private', { context: 'Editor: Radio label to set post to private' } ),
 				icon: 'not-visible',
 				value: 'private',
 				onClick: this.onSetToPrivate
 			},
 			{
-				label: this.translate( 'Password Protected', { context: 'Editor: Radio label to set post to password protected' } ),
+				label: this.props.translate( 'Password Protected', { context: 'Editor: Radio label to set post to password protected' } ),
 				icon: 'lock',
 				value: 'password',
 				onClick: () => {
@@ -428,9 +445,9 @@ const EditorVisibility = React.createClass( {
 			<div className="editor-visibility__dropdown">
 				<FormFieldset className="editor-fieldset">
 					<FormLegend className="editor-fieldset__legend">
-						{ this.translate( 'Post Visibility' ) }
+						{ this.props.translate( 'Post Visibility' ) }
 					</FormLegend>
-					<SelectDropdown selectedText={ selectedItem ? selectedItem.label : this.translate( 'Select an option' ) }>
+					<SelectDropdown selectedText={ selectedItem ? selectedItem.label : this.props.translate( 'Select an option' ) }>
 						{ dropdownItems.map( option =>
 							<DropdownItem
 								selected={ option.value === visibility }
@@ -479,4 +496,4 @@ export default connect(
 		};
 	},
 	{ editPost }
-)( EditorVisibility );
+)( localize( EditorVisibility ) );

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -418,7 +418,7 @@ const EditorVisibility = React.createClass( {
 		const dropdownItems = [
 			{
 				label: this.props.translate( 'Public', { context: 'Editor: Radio label to set post visible to public' } ),
-				icon: 'visible',
+				icon: 'globe',
 				value: 'public',
 				onClick: () => {
 					this.updateDropdownVisibility( 'public' );
@@ -426,7 +426,7 @@ const EditorVisibility = React.createClass( {
 			},
 			{
 				label: this.props.translate( 'Private', { context: 'Editor: Radio label to set post to private' } ),
-				icon: 'not-visible',
+				icon: 'user',
 				value: 'private',
 				onClick: this.onSetToPrivate
 			},

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -252,9 +252,15 @@ const EditorVisibility = React.createClass( {
 		let message;
 
 		if ( this.props.type === 'page' ) {
-			message = this.props.translate( 'Private pages are only visible to administrators and editors of this site. Would you like to privately publish this page now?' );
+			message = this.props.translate(
+				'Private pages are only visible to administrators and editors of this site. ' +
+				'Would you like to privately publish this page now?'
+			);
 		} else {
-			message = this.props.translate( 'Private posts are only visible to administrators and editors of this site. Would you like to privately publish this post now?' );
+			message = this.props.translate(
+				'Private posts are only visible to administrators and editors of this site. ' +
+				'Would you like to privately publish this post now?'
+			);
 		}
 
 		accept( message, ( accepted ) => {

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -42,12 +42,28 @@
 		}
 	}
 
+	.gridicons-globe {
+		color: $alert-green;
+	}
+
+	.gridicons-user {
+		color: $alert-yellow;
+	}
+
+	.gridicons-lock {
+		color: $alert-red;
+	}
+
 	.gridicon.is_active {
 		color: $gray-dark;
 
 		&:hover {
 			color: lighten( $gray, 15% );
 		}
+	}
+
+	.is-selected .gridicon {
+		color: #fff;
 	}
 }
 


### PR DESCRIPTION
Follows #14517, which was merged to allow work to get started (#14533) on integrating the component into the new `EditorConfirmationSidebar` (#14382). Currently only available behind 'post-editor/delta-post-publish-flow' flag.

This PR will clean up the styling and functionality of the updated component to match the mock:

<img width="370" alt="editor-visibility-mock" src="https://cloud.githubusercontent.com/assets/942359/26531501/781e76d6-43b8-11e7-8db7-f86075e99d73.png">

This is part of a larger epic (See p3Ex-2ri-p2)

**To test:**
- Checkout branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Make sure that the updated `EditorVisibility` component is used in the post editor 'Status' section.
- Change the post visibility to verify functionality:
 - 'Password Protected' should show/hide a password field under the dropdown
 - 'Members Only' should show the privacy confirmation modal to publish the post privately
- Run the branch again without the feature flag enabled and make sure the `EditorVisibility` component works as normal