### PR TITLE
Signup: Refactor WpcomLoginForm component and add tests.

### DIFF
--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 const debug = require( 'debug' )( 'calypso:signup:wpcom-login' );
 
 /**
@@ -9,17 +9,18 @@ const debug = require( 'debug' )( 'calypso:signup:wpcom-login' );
  */
 import config from 'config';
 
-module.exports = React.createClass( {
-	displayName: 'WpcomLoginForm',
+export default class WpcomLoginForm extends Component {
 
-	componentDidMount: function() {
+	form = null;
+
+	componentDidMount() {
 		debug( 'submit form' );
-		this.refs.wpcomLoginForm.submit();
-	},
+		this.form.submit();
+	}
 
-	action: function() {
-		var subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/,
-			subdomain = '';
+	action() {
+		const subdomainRegExp = /^https?:\/\/([a-z0-9]*).wordpress.com/;
+		let subdomain = '';
 
 		if ( subdomainRegExp.test( this.props.redirectTo ) &&
 			config( 'hostname' ) !== 'wpcalypso.wordpress.com' &&
@@ -27,10 +28,10 @@ module.exports = React.createClass( {
 			subdomain = this.props.redirectTo.match( subdomainRegExp )[ 1 ] + '.';
 		}
 
-		return 'https://' + subdomain + 'wordpress.com/wp-login.php';
-	},
+		return `https://${ subdomain }wordpress.com/wp-login.php`;
+	}
 
-	renderExtraFields: function() {
+	renderExtraFields() {
 		const { extraFields } = this.props;
 
 		if ( ! extraFields ) {
@@ -39,16 +40,20 @@ module.exports = React.createClass( {
 
 		return (
 			<div>
-				{ Object.keys( extraFields ).map( function( field ) {
+				{ Object.keys( extraFields ).map( ( field ) => {
 					return <input key={ field } type="hidden" name={ field } value={ extraFields[ field ] } />;
 				} ) }
 			</div>
 		);
-	},
+	}
 
-	render: function() {
+	storeFormRef = ( form ) => {
+		this.form = form;
+	}
+
+	render() {
 		return (
-			<form method="post" action={ this.action() } ref="wpcomLoginForm">
+			<form method="post" action={ this.action() } ref={ this.storeFormRef }>
 				<input type="hidden" name="log" value={ this.props.log } />
 				<input type="hidden" name="pwd" value={ this.props.pwd } />
 				<input type="hidden" name="authorization" value={ this.props.authorization } />
@@ -57,4 +62,4 @@ module.exports = React.createClass( {
 			</form>
 		);
 	}
-} );
+}

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'WpcomLoginForm', () => {
+	let WpcomLoginForm, mockHostname;
+	const props = {
+		log: 'a',
+		pwd: 'b',
+		authorization: 'c',
+		redirectTo: 'https://test.wordpress.com',
+	};
+
+	useMockery( mockery => {
+		mockery.registerMock( 'config', () => mockHostname );
+	} );
+
+	before( () => {
+		WpcomLoginForm = require( '..' );
+	} );
+
+	beforeEach( () => {
+		mockHostname = 'wordpress.com';
+	} );
+
+	it( 'should render default fields as expected.', () => {
+		const wrapper = shallow(
+			<WpcomLoginForm { ...props } />
+		);
+
+		// should render root form element
+		const form = wrapper.find( 'form' );
+		expect( form ).to.have.length( 1 );
+		expect( form.prop( 'method' ) ).to.equal( 'post' );
+		expect( form.prop( 'action' ) ).to.equal( 'https://test.wordpress.com/wp-login.php' );
+
+		// form should include default hidden elements
+		expect( wrapper.find( 'form > input[type="hidden"]' ) ).to.have.length( 4 );
+		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'a' );
+		expect( wrapper.find( 'form > input[name="pwd"]' ).prop( 'value' ) ).to.equal( 'b' );
+		expect( wrapper.find( 'form > input[name="authorization"]' ).prop( 'value' ) ).to.equal( 'c' );
+		expect( wrapper.find( 'form > input[name="redirect_to"]' ).prop( 'value' ) ).to.equal( 'https://test.wordpress.com' );
+
+		// when update a prop
+		wrapper.setProps( { log: 'log' } );
+		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'log' );
+	} );
+
+	it( 'should render extra fields if extraFields prop is passed.', () => {
+		const wrapper = shallow(
+			<WpcomLoginForm
+				{ ...props }
+				extraFields={ {
+					foo: 'bar',
+					lorem: 'ipsum'
+				} }
+			/>
+		);
+
+		expect( wrapper.find( 'input[type="hidden"]' ) ).to.have.length( 6 );
+		expect( wrapper.find( 'input[name="foo"]' ).prop( 'value' ) ).to.equal( 'bar' );
+		expect( wrapper.find( 'input[name="lorem"]' ).prop( 'value' ) ).to.equal( 'ipsum' );
+	} );
+
+	it( 'its action should be under the wpcom subdomain that `redirectTo` prop contains.', () => {
+		const wrapper = shallow(
+			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />
+		);
+
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal( 'https://foo.wordpress.com/wp-login.php' );
+
+		wrapper.setProps( { redirectTo: 'https://bar.wordpress.com' } );
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal( 'https://bar.wordpress.com/wp-login.php' );
+	} );
+
+	it( 'its action should has no subdomain when `hostname` is wpcalypso.wpcom or horizon.wpcom.', () => {
+		const wrapper = shallow(
+			<WpcomLoginForm { ...props } redirectTo="https://foo.wordpress.com" />
+		);
+
+		// should has the same hostname with redirectTo prop.
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal( 'https://foo.wordpress.com/wp-login.php' );
+
+		// should be default url
+		mockHostname = 'wpcalypso.wordpress.com';
+		wrapper.setProps( { log: 'wpcalpso' } ); // to update form action
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal( 'https://wordpress.com/wp-login.php' );
+
+		// should has the same hostname with redirectTo prop.
+		mockHostname = 'bar.wordpress.com';
+		wrapper.setProps( { log: 'bar' } ); // to update form action
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal( 'https://foo.wordpress.com/wp-login.php' );
+
+		// should be default url
+		mockHostname = 'horizon.wordpress.com';
+		wrapper.setProps( { log: 'horizon' } ); // to update form action
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal( 'https://wordpress.com/wp-login.php' );
+	} );
+
+	it( 'its action should has no subdomain when `redirectTo` prop is not a subdomain of wpcom.', () => {
+		const wrapper = shallow(
+			<WpcomLoginForm { ...props } redirectTo="https://wordpress.org" />
+		);
+
+		expect( wrapper.find( 'form' ).prop( 'action' ) ).to.equal( 'https://wordpress.com/wp-login.php' );
+	} );
+} );

--- a/client/signup/wpcom-login-form/test/index.jsx
+++ b/client/signup/wpcom-login-form/test/index.jsx
@@ -13,9 +13,9 @@ import useMockery from 'test/helpers/use-mockery';
 describe( 'WpcomLoginForm', () => {
 	let WpcomLoginForm, mockHostname;
 	const props = {
-		log: 'a',
-		pwd: 'b',
-		authorization: 'c',
+		log: 'log_text',
+		pwd: 'secret',
+		authorization: 'authorization_token',
 		redirectTo: 'https://test.wordpress.com',
 	};
 
@@ -44,14 +44,14 @@ describe( 'WpcomLoginForm', () => {
 
 		// form should include default hidden elements
 		expect( wrapper.find( 'form > input[type="hidden"]' ) ).to.have.length( 4 );
-		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'a' );
-		expect( wrapper.find( 'form > input[name="pwd"]' ).prop( 'value' ) ).to.equal( 'b' );
-		expect( wrapper.find( 'form > input[name="authorization"]' ).prop( 'value' ) ).to.equal( 'c' );
+		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'log_text' );
+		expect( wrapper.find( 'form > input[name="pwd"]' ).prop( 'value' ) ).to.equal( 'secret' );
+		expect( wrapper.find( 'form > input[name="authorization"]' ).prop( 'value' ) ).to.equal( 'authorization_token' );
 		expect( wrapper.find( 'form > input[name="redirect_to"]' ).prop( 'value' ) ).to.equal( 'https://test.wordpress.com' );
 
 		// when update a prop
-		wrapper.setProps( { log: 'log' } );
-		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'log' );
+		wrapper.setProps( { log: 'another_log' } );
+		expect( wrapper.find( 'form > input[name="log"]' ).prop( 'value' ) ).to.equal( 'another_log' );
 	} );
 
 	it( 'should render extra fields if extraFields prop is passed.', () => {


### PR DESCRIPTION
This PR will:
- Turn React.createClass into ES6 class.
- Migrate the legacy string ref to a function one.
- Add test cases for the component.