### PR TITLE
Data Layer HTTP: Fix request query for WP REST API POST

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -47,7 +47,7 @@ export const http = ( {
 		body,
 		method,
 		path,
-		query: method === 'GET' ? { ...query, ...version } : version,
+		query: { ...query, ...version },
 		formData,
 		onSuccess: onSuccess || action,
 		onFailure: onFailure || action,


### PR DESCRIPTION
The previous code prohibited sending a query object when using a method
other than GET. However, the query object is used for sending WP REST
API requests via the Jetpack API proxy. So sending a POST with a query
object is necessary.

To test:

`npm test` to ensure all tests pass.
Use functions of the normal data layer calls like Reader and Sites.

To try out new functionality, see #14650 