### PR TITLE
Update shrinkwrap for newer calypso-prettier

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -770,7 +770,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000671"
+      "version": "1.0.30000676"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1282,7 +1282,7 @@
       "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.1.2"
+      "version": "3.1.3"
     },
     "delegates": {
       "version": "1.0.0"
@@ -2481,7 +2481,7 @@
       "version": "1.0.1"
     },
     "is-dotfile": {
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     "is-equal-shallow": {
       "version": "0.1.3"
@@ -2537,11 +2537,11 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "2.0.1",
+      "version": "2.0.3",
       "dev": true,
       "dependencies": {
         "isobject": {
-          "version": "1.0.2",
+          "version": "3.0.0",
           "dev": true
         }
       }
@@ -2648,7 +2648,7 @@
       }
     },
     "istanbul-api": {
-      "version": "1.1.8",
+      "version": "1.1.9",
       "dev": true,
       "dependencies": {
         "async": {
@@ -2658,15 +2658,15 @@
       }
     },
     "istanbul-lib-coverage": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "1.7.1",
+      "version": "1.7.2",
       "dev": true,
       "dependencies": {
         "semver": {
@@ -2676,11 +2676,11 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dev": true
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dev": true,
       "dependencies": {
         "debug": {
@@ -2698,7 +2698,7 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dev": true
     },
     "jade": {
@@ -3240,7 +3240,7 @@
       }
     },
     "levelup": {
-      "version": "1.3.7"
+      "version": "1.3.8"
     },
     "leven": {
       "version": "1.0.2",
@@ -3638,13 +3638,13 @@
       }
     },
     "node-abi": {
-      "version": "2.0.2"
+      "version": "2.0.3"
     },
     "node-contains": {
       "version": "1.0.0"
     },
     "node-dir": {
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "minimatch": {
           "version": "3.0.4"
@@ -4116,8 +4116,8 @@
     },
     "prettier": {
       "version": "1.1.7",
-      "from": "git+https://github.com/Automattic/calypso-prettier.git#ee9c5e17a3fdc14ff344bbc945575f1b293f2b95",
-      "resolved": "git+https://github.com/Automattic/calypso-prettier.git#ee9c5e17a3fdc14ff344bbc945575f1b293f2b95",
+      "from": "git+https://github.com/Automattic/calypso-prettier.git#28be4a70ff31bd161c545de4fac66f8a9d094a48",
+      "resolved": "git+https://github.com/Automattic/calypso-prettier.git#28be4a70ff31bd161c545de4fac66f8a9d094a48",
       "dev": true,
       "dependencies": {
         "ast-types": {


### PR DESCRIPTION
Update to pick up https://github.com/Automattic/calypso-prettier/pull/2, which hard codes the "options" typically used by prettier.