### PR TITLE
WooCommerce: Update WC-API calls to use v3 of the API.

### DIFF
--- a/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
@@ -25,7 +25,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v2/payment_gateways&_method=get' } )
+				.query( { path: '/wc/v3/payment_gateways&_method=get' } )
 				.reply( 200, {
 					data: [ {
 						id: 'bacs',

--- a/client/extensions/woocommerce/state/sites/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/actions.js
@@ -18,7 +18,7 @@ export function fetchProductCategories( siteId ) {
 		dispatch( getAction );
 
 		const jpPath = `/jetpack-blogs/${ siteId }/rest-api/`;
-		const apiPath = '/wc/v2/products/categories';
+		const apiPath = '/wc/v3/products/categories';
 
 		// TODO: Modify this to use the extensions data layer.
 		return wp.req.get( { path: jpPath }, { path: apiPath } )

--- a/client/extensions/woocommerce/state/sites/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/actions.js
@@ -26,7 +26,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v2/products/categories' } )
+				.query( { path: '/wc/v3/products/categories' } )
 				.reply( 200, {
 					data: [ {
 						id: 10,

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -39,7 +39,7 @@ export function createProduct( siteId, product, successAction = null, failureAct
 
 		const jetpackProps = { path: `/jetpack-blogs/${ siteId }/rest-api/` };
 		const httpProps = {
-			path: '/wc/v2/products',
+			path: '/wc/v3/products',
 			body: JSON.stringify( productData ),
 			json: true,
 		};

--- a/client/extensions/woocommerce/state/sites/request.js
+++ b/client/extensions/woocommerce/state/sites/request.js
@@ -29,7 +29,7 @@ const _request = ( method, path, siteId, body ) => {
 			path: `/jetpack-blogs/${ siteId }/rest-api/`
 		},
 		{
-			path: `/wc/v2/${ path }&_method=${ method }`,
+			path: `/wc/v3/${ path }&_method=${ method }`,
 			body: body && JSON.stringify( body ),
 		}
 	).then( ( { data } ) => omitDeep( data, '_links' ) );
@@ -45,14 +45,14 @@ const _request = ( method, path, siteId, body ) => {
 export default ( siteId ) => ( {
 	/**
 	 * Sends a GET request to the API
-	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v2/" prefix
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
 	 * @return {Promise} Resolves with the JSON response, or rejects with an error
 	 */
 	get: ( path ) => _request( 'get', path, siteId ),
 
 	/**
 	 * Sends a POST request to the API
-	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v2/" prefix
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
 	 * @param {Object} body Payload to send
 	 * @return {Promise} Resolves with the JSON response, or rejects with an error
 	 */
@@ -62,7 +62,7 @@ export default ( siteId ) => ( {
 	 * Sends a PUT request to the API.
 	 * Note that the underlying request will be a POST, with an special URL parameter to
 	 * be interpreted by the WPCOM server as a PUT request.
-	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v2/" prefix
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
 	 * @param {Object} body Payload to send
 	 * @return {Promise} Resolves with the JSON response, or rejects with an error
 	 */
@@ -72,7 +72,7 @@ export default ( siteId ) => ( {
 	 * Sends a DELETE request to the API.
 	 * Note that the underlying request will be a POST, with an special URL parameter to
 	 * be interpreted by the WPCOM server as a DELETE request.
-	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v2/" prefix
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
 	 * @return {Promise} Resolves with the JSON response, or rejects with an error
 	 */
 	del: ( path ) => _request( 'delete', path, siteId ),

--- a/client/extensions/woocommerce/state/sites/settings/general/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/actions.js
@@ -25,7 +25,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v2/settings/general&_method=get' } )
+				.query( { path: '/wc/v3/settings/general&_method=get' } )
 				.reply( 200, {
 					data: [ {
 						id: 'woocommerce_default_country',

--- a/client/extensions/woocommerce/state/sites/shipping-zones/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/test/actions.js
@@ -25,7 +25,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v2/shipping/zones&_method=get' } )
+				.query( { path: '/wc/v3/shipping/zones&_method=get' } )
 				.reply( 200, {
 					data: [ {
 						id: 0,


### PR DESCRIPTION
This PR updates all of our current API calls to use `v3` of the WC-API so that improvements and new endpoints can be used for Calypso.

This PR officially makes running the REST API feature plugin a prerequisite (#14699). That means we all need to have it running to test PRs once this is merged to master.

You can grab the feature plugin from GitHub: https://github.com/woocommerce/wc-api-dev/releases and install it. I'll create pre-releases as new changes are made.

To Test:
* Run `make test` and make sure all tests pass.
* Install and activate the API feature plugin.
* Go to `http://calypso.localhost:3000/store/products/:site/add`.
* Test the category drop down and make sure it populates with categories from your site.
* Test saving a product and make sure it is created on the remote site.
* Go to `http://calypso.localhost:3000/store/settings/:site/payments`.
* Make sure the drop-down populates with currencies.