### PR TITLE
Update notes panel for text-styling updates

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -124,7 +124,7 @@
       "version": "2.0.0"
     },
     "arr-flatten": {
-      "version": "1.0.3"
+      "version": "1.1.0"
     },
     "array-differ": {
       "version": "1.0.0",
@@ -781,7 +781,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000696"
+      "version": "1.0.30000697"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -989,7 +989,7 @@
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "2.10.0",
+          "version": "2.11.0",
           "dev": true
         },
         "glob": {
@@ -1809,7 +1809,7 @@
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "5.0.3",
+          "version": "5.1.1",
           "dev": true
         }
       }
@@ -2905,7 +2905,7 @@
           "version": "1.5.2"
         },
         "commander": {
-          "version": "2.10.0"
+          "version": "2.11.0"
         }
       }
     },
@@ -2989,7 +2989,7 @@
       "version": "1.0.5"
     },
     "irregular-plurals": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dev": true
     },
     "is-arrayish": {
@@ -3075,7 +3075,7 @@
       "dev": true,
       "dependencies": {
         "isobject": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "dev": true
         }
       }
@@ -3359,7 +3359,7 @@
           "dev": true
         },
         "diff": {
-          "version": "3.2.0",
+          "version": "3.3.0",
           "dev": true
         },
         "jest-matcher-utils": {
@@ -3531,7 +3531,7 @@
           "dev": true
         },
         "diff": {
-          "version": "3.2.0",
+          "version": "3.3.0",
           "dev": true
         },
         "supports-color": {
@@ -4334,7 +4334,7 @@
       "dev": true
     },
     "notifications-panel": {
-      "version": "1.1.16"
+      "version": "1.1.19"
     },
     "npm-path": {
       "version": "1.1.0",
@@ -4657,7 +4657,7 @@
       "version": "3.3.0"
     },
     "prebuild-install": {
-      "version": "2.1.2",
+      "version": "2.2.0",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -4737,7 +4737,7 @@
           "optional": true
         },
         "tiny-emitter": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "optional": true
         }
       }
@@ -4924,7 +4924,7 @@
           "version": "5.8.38"
         },
         "commander": {
-          "version": "2.10.0"
+          "version": "2.11.0"
         }
       }
     },
@@ -5201,9 +5201,6 @@
       "dependencies": {
         "qs": {
           "version": "6.4.0"
-        },
-        "tunnel-agent": {
-          "version": "0.6.0"
         },
         "uuid": {
           "version": "3.1.0"
@@ -6008,7 +6005,7 @@
       "version": "0.0.0"
     },
     "tunnel-agent": {
-      "version": "0.4.3"
+      "version": "0.6.0"
     },
     "tween.js": {
       "version": "16.3.1"
@@ -6240,7 +6237,7 @@
           "dev": true
         },
         "commander": {
-          "version": "2.10.0",
+          "version": "2.11.0",
           "dev": true
         },
         "content-disposition": {
@@ -6366,7 +6363,7 @@
           "dev": true
         },
         "commander": {
-          "version": "2.10.0",
+          "version": "2.11.0",
           "dev": true
         },
         "component-emitter": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -124,7 +124,7 @@
       "version": "2.0.0"
     },
     "arr-flatten": {
-      "version": "1.1.0"
+      "version": "1.0.3"
     },
     "array-differ": {
       "version": "1.0.0",
@@ -781,7 +781,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000697"
+      "version": "1.0.30000696"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -989,7 +989,7 @@
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "2.11.0",
+          "version": "2.10.0",
           "dev": true
         },
         "glob": {
@@ -1809,7 +1809,7 @@
       "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "5.1.1",
+          "version": "5.0.3",
           "dev": true
         }
       }
@@ -2905,7 +2905,7 @@
           "version": "1.5.2"
         },
         "commander": {
-          "version": "2.11.0"
+          "version": "2.10.0"
         }
       }
     },
@@ -2989,7 +2989,7 @@
       "version": "1.0.5"
     },
     "irregular-plurals": {
-      "version": "1.3.0",
+      "version": "1.2.0",
       "dev": true
     },
     "is-arrayish": {
@@ -3075,7 +3075,7 @@
       "dev": true,
       "dependencies": {
         "isobject": {
-          "version": "3.0.1",
+          "version": "3.0.0",
           "dev": true
         }
       }
@@ -3359,7 +3359,7 @@
           "dev": true
         },
         "diff": {
-          "version": "3.3.0",
+          "version": "3.2.0",
           "dev": true
         },
         "jest-matcher-utils": {
@@ -3531,7 +3531,7 @@
           "dev": true
         },
         "diff": {
-          "version": "3.3.0",
+          "version": "3.2.0",
           "dev": true
         },
         "supports-color": {
@@ -4657,7 +4657,7 @@
       "version": "3.3.0"
     },
     "prebuild-install": {
-      "version": "2.2.0",
+      "version": "2.1.2",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -4737,7 +4737,7 @@
           "optional": true
         },
         "tiny-emitter": {
-          "version": "2.0.1",
+          "version": "2.0.0",
           "optional": true
         }
       }
@@ -4924,7 +4924,7 @@
           "version": "5.8.38"
         },
         "commander": {
-          "version": "2.11.0"
+          "version": "2.10.0"
         }
       }
     },
@@ -5201,6 +5201,9 @@
       "dependencies": {
         "qs": {
           "version": "6.4.0"
+        },
+        "tunnel-agent": {
+          "version": "0.6.0"
         },
         "uuid": {
           "version": "3.1.0"
@@ -6005,7 +6008,7 @@
       "version": "0.0.0"
     },
     "tunnel-agent": {
-      "version": "0.6.0"
+      "version": "0.4.3"
     },
     "tween.js": {
       "version": "16.3.1"
@@ -6237,7 +6240,7 @@
           "dev": true
         },
         "commander": {
-          "version": "2.11.0",
+          "version": "2.10.0",
           "dev": true
         },
         "content-disposition": {
@@ -6363,7 +6366,7 @@
           "dev": true
         },
         "commander": {
-          "version": "2.11.0",
+          "version": "2.10.0",
           "dev": true
         },
         "component-emitter": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "morgan": "1.2.0",
     "ms": "0.7.1",
     "node-sass": "3.7.0",
-    "notifications-panel": "1.1.16",
+    "notifications-panel": "1.1.19",
     "npm-run-all": "4.0.2",
     "numeral": "2.0.4",
     "page": "1.6.4",


### PR DESCRIPTION
Version-bumps notes panel to pull in recent text-styling updates

Previously only those text styles indicated from the notifications API were being rendered in the notifications panel. In Automattic/notifications-panel#109 we started parsing the paintext values in the notifications themselves and rendering a few more styles: namely bullet points, todo lists, code blocks, inline code, and header-like prefixes on sentences.

This PR simply updates Calypso to use the version of the notifications panel which adds in these rendering.

@see Automattic/notifications-panel#109