### PR TITLE
me/Sites use the new site_activity query parameter

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -88,7 +88,7 @@ export function requestSites() {
 		dispatch( {
 			type: SITES_REQUEST
 		} );
-		return wpcom.me().sites( { site_visibility: 'all', include_domain_only: true } ).then( ( response ) => {
+		return wpcom.me().sites( { site_visibility: 'all', include_domain_only: true, site_activity: 'active' } ).then( ( response ) => {
 			dispatch( receiveSites( response.sites ) );
 			dispatch( {
 				type: SITES_REQUEST_SUCCESS

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -85,7 +85,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true' )
+					.get( '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active' )
 					.reply( 200, {
 						sites: [
 							{ ID: 2916284, name: 'WordPress.com Example Blog' },
@@ -123,7 +123,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true' )
+					.get( '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active' )
 					.reply( 403, {
 						error: 'authorization_required',
 						message: 'An active access token must be used to access sites.'


### PR DESCRIPTION
Hides inactive jetpack sites. To make to declutter a users sites list.
Currently if a user has not correctly disconnected a Jetpack site they still show up on calypso and add confusion. This PR would help by just removing them since they can add a lot of confusion.


Similar to https://github.com/Automattic/wp-calypso/pull/14532

To test
Apply the following to you sandbox D5799-code and make sure your browser is talking to your sandbox api.

Then any site that is marked as disconnected will not be visible any more in calypso.