### PR TITLE
Editor: preserve the query string in maybeRedirect()

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -64,10 +64,6 @@ const actionMap = {
 };
 
 function buildQuerystringForPost( post ) {
-	const primarySite = sitesList.getPrimary();
-	if ( ! primarySite ) {
-		return;
-	}
 	const args = {};
 
 	if ( post.content_embeds && post.content_embeds.length ) {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -71,8 +71,11 @@ function maybeRedirect( context ) {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
 
-	const path = getEditorPath( state, siteId, postId );
+	let path = getEditorPath( state, siteId, postId, 'post', context.query );
 	if ( path !== context.pathname ) {
+		if ( context.querystring ) {
+			path += `?${ context.querystring }`;
+		}
 		page.redirect( path );
 		return true;
 	}


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/issues/14589 we noticed that the Reader share button, which prepopulates a post using the blog ID and query string args, was no longer working.

A share URL typically looks like this:

http://calypso.localhost:3000/post/1606950?title=Spotlight%3A%20Sharon%20Kendrick%20%E2%80%94%20Just%20Reviews&text=&url=https%3A%2F%2Ftillie49.wordpress.com%2F2017%2F05%2F30%2Fspotlight-sharon-kendrick%2F

`/post/<blogId>` was being redirected to the `/post/<subdomain>`, but without the query string. This PR retains the query string and fixes pre-population of the post.

Todo:
- [ ] Title doesn't update immediately - only on first autosave when the post becomes a draft