### PR TITLE
WooCommerce: Add SKU editor to the product form

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -3,12 +3,14 @@
  */
 import React, { Component, PropTypes } from 'react';
 import i18n from 'i18n-calypso';
+import { trim } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormClickToEditInput from 'woocommerce/components/form-click-to-edit-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
@@ -29,6 +31,11 @@ export default class ProductFormDetailsCard extends Component {
 	constructor( props ) {
 		super( props );
 
+		const { product } = props;
+		this.state = {
+			updateSkuOnNameChange: ! product.name ? true : false,
+		};
+
 		this.setName = this.setName.bind( this );
 		this.setDescription = this.setDescription.bind( this );
 		this.toggleFeatured = this.toggleFeatured.bind( this );
@@ -38,7 +45,24 @@ export default class ProductFormDetailsCard extends Component {
 	// into a general purpose Higher Order Component
 	setName( e ) {
 		const { product, editProduct } = this.props;
-		editProduct( product, { name: e.target.value } );
+		const name = e.target.value;
+		editProduct( product, { name } );
+
+		if ( this.state.updateSkuOnNameChange ) {
+			const sku = trim( name ).toLowerCase().replace( /\s+/g, '-' );
+			editProduct( product, { sku } );
+		}
+	}
+
+	setSku = ( sku ) => {
+		const { product, editProduct } = this.props;
+		editProduct( product, { sku } );
+
+		if ( this.state.updateSkuOnNameChange ) {
+			this.setState( {
+				updateSkuOnNameChange: false,
+			} );
+		}
 	}
 
 	setDescription( e ) {
@@ -71,6 +95,7 @@ export default class ProductFormDetailsCard extends Component {
 		const { product } = this.props;
 		const images = product.images || [];
 		const __ = i18n.translate;
+
 		return (
 			<Card className="products__product-form-details">
 				<div className="products__product-form-details-featured">
@@ -89,9 +114,19 @@ export default class ProductFormDetailsCard extends Component {
 						onRemove={ this.onImageRemove }
 					/>
 					<div className="products__product-form-details-basic">
-						<FormFieldSet>
+						<FormFieldSet className="products__product-form-details-basic-name">
 							<FormLabel htmlFor="name">{ __( 'Product name' ) }</FormLabel>
 							<FormTextInput name="name" value={ product.name || '' } onChange={ this.setName } />
+						</FormFieldSet>
+						<FormFieldSet className="products__product-form-details-basic-sku">
+							<FormLabel htmlFor="sku">{ __( 'SKU:' ) }</FormLabel>
+							<FormClickToEditInput
+								name="sku"
+								value={ product.sku || '' }
+								placeholder="-"
+								onChange={ this.setSku }
+								disabled={ product.name || product.sku ? false : true }
+							/>
 						</FormFieldSet>
 						<FormFieldSet className="products__product-form-details-basic-description">
 							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -33,7 +33,7 @@ export default class ProductFormDetailsCard extends Component {
 
 		const { product } = props;
 		this.state = {
-			updateSkuOnNameChange: ! product.name ? true : false,
+			updateSkuOnNameChange: ! product.name,
 		};
 
 		this.setName = this.setName.bind( this );
@@ -116,14 +116,20 @@ export default class ProductFormDetailsCard extends Component {
 					<div className="products__product-form-details-basic">
 						<FormFieldSet className="products__product-form-details-basic-name">
 							<FormLabel htmlFor="name">{ __( 'Product name' ) }</FormLabel>
-							<FormTextInput name="name" value={ product.name || '' } onChange={ this.setName } />
+							<FormTextInput
+								id="name"
+								value={ product.name || '' }
+								onChange={ this.setName }
+							/>
 						</FormFieldSet>
 						<FormFieldSet className="products__product-form-details-basic-sku">
 							<FormLabel htmlFor="sku">{ __( 'SKU:' ) }</FormLabel>
 							<FormClickToEditInput
-								name="sku"
+								id="sku"
 								value={ product.sku || '' }
 								placeholder="-"
+								updateAriaLabel={ __( 'Update SKU' ) }
+								editAriaLabel={ __( 'Edit SKU' ) }
 								onChange={ this.setSku }
 								disabled={ product.name || product.sku ? false : true }
 							/>
@@ -131,7 +137,7 @@ export default class ProductFormDetailsCard extends Component {
 						<FormFieldSet className="products__product-form-details-basic-description">
 							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>
 							<FormTextArea
-								name="description"
+								id="description"
 								value={ product.description || '' }
 								onChange={ this.setDescription }
 								rows="8" />

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -10,6 +10,7 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
+import FormClickToEditInput from 'woocommerce/components/form-click-to-edit-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -49,6 +50,12 @@ class ProductFormVariationsModal extends React.Component {
 		editProductVariation( product, variation, { description: e.target.value } );
 	}
 
+	setSku = ( sku ) => {
+		const { product, editProductVariation } = this.props;
+		const variation = this.selectedVariation();
+		editProductVariation( product, variation, { sku } );
+	}
+
 	toggleVisible() {
 		const { product, editProductVariation } = this.props;
 		const variation = this.selectedVariation();
@@ -82,11 +89,25 @@ class ProductFormVariationsModal extends React.Component {
 
 				<div className="products__product-form-modal-contents">
 					<h2>{ formattedVariationName( variation ) }</h2>
-					<span className="products__product-form-sku">SKU:</span>
+					<FormFieldSet className="products__product-form-details-basic-sku">
+						<FormLabel htmlFor="sku">{ translate( 'SKU:' ) }</FormLabel>
+						<FormClickToEditInput
+							id="sku"
+							value={ variation.sku || '' }
+							placeholder="-"
+							onChange={ this.setSku }
+							updateAriaLabel={ translate( 'Update SKU' ) }
+							editAriaLabel={ translate( 'Edit SKU' ) }
+						/>
+					</FormFieldSet>
 
 					<FormFieldSet className="products__product-form-variation-description">
 						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
-						<FormTextArea name="description" value={ variation.description || '' } onChange={ this.setDescription } />
+						<FormTextArea
+							id="description"
+							value={ variation.description || '' }
+							onChange={ this.setDescription }
+						/>
 						<FormSettingExplanation>{ translate(
 								'This will be displayed in addition to the main product description when this variation is selected.'
 						) }</FormSettingExplanation>

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -206,6 +206,27 @@
 	margin-bottom: 0;
 }
 
+.products__product-form-details-basic-name {
+	margin-bottom: 8px;
+}
+
+.products__product-form-details-basic-sku {
+	.form-label {
+		display: inline;
+		margin-right: 4px;
+		color: $gray-text-min;
+		font-weight: normal;
+	}
+
+	input {
+		width: 65%;
+	}
+
+	.form-click-to-edit-input__text {
+		color: $gray-text-min;
+	}
+}
+
 .products__variation-types-form-wrapper {
 	padding: 24px;
 	border-top: 1px solid $gray-light;

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -211,15 +211,19 @@
 }
 
 .products__product-form-details-basic-sku {
+	margin-top: 0;
+	margin-bottom: 4px;
+
 	.form-label {
 		display: inline;
 		margin-right: 4px;
-		color: $gray-text-min;
-		font-weight: normal;
+		color: $gray-dark;
+		font-size: 13px;
 	}
 
 	input {
 		width: 65%;
+		font-size: 13px;
 	}
 
 	.form-click-to-edit-input__text {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -207,18 +207,20 @@
 }
 
 .products__product-form-details-basic-name {
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 }
 
 .products__product-form-details-basic-sku {
 	margin-top: 0;
-	margin-bottom: 4px;
+	margin-bottom: 12px;
+	font-size: 13px;
 
 	.form-label {
 		display: inline;
 		margin-right: 4px;
 		color: $gray-dark;
 		font-size: 13px;
+		line-height: 35px;
 	}
 
 	input {
@@ -226,8 +228,33 @@
 		font-size: 13px;
 	}
 
+	.form-click-to-edit-input__wrapper {
+		min-height: 35px;
+		display: inline-block;
+		transform: translateY(5px);
+
+		&.editing {
+			transform: none;
+		}
+	}
+
 	.form-click-to-edit-input__text {
 		color: $gray-text-min;
+		display: inline-block;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		max-width: 220px;
+	}
+
+	.form-text-input {
+		width: 220px;
+		margin-bottom: 5px;
+		padding: 4px 8px;
+	}
+
+	.button {
+		padding: 0;
 	}
 }
 

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import Gridicon from 'gridicons';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FormTextInput from 'components/forms/form-text-input';
+
+class FormClickToEditInput extends Component {
+
+	static propTypes = {
+		onChange: PropTypes.func,
+		value: PropTypes.string,
+		placeholder: PropTypes.string,
+		disabled: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		onChange: noop,
+		placeholder: '',
+		value: '',
+		disabled: false,
+	};
+
+	state = {
+		isEditing: false,
+		value: '',
+	};
+
+	editStart = () => {
+		const { value } = this.props;
+		this.setState( {
+			isEditing: true,
+			value
+		} );
+	}
+
+	editEnd = () => {
+		const { onChange } = this.props;
+		if ( this.props.value !== this.state.value ) {
+			onChange( this.state.value );
+		}
+
+		this.setState( {
+			isEditing: false,
+			value: '',
+		} );
+	}
+
+	onInputChange = ( e ) => {
+		this.setState( {
+			value: e.target.value
+		} );
+	}
+
+	renderInput() {
+		const props = { ...this.props,
+			onChange: this.onInputChange,
+			value: this.state.value,
+		};
+		return (
+			<span className="form-click-to-edit-input__wrapper editing">
+				<FormTextInput
+					{ ...props }
+					autoFocus
+					className="form-click-to-edit-input__input"
+				/>
+				<Button
+					borderless
+					onClick={ this.editEnd }
+				>
+					<Gridicon icon="checkmark" />
+				</Button>
+			</span>
+		);
+	}
+
+	renderText() {
+		const { value, placeholder, disabled } = this.props;
+		return (
+			<span className="form-click-to-edit-input__wrapper">
+				<span className="form-click-to-edit-input__text">
+					{ value || placeholder }
+				</span>
+
+				{ ! disabled && (
+					<Button
+						borderless
+						onClick={ this.editStart }
+					>
+						<Gridicon icon="pencil" />
+					</Button>
+				) }
+			</span>
+		);
+	}
+
+	render() {
+		const { isEditing } = this.state;
+
+		if ( isEditing ) {
+			return this.renderInput();
+		}
+
+		return this.renderText();
+	}
+}
+
+export default FormClickToEditInput;

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { noop } from 'lodash';
 
@@ -82,8 +83,12 @@ class FormClickToEditInput extends Component {
 
 	renderText() {
 		const { value, placeholder, disabled } = this.props;
+		const classes = classNames( 'form-click-to-edit-input__wrapper', {
+			'is-empty': ! ( value ),
+			'has-value': ( value ),
+		} );
 		return (
-			<span className="form-click-to-edit-input__wrapper">
+			<span className={ classes }>
 				<span className="form-click-to-edit-input__text">
 					{ value || placeholder }
 				</span>

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { noop } from 'lodash';
+import { noop, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,8 @@ class FormClickToEditInput extends Component {
 		value: PropTypes.string,
 		placeholder: PropTypes.string,
 		disabled: PropTypes.bool,
+		updateAriaLabel: PropTypes.string,
+		editAriaLabel: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -26,6 +28,8 @@ class FormClickToEditInput extends Component {
 		placeholder: '',
 		value: '',
 		disabled: false,
+		updateAriaLabel: '',
+		editAriaLabel: '',
 	};
 
 	state = {
@@ -67,13 +71,15 @@ class FormClickToEditInput extends Component {
 		return (
 			<span className="form-click-to-edit-input__wrapper editing">
 				<FormTextInput
-					{ ...props }
+					{ ...omit( props, [ 'updateAriaLabel', 'editAriaLabel' ] ) }
+					onBlur={ this.editEnd }
 					autoFocus
 					className="form-click-to-edit-input__input"
 				/>
 				<Button
 					borderless
 					onClick={ this.editEnd }
+					aria-label={ this.props.updateAriaLabel }
 				>
 					<Gridicon icon="checkmark" />
 				</Button>
@@ -82,14 +88,17 @@ class FormClickToEditInput extends Component {
 	}
 
 	renderText() {
-		const { value, placeholder, disabled } = this.props;
+		const { value, placeholder, disabled, editAriaLabel } = this.props;
 		const classes = classNames( 'form-click-to-edit-input__wrapper', {
 			'is-empty': ! ( value ),
 			'has-value': ( value ),
 		} );
 		return (
 			<span className={ classes }>
-				<span className="form-click-to-edit-input__text">
+				<span
+					className="form-click-to-edit-input__text"
+					onClick={ ! disabled && this.editStart }
+				>
 					{ value || placeholder }
 				</span>
 
@@ -97,6 +106,7 @@ class FormClickToEditInput extends Component {
 					<Button
 						borderless
 						onClick={ this.editStart }
+						aria-label={ editAriaLabel }
 					>
 						<Gridicon icon="pencil" />
 					</Button>

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/style.scss
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/style.scss
@@ -1,0 +1,14 @@
+.form-click-to-edit-input__wrapper {
+
+	.gridicon {
+		margin-left: 8px;
+		width: 16px;
+		height: 16px;
+	}
+
+	.gridicons-pencil {
+		top: -3px;
+		margin-top: 0;
+	}
+
+}

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/style.scss
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/style.scss
@@ -2,13 +2,12 @@
 
 	.gridicon {
 		margin-left: 8px;
-		width: 16px;
-		height: 16px;
-	}
+		width: 13px;
+		height: 13px;
+		top: 0;
 
-	.gridicons-pencil {
-		top: -3px;
-		margin-top: 0;
+		&.gridicons-checkmark {
+			top: 5px;
+		}
 	}
-
 }

--- a/client/extensions/woocommerce/lib/generate-variations/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/index.js
@@ -1,10 +1,20 @@
 /**
+ * External dependencies
+ */
+import { trim } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import formattedVariationName from '../formatted-variation-name';
+
+/**
  * Generates variation objects based on a product's attributes.
  *
  * @param {Object} product Product object.
  * @return {Array} Array of variation objects.
  */
-export default function generateVariations( { attributes } ) {
+export default function generateVariations( { name, attributes } ) {
 	const variationTypes = [];
 	const variationAttributes = (
 		attributes &&
@@ -21,8 +31,17 @@ export default function generateVariations( { attributes } ) {
 	} );
 
 	return cartesian( ...variationTypes ).map( function( combination ) {
-		return { attributes: combination };
+		const sku = generateDefaultSku( name, combination );
+		return {
+			attributes: combination,
+			sku,
+		};
 	} );
+}
+
+function generateDefaultSku( productName, attributes ) {
+	const sku = ( productName && ( productName + '-' ) || '' ) + formattedVariationName( { attributes } );
+	return trim( sku.toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' ) );
 }
 
 // http://stackoverflow.com/a/29585704

--- a/client/extensions/woocommerce/lib/generate-variations/test/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/test/index.js
@@ -37,23 +37,19 @@ describe( 'generateVariations', () => {
 		] };
 
 		const variations = generateVariations( product );
-		expect( variations[ 0 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Red',
-				},
-			]
-		} );
+		expect( variations[ 0 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Red',
+			},
+		] );
 
-		expect( variations[ 1 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Blue',
-				},
-			]
-		} );
+		expect( variations[ 1 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Blue',
+			},
+		] );
 	} );
 	it( 'generates a cartesian of variations when passed a product with multiple variation attributes', () => {
 		const product = { id: 1, attributes: [
@@ -73,31 +69,27 @@ describe( 'generateVariations', () => {
 
 		const variations = generateVariations( product );
 
-		expect( variations[ 0 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Red'
-				},
-				{
-					name: 'Size',
-					option: 'Small',
-				}
-			]
-		} );
+		expect( variations[ 0 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Red'
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			}
+		] );
 
-		expect( variations[ 1 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Blue'
-				},
-				{
-					name: 'Size',
-					option: 'Small',
-				}
-			]
-		} );
+		expect( variations[ 1 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Blue'
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			}
+		] );
 	} );
 	it( 'generates a complex cartesian of variations when passed a product with multiple variation attributes and multiple options', () => {
 		const product = { id: 1, attributes: [
@@ -124,21 +116,62 @@ describe( 'generateVariations', () => {
 		const variations = generateVariations( product );
 
 		expect( variations.length ).to.eql( 12 );
-		expect( variations[ 0 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Red',
-				},
-				{
-					name: 'Size',
-					option: 'Small',
-				},
-				{
-					name: 'Sleeves',
-					option: 'Short',
-				},
-			]
-		} );
+		expect( variations[ 0 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Red',
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			},
+			{
+				name: 'Sleeves',
+				option: 'Short',
+			},
+		] );
+	} );
+
+	it( 'generates a default variation sku with product name', () => {
+		const product = { id: 1, name: 'Shirt', attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue' ],
+				variation: true,
+				uid: 'edit_0',
+			},
+			{
+				name: 'Size',
+				options: [ 'Small' ],
+				variation: true,
+				uid: 'edit_1',
+			},
+		] };
+
+		const variations = generateVariations( product );
+
+		expect( variations[ 0 ].sku ).to.equal( 'shirt-red-small' );
+		expect( variations[ 1 ].sku ).to.equal( 'shirt-blue-small' );
+	} );
+
+	it( 'generates a default variation sku without a product name', () => {
+		const product = { id: 2, attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue' ],
+				variation: true,
+				uid: 'edit_0',
+			},
+			{
+				name: 'Size',
+				options: [ 'Small' ],
+				variation: true,
+				uid: 'edit_1',
+			},
+		] };
+
+		const variations = generateVariations( product );
+		expect( variations[ 0 ].sku ).to.equal( 'red-small' );
+		expect( variations[ 1 ].sku ).to.equal( 'blue-small' );
 	} );
 } );

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -130,6 +130,7 @@ function editProductVariations( productEdits, variations ) {
 			creates.push( {
 				id: { index: Number( uniqueId() ) },
 				attributes: variation.attributes,
+				sku: variation.sku,
 				visible: true,
 			} );
 		}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -13,6 +13,7 @@
 	@import 'components/action-header/style';
 	@import 'components/address-view/style';
 	@import 'components/extended-header/style';
+	@import 'components/form-click-to-edit-input/style';
 	@import 'components/form-dimensions-input/style';
 	@import 'components/product-image-uploader/style';
 	@import 'app/settings/shipping/style';


### PR DESCRIPTION
This PR introduces a generalized `FormClickToEditInput` component that behaves as described in [product mocks](https://www.dropbox.com/s/5gspfg0886qh3yw/add%20product.sketch?dl=0). It displays its value as text with a pencil/edit icon that transforms into an input when clicked. The value is set when the user clicks a checkmark.

This PR also hooks up the component to the product form and generates a SKU when entering a name.

Default state:
<img width="358" alt="screen shot 2017-06-01 at 2 19 17 pm" src="https://cloud.githubusercontent.com/assets/689165/26704696/d37af268-46e5-11e7-8f5c-3cb0f18a5be8.png">

SKU after typing a name:
<img width="358" alt="screen shot 2017-06-01 at 2 18 57 pm" src="https://cloud.githubusercontent.com/assets/689165/26704699/d94c3e40-46e5-11e7-8c60-11b8493c19f9.png">

SKU editing mode:
<img width="360" alt="screen shot 2017-06-01 at 2 19 06 pm" src="https://cloud.githubusercontent.com/assets/689165/26704703/de1e6074-46e5-11e7-8e87-f1001e4704db.png">

To Test:
* Visit `http://calypso.localhost:3000/store/products/:site/add`
* Type in a product name, and watch the SKU start appearing. A pencil icon should also appear.
* Click the pencil icon and see an input appear.
* Enter a new/custom SKU and click the checkmark.
* The SKU should update.

Closes #13653
cc @kellychoffman @jameskoster since this contains UI.