### PR TITLE
Remove link to 2FA push method and don't stop polling

### DIFF
--- a/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	startPollAppPushAuth,
+	stopPollAppPushAuth,
+} from 'state/login/actions';
+import {
+	getTwoFactorPushPollSuccess,
+} from 'state/login/selectors';
+
+class PushNotificationApprovalPoller extends Component {
+	static propTypes = {
+		onSuccess: PropTypes.func.isRequired,
+		pushSuccess: PropTypes.bool.isRequired,
+		startPollAppPushAuth: PropTypes.func.isRequired,
+		stopPollAppPushAuth: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		this.props.startPollAppPushAuth();
+	}
+
+	componentWillUnmount() {
+		this.props.stopPollAppPushAuth();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! this.props.pushSuccess && nextProps.pushSuccess ) {
+			this.props.onSuccess();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		pushSuccess: getTwoFactorPushPollSuccess( state ),
+	} ),
+	{
+		startPollAppPushAuth,
+		stopPollAppPushAuth,
+	}
+)( PushNotificationApprovalPoller );

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -68,14 +68,6 @@ class TwoFactorActions extends Component {
 						</a>
 					</p>
 				) }
-
-				{ isPushSupported && twoFactorAuthType !== 'push' && (
-					<p>
-						<a href={ login( { isNative: true, twoFactorAuthType: 'push' } ) }>
-							{ translate( 'The WordPress mobile app' ) }
-						</a>
-					</p>
-				) }
 			</Card>
 		);
 	}

--- a/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
+++ b/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 
@@ -9,38 +8,12 @@ import React, { Component, PropTypes } from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
-import {
-	startPollAppPushAuth,
-	stopPollAppPushAuth,
-} from 'state/login/actions';
-import {
-	isTwoFactorAuthTypeSupported,
-	getTwoFactorPushPollSuccess,
-} from 'state/login/selectors';
 import TwoFactorActions from './two-factor-actions';
 
 class WaitingTwoFactorNotificationApproval extends Component {
 	static propTypes = {
-		onSuccess: PropTypes.func.isRequired,
-		pushSuccess: PropTypes.bool.isRequired,
-		startPollAppPushAuth: PropTypes.func.isRequired,
-		stopPollAppPushAuth: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
-
-	componentDidMount() {
-		this.props.startPollAppPushAuth();
-	}
-
-	componentWillUnmount() {
-		this.props.stopPollAppPushAuth();
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( ! this.props.pushSuccess && nextProps.pushSuccess ) {
-			this.props.onSuccess();
-		}
-	}
 
 	render() {
 		const { translate } = this.props;
@@ -72,13 +45,4 @@ class WaitingTwoFactorNotificationApproval extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		isSmsAuthSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
-		pushSuccess: getTwoFactorPushPollSuccess( state ),
-	} ),
-	{
-		startPollAppPushAuth,
-		stopPollAppPushAuth,
-	}
-)( localize( WaitingTwoFactorNotificationApproval ) );
+export default localize( WaitingTwoFactorNotificationApproval );


### PR DESCRIPTION
This PR:
* Removes the stopping of polling from push auth to allow user approving the push even if she navigated away ( like the sms screen )
* Removes the link to the push screen as we currently not re-sending the push notification.

Another take on #14615

#### Testing instructions
1. Run `git checkout update/update/2fa-remove-push-link` and start your server, or open a [live branch](https://calypso.live/?branch=update/2fa-remove-push-link)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Login with account that has 2FA with push, assert you presented with the push polling screen.
4. Click `Code via text message`
5. Assert there is no link to `push` - `Login with WordPress.com app`
6. Assert you received SMS message with a code, however click `approve` on the push notification instead.
7. Assert you're indeed logged-in.

#### Reviews
  
- [x] Code
- [x] Product
