### PR TITLE
WooCommerce: Add variation image management

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -116,7 +116,7 @@ class ProductFormVariationsRow extends Component {
 	renderImage = () => {
 		const { src, placeholder, isUploading } = this.state;
 
-		let image;
+		let image = null;
 		if ( src && ! isUploading ) {
 			image = (
 				<figure>
@@ -160,7 +160,9 @@ class ProductFormVariationsRow extends Component {
 					onSelect={ this.onSelect }
 					onUpload={ this.onUpload }
 					onError={ this.onError }
-				>{image}</ProductImageUploader>
+				>
+					{image}
+				</ProductImageUploader>
 				{removeButton}
 			</div>
 		);

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -116,10 +116,6 @@ class ProductFormVariationsRow extends Component {
 	renderImage = () => {
 		const { src, placeholder, isUploading } = this.state;
 
-		const classes = classNames( 'products__product-form-variation-image', {
-			preview: null === src,
-		} );
-
 		let image;
 		if ( src && ! isUploading ) {
 			image = (
@@ -138,6 +134,11 @@ class ProductFormVariationsRow extends Component {
 				</figure>
 			);
 		}
+
+		const classes = classNames( 'products__product-form-variation-image', {
+			preview: null === src,
+			uploader: ! image,
+		} );
 
 		const removeButton = image && (
 			<Button

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -1,111 +1,228 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
+import { head } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
+import Button from 'components/button';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import ImagePreloader from 'components/image-preloader';
+import ProductImageUploader from 'woocommerce/components/product-image-uploader';
+import Spinner from 'components/spinner';
 
-const ProductFormVariationsRow = ( {
-	product,
-	variation,
-	editProductVariation,
-	onShowDialog,
-	translate,
-	manageStock,
-} ) => {
+class ProductFormVariationsRow extends Component {
+	static propTypes = {
+		product: PropTypes.object.isRequired,
+		variation: PropTypes.object.isRequired,
+		manageStock: PropTypes.bool,
+		onShowDialog: PropTypes.func,
+		editProductVariation: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+		const { variation } = props;
+		const image = variation && variation.image || {};
+
+		this.state = {
+			id: image.id || null,
+			src: image.src || null,
+			placeholder: null,
+			transientId: null,
+			isUploading: false,
+		};
+	}
+
 	// TODO: Consildate the following set/toggle functions with a helper (along with the form-details functions).
-	const setPrice = ( e ) => {
+	setPrice = ( e ) => {
+		const { editProductVariation, product, variation } = this.props;
 		editProductVariation( product, variation, { regular_price: e.target.value } );
-	};
+	}
 
-	const setWeight = ( e ) => {
+	setWeight = ( e ) => {
+		const { editProductVariation, product, variation } = this.props;
 		editProductVariation( product, variation, { weight: e.target.value } );
-	};
+	}
 
-	const setDimension = ( e ) => {
+	setDimension = ( e ) => {
+		const { editProductVariation, product, variation } = this.props;
 		const dimensions = { ...variation.dimensions, [ e.target.name ]: e.target.value };
 		editProductVariation( product, variation, { dimensions } );
-	};
+	}
 
-	const setStockQuantity = ( e ) => {
+	setStockQuantity = ( e ) => {
+		const { editProductVariation, product, variation } = this.props;
 		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
 		editProductVariation( product, variation, { stock_quantity } );
-	};
+	}
 
-	const showDialog = () => {
+	showDialog = () => {
+		const { variation, onShowDialog } = this.props;
 		onShowDialog( variation.id );
-	};
+	}
 
-	return (
-		<tr className="products__product-form-variation-row">
-			<td className="products__product-id">
-				<div className="products__product-name-thumb">
-					<div className="products__product-form-variation-image"></div>
-					<span className="products__product-name products__variation-settings-link" onClick={ showDialog }>
-						{ formattedVariationName( variation ) }
-					</span>
-				</div>
-			</td>
-			<td>
-				<FormCurrencyInput noWrap
-					currencySymbolPrefix="$"
-					name="price"
-					value={ variation.regular_price || '' }
-					placeholder="0.00"
-					onChange={ setPrice }
-					size="4"
-				/>
-			</td>
-			<td>
-				<div className="products__product-dimensions-weight">
-					<FormDimensionsInput
-						className="products__product-dimensions-input"
-						unit="in"
-						dimensions={ variation.dimensions }
-						onChange={ setDimension }
-						noWrap
+	onSelect = ( files ) => {
+		const file = head( files );
+		this.setState( {
+			placeholder: file.preview,
+			transientId: file.ID,
+			isUploading: true,
+		} );
+	}
+
+	onUpload = ( file ) => {
+		const { editProductVariation, product, variation } = this.props;
+		const image = {
+			src: file.URL,
+			id: file.ID,
+		};
+		this.setState( { ...image,
+			transientId: null,
+			isUploading: false,
+		} );
+		editProductVariation( product, variation, { image } );
+	}
+
+	onError = () => {
+		this.setState( {
+			placeholder: null,
+			transientId: null,
+			isUploading: false,
+		} );
+	}
+
+	removeImage = () => {
+		const { editProductVariation, product, variation } = this.props;
+		this.setState( {
+			placeholder: null,
+			transientId: null,
+			isUploading: false,
+			src: null,
+			id: null,
+		} );
+		editProductVariation( product, variation, { image: {} } );
+	}
+
+	renderImage = () => {
+		const { src, placeholder, isUploading } = this.state;
+
+		const classes = classNames( 'products__product-form-variation-image', {
+			preview: null === src,
+		} );
+
+		let image;
+		if ( src && ! isUploading ) {
+			image = (
+				<figure>
+					<ImagePreloader
+						src={ src }
+						placeholder={ placeholder && ( <img src={ placeholder } /> ) || ( <span /> ) }
 					/>
-					<div className="products__product-weight-input">
-						<FormTextInputWithAffixes
-							name="weight"
-							type="number"
-							suffix="g"
-							value={ variation.weight || '' }
-							onChange={ setWeight }
-							size="4"
+				</figure>
+			);
+		} else if ( isUploading ) {
+			image = (
+				<figure>
+					<img src={ placeholder || ( <span /> ) } />
+					<Spinner />
+				</figure>
+			);
+		}
+
+		const removeButton = image && (
+			<Button
+				compact
+				onClick={ this.removeImage }
+				className="products__product-form-variation-image-remove">
+					<Gridicon
+						icon="cross"
+						size={ 24 }
+						className="products__product-form-variation-image-remove-icon" />
+			</Button>
+		);
+
+		return (
+			<div className={ classes }>
+				<ProductImageUploader
+					compact
+					multiple={ false }
+					onSelect={ this.onSelect }
+					onUpload={ this.onUpload }
+					onError={ this.onError }
+				>{image}</ProductImageUploader>
+				{removeButton}
+			</div>
+		);
+	}
+
+	render() {
+		const { variation, manageStock, translate } = this.props;
+		return (
+			<tr className="products__product-form-variation-row">
+				<td className="products__product-id">
+					<div className="products__product-name-thumb">
+						{ this.renderImage() }
+						<span className="products__product-name products__variation-settings-link" onClick={ this.showDialog }>
+							{ formattedVariationName( variation ) }
+						</span>
+					</div>
+				</td>
+				<td>
+					<FormCurrencyInput noWrap
+						currencySymbolPrefix="$"
+						name="price"
+						value={ variation.regular_price || '' }
+						placeholder="0.00"
+						onChange={ this.setPrice }
+						size="4"
+					/>
+				</td>
+				<td>
+					<div className="products__product-dimensions-weight">
+						<FormDimensionsInput
+							className="products__product-dimensions-input"
+							unit="in"
+							dimensions={ variation.dimensions }
+							onChange={ this.setDimension }
 							noWrap
 						/>
+						<div className="products__product-weight-input">
+							<FormTextInputWithAffixes
+								name="weight"
+								type="number"
+								suffix="g"
+								value={ variation.weight || '' }
+								onChange={ this.setWeight }
+								size="4"
+								noWrap
+							/>
+						</div>
 					</div>
-				</div>
-			</td>
-			<td>
-				<div className="products__product-manage-stock">
-					{ manageStock && ( <FormTextInput
-						name="stock_quantity"
-						value={ variation.stock_quantity || '' }
-						type="number"
-						onChange={ setStockQuantity }
-						placeholder={ translate( 'Quantity' ) }
-					/> ) }
-				</div>
-			</td>
-		</tr>
-	);
-};
-
-ProductFormVariationsRow.propTypes = {
-	product: PropTypes.object.isRequired,
-	variation: PropTypes.object.isRequired,
-	manageStock: PropTypes.bool,
-	editProductVariation: PropTypes.func.isRequired,
-};
+				</td>
+				<td>
+					<div className="products__product-manage-stock">
+						{ manageStock && ( <FormTextInput
+							name="stock_quantity"
+							value={ variation.stock_quantity || '' }
+							type="number"
+							onChange={ this.setStockQuantity }
+							placeholder={ translate( 'Quantity' ) }
+						/> ) }
+					</div>
+				</td>
+			</tr>
+		);
+	}
+}
 
 export default localize( ProductFormVariationsRow );

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -333,19 +333,25 @@
 }
 
 .products__product-form-variation-image {
-	height: 55px;
-	width: 55px;
-	margin-bottom: 16px;
+	margin-bottom: 0;
 	margin-right: 0px;
 	flex-shrink: 0;
 	position: relative;
 
-	&:hover {
-		cursor: pointer;
+	.product-image-uploader__picker.compact {
+		height: 40px;
+		width: 40px;
+		margin-bottom: 0;
+		margin-right: 0;
+		margin-left: 0;
+
+		.file-picker {
+			height: 42px;
+		}
 	}
 
-	.product-image-uploader__picker {
-		min-width: 100%;
+	&:hover {
+		cursor: pointer;
 	}
 
 	.products__product-form-variation-image-remove {
@@ -373,9 +379,10 @@
 	}
 
 	figure {
-		width: 60px;
-		height: 60px;
+		width: 40px;
+		height: 40px;
 		overflow: hidden;
+		border: 1px solid lighten( $gray, 30% );
 
 		img {
 			position: absolute;
@@ -407,18 +414,10 @@
 	}
 }
 
-.products__product-form-variation-image.uploader .product-image-uploader__picker {
-	height: 55px;
-	width: 55px;
-
-	.file-picker {
-		height: inherit;
-	}
-}
-
 .products__product-form-variation-table-wrapper .products__product-form-variation-image {
 	margin-bottom: 0;
-	margin-right: 8px;
+	margin-right: 12px;
+	max-height: 42px;
 }
 
 .products__product-form-variation-all-row .products__product-id {
@@ -428,7 +427,6 @@
 .products__product-name-thumb {
 	display: inline-flex;
 	flex-direction: row;
-	max-width: 120px;
 	align-items: center;
 }
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -373,10 +373,18 @@
 	}
 
 	figure {
-		position: relative;
+		width: 60px;
+		height: 60px;
 		overflow: hidden;
-		height: 0;
-		padding-bottom: 100%;
+
+		img {
+			position: absolute;
+			left: 50%;
+			top: 50%;
+			height: 100%;
+			width: auto;
+			transform: translate( -50%,-50% );
+		}
 	}
 
 	.products__product-form-variation-image.preview figure::after {
@@ -396,6 +404,15 @@
 		top: 50%;
 		left: 50%;
 		transform: translate( -50%, -50% );
+	}
+}
+
+.products__product-form-variation-image.uploader .product-image-uploader__picker {
+	height: 55px;
+	width: 55px;
+
+	.file-picker {
+		height: inherit;
 	}
 }
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -360,7 +360,7 @@
 		right: 0;
 		width: 14px;
 		height: 14px;
-		transform: translate( 25%, -25% );
+		transform: translate( 33%, -33% );
 		border: 1px solid lighten( $gray, 10% );
 		border-radius: 50%;
 		background-color: $gray-light;
@@ -378,11 +378,14 @@
 		color: lighten( $gray, 10% );
 	}
 
+	&:not(.uploader) {
+		border: 1px solid lighten( $gray, 30% );
+	}
+
 	figure {
 		width: 40px;
 		height: 40px;
 		overflow: hidden;
-		border: 1px solid lighten( $gray, 30% );
 
 		img {
 			position: absolute;
@@ -428,6 +431,7 @@
 	display: inline-flex;
 	flex-direction: row;
 	align-items: center;
+	transform: translateY(2px);
 }
 
 .products__product-name {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -332,17 +332,74 @@
 	min-width: 75px;
 }
 
-/* TODO: remove placeholder styles once implemented */
 .products__product-form-variation-image {
-	background: $gray-light;
-	height: 40px;
-	width: 40px;
+	height: 55px;
+	width: 55px;
 	margin-bottom: 16px;
 	margin-right: 0px;
 	flex-shrink: 0;
+	position: relative;
+
+	&:hover {
+		cursor: pointer;
+	}
+
+	.product-image-uploader__picker {
+		min-width: 100%;
+	}
+
+	.products__product-form-variation-image-remove {
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 14px;
+		height: 14px;
+		transform: translate( 25%, -25% );
+		border: 1px solid lighten( $gray, 10% );
+		border-radius: 50%;
+		background-color: $gray-light;
+		cursor: pointer;
+	}
+
+	.products__product-form-variation-image-remove-icon.gridicon {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+		width: 12px;
+		height: 12px;
+		margin: 0;
+		color: lighten( $gray, 10% );
+	}
+
+	figure {
+		position: relative;
+		overflow: hidden;
+		height: 0;
+		padding-bottom: 100%;
+	}
+
+	.products__product-form-variation-image.preview figure::after {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+
+	.products__product-form-variation-image.preview img {
+		opacity: 0.7;
+	}
+
+	.spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+	}
 }
 
-.products__product-form-variation-table-wrapper .products__product-form-variation-image{
+.products__product-form-variation-table-wrapper .products__product-form-variation-image {
 	margin-bottom: 0;
 	margin-right: 8px;
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -431,7 +431,7 @@
 	display: inline-flex;
 	flex-direction: row;
 	align-items: center;
-	transform: translateY(2px);
+	transform: translateY( 2px );
 }
 
 .products__product-name {

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { head, uniqueId, find, noop } from 'lodash';
+import { head, uniqueId, find, noop, trim } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
@@ -238,7 +238,7 @@ class ProductImageUploader extends Component {
 			return this.renderPlaceholder();
 		}
 
-		if ( 'undefined' !== typeof children ) {
+		if ( '' !== trim( children ) ) {
 			return (
 				<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
 					{ this.renderChildren() }

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { head, uniqueId, find, noop } from 'lodash';
 import Gridicon from 'gridicons';
@@ -212,13 +213,18 @@ class ProductImageUploader extends Component {
 	}
 
 	renderPlaceholder() {
-		const { translate } = this.props;
+		const { translate, compact } = this.props;
+
+		const classes = classNames( 'product-image-uploader__wrapper placeholder', {
+			compact,
+		} );
+
 		return (
-			<div className="product-image-uploader__wrapper placeholder">
+			<div className={ classes }>
 				<div className="product-image-uploader__picker">
 					<div className="product-image-uploader__file-picker">
 						<Gridicon icon="add-image" size={ 36 } />
-						<p>{ translate( 'Loading' ) }</p>
+						<p>{ ! compact && translate( 'Loading' ) }</p>
 					</div>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -106,3 +106,8 @@
 		cursor: default;
 	}
 }
+
+.product-image-uploader__wrapper.placeholder.compact {
+	width: 55px;
+	height: 55px;
+}

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -79,6 +79,10 @@
 		width: 100%;
 		height: 100%;
 
+		@include breakpoint( ">960px" ) {
+			height: 72px;
+		}
+
 		.gridicon {
 			position: absolute;
 			top: 50%;


### PR DESCRIPTION
This PR adds variation image management so that an can be set for each variation. It uses the same uploader component as #14596 to share code.


To test:
* Visit `http://calypso.localhost:3000/store/products/:site/add`.
* Toggle "This product has variations"
* Type in a few variation types so that they show up in the editing table.
* Click the upload button next to a variation and upload an image for it.
* Your image should upload (or if an upload fails, an error notice should be displayed).
* Click the "x" on an image to remove it from the variation.

<img width="824" alt="screen shot 2017-05-30 at 11 15 46 am" src="https://cloud.githubusercontent.com/assets/689165/26598412/0860950e-452a-11e7-92f3-ccf1bcd16029.png">

cc @kellychoffman @jameskoster This PR contains UI.