### PR TITLE
Plans: add plan matching function for yearly/monthly plans

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1238,29 +1238,3 @@ export function getPlanClass( plan ) {
 			return '';
 	}
 }
-
-export function getMonthlyPlanByYearly( plan ) {
-	switch ( plan ) {
-		case PLAN_JETPACK_PREMIUM:
-			return PLAN_JETPACK_PREMIUM_MONTHLY;
-		case PLAN_JETPACK_BUSINESS:
-			return PLAN_JETPACK_BUSINESS_MONTHLY;
-		case PLAN_JETPACK_PERSONAL:
-			return PLAN_JETPACK_PERSONAL_MONTHLY;
-		default:
-			return '';
-	}
-}
-
-export function getYearlyPlanByMonthly( plan ) {
-	switch ( plan ) {
-		case PLAN_JETPACK_PREMIUM_MONTHLY:
-			return PLAN_JETPACK_PREMIUM;
-		case PLAN_JETPACK_BUSINESS_MONTHLY:
-			return PLAN_JETPACK_BUSINESS;
-		case PLAN_JETPACK_PERSONAL_MONTHLY:
-			return PLAN_JETPACK_PERSONAL;
-		default:
-			return '';
-	}
-}

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -149,8 +149,15 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalTy
 	} );
 }
 
-export function getMonthlyPlanByYearly( plan ) {
-	switch ( plan ) {
+/**
+ * Returns the monthly slug which corresponds to the provided yearly slug or "" if the slug is
+ * not a recognized or cannot be converted.
+ *
+ * @param  {String} planSlug Slug to convert to monthly.
+ * @return {String}          Monthly version slug or "" if the slug could not be converted.
+ */
+export function getMonthlyPlanByYearly( planSlug ) {
+	switch ( planSlug ) {
 		case PLAN_JETPACK_PREMIUM:
 			return PLAN_JETPACK_PREMIUM_MONTHLY;
 		case PLAN_JETPACK_BUSINESS:
@@ -162,8 +169,15 @@ export function getMonthlyPlanByYearly( plan ) {
 	}
 }
 
-export function getYearlyPlanByMonthly( plan ) {
-	switch ( plan ) {
+/**
+ * Returns the yearly slug which corresponds to the provided monthly slug or "" if the slug is
+ * not a recognized or cannot be converted.
+ *
+ * @param  {String} planSlug Slug to convert to yearly.
+ * @return {String}          Yearly version slug or "" if the slug could not be converted.
+ */
+export function getYearlyPlanByMonthly( planSlug ) {
+	switch ( planSlug ) {
 		case PLAN_JETPACK_PREMIUM_MONTHLY:
 			return PLAN_JETPACK_PREMIUM;
 		case PLAN_JETPACK_BUSINESS_MONTHLY:

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -22,8 +22,14 @@ import {
 	FEATURES_LIST,
 	PLANS_LIST,
 	PLAN_FREE,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_FREE,
-	PLAN_PERSONAL
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_PERSONAL,
 } from 'lib/plans/constants';
 
 /**
@@ -141,6 +147,32 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan, intervalTy
 
 		return ! isJetpackPlan( plan );
 	} );
+}
+
+export function getMonthlyPlanByYearly( plan ) {
+	switch ( plan ) {
+		case PLAN_JETPACK_PREMIUM:
+			return PLAN_JETPACK_PREMIUM_MONTHLY;
+		case PLAN_JETPACK_BUSINESS:
+			return PLAN_JETPACK_BUSINESS_MONTHLY;
+		case PLAN_JETPACK_PERSONAL:
+			return PLAN_JETPACK_PERSONAL_MONTHLY;
+		default:
+			return '';
+	}
+}
+
+export function getYearlyPlanByMonthly( plan ) {
+	switch ( plan ) {
+		case PLAN_JETPACK_PREMIUM_MONTHLY:
+			return PLAN_JETPACK_PREMIUM;
+		case PLAN_JETPACK_BUSINESS_MONTHLY:
+			return PLAN_JETPACK_BUSINESS;
+		case PLAN_JETPACK_PERSONAL_MONTHLY:
+			return PLAN_JETPACK_PERSONAL;
+		default:
+			return '';
+	}
 }
 
 export const isPlanFeaturesEnabled = () => {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -175,6 +175,25 @@ export function getYearlyPlanByMonthly( plan ) {
 	}
 }
 
+/**
+ * Returns true if plans match regardless of their interval.
+ * For example (fake plans):
+ *     isPlanMatch( 'proYearly', 'proYearly' ) => true
+ *     isPlanMatch( 'proYearly', 'proMonthly' ) => true
+ *     isPlanMatch( 'proYearly', 'personalYearly' ) => false
+ *
+ * @param  {String}  planSlugA One of the plan slugs to compare
+ * @param  {String}  planSlugB One of the plan slugs to compare
+ * @return {Boolean}           Whether the plans match
+ */
+export function isPlanMatch( planSlugA, planSlugB ) {
+	return (
+		planSlugA === planSlugB ||
+		getMonthlyPlanByYearly( planSlugA ) === planSlugB ||
+		planSlugA === getMonthlyPlanByYearly( planSlugB )
+	);
+}
+
 export const isPlanFeaturesEnabled = () => {
 	return isEnabled( 'manage/plan-features' );
 };

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -190,15 +190,16 @@ export function getYearlyPlanByMonthly( planSlug ) {
 }
 
 /**
- * Returns true if plans match regardless of their interval.
+ * Returns true if plan "types" match regardless of their interval.
+ *
  * For example (fake plans):
- *     planLevelsMatch( 'proYearly', 'proYearly' ) => true
- *     planLevelsMatch( 'proYearly', 'proMonthly' ) => true
- *     planLevelsMatch( 'proYearly', 'personalYearly' ) => false
+ *     planLevelsMatch( PRO_YEARLY, PRO_YEARLY ) => true
+ *     planLevelsMatch( PRO_YEARLY, PRO_MONTHLY ) => true
+ *     planLevelsMatch( PRO_YEARLY, PERSONAL_YEARLY ) => false
  *
  * @param  {String}  planSlugA One of the plan slugs to compare
  * @param  {String}  planSlugB One of the plan slugs to compare
- * @return {Boolean}           Whether the plans match
+ * @return {Boolean}           Whether the plan "types" match regardless of interval
  */
 export function planLevelsMatch( planSlugA, planSlugB ) {
 	return (

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -178,15 +178,15 @@ export function getYearlyPlanByMonthly( plan ) {
 /**
  * Returns true if plans match regardless of their interval.
  * For example (fake plans):
- *     isPlanMatch( 'proYearly', 'proYearly' ) => true
- *     isPlanMatch( 'proYearly', 'proMonthly' ) => true
- *     isPlanMatch( 'proYearly', 'personalYearly' ) => false
+ *     planLevelsMatch( 'proYearly', 'proYearly' ) => true
+ *     planLevelsMatch( 'proYearly', 'proMonthly' ) => true
+ *     planLevelsMatch( 'proYearly', 'personalYearly' ) => false
  *
  * @param  {String}  planSlugA One of the plan slugs to compare
  * @param  {String}  planSlugB One of the plan slugs to compare
  * @return {Boolean}           Whether the plans match
  */
-export function isPlanMatch( planSlugA, planSlugB ) {
+export function planLevelsMatch( planSlugA, planSlugB ) {
 	return (
 		planSlugA === planSlugB ||
 		getMonthlyPlanByYearly( planSlugA ) === planSlugB ||

--- a/client/lib/plans/test/index.js
+++ b/client/lib/plans/test/index.js
@@ -1,0 +1,41 @@
+/**
+ * External Dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal Dependencies
+ */
+import { isPlanMatch } from '..';
+import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+} from '../constants';
+
+describe( 'isPlanMatch', () => {
+	it( 'should return true for identical plans', () => {
+		expect( isPlanMatch( PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS ) ).to.be.true;
+	} );
+
+	it( 'should return true for matching plans', () => {
+		const matchingPlans = [
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_BUSINESS ],
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PREMIUM ],
+		];
+		matchingPlans.forEach(
+			( [ slugA, slugB ] ) => expect( isPlanMatch( slugA, slugB ) ).to.be.true
+		);
+	} );
+
+	it( 'should return false for non-matching plans', () => {
+		expect( isPlanMatch( PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL ) ).to.be.false;
+	} );
+} );

--- a/client/lib/plans/test/index.js
+++ b/client/lib/plans/test/index.js
@@ -1,3 +1,4 @@
+// @format
 /**
  * External Dependencies
  */
@@ -8,17 +9,41 @@ import { expect } from 'chai';
  */
 import { isPlanMatch } from '..';
 import {
+	PLAN_BUSINESS,
+	PLAN_FREE,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
 } from '../constants';
 
 describe( 'isPlanMatch', () => {
+	const testPlansArrayIndependentOfOrder = ( plansArray, result ) =>
+		plansArray.forEach( ( [ slugA, slugB ] ) => {
+			expect( isPlanMatch( slugA, slugB ) ).to.be[ result ];
+			expect( isPlanMatch( slugB, slugA ) ).to.be[ result ];
+		} );
+
 	it( 'should return true for identical plans', () => {
-		expect( isPlanMatch( PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS ) ).to.be.true;
+		const identicalPlans = [
+			[ PLAN_BUSINESS, PLAN_BUSINESS ],
+			[ PLAN_FREE, PLAN_FREE ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS ],
+			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_FREE, PLAN_JETPACK_FREE ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL ],
+			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM ],
+			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_PERSONAL, PLAN_PERSONAL ],
+			[ PLAN_PREMIUM, PLAN_PREMIUM ],
+		];
+		testPlansArrayIndependentOfOrder( identicalPlans, 'true' );
 	} );
 
 	it( 'should return true for matching plans', () => {
@@ -26,16 +51,31 @@ describe( 'isPlanMatch', () => {
 			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ],
 			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ],
 			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ],
-			[ PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_JETPACK_BUSINESS ],
-			[ PLAN_JETPACK_PERSONAL_MONTHLY, PLAN_JETPACK_PERSONAL ],
-			[ PLAN_JETPACK_PREMIUM_MONTHLY, PLAN_JETPACK_PREMIUM ],
 		];
-		matchingPlans.forEach(
-			( [ slugA, slugB ] ) => expect( isPlanMatch( slugA, slugB ) ).to.be.true
-		);
+		testPlansArrayIndependentOfOrder( matchingPlans, 'true' );
 	} );
 
 	it( 'should return false for non-matching plans', () => {
-		expect( isPlanMatch( PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL ) ).to.be.false;
+		const nonMatchingPlans = [
+			[ PLAN_JETPACK_BUSINESS, PLAN_BUSINESS ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_FREE ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_PERSONAL ],
+			[ PLAN_JETPACK_BUSINESS, PLAN_PREMIUM ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_BUSINESS ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_FREE ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PREMIUM_MONTHLY ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_PERSONAL ],
+			[ PLAN_JETPACK_PERSONAL, PLAN_PREMIUM ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_BUSINESS ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_FREE ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_BUSINESS_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PERSONAL_MONTHLY ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_PERSONAL ],
+			[ PLAN_JETPACK_PREMIUM, PLAN_PREMIUM ],
+		];
+		testPlansArrayIndependentOfOrder( nonMatchingPlans, 'false' );
 	} );
 } );

--- a/client/lib/plans/test/index.js
+++ b/client/lib/plans/test/index.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 /**
  * Internal Dependencies
  */
-import { isPlanMatch } from '..';
+import { planLevelsMatch } from '..';
 import {
 	PLAN_BUSINESS,
 	PLAN_FREE,
@@ -22,11 +22,11 @@ import {
 	PLAN_PREMIUM,
 } from '../constants';
 
-describe( 'isPlanMatch', () => {
+describe( 'planLevelsMatch', () => {
 	const testPlansArrayIndependentOfOrder = ( plansArray, result ) =>
 		plansArray.forEach( ( [ slugA, slugB ] ) => {
-			expect( isPlanMatch( slugA, slugB ) ).to.be[ result ];
-			expect( isPlanMatch( slugB, slugA ) ).to.be[ result ];
+			expect( planLevelsMatch( slugA, slugB ) ).to.be[ result ];
+			expect( planLevelsMatch( slugB, slugA ) ).to.be[ result ];
 		} );
 
 	it( 'should return true for identical plans', () => {

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -13,7 +13,8 @@ import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import { isMonthly, getYearlyPlanByMonthly } from 'lib/plans/constants';
+import { isMonthly } from 'lib/plans/constants';
+import { getYearlyPlanByMonthly } from 'lib/plans';
 import { planItem } from 'lib/cart-values/cart-items';
 import { addItem } from 'lib/upgrades/actions';
 import {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -31,12 +31,14 @@ import {
 	isMonthly,
 	getPlanFeaturesObject,
 	getPlanClass,
-	getMonthlyPlanByYearly,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 } from 'lib/plans/constants';
-import { isFreePlan } from 'lib/plans';
+import {
+	getMonthlyPlanByYearly,
+	isFreePlan,
+} from 'lib/plans';
 import {
 	getPlanPath,
 	canUpgradeToPlan,


### PR DESCRIPTION
`isPlanMatch` helps to identify plans regardless of their interval.

To test:
* ensure tests pass `npm run test-client`
* Ensure plan features continue to render correctly monthly/yearly (make sure the import/export I moved works correctly): http://calypso.localhost:3000/plans/$jetpackSite