### PR TITLE
Woo-Connect Insights: Add Tabs to Main Chart

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -38,6 +38,7 @@ class StoreStats extends Component {
 					query={ ordersQuery }
 					selectedDate={ selectedDate }
 					siteId={ siteId }
+					unit={ unit }
 				/>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -5,6 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import page from 'page';
+import { findIndex } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +15,9 @@ import QuerySiteStats from 'components/data/query-site-stats';
 import { getSiteStatsNormalizedData, isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import ElementChart from 'components/chart';
 import Legend from 'components/chart/legend';
+import Tabs from 'my-sites/stats/stats-tabs';
+import Tab from 'my-sites/stats/stats-tabs/tab';
+import { calculateDelta } from 'woocommerce/app/store-stats/utils';
 
 class StoreStatsChart extends Component {
 	static propTypes = {
@@ -23,6 +27,7 @@ class StoreStatsChart extends Component {
 		query: PropTypes.object.isRequired,
 		selectedDate: PropTypes.string.isRequired,
 		siteId: PropTypes.number,
+		unit: PropTypes.string.isRequired,
 	};
 
 	state = {
@@ -33,50 +38,44 @@ class StoreStatsChart extends Component {
 		page.redirect( `${ this.props.path }?startDate=${ bar.data.period }` );
 	};
 
+	tabClick = tab => {
+		this.setState( {
+			selectedTabIndex: tab.index,
+		} );
+	};
+
 	buildChartData = ( item, selectedTab ) => {
 		const { selectedDate } = this.props;
 		const className = classnames( item.classNames.join( ' ' ), {
 			'is-selected': item.period === selectedDate,
 		} );
-		let value;
-		switch ( selectedTab.attr ) {
-			case 'total_sales':
-				value = item.total_sales;
-				break;
-			case 'net_sales':
-				value = Number( item.total_sales ) - Number( item.total_tax );
-				break;
-			case 'orders':
-				value = item.orders;
-				break;
-			case 'order_average':
-				value = item.orders === '0' ? 0 : Number( item.total_sales ) / Number( item.orders );
-				break;
-			default:
-				value = 0;
-		}
 		return {
 			label: item.labelDay,
-			value,
+			value: item[ selectedTab.attr ],
 			nestedValue: null,
 			data: item,
 			tooltipData: [],
 			className,
 		};
-	}
+	};
+
+	getSelectedIndex = data => {
+		return findIndex( data, d => d.period === this.props.selectedDate );
+	};
 
 	render() {
-		const { siteId, query, data } = this.props;
+		const { siteId, query, data, unit } = this.props;
 		const { selectedTabIndex } = this.state;
 		const tabs = [
-			{ label: 'Gross Sales', attr: 'total_sales' },
+			{ label: 'Gross Sales', attr: 'gross_sales' },
 			{ label: 'Net Sales', attr: 'net_sales' },
 			{ label: 'Orders', attr: 'orders' },
-			{ label: 'Average Order Value', attr: 'order_average' },
+			{ label: 'Average Order Value', attr: 'avg_order_value' },
 		];
 		const selectedTab = tabs[ selectedTabIndex ];
-		const isLoading = ! ! data.length;
+		const isLoading = ! data.length;
 		const chartData = data.map( item => this.buildChartData( item, selectedTab ) );
+		const selectedIndex = this.getSelectedIndex( data );
 		return (
 			<Card className="store-stats-chart stats-module">
 				{ siteId && <QuerySiteStats
@@ -88,6 +87,27 @@ class StoreStatsChart extends Component {
 					activeTab={ selectedTab }
 				/>
 				<ElementChart loading={ isLoading } data={ chartData } barClick={ this.barClick } />
+				<Tabs data={ chartData }>
+					{ tabs.map( ( tab, tabIndex ) => {
+						if ( ! isLoading ) {
+							const itemChartData = this.buildChartData( data[ selectedIndex ], tabs[ tabIndex ] );
+							const delta = calculateDelta( data[ selectedIndex ], data[ selectedIndex - 1 ], tabs[ tabIndex ].attr, unit );
+							return (
+								<Tab
+									key={ tab.attr }
+									index={ tabIndex }
+									selected={ tabIndex === selectedTabIndex }
+									tabClick={ this.tabClick }
+								>
+									<div>{ tab.label }</div>
+									<div>{ itemChartData.value }</div>
+									<div>{ delta.value }</div>
+									<div>{ delta.since }</div>
+								</Tab>
+							);
+						}
+					} ) }
+				</Tabs>
 			</Card>
 		);
 	}

--- a/client/extensions/woocommerce/app/store-stats/test/index.js
+++ b/client/extensions/woocommerce/app/store-stats/test/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+/**
+ * Internal dependencies
+ */
+import { calculateDelta } from '../utils';
+
+describe( 'calculateDelta', () => {
+	it( 'should return a correctly formed object', () => {
+		const item = { doodads: 75 };
+		const previousItem = { doodads: 50 };
+		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
+		assert.isObject( delta );
+		assert.isString( delta.value );
+		assert.isString( delta.since );
+		assert.isArray( delta.classes );
+	} );
+
+	it( 'should return correct values', () => {
+		const item = { doodads: 75 };
+		const previousItem = { doodads: 50, labelDay: 'a fortnight' };
+		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
+		assert.equal( delta.value, '50%' );
+		assert.equal( delta.since, 'since a fortnight' );
+		assert.include( delta.classes, 'is-favorable' );
+		assert.include( delta.classes, 'is-increase' );
+	} );
+
+	it( 'should return correct sign and direction', () => {
+		const item = { doodads: 75 };
+		const previousItem = { doodads: 100 };
+		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
+		assert.include( delta.classes, 'is-unfavorable' );
+		assert.include( delta.classes, 'is-decrease' );
+		assert.lengthOf( delta.classes, 2 );
+	} );
+
+	it( 'should return correct sign and direction for properties where less is good', () => {
+		const item = { total_refund: 75 };
+		const previousItem = { total_refund: 100 };
+		const delta = calculateDelta( item, previousItem, 'total_refund', 'day' );
+		assert.include( delta.classes, 'is-favorable' );
+		assert.include( delta.classes, 'is-decrease' );
+		assert.lengthOf( delta.classes, 2 );
+	} );
+
+	it( 'should return correct sign and direction for value of 0', () => {
+		const item = { doodads: 100 };
+		const previousItem = { doodads: 100 };
+		const delta = calculateDelta( item, previousItem, 'doodads', 'day' );
+		assert.include( delta.classes, 'is-neutral' );
+		assert.lengthOf( delta.classes, 1 );
+	} );
+} );

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * @typedef {Object} Delta
+ * @property {string} classes - CSS classes to be used to render arrows
+ * @property {string} since - Use of labels to create a phrase, "Since May 2"
+ * @property {Array} value - Value as a percent
+ */
+
+/**
+ * Calculate all elements needed to render a delta on a time series.
+ *
+ * @param {Object} item - data point from a time series
+ * @param {Object|undefined} previousItem - the previous data point, if it exists
+ * @param {string} attr - the property name to compare
+ * @param {string} unit - day, week, month, or year
+ * @return {Delta} - An object used to render the UI element
+ */
+export function calculateDelta( item, previousItem, attr, unit ) {
+	const negativeIsBeneficialAttributes = [ 'total_refund' ];
+	const sinceLabels = {
+		day: 'labelDay',
+		week: 'labelWeek',
+		month: 'labelMonth',
+		year: 'labelYear',
+	};
+	let value = 0;
+	if ( previousItem && previousItem[ attr ] !== 0 ) {
+		const current = item[ attr ];
+		const previous = previousItem[ attr ];
+		value = Math.round( ( ( current - previous ) / previous ) * 100 );
+	}
+	const isIncrease = value > 0;
+	const isIncreaseFavorable = includes( negativeIsBeneficialAttributes, attr ) ? ! isIncrease : isIncrease;
+	const classes = classnames( {
+		'is-neutral': value === 0,
+		'is-increase': value > 0,
+		'is-decrease': value < 0,
+		'is-favorable': value !== 0 && isIncreaseFavorable,
+		'is-unfavorable': value !== 0 && ! isIncreaseFavorable,
+	} );
+	const since = previousItem ? `since ${ previousItem[ sinceLabels[ unit ] ] }` : null;
+	return {
+		classes: classes.split( ' ' ),
+		since,
+		value: `${ Math.abs( value ) }%`,
+	};
+}

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -27,7 +27,7 @@ export default React.createClass( {
 		const { children, data, activeIndex, activeKey, tabs, switchTab, selectedTab, borderless } = this.props;
 		let statsTabs;
 
-		if ( data ) {
+		if ( data && ! children ) {
 			const activeData = find( data, { [ activeKey ]: activeIndex } );
 
 			statsTabs = tabs.map( ( tab ) => {

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -31,7 +31,12 @@ export default React.createClass( {
 	},
 
 	ensureValue( value ) {
-		if ( ( ! this.props.loading ) && ( value || value === 0 ) ) {
+		const { loading, children } = this.props;
+		if ( children ) {
+			return null;
+		}
+
+		if ( ( ! loading ) && ( value || value === 0 ) ) {
 			return this.numberFormat( value );
 		}
 


### PR DESCRIPTION
### Tabs
Render tabs with data and functionality. The presentation and styling of the tabs will be in a separate pull request.

![screen shot 2017-05-31 at 1 51 33 pm](https://cloud.githubusercontent.com/assets/1922453/26612350/4ee47fac-4608-11e7-998f-014bce948eb2.png)

### Things to Note
Some metrics, when observed to have a decrease, are considered good (like refunds). I decoupled direction and color into separate classes for rendering these arrows. In the case of refunds, a decrease will show a down arrow (`is-decrease` class) and have it be green(`is-positive` class).
![screen shot 2017-05-31 at 1 36 53 pm](https://cloud.githubusercontent.com/assets/1922453/26612433/dc7210b4-4608-11e7-84cc-fc9a392d28b3.png)

I'm also reusing `my-sites/stats/stats-tabs` components and slightly modified them so they can accept children to be purely presentational components.

Fixes https://github.com/Automattic/wp-calypso/issues/14312