### PR TITLE
Add devdocs page for SitePlaceholder block

### DIFF
--- a/client/blocks/site/docs/placeholder-example.jsx
+++ b/client/blocks/site/docs/placeholder-example.jsx
@@ -1,0 +1,17 @@
+/**
+* External dependencies
+*/
+import React, { PureComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SitePlaceholder from 'blocks/site/placeholder';
+
+export default class SitePlaceholderExample extends PureComponent {
+	static displayName = 'SitePlaceholderExample';
+
+	render() {
+		return <SitePlaceholder />;
+	}
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -31,6 +31,7 @@ import PostSchedule from 'components/post-schedule/docs/example';
 import PostSelector from 'my-sites/post-selector/docs/example';
 import AllSites from 'my-sites/all-sites/docs/example';
 import Site from 'blocks/site/docs/example';
+import SitePlaceholder from 'blocks/site/docs/placeholder-example';
 import SitesDropdown from 'components/sites-dropdown/docs/example';
 import SiteIcon from 'blocks/site-icon/docs/example';
 import Theme from 'components/theme/docs/example';
@@ -124,6 +125,7 @@ export default React.createClass( {
 					<PostSelector />
 					<AllSites />
 					<Site />
+					<SitePlaceholder />
 					<SitesDropdown />
 					<SiteIcon />
 					<Theme />


### PR DESCRIPTION
This block is being used in Calypso, but had no devdocs page.

To test:
* Visit https://calypso.live/devdocs/blocks?branch=add/siteplaceholder-block-devdoc
* You should see the `SitePlaceholder` example in the list (searchable).

Will help to work on #14329