### PR TITLE
Check plan match (monthly/yearly) to show manage button.

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -19,6 +19,7 @@ const PlanFeaturesActions = ( {
 	primaryUpgrade = false,
 	freePlan = false,
 	onUpgradeClick = noop,
+	currentPlanMatch,
 	isPlaceholder = false,
 	isPopular,
 	isInSignup,
@@ -37,7 +38,10 @@ const PlanFeaturesActions = ( {
 		className
 	);
 
-	if ( current && ! isInSignup ) {
+	if (
+		( current || currentPlanMatch ) &&
+		! isInSignup
+	) {
 		upgradeButton = (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				{ canPurchase ? translate( 'Manage Plan' ) : translate( 'View Plan' ) }
@@ -86,6 +90,7 @@ PlanFeaturesActions.propTypes = {
 	available: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	freePlan: PropTypes.bool,
+	currentPlanMatch: PropTypes.bool.isRequired,
 	isPlaceholder: PropTypes.bool,
 	isLandingPage: PropTypes.bool
 };

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -105,7 +105,14 @@ class PlanFeatures extends Component {
 
 	renderMobileView() {
 		const {
-			canPurchase, translate, planProperties, isInSignup, isLandingPage, intervalType, site, basePlansPath
+			basePlansPath,
+			canPurchase,
+			intervalType,
+			isInSignup,
+			isLandingPage,
+			planProperties,
+			site,
+			translate,
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -126,6 +133,7 @@ class PlanFeatures extends Component {
 			const {
 				available,
 				currencyCode,
+				currentPlanMatch,
 				current,
 				features,
 				onUpgradeClick,
@@ -139,6 +147,7 @@ class PlanFeatures extends Component {
 				hideMonthly
 			} = properties;
 			const { rawPrice, discountPrice } = properties;
+
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
@@ -165,6 +174,7 @@ class PlanFeatures extends Component {
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
+						currentPlanMatch={ currentPlanMatch }
 						primaryUpgrade={ primaryUpgrade }
 						available = { available }
 						onUpgradeClick={ onUpgradeClick }
@@ -174,6 +184,7 @@ class PlanFeatures extends Component {
 						isLandingPage={ isLandingPage }
 						isPopular = { popular }
 						planName ={ planConstantObj.getTitle() }
+						manageHref={ `/plans/my-plan/${ site.slug }` }
 					/>
 					<FoldableCard
 						header={ translate( 'Show features' ) }
@@ -271,6 +282,7 @@ class PlanFeatures extends Component {
 			const {
 				available,
 				current,
+				currentPlanMatch,
 				onUpgradeClick,
 				planName,
 				primaryUpgrade,
@@ -291,6 +303,7 @@ class PlanFeatures extends Component {
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
+						currentPlanMatch={ currentPlanMatch }
 						available = { available }
 						primaryUpgrade={ primaryUpgrade }
 						planName ={ planConstantObj.getTitle() }
@@ -385,6 +398,7 @@ class PlanFeatures extends Component {
 			const {
 				available,
 				current,
+				currentPlanMatch,
 				onUpgradeClick,
 				planName,
 				primaryUpgrade,
@@ -402,6 +416,7 @@ class PlanFeatures extends Component {
 					<PlanFeaturesActions
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
+						currentPlanMatch={ currentPlanMatch }
 						current={ current }
 						available = { available }
 						primaryUpgrade={ primaryUpgrade }
@@ -468,6 +483,7 @@ export default connect(
 				const newPlan = isNew( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
 				const showMonthlyPrice = ! relatedMonthlyPlan && showMonthly;
+				const currentPlanMatch = !! ( sitePlan && ( getPlanClass( sitePlan.product_slug ) === getPlanClass( plan ) ) );
 
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {
 					isPlaceholder = true;
@@ -478,6 +494,7 @@ export default connect(
 					available: available,
 					currencyCode: getCurrentUserCurrencyCode( state ),
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
+					currentPlanMatch,
 					discountPrice: getPlanDiscountedRawPrice( state,
 						selectedSiteId,
 						plan,


### PR DESCRIPTION
Show the "Manage plan" button regardless of monthly/yearly interval.

Desktop monthly:

![desk-monthly](https://cloud.githubusercontent.com/assets/841763/26546682/85fafcb2-446b-11e7-9a51-1e00b2256e97.png)

Desktop yearly:

![desk-yearly](https://cloud.githubusercontent.com/assets/841763/26546686/8b5e0488-446b-11e7-955a-6d051ac00add.png)

Mobile monthly:

![mobile-monthly](https://cloud.githubusercontent.com/assets/841763/26546707/a284fca2-446b-11e7-9269-61728239d685.png)

Mobile yearly:

![mobile-yearly](https://cloud.githubusercontent.com/assets/841763/26546709/a5b2f582-446b-11e7-8acc-dbe81ae26b49.png)

To test:
* Visit `http://calypso.localhost:3000/plans/monthly/:site` for a Jetpack connected site with a paid plan.
* Ensure you see the "Manage Plan" button regardless of monthly/yearly interval.
* Ensure the button works correctly with all views.
* Ensure the mobile view has the same behavior.
* Ensure there are no issues or regressions introduced for sites on the Free plan or for WordPress.com sites.

Partially implements #7228 