### PR TITLE
WooCommerce: Switch to extension-based paths, rather than file-relative paths

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -13,13 +13,13 @@ import Main from 'components/main';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { successNotice, errorNotice } from 'state/notices/actions';
 
-import { editProduct, editProductAttribute } from '../../state/ui/products/actions';
-import { getCurrentlyEditingProduct } from '../../state/ui/products/selectors';
-import { getProductVariationsWithLocalEdits } from '../../state/ui/products/variations/selectors';
-import { editProductVariation } from '../../state/ui/products/variations/actions';
-import { fetchProductCategories } from '../../state/wc-api/product-categories/actions';
-import { getProductCategories } from '../../state/wc-api/product-categories/selectors';
-import { createProduct } from '../../state/wc-api/products/actions';
+import { editProduct, editProductAttribute } from 'woocommerce/state/ui/products/actions';
+import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
+import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
+import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
+import { fetchProductCategories } from 'woocommerce/state/wc-api/product-categories/actions';
+import { getProductCategories } from 'woocommerce/state/wc-api/product-categories/selectors';
+import { createProduct } from 'woocommerce/state/wc-api/products/actions';
 import ProductForm from './product-form';
 import ProductHeader from './product-header';
 

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormCurrencyInput from 'components/forms/form-currency-input';
-import FormDimensionsInput from '../../components/form-dimensions-input';
+import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import formattedVariationName from '../../lib/formatted-variation-name';
+import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -7,9 +7,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import formattedVariationName from '../../lib/formatted-variation-name';
+import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
 import FormCurrencyInput from 'components/forms/form-currency-input';
-import FormDimensionsInput from '../../components/form-dimensions-input';
+import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -10,7 +10,7 @@ import { find, isNumber } from 'lodash';
  */
 import Dialog from 'components/dialog';
 import FormCurrencyInput from 'components/forms/form-currency-input';
-import FormDimensionsInput from '../../components/form-dimensions-input';
+import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import CompactFormToggle from 'components/forms/form-toggle/compact';

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -8,7 +8,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import ActionHeader from '../../components/action-header';
+import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 
 const ProductHeader = ( { onTrash, onSave, translate } ) => {

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -8,8 +8,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import ListItem from '../../../components/list/list-item';
-import ListItemField from '../../../components/list/list-item-field';
+import ListItem from 'woocommerce/components/list/list-item';
+import ListItemField from 'woocommerce/components/list/list-item-field';
 
 const PaymentMethodItem = ( { method, translate } ) => {
 	return (

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -9,14 +9,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AddressView from '../../../components/address-view';
+import AddressView from 'woocommerce/components/address-view';
 import Card from 'components/card';
-import ExtendedHeader from '../../../components/extended-header';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 import FormSelect from 'components/forms/form-select';
 
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getPaymentCurrencySettings } from '../../../state/wc-api/settings/general/selectors';
-import { fetchSettingsGeneral } from '../../../state/wc-api/settings/general/actions';
+import { getPaymentCurrencySettings } from 'woocommerce/state/wc-api/settings/general/selectors';
+import { fetchSettingsGeneral } from 'woocommerce/state/wc-api/settings/general/actions';
 
 class SettingsPaymentsLocationCurrency extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/settings/payments/payments-off-site.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-off-site.js
@@ -9,12 +9,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ExtendedHeader from '../../../components/extended-header';
-import { fetchPaymentMethods } from '../../../state/wc-api/payment-methods/actions';
-import { getPaymentMethodsGroup } from '../../../state/wc-api/payment-methods/selectors';
-import List from '../../../components/list/list';
-import ListHeader from '../../../components/list/list-header';
-import ListItemField from '../../../components/list/list-item-field';
+import ExtendedHeader from 'woocommerce/components/extended-header';
+import { fetchPaymentMethods } from 'woocommerce/state/wc-api/payment-methods/actions';
+import { getPaymentMethodsGroup } from 'woocommerce/state/wc-api/payment-methods/selectors';
+import List from 'woocommerce/components/list/list';
+import ListHeader from 'woocommerce/components/list/list-header';
+import ListItemField from 'woocommerce/components/list/list-item-field';
 import PaymentMethodItem from './payment-method-item';
 
 class SettingsPaymentsOffSite extends Component {

--- a/client/extensions/woocommerce/app/settings/payments/payments-offline.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-offline.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import ExtendedHeader from '../../../components/extended-header';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 
 class SettingsPaymentsOffline extends Component {
 

--- a/client/extensions/woocommerce/app/settings/payments/payments-on-site.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-on-site.js
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import ExtendedHeader from '../../../components/extended-header';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 
 class SettingsPaymentsOnSite extends Component {
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-labels.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-labels.js
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import ExtendedHeader from '../../../components/extended-header';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
@@ -7,9 +7,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AddressView from '../../../components/address-view';
+import AddressView from 'woocommerce/components/address-view';
 import Card from 'components/card';
-import ExtendedHeader from '../../../components/extended-header';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 import Notice from 'components/notice';
 
 class ShippingOrigin extends Component {

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-package-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-package-list.js
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import ExtendedHeader from '../../../components/extended-header';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 import ShippingPackage from './shipping-package';
 
 class ShippingPackageList extends Component {

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import ExtendedHeader from '../../../components/extended-header';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 import ShippingZone from './shipping-zone';
 import ShippingZoneDialog from './shipping-zone-dialog';
 


### PR DESCRIPTION
After some discussion in slack, we're going to use extension-relative paths for components, state, and lib — which will make it clear when we're using our custom components, and also remove the fragility (and mental overhead) of multiple levels of nested `../`s. Webpack will already search within `client/extensions`, so we can just start using `woocommerce/components/*` etc.

This PR updates all existing imports from `components`, `state`, and `lib`. I've tested by running the extension tests, and by clicking through the existing pages.