### PR TITLE
Automatically create an account when user logins with his social account and redirect to /start

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import config from 'config';
 import { loginSocialUser } from 'state/login/actions';
-import { errorNotice, infoNotice } from 'state/notices/actions';
+import { errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 import wpcom from 'lib/wp';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 
@@ -19,6 +19,7 @@ class SocialLoginForm extends Component {
 	static propTypes = {
 		errorNotice: PropTypes.func.isRequired,
 		infoNotice: PropTypes.func.isRequired,
+		removeNotice: PropTypes.func.isRequired,
 		onSuccess: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
@@ -37,8 +38,9 @@ class SocialLoginForm extends Component {
 			this.props.onSuccess();
 		} ).catch( error => {
 			if ( error === 'unknown_user' ) {
-				this.props.infoNotice( this.props.translate( 'Creating your account' ) );
+				const { notice } = this.props.infoNotice( this.props.translate( 'Creating your account' ) );
 				wpcom.undocumented().usersSocialNew( 'google', response.Zi.id_token, 'login', ( wpcomError, wpcomResponse ) => {
+					this.props.removeNotice( notice.noticeId );
 					if ( wpcomError ) {
 						this.props.errorNotice( wpcomError.message );
 					} else {
@@ -67,10 +69,13 @@ class SocialLoginForm extends Component {
 						responseHandler={ this.handleGoogleResponse } />
 				</div>
 
-				{ this.state.bearerToken &&
-					<WpcomLoginForm log={ this.state.username }
-									authorization={ 'Bearer ' + this.state.bearerToken }
-									redirectTo="/start" /> }
+				{ this.state.bearerToken && (
+					<WpcomLoginForm
+						log={ this.state.username }
+						authorization={ 'Bearer ' + this.state.bearerToken }
+						redirectTo="/start"
+					/>
+				) }
 			</div>
 		);
 	}
@@ -81,6 +86,7 @@ export default connect(
 	{
 		errorNotice,
 		infoNotice,
+		removeNotice,
 		loginSocialUser,
 	}
 )( localize( SocialLoginForm ) );

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -11,13 +11,14 @@ import { localize } from 'i18n-calypso';
  */
 import config from 'config';
 import { loginSocialUser } from 'state/login/actions';
-import { errorNotice } from 'state/notices/actions';
+import { errorNotice, infoNotice } from 'state/notices/actions';
 import wpcom from 'lib/wp';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 
 class SocialLoginForm extends Component {
 	static propTypes = {
 		errorNotice: PropTypes.func.isRequired,
+		infoNotice: PropTypes.func.isRequired,
 		onSuccess: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
@@ -36,6 +37,7 @@ class SocialLoginForm extends Component {
 			this.props.onSuccess();
 		} ).catch( error => {
 			if ( error === 'unknown_user' ) {
+				this.props.infoNotice( this.props.translate( 'Creating your account' ) );
 				wpcom.undocumented().usersSocialNew( 'google', response.Zi.id_token, 'login', ( wpcomError, wpcomResponse ) => {
 					if ( wpcomError ) {
 						this.props.errorNotice( wpcomError.message );
@@ -78,6 +80,7 @@ export default connect(
 	null,
 	{
 		errorNotice,
+		infoNotice,
 		loginSocialUser,
 	}
 )( localize( SocialLoginForm ) );


### PR DESCRIPTION
This PR handles the `unknown_user` error returned on social login when the account does not exist, and instead tries to create a new account and redirect the user to `/start`

### Testing Instructions
- Boot this branch, open a private window and go to http://calypso.localhost:3000/log-in
- Click on "Continue with Google"
- Enter your information for a Google account which is not already connected to WordPress.com.
- Notice that you don't see an error but instead a notice telling you that your account is being created
- Ensure you are redirected to `/start`

### Reviews
- [ ] Code
- [ ] Product
