### PR TITLE
Comments: Add actions transitions and notices

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -18,6 +18,15 @@
 	}
 }
 
+.comment-detail__transition-leave {
+	opacity: 1;
+
+	&.comment-detail__transition-leave-active {
+		opacity: 0.01;
+		transition: opacity .15s linear;
+	}
+}
+
 .comment-detail__author-avatar {
 	flex-shrink: 0;
 }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -18,6 +18,15 @@
 	}
 }
 
+.comment-detail__transition-enter {
+	opacity: 0.01;
+
+	&.comment-detail__transition-enter-active {
+		opacity: 1;
+		transition: opacity .15s linear;
+	}
+}
+
 .comment-detail__transition-leave {
 	opacity: 1;
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -50,14 +50,13 @@ export class CommentList extends Component {
 			isPersistent: true,
 		};
 
-		if ( 'delete' !== newStatus && 'like' !== newStatus ) {
+		if ( 'delete' !== newStatus ) {
 			options.button = translate( 'Undo' );
 			options.onClick = () => this.setCommentStatus( commentId, previousStatus, { showNotice: false } );
 		}
 
 		switch ( newStatus ) {
 			case 'approved':
-			case 'like':
 				return createCommentNotice( 'is-success', translate( 'Comment approved.' ), options );
 			case 'unapproved':
 				return createCommentNotice( 'is-info', translate( 'Comment unapproved.' ), options );
@@ -84,9 +83,10 @@ export class CommentList extends Component {
 		const newLikeValue = ! comment.i_like;
 
 		if ( 'unapproved' === comment.status ) {
-			this.showNotice( commentId, 'like', 'unapproved' );
+			this.showNotice( commentId, 'approved', 'unapproved' );
 		}
 
+		// If like changes to true, also approve the comment
 		this.setState( {
 			comments: {
 				...this.state.comments,
@@ -108,6 +108,9 @@ export class CommentList extends Component {
 
 		this.props.removeNotice( `comment-notice-${ commentId }` );
 
+		// If the comment is not approved anymore, also remove the like, otherwise keep its previous value
+		const newLikeValue = 'approved' === status ? comment.i_like : false;
+
 		if ( options.showNotice ) {
 			this.showNotice( commentId, status, comment.status );
 		}
@@ -115,7 +118,11 @@ export class CommentList extends Component {
 		this.setState( {
 			comments: {
 				...this.state.comments,
-				[ commentId ]: { ...comment, status },
+				[ commentId ]: {
+					...comment,
+					i_like: newLikeValue,
+					status,
+				},
 			},
 		} );
 	}

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -160,7 +160,7 @@ export class CommentList extends Component {
 					toggleBulkEdit: this.toggleBulkEdit,
 				} } />
 				<ReactCSSTransitionGroup
-					transitionEnterTimeout={ 0 }
+					transitionEnterTimeout={ 150 }
 					transitionLeaveTimeout={ 150 }
 					transitionName="comment-detail__transition"
 				>

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { filter, map } from 'lodash';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 /**
  * Internal dependencies
@@ -100,18 +101,24 @@ export class CommentList extends Component {
 					status,
 					toggleBulkEdit: this.toggleBulkEdit,
 				} } />
-				{ map( filteredComments, comment =>
-					<CommentDetail
-						commentId={ comment.ID }
-						deleteForever={ this.deleteForever( comment.ID ) }
-						isBulkEdit={ isBulkEdit }
-						key={ `comment-${ siteId }-${ comment.ID }` }
-						setCommentStatus={ this.setCommentStatus }
-						siteId={ siteId }
-						toggleCommentLike={ this.toggleCommentLike }
-						{ ...comment }
-					/>
-				) }
+				<ReactCSSTransitionGroup
+					transitionEnterTimeout={ 0 }
+					transitionLeaveTimeout={ 150 }
+					transitionName="comment-detail__transition"
+				>
+					{ map( filteredComments, comment =>
+						<CommentDetail
+							commentId={ comment.ID }
+							deleteForever={ this.deleteForever( comment.ID ) }
+							isBulkEdit={ isBulkEdit }
+							key={ `comment-${ siteId }-${ comment.ID }` }
+							setCommentStatus={ this.setCommentStatus }
+							siteId={ siteId }
+							toggleCommentLike={ this.toggleCommentLike }
+							{ ...comment }
+						/>
+					) }
+				</ReactCSSTransitionGroup>
 			</div>
 		);
 	}


### PR DESCRIPTION
Introduce in the Comment Management lists both a quick fade out transition for disappearing comments and an undoable global notice in response to actions.

## Changes

- Add `ReactCSSTransitionGroup` to handle a fade out transition on component unmount.
Please note that `ReactCSSTransitionGroup` is deprecated as of React 15.0, and its replacement is tracked in https://github.com/Automattic/wp-calypso/issues/13321.

- Add global notices in response to actions performed on comments.
  - All notices (except "Delete Permanently") feature an Undo button, that simply fires the `setCommentStatus` method with the previous comment status.
  - Undos don't trigger any notice, and are therefore not undoable directly in the notice (they can of course be undone by via comment action).
  - The notices are not stacked together, but performing multiple actions on the same comment (e.g. `approve -> unapprove -> approve -> etc.`) only displays one single notice containing the last performed action.
In other words, we display one notice top for each actioned comment.
  - The notices are set to last 5 seconds before automatically disappearing.
  - The notices are persistent on route changes.
This is to prevent them to disappear when changing Comment Management list.
The side effect, though, is that undoing a notice while outside the Comment Management would trigger the `setCommentStatus` method of the `CommentList` component, which is not mounted anymore.
I'm not exactly sure how to solve this.
