### PR TITLE
Site Settings: Remove post type toggle when theme supports it

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -14,10 +14,12 @@ import FormFieldset from 'components/forms/form-fieldset';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
+import { isPostTypeSupported } from 'state/post-types/selectors';
 import { activateModule } from 'state/jetpack/modules/actions';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
+import QueryPostTypes from 'components/data/query-post-types';
 
 class CustomContentTypes extends Component {
 	componentDidUpdate() {
@@ -52,6 +54,14 @@ class CustomContentTypes extends Component {
 		return isRequestingSettings || isSavingSettings;
 	}
 
+	renderDescription( description ) {
+		return (
+			<FormSettingExplanation isIndented>
+				{ description }
+			</FormSettingExplanation>
+		);
+	}
+
 	renderToggle( name, label, description ) {
 		const {
 			activatingCustomContentTypesModule,
@@ -67,9 +77,19 @@ class CustomContentTypes extends Component {
 				>
 					{ label }
 				</CompactFormToggle>
-				<FormSettingExplanation isIndented>
-					{ description }
-				</FormSettingExplanation>
+				{ this.renderDescription( description ) }
+			</div>
+		);
+	}
+
+	renderSupportedContentType( fieldName, fieldLabel, fieldDescription ) {
+		return (
+			<div className="custom-content-types__module-settings">
+				<div className="custom-content-types__form-toggle-placeholder form-toggle__placeholder">
+					{ fieldLabel }
+				</div>
+
+				{ this.renderDescription( fieldDescription ) }
 			</div>
 		);
 	}
@@ -83,7 +103,10 @@ class CustomContentTypes extends Component {
 	}
 
 	renderTestimonialSettings() {
-		const { translate } = this.props;
+		const {
+			isTestimonialSupported,
+			translate
+		} = this.props;
 		const fieldLabel = translate( 'Testimonials' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
@@ -95,11 +118,18 @@ class CustomContentTypes extends Component {
 			}
 		);
 
+		if ( isTestimonialSupported ) {
+			return this.renderSupportedContentType( 'jetpack_testimonial', fieldLabel, fieldDescription );
+		}
+
 		return this.renderContentTypeSettings( 'jetpack_testimonial', fieldLabel, fieldDescription );
 	}
 
 	renderPortfolioSettings() {
-		const { translate } = this.props;
+		const {
+			isPortfolioSupported,
+			translate
+		} = this.props;
 		const fieldLabel = translate( 'Portfolios' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}portfolios{{/link}}. If your theme doesn’t support portfolios yet, ' +
@@ -111,13 +141,23 @@ class CustomContentTypes extends Component {
 			}
 		);
 
+		if ( isPortfolioSupported ) {
+			return this.renderSupportedContentType( 'jetpack_portfolio', fieldLabel, fieldDescription );
+		}
+
 		return this.renderContentTypeSettings( 'jetpack_portfolio', fieldLabel, fieldDescription );
 	}
 
 	render() {
-		const { translate } = this.props;
+		const {
+			siteId,
+			translate
+		} = this.props;
+
 		return (
 			<div>
+				{ siteId && <QueryPostTypes siteId={ siteId } /> }
+
 				<SectionHeader label={ translate( 'Custom content types' ) } />
 
 				<Card className="custom-content-types__card site-settings">
@@ -159,6 +199,8 @@ export default connect(
 
 		return {
 			siteId,
+			isPortfolioSupported: isPostTypeSupported( state, siteId, 'jetpack-portfolio' ),
+			isTestimonialSupported: isPostTypeSupported( state, siteId, 'jetpack-testimonial' ),
 			customContentTypesModuleActive: isJetpackModuleActive( state, siteId, 'custom-content-types' ),
 			activatingCustomContentTypesModule: isActivatingJetpackModule( state, siteId, 'custom-content-types' ),
 		};

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -90,7 +90,8 @@
 		}
 	}
 
-	.form-toggle__wrapper + p.form-setting-explanation.is-indented {
+	.form-toggle__wrapper + p.form-setting-explanation.is-indented,
+	.form-toggle__placeholder + p.form-setting-explanation.is-indented {
 		margin-left: 36px;
 	}
 


### PR DESCRIPTION
This PR updates the Custom Content Types card to hide the toggles for a certain post type if that post type is already supported by the active theme. This is necessary, because even though the toggle works fine in that case (saves and retrieves the value properly), it doesn't reflect whether the corresponding post type is displayed in the sidebar. This PR is part of #13568.

Before:
![](https://cldup.com/pCi6OHbiFO.png)

After:
![](https://cldup.com/m2Ib_T9gSe.png)

Note: if a post type is not supported for a theme, the toggle will still be shown for that post type, as it is on the "Before" screenshot. The "After" screenshot is from a site that uses a theme that supports both the Testimonials and the Portfolio post types.

To test:
* Checkout this branch or get it going on calypso.live.
* Go to `/settings/writing/$site`, where `$site` is one of your Jetpack sites (wp.com sites will be supported too when we land #14572).
* Use a theme that supports both post the Testimonial and Portfolio post types.
* Verify the toggles are not displayed.
* Use a theme that supports one of the Testimonial and Portfolio post types.
* Verify only the toggle of the non-supported post type is displayed.
* Verify the post type toggles work as they did before.