### PR TITLE
Components: add icon support to SelectDropdown

### DIFF
--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -51,6 +51,10 @@ Used for displaying the text on the dropdown header.
 
 Used for displaying the count on the dropdown header.
 
+`selectedIcon`
+
+Used for displaying an icon on the dropdown header.
+
 `className`
 
 Optional extra class(es) to be applied to the `.select-dropdown`.
@@ -70,6 +74,10 @@ Boolean representing the selected visual state. `selected={ true }` creates a bl
 Optional number to show a Count next to the item text.
 
 ![selected example screenshot](https://cldup.com/BOZktaoqTT.png)
+
+`icon`
+
+Optional icon to show before the item text.
 
 `path`
 

--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -83,6 +83,10 @@ Optional icon to show before the item text.
 
 Optional URL to navigate to when option is clicked.
 
+`disabled`
+
+Optional bool to disable dropdown item.
+
 `onClick`
 
 Optional callback that will be applied when a `DropdownItem` has been clicked. This could be used for updating a parent's state, tracking analytics, etc.

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -23,7 +23,7 @@ const SelectDropdownDemo = React.createClass( {
 			childSelected: 'Published',
 			selectedCount: 10,
 			compactButtons: false,
-			selectedIcon: null
+			selectedIcon: <Gridicon icon="align-image-left" size={ 18 } />
 		};
 	},
 
@@ -133,33 +133,32 @@ const SelectDropdownDemo = React.createClass( {
 					className="select-dropdown-example__fixed-width"
 					compact={ this.state.compactButtons }
 					onSelect={ this.onDropdownSelect }
-					selectedText="Published"
-					selectedCount={ 10 }
-					selectedIcon={ <Gridicon icon="align-image-left" size={ 18 } /> }
+					selectedText={ this.state.childSelected }
+					selectedIcon={ this.state.selectedIcon }
 				>
 
 					<DropdownLabel><strong>Statuses</strong></DropdownLabel>
 
 					<DropdownItem
-						count={ 10 }
 						selected={ this.state.childSelected === 'Published' }
 						icon={ <Gridicon icon="align-image-left" size={ 18 } /> }
+						onClick={ this.selectItem.bind( this, 'Published', null, <Gridicon icon="align-image-left" size={ 18 } /> ) }
 					>
 						Published
 					</DropdownItem>
 
 					<DropdownItem
-						count={ 4 }
 						selected={ this.state.childSelected === 'Scheduled' }
 						icon={ <Gridicon icon="calendar" size={ 18 } /> }
+						onClick={ this.selectItem.bind( this, 'Scheduled', null, <Gridicon icon="calendar" size={ 18 } /> ) }
 					>
 						Scheduled
 					</DropdownItem>
 
 					<DropdownItem
-						count={ 3343 }
 						selected={ this.state.childSelected === 'Drafts' }
 						icon={ <Gridicon icon="create" size={ 18 } /> }
+						onClick={ this.selectItem.bind( this, 'Drafts', null, <Gridicon icon="create" size={ 18 } /> ) }
 					>
 						Drafts
 					</DropdownItem>
@@ -170,6 +169,7 @@ const SelectDropdownDemo = React.createClass( {
 						count={ 3 }
 						selected={ this.state.childSelected === 'Trashed' }
 						icon={ <Gridicon icon="trash" size={ 18 } /> }
+						onClick={ this.selectItem.bind( this, 'Trashed', null, <Gridicon icon="trash" size={ 18 } /> ) }
 					>
 						Trashed
 					</DropdownItem>
@@ -179,12 +179,13 @@ const SelectDropdownDemo = React.createClass( {
 		);
 	},
 
-	selectItem: function( childSelected, count, event ) {
+	selectItem: function( childSelected, count, icon, event ) {
 		event.preventDefault();
 
 		this.setState( {
 			childSelected: childSelected,
-			selectedCount: count
+			selectedCount: count,
+			selectedIcon: icon
 		} );
 
 		console.log( 'Select Dropdown Item (selected):', childSelected );

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -123,6 +123,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem count={ 10 } selected={ true } >Published publish publish publish</DropdownItem>
 					<DropdownItem count={ 4 } > Scheduled scheduled</DropdownItem>
 					<DropdownItem>Drafts</DropdownItem>
+					<DropdownItem disabled={ true }>Disabled Item</DropdownItem>
 					<DropdownSeparator />
 					<DropdownItem count={ 3 }>Trashed</DropdownItem>
 				</SelectDropdown>

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
 import Gridicon from 'gridicons';
 
 /**
@@ -13,38 +12,39 @@ import DropdownItem from 'components/select-dropdown/item';
 import DropdownLabel from 'components/select-dropdown/label';
 import DropdownSeparator from 'components/select-dropdown/separator';
 
-const SelectDropdownDemo = React.createClass( {
-	displayName: 'SelectDropdown',
+class SelectDropdownDemo extends React.Component {
+	static defaultProps = {
+		options: [
+			{ value: 'status-options', label: 'Statuses', isLabel: true },
+			{ value: 'published', label: 'Published', count: 12 },
+			{ value: 'scheduled', label: 'Scheduled' },
+			{ value: 'drafts', label: 'Drafts' },
+			null,
+			{ value: 'trashed', label: 'Trashed' }
+		]
+	}
 
-	mixins: [ PureRenderMixin ],
+	constructor( props ) {
+		super( props );
 
-	getInitialState: function() {
-		return {
+		this.toggleButtons = this.toggleButtons.bind( this );
+		this.selectItem = this.selectItem.bind( this );
+
+		const initialState = {
 			childSelected: 'Published',
 			selectedCount: 10,
 			compactButtons: false,
 			selectedIcon: <Gridicon icon="align-image-left" size={ 18 } />
 		};
-	},
 
-	getDefaultProps: function() {
-		return {
-			options: [
-				{ value: 'status-options', label: 'Statuses', isLabel: true },
-				{ value: 'published', label: 'Published', count: 12 },
-				{ value: 'scheduled', label: 'Scheduled' },
-				{ value: 'drafts', label: 'Drafts' },
-				null,
-				{ value: 'trashed', label: 'Trashed' }
-			]
-		};
-	},
+		this.state = initialState;
+	}
 
-	toggleButtons: function() {
+	toggleButtons() {
 		this.setState( { compactButtons: ! this.state.compactButtons } );
-	},
+	}
 
-	render: function() {
+	render() {
 		const toggleButtonsText = this.state.compactButtons
 			? 'Normal Buttons'
 			: 'Compact Buttons';
@@ -77,7 +77,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem
 						count={ 10 }
 						selected={ this.state.childSelected === 'Published' }
-						onClick={ this.selectItem.bind( this, 'Published', 10 ) }
+						onClick={ this.getSelectItemHandler( 'Published', 10 ) }
 					>
 						Published
 					</DropdownItem>
@@ -85,7 +85,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem
 						count={ 4 }
 						selected={ this.state.childSelected === 'Scheduled' }
-						onClick={ this.selectItem.bind( this, 'Scheduled', 4 ) }
+						onClick={ this.getSelectItemHandler( 'Scheduled', 4 ) }
 					>
 						Scheduled
 					</DropdownItem>
@@ -93,7 +93,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem
 						count={ 3343 }
 						selected={ this.state.childSelected === 'Drafts' }
-						onClick={ this.selectItem.bind( this, 'Drafts', 3343 ) }
+						onClick={ this.getSelectItemHandler( 'Drafts', 3343 ) }
 					>
 						Drafts
 					</DropdownItem>
@@ -103,7 +103,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem
 						count={ 3 }
 						selected={ this.state.childSelected === 'Trashed' }
-						onClick={ this.selectItem.bind( this, 'Trashed', 3 ) }
+						onClick={ this.getSelectItemHandler( 'Trashed', 3 ) }
 					>
 						Trashed
 					</DropdownItem>
@@ -143,7 +143,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem
 						selected={ this.state.childSelected === 'Published' }
 						icon={ <Gridicon icon="align-image-left" size={ 18 } /> }
-						onClick={ this.selectItem.bind( this, 'Published', null, <Gridicon icon="align-image-left" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Published', null, <Gridicon icon="align-image-left" size={ 18 } /> ) }
 					>
 						Published
 					</DropdownItem>
@@ -151,7 +151,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem
 						selected={ this.state.childSelected === 'Scheduled' }
 						icon={ <Gridicon icon="calendar" size={ 18 } /> }
-						onClick={ this.selectItem.bind( this, 'Scheduled', null, <Gridicon icon="calendar" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Scheduled', null, <Gridicon icon="calendar" size={ 18 } /> ) }
 					>
 						Scheduled
 					</DropdownItem>
@@ -159,7 +159,7 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem
 						selected={ this.state.childSelected === 'Drafts' }
 						icon={ <Gridicon icon="create" size={ 18 } /> }
-						onClick={ this.selectItem.bind( this, 'Drafts', null, <Gridicon icon="create" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Drafts', null, <Gridicon icon="create" size={ 18 } /> ) }
 					>
 						Drafts
 					</DropdownItem>
@@ -170,7 +170,7 @@ const SelectDropdownDemo = React.createClass( {
 						count={ 3 }
 						selected={ this.state.childSelected === 'Trashed' }
 						icon={ <Gridicon icon="trash" size={ 18 } /> }
-						onClick={ this.selectItem.bind( this, 'Trashed', null, <Gridicon icon="trash" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Trashed', null, <Gridicon icon="trash" size={ 18 } /> ) }
 					>
 						Trashed
 					</DropdownItem>
@@ -178,11 +178,16 @@ const SelectDropdownDemo = React.createClass( {
 
 			</div>
 		);
-	},
+	}
 
-	selectItem: function( childSelected, count, icon, event ) {
-		event.preventDefault();
+	getSelectItemHandler = ( name, count, icon ) => {
+		return event => {
+			event.preventDefault();
+			this.selectItem( name, count, icon );
+		};
+	}
 
+	selectItem( childSelected, count, icon ) {
 		this.setState( {
 			childSelected: childSelected,
 			selectedCount: count,
@@ -190,11 +195,11 @@ const SelectDropdownDemo = React.createClass( {
 		} );
 
 		console.log( 'Select Dropdown Item (selected):', childSelected );
-	},
+	}
 
-	onDropdownSelect: function( option ) {
+	onDropdownSelect( option ) {
 		console.log( 'Select Dropdown (selected):', option );
 	}
-} );
+}
 
-module.exports = SelectDropdownDemo;
+export default SelectDropdownDemo;

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -27,9 +27,6 @@ class SelectDropdownDemo extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		this.toggleButtons = this.toggleButtons.bind( this );
-		this.selectItem = this.selectItem.bind( this );
-
 		const initialState = {
 			childSelected: 'Published',
 			selectedCount: 10,
@@ -40,7 +37,7 @@ class SelectDropdownDemo extends React.Component {
 		this.state = initialState;
 	}
 
-	toggleButtons() {
+	toggleButtons = () => {
 		this.setState( { compactButtons: ! this.state.compactButtons } );
 	}
 
@@ -158,7 +155,6 @@ class SelectDropdownDemo extends React.Component {
 					<DropdownSeparator />
 
 					<DropdownItem
-						count={ 3 }
 						selected={ this.state.childSelected === 'Trashed' }
 						icon={ <Gridicon icon="trash" size={ 18 } /> }
 						onClick={ this.getSelectItemHandler( 'Trashed', 3, <Gridicon icon="trash" size={ 18 } /> ) }
@@ -196,7 +192,7 @@ class SelectDropdownDemo extends React.Component {
 		};
 	}
 
-	selectItem( childSelected, count, icon ) {
+	selectItem = ( childSelected, count, icon ) => {
 		this.setState( {
 			childSelected: childSelected,
 			selectedCount: count,

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -128,10 +128,22 @@ class SelectDropdownDemo extends React.Component {
 					<DropdownItem count={ 3 }>Trashed</DropdownItem>
 				</SelectDropdown>
 
-				<h3 style={ { marginTop: 20 } }>With Icons</h3>
+				<h3 style={ { marginTop: 20 } }>With Icons in Items Passed as Options</h3>
 
 				<SelectDropdown
-					className="select-dropdown-example__fixed-width"
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					options={ [
+						{ value: 'published', label: 'Published', icon: <Gridicon icon="align-image-left" size={ 18 } /> },
+						{ value: 'scheduled', label: 'Scheduled', icon: <Gridicon icon="calendar" size={ 18 } /> },
+						{ value: 'drafts', label: 'Drafts', icon: <Gridicon icon="create" size={ 18 } /> },
+						{ value: 'trashed', label: 'Trashed', icon: <Gridicon icon="trash" size={ 18 } /> },
+					] }
+				/>
+
+				<h3 style={ { marginTop: 20 } }>With Icons in Items Passed as Children</h3>
+
+				<SelectDropdown
 					compact={ this.state.compactButtons }
 					onSelect={ this.onDropdownSelect }
 					selectedText={ this.state.childSelected }

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -21,7 +22,8 @@ const SelectDropdownDemo = React.createClass( {
 		return {
 			childSelected: 'Published',
 			selectedCount: 10,
-			compactButtons: false
+			compactButtons: false,
+			selectedIcon: null
 		};
 	},
 
@@ -123,6 +125,54 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem>Drafts</DropdownItem>
 					<DropdownSeparator />
 					<DropdownItem count={ 3 }>Trashed</DropdownItem>
+				</SelectDropdown>
+
+				<h3 style={ { marginTop: 20 } }>With Icons</h3>
+
+				<SelectDropdown
+					className="select-dropdown-example__fixed-width"
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					selectedText="Published"
+					selectedCount={ 10 }
+					selectedIcon={ <Gridicon icon="align-image-left" size={ 18 } /> }
+				>
+
+					<DropdownLabel><strong>Statuses</strong></DropdownLabel>
+
+					<DropdownItem
+						count={ 10 }
+						selected={ this.state.childSelected === 'Published' }
+						icon={ <Gridicon icon="align-image-left" size={ 18 } /> }
+					>
+						Published
+					</DropdownItem>
+
+					<DropdownItem
+						count={ 4 }
+						selected={ this.state.childSelected === 'Scheduled' }
+						icon={ <Gridicon icon="calendar" size={ 18 } /> }
+					>
+						Scheduled
+					</DropdownItem>
+
+					<DropdownItem
+						count={ 3343 }
+						selected={ this.state.childSelected === 'Drafts' }
+						icon={ <Gridicon icon="create" size={ 18 } /> }
+					>
+						Drafts
+					</DropdownItem>
+
+					<DropdownSeparator />
+
+					<DropdownItem
+						count={ 3 }
+						selected={ this.state.childSelected === 'Trashed' }
+						icon={ <Gridicon icon="trash" size={ 18 } /> }
+					>
+						Trashed
+					</DropdownItem>
 				</SelectDropdown>
 
 			</div>

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -109,27 +109,7 @@ class SelectDropdownDemo extends React.Component {
 					</DropdownItem>
 				</SelectDropdown>
 
-				<h3 style={ { marginTop: 20 } }>max-width: 220px;</h3>
-
-				<SelectDropdown
-					className="select-dropdown-example__fixed-width"
-					compact={ this.state.compactButtons }
-					onSelect={ this.onDropdownSelect }
-					selectedText="Published publish publish publish"
-					selectedCount={ 454 }
-				>
-
-					<DropdownLabel><strong>Statuses</strong></DropdownLabel>
-					<DropdownItem count={ 10 } selected={ true } >Published publish publish publish</DropdownItem>
-					<DropdownItem count={ 4 } > Scheduled scheduled</DropdownItem>
-					<DropdownItem>Drafts</DropdownItem>
-					<DropdownItem disabled={ true }>Disabled Item</DropdownItem>
-					<DropdownSeparator />
-					<DropdownItem count={ 3 }>Trashed</DropdownItem>
-				</SelectDropdown>
-
 				<h3 style={ { marginTop: 20 } }>With Icons in Items Passed as Options</h3>
-
 				<SelectDropdown
 					compact={ this.state.compactButtons }
 					onSelect={ this.onDropdownSelect }
@@ -142,7 +122,6 @@ class SelectDropdownDemo extends React.Component {
 				/>
 
 				<h3 style={ { marginTop: 20 } }>With Icons in Items Passed as Children</h3>
-
 				<SelectDropdown
 					compact={ this.state.compactButtons }
 					onSelect={ this.onDropdownSelect }
@@ -155,7 +134,7 @@ class SelectDropdownDemo extends React.Component {
 					<DropdownItem
 						selected={ this.state.childSelected === 'Published' }
 						icon={ <Gridicon icon="align-image-left" size={ 18 } /> }
-						onClick={ this.getSelectItemHandler( 'Published', null, <Gridicon icon="align-image-left" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Published', 10, <Gridicon icon="align-image-left" size={ 18 } /> ) }
 					>
 						Published
 					</DropdownItem>
@@ -163,7 +142,7 @@ class SelectDropdownDemo extends React.Component {
 					<DropdownItem
 						selected={ this.state.childSelected === 'Scheduled' }
 						icon={ <Gridicon icon="calendar" size={ 18 } /> }
-						onClick={ this.getSelectItemHandler( 'Scheduled', null, <Gridicon icon="calendar" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Scheduled', 4, <Gridicon icon="calendar" size={ 18 } /> ) }
 					>
 						Scheduled
 					</DropdownItem>
@@ -171,7 +150,7 @@ class SelectDropdownDemo extends React.Component {
 					<DropdownItem
 						selected={ this.state.childSelected === 'Drafts' }
 						icon={ <Gridicon icon="create" size={ 18 } /> }
-						onClick={ this.getSelectItemHandler( 'Drafts', null, <Gridicon icon="create" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Drafts', 3343, <Gridicon icon="create" size={ 18 } /> ) }
 					>
 						Drafts
 					</DropdownItem>
@@ -182,10 +161,28 @@ class SelectDropdownDemo extends React.Component {
 						count={ 3 }
 						selected={ this.state.childSelected === 'Trashed' }
 						icon={ <Gridicon icon="trash" size={ 18 } /> }
-						onClick={ this.getSelectItemHandler( 'Trashed', null, <Gridicon icon="trash" size={ 18 } /> ) }
+						onClick={ this.getSelectItemHandler( 'Trashed', 3, <Gridicon icon="trash" size={ 18 } /> ) }
 					>
 						Trashed
 					</DropdownItem>
+				</SelectDropdown>
+
+				<h3 style={ { marginTop: 20 } }>max-width: 220px;</h3>
+				<SelectDropdown
+					className="select-dropdown-example__fixed-width"
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					selectedText="Published publish publish publish"
+					selectedCount={ 10 }
+				>
+
+					<DropdownLabel><strong>Statuses</strong></DropdownLabel>
+					<DropdownItem count={ 10 } selected={ true } >Published publish publish publish</DropdownItem>
+					<DropdownItem count={ 4 } > Scheduled scheduled</DropdownItem>
+					<DropdownItem count={ 3343 }>Drafts</DropdownItem>
+					<DropdownItem disabled={ true }>Disabled Item</DropdownItem>
+					<DropdownSeparator />
+					<DropdownItem count={ 3 }>Trashed</DropdownItem>
 				</SelectDropdown>
 
 			</div>

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -133,7 +133,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected text
-		const selectedValue = selected ? selected : this.getInitialSelectedItem( this.props );
+		const selectedValue = selected || this.getInitialSelectedItem( this.props );
 		return result( find( options, { value: selectedValue } ), 'label' );
 	}
 
@@ -146,7 +146,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected icon
-		const selectedValue = selected ? selected : this.getInitialSelectedItem( this.props );
+		const selectedValue = selected || this.getInitialSelectedItem( this.props );
 		return result( find( options, { value: selectedValue } ), 'icon' );
 	}
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -208,7 +208,7 @@ class SelectDropdown extends Component {
 					selected={ this.state.selected === item.value }
 					onClick={ this.onSelectItem( item ) }
 					path={ item.path }
-					item={ item.icon }
+					icon={ item.icon }
 				>
 					{ item.label }
 				</DropdownItem>

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -259,8 +259,9 @@ class SelectDropdown extends Component {
 					>
 						<span className="select-dropdown__header-text">
 							{
-								selectedIcon.type === Gridicon &&
-								selectedIcon
+								selectedIcon && selectedIcon.type === Gridicon
+									? selectedIcon
+									: null
 							}
 							{ selectedText }
 						</span>

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -9,6 +9,7 @@ import findIndex from 'lodash/findIndex';
 import map from 'lodash/map';
 import result from 'lodash/result';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import Count from 'components/count';
 class SelectDropdown extends Component {
 	static propTypes = {
 		selectedText: PropTypes.string,
+		selectedIcon: PropTypes.element,
 		selectedCount: PropTypes.number,
 		initialSelected: PropTypes.string,
 		className: PropTypes.string,
@@ -36,7 +38,8 @@ class SelectDropdown extends Component {
 			PropTypes.shape( {
 				value: PropTypes.string.isRequired,
 				label: PropTypes.string.isRequired,
-				path: PropTypes.string
+				path: PropTypes.string,
+				icon: PropTypes.element
 			} )
 		)
 	}
@@ -134,6 +137,19 @@ class SelectDropdown extends Component {
 		return result( find( options, { value: selectedValue } ), 'label' );
 	}
 
+	getSelectedIcon() {
+		const { options, selectedIcon } = this.props;
+		const { selected } = this.state;
+
+		if ( selectedIcon ) {
+			return selectedIcon;
+		}
+
+		// return currently selected icon
+		const selectedValue = selected ? selected : this.getInitialSelectedItem( this.props );
+		return result( find( options, { value: selectedValue } ), 'icon' );
+	}
+
 	dropdownOptions() {
 		let refIndex = 0;
 		const self = this;
@@ -192,6 +208,7 @@ class SelectDropdown extends Component {
 					selected={ this.state.selected === item.value }
 					onClick={ this.onSelectItem( item ) }
 					path={ item.path }
+					item={ item.icon }
 				>
 					{ item.label }
 				</DropdownItem>
@@ -219,6 +236,7 @@ class SelectDropdown extends Component {
 		const dropdownClassName = classNames( dropdownClasses );
 
 		const selectedText = this.getSelectedText();
+		const selectedIcon = this.getSelectedIcon();
 
 		return (
 			<div style={ this.props.style } className={ dropdownClassName }>
@@ -240,6 +258,10 @@ class SelectDropdown extends Component {
 						className="select-dropdown__header"
 					>
 						<span className="select-dropdown__header-text">
+							{
+								selectedIcon.type === Gridicon &&
+								selectedIcon
+							}
 							{ selectedText }
 						</span>
 						{

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -47,8 +47,9 @@ class SelectDropdownItem extends Component {
 					aria-selected={ this.props.selected } >
 					<span className="select-dropdown__item-text">
 						{
-							this.props.icon.type === Gridicon &&
-							this.props.icon
+							this.props.icon && this.props.icon.type === Gridicon
+								? this.props.icon
+								: null
 						}
 						{ this.props.children }
 					</span>

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -16,7 +17,8 @@ class SelectDropdownItem extends Component {
 		isDropdownOpen: React.PropTypes.bool,
 		selected: React.PropTypes.bool,
 		onClick: React.PropTypes.func,
-		count: React.PropTypes.number
+		count: React.PropTypes.number,
+		icon: React.PropTypes.element,
 	}
 
 	static defaultProps = {
@@ -28,7 +30,8 @@ class SelectDropdownItem extends Component {
 		const optionClassName = classNames( this.props.className, {
 			'select-dropdown__item': true,
 			'is-selected': this.props.selected,
-			'is-disabled': this.props.disabled
+			'is-disabled': this.props.disabled,
+			'has-icon': !! this.props.icon
 		} );
 
 		return (
@@ -43,6 +46,10 @@ class SelectDropdownItem extends Component {
 					tabIndex={ this.props.isDropdownOpen ? 0 : '' }
 					aria-selected={ this.props.selected } >
 					<span className="select-dropdown__item-text">
+						{
+							this.props.icon.type === Gridicon &&
+							this.props.icon
+						}
 						{ this.props.children }
 					</span>
 					{

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -18,6 +18,7 @@ class SelectDropdownItem extends Component {
 		selected: React.PropTypes.bool,
 		onClick: React.PropTypes.func,
 		count: React.PropTypes.number,
+		disabled: React.PropTypes.bool,
 		icon: React.PropTypes.element,
 	}
 

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -122,7 +122,7 @@ $compact-header-height: 35;
 	}
 
 	.gridicon {
-		margin-right: #{ ( $side-margin / 4 ) }px;
+		margin-right: #{ ( $side-margin / 2 ) }px;
 		vertical-align: text-bottom;
 
 		.is-compact & {
@@ -227,7 +227,7 @@ $compact-header-height: 35;
 	}
 
 	.gridicon {
-		margin-right: #{ ( $side-margin / 4 ) }px;
+		margin-right: #{ ( $side-margin / 2 ) }px;
 		vertical-align: text-bottom;
 	}
 }

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -53,7 +53,7 @@ $compact-header-height: 35;
 .select-dropdown__header {
 	height: #{ $header-height }px;
 	line-height: #{ $header-height - 3 }px;
-	padding: 0 #{ $side-margin + 20 }px 0 #{ $side-margin }px;
+	padding: 0 75px 0 #{ $side-margin }px;
 	box-sizing: border-box;
 
 	border-style: solid;

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -120,6 +120,15 @@ $compact-header-height: 35;
 		right: 40px;
 		top: #{ ( $header-height - 18 - 2 ) / 2 }px;
 	}
+
+	.gridicon {
+		margin-right: #{ ( $side-margin / 4 ) }px;
+		vertical-align: text-bottom;
+
+		.is-compact & {
+			display: none;
+		}
+	}
 }
 
 .select-dropdown__header-text {
@@ -215,6 +224,11 @@ $compact-header-height: 35;
 		&.is-selected:hover {
 			color: $white;
 		}
+	}
+
+	.gridicon {
+		margin-right: #{ ( $side-margin / 4 ) }px;
+		vertical-align: text-bottom;
 	}
 }
 

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -53,7 +53,7 @@ $compact-header-height: 35;
 .select-dropdown__header {
 	height: #{ $header-height }px;
 	line-height: #{ $header-height - 3 }px;
-	padding: 0 75px 0 #{ $side-margin }px;
+	padding: 0 #{ $side-margin + 20 }px 0 #{ $side-margin }px;
 	box-sizing: border-box;
 
 	border-style: solid;

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -464,8 +464,8 @@ const EditorVisibility = React.createClass( {
 								key={ option.value }
 								value={ option.value }
 								onClick={ option.onClick }
+								icon={ <Gridicon icon={ option.icon } size={ 18 } /> }
 							>
-								<Gridicon icon={ option.icon } size={ 18 } />
 								{ option.label }
 							</DropdownItem>
 						) }


### PR DESCRIPTION
In #14517, the `EditorVisibility` component was updated to use the `SelectDropdown` component instead of a popover. Since `SelectDropdownItem` requires a string for children props, this adds `Gridicon` support as a prop to the component.

**Mock:**
<img width="370" alt="781e76d6-43b8-11e7-8db7-f86075e99d73" src="https://cloud.githubusercontent.com/assets/942359/26612598/d4415e66-4583-11e7-9857-d59090943dd2.png">

**To Test:**
- Checkout branch
- Head to [UI component devdocs](http://calypso.localhost:3000/devdocs/design)
- Make sure that `SelectDropdown` examples are properly rendered and that no new errors have been introduced
- Navigate to other examples of `SelectDropdown` usage (tinyMCE contact form, account help form) and make sure they're working as expected.