### PR TITLE
Publicize: move to new scheduled endpoints

### DIFF
--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -25,16 +25,22 @@ export function fetchPostShareActionsScheduled( siteId, postId ) {
 			postId,
 		} );
 
-		const getScheduledPath = `/sites/${ siteId }/post/${ postId }/publicize/scheduled`;
-		return wpcom.req.get( getScheduledPath, ( error, data ) => {
-			if ( error || ! data.items ) {
-				return dispatch( { type: PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_FAILURE, siteId, postId, error } );
-			}
+		const getScheduledPath = `/sites/${ siteId }/posts/${ postId }/publicize/scheduled-actions`;
+		return wpcom.req.get(
+			{
+				path: getScheduledPath,
+				apiNamespace: 'wpcom/v2',
+			},
+			( error, data ) => {
+				if ( error || ! data.items ) {
+					return dispatch( { type: PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_FAILURE, siteId, postId, error } );
+				}
 
-			const actions = {};
-			data.items.forEach( action => ( actions[ action.ID ] = action ) );
-			dispatch( { type: PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS, siteId, postId, actions } );
-		} );
+				const actions = {};
+				data.items.forEach( action => ( actions[ action.ID ] = action ) );
+				dispatch( { type: PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS, siteId, postId, actions } );
+			}
+		);
 	};
 }
 
@@ -68,15 +74,21 @@ export function deletePostShareAction( siteId, postId, actionId ) {
 			actionId
 		} );
 
-		const deleteActionPath = `/sites/${ siteId }/post/${ postId }/publicize/action/${ actionId }/delete`;
-		return wpcom.req.post( deleteActionPath, ( error, data ) => {
-			if ( error || ! data.success ) {
-				// TODO: consider return an WP_Error instance istead of `! data.item`
-				return dispatch( { type: PUBLICIZE_SHARE_ACTION_DELETE_FAILURE, siteId, postId, actionId, error } );
-			}
+		const deleteActionPath = `/sites/${ siteId }/posts/${ postId }/publicize/scheduled-actions/${ actionId }`;
+		return wpcom.req.del(
+			{
+				path: deleteActionPath,
+				apiNamespace: 'wpcom/v2',
+			},
+			( error, data ) => {
+				if ( error || ! data.success ) {
+					// TODO: consider return an WP_Error instance istead of `! data.item`
+					return dispatch( { type: PUBLICIZE_SHARE_ACTION_DELETE_FAILURE, siteId, postId, actionId, error } );
+				}
 
-			dispatch( { type: PUBLICIZE_SHARE_ACTION_DELETE_SUCCESS, siteId, postId, actionId } );
-		} );
+				dispatch( { type: PUBLICIZE_SHARE_ACTION_DELETE_SUCCESS, siteId, postId, actionId } );
+			}
+		);
 	};
 }
 
@@ -89,18 +101,23 @@ export function editPostShareAction( siteId, postId, actionId, message, share_da
 			actionId,
 		} );
 
-		return wpcom.req.post( {
-			path: `/sites/${ siteId }/post/${ postId }/publicize/action/${ actionId }/edit`,
-			body: { message, share_date },
-		}, ( error, data ) => {
-			if ( error || ! data.item ) {
-				// TODO: consider return an WP_Error instance istead of `! data.item`
-				return dispatch( { type: PUBLICIZE_SHARE_ACTION_EDIT_FAILURE, siteId, postId, actionId, error } );
-			}
+		const editActionPath = `/sites/${ siteId }/posts/${ postId }/publicize/scheduled-actions/${ actionId }`;
+		return wpcom.req.put(
+			{
+				path: editActionPath,
+				body: { message, share_date },
+				apiNamespace: 'wpcom/v2',
+			},
+			( error, data ) => {
+				if ( error || ! data.item ) {
+					// TODO: consider return an WP_Error instance istead of `! data.item`
+					return dispatch( { type: PUBLICIZE_SHARE_ACTION_EDIT_FAILURE, siteId, postId, actionId, error } );
+				}
 
-			// TODO: until we have proper data coming
-			data.item.ID = actionId;
-			dispatch( { type: PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS, siteId, postId, actionId, item: data.item } );
-		} );
+				// TODO: until we have proper data coming
+				data.item.ID = actionId;
+				dispatch( { type: PUBLICIZE_SHARE_ACTION_EDIT_SUCCESS, siteId, postId, actionId, item: data.item } );
+			}
+		);
 	};
 }


### PR DESCRIPTION
In D5730-code, @sirbrillig added new `wpcom/v2` endpoints for Publicize Scheduling. In this PR, we rewrite the functionality to use these new endpoints.

## Testing instructions

0. In `config/development.json`, enable `publicize-scheduling` feature.
1. Using https://developer.wordpress.com/docs/api/console-2014/, create a new scheduled action for a post:

   ![selection_320](https://cloud.githubusercontent.com/assets/4988512/26577717/9bce4892-452d-11e7-8b2d-58c3c1dc9a33.png)

2. In Calypso, click on "Share" under that post and navigate to "Scheduled" tab below. You should see the newly scheduled action.

I'm not sure how to test `deletePostShareAction` and `editPostShareAction` since we don't use that currently.
