### PR TITLE
Update select menus styling

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -210,8 +210,9 @@ select {
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
-	font-size: 14px;
-	font-weight: 700;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 1.4em;
 	text-overflow: ellipsis;
 	text-decoration: none;
 	vertical-align: top;


### PR DESCRIPTION
In usability testing various things in the past we've observed users sometimes skipping over select menus (dropdowns) in forms because the bold type makes it seem filled out vs. other fields because it looks different than the placeholder text in the other fields. This typically happens in a form with multiple fields and where the select menu is on the same line as other form inputs.

This updates the `<select>` to closely match text inputs, specifically:

- Changing to `font-weight: 400;`.
- Increasing font-size to 16.
- Increasing line-height to match the height of text inputs.

Before | After
--------- | ---------
![screen shot 2017-05-31 at 8 49 32 am](https://cloud.githubusercontent.com/assets/12596797/26632416/1ff537ec-45de-11e7-9db7-5a49ffd0a6da.png) | ![screen shot 2017-05-31 at 8 44 37 am](https://cloud.githubusercontent.com/assets/12596797/26632343/d58a79ba-45dd-11e7-9964-025dad5329c6.png)




**To test:**
- Checkout this branch.
- Test out areas where we use select menus (form dropdowns):
     - Settings
     - Checkout (particularly for Domains)
     - Other places?