### PR TITLE
Extensions: WPSC - Minor tweaks / fixes to WP Super Cache settings

### DIFF
--- a/client/extensions/wp-super-cache/cache-location.jsx
+++ b/client/extensions/wp-super-cache/cache-location.jsx
@@ -18,6 +18,7 @@ import WrapSettingsForm from './wrap-settings-form';
 const CacheLocation = ( {
 	fields: {
 		cache_path,
+		default_cache_path,
 	},
 	handleChange,
 	handleSubmitForm,
@@ -55,7 +56,7 @@ const CacheLocation = ( {
 								'/cache/ which translates to {{cacheLocation/}}',
 								{
 									components: {
-										cacheLocation: <span>{ cache_path || '' }</span>,
+										cacheLocation: <span>{ default_cache_path || '' }</span>,
 									}
 								}
 							) }
@@ -70,6 +71,7 @@ const CacheLocation = ( {
 const getFormSettings = settings => {
 	return pick( settings, [
 		'cache_path',
+		'default_cache_path',
 	] );
 };
 

--- a/client/extensions/wp-super-cache/cache-location.jsx
+++ b/client/extensions/wp-super-cache/cache-location.jsx
@@ -17,8 +17,8 @@ import WrapSettingsForm from './wrap-settings-form';
 
 const CacheLocation = ( {
 	fields: {
-		cache_path,
-		default_cache_path,
+		cache_path = '',
+		default_cache_path = '',
 	},
 	handleChange,
 	handleSubmitForm,
@@ -49,14 +49,14 @@ const CacheLocation = ( {
 						<FormTextInput
 							disabled={ isDisabled }
 							onChange={ handleChange( 'cache_path' ) }
-							value={ cache_path || '' } />
+							value={ cache_path } />
 						<FormSettingExplanation>
 							{ translate(
 								'Change the location of your cache files. The default is WP_CONTENT_DIR . ' +
 								'/cache/ which translates to {{cacheLocation/}}',
 								{
 									components: {
-										cacheLocation: <span>{ default_cache_path || '' }</span>,
+										cacheLocation: <span>{ default_cache_path }</span>,
 									}
 								}
 							) }

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -9,6 +9,7 @@ import { get, pick } from 'lodash';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
@@ -36,7 +37,6 @@ const Caching = ( {
 	translate,
 } ) => {
 	const isDisabled = isRequesting || isSaving || isReadOnly;
-	const htaccessMessage = get( htaccess_ro, 'message' );
 	const modRewriteMessage = get( mod_rewrite_missing, 'message' );
 
 	return (
@@ -55,11 +55,26 @@ const Caching = ( {
 			</SectionHeader>
 			<Card>
 				<form>
-					{ htaccessMessage &&
+					{ htaccess_ro &&
 					<Notice
 						showDismiss={ false }
 						status="is-warning"
-						text={ htaccessMessage } />
+						text={ translate( 'The .htaccess file is readonly and cannot be updated. Cache files ' +
+							'will still be served by PHP. See {{a}}Changing File Permissions{{/a}} on WordPress.org ' +
+							'for help on fixing this.',
+							{
+								components: {
+									a: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://codex.wordpress.org/Changing_File_Permissions"
+										/>
+									),
+								}
+							}
+						) }
+						/>
 					}
 
 					{ modRewriteMessage &&

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -159,7 +159,7 @@ class ContentsTab extends Component {
 				{ ! isEmpty( get( wpcache, 'cached_list' ) ) &&
 					<CacheStats
 						files={ wpcache.cached_list }
-						header={ translate( 'Fresh WP-Cached Files' ) }
+						header={ translate( 'Fresh Full Cache Files' ) }
 						isCached={ true }
 						isSupercache={ false } />
 				}
@@ -167,7 +167,7 @@ class ContentsTab extends Component {
 				{ ! isEmpty( get( wpcache, 'expired_list' ) ) &&
 					<CacheStats
 						files={ wpcache.expired_list }
-						header={ translate( 'Stale WP-Cached Files' ) }
+						header={ translate( 'Stale Full Cache Files' ) }
 						isCached={ false }
 						isSupercache={ false } />
 				}

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -135,16 +135,6 @@ class ContentsTab extends Component {
 						</div>
 					}
 
-					{ ( wpcache || supercache ) &&
-						<p className="wp-super-cache__cache-stat-refresh">
-							{ translate(
-								'Cache stats last generated: %(generated)d minutes ago.',
-								{
-									args: { generated: ( get( stats, 'generated', 0 ) ) },
-								}
-							) }
-						</p>
-					}
 						<Button
 							compact
 							busy={ isGenerating }

--- a/client/extensions/wp-super-cache/contents-tab.js
+++ b/client/extensions/wp-super-cache/contents-tab.js
@@ -190,7 +190,7 @@ class ContentsTab extends Component {
 				</div>
 
 				<Card>
-					{ cache_max_time &&
+					{ cache_max_time > 0 &&
 						<p>
 							{ translate(
 								'Expired files are files older than %(cache_max_time)d seconds. They are still used by ' +

--- a/client/extensions/wp-super-cache/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/expiry-time.jsx
@@ -53,8 +53,11 @@ const ExpiryTime = ( {
 				<FormTextInput
 					className="wp-super-cache__cache-timeout"
 					disabled={ isDisabled }
+					min="0"
 					onChange={ handleChange( 'cache_max_time' ) }
-					value={ cache_max_time || '' } />
+					step="1"
+					type="number"
+					value={ cache_max_time || 0 } />
 				{ translate( 'seconds' ) }
 				<FormSettingExplanation>
 					{
@@ -86,7 +89,10 @@ const ExpiryTime = ( {
 						{ translate( 'Timer' ) }
 						<FormTextInput
 							disabled={ isDisabled || ( 'interval' !== cache_schedule_type ) }
+							min="1"
 							onChange={ handleChange( 'cache_time_interval' ) }
+							step="1"
+							type="number"
 							value={ cache_time_interval || '' } />
 						{ translate( 'seconds' ) }
 					</span>

--- a/client/extensions/wp-super-cache/lock-down.jsx
+++ b/client/extensions/wp-super-cache/lock-down.jsx
@@ -72,8 +72,7 @@ const LockDown = ( {
 						</FormSettingExplanation>
 
 						<Notice
-							isCompact={ true }
-							className="wp-super-cache__lock-down-notice"
+							isCompact
 							status={ cache_lock_down ? 'is-warning' : 'is-info' }
 							text={ cache_lock_down
 								? translate( 'WordPress is locked down. Super Cache static files will not be deleted ' +

--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ const Miscellaneous = ( {
 	translate,
 } ) => {
 	const isDisabled = isRequesting || isSaving || isReadOnly;
-	const compressionDisabled = notices && notices.compression_disabled;
+	const compressionDisabledMessage = get( notices.compression_disabled, 'message' );
 
 	return (
 		<div>
@@ -43,14 +43,14 @@ const Miscellaneous = ( {
 			</SectionHeader>
 			<Card>
 				<form>
-					{ compressionDisabled && compressionDisabled.message &&
+					{ compressionDisabledMessage &&
 					<Notice
 						showDismiss={ false }
-						status={ compressionDisabled.type ? `is-${ compressionDisabled.type }` : 'is-info' }
-						text={ compressionDisabled.message } />
+						status="is-warning"
+						text={ compressionDisabledMessage } />
 					}
 					<FormFieldset>
-						{ ! compressionDisabled &&
+						{ ! compressionDisabledMessage &&
 						<FormToggle
 							checked={ !! cache_compression }
 							disabled={ isDisabled }
@@ -65,7 +65,7 @@ const Miscellaneous = ( {
 							</span>
 						</FormToggle>
 						}
-						{ ! compressionDisabled &&
+						{ ! compressionDisabledMessage &&
 						<Notice
 							isCompact
 							className="wp-super-cache__toggle-notice"

--- a/client/extensions/wp-super-cache/miscellaneous.jsx
+++ b/client/extensions/wp-super-cache/miscellaneous.jsx
@@ -65,6 +65,14 @@ const Miscellaneous = ( {
 							</span>
 						</FormToggle>
 						}
+						{ ! compressionDisabled &&
+						<Notice
+							isCompact
+							className="wp-super-cache__toggle-notice"
+							text={ translate( 'Compression is disabled by default because some hosts have problems ' +
+								'with compressed files. Switching it on and off clears the cache.' ) }
+							/>
+						}
 
 						<FormToggle
 							checked={ !! dont_cache_logged_in }
@@ -113,8 +121,8 @@ const Miscellaneous = ( {
 						{ cache_mod_rewrite &&
 							<Notice
 								isCompact
-								className="wp-super-cache__miscellaneous-304-notice"
-								status="is-error"
+								className="wp-super-cache__toggle-notice"
+								status="is-warning"
 								text={ translate( '304 browser caching is only supported when mod_rewrite caching ' +
 									'is not used.' ) }
 							/>
@@ -123,7 +131,7 @@ const Miscellaneous = ( {
 						{ ! cache_mod_rewrite &&
 							<Notice
 								isCompact
-								className="wp-super-cache__miscellaneous-304-notice"
+								className="wp-super-cache__toggle-notice"
 								text={ translate( '304 support is disabled by default because some hosts have had problems with the ' +
 									'headers used in the past.' ) }
 							/>

--- a/client/extensions/wp-super-cache/state/settings/schema.js
+++ b/client/extensions/wp-super-cache/state/settings/schema.js
@@ -39,7 +39,6 @@ export const itemsSchema = {
 				is_cache_enabled: { type: 'boolean' },
 				is_mfunc_enabled: { type: 'boolean' },
 				is_mobile_enabled: { type: 'boolean' },
-				is_preload_enabled: { type: 'boolean' },
 				is_preloading: { type: 'boolean' },
 				is_super_cache_enabled: { type: 'boolean' },
 				make_known_anon: { type: 'boolean' },

--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -41,6 +41,7 @@ export const sanitizeSettings = settings => {
 			case 'cache_mobile_prefixes':
 			case 'cache_mod_rewrite':
 			case 'cache_next_gc':
+			case 'default_cache_path':
 			case 'is_preloading':
 			case 'minimum_preload_interval':
 			case 'post_count':

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -188,7 +188,7 @@
 	margin-top: -10px;
 }
 
-.wp-super-cache__miscellaneous-304-notice.is-compact {
+.wp-super-cache__toggle-notice.is-compact {
 	margin-left: 36px;
 	margin-bottom: 5px;
 }

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -92,11 +92,6 @@
 	display: block;
 }
 
-.wp-super-cache__cache-stat-refresh {
-	font-style: italic;
-	font-size: 13px;
-}
-
 .wp-super-cache__foldable-card.is-compact .foldable-card__header {
 	padding: 24px;
 }


### PR DESCRIPTION
This PR fixes a number of minor issues uncovered while doing a full test of the WPSC functionality:

- Adds a notice about compression  in the _Miscellaneous_ section of the _Advanced_ tab:
![miscellanous-notices](https://cloud.githubusercontent.com/assets/1190420/26723181/4ae70564-4761-11e7-9321-5ef676e75ad5.jpg)
- Simplifies the logic for checking for the existence of the `compression_disabled` notice
- Uses a `number` input type for those text boxes that accept numeric data
- Removes unused `wp-super-cache__lock-down-notice` CSS `className` attribute
- Fixes an issue where, if `cache_max_time` was 0, then 0 would be displayed on the _Contents_ tab
- Updates the labels displayed for cache stats on the _Contents_ tab
- Removes the cache stats generation timestamp from the _Contents_ tab, as it doesn't work well in WP Admin and can cause confusion
- Uses `default_cache_path` in the explanation of the _Cache Location_ setting:
![cache-location-explanation](https://cloud.githubusercontent.com/assets/1190420/26827589/01f6c398-4a8c-11e7-98b8-3b62898d0528.jpg)
- Fixes the notice that is displayed when the .htaccess file is readonly:
![htaccess-notice](https://cloud.githubusercontent.com/assets/1190420/26827499/9f0fc81a-4a8b-11e7-89a4-416fac8a1539.jpg)
