### PR TITLE
Reader Manage Button: bg color edit --> manage

### DIFF
--- a/client/reader/sidebar/helper.js
+++ b/client/reader/sidebar/helper.js
@@ -10,9 +10,9 @@ const exported = {
 	itemLinkClass: function( path, currentPath, additionalClasses ) {
 		const basePathLowerCase = decodeURIComponent( currentPath )
 			.split( '?' )[ 0 ]
-			.replace( /\/edit$/, '' )
+			.replace( /\/manage$/, '' )
 			.toLowerCase(),
-			pathLowerCase = decodeURIComponent( path ).replace( /\/edit$/, '' ).toLowerCase();
+			pathLowerCase = decodeURIComponent( path ).replace( /\/manage$/, '' ).toLowerCase();
 
 		let selected = basePathLowerCase === pathLowerCase, isActionButtonSelected = false;
 
@@ -21,9 +21,9 @@ const exported = {
 			selected = '/following' === basePathLowerCase;
 		}
 
-		// Are we on an edit page?
+		// Are we on the manage page?
 		const pathWithoutQueryString = currentPath.split( '?' )[ 0 ];
-		if ( selected && !! pathWithoutQueryString.match( /\/edit$/ ) ) {
+		if ( selected && !! pathWithoutQueryString.match( /\/manage$/ ) ) {
 			isActionButtonSelected = true;
 		}
 


### PR DESCRIPTION
This PR makes it so that the Manage button changes color while on the following/manage page (just as it had for following/edit).

fixes https://github.com/Automattic/wp-calypso/pull/14578#issuecomment-305667043

to test: 
1. go to https://calypso.live/following/manage?branch=fix/reader/manage-button-color
2. ensure the manage button appears like the one here: https://github.com/Automattic/wp-calypso/issues/14690#issuecomment-305612196