### PR TITLE
Editor: fixing TinyMCE 4.6.3 `lightgray` line-height import glitching Calypso 

### DIFF
--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -10,6 +10,11 @@ body {
 p {
 	margin: 0 0 24px 0;
 
+	.mce-content-body & {
+		/* To override lightgray/content.min.css */
+		line-height: inherit;
+	}
+
 	&:last-child {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
TinyMCE 4.6.3 from Core changed (for .com, on May 31) `line-height` from `inherit` to `1.2`: 

![screen shot 2017-06-02 at 14 18 46](https://cloud.githubusercontent.com/assets/4389/26728738/254b368a-47a3-11e7-8d13-5ead7e11f7c5.png)

This PR restores the correct height ("Before" above) by adding an override in our Calypso styling SCSS.

I'm not 100% confident about the cleanliness of this solution, as TinyMCE seems prefixing everything with `.mce-content-body` while we use clean `p`, so this issue might crop up again in the future. However, it works.

### To Test

1. Open My Sites → Posts
2. Either create a new post or edit one
3. Check the line height is now correct (as "Before" above).