### PR TITLE
Add tracking for popover cart impressions.

### DIFF
--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -19,6 +19,7 @@ import Popover from 'components/popover';
 import CartEmpty from './cart-empty';
 import CartPlanAd from './cart-plan-ad';
 import { isCredits } from 'lib/products-values';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 const PopoverCart = React.createClass( {
 	propTypes: {
@@ -56,7 +57,12 @@ const PopoverCart = React.createClass( {
 			const className = abtest( 'pulsingCartTestingAB' ) === 'modified'
 					? 'popover-cart__count-badge count-badge-pulsing'
 					: 'popover-cart__count-badge';
-			countBadge = <div className={ className }>{ this.itemCount() }</div>;
+			countBadge = (
+				<div className={ className }>
+					{ this.itemCount() }
+					<TrackComponentView eventName="calypso_popover_cart_badge_impression" />
+				</div>
+			);
 		}
 
 		return (
@@ -85,6 +91,9 @@ const PopoverCart = React.createClass( {
 						onClose={ this.onClose }
 						context={ this.refs.toggleButton }>
 					{ this.cartBody() }
+				<TrackComponentView
+					eventName="calypso_popover_cart_content_impression"
+					eventProperties={ { style: 'popover' } } />
 				</Popover>
 			);
 		}
@@ -93,6 +102,9 @@ const PopoverCart = React.createClass( {
 				<div className="popover-cart__mobile-cart">
 					<div className="top-arrow"></div>
 					{ this.cartBody() }
+					<TrackComponentView
+						eventName="calypso_popover_cart_content_impression"
+						eventProperties={ { style: 'mobile-cart' } } />
 				</div>
 			);
 		}


### PR DESCRIPTION
Currently there is no tracking of popover cart impressions.

This adds `calypso_popover_cart_badge_impression` events for rendering the popover shopping cart badge and `calypso_popover_cart_content_impression` when the cart contents are revealed.

These events are needed to determine the impact of the animation in the `pulsingCartTestingAB` a/b test (see #14652).

To test:

* create a free site
* add a plan to the cart on `/plans/$SITE` (which will take you to the checkout page)
* execute `localStorage.setItem('debug', 'calypso:analytics:tracks');` in the console
* navigate back to previous route
* you should see a `calypso_popover_cart_badge_impression` event in the console
* click on the cart to reveal the cart contents
* you should see a `calypso_popover_cart_content_impression` (with event property `style` = `popover` on desktop or `mobile-cart` on mobile)
 