### PR TITLE
Replace Intergalactic with Intergalactic 2 in signup

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -55,11 +55,11 @@ export const themes = [
 	},
 	{
 		name: 'Intergalactic',
-		slug: 'intergalactic',
+		slug: 'intergalactic-2',
 		repo: 'pub',
 		fallback: true,
 		design: 'blog',
-		demo_uri: 'https://intergalacticdemo.wordpress.com',
+		demo_uri: 'https://intergalactic2demo.wordpress.com',
 		verticals: []
 	},
 	{


### PR DESCRIPTION
Instructions for local testing:

1. Switch to this PR
2. Go to calypso.localhost:3000/start
3. Click "Start with a Blog"
4. Make sure Intergalactic 2 shows up instead of Intergalactic. Intergalactic 2 has a star logo in the screenshot; the original Intergalactic has no logo. (Note: You may need to hit 'Back' and try again if this theme doesn't appear the first time).

Thanks!