### PR TITLE
AT: adds test mentioning plugins and themes in /plans pages

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,6 +16,14 @@ module.exports = {
 		},
 		defaultVariation: 'hideSurveyStep',
 	},
+	businessPlanDescriptionAT: {
+		datestamp: '20170605',
+		variations: {
+			original: 50,
+			pluginsAndThemes: 50,
+		},
+		defaultVariation: 'original',
+	},
 	presaleChatButton: {
 		datestamp: '20170328',
 		variations: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -187,13 +187,25 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_BUSINESS,
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
-		getDescription: () => i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
+		getDescription: ( abtest ) => {
+			if ( abtest( 'businessPlanDescriptionAT' ) === 'pluginsAndThemes' ) {
+				return i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
+				' business website with custom plugins and themes, unlimited premium and business theme templates,' +
+				' Google Analytics support, unlimited' +
+				' storage, and the ability to remove WordPress.com branding.', {
+					components: {
+						strong: <strong className="plans__features plan-features__targeted-description-heading" />
+					}
+				} );
+			}
+			return i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
 			' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
 			' storage, and the ability to remove WordPress.com branding.', {
 				components: {
 					strong: <strong className="plans__features plan-features__targeted-description-heading" />
 				}
-			} ),
+			} );
+		},
 		getFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_JETPACK_ESSENTIAL,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -188,7 +188,7 @@ export const PLANS_LIST = {
 		availableFor: ( plan ) => includes( [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ], plan ),
 		getPathSlug: () => 'business',
 		getDescription: ( abtest ) => {
-			if ( abtest( 'businessPlanDescriptionAT' ) === 'pluginsAndThemes' ) {
+			if ( abtest && abtest( 'businessPlanDescriptionAT' ) === 'pluginsAndThemes' ) {
 				return i18n.translate( '{{strong}}Best for Small Business:{{/strong}} Power your' +
 				' business website with custom plugins and themes, unlimited premium and business theme templates,' +
 				' Google Analytics support, unlimited' +


### PR DESCRIPTION
This change adds an  abtest at 50/50 mentioning custom plugins and themes as the first feature in the Business Plan description at the top of our plans pages.

![description with plugins and themes](http://cld.wthms.co/RarffW+)

## Testing
You can toggle the test on and off using the debug bar. The test is called `businessPlanDescriptionAT`, and the possible values are `original` and `pluginsAndThemes`.

![toggle test ui](http://cld.wthms.co/CiOaDy+)

This description is used in three different places, but it's only updated in the first two. The third is worth testing just to make sure the code runs without error (needed to add a safety check on the `abtest` parameter).
- NUX plans page (`/start/plans`)
- Site plans page (`/plans/:site`)
- Manage purchase page (`/me/purchases/:site/:transaction_ID`... from the "plans" page, click "manage plan", and then "manage payment").


