### PR TITLE
WooCommerce: Add SKU editor to the variation modal and generate default SKUs

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -10,6 +10,7 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
+import FormClickToEditInput from 'woocommerce/components/form-click-to-edit-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -49,6 +50,12 @@ class ProductFormVariationsModal extends React.Component {
 		editProductVariation( product, variation, { description: e.target.value } );
 	}
 
+	setSku = ( sku ) => {
+		const { product, editProductVariation } = this.props;
+		const variation = this.selectedVariation();
+		editProductVariation( product, variation, { sku } );
+	}
+
 	toggleVisible() {
 		const { product, editProductVariation } = this.props;
 		const variation = this.selectedVariation();
@@ -82,11 +89,25 @@ class ProductFormVariationsModal extends React.Component {
 
 				<div className="products__product-form-modal-contents">
 					<h2>{ formattedVariationName( variation ) }</h2>
-					<span className="products__product-form-sku">SKU:</span>
+					<FormFieldSet className="products__product-form-details-basic-sku">
+						<FormLabel htmlFor="sku">{ translate( 'SKU:' ) }</FormLabel>
+						<FormClickToEditInput
+							id="sku"
+							value={ variation.sku || '' }
+							placeholder="-"
+							onChange={ this.setSku }
+							updateAriaLabel={ translate( 'Update SKU' ) }
+							editAriaLabel={ translate( 'Edit SKU' ) }
+						/>
+					</FormFieldSet>
 
 					<FormFieldSet className="products__product-form-variation-description">
 						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
-						<FormTextArea name="description" value={ variation.description || '' } onChange={ this.setDescription } />
+						<FormTextArea
+							id="description"
+							value={ variation.description || '' }
+							onChange={ this.setDescription }
+						/>
 						<FormSettingExplanation>{ translate(
 								'This will be displayed in addition to the main product description when this variation is selected.'
 						) }</FormSettingExplanation>

--- a/client/extensions/woocommerce/lib/generate-variations/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/index.js
@@ -1,10 +1,20 @@
 /**
+ * External dependencies
+ */
+import { trim } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import formattedVariationName from '../formatted-variation-name';
+
+/**
  * Generates variation objects based on a product's attributes.
  *
  * @param {Object} product Product object.
  * @return {Array} Array of variation objects.
  */
-export default function generateVariations( { attributes } ) {
+export default function generateVariations( { name, attributes } ) {
 	const variationTypes = [];
 	const variationAttributes = (
 		attributes &&
@@ -21,8 +31,17 @@ export default function generateVariations( { attributes } ) {
 	} );
 
 	return cartesian( ...variationTypes ).map( function( combination ) {
-		return { attributes: combination };
+		const sku = generateDefaultSku( name, combination );
+		return {
+			attributes: combination,
+			sku,
+		};
 	} );
+}
+
+function generateDefaultSku( productName, attributes ) {
+	const sku = ( productName && ( productName + '-' ) || '' ) + formattedVariationName( { attributes } );
+	return trim( sku.toLowerCase().replace( /\s+/g, '-' ).replace( /-{2,}/g, '-' ) );
 }
 
 // http://stackoverflow.com/a/29585704

--- a/client/extensions/woocommerce/lib/generate-variations/test/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/test/index.js
@@ -37,23 +37,19 @@ describe( 'generateVariations', () => {
 		] };
 
 		const variations = generateVariations( product );
-		expect( variations[ 0 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Red',
-				},
-			]
-		} );
+		expect( variations[ 0 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Red',
+			},
+		] );
 
-		expect( variations[ 1 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Blue',
-				},
-			]
-		} );
+		expect( variations[ 1 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Blue',
+			},
+		] );
 	} );
 	it( 'generates a cartesian of variations when passed a product with multiple variation attributes', () => {
 		const product = { id: 1, attributes: [
@@ -73,31 +69,27 @@ describe( 'generateVariations', () => {
 
 		const variations = generateVariations( product );
 
-		expect( variations[ 0 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Red'
-				},
-				{
-					name: 'Size',
-					option: 'Small',
-				}
-			]
-		} );
+		expect( variations[ 0 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Red'
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			}
+		] );
 
-		expect( variations[ 1 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Blue'
-				},
-				{
-					name: 'Size',
-					option: 'Small',
-				}
-			]
-		} );
+		expect( variations[ 1 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Blue'
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			}
+		] );
 	} );
 	it( 'generates a complex cartesian of variations when passed a product with multiple variation attributes and multiple options', () => {
 		const product = { id: 1, attributes: [
@@ -124,21 +116,62 @@ describe( 'generateVariations', () => {
 		const variations = generateVariations( product );
 
 		expect( variations.length ).to.eql( 12 );
-		expect( variations[ 0 ] ).to.eql( {
-			attributes: [
-				{
-					name: 'Color',
-					option: 'Red',
-				},
-				{
-					name: 'Size',
-					option: 'Small',
-				},
-				{
-					name: 'Sleeves',
-					option: 'Short',
-				},
-			]
-		} );
+		expect( variations[ 0 ].attributes ).to.eql( [
+			{
+				name: 'Color',
+				option: 'Red',
+			},
+			{
+				name: 'Size',
+				option: 'Small',
+			},
+			{
+				name: 'Sleeves',
+				option: 'Short',
+			},
+		] );
+	} );
+
+	it( 'generates a default variation sku with product name', () => {
+		const product = { id: 1, name: 'Shirt', attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue' ],
+				variation: true,
+				uid: 'edit_0',
+			},
+			{
+				name: 'Size',
+				options: [ 'Small' ],
+				variation: true,
+				uid: 'edit_1',
+			},
+		] };
+
+		const variations = generateVariations( product );
+
+		expect( variations[ 0 ].sku ).to.equal( 'shirt-red-small' );
+		expect( variations[ 1 ].sku ).to.equal( 'shirt-blue-small' );
+	} );
+
+	it( 'generates a default variation sku without a product name', () => {
+		const product = { id: 2, attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue' ],
+				variation: true,
+				uid: 'edit_0',
+			},
+			{
+				name: 'Size',
+				options: [ 'Small' ],
+				variation: true,
+				uid: 'edit_1',
+			},
+		] };
+
+		const variations = generateVariations( product );
+		expect( variations[ 0 ].sku ).to.equal( 'red-small' );
+		expect( variations[ 1 ].sku ).to.equal( 'blue-small' );
 	} );
 } );

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -130,6 +130,7 @@ function editProductVariations( productEdits, variations ) {
 			creates.push( {
 				id: { index: Number( uniqueId() ) },
 				attributes: variation.attributes,
+				sku: variation.sku,
 				visible: true,
 			} );
 		}


### PR DESCRIPTION
This PR hooks up the SKU editor to the variation modal so SKUs can be changed for each variation. It also automatically generates default SKUs when generating variations based on name & attributes.

To Test:
* Run `make test` and make sure all tests pass.
* Visit `http://calypso.localhost:3000/store/products/:site/add`
* Type in a product name.
* Toggle the variations card.
* Enter a variation type (like `Color`) and a few values like `Red, Green, Blue`.
* Click one of the variation links to open the variation modal.
* Click the pencil icon to edit the generated SKU.
* Click the checkmark to save the value.

<img width="1388" alt="screen shot 2017-06-01 at 4 27 41 pm" src="https://cloud.githubusercontent.com/assets/689165/26704915/4c03a81e-46e7-11e7-8f11-0f20d1055f2a.png">

cc @kellychoffman @jameskoster since this contains UI.

Closes #13653.
Depends on #14702.