### PR TITLE
Themes: Show site selector for /upload url direct hit

### DIFF
--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -35,7 +35,7 @@ export default function( router ) {
 			loggedOut,
 			makeLayout
 		);
-		router( '/themes/upload/*', makeLayout );
+		router( '/themes/upload*', makeLayout );
 		// Redirect legacy (Atlas-based Theme Showcase v4) routes
 		router( [
 			'/themes/:site?/search/:search',

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -35,7 +35,7 @@ export default function( router ) {
 			loggedOut,
 			makeLayout
 		);
-		router( '/themes/upload*', makeLayout );
+		router( [ '/themes/upload', '/themes/upload/*' ], makeLayout );
 		// Redirect legacy (Atlas-based Theme Showcase v4) routes
 		router( [
 			'/themes/:site?/search/:search',

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -41,6 +41,8 @@ export default function( router ) {
 				makeLayout
 			);
 		} else {
+			router( '/themes/upload*', '/themes' );
+
 			const loggedOutRoutes = [
 				'/themes/:tier(free|premium)?',
 				'/themes/:tier(free|premium)?/filter/:filter',

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -41,7 +41,9 @@ export default function( router ) {
 				makeLayout
 			);
 		} else {
-			router( '/themes/upload*', '/themes' );
+			// No uploads when logged-out, so redirect to main showcase page
+			router( '/themes/upload', '/themes' );
+			router( '/themes/upload/*', '/themes' );
 
 			const loggedOutRoutes = [
 				'/themes/:tier(free|premium)?',


### PR DESCRIPTION
Logged-in visits to wordress.com/themes/upload were redirecting to /theme/upload and showing an 'empty' message.

Tweak the server routing so that this route is not redirected, and tweak client routing so that logged-out hits redirect to /themes.

**Before**
<img width="802" alt="screen shot 2017-06-02 at 14 22 54" src="https://cloud.githubusercontent.com/assets/7767559/26727510/129f9a98-479f-11e7-8ab8-a5958850102d.png">

**After**
<img width="750" alt="screen shot 2017-06-02 at 14 23 09" src="https://cloud.githubusercontent.com/assets/7767559/26727524/17639f0c-479f-11e7-87d4-8e01d2a9217b.png">

**To Test**
* Check /themes/upload logged-in and logged-out
* Also check /themes/upload/{site} logged-in and logged-out
* All other themes routes should work as before
