### PR TITLE
Update confirmation sidebar ground control

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -40,16 +40,6 @@ class EditorConfirmationSidebar extends React.Component {
 		this.props.onPublish( true );
 	};
 
-	isFutureDated( post ) {
-		if ( ! post ) {
-			return false;
-		}
-
-		const oneMinute = 1000 * 60;
-
-		return post && ( +new Date() + oneMinute < +new Date( post.date ) );
-	}
-
 	getPublishButtonLabel( publishButtonStatus ) {
 		switch ( publishButtonStatus ) {
 			case 'update':

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -81,8 +82,14 @@ class EditorConfirmationSidebar extends React.Component {
 						'is-active': isSidebarActive,
 					} ) }>
 						<div className="editor-confirmation-sidebar__ground-control">
-							<div className="editor-confirmation-sidebar__cancel" onClick={ this.closeOverlay }>
-								{ this.props.translate( 'Cancel' ) }
+							<div className="editor-confirmation-sidebar__close">
+								<Button
+									borderless
+									onClick={ this.closeOverlay }
+									title={ this.props.translate( 'Close sidebar' ) }
+									aria-label={ this.props.translate( 'Close sidebar' ) }>
+									<Gridicon icon="cross" />
+								</Button>
 							</div>
 							<div className="editor-confirmation-sidebar__action">
 								<Button onClick={ this.closeAndPublish }>{ this.props.translate( 'Publish' ) }</Button>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -18,6 +18,7 @@ import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
+import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
@@ -49,12 +50,30 @@ class EditorConfirmationSidebar extends React.Component {
 		return post && ( +new Date() + oneMinute < +new Date( post.date ) );
 	}
 
-	getButtonLabel() {
-		if ( this.isFutureDated( this.props.post ) ) {
-			return this.props.translate( 'Schedule' );
+	getPublishButtonLabel( publishButtonStatus ) {
+		switch ( publishButtonStatus ) {
+			case 'update':
+				return this.props.translate( 'Update' );
+			case 'schedule':
+				return this.props.translate( 'Schedule' );
+			case 'publish':
+				return this.props.translate( 'Publish' );
+			case 'requestReview':
+				return this.props.translate( 'Submit for Review' );
+		}
+	}
+
+	renderPublishButton() {
+		if ( ! this.props.site || ! this.props.post || ! this.props.savedPost ) {
+			return;
 		}
 
-		return this.props.translate( 'Publish' );
+		const publishButtonStatus = getPublishButtonStatus( this.props.site, this.props.post, this.props.savedPost );
+		const buttonLabel = this.getPublishButtonLabel( publishButtonStatus );
+
+		return (
+			<Button onClick={ this.closeAndPublish }>{ buttonLabel }</Button>
+		);
 	}
 
 	renderPrivacyControl() {
@@ -110,7 +129,7 @@ class EditorConfirmationSidebar extends React.Component {
 								</Button>
 							</div>
 							<div className="editor-confirmation-sidebar__action">
-								<Button onClick={ this.closeAndPublish }>{ this.getButtonLabel() }</Button>
+								{ this.renderPublishButton() }
 							</div>
 						</div>
 						<div className="editor-confirmation-sidebar__content-wrap">

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -39,6 +39,24 @@ class EditorConfirmationSidebar extends React.Component {
 		this.props.onPublish( true );
 	};
 
+	isFutureDated( post ) {
+		if ( ! post ) {
+			return false;
+		}
+
+		const oneMinute = 1000 * 60;
+
+		return post && ( +new Date() + oneMinute < +new Date( post.date ) );
+	}
+
+	getButtonLabel() {
+		if ( this.isFutureDated( this.props.post ) ) {
+			return this.props.translate( 'Schedule' );
+		}
+
+		return this.props.translate( 'Publish' );
+	}
+
 	renderPrivacyControl() {
 		if ( ! this.props.post ) {
 			return;
@@ -92,7 +110,7 @@ class EditorConfirmationSidebar extends React.Component {
 								</Button>
 							</div>
 							<div className="editor-confirmation-sidebar__action">
-								<Button onClick={ this.closeAndPublish }>{ this.props.translate( 'Publish' ) }</Button>
+								<Button onClick={ this.closeAndPublish }>{ this.getButtonLabel() }</Button>
 							</div>
 						</div>
 						<div className="editor-confirmation-sidebar__content-wrap">

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -85,7 +85,7 @@ class EditorConfirmationSidebar extends React.Component {
 								{ this.props.translate( 'Cancel' ) }
 							</div>
 							<div className="editor-confirmation-sidebar__action">
-								<Button onClick={ this.closeAndPublish } compact>{ this.props.translate( 'Publish' ) }</Button>
+								<Button onClick={ this.closeAndPublish }>{ this.props.translate( 'Publish' ) }</Button>
 							</div>
 						</div>
 						<div className="editor-confirmation-sidebar__content-wrap">

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -71,7 +71,6 @@
 .editor-confirmation-sidebar__ground-control {
 	@extend .card;
 	display: flex;
-	//justify-content: flex-end;
 	flex-direction: row;
 	flex-wrap: wrap;
 	position: relative;
@@ -91,7 +90,6 @@
 	border-color: darken( $alert-green, 20% );
 	color: $white;
 
-	text-transform: none;
 	padding: 7px 22px;
 	margin-left: 12px;
 

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -71,7 +71,7 @@
 .editor-confirmation-sidebar__ground-control {
 	@extend .card;
 	display: flex;
-	justify-content: flex-end;
+	//justify-content: flex-end;
 	flex-direction: row;
 	flex-wrap: wrap;
 	position: relative;

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -77,7 +77,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-	padding: 9px 24px;
+	padding: 4px 24px 0;
 	width: 100%;
 }
 

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -71,7 +71,7 @@
 .editor-confirmation-sidebar__ground-control {
 	@extend .card;
 	display: flex;
-	justify-content: space-between;
+	justify-content: flex-end;
 	flex-direction: row;
 	flex-wrap: wrap;
 	position: relative;
@@ -82,9 +82,8 @@
 	width: 100%;
 }
 
-.editor-confirmation-sidebar__cancel {
-	flex-grow: 1;
-	color: $alert-red;
+.editor-confirmation-sidebar__close {
+  margin-right: auto;
 }
 
 .editor-confirmation-sidebar__action .button {

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -77,7 +77,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-	padding: 4px 24px 0;
+	padding: 0 24px;
 	width: 100%;
 }
 
@@ -91,7 +91,7 @@
 	color: $white;
 
 	padding: 7px 22px;
-	margin-left: 12px;
+	margin: 4px 0 4px 12px;
 
 	&:hover,
 	&:focus {

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -123,7 +123,6 @@ export class EditorPublishButton extends Component {
 			<Button
 				className="editor-publish-button"
 				primary
-				compact
 				busy={ this.props.busy }
 				onClick={ this.onClick }
 				disabled={ ! this.isEnabled() }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -36,7 +36,7 @@ import config from 'config';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
 import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
-import { receivePost, savePostSuccess } from 'state/posts/actions';
+import { editPost, receivePost, savePostSuccess } from 'state/posts/actions';
 import { getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { hasBrokenSiteUserConnection } from 'state/selectors';
@@ -732,9 +732,15 @@ export const PostEditor = React.createClass( {
 	},
 
 	setPostDate: function( date ) {
+		const { siteId, postId } = this.props;
 		const dateValue = date ? date.format() : null;
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { date: dateValue } );
+
+		if ( siteId && postId ) {
+			this.props.editPost( siteId, postId, { date: dateValue } );
+		}
+
 		this.checkForDateChange( dateValue );
 	},
 
@@ -875,6 +881,7 @@ export default connect(
 			setEditorLastDraft,
 			resetEditorLastDraft,
 			receivePost,
+			editPost,
 			savePostSuccess,
 			setEditorModePreference: savePreference.bind( null, 'editor-mode' ),
 			setEditorSidebar: savePreference.bind( null, 'editor-sidebar' ),


### PR DESCRIPTION
This PR makes some visual changes to the publish confirmation sidebar.

- It changes the Publish button to be non-compact, and makes sure that it overlaps with the Publish button on the editor sidebar so that users can keep clicking for fast publishing (should they already be familiar with the publish steps)
- It removes the text transformation from the Publish button so that we don't yell, especially when the Publish button on the sidebar is not going to publish but lead to the confirmation step only
- "Close" has been changed to a cross to have the more intuitive behavior we have on the editor sidebar

![screen shot 2017-06-06 at 11 28 42 am](https://cloud.githubusercontent.com/assets/1017839/26822990/3dee7d76-4aac-11e7-8f5c-d2001ea5f930.png)


![dlbfjnmfyx](https://cloud.githubusercontent.com/assets/1017839/26822995/413dbb2c-4aac-11e7-9774-37b9913904a1.gif)

This PR also changes the action button label to match what is shown on the editor sidebar:

![cseug5tgdz](https://user-images.githubusercontent.com/1017839/26848372-8206b8e4-4b00-11e7-992d-8c08a24ff5ae.gif)

To test:

- Checkout branch and run with the feature-flag enabled: ENABLE_FEATURES=post-editor/delta-post-publish-flow make run
- Load the editor and draft a post. Do not change the date.
- Verify that the action button on the editor sidebar and confirmation sidebar are the same kind (not compact) and that no text transformation was applied.
- Verify that a cross is shown on the confirmation sidebar, and it works as expected: closes the confirmation sidebar, and the resize behavior is correct
- Change the date of the post, and verify that the action button label changes to Schedule
