### PR TITLE
Signup: Remove `sites-list` usage from the signup library.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -19,7 +19,6 @@ import page from 'page';
  * Internal dependencies
  */
 import wpcom from 'lib/wp' ;
-const sites = require( 'lib/sites-list' )();
 const user = require( 'lib/user' )();
 import { getSavedVariations } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
@@ -147,21 +146,6 @@ function createSiteWithCart( callback, dependencies, {
 	} );
 }
 
-function fetchSitesUntilSiteAppears( siteSlug, callback ) {
-	if ( sites.select( siteSlug ) ) {
-		callback();
-		return;
-	}
-
-	sites.once( 'change', function() {
-		fetchSitesUntilSiteAppears( siteSlug, callback );
-	} );
-
-	// this call is deferred because sites.fetching is not set to false until
-	// after sites has emitted a `change` event
-	defer( sites.fetch.bind( sites ) );
-}
-
 function fetchReduxSite( siteSlug, { dispatch, getState }, callback ) {
 	if ( getSiteId( getState(), siteSlug ) ) {
 		debug( 'fetchReduxSite: found new site' );
@@ -179,16 +163,13 @@ function fetchReduxSite( siteSlug, { dispatch, getState }, callback ) {
 function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
 	async.parallel( [
 		callback => {
-			fetchSitesUntilSiteAppears( siteSlug, callback );
+			reduxStore
+				? fetchReduxSite( siteSlug, reduxStore, callback )
+				: callback();
 		},
 		callback => {
 			user.once( 'change', callback );
 			user.fetch();
-		},
-		callback => {
-			reduxStore
-				? fetchReduxSite( siteSlug, reduxStore, callback )
-				: callback();
 		},
 	], onComplete );
 }


### PR DESCRIPTION
This PR removes `sites-list` from `client/lib/signup`. See #13279 .

**Testing**
* Check out this branch.
* Load `http://calypso.localhost:3000/start/` while logged in to Calypso. Do not test logged out; `fetchSitesAndUser` will never be called in that case.
* Run through signup, and be sure there are no (related) errors.
* Run tests and be sure they pass: `npm run test-client client/lib/signup/test`.