### PR TITLE
Login: Update return link to point back to WordPress.com

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -65,8 +65,6 @@ export class Login extends React.Component {
 		this.props.showMagicLoginRequestForm();
 	};
 
-	state = { loaded: false };
-
 	magicLoginMainContent() {
 		const {
 			magicLoginView,
@@ -97,13 +95,6 @@ export class Login extends React.Component {
 		}
 	}
 
-	componentDidMount() {
-		// Turning off eslint rule, as this flag is telling us when the component is
-		// loaded in the browser, which isn't guaranteed until componentDidMount() fires.
-		// eslint-disable-next-line react/no-did-mount-set-state
-		this.setState( { loaded: true } );
-	}
-
 	goBack = event => {
 		event.preventDefault();
 
@@ -130,15 +121,14 @@ export class Login extends React.Component {
 				</a>;
 		}
 
-		let goBackLink;
-		if ( this.state.loaded && window.history.length > 1 ) {
-			goBackLink = ! magicLoginView && <a
-				href="#"
-				key="back-link"
-				onClick={ this.goBack }>
-					<Gridicon icon="arrow-left" size={ 18 } /> { translate( 'Return' ) }
-				</a>;
-		}
+		const backToWpcomLink = ! magicLoginView && (
+			<a
+				href="https://wordpress.com"
+				key="return-to-wpcom-link"
+			>
+				<Gridicon icon="arrow-left" size={ 18 } /> { translate( 'Back to WordPress.com' ) }
+			</a>
+		);
 
 		const showMagicLoginLink = magicLoginEnabled && ! magicLoginView && ! twoFactorAuthType && (
 			<a href="#"
@@ -179,7 +169,7 @@ export class Login extends React.Component {
 			helpLink,
 			showMagicLoginLink,
 			resetPasswordLink,
-			goBackLink,
+			backToWpcomLink,
 		] );
 	}
 

--- a/client/login/wp-login/test/test.jsx
+++ b/client/login/wp-login/test/test.jsx
@@ -21,40 +21,10 @@ describe( 'Login', () => {
 	} );
 
 	describe( 'footerLinks', () => {
-		context( 'when state is not loaded', () => {
-			it( 'should not have a return button', () => {
-				const login = shallow( <Login queryArguments={ { redirect_to: '' } } translate={ identity } /> );
+		it( 'should have a "Back to WordPress.com" link', () => {
+			const login = shallow( <Login queryArguments={ { redirect_to: '' } } translate={ identity } /> );
 
-				expect( login.find( '.wp-login__footer > a' ).length ).to.equal( 1 );
-			} );
-		} );
-
-		context( 'after state is loaded', () => {
-			context( 'there is no history', () => {
-				it( 'should not have a return button', () => {
-					const login = shallow( <Login queryArguments={ { redirect_to: '' } } translate={ identity } /> );
-					login.setState( { loaded: true } );
-
-					expect( login.find( '.wp-login__footer > a' ).length ).to.equal( 1 );
-				} );
-			} );
-
-			context( 'there is history', () => {
-				before( () => {
-					window.history.pushState( {}, '' );
-				} );
-
-				it( 'should have a return button if there is history', () => {
-					const login = shallow( <Login queryArguments={ { redirect_to: '' } } translate={ identity } /> );
-					login.setState( { loaded: true } );
-
-					expect( login.find( '.wp-login__footer > a' ).length ).to.equal( 2 );
-				} );
-
-				after( () => {
-					window.history.back();
-				} );
-			} );
+			expect( login.find( '.wp-login__footer > a' ).contains( 'Back to WordPress.com' ) ).to.equal( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
As discussed elsewhere, this is more desirable than traversing the user's history, and is the existing behavior of the link on `wp-login.php`.

**Testing**
- Visit `/log-in`.
- Assert that there is a link back to WordPress.com where the existing "Return" link used to be.

- [x] Code
- [ ] Product