### PR TITLE
Limit style attributes to gallery elements

### DIFF
--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -9,14 +9,17 @@ export default function removeContentStyles( post, dom ) {
 	}
 
 	// if there are any specials in the post, skip it
-	if ( dom.querySelector( '.gallery, .tiled-gallery, blockquote[class^="instagram-"], blockquote[class^="twitter-"]' ) ) {
+	if ( dom.querySelector( 'blockquote[class^="instagram-"], blockquote[class^="twitter-"]' ) ) {
 		return post;
 	}
 
 	// remove most style attributes
 	const styled = dom.querySelectorAll( '[style]' );
 	forEach( styled, function( element ) {
-		element.removeAttribute( 'style' );
+		// Leave inline styles intact for gallery markup
+		if ( ! element.matches( '.gallery-row, .gallery-group' ) ) {
+			element.removeAttribute( 'style' );
+		}
 	} );
 
 	// remove all style elements

--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -21,16 +21,16 @@ export default function removeContentStyles( post, dom ) {
 		}
 	} );
 
-	// remove all style elements
+	// remove all style elements outside of galleries and embeds
 	forEach( dom.querySelectorAll( 'style' ), function( element ) {
 		if ( ! element.matches( whitelistSelector ) ) {
 			element.parentNode && element.parentNode.removeChild( element );
 		}
 	} );
 
-	// remove align from non images
+	// remove align from non images. Unlike above, img align is permitted anywhere.
 	forEach( dom.querySelectorAll( '[align]' ), element => {
-		if ( element.tagName !== 'IMG' && ! element.matches( whitelistSelector ) ) {
+		if ( element.tagName !== 'IMG' ) {
 			element.removeAttribute( 'align' );
 		}
 	} );

--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -30,7 +30,7 @@ export default function removeContentStyles( post, dom ) {
 
 	// remove align from non images
 	forEach( dom.querySelectorAll( '[align]' ), element => {
-		if ( element.tagName !== 'IMG' && !element.matches( whitelistSelector ) ) {
+		if ( element.tagName !== 'IMG' && ! element.matches( whitelistSelector ) ) {
 			element.removeAttribute( 'align' );
 		}
 	} );

--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -8,28 +8,29 @@ export default function removeContentStyles( post, dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
 
-	// if there are any specials in the post, skip it
-	if ( dom.querySelector( 'blockquote[class^="instagram-"], blockquote[class^="twitter-"]' ) ) {
-		return post;
-	}
+	// Whitelist the markup for galleries, Instagram, and Twitter. Styling will be allowed on elements that match this selector.
+	const whitelistSelector = '.gallery, .gallery *, .gallery-row, .gallery-row *, .gallery-group, .gallery-group *, ' +
+	'blockquote[class^="instagram-"], blockquote[class^="instagram-"] *, ' +
+	'blockquote[class^="twitter-"], blockquote[class^="twitter-"] *';
 
 	// remove most style attributes
 	const styled = dom.querySelectorAll( '[style]' );
 	forEach( styled, function( element ) {
-		// Leave inline styles intact for gallery markup
-		if ( ! element.matches( '.gallery-row, .gallery-group' ) ) {
+		if ( ! element.matches( whitelistSelector ) ) {
 			element.removeAttribute( 'style' );
 		}
 	} );
 
 	// remove all style elements
 	forEach( dom.querySelectorAll( 'style' ), function( element ) {
-		element.parentNode && element.parentNode.removeChild( element );
+		if ( ! element.matches( whitelistSelector ) ) {
+			element.parentNode && element.parentNode.removeChild( element );
+		}
 	} );
 
 	// remove align from non images
 	forEach( dom.querySelectorAll( '[align]' ), element => {
-		if ( element.tagName !== 'IMG' ) {
+		if ( element.tagName !== 'IMG' && !element.matches( whitelistSelector ) ) {
 			element.removeAttribute( 'align' );
 		}
 	} );

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -391,14 +391,39 @@ describe( 'index', function() {
 		it( 'leaves galleries intact', function( done ) {
 			normalizer(
 				{
-					content: '<style>.gallery{}</style><div class="gallery" style="width: 100000px"><div style="width:100px">some content</div></div>' //eslint-disable-line max-len
+					content: '<div class="gallery" style="width: 100000px"><style>.gallery{}</style><div style="width:100px">some content</div></div>' //eslint-disable-line max-len
 				},
 				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ], function( err, normalized ) {
-					assert.equal( normalized.content, '<style>.gallery{}</style><div class="gallery" style="width: 100000px"><div style="width:100px">some content</div></div>' ); //eslint-disable-line max-len
+					assert.equal( normalized.content, '<div class="gallery" style="width: 100000px"><style>.gallery{}</style><div style="width:100px">some content</div></div>' ); //eslint-disable-line max-len
 					done( err );
 				}
 			);
 		} );
+
+		it( 'leaves twitter emdeds intact', function( done ) {
+			normalizer(
+				{
+					content: '<div class="embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr"></p></blockquote><script async="" src="//platform.twitter.com/widgets.js" charset="utf-8"></script></div>' //eslint-disable-line max-len
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ], function( err, normalized ) {
+					assert.equal( normalized.content, '<div class="embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr"></p></blockquote><script async="" src="//platform.twitter.com/widgets.js" charset="utf-8"></script></div>' ); //eslint-disable-line max-len
+					done( err );
+				}
+			);
+		} );
+
+		it( 'leaves instagram emdeds intact', function( done ) {
+			normalizer(
+				{
+					content: '<blockquote class="instagram-media" style="background:#FFF;"><div style="padding:8px;"><p style="margin:8px 0 0 0;"> <a style="color:#000;"></a></p></div></blockquote>' //eslint-disable-line max-len
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.removeStyles ] ) ], function( err, normalized ) {
+					assert.equal( normalized.content, '<blockquote class="instagram-media" style="background:#FFF;"><div style="padding:8px;"><p style="margin:8px 0 0 0;"> <a style="color:#000;"></a></p></div></blockquote>' ); //eslint-disable-line max-len
+					done( err );
+				}
+			);
+		} );
+
 	} );
 
 	describe( 'content.makeImagesSafe', function() {


### PR DESCRIPTION
Instead of allowing all `style` attributes in posts with galleries, this limits the allowance to specific gallery elements within the post.

This should fix #13356 and similar issues with over-formatting of posts containing galleries.

I think the Instagram and Twitter items can probably receive similar treatment, but I haven't found examples of those for testing.