### PR TITLE
Comments: select a site on filter paths

### DIFF
--- a/client/components/data/query-site-comments/index.jsx
+++ b/client/components/data/query-site-comments/index.jsx
@@ -9,7 +9,9 @@ import { connect } from 'react-redux';
  */
 import { requestCommentsList } from 'state/comments/actions';
 
-const requestComments = ( { requestSiteComments, siteId, status } ) => requestSiteComments( { siteId, status } );
+const requestComments = ( { requestSiteComments, siteId, status } ) => (
+	siteId && requestSiteComments( { siteId, status } )
+);
 
 export class QuerySiteComments extends Component {
 	componentDidMount() {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -20,6 +20,7 @@ import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
+import QuerySiteComments from 'components/data/query-site-comments';
 
 export class CommentList extends Component {
 	static propTypes = {
@@ -162,6 +163,7 @@ export class CommentList extends Component {
 
 		return (
 			<div className="comment-list">
+				<QuerySiteComments siteId={ siteId } status="all" />
 				<CommentNavigation { ...{
 					isBulkEdit,
 					siteSlug,

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -50,7 +50,7 @@ export class CommentNavigation extends Component {
 
 	getStatusPath = status => 'unapproved' !== status
 		? `/comments/${ status }/${ this.props.siteSlug }`
-		: `/comments/${ this.props.siteSlug }`;
+		: `/comments/pending/${ this.props.siteSlug }`;
 
 	render() {
 		const {

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -3,18 +3,18 @@
  */
 import { renderWithReduxStore } from 'lib/react-helpers';
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
 import route from 'lib/route';
 import CommentsManagement from './main';
+import controller from 'my-sites/controller';
 
 export const comments = function( context ) {
 	const siteSlug = route.getSiteFragment( context.path );
-	const status = ( context.params.status && siteSlug !== context.params.status )
-		? context.params.status
-		: 'unapproved';
+	const status = context.params.status === 'pending' ? 'unapproved' : context.params.status;
 
 	renderWithReduxStore(
 		<CommentsManagement
@@ -25,4 +25,14 @@ export const comments = function( context ) {
 		'primary',
 		context.store
 	);
+};
+
+export const sites = function( context ) {
+	const { status } = context.params;
+	const siteSlug = route.getSiteFragment( context.path );
+
+	if ( status === siteSlug ) {
+		return page.redirect( `/comments/pending/${ siteSlug }` );
+	}
+	controller.sites( context );
 };

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -7,7 +7,7 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from 'my-sites/controller';
-import { comments } from './controller';
+import { comments, sites } from './controller';
 import config from 'config';
 
 export default function() {
@@ -17,7 +17,12 @@ export default function() {
 			controller.sites
 		);
 
-		page( '/comments/:status?/:site',
+		page( '/comments/:status',
+			controller.siteSelection,
+			sites,
+		);
+
+		page( '/comments/:status/:site',
 			controller.siteSelection,
 			controller.navigation,
 			comments

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -13,7 +13,6 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import CommentList from './comment-list';
-import QuerySiteComments from 'components/data/query-site-comments';
 
 export class CommentsManagement extends Component {
 	static propTypes = {
@@ -37,7 +36,6 @@ export class CommentsManagement extends Component {
 		return (
 			<Main className="comments" wideLayout>
 				<PageViewTracker path={ basePath } title="Manage Comments" />
-				<QuerySiteComments siteId={ siteId } status="all" />
 				<DocumentHead title={ translate( 'Manage Comments' ) } />
 				<CommentList
 					siteId={ siteId }


### PR DESCRIPTION
Currently comments does not support an all sites view. This PR fixes behavior where navigating to http://calypso.localhost:3000/comments/all would not prompt the user for site selection. This PR also updates behavior where http://calypso.localhost:3000/comments/:siteId: will redirect to  http://calypso.localhost:3000/comments/pending/:siteId: 

I'm open to other ideas on routing, though I did run into some trouble when trying to preserve displaying unapproved comments on `http://calypso.localhost:3000/comments/:siteId:` with these requirements

### Testing Instructions
- Navigate to http://calypso.localhost:3000/comments
- The site picker is shown
- When a site is selected, we're redirected to http://calypso.localhost:3000/comments/pending/:siteId:
- No strange behavior when clicking on the other filters
- Navigate to http://calypso.localhost:3000/comments/all
- Select a site
- We're redirected to http://calypso.localhost:3000/comments/all/:siteId:
- No strange behavior when clicking on the other filters

cc @Automattic/lannister 