### PR TITLE
Site Settings: Exploration - Update actions to rely on the data layer

### DIFF
--- a/client/state/data-layer/wpcom/sites/index.js
+++ b/client/state/data-layer/wpcom/sites/index.js
@@ -11,6 +11,7 @@ import media from './media';
 import plugins from './plugins';
 import posts from './posts';
 import simplePayments from './simple-payments';
+import settings from './settings';
 
 export default mergeHandlers(
 	activity,
@@ -21,5 +22,6 @@ export default mergeHandlers(
 	media,
 	plugins,
 	posts,
+	settings,
 	simplePayments,
 );

--- a/client/state/data-layer/wpcom/sites/settings/index.js
+++ b/client/state/data-layer/wpcom/sites/settings/index.js
@@ -1,0 +1,64 @@
+/**
+ * Internal dependencies
+ */
+import {
+	SITE_SETTINGS_REQUEST,
+	SITE_SETTINGS_REQUEST_FAILURE,
+	SITE_SETTINGS_REQUEST_SUCCESS,
+} from 'state/action-types';
+import { receiveSiteSettings } from 'state/site-settings/actions';
+import { normalizeSettings } from 'state/site-settings/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+
+/**
+ * Normalize data from the REST API.
+ *
+ * @param {Object} data REST-API response
+ * @return {Object}     normalized settings.
+ */
+function fromApi( { name, description, settings } ) {
+	return {
+		...normalizeSettings( settings ),
+		blogname: name,
+		blogdescription: description,
+	};
+}
+
+export const fetchSiteSettings = ( { dispatch }, action ) => {
+	const { siteId } = action;
+
+	dispatch(
+		http(
+			{
+				method: 'GET',
+				path: `/sites/${ siteId }/settings`,
+				apiVersion: '1.1',
+			},
+			action
+		)
+	);
+};
+
+export const replaceSiteSettings = ( { dispatch }, action, next, data ) => {
+	const { siteId } = action;
+	dispatch( receiveSiteSettings( siteId, fromApi( data ) ) );
+	dispatch( {
+		type: SITE_SETTINGS_REQUEST_SUCCESS,
+		siteId,
+	} );
+};
+
+export const announceFetchFailure = ( { dispatch }, { siteId, meta } ) => {
+	dispatch( {
+		type: SITE_SETTINGS_REQUEST_FAILURE,
+		siteId,
+		error: meta.dataLayer.error,
+	} );
+};
+
+export default {
+	[ SITE_SETTINGS_REQUEST ]: [
+		dispatchRequest( fetchSiteSettings, replaceSiteSettings, announceFetchFailure ),
+	],
+};

--- a/client/state/data-layer/wpcom/sites/settings/index.js
+++ b/client/state/data-layer/wpcom/sites/settings/index.js
@@ -2,9 +2,13 @@
  * Internal dependencies
  */
 import {
+	SITE_SETTINGS_SAVE,
+	SITE_SETTINGS_SAVE_FAILURE,
+	SITE_SETTINGS_SAVE_SUCCESS,
 	SITE_SETTINGS_REQUEST,
 	SITE_SETTINGS_REQUEST_FAILURE,
 	SITE_SETTINGS_REQUEST_SUCCESS,
+	SITE_SETTINGS_UPDATE,
 } from 'state/action-types';
 import { receiveSiteSettings } from 'state/site-settings/actions';
 import { normalizeSettings } from 'state/site-settings/utils';
@@ -57,8 +61,48 @@ export const announceFetchFailure = ( { dispatch }, { siteId, meta } ) => {
 	} );
 };
 
+export const saveSiteSettings = ( { dispatch }, action ) => {
+	const { siteId, settings } = action;
+
+	dispatch(
+		http(
+			{
+				method: 'POST',
+				path: `/sites/${ siteId }/settings`,
+				apiVersion: '1.1',
+				body: settings,
+			},
+			action
+		)
+	);
+};
+
+export const updateSiteSettings = ( { dispatch }, action, next, { updated } ) => {
+	const { siteId } = action;
+	dispatch( {
+		type: SITE_SETTINGS_UPDATE,
+		siteId,
+		settings: normalizeSettings( updated )
+	} );
+	dispatch( {
+		type: SITE_SETTINGS_SAVE_SUCCESS,
+		siteId,
+	} );
+};
+
+export const announceSaveFailure = ( { dispatch }, { siteId, meta } ) => {
+	dispatch( {
+		type: SITE_SETTINGS_SAVE_FAILURE,
+		siteId,
+		error: meta.dataLayer.error,
+	} );
+};
+
 export default {
 	[ SITE_SETTINGS_REQUEST ]: [
 		dispatchRequest( fetchSiteSettings, replaceSiteSettings, announceFetchFailure ),
+	],
+	[ SITE_SETTINGS_SAVE ]: [
+		dispatchRequest( saveSiteSettings, updateSiteSettings, announceSaveFailure ),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/settings/test/index.js
+++ b/client/state/data-layer/wpcom/sites/settings/test/index.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+
+import {
+	replaceSiteSettings,
+	fetchSiteSettings,
+} from '../';
+
+describe( '#replaceSiteSettings', () => {
+	let dispatch;
+
+	beforeEach( () => dispatch = spy() );
+
+	it( 'should dispatch action to add received settings into state', () => {
+		const settings = {
+			a: 1,
+		};
+		replaceSiteSettings( { dispatch }, { siteId: 123456 }, null, { settings } );
+		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch.firstCall ).to.have.been.calledWithMatch( {
+			type: 'SITE_SETTINGS_RECEIVE',
+			siteId: 123456,
+			settings,
+		} );
+	} );
+} );
+
+describe( '#fetchSiteSettings', () => {
+	let dispatch;
+
+	beforeEach( () => dispatch = spy() );
+
+	it( 'should dispatch HTTP request for site settings', () => {
+		fetchSiteSettings( { dispatch }, { siteId: 123456 } );
+
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			type: 'WPCOM_HTTP_REQUEST',
+			path: '/sites/123456/settings',
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/settings/test/index.js
+++ b/client/state/data-layer/wpcom/sites/settings/test/index.js
@@ -7,10 +7,10 @@ import { spy } from 'sinon';
 /**
  * Internal dependencies
  */
-
 import {
-	replaceSiteSettings,
 	fetchSiteSettings,
+	replaceSiteSettings,
+	updateSiteSettings,
 } from '../';
 
 describe( '#replaceSiteSettings', () => {
@@ -33,6 +33,40 @@ describe( '#replaceSiteSettings', () => {
 } );
 
 describe( '#fetchSiteSettings', () => {
+	let dispatch;
+
+	beforeEach( () => dispatch = spy() );
+
+	it( 'should dispatch HTTP request for site settings', () => {
+		fetchSiteSettings( { dispatch }, { siteId: 123456 } );
+
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			type: 'WPCOM_HTTP_REQUEST',
+			path: '/sites/123456/settings',
+		} );
+	} );
+} );
+
+describe( '#updateSiteSettings', () => {
+	let dispatch;
+	const updated = {
+		a: 1,
+	};
+
+	beforeEach( () => dispatch = spy() );
+
+	it( 'should dispatch action to update state with updated settings', () => {
+		updateSiteSettings( { dispatch }, { siteId: 123456 }, null, { updated } );
+		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch.firstCall ).to.have.been.calledWith( {
+			type: 'SITE_SETTINGS_UPDATE',
+			siteId: 123456,
+			settings: updated,
+		} );
+	} );
+} );
+
+describe( '#saveSiteSettings', () => {
 	let dispatch;
 
 	beforeEach( () => dispatch = spy() );

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
 import {
 	SITE_SETTINGS_RECEIVE,
 	SITE_SETTINGS_REQUEST,
 	SITE_SETTINGS_SAVE,
-	SITE_SETTINGS_SAVE_FAILURE,
-	SITE_SETTINGS_SAVE_SUCCESS,
 	SITE_SETTINGS_UPDATE
 } from 'state/action-types';
-import { normalizeSettings } from './utils';
 
 /**
  * Returns an action object to be used in signalling that site settings have been received.
@@ -53,27 +49,16 @@ export const requestSiteSettings = ( siteId ) => ( {
 	siteId
 } );
 
-export function saveSiteSettings( siteId, settings ) {
-	return ( dispatch ) => {
-		dispatch( {
-			type: SITE_SETTINGS_SAVE,
-			siteId
-		} );
+/**
+ * Returns an action object to be used to trigger a request to save site settings.
+ *
+ * @param  {Number} siteId   Site ID
+ * @param  {Object} settings The new settings values to be saved
+ * @return {Object}          Action object
+ */
+export const saveSiteSettings = ( siteId, settings ) => ( {
+	type: SITE_SETTINGS_SAVE,
+	siteId,
+	settings
+} );
 
-		return wpcom.undocumented().settings( siteId, 'post', settings )
-			.then( ( { updated } ) => {
-				dispatch( updateSiteSettings( siteId, normalizeSettings( updated ) ) );
-				dispatch( {
-					type: SITE_SETTINGS_SAVE_SUCCESS,
-					siteId
-				} );
-			} )
-			.catch( error => {
-				dispatch( {
-					type: SITE_SETTINGS_SAVE_FAILURE,
-					siteId,
-					error
-				} );
-			} );
-	};
-}

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -5,8 +5,6 @@ import wpcom from 'lib/wp';
 import {
 	SITE_SETTINGS_RECEIVE,
 	SITE_SETTINGS_REQUEST,
-	SITE_SETTINGS_REQUEST_FAILURE,
-	SITE_SETTINGS_REQUEST_SUCCESS,
 	SITE_SETTINGS_SAVE,
 	SITE_SETTINGS_SAVE_FAILURE,
 	SITE_SETTINGS_SAVE_SUCCESS,
@@ -45,42 +43,15 @@ export function updateSiteSettings( siteId, settings ) {
 }
 
 /**
- * Returns an action thunk which, when invoked, triggers a network request to
- * retrieve site settings
+ * Returns an action object to be used to trigger a network request to retrieve site settings.
  *
  * @param  {Number} siteId Site ID
- * @return {Function}      Action thunk
+ * @return {Object}        Action object
  */
-export function requestSiteSettings( siteId ) {
-	return ( dispatch ) => {
-		dispatch( {
-			type: SITE_SETTINGS_REQUEST,
-			siteId
-		} );
-
-		return wpcom.undocumented().settings( siteId )
-			.then( ( { name, description, settings } ) => {
-				const savedSettings = {
-					...( normalizeSettings( settings ) ),
-					blogname: name,
-					blogdescription: description
-				};
-
-				dispatch( receiveSiteSettings( siteId, savedSettings ) );
-				dispatch( {
-					type: SITE_SETTINGS_REQUEST_SUCCESS,
-					siteId
-				} );
-			} )
-			.catch( error => {
-				dispatch( {
-					type: SITE_SETTINGS_REQUEST_FAILURE,
-					siteId,
-					error
-				} );
-			} );
-	};
-}
+export const requestSiteSettings = ( siteId ) => ( {
+	type: SITE_SETTINGS_REQUEST,
+	siteId
+} );
 
 export function saveSiteSettings( siteId, settings ) {
 	return ( dispatch ) => {

--- a/client/state/site-settings/test/actions.js
+++ b/client/state/site-settings/test/actions.js
@@ -12,8 +12,6 @@ import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	SITE_SETTINGS_RECEIVE,
 	SITE_SETTINGS_REQUEST,
-	SITE_SETTINGS_REQUEST_FAILURE,
-	SITE_SETTINGS_REQUEST_SUCCESS,
 	SITE_SETTINGS_SAVE,
 	SITE_SETTINGS_SAVE_FAILURE,
 	SITE_SETTINGS_SAVE_SUCCESS,
@@ -57,59 +55,12 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'requestSiteSettings()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.get( '/rest/v1.1/sites/2916284/settings' )
-				.reply( 200, {
-					name: 'blog name',
-					description: 'blog description',
-					settings: { settingKey: 'cat' }
-				} )
-				.get( '/rest/v1.1/sites/2916285/settings' )
-				.reply( 403, {
-					error: 'authorization_required',
-					message: 'User cannot access this private blog.'
-				} );
-		} );
+		it( 'should return an action object', () => {
+			const action = requestSiteSettings( 2916284 );
 
-		it( 'should dispatch fetch action when thunk triggered', () => {
-			requestSiteSettings( 2916284 )( spy );
-
-			expect( spy ).to.have.been.calledWith( {
+			expect( action ).to.eql( {
 				type: SITE_SETTINGS_REQUEST,
 				siteId: 2916284
-			} );
-		} );
-
-		it( 'should dispatch receive action when request completes', () => {
-			return requestSiteSettings( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith(
-					receiveSiteSettings( 2916284, {
-						blogname: 'blog name',
-						blogdescription: 'blog description',
-						settingKey: 'cat'
-					} )
-				);
-			} );
-		} );
-
-		it( 'should dispatch request success action when request completes', () => {
-			return requestSiteSettings( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_SETTINGS_REQUEST_SUCCESS,
-					siteId: 2916284
-				} );
-			} );
-		} );
-
-		it( 'should dispatch fail action when request fails', () => {
-			return requestSiteSettings( 2916285 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_SETTINGS_REQUEST_FAILURE,
-					siteId: 2916285,
-					error: sinon.match( { message: 'User cannot access this private blog.' } )
-				} );
 			} );
 		} );
 	} );

--- a/client/state/site-settings/test/actions.js
+++ b/client/state/site-settings/test/actions.js
@@ -1,20 +1,15 @@
 /**
  * External dependencies
  */
-import sinon from 'sinon';
 import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-import useNock from 'test/helpers/use-nock';
-import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	SITE_SETTINGS_RECEIVE,
 	SITE_SETTINGS_REQUEST,
 	SITE_SETTINGS_SAVE,
-	SITE_SETTINGS_SAVE_FAILURE,
-	SITE_SETTINGS_SAVE_SUCCESS,
 	SITE_SETTINGS_UPDATE
 } from 'state/action-types';
 import {
@@ -25,8 +20,6 @@ import {
 } from '../actions';
 
 describe( 'actions', () => {
-	let spy;
-	useSandbox( ( sandbox ) => spy = sandbox.spy() );
 
 	describe( 'receiveSiteSettings()', () => {
 		it( 'should return an action object', () => {
@@ -66,55 +59,13 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'saveSiteSettings()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( '/rest/v1.1/sites/2916284/settings' )
-				.reply( 200, {
-					updated: { real_update: 'ribs' }
-				} )
-				.post( '/rest/v1.1/sites/2916285/settings' )
-				.reply( 403, {
-					error: 'authorization_required',
-					message: 'User cannot access this private blog.'
-				} );
-		} );
+		it( 'should return an action object', () => {
+			const action = saveSiteSettings( 2916284, { settingKey: 'chicken' } );
 
-		it( 'should dispatch fetch action when thunk triggered', () => {
-			saveSiteSettings( 2916284, { settingKey: 'chicken' } )( spy );
-
-			expect( spy ).to.have.been.calledWith( {
+			expect( action ).to.eql( {
 				type: SITE_SETTINGS_SAVE,
-				siteId: 2916284
-			} );
-		} );
-
-		it( 'should dispatch update action when request completes', () => {
-			return saveSiteSettings( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith(
-					updateSiteSettings( 2916284, {
-						real_update: 'ribs'
-					} )
-				);
-			} );
-		} );
-
-		it( 'should dispatch save success action when request completes', () => {
-			return saveSiteSettings( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_SETTINGS_SAVE_SUCCESS,
-					siteId: 2916284
-				} );
-			} );
-		} );
-
-		it( 'should dispatch fail action when request fails', () => {
-			return saveSiteSettings( 2916285 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_SETTINGS_SAVE_FAILURE,
-					siteId: 2916285,
-					error: sinon.match( { message: 'User cannot access this private blog.' } )
-				} );
+				siteId: 2916284,
+				settings: { settingKey: 'chicken' }
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes introduced by this PR

1. Introduces handlers for requesting and saving site settings.
1. Updates the state actions `saveSiteSettings` and `requestSiteSettings` to not use thunks anymore.

#### Testing instructions.

1. Launch this branch.
1. Visit `/settings` for any given site. 
1. Confirm that settings are read into the state by inspecting the `SITE_SETTINGS_RECEIVE` action with the Redux Dev Tools
1. Confirm that the toggles are enabled after the UI loads, menaning the data is in the state already.
1. Confirm that you can update one of the settings (maybe a toggle) and refresh the page to confirm that the change persisted
2. In your browser, try to block requests for `*/sites/*/settings` (Chrome Canary helps) in order to check if you get a red notice shown when the request fails after trying to update one of the settings.
1. Run the unit tests:
   ```sh
    npm run test-client client/state/data-layer/wpcom/site/settings
    npm run test-client client/state/site-settings
   ```
  