### PR TITLE
Security: Add max length to the backup code's prompt input field

### DIFF
--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -133,6 +133,7 @@ module.exports = React.createClass( {
 						disabled={ this.state.submittingCode }
 						name="backup-code-entry"
 						autoComplete="off"
+						maxLength="8"
 						placeholder={ constants.eightDigitBackupCodePlaceholder }
 						valueLink={ this.linkState( 'backupCodeEntry' ) }
 						onFocus={ function() {


### PR DESCRIPTION
I copied backup code with the trailing space when trying to verify it. I didn't notice it at first and spent a few seconds looking at the screen trying to understand why the `Verify` button is disabled. See:

![screen shot 2017-06-01 at 12 01 25](https://cloud.githubusercontent.com/assets/699132/26675416/26b61e52-46c4-11e7-8647-784b1c125f58.png)

This PR adds the `maxlength` attribute to the input field to mitigate this issue.

### Testing

1. Go to http://calypso.localhost:3000/me/security/two-step and enable one of 2FA methods. Make sure you copy all codes.
2. Try to verify your code and paste code with trailing spaces. Make sure that only the first 8 digits are pasted to the input.