### PR TITLE
Publicize scheduling: Reformat connection list to be indexed by ID

### DIFF
--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get, includes, map, difference } from 'lodash';
+import { get, includes, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
 import Gridicon from 'gridicons';
@@ -147,10 +147,9 @@ class PostShare extends Component {
 			connections,
 		} = this.props;
 		if ( this.state.scheduledDate ) {
-			const servicesToPublish = difference(
-				connections.map( connection => connection.keyring_connection_ID ),
-				this.state.skipped
-			);
+			const servicesToPublish = connections
+				.filter( connection => this.state.skipped.indexOf( connection.keyring_connection_ID ) === -1 )
+				.map( connection => connection.ID );
 			this.props.schedulePostShareAction(
 				siteId,
 				postId,


### PR DESCRIPTION
This reformats list of connections passed to scheduled endpoint
It is now indexed by ID instead of keyring_connections_id.

Here the first one is actually after the change:

<img width="597" alt="zrzut ekranu 2017-06-02 o 17 24 02" src="https://cloud.githubusercontent.com/assets/3775068/26732918/8d3d231e-47b9-11e7-836c-411edf2f4dab.png">

It fixes 2 bugs 
- now the account appears properly in scheduled list
- It actually works with scheduling system

## Testing
- build with a flag `ENABLE_FEATURES=publicize-scheduling make run`
- site with business and social accounts connected
- go to post list
- click share
- click calendar
- pick a time one minute later
- click schedule
- confirm that now you see your action in scheduled list with proper handle
- wait after time has passed
- use `wpsh` to trigger waiting jobs:
`print_r(queue_async_job( array() , 'cron_publicize_scheduled_actions' ) );` and then `async-jobs/tester.php` the output
- confirm that shares have gone out