### PR TITLE
WooCommerce: Fix the token field text size to match other inputs.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -27,6 +27,11 @@
 	}
 }
 
+.products__form .token-field__input,
+.products__form .token-field__token-text {
+	font-size: 16px;
+}
+
 .products__product-form-details-wrapper {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
The font size of the token field input (used in "additional details", categories, and variations) was smaller then the rest of our form so things didn't visually match up.

This fixes both the token, and typing font sizes.

cc @jameskoster 