### PR TITLE
Site Settings: Add posts per page field to Custom Content Types card

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -93,7 +93,7 @@ class CustomContentTypes extends Component {
 		return (
 			<div className="custom-content-types__indented-form-field indented-form-field">
 				{ translate(
-					'Display {{field /}} %s per page load',
+					'Display {{field /}} %s per page',
 					{
 						args: postTypeLabel.toLowerCase(),
 						components: {

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -142,9 +142,9 @@ class CustomContentTypes extends Component {
 
 	renderPortfolioSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'Portfolios' );
+		const fieldLabel = translate( 'Portfolio projects' );
 		const fieldDescription = translate(
-			'Add, organize, and display {{link}}portfolios{{/link}}. If your theme doesn’t support portfolios yet, ' +
+			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
 			'you can display them using the shortcode ( [portfolios] ).',
 			{
 				components: {

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
@@ -160,24 +159,20 @@ class CustomContentTypes extends Component {
 	render() {
 		const { translate } = this.props;
 		return (
-			<div>
-				<SectionHeader label={ translate( 'Custom content types' ) } />
+			<Card className="custom-content-types site-settings">
+				<FormFieldset>
+					<div className="custom-content-types__info-link-container site-settings__info-link-container">
+						<InfoPopover position="left">
+							<ExternalLink href="https://support.wordpress.com/custom-post-types/" icon target="_blank">
+								{ translate( 'Learn more about Custom Content Types.' ) }
+							</ExternalLink>
+						</InfoPopover>
+					</div>
 
-				<Card className="custom-content-types__card site-settings">
-					<FormFieldset>
-						<div className="custom-content-types__info-link-container site-settings__info-link-container">
-							<InfoPopover position="left">
-								<ExternalLink href="https://support.wordpress.com/custom-post-types/" icon target="_blank">
-									{ translate( 'Learn more about Custom Content Types.' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-
-						{ this.renderTestimonialSettings() }
-						{ this.renderPortfolioSettings() }
-					</FormFieldset>
-				</Card>
-			</div>
+					{ this.renderTestimonialSettings() }
+					{ this.renderPortfolioSettings() }
+				</FormFieldset>
+			</Card>
 		);
 	}
 }

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormTextInput from 'components/forms/form-text-input';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isActivatingJetpackModule } from 'state/selectors';
@@ -73,9 +74,45 @@ class CustomContentTypes extends Component {
 				>
 					{ label }
 				</CompactFormToggle>
+
+				{ this.renderPostsPerPageField( name, label ) }
+
 				<FormSettingExplanation isIndented>
 					{ description }
 				</FormSettingExplanation>
+			</div>
+		);
+	}
+
+	renderPostsPerPageField( fieldName, postTypeLabel ) {
+		const {
+			fields,
+			onChangeField,
+			translate,
+		} = this.props;
+		const numberFieldName = fieldName + '_posts_per_page';
+		return (
+			<div className="custom-content-types__indented-form-field indented-form-field">
+				{ translate(
+					'Display {{field /}} %s per page load',
+					{
+						args: postTypeLabel.toLowerCase(),
+						components: {
+							field: (
+								<FormTextInput
+									name={ numberFieldName }
+									type="number"
+									step="1"
+									min="0"
+									id={ numberFieldName }
+									value={ 'undefined' === typeof fields[ numberFieldName ] ? 10 : fields[ numberFieldName ] }
+									onChange={ onChangeField( numberFieldName ) }
+									disabled={ this.isFormPending() }
+								/>
+							)
+						}
+					}
+				) }
 			</div>
 		);
 	}
@@ -153,6 +190,7 @@ CustomContentTypes.defaultProps = {
 
 CustomContentTypes.propTypes = {
 	handleAutosavingToggle: PropTypes.func.isRequired,
+	onChangeField: PropTypes.func.isRequired,
 	isSavingSettings: PropTypes.bool,
 	isRequestingSettings: PropTypes.bool,
 	fields: PropTypes.object,

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -129,7 +129,7 @@ class CustomContentTypes extends Component {
 		const fieldLabel = translate( 'Testimonials' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
-			'you can display them using the shortcode ( [testimonials] ).',
+			'you can display them using the shortcode [testimonials].',
 			{
 				components: {
 					link: <a href="https://support.wordpress.com/testimonials/" />
@@ -145,7 +145,7 @@ class CustomContentTypes extends Component {
 		const fieldLabel = translate( 'Portfolio Projects' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
-			'you can display them using the shortcode ( [portfolio] ).',
+			'you can display them using the shortcode [portfolio].',
 			{
 				components: {
 					link: <a href="https://support.wordpress.com/portfolios/" />

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -74,7 +74,7 @@ class CustomContentTypes extends Component {
 					{ label }
 				</CompactFormToggle>
 
-				{ this.renderPostsPerPageField( name, label ) }
+				{ this.renderPostsPerPageField( name, label, ! fields[ name ] ) }
 
 				<FormSettingExplanation isIndented>
 					{ description }
@@ -83,7 +83,7 @@ class CustomContentTypes extends Component {
 		);
 	}
 
-	renderPostsPerPageField( fieldName, postTypeLabel ) {
+	renderPostsPerPageField( fieldName, postTypeLabel, isDisabled = false ) {
 		const {
 			fields,
 			onChangeField,
@@ -106,7 +106,7 @@ class CustomContentTypes extends Component {
 									id={ numberFieldName }
 									value={ 'undefined' === typeof fields[ numberFieldName ] ? 10 : fields[ numberFieldName ] }
 									onChange={ onChangeField( numberFieldName ) }
-									disabled={ this.isFormPending() }
+									disabled={ this.isFormPending() || isDisabled }
 								/>
 							)
 						}

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -74,7 +74,7 @@ class CustomContentTypes extends Component {
 					{ label }
 				</CompactFormToggle>
 
-				{ this.renderPostsPerPageField( name, label, ! fields[ name ] ) }
+				{ this.renderPostsPerPageField( name, label ) }
 
 				<FormSettingExplanation isIndented>
 					{ description }
@@ -83,7 +83,7 @@ class CustomContentTypes extends Component {
 		);
 	}
 
-	renderPostsPerPageField( fieldName, postTypeLabel, isDisabled = false ) {
+	renderPostsPerPageField( fieldName, postTypeLabel ) {
 		const {
 			fields,
 			onChangeField,
@@ -106,7 +106,7 @@ class CustomContentTypes extends Component {
 									id={ numberFieldName }
 									value={ 'undefined' === typeof fields[ numberFieldName ] ? 10 : fields[ numberFieldName ] }
 									onChange={ onChangeField( numberFieldName ) }
-									disabled={ this.isFormPending() || isDisabled }
+									disabled={ this.isFormPending() || ! fields[ fieldName ] }
 								/>
 							)
 						}

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -142,7 +142,7 @@ class CustomContentTypes extends Component {
 
 	renderPortfolioSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'Portfolio projects' );
+		const fieldLabel = translate( 'Portfolio Projects' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
 			'you can display them using the shortcode ( [portfolios] ).',

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -145,7 +145,7 @@ class CustomContentTypes extends Component {
 		const fieldLabel = translate( 'Portfolio Projects' );
 		const fieldDescription = translate(
 			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
-			'you can display them using the shortcode ( [portfolios] ).',
+			'you can display them using the shortcode ( [portfolio] ).',
 			{
 				components: {
 					link: <a href="https://support.wordpress.com/portfolios/" />

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -127,6 +127,7 @@ class SiteSettingsFormWriting extends Component {
 
 				<CustomContentTypes
 					handleAutosavingToggle={ handleAutosavingToggle }
+					onChangeField={ onChangeField }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
@@ -196,7 +197,9 @@ const getFormSettings = settings => {
 		'default_post_format',
 		'custom-content-types',
 		'jetpack_testimonial',
+		'jetpack_testimonial_posts_per_page',
 		'jetpack_portfolio',
+		'jetpack_portfolio_posts_per_page',
 		'infinite-scroll',
 		'infinite_scroll',
 		'minileven',

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -125,6 +125,10 @@ class SiteSettingsFormWriting extends Component {
 					)
 				}
 
+				{
+					this.renderSectionHeader( translate( 'Custom content types' ) )
+				}
+
 				<CustomContentTypes
 					handleAutosavingToggle={ handleAutosavingToggle }
 					onChangeField={ onChangeField }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -90,7 +90,9 @@
 		}
 	}
 
-	.form-toggle__wrapper + p.form-setting-explanation.is-indented {
+	.form-toggle__wrapper + p.form-setting-explanation.is-indented,
+	.indented-form-field,
+	.indented-form-field + p.form-setting-explanation.is-indented {
 		margin-left: 36px;
 	}
 


### PR DESCRIPTION
This PR adds posts per page fields for Testimonials and Portfolio in the Custom Content Types card, as suggested in #13568. Since these need manual intervention in order to be saved, the PR also introduces a "Save Changes" button to the Custom Content Types card.

Since #14572 introduced back CPT support for WordPress.com sites, this means we'll be able to manage portfolio/testimonials posts per page for both Jetpack and WordPress.com sites 🎉 

It's worth to mention that #14574 introduces some behavioral changes and alters some of the copy in form field explanations that are below the toggles.

Before:
![](https://cldup.com/-8jB145nFA.png)

After:
![](https://cldup.com/y5PRViDVIH.png)

To test:
* Checkout this branch, or get it going on calypso.live
* Go to `/settings/writing/$site`, where `$site` is one of your WordPress.com sites.
* Verify the Testimonials and Portfolio posts per page values are correct (compare with the ones in writing settings in your site's wp-admin)
* Change the Testimonials and Portfolio posts per page values, click the Save button, and verify they save correctly.
* Test all of the above for a Jetpack site.