### PR TITLE
Site Settings: Check for site before querying Jetpack connection

### DIFF
--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -209,7 +209,7 @@ class Sitemaps extends Component {
 
 		return (
 			<div>
-				<QueryJetpackConnection siteId={ siteId } />
+				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }
 
 				<SectionHeader label={ translate( 'Sitemaps' ) } />
 


### PR DESCRIPTION
When you load `/settings/traffic/$site` for a Jetpack site with empty Redux state store, it'll display a warning:

![](https://cldup.com/wOIOOD8B7z.png)

This PR fixes this warning by adding a `siteId` check before rendering the query component.

To test:
* Checkout this branch
* Clear your Redux state store.
* Go to `/settings/traffic/$site` where `$site` is a Jetpack site.
* Verify you no longer see this warning.