### PR TITLE
Framework: Remove sites-list from ProfileLinksAddWordPress

### DIFF
--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -11,15 +11,13 @@ import FormButton from 'components/forms/form-button';
 import Notice from 'components/notice';
 import Site from 'blocks/site';
 import sitesFactory from 'lib/sites-list';
-import eventRecorder from 'me/event-recorder';
+import { recordCheckboxEvent, recordClickEvent } from 'me/event-recorder';
 
 const sites = sitesFactory();
 
 export default React.createClass( {
 
 	displayName: 'ProfileLinksAddWordPress',
-
-	mixins: [ eventRecorder ],
 
 	// an empty initial state is required to keep render and handleCheckedChange
 	// code simpler / easier to maintain
@@ -146,7 +144,7 @@ export default React.createClass( {
 					<li
 						key={ site.ID }
 						className="profile-links-add-wordpress__item"
-						onClick={ this.recordCheckboxEvent( 'Add WordPress Site' ) }
+						onClick={ recordCheckboxEvent( 'Add WordPress Site' ) }
 					>
 						<input
 							className="profile-links-add-wordpress__checkbox"
@@ -178,14 +176,14 @@ export default React.createClass( {
 				{ this.possiblyRenderError() }
 				<FormButton
 					disabled={ ( 0 === checkedCount ) ? true : false }
-					onClick={ this.recordClickEvent( 'Add WordPress Sites Button' ) }
+					onClick={ recordClickEvent( 'Add WordPress Sites Button' ) }
 				>
 					{ this.translate( 'Add Site', 'Add Sites', { count: checkedCount } ) }
 				</FormButton>
 				<FormButton
 					className="profile-links-add-wordpress__cancel"
 					isPrimary={ false }
-					onClick={ this.recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
+					onClick={ recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
 				>
 					{ this.translate( 'Cancel' ) }
 				</FormButton>
@@ -207,7 +205,7 @@ export default React.createClass( {
 									jetpackLink: <a
 													href="#"
 													className="profile-links-add-wordpress__jetpack-link"
-													onClick={ this.recordClickEvent( 'Jetpack Link in Profile Links', this.onJetpackMe ) }
+													onClick={ recordClickEvent( 'Jetpack Link in Profile Links', this.onJetpackMe ) }
 												/>
 								}
 							}
@@ -215,14 +213,14 @@ export default React.createClass( {
 					}
 				</p>
 				<FormButton
-					onClick={ this.recordClickEvent( 'Create Sites Button in Profile Links', this.onCreateSite ) }
+					onClick={ recordClickEvent( 'Create Sites Button in Profile Links', this.onCreateSite ) }
 					>
 					{ this.translate( 'Create Site' ) }
 				</FormButton>
 				<FormButton
 					className="profile-links-add-wordpress__cancel"
 					isPrimary={ false }
-					onClick={ this.recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
+					onClick={ recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
 				>
 					{ this.translate( 'Cancel' ) }
 				</FormButton>

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,28 +16,25 @@ import { recordCheckboxEvent, recordClickEvent } from 'me/event-recorder';
 
 const sites = sitesFactory();
 
-export default React.createClass( {
-
-	displayName: 'ProfileLinksAddWordPress',
-
+class ProfileLinksAddWordPress extends Component {
 	// an empty initial state is required to keep render and handleCheckedChange
 	// code simpler / easier to maintain
-	getInitialState() {
-		return {};
-	},
+	state = {};
 
-	handleCheckedChanged( event ) {
+	handleCheckedChanged = ( event ) => {
 		const updates = {};
 		updates[ event.target.name ] = event.target.checked;
 		this.setState( updates );
-	},
+	};
 
-	onSelect( inputName, event ) {
-		const updates = {};
-		event.preventDefault();
-		updates[ inputName ] = ! this.state[ inputName ];
-		this.setState( updates );
-	},
+	onSelect = ( inputName ) => {
+		return ( event ) => {
+			const updates = {};
+			event.preventDefault();
+			updates[ inputName ] = ! this.state[ inputName ];
+			this.setState( updates );
+		};
+	};
 
 	getCheckedCount() {
 		let checkedCount = 0;
@@ -47,9 +45,9 @@ export default React.createClass( {
 			}
 		}
 		return checkedCount;
-	},
+	}
 
-	onAddableSubmit( event ) {
+	onAddableSubmit = ( event ) => {
 		const links = [];
 		let siteID, site, inputName;
 
@@ -67,37 +65,38 @@ export default React.createClass( {
 		}
 
 		this.props.userProfileLinks.addProfileLinks( links, this.onSubmitResponse );
-	},
+	};
 
-	onCancel( event ) {
+	onCancel = ( event ) => {
 		event.preventDefault();
 		this.props.onCancel();
-	},
+	};
 
-	onCreateSite( event ) {
+	onCreateSite = ( event ) => {
 		event.preventDefault();
 		window.open( config( 'signup_url' ) + '?ref=me-profile-links' );
 		this.props.onCancel();
-	},
+	};
 
-	onJetpackMe( event ) {
+	onJetpackMe = ( event ) => {
 		event.preventDefault();
 		window.open( 'http://jetpack.me/' );
 		this.props.onCancel();
-	},
+	};
 
-	onSubmitResponse( error, data ) {
+	onSubmitResponse = ( error, data ) => {
+		const { translate } = this.props;
 		if ( error ) {
 			this.setState(
 				{
-					lastError: this.translate( 'Unable to add any links right now. Please try again later.' )
+					lastError: translate( 'Unable to add any links right now. Please try again later.' )
 				}
 			);
 			return;
 		} else if ( data.malformed ) {
 			this.setState(
 				{
-					lastError: this.translate( 'An unexpected error occurred. Please try again later.' )
+					lastError: translate( 'An unexpected error occurred. Please try again later.' )
 				}
 			);
 			return;
@@ -107,13 +106,13 @@ export default React.createClass( {
 		}
 
 		this.props.onSuccess();
-	},
+	};
 
-	clearLastError() {
+	clearLastError = () => {
 		this.setState( {
 			lastError: false
 		} );
-	},
+	};
 
 	possiblyRenderError() {
 		if ( ! this.state.lastError ) {
@@ -128,7 +127,7 @@ export default React.createClass( {
 				{ this.state.lastError }
 			</Notice>
 		);
-	},
+	}
 
 	renderAddableSites() {
 		return (
@@ -155,20 +154,21 @@ export default React.createClass( {
 						<Site
 							site={ site }
 							indicator={ false }
-							onSelect={ this.onSelect.bind( this, inputName ) } />
+							onSelect={ this.onSelect( inputName ) } />
 					</li>
 				);
 			} )
 		);
-	},
+	}
 
 	renderAddableSitesForm() {
+		const { translate } = this.props;
 		const checkedCount = this.getCheckedCount();
 
 		return (
 			<form className="profile-links-add-wordpress" onSubmit={ this.onAddableSubmit }>
 				<p>
-					{ this.translate( 'Please select one or more sites to add to your profile.' ) }
+					{ translate( 'Please select one or more sites to add to your profile.' ) }
 				</p>
 				<ul className="profile-links-add-wordpress__list">
 					{ this.renderAddableSites() }
@@ -178,27 +178,29 @@ export default React.createClass( {
 					disabled={ ( 0 === checkedCount ) ? true : false }
 					onClick={ recordClickEvent( 'Add WordPress Sites Button' ) }
 				>
-					{ this.translate( 'Add Site', 'Add Sites', { count: checkedCount } ) }
+					{ translate( 'Add Site', 'Add Sites', { count: checkedCount } ) }
 				</FormButton>
 				<FormButton
 					className="profile-links-add-wordpress__cancel"
 					isPrimary={ false }
 					onClick={ recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
 				>
-					{ this.translate( 'Cancel' ) }
+					{ translate( 'Cancel' ) }
 				</FormButton>
 			</form>
 		);
-	},
+	}
 
 	renderInvitationForm() {
+		const { translate } = this.props;
+
 		return (
 			<form>
 				<p>
 					{
-						this.translate(
+						translate(
 							'You have no public sites on WordPress.com yet, but if you like you ' +
-							'can create one now.  You may also add self-hosted WordPress ' +
+							'can create one now. You may also add self-hosted WordPress ' +
 							'sites here after installing {{jetpackLink}}Jetpack{{/jetpackLink}} on them.',
 							{
 								components: {
@@ -215,18 +217,18 @@ export default React.createClass( {
 				<FormButton
 					onClick={ recordClickEvent( 'Create Sites Button in Profile Links', this.onCreateSite ) }
 					>
-					{ this.translate( 'Create Site' ) }
+					{ translate( 'Create Site' ) }
 				</FormButton>
 				<FormButton
 					className="profile-links-add-wordpress__cancel"
 					isPrimary={ false }
 					onClick={ recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
 				>
-					{ this.translate( 'Cancel' ) }
+					{ translate( 'Cancel' ) }
 				</FormButton>
 			</form>
 		);
-	},
+	}
 
 	render() {
 		return (
@@ -235,4 +237,6 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default localize( ProfileLinksAddWordPress );

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -12,9 +12,9 @@ import { keyBy } from 'lodash';
 import config from 'config';
 import FormButton from 'components/forms/form-button';
 import Notice from 'components/notice';
-import Site from 'blocks/site';
-import { recordCheckboxEvent, recordClickEvent } from 'me/event-recorder';
+import { recordClickEvent } from 'me/event-recorder';
 import { getPublicSites, getSites } from 'state/selectors';
+import ProfileLinksAddWordPressSite from './site';
 
 class ProfileLinksAddWordPress extends Component {
 	// an empty initial state is required to keep render and handleCheckedChange
@@ -28,12 +28,9 @@ class ProfileLinksAddWordPress extends Component {
 	};
 
 	onSelect = ( inputName ) => {
-		return ( event ) => {
-			const updates = {};
-			event.preventDefault();
-			updates[ inputName ] = ! this.state[ inputName ];
-			this.setState( updates );
-		};
+		const updates = {};
+		updates[ inputName ] = ! this.state[ inputName ];
+		this.setState( updates );
 	};
 
 	getCheckedCount() {
@@ -143,22 +140,13 @@ class ProfileLinksAddWordPress extends Component {
 				}
 
 				return (
-					<li
-						key={ site.ID }
-						className="profile-links-add-wordpress__item"
-						onClick={ recordCheckboxEvent( 'Add WordPress Site' ) }
-					>
-						<input
-							className="profile-links-add-wordpress__checkbox"
-							type="checkbox"
-							name={ inputName }
-							onChange={ this.handleCheckedChanged }
-							checked={ checkedState } />
-						<Site
-							site={ site }
-							indicator={ false }
-							onSelect={ this.onSelect( inputName ) } />
-					</li>
+					<ProfileLinksAddWordPressSite
+						key={ inputName }
+						site={ site }
+						checked={ checkedState }
+						onChange={ this.handleCheckedChanged }
+						onSelect={ this.onSelect }
+					/>
 				);
 			} )
 		);

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -42,7 +42,7 @@ class ProfileLinksAddWordPress extends Component {
 		this.setState( updates );
 	};
 
-	onSelect = ( inputName ) => {
+	onSelect = ( event, inputName ) => {
 		const updates = {};
 		updates[ inputName ] = ! this.state[ inputName ];
 		this.setState( updates );

--- a/client/me/profile-links-add-wordpress/site.jsx
+++ b/client/me/profile-links-add-wordpress/site.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Site from 'blocks/site';
+import { recordCheckboxEvent } from 'me/event-recorder';
+
+class ProfileLinksAddWordPressSite extends Component {
+	static propTypes = {
+		onChange: PropTypes.func.isRequired,
+		onSelect: PropTypes.func.isRequired,
+		site: PropTypes.object.isRequired,
+		checked: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		checked: false,
+	};
+
+	inputName = `site-${ this.props.site.ID }`;
+
+	onSelect = this.props.onSelect.bind( null, this.inputName );
+
+	render() {
+		const { checked, onChange, site } = this.props;
+
+		return (
+			<li
+				key={ site.ID }
+				className="profile-links-add-wordpress__item"
+				onClick={ recordCheckboxEvent( 'Add WordPress Site' ) }
+			>
+				<input
+					className="profile-links-add-wordpress__checkbox"
+					type="checkbox"
+					name={ this.inputName }
+					onChange={ onChange }
+					checked={ checked } />
+				<Site
+					site={ site }
+					indicator={ false }
+					onSelect={ this.onSelect } />
+			</li>
+		);
+	}
+}
+
+export default ProfileLinksAddWordPressSite;

--- a/client/me/profile-links-add-wordpress/site.jsx
+++ b/client/me/profile-links-add-wordpress/site.jsx
@@ -21,9 +21,13 @@ class ProfileLinksAddWordPressSite extends Component {
 		checked: false,
 	};
 
-	inputName = `site-${ this.props.site.ID }`;
+	onSelect = ( event ) => {
+		this.props.onSelect( event, this.getInputName() );
+	};
 
-	onSelect = this.props.onSelect.bind( null, this.inputName );
+	getInputName() {
+		return `site-${ this.props.site.ID }`;
+	}
 
 	render() {
 		const { checked, onChange, site } = this.props;
@@ -37,7 +41,7 @@ class ProfileLinksAddWordPressSite extends Component {
 				<input
 					className="profile-links-add-wordpress__checkbox"
 					type="checkbox"
-					name={ this.inputName }
+					name={ this.getInputName() }
 					onChange={ onChange }
 					checked={ checked } />
 				<Site

--- a/client/state/selectors/get-public-sites.js
+++ b/client/state/selectors/get-public-sites.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { getSite } from 'state/sites/selectors';
+
+/**
+ * Get all public sites
+ *
+ * @param {Object} state  Global state tree
+ * @return {Array}        Site objects
+ */
+export default function getPublicSites( state ) {
+	return Object.values( state.sites.items )
+		.filter( site => ! site.is_private )
+		.map( site => getSite( state, site.ID ) );
+}

--- a/client/state/selectors/get-public-sites.js
+++ b/client/state/selectors/get-public-sites.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getSite } from 'state/sites/selectors';
+import createSelector from 'lib/create-selector';
 
 /**
  * Get all public sites
@@ -9,8 +10,11 @@ import { getSite } from 'state/sites/selectors';
  * @param {Object} state  Global state tree
  * @return {Array}        Site objects
  */
-export default function getPublicSites( state ) {
-	return Object.values( state.sites.items )
-		.filter( site => ! site.is_private )
-		.map( site => getSite( state, site.ID ) );
-}
+export default createSelector(
+	( state ) => {
+		return Object.values( state.sites.items )
+			.filter( site => ! site.is_private )
+			.map( site => getSite( state, site.ID ) );
+	},
+	( state ) => state.sites.items
+);

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -100,6 +100,7 @@ export getSiteIconId from './get-site-icon-id';
 export getSiteIconUrl from './get-site-icon-url';
 export getPostShareScheduledActions from './get-post-share-scheduled-actions';
 export getPostSharePublishedActions from './get-post-share-published-actions';
+export getPublicSites from './get-public-sites';
 export getSiteId from './get-site-id';
 export getSiteMonitorSettings from './get-site-monitor-settings';
 export getSiteSetting from './get-site-setting';

--- a/client/state/selectors/test/get-public-sites.js
+++ b/client/state/selectors/test/get-public-sites.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getPublicSites } from '../';
+
+describe( 'getPublicSites()', () => {
+	it( 'should return an empty array if no sites in state', () => {
+		const state = {
+			sites: {
+				items: {}
+			}
+		};
+		const sites = getPublicSites( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return the public sites in state', () => {
+		const state = {
+			sites: {
+				items: {
+					2916284: {
+						ID: 2916284,
+						is_private: false,
+						name: 'WordPress.com Example Blog',
+						URL: 'http://example.com',
+						options: {
+							unmapped_url: 'http://example.com'
+						}
+					},
+					2916285: {
+						ID: 2916285,
+						is_private: true,
+						name: 'WordPress.com Non visible Blog',
+						URL: 'http://example2.com',
+						options: {
+							unmapped_url: 'http://example2.com'
+						}
+					}
+				}
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getPublicSites( state );
+		expect( sites ).to.eql( [
+			{
+				ID: 2916284,
+				is_private: false,
+				name: 'WordPress.com Example Blog',
+				URL: 'http://example.com',
+				title: 'WordPress.com Example Blog',
+				domain: 'example.com',
+				slug: 'example.com',
+				hasConflict: false,
+				is_customizable: false,
+				is_previewable: false,
+				options: {
+					default_post_format: 'standard',
+					unmapped_url: 'http://example.com'
+				}
+			}
+		] );
+	} );
+} );


### PR DESCRIPTION
This PR removes the `sites-list` usage from the `ProfileLinksAddWordPress` component. It also ES6ifies the component and introduces a straightforward `getPublicSites` selector that we need in order to allow only public sites to be added as profile links.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me
* In the "Profile Links" section, click the "Add" button and from the dropdown menu click "Add WordPress Site"
* Verify the profile link addition works properly and there are no regressions.
* Verify the tests of the new selector pass:

```
npm run test-client client/state/selectors/test/get-public-sites.js
```