### PR TITLE
Site Settings: Enable Custom Content Types card for WP.com sites

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -15,6 +15,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
 import { activateModule } from 'state/jetpack/modules/actions';
+import { isJetpackSite } from 'state/sites/selectors';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
@@ -25,8 +26,13 @@ class CustomContentTypes extends Component {
 			activatingCustomContentTypesModule,
 			customContentTypesModuleActive,
 			fields,
-			siteId
+			siteId,
+			siteIsJetpack,
 		} = this.props;
+
+		if ( ! siteIsJetpack ) {
+			return;
+		}
 
 		if ( customContentTypesModuleActive !== false ) {
 			return;
@@ -146,7 +152,6 @@ CustomContentTypes.defaultProps = {
 };
 
 CustomContentTypes.propTypes = {
-	onSubmitForm: PropTypes.func.isRequired,
 	handleAutosavingToggle: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
@@ -159,6 +164,7 @@ export default connect(
 
 		return {
 			siteId,
+			siteIsJetpack: isJetpackSite( state, siteId ),
 			customContentTypesModuleActive: isJetpackModuleActive( state, siteId, 'custom-content-types' ),
 			activatingCustomContentTypesModule: isActivatingJetpackModule( state, siteId, 'custom-content-types' ),
 		};

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -124,18 +124,18 @@ class SiteSettingsFormWriting extends Component {
 						</div>
 					)
 				}
+
+				<CustomContentTypes
+					handleAutosavingToggle={ handleAutosavingToggle }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+
 				{
 					this.props.isJetpackSite && this.props.jetpackSettingsUISupported && (
 						<div>
 							<QueryJetpackModules siteId={ this.props.siteId } />
-
-							<CustomContentTypes
-								onSubmitForm={ this.props.handleSubmitForm }
-								handleAutosavingToggle={ handleAutosavingToggle }
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-								fields={ fields }
-							/>
 
 							<ThemeEnhancements
 								onSubmitForm={ this.props.handleSubmitForm }


### PR DESCRIPTION
This PR enables the Custom Content Types card again for WordPress.com sites. To achieve this, we're separating the module activation logic to work only for Jetpack sites, and we're displaying the `CustomContentTypes` card for all site types. Addresses part of #13568.

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/writing/$site`, where `$site` is a WordPress.com site.
* Verify the Custom Content Types card is displayed in the Writing section.
* Verify both of the Testimonials and Portfolios toggles are working properly, saving and retrieving data properly.
* Go to `/settings/writing/$site`, where `$site` is a Jetpack site.
* Verify the Custom Content Types card is displayed in the Writing section.
* Verify both of the Testimonials and Portfolios toggles are working properly, saving and retrieving data properly.
* Disable the Custom Content Types module for your site and verify it gets automatically activated when you visit the Writing page for a Jetpack site.