### PR TITLE
Editor: implement icons in EditorVisibility dropdown component.

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -44,35 +44,44 @@
 
 .editor-confirmation-sidebar__sidebar {
 	@extend .sidebar;
-	width: $sidebar-width-max;
+	width: $sidebar-width-min;
 	background: $sidebar-bg-color;
 	position: fixed;
 		left: auto;
-		right: -$sidebar-width-max;
+		right: -$sidebar-width-min;
 	z-index: z-index( 'root', '.editor-confirmation-sidebar__sidebar' );
 	border-left: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
 
 	&.is-active {
-		transform: translateX( -$sidebar-width-max );
+		transform: translateX( -$sidebar-width-min );
 	}
 
-  @include breakpoint( "<660px" ) {
-	transition: none;
-	border-left: none;
-	pointer-events: auto;
+	@include breakpoint( ">960px" ) {
+		width: $sidebar-width-max;
+		right: -$sidebar-width-max;
 
-	&.is-active {
-		height: auto;
-		width: 100%;
-		position: fixed;
-			top: 47px;
-			right: auto;
-			left: 0;
-		transform: none;
+		&.is-active {
+			transform: translateX( -$sidebar-width-max );
+		}
 	}
-  }
+
+	@include breakpoint( "<660px" ) {
+		transition: none;
+		border-left: none;
+		pointer-events: auto;
+
+		&.is-active {
+			height: auto;
+			width: 100%;
+			position: fixed;
+				top: 47px;
+				right: auto;
+				left: 0;
+			transform: none;
+		}
+	}
 }
 
 .editor-confirmation-sidebar__ground-control {

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -44,18 +44,18 @@
 
 .editor-confirmation-sidebar__sidebar {
 	@extend .sidebar;
-	width: 374px;
+	width: $sidebar-width-max;
 	background: $sidebar-bg-color;
 	position: fixed;
 		left: auto;
-		right: -374px;
+		right: -$sidebar-width-max;
 	z-index: z-index( 'root', '.editor-confirmation-sidebar__sidebar' );
 	border-left: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
 
 	&.is-active {
-		transform: translateX( -374px );
+		transform: translateX( -$sidebar-width-max );
 	}
 
   @include breakpoint( "<660px" ) {

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -428,7 +428,7 @@ const EditorVisibility = React.createClass( {
 		const dropdownItems = [
 			{
 				label: this.props.translate( 'Public', { context: 'Editor: Radio label to set post visible to public' } ),
-				icon: 'globe',
+				icon: <Gridicon icon="globe" size={ 18 } />,
 				value: 'public',
 				onClick: () => {
 					this.updateDropdownVisibility( 'public' );
@@ -436,13 +436,13 @@ const EditorVisibility = React.createClass( {
 			},
 			{
 				label: this.props.translate( 'Private', { context: 'Editor: Radio label to set post to private' } ),
-				icon: 'user',
+				icon: <Gridicon icon="user" size={ 18 } />,
 				value: 'private',
 				onClick: this.onSetToPrivate
 			},
 			{
 				label: this.props.translate( 'Password Protected', { context: 'Editor: Radio label to set post to password protected' } ),
-				icon: 'lock',
+				icon: <Gridicon icon="lock" size={ 18 } />,
 				value: 'password',
 				onClick: () => {
 					this.updateDropdownVisibility( 'password' );
@@ -457,14 +457,17 @@ const EditorVisibility = React.createClass( {
 					<FormLegend className="editor-fieldset__legend">
 						{ this.props.translate( 'Post Visibility' ) }
 					</FormLegend>
-					<SelectDropdown selectedText={ selectedItem ? selectedItem.label : this.props.translate( 'Select an option' ) }>
+					<SelectDropdown
+						selectedText={ selectedItem ? selectedItem.label : this.props.translate( 'Select an option' ) }
+						selectedIcon={ selectedItem.icon }
+					>
 						{ dropdownItems.map( option =>
 							<DropdownItem
 								selected={ option.value === visibility }
 								key={ option.value }
 								value={ option.value }
 								onClick={ option.onClick }
-								icon={ <Gridicon icon={ option.icon } size={ 18 } /> }
+								icon={ option.icon }
 							>
 								{ option.label }
 							</DropdownItem>

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -6,7 +6,7 @@
 	margin: 0;
 }
 
-.editor-visibility__dropdown{
+.editor-visibility__dropdown {
 	text-align: left;
 	width: 100%;
 
@@ -14,6 +14,19 @@
 	.select-dropdown__container {
 		max-width: 100%;
 		width: 100%;
+	}
+
+	.select-dropdown__header {
+		padding: 0 #{ $side-margin + 20 }px 0 #{ $side-margin }px;
+		max-width: ( $sidebar-width-max - $accordion-padding * 2 );
+
+		@include breakpoint( "<960px" ) {
+			max-width: ( $sidebar-width-min - $accordion-padding * 2 );
+		}
+		@include breakpoint( "<660px" ) {
+			max-width: 100%;
+			min-width: ( $sidebar-width-max - $accordion-padding * 2 );
+		}
 	}
 
 	.form-text-input {
@@ -30,16 +43,6 @@
 
 		&.password {
 			margin-bottom: 0;
-		}
-	}
-
-	.gridicon {
-		cursor: pointer;
-		vertical-align: middle;
-		margin-right: 4px;
-
-		&:hover {
-			color: $gray-dark;
 		}
 	}
 


### PR DESCRIPTION
Follows #14617.

In #14517, the `EditorVisibility` component was updated to use the `SelectDropdown` component instead of a popover. In #14617, the `SelectDropdown` component is being updated to accept icons. This PR properly implements the icons in the `EditorVisibility` component.

**Mock:**
<img width="386" alt="editor-visibility-dropdown-mobile" src="https://cloud.githubusercontent.com/assets/942359/26692900/551c462a-46d0-11e7-889b-4554a2dddc18.png">

This is part of a larger epic (See p3Ex-2ri-p2)

**To Test:**
- Checkout branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Make sure that the updated `EditorVisibility` component is used in the post editor 'Status' section.
- Verify that the correct icon (public>globe, private>user, password>lock) is visible in the dropdown header and for each item inside the dropdown.
- Change the post visibility to verify functionality:
 - 'Password Protected' should show/hide a password field under the dropdown
 - 'Members Only' should show the privacy confirmation modal to publish the post privately
- Run the branch again without the feature flag enabled and make sure the `EditorVisibility` component works as normal as a popover
