### PR TITLE
Sidebar: Temporarily disable sharing link

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -346,30 +346,32 @@ export class MySitesSidebar extends Component {
 	};
 
 	sharing() {
-		const { isJetpack, isSharingEnabledOnJetpackSite, site } = this.props;
-		const sharingLink = '/sharing' + this.props.siteSuffix;
+		// Temporarily disable Sharing due to problems with publicize
+		return null;
+		//const { isJetpack, isSharingEnabledOnJetpackSite, site } = this.props;
+		//const sharingLink = '/sharing' + this.props.siteSuffix;
+		//
+		//if ( site && ! this.props.canUserPublishPosts ) {
+		//return null;
+		//}
+		//
+		//if ( ! this.props.siteId ) {
+		//return null;
+		//}
+		//
+		//if ( isJetpack && ! isSharingEnabledOnJetpackSite ) {
+		//return null;
+		//}
 
-		if ( site && ! this.props.canUserPublishPosts ) {
-			return null;
-		}
-
-		if ( ! this.props.siteId ) {
-			return null;
-		}
-
-		if ( isJetpack && ! isSharingEnabledOnJetpackSite ) {
-			return null;
-		}
-
-		return (
-			<SidebarItem
-				label={ this.props.translate( 'Sharing' ) }
-				className={ this.itemLinkClass( '/sharing', 'sharing' ) }
-				link={ sharingLink }
-				onNavigate={ this.onNavigate }
-				icon="share"
-				preloadSectionName="sharing" />
-		);
+		//return (
+		//<SidebarItem
+		//label={ this.props.translate( 'Sharing' ) }
+		//className={ this.itemLinkClass( '/sharing', 'sharing' ) }
+		//link={ sharingLink }
+		//onNavigate={ this.onNavigate }
+		//icon="share"
+		//preloadSectionName="sharing" />
+	//);
 	}
 
 	users() {


### PR DESCRIPTION
Publicize is having problems and has been temporarily disabled.

Before:

<img width="271" alt="screen shot 2017-05-31 at 12 58 46 pm" src="https://cloud.githubusercontent.com/assets/2036909/26643918/ef45ec54-4600-11e7-9e2a-0b57c0fb29a2.png">

After:

<img width="282" alt="screen shot 2017-05-31 at 12 58 56 pm" src="https://cloud.githubusercontent.com/assets/2036909/26643921/f42484ce-4600-11e7-92fe-17e5bbeaabda.png">
