### PR TITLE
Docs: Added extra set up instruction to hello-world

### DIFF
--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -4,7 +4,11 @@ After learning a bit about the values of the project, let’s get a taste of the
 
 First [get setup with Calypso locally](../install.md) if you haven't already.
 
-Load [http://calypso.localhost:3000](http://calypso.localhost:3000/) in your browser. All good? Cool, now let’s build our _Hello, World!_.
+Load [http://calypso.localhost:3000](http://calypso.localhost:3000/) in your browser. 
+
+For this example to work, you need to have signed into WordPress **and** have already set up at least one site.
+
+All good? Cool, now let’s build our _Hello, World!_.
 
 ## Adding a new section
 


### PR DESCRIPTION
The Hello World doc may not be comprehensive, but it's a gentle, first stop for Calypso n00bs like myself who just want to get stuck into coding. 

Looks like the controller.siteSelection method checks if currentUser.site_count or currentUser.visible_site_count is 0, and hence it skips rendering the hello-world module.

The alternative might be to suggest just passing the helloWorldController to page:
`page( '/hello-world/:domain?', helloWorldController.helloWorld );
`
and setting the `enableLoggedOut` prop in the the section module to `true`:
```
if ( config.isEnabled( 'hello-world' ) ) {
	sections.push( {
		name: 'hello-world',
		paths: [ '/hello-world' ],
		module: 'my-sites/hello-world',
		enableLoggedOut: true
	} );
}
```

I guess the only benefit would be that people who don't want to immediately sign in and create a site can get something running straight away. ;)

Anyway, happy to hear any tips, or how a simple tutorial might be expanded in the future (tests, importing components, reduxing etc).

Cheers and keep up the great work. 