### PR TITLE
Pages: Guard against an error when site info isn't yet present

### DIFF
--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -44,10 +44,14 @@ var utils = {
 
 		if ( post.site_ID ) {
 			site = sites.getSite( post.site_ID );
+			if ( ! ( site && site.options ) ) {
+				// site info is still loading, just use what we already have until it does
+				return previewUrl;
+			}
 			if ( site.options.is_mapped_domain ) {
 				previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
 			}
-			if ( site.options && site.options.frame_nonce ) {
+			if ( site.options.frame_nonce ) {
 				parsed = url.parse( previewUrl, true );
 				parsed.query[ 'frame-nonce' ] = site.options.frame_nonce;
 				delete parsed.search;


### PR DESCRIPTION
When localStorage is empty & someone browses directly to `/pages/*`, a `TypeError` is occurring.

Reported at: https://github.com/Automattic/wp-calypso/pull/14613#pullrequestreview-41718986

This just uses the site info we have on hand until the site info loads.

## To Reproduce
* Run master branch without the conditional "sympathy" which randomly skips the hydration of cached state (if we don't do this, it will not occur reliably):
`ENABLE_FEATURES=no-force-sympathy make run`
* Browse to http://calypso.localhost:3000/pages (or on a specific site)
* do `localStorage.clear()` in your console
* quickly reload the page

You should see an error in your console (`Uncaught TypeError: Cannot read property 'options' of undefined`) & the pages will take longer to show.

## To Test

* Switch to this branch & repeat the above
* The error should not occur & the pages should load more quickly