### PR TITLE
updates FAQ copy on plans page

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -600,7 +600,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_UPLOAD_THEMES ]: {
 		getSlug: () => FEATURE_UPLOAD_THEMES,
-		getTitle: () => i18n.translate( 'Upload themes' ),
+		getTitle: () => i18n.translate( 'Upload Themes' ),
 		getDescription: () => i18n.translate( 'Upload custom themes on your site.' )
 	},
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -215,9 +215,9 @@ class PlansFeaturesMain extends Component {
 				<FAQItem
 					question={ translate( 'Can I install plugins?' ) }
 					answer={ translate(
-						'Yes! With the WordPress.com Business plan you can search for and install community plugins.' +
-						' All plans also include their own set of pre-installed plugins suites tailored just' +
-						' for them. {{a}}Check out all included plugins{{/a}}.',
+						'Yes! With the WordPress.com Business plan you can search for and install external plugins.' +
+						' All plans already come with a custom set of plugins tailored just for them.' +
+						' {{a}}Check out all included plugins{{/a}}.',
 						{
 							components: { a: <a href={ `/plugins/${ site.slug }` } /> }
 						}
@@ -228,8 +228,8 @@ class PlansFeaturesMain extends Component {
 					question={ translate( 'Can I upload my own theme?' ) }
 					answer={ translate(
 						'Yes! With the WordPress.com Business plan you can upload any theme you\'d like.' +
-						' All plans allow access to search our {{a}}directory of free and premium themes{{/a}}' +
-						' which have been reviewed by our team and represent the highest quality.',
+						' All plans give you access to our {{a}}directory of free and premium themes{{/a}}.' +
+						' These are among the highest-quality WordPress themes, hand-picked and reviewed by our team.',
 						{
 							components: { a: <a href={ `/themes/${ site.slug }` } /> }
 						}
@@ -249,7 +249,7 @@ class PlansFeaturesMain extends Component {
 					question={ translate( 'Do you offer email accounts?' ) }
 					answer={ translate(
 						'Yes. If you register a new domain with our Personal, Premium, or Business plans, you can optionally' +
-						' add G Suite. You can also set up email forwarding for any custom domain' +
+						' add Google-powered G Suite. You can also set up email forwarding for any custom domain' +
 						' registered through WordPress.com. {{a}}Find out more about email{{/a}}.',
 						{
 							components: {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -248,7 +248,7 @@ class PlansFeaturesMain extends Component {
 				<FAQItem
 					question={ translate( 'Do you offer email accounts?' ) }
 					answer={ translate(
-						'Yes. If you register a new domain with our Personal, Premium, or Business plans, you can optionally' +
+						'Yes. If you register a new domain with our Personal, Premium, or Business plans, you can' +
 						' add Google-powered G Suite. You can also set up email forwarding for any custom domain' +
 						' registered through WordPress.com. {{a}}Find out more about email{{/a}}.',
 						{

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -197,7 +197,7 @@ class PlansFeaturesMain extends Component {
 				<FAQItem
 					question={ translate( 'Do you sell domains?' ) }
 					answer={ translate(
-						'Yes! The personal, premium, and business plans include a free custom domain. That includes new' +
+						'Yes! The Personal, Premium, and Business plans include a free custom domain. That includes new' +
 						' domains purchased through WordPress.com or your own existing domain that you can map' +
 						' to your WordPress.com site. {{a}}Find out more about domains.{{/a}}',
 						{
@@ -213,11 +213,10 @@ class PlansFeaturesMain extends Component {
 				/>
 
 				<FAQItem
-					question={ translate( 'Can I upload my own plugins?' ) }
+					question={ translate( 'Can I install plugins?' ) }
 					answer={ translate(
-						'While uploading your own plugins is not available on WordPress.com, we include the most' +
-						' popular plugin functionality within our sites automatically. The premium and business' +
-						' plans even include their own set of plugins suites tailored just' +
+						'Yes! With the WordPress.com Business plan you can search for and install community plugins.' +
+						' All other plans include their own set of plugins suites tailored just' +
 						' for them. {{a}}Check out all included plugins{{/a}}.',
 						{
 							components: { a: <a href={ `/plugins/${ site.slug }` } /> }
@@ -226,12 +225,11 @@ class PlansFeaturesMain extends Component {
 				/>
 
 				<FAQItem
-					question={ translate( 'Can I install my own theme?' ) }
+					question={ translate( 'Can I upload my own theme?' ) }
 					answer={ translate(
-						'We don’t currently allow custom themes to be uploaded to WordPress.com. We do this to keep' +
-						' your site secure but all themes in our {{a}}theme directory{{/a}} have been reviewed' +
-						' by our team and represent the highest quality. The business plan even supports' +
-						' unlimited premium theme access.',
+						'Yes! With the WordPress.com Business plan you can upload any theme you\'d like.' +
+						' All plans allow access to search our {{a}}directory of free and premium themes{{/a}}' +
+						' which have been reviewed by our team and represent the highest quality.',
 						{
 							components: { a: <a href={ `/themes/${ site.slug }` } /> }
 						}
@@ -243,14 +241,14 @@ class PlansFeaturesMain extends Component {
 					answer={ translate(
 						'No. All WordPress.com sites include our specially tailored WordPress hosting to ensure' +
 						' your site stays available and secure at all times. You can even use your own domain' +
-						' when you upgrade to the premium or business plan.'
+						' when you upgrade to the Personal, Premium, or Business plan.'
 					) }
 				/>
 
 				<FAQItem
 					question={ translate( 'Do you offer email accounts?' ) }
 					answer={ translate(
-						'Yes. If you register a new domain with our premium or business plans, you can optionally' +
+						'Yes. If you register a new domain with our Personal, Premium, or Business plans, you can optionally' +
 						' add G Suite. You can also set up email forwarding for any custom domain' +
 						' registered through WordPress.com. {{a}}Find out more about email{{/a}}.',
 						{

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -216,7 +216,7 @@ class PlansFeaturesMain extends Component {
 					question={ translate( 'Can I install plugins?' ) }
 					answer={ translate(
 						'Yes! With the WordPress.com Business plan you can search for and install community plugins.' +
-						' All other plans include their own set of plugins suites tailored just' +
+						' All plans also include their own set of pre-installed plugins suites tailored just' +
 						' for them. {{a}}Check out all included plugins{{/a}}.',
 						{
 							components: { a: <a href={ `/plugins/${ site.slug }` } /> }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -286,8 +286,7 @@ class PlansFeaturesMain extends Component {
 					question={ translate( 'Will upgrading affect my content?' ) }
 					answer={ translate(
 						'Plans add extra features to your site, but they do not affect the content of your site' +
-						" or your site's followers. You will never lose content by upgrading or downgrading" +
-						" your site's plan."
+						" or your site's followers."
 					) }
 				/>
 


### PR DESCRIPTION
We weren't accounting for our new ability to install plugins and themes, nor were we consistently using the capitalized plan name as is standard. With the updates, it should look like this.

![plans FAQ](http://cld.wthms.co/XkG3yW+)

## Testing
Run this branch and double-check the content at `/plans/:site`. I'd like a sanity check on the content before I merge, so we don't have to create multiple translations requests if this needs any tweaks.