### PR TITLE
Fix Extensions data-layer: middleware and handlers

### DIFF
--- a/client/state/data-layer/extensions-middleware.js
+++ b/client/state/data-layer/extensions-middleware.js
@@ -16,6 +16,9 @@ const configuration = configureMiddleware( Object.create( null ), Object.create(
 export function configureMiddleware( handlers, config = configuration ) {
 	config.handlers = handlers;
 	config.middleware = buildMiddleware( handlers );
+	if ( config.store && config.next ) {
+		config.handleAction = config.middleware( config.store )( config.next );
+	}
 	return config;
 }
 
@@ -50,7 +53,7 @@ export function removeHandlers( name, config = configuration ) {
 }
 
 export function buildMiddleware( handlersByExtension ) {
-	const allHandlers = Object.values( handlersByExtension ).reduce( mergeHandlers, Object.create( null ) );
+	const allHandlers = mergeHandlers( ...Object.values( handlersByExtension ) ) || [];
 
 	return middleware( allHandlers );
 }
@@ -58,5 +61,15 @@ export function buildMiddleware( handlersByExtension ) {
 /**
  * Extensions Middleware
  */
-export default configuration.middleware;
+export default store => next => {
+	configuration.store = store;
+	configuration.next = next;
+
+	// Re-generate configuration.handleAction.
+	configureMiddleware( configuration.handlers, configuration );
+
+	return action => {
+		return configuration.handleAction( action );
+	};
+};
 

--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -235,5 +235,18 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 		expect( removeHandlers( 'my-extension', config ) ).to.eql( true );
 		expect( removeHandlers( 'my-extension', config ) ).to.eql( false );
 	} );
+
+	it( 'should create a new middleware and handleAction function each time it is reconfigured.', () => {
+		const config = configureMiddleware( {}, { store: {}, next: () => {} } );
+		const middleware1 = config.middleware;
+		const handleAction1 = config.handleAction;
+
+		addHandlers( 'my-extension', {}, config );
+		const middleware2 = config.middleware;
+		const handleAction2 = config.handleAction;
+
+		expect( middleware1 ).to.not.equal( middleware2 );
+		expect( handleAction1 ).to.not.equal( handleAction2 );
+	} );
 } );
 


### PR DESCRIPTION
1. There was an issue with the handlers not being compatible with
pre-merged handlers.

2. The middleware was holding on to an outdated function and running it
instead of the updated configuration with newly added handlers.

Both of these issues have been fixed and a new test has been added.

To test:

Run `make test` and ensure all tests pass.
