### PR TITLE
Add initial README for WooCommerce extension.

### DIFF
--- a/client/extensions/woocommerce/README.md
+++ b/client/extensions/woocommerce/README.md
@@ -1,0 +1,14 @@
+# WooCommerce for Calypso
+
+Sell anything, beautifully. Now from Calypso.
+
+## Prerequisites
+
+WooCommerce for Calypso requires a few plugins to be in place on your WordPress.org installation in order to work properly:
+
+- [Jetpack](https://github.com/Automattic/jetpack) - powers the API behind Calypso.
+- [WooCommerce](https://github.com/woocommerce/woocommerce) - at least 3.1 (use `master` for now).
+- [WooCommerce API Dev](https://github.com/woocommerce/wc-api-dev) - a feature plugin that augments the core WooCommerce REST API. (with development moving at a more rapid pace - keep this one up to date!)
+- [WooCommerce Services](https://github.com/Automattic/woocommerce-services/) - powers USPS shipping in Calypso.
+
+Ensure that all plugins are installed and activated. Jetpack should be connected to WordPress.com, and WooCommerce Services should be connected to Jetpack.


### PR DESCRIPTION
Lists prerequisite WordPress.org plugins required for now.