### PR TITLE
Fix: Add client/extensions as root for server.

### DIFF
--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -55,7 +55,7 @@ function getExternals() {
 
 const webpackConfig = {
 	devtool: 'source-map',
-	entry: 'index.js',
+	entry: path.join( __dirname, 'index.js' ),
 	target: 'node',
 	output: {
 		path: path.join( __dirname, 'build' ),
@@ -93,7 +93,7 @@ const webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '', '.json', '.js', '.jsx' ],
-		root: [ path.join( __dirname, 'server' ), path.join( __dirname, 'client' ), __dirname ],
+		root: [ __dirname, path.join( __dirname, 'server' ), path.join( __dirname, 'client' ), path.join( __dirname, 'client', 'extensions' ) ],
 		modulesDirectories: [ 'node_modules' ]
 	},
 	node: {


### PR DESCRIPTION
This adds `client/extensions` as a root path for the server build. This
allows extension-based imports like is already allowed on the client.

Where this makes a difference is especially in the reducers and
sections, which are built by webpack loaders.

This also specifies the root directory for the index.js entry point,
because it was conflicting with `client/extensions/index.js`

To Test:

1. Go to an extension's `state/reducer.js` file and change an import from a relative path to an absolute one (e.g. `client/extensions/woocommerce/state/reducer.js`, change `'./ui/reducer'` to `'woocommerce/state/ui/reducer'`)
2. Run `npm start`. With this change, it should build. Without this change, it will not.
