### PR TITLE
Domain management: make privacy CTAs and info optional

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -35,6 +35,7 @@ function createDomainObjects( dataTransferObject ) {
 			name: domain.domain,
 			owner: domain.owner,
 			privateDomain: domain.private_domain,
+			privacyAvailable: domain.privacy_available,
 			pendingTransfer: domain.pending_transfer,
 			registrar: domain.registrar,
 			registrationMoment: domain.registration_date && i18n.moment( domain.registration_date ),

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -46,6 +46,7 @@ describe( 'assembler', () => {
 			manualTransferRequired: undefined,
 			owner: undefined,
 			privateDomain: undefined,
+			privacyAvailable: undefined,
 			pendingTransfer: undefined,
 			registrar: undefined,
 			registrationMoment: undefined,

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
@@ -54,6 +54,14 @@ const ContactsPrivacyCard = React.createClass( {
 	},
 
 	getNotice() {
+		if ( ! this.props.privacyAvailable ) {
+			return (
+				<Notice status="is-info" showDismiss={ false }>
+					{ this.translate( 'Privacy Protection is not available for this domain.' ) }
+				</Notice>
+			);
+		}
+
 		if ( this.props.hasPrivacyProtection && this.props.privateDomain ) {
 			return (
 				<Notice status="is-success" showDismiss={ false }>

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
@@ -55,10 +55,13 @@ const ContactsPrivacyCard = React.createClass( {
 	},
 
 	getNotice() {
-		if ( this.props.hasPrivacyProtection && this.props.privateDomain ) {
+
+		const { hasPrivacyProtection, privateDomain, translate, selectedSite, selectedDomainName } = this.props;
+
+		if ( hasPrivacyProtection && privateDomain ) {
 			return (
 				<Notice status="is-success" showDismiss={ false }>
-					{ this.props.translate(
+					{ translate(
 						'{{strong}}Privacy Protection{{/strong}} is turned on for this domain. ' +
 						'Your contact information is {{strong}}private{{/strong}}. ',
 						{
@@ -69,10 +72,10 @@ const ContactsPrivacyCard = React.createClass( {
 					) }
 				</Notice>
 			);
-		} else if ( this.props.hasPrivacyProtection && ! this.props.privateDomain ) {
+		} else if ( hasPrivacyProtection && ! privateDomain ) {
 			return (
 				<Notice status="is-warning" showDismiss={ false }>
-					{ this.props.translate(
+					{ translate(
 						'{{strong}}Privacy Protection{{/strong}} is temporarily ' +
 						'disabled for this domain while the domain is being transferred. ' +
 						'Your contact information is {{strong}}public{{/strong}}. ' +
@@ -80,7 +83,7 @@ const ContactsPrivacyCard = React.createClass( {
 						{
 							components: {
 								strong: <strong />,
-								a: <a href={ paths.domainManagementTransferOut( this.props.selectedSite.slug, this.props.selectedDomainName ) } />
+								a: <a href={ paths.domainManagementTransferOut( selectedSite.slug, selectedDomainName ) } />
 							}
 						}
 					) }
@@ -90,7 +93,7 @@ const ContactsPrivacyCard = React.createClass( {
 
 		return (
 			<Notice status="is-warning" showDismiss={ false }>
-				{ this.props.translate(
+				{ translate(
 					'{{strong}}Privacy Protection{{/strong}} is turned off for this domain. ' +
 					'Your contact information is {{strong}}public{{/strong}}. ' +
 					'{{a}}Enable Privacy Protection{{/a}}',
@@ -99,7 +102,7 @@ const ContactsPrivacyCard = React.createClass( {
 							strong: <strong />,
 							a: <a
 								href={ paths.domainManagementPrivacyProtection(
-									this.props.selectedSite.slug, this.props.selectedDomainName ) } />
+									selectedSite.slug, selectedDomainName ) } />
 						}
 					}
 				) }

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
@@ -55,8 +55,11 @@ const ContactsPrivacyCard = React.createClass( {
 	},
 
 	getNotice() {
+		const { privacyAvailable, hasPrivacyProtection, privateDomain, translate, selectedSite, selectedDomainName } = this.props;
 
-		const { hasPrivacyProtection, privateDomain, translate, selectedSite, selectedDomainName } = this.props;
+		if ( ! privacyAvailable ) {
+			return false;
+		}
 
 		if ( hasPrivacyProtection && privateDomain ) {
 			return (

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -29,11 +30,11 @@ const ContactsPrivacyCard = React.createClass( {
 	render() {
 		return (
 			<div>
-				<SectionHeader label={ this.translate( 'Domain Contacts' ) } />
+				<SectionHeader label={ this.props.translate( 'Domain Contacts' ) } />
 
 				<CompactCard className="contacts-privacy-card">
 					<p className="settings-explanation">
-						{ this.translate(
+						{ this.props.translate(
 							'Domain owners are required to make their contact information available to the public. ' +
 							'{{a}}Learn more.{{/a}}',
 							{
@@ -57,7 +58,7 @@ const ContactsPrivacyCard = React.createClass( {
 		if ( ! this.props.privacyAvailable ) {
 			return (
 				<Notice status="is-info" showDismiss={ false }>
-					{ this.translate( 'Privacy Protection is not available for this domain.' ) }
+					{ this.props.translate( 'Privacy Protection is not available for this domain.' ) }
 				</Notice>
 			);
 		}
@@ -65,7 +66,7 @@ const ContactsPrivacyCard = React.createClass( {
 		if ( this.props.hasPrivacyProtection && this.props.privateDomain ) {
 			return (
 				<Notice status="is-success" showDismiss={ false }>
-					{ this.translate(
+					{ this.props.translate(
 						'{{strong}}Privacy Protection{{/strong}} is turned on for this domain. ' +
 						'Your contact information is {{strong}}private{{/strong}}. ',
 						{
@@ -79,7 +80,7 @@ const ContactsPrivacyCard = React.createClass( {
 		} else if ( this.props.hasPrivacyProtection && ! this.props.privateDomain ) {
 			return (
 				<Notice status="is-warning" showDismiss={ false }>
-					{ this.translate(
+					{ this.props.translate(
 						'{{strong}}Privacy Protection{{/strong}} is temporarily ' +
 						'disabled for this domain while the domain is being transferred. ' +
 						'Your contact information is {{strong}}public{{/strong}}. ' +
@@ -97,7 +98,7 @@ const ContactsPrivacyCard = React.createClass( {
 
 		return (
 			<Notice status="is-warning" showDismiss={ false }>
-				{ this.translate(
+				{ this.props.translate(
 					'{{strong}}Privacy Protection{{/strong}} is turned off for this domain. ' +
 					'Your contact information is {{strong}}public{{/strong}}. ' +
 					'{{a}}Enable Privacy Protection{{/a}}',
@@ -115,4 +116,4 @@ const ContactsPrivacyCard = React.createClass( {
 	}
 } );
 
-module.exports = ContactsPrivacyCard;
+module.exports = localize( ContactsPrivacyCard );

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
@@ -55,14 +55,6 @@ const ContactsPrivacyCard = React.createClass( {
 	},
 
 	getNotice() {
-		if ( ! this.props.privacyAvailable ) {
-			return (
-				<Notice status="is-info" showDismiss={ false }>
-					{ this.props.translate( 'Privacy Protection is not available for this domain.' ) }
-				</Notice>
-			);
-		}
-
 		if ( this.props.hasPrivacyProtection && this.props.privateDomain ) {
 			return (
 				<Notice status="is-success" showDismiss={ false }>

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
@@ -34,7 +34,7 @@ const ContactsPrivacy = React.createClass( {
 		}
 
 		const domain = getSelectedDomain( this.props ),
-			{ hasPrivacyProtection, privateDomain, currentUserCanManage } = domain,
+			{ hasPrivacyProtection, privateDomain, privacyAvailable, currentUserCanManage } = domain,
 			contactInformation = privateDomain
 				? findPrivacyServiceWhois( this.props.whois.data )
 				: findRegistrantWhois( this.props.whois.data );
@@ -54,6 +54,7 @@ const ContactsPrivacy = React.createClass( {
 						selectedSite={ this.props.selectedSite }
 						hasPrivacyProtection={ hasPrivacyProtection }
 						privateDomain={ privateDomain }
+						privacyAvailable={ privacyAvailable }
 						currentUserCanManage={ currentUserCanManage } />
 
 					<VerticalNavItem
@@ -61,7 +62,7 @@ const ContactsPrivacy = React.createClass( {
 						{ this.translate( 'Edit Contact Info' ) }
 					</VerticalNavItem>
 
-					{ ! hasPrivacyProtection && (
+					{ ! hasPrivacyProtection && privacyAvailable && (
 						<VerticalNavItem
 							path={ paths.domainManagementPrivacyProtection( this.props.selectedSite.slug, this.props.selectedDomainName ) }>
 							{ this.translate( 'Privacy Protection' ) }

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -53,25 +53,28 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	getPrivacyProtection() {
-		const { hasPrivacyProtection, privateDomain, name, pendingTransfer } = this.props.domain,
+		const { hasPrivacyProtection, privateDomain, privacyAvailable, name, pendingTransfer } = this.props.domain,
 			{ slug } = this.props.selectedSite,
 			{ translate } = this.props,
 			privacyPath = paths.domainManagementContactsPrivacy( slug, name ),
 			transferPath = paths.domainManagementTransferOut( slug, name );
+		let label;
+
+		if ( ! privacyAvailable ) {
+			return false;
+		}
 
 		if ( pendingTransfer ) {
-			return this.getLabel( {
+			label = this.getLabel( {
 				status: 'is-warning',
 				icon: 'notice',
 				message: translate( 'Pending Transfer', {
 					context: 'An icon label when domain is pending transfer.'
 				} )
 			} );
-		}
-
-		if ( hasPrivacyProtection ) {
+		} else if ( hasPrivacyProtection ) {
 			if ( privateDomain ) {
-				return this.getLabel( {
+				label = this.getLabel( {
 					status: 'is-success',
 					icon: 'lock',
 					href: privacyPath,
@@ -79,26 +82,32 @@ const RegisteredDomain = React.createClass( {
 						context: 'An icon label when Privacy Protection is enabled.'
 					} )
 				} );
+			} else {
+				label = this.getLabel( {
+					status: 'is-warning',
+					icon: 'notice',
+					href: transferPath,
+					message: translate( 'Disabled for Transfer', {
+						context: 'An icon label when Privacy Protection is temporarily disabled for transfer.'
+					} )
+				} );
 			}
-
-			return this.getLabel( {
+		} else {
+			label = this.getLabel( {
 				status: 'is-warning',
 				icon: 'notice',
-				href: transferPath,
-				message: translate( 'Disabled for Transfer', {
-					context: 'An icon label when Privacy Protection is temporarily disabled for transfer.'
+				href: privacyPath,
+				message: translate( 'None', {
+					context: 'An icon label when Privacy Protection is not purchased by the user.'
 				} )
 			} );
 		}
 
-		return this.getLabel( {
-			status: 'is-warning',
-			icon: 'notice',
-			href: privacyPath,
-			message: translate( 'None', {
-				context: 'An icon label when Privacy Protection is not purchased by the user.'
-			} )
-		} );
+		return (
+			<Property label={ translate( 'Privacy Protection' ) }>
+				{ label }
+			</Property>
+		);
 	},
 
 	handlePaymentSettingsClick() {
@@ -208,9 +217,7 @@ const RegisteredDomain = React.createClass( {
 
 						{ this.getAutoRenewalOrExpirationDate() }
 
-						<Property label={ translate( 'Privacy Protection' ) }>
-							{ this.getPrivacyProtection() }
-						</Property>
+						{ this.getPrivacyProtection() }
 
 						<SubscriptionSettings
 							onClick={ this.handlePaymentSettingsClick } />

--- a/client/state/sites/domains/assembler.js
+++ b/client/state/sites/domains/assembler.js
@@ -16,6 +16,7 @@ export const createSiteDomainObject = domain => {
 		expirySoon: Boolean( domain.expiry_soon ),
 		googleAppsSubscription: Object( domain.google_apps_subscription ),
 		hasPrivacyProtection: Boolean( domain.has_private_registration ),
+		privacyAvailable: Boolean( domain.privacy_available ),
 		hasRegistration: Boolean( domain.has_registration ),
 		hasZone: Boolean( domain.has_zone ),
 		isPendingIcannVerification: Boolean( domain.is_pending_icann_verification ),

--- a/client/state/sites/domains/test/fixture.js
+++ b/client/state/sites/domains/test/fixture.js
@@ -31,6 +31,7 @@ export const DOMAIN_PRIMARY = {
 		status: 'no_subscription'
 	},
 	hasPrivacyProtection: false,
+	privacyAvailable: false,
 	hasRegistration: false,
 	hasZone: true,
 	isPendingIcannVerification: false,
@@ -65,6 +66,7 @@ export const DOMAIN_NOT_PRIMARY = {
 		status: 'no_subscription'
 	},
 	hasPrivacyProtection: false,
+	privacyAvailable: false,
 	hasRegistration: false,
 	hasZone: false,
 	isPendingIcannVerification: false,
@@ -100,6 +102,7 @@ export const REST_API_SITE_DOMAIN_FIRST = {
 		status: 'no_subscription'
 	},
 	has_private_registration: false,
+	privacyAvailable: false,
 	has_registration: false,
 	has_zone: true,
 	current_user_can_manage: true,
@@ -132,6 +135,7 @@ export const REST_API_SITE_DOMAIN_SECOND = {
 		status: 'no_subscription'
 	},
 	has_private_registration: false,
+	privacyAvailable: false,
 	has_registration: false,
 	has_zone: false,
 	current_user_can_manage: true,


### PR DESCRIPTION
Some TLDs do not support privacy.
This hides some calls to actions, notices, and warnings that are privacy related for TLDs where we do not support privacy.

Requires backend D5882

**Without this PR:**
Domain settings screen:
<img width="750" alt="screen shot 2017-06-05 at 18 15 32" src="https://cloud.githubusercontent.com/assets/844866/26790066/1222e114-4a1b-11e7-9976-8713aabc63af.png">
Contacts and Privacy screen:
<img width="755" alt="screen shot 2017-06-05 at 18 15 21" src="https://cloud.githubusercontent.com/assets/844866/26790083/262472e0-4a1b-11e7-8b16-3ac688fee326.png">

**With this PR:**
Domain settings screen:
<img width="813" alt="screen shot 2017-06-05 at 18 15 46" src="https://cloud.githubusercontent.com/assets/844866/26790100/34991916-4a1b-11e7-8930-edf730d15873.png">

Contacts and Privacy screen:
<img width="765" alt="screen shot 2017-06-05 at 18 20 04" src="https://cloud.githubusercontent.com/assets/844866/26790229/a88362d2-4a1b-11e7-9144-4f00632360b1.png">


Related #14545