### PR TITLE
Upgrades: add ability to link to renewal checkout

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -60,10 +60,9 @@ export function canUpgradeToPlan( planKey, site ) {
 	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
 }
 
-export function getUpgradePlanSlugFromPath( path, site ) {
+export function getUpgradePlanSlugFromPath( path ) {
 	return find( Object.keys( PLANS_LIST ), planKey => (
-		( planKey === path || getPlanPath( planKey ) === path ) &&
-		canUpgradeToPlan( planKey, site )
+		planKey === path || getPlanPath( planKey ) === path
 	) );
 }
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -118,7 +118,7 @@ const Checkout = React.createClass( {
 	},
 
 	addProductToCart: function() {
-		const planSlug = getUpgradePlanSlugFromPath( this.props.product, this.props.selectedSite );
+		const planSlug = getUpgradePlanSlugFromPath( this.props.product );
 
 		let cartItem,
 			cartMeta;
@@ -135,6 +135,13 @@ const Checkout = React.createClass( {
 		if ( startsWith( this.props.product, 'domain-mapping' ) ) {
 			cartMeta = this.props.product.split( ':' )[ 1 ];
 			cartItem = domainMapping( { domain: cartMeta } );
+		}
+
+		if ( this.props.purchaseId ) {
+			cartItem = cartItems.getRenewalItemFromCartItem( cartItem, {
+				id: this.props.purchaseId,
+				domain: this.props.selectedSiteSlug
+			} );
 		}
 
 		if ( cartItem ) {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -15,8 +15,6 @@ const analytics = require( 'lib/analytics' ),
 	clearSitePlans = require( 'state/sites/plans/actions' ).clearSitePlans,
 	clearPurchases = require( 'state/purchases/actions' ).clearPurchases,
 	DomainDetailsForm = require( './domain-details-form' ),
-	domainMapping = require( 'lib/cart-values/cart-items' ).domainMapping,
-	noAdsItem = require( 'lib/cart-values/cart-items' ).noAdsItem,
 	fetchReceiptCompleted = require( 'state/receipts/actions' ).fetchReceiptCompleted,
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	hasDomainDetails = require( 'lib/store-transactions' ).hasDomainDetails,
@@ -28,9 +26,13 @@ const analytics = require( 'lib/analytics' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
 	SecurePaymentFormPlaceholder = require( './secure-payment-form-placeholder' ),
 	supportPaths = require( 'lib/url/support' ),
-	themeItem = require( 'lib/cart-values/cart-items' ).themeItem,
 	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
 	upgradesActions = require( 'lib/upgrades/actions' );
+import {
+	domainMapping,
+	noAdsItem,
+	themeItem
+} from 'lib/cart-values/cart-items';
 import { getStoredCards } from 'state/stored-cards/selectors';
 import {
 	isValidFeatureKey,

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -196,6 +196,7 @@ module.exports = {
 					<Checkout
 						product={ product }
 						productsList={ productsList }
+						purchaseId={ context.params.purchaseId }
 						selectedFeature={ selectedFeature }
 					/>
 				</CheckoutData>

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -275,6 +275,12 @@ module.exports = function() {
 			upgradesController.checkout
 		);
 
+		page(
+			'/checkout/:product/renew/:purchaseId/:domain',
+			controller.siteSelection,
+			upgradesController.checkout
+		);
+
 		// Visting /checkout without a plan or product should be redirected to /plans
 		page( '/checkout', '/plans' );
 	}


### PR DESCRIPTION
This adds support for links to plan, mapping, and registration renewals

Domain Registration renewals require server changes ( D5878, D5875 )

To test:
1. Add an expiring subscription from SA
2. The link that is expected to add that subscription to cart has the following format:
`/checkout/productSlug:meta/renew/123456/mytestsite.wordpress.com`

addProductToCart in the checkout works with some non-standard pretty-slugs that replace the server slugs for plans with the pretty ones, and I add a pretty slug for the legacy no-ads upgrade because the default one is is long and has /.

Also test links to checkout for plans:
`/checkout/mytestsite.wordpress.com/premium`
`/checkout/mytestsite.wordpress.com/business`
`/checkout/mytestsite.wordpress.com/personal`