### PR TITLE
Directly: Prevent multiple questions and tweak copy

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -591,6 +591,7 @@ const HelpContact = React.createClass( {
 	 */
 	getView: function() {
 		const { olark, confirmation } = this.state;
+		const { translate } = this.props;
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
@@ -630,11 +631,12 @@ const HelpContact = React.createClass( {
 			// removed and re-mounted. Using `confirmation` in component state would mean you could
 			// ask a new Directy question every time you left the help section and came back.
 			const directlyConfirmation = {
-				title: this.props.translate( 'We\'re on it!' ),
-				message: this.props.translate(
-					'Our {{strong}}Expert Users{{/strong}} have received your question and ' +
-					'you will be hearing back shortly. Feel free to close this page if you need ' +
-					'and we\'ll send you an email when our experts respond.',
+				title: translate( "We're on it!" ),
+				message: translate(
+					'We sent your question to our {{strong}}Expert Users{{/strong}}. ' +
+					'You will hear back via email as soon as an Expert has responded ' +
+					'(usually within an hour). For now you can close this window or ' +
+					'continue using WordPress.com.',
 					{
 						components: {
 							strong: <strong />
@@ -654,7 +656,7 @@ const HelpContact = React.createClass( {
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) &&
 					<Notice
 						status="is-warning"
-						text={ this.props.translate( 'We had trouble loading the support information for your account. ' +
+						text={ translate( 'We had trouble loading the support information for your account. ' +
 							'Please check your internet connection and reload the page, or try again later.' ) }
 						showDismiss={ false }
 					/>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -492,13 +492,14 @@ const HelpContact = React.createClass( {
 					onSubmit: this.submitDirectlyQuestion,
 					buttonLabel: translate( 'Ask an Expert' ),
 					formDescription: translate(
-						'Chat with an {{strong}}Expert User{{/strong}} of WordPress.com. ' +
-						'These are other users, like yourself, that have been selected ' +
-						'because of their knowledge to help answer your questions. ' +
-						'{{strong}}Please do not{{/strong}} provide financial or ' +
-						'contact information when submitting this form.',
+						'{{p}}Get help from an {{strong}}Expert User{{/strong}} of WordPress.com. ' +
+						'These are other users, like yourself, who have been selected because ' +
+						'of their knowledge to help answer your questions.{{/p}}' +
+						'{{p}}{{strong}}Please do not{{/strong}} provide financial or contact ' +
+						'information when submitting this form.{{/p}}',
 						{
 							components: {
+								p: <p />,
 								strong: <strong />
 							}
 						} ),

--- a/client/state/help/directly/reducer.js
+++ b/client/state/help/directly/reducer.js
@@ -4,6 +4,7 @@
 import { combineReducers, createReducer } from 'state/utils';
 
 import {
+	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
 	DIRECTLY_INITIALIZATION_SUCCESS,
 	DIRECTLY_INITIALIZATION_ERROR,
@@ -15,6 +16,16 @@ import {
 	STATUS_ERROR,
 } from './constants';
 
+export const questionAsked = ( state = null, action ) => {
+	switch ( action.type ) {
+		case DIRECTLY_ASK_QUESTION:
+			const { questionText, name, email } = action;
+			return { questionText, name, email };
+	}
+
+	return state;
+};
+
 export const status = createReducer( STATUS_UNINITIALIZED, {
 	[ DIRECTLY_INITIALIZATION_START ]: () => STATUS_INITIALIZING,
 	[ DIRECTLY_INITIALIZATION_SUCCESS ]: () => STATUS_READY,
@@ -22,5 +33,6 @@ export const status = createReducer( STATUS_UNINITIALIZED, {
 } );
 
 export default combineReducers( {
+	questionAsked,
 	status,
 } );

--- a/client/state/help/directly/test/reducer.js
+++ b/client/state/help/directly/test/reducer.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
 	DIRECTLY_INITIALIZATION_SUCCESS,
 	DIRECTLY_INITIALIZATION_ERROR,
@@ -18,14 +19,32 @@ import {
 	STATUS_ERROR,
 } from '../constants';
 import reducer, {
+	questionAsked,
 	status,
 } from '../reducer';
 
 describe( 'reducer', () => {
 	it( 'should include expected keys in return value', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'questionAsked',
 			'status',
 		] );
+	} );
+
+	describe( '#questionAsked()', () => {
+		it( 'should default to null', () => {
+			const state = questionAsked( undefined, {} );
+			expect( state ).to.eql( null );
+		} );
+
+		it( 'should set once a question is asked', () => {
+			const questionText = 'What is the answer to the ultimate question of life, the universe, and everything?';
+			const name = 'Douglas Adams';
+			const email = 'doug@hhguide.com';
+			const action = { type: DIRECTLY_ASK_QUESTION, questionText, name, email };
+			const state = questionAsked( undefined, action );
+			expect( state ).to.eql( { questionText, name, email } );
+		} );
 	} );
 
 	describe( '#status()', () => {

--- a/client/state/selectors/has-user-asked-a-directly-question.js
+++ b/client/state/selectors/has-user-asked-a-directly-question.js
@@ -1,0 +1,12 @@
+/**
+ * Tells whether the user has asked a question through the Directly RTM widget.
+ *
+ * @see lib/directly for more about Directly
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {Boolean}        Whether a question has been asked
+ */
+
+export default function hasUserAskedADirectlyQuestion( state ) {
+	return state.help.directly.questionAsked !== null;
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -76,6 +76,7 @@ export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getSelectedOrAllSites from './get-selected-or-all-sites';
 export getScheduledPublicizeShareActionTime from './get-scheduled-publicize-share-action-time';
+export hasUserAskedADirectlyQuestion from './has-user-asked-a-directly-question';
 export isSchedulingPublicizeShareActionError from './is-scheduling-publicize-share-action-error';
 export getSharingButtons from './get-sharing-buttons';
 export getSiteComments from './get-site-comments';
@@ -202,4 +203,3 @@ export prependThemeFilterKeys from './prepend-theme-filter-keys';
 export shouldCloseVideoEditorModal from './should-close-video-editor-modal';
 export shouldShowVideoEditorError from './should-show-video-editor-error';
 export shouldSyncReaderFollows from './should-sync-reader-follows';
-

--- a/client/state/selectors/test/has-user-asked-a-directly-question.js
+++ b/client/state/selectors/test/has-user-asked-a-directly-question.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -9,11 +10,11 @@ import { expect } from 'chai';
 import { hasUserAskedADirectlyQuestion } from '../';
 
 describe( 'hasUserAskedADirectlyQuestion()', () => {
-	const questionData = {
+	const questionData = deepFreeze( {
 		questionText: 'ABC',
 		name: '123',
 		email: 'fake@wordpress.com'
-	};
+	} );
 
 	it( 'should be false when null', () => {
 		const state = { help: { directly: { questionAsked: null } } };

--- a/client/state/selectors/test/has-user-asked-a-directly-question.js
+++ b/client/state/selectors/test/has-user-asked-a-directly-question.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { hasUserAskedADirectlyQuestion } from '../';
+
+describe( 'hasUserAskedADirectlyQuestion()', () => {
+	const questionData = {
+		questionText: 'ABC',
+		name: '123',
+		email: 'fake@wordpress.com'
+	};
+
+	it( 'should be false when null', () => {
+		const state = { help: { directly: { questionAsked: null } } };
+		expect( hasUserAskedADirectlyQuestion( state ) ).to.be.false;
+	} );
+
+	it( 'should be true when a question is present', () => {
+		const state = { help: { directly: { questionAsked: questionData } } };
+		expect( hasUserAskedADirectlyQuestion( state ) ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
Our Directly reps have noticed that we're getting a fair percentage of repeat questions from users who return to the contact form and ask the same thing before they get a response from their first question. This PR gives a best quick effort to curtail this.

Ref: 212-gh-hg

### To reproduce

- In `master` sign in as a free user and go to `/help/contact`. If you don't see the Directly form appear you may need to sign in as a different user, since we throttle based on user ID.
- Ask a question (this goes a sandbox Directly account on `development` so don't worry)
- Minimize the Directly interface and click on the "Contact Us" button
- You should see the Directly form appear and be able to fill it out again to ask a new question (this is undesired)

### To test the fix

- Grab the `update/directly-tweaks` branch and follow the steps above
- Instead of seeing the form when you go back you should see a confirmation message

### Copy review needed

The copy tweaks to the form came from Directly, but there was no copy given for the confirmation screen. Here's what I put together, and it can be changed very easily:

<img width="833" alt="screen shot 2017-06-05 at 9 04 19 pm" src="https://cloud.githubusercontent.com/assets/518059/26811144/94bc2512-4a35-11e7-9ee5-ef9b50f1bbad.png">

> #### We're on it!
> Our __Expert Users__ have received your question and you will be hearing back shortly. Feel free to close this page if you need and we'll send you an email when our experts respond.

### Caveats

When the user refreshes the page, they are still able to go back to the help form and ask the same question again. Directly does not provide any API to determine if a user's questions have been answered, so it's probably safest for us to assume that after a page load, the user should always have access to the Directly question form again.