### PR TITLE
Update/Design: Fix spacing between site-settings footer credit explanation and button

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -35,6 +35,7 @@ import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { preventWidows } from 'lib/formatting';
 
 class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {
@@ -471,7 +472,10 @@ class SiteSettingsFormGeneral extends Component {
 						<SectionHeader label={ translate( 'Footer Credit' ) } />
 						<CompactCard className="site-settings__footer-credit-explanation">
 							<p>
-								{ translate( 'You can customize your website by changing the footer credit in customizer.' ) }
+								{ preventWidows(
+									translate( 'You can customize your website by changing the footer credit in customizer.' ),
+									2 )
+								}
 							</p>
 							<div>
 								<Button className="site-settings__footer-credit-change" href={ '/customize/identity/' + siteSlug }>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -288,6 +288,7 @@
 .site-settings__footer-credit-change {
 	width: 175px;
 	text-align:center;
+	margin-left: 12px;
 }
 
 .site-settings__footer-credit-explanation {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -288,7 +288,7 @@
 .site-settings__footer-credit-change {
 	width: 175px;
 	text-align:center;
-	margin-left: 12px;
+	margin-left: 24px;
 }
 
 .site-settings__footer-credit-explanation {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -295,6 +295,9 @@
 	display:flex;
 	flex-direction: row;
 	justify-content: space-between;
+} 
+.site-settings__footer-credit-explanation p {
+	margin: 0
 }
 
 


### PR DESCRIPTION
closes #14412

When on page [ https://wordpress.com/settings/general/SITE_URL]( https://wordpress.com/settings/general/) the edit credit button is very close to the explanation text.

Add `margin-left: 12px` to the footer credit update button in site settings. I picked 12 px because on my browser that was the max before turning the explanation text into a two-liner. Please let me know if this is preserved on your browsers, or if more space is preferred over keeping the flow of the text.

Gives some breathing room between text and button
Here is the before margin-left:

![before image](http://i.imgur.com/QD1loD2.png)


And the after:

![after image](http://i.imgur.com/hVBPbzi.png)


cc @lsinger 

p.s. Thank you calypso team for the First Timer label! This got me up to speed on the CONTRIBUTING.md and I feel ready to get involved.