### PR TITLE
Pages: Open pages in a new tab if no site is selected

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -34,6 +34,7 @@ import {
 	hasStaticFrontPage,
 	isSitePreviewable,
 } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isFrontPage,
 	isPostsPage,
@@ -478,12 +479,16 @@ export default connect(
 	( state, props ) => {
 		const site = getSite( state, props.page.site_ID );
 		const siteSlugOrId = get( site, 'slug' ) || get( site, 'ID', null );
+		const selectedSiteId = getSelectedSiteId( state );
+		const isPreviewable =
+			false !== isSitePreviewable( state, props.page.site_ID ) &&
+			site.ID === selectedSiteId;
 
 		return {
 			hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),
 			isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID ),
 			isPostsPage: isPostsPage( state, props.page.site_ID, props.page.ID ),
-			isPreviewable: false !== isSitePreviewable( state, props.page.site_ID ),
+			isPreviewable,
 			previewURL: getPreviewURL( props.page ),
 			site,
 			siteSlugOrId,

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -482,7 +482,7 @@ export default connect(
 		const selectedSiteId = getSelectedSiteId( state );
 		const isPreviewable =
 			false !== isSitePreviewable( state, props.page.site_ID ) &&
-			site.ID === selectedSiteId;
+			site && site.ID === selectedSiteId;
 
 		return {
 			hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),


### PR DESCRIPTION
Currently, when you visit the pages list with no site is selected, previewing pages does not work.

When you click the `View Page` menu item, the menu closes and nothing else visibly occurs.

<img width="283" alt="screen shot 2017-06-05 at 1 31 45 pm" src="https://cloud.githubusercontent.com/assets/1587282/26795391/7d4241ec-49f3-11e7-8b94-65ba94aefb2f.png">

I attempted to dig into why the preview is not working, but it wasn't immediately obvious to me. This workaround opens the page in a new tab if the page does not belong to the selected site. If anyone knows how to make this work in the preview system, I'm happy to close this PR if you can fix it quickly :)

## To Test

* Sign in with an account with multiple sites
* Visit http://calypso.localhost:3000/pages
* Click the `ellipsis` gridicon beside a page
* Click the `View Page` item
  * It should open the page in a new tab
* Test on `drafts` | `scheduled` | `trash` subsections as well