### PR TITLE
SiteSelector: Redirect to slug-based paths instead of siteId-based paths

### DIFF
--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -14,6 +14,7 @@ import observe from 'lib/mixins/data-observe';
 import SiteSelector from 'components/site-selector';
 import { addSiteFragment } from 'lib/route';
 import { getSites } from 'state/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
 export const Sites = React.createClass( {
@@ -53,12 +54,13 @@ export const Sites = React.createClass( {
 		return site;
 	},
 
-	onSiteSelect: function( slug ) {
+	onSiteSelect: function( siteId ) {
 		let path = this.props.path;
 		if ( path === '/sites' ) {
 			path = '/stats/insights';
 		}
-		page( addSiteFragment( path, slug ) );
+		page( addSiteFragment( path, this.props.getSiteSlug( siteId ) ) );
+		return true;
 	},
 
 	getHeaderText() {
@@ -103,6 +105,7 @@ export default connect(
 		return {
 			selectedSite: getSelectedSite( state ),
 			sites: getSites( state ),
+			getSiteSlug: siteId => getSiteSlug( state, siteId )
 		};
 	}
 )( Sites );

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -55,11 +55,7 @@ export const Sites = React.createClass( {
 	},
 
 	onSiteSelect: function( siteId ) {
-		let path = this.props.path;
-		if ( path === '/sites' ) {
-			path = '/stats/insights';
-		}
-		page( addSiteFragment( path, this.props.getSiteSlug( siteId ) ) );
+		this.props.selectSite( siteId, this.props.path );
 		return true;
 	},
 
@@ -100,12 +96,19 @@ export const Sites = React.createClass( {
 	}
 } );
 
+const selectSite = ( siteId, rawPath ) => ( dispatch, getState ) => {
+	const path = ( rawPath === '/sites' )
+		? '/stats/insights'
+		: rawPath;
+	page( addSiteFragment( path, getSiteSlug( getState(), siteId ) ) );
+};
+
 export default connect(
 	( state ) => {
 		return {
 			selectedSite: getSelectedSite( state ),
 			sites: getSites( state ),
-			getSiteSlug: siteId => getSiteSlug( state, siteId )
 		};
-	}
+	},
+	{ selectSite }
 )( Sites );


### PR DESCRIPTION
Currently, the site selector is redirecting to paths using the numeric siteId. 

**Before**

![before](https://cloud.githubusercontent.com/assets/746152/26583685/8724a4ec-451c-11e7-9cae-02f0ef81e25d.gif)

**After**

![after](https://cloud.githubusercontent.com/assets/746152/26584999/35d8b7a4-4521-11e7-937c-9ccb550c82b3.gif)


#### Testing instructions

1. Visit `/settings` or `/sites` without a site slug to get the site selector.
1. Click any of your sites
1. Confirm that you're redirected to an URL that has the slug on it instead of the site id. 
