### PR TITLE
Notes: Open links via injected middleware

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -155,6 +155,8 @@ export class Notifications extends Component {
 		const localeSlug = get( user.get(), 'localeSlug', config( 'i18n_default_locale_slug' ) );
 
 		const customMiddleware = {
+			OPEN_LINK: [ ( store, { href } ) => window.open( href, '_blank' ) ],
+			OPEN_POST: [ ( store, { href } ) => window.open( href, '_blank' ) ],
 			VIEW_SETTINGS: [ () => {
 				this.props.checkToggle();
 				page( '/me/notifications' );


### PR DESCRIPTION
In the notifications panel we recently started intercepting links and
issuing Redux actions in place of the browser performing its default
behavior on click.

This patch will preserve the existing behavior in Calypso for when we
update the version of the notifications panel: open links in a new
browser session.