### PR TITLE
Woo-Connect Insights: Add Period Nav

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -3,15 +3,17 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
 import Navigation from './store-stats-navigation';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Chart from './store-stats-chart';
+import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
+import DatePicker from 'my-sites/stats/stats-date-picker';
 
 class StoreStats extends Component {
 	static propTypes = {
@@ -22,8 +24,8 @@ class StoreStats extends Component {
 	};
 
 	render() {
-		const { siteId, unit, startDate, path } = this.props;
-		const today = this.props.moment().format( 'YYYY-MM-DD' );
+		const { siteId, unit, startDate, path, slug } = this.props;
+		const today = moment().format( 'YYYY-MM-DD' );
 		const selectedDate = startDate || today;
 		const ordersQuery = {
 			unit,
@@ -32,7 +34,7 @@ class StoreStats extends Component {
 		};
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
-				<Navigation unit={ unit } type="orders" />
+				<Navigation unit={ unit } type="orders" slug={ slug } />
 				<Chart
 					path={ path }
 					query={ ordersQuery }
@@ -40,17 +42,29 @@ class StoreStats extends Component {
 					siteId={ siteId }
 					unit={ unit }
 				/>
+				<StatsPeriodNavigation
+					date={ selectedDate }
+					period={ unit }
+					url={ `/store/stats/orders/${ unit }/${ slug }` }
+				>
+					<DatePicker
+						period={ unit }
+						date={ selectedDate }
+						query={ ordersQuery }
+						statsType="statsOrders"
+						showQueryDate
+					/>
+				</StatsPeriodNavigation>
 			</Main>
 		);
 	}
 }
 
-const localizedStats = localize( StoreStats );
-
 export default connect(
 	state => {
 		return {
+			slug: getSelectedSiteSlug( state ),
 			siteId: getSelectedSiteId( state ),
 		};
 	}
-)( localizedStats );
+)( StoreStats );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -2,8 +2,7 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,7 +12,6 @@ import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import FollowersCount from 'blocks/followers-count';
 import SegmentedControl from 'components/segmented-control';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const StoreStatsNavigation = props => {
 	const { translate, slug, type, unit } = props;
@@ -52,11 +50,4 @@ StoreStatsNavigation.propTypes = {
 	slug: PropTypes.string
 };
 
-export default connect(
-	state => {
-		return {
-			slug: getSelectedSiteSlug( state ),
-			translate: i18n.translate,
-		};
-	}
-)( StoreStatsNavigation );
+export default localize( StoreStatsNavigation );


### PR DESCRIPTION
### Add the date period navigator
![screen shot 2017-06-01 at 1 05 28 pm](https://cloud.githubusercontent.com/assets/1922453/26660431/3ad4b260-46cc-11e7-8384-37da3e993e1f.png)

### Changes
Since `slug` was required by the main component, I pass it down to the `statsNavigator` so it won't need to be `connect`ed.

### showQueryDate
Site Stats' `StatsPeriodNavigation` comes with logic to check how fresh the data is. I hooked up the relevant information (query and statsType) and it works (reusability FTW). It does this by checking the last time a query was made and rendering the timestamp. `QuerySiteStats` has logic to make a query every 3 minutes, confirmed by viewing the Network tab.

@westi Just because a query was made does not mean the information on wpcom is synced. Do we feel confident enough in the sync to display this message to the user?


Fixes https://github.com/Automattic/wp-calypso/issues/14501