### PR TITLE
Happychat: Remove temporary "staging events"

### DIFF
--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -81,23 +81,6 @@ class Connection extends EventEmitter {
 		);
 	}
 
-	// This is a temporary measure — we want to start sending some events that are
-	// picked up by the staged HUD but not by the production HUD. The only way to do this
-	// now is to send a different event type, and make the staging HUD render this event.
-	// Once the HUD side ships to production, we should delete this function and just use
-	// sendEvent for event messages.
-	sendStagingEvent( message ) {
-		this.openSocket.then(
-			socket => socket.emit( 'message', {
-				text: message,
-				id: uuid(),
-				type: 'customer-event-staging',
-				meta: { forOperator: true, event_type: 'customer-event-staging' }
-			} ),
-			e => debug( 'failed to send message', e )
-		);
-	}
-
 	sendLog( message ) {
 		this.openSocket.then(
 			socket => socket.emit( 'message', {

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -260,7 +260,7 @@ export const sendAnalyticsLogEvent = ( connection, { meta: { analytics: analytic
 			const eventMessage = getEventMessageFromTracksData( { name, properties } );
 			if ( eventMessage ) {
 				// Once we want these events to appear in production we should change this to sendEvent
-				connection.sendStagingEvent( eventMessage );
+				connection.sendEvent( eventMessage );
 			}
 
 			// Always send a log for every tracks event
@@ -286,7 +286,7 @@ export const sendActionLogsAndEvents = ( connection, { getState }, action ) => {
 	const eventMessage = getEventMessageFromActionData( action );
 	if ( eventMessage ) {
 		// Once we want these events to appear in production we should change this to sendEvent
-		connection.sendStagingEvent( eventMessage );
+		connection.sendEvent( eventMessage );
 	}
 };
 

--- a/client/state/happychat/test/middleware.js
+++ b/client/state/happychat/test/middleware.js
@@ -296,7 +296,7 @@ describe( 'middleware', () => {
 		useSandbox( sandbox => {
 			connection = {
 				sendLog: sandbox.stub(),
-				sendStagingEvent: sandbox.stub(),
+				sendEvent: sandbox.stub(),
 			};
 		} );
 
@@ -309,7 +309,7 @@ describe( 'middleware', () => {
 			sendAnalyticsLogEvent( connection, { meta: { analytics: analyticsMeta } } );
 
 			expect( connection.sendLog ).not.to.have.been.called;
-			expect( connection.sendStagingEvent ).not.to.have.been.called;
+			expect( connection.sendEvent ).not.to.have.been.called;
 		} );
 
 		it( 'should send log events for all listed tracks events', () => {
@@ -337,7 +337,7 @@ describe( 'middleware', () => {
 			];
 			sendAnalyticsLogEvent( connection, { meta: { analytics: analyticsMeta } } );
 
-			expect( connection.sendStagingEvent.callCount ).to.equal( 2 );
+			expect( connection.sendEvent.callCount ).to.equal( 2 );
 		} );
 	} );
 
@@ -366,7 +366,7 @@ describe( 'middleware', () => {
 		useSandbox( sandbox => {
 			connection = {
 				sendLog: sandbox.stub(),
-				sendStagingEvent: sandbox.stub(),
+				sendEvent: sandbox.stub(),
 			};
 
 			getState = sandbox.stub();
@@ -389,7 +389,7 @@ describe( 'middleware', () => {
 			sendActionLogsAndEvents( connection, { getState }, action );
 
 			expect( connection.sendLog ).not.to.have.been.called;
-			expect( connection.sendStagingEvent ).not.to.have.been.called;
+			expect( connection.sendEvent ).not.to.have.been.called;
 		} );
 
 		it( 'should not send log events if the Happychat connection is unassigned', () => {
@@ -405,7 +405,7 @@ describe( 'middleware', () => {
 			sendActionLogsAndEvents( connection, { getState }, action );
 
 			expect( connection.sendLog ).not.to.have.been.called;
-			expect( connection.sendStagingEvent ).not.to.have.been.called;
+			expect( connection.sendEvent ).not.to.have.been.called;
 		} );
 
 		it( 'should send matching events when Happychat is connected and assigned', () => {
@@ -429,7 +429,7 @@ describe( 'middleware', () => {
 			expect( connection.sendLog.callCount ).to.equal( 4 );
 			// The two whitelisted analytics events and the HAPPYCHAT_BLUR action itself
 			// will be sent as customer events
-			expect( connection.sendStagingEvent.callCount ).to.equal( 3 );
+			expect( connection.sendEvent.callCount ).to.equal( 3 );
 		} );
 	} );
 } );


### PR DESCRIPTION
"Customer staging events" were used to send events from production Calypso to staging Happychat only (to test out analytics/user event notifications). Those are now in production, so this PR replaces "Customer staging events" with the normal "Customer events".

### To test

- Start a Happychat session
- In Calypso, change the theme for one of your sites
- In the HUD you should see new events appearing in the Analytics Log, and you should see a `Changed theme from X to Y` message inline.