### PR TITLE
Components: Implement highlight feature in Card component

### DIFF
--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -34,4 +34,4 @@ render: function() {
 * `tagName` (Optional): Allows you to control the tag name of the card wrapper (only if `href` is not specified).
 * `target` (Optional): If set and used with `href` then this controls where the link opens. It also changes the Gridicon to "external"
 * `compact` (Optional): Whether the card should be rendered as compact
-* `highlight` (Optional): Whether the card should be rendered as highlighted
+* `highlight` (Optional): The specific highlight of this card. Can be one of the following: `false` (no highlight, default), `info`, `success`, `error` or `warning`.

--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -33,3 +33,4 @@ render: function() {
 * `href` (Optional): If set then the card becomes a link, with a Gridicon chevron on the right.
 * `target` (Optional): If set and used with `href` then this controls where the link opens. It also changes the Gridicon to "external"
 * `compact` (Optional): Whether the card should be rendered as compact
+* `highlight` (Optional): Whether the card should be rendered as highlighted

--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -31,6 +31,7 @@ render: function() {
 
 * `className`: You can add classes to either.
 * `href` (Optional): If set then the card becomes a link, with a Gridicon chevron on the right.
+* `tagName` (Optional): Allows you to control the tag name of the card wrapper (only if `href` is not specified).
 * `target` (Optional): If set and used with `href` then this controls where the link opens. It also changes the Gridicon to "external"
 * `compact` (Optional): Whether the card should be rendered as compact
 * `highlight` (Optional): Whether the card should be rendered as highlighted

--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -38,6 +38,7 @@ var Cards = React.createClass( {
 					<Card className="awesome sauce">I am a third Card with custom classes!</Card>
 					<Card href="#cards">I am a linkable Card</Card>
 					<Card href="#cards" target="_blank" rel="noopener noreferrer">I am a externally linked Card</Card>
+					<Card highlight>I am a highlighted Card</Card>
 				</div>
 			);
 		} else {
@@ -48,6 +49,7 @@ var Cards = React.createClass( {
 					<CompactCard className="awesome sauce">I am a third CompactCard with custom classes!</CompactCard>
 					<CompactCard href="#cards">I am a linkable CompactCard</CompactCard>
 					<CompactCard href="#cards" target="_blank" rel="noopener noreferrer">I am a externally linked CompactCard</CompactCard>
+					<CompactCard highlight>I am a highlighted CompactCard</CompactCard>
 				</div>
 			);
 		}

--- a/client/components/card/docs/example.jsx
+++ b/client/components/card/docs/example.jsx
@@ -38,7 +38,10 @@ var Cards = React.createClass( {
 					<Card className="awesome sauce">I am a third Card with custom classes!</Card>
 					<Card href="#cards">I am a linkable Card</Card>
 					<Card href="#cards" target="_blank" rel="noopener noreferrer">I am a externally linked Card</Card>
-					<Card highlight>I am a highlighted Card</Card>
+					<Card highlight="info">I am a Card, highlighted as info</Card>
+					<Card highlight="success">I am a Card, highlighted as success</Card>
+					<Card highlight="error">I am a Card, highlighted as error</Card>
+					<Card highlight="warning">I am a Card, highlighted as warning</Card>
 				</div>
 			);
 		} else {
@@ -49,7 +52,10 @@ var Cards = React.createClass( {
 					<CompactCard className="awesome sauce">I am a third CompactCard with custom classes!</CompactCard>
 					<CompactCard href="#cards">I am a linkable CompactCard</CompactCard>
 					<CompactCard href="#cards" target="_blank" rel="noopener noreferrer">I am a externally linked CompactCard</CompactCard>
-					<CompactCard highlight>I am a highlighted CompactCard</CompactCard>
+					<CompactCard highlight="info">I am a CompactCard, highlighted as info</CompactCard>
+					<CompactCard highlight="success">I am a CompactCard, highlighted as success</CompactCard>
+					<CompactCard highlight="error">I am a CompactCard, highlighted as error</CompactCard>
+					<CompactCard highlight="warning">I am a CompactCard, highlighted as warning</CompactCard>
 				</div>
 			);
 		}

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -35,7 +35,7 @@ export default React.createClass( {
 	getHighlightClass() {
 		const { highlight } = this.props;
 		if ( ! highlight ) {
-			return '';
+			return false;
 		}
 
 		return 'is-' + highlight;

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -16,7 +16,13 @@ export default React.createClass( {
 		target: React.PropTypes.string,
 		compact: React.PropTypes.bool,
 		children: React.PropTypes.node,
-		highlight: React.PropTypes.bool,
+		highlight: React.PropTypes.oneOf( [
+			false,
+			'error',
+			'info',
+			'success',
+			'warning',
+		] ),
 	},
 
 	getDefaultProps() {
@@ -26,14 +32,22 @@ export default React.createClass( {
 		};
 	},
 
+	getHighlightClass() {
+		const { highlight } = this.props;
+		if ( ! highlight ) {
+			return '';
+		}
+
+		return 'is-' + highlight;
+	},
+
 	render: function() {
 		const className = classnames( 'card', this.props.className, {
 			'is-card-link': !! this.props.href,
 			'is-compact': this.props.compact,
-			'is-highlighted': this.props.highlight,
-		} );
+		}, this.getHighlightClass() );
 
-		const omitProps = [ 'compact', 'tagName' ];
+		const omitProps = [ 'compact', 'highlight', 'tagName' ];
 
 		let linkIndicator;
 		if ( this.props.href ) {

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -15,19 +15,22 @@ export default React.createClass( {
 		tagName: React.PropTypes.string,
 		target: React.PropTypes.string,
 		compact: React.PropTypes.bool,
-		children: React.PropTypes.node
+		children: React.PropTypes.node,
+		highlight: React.PropTypes.bool,
 	},
 
 	getDefaultProps() {
 		return {
-			tagName: 'div'
+			tagName: 'div',
+			highlight: false,
 		};
 	},
 
 	render: function() {
 		const className = classnames( 'card', this.props.className, {
 			'is-card-link': !! this.props.href,
-			'is-compact': this.props.compact
+			'is-compact': this.props.compact,
+			'is-highlighted': this.props.highlight,
 		} );
 
 		const omitProps = [ 'compact', 'tagName' ];

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -29,8 +29,27 @@
 		padding-right: 48px;
 	}
 
-	&.is-highlighted {
-		border-left: 3px solid $blue-wordpress;
+	&.is-error,
+	&.is-info,
+	&.is-success,
+	&.is-warning {
+		border-left: 3px solid;
+	}
+
+	&.is-error {
+		border-left-color: $alert-red;
+	}
+
+	&.is-info {
+		border-left-color: $blue-wordpress;
+	}
+
+	&.is-success {
+		border-left-color: $alert-green;
+	}
+
+	&.is-warning {
+		border-left-color: $alert-yellow;
 	}
 }
 

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -28,6 +28,10 @@
 	&.is-card-link {
 		padding-right: 48px;
 	}
+
+	&.is-highlighted {
+		border-left: 3px solid $blue-wordpress;
+	}
 }
 
 // Clickable Card

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -29,27 +29,20 @@
 		padding-right: 48px;
 	}
 
-	&.is-error,
-	&.is-info,
-	&.is-success,
-	&.is-warning {
-		border-left: 3px solid;
-	}
-
 	&.is-error {
-		border-left-color: $alert-red;
+		box-shadow: inset 3px 0 0 $alert-red;
 	}
 
 	&.is-info {
-		border-left-color: $blue-wordpress;
+		box-shadow: inset 3px 0 0 $blue-wordpress;
 	}
 
 	&.is-success {
-		border-left-color: $alert-green;
+		box-shadow: inset 3px 0 0 $alert-green;
 	}
 
 	&.is-warning {
-		border-left-color: $alert-yellow;
+		box-shadow: inset 3px 0 0 $alert-yellow;
 	}
 }
 


### PR DESCRIPTION
As suggested in #14253, we'll need a hybrid between `Banner` and `Component`. To achieve this, this PR suggests that we implement an additional prop to `Card`, because it's more robust than `Banner`. This PR lays the groundwork for #14253.

The additional prop is called `highlight` and will accept one of the following values: `false` (which is the default one), `info`, `success`, `error` or `warning`. When the `highlight` is `false`, it'll behave like an ordinary card. If any of the other options are specified as a `highlight`, that'll add a small border to the left of the card, which will be colored in context with the specified type of  highlight.

This will allow us to create banners with a more complex content than what currently `Banner` allows us. 

**Preview:**

Regular cards:
![](https://cldup.com/PbrbGN6ng4.png)

Compact cards:
![](https://cldup.com/Mm0UT5DAKA.png)

To test:
* Checkout this branch
* Go to `/devdocs/design/cards`
* Verify the new `Card` examples look as demonstrated in the screenshots
* Verify the new `CompactCard` examples look as demonstrated in the screenshots
* Verify the regular examples are not affected at all.