### PR TITLE
Sites: Update getSiteBySlug

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -88,7 +88,7 @@ export default React.createClass( {
 		return (
 			<div className={ siteClass }>
 				<a className="site__content"
-					href={ this.props.homeLink ? site.slug : this.props.href }
+					href={ this.props.homeLink ? site.URL : this.props.href }
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
 					title={ this.props.homeLink

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -88,7 +88,7 @@ export default React.createClass( {
 		return (
 			<div className={ siteClass }>
 				<a className="site__content"
-					href={ this.props.homeLink ? site.URL : this.props.href }
+					href={ this.props.homeLink ? site.slug : this.props.href }
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
 					title={ this.props.homeLink

--- a/client/lib/site/computed-attributes.js
+++ b/client/lib/site/computed-attributes.js
@@ -32,7 +32,10 @@ export default function( site ) {
 	// If a site has an `is_redirect` property use the `unmapped_url`
 	// for the slug and domain to match the wordpress.com original site.
 	if ( ( attributes.options && attributes.options.is_redirect ) || site.hasConflict ) {
-		attributes.URL = attributes.options.unmapped_url;
+		if ( site.hasConflict ) {
+			// we only need to use the unmapped URL for conflicting sites
+			attributes.URL = attributes.options.unmapped_url;
+		}
 		attributes.slug = withoutHttp( attributes.options.unmapped_url );
 		attributes.domain = attributes.slug;
 	}

--- a/client/lib/site/computed-attributes.js
+++ b/client/lib/site/computed-attributes.js
@@ -32,6 +32,7 @@ export default function( site ) {
 	// If a site has an `is_redirect` property use the `unmapped_url`
 	// for the slug and domain to match the wordpress.com original site.
 	if ( ( attributes.options && attributes.options.is_redirect ) || site.hasConflict ) {
+		attributes.URL = attributes.options.unmapped_url;
 		attributes.slug = withoutHttp( attributes.options.unmapped_url );
 		attributes.domain = attributes.slug;
 	}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -82,12 +82,16 @@ export const getSite = createSelector(
 			return null;
 		}
 
-		return {
+		const decoratedSite = {
 			...site,
-			...getComputedAttributes( site ),
-			...getJetpackComputedAttributes( state, siteId ),
 			hasConflict: isSiteConflicting( state, siteId ),
 			is_previewable: isSitePreviewable( state, siteId )
+		};
+
+		return {
+			...decoratedSite,
+			...getComputedAttributes( decoratedSite ),
+			...getJetpackComputedAttributes( state, siteId ),
 		};
 	},
 	( state ) => state.sites.items

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import {
+	assign,
 	compact,
 	every,
 	filter,
@@ -73,7 +74,7 @@ export const getSiteBySlug = createSelector(
  */
 export const getSite = createSelector(
 	( state, siteId ) => {
-		const site = getRawSite( state, siteId ) ||
+		let site = getRawSite( state, siteId ) ||
 			// Support for non-ID site retrieval
 			// Replaces SitesList#getSite
 			getSiteBySlug( state, siteId );
@@ -82,17 +83,15 @@ export const getSite = createSelector(
 			return null;
 		}
 
-		const decoratedSite = {
-			...site,
-			hasConflict: isSiteConflicting( state, siteId ),
-			is_previewable: isSitePreviewable( state, siteId )
-		};
+		// To avoid mutating the original site object, create a shallow clone
+		// before assigning computed properties
+		site = { ...site };
+		site.hasConflict = isSiteConflicting( state, siteId );
+		assign( site, getComputedAttributes( site ) );
+		assign( site, getJetpackComputedAttributes( state, siteId ) );
+		site.is_previewable = isSitePreviewable( state, siteId );
 
-		return {
-			...decoratedSite,
-			...getComputedAttributes( decoratedSite ),
-			...getJetpackComputedAttributes( state, siteId ),
-		};
+		return site;
 	},
 	( state ) => state.sites.items
 );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -55,7 +55,8 @@ export const getRawSite = ( state, siteId ) => {
 export const getSiteBySlug = createSelector(
 	( state, siteSlug ) => (
 		find( state.sites.items, ( item, siteId ) => (
-			getSiteSlug( state, siteId ) === siteSlug
+			// find always passes the siteId as a string. We need it as a integer
+			getSiteSlug( state, parseInt( siteId, 10 ) ) === siteSlug
 		) ) || null
 	),
 	( state ) => state.sites.items

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -185,7 +185,7 @@ describe( 'selectors', () => {
 			expect( site ).to.eql( {
 				ID: 2916284,
 				name: 'WordPress.com Example Blog',
-				URL: 'https://example.com',
+				URL: 'https://example.wordpress.com',
 				title: 'WordPress.com Example Blog',
 				domain: 'example.wordpress.com',
 				slug: 'example.wordpress.com',

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -71,6 +71,7 @@ describe( 'selectors', () => {
 	beforeEach( () => {
 		getSite.memoizedSelector.cache.clear();
 		getSiteCollisions.memoizedSelector.cache.clear();
+		getSiteBySlug.memoizedSelector.cache.clear();
 	} );
 
 	describe( '#getRawSite()', () => {
@@ -1437,6 +1438,7 @@ describe( 'selectors', () => {
 					items: {
 						77203199: {
 							ID: 77203199,
+
 							URL: 'https://testtwosites2014.wordpress.com/path/to/site'
 						}
 					}
@@ -1445,6 +1447,31 @@ describe( 'selectors', () => {
 			const site = getSiteBySlug( state, 'testtwosites2014.wordpress.com::path::to::site' );
 
 			expect( site ).to.equal( state.sites.items[ 77203199 ] );
+		} );
+
+		it( 'should return a matched site jetpack site when the sites conflict', () => {
+			const state = {
+				sites: {
+					items: {
+						1: {
+							ID: 1,
+							URL: 'https://example.com',
+							jetpack: false,
+							option: {
+								unmapped_url: 'https://abc.wordpress.com',
+								is_redirect: false,
+							}
+						},
+						2: {
+							ID: 2,
+							jetpack: true,
+							URL: 'https://example.com'
+						},
+					}
+				}
+			};
+			const site = getSiteBySlug( state, 'example.com' );
+			expect( site ).to.equal( state.sites.items[ 2 ] );
 		} );
 	} );
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -152,6 +152,53 @@ describe( 'selectors', () => {
 				}
 			} );
 		} );
+
+		it( 'should return a normalized site with correct slug when sites with collisions are passed in attributes', () => {
+			const site = getSite( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							name: 'WordPress.com Example Blog',
+							URL: 'https://example.com',
+							jetpack: false,
+							options: {
+								unmapped_url: 'https://example.wordpress.com'
+							}
+						},
+						3916284: {
+							ID: 3916284,
+							name: 'Jetpack Example Blog',
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								unmapped_url: 'https://example.com'
+							}
+						}
+					},
+				},
+				siteSettings: {
+					items: {},
+				},
+			}, 2916284 );
+
+			expect( site ).to.eql( {
+				ID: 2916284,
+				name: 'WordPress.com Example Blog',
+				URL: 'https://example.com',
+				title: 'WordPress.com Example Blog',
+				domain: 'example.wordpress.com',
+				slug: 'example.wordpress.com',
+				hasConflict: true,
+				jetpack: false,
+				is_customizable: false,
+				is_previewable: true,
+				options: {
+					default_post_format: 'standard',
+					unmapped_url: 'https://example.wordpress.com'
+				}
+			} );
+		} );
 	} );
 
 	describe( '#getSiteCollisions', () => {
@@ -1611,7 +1658,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getSitePlanSlug()', () => {
+	describe( '#getSitePlanSlug()', () => {
 		it( 'should return undefined if the plan slug is not known', () => {
 			const planSlug = getSitePlanSlug( {
 				sites: {


### PR DESCRIPTION
getSiteSlug needs an integer to be passed into it as siteId.
lodashe's `find()` function was turning the object keys into string which in turn
failed to mark site's as having a conflict or not and returned the wrong site.

This PR helps fix the #6779 issue. 
My making sure that the getSiteBySlug works as expected always. 

**To test**
have a Jetpack site that shares the same domain as a .com site and visit you are now able to visit the Jetpack site as expected. The domain should always resolve to the jetpack sites. 
