### PR TITLE
Login: Add tracks events to `SocialLoginForm`

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -37,7 +37,7 @@ class SocialLoginForm extends Component {
 		this.props.loginSocialUser( 'google', response.Zi.id_token ).then( () => {
 			this.props.onSuccess();
 		} ).catch( error => {
-			if ( error === 'unknown_user' ) {
+			if ( error.code === 'unknown_user' ) {
 				const { notice } = this.props.infoNotice( this.props.translate( 'Creating your account' ) );
 				wpcom.undocumented().usersSocialNew( 'google', response.Zi.id_token, 'login', ( wpcomError, wpcomResponse ) => {
 					this.props.removeNotice( notice.noticeId );
@@ -51,7 +51,7 @@ class SocialLoginForm extends Component {
 					}
 				} );
 			} else {
-				this.props.errorNotice( error );
+				this.props.errorNotice( error.message );
 			}
 		} );
 	};

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -65,29 +65,29 @@ const errorFields = {
  * Retrieves the first error message from the specified HTTP error.
  *
  * @param {Object} httpError HTTP error
- * @returns {{message: string, field: string}} an error message and the id of the corresponding field, if not global
+ * @returns {{code: string?, message: string, field: string}} an error message and the id of the corresponding field, if not global
  */
 function getErrorFromHTTPError( httpError ) {
 	let message;
 	let field = 'global';
 
-	const errorKey = get( httpError, 'response.body.data.errors[0]' );
+	const code = get( httpError, 'response.body.data.errors[0]' );
 
-	if ( errorKey ) {
-		if ( errorKey in errorMessages ) {
-			message = errorMessages[ errorKey ];
+	if ( code ) {
+		if ( code in errorMessages ) {
+			message = errorMessages[ code ];
 
-			if ( errorKey in errorFields ) {
-				field = errorFields[ errorKey ];
+			if ( code in errorFields ) {
+				field = errorFields[ code ];
 			}
 		} else {
-			message = errorKey;
+			message = code;
 		}
 	} else {
 		message = get( httpError, 'response.body.data', httpError.message );
 	}
 
-	return { message, field };
+	return { code, message, field };
 }
 
 /**


### PR DESCRIPTION
This PR adds the following events to `SocialLoginForm`:

- `calypso_social_login_form_login_success`
- `calypso_social_login_form_login_fail`
- `calypso_social_login_form_signup_success` (for when a user signs up through this form)
- `calypso_social_login_form_signup_fail` (for when that signup fails)

**Testing**
First, execute `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in your console.

`calypso_social_login_form_login_success`
- Visit `/log-in`.
- Log in with a Google account that has already signed up.
- Assert that this event is logged.

`calypso_social_login_form_signup_success`
- Visit `/log-in`.
- Log in with a Google account that has not signed up.
- Assert that this event is logged.

`calypso_social_login_form_signup_fail`
- Apply patch pb-1a0e7
- Visit `/log-in`.
- Log in with any Google account.
- Assert that this event is logged.

`calypso_social_login_form_login_fail`
- Apply patch pb-1a0e4
- Attempt to log in to a Google account on `/log-in`.
- Assert that this event is logged.

- [x] Code
- [x] Product