### PR TITLE
Components: Query post types when post type settings are changed

### DIFF
--- a/client/components/data/query-post-types/index.jsx
+++ b/client/components/data/query-post-types/index.jsx
@@ -33,11 +33,12 @@ class QueryPostTypes extends Component {
 			themeSlug
 		} = this.props;
 		const {
+			postTypeSettings: nextPostTypeSettings,
 			siteId: nextSiteId,
 			themeSlug: nextThemeSlug
 		} = nextProps;
 		const hasThemeChanged = themeSlug && nextThemeSlug && themeSlug !== nextThemeSlug;
-		const hasPostTypeSettingChanged = ! isEqual( postTypeSettings, nextProps.postTypeSettings );
+		const hasPostTypeSettingChanged = ! isEqual( postTypeSettings, nextPostTypeSettings );
 
 		if ( siteId !== nextSiteId || hasThemeChanged || hasPostTypeSettingChanged ) {
 			this.request( nextProps );

--- a/client/components/data/query-post-types/index.jsx
+++ b/client/components/data/query-post-types/index.jsx
@@ -3,12 +3,14 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { isEqual, pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isRequestingPostTypes } from 'state/post-types/selectors';
 import { getSiteOption } from 'state/sites/selectors';
+import { getSiteSettings } from 'state/site-settings/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 
 class QueryPostTypes extends Component {
@@ -16,6 +18,7 @@ class QueryPostTypes extends Component {
 		siteId: PropTypes.number.isRequired,
 		requestingPostTypes: PropTypes.bool,
 		themeSlug: PropTypes.string,
+		postTypeSettings: PropTypes.object,
 		requestPostTypes: PropTypes.func
 	};
 
@@ -24,10 +27,19 @@ class QueryPostTypes extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { siteId, themeSlug } = this.props;
-		const { siteId: nextSiteId, themeSlug: nextThemeSlug } = nextProps;
+		const {
+			postTypeSettings,
+			siteId,
+			themeSlug
+		} = this.props;
+		const {
+			siteId: nextSiteId,
+			themeSlug: nextThemeSlug
+		} = nextProps;
 		const hasThemeChanged = themeSlug && nextThemeSlug && themeSlug !== nextThemeSlug;
-		if ( siteId !== nextSiteId || hasThemeChanged ) {
+		const hasPostTypeSettingChanged = ! isEqual( postTypeSettings, nextProps.postTypeSettings );
+
+		if ( siteId !== nextSiteId || hasThemeChanged || hasPostTypeSettingChanged ) {
 			this.request( nextProps );
 		}
 	}
@@ -47,7 +59,10 @@ class QueryPostTypes extends Component {
 
 export default connect(
 	( state, ownProps ) => {
+		const settings = getSiteSettings( state, ownProps.siteId );
+
 		return {
+			postTypeSettings: pick( settings, [ 'jetpack_portfolio', 'jetpack_testimonial' ] ),
 			requestingPostTypes: isRequestingPostTypes( state, ownProps.siteId ),
 			themeSlug: getSiteOption( state, ownProps.siteId, 'theme_slug' )
 		};


### PR DESCRIPTION
Currently, enabling/disabling a post type in the Custom Content Types card does not update the sidebar with the latest post types. For example, if the **Testimonial** post type is enabled, and you disable it, and it's not supported by the active theme, it should be removed from the sidebar right away. Right now, in order to see it removed, you need to refresh Calypso. 

This PR fixes this issue by issuing a fresh request of the site post types when post type settings are changed. This approach is familiar already, as we fetch post types the same way when we switch to a different theme. 

The previous approach was with a callback, but it was not a scalable solution (#14576).

This PR is part of #13568.

To test:
* Checkout this branch.
* Go to `/settings/writing/$site`, where `$site` is one of your Jetpack sites (wp.com sites will be supported too when we land #14572).
* Activate a theme that does not support the **Testimonial** post type.
* Activate the **Testimonial** post type and verify sure the **Testimonial** item shows in the sidebar menu shortly.
* Deactivate the **Testimonial** post type and verify the **Testimonial** item gets removed from the sidebar menu shortly.