### PR TITLE
Plugins: Use Redux connection status for PluginInstallButton

### DIFF
--- a/client/components/data/query-site-connection-status/index.jsx
+++ b/client/components/data/query-site-connection-status/index.jsx
@@ -12,7 +12,7 @@ import { requestConnectionStatus } from 'state/sites/connection/actions';
 
 class QuerySiteConnectionStatus extends Component {
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
+		siteId: PropTypes.number,
 		requestingSiteConnectionStatus: PropTypes.bool,
 		requestConnectionStatus: PropTypes.func
 	};
@@ -28,7 +28,7 @@ class QuerySiteConnectionStatus extends Component {
 	}
 
 	request( props ) {
-		if ( props.requestingSiteConnectionStatus ) {
+		if ( props.requestingSiteConnectionStatus || ! props.siteId ) {
 			return;
 		}
 

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -24,6 +24,7 @@ export class PluginInstallButton extends Component {
 		const {
 			isEmbed,
 			selectedSite,
+			siteId,
 			isInstalling,
 			plugin,
 			notices,
@@ -40,13 +41,13 @@ export class PluginInstallButton extends Component {
 		if ( isEmbed ) {
 			recordGAEvent( 'Plugins', 'Install with no selected site', 'Plugin Name', plugin.slug );
 			recordEvent( 'calypso_plugin_install_click_from_sites_list', {
-				site: selectedSite.ID,
+				site: siteId,
 				plugin: plugin.slug
 			} );
 		} else {
 			recordGAEvent( 'Plugins', 'Install on selected Site', 'Plugin Name', plugin.slug );
 			recordEvent( 'calypso_plugin_install_click_from_plugin_info', {
-				site: selectedSite.ID,
+				site: siteId,
 				plugin: plugin.slug
 			} );
 		}
@@ -55,13 +56,13 @@ export class PluginInstallButton extends Component {
 	updateJetpackAction = () => {
 		const {
 			plugin,
-			selectedSite,
+			siteId,
 			recordGoogleEvent: recordGAEvent,
 			recordTracksEvent: recordEvent } = this.props;
 
 		recordGAEvent( 'Plugins', 'Update jetpack', 'Plugin Name', plugin.slug );
 		recordEvent( 'calypso_plugin_update_jetpack', {
-			site: selectedSite.ID,
+			site: siteId,
 			plugin: plugin.slug
 		} );
 	}
@@ -79,7 +80,7 @@ export class PluginInstallButton extends Component {
 	}
 
 	getDisabledInfo() {
-		const { translate, selectedSite } = this.props;
+		const { translate, selectedSite, siteId } = this.props;
 		if ( ! selectedSite ) { // we don't have enough info
 			return null;
 		}
@@ -106,7 +107,7 @@ export class PluginInstallButton extends Component {
 						{ translate( 'Plugin install is not available for %(site)s:', { args: { site: selectedSite.title } } ) }
 					</p>
 				);
-				const list = reasons.map( ( reason, i ) => ( <li key={ 'reason-i' + i + '-' + selectedSite.ID } >{ reason }</li> ) );
+				const list = reasons.map( ( reason, i ) => ( <li key={ 'reason-i' + i + '-' + siteId } >{ reason }</li> ) );
 				html.push( <ul className="plugin-action__disabled-info-list" key="reason-shell-list">{ list }</ul> );
 			} else {
 				html.push(
@@ -250,11 +251,11 @@ export class PluginInstallButton extends Component {
 	}
 
 	render() {
-		const { selectedSite } = this.props;
+		const { siteId } = this.props;
 
 		return (
 			<div>
-				{ selectedSite && <QuerySiteConnectionStatus siteId={ selectedSite.ID } /> }
+				<QuerySiteConnectionStatus siteId={ siteId } />
 				{ this.renderNoticeOrButton() }
 			</div>
 		);
@@ -272,9 +273,14 @@ PluginInstallButton.propTypes = {
 };
 
 export default connect(
-	( state, ownProps ) => ( {
-		siteIsConnected: ownProps.selectedSite && getSiteConnectionStatus( state, ownProps.selectedSite.ID ),
-	} ),
+	( state, { selectedSite } ) => {
+		const siteId = selectedSite && selectedSite.ID;
+
+		return {
+			siteId,
+			siteIsConnected: getSiteConnectionStatus( state, siteId ),
+		};
+	},
 	{
 		recordGoogleEvent,
 		recordTracksEvent

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -16,6 +16,8 @@ import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import utils from 'lib/site/utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import QuerySiteConnectionStatus from 'components/data/query-site-connection-status';
+import { getSiteConnectionStatus } from 'state/selectors';
 
 export class PluginInstallButton extends Component {
 	installAction = () => {
@@ -233,16 +235,29 @@ export class PluginInstallButton extends Component {
 		);
 	}
 
-	render() {
-		const { selectedSite } = this.props;
-		if ( selectedSite.unreachable ) {
+	renderNoticeOrButton() {
+		const { selectedSite, siteIsConnected } = this.props;
+
+		if ( siteIsConnected === false ) {
 			return this.renderUnreachableNotice();
 		}
+
 		if ( ! selectedSite.canUpdateFiles ) {
 			return this.renderDisabledNotice();
 		}
 
 		return this.renderButton();
+	}
+
+	render() {
+		const { selectedSite } = this.props;
+
+		return (
+			<div>
+				{ selectedSite && <QuerySiteConnectionStatus siteId={ selectedSite.ID } /> }
+				{ this.renderNoticeOrButton() }
+			</div>
+		);
 	}
 }
 
@@ -257,7 +272,9 @@ PluginInstallButton.propTypes = {
 };
 
 export default connect(
-	null,
+	( state, ownProps ) => ( {
+		siteIsConnected: ownProps.selectedSite && getSiteConnectionStatus( state, ownProps.selectedSite.ID ),
+	} ),
 	{
 		recordGoogleEvent,
 		recordTracksEvent


### PR DESCRIPTION
In #13221 we removed usage of `site.callHome()` in favor of its Redux counterpart, however there was one occurrence of `.unreachable` that we missed - in `PluginInstallButton`. This PR updates this to use Redux, too.

To test:
* Checkout this branch.
* Pick a Jetpack site `$site` that doesn't have WP Super Cache installed.
* Go to `/plugins/wp-super-cache/$site`.
* Verify the plugin **Install** button looks properly.
* Break the site, for example by `exit`ing somewhere in the WP core, a plugin or a theme - this will simulate that connection is broken.
* Verify the **Site Unreachable** notice looks is displayed instead of the **Install** button.
* Test with a clean Redux state and verify it works with no warnings/errors.

![](https://cldup.com/RH7Te1oPWv.png)

![](https://cldup.com/Z1OCGfJ6cJ.png)