### PR TITLE
Woo-Connect Insights: Add Top Sellers to Orders Page

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -4,6 +4,7 @@
 import { translate } from 'i18n-calypso';
 
 export const topProducts = {
+	basePath: '/store/stats/products',
 	title: translate( 'Products' ),
 	values: [
 		{ key: 'name', title: translate( 'Title' ) },
@@ -15,6 +16,7 @@ export const topProducts = {
 };
 
 export const topCategories = {
+	basePath: '/store/stats/categories',
 	title: translate( 'Categories' ),
 	values: [
 		{ key: 'name', title: translate( 'Title' ) },
@@ -26,6 +28,7 @@ export const topCategories = {
 };
 
 export const topCoupons = {
+	basePath: '/store/stats/coupons',
 	title: translate( 'Coupons' ),
 	values: [
 		{ key: 'name', title: translate( 'Title' ) },

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -28,7 +28,7 @@ export default function StatsController( context ) {
 		page.redirect( `/store/stats/orders/day/${ context.params.site }` );
 	}
 	const props = {
-		context: context,
+		querystring: context.querystring,
 		type: context.params.type,
 		unit: context.params.unit,
 		path: context.pathname,

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -14,19 +14,23 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Chart from './store-stats-chart';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import DatePicker from 'my-sites/stats/stats-date-picker';
-import { UNITS } from './constants';
+import Module from './store-stats-module';
+import List from './store-stats-list';
+import SectionHeader from 'components/section-header';
+import { topProducts, topCategories, topCoupons, UNITS } from 'woocommerce/app/store-stats/constants';
 
 class StoreStats extends Component {
 	static propTypes = {
 		path: PropTypes.string.isRequired,
 		queryDate: PropTypes.string,
+		querystring: PropTypes.string,
 		selectedDate: PropTypes.string,
 		siteId: PropTypes.number,
 		unit: PropTypes.string.isRequired,
 	};
 
 	render() {
-		const { path, queryDate, selectedDate, siteId, slug, unit } = this.props;
+		const { path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
 		const unitQueryDate = ( unit === 'week' )
 			? `${ moment( queryDate ).format( UNITS[ unit ].format ) }-W${ moment( queryDate ).isoWeek() }`
 			: moment( queryDate ).format( UNITS[ unit ].format );
@@ -38,6 +42,14 @@ class StoreStats extends Component {
 			date: queryDate,
 			quantity: UNITS[ unit ].quantity,
 		};
+		const topQuery = {
+			unit,
+			date: selectedDate,
+			limit: 10,
+		};
+		const widgets = [ topProducts, topCategories, topCoupons ];
+		const widgetPath = `/${ unit }/${ slug }${ querystring ? '?' : '' }${ querystring || '' }`;
+
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
 				<Navigation unit={ unit } type="orders" slug={ slug } />
@@ -66,6 +78,33 @@ class StoreStats extends Component {
 						showQueryDate
 					/>
 				</StatsPeriodNavigation>
+				<div className="store-stats__widgets">
+				{ widgets.map( widget => {
+					const header = (
+						<SectionHeader href={ widget.basePath + widgetPath }>
+							{ widget.title }
+						</SectionHeader>
+					);
+					return (
+						<div className="store-stats__widgets-column" key={ widget.basePath }>
+							<Module
+								siteId={ siteId }
+								header={ header }
+								emptyMessage={ widget.empty }
+								query={ topQuery }
+								statType={ widget.statType }
+							>
+								<List
+									siteId={ siteId }
+									values={ widget.values }
+									query={ topQuery }
+									statType={ widget.statType }
+								/>
+							</Module>
+						</div>
+					);
+				} ) }
+				</div>
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -29,14 +29,25 @@ class StoreStats extends Component {
 		unit: PropTypes.string.isRequired,
 	};
 
+	getUnitPeriod = ( date ) => {
+		const { unit } = this.props;
+		return ( unit === 'week' )
+			? `${ moment( date ).format( UNITS[ unit ].format ) }-W${ moment( date ).isoWeek() }`
+			: moment( date ).format( UNITS[ unit ].format );
+	};
+
+	getEndPeriod = ( date ) => {
+		const { unit } = this.props;
+		return ( unit === 'week' )
+			? moment( date ).endOf( 'isoWeek' ).format( 'YYYY-MM-DD' )
+			: moment( date ).endOf( unit ).format( 'YYYY-MM-DD' );
+	};
+
 	render() {
 		const { path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
-		const unitQueryDate = ( unit === 'week' )
-			? `${ moment( queryDate ).format( UNITS[ unit ].format ) }-W${ moment( queryDate ).isoWeek() }`
-			: moment( queryDate ).format( UNITS[ unit ].format );
-		const unitSelectedDate = ( unit === 'week' )
-			? moment( selectedDate ).endOf( 'isoWeek' ).format( 'YYYY-MM-DD' )
-			: moment( selectedDate ).endOf( unit ).format( 'YYYY-MM-DD' );
+		const unitQueryDate = this.getUnitPeriod( queryDate );
+		const unitSelectedDate = this.getUnitPeriod( selectedDate );
+		const endSelectedDate = this.getEndPeriod( selectedDate );
 		const ordersQuery = {
 			unit,
 			date: queryDate,
@@ -44,7 +55,7 @@ class StoreStats extends Component {
 		};
 		const topQuery = {
 			unit,
-			date: selectedDate,
+			date: unitSelectedDate,
 			limit: 10,
 		};
 		const widgets = [ topProducts, topCategories, topCoupons ];
@@ -56,7 +67,7 @@ class StoreStats extends Component {
 				<Chart
 					path={ path }
 					query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
-					selectedDate={ unitSelectedDate }
+					selectedDate={ endSelectedDate }
 					siteId={ siteId }
 					unit={ unit }
 				/>

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -25,17 +25,17 @@ const listType = {
 
 class StoreStatsListView extends Component {
 	static propTypes = {
-		context: PropTypes.object.isRequired,
 		path: PropTypes.string.isRequired,
 		selectedDate: PropTypes.string,
 		siteId: PropTypes.number,
-		unit: PropTypes.string.isRequired,
+		querystring: PropTypes.string,
 		type: PropTypes.string.isRequired,
+		unit: PropTypes.string.isRequired,
 	};
 
 	goBack = () => {
 		const pathParts = this.props.path.split( '/' );
-		const queryString = this.props.context.querystring ? '?' + this.props.context.querystring : '';
+		const queryString = this.props.querystring ? '?' + this.props.querystring : '';
 		const pathExtra = `${ pathParts[ pathParts.length - 2 ] }/${ pathParts[ pathParts.length - 1 ] }${ queryString }`;
 		const defaultBack = `/store/stats/orders/${ pathExtra }`;
 

--- a/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
@@ -7,9 +7,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import {
-	getSiteStatsNormalizedData
-} from 'state/stats/lists/selectors';
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -1,0 +1,29 @@
+.store-stats__widgets {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+.store-stats__widgets-column {
+	width: 100%;
+
+	.module-content-text.is-error {
+		padding-top: 11px;
+	}
+}
+
+@include breakpoint( ">960px" ) {
+	.store-stats__widgets {
+		flex-direction: row;
+		flex-wrap: wrap;
+	}
+	.store-stats__widgets-column {
+		width: calc(50% - 4px);
+	}
+}
+
+@include breakpoint( ">1280px" ) {
+	.store-stats__widgets-column {
+		width: calc(33% - 3px);
+	}
+}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -29,6 +29,7 @@
 	@import 'components/store-address/style';
 	@import 'app/store-stats/store-stats-chart/style';
 	@import 'app/store-stats/store-stats-navigation/style';
+	@import 'app/store-stats/style';
 	@import 'components/delta/style';
 
 	.components__action-header {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -301,7 +301,7 @@ UndocumentedSite.prototype.statsOrders = function( query ) {
 };
 
 /**
- * Requests Store top-* lists
+ * Requests Store top-sellers stats
  *
  * @param {object} query query parameters
  * @return {Promise} A Promise to resolve when complete.
@@ -314,7 +314,7 @@ UndocumentedSite.prototype.statsTopSellers = function( query ) {
 };
 
 /**
- * Requests Store top-* lists
+ * Requests Store top earners
  *
  * @param {object} query query parameters
  * @return {Promise} A Promise to resolve when complete.
@@ -327,7 +327,7 @@ UndocumentedSite.prototype.statsTopEarners = function( query ) {
 };
 
 /**
- * Requests Store top-* lists
+ * Requests Store top categories
  *
  * @param {object} query query parameters
  * @return {Promise} A Promise to resolve when complete.

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -177,7 +177,6 @@ export const getSiteStatsNormalizedData = createSelector(
 			const site = getSite( state, siteId );
 			return normalizers[ statType ].call( this, data, query, siteId, site );
 		}
-
 		return data;
 	},
 	( state, siteId, statType, query ) => getSiteStatsForQuery( state, siteId, statType, query ),


### PR DESCRIPTION
### Render Top Products
![screen shot 2017-06-02 at 4 59 20 pm](https://cloud.githubusercontent.com/assets/1922453/26711524/ff34feba-47b4-11e7-8638-0346126f9769.png)

Fixes https://github.com/Automattic/wp-calypso/issues/14499
Fixes https://github.com/Automattic/wp-calypso/issues/14498