### PR TITLE
Change SiteURLInput to SiteUrlInput

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -14,7 +14,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
-import SiteURLInput from '../site-url-input';
+import SiteUrlInput from '../site-url-input';
 import ReaderBack from 'blocks/reader-full-post/back';
 
 import WordPressLogo from 'components/wordpress-logo';
@@ -95,7 +95,7 @@ class JetpackNewSite extends Component {
 							<div className="jetpack-new-site__card-description">
 								{ this.props.translate( 'We’ll be using the Jetpack plugin to connect your site to WordPress.com.' ) }
 							</div>
-							<SiteURLInput
+							<SiteUrlInput
 								onChange={ this.handleJetpackUrlChange }
 								onSubmit={ this.handleJetpackSubmit }
 								handleOnClickTos={ this.handleOnClickTos }
@@ -114,7 +114,7 @@ class JetpackNewSite extends Component {
 							</div>
 							<div className="jetpack-new-site__mobile-jetpack-site">
 								<p>{ this.props.translate( 'Add an existing WordPress site with Jetpack:' ) }</p>
-								<SiteURLInput
+								<SiteUrlInput
 									onChange={ this.handleJetpackUrlChange }
 									onSubmit={ this.handleJetpackSubmit }
 									handleOnClickTos={ this.handleOnClickTos }


### PR DESCRIPTION
Casing is corrected to match Calypso standards.

May have helped in detecting #14475 through `grep` or similar.

To test
* Visit https://calypso.live/jetpack/new?branch=fix/siteurlinput-casing
* Set `localStorage.setItem( 'ABTests', '{"newSiteWithJetpack_20170419":"showNewJetpackSite"}' );`
* Refresh
* Ensure build is correct, no errors are introduced.