### PR TITLE
Editor: Port the WPEmoji TinyMCE plugin from Core to Calypso

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -46,6 +46,7 @@ import embedReversalPlugin from './plugins/embed-reversal/plugin';
 import EditorHtmlToolbar from 'post-editor/editor-html-toolbar';
 import mentionsPlugin from './plugins/mentions/plugin';
 import markdownPlugin from './plugins/markdown/plugin';
+import wpEmojiPlugin from './plugins/wpemoji/plugin';
 
 [
 	wpcomPlugin,
@@ -70,6 +71,7 @@ import markdownPlugin from './plugins/markdown/plugin';
 	toolbarPinPlugin,
 	embedReversalPlugin,
 	markdownPlugin,
+	wpEmojiPlugin,
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
@@ -121,6 +123,7 @@ const PLUGINS = [
 	'wplink',
 	'AtD',
 	'directionality',
+	'wpemoji',
 	'wpcom/autoresize',
 	'wpcom/media',
 	'wpcom/advanced',

--- a/client/components/tinymce/plugins/wpemoji/plugin.js
+++ b/client/components/tinymce/plugins/wpemoji/plugin.js
@@ -69,7 +69,7 @@ function wpemoji( editor ) {
 			}
 		} );
 	} else if ( ! isWin ) {
-		// In MacOS inserting emoji doesn't trigger the stanradr keyboard events.
+		// In MacOS inserting emoji doesn't trigger the standard keyboard events.
 		// Thankfully it triggers the 'input' event.
 		// This works in Android and iOS as well.
 		editor.on( 'keydown keyup', function( event ) {

--- a/client/components/tinymce/plugins/wpemoji/plugin.js
+++ b/client/components/tinymce/plugins/wpemoji/plugin.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+import twemoji from 'twemoji';
+
+/**
+ * TinyMCE plugin tweaking Markdown behaviour.
+ *
+ * @param {Object} editor TinyMCE editor instance
+ */
+function wpemoji( editor ) {
+	let typing = false;
+	const env = tinymce.Env,
+		ua = window.navigator.userAgent,
+		isWin = ua.indexOf( 'Windows' ) > -1,
+		isWin8 = ( function() {
+			const match = ua.match( /Windows NT 6\.(\d)/ );
+
+			if ( match && match[ 1 ] > 1 ) {
+				return true;
+			}
+
+			return false;
+		}() );
+
+	function setImgAttr( image ) {
+		image.className = 'emoji';
+		image.setAttribute( 'data-mce-resize', 'false' );
+		image.setAttribute( 'data-mce-placeholder', '1' );
+		image.setAttribute( 'data-wp-emoji', '1' );
+	}
+
+	function replaceEmoji( node ) {
+		const imgAttr = {
+			'data-mce-resize': 'false',
+			'data-mce-placeholder': '1',
+			'data-wp-emoji': '1'
+		};
+
+		twemoji.parse( node, { imgAttr: imgAttr } );
+	}
+
+	// Test if the node text contains emoji char(s) and replace.
+	function parseNode( node ) {
+		let selection, bookmark;
+
+		if ( node && twemoji.test( node.textContent || node.innerText ) ) {
+			if ( env.webkit ) {
+				selection = editor.selection;
+				bookmark = selection.getBookmark();
+			}
+
+			replaceEmoji( node );
+
+			if ( env.webkit ) {
+				selection.moveToBookmark( bookmark );
+			}
+		}
+	}
+
+	if ( isWin8 ) {
+		// Windows 8+ emoji can be "typed" with the onscreen keyboard.
+		// That triggers the normal keyboard events, but not the 'input' event.
+		// Thankfully it sets keyCode 231 when the onscreen keyboard inserts any emoji.
+		editor.on( 'keyup', function( event ) {
+			if ( event.keyCode === 231 ) {
+				parseNode( editor.selection.getNode() );
+			}
+		} );
+	} else if ( ! isWin ) {
+		// In MacOS inserting emoji doesn't trigger the stanradr keyboard events.
+		// Thankfully it triggers the 'input' event.
+		// This works in Android and iOS as well.
+		editor.on( 'keydown keyup', function( event ) {
+			typing = ( event.type === 'keydown' );
+		} );
+
+		editor.on( 'input', function() {
+			if ( typing ) {
+				return;
+			}
+
+			parseNode( editor.selection.getNode() );
+		} );
+	}
+
+	editor.on( 'setcontent', function( event ) {
+		const selection = editor.selection,
+			node = selection.getNode();
+
+		if ( twemoji.test( node.textContent || node.innerText ) ) {
+			replaceEmoji( node );
+
+			// In IE all content in the editor is left selected after wp.emoji.parse()...
+			// Collapse the selection to the beginning.
+			if ( env.ie && env.ie < 9 && event.load && node && node.nodeName === 'BODY' ) {
+				selection.collapse( true );
+			}
+		}
+	} );
+
+	// Convert Twemoji compatible pasted emoji replacement images into our format.
+	editor.on( 'PastePostProcess', function( event ) {
+		tinymce.each( editor.dom.$( 'img.emoji', event.node ), function( image ) {
+			if ( image.alt && window.twemoji.test( image.alt ) ) {
+				setImgAttr( image );
+			}
+		} );
+	} );
+
+	editor.on( 'postprocess', function( event ) {
+		if ( event.content ) {
+			event.content = event.content.replace( /<img[^>]+data-wp-emoji="[^>]+>/g, function( img ) {
+				const alt = img.match( /alt="([^"]+)"/ );
+
+				if ( alt && alt[ 1 ] ) {
+					return alt[ 1 ];
+				}
+
+				return img;
+			} );
+		}
+	} );
+
+	editor.on( 'resolvename', function( event ) {
+		if ( event.target.nodeName === 'IMG' && editor.dom.getAttrib( event.target, 'data-wp-emoji' ) ) {
+			event.preventDefault();
+		}
+	} );
+}
+
+export default function() {
+	tinymce.PluginManager.add( 'wpemoji', wpemoji );
+}
+

--- a/client/components/tinymce/plugins/wpemoji/plugin.js
+++ b/client/components/tinymce/plugins/wpemoji/plugin.js
@@ -85,19 +85,8 @@ function wpemoji( editor ) {
 		} );
 	}
 
-	editor.on( 'setcontent', function( event ) {
-		const selection = editor.selection,
-			node = selection.getNode();
-
-		if ( twemoji.test( node.textContent || node.innerText ) ) {
-			replaceEmoji( node );
-
-			// In IE all content in the editor is left selected after wp.emoji.parse()...
-			// Collapse the selection to the beginning.
-			if ( env.ie && env.ie < 9 && event.load && node && node.nodeName === 'BODY' ) {
-				selection.collapse( true );
-			}
-		}
+	editor.on( 'setcontent', function() {
+		parseNode( editor.selection.getNode() );
 	} );
 
 	// Convert Twemoji compatible pasted emoji replacement images into our format.

--- a/client/components/tinymce/plugins/wpemoji/plugin.js
+++ b/client/components/tinymce/plugins/wpemoji/plugin.js
@@ -103,7 +103,7 @@ function wpemoji( editor ) {
 	// Convert Twemoji compatible pasted emoji replacement images into our format.
 	editor.on( 'PastePostProcess', function( event ) {
 		tinymce.each( editor.dom.$( 'img.emoji', event.node ), function( image ) {
-			if ( image.alt && window.twemoji.test( image.alt ) ) {
+			if ( image.alt && twemoji.test( image.alt ) ) {
 				setImgAttr( image );
 			}
 		} );


### PR DESCRIPTION
This pull request addresses #319 by porting the WPEmoji plugin from Core.

#### Testing instructions

1. Run `git checkout add/319-port-tinymce-wpemoji` and start your server, or open a [live branch](https://calypso.live/?branch=add/319-port-tinymce-wpemoji)
2. Open the [`Post Editor` page](http://calypso.localhost:3000/post)
3. Check that typing an emoji using your OS's emoji keyboard transforms to a Twemoji image.
4. Check that pasting [an emoji your browser doesn't support](https://emojipedia.org/bearded-person/) transforms to a twemoji image.
5. Check that copying pasting content to, from, and between editor instances behaves correctly. (The editor should always show Twemoji images, other text areas should show native emoji rendering.)

#### Reviews

- [ ] Code
