### PR TITLE
WooCommerce: Add product image management

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -13,6 +13,7 @@ import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
+import ProductFormImages from './product-form-images';
 
 export default class ProductFormDetailsCard extends Component {
 
@@ -51,7 +52,7 @@ export default class ProductFormDetailsCard extends Component {
 	}
 
 	render() {
-		const { product } = this.props;
+		const { product, editProduct } = this.props;
 		const __ = i18n.translate;
 		return (
 			<Card className="products__product-form-details">
@@ -65,9 +66,10 @@ export default class ProductFormDetailsCard extends Component {
 					</FormLabel>
 				</div>
 				<div className="products__product-form-details-wrapper">
-					<div className="products__product-form-details-images">
-
-					</div>
+					<ProductFormImages
+						product={ product }
+						editProduct={ editProduct }
+					/>
 					<div className="products__product-form-details-basic">
 						<FormFieldSet>
 							<FormLabel htmlFor="name">{ __( 'Product name' ) }</FormLabel>

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -51,8 +51,25 @@ export default class ProductFormDetailsCard extends Component {
 		editProduct( product, { featured: ! product.featured } );
 	}
 
-	render() {
+	onImageUpload = ( image ) => {
 		const { product, editProduct } = this.props;
+		const images = product.images && [ ...product.images ] || [];
+		images.push( {
+			id: image.ID,
+			src: image.URL,
+		} );
+		editProduct( product, { images } );
+	}
+
+	onImageRemove = ( id ) => {
+		const { product, editProduct } = this.props;
+		const images = product.images && [ ...product.images ].filter( i => i.id !== id ) || [];
+		editProduct( product, { images } );
+	}
+
+	render() {
+		const { product } = this.props;
+		const images = product.images || [];
 		const __ = i18n.translate;
 		return (
 			<Card className="products__product-form-details">
@@ -67,8 +84,9 @@ export default class ProductFormDetailsCard extends Component {
 				</div>
 				<div className="products__product-form-details-wrapper">
 					<ProductFormImages
-						product={ product }
-						editProduct={ editProduct }
+						images={ images }
+						onUpload={ this.onImageUpload }
+						onRemove={ this.onImageRemove }
 					/>
 					<div className="products__product-form-details-basic">
 						<FormFieldSet>

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -77,7 +77,11 @@ export default class ProductFormDetailsCard extends Component {
 						</FormFieldSet>
 						<FormFieldSet className="products__product-form-details-basic-description">
 							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>
-							<FormTextArea name="description" value={ product.description || '' } onChange={ this.setDescription } />
+							<FormTextArea
+								name="description"
+								value={ product.description || '' }
+								onChange={ this.setDescription }
+								rows="8" />
 						</FormFieldSet>
 					</div>
 				</div>

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -120,7 +120,7 @@ class ProductFormImages extends Component {
 		);
 	}
 
-	renderImage = ( image ) => {
+	renderImage = ( image, thumb = true ) => {
 		const { src } = image;
 		const id = image.id || image.transientId;
 
@@ -130,6 +130,7 @@ class ProductFormImages extends Component {
 
 		const classes = classNames( 'products__product-form-images-item', {
 			preview: null === src,
+			thumb,
 		} );
 
 		return (
@@ -159,7 +160,7 @@ class ProductFormImages extends Component {
 
 				<div className="products__product-form-images">
 					<div className="products__product-form-images-featured">
-						{ featuredImage && this.renderImage( featuredImage ) }
+						{ featuredImage && this.renderImage( featuredImage, false ) }
 					</div>
 
 					<div className="products__product-form-images-thumbs">

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -1,0 +1,164 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import ImagePreloader from 'components/image-preloader';
+import ProductImageUploader from 'woocommerce/components/product-image-uploader';
+import Spinner from 'components/spinner';
+
+class ProductFormImages extends Component {
+	static propTypes = {
+		product: PropTypes.shape( {
+			images: PropTypes.array,
+		} ),
+		editProduct: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+		const { product } = this.props;
+		const images = product.images || [];
+		this.state = {
+			images,
+		};
+	}
+
+	onUpload = ( file ) => {
+		const { product, editProduct } = this.props;
+		const images = product.images && [ ...product.images ] || [];
+		images.push( {
+			id: file.ID,
+			src: file.URL,
+		} );
+		editProduct( product, { images } );
+
+		const stateImages = [ ...this.state.images ].map( ( i ) => {
+			if ( i.transientId === file.transientId ) {
+				return { ...i,
+					src: file.URL,
+					id: file.ID,
+				};
+			}
+			return i;
+		} );
+
+		this.setState( {
+			images: stateImages,
+		} );
+	}
+
+	onSelect = ( files ) => {
+		const { images } = this.state;
+		const newImages = files.map( ( file ) => {
+			return {
+				placeholder: file.preview,
+				transientId: file.ID,
+				src: null,
+				id: null,
+			};
+		} );
+		this.setState( {
+			images: [ ...images, ...newImages ],
+		} );
+	}
+
+	onError = ( file ) => {
+		const images = [ ...this.state.images ].filter( i => i.transientId !== file.transientId );
+		this.setState( {
+			images
+		} );
+	}
+
+	removeImage = ( index ) => {
+		const { product, editProduct } = this.props;
+		const stateImages = [ ...this.state.images ];
+		const removedImage = stateImages.splice( index, 1 );
+		this.setState( {
+			images: stateImages,
+		} );
+
+		const id = removedImage[ 0 ].id || null;
+		if ( null !== id ) {
+			const images = product.images && [ ...product.images ].filter( i => i.id !== id ) || [];
+			editProduct( product, { images } );
+		}
+	}
+
+	renderImage = ( image, index ) => {
+		const { src, placeholder } = image;
+
+		const removeImage = () => {
+			this.removeImage( index );
+		};
+
+		const classes = classNames( 'products__product-form-images-item', {
+			preview: null === src,
+		} );
+
+		return (
+			<div className={ classes } key={ index }>
+				{ src && (
+					<figure>
+						<ImagePreloader
+							src={ src }
+							placeholder={ placeholder && ( <img src={ placeholder } /> ) || ( <span /> ) }
+						/>
+					</figure>
+				) || (
+					<figure>
+						<img src={ placeholder || ( <span /> ) } />
+						<Spinner />
+					</figure>
+				) }
+				<Button
+					onClick={ removeImage }
+					compact
+					className="products__product-form-images-item-remove">
+					<Gridicon
+						icon="cross"
+						size={ 24 }
+						className="products__product-form-images-item-remove-icon" />
+				</Button>
+			</div>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+		const { images } = this.state;
+
+		return (
+			<div className="products__product-form-images-wrapper">
+				<FormLabel>{ translate( 'Product Images' ) }</FormLabel>
+
+				<div className="products__product-form-images">
+					{ images.map( ( image, index ) =>
+						this.renderImage( image, index )
+					) }
+					<ProductImageUploader
+						onSelect={ this.onSelect }
+						onUpload={ this.onUpload }
+						onError={ this.onError }
+						compact={ images.length > 0 }
+					/>
+				</div>
+
+				<FormSettingExplanation>{ translate(
+					'For best results, upload photos larger than 1000x1000px.'
+				) }</FormSettingExplanation>
+			</div>
+		);
+	}
+}
+
+export default localize( ProductFormImages );

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -125,7 +125,7 @@ class ProductFormImages extends Component {
 					compact
 					className="products__product-form-images-item-remove">
 					<Gridicon
-						icon="cross"
+						icon="cross-small"
 						size={ 24 }
 						className="products__product-form-images-item-remove-icon" />
 				</Button>

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -167,13 +167,14 @@ class ProductFormImages extends Component {
 						{ images.map( ( image ) =>
 							this.renderImage( image )
 						) }
+
+						<ProductImageUploader
+							onSelect={ this.onSelect }
+							onUpload={ this.onUpload }
+							onError={ this.onError }
+							compact={ this.state.images.length > 0 }
+						/>
 					</div>
-					<ProductImageUploader
-						onSelect={ this.onSelect }
-						onUpload={ this.onUpload }
-						onError={ this.onError }
-						compact={ this.state.images.length > 0 }
-					/>
 				</div>
 
 				<FormSettingExplanation>{ translate(

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -34,17 +34,83 @@
 		flex-direction: row;
 	}
 }
-/* TODO: remove placeholder styles once implemented */
-.products__product-form-details-images {
-	background: $gray-light;
-	height: 200px;
-	margin-bottom: 16px;
-	@include breakpoint( ">960px" ) {
-		margin-bottom: 0;
+
+.products__product-form-images {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+
+	.products__product-form-images-item {
+		position: relative;
+		display: inline-block;
+		margin-right: 16px;
+
+		img {
+			width: 60px;
+		}
+
+		&:first-child {
+			margin-right: 0;
+			margin-bottom: 16px;
+
+			img {
+				width: 300px;
+			}
+		}
+	}
+
+	figure {
+		position: relative;
+		overflow: hidden;
+		height: 0;
+		padding-bottom: 100%;
+	}
+
+	.products__product-form-images-item.preview figure::after {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+
+	.products__product-form-images-item.preview img {
+		opacity: 0.7;
+	}
+
+	.spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+	}
+
+	.products__product-form-images-item-remove {
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 28px;
+		height: 28px;
+		transform: translate( 25%, -25% );
+		border: 1px solid lighten( $gray, 10% );
+		border-radius: 50%;
+		background-color: $gray-light;
+		cursor: pointer;
+	}
+
+	.products__product-form-images-item-remove-icon.gridicon {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+		width: 24px;
+		height: 24px;
+		margin: 0;
+		color: lighten( $gray, 10% );
 	}
 }
 
-.products__product-form-details-images,
+.products__product-form-images-wrapper,
 .products__product-form-details-basic {
 	flex: 1;
 	@include breakpoint( ">960px" ) {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -62,17 +62,17 @@
 
 		img {
 			width: 55px;
+			display: block;
 		}
 
 		&:first-child {
 			margin-right: 0;
 			clear: both;
-			@include breakpoint( "<960px" ) {
-				margin-right: 40%;
-			}
+			width: 100%;
 
 			img {
-				width: 300px;
+				width: 100%;
+				height: auto;
 			}
 		}
 	}
@@ -80,8 +80,6 @@
 	figure {
 		position: relative;
 		overflow: hidden;
-		height: 0;
-		padding-bottom: 100%;
 	}
 
 	.products__product-form-images-item.preview figure::after {
@@ -137,10 +135,11 @@
 }
 
 .products__product-form-images-wrapper {
-	flex: 1;
+	width: 100%;
 	margin-bottom: 16px;
 	@include breakpoint( ">960px" ) {
 		margin-bottom: 0;
+		width: 250px;
 	}
 }
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -43,38 +43,8 @@
 	.products__product-form-images-item {
 		position: relative;
 		display: inline-block;
-		margin-right: 2%;
 		margin-bottom: 16px;
-		width: 18.4%;
-
-		@include breakpoint( ">960px" ) {
-			width: 30%;
-			margin-right: 5%;
-		}
-
-		&:nth-child( 4 ) {
-			margin-right: 2%;
-
-			@include breakpoint( ">960px" ) {
-				margin-right: 0;
-			}
-		}
-
-		&:nth-child( 5 ) {
-			clear: both;
-		}
-
-		&:nth-child( 6 ) {
-			margin-right: 0;
-
-			@include breakpoint( ">960px" ) {
-				margin-right: 5%;
-			}
-		}
-
-		&:nth-child( 7 ) {
-			clear: both;
-		}
+		margin-right: 16px;
 
 		figure {
 			border: 1px solid lighten( $gray, 30% );
@@ -117,6 +87,21 @@
 		top: 50%;
 		left: 50%;
 		transform: translate( -50%, -50% );
+	}
+
+	.products__product-form-images-item.thumb figure {
+		width: 60px;
+		height: 60px;
+		overflow: hidden;
+
+		img {
+			position: absolute;
+			left: 50%;
+			top: 50%;
+			height: 100%;
+			width: auto;
+			transform: translate( -50%,-50% );
+		}
 	}
 
 	.products__product-form-images-item-remove {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -44,7 +44,13 @@
 		position: relative;
 		display: inline-block;
 		margin-bottom: 16px;
-		margin-right: 16px;
+		margin-right: 8px;
+		margin-left: 8px;
+
+		@include breakpoint( ">960px" ) {
+			margin-left: 0;
+			margin-right: 16px;
+		}
 
 		figure {
 			border: 1px solid lighten( $gray, 30% );
@@ -60,6 +66,7 @@
 	.products__product-form-images-featured {
 		.products__product-form-images-item {
 			margin-right: 0;
+			margin-left: 0;
 			clear: both;
 			width: 100%;
 		}
@@ -89,9 +96,27 @@
 		transform: translate( -50%, -50% );
 	}
 
+	.products__product-form-images-thumbs {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+
+		@include breakpoint( ">960px" ) {
+			justify-content: flex-start;
+		}
+
+		.products__product-form-images-item.thumb {
+			&:nth-child( 3n ) {
+				@include breakpoint( ">960px" ) {
+						margin-right: 0;
+				}
+			}
+		}
+	}
+
 	.products__product-form-images-item.thumb figure {
-		width: 60px;
-		height: 60px;
+		width: 70px;
+		height: 70px;
 		overflow: hidden;
 
 		img {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -47,11 +47,32 @@
 		margin-bottom: 16px;
 		width: 18.4%;
 
-		&:nth-child( 6n ) {
-			margin-right: 0;
+		@include breakpoint( ">960px" ) {
+			width: 30%;
+			margin-right: 5%;
 		}
 
-		&:nth-child( 7n ) {
+		&:nth-child( 4 ) {
+			margin-right: 2%;
+
+			@include breakpoint( ">960px" ) {
+				margin-right: 0;
+			}
+		}
+
+		&:nth-child( 5 ) {
+			clear: both;
+		}
+
+		&:nth-child( 6 ) {
+			margin-right: 0;
+
+			@include breakpoint( ">960px" ) {
+				margin-right: 5%;
+			}
+		}
+
+		&:nth-child( 7 ) {
 			clear: both;
 		}
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -190,6 +190,10 @@
 	resize: vertical;
 }
 
+.products__product-form-details-basic-description {
+	margin-bottom: 0;
+}
+
 .products__variation-types-form-wrapper {
 	padding: 24px;
 	border-top: 1px solid $gray-light;

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -44,14 +44,32 @@
 		position: relative;
 		display: inline-block;
 		margin-right: 16px;
+		margin-bottom: 16px;
+
+		&:nth-child(4) {
+		@include breakpoint( ">960px" ) {
+			margin-right: 0;
+			}
+		}
+
+		&:nth-child(2) {
+			clear: left;
+		}
+
+		figure {
+			border: 1px solid lighten( $gray, 30% );
+		}
 
 		img {
-			width: 60px;
+			width: 55px;
 		}
 
 		&:first-child {
 			margin-right: 0;
-			margin-bottom: 16px;
+			clear: both;
+			@include breakpoint( "<960px" ) {
+				margin-right: 40%;
+			}
 
 			img {
 				width: 300px;
@@ -96,6 +114,10 @@
 		border-radius: 50%;
 		background-color: $gray-light;
 		cursor: pointer;
+
+		&:hover {
+			background: lighten( $gray, 30% );
+		}
 	}
 
 	.products__product-form-images-item-remove-icon.gridicon {
@@ -107,12 +129,31 @@
 		height: 24px;
 		margin: 0;
 		color: lighten( $gray, 10% );
+
+		&:hover {
+			color: $gray;
+		}
 	}
+}
+
+.products__product-form-images-wrapper {
+	flex: 1;
+	margin-bottom: 16px;
+	@include breakpoint( ">960px" ) {
+		margin-bottom: 0;
+	}
+}
+
+.products__product-form-images-wrapper .form-setting-explanation {
+	margin: 0;
+}
+
+.products__product-form-details-basic {
+	flex: 2
 }
 
 .products__product-form-images-wrapper,
 .products__product-form-details-basic {
-	flex: 1;
 	@include breakpoint( ">960px" ) {
 		margin-right: 32px;
 	}

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -43,17 +43,16 @@
 	.products__product-form-images-item {
 		position: relative;
 		display: inline-block;
-		margin-right: 16px;
+		margin-right: 2%;
 		margin-bottom: 16px;
+		width: 18.4%;
 
-		&:nth-child(4) {
-		@include breakpoint( ">960px" ) {
+		&:nth-child( 6n ) {
 			margin-right: 0;
-			}
 		}
 
-		&:nth-child(2) {
-			clear: left;
+		&:nth-child( 7n ) {
+			clear: both;
 		}
 
 		figure {
@@ -61,19 +60,15 @@
 		}
 
 		img {
-			width: 55px;
 			display: block;
+			width: 100%;
+			height: auto;
 		}
 
 		&:first-child {
 			margin-right: 0;
 			clear: both;
 			width: 100%;
-
-			img {
-				width: 100%;
-				height: auto;
-			}
 		}
 	}
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -85,8 +85,10 @@
 			width: 100%;
 			height: auto;
 		}
+	}
 
-		&:first-child {
+	.products__product-form-images-featured {
+		.products__product-form-images-item {
 			margin-right: 0;
 			clear: both;
 			width: 100%;

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -96,7 +96,7 @@ class ProductImageUploader extends Component {
 		const filesToUpload = [];
 
 		images.forEach( function( image ) {
-			if ( maxUploadSize !== null && image.size > maxUploadSize ) {
+			if ( maxUploadSize && image.size > maxUploadSize ) {
 				errorNotice( translate( '%(name)s exceeds the maximum upload size (%(size)s) for this site.', {
 					args: {
 						name: image.name,

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -182,8 +182,10 @@ class ProductImageUploader extends Component {
 		return (
 			<div className="product-image-uploader__wrapper placeholder">
 				<div className="product-image-uploader__picker">
+					<div className="product-image-uploader__file-picker">
 						<Gridicon icon="add-image" size={ 36 } />
 						<p>{ translate( 'Loading' ) }</p>
+					</div>
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -182,7 +182,7 @@ class ProductImageUploader extends Component {
 		return (
 			<div className="product-image-uploader__wrapper placeholder">
 				<div className="product-image-uploader__picker">
-						<Gridicon icon="add-outline" size={ 36 } />
+						<Gridicon icon="add-image" size={ 36 } />
 						<p>{ translate( 'Loading' ) }</p>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -1,0 +1,166 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { head, uniqueId, find, noop } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { errorNotice as errorNoticeAction } from 'state/notices/actions';
+
+import DropZone from 'components/drop-zone';
+import FilePicker from 'components/file-picker';
+import MediaActions from 'lib/media/actions';
+import MediaUtils from 'lib/media/utils';
+import MediaStore from 'lib/media/store';
+
+class ProductImageUploader extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+		multiple: PropTypes.bool,
+		compact: PropTypes.bool,
+		onSelect: PropTypes.func,
+		onUpload: PropTypes.func,
+		onError: PropTypes.func,
+		onFinish: PropTypes.func,
+	};
+
+	static defaultProps = {
+		multiple: true,
+		compact: false,
+		onSelect: noop,
+		onUpload: noop,
+		onError: noop,
+		onFinish: noop,
+	}
+
+	onPick = ( files ) => {
+		const { siteId, multiple } = this.props;
+		const { translate, errorNotice } = this.props;
+		const { onSelect, onUpload, onError, onFinish } = this.props;
+
+		// DropZone supplies an array, FilePicker supplies a FileList
+		let images = Array.isArray( files ) ? MediaUtils.filterItemsByMimePrefix( files, 'image' ) : [ ...files ];
+		if ( ! images ) {
+			return false;
+		}
+
+		if ( multiple === false ) {
+			images = [ images.shift() ];
+		}
+
+		const transientIds = [];
+		const filesToUpload = [];
+		images.forEach( function( image ) {
+			const transientId = uniqueId( 'product-images-' );
+			transientIds.push( transientId );
+			filesToUpload.push( {
+				ID: transientId,
+				fileContents: image,
+				fileName: image.name,
+				preview: URL.createObjectURL( image ),
+			} );
+		} );
+
+		onSelect( filesToUpload );
+
+		const uploadedIds = [];
+		const handleUpload = () => {
+			const transientId = head( transientIds );
+			const media = MediaStore.get( siteId, transientId );
+			const isUploadInProgress = media && MediaUtils.isItemBeingUploaded( media );
+
+			// File has finished uploading or failed.
+			if ( ! isUploadInProgress ) {
+				if ( media ) {
+					const file = find( filesToUpload, ( f ) => f.ID === transientId );
+					onUpload( {
+						ID: media.ID,
+						transientId,
+						URL: media.URL,
+						placeholder: file.preview,
+					} );
+					uploadedIds.push( transientId );
+				} else {
+					onError( {
+						file: media,
+						transientId,
+					} );
+					errorNotice( translate( 'There was a problem uploading %s.', {
+						args: media && media.file || translate( 'an image' )
+					} ) );
+				}
+
+				transientIds.shift();
+				if ( transientIds.length === 0 ) {
+					MediaStore.off( 'change', handleUpload );
+					onFinish( uploadedIds );
+				}
+			}
+		};
+
+		MediaStore.on( 'change', handleUpload );
+		MediaActions.add( siteId, filesToUpload );
+	}
+
+	renderCompactUploader() {
+		const { multiple } = this.props;
+		return (
+			<div className="product-image-uploader__picker compact">
+				<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick } >
+					<Gridicon icon="add-outline" size={ 24 } />
+				</FilePicker>
+			</div>
+		);
+	}
+
+	renderUploader() {
+		const { translate, multiple } = this.props;
+		return (
+			<div className="product-image-uploader__wrapper">
+				<div className="product-image-uploader__picker">
+					<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
+						<Gridicon icon="add-outline" size={ 36 } />
+						<p>{ translate( 'Add images' ) }</p>
+					</FilePicker>
+				</div>
+				<DropZone onFilesDrop={ this.onPick } />
+			</div>
+		);
+	}
+
+	renderChildren() {
+		return React.Children.map( this.props.children, function( child ) {
+			return <div>{ child }</div>;
+		} );
+	}
+
+	render() {
+		const { compact, children, multiple } = this.props;
+
+		if ( children !== undefined ) {
+			return (
+				<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
+					{ this.renderChildren() }
+				</FilePicker>
+			);
+		}
+
+		return compact && this.renderCompactUploader() || this.renderUploader();
+	}
+
+}
+
+function mapStateToProps( state ) {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+	};
+}
+
+export default connect( mapStateToProps, { errorNotice: errorNoticeAction } )( localize( ProductImageUploader ) );

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -150,7 +150,7 @@ class ProductImageUploader extends Component {
 		return (
 			<div className="product-image-uploader__picker compact">
 				<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick } >
-					<Gridicon icon="add-outline" size={ 24 } />
+					<Gridicon icon="add-image" size={ 24 } />
 				</FilePicker>
 			</div>
 		);
@@ -162,7 +162,7 @@ class ProductImageUploader extends Component {
 			<div className="product-image-uploader__wrapper">
 				<div className="product-image-uploader__picker">
 					<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
-						<Gridicon icon="add-outline" size={ 36 } />
+						<Gridicon icon="add-image" size={ 36 } />
 						<p>{ translate( 'Add images' ) }</p>
 					</FilePicker>
 				</div>

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -1,13 +1,14 @@
 .product-image-uploader__wrapper {
 	background: $gray-light;
 	height: 250px;
-	width: 250px;
+	width: 100%;
 	position: relative;
 	margin-bottom: 16px;
 	border: 1px dashed $gray;
 	border-radius: 5px;
 	@include breakpoint( ">960px" ) {
 		margin-bottom: 0;
+		width: 250px;
 	}
 
 	.product-image-uploader__picker {

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -6,9 +6,8 @@
 	margin-bottom: 16px;
 	border: 1px dashed $gray;
 	border-radius: 5px;
-	@include breakpoint( ">960px" ) {
-		width: 250px;
-	}
+	width: 250px;
+
 
 	.product-image-uploader__picker {
 		position: absolute;
@@ -47,27 +46,38 @@
 }
 
 .product-image-uploader__picker.compact {
-	width: 18.4%;
 	position: relative;
 	margin-bottom: 16px;
-	align-self: stretch;
+	margin-left: 8px;
+	margin-right: 8px;
+	background: $gray-light;
+	border: 1px dashed $gray;
+	width: 70px;
+	height: 70px;
+	border-radius: 5px;
+	display: inline-block;
 
 	@include breakpoint( ">960px" ) {
-		width: 30%;
+		margin-left: 0;
+		margin-right: 16px;
+	}
+
+	&:nth-child( 3n ) {
+		@include breakpoint( ">960px" ) {
+			margin-right: 0;
+		}
 	}
 
 	.file-picker,
 	.product-image-uploader__file-picker {
 		display: block;
 		text-align: center;
-		border: 1px dashed $gray;
-		min-height: 60px;
-		height: 100%;
-		border-radius: 5px;
 		cursor: pointer;
-		background: $gray-light;
-		position: relative;
-		box-sizing: border-box;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
 
 		.gridicon {
 			position: absolute;
@@ -81,26 +91,6 @@
 	&:hover {
 		.gridicon {
 			color: darken( $gray, 30% );
-		}
-	}
-
-	&:nth-child( 6 ) {
-		margin-right: 0;
-
-		@include breakpoint( ">960px" ) {
-			margin-right: 5%;
-		}
-	}
-
-	&:nth-child( 7 ) {
-		clear: both;
-	}
-
-	&:nth-child( 7 ),
-	&:nth-child( 4 ) {
-		@include breakpoint( ">960px" ) {
-			clear: none;
-			margin-right: 0;
 		}
 	}
 }

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -67,6 +67,7 @@
 		cursor: pointer;
 		background: $gray-light;
 		position: relative;
+		box-sizing: border-box;
 
 		.gridicon {
 			position: absolute;

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -31,8 +31,8 @@
 
 .product-image-uploader__picker.compact {
 	background: $gray-light;
-	height: 55px;
-	width: 55px;
+	height: 60px;
+	width: 18.4%;
 	position: relative;
 	margin-bottom: 16px;
 	border: 1px dashed $gray;
@@ -43,6 +43,10 @@
 		display: block;
 		text-align: center;
 		padding-top: 16px;
+	}
+
+	&:nth-child( 7n ) {
+		clear: both;
 	}
 }
 

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -30,23 +30,42 @@
 }
 
 .product-image-uploader__picker.compact {
-	background: $gray-light;
-	height: 60px;
 	width: 18.4%;
 	position: relative;
 	margin-bottom: 16px;
-	border: 1px dashed $gray;
-	border-radius: 5px;
-	cursor: pointer;
+
+	@include breakpoint( ">960px" ) {
+		width: 30%;
+	}
 
 	.file-picker {
 		display: block;
 		text-align: center;
-		padding-top: 16px;
+		border: 1px dashed $gray;
+		height: 60px;
+		border-radius: 5px;
+		cursor: pointer;
+		background: $gray-light;
 	}
 
-	&:nth-child( 7n ) {
+	&:nth-child( 6 ) {
+		margin-right: 0;
+
+		@include breakpoint( ">960px" ) {
+			margin-right: 5%;
+		}
+	}
+
+	&:nth-child( 7 ) {
 		clear: both;
+	}
+
+	&:nth-child( 7 ),
+	&:nth-child( 4 ) {
+		@include breakpoint( ">960px" ) {
+			clear: none;
+			margin-right: 0;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -36,3 +36,11 @@
 		padding-top: 12px;
 	}
 }
+
+.product-image-uploader__wrapper.placeholder {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	cursor: default;
+	.product-image-uploader__picker {
+		cursor: default;
+	}
+}

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -21,7 +21,8 @@
 		display: flex;
 		align-items: center;
 
-		.file-picker {
+		.file-picker,
+		.product-image-uploader__file-picker {
 			margin: 0 auto;
 
 			p {
@@ -55,7 +56,8 @@
 		width: 30%;
 	}
 
-	.file-picker {
+	.file-picker,
+	.product-image-uploader__file-picker {
 		display: block;
 		text-align: center;
 		border: 1px dashed $gray;

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -7,17 +7,27 @@
 	border: 1px dashed $gray;
 	border-radius: 5px;
 	@include breakpoint( ">960px" ) {
-		margin-bottom: 0;
 		width: 250px;
 	}
 
 	.product-image-uploader__picker {
 		position: absolute;
-		top: 55%;
-		left: 50%;
-		transform: translate(-50%, -50%);
+		top: 0;
+		left: 0;
+		height: 100%;
+		width: 100%;
 		text-align: center;
 		cursor: pointer;
+		display: flex;
+		align-items: center;
+
+		.file-picker {
+			margin: 0 auto;
+
+			p {
+				margin: 0;
+			}
+		}
 
 		.gridicon {
 			color: darken( $gray, 10% );
@@ -25,6 +35,12 @@
 
 		p {
 			font-size: 14px;
+		}
+
+		&:hover {
+			.gridicon {
+				color: darken( $gray, 30% );
+			}
 		}
 	}
 }
@@ -46,6 +62,21 @@
 		border-radius: 5px;
 		cursor: pointer;
 		background: $gray-light;
+		position: relative;
+
+		.gridicon {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate( -50%, -50% );
+			color: darken( $gray, 10% );
+		}
+	}
+
+	&:hover {
+		.gridicon {
+			color: darken( $gray, 30% );
+		}
 	}
 
 	&:nth-child( 6 ) {

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -49,6 +49,7 @@
 	width: 18.4%;
 	position: relative;
 	margin-bottom: 16px;
+	align-self: stretch;
 
 	@include breakpoint( ">960px" ) {
 		width: 30%;
@@ -58,15 +59,12 @@
 		display: block;
 		text-align: center;
 		border: 1px dashed $gray;
-		height: 60px;
+		min-height: 60px;
+		height: 100%;
 		border-radius: 5px;
 		cursor: pointer;
 		background: $gray-light;
 		position: relative;
-
-		@include breakpoint( ">960px" ) {
-			height: 72px;
-		}
 
 		.gridicon {
 			position: absolute;

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -64,6 +64,10 @@
 		background: $gray-light;
 		position: relative;
 
+		@include breakpoint( ">960px" ) {
+			height: 72px;
+		}
+
 		.gridicon {
 			position: absolute;
 			top: 50%;

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -1,0 +1,38 @@
+.product-image-uploader__wrapper {
+	background: $gray-light;
+	height: 250px;
+	width: 250px;
+	position: relative;
+	margin-bottom: 16px;
+	border: 1px dashed $gray;
+	border-radius: 5px;
+	@include breakpoint( ">960px" ) {
+		margin-bottom: 0;
+	}
+
+	.product-image-uploader__picker {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		text-align: center;
+		cursor: pointer;
+	}
+}
+
+.product-image-uploader__picker.compact {
+	background: $gray-light;
+	height: 50px;
+	width: 50px;
+	position: relative;
+	margin-bottom: 16px;
+	border: 1px dashed $gray;
+	border-radius: 5px;
+	cursor: pointer;
+
+	.file-picker {
+		display: block;
+		text-align: center;
+		padding-top: 12px;
+	}
+}

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -12,18 +12,26 @@
 
 	.product-image-uploader__picker {
 		position: absolute;
-		top: 50%;
+		top: 55%;
 		left: 50%;
 		transform: translate(-50%, -50%);
 		text-align: center;
 		cursor: pointer;
+
+		.gridicon {
+			color: darken( $gray, 10% );
+		}
+
+		p {
+			font-size: 14px;
+		}
 	}
 }
 
 .product-image-uploader__picker.compact {
 	background: $gray-light;
-	height: 50px;
-	width: 50px;
+	height: 55px;
+	width: 55px;
 	position: relative;
 	margin-bottom: 16px;
 	border: 1px dashed $gray;
@@ -33,7 +41,7 @@
 	.file-picker {
 		display: block;
 		text-align: center;
-		padding-top: 12px;
+		padding-top: 16px;
 	}
 }
 

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -14,6 +14,7 @@
 	@import 'components/address-view/style';
 	@import 'components/extended-header/style';
 	@import 'components/form-dimensions-input/style';
+	@import 'components/product-image-uploader/style';
 	@import 'app/settings/shipping/style';
 	@import 'components/list/style';
 	@import 'app/dashboard/style';


### PR DESCRIPTION
This PR introduces a product image uploader and allows you to upload multiple product images, as well as remove them. Images are uploaded to the media library.

This is using Calypso's `DropZone` and `FilePicker` components for v1. We should look at using the media modal post v1 (it looked tied to the post-editor/TinyMCE so I went this route for our MVP). 

To test:
* Visit `http://calypso.localhost:3000/store/products/:site/add`.
* Click "Add Images" or drag and drop some images to the upload area.
* Watch as your images upload (spinner/busy state). You should see an instant preview of them.
* Your images should upload (or if an upload fails, an error notice should be displayed).
* You should be able to upload additional images if wanted.
* Click the "x" on an image to remove it from the product.

<img width="773" alt="screen shot 2017-05-30 at 10 54 54 am" src="https://cloud.githubusercontent.com/assets/689165/26597629/79107344-4527-11e7-802f-4007caa8153a.png">

<img width="795" alt="screen shot 2017-05-30 at 10 59 12 am" src="https://cloud.githubusercontent.com/assets/689165/26597642/80a2b306-4527-11e7-916b-2ad28b208868.png">

Closes #13658, #13656.

Related: This works better on the front end with https://github.com/woocommerce/wc-api-dev/pull/1, which removes a dummy placeholder image from the response, and makes setting images without manually setting positions. However, we will need to bump to using v3 with the feature plugin installed. These changes work without that branch, though.