### PR TITLE
Publicize Scheduling: make the "Trash" btn on scheduled share work

### DIFF
--- a/client/my-sites/post-share/publicize-actions-list.jsx
+++ b/client/my-sites/post-share/publicize-actions-list.jsx
@@ -46,7 +46,7 @@ class PublicizeActionsList extends PureComponent {
 	setFooterSection = selectedShareTab => () => this.setState( { selectedShareTab } );
 
 	renderFooterSectionItem( {
-		actionId,
+		ID: actionId,
 		connectionName,
 		message,
 		shareDate,
@@ -117,7 +117,7 @@ class PublicizeActionsList extends PureComponent {
 		};
 	}
 
-	closeDeleteDialog( dialogAction ) {
+	closeDeleteDialog = ( dialogAction ) => {
 		if ( dialogAction === 'delete' ) {
 			const {
 				siteId,
@@ -128,7 +128,7 @@ class PublicizeActionsList extends PureComponent {
 		}
 
 		this.setState( { showDeleteDialog: false } );
-	}
+	};
 
 	renderActionsList = ( actions ) => (
 			<div>

--- a/client/my-sites/post-share/publicize-actions-list.jsx
+++ b/client/my-sites/post-share/publicize-actions-list.jsx
@@ -26,6 +26,8 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import { isEnabled } from 'config';
+import Dialog from 'components/dialog';
+import { deletePostShareAction } from 'state/sharing/publicize/publicize-actions/actions';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {
@@ -37,9 +39,14 @@ class PublicizeActionsList extends PureComponent {
 
 	state = {
 		selectedShareTab: SCHEDULED,
+		showDeleteDialog: false,
+		selectedScheduledShareId: null
 	};
+
 	setFooterSection = selectedShareTab => () => this.setState( { selectedShareTab } );
+
 	renderFooterSectionItem( {
+		actionId,
 		connectionName,
 		message,
 		shareDate,
@@ -64,25 +71,33 @@ class PublicizeActionsList extends PureComponent {
 						{ message }
 					</div>
 				</div>
-				{ this.renderElipsisMenu() }
+				{ this.renderElipsisMenu( actionId ) }
 			</CompactCard>
 		);
 	}
 
-	renderElipsisMenu() {
+	renderElipsisMenu( publicizeActionId ) {
 		const actions = [];
 		const { translate } = this.props;
 
 		if ( isEnabled( 'publicize-preview' ) ) {
-			actions.push( <PopoverMenuItem icon="visible">
-				{ translate( 'Preview' ) }
-			</PopoverMenuItem> );
+			actions.push(
+				<PopoverMenuItem key="1" icon="visible">
+					{ translate( 'Preview' ) }
+				</PopoverMenuItem>
+			);
 		}
 
 		if ( this.state.selectedShareTab === SCHEDULED ) {
-			actions.push( <PopoverMenuItem icon="trash">
-				{ translate( 'Trash' ) }
-			</PopoverMenuItem> );
+			actions.push(
+				<PopoverMenuItem
+					onClick={ this.deleteScheduledAction( publicizeActionId ) }
+					key="2"
+					icon="trash"
+				>
+					{ translate( 'Trash' ) }
+				</PopoverMenuItem>
+			);
 		}
 
 		if ( actions.length === 0 ) {
@@ -93,11 +108,54 @@ class PublicizeActionsList extends PureComponent {
 		</EllipsisMenu> );
 	}
 
+	deleteScheduledAction( actionId ) {
+		return () => {
+			this.setState( {
+				showDeleteDialog: true,
+				selectedScheduledShareId: actionId
+			} );
+		};
+	}
+
+	closeDeleteDialog( dialogAction ) {
+		if ( dialogAction === 'delete' ) {
+			const {
+				siteId,
+				postId
+			} = this.props;
+
+			this.props.deletePostShareAction( siteId, postId, this.state.selectedScheduledShareId );
+		}
+
+		this.setState( { showDeleteDialog: false } );
+	}
+
 	renderActionsList = ( actions ) => (
-		<div>
-			{ actions.map( ( item, index ) => this.renderFooterSectionItem( item, index ) ) }
-		</div>
-	);
+			<div>
+				{ actions.map( ( item, index ) => this.renderFooterSectionItem( item, index ) ) }
+			</div>
+		);
+
+	renderDeleteDialog() {
+		const { translate } = this.props;
+
+		const buttons = [
+			{ action: 'cancel', label: translate( 'Cancel' ) },
+			{ action: 'delete', label: translate( 'Delete scheduled share' ), isPrimary: true },
+		];
+
+		return (
+			<Dialog
+				isVisible={ this.state.showDeleteDialog }
+				buttons={ buttons }
+				onClose={ this.closeDeleteDialog }
+			>
+				<h1>{ translate( 'Confirmation' ) }</h1>
+				<p>{ translate( 'Do you want to delete the scheduled share?' ) }</p>
+			</Dialog>
+		);
+	}
+
 	render() {
 		const {
 			postId,
@@ -105,6 +163,7 @@ class PublicizeActionsList extends PureComponent {
 			scheduledActions,
 			publishedActions,
 		} = this.props;
+
 		return (
 			<div>
 				<SectionNav className="post-share__footer-nav" selectedText={ 'some text' }>
@@ -139,6 +198,8 @@ class PublicizeActionsList extends PureComponent {
 						</div>
 					}
 				</div>
+
+				{ this.renderDeleteDialog() }
 			</div>
 		);
 	}
@@ -151,4 +212,5 @@ export default connect(
 			publishedActions: getPostSharePublishedActions( state, siteId, postId ),
 		};
 	},
+	{ deletePostShareAction },
 )( localize( PublicizeActionsList ) );

--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -85,7 +85,7 @@ export function deletePostShareAction( siteId, postId, actionId ) {
 				method: 'DELETE',
 			},
 			( error, data ) => {
-				if ( error || ! data.success ) {
+				if ( error || ! data ) {
 					// TODO: consider return an WP_Error instance istead of `! data.item`
 					return dispatch( { type: PUBLICIZE_SHARE_ACTION_DELETE_FAILURE, siteId, postId, actionId, error } );
 				}

--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -86,7 +86,6 @@ export function deletePostShareAction( siteId, postId, actionId ) {
 			},
 			( error, data ) => {
 				if ( error || ! data ) {
-					// TODO: consider return an WP_Error instance istead of `! data.item`
 					return dispatch( { type: PUBLICIZE_SHARE_ACTION_DELETE_FAILURE, siteId, postId, actionId, error } );
 				}
 

--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -78,10 +78,11 @@ export function deletePostShareAction( siteId, postId, actionId ) {
 		} );
 
 		const deleteActionPath = `/sites/${ siteId }/posts/${ postId }/publicize/scheduled-actions/${ actionId }`;
-		return wpcom.req.del(
+		return wpcom.req.get(
 			{
 				path: deleteActionPath,
 				apiNamespace: 'wpcom/v2',
+				method: 'DELETE',
 			},
 			( error, data ) => {
 				if ( error || ! data.success ) {


### PR DESCRIPTION
After you schedule a share, it will be shown in the "Scheduled" shares. There's a three-dot menu on the right containing the Trash button. In this PR, we make it work. We also add a simple modal confirmation whether the user really wants to delete the scheduled share.

<img width="781" alt="screen shot 2017-05-30 at 6 00 23 pm" src="https://cloud.githubusercontent.com/assets/2036909/26607005/518e3f5a-4562-11e7-802d-7823094677df.png">

<img width="790" alt="screen shot 2017-05-30 at 6 00 30 pm" src="https://cloud.githubusercontent.com/assets/2036909/26607013/55ae1452-4562-11e7-97a6-d0244e84f981.png">

