### PR TITLE
Fix Data Layer: Don't double-dispatch network repsonses

### DIFF
--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -14,6 +14,25 @@ const mergedHandlers = mergeHandlers(
 	wpcomHandlers,
 );
 
+const shouldNext = action => {
+	const meta = action.meta;
+	if ( ! meta ) {
+		return true;
+	}
+
+	const data = meta.dataLayer;
+	if ( ! data ) {
+		return true;
+	}
+
+	// is a network response, don't reissue
+	if ( data.data || data.error || data.headers ) {
+		return false;
+	}
+
+	return true;
+};
+
 /**
  * WPCOM Middleware API
  *
@@ -83,7 +102,9 @@ export const middleware = handlers => store => next => {
 		// make sure we pass along this action
 		// eventually this will return to the
 		// simpler `return next( action )`
-		nextActions.add( action );
+		if ( shouldNext( action ) ) {
+			nextActions.add( action );
+		}
 		nextActions.forEach( localNext );
 	};
 };


### PR DESCRIPTION
Previously when using the `dispatchRequest()` helper to reuse a given
action type for the network response of a network request we were
continuing to pass along the action to `next()` even after it returns as
the continuation of the request.

Only the first issuance of that action should be passed along to
`next()`. This change fixes that by looking for artefacts of the network
request and preventing `next()`ing if it's a response.