### PR TITLE
Editor: Temporarily disable sharing accordion in editor

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -350,7 +350,7 @@ const EditorDrawer = React.createClass( {
 				{ this.renderTaxonomies() }
 				{ this.renderFeaturedImage() }
 				{ this.renderPageOptions() }
-				{ this.renderSharing() }
+				{ false && this.renderSharing() }
 				{ this.renderPostFormats() }
 				{ this.renderSeo() }
 				{ this.renderMoreOptions() }


### PR DESCRIPTION
Temporarily hide the sharing accordion in the post editor

__Before__
![new_post_ _trout_bummin_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/26645293/63c491ee-45ec-11e7-88fd-99d4c199f80e.png)

__After__
![edit_post_ _testing_timmy_timmay_timmaay_timmaaay_timmaaaay_timmaaaaay_timmaaaaaay_timmaaaaaaay_timmaaaaaaaay_timmaaaaaaaaay_timmaaaaaaaaaay_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/26645311/72befba8-45ec-11e7-868b-927e76c906b0.png)

