### PR TITLE
Comments: Revert accidental removal of transitions

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -21,21 +21,23 @@
 .comment-detail__transition-enter {
 	opacity: 0.01;
 	visibility: hidden;
-}
-.comment-detail__transition-enter-active {
-	opacity: 1;
-	visibility: visible;
-	transition: all .15s linear;
-	transition-delay: .15s;
+
+	&.comment-detail__transition-enter-active {
+		opacity: 1;
+		visibility: visible;
+		transition: all .15s linear;
+		transition-delay: .15s;
+	}
 }
 .comment-detail__transition-leave {
 	opacity: 1;
 	visibility: visible;
-}
-.comment-detail__transition-leave-active {
-	opacity: 0.01;
-	visibility: hidden;
-	transition: all .15s linear;
+
+	&.comment-detail__transition-leave-active {
+		opacity: 0.01;
+		visibility: hidden;
+		transition: all .15s linear;
+	}
 }
 
 .comment-detail__author-avatar {

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -27,20 +27,22 @@
 .comment-list__transition-enter {
 	opacity: 0.01;
 	visibility: hidden;
-}
-.comment-list__transition-enter-active {
-	opacity: 1;
-	visibility: visible;
-	transition: all .15s linear;
-	transition-delay: .15s;
+
+	&.comment-list__transition-enter-active {
+		opacity: 1;
+		visibility: visible;
+		transition: all .15s linear;
+		transition-delay: .15s;
+	}
 }
 
 .comment-list__transition-leave {
 	opacity: 1;
 	visibility: visible;
-}
-.comment-list__transition-leave-active {
-	opacity: 0.01;
-	visibility: hidden;
-	transition: all 0.15s linear;
+
+	&.comment-list__transition-leave-active {
+		opacity: 0.01;
+		visibility: hidden;
+		transition: all 0.15s linear;
+	}
 }


### PR DESCRIPTION
A rushed last-minute change in #14555 accidentally killed the Comment Management transitions.
We indeed needed the extra specificity.