### PR TITLE
SEO: assign to empty object to avoid assigning to undefined/null

### DIFF
--- a/client/components/seo/reader-preview/index.js
+++ b/client/components/seo/reader-preview/index.js
@@ -20,11 +20,13 @@ export class ReaderPreview extends PureComponent {
 
 		// Add some ReaderPost specific properties that are necessary
 		const readerPost = Object.assign(
+			{},
 			post,
 			{ better_excerpt: postExcerpt },
 			postImage && { canonical_media: { src: postImage } },
 			( postImage && ! postExcerpt ) && { display_type: DisplayTypes.PHOTO_ONLY },
 			{ author: Object.assign(
+				{},
 				post.author,
 				{ has_avatar: true }
 			) }


### PR DESCRIPTION
I think this issue was causing some problems with loading the editor (was originally tagged as an AT issue: "Editor: missing page content"). Search for that issue for testing instructions (or ping me).

In two places in this code, we're using `Object.assign` to augment an object, but in practice that object was not always loaded at the time of rendering. This leads to a fatal error that looks like this:

![fatal error](http://cld.wthms.co/9On0E+)

When it happens it causes the editor to not load the post content. While passing null/undefined as the first argument in `Object.assign()` results in a fatal error, you _can_ pass null/undefined as any of the following arguments. So it's ok to do `Object.assign( {}, undefined, { test: true } )`