### PR TITLE
Revert "Posts list: Post Preview button shows the front page of the site, instead of the post itself"

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -356,23 +356,8 @@ export default connect(
 			editUrl: getEditorPath( state, post.site_ID, post.ID, 'post' ),
 			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
-			selectedSiteId,
-
-			/*
-			 * getPostPreviewUrl() relies on the post to be in Redux.
-			 *
-			 * There is an out of sync issue, because the posts list is fetched
-			 * through Flux and the Redux store is not filled with the proper
-			 * Posts data.
-			 *
-			 * This is a hack to work around that issue for the moment. It must
-			 * be removed when the posts list is updated to fetch the posts
-			 * through the newer QueryPosts component.
-			 *
-			 * FIXME(biskobe,mcsf): undo hack
-			 * //previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
-			 */
-			previewUrl: getPostPreviewUrl( state, null, null, post )
+			previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
+			selectedSiteId
 		};
 	},
 	{ setPreviewUrl, setLayoutFocus }

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -421,21 +421,13 @@ export function getEditedPostSlug( state, siteId, postId ) {
  * Returns the most reliable preview URL for the post by site ID, post ID pair,
  * or null if a preview URL cannot be determined.
  *
- * @param  {Object}  state     Global state tree
- * @param  {Number}  siteId    Site ID
- * @param  {Number}  postId    Post ID
- * @param  {Object}  [rawPost] Raw post object. See wp-calypso#14456
- * @return {?String}           Post preview URL
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  postId Post ID
+ * @return {?String}        Post preview URL
  */
-export function getPostPreviewUrl( state, siteId, postId, rawPost = null ) {
-	const shouldUseRawPost = siteId === null &&
-		postId === null &&
-		rawPost !== null;
-
-	const post = shouldUseRawPost
-		? rawPost
-		: getSitePost( state, siteId, postId );
-
+export function getPostPreviewUrl( state, siteId, postId ) {
+	const post = getSitePost( state, siteId, postId );
 	if ( ! post ) {
 		return null;
 	}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#14456

Got the following in stage:

```Mixed Content: The page at 'https://wordpress.com/posts/lamda.blog' was loaded over HTTPS, but requested an insecure resource 'http://lamda.blog/2017/01/15/of-vocabulary-and-contracts/?iframe=true&theme_preview=true&frame-nonce=eabad4b27c&cachebust=0'. This request has been blocked; the content must be served over HTTPS.```