### PR TITLE
Reader: Adjust padding around Longreads publisher intros

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -334,15 +334,13 @@
 // Longreads-Specific Full Post View Styles
 .blog-70135762 .reader-full-post__story-content {
 	
-	.publisher-intro {
-		img {
-			margin-bottom: 0;
-		}
+	.publisher-intro img {
+		margin-bottom: 0;
+	}
 
-		@include breakpoint( "<660px" ) {
-			p:first-child {
-				margin-bottom: 0;
-			}
+	@include breakpoint( "<660px" ) {
+		.publisher-intro p:first-child {
+			margin-bottom: 0;
 		}
 	}
 }

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -333,9 +333,10 @@
 
 // Longreads-Specific Full Post View Styles
 .blog-70135762 .reader-full-post__story-content {
-	
+
 	.publisher-intro img {
-		margin-bottom: 0;
+		float: left;
+		margin: 0 20px 0 0;
 	}
 
 	@include breakpoint( "<660px" ) {

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -339,8 +339,8 @@
 		margin: 0 20px 0 0;
 	}
 
-	@include breakpoint( "<660px" ) {
-		.publisher-intro p:first-child {
+	.publisher-intro p:first-child {
+		@include breakpoint( "<660px" ) {
 			margin-bottom: 0;
 		}
 	}

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -331,6 +331,22 @@
 	}
 }
 
+// Longreads-Specific Full Post View Styles
+.blog-70135762 .reader-full-post__story-content {
+	
+	.publisher-intro {
+		img {
+			margin-bottom: 0;
+		}
+
+		@include breakpoint( "<660px" ) {
+			p:first-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+
 // gizmodo fixes
 .reader-full-post.feed-10080096 {
 	.align--bleed {


### PR DESCRIPTION
We sometimes include short introduction block quotes that highlight publishers on Longreads posts. When we do, they always have the `publisher-intro` class. 

The Reader adds some unnecessary padding around the images within those intros. This PR removes that extra padding. 

---

**Before:** (Changes are evident in the spacing around the "TMI" logo in these screenshots)

<img width="1024" alt="screen shot 2017-05-31 at 8 40 00 am" src="https://cloud.githubusercontent.com/assets/1202812/26632959/d09e22d8-45df-11e7-8e60-2dcc8426be5e.png">
<img width="360" alt="screen shot 2017-05-31 at 8 40 14 am" src="https://cloud.githubusercontent.com/assets/1202812/26632960/d0a13d7e-45df-11e7-90bf-c38b4c00951e.png">

**After:**

<img width="1024" alt="screen shot 2017-05-31 at 8 39 32 am" src="https://cloud.githubusercontent.com/assets/1202812/26632964/d5fed42a-45df-11e7-8974-e8de507eb794.png">
<img width="360" alt="screen shot 2017-05-31 at 8 39 10 am" src="https://cloud.githubusercontent.com/assets/1202812/26632973/ddfb29a8-45df-11e7-937c-0b63d912a3bd.png">

---

I used the blog-specific class for Longreads (`blog-70135762`) to target this. We’ve done similar things for the Daily Post and Discover in the past. 

To test, visit full-post views of stories with the publisher intro. For example: 
http://calypso.localhost:3000/read/feeds/22973954/posts/1476030312
http://calypso.localhost:3000/read/feeds/22973954/posts/1433727023