### PR TITLE
Comments: Add action faker

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -20,7 +20,7 @@ export const CommentDetailActions = ( {
 	edit,
 	commentIsLiked,
 	commentStatus,
-	deleteForever,
+	deleteCommentPermanently,
 	toggleApprove,
 	toggleLike,
 	toggleSpam,
@@ -99,7 +99,7 @@ export const CommentDetailActions = ( {
 			{ hasAction( commentStatus, 'delete' ) &&
 				<a
 					className="comment-detail__action-delete"
-					onClick={ deleteForever }
+					onClick={ deleteCommentPermanently }
 				>
 					<Gridicon icon="trash" />
 					<span>{ translate( 'Delete Permanently' ) }</span>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -19,7 +19,7 @@ export const CommentDetailHeader = ( {
 	commentContent,
 	commentIsLiked,
 	commentStatus,
-	deleteForever,
+	deleteCommentPermanently,
 	edit,
 	isBulkEdit,
 	isExpanded,
@@ -41,7 +41,7 @@ export const CommentDetailHeader = ( {
 					edit={ edit }
 					commentIsLiked={ commentIsLiked }
 					commentStatus={ commentStatus }
-					deleteForever={ deleteForever }
+					deleteCommentPermanently={ deleteCommentPermanently }
 					toggleApprove={ toggleApprove }
 					toggleLike={ toggleLike }
 					toggleSpam={ toggleSpam }

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { keyBy, omit } from 'lodash';
+
+export const CommentFaker = WrappedCommentList => class extends Component {
+	state = {
+		comments: {},
+	};
+
+	componentWillMount() {
+		if ( this.props.comments.length ) {
+			this.setState( { comments: keyBy( this.props.comments, 'ID' ) } );
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! this.props.comments.length ) {
+			this.setState( { comments: keyBy( nextProps.comments, 'ID' ) } );
+		}
+	}
+
+	deleteCommentPermanently = commentId => this.setState( { comments: omit( this.state.comments, commentId ) } );
+
+	setCommentLike = ( commentId, likeValue ) => {
+		const comment = this.state.comments[ commentId ];
+
+		// If like changes to true, also approve the comment
+		this.setState( {
+			comments: {
+				...this.state.comments,
+				[ commentId ]: {
+					...comment,
+					i_like: likeValue,
+					status: likeValue ? 'approved' : comment.status,
+				}
+			},
+		} );
+	}
+
+	setCommentStatus = ( commentId, status ) => {
+		const comment = this.state.comments[ commentId ];
+
+		// If the comment is not approved anymore, also remove the like, otherwise keep its previous value
+		this.setState( {
+			comments: {
+				...this.state.comments,
+				[ commentId ]: {
+					...comment,
+					i_like: 'approved' === status ? comment.i_like : false,
+					status,
+				}
+			},
+		} );
+	}
+
+	toggleCommentLike = commentId => {
+		const comment = this.state.comments[ commentId ];
+		const likeValue = ! comment.i_like;
+
+		// If like changes to true, also approve the comment
+		this.setState( {
+			comments: {
+				...this.state.comments,
+				[ commentId ]: {
+					...comment,
+					i_like: likeValue,
+					status: likeValue ? 'approved' : comment.status,
+				}
+			},
+		} );
+	}
+
+	render() {
+		return (
+			<WrappedCommentList
+				{ ...this.props }
+				comments={ this.state.comments }
+				deleteCommentPermanently={ this.deleteCommentPermanently }
+				setCommentLike={ this.setCommentLike }
+				setCommentStatus={ this.setCommentStatus }
+				toggleCommentLike={ this.toggleCommentLike }
+			/>
+		);
+	}
+};
+
+export default CommentFaker;

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { keyBy, omit } from 'lodash';
+import { get, keyBy, omit } from 'lodash';
 
 /**
  * `CommentFaker` is a HOC to easily test the Comments Management without the necessity of real data or actions.
@@ -64,22 +64,10 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 		} );
 	}
 
-	toggleCommentLike = commentId => {
-		const comment = this.state.comments[ commentId ];
-		const likeValue = ! comment.i_like;
-
-		// If like changes to true, also approve the comment
-		this.setState( {
-			comments: {
-				...this.state.comments,
-				[ commentId ]: {
-					...comment,
-					i_like: likeValue,
-					status: likeValue ? 'approved' : comment.status,
-				}
-			},
-		} );
-	}
+	toggleCommentLike = commentId => this.setCommentLike(
+		commentId,
+		! get( this.state.comments, [ commentId, 'i_like' ], false )
+	);
 
 	render() {
 		return (

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -19,18 +19,18 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 	};
 
 	componentWillMount() {
-		if ( this.props.comments.length ) {
-			this.setState( { comments: keyBy( this.props.comments, 'ID' ) } );
-		}
+		this.getCommentsFromProps( this.props );
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! this.props.comments.length ) {
-			this.setState( { comments: keyBy( nextProps.comments, 'ID' ) } );
+			this.getCommentsFromProps( nextProps );
 		}
 	}
 
 	deleteCommentPermanently = commentId => this.setState( { comments: omit( this.state.comments, commentId ) } );
+
+	getCommentsFromProps = ( { comments } ) => this.setState( { comments: keyBy( comments, 'ID' ) } );
 
 	setCommentLike = ( commentId, likeValue ) => {
 		const comment = this.state.comments[ commentId ];

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { get, keyBy, omit } from 'lodash';
+import { get, keyBy, omit, values } from 'lodash';
 
 /**
  * `CommentFaker` is a HOC to easily test the Comments Management without the necessity of real data or actions.
@@ -73,7 +73,7 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 		return (
 			<WrappedCommentList
 				{ ...this.props }
-				comments={ this.state.comments }
+				comments={ values( this.state.comments ) }
 				deleteCommentPermanently={ this.deleteCommentPermanently }
 				setCommentLike={ this.setCommentLike }
 				setCommentStatus={ this.setCommentStatus }

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -4,6 +4,15 @@
 import React, { Component } from 'react';
 import { keyBy, omit } from 'lodash';
 
+/**
+ * `CommentFaker` is a HOC to easily test the Comments Management without the necessity of real data or actions.
+ *
+ * It takes the comments passed via props (with mock data, Redux-connected, etc.) and puts them in its internal state.
+ * Then passes them and various actions (status and like setters) to the actual comment list component.
+ *
+ * Once data and actions will be completely Reduxified, it will be enough to remove the `CommentFaker` call
+ * and use the `mapDispatchToProps` actions instead, leaving this component still useful for testing purposes.
+ */
 export const CommentFaker = WrappedCommentList => class extends Component {
 	state = {
 		comments: {},

--- a/client/blocks/comment-detail/docs/example.jsx
+++ b/client/blocks/comment-detail/docs/example.jsx
@@ -9,7 +9,7 @@ import { map } from 'lodash';
  */
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
-import { CommentFaker } from 'my-sites/comments/comment-list';
+import CommentFaker from './comment-faker';
 
 // Mock data
 const mockComment = {

--- a/client/blocks/comment-detail/docs/example.jsx
+++ b/client/blocks/comment-detail/docs/example.jsx
@@ -52,10 +52,10 @@ const CommentList = ( {
 	toggleCommentLike,
 } ) =>
 	<div>
-		{ map( comments, ( comment, index ) =>
+		{ map( comments, comment =>
 			<CommentDetail
-				key={ index }
-				{ ...comment }
+				comment={ comment }
+				key={ comment.ID }
 				setCommentStatus={ setCommentStatus }
 				siteId={ mockSite.id }
 				toggleCommentLike={ toggleCommentLike }

--- a/client/blocks/comment-detail/docs/example.jsx
+++ b/client/blocks/comment-detail/docs/example.jsx
@@ -2,118 +2,73 @@
  * External dependencies
  */
 import React from 'react';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
+import { CommentFaker } from 'my-sites/comments/comment-list';
 
 // Mock data
-const mockAuthor = {
-	avatarUrl: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?s=96&d=mm&r=G',
-	displayName: 'Test User',
-	email: 'test@test.com',
-	id: 12345678,
-	ip: '127.0.0.1',
-	isBlocked: false,
-	url: 'http://discover.wordpress.com',
-	username: 'testuser',
-};
-
 const mockComment = {
+	author: {
+		avatar_URL: 'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?s=96&d=mm&r=G',
+		email: 'test@test.com',
+		ID: 12345678,
+		ip: '127.0.0.1',
+		isBlocked: false,
+		name: 'Test User',
+		nice_name: 'testuser',
+		URL: 'http://discover.wordpress.com',
+	},
 	content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Contemnit enim disserendi elegantiam, confuse loquitur. Suo genere perveniant ad extremum; Id mihi magnum videtur. Vide, quantum, inquam, fallare, Torquate. Aliter homines, aliter philosophos loqui putas oportere? Perge porro; Quibus ego vehementer assentior. Tubulo putas dicere? Sed ille, ut dixi, vitiose. Refert tamen, quo modo. Quid nunc honeste dicit? Scrupulum, inquam, abeunti; Quam si explicavisset, non tam haesitaret. Sed quid sentiat, non videtis. At enim sequor utilitatem. Si longus, levis.',
 	date: '2017-05-12 16:00:00',
-	id: 12345678,
-	isLiked: false,
+	ID: 12345678,
+	i_like: false,
+	post: {
+		author: { name: 'Test User' },
+		title: 'Test Post',
+		link: 'http://discover.wordpress.com',
+	},
 	replied: true,
 	status: 'approved',
-};
-
-const mockPost = {
-	authorDisplayName: 'Test User',
-	title: 'Test Post',
-	url: 'http://discover.wordpress.com',
-};
+}
 
 const mockSite = {
 	id: 3584907,
 };
 
+const mockComments = [
+	{ ...mockComment, ID: 1 },
+	{ ...mockComment, ID: 2 },
+	{ ...mockComment, ID: 3 },
+];
+
+const CommentList = ( {
+	comments,
+	setCommentLike,
+	setCommentStatus,
+} ) =>
+	<div>
+		{ map( comments, ( comment, index ) =>
+			<CommentDetail
+				key={ index }
+				{ ...comment }
+				setCommentStatus={ setCommentStatus }
+				siteId={ mockSite.id }
+				toggleCommentLike={ () => setCommentLike( comment.ID, ! comment.i_like ) }
+			/>
+		) }
+	</div>;
+
+const CommentListFake = CommentFaker( CommentList );
 
 export const CommentDetailExample = () =>
 	<div>
 		<CommentDetailPlaceholder />
-
-		<CommentDetail
-			authorAvatarUrl={ mockAuthor.avatarUrl }
-			authorDisplayName={ mockAuthor.displayName }
-			authorEmail={ mockAuthor.email }
-			authorId={ mockAuthor.id }
-			authorIp={ mockAuthor.ip }
-			authorIsBlocked={ mockAuthor.isBlocked }
-			authorUrl={ mockAuthor.url }
-			authorUsername={ mockAuthor.username }
-
-			commentContent={ mockComment.content }
-			commentDate={ mockComment.date }
-			commentId={ mockComment.id }
-			commentIsLiked={ mockComment.isLiked }
-			commentStatus={ mockComment.status }
-			repliedToComment={ mockComment.replied }
-
-			postAuthorDisplayName={ mockPost.authorDisplayName }
-			postTitle={ mockPost.title }
-			postUrl={ mockPost.url }
-
-			siteId={ mockSite.id }
-		/>
-		<CommentDetail
-			authorAvatarUrl={ mockAuthor.avatarUrl }
-			authorDisplayName={ mockAuthor.displayName }
-			authorEmail={ mockAuthor.email }
-			authorId={ mockAuthor.id }
-			authorIp={ mockAuthor.ip }
-			authorIsBlocked={ mockAuthor.isBlocked }
-			authorUrl={ mockAuthor.url }
-			authorUsername={ mockAuthor.username }
-
-			commentContent={ mockComment.content }
-			commentDate={ mockComment.date }
-			commentId={ mockComment.id }
-			commentIsLiked={ mockComment.isLiked }
-			commentStatus={ mockComment.status }
-			repliedToComment={ mockComment.replied }
-
-			postAuthorDisplayName={ mockPost.authorDisplayName }
-			postTitle={ mockPost.title }
-			postUrl={ mockPost.url }
-
-			siteId={ mockSite.id }
-		/>
-		<CommentDetail
-			authorAvatarUrl={ mockAuthor.avatarUrl }
-			authorDisplayName={ mockAuthor.displayName }
-			authorEmail={ mockAuthor.email }
-			authorId={ mockAuthor.id }
-			authorIp={ mockAuthor.ip }
-			authorIsBlocked={ mockAuthor.isBlocked }
-			authorUrl={ mockAuthor.url }
-			authorUsername={ mockAuthor.username }
-
-			commentContent={ mockComment.content }
-			commentDate={ mockComment.date }
-			commentId={ mockComment.id }
-			commentIsLiked={ mockComment.isLiked }
-			commentStatus={ mockComment.status }
-			repliedToComment={ mockComment.replied }
-
-			postAuthorDisplayName={ mockPost.authorDisplayName }
-			postTitle={ mockPost.title }
-			postUrl={ mockPost.url }
-
-			siteId={ mockSite.id }
-		/>
+		<CommentListFake comments={ mockComments } />
 	</div>;
 
 CommentDetailExample.displayName = 'CommentDetail';

--- a/client/blocks/comment-detail/docs/example.jsx
+++ b/client/blocks/comment-detail/docs/example.jsx
@@ -48,8 +48,8 @@ const mockComments = [
 
 const CommentList = ( {
 	comments,
-	setCommentLike,
 	setCommentStatus,
+	toggleCommentLike,
 } ) =>
 	<div>
 		{ map( comments, ( comment, index ) =>
@@ -58,7 +58,7 @@ const CommentList = ( {
 				{ ...comment }
 				setCommentStatus={ setCommentStatus }
 				siteId={ mockSite.id }
-				toggleCommentLike={ () => setCommentLike( comment.ID, ! comment.i_like ) }
+				toggleCommentLike={ toggleCommentLike }
 			/>
 		) }
 	</div>;

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -30,6 +30,7 @@ export class CommentDetail extends Component {
 		commentId: PropTypes.number,
 		commentIsLiked: PropTypes.bool,
 		commentStatus: PropTypes.string,
+		deleteCommentPermanently: PropTypes.func,
 		isBulkEdit: PropTypes.bool,
 		postAuthorDisplayName: PropTypes.string,
 		postTitle: PropTypes.string,
@@ -107,7 +108,7 @@ export class CommentDetail extends Component {
 			commentDate,
 			commentIsLiked,
 			commentStatus,
-			deleteForever,
+			deleteCommentPermanently,
 			isBulkEdit,
 			postAuthorDisplayName,
 			postTitle,
@@ -140,7 +141,7 @@ export class CommentDetail extends Component {
 					commentContent={ commentContent }
 					commentIsLiked={ commentIsLiked }
 					commentStatus={ commentStatus }
-					deleteForever={ deleteForever }
+					deleteCommentPermanently={ deleteCommentPermanently }
 					isBulkEdit={ isBulkEdit }
 					isExpanded={ isExpanded }
 					toggleApprove={ this.toggleApprove }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -189,7 +189,7 @@ const mapStateToProps = ( state, ownProps ) => ( {
 	authorUsername: get( ownProps, 'author.nice_name' ),
 	commentContent: ownProps.content,
 	commentDate: ownProps.date,
-	commentId: ownProps.commentId,
+	commentId: ownProps.ID,
 	commentIsLiked: ownProps.i_like,
 	commentStatus: ownProps.status,
 	postAuthorDisplayName: get( ownProps, 'post.author.name' ),

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -179,25 +179,32 @@ export class CommentDetail extends Component {
 	}
 }
 
-const mapStateToProps = ( state, ownProps ) => ( {
-	authorAvatarUrl: get( ownProps, 'author.avatar_URL' ),
-	authorDisplayName: get( ownProps, 'author.name' ),
-	authorEmail: get( ownProps, 'author.email' ),
-	authorId: get( ownProps, 'author.ID' ),
-	authorIp: get( ownProps, 'author.ip' ), // TODO: not available in the current data structure
-	authorIsBlocked: get( ownProps, 'author.isBlocked' ), // TODO: not available in the current data structure
-	authorUrl: get( ownProps, 'author.URL' ),
-	authorUsername: get( ownProps, 'author.nice_name' ),
-	commentContent: ownProps.content,
-	commentDate: ownProps.date,
-	commentId: ownProps.ID,
-	commentIsLiked: ownProps.i_like,
-	commentStatus: ownProps.status,
-	postAuthorDisplayName: get( ownProps, 'post.author.name' ),
-	postTitle: get( ownProps, 'post.title' ),
-	postUrl: get( ownProps, 'post.link' ),
-	repliedToComment: ownProps.replied, // TODO: not available in the current data structure
-	siteId: ownProps.siteId,
-} );
+const mapStateToProps = ( state, ownProps ) => {
+	// TODO: replace with
+	// `const comment = ownProps.comment || getComment( ownProps.commentId );`
+	// when the selector is ready.
+	const comment = ownProps.comment;
+
+	return ( {
+		authorAvatarUrl: get( comment, 'author.avatar_URL' ),
+		authorDisplayName: get( comment, 'author.name' ),
+		authorEmail: get( comment, 'author.email' ),
+		authorId: get( comment, 'author.ID' ),
+		authorIp: get( comment, 'author.ip' ), // TODO: not available in the current data structure
+		authorIsBlocked: get( comment, 'author.isBlocked' ), // TODO: not available in the current data structure
+		authorUrl: get( comment, 'author.URL' ),
+		authorUsername: get( comment, 'author.nice_name' ),
+		commentContent: comment.content,
+		commentDate: comment.date,
+		commentId: comment.ID,
+		commentIsLiked: comment.i_like,
+		commentStatus: comment.status,
+		postAuthorDisplayName: get( comment, 'post.author.name' ),
+		postTitle: get( comment, 'post.title' ),
+		postUrl: get( comment, 'post.link' ),
+		repliedToComment: comment.replied, // TODO: not available in the current data structure
+		siteId: comment.siteId,
+	} );
+};
 
 export default connect( mapStateToProps )( CommentDetail );

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -68,14 +68,19 @@ export class CommentDetail extends Component {
 
 	blockUser = () => {
 		this.setState( { authorIsBlocked: ! this.state.authorIsBlocked } );
-	};
+	}
+
+	deleteCommentPermanently = () => {
+		const { commentId, deleteCommentPermanently } = this.props;
+		deleteCommentPermanently( commentId );
+	}
 
 	edit = () => noop;
 
 	toggleApprove = () => {
 		const { commentId, commentStatus, setCommentStatus } = this.props;
 		setCommentStatus( commentId, 'approved' === commentStatus ? 'unapproved' : 'approved' );
-	};
+	}
 
 	toggleExpanded = () => {
 		this.setState( { isExpanded: ! this.state.isExpanded } );
@@ -84,17 +89,17 @@ export class CommentDetail extends Component {
 	toggleLike = () => {
 		const { commentId, toggleCommentLike } = this.props;
 		toggleCommentLike( commentId );
-	};
+	}
 
 	toggleSpam = () => {
 		const { commentId, commentStatus, setCommentStatus } = this.props;
 		setCommentStatus( commentId, 'spam' === commentStatus ? 'approved' : 'spam' );
-	};
+	}
 
 	toggleTrash = () => {
 		const { commentId, commentStatus, setCommentStatus } = this.props;
 		setCommentStatus( commentId, 'trash' === commentStatus ? 'approved' : 'trash' );
-	};
+	}
 
 	render() {
 		const {
@@ -108,7 +113,6 @@ export class CommentDetail extends Component {
 			commentDate,
 			commentIsLiked,
 			commentStatus,
-			deleteCommentPermanently,
 			isBulkEdit,
 			postAuthorDisplayName,
 			postTitle,
@@ -141,7 +145,7 @@ export class CommentDetail extends Component {
 					commentContent={ commentContent }
 					commentIsLiked={ commentIsLiked }
 					commentStatus={ commentStatus }
-					deleteCommentPermanently={ deleteCommentPermanently }
+					deleteCommentPermanently={ this.deleteCommentPermanently }
 					isBulkEdit={ isBulkEdit }
 					isExpanded={ isExpanded }
 					toggleApprove={ this.toggleApprove }

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -23,6 +23,7 @@ import CalendarButton from 'blocks/calendar-button/docs/example';
 import CalendarPopover from 'blocks/calendar-popover/docs/example';
 import AuthorSelector from 'blocks/author-selector/docs/example';
 import CommentButtons from 'blocks/comment-button/docs/example';
+import CommentDetail from 'blocks/comment-detail/docs/example';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog/docs/example';
 import FollowButton from 'blocks/follow-button/docs/example';
 import LikeButtons from 'blocks/like-button/docs/example';
@@ -110,6 +111,7 @@ export default React.createClass( {
 					<CalendarButton />
 					<CalendarPopover />
 					<CommentButtons />
+					<CommentDetail />
 					<DisconnectJetpackDialog />
 					<CreditCardForm />
 					<FollowButton />

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -150,13 +150,13 @@ export class CommentList extends Component {
 				>
 					{ map( filteredComments, comment =>
 						<CommentDetail
+							comment={ comment }
 							deleteCommentPermanently={ this.deleteCommentPermanently( comment.ID ) }
 							isBulkEdit={ isBulkEdit }
 							key={ `comment-${ siteId }-${ comment.ID }` }
 							setCommentStatus={ this.setCommentStatus }
 							siteId={ siteId }
 							toggleCommentLike={ this.toggleCommentLike }
-							{ ...comment }
 						/>
 					) }
 				</ReactCSSTransitionGroup>

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -150,7 +150,6 @@ export class CommentList extends Component {
 				>
 					{ map( filteredComments, comment =>
 						<CommentDetail
-							commentId={ comment.ID }
 							deleteForever={ this.deleteForever( comment.ID ) }
 							isBulkEdit={ isBulkEdit }
 							key={ `comment-${ siteId }-${ comment.ID }` }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -38,7 +38,7 @@ export class CommentList extends Component {
 		isBulkEdit: false,
 	};
 
-	deleteCommentPermanently = commentId => () => {
+	deleteCommentPermanently = commentId => {
 		this.props.removeNotice( `comment-notice-${ commentId }` );
 		this.showNotice( commentId, 'delete', 'trash' );
 
@@ -152,7 +152,7 @@ export class CommentList extends Component {
 					{ map( filteredComments, comment =>
 						<CommentDetail
 							comment={ comment }
-							deleteCommentPermanently={ this.deleteCommentPermanently( comment.ID ) }
+							deleteCommentPermanently={ this.deleteCommentPermanently }
 							isBulkEdit={ isBulkEdit }
 							key={ `comment-${ siteId }-${ comment.ID }` }
 							setCommentStatus={ this.setCommentStatus }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, get, map, size } from 'lodash';
+import { filter, find, get, map, size } from 'lodash';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 /**
@@ -24,7 +24,7 @@ import EmptyContent from 'components/empty-content';
 
 export class CommentList extends Component {
 	static propTypes = {
-		comments: PropTypes.object,
+		comments: PropTypes.array,
 		deleteCommentPermanently: PropTypes.func,
 		setCommentLike: PropTypes.func,
 		setCommentStatus: PropTypes.func,
@@ -60,7 +60,7 @@ export class CommentList extends Component {
 	}
 
 	setCommentStatus = ( commentId, status, options = { showNotice: true } ) => {
-		const comment = this.props.comments[ commentId ];
+		const comment = find( this.props.comments, [ 'ID', commentId ] );
 
 		if ( status === comment.status ) {
 			return;
@@ -108,7 +108,7 @@ export class CommentList extends Component {
 	toggleBulkEdit = () => this.setState( { isBulkEdit: ! this.state.isBulkEdit } );
 
 	toggleCommentLike = commentId => {
-		const comment = this.props.comments[ commentId ];
+		const comment = find( this.props.comments, [ 'ID', commentId ] );
 
 		if ( 'unapproved' === comment.status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -187,11 +187,17 @@ export class CommentList extends Component {
 	}
 }
 
-const CommentFaker = WrappedCommentList => class extends Component {
+export const CommentFaker = WrappedCommentList => class extends Component {
 	state = {
 		comments: {},
 		isBulkEdit: false,
 	};
+
+	componentWillMount() {
+		if ( this.props.comments.length ) {
+			this.setState( { comments: keyBy( this.props.comments, 'ID' ) } );
+		}
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( ! this.props.comments.length ) {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -29,6 +29,7 @@ export class CommentList extends Component {
 		setCommentStatus: PropTypes.func,
 		siteId: PropTypes.number,
 		status: PropTypes.string,
+		toggleCommentLike: PropTypes.func,
 		translate: PropTypes.func,
 	};
 
@@ -107,14 +108,13 @@ export class CommentList extends Component {
 
 	toggleCommentLike = commentId => {
 		const comment = this.props.comments[ commentId ];
-		const newLikeValue = ! comment.i_like;
 
 		if ( 'unapproved' === comment.status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
 			this.showNotice( commentId, 'approved', 'unapproved' );
 		}
 
-		this.props.setCommentLike( commentId, newLikeValue );
+		this.props.toggleCommentLike( commentId );
 	}
 
 	render() {
@@ -237,6 +237,22 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 		} );
 	}
 
+	toggleCommentLike = commentId => {
+		const comment = this.state.comments[ commentId ];
+		const likeValue = ! comment.i_like;
+		// If like changes to true, also approve the comment
+		this.setState( {
+			comments: {
+				...this.state.comments,
+				[ commentId ]: {
+					...comment,
+					i_like: likeValue,
+					status: likeValue ? 'approved' : comment.status,
+				}
+			},
+		} );
+	}
+
 	render() {
 		return (
 			<WrappedCommentList
@@ -245,6 +261,7 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 				deleteComment={ this.deleteComment }
 				setCommentLike={ this.setCommentLike }
 				setCommentStatus={ this.setCommentStatus }
+				toggleCommentLike={ this.toggleCommentLike }
 			/>
 		);
 	}

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -24,7 +24,7 @@ import EmptyContent from 'components/empty-content';
 export class CommentList extends Component {
 	static propTypes = {
 		comments: PropTypes.object,
-		deleteComment: PropTypes.func,
+		deleteCommentPermanently: PropTypes.func,
 		setCommentLike: PropTypes.func,
 		setCommentStatus: PropTypes.func,
 		siteId: PropTypes.number,
@@ -37,7 +37,7 @@ export class CommentList extends Component {
 		isBulkEdit: false,
 	};
 
-	deleteForever = commentId => () => {
+	deleteCommentPermanently = commentId => () => {
 		this.props.removeNotice( `comment-notice-${ commentId }` );
 		this.showNotice( commentId, 'delete', 'trash' );
 
@@ -150,7 +150,7 @@ export class CommentList extends Component {
 				>
 					{ map( filteredComments, comment =>
 						<CommentDetail
-							deleteForever={ this.deleteForever( comment.ID ) }
+							deleteCommentPermanently={ this.deleteCommentPermanently( comment.ID ) }
 							isBulkEdit={ isBulkEdit }
 							key={ `comment-${ siteId }-${ comment.ID }` }
 							setCommentStatus={ this.setCommentStatus }
@@ -258,7 +258,7 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 			<WrappedCommentList
 				{ ...this.props }
 				comments={ this.state.comments }
-				deleteComment={ this.deleteComment }
+				deleteCommentPermanently={ this.deleteCommentPermanently }
 				setCommentLike={ this.setCommentLike }
 				setCommentStatus={ this.setCommentStatus }
 				toggleCommentLike={ this.toggleCommentLike }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, get, keyBy, map, omit, size } from 'lodash';
+import { filter, get, map, size } from 'lodash';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 /**
@@ -18,6 +18,7 @@ import { getNotices } from 'state/notices/selectors';
 import getSiteComments from 'state/selectors/get-site-comments';
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
+import CommentFaker from 'blocks/comment-detail/docs/comment-faker';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
 
@@ -186,86 +187,6 @@ export class CommentList extends Component {
 		);
 	}
 }
-
-export const CommentFaker = WrappedCommentList => class extends Component {
-	state = {
-		comments: {},
-		isBulkEdit: false,
-	};
-
-	componentWillMount() {
-		if ( this.props.comments.length ) {
-			this.setState( { comments: keyBy( this.props.comments, 'ID' ) } );
-		}
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( ! this.props.comments.length ) {
-			this.setState( { comments: keyBy( nextProps.comments, 'ID' ) } );
-		}
-	}
-
-	deleteCommentPermanently = commentId => this.setState( { comments: omit( this.state.comments, commentId ) } );
-
-	setCommentLike = ( commentId, likeValue ) => {
-		const comment = this.state.comments[ commentId ];
-		// If like changes to true, also approve the comment
-		this.setState( {
-			comments: {
-				...this.state.comments,
-				[ commentId ]: {
-					...comment,
-					i_like: likeValue,
-					status: likeValue ? 'approved' : comment.status,
-				}
-			},
-		} );
-	}
-
-	setCommentStatus = ( commentId, status ) => {
-		const comment = this.state.comments[ commentId ];
-		// If the comment is not approved anymore, also remove the like, otherwise keep its previous value
-		this.setState( {
-			comments: {
-				...this.state.comments,
-				[ commentId ]: {
-					...comment,
-					i_like: 'approved' === status ? comment.i_like : false,
-					status,
-				}
-			},
-		} );
-	}
-
-	toggleCommentLike = commentId => {
-		const comment = this.state.comments[ commentId ];
-		const likeValue = ! comment.i_like;
-		// If like changes to true, also approve the comment
-		this.setState( {
-			comments: {
-				...this.state.comments,
-				[ commentId ]: {
-					...comment,
-					i_like: likeValue,
-					status: likeValue ? 'approved' : comment.status,
-				}
-			},
-		} );
-	}
-
-	render() {
-		return (
-			<WrappedCommentList
-				{ ...this.props }
-				comments={ this.state.comments }
-				deleteCommentPermanently={ this.deleteCommentPermanently }
-				setCommentLike={ this.setCommentLike }
-				setCommentStatus={ this.setCommentStatus }
-				toggleCommentLike={ this.toggleCommentLike }
-			/>
-		);
-	}
-};
 
 const mapStateToProps = ( state, { siteId } ) => {
 	const comments = getSiteComments( state, siteId );


### PR DESCRIPTION
Incidentally fixes #14581

Introduce a `CommentFaker` HOC to easily test the Comments Management without the necessity of real data or actions.

See: https://github.com/Automattic/wp-calypso/pull/14593#issuecomment-305203184

`CommentFaker` takes the comments passed via props (with mock data, Redux-connected, etc.) and puts them in its internal state.
Then passes them and various actions (status and like setters) to the actual comment list component.
Once data and actions are completely Reduxified, it will be enough to remove the `CommentFaker` call and use the `mapDispatchToProps` actions instead.

## Notes:

- I've added two different methods to set the comment like.
Once we're set on one version, we can easily delete the other and adapt the structure in no time.
  - `toggleCommentLike( commentId )`: this is the function currently expected by `CommentDetail`.
  - `setCommentLike( commentId, likeValue )`: explicitly set the like to a defined value. This is likely the function that will be provided by the API and Redux.

- I've not included the notice related actions in the `CommentFaker` as I consider their implementation pretty much final.