### PR TITLE
Comments: Use the correct data structure in the CommentDetail docs

### DIFF
--- a/client/blocks/comment-detail/docs/example.jsx
+++ b/client/blocks/comment-detail/docs/example.jsx
@@ -9,107 +9,50 @@ import React from 'react';
 import CommentDetail from 'blocks/comment-detail';
 
 // Mock data
-const mockAuthor = {
-	avatarUrl: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?s=96&d=mm&r=G',
-	displayName: 'Test User',
-	email: 'test@test.com',
-	id: 12345678,
-	ip: '127.0.0.1',
-	isBlocked: false,
-	url: 'http://discover.wordpress.com',
-	username: 'testuser',
-};
-
 const mockComment = {
+	author: {
+		avatar_URL: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?s=96&d=mm&r=G',
+		email: 'test@test.com',
+		ID: 12345678,
+		ip: '127.0.0.1',
+		isBlocked: false,
+		name: 'Test User',
+		nice_name: 'testuser',
+		URL: 'http://discover.wordpress.com',
+	},
 	content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Contemnit enim disserendi elegantiam, confuse loquitur. Suo genere perveniant ad extremum; Id mihi magnum videtur. Vide, quantum, inquam, fallare, Torquate. Aliter homines, aliter philosophos loqui putas oportere? Perge porro; Quibus ego vehementer assentior. Tubulo putas dicere? Sed ille, ut dixi, vitiose. Refert tamen, quo modo. Quid nunc honeste dicit? Scrupulum, inquam, abeunti; Quam si explicavisset, non tam haesitaret. Sed quid sentiat, non videtis. At enim sequor utilitatem. Si longus, levis.',
 	date: '2017-05-12 16:00:00',
-	id: 12345678,
-	isLiked: false,
+	ID: 12345678,
+	i_like: false,
+	post: {
+		author: { name: 'Test User' },
+		title: 'Test Post',
+		link: 'http://discover.wordpress.com',
+	},
 	replied: true,
 	status: 'approved',
-};
-
-const mockPost = {
-	authorDisplayName: 'Test User',
-	title: 'Test Post',
-	url: 'http://discover.wordpress.com',
-};
+}
 
 const mockSite = {
 	id: 3584907,
 };
 
-
 export const CommentDetailExample = () =>
 	<div>
 		<CommentDetail
-			authorAvatarUrl={ mockAuthor.avatarUrl }
-			authorDisplayName={ mockAuthor.displayName }
-			authorEmail={ mockAuthor.email }
-			authorId={ mockAuthor.id }
-			authorIp={ mockAuthor.ip }
-			authorIsBlocked={ mockAuthor.isBlocked }
-			authorUrl={ mockAuthor.url }
-			authorUsername={ mockAuthor.username }
-
-			commentContent={ mockComment.content }
-			commentDate={ mockComment.date }
-			commentId={ mockComment.id }
-			commentIsLiked={ mockComment.isLiked }
-			commentStatus={ mockComment.status }
-			repliedToComment={ mockComment.replied }
-
-			postAuthorDisplayName={ mockPost.authorDisplayName }
-			postTitle={ mockPost.title }
-			postUrl={ mockPost.url }
-
-			siteId={ mockSite.id }
+			commentId={ mockComment.ID }
+			siteId={ mockSite.ID }
+			{ ...mockComment }
 		/>
 		<CommentDetail
-			authorAvatarUrl={ mockAuthor.avatarUrl }
-			authorDisplayName={ mockAuthor.displayName }
-			authorEmail={ mockAuthor.email }
-			authorId={ mockAuthor.id }
-			authorIp={ mockAuthor.ip }
-			authorIsBlocked={ mockAuthor.isBlocked }
-			authorUrl={ mockAuthor.url }
-			authorUsername={ mockAuthor.username }
-
-			commentContent={ mockComment.content }
-			commentDate={ mockComment.date }
-			commentId={ mockComment.id }
-			commentIsLiked={ mockComment.isLiked }
-			commentStatus={ mockComment.status }
-			repliedToComment={ mockComment.replied }
-
-			postAuthorDisplayName={ mockPost.authorDisplayName }
-			postTitle={ mockPost.title }
-			postUrl={ mockPost.url }
-
-			siteId={ mockSite.id }
+			commentId={ mockComment.ID }
+			siteId={ mockSite.ID }
+			{ ...mockComment }
 		/>
 		<CommentDetail
-			authorAvatarUrl={ mockAuthor.avatarUrl }
-			authorDisplayName={ mockAuthor.displayName }
-			authorEmail={ mockAuthor.email }
-			authorId={ mockAuthor.id }
-			authorIp={ mockAuthor.ip }
-			authorIsBlocked={ mockAuthor.isBlocked }
-			authorUrl={ mockAuthor.url }
-			authorUsername={ mockAuthor.username }
-
-			commentContent={ mockComment.content }
-			commentDate={ mockComment.date }
-			commentId={ mockComment.id }
-			commentIsLiked={ mockComment.isLiked }
-			commentStatus={ mockComment.status }
-			repliedToComment={ mockComment.replied }
-
-			postAuthorDisplayName={ mockPost.authorDisplayName }
-			postTitle={ mockPost.title }
-			postUrl={ mockPost.url }
-
-			siteId={ mockSite.id }
+			commentId={ mockComment.ID }
+			siteId={ mockSite.ID }
+			{ ...mockComment }
 		/>
 	</div>;
 


### PR DESCRIPTION
Fixes #14581 

Updates the data structure used by `CommentDetail` in its docs after the heavy changes introduced in #14510.

Props to @hoverduck for the catch!
Thumbs down to me for forgetting about it.

## Changes:

From:
<img width="780" alt="screen shot 2017-05-30 at 9 11 14 am" src="https://cloud.githubusercontent.com/assets/7233112/26584769/fd1d4e06-4517-11e7-9536-4f4828f64dce.png">

To:
<img width="776" alt="screen shot 2017-05-30 at 9 11 18 am" src="https://cloud.githubusercontent.com/assets/7233112/26584775/025ab87c-4518-11e7-913b-c0f97d5a8873.png">

And now back again:
<img width="780" alt="screen shot 2017-05-30 at 9 11 14 am" src="https://cloud.githubusercontent.com/assets/7233112/26584769/fd1d4e06-4517-11e7-9536-4f4828f64dce.png">