### PR TITLE
Reader: Wrap site meta info around Follow button

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -311,8 +311,12 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .search-stream .reader-subscription-list-item__byline {
 	margin-right: 0;
+
+	.reader-subscription-list-item__site-title::after {
+		width: 10%;
+	}
 }
 
-.search-stream {
+.search-stream .reader-subscription-list-item__site-excerpt {
 	margin-top: 3px;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -294,3 +294,25 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	padding-bottom: 10px;
 	width: 100%;
 }
+
+// Site Results
+.search-stream .reader-subscription-list-item__options {
+	position: absolute;
+		right: 15px;
+
+	@include breakpoint( ">660px" ) {
+		right: 0;
+	}
+}
+
+.search-stream .reader-subscription-list-item__site-title {
+	width: calc( 100% - 60px );
+}
+
+.search-stream .reader-subscription-list-item__byline {
+	margin-right: 0;
+}
+
+.search-stream {
+	margin-top: 3px;
+}


### PR DESCRIPTION
**Before:**
![screenshot 2017-06-02 17 36 57](https://cloud.githubusercontent.com/assets/4924246/26749149/a2c2e678-47ba-11e7-9c72-1b53fea71f2b.png)

**After:**
![screenshot 2017-06-02 19 52 09](https://cloud.githubusercontent.com/assets/4924246/26749996/ffebf8dc-47cc-11e7-9d5c-5e81a3a9c21a.png)

Related: https://github.com/Automattic/wp-calypso/pull/13198
