### PR TITLE
Site Settings: Request site post types upon content types toggling

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -15,6 +15,7 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
 import { activateModule } from 'state/jetpack/modules/actions';
+import { requestPostTypes } from 'state/post-types/actions';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
@@ -52,6 +53,13 @@ class CustomContentTypes extends Component {
 		return isRequestingSettings || isSavingSettings;
 	}
 
+	requestSitePostTypes = () => {
+		const { siteId } = this.props;
+		if ( siteId ) {
+			this.props.requestPostTypes( siteId );
+		}
+	}
+
 	renderToggle( name, label, description ) {
 		const {
 			activatingCustomContentTypesModule,
@@ -63,7 +71,7 @@ class CustomContentTypes extends Component {
 				<CompactFormToggle
 					checked={ !! fields[ name ] }
 					disabled={ this.isFormPending() || activatingCustomContentTypesModule }
-					onChange={ handleAutosavingToggle( name ) }
+					onChange={ handleAutosavingToggle( name, this.requestSitePostTypes ) }
 				>
 					{ label }
 				</CompactFormToggle>
@@ -164,6 +172,7 @@ export default connect(
 		};
 	},
 	{
-		activateModule
+		activateModule,
+		requestPostTypes
 	}
 )( localize( CustomContentTypes ) );

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -108,14 +108,20 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.trackEvent( 'Clicked Save Settings Button' );
 		};
 
-		submitForm = () => {
+		submitForm = ( callback ) => {
 			const { fields, settingsFields, siteId, jetpackSettingsUISupported } = this.props;
 			this.props.removeNotice( 'site-settings-save' );
 
-			this.props.saveSiteSettings( siteId, pick( fields, settingsFields.site ) );
+			const settingsRequests = [
+				this.props.saveSiteSettings( siteId, pick( fields, settingsFields.site ) )
+			];
+
 			if ( jetpackSettingsUISupported ) {
-				this.props.updateSettings( siteId, pick( fields, settingsFields.jetpack ) );
+				settingsRequests.push( this.props.updateSettings( siteId, pick( fields, settingsFields.jetpack ) ) );
 			}
+
+			Promise.all( settingsRequests )
+				.then( () => callback && callback() );
 		};
 
 		handleRadio = event => {
@@ -150,10 +156,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] } );
 		};
 
-		handleAutosavingToggle = name => () => {
+		handleAutosavingToggle = ( name, callback ) => () => {
 			this.props.trackEvent( `Toggled ${ name }` );
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] }, () => {
-				this.submitForm();
+				this.submitForm( callback );
 			} );
 		};
 


### PR DESCRIPTION
Currently, enabling/disabling a post type in the Custom Content Types card does not update the sidebar with the latest post types. For example, if the **Testimonial** post type is enabled, and you disable it, and it's not supported by the active theme, it should be removed from the sidebar right away. Right now, in order to see it removed, you need to refresh Calypso. 

This PR fixes this issue by:
* Introducing support for callbacks to `handleAutosavingToggle` in the `wrapSettingsForm` HoC.
* Requesting the site post types by passing the request as a callback after settings are saved.

This PR is part of #13568.

To test:
* Checkout this branch.
* Go to `/settings/writing/$site`, where `$site` is one of your Jetpack sites (wp.com sites will be supported too when we land #14572).
* Activate a theme that does not support the **Testimonial** post type.
* Activate the **Testimonial** post type and verify sure the **Testimonial** item shows in the sidebar menu shortly.
* Deactivate the **Testimonial** post type and verify the **Testimonial** item gets removed from the sidebar menu shortly.