### PR TITLE
Add/tests for marketing survey step components

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/business-at-step.jsx
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { BusinessATStep }	from '../business-at-step';
+import { BusinessATStep } from '../business-at-step';
 
 describe( 'BusinessATStep', function() {
 	describe( 'rendering translated content', function() {

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/business-at-step.jsx
@@ -19,7 +19,7 @@ describe( 'BusinessATStep', function() {
 
 		beforeEach( function() {
 			wrapper = shallow(
-				<BusinessATStep recordTracksEvent={ noop } translate={ translate }></BusinessATStep>
+				<BusinessATStep recordTracksEvent={ noop } translate={ translate } />
 			);
 		} );
 

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/business-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/business-at-step.jsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { stub } from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { BusinessATStep }	from '../business-at-step';
+
+describe( 'BusinessATStep', function() {
+	describe( 'rendering translated content', function() {
+		let wrapper;
+		const translate = ( content ) => `Translated: ${ content }`;
+
+		beforeEach( function() {
+			wrapper = shallow(
+				<BusinessATStep recordTracksEvent={ noop } translate={ translate }></BusinessATStep>
+			);
+		} );
+
+		it( 'should render translated heading content', function() {
+			expect(
+				wrapper.find( 'FormSectionHeading' ).props().children
+			).to.equal(
+				'Translated: New! Install Custom Plugins and Themes'
+			);
+		} );
+
+		it( 'should render translated link content', function() {
+			expect(
+				wrapper.find( 'FormFieldset > p' ).at( 0 ).props().children
+			).to.equal(
+				'Translated: Have a theme or plugin you need to install to build the site you want? ' +
+				'Now you can! ' +
+				'Learn more about {{pluginLink}}installing plugins{{/pluginLink}} and ' +
+				'{{themeLink}}uploading themes{{/themeLink}} today.',
+			);
+		} );
+
+		it( 'should render translated confirmation content', function() {
+			expect(
+				wrapper.find( 'FormFieldset > p' ).at( 1 ).props().children
+			).to.equal(
+				'Translated: Are you sure you want to cancel your subscription and lose access to these new features?'
+			);
+		} );
+	} );
+
+	describe( 'rendered links', function() {
+		const translate = ( content, params ) => {
+			if ( params && params.components ) {
+				return (
+					<div>
+						{ params.components.pluginLink }
+						{ params.components.themeLink }
+					</div>
+				);
+			}
+			return null;
+		};
+		let recordTracksEvent, wrapper;
+
+		beforeEach( function() {
+			recordTracksEvent = stub();
+			wrapper = shallow(
+				<BusinessATStep translate={ translate } recordTracksEvent={ recordTracksEvent } />
+			);
+		} );
+
+		it( 'should fire tracks event for plugin support link when clicked', function() {
+			wrapper.find( 'a' ).at( 0 ).simulate( 'click' );
+
+			expect( recordTracksEvent ).to.have.been.calledWith( 'calypso_cancellation_business_at_plugin_support_click' );
+		} );
+
+		it( 'should fire tracks event for theme support link when clicked', function() {
+			wrapper.find( 'a' ).at( 1 ).simulate( 'click' );
+
+			expect( recordTracksEvent ).to.have.been.calledWith( 'calypso_cancellation_business_at_theme_support_click' );
+		} );
+	} );
+} );

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/upgrade-at-step.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { stub } from 'sinon';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { UpgradeATStep }	from '../upgrade-at-step';
+
+describe( 'UpgradeATStep', function() {
+	const selectedSite = { slug: 'site_slug' };
+
+	describe( 'rendering translated content', function() {
+		let wrapper;
+		const translate = ( content ) => `Translated: ${ content }`;
+
+		beforeEach( function() {
+			wrapper = shallow(
+				<UpgradeATStep recordTracksEvent={ noop } translate={ translate } selectedSite={ selectedSite } />
+			);
+		} );
+
+		it( 'should render translated heading content', function() {
+			expect(
+				wrapper.find( 'FormSectionHeading' ).props().children
+			).to.equal(
+				'Translated: New! Install Custom Plugins and Themes'
+			);
+		} );
+
+		it( 'should render translated link content', function() {
+			expect(
+				wrapper.find( 'FormFieldset > p' ).props().children
+			).to.equal(
+				'Translated: Did you know that you can now use third-party plugins and themes on the WordPress.com Business plan? ' +
+				'Claim a 25% discount when you upgrade your site today - {{b}}enter the code BIZC25 at checkout{{/b}}.'
+			);
+		} );
+
+		it( 'should render translated confirmation content', function() {
+			expect(
+				wrapper.find( 'FormFieldset > Button' ).props().children
+			).to.equal(
+				'Translated: Upgrade My Site'
+			);
+		} );
+	} );
+
+	it( 'should render button with link to business plan checkout', function() {
+		const wrapper = shallow(
+			<UpgradeATStep recordTracksEvent={ noop } translate={ noop } selectedSite={ selectedSite } />
+		);
+
+		expect(
+			wrapper.find( 'Button' ).props().href
+		).to.equal(
+			'/checkout/site_slug/business'
+		);
+	} );
+
+	it( 'should fire tracks event when button is clicked', function() {
+		const	recordTracksEvent = stub();
+		const wrapper = shallow(
+			<UpgradeATStep recordTracksEvent={ recordTracksEvent } translate={ noop } selectedSite={ selectedSite } />
+		);
+
+		wrapper.find( 'Button' ).simulate( 'click' );
+
+		expect( recordTracksEvent ).to.have.been.calledWith( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
+	} );
+} );

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/upgrade-at-step.jsx
@@ -64,7 +64,7 @@ describe( 'UpgradeATStep', function() {
 	} );
 
 	it( 'should fire tracks event when button is clicked', function() {
-		const	recordTracksEvent = stub();
+		const recordTracksEvent = stub();
 		const wrapper = shallow(
 			<UpgradeATStep recordTracksEvent={ recordTracksEvent } translate={ noop } selectedSite={ selectedSite } />
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/test/upgrade-at-step.jsx
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { UpgradeATStep }	from '../upgrade-at-step';
+import { UpgradeATStep } from '../upgrade-at-step';
 
 describe( 'UpgradeATStep', function() {
 	const selectedSite = { slug: 'site_slug' };

--- a/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/stepComponents/upgrade-at-step.jsx
@@ -27,7 +27,7 @@ export class UpgradeATStep extends Component {
 	}
 
 	onClick = () => {
-		this.props.recordTracksEvent( 'calypso_cancellation_business_at_plugin_support_click' );
+		this.props.recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
 	}
 
 	render() {


### PR DESCRIPTION
This PR just adds unit tests for some recently added cancellation survey step components.

It also fixes a bug where a misleading tracks event is fired when a user cancelling a personal/premium plan clicks on the 'upgrade' CTA.

This is a step toward extracting each individual step from `client/components/marketing-survey/cancel-purchase-form/index.jsx` component.