### PR TITLE
Add stats for when NPS survey notice is displayed.

### DIFF
--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -23,6 +23,7 @@ import {
 import {
 	hasAnsweredNpsSurvey,
 } from 'state/nps-survey/selectors';
+import analytics from 'lib/analytics';
 
 class NpsSurvey extends Component {
 	static propTypes = {
@@ -71,6 +72,9 @@ class NpsSurvey extends Component {
 			'is-recommendation-selected': Number.isInteger( this.state.score ),
 			'is-submitted': this.props.hasAnswered,
 		} );
+
+		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_displayed' );
+		analytics.tracks.recordEvent( 'calypso_nps_survey_displayed' );
 
 		return (
 			<Card className={ className }>

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -65,6 +65,11 @@ class NpsSurvey extends Component {
 		}, 0 );
 	}
 
+	componentWillMount() {
+		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_displayed' );
+		analytics.tracks.recordEvent( 'calypso_nps_survey_displayed' );
+	}
+
 	render() {
 		const { translate } = this.props;
 
@@ -72,9 +77,6 @@ class NpsSurvey extends Component {
 			'is-recommendation-selected': Number.isInteger( this.state.score ),
 			'is-submitted': this.props.hasAnswered,
 		} );
-
-		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_displayed' );
-		analytics.tracks.recordEvent( 'calypso_nps_survey_displayed' );
 
 		return (
 			<Card className={ className }>

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -25,6 +25,7 @@ import {
 	isSectionAndSessionEligibleForNpsSurvey,
 	wasNpsSurveyShownThisSession,
 } from 'state/nps-survey/selectors';
+import analytics from 'lib/analytics';
 
 const SURVEY_NAME = 'calypso-global-notice-radio-buttons-v1';
 
@@ -58,6 +59,9 @@ class NpsSurveyNotice extends Component {
 			// (2) the user notices the notice more, since it will cause a change to the
 			//     screen they are already looking at
 			setTimeout( this.props.showNpsSurveyNotice, 3000 );
+
+			analytics.mc.bumpStat( 'calypso_nps_survey', 'displayed' );
+			analytics.tracks.recordEvent( 'calypso_nps_survey_displayed' );
 		}
 	}
 

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -60,8 +60,8 @@ class NpsSurveyNotice extends Component {
 			//     screen they are already looking at
 			setTimeout( this.props.showNpsSurveyNotice, 3000 );
 
-			analytics.mc.bumpStat( 'calypso_nps_survey', 'displayed' );
-			analytics.tracks.recordEvent( 'calypso_nps_survey_displayed' );
+			analytics.mc.bumpStat( 'calypso_nps_survey', 'notice_displayed' );
+			analytics.tracks.recordEvent( 'calypso_nps_notice_displayed' );
 		}
 	}
 


### PR DESCRIPTION
This PR adds a stat and a Tracks event to the display of the NPS survey notice.

![screen shot 2017-06-01 at 11 05 49 am](https://cloud.githubusercontent.com/assets/1017839/26675210/5624ea34-46c3-11e7-9f47-4b33b1d39978.png)


![screen shot 2017-06-01 at 11 57 48 am](https://cloud.githubusercontent.com/assets/1017839/26675211/5953501a-46c3-11e7-9917-348808d00ded.png)


To test:

- Open your browser's console, and enter the line `localStorage.setItem( 'debug', 'calypso:analytics*' )`
- In your browser's console, enter the line `npsSurvey();` to trigger the survey notice in development.
- Make sure that in the console you see a stat getting bumped in the `calypso_nps_survey` group with the name `displayed`.
- Make sure you see a Tracks event recorded with the name `calypso_nps_survey_displayed`