### PR TITLE
Editor confirmation sidebar: Update publishing state

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -68,16 +68,16 @@ class EditorConfirmationSidebar extends React.Component {
 	getBusyButtonLabel( publishButtonStatus ) {
 		switch ( publishButtonStatus ) {
 			case 'update':
-				return this.props.translate( 'Updating…' );
+				return this.props.translate( 'Updating...' );
 			case 'schedule':
-				return this.props.translate( 'Scheduling…' );
+				return this.props.translate( 'Scheduling...' );
 			case 'publish':
-				return this.props.translate( 'Publishing…' );
+				return this.props.translate( 'Publishing...' );
 			case 'requestReview':
-				return this.props.translate( 'Submitting for Review…' );
+				return this.props.translate( 'Submitting for Review...' );
 		}
 
-		return this.props.translate( 'Publishing…' );
+		return this.props.translate( 'Publishing...' );
 	}
 
 	renderPrivacyControl() {

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -64,6 +64,20 @@ class EditorConfirmationSidebar extends React.Component {
 		return (
 			<Button onClick={ this.closeAndPublish }>{ buttonLabel }</Button>
 		);
+
+	getBusyButtonLabel( publishButtonStatus ) {
+		switch ( publishButtonStatus ) {
+			case 'update':
+				return this.props.translate( 'Updating…' );
+			case 'schedule':
+				return this.props.translate( 'Scheduling…' );
+			case 'publish':
+				return this.props.translate( 'Publishing…' );
+			case 'requestReview':
+				return this.props.translate( 'Submitting for Review…' );
+		}
+
+		return this.props.translate( 'Publishing…' );
 	}
 
 	renderPrivacyControl() {
@@ -90,6 +104,23 @@ class EditorConfirmationSidebar extends React.Component {
 		);
 	}
 
+	renderPublishingBusyButton() {
+		if ( 'publishing' !== this.props.state ) {
+			return;
+		}
+
+		if ( ! this.props.site || ! this.props.post || ! this.props.savedPost ) {
+			return;
+		}
+
+		const publishButtonStatus = getPublishButtonStatus( this.props.site, this.props.post, this.props.savedPost );
+		const buttonLabel = this.getBusyButtonLabel( publishButtonStatus );
+
+		return (
+			<Button disabled className="editor-confirmation-sidebar__publishing-button is-busy is-primary">{ buttonLabel }</Button>
+		);
+	}
+
 	render() {
 		const isSidebarActive = this.props.state === 'open';
 		const isOverlayActive = this.props.state !== 'closed';
@@ -103,7 +134,9 @@ class EditorConfirmationSidebar extends React.Component {
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__overlay': true,
 						'is-active': isOverlayActive,
-					} ) } onClick={ this.closeOverlay } />
+					} ) } onClick={ this.closeOverlay }>
+						{ this.renderPublishingBusyButton() }
+					</div>
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__sidebar': true,
 						'is-active': isSidebarActive,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -64,6 +64,7 @@ class EditorConfirmationSidebar extends React.Component {
 		return (
 			<Button onClick={ this.closeAndPublish }>{ buttonLabel }</Button>
 		);
+	}
 
 	getBusyButtonLabel( publishButtonStatus ) {
 		switch ( publishButtonStatus ) {

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -35,6 +35,12 @@
 	}
 }
 
+.editor-confirmation-sidebar__publishing-button {
+	position: absolute;
+		top: 56px;
+		right: 16px;
+}
+
 .editor-confirmation-sidebar__sidebar {
 	@extend .sidebar;
 	width: 374px;

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -37,8 +37,9 @@
 
 .editor-confirmation-sidebar__publishing-button {
 	position: absolute;
-		top: 56px;
+		top: 53px;
 		right: 16px;
+		min-width: 142px;
 }
 
 .editor-confirmation-sidebar__sidebar {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -670,7 +670,7 @@ export const PostEditor = React.createClass( {
 		}
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( 'closed' );
+			this.setConfirmationSidebar( 'publishing' );
 		}
 
 		// determine if this is a private publish
@@ -700,6 +700,10 @@ export const PostEditor = React.createClass( {
 
 	onPublishFailure: function( error ) {
 		this.onSaveFailure( error, 'publishFailure' );
+
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+			this.setConfirmationSidebar( 'closed' );
+		}
 	},
 
 	onPublishSuccess: function() {
@@ -712,6 +716,10 @@ export const PostEditor = React.createClass( {
 			message = 'scheduled';
 		} else {
 			message = 'published';
+		}
+
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+			this.setConfirmationSidebar( 'closed' );
 		}
 
 		this.onSaveSuccess( message, ( message === 'published' ? 'view' : 'preview' ), savedPost.URL );


### PR DESCRIPTION
This PR sets the 'publishing' state upon confirmation in the sidebar. This closes the sidebar and displays a busy button that says "Publishing..." (or "Scheduling...") until the publish either succeeds or fails. The overlay is then closed.

![sidebar-publishing](https://cloud.githubusercontent.com/assets/363749/26805747/fe376f92-4a12-11e7-927b-daebfa0dccb3.gif)

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p8F9tW-3F-p2.

To test:
* Checkout branch and run with the feature-flag enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Load the editor and draft a post. Do not change the date.
* In Chrome you can throttle the connection speed from the network tab of developer tools. Select a slower speed such as GPRS.
![image](https://cloud.githubusercontent.com/assets/363749/26805805/63b06b62-4a13-11e7-88fd-29bb60ea65eb.png)
* If you don't use Chrome, throttling is possible in [Firefox](https://blog.nightly.mozilla.org/2016/11/07/simulate-slow-connections-with-the-network-throttling-tool/) or search for instructions to Throttle within your browser of choice.
* Click on "Publish". The sidebar should close and you should see "Publishing...".
* After the post has published, the overlay should disappear and you should see the current behavior (your post in the editor with a confirmation message)
* Repeat the process with a new post. Set the post to a future date. After clicking "Publish" in the confirmation dialog (that text to be updated in a future PR), you should see a busy button that reads "Scheduling...".
