### PR TITLE
Extensions: WPSC - Disable some settings if wp-cache-config.php file is read-only

### DIFF
--- a/client/extensions/wp-super-cache/accepted-filenames.jsx
+++ b/client/extensions/wp-super-cache/accepted-filenames.jsx
@@ -23,6 +23,7 @@ class AcceptedFilenames extends Component {
 		fields: PropTypes.object,
 		handleChange: PropTypes.func.isRequired,
 		handleSubmitForm: PropTypes.func.isRequired,
+		isReadOnly: PropTypes.bool.isRequired,
 		isRequesting: PropTypes.bool,
 		isSaving: PropTypes.bool,
 		setFieldValue: PropTypes.func.isRequired,
@@ -38,6 +39,7 @@ class AcceptedFilenames extends Component {
 	renderToggle = ( fieldName, fieldLabel ) => {
 		const {
 			fields: { pages },
+			isReadOnly,
 			isRequesting,
 			isSaving,
 		} = this.props;
@@ -45,7 +47,7 @@ class AcceptedFilenames extends Component {
 		return (
 			<FormToggle
 				checked={ !! pages && !! pages[ fieldName ] }
-				disabled={ isRequesting || isSaving }
+				disabled={ isRequesting || isSaving || isReadOnly }
 				onChange={ this.handleToggle( fieldName ) }>
 				<span>
 					{ fieldLabel }
@@ -77,6 +79,7 @@ class AcceptedFilenames extends Component {
 			fields,
 			handleChange,
 			handleSubmitForm,
+			isReadOnly,
 			isRequesting,
 			isSaving,
 			translate,
@@ -85,6 +88,7 @@ class AcceptedFilenames extends Component {
 			cache_acceptable_files,
 			cache_rejected_uri,
 		} = fields;
+		const isDisabled = isRequesting || isSaving || isReadOnly;
 
 		return (
 			<div>
@@ -92,7 +96,7 @@ class AcceptedFilenames extends Component {
 					<Button
 						compact
 						primary
-						disabled={ isRequesting || isSaving }
+						disabled={ isDisabled }
 						onClick={ handleSubmitForm }>
 						{ isSaving
 							? translate( 'Saving…' )
@@ -142,7 +146,7 @@ class AcceptedFilenames extends Component {
 								{ translate( 'Do not cache pages that contain the following strings:' ) }
 							</FormLabel>
 							<FormTextarea
-								disabled={ isRequesting || isSaving }
+								disabled={ isDisabled }
 								onChange={ handleChange( 'cache_rejected_uri' ) }
 								value={ cache_rejected_uri } />
 							<FormSettingExplanation>
@@ -160,7 +164,7 @@ class AcceptedFilenames extends Component {
 								{ translate( 'Whitelisted filenames:' ) }
 							</FormLabel>
 							<FormTextarea
-								disabled={ isRequesting || isSaving }
+								disabled={ isDisabled }
 								onChange={ handleChange( 'cache_acceptable_files' ) }
 								value={ cache_acceptable_files } />
 							<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/advanced-tab.jsx
+++ b/client/extensions/wp-super-cache/advanced-tab.jsx
@@ -28,24 +28,25 @@ const AdvancedTab = ( {
 		is_cache_enabled,
 		is_super_cache_enabled,
 	},
+	isReadOnly,
 	notices,
 	siteId,
 } ) => {
 	return (
 		<div>
 			<QueryNotices siteId={ siteId } />
-			<Caching notices={ notices } />
-			<Miscellaneous notices={ notices } />
-			<Advanced />
-			<CacheLocation />
-			<ExpiryTime />
-			<AcceptedFilenames />
-			<RejectedUserAgents />
-			<LockDown />
+			<Caching isReadOnly={ isReadOnly } notices={ notices } />
+			<Miscellaneous isReadOnly={ isReadOnly } notices={ notices } />
+			<Advanced isReadOnly={ isReadOnly } />
+			<CacheLocation isReadOnly={ isReadOnly } />
+			<ExpiryTime isReadOnly={ isReadOnly } />
+			<AcceptedFilenames isReadOnly={ isReadOnly } />
+			<RejectedUserAgents isReadOnly={ isReadOnly } />
+			<LockDown isReadOnly={ isReadOnly } />
 			{ is_cache_enabled && is_super_cache_enabled &&
 				<DirectlyCachedFiles notices={ notices } />
 			}
-			<FixConfig />
+			<FixConfig isReadOnly={ isReadOnly } />
 		</div>
 	);
 };
@@ -55,9 +56,7 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const notices = getNotices( state, siteId );
 
-		return {
-			notices,
-		};
+		return { notices };
 	}
 );
 

--- a/client/extensions/wp-super-cache/advanced.jsx
+++ b/client/extensions/wp-super-cache/advanced.jsx
@@ -31,10 +31,13 @@ const Advanced = ( {
 		refresh_current_only_on_comments,
 	},
 	handleAutosavingToggle,
+	isReadOnly,
 	isRequesting,
 	isSaving,
 	translate,
 } ) => {
+	const isDisabled = isRequesting || isSaving || isReadOnly;
+
 	return (
 		<div>
 			<SectionHeader
@@ -45,7 +48,7 @@ const Advanced = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! is_mfunc_enabled }
-							disabled={ isRequesting || isSaving || !! cache_mod_rewrite }
+							disabled={ isDisabled || !! cache_mod_rewrite }
 							onChange={ handleAutosavingToggle( 'is_mfunc_enabled' ) }>
 							<span>
 								{ translate(
@@ -68,7 +71,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! is_mobile_enabled }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'is_mobile_enabled' ) }>
 							<span>
 								{ translate(
@@ -116,7 +119,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! disable_utf8 }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'disable_utf8' ) }>
 							<span>
 								{ translate(
@@ -128,7 +131,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! clear_cache_on_post_edit }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'clear_cache_on_post_edit' ) }>
 							<span>
 								{ translate( 'Clear all cache files when a post or page is published or updated.' ) }
@@ -137,7 +140,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! front_page_checks }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'front_page_checks' ) }>
 							<span>
 								{ translate(
@@ -151,7 +154,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! refresh_current_only_on_comments }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'refresh_current_only_on_comments' ) }>
 							<span>
 								{ translate( 'Only refresh current page when comments made.' ) }
@@ -160,7 +163,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! cache_list }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_list' ) }>
 							<span>
 								{ translate( 'List the newest cached pages on this page.' ) }
@@ -169,7 +172,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ ! cache_disable_locking }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_disable_locking' ) }>
 							<span>
 								{ translate( 'Coarse file locking. You do not need this as it will slow down your website.' ) }
@@ -178,7 +181,7 @@ const Advanced = ( {
 
 						<FormToggle
 							checked={ !! cache_late_init }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_late_init' ) }>
 							<span>
 								{ translate(

--- a/client/extensions/wp-super-cache/cache-location.jsx
+++ b/client/extensions/wp-super-cache/cache-location.jsx
@@ -21,17 +21,20 @@ const CacheLocation = ( {
 	},
 	handleChange,
 	handleSubmitForm,
+	isReadOnly,
 	isRequesting,
 	isSaving,
 	translate,
 } ) => {
+	const isDisabled = isRequesting || isSaving || isReadOnly;
+
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Cache Location' ) }>
 				<Button
 					compact
 					primary
-					disabled={ isRequesting || isSaving }
+					disabled={ isDisabled }
 					onClick={ handleSubmitForm }>
 					{ isSaving
 						? translate( 'Saving…' )
@@ -43,7 +46,7 @@ const CacheLocation = ( {
 				<form>
 					<FormFieldset>
 						<FormTextInput
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleChange( 'cache_path' ) }
 							value={ cache_path || '' } />
 						<FormSettingExplanation>

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -26,6 +26,7 @@ const Caching = ( {
 	handleAutosavingToggle,
 	handleRadio,
 	handleSubmitForm,
+	isReadOnly,
 	isRequesting,
 	isSaving,
 	notices: {
@@ -34,6 +35,7 @@ const Caching = ( {
 	},
 	translate,
 } ) => {
+	const isDisabled = isRequesting || isSaving || isReadOnly;
 	const htaccessMessage = get( htaccess_ro, 'message' );
 	const modRewriteMessage = get( mod_rewrite_missing, 'message' );
 
@@ -43,7 +45,7 @@ const Caching = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting || isSaving }
+					disabled={ isDisabled }
 					onClick={ handleSubmitForm }>
 					{ isSaving
 						? translate( 'Saving…' )
@@ -69,7 +71,7 @@ const Caching = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! is_cache_enabled }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }>
 							<span>
 								{ translate( 'Enable Page Caching' ) }
@@ -81,7 +83,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ 'mod_rewrite' === cache_type }
-								disabled={ isRequesting || isSaving || ! is_cache_enabled }
+								disabled={ isDisabled || ! is_cache_enabled }
 								name="cache_type"
 								onChange={ handleRadio }
 								value="mod_rewrite" />
@@ -93,7 +95,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ 'PHP' === cache_type }
-								disabled={ isRequesting || isSaving || ! is_cache_enabled }
+								disabled={ isDisabled || ! is_cache_enabled }
 								name="cache_type"
 								onChange={ handleRadio }
 								value="PHP" />
@@ -110,7 +112,7 @@ const Caching = ( {
 						<FormLabel>
 							<FormRadio
 								checked={ 'wpcache' === cache_type }
-								disabled={ isRequesting || isSaving || ! is_cache_enabled }
+								disabled={ isDisabled || ! is_cache_enabled }
 								name="cache_type"
 								onChange={ handleRadio }
 								value="wpcache" />

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -36,6 +36,7 @@ class ContentsTab extends Component {
 		handleDeleteCache: PropTypes.func.isRequired,
 		isDeleting: PropTypes.bool,
 		isMultisite: PropTypes.bool,
+		isReadOnly: PropTypes.bool.isRequired,
 		site: PropTypes.object.isRequired,
 		siteTitle: PropTypes.string,
 		translate: PropTypes.func.isRequired,
@@ -116,9 +117,11 @@ class ContentsTab extends Component {
 			isDeleting,
 			isGenerating,
 			isMultisite,
+			isReadOnly,
 			stats,
 			translate,
 		} = this.props;
+		const isDisabled = isDeleting || isReadOnly;
 		const supercache = ( get( stats, 'supercache', {} ) );
 		const wpcache = ( get( stats, 'wpcache', {} ) );
 
@@ -236,14 +239,14 @@ class ContentsTab extends Component {
 							compact
 							primary
 							busy={ this.state.isDeletingExpired }
-							disabled={ isDeleting }
+							disabled={ isDisabled }
 							onClick={ this.deleteExpiredCache }>
 							{ translate( 'Delete Expired' ) }
 						</Button>
 						<Button
 							compact
 							busy={ this.state.isDeleting }
-							disabled={ isDeleting }
+							disabled={ isDisabled }
 							onClick={ this.deleteCache }>
 							{ translate( 'Delete Cache' ) }
 						</Button>
@@ -251,7 +254,7 @@ class ContentsTab extends Component {
 							<Button
 								compact
 								busy={ this.state.isDeletingAll }
-								disabled={ isDeleting }
+								disabled={ isDisabled }
 								onClick={ this.deleteAllCaches }>
 								{ translate( 'Delete Cache On All Blogs' ) }
 							</Button>

--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -29,6 +29,7 @@ class EasyTab extends Component {
 		handleAutosavingToggle: PropTypes.func.isRequired,
 		handleDeleteCache: PropTypes.func.isRequired,
 		isDeleting: PropTypes.bool,
+		isReadOnly: PropTypes.bool.isRequired,
 		isRequesting: PropTypes.bool,
 		isSaving: PropTypes.bool,
 		isTesting: PropTypes.bool,
@@ -85,6 +86,7 @@ class EasyTab extends Component {
 			},
 			handleAutosavingToggle,
 			isDeleting,
+			isReadOnly,
 			isRequesting,
 			isSaving,
 			isTesting,
@@ -107,7 +109,7 @@ class EasyTab extends Component {
 					<form>
 						<FormToggle
 							checked={ !! is_cache_enabled }
-							disabled={ isRequesting || isSaving }
+							disabled={ isRequesting || isSaving || isReadOnly }
 							onChange={ handleAutosavingToggle( 'is_cache_enabled' ) }>
 							<span>
 								{ translate( 'Enable Page Caching' ) }
@@ -196,7 +198,7 @@ class EasyTab extends Component {
 						<Button
 							compact
 							busy={ this.state.isDeleting }
-							disabled={ isDeleting }
+							disabled={ isDeleting || isReadOnly }
 							name="wp_delete_cache"
 							onClick={ this.deleteCache }>
 							{ translate( 'Delete Cache' ) }
@@ -205,7 +207,7 @@ class EasyTab extends Component {
 							<Button
 								compact
 								busy={ this.state.isDeletingAll }
-								disabled={ isDeleting }
+								disabled={ isDeleting || isReadOnly }
 								name="wp_delete_all_cache"
 								onClick={ this.deleteAllCaches }>
 								{ translate( 'Delete Cache On All Blogs' ) }

--- a/client/extensions/wp-super-cache/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/expiry-time.jsx
@@ -36,10 +36,13 @@ const ExpiryTime = ( {
 	handleRadio,
 	handleSelect,
 	handleSubmitForm,
+	isReadOnly,
 	isRequesting,
 	isSaving,
 	translate,
 } ) => {
+	const isDisabled = isRequesting || isSaving || isReadOnly;
+
 	const renderCacheTimeout = () => {
 		return (
 			<FormFieldset>
@@ -49,7 +52,7 @@ const ExpiryTime = ( {
 
 				<FormTextInput
 					className="wp-super-cache__cache-timeout"
-					disabled={ isRequesting || isSaving }
+					disabled={ isDisabled }
 					onChange={ handleChange( 'cache_max_time' ) }
 					value={ cache_max_time || '' } />
 				{ translate( 'seconds' ) }
@@ -75,14 +78,14 @@ const ExpiryTime = ( {
 				<FormLabel>
 					<FormRadio
 						checked={ 'interval' === cache_schedule_type }
-						disabled={ isRequesting || isSaving }
+						disabled={ isDisabled }
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="interval" />
 					<span>
 						{ translate( 'Timer' ) }
 						<FormTextInput
-							disabled={ isRequesting || isSaving || ( 'interval' !== cache_schedule_type ) }
+							disabled={ isDisabled || ( 'interval' !== cache_schedule_type ) }
 							onChange={ handleChange( 'cache_time_interval' ) }
 							value={ cache_time_interval || '' } />
 						{ translate( 'seconds' ) }
@@ -95,14 +98,14 @@ const ExpiryTime = ( {
 				<FormLabel className="wp-super-cache__clock">
 					<FormRadio
 						checked={ 'time' === cache_schedule_type }
-						disabled={ isRequesting || isSaving }
+						disabled={ isDisabled }
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="time" />
 					<span>
 						{ translate( 'Clock' ) }
 						<FormTextInput
-							disabled={ isRequesting || isSaving || ( 'time' !== cache_schedule_type ) }
+							disabled={ isDisabled || ( 'time' !== cache_schedule_type ) }
 							onChange={ handleChange( 'cache_scheduled_time' ) }
 							value={ cache_scheduled_time || '' } />
 						{ translate( 'HH:MM' ) }
@@ -119,7 +122,7 @@ const ExpiryTime = ( {
 					</FormLabel>
 
 					<FormSelect
-						disabled={ isRequesting || isSaving || ( 'time' !== cache_schedule_type ) }
+						disabled={ isDisabled || ( 'time' !== cache_schedule_type ) }
 						id="cache_schedule_interval"
 						name="cache_schedule_interval"
 						onChange={ handleSelect }
@@ -146,7 +149,7 @@ const ExpiryTime = ( {
 
 				<FormToggle
 					checked={ !! cache_gc_email_me }
-					disabled={ isRequesting || isSaving }
+					disabled={ isDisabled }
 					id="cache_gc_email_me"
 					onChange={ handleAutosavingToggle( 'cache_gc_email_me' ) }>
 					<span>
@@ -171,7 +174,7 @@ const ExpiryTime = ( {
 				<Button
 					compact
 					primary
-					disabled={ isRequesting || isSaving }
+					disabled={ isDisabled }
 					onClick={ handleSubmitForm }>
 					{ isSaving
 						? translate( 'Saving…' )

--- a/client/extensions/wp-super-cache/fix-config.jsx
+++ b/client/extensions/wp-super-cache/fix-config.jsx
@@ -18,6 +18,7 @@ import { isRestoringSettings } from './state/settings/selectors';
 
 class FixConfig extends Component {
 	static propTypes = {
+		isReadOnly: PropTypes.bool.isRequired,
 		isRestoring: PropTypes.bool.isRequired,
 		restoreSettings: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
@@ -27,7 +28,11 @@ class FixConfig extends Component {
 	restoreSettings = () => this.props.restoreSettings( this.props.siteId );
 
 	render() {
-		const { isRestoring, translate } = this.props;
+		const {
+			isReadOnly,
+			isRestoring,
+			translate,
+		} = this.props;
 
 		return (
 			<div>
@@ -36,7 +41,7 @@ class FixConfig extends Component {
 					<Button
 						compact
 						busy={ isRestoring }
-						disabled={ isRestoring }
+						disabled={ isRestoring || isReadOnly }
 						onClick={ this.restoreSettings }>
 						{ translate( 'Restore Default Configuration' ) }
 					</Button>

--- a/client/extensions/wp-super-cache/lock-down.jsx
+++ b/client/extensions/wp-super-cache/lock-down.jsx
@@ -22,6 +22,7 @@ const LockDown = ( {
 		cache_lock_down,
 	},
 	handleAutosavingToggle,
+	isReadOnly,
 	isRequesting,
 	isSaving,
 	translate,
@@ -39,7 +40,7 @@ const LockDown = ( {
 					<FormFieldset>
 						<FormToggle
 							checked={ !! cache_lock_down }
-							disabled={ isRequesting || isSaving }
+							disabled={ isRequesting || isSaving || isReadOnly }
 							onChange={ handleAutosavingToggle( 'cache_lock_down' ) }>
 							<span>
 								{ translate( 'Enable lock down to prepare your server for an expected spike in traffic.' ) }

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -29,7 +29,7 @@ const WPSuperCache = ( { notices, site, siteId, tab } ) => {
 			case Tabs.CDN:
 				return <CdnTab />;
 			case Tabs.CONTENTS:
-				return <ContentsTab />;
+				return <ContentsTab isReadOnly={ isReadOnly } />;
 			case Tabs.PRELOAD:
 				return <PreloadTab />;
 			default:

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -57,11 +57,12 @@ class WPSuperCache extends Component {
 			siteId,
 			tab,
 		} = this.props;
+		const mainClassName = 'wp-super-cache__main';
 		const cacheDisabled = get( notices, 'cache_disabled' );
 		const cacheDisabledMessage = get( notices.cache_disabled, 'message' );
 
 		return (
-			<Main className="wp-super-cache__main">
+			<Main className={ mainClassName }>
 				<QueryNotices siteId={ siteId } />
 
 				{ cacheDisabled &&

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -25,7 +25,7 @@ const WPSuperCache = ( { notices, site, siteId, tab } ) => {
 	const renderTab = isReadOnly => {
 		switch ( tab ) {
 			case Tabs.ADVANCED:
-				return <AdvancedTab />;
+				return <AdvancedTab isReadOnly={ isReadOnly } />;
 			case Tabs.CDN:
 				return <CdnTab />;
 			case Tabs.CONTENTS:

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -22,7 +22,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getNotices } from './state/notices/selectors';
 
 const WPSuperCache = ( { notices, site, siteId, tab } ) => {
-	const renderTab = () => {
+	const renderTab = isReadOnly => {
 		switch ( tab ) {
 			case Tabs.ADVANCED:
 				return <AdvancedTab />;
@@ -33,7 +33,7 @@ const WPSuperCache = ( { notices, site, siteId, tab } ) => {
 			case Tabs.PRELOAD:
 				return <PreloadTab />;
 			default:
-				return <EasyTab />;
+				return <EasyTab isReadOnly={ isReadOnly } />;
 		}
 	};
 
@@ -52,7 +52,7 @@ const WPSuperCache = ( { notices, site, siteId, tab } ) => {
 			}
 
 			<Navigation activeTab={ tab } site={ site } />
-			{ renderTab() }
+			{ renderTab( !! cacheDisabled ) }
 		</Main>
 	);
 };

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,12 +12,16 @@ import AdvancedTab from './advanced-tab';
 import CdnTab from './cdn-tab';
 import ContentsTab from './contents-tab';
 import EasyTab from './easy-tab';
-import PreloadTab from './preload-tab';
 import Main from 'components/main';
 import Navigation from './navigation';
+import Notice from 'components/notice';
+import PreloadTab from './preload-tab';
+import QueryNotices from './data/query-notices';
 import { Tabs } from './constants';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getNotices } from './state/notices/selectors';
 
-const WPSuperCache = ( { site, tab } ) => {
+const WPSuperCache = ( { notices, site, siteId, tab } ) => {
 	const renderTab = () => {
 		switch ( tab ) {
 			case Tabs.ADVANCED:
@@ -31,8 +37,20 @@ const WPSuperCache = ( { site, tab } ) => {
 		}
 	};
 
+	const cacheDisabled = get( notices, 'cache_disabled' );
+	const cacheDisabledMessage = get( notices.cache_disabled, 'message' );
+
 	return (
 		<Main className="wp-super-cache__main">
+			<QueryNotices siteId={ siteId } />
+
+			{ cacheDisabled &&
+			<Notice
+				showDismiss={ false }
+				status="is-error"
+				text={ cacheDisabledMessage } />
+			}
+
 			<Navigation activeTab={ tab } site={ site } />
 			{ renderTab() }
 		</Main>
@@ -40,12 +58,25 @@ const WPSuperCache = ( { site, tab } ) => {
 };
 
 WPSuperCache.propTypes = {
-	site: React.PropTypes.object,
+	notices: PropTypes.object.isRequired,
+	site: PropTypes.object,
+	siteId: PropTypes.number,
 	tab: PropTypes.string,
 };
 
 WPSuperCache.defaultProps = {
-	tab: ''
+	tab: '',
 };
 
-export default WPSuperCache;
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			notices: getNotices( state, siteId ),
+			siteId,
+		};
+	}
+);
+
+export default connectComponent( WPSuperCache );

--- a/client/extensions/wp-super-cache/main.jsx
+++ b/client/extensions/wp-super-cache/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 
@@ -21,8 +21,21 @@ import { Tabs } from './constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getNotices } from './state/notices/selectors';
 
-const WPSuperCache = ( { notices, site, siteId, tab } ) => {
-	const renderTab = isReadOnly => {
+class WPSuperCache extends Component {
+	static propTypes = {
+		notices: PropTypes.object.isRequired,
+		site: PropTypes.object,
+		siteId: PropTypes.number,
+		tab: PropTypes.string,
+	};
+
+	static defaultProps = {
+		tab: '',
+	};
+
+	renderTab( isReadOnly ) {
+		const { tab } = this.props;
+
 		switch ( tab ) {
 			case Tabs.ADVANCED:
 				return <AdvancedTab isReadOnly={ isReadOnly } />;
@@ -35,38 +48,35 @@ const WPSuperCache = ( { notices, site, siteId, tab } ) => {
 			default:
 				return <EasyTab isReadOnly={ isReadOnly } />;
 		}
-	};
+	}
 
-	const cacheDisabled = get( notices, 'cache_disabled' );
-	const cacheDisabledMessage = get( notices.cache_disabled, 'message' );
+	render() {
+		const {
+			notices,
+			site,
+			siteId,
+			tab,
+		} = this.props;
+		const cacheDisabled = get( notices, 'cache_disabled' );
+		const cacheDisabledMessage = get( notices.cache_disabled, 'message' );
 
-	return (
-		<Main className="wp-super-cache__main">
-			<QueryNotices siteId={ siteId } />
+		return (
+			<Main className="wp-super-cache__main">
+				<QueryNotices siteId={ siteId } />
 
-			{ cacheDisabled &&
-			<Notice
-				showDismiss={ false }
-				status="is-error"
-				text={ cacheDisabledMessage } />
-			}
+				{ cacheDisabled &&
+				<Notice
+					showDismiss={ false }
+					status="is-error"
+					text={ cacheDisabledMessage } />
+				}
 
-			<Navigation activeTab={ tab } site={ site } />
-			{ renderTab( !! cacheDisabled ) }
-		</Main>
-	);
-};
-
-WPSuperCache.propTypes = {
-	notices: PropTypes.object.isRequired,
-	site: PropTypes.object,
-	siteId: PropTypes.number,
-	tab: PropTypes.string,
-};
-
-WPSuperCache.defaultProps = {
-	tab: '',
-};
+				<Navigation activeTab={ tab } site={ site } />
+				{ this.renderTab( !! cacheDisabled ) }
+			</Main>
+		);
+	}
+}
 
 const connectComponent = connect(
 	( state ) => {

--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -27,11 +27,13 @@ const Miscellaneous = ( {
 		use_304_headers,
 	},
 	handleAutosavingToggle,
+	isReadOnly,
 	isRequesting,
 	isSaving,
 	notices,
 	translate,
 } ) => {
+	const isDisabled = isRequesting || isSaving || isReadOnly;
 	const compressionDisabled = notices && notices.compression_disabled;
 
 	return (
@@ -51,7 +53,7 @@ const Miscellaneous = ( {
 						{ ! compressionDisabled &&
 						<FormToggle
 							checked={ !! cache_compression }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_compression' ) }>
 							<span>
 								{ translate(
@@ -66,7 +68,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! dont_cache_logged_in }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'dont_cache_logged_in' ) }>
 							<span>
 								{ translate(
@@ -80,7 +82,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! cache_rebuild }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_rebuild' ) }>
 							<span>
 								{ translate(
@@ -95,7 +97,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! use_304_headers }
-							disabled={ isRequesting || isSaving || !! cache_mod_rewrite }
+							disabled={ isDisabled || !! cache_mod_rewrite }
 							onChange={ handleAutosavingToggle( 'use_304_headers' ) }>
 							<span>
 								{ translate(
@@ -129,7 +131,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! no_cache_for_get }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'no_cache_for_get' ) }>
 							<span>
 								{ translate( 'Don’t cache pages with GET parameters. (?x=y at the end of a url)' ) }
@@ -138,7 +140,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! make_known_anon }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'make_known_anon' ) }>
 							<span>
 								{ translate( 'Make known users anonymous so they’re served supercached static files.' ) }
@@ -147,7 +149,7 @@ const Miscellaneous = ( {
 
 						<FormToggle
 							checked={ !! cache_hello_world }
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleAutosavingToggle( 'cache_hello_world' ) }>
 							<span>
 								{ translate( 'Proudly tell the world your server is {{fry}}Stephen Fry proof{{/fry}}! ' +

--- a/client/extensions/wp-super-cache/rejected-user-agents.jsx
+++ b/client/extensions/wp-super-cache/rejected-user-agents.jsx
@@ -21,17 +21,20 @@ const RejectedUserAgents = ( {
 	},
 	handleChange,
 	handleSubmitForm,
+	isReadOnly,
 	isRequesting,
 	isSaving,
 	translate,
 } ) => {
+	const isDisabled = isRequesting || isSaving || isReadOnly;
+
 	return (
 		<div>
 			<SectionHeader label={ translate( 'Rejected User Agents' ) }>
 				<Button
 					compact
 					primary
-					disabled={ isRequesting || isSaving }
+					disabled={ isDisabled }
 					onClick={ handleSubmitForm }>
 					{ isSaving
 						? translate( 'Saving…' )
@@ -43,7 +46,7 @@ const RejectedUserAgents = ( {
 				<form>
 					<FormFieldset>
 						<FormTextarea
-							disabled={ isRequesting || isSaving }
+							disabled={ isDisabled }
 							onChange={ handleChange( 'cache_rejected_user_agent' ) }
 							value={ cache_rejected_user_agent } />
 						<FormSettingExplanation>


### PR DESCRIPTION
The WP Super Cache plugin disables some settings and displays the following notice if the `wp-cache-config.php` file is read-only:

![plugin-read-only-notice](https://cloud.githubusercontent.com/assets/1190420/26554682/8489fccc-445f-11e7-9632-ff0c3a3ddbc0.jpg)

This PR adds a similar notice to Calypso, the text of which comes from the API (I've asked for more information to be added to the notice that tells the user what they need to do to correct the problem):

![read-only-notice](https://cloud.githubusercontent.com/assets/1190420/26554618/16d02a62-445f-11e7-9dcc-013c288bcf23.jpg)

It also disables the following settings to match what the plugin does:
- _Caching_ and _Delete Cached Pages_ sections of the _Easy_ tab.
- All sections of the _Advanced_ tab except _Directly Cached Files_.
- _Delete Expired_, _Delete Cache_ and _Delete Cache on All Blogs_ buttons of the _Contents_ tab.