### PR TITLE
Update/ use blog id in api requests for posts and pages

### DIFF
--- a/client/components/post-list-fetcher/index.jsx
+++ b/client/components/post-list-fetcher/index.jsx
@@ -26,7 +26,7 @@ function dispatchQueryActions( postListStoreId, query ) {
 function queryPosts( props ) {
 	var query = {
 		type: props.type || 'post',
-		siteID: props.siteID,
+		siteId: props.siteId,
 		status: props.status,
 		author: props.author,
 		search: props.search,
@@ -81,7 +81,7 @@ function shouldQueryPosts( props, nextProps ) {
 		props.number !== nextProps.number ||
 		props.before !== nextProps.before ||
 		props.after !== nextProps.after ||
-		props.siteID !== nextProps.siteID ||
+		props.siteId !== nextProps.siteId ||
 		props.postListStoreId !== nextProps.postListStoreId;
 }
 
@@ -93,7 +93,7 @@ PostListFetcher = React.createClass( {
 		status: React.PropTypes.string,
 		author: React.PropTypes.number,
 		search: React.PropTypes.string,
-		siteID: React.PropTypes.any,
+		siteId: React.PropTypes.number,
 		withImages: React.PropTypes.bool,
 		withCounts: React.PropTypes.bool,
 		excludeTree: React.PropTypes.number,

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -429,9 +429,7 @@ PostActions = {
 	* @api public
 	*/
 	fetchNextPage: function( postListStoreId = 'default' ) {
-		var params, id, siteID, postListStore;
-
-		postListStore = postListStoreFactory( postListStoreId );
+		const postListStore = postListStoreFactory( postListStoreId );
 
 		if ( postListStore.isLastPage() || postListStore.isFetchingNextPage() ) {
 			return;
@@ -442,13 +440,13 @@ PostActions = {
 			postListStoreId: postListStoreId
 		} );
 
-		id = postListStore.getID();
-		params = postListStore.getNextPageParams();
-		siteID = postListStore.getSiteID();
+		const id = postListStore.getID();
+		const params = postListStore.getNextPageParams();
+		const siteId = postListStore.getSiteId();
 
-		if ( siteID ) {
+		if ( siteId ) {
 			wpcom
-				.site( siteID )
+				.site( siteId )
 				.postsList( params, PostActions.receivePage.bind( null, id, postListStoreId ) );
 		} else {
 			wpcom
@@ -468,9 +466,7 @@ PostActions = {
 	},
 
 	fetchUpdated: function( postListStoreId = 'default' ) {
-		var id, params, siteID, postListStore;
-
-		postListStore = postListStoreFactory( postListStoreId );
+		const postListStore = postListStoreFactory( postListStoreId );
 
 		if ( postListStore.isFetchingNextPage() ) {
 			return;
@@ -481,14 +477,14 @@ PostActions = {
 			postListStoreId: postListStoreId
 		} );
 
-		id = postListStore.getID();
-		params = postListStore.getUpdatesParams();
-		siteID = postListStore.getSiteID();
+		const id = postListStore.getID();
+		const params = postListStore.getUpdatesParams();
+		const siteId = postListStore.getSiteId();
 
-		if ( siteID ) {
-			debug( 'Fetching posts that have been updated for %s since %s %o', siteID, params.modified_after, params );
+		if ( siteId ) {
+			debug( 'Fetching posts that have been updated for %s since %s %o', siteId, params.modified_after, params );
 			wpcom
-				.site( siteID )
+				.site( siteId )
 				.postsList( params, PostActions.receiveUpdated.bind( null, id, postListStoreId ) );
 		} else {
 			debug( 'Fetching posts that have been updated since %s %o', params.modified_after, params );

--- a/client/lib/posts/post-counts-store.js
+++ b/client/lib/posts/post-counts-store.js
@@ -34,7 +34,7 @@ var _counts = {},
 function getSiteId( id ) {
 	var site, siteId;
 
-	id = id || PostListStore.getSiteID();
+	id = id || PostListStore.getSiteId();
 
 	site = sites.getSite( id );
 

--- a/client/lib/posts/post-list-cache-store.js
+++ b/client/lib/posts/post-list-cache-store.js
@@ -75,7 +75,7 @@ function markDirty( post, oldStatus ) {
 			continue;
 		}
 
-		if ( -1 === affectedSites.indexOf( list.query.siteID ) ) {
+		if ( -1 === affectedSites.indexOf( list.query.siteId ) ) {
 			continue;
 		}
 

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -29,7 +29,7 @@ import PostListCacheStore,
  * Module Variables
  */
 const _defaultQuery = {
-	siteID: false,
+	siteId: false,
 	type: 'post',
 	status: 'publish',
 	orderBy: 'date',
@@ -91,8 +91,8 @@ export default function( id ) {
 	function queryPosts( options ) {
 		let query = assign( {}, _defaultQuery, options );
 
-		if ( query.siteID && typeof query.siteID === 'string' ) {
-			query.siteID = query.siteID.replace( /::/g, '/' );
+		if ( query.siteId && typeof query.siteId === 'string' ) {
+			query.siteId = query.siteId.replace( /::/g, '/' );
 		}
 
 		if ( query.status === 'draft,pending' ) {
@@ -277,7 +277,7 @@ export default function( id ) {
 		}
 
 		getSiteID() {
-			return _activeList.query.siteID;
+			return _activeList.query.siteId;
 		}
 
 		// Get list of posts from current object
@@ -352,7 +352,7 @@ export default function( id ) {
 				params.search = query.search;
 			}
 
-			if ( ! params.siteID ) {
+			if ( ! params.siteId ) {
 				// Only query from visible sites
 				params.site_visibility = 'visible';
 			}
@@ -376,7 +376,7 @@ export default function( id ) {
 				params.search = query.search;
 			}
 
-			if ( ! params.siteID ) {
+			if ( ! params.siteId ) {
 				// Only query from visible sites
 				params.site_visibility = 'visible';
 			}

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -91,10 +91,6 @@ export default function( id ) {
 	function queryPosts( options ) {
 		let query = assign( {}, _defaultQuery, options );
 
-		if ( query.siteId && typeof query.siteId === 'string' ) {
-			query.siteId = query.siteId.replace( /::/g, '/' );
-		}
-
 		if ( query.status === 'draft,pending' ) {
 			query.orderBy = 'modified';
 		}

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -272,7 +272,7 @@ export default function( id ) {
 			return _activeList.id;
 		}
 
-		getSiteID() {
+		getSiteId() {
 			return _activeList.query.siteId;
 		}
 

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -185,9 +185,9 @@ describe( 'post-list-store', () => {
 		} );
 	} );
 
-	describe( '#getSiteID', () => {
+	describe( '#getSiteId', () => {
 		it( 'should the return site ID', () => {
-			assert.equal( defaultPostListStore.getSiteID(), defaultPostListStore.get().query.siteID );
+			assert.equal( defaultPostListStore.getSiteId(), defaultPostListStore.get().query.siteId );
 		} );
 	} );
 
@@ -334,7 +334,7 @@ describe( 'post-list-store', () => {
 			assert.notEqual( currentCacheId, defaultPostListStore.getID() );
 		} );
 
-		it( 'should set site_visibility if no siteID is present', () => {
+		it( 'should set site_visibility if no siteId is present', () => {
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, { type: 'page' } );
 			assert.equal( defaultPostListStore.getNextPageParams().site_visibility, 'visible' );
 		} );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -48,7 +48,7 @@ var PageList = React.createClass( {
 			<PostListFetcher
 				type="page"
 				number={ 100 }
-				siteID={ this.props.siteId }
+				siteId={ this.props.siteId }
 				status={ mapStatus( this.props.status ) }
 				search={ this.props.search }>
 				<Pages
@@ -268,7 +268,7 @@ var Pages = React.createClass( {
 
 			// Render each page
 			return (
-				<Page key={ 'page-' + page.global_ID } page={ page } multisite={ this.props.siteID === false } />
+				<Page key={ 'page-' + page.global_ID } page={ page } multisite={ this.props.siteId === false } />
 			);
 		}, this );
 

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -84,7 +84,6 @@ module.exports = {
 		renderWithReduxStore(
 			React.createElement( Posts, {
 				context: context,
-				siteID: siteID,
 				author: author,
 				statusSlug: statusSlug,
 				search: search,

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -6,7 +6,7 @@ var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:posts' );
 
 import { connect } from 'react-redux';
-import { debounce, isEmpty, isEqual, omit } from 'lodash';
+import { debounce, isEqual, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,6 +22,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	mapStatus = route.mapPostStatus;
 
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { hasInitializedSites } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 var GUESSED_POST_HEIGHT = 250;
@@ -258,7 +259,7 @@ var Posts = React.createClass( {
 			i;
 
 		// posts have loaded, sites have loaded, and we have a site instance or are viewing all-sites
-		if ( posts.length ) {
+		if ( posts.length && this.props.hasSites ) {
 			postList = (
 				<InfiniteList
 					key={ 'list-' + this.props.listId } // to reset scroll for new list
@@ -301,6 +302,6 @@ var Posts = React.createClass( {
 export default connect(
 	( state ) => ( {
 		selectedSiteId: getSelectedSiteId( state ),
-		hasSites: ! isEmpty( state.sites.items )
+		hasSites: hasInitializedSites( state )
 	} )
 )( PostList );

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -35,14 +35,14 @@ var PostList = React.createClass( {
 		search: React.PropTypes.string,
 		hasSites: React.PropTypes.bool,
 		statusSlug: React.PropTypes.string,
-		siteID: React.PropTypes.any,
+		siteId: React.PropTypes.number,
 		author: React.PropTypes.number
 	},
 
 	render: function() {
 		return (
 			<PostListFetcher
-				siteID={ this.props.siteID }
+				siteId={ this.props.siteId }
 				status={ mapStatus( this.props.statusSlug ) }
 				author={ this.props.author }
 				withImages={ true }
@@ -68,7 +68,7 @@ var Posts = React.createClass( {
 		postImages: React.PropTypes.object.isRequired,
 		posts: React.PropTypes.array.isRequired,
 		search: React.PropTypes.string,
-		siteID: React.PropTypes.any,
+		siteId: React.PropTypes.number,
 		hasSites: React.PropTypes.bool.isRequired,
 		statusSlug: React.PropTypes.string,
 		trackScrollPage: React.PropTypes.func.isRequired
@@ -155,7 +155,7 @@ var Posts = React.createClass( {
 					} )	}
 			/>;
 		} else {
-			newPostLink = this.props.siteID ? '/post/' + this.props.siteID : '/post';
+			newPostLink = this.props.siteId ? '/post/' + this.props.siteId : '/post';
 
 			if ( this.props.hasRecentError ) {
 				attributes = {
@@ -177,7 +177,7 @@ var Posts = React.createClass( {
 							title: this.translate( 'You don\'t have any scheduled posts.' ),
 							line: this.translate( 'Would you like to schedule a draft to publish?' ),
 							action: this.translate( 'Edit Drafts' ),
-							actionURL: ( this.props.siteID ) ? '/posts/drafts/' + this.props.siteID : '/posts/drafts'
+							actionURL: ( this.props.siteId ) ? '/posts/drafts/' + this.props.siteId : '/posts/drafts'
 						};
 						break;
 					case 'trashed':

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -88,7 +88,8 @@ const PostsNavigation = React.createClass( {
 
 		const author = this.props.author ? '/my' : '',
 			statusSlug = this.props.statusSlug ? '/' + this.props.statusSlug : '',
-			siteFilter = this.props.siteId ? '/' + this.props.siteId : '';
+			siteFilter = this.props.siteSlug ? '/' + this.props.siteSlug : '';
+
 		let showMyFilter = true;
 
 		this.filterStatuses = {

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -169,6 +169,10 @@ const PostsNavigation = React.createClass( {
 				count = 0;
 			}
 
+			if ( null === count || false === count ) {
+				count = 0;
+			}
+
 			statusItems.push(
 				<NavItem
 					className={ 'is-' + status }

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -70,10 +70,10 @@ const PostsNavigation = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.siteID !== nextProps.siteID ||
+		if ( this.props.siteId !== nextProps.siteId ||
 			this.props.author !== nextProps.author ||
 			this.props.statusSlug !== nextProps.statusSlug ) {
-			this._setPostCounts( nextProps.siteID, nextProps.author ? 'mine' : 'all' );
+			this._setPostCounts( nextProps.siteId, nextProps.author ? 'mine' : 'all' );
 		}
 	},
 
@@ -271,17 +271,17 @@ const PostsNavigation = React.createClass( {
 	/**
 	 * Set immediately post filters state
 	 *
-	 * @param {String} siteID - site ID
+	 * @param {String} siteId - site ID
 	 * @param {String} scope - scope `all` or `mine`
 	 * @return {void}
 	 */
-	_setPostCounts( siteID, scope ) {
+	_setPostCounts( siteId, scope ) {
 		// print default filters for `All my Sites`
-		if ( ! siteID || null === this.props.siteId ) {
+		if ( ! siteId|| null === this.props.siteId ) {
 			return this._defaultStateOptions();
 		}
 
-		if ( ! PostCountsStore.getTotalCount( siteID, 'all' ) ) {
+		if ( ! PostCountsStore.getTotalCount( siteId, 'all' ) ) {
 			return this.setState( {
 				show: true,
 				loading: true
@@ -291,11 +291,11 @@ const PostsNavigation = React.createClass( {
 		this.setState( {
 			show: true,
 			loading: false,
-			counts: this._getCounts( siteID, scope )
+			counts: this._getCounts( siteId, scope )
 		} );
 	},
 
-	_updatePostCounts( siteID = this.props.siteId, scope ) {
+	_updatePostCounts( siteId = this.props.siteId, scope ) {
 		scope = scope || ( this.props.author ? 'mine' : 'all' );
 
 		// is `All my sites` selected`
@@ -309,10 +309,10 @@ const PostsNavigation = React.createClass( {
 			counts: {}
 		};
 
-		if ( PostCountsStore.getTotalCount( siteID, 'all' ) ) {
-			state.counts = this._getCounts( siteID, scope );
+		if ( PostCountsStore.getTotalCount( siteId, 'all' ) ) {
+			state.counts = this._getCounts( siteId, scope );
 		} else {
-			debug( '[%s] clean counts', siteID || 'All my sites' );
+			debug( '[%s] clean counts', siteId || 'All my sites' );
 			state.show = false;
 			state.counts = {};
 		}
@@ -326,17 +326,17 @@ const PostsNavigation = React.createClass( {
 	 * `me` scope.
 	 * Also calc and remove unallowed statuses.
 	 *
-	 * @param {String} siteID - Site identifier
+	 * @param {String} siteId - Site identifier
 	 * @param {String} [scope] - Optional scope (mine or all)
 	 * @return {Object} counts
 	 */
-	_getCounts( siteID = this.props.siteId, scope ) {
+	_getCounts( siteId = this.props.siteId, scope ) {
 		var counts = {},
 			status;
 
 		scope = scope || ( this.props.author ? 'mine' : 'all' );
-		let all = PostCountsStore.get( siteID, 'all' );
-		let mine = PostCountsStore.get( siteID, 'mine' );
+		const all = PostCountsStore.get( siteId, 'all' );
+		const mine = PostCountsStore.get( siteId, 'mine' );
 
 		// make a copy of counts object
 		for ( status in all ) {

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -278,7 +278,7 @@ const PostsNavigation = React.createClass( {
 	 */
 	_setPostCounts( siteId, scope ) {
 		// print default filters for `All my Sites`
-		if ( ! siteId|| null === this.props.siteId ) {
+		if ( ! siteId || null === this.props.siteId ) {
 			return this._defaultStateOptions();
 		}
 

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -200,7 +200,7 @@ export default React.createClass( {
 					{ postUtils.isPage( this.props.post )
 						? postScheduler
 						: <PostListFetcher
-							siteID={ this.props.site.ID }
+							siteId={ this.props.site.ID }
 							status="publish,future"
 							before={ this.state.lastDayOfTheMonth.format() }
 							after={ this.state.firstDayOfTheMonth.format() }


### PR DESCRIPTION
Replaces https://github.com/Automattic/wp-calypso/pull/13670 also Fixes #6779

This PR updates instanced of siteID to siteId to remove confusion as to what the different value is for. 
This makes sure that we are always using the site_id in the api calls when interacting with the api.
Checks that siteId is always passed as a number. 
Make sure that the initial load of posts view for a single and multisite view is as expected. 

**To test:**
Load the posts and pages view with an empty cache on for a single site as well as all sites views.

Do you get the expected results (loading states) and not see any js errors.



