### PR TITLE
WIP: Experiment with new explicit comment data model

### DIFF
--- a/client/state/comments/from-api.js
+++ b/client/state/comments/from-api.js
@@ -32,15 +32,25 @@ const toInfo = ( { content, date, i_like, parent, status } ) => {
 };
 
 export const fromApi = ( siteId, comment ) => {
-	if ( ! comment.content ) {
+	if (
+		siteId &&
+		comment.post && comment.post.ID &&
+		comment.ID &&
+		comment.author &&
+		comment.content
+	) {
+		return new LoadedComment( {
+			siteId,
+			postId: comment.post.ID,
+			commentId: comment.ID,
+			author: toAuthor( comment.author ),
+			info: toInfo( comment ),
+		} );
+	}
+
+	if ( siteId && comment.ID ) {
 		return new LoadingComment( siteId, comment.ID );
 	}
 
-	return new LoadedComment( {
-		siteId,
-		postId: comment.post.ID,
-		commentId: comment.ID,
-		author: toAuthor( comment.author ),
-		info: toInfo( comment ),
-	} );
+	return null;
 };

--- a/client/state/comments/from-api.js
+++ b/client/state/comments/from-api.js
@@ -4,7 +4,7 @@
 import { AnonymousUser, WordPressUser } from './models/comment-author';
 import { CommentInfo } from './models/comment-info';
 import { Approved, Pending, Spam, Trash } from './models/comment-status';
-import { LoadedComment } from './models/comment';
+import { LoadedComment, LoadingComment } from './models/comment';
 
 const toAuthor = ( { avatar_URL, email, ID, name } ) =>
 	ID > 0
@@ -32,6 +32,10 @@ const toInfo = ( { content, date, i_like, parent, status } ) => {
 };
 
 export const fromApi = ( siteId, comment ) => {
+	if ( ! comment.content ) {
+		return new LoadingComment( siteId, comment.ID );
+	}
+
 	return new LoadedComment( {
 		siteId,
 		postId: comment.post.ID,

--- a/client/state/comments/from-api.js
+++ b/client/state/comments/from-api.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { AnonymousUser, WordPressUser } from './models/comment-author';
+import { CommentInfo } from './models/comment-info';
+import { Approved, Pending, Spam, Trash } from './models/comment-status';
+import { LoadedComment } from './models/comment';
+
+const toAuthor = ( { avatar_URL, email, ID, name } ) =>
+	ID > 0
+		? new WordPressUser( ID )
+		: new AnonymousUser( { avatar: avatar_URL, displayName: name, email, url: URL } );
+
+const toStatus = text => {
+	switch ( text ) {
+		case 'approved': return new Approved();
+		case 'spam': return new Spam();
+		case 'trash': return new Trash();
+		case 'unapproved': return new Pending();
+		default: return new Pending();
+	}
+};
+
+const toInfo = ( { content, date, i_like, parent, status } ) => {
+	return new CommentInfo( {
+		content,
+		createdAt: Date.parse( date ),
+		isLiked: i_like,
+		parentId: parent ? parent.ID : 0,
+		status: toStatus( status ),
+	} );
+};
+
+export const fromApi = ( siteId, comment ) => {
+	return new LoadedComment( {
+		siteId,
+		postId: comment.post.ID,
+		commentId: comment.ID,
+		author: toAuthor( comment.author ),
+		info: toInfo( comment ),
+	} );
+};

--- a/client/state/comments/models/comment-author.js
+++ b/client/state/comments/models/comment-author.js
@@ -1,0 +1,29 @@
+export function Author( constructor ) {
+	Object.defineProperty( this, 'constructor', {
+		value: constructor || this
+	} );
+}
+
+export function AnonymousUser( {
+	avatar = null,
+	displayName = '',
+	email = null,
+	url = null,
+} ) {
+	const user = new Author( AnonymousUser );
+
+	user.avatar = avatar;
+	user.displayName = displayName;
+	user.email = email;
+	user.url = url;
+
+	return user;
+}
+
+export function WordPressUser( userId ) {
+	const user = new Author( WordPressUser );
+
+	user.userId = userId;
+
+	return user;
+}

--- a/client/state/comments/models/comment-info.js
+++ b/client/state/comments/models/comment-info.js
@@ -1,0 +1,15 @@
+export function CommentInfo( {
+	actions = null,
+	content = '',
+	createdAt = Date.now(),
+	isLiked = false,
+	parentId = 0,
+	status = null,
+} ) {
+	this.actions = actions;
+	this.content = content;
+	this.createdAt = createdAt;
+	this.isLiked = isLiked;
+	this.parentId = parentId;
+	this.status = status;
+}

--- a/client/state/comments/models/comment-status.js
+++ b/client/state/comments/models/comment-status.js
@@ -1,0 +1,21 @@
+export function CommentStatus( constructor ) {
+	Object.defineProperty( this, 'constructor', {
+		value: constructor || this
+	} );
+}
+
+export function Approved() {
+	return new CommentStatus( Approved );
+}
+
+export function Pending() {
+	return new CommentStatus( Pending );
+}
+
+export function Spam() {
+	return new CommentStatus( Spam );
+}
+
+export function Trash() {
+	return new CommentStatus( Trash );
+}

--- a/client/state/comments/models/comment-status.js
+++ b/client/state/comments/models/comment-status.js
@@ -1,21 +1,23 @@
-export function CommentStatus( constructor ) {
+export function CommentStatus( constructor, name ) {
 	Object.defineProperty( this, 'constructor', {
 		value: constructor || this
 	} );
+
+	this.name = name;
 }
 
 export function Approved() {
-	return new CommentStatus( Approved );
+	return new CommentStatus( Approved, 'approved' );
 }
 
 export function Pending() {
-	return new CommentStatus( Pending );
+	return new CommentStatus( Pending, 'pending' );
 }
 
 export function Spam() {
-	return new CommentStatus( Spam );
+	return new CommentStatus( Spam, 'spam' );
 }
 
 export function Trash() {
-	return new CommentStatus( Trash );
+	return new CommentStatus( Trash, 'trash' );
 }

--- a/client/state/comments/models/comment.js
+++ b/client/state/comments/models/comment.js
@@ -1,0 +1,34 @@
+export function Comment( constructor ) {
+	Object.defineProperty( this, 'constructor', {
+		value: constructor || this
+	} );
+}
+
+export function LoadingComment( siteId, commentId ) {
+	const comment = new Comment( LoadingComment );
+
+	comment.siteId = siteId;
+	comment.commentId = commentId;
+
+	return comment;
+}
+
+export function LoadedComment( {
+	siteId = 0,
+	postId = 0,
+	commentId = 0,
+	author = null,
+	info = null,
+} ) {
+	const comment = new Comment( LoadedComment );
+
+	comment.siteId = siteId;
+	comment.postId = postId;
+	comment.commentId = commentId;
+	comment.author = author;
+	comment.info = info;
+
+	return comment;
+}
+
+export default Comment;

--- a/client/state/comments/models/comment.js
+++ b/client/state/comments/models/comment.js
@@ -1,3 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { Author } from './comment-author'; // eslint-disable-line no-unused-vars
+import { CommentInfo } from './comment-info'; // eslint-disable-line no-unused-vars
+
 export function Comment( constructor ) {
 	Object.defineProperty( this, 'constructor', {
 		value: constructor || this
@@ -13,6 +19,17 @@ export function LoadingComment( siteId, commentId ) {
 	return comment;
 }
 
+/**
+ * Create a new loaded comment value
+ *
+ * @param {Number} siteId site id
+ * @param {Number} postId post id
+ * @param {Number} commentId comment id
+ * @param {Author} author comment author
+ * @param {CommentInfo} info comment information
+ * @returns {Comment} represents a comment with its content
+ * @constructor
+ */
 export function LoadedComment( {
 	siteId = 0,
 	postId = 0,

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -43,7 +43,7 @@ export const fetchCommentsList = ( { dispatch }, action ) => {
 export const addComments = ( { dispatch }, { query: { siteId } }, next, { comments } ) => {
 	const byPost = groupBy( comments, ( { post: { ID } } ) => ID );
 
-	console.log( comments.map( c => fromApi( siteId, c ) ) ); // eslint-disable-line no-console
+	window.comments = comments.map( c => fromApi( siteId, c ) );
 
 	forEach( byPost, ( postComments, postId ) => dispatch( {
 		type: COMMENTS_RECEIVE,

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -11,6 +11,7 @@ import { COMMENTS_LIST_REQUEST, COMMENTS_RECEIVE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
+import { fromApi } from 'state/comments/from-api';
 import { errorNotice } from 'state/notices/actions';
 import { getRawSite } from 'state/sites/selectors';
 
@@ -41,6 +42,8 @@ export const fetchCommentsList = ( { dispatch }, action ) => {
 
 export const addComments = ( { dispatch }, { query: { siteId } }, next, { comments } ) => {
 	const byPost = groupBy( comments, ( { post: { ID } } ) => ID );
+
+	console.log( comments.map( c => fromApi( siteId, c ) ) ); // eslint-disable-line no-console
 
 	forEach( byPost, ( postComments, postId ) => dispatch( {
 		type: COMMENTS_RECEIVE,

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -11,7 +11,6 @@ import { COMMENTS_LIST_REQUEST, COMMENTS_RECEIVE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 
-import { fromApi } from 'state/comments/from-api';
 import { errorNotice } from 'state/notices/actions';
 import { getRawSite } from 'state/sites/selectors';
 
@@ -42,8 +41,6 @@ export const fetchCommentsList = ( { dispatch }, action ) => {
 
 export const addComments = ( { dispatch }, { query: { siteId } }, next, { comments } ) => {
 	const byPost = groupBy( comments, ( { post: { ID } } ) => ID );
-
-	window.comments = comments.map( c => fromApi( siteId, c ) );
 
 	forEach( byPost, ( postComments, postId ) => dispatch( {
 		type: COMMENTS_RECEIVE,


### PR DESCRIPTION
The general idea here is to have a defined meaning for "what is a comment in Calypso" and to have related data split out into separate objects in the state tree. That is, for example, to mean that WordPress.com user information can come from `state/users[ comment.userId ].displayName` instead of `state/comments[ commentId ].user.displayName` etc…

**Testing**
Navigate to calypso.localhost:3000/comments, select a site, then look at the console