### PR TITLE
Webpack build monitor 

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -219,6 +219,7 @@
 @import 'components/vertical-nav/item/style';
 @import 'components/vertical-menu/style';
 @import 'components/web-preview/style';
+@import 'components/webpack-build-monitor/style';
 @import 'blocks/credit-card-form/style';
 @import 'devdocs/docs-example/style';
 @import 'devdocs/docs-selectors/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -166,6 +166,7 @@ $z-layers: (
 		'.guided-tours__overlay': 200050,
 		'.guided-tours__step': 201000,
 		'.wpcom-site__global-noscript': 300000, // JS off always visible
+		'.webpack-build-monitor': 99999999,
 		'#habla_window_div.habla_window_div_base': 99999999 //olark
 	),
 	'.ribbon': (

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -30,16 +30,15 @@ const reducer = ( state = IDLE, { message } ) => {
 			return BUILDING;
 		case '[HMR] App is up to date.':
 		case '[WDS] Nothing changed.':
-			// Once completed, set the status to idle unless there's an error
-			return state === ERROR ? ERROR : IDLE;
-		case '[WDS] Errors while compiling.':
-			return ERROR;
 		case '[WDS] App hot update...':
 		case 'Reloading CSS: ':
-			return IDLE;
+			// Once completed, set the status to idle unless there's an error
+			return state === ERROR || state === NEEDS_RELOAD ? state : IDLE;
+		case '[WDS] Errors while compiling.':
+			return ERROR;
 		case '[HMR] Cannot find update. Need to do a full reload!':
 		case `[HMR] The following modules couldn't be hot updated: (They would need a full reload!)`: // eslint-disable-line
-			return NEEDS_RELOAD;
+			return state === ERROR ? ERROR : NEEDS_RELOAD;
 	}
 	return state;
 };
@@ -57,7 +56,7 @@ console.log = wrapConsole( console.log );
 
 class WebpackBuildMonitor extends React.Component {
 	componentDidMount() {
-		this.unsubscribe = store.subscribe( () => this.setState( store.getState() ) );
+		this.unsubscribe = store.subscribe( () => this.setState( { status: store.getState() } ) );
 	}
 
 	componentWillUnmount() {

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -60,9 +60,9 @@ const reduce = combineReducers(
 );
 const store = createStore( reduce );
 
-const wrapConsole = fn => message => {
+const wrapConsole = fn => ( message, ...args ) => {
 	store.dispatch( { type: 'WebpackBuildLog', message } );
-	fn.call( this, message );
+	fn.call( window, message, ...args );
 };
 
 

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -1,0 +1,112 @@
+/* eslint-disable no-console */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Spinner from 'components/spinner';
+
+const CONNECTED = 'CONNECTED';
+const DISCONNECTED = 'DISCONNECTED';
+const STATUS_BUILDING = 'STATUS_BUILDING';
+const STATUS_ERROR = 'STATUS_ERROR';
+const STATUS_IDLE = 'STATUS_IDLE';
+
+// Reducer for the CSS build status
+const cssStatus = ( state = STATUS_IDLE, message ) => {
+	switch ( message ) {
+		case 'Building CSS…':
+			return STATUS_BUILDING;
+		case 'Reloading CSS: ':
+			return STATUS_IDLE;
+	}
+	return state;
+};
+
+// Reducer for the JS build status
+const jsStatus = ( state = STATUS_IDLE, message ) => {
+	switch ( message ) {
+		case '[WDS] App updated. Recompiling...':
+			return STATUS_BUILDING;
+		case '[HMR] App is up to date.':
+		case '[WDS] Nothing changed.':
+			// Once completed, set the status to idle unless there's an error
+			return state === STATUS_ERROR ? state : STATUS_IDLE;
+		case '[WDS] Errors while compiling.':
+			return STATUS_ERROR;
+	}
+	return state;
+};
+
+// Reducer for the Webpack Dev Server status
+const wdsStatus = ( state = CONNECTED, message ) => {
+	switch ( message ) {
+		case '[WDS] Disconnected!':
+			return DISCONNECTED;
+	}
+	return state;
+};
+
+// Reducer for the component state
+const getState = ( state = {}, message ) => {
+	return {
+		cssStatus: cssStatus( state.cssStatus, message ),
+		jsStatus: jsStatus( state.jsStatus, message ),
+		wdsStatus: wdsStatus( state.wdsStatus, message ),
+	};
+};
+
+class WebpackBuildMonitor extends React.Component {
+	constructor() {
+		super();
+		this.state = getState();
+
+		// Spy on console to watch for messages from Webpack Dev Server
+		console.error = this.wrapConsoleFn( console.error );
+		console.log = this.wrapConsoleFn( console.log );
+	}
+
+	wrapConsoleFn = ( fn ) => ( message ) => {
+		this.setState( getState( this.state, message ) );
+		fn.call( this, message );
+	}
+
+	render() {
+		if ( this.state.wdsStatus === DISCONNECTED ) {
+			return (
+				<div className="webpack-build-monitor is-error">
+					Dev server disconnected
+				</div>
+			);
+		}
+
+		if ( this.state.cssStatus === STATUS_ERROR || this.state.jsStatus === STATUS_ERROR ) {
+			return (
+				<div className="webpack-build-monitor is-error">
+					Build error
+				</div>
+			);
+		}
+
+		if ( this.state.cssStatus === STATUS_BUILDING || this.state.jsStatus === STATUS_BUILDING ) {
+			return (
+				<div className="webpack-build-monitor ">
+					<Spinner size={ 11 } className="webpack-build-monitor__spinner" />
+					Rebuilding
+				</div>
+			);
+		}
+
+		return null;
+	}
+}
+
+// QUESTIONS:
+// - Worth saying whether it's JS or CSS that's loading/errored?
+// - Worth adding a "dirty" state, or a fading message to confirm when HMR works?
+
+export default WebpackBuildMonitor;

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -44,7 +44,7 @@ const reducer = ( state = IDLE, { message } ) => {
 		return MESSAGE_STATUS_MAP[ message ]( state );
 	} else if ( isDoneBuilding( message ) ) {
 		return doneBuilding( state );
-	} else if ( needsReload ) {
+	} else if ( needsReload( message ) ) {
 		return NEEDS_RELOAD;
 	}
 

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { createStore } from 'redux';
 import classNames from 'classnames';
-import { startsWith, find, includes } from 'lodash';
+import { find, includes, startsWith } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -77,7 +77,7 @@ const STATUS_TEXTS = {
 	[ ERROR ]: 'Build error',
 	[ BUILDING_JS ]: 'Rebuilding Javascript',
 	[ BUILDING_CSS ]: 'Rebuilding CSS',
-	[ BUILDING_BOTH ]: 'Rebuiling both JS and CSS',
+	[ BUILDING_BOTH ]: 'Rebuilding JS and CSS',
 };
 
 class WebpackBuildMonitor extends React.Component {

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /* eslint-disable no-console */
 
 /**
@@ -52,9 +53,9 @@ const reducer = ( state = IDLE, { type, message } ) => {
 		return state;
 	}
 
-	const getNextState = find( MESSAGE_STATUS_MAP, ( v, messagePrefix ) =>
-		startsWith( message, messagePrefix ),
-	) || identity;
+	const getNextState =
+		find( MESSAGE_STATUS_MAP, ( v, messagePrefix ) => startsWith( message, messagePrefix ) ) ||
+		identity;
 
 	return getNextState( state );
 };

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import { createStore } from 'redux';
-import cx from 'classnames';
+import classNames from 'classnames';
 import { startsWith, find, includes } from 'lodash';
 
 /**
@@ -94,7 +94,7 @@ class WebpackBuildMonitor extends React.Component {
 			return null;
 		}
 
-		const classnames = cx( 'webpack-build-monitor', {
+		const classnames = classNames( 'webpack-build-monitor', {
 			'is-error': status === ERROR || status === DISCONNECTED,
 		} );
 

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -1,0 +1,36 @@
+.webpack-build-monitor {
+	position: fixed;
+	bottom: 20px;
+	right: 83px;
+	z-index: z-index( 'root', '.webpack-build-monitor' );
+	font-size: 9px;
+	padding: 4px 6px;
+	background: $alert-green;
+	color: $white;
+	text-transform: uppercase;
+	letter-spacing: 1px;
+	border-radius: 3px;
+	display: flex;
+	align-items: center;
+	line-height: 11px;
+	&.is-error {
+		background: $alert-red;
+	}
+}
+
+.webpack-build-monitor__spinner {
+	margin-right: 6px;
+}
+
+.webpack-build-monitor__text {
+	margin-left: 6px;
+	display: block;
+}
+
+.webpack-build-monitor .spinner__progress {
+	fill: currentColor;
+}
+
+.webpack-build-monitor .spinner__border {
+	fill: lighten( $alert-green, 30% );
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -168,6 +168,7 @@ Layout = React.createClass( {
 					isActive={ translator.isActivated() } />
 				{ this.renderPreview() }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
+				{ 'development' === config( 'env' ) && <AsyncLoad require="components/webpack-build-monitor" /> }
 				<AppBanner />
 			</div>
 		);

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -168,7 +168,7 @@ Layout = React.createClass( {
 					isActive={ translator.isActivated() } />
 				{ this.renderPreview() }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
-				{ 'development' === config( 'env' ) && <AsyncLoad require="components/webpack-build-monitor" /> }
+				{ 'development' === process.env.NODE_ENV && <AsyncLoad require="components/webpack-build-monitor" /> }
 				<AppBanner />
 			</div>
 		);


### PR DESCRIPTION
Builds off of this pr: https://github.com/Automattic/wp-calypso/pull/13968

Changes made:
- use process.env.NODE_ENV so that it can be fully removed from production builds (won't even generate the chunks now).  Using `config( 'env' )` does a runtime check whereas using the value in process.env.NODE_ENV can be stripped out by webpack.
- collapsed all of the reducers to a single reducer because I don't think we need the granularity
- moved to using _actual_ redux instead of the redux-like state management
- added support for a "needs refresh" status.  this required also wrapping `console.warn`
- before I believe there was a bug in wrapConsolFn where it didn't pass along the rest of the args.  that means anything that was `console.error( '%s', subThing )` would break

To test:
- [ ] make sure the async chunk isn't built or included in docker
- [ ] test turning off webpack server/ turning back on, erroring, fixing errors, etc.

![build-monitor](https://user-images.githubusercontent.com/4656974/28220002-ee2e293c-688b-11e7-9c96-bcd547043019.gif)
