### PR TITLE
WooCommerce: Switch to the darker gray variable meant for text

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -225,7 +225,7 @@
 }
 
 .products__product-form-sku {
-		color: $gray;
+		color: $gray-text-min;
 }
 
 .products__variation-settings-link {
@@ -358,7 +358,7 @@
 .products__additional-details-preview-label {
 	text-transform: uppercase;
 	font-size: 11px;
-	color: $gray;
+	color: $gray-text-min;
 }
 
 .products__additional-details-preview-title {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -8,7 +8,7 @@
 	p.payments__method-suggested {
 		font-size: 11px;
 		text-transform: uppercase;
-		color: $gray;
+		color: $gray-text-min;
 	}
 
 	p.payments__method-suggested,

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -1,6 +1,6 @@
 .shipping__credit-card-description {
 	margin-bottom: 4px;
-	color: $gray;
+	color: $gray-text-min;
 	padding-bottom: 8px;
 	font-size: 12px;
 	line-height: 18px;
@@ -69,7 +69,7 @@
 .shipping__zones-row-method-description,
 .shipping__card-name {
 	margin-bottom: 0;
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 13px;
 }
 
@@ -127,7 +127,7 @@
 
 .shipping__card-date {
 	float: right;
-	color: $gray;
+	color: $gray-text-min;
 	font-style: italic;
 }
 

--- a/client/extensions/woocommerce/components/extended-header/style.scss
+++ b/client/extensions/woocommerce/components/extended-header/style.scss
@@ -5,7 +5,7 @@
 }
 
 .extended-header__header-description {
-	color: $gray;
+	color: $gray-text-min;
 	font-size: 12px;
 	line-height: 18px;
 	padding-bottom: 8px;


### PR DESCRIPTION
In #11368 a color variable was added, `$gray-text-min`, which is meant to be the lightest grey we can use on a white background for the text to have sufficient color contrast. This PR updates the few places in the WooCommerce extension where we've used `$gray` instead, which is too light.