### PR TITLE
Checkout: Only show privacy upsell if all domains support privacy

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -283,6 +283,12 @@ function hasDomainRegistration( cart ) {
 	return some( getAll( cart ), isDomainRegistration );
 }
 
+function hasOnlyDomainRegistrationsWithPrivacySupport( cart ) {
+	return every( getDomainRegistrations( cart ), function( cartItem ) {
+		return ! privacyNotAvailable( cartItem );
+	} );
+}
+
 function hasDomainMapping( cart ) {
 	return some( getAll( cart ), productsValues.isDomainMapping );
 }
@@ -714,6 +720,16 @@ function isRenewal( cartItem ) {
 }
 
 /**
+ * Determines whether a cart item does not supports privacy
+ *
+ * @param {Object} cartItem - `CartItemValue` object
+ * @returns {boolean} true if item does not support privacu
+ */
+function privacyNotAvailable( cartItem ) {
+	return cartItem.extra && cartItem.extra.privacy_not_available;
+}
+
+/**
  * Get the included domain for a cart item
  *
  * @param {Object} cartItem - `CartItemValue` object
@@ -802,6 +818,7 @@ module.exports = {
 	hasDomainInCart,
 	hasDomainMapping,
 	hasDomainRegistration,
+	hasOnlyDomainRegistrationsWithPrivacySupport,
 	hasFreeTrial,
 	hasGoogleApps,
 	hasOnlyFreeTrial,

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -285,7 +285,7 @@ function hasDomainRegistration( cart ) {
 
 function hasOnlyDomainRegistrationsWithPrivacySupport( cart ) {
 	return every( getDomainRegistrations( cart ), function( cartItem ) {
-		return ! privacyNotAvailable( cartItem );
+		return privacyAvailable( cartItem );
 	} );
 }
 
@@ -724,13 +724,13 @@ function isRenewal( cartItem ) {
 }
 
 /**
- * Determines whether a cart item does not supports privacy
+ * Determines whether a cart item supports privacy
  *
  * @param {Object} cartItem - `CartItemValue` object
- * @returns {boolean} true if item does not support privacu
+ * @returns {boolean} true if item supports privacy
  */
-function privacyNotAvailable( cartItem ) {
-	return cartItem.extra && cartItem.extra.privacy_not_available;
+function privacyAvailable( cartItem ) {
+	return cartItem.extra && cartItem.extra.privacy_available;
 }
 
 /**

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var update = require( 'react-addons-update' );
-import { every, assign, flow, isEqual, merge, reject, tail, some, uniq, flatten, filter, find } from 'lodash';
+import { every, assign, flow, isEqual, merge, reject, tail, some, uniq, flatten, filter, find, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -284,9 +284,7 @@ function hasDomainRegistration( cart ) {
 }
 
 function hasOnlyDomainRegistrationsWithPrivacySupport( cart ) {
-	return every( getDomainRegistrations( cart ), function( cartItem ) {
-		return privacyAvailable( cartItem );
-	} );
+	return every( getDomainRegistrations( cart ), privacyAvailable );
 }
 
 function hasDomainMapping( cart ) {
@@ -730,7 +728,7 @@ function isRenewal( cartItem ) {
  * @returns {boolean} true if item supports privacy
  */
 function privacyAvailable( cartItem ) {
-	return cartItem.extra && cartItem.extra.privacy_available;
+	return get( cartItem, 'extra.privacy_available', true );
 }
 
 /**

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -410,7 +410,11 @@ function themeItem( themeSlug, source ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function domainRegistration( properties ) {
-	return assign( domainItem( properties.productSlug, properties.domain, properties.source ), { is_domain_registration: true } );
+	return assign( domainItem( properties.productSlug, properties.domain, properties.source ),
+		{
+			is_domain_registration: true,
+			...( properties.extra ? { extra: properties.extra } : {} ),
+		} );
 }
 
 /**

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -9,6 +9,7 @@ import {
 	camelCase,
 	deburr,
 	first,
+	has,
 	head,
 	indexOf,
 	kebabCase,
@@ -475,7 +476,9 @@ class DomainDetailsForm extends PureComponent {
 	}
 
 	finish( options = {} ) {
-		this.setPrivacyProtectionSubscriptions( options.addPrivacy && options.addPrivacy !== false );
+		if ( has( options.addPrivacy ) ) {
+			this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
+		}
 
 		const allFieldValues = this.getAllFieldValues();
 		debug( 'finish: allFieldValues:', allFieldValues );

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -231,6 +231,10 @@ class DomainDetailsForm extends PureComponent {
 		return formState.getFieldValue( this.state.form, 'countryCode' ) === 'NL' && cartItems.hasTld( this.props.cart, 'nl' );
 	}
 
+	allDomainRegistrationsSupportPrivacy() {
+		return cartItems.hasOnlyDomainRegistrationsWithPrivacySupport( this.props.cart );
+	}
+
 	allDomainRegistrationsHavePrivacy() {
 		return cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0;
 	}
@@ -428,7 +432,8 @@ class DomainDetailsForm extends PureComponent {
 				return this.switchToNextStep();
 			}
 
-			if ( ! this.allDomainRegistrationsHavePrivacy() ) {
+			if ( this.allDomainRegistrationsSupportPrivacy() &&
+				! this.allDomainRegistrationsHavePrivacy() ) {
 				this.openDialog();
 				return;
 			}
@@ -470,7 +475,7 @@ class DomainDetailsForm extends PureComponent {
 	}
 
 	finish( options = {} ) {
-		this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
+		this.setPrivacyProtectionSubscriptions( options.addPrivacy && options.addPrivacy !== false );
 
 		const allFieldValues = this.getAllFieldValues();
 		debug( 'finish: allFieldValues:', allFieldValues );
@@ -516,7 +521,11 @@ class DomainDetailsForm extends PureComponent {
 
 		return (
 			<div>
-				{ cartItems.hasDomainRegistration( this.props.cart ) && this.renderPrivacySection() }
+				{
+					cartItems.hasDomainRegistration( this.props.cart ) &&
+					this.allDomainRegistrationsSupportPrivacy() &&
+					this.renderPrivacySection()
+				}
 				<PaymentBox
 					currentPage={ this.state.currentStep }
 					classSet={ classSet }

--- a/client/my-sites/upgrades/checkout/test/domain-details-form.js
+++ b/client/my-sites/upgrades/checkout/test/domain-details-form.js
@@ -45,13 +45,22 @@ describe( 'Domain Details Form', () => {
 	const domainProduct = domainRegistration( {
 		productSlug: 'normal_domain',
 		domain: 'test.test',
+	} );
+
+	const domainProductWithExplicitPrivacy = domainRegistration( {
+		productSlug: 'normal_domain',
+		domain: 'test.test',
 		extra: {
 			privacy_available: true
 		},
 	} );
 
+
 	const domainProductWithoutPrivacy = domainRegistration( {
 		productSlug: 'unprivate_domain',
+		extra: {
+			privacy_available: false
+		},
 	} );
 
 	it( 'does not blow up with default props', () => {
@@ -70,7 +79,7 @@ describe( 'Domain Details Form', () => {
 		const propsWithDomain = merge(
 			{},
 			defaultProps,
-			{ cart: { products: [ domainProduct ] } }
+			{ cart: { products: [ domainProductWithExplicitPrivacy ] } }
 		);
 
 		const wrapper = shallow( <DomainDetailsForm { ...propsWithDomain } /> );
@@ -107,10 +116,21 @@ describe( 'Domain Details Form', () => {
 		const mixedSupportProps = merge(
 			{},
 			defaultProps,
-			{ cart: { products: [ domainProduct, domainProductWithoutPrivacy ] } }
+			{ cart: { products: [ domainProductWithExplicitPrivacy, domainProductWithoutPrivacy ] } }
 		);
 		const wrapper = shallow( <DomainDetailsForm { ...mixedSupportProps } /> );
 
 		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 0 );
+	} );
+
+	it( 'should render privacy upsell without explicit privacy support', () => {
+		const mixedSupportProps = merge(
+			{},
+			defaultProps,
+			{ cart: { products: [ domainProduct ] } }
+		);
+		const wrapper = shallow( <DomainDetailsForm { ...mixedSupportProps } /> );
+
+		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 1 );
 	} );
 } );

--- a/client/my-sites/upgrades/checkout/test/domain-details-form.js
+++ b/client/my-sites/upgrades/checkout/test/domain-details-form.js
@@ -45,13 +45,13 @@ describe( 'Domain Details Form', () => {
 	const domainProduct = domainRegistration( {
 		productSlug: 'normal_domain',
 		domain: 'test.test',
+		extra: {
+			privacy_available: true
+		},
 	} );
 
 	const domainProductWithoutPrivacy = domainRegistration( {
 		productSlug: 'unprivate_domain',
-		extra: {
-			privacy_not_available: true
-		},
 	} );
 
 	it( 'does not blow up with default props', () => {

--- a/client/my-sites/upgrades/checkout/test/domain-details-form.js
+++ b/client/my-sites/upgrades/checkout/test/domain-details-form.js
@@ -55,7 +55,6 @@ describe( 'Domain Details Form', () => {
 		},
 	} );
 
-
 	const domainProductWithoutPrivacy = domainRegistration( {
 		productSlug: 'unprivate_domain',
 		extra: {

--- a/client/my-sites/upgrades/checkout/test/domain-details-form.js
+++ b/client/my-sites/upgrades/checkout/test/domain-details-form.js
@@ -1,0 +1,116 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { identity, merge } from 'lodash';
+import { domainRegistration, domainPrivacyProtection } from 'lib/cart-values/cart-items';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+const wpcomMock = {
+	undocumented: () => wpcomMock,
+	me: () => wpcomMock,
+	get: () => wpcomMock,
+	getProducts: () => wpcomMock,
+	getDomainContactInformation: () => wpcomMock,
+	bind: () => wpcomMock,
+};
+
+describe( 'Domain Details Form', () => {
+	let DomainDetailsForm;
+	// needed, because some dependency of dependency uses `window`
+	useFakeDom();
+
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'lib/analytics', {} );
+		mockery.registerMock( 'i18n-calypso', { localize: identity } );
+		mockery.registerMock( 'lib/wp', wpcomMock );
+		DomainDetailsForm = require( '../domain-details-form' );
+	} );
+
+	const defaultProps = {
+		productsList: {},
+		cart: {
+			products: [],
+		},
+		translate: identity,
+	};
+
+	const domainProduct = domainRegistration( {
+		productSlug: 'normal_domain',
+		domain: 'test.test',
+	} );
+
+	const domainProductWithoutPrivacy = domainRegistration( {
+		productSlug: 'unprivate_domain',
+		extra: {
+			privacy_not_available: true
+		},
+	} );
+
+	it( 'does not blow up with default props', () => {
+		const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+
+		expect( wrapper ).to.have.length( 1 );
+	} );
+
+	it( 'does not render privacy with no domains', () => {
+		const wrapper = shallow( <DomainDetailsForm { ...defaultProps } /> );
+
+		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 0 );
+	} );
+
+	it( 'should render the privacy upsell with a domain with privacy support', () => {
+		const propsWithDomain = merge(
+			{},
+			defaultProps,
+			{ cart: { products: [ domainProduct ] } }
+		);
+
+		const wrapper = shallow( <DomainDetailsForm { ...propsWithDomain } /> );
+
+		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 1 );
+	} );
+
+	it( 'should render privacy upsell for domain with support and privacy product', () => {
+		const privacyProduct = domainPrivacyProtection( { domain: 'test.test' } );
+
+		const propsWithDomainWithPrivacy = merge(
+			{},
+			defaultProps,
+			{ cart: { products: [ domainProduct, privacyProduct ] } }
+		);
+
+		const wrapper = shallow( <DomainDetailsForm { ...propsWithDomainWithPrivacy } /> );
+
+		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 1 );
+	} );
+
+	it( "should not render the privacy upsell with a domain that doesn't support privacy", () => {
+		const propsWithDomainWithNoPrivacy = merge(
+			{},
+			defaultProps,
+			{ cart: { products: [ domainProductWithoutPrivacy ] } }
+		);
+		const wrapper = shallow( <DomainDetailsForm { ...propsWithDomainWithNoPrivacy } /> );
+
+		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 0 );
+	} );
+
+	it( 'should not render the privacy upsell with mixed privacy support', () => {
+		const mixedSupportProps = merge(
+			{},
+			defaultProps,
+			{ cart: { products: [ domainProduct, domainProductWithoutPrivacy ] } }
+		);
+		const wrapper = shallow( <DomainDetailsForm { ...mixedSupportProps } /> );
+
+		expect( wrapper.find( 'PrivacyProtection' ) ).to.have.length( 0 );
+	} );
+} );


### PR DESCRIPTION
This is the path of least resistance to handle the fact that some upcoming TLDs do not offer private registrations.

If any of the domains in the cart doesn't support private registrations, the privacy section and privacy dialogue won't be shown at all.

In the future, we can work out the UI and logic for adding privacy to the domains that support it.

- [x] TODO: add tests 
