### PR TITLE
Activity Log: New Dialog component for confirming Restore

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -377,6 +377,7 @@
 @import 'my-sites/stats/style';
 @import 'my-sites/stats/activity-log/style';
 @import 'my-sites/stats/activity-log-banner/style';
+@import 'my-sites/stats/activity-log-confirm-dialog/style';
 @import 'my-sites/stats/activity-log-day/style';
 @import 'my-sites/stats/activity-log-item/style';
 @import 'my-sites/stats/all-time/style';

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import Button from 'components/button';
+import Gridicon from 'gridicons';
+
+class ActivityLogConfirmDialog extends Component {
+	static propTypes = {
+		siteName: PropTypes.string.isRequired,
+	};
+
+	static defaultProps = {
+		siteName: 'YourAwesomeSite', // FIXME: real site name
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showDialog: true,
+		};
+
+		this.onCloseDialog = this.onCloseDialog.bind( this );
+	}
+
+	renderButtons() {
+		const { translate } = this.props;
+		return (
+			<div>
+				<Button onClick={ this.onCloseDialog }>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button primary scary onClick={ this.onCloseDialog }>
+					{ translate( 'Restore' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	onCloseDialog() {
+		this.setState( { showDialog: false } );
+	}
+
+	render() {
+		const {
+			translate,
+			siteName,
+		} = this.props;
+
+		return (
+			<Dialog
+				additionalClassNames="activity-log-confirm-dialog"
+				isVisible={ this.state.showDialog }
+			>
+				<h1>{ translate( 'Restore Site' ) }</h1>
+				<p className="activity-log-confirm-dialog__highlight">
+					{
+						translate(
+							'To proceed please confirm this restore on your site %(siteName)s',
+							{ args: { siteName } }
+						)
+					}
+				</p>
+
+				<div className="activity-log-confirm-dialog__line">
+					<Gridicon icon={ 'history' } />
+					{
+						translate( 'Restoring to {{b}}%(time)s{{/b}}', {
+							args: { time: '31 May, 2017 at 3:58 PM.', /* FIXME: real time */ },
+							components: { b: <b /> }
+						} )
+					}
+				</div>
+				<div className="activity-log-confirm-dialog__line">
+					<Gridicon icon={ 'notice' } />
+					{ translate( 'This will remove all content and options created or changed since then.' ) }
+				</div>
+
+				<div className="activity-log-confirm-dialog__button-wrap">
+					{ this.renderButtons() }
+				</div>
+
+				<a
+					className="activity-log-confirm-dialog__more-info-link"
+					href="#" // FIXME: real link
+				>
+					{ translate( 'Read More about Site Restores' ) }
+				</a>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( ActivityLogConfirmDialog );

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -20,15 +20,7 @@ class ActivityLogConfirmDialog extends Component {
 		siteName: 'YourAwesomeSite', // FIXME: real site name
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			showDialog: true,
-		};
-
-		this.onCloseDialog = this.onCloseDialog.bind( this );
-	}
+	state = { showDialog: true };
 
 	renderButtons() {
 		const { translate } = this.props;
@@ -44,9 +36,7 @@ class ActivityLogConfirmDialog extends Component {
 		);
 	}
 
-	onCloseDialog() {
-		this.setState( { showDialog: false } );
-	}
+	onCloseDialog = () => this.setState( { showDialog: false } );
 
 	render() {
 		const {

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -13,41 +13,52 @@ import Gridicon from 'gridicons';
 
 class ActivityLogConfirmDialog extends Component {
 	static propTypes = {
+		isVisible: PropTypes.bool.isRequired,
+		onClose: PropTypes.func.isRequired,
+		onConfirm: PropTypes.func.isRequired,
 		siteName: PropTypes.string.isRequired,
+		dateIsoString: PropTypes.string.isRequired,
+
+		// Localize
+		translate: PropTypes.func.isRequired,
+		moment: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
-		siteName: 'YourAwesomeSite', // FIXME: real site name
+		isVisible: false,
 	};
 
-	state = { showDialog: true };
-
 	renderButtons() {
-		const { translate } = this.props;
+		const {
+			onClose,
+			onConfirm,
+			translate,
+		} = this.props;
 		return (
 			<div>
-				<Button onClick={ this.onCloseDialog }>
+				<Button onClick={ onClose }>
 					{ translate( 'Cancel' ) }
 				</Button>
-				<Button primary scary onClick={ this.onCloseDialog }>
+				<Button primary scary onClick={ onConfirm }>
 					{ translate( 'Restore' ) }
 				</Button>
 			</div>
 		);
 	}
 
-	onCloseDialog = () => this.setState( { showDialog: false } );
-
 	render() {
 		const {
-			translate,
+			isVisible,
+			moment,
 			siteName,
+			dateIsoString,
+			translate,
 		} = this.props;
 
 		return (
 			<Dialog
 				additionalClassNames="activity-log-confirm-dialog"
-				isVisible={ this.state.showDialog }
+				isVisible={ isVisible }
 			>
 				<h1>{ translate( 'Restore Site' ) }</h1>
 				<p className="activity-log-confirm-dialog__highlight">
@@ -63,8 +74,10 @@ class ActivityLogConfirmDialog extends Component {
 					<Gridicon icon={ 'history' } />
 					{
 						translate( 'Restoring to {{b}}%(time)s{{/b}}', {
-							args: { time: '31 May, 2017 at 3:58 PM.', /* FIXME: real time */ },
-							components: { b: <b /> }
+							args: {
+								time: moment( dateIsoString ).format( 'LLL' ),
+							},
+							components: { b: <b /> },
 						} )
 					}
 				</div>

--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -1,0 +1,75 @@
+
+.activity-log-confirm-dialog.dialog.card {
+	text-align: center;
+	max-width: 400px;
+}
+
+.activity-log-confirm-dialog .dialog__content {
+	color: darken( $gray, 20% );
+
+	h1 {
+		color: $gray-dark;
+		font-size: 24px;
+		font-weight: 300;
+		height: 2em;
+		line-height: 32px;
+		margin-top: .5em;
+		margin-bottom: .5em;
+	}
+}
+
+.activity-log-confirm-dialog__highlight {
+	color: darken( $gray, 10% );
+	margin-bottom: 1.5em;
+	font-size: 16px;
+}
+
+.activity-log-confirm-dialog__line {
+	padding: 14px 24px 14px 44px;
+	text-align: left;
+	font-size: 13px;
+	border-bottom: 1px solid lighten( $gray, 25% );
+
+	&:first-of-type {
+		border-top: 1px solid lighten( $gray, 25% );
+	}
+
+	.gridicon {
+		float: left;
+		width: 18px;
+		height: 18px;
+		margin-left: -28px;
+	}
+}
+
+.activity-log-confirm-dialog__button-wrap {
+	margin-top: 32px;
+	margin-bottom:16px;
+
+	.button {
+		margin: 0 4px;
+	}
+}
+
+.activity-log-confirm-dialog__more-info-link {
+	font-size: 13px;
+}
+
+.activity-log-confirm-dialog__dialog__action-buttons {
+	overflow: hidden;
+	border-top: 1px solid lighten( $gray, 30% );
+	padding: 16px;
+	margin: 0 -24px -24px;
+	text-align: right;
+
+	.button {
+		margin-left: 10px;
+		min-width: 80px;
+
+		.is-left-aligned {
+			float: left;
+			margin-left: 0;
+			margin-right: 10px;
+		}
+	}
+}

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -8,6 +8,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import ActivityLogItem from '../activity-log-item';
@@ -17,12 +18,23 @@ class ActivityLogDay extends Component {
 		isRewindEnabled: PropTypes.bool,
 		logs: PropTypes.array.isRequired,
 		siteId: PropTypes.number,
-		dateString: PropTypes.string.isRequired,
+		dateIsoString: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
 		isRewindEnabled: true,
 	};
+
+	state = {
+		isRestoreConfirmDialogOpen: false,
+	};
+
+	handleRestoreClick = () => this.setState( { isRestoreConfirmDialogOpen: true } );
+
+	handleRestoreDialogClose = () => this.setState( { isRestoreConfirmDialogOpen: false } );
+
+	// FIXME: Handle confirm correctly
+	handleRestoreDialogConfirm = () => this.setState( { isRestoreConfirmDialogOpen: false } );
 
 	/**
 	 * Return a button to rewind to this point.
@@ -35,9 +47,10 @@ class ActivityLogDay extends Component {
 			<Button
 				primary={ 'primary' === type }
 				disabled={ ! this.props.isRewindEnabled }
+				onClick={ this.handleRestoreClick }
 				compact
 			>
-				<Gridicon icon={ 'history' } size={ 18 } />
+				<Gridicon icon="history" size={ 18 } />
 				{ this.props.translate( 'Rewind to this day' ) }
 			</Button>
 		);
@@ -50,13 +63,14 @@ class ActivityLogDay extends Component {
 	 */
 	getEventsHeading() {
 		const {
+			dateIsoString,
 			logs,
+			moment,
 			translate,
-			dateString
 		} = this.props;
 		return (
 			<div>
-				<div className="activity-log-day__day">{ dateString }</div>
+				<div className="activity-log-day__day">{ moment( dateIsoString ).format( 'LL' ) }</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,
@@ -69,8 +83,12 @@ class ActivityLogDay extends Component {
 
 	render() {
 		const {
-			logs
+			logs,
+			dateIsoString,
 		} = this.props;
+
+		// FIXME get real props
+		const siteName = 'Placeholder site name';
 
 		return (
 			<div className="activity-log-day">
@@ -97,6 +115,13 @@ class ActivityLogDay extends Component {
 						);
 					} ) }
 				</FoldableCard>
+				<ActivityLogConfirmDialog
+					isVisible={ this.state.isRestoreConfirmDialogOpen }
+					siteName={ siteName }
+					dateIsoString={ dateIsoString }
+					onClose={ this.handleRestoreDialogClose }
+					onConfirm={ this.handleRestoreDialogConfirm }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -19,7 +19,6 @@ import ActivityLogDay from '../activity-log-day';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import SuccessBanner from '../activity-log-banner/success-banner';
-import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 
 class ActivityLog extends Component {
 	componentDidMount() {
@@ -289,7 +288,7 @@ class ActivityLog extends Component {
 			( daily_logs, isoString ) => (
 				<ActivityLogDay
 					key={ isoString }
-					dateString={ moment( isoString ).format( 'LL' ) }
+					dateIsoString={ isoString }
 					logs={ daily_logs }
 					siteId={ siteId }
 					isRewindEnabled={ true }
@@ -307,7 +306,6 @@ class ActivityLog extends Component {
 					section="activity"
 				/>
 				{ this.renderBanner() }
-				<ActivityLogConfirmDialog />
 				<section className="activity-log__wrapper">
 					{ logsGroupedByDate }
 				</section>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -19,6 +19,7 @@ import ActivityLogDay from '../activity-log-day';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import SuccessBanner from '../activity-log-banner/success-banner';
+import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 
 class ActivityLog extends Component {
 	componentDidMount() {
@@ -306,6 +307,7 @@ class ActivityLog extends Component {
 					section="activity"
 				/>
 				{ this.renderBanner() }
+				<ActivityLogConfirmDialog />
 				<section className="activity-log__wrapper">
 					{ logsGroupedByDate }
 				</section>


### PR DESCRIPTION
New `ActivityLogConfirmDialog` component.  It mimics the structure and styles of the `DisconnectJetpackDialog` component.  

As mentioned in #14663, this component will be used when a restore request is given. 

![screen shot 2017-06-02 at 10 45 36 am](https://cloud.githubusercontent.com/assets/7129409/26731186/38141aba-4781-11e7-9bc5-85d9dac25568.png)

To do: 
- [ ] Pass real props
- [ ] Add tracking events
- [ ] Make the confirm button fire an action to perform the restore.  

Fixes: #14663