### PR TITLE
API: add endpoints for external media

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -257,6 +257,25 @@ UndocumentedSite.prototype.getConnection = function( connectionId ) {
 };
 
 /**
+ * Upload an external media item to the WordPress media library
+ *
+ * @param {string} service - external media service name (i.e 'google_photos')
+ * @param {array} files - array of external media file IDs
+ *
+ * @return {Object} promise - resolves on completion of the GET request
+ */
+UndocumentedSite.prototype.uploadExternalMedia = function( service, files ) {
+	debug( '/sites/:site_id:/external-media-upload query' );
+
+	return this.wpcom.req.post( {
+		path: '/sites/' + this._id + '/external-media-upload',
+	}, {
+		external_ids: files,
+		service
+	} );
+};
+
+/**
  * Runs Theme Setup (Headstart).
  *
  * @return {Promise} A Promise to resolve when complete.

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2311,6 +2311,21 @@ Undocumented.prototype.initiateTransfer = function( siteId, plugin, theme, onPro
 };
 
 /**
+ * Returns a list of media from an external media service. Similar to Site.mediaList in use, but
+ * with a more restricted set of query params.
+ *
+ * @param {Object} query - Media query, supports 'path', 'search', 'max', 'page_handle', and 'source'
+ * @param {Function} fn - The callback function
+ *
+ * @returns {Promise} promise for handling result
+ */
+Undocumented.prototype.externalMediaList = function( query, fn ) {
+	debug( `/meta/external-media/${ query.source }` );
+
+	return this.wpcom.req.get( `/meta/external-media/${ query.source }`, query, fn );
+};
+
+/**
  * Fetch the status of an Automated Transfer.
  *
  * @param {int} siteId -- the ID of the site being transferred


### PR DESCRIPTION
Adds external media endpoints to Calypso.

- Retrieve a list of external media, given a service name and other query parameters
- Copy media items from an external service to the WP media library