### PR TITLE
Checkout: Use isMainNetworkSite computed attribute in JetpackPlanDetails

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
@@ -41,7 +41,7 @@ const JetpackPlanDetails = ( { selectedSite } ) => {
 				'calypso_plans_autoconfig_halt_jpversion',
 				{ jetpack_version: selectedSite.options.jetpack_version }
 			);
-		} else if ( selectedSite.is_multisite && ! selectedSite.isMainNetworkSite() ) {
+		} else if ( selectedSite.is_multisite && ! selectedSite.isMainNetworkSite ) {
 			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_halt_multisite' );
 		} else if ( selectedSite.options.is_multi_network ) {
 			analytics.tracks.recordEvent( 'calypso_plans_autoconfig_halt_multinetwork' );


### PR DESCRIPTION
This PR fixes #14405, where an error occurs when user updates from a Free Jetpack plan to a Premium one. It appears this has slipped through our fingers in the sites-list migration.

To test:

* Go to /plans/$site where $site is a Jetpack site on the Free plan.
* Click the "Premium" upgrade button.
* Complete the purchase.
* Verify purchase completes successfully and you're redirected properly without errors.