### PR TITLE
Fix site placeholder hover

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -11,6 +11,8 @@
 	position: relative;
 
 	&.is-loading {
+		pointer-events: none;
+
 		.site-icon {
 			animation: pulse-light 0.8s ease-in-out infinite;
 		}


### PR DESCRIPTION
Fixes #14329 

I'm totally fine keeping the "example" content in there as we do that in many placeholders. This just disables any user interaction.

### Hovered Placeholder

| Before | After |
| --- | --- |
| <img width="391" alt="screen shot 2017-06-02 at 13 57 15" src="https://cloud.githubusercontent.com/assets/156676/26725126/4d45cc64-479d-11e7-8c0f-98417ff9e0a0.png"> | <img width="388" alt="screen shot 2017-06-02 at 14 09 38" src="https://cloud.githubusercontent.com/assets/156676/26725135/543910ee-479d-11e7-844a-34309070c607.png"> (no background or cursor change) | 
