### PR TITLE
Woo-Connect Insights: Rethink Store Stats Namespace

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -37,7 +37,7 @@ export default function StatsController( context ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			placeholder={ <StatsPagePlaceholder className="woocommerce" /> }
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
-			require="extensions/woocommerce/app/stats"
+			require="extensions/woocommerce/app/store-stats"
 			{ ...props }
 		/>,
 		document.getElementById( 'primary' ),

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -9,11 +9,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Main from 'components/main';
-import StatsNavigation from './stats-navigation';
+import Navigation from './store-stats-navigation';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import StatsChart from './stats-chart';
+import Chart from './store-stats-chart';
 
-class Stats extends Component {
+class StoreStats extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		unit: PropTypes.string.isRequired,
@@ -31,9 +31,9 @@ class Stats extends Component {
 			quantity: '30'
 		};
 		return (
-			<Main className="woocommerce stats" wideLayout={ true }>
-				<StatsNavigation unit={ unit } type="orders" />
-				<StatsChart
+			<Main className="store-stats woocommerce" wideLayout={ true }>
+				<Navigation unit={ unit } type="orders" />
+				<Chart
 					path={ path }
 					query={ ordersQuery }
 					selectedDate={ selectedDate }
@@ -44,7 +44,7 @@ class Stats extends Component {
 	}
 }
 
-const localizedStats = localize( Stats );
+const localizedStats = localize( StoreStats );
 
 export default connect(
 	state => {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -15,7 +15,7 @@ import { getSiteStatsNormalizedData, isRequestingSiteStatsForQuery } from 'state
 import ElementChart from 'components/chart';
 import Legend from 'components/chart/legend';
 
-class StatsChart extends Component {
+class StoreStatsChart extends Component {
 	static propTypes = {
 		data: PropTypes.array.isRequired,
 		isRequesting: PropTypes.bool.isRequired,
@@ -63,7 +63,7 @@ class StatsChart extends Component {
 			tooltipData: [],
 			className,
 		};
-	};
+	}
 
 	render() {
 		const { siteId, query, data } = this.props;
@@ -78,7 +78,7 @@ class StatsChart extends Component {
 		const isLoading = ! ! data.length;
 		const chartData = data.map( item => this.buildChartData( item, selectedTab ) );
 		return (
-			<Card className="stats-chart stats-module">
+			<Card className="store-stats-chart stats-module">
 				{ siteId && <QuerySiteStats
 					query={ query }
 					siteId={ siteId }
@@ -100,4 +100,4 @@ export default connect(
 			isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsOrders', query ),
 		};
 	}
-)( StatsChart );
+)( StoreStatsChart );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -15,7 +15,7 @@ import FollowersCount from 'blocks/followers-count';
 import SegmentedControl from 'components/segmented-control';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-const StatsNavigation = props => {
+const StoreStatsNavigation = props => {
 	const { translate, slug, type, unit } = props;
 	const units = {
 		day: translate( 'Days' ),
@@ -37,7 +37,6 @@ const StatsNavigation = props => {
 				) ) }
 			</NavTabs>
 			<SegmentedControl
-				className="stats-navigation__control"
 				initialSelected="store"
 				options={ [
 					{ value: 'site', label: translate( 'Site' ), path: `/stats/${ unit }/${ slug }` },
@@ -49,7 +48,7 @@ const StatsNavigation = props => {
 	);
 };
 
-StatsNavigation.propTypes = {
+StoreStatsNavigation.propTypes = {
 	slug: PropTypes.string
 };
 
@@ -60,4 +59,4 @@ export default connect(
 			translate: i18n.translate,
 		};
 	}
-)( StatsNavigation );
+)( StoreStatsNavigation );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -16,7 +16,7 @@ import ProductCreate from './app/products/product-create';
 import Dashboard from './app/dashboard';
 import SettingsPayments from './app/settings/payments';
 import Shipping from './app/settings/shipping';
-import StatsController from './app/stats/controller';
+import StatsController from './app/store-stats/controller';
 import StoreSidebar from './store-sidebar';
 
 const getStorePages = () => {


### PR DESCRIPTION
### Why?

In order to avoid CSS collisions with any similar components in `my-sites/stats`, such as `stats-list`, we will need to use names such as `store-stats-list`. 

### Before
<img width="266" alt="screen shot 2017-05-29 at 12 49 37 pm" src="https://cloud.githubusercontent.com/assets/1922453/26533458/68445a40-446d-11e7-8802-f975cc04b2b0.png">

### After
<img width="290" alt="screen shot 2017-05-29 at 12 50 06 pm" src="https://cloud.githubusercontent.com/assets/1922453/26533462/7004bf04-446d-11e7-858c-4ee09ba3be6a.png">

Built on top of https://github.com/Automattic/wp-calypso/pull/14400. ~Until that gets merged, the diff is here, https://github.com/Automattic/wp-calypso/compare/add/woo-stats-chart...fix/woo-stats-namespace?expand=1~ Merged

Fixes https://github.com/Automattic/wp-calypso/issues/14504