### PR TITLE
Unify translatable strings

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -248,7 +248,7 @@ class RegistrantExtraInfoForm extends React.PureComponent {
 						<FormTextInput
 							id="placeOfBirth"
 							value={ placeOfBirth }
-							placeholder={ translate( 'City of birth' ) }
+							placeholder={ translate( 'City of Birth' ) }
 							onChange={ this.handleChangeEvent } />
 					</FormFieldset>
 				) }


### PR DESCRIPTION
Oh, the shame :'(

Just matching case so we can translate the strings once instead of twice.