### PR TITLE
Happychat: Prevent Chat bubble from appearing always for all users

### DIFF
--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -16,7 +16,7 @@ import viewport from 'lib/viewport';
 import {
 	hasUnreadMessages,
 	isHappychatAvailable,
-	isHappychatChatActive,
+	hasActiveHappychatSession,
 } from 'state/happychat/selectors';
 import { connectChat } from 'state/happychat/actions';
 import { openChat } from 'state/ui/happychat/actions';
@@ -89,7 +89,7 @@ export default connect(
 	state => ( {
 		hasUnread: hasUnreadMessages( state ),
 		isChatAvailable: isHappychatAvailable( state ),
-		isChatActive: isHappychatChatActive( state ),
+		isChatActive: hasActiveHappychatSession( state ),
 	} ),
 	{
 		openChat,

--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -12,7 +12,7 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import config from 'config';
 import HappychatButton from 'components/happychat/button';
-import { isHappychatChatActive } from 'state/happychat/selectors';
+import { hasActiveHappychatSession } from 'state/happychat/selectors';
 
 const SidebarFooter = ( { translate, children, isHappychatButtonVisible } ) => (
 	<div className="sidebar__footer">
@@ -32,6 +32,6 @@ const SidebarFooter = ( { translate, children, isHappychatButtonVisible } ) => (
 	</div>
 );
 
-const mapState = ( state ) => ( { isHappychatButtonVisible: isHappychatChatActive( state ) } );
+const mapState = ( state ) => ( { isHappychatButtonVisible: hasActiveHappychatSession( state ) } );
 
 export default connect( mapState )( localize( SidebarFooter ) );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -14,7 +14,7 @@ import config from 'config';
 import Button from 'components/button';
 import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
-import { isHappychatAvailable, isHappychatChatActive } from 'state/happychat/selectors';
+import { isHappychatAvailable, hasActiveHappychatSession } from 'state/happychat/selectors';
 import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
@@ -363,7 +363,7 @@ class CancelPurchaseButton extends Component {
 export default connect(
 	state => ( {
 		isChatAvailable: isHappychatAvailable( state ),
-		isChatActive: isHappychatChatActive( state ),
+		isChatActive: hasActiveHappychatSession( state ),
 	} ),
 	{
 		clearPurchases,

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -32,7 +32,7 @@ import { isDomainRegistration, isPlan, isGoogleApps, isJetpackPlan } from 'lib/p
 import notices from 'notices';
 import purchasePaths from '../paths';
 import { removePurchase } from 'state/purchases/actions';
-import { isHappychatAvailable, isHappychatChatActive } from 'state/happychat/selectors';
+import { isHappychatAvailable, hasActiveHappychatSession } from 'state/happychat/selectors';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import userFactory from 'lib/user';
 import { isDomainOnlySite as isDomainOnly } from 'state/selectors';
@@ -434,7 +434,7 @@ export default connect(
 	( state, { selectedSite } ) => ( {
 		isDomainOnlySite: isDomainOnly( state, selectedSite && selectedSite.ID ),
 		isChatAvailable: isHappychatAvailable( state ),
-		isChatActive: isHappychatChatActive( state ),
+		isChatActive: hasActiveHappychatSession( state ),
 	} ),
 	{
 		receiveDeletedSite,

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -24,7 +24,6 @@ import Button from 'components/button';
 import purchasesPaths from 'me/purchases/paths';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isHappychatAvailable } from 'state/happychat/selectors';
 
 const MeSidebar = React.createClass( {
 
@@ -181,8 +180,7 @@ const MeSidebar = React.createClass( {
 
 function mapStateToProps( state ) {
 	return {
-		currentUser: getCurrentUser( state ),
-		isHappychatAvailable: isHappychatAvailable( state )
+		currentUser: getCurrentUser( state )
 	};
 }
 

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -22,6 +22,7 @@ const HAPPYCHAT_INACTIVE_TIMEOUT_MS = 1000 * 60 * 10;
 export const HAPPYCHAT_CHAT_STATUS_ABANDONED = 'abandoned';
 export const HAPPYCHAT_CHAT_STATUS_ASSIGNED = 'assigned';
 export const HAPPYCHAT_CHAT_STATUS_ASSIGNING = 'assigning';
+export const HAPPYCHAT_CHAT_STATUS_BLOCKED = 'blocked';
 export const HAPPYCHAT_CHAT_STATUS_CLOSED = 'closed';
 export const HAPPYCHAT_CHAT_STATUS_DEFAULT = 'default';
 export const HAPPYCHAT_CHAT_STATUS_NEW = 'new';
@@ -70,7 +71,12 @@ export const isHappychatChatAssigned = createSelector(
  */
 export const hasActiveHappychatSession = createSelector(
 	state => ! includes(
-		[ HAPPYCHAT_CHAT_STATUS_DEFAULT, HAPPYCHAT_CHAT_STATUS_NEW, HAPPYCHAT_CHAT_STATUS_CLOSED ],
+		[
+			HAPPYCHAT_CHAT_STATUS_BLOCKED,
+			HAPPYCHAT_CHAT_STATUS_CLOSED,
+			HAPPYCHAT_CHAT_STATUS_DEFAULT,
+			HAPPYCHAT_CHAT_STATUS_NEW,
+		],
 		state.happychat.chatStatus
 	),
 	state => state.happychat.chatStatus
@@ -117,6 +123,7 @@ export const canUserSendMessages = state => (
 	isHappychatAvailable( state ) &&
 	! includes(
 		[
+			HAPPYCHAT_CHAT_STATUS_BLOCKED,
 			HAPPYCHAT_CHAT_STATUS_DEFAULT,
 			HAPPYCHAT_CHAT_STATUS_PENDING,
 			HAPPYCHAT_CHAT_STATUS_MISSED,

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -19,13 +19,14 @@ import {
 // How much time needs to pass before we consider the session inactive:
 const HAPPYCHAT_INACTIVE_TIMEOUT_MS = 1000 * 60 * 10;
 
-export const HAPPYCHAT_CHAT_STATUS_DEFAULT = 'default';
+export const HAPPYCHAT_CHAT_STATUS_ABANDONED = 'abandoned';
 export const HAPPYCHAT_CHAT_STATUS_ASSIGNED = 'assigned';
 export const HAPPYCHAT_CHAT_STATUS_ASSIGNING = 'assigning';
-export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
-export const HAPPYCHAT_CHAT_STATUS_MISSED = 'missed';
-export const HAPPYCHAT_CHAT_STATUS_ABANDONED = 'abandoned';
 export const HAPPYCHAT_CHAT_STATUS_CLOSED = 'closed';
+export const HAPPYCHAT_CHAT_STATUS_DEFAULT = 'default';
+export const HAPPYCHAT_CHAT_STATUS_NEW = 'new';
+export const HAPPYCHAT_CHAT_STATUS_MISSED = 'missed';
+export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
 
 /**
  * Returns the geo location of the current user, based happychat session initiation (on ip)
@@ -60,12 +61,18 @@ export const isHappychatChatAssigned = createSelector(
 	state => get( state, 'happychat.chatStatus' ) === HAPPYCHAT_CHAT_STATUS_ASSIGNED
 );
 
-export const isHappychatAcceptingChats = createSelector(
-	state => state.happychat.isAvailable
-);
-
-export const isHappychatChatActive = createSelector(
-	state => ! includes( [ HAPPYCHAT_CHAT_STATUS_DEFAULT ], state.happychat.chatStatus ) && isHappychatAcceptingChats( state ),
+/**
+ * Returns true if there's an active chat session in-progress. Chat sessions with
+ * the status `new`, `default`, or `closed` are considered inactive, as the session
+ * is not connected to an operator.
+ * @param {Object} state - global redux state
+ * @return {Boolean} Whether there's an active Happychat session happening
+ */
+export const hasActiveHappychatSession = createSelector(
+	state => ! includes(
+		[ HAPPYCHAT_CHAT_STATUS_DEFAULT, HAPPYCHAT_CHAT_STATUS_NEW, HAPPYCHAT_CHAT_STATUS_CLOSED ],
+		state.happychat.chatStatus
+	),
 	state => state.happychat.chatStatus
 );
 
@@ -82,10 +89,12 @@ export const getHappychatStatus = createSelector(
 	state => state.happychat.chatStatus
 );
 
-export const isHappychatAvailable = createSelector(
-	state => isHappychatAcceptingChats( state ) || isHappychatChatActive( state ),
-	[ isHappychatAcceptingChats, isHappychatChatActive ]
-);
+/**
+ * Returns true if Happychat is available to take new chats.
+ * @param {Object} state - global redux state
+ * @return {Boolean} Whether Happychat is available for new chats
+ */
+export const isHappychatAvailable = state => isHappychatClientConnected( state ) && state.happychat.isAvailable;
 
 /**
  * Gets timeline chat events from the happychat state
@@ -97,16 +106,24 @@ export const getHappychatTimeline = createSelector(
 	state => map( state.happychat.timeline, 'id' )
 );
 
-export const canUserSendMessages = createSelector(
-	state => (
-		getHappychatConnectionStatus( state ) === 'connected' &&
-		! includes(
-			[	HAPPYCHAT_CHAT_STATUS_PENDING, HAPPYCHAT_CHAT_STATUS_MISSED,
-				HAPPYCHAT_CHAT_STATUS_ABANDONED ],
-			getHappychatChatStatus( state )
-		) && isHappychatAcceptingChats( state )
-	),
-	[ getHappychatConnectionStatus, getHappychatChatStatus ]
+/**
+ * Returns true if the user should be able to send messages to operators based on
+ * chat status. For example new chats and ongoing chats should be able to send messages,
+ * but blocked or pending chats should not.
+ * @param {Object} state - global redux state
+ * @return {Boolean} Whether the user is able to send messages
+ */
+export const canUserSendMessages = state => (
+	isHappychatAvailable( state ) &&
+	! includes(
+		[
+			HAPPYCHAT_CHAT_STATUS_DEFAULT,
+			HAPPYCHAT_CHAT_STATUS_PENDING,
+			HAPPYCHAT_CHAT_STATUS_MISSED,
+			HAPPYCHAT_CHAT_STATUS_ABANDONED
+		],
+		getHappychatChatStatus( state )
+	)
 );
 
 export const wasHappychatRecentlyActive = state => {

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -86,38 +87,38 @@ describe( 'selectors', () => {
 		];
 
 		it( 'should return false if Happychat is unavailable', () => {
-			const state = {
+			const state = deepFreeze( {
 				happychat: {
 					connectionStatus: 'uninitialized',
 					isAvailable: false,
 					chatStatus: HAPPYCHAT_CHAT_STATUS_NEW
 				}
-			};
+			} );
 			expect( canUserSendMessages( state ) ).to.be.false;
 		} );
 
 		it( "should return false if Happychat is available but the chat status doesn't allow messaging", () => {
 			messagingDisabledChatStatuses.forEach( status => {
-				const state = {
+				const state = deepFreeze( {
 					happychat: {
 						connectionStatus: 'connected',
 						isAvailable: true,
 						chatStatus: status
 					}
-				};
+				} );
 				expect( canUserSendMessages( state ) ).to.be.false;
 			} );
 		} );
 
 		it( 'should return true if Happychat is available and the chat status allows messaging', () => {
 			messagingEnabledChatStatuses.forEach( status => {
-				const state = {
+				const state = deepFreeze( {
 					happychat: {
 						connectionStatus: 'connected',
 						isAvailable: true,
 						chatStatus: status
 					}
-				};
+				} );
 				expect( canUserSendMessages( state ) ).to.be.true;
 			} );
 		} );
@@ -125,7 +126,7 @@ describe( 'selectors', () => {
 
 	describe( '#getLostFocusTimestamp', () => {
 		it( 'returns the current timestamp', () => {
-			const state = { happychat: { lostFocusAt: NOW } };
+			const state = deepFreeze( { happychat: { lostFocusAt: NOW } } );
 			expect( getLostFocusTimestamp( state ) ).to.eql( NOW );
 		} );
 	} );
@@ -143,32 +144,32 @@ describe( 'selectors', () => {
 		];
 
 		it( 'returns false if Happychat is focused', () => {
-			const state = {
+			const state = deepFreeze( {
 				happychat: {
 					timeline,
 					lostFocusAt: null
 				}
-			};
+			} );
 			expect( hasUnreadMessages( state ) ).to.be.false;
 		} );
 
 		it( 'returns false if there are no new messages since the Happychat was blurred', () => {
-			const state = {
+			const state = deepFreeze( {
 				happychat: {
 					timeline,
 					lostFocusAt: NOW + ONE_MINUTE
 				}
-			};
+			} );
 			expect( hasUnreadMessages( state ) ).to.be.false;
 		} );
 
 		it( 'returns true if there are one or more messages after Happychat was blurred', () => {
-			const state = {
+			const state = deepFreeze( {
 				happychat: {
 					timeline,
 					lostFocusAt: NOW - ONE_MINUTE - ONE_MINUTE
 				}
-			};
+			} );
 			expect( hasUnreadMessages( state ) ).to.be.true;
 		} );
 	} );
@@ -190,14 +191,14 @@ describe( 'selectors', () => {
 
 		it( 'should be false when chatStatus indicates the user has no active session', () => {
 			inactiveChatStatuses.forEach( status => {
-				const state = { happychat: { chatStatus: status } };
+				const state = deepFreeze( { happychat: { chatStatus: status } } );
 				expect( hasActiveHappychatSession( state ) ).to.be.false;
 			} );
 		} );
 
 		it( 'should be true when chatStatus indicates the user has an active session', () => {
 			activeChatStatuses.forEach( status => {
-				const state = { happychat: { chatStatus: status } };
+				const state = deepFreeze( { happychat: { chatStatus: status } } );
 				expect( hasActiveHappychatSession( state ) ).to.be.true;
 			} );
 		} );
@@ -205,32 +206,32 @@ describe( 'selectors', () => {
 
 	describe( '#isHappychatAvailable', () => {
 		it( "should be false if there's no active connection", () => {
-			const state = {
+			const state = deepFreeze( {
 				happychat: {
 					connectionStatus: 'uninitialized',
 					isAvailable: true
 				}
-			};
+			} );
 			expect( isHappychatAvailable( state ) ).to.be.false;
 		} );
 
 		it( "should be false if Happychat isn't accepting new connections", () => {
-			const state = {
+			const state = deepFreeze( {
 				happychat: {
 					connectionStatus: 'connected',
 					isAvailable: false
 				}
-			};
+			} );
 			expect( isHappychatAvailable( state ) ).to.be.false;
 		} );
 
 		it( "should be true when there's a connection and connections are being accepted", () => {
-			const state = {
+			const state = deepFreeze( {
 				happychat: {
 					connectionStatus: 'connected',
 					isAvailable: true
 				}
-			};
+			} );
 			expect( isHappychatAvailable( state ) ).to.be.true;
 		} );
 	} );

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -110,6 +110,19 @@ describe( 'selectors', () => {
 			} );
 		} );
 
+		it( 'should return true if Happychat is available but client is not connected', () => {
+			messagingEnabledChatStatuses.forEach( status => {
+				const state = deepFreeze( {
+					happychat: {
+						connectionStatus: 'uninitialized',
+						isAvailable: true,
+						chatStatus: status
+					}
+				} );
+				expect( canUserSendMessages( state ) ).to.be.false;
+			} );
+		} );
+
 		it( 'should return true if Happychat is available and the chat status allows messaging', () => {
 			messagingEnabledChatStatuses.forEach( status => {
 				const state = deepFreeze( {


### PR DESCRIPTION
Currently, all users are seeing the chat bubble appear in the left sidebar's footer once Happychat connects, whether they should or not. This is due to some regressions in Happychat selector logic and a lack of clarity in those selectors' intent.

This PR cleans up those selectors so that only users in an active Happychat conversation will see the chat bubble.

Refs: 522-gh-happychat + 440-gh-happychat

### To reproduce

- In `master` sign in as a free user or create a new free account
- Navigate to `/help/contact`
- You should see the Happychat bubble appear (this should not happen)

### To test the fix

- Reproduce steps above with `happychat/fix-chat-bubble-logic` branch, and the chat bubble should not appear


### To test against regressions

- Sign in as a paid user and start a Happychat session
- The bubble should appear
- Refresh the page — the bubble should still be there (unless Calypso reset your Redux state on refresh)
- `/end` the chat from the operator and refresh Calypso — you should not see the bubble

### Check selector logic

These selectors were modified: `hasActiveHappychatSession`, `isHappychatAvailable`, `canUserSendMessages`

Read the docblocks added above the modified selectors — do the selector name and logic seem to do what the description says it should do?

Check each usage in the code of those selectors (there's not _that_ many). Does the intention of the selector match how its being used in each instance?

