### PR TITLE
Extensions: WPSC - Fetch notice from notices endpoint instead of hardcoding it

### DIFF
--- a/client/extensions/wp-super-cache/easy-tab.jsx
+++ b/client/extensions/wp-super-cache/easy-tab.jsx
@@ -15,12 +15,14 @@ import Card from 'components/card';
 import Notice from 'components/notice';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle/compact';
+import QueryNotices from './data/query-notices';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 import { testCache } from './state/cache/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteTitle } from 'state/sites/selectors';
 import { getCacheTestResults, isTestingCache } from './state/cache/selectors';
+import { getNotices } from './state/notices/selectors';
 
 class EasyTab extends Component {
 	static propTypes = {
@@ -79,24 +81,18 @@ class EasyTab extends Component {
 			cacheTestResults: {
 				attempts = {},
 			},
-			fields: {
-				cache_mod_rewrite,
-				is_cache_enabled,
-			},
+			fields: { is_cache_enabled },
 			handleAutosavingToggle,
 			isDeleting,
 			isRequesting,
 			isSaving,
 			isTesting,
+			notices: { php_mod_rewrite },
 			site,
+			siteId,
 			translate,
 		} = this.props;
-		const enableCacheNotice = translate(
-			'PHP caching is enabled but Supercache mod_rewrite rules were ' +
-			'detected. Cached files will be served using those rules. If your site is working ok, ' +
-			'please ignore this message. Otherwise, you can edit the .htaccess file in the root of your ' +
-			'install and remove the SuperCache rules.'
-		);
+		const phpModRewriteMessage = get( php_mod_rewrite, 'message' );
 
 		return (
 			<div>
@@ -116,8 +112,11 @@ class EasyTab extends Component {
 					</form>
 				</Card>
 
-				{ is_cache_enabled && ! cache_mod_rewrite &&
-					<Notice text={ enableCacheNotice } showDismiss={ false } className="wp-super-cache__notice-hug-card" />
+				{ phpModRewriteMessage &&
+				<Notice
+					className="wp-super-cache__notice-hug-card"
+					showDismiss={ false }
+					text={ phpModRewriteMessage } />
 				}
 
 				{ is_cache_enabled &&
@@ -213,6 +212,7 @@ class EasyTab extends Component {
 						}
 					</div>
 				</Card>
+				<QueryNotices siteId={ siteId } />
 			</div>
 		);
 	}
@@ -224,10 +224,12 @@ const connectComponent = connect(
 		const siteTitle = getSiteTitle( state, siteId );
 		const isTesting = isTestingCache( state, siteId );
 		const cacheTestResults = getCacheTestResults( state, siteId );
+		const notices = getNotices( state, siteId );
 
 		return {
 			cacheTestResults,
 			isTesting,
+			notices,
 			siteTitle,
 		};
 	},


### PR DESCRIPTION
The conditional logic that determines whether or not to display the notice on the _Easy_ tab was flawed. As there are additional checks that need to be made, this logic is now handled server-side and, if applicable, the notice is returned by the `notices` endpoint.

## Before
![php_mod_rewrite-notice-before](https://cloud.githubusercontent.com/assets/1190420/26693241/84eb3086-46d1-11e7-89fa-edcb4d230a47.jpg)

## After
![php_mod_rewrite-notice-after](https://cloud.githubusercontent.com/assets/1190420/26693247/89cef20e-46d1-11e7-980f-3d26cd05cd99.jpg)
