### PR TITLE
WooCommerce: Add READMEs to state trees

### DIFF
--- a/client/extensions/woocommerce/state/README.md
+++ b/client/extensions/woocommerce/state/README.md
@@ -1,0 +1,16 @@
+State
+=====
+
+This directory contains all of the behavior describing the application state for the woocommerce extension. This is a sub-tree of the global state, stored in `state.extensions.woocommerce`.
+
+## Structure
+
+### [`site`](site/README.md)
+
+### [`ui`](ui/README.md)
+
+Holds data changed in the UI but not yet saved
+
+### [`sites`](sites/README.md)
+
+Handles data fetched from the remote site's API

--- a/client/extensions/woocommerce/state/README.md
+++ b/client/extensions/woocommerce/state/README.md
@@ -5,11 +5,9 @@ This directory contains all of the behavior describing the application state for
 
 ## Structure
 
-### [`site`](site/README.md)
-
 ### [`ui`](ui/README.md)
 
-Holds data changed in the UI but not yet saved
+Tracks all UI state. Currently this includes "edit states" of API data.
 
 ### [`sites`](sites/README.md)
 

--- a/client/extensions/woocommerce/state/sites/README.md
+++ b/client/extensions/woocommerce/state/sites/README.md
@@ -1,0 +1,34 @@
+Sites
+=====
+
+This module is used to manage data and requests to/from the WooCommerce API. 
+
+## Reducer structure
+
+```js
+{
+	[siteId]: {
+		paymentMethods: {},
+		productCategories: {},
+		products: {},
+		settings: {
+			general: {},
+			products: {},
+		},
+		shippingMethods: {},
+		shippingZoneMethods: {},
+		shippingZones: {},
+	}
+}
+```
+
+- [paymentMethods](payment-methods/README.md)
+- [productCategories](product-categories/README.md)
+- [products](products/README.md)
+- [settings: general](settings/general/README.md)
+- [settings: products](settings/products/README.md)
+- [shippingZones](shipping-zones/README.md)
+
+## request.js
+
+This adds a higher-level layer on top of the WPCOM.JS library, made specifically for making requests to a Jetpack-connected WooCommerce site. This should not need to be accessed outside of actions in this sub-tree.

--- a/client/extensions/woocommerce/state/sites/payment-methods/README.md
+++ b/client/extensions/woocommerce/state/sites/payment-methods/README.md
@@ -1,0 +1,44 @@
+Payment Methods
+===============
+
+This module is used to manage payment methods for a site.
+
+## Actions
+
+### `fetchPaymentMethods( siteId: number )`
+
+Get the payment methods available on a site.
+
+## Reducer
+
+A list of supported payment methods as returned from the site's API, saved on a per-site basis.
+
+```js
+{
+	"paymentMethods": [ {
+		"id": "bacs",
+		"title": "Direct bank transfer",
+		"description": "Make your payment directly into our bank account. Please use your Order ID as the payment reference. Your order won't be shipped until the funds have cleared in our account.",
+		"order": "",
+		"enabled": false,
+		"method_title": "BACS",
+		"method_description": "Allows payments by BACS, more commonly known as direct bank/wire transfer.",
+		"settings": { … },
+		"methodType": "offline",
+	}, { … } ]
+}
+```
+
+## Selectors
+
+### `arePaymentMethodsLoaded( state, [siteId] )`
+
+Whether the payment methods list has been successfully loaded from the server. Optional `siteId`, will default to currently selected site.
+
+### `arePaymentMethodsLoading( state, [siteId] )`
+
+Whether the payment methods list is currently being retrieved from the server. Optional `siteId`, will default to currently selected site.
+
+### `getPaymentMethodsGroup( state, type, [siteId] )`
+
+Gets group of payment methods by type (offline, off-site, on-site). Optional `siteId`, will default to currently selected site.

--- a/client/extensions/woocommerce/state/sites/product-categories/README.md
+++ b/client/extensions/woocommerce/state/sites/product-categories/README.md
@@ -1,0 +1,36 @@
+Product Categories
+==================
+
+This module is used to manage product categories for a site.
+
+## Actions
+
+### `fetchProductCategories( siteId: number )`
+
+Get the list of product categories from the remote site.
+
+## Reducer
+
+A list of settings as returned from the site's API, saved on a per-site basis.
+
+```js
+{
+	"productCategories": [ {
+		"id": 10
+		"name": "Watercolor"
+		"slug": "watercolor"
+		"parent": 0
+		"description": ""
+		"display": "default"
+		"image": []
+		"menu_order": 0
+		"count": 2
+	}, { … } ]
+}
+```
+
+## Selectors
+
+### `getProductCategories( state, siteId: number )`
+
+Get the list of categories from a given site, or an empty array if nothing's there yet.

--- a/client/extensions/woocommerce/state/sites/product-categories/README.md
+++ b/client/extensions/woocommerce/state/sites/product-categories/README.md
@@ -11,7 +11,7 @@ Get the list of product categories from the remote site.
 
 ## Reducer
 
-A list of settings as returned from the site's API, saved on a per-site basis.
+A list of product categories as returned from the site's API, saved on a per-site basis.
 
 ```js
 {

--- a/client/extensions/woocommerce/state/sites/products/README.md
+++ b/client/extensions/woocommerce/state/sites/products/README.md
@@ -1,0 +1,16 @@
+Products
+========
+
+This module is used to manage products for a site.
+
+## Actions
+
+### `createProduct( siteId, product, [successAction], [failureAction] )`
+
+Create a product on the remote site via API. May also call action creator callbacks: successAction on successful product creation, or failureAction on an error.
+
+## Reducer
+
+A list of products as returned from the site's API, saved on a per-site basis.
+
+## Selectors

--- a/client/extensions/woocommerce/state/sites/settings/README.md
+++ b/client/extensions/woocommerce/state/sites/settings/README.md
@@ -1,0 +1,15 @@
+Settings
+================
+
+This folder contains sub-trees for all settings for a site. See the individual READMEs for more details.
+
+## Reducer
+
+```js
+{
+	"settings": {
+		"general": [],
+		"products": [],
+	}
+}
+```

--- a/client/extensions/woocommerce/state/sites/settings/general/README.md
+++ b/client/extensions/woocommerce/state/sites/settings/general/README.md
@@ -1,0 +1,49 @@
+General Settings
+================
+
+This module is used to manage general settings for a site.
+
+## Actions
+
+### `fetchSettingsGeneral( siteId: number )`
+
+Pull general settings from the remote site. Does not run if the settings are loading or already loaded.
+
+## Reducer
+
+This is saved on a per-site basis, either as "LOADING" (when requesting settings), or a list of settings as returned from the site's API.
+
+```js
+{
+	"settingsGeneral": "LOADING",
+	// or
+	"settingsGeneral": [ {
+		"id": "woocommerce_allowed_countries",
+		"label": "Selling location(s)",
+		"description": "This option lets you limit which countries you are willing to sell to.",
+		"type": "select",
+		"default": "all",
+		"options": {
+			"all": "Sell to all countries",
+			"all_except": "Sell to all countries, except for&hellip;",
+			"specific": "Sell to specific countries"
+		},
+		"tip": "This option lets you limit which countries you are willing to sell to.",
+		"value": "all",
+	}, { … } ],
+}
+```
+
+## Selectors
+
+### `areSettingsGeneralLoaded( state, [siteId] )`
+
+Whether the general settings list has been successfully loaded from the server. Optional `siteId`, will default to currently selected site.
+
+### `areSettingsGeneralLoading( state, [siteId] )`
+
+Whether the general settings list is currently being retrieved from the server. Optional `siteId`, will default to currently selected site.
+
+### `getPaymentCurrencySettings( state, siteId: number )`
+
+Gets payment currency from API data.

--- a/client/extensions/woocommerce/state/sites/settings/general/README.md
+++ b/client/extensions/woocommerce/state/sites/settings/general/README.md
@@ -15,22 +15,26 @@ This is saved on a per-site basis, either as "LOADING" (when requesting settings
 
 ```js
 {
-	"settingsGeneral": "LOADING",
+	"settings": {
+		"general": "LOADING"
+	}
 	// or
-	"settingsGeneral": [ {
-		"id": "woocommerce_allowed_countries",
-		"label": "Selling location(s)",
-		"description": "This option lets you limit which countries you are willing to sell to.",
-		"type": "select",
-		"default": "all",
-		"options": {
-			"all": "Sell to all countries",
-			"all_except": "Sell to all countries, except for&hellip;",
-			"specific": "Sell to specific countries"
-		},
-		"tip": "This option lets you limit which countries you are willing to sell to.",
-		"value": "all",
-	}, { … } ],
+	"settings": {
+		"general": [ {
+			"id": "woocommerce_allowed_countries",
+			"label": "Selling location(s)",
+			"description": "This option lets you limit which countries you are willing to sell to.",
+			"type": "select",
+			"default": "all",
+			"options": {
+				"all": "Sell to all countries",
+				"all_except": "Sell to all countries, except for&hellip;",
+				"specific": "Sell to specific countries"
+			},
+			"tip": "This option lets you limit which countries you are willing to sell to.",
+			"value": "all",
+		}, { … } ],
+	},
 }
 ```
 

--- a/client/extensions/woocommerce/state/sites/shipping-zones/README.md
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/README.md
@@ -1,0 +1,40 @@
+Shipping Zones
+==============
+
+This module is used to manage the shipping zones for a site.
+
+## Actions
+
+### `fetchShippingZones( siteId: number )`
+
+Pull shipping zones from the remote site. Does not run if the shipping zones are loading or already loaded.
+
+## Reducer
+
+This is saved on a per-site basis, either as "LOADING" (when requesting zones), or a list of zones as returned from the site's API.
+
+```js
+{
+	"shippingZones": "LOADING",
+	// or
+	"shippingZones": [ {
+		"id": 0,
+		"name": "Rest of the World",
+		"order": 0,
+	}, { … } ],
+}
+```
+
+## Selectors
+
+### `areShippingZonesLoaded( state, [siteId] )`
+
+Whether the shipping zones list has been successfully loaded from the server. Optional `siteId`, will default to currently selected site.
+
+### `areShippingZonesLoading( state, [siteId] )`
+
+Whether the shipping zones list is currently being retrieved from the server. Optional `siteId`, will default to currently selected site.
+
+### `getAPIShippingZones( state, [siteId] )`
+
+Get list of shipping zones for a site. Optional `siteId`, will default to currently selected site.


### PR DESCRIPTION
I started adding READMEs to figure out what was going on in the state, and thought it would be useful to have them for real 🙂 I'm not sure if the info I've added is correct, but sometimes it's easier to correct someone rather than write from scratch, so please check over and offer any corrections.

In some cases I'm almost certain I have it wrong — for example, I don't know if `ui` is what I said in the [main state README](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/README.md). Also there, I don't know what `site` is meant to contain.

Here are the readmes added:

- [`state/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/README.md)
- [`state/sites/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/sites/README.md)
- [`state/sites/payment-methods/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/sites/payment-methods/README.md)
- [`state/sites/product-categories/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/sites/product-categories/README.md)
- [`state/sites/products/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/sites/products/README.md)
- [`state/sites/settings/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/sites/settings/README.md)
- [`state/sites/settings/general/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/sites/settings/general/README.md)
- [`state/sites/shipping-zones/README.md`](https://github.com/Automattic/wp-calypso/tree/add/woocommerce-state-readmes/client/extensions/woocommerce/state/sites/shipping-zones/README.md)