### PR TITLE
Add pulsing shopping cart badge

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -108,4 +108,14 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
+	pulsingCartTestingAB: {
+		datestamp: '20170601',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+		allowAnyLocale: true,
+	},
 };

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -10,6 +10,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import CartBody from './cart-body';
 import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
 import CartMessagesMixin from './cart-messages-mixin';
@@ -45,13 +46,15 @@ const PopoverCart = React.createClass( {
 	mixins: [ CartMessagesMixin ],
 
 	render: function() {
-		var countBadge,
-			classes = classNames( {
-				'popover-cart': true,
-				pinned: this.props.pinned
-			} );
+		let countBadge;
+		const	classes = classNames( {
+			'popover-cart': true,
+			pinned: this.props.pinned
+		} );
 
-		if ( this.itemCount() ) {
+		if ( abtest( 'pulsingCartTestingAB' ) === 'modified' ) {
+			countBadge = <div className="cart__pulsing-badge"></div>;
+		} else if ( this.itemCount() ) {
 			countBadge = <div className="popover-cart__count-badge">{ this.itemCount() }</div>;
 		}
 

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -52,10 +52,9 @@ const PopoverCart = React.createClass( {
 			pinned: this.props.pinned
 		} );
 
-		if ( abtest( 'pulsingCartTestingAB' ) === 'modified' ) {
-			countBadge = <div className="cart__pulsing-badge"></div>;
-		} else if ( this.itemCount() ) {
-			countBadge = <div className="popover-cart__count-badge">{ this.itemCount() }</div>;
+		if ( this.itemCount() ) {
+			const className = abtest( 'pulsingCartTestingAB' ) === 'modified' ? 'cart__pulsing-badge' : 'popover-cart__count-badge';
+			countBadge = <div className={ className }>{ this.itemCount() }</div>;
 		}
 
 		return (

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -53,7 +53,9 @@ const PopoverCart = React.createClass( {
 		} );
 
 		if ( this.itemCount() ) {
-			const className = abtest( 'pulsingCartTestingAB' ) === 'modified' ? 'cart__pulsing-badge' : 'popover-cart__count-badge';
+			const className = abtest( 'pulsingCartTestingAB' ) === 'modified'
+					? 'popover-cart__count-badge count-badge-pulsing'
+					: 'popover-cart__count-badge';
 			countBadge = <div className={ className }>{ this.itemCount() }</div>;
 		}
 

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -227,6 +227,54 @@
 	text-align: center;
 }
 
+.cart__pulsing-badge {
+	background: $blue-medium;
+	border-radius: 16px;
+	color: $white;
+	cursor: pointer;
+	display: inline-block;
+	float: right;
+	font-size: 11px;
+	height: 16px;
+	width: 6px;
+	padding: 0 5px;
+	position: absolute;
+	top: 5px;
+	right: 5px;
+	box-shadow: 0 0 0 rgba(0,170,220, 0.4);
+	animation: pulsing-badge 2s infinite;
+}
+
+.cart__pulsing-badge:hover {
+	animation: none;
+}
+
+@-webkit-keyframes pulsing-badge {
+	0% {
+		-webkit-box-shadow: 0 0 0 0 rgba(0,170,220, 0.4);
+	}
+	70% {
+		-webkit-box-shadow: 0 0 0 10px rgba(0,170,220, 0);
+	}
+	100% {
+		-webkit-box-shadow: 0 0 0 0 rgba(0,170,220, 0);
+	}
+}
+@keyframes pulsing-badge {
+	0% {
+		-moz-box-shadow: 0 0 0 0 rgba(0,170,220, 0.4);
+		box-shadow: 0 0 0 0 rgba(0,170,220, 0.4);
+	}
+	70% {
+		-moz-box-shadow: 0 0 0 10px rgba(0,170,220, 0);
+		box-shadow: 0 0 0 10px rgba(0,170,220, 0);
+	}
+	100% {
+		-moz-box-shadow: 0 0 0 0 rgba(0,170,220, 0);
+		box-shadow: 0 0 0 0 rgba(0,170,220, 0);
+	}
+}
+
 div.popover-cart__popover {
 	width: 330px;
 

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -236,11 +236,11 @@
 	float: right;
 	font-size: 11px;
 	height: 16px;
-	width: 6px;
 	padding: 0 5px;
 	position: absolute;
 	top: 5px;
 	right: 5px;
+	text-align: center;
 	box-shadow: 0 0 0 rgba(0,170,220, 0.4);
 	animation: pulsing-badge 2s infinite;
 }

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -227,50 +227,23 @@
 	text-align: center;
 }
 
-.cart__pulsing-badge {
-	background: $blue-medium;
-	border-radius: 16px;
-	color: $white;
-	cursor: pointer;
-	display: inline-block;
-	float: right;
-	font-size: 11px;
-	height: 16px;
-	padding: 0 5px;
-	position: absolute;
-	top: 5px;
-	right: 5px;
-	text-align: center;
+.count-badge-pulsing {
 	box-shadow: 0 0 0 rgba(0,170,220, 0.4);
 	animation: pulsing-badge 2s infinite;
 }
 
-.cart__pulsing-badge:hover {
+.count-badge-pulsing:hover {
 	animation: none;
 }
 
-@-webkit-keyframes pulsing-badge {
-	0% {
-		-webkit-box-shadow: 0 0 0 0 rgba(0,170,220, 0.4);
-	}
-	70% {
-		-webkit-box-shadow: 0 0 0 10px rgba(0,170,220, 0);
-	}
-	100% {
-		-webkit-box-shadow: 0 0 0 0 rgba(0,170,220, 0);
-	}
-}
 @keyframes pulsing-badge {
 	0% {
-		-moz-box-shadow: 0 0 0 0 rgba(0,170,220, 0.4);
 		box-shadow: 0 0 0 0 rgba(0,170,220, 0.4);
 	}
 	70% {
-		-moz-box-shadow: 0 0 0 10px rgba(0,170,220, 0);
 		box-shadow: 0 0 0 10px rgba(0,170,220, 0);
 	}
 	100% {
-		-moz-box-shadow: 0 0 0 0 rgba(0,170,220, 0);
 		box-shadow: 0 0 0 0 rgba(0,170,220, 0);
 	}
 }


### PR DESCRIPTION
This is an a/b test to try a pulsing badge instead of the existing shopping cart badge.

Existing users are included in this a/b test and because there is no new visible text, all locales are also included.

original

<img width="556" alt="screen shot 2017-06-01 at 5 48 42 pm" src="https://cloud.githubusercontent.com/assets/1926/26669829/aa590a52-46f2-11e7-9e77-6d0d17048db1.png">

modified

![modified](https://cloud.githubusercontent.com/assets/1926/26684759/56180842-472b-11e7-9e0b-696ba089e14d.gif)

# Testing

* create a site with a free plan
* navigate to `/plans/<site>`
* select a paid plan
* execute the following in the console:
```
localStorage.setItem( 'ABTests', '{"pulsingCartTestingAB_20170601":"modified"}' );
```
* navigate back to `/plans/<site>`
* you should see the pulsing cart badge
* execute the following in the console:
```
localStorage.setItem( 'ABTests', '{"pulsingCartTestingAB_20170601":"original"}' );
```
* navigate back to `/plans/<site>`
* you should see the original badge

