### PR TITLE
Add ActivityLogBanner component to show progress/status of restores

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -374,6 +374,7 @@
 @import 'my-sites/sites/style';
 @import 'my-sites/stats/style';
 @import 'my-sites/stats/activity-log/style';
+@import 'my-sites/stats/activity-log-banner/style';
 @import 'my-sites/stats/activity-log-day/style';
 @import 'my-sites/stats/activity-log-item/style';
 @import 'my-sites/stats/all-time/style';

--- a/client/my-sites/stats/activity-log-banner/index.jsx
+++ b/client/my-sites/stats/activity-log-banner/index.jsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Gridicon from 'gridicons';
+import ProgressBar from 'components/progress-bar';
+import Button from 'components/button';
+
+class ActivityLogBanner extends Component {
+
+	static propTypes = {
+		isRestoring: PropTypes.bool,
+		isProblem: PropTypes.bool,
+		progress: PropTypes.number,
+	};
+
+	static defaultProps = {
+		isRestoring: false,
+		isProblem: false,
+		progress: 100,
+	};
+
+	isRestoring() {
+		const {
+			translate,
+			progress,
+		} = this.props;
+
+		return (
+			<div>
+				<h2 className="activity-log-banner__content-title">{ translate( 'Currently restoring your site' ) }</h2>
+				<div className="activity-log-banner__content-body">
+					{
+						translate( "We're in the process of restoring your site to %(date)s. ", {
+							args: {
+								// todo: change with real date data
+								date: 'March 17, 2017'
+							}
+						} )
+					}
+					<br />
+					{
+						translate( "You'll receive a notification once it's complete!" )
+					}
+				</div>
+				<div className="activity-log-banner__content-meta"><em>{
+					translate( 'Currently restoring posts…' )
+				}</em></div>
+				<ProgressBar value={ progress } compact isPulsing />
+			</div>
+		);
+	}
+
+	hasProblem() {
+		const {
+			translate,
+		} = this.props;
+
+		return (
+			<div>
+				<Gridicon icon="cross-small" onClick={ noop } />
+				<h2 className="activity-log-banner__content-title">{ translate( 'Problem restoring your site' ) }</h2>
+				<div className="activity-log-banner__content-body">
+					{ translate( 'We came across a problem while trying to restore your site.' ) }
+				</div>
+				<Button primary >
+					{ translate( 'Try again' ) }
+				</Button>
+				<Button>
+					{ translate( 'Get help' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	getContent() {
+		const {
+			isRestoring,
+			isProblem
+		} = this.props;
+
+		return (
+			<div className="activity-log-banner__content">
+				{ isRestoring && this.isRestoring() }
+				{ isProblem && this.hasProblem() }
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<Card className="activity-log-banner">
+				<div className="activity-log-banner__icon">
+					<Gridicon icon="info" size={ 24 } />
+				</div>
+				{ this.getContent() }
+			</Card>
+		);
+	}
+}
+
+export default localize( ActivityLogBanner );

--- a/client/my-sites/stats/activity-log-banner/style.scss
+++ b/client/my-sites/stats/activity-log-banner/style.scss
@@ -1,0 +1,39 @@
+.activity-log-banner {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	align-content: flex-start;
+	align-items: flex-start;
+	border-left: 3px solid $alert-red;
+	padding-left: 8px;
+}
+.activity-log-banner__icon {
+	width: 24px;
+	height: 24px;
+	margin-left: 2px;
+	margin-right: 16px;
+	padding: 8px;
+	color: $white;
+	background-color: $alert-red;
+	border-radius: 50%;
+}
+.activity-log-banner__content {
+	flex-grow: 1;
+	flex-shrink: 0;
+	flex-basis: 200px;
+}
+.activity-log-banner__action {
+	width: 50px;
+}
+
+.activity-log-banner__content-title {
+	margin-bottom: 8px;
+	font-weight: 600;
+	color: $alert-red;
+}
+
+.activity-log-banner__content-meta {
+	font-size: 12px;
+	color: $gray;
+}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -16,6 +16,7 @@ import StatsFirstView from '../stats-first-view';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from '../stats-navigation';
 import ActivityLogDay from '../activity-log-day';
+import ActivityLogBanner from '../activity-log-banner';
 
 class ActivityLog extends Component {
 	componentDidMount() {
@@ -293,6 +294,7 @@ class ActivityLog extends Component {
 					slug={ slug }
 					section="activity"
 				/>
+				<ActivityLogBanner />
 				<section className="activity-log__wrapper">
 					{ logsGroupedByDate }
 				</section>


### PR DESCRIPTION
Will close out #14664

In progress until it's styled.  

This adds a component to show the status a Rewind restore.  

To Test: 
Since it's not yet connected to any real state, you can test the component UI by changing the default props and viewing in `/stats/activity/:site_id`

