### PR TITLE
Plugins: update 404 illustration (broken link)

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -42,7 +42,7 @@ export const PluginPanel = ( {
 		const accessError = {
 			title: translate( 'Not Available' ),
 			line: translate( 'The page you requested could not be found' ),
-			illustration: '/calypso/images/drake/drake-404.svg',
+			illustration: '/calypso/images/illustrations/illustration-404.svg',
 			fullWidth: true
 		};
 		return (


### PR DESCRIPTION
Drake gives us a 404.

Before:
![screen shot 2017-05-30 at 15 17 45](https://cloud.githubusercontent.com/assets/115071/26607484/8831789a-454b-11e7-81c3-dd8da74631c4.png)

After:
![screen shot 2017-05-30 at 15 16 09](https://cloud.githubusercontent.com/assets/115071/26607489/8e3884ae-454b-11e7-9ed8-82c871e65f2d.png)

As an author of a site go to the sites plugins page. 

You should now see the ^ illustration. 
