### PR TITLE
Fix broken image on G Suite screen

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/product-details.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/product-details.jsx
@@ -62,7 +62,7 @@ class GoogleAppsProductDetails extends Component {
 					</h5>
 
 					<h5 className="google-apps-dialog__product-feature">
-						<img src="/calypso/images/g-suite/logo_sheets_48dp.svg" />
+						<img src="/calypso/images/g-suite/logo_hangouts_48dp.svg" />
 						<p>{ translate( 'Video and voice calls' ) }</p>
 					</h5>
 				</div>


### PR DESCRIPTION
Fixes a broken image appearing on the G Suite screen.

Before | After
------------ | -------------
<img width="736" alt="screen shot 2017-06-05 at 15 09 47" src="https://cloud.githubusercontent.com/assets/448298/26799432/aad25bdc-4a03-11e7-9635-8f271c979471.png"> | <img width="735" alt="screen shot 2017-06-05 at 15 10 30" src="https://cloud.githubusercontent.com/assets/448298/26799429/a77cf014-4a03-11e7-8aad-c41e567134e1.png">

#### Testing

* Run `git checkout fix/gsuite-hangouts-image` and start your server
* Go to `Domains` and click `Add Domain` to add a domain to your site
* Search for and select a domain
* Assert that the design looks correct as above and the SVG image for `Video and voice calls` is appearing