### PR TITLE
Fix Shipping Zone UI selectors when the user hasn't edited anything yet.

### DIFF
--- a/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
@@ -25,8 +25,13 @@ export const getShippingZones = ( state, siteId = getSelectedSiteId( state ) ) =
 	}
 	const zones = [ ...getAPIShippingZones( state, siteId ) ];
 
+	const edits = getShippingZonesEdits( state, siteId );
+	if ( ! edits ) {
+		return zones;
+	}
+
 	// Overlay the current edits on top of (a copy of) the wc-api zones
-	const { creates, updates, deletes } = getShippingZonesEdits( state, siteId );
+	const { creates, updates, deletes } = edits;
 	deletes.forEach( ( { id } ) => remove( zones, { id } ) );
 	updates.forEach( ( update ) => {
 		const index = findIndex( zones, { id: update.id } );
@@ -45,15 +50,18 @@ export const getShippingZones = ( state, siteId = getSelectedSiteId( state ) ) =
  * (including the non-committed changes). If no zone is being edited, this will return null.
  */
 export const getCurrentlyEditingShippingZone = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const { currentlyEditingId, currentlyEditingChanges } = getShippingZonesEdits( state, siteId );
-	if ( null === currentlyEditingId ) {
+	const edits = getShippingZonesEdits( state, siteId );
+	if ( ! edits ) {
 		return null;
 	}
-	const zone = find( getShippingZones( state, siteId ), { id: currentlyEditingId } );
+	if ( null === edits.currentlyEditingId ) {
+		return null;
+	}
+	const zone = find( getShippingZones( state, siteId ), { id: edits.currentlyEditingId } );
 	if ( ! zone ) {
 		return null;
 	}
-	return { ...zone, ...currentlyEditingChanges };
+	return { ...zone, ...edits.currentlyEditingChanges };
 };
 
 /**

--- a/client/extensions/woocommerce/state/ui/shipping/zones/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/test/selectors.js
@@ -56,6 +56,32 @@ describe( 'selectors', () => {
 			expect( getShippingZones( state ) ).to.deep.equal( [] );
 		} );
 
+		it( 'should return the WC-API zones list if there are no edits in the state', () => {
+			const state = {
+				extensions: {
+					woocommerce: {
+						wcApi: {
+							123: {
+								shippingZones: [
+									{ id: 1, name: 'Zone1' },
+									{ id: 2, name: 'Zone2' },
+								],
+							},
+						},
+						ui: {},
+					},
+				},
+				ui: {
+					selectedSiteId: 123,
+				},
+			};
+
+			expect( getShippingZones( state ) ).to.deep.equal( [
+				{ id: 1, name: 'Zone1' },
+				{ id: 2, name: 'Zone2' },
+			] );
+		} );
+
 		it( 'should apply the "edits" changes to the zone list', () => {
 			const state = {
 				extensions: {


### PR DESCRIPTION
Fixes a bug in the UI selectors for Shipping Zones, where it would crash if the user hadn't made any "edits" yet.

I've included a test that failed in `master`, and of course is fixed by this PR.