### PR TITLE
Make `wpcom_user_bootstrap` a feature

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -143,7 +143,7 @@ export const locales = currentUser => {
 
 	// When the user is not bootstrapped, we also bootstrap the
 	// locale strings
-	if ( ! config.isEnabled( 'wpcom_user_bootstrap' ) ) {
+	if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		switchUserLocale( currentUser );
 	}
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -143,7 +143,7 @@ export const locales = currentUser => {
 
 	// When the user is not bootstrapped, we also bootstrap the
 	// locale strings
-	if ( ! config( 'wpcom_user_bootstrap' ) ) {
+	if ( ! config.isEnabled( 'wpcom_user_bootstrap' ) ) {
 		switchUserLocale( currentUser );
 	}
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -61,7 +61,7 @@ User.prototype.initialize = function() {
 		return;
 	}
 
-	if ( config.isEnabled( 'wpcom_user_bootstrap' ) ) {
+	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		this.data = window.currentUser || false;
 
 		// Store the current user in localStorage so that we can use it to determine
@@ -131,7 +131,7 @@ User.prototype.fetch = function() {
 
 	me.get( { meta: 'flags' }, function( error, data ) {
 		if ( error ) {
-			if ( ! config.isEnabled( 'wpcom_user_bootstrap' ) && error.error === 'authorization_required' ) {
+			if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) && error.error === 'authorization_required' ) {
 				/**
 				 * if the user bootstrap is disabled (in development), we need to rely on a request to
 				 * /me to determine if the user is logged in.

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -61,7 +61,7 @@ User.prototype.initialize = function() {
 		return;
 	}
 
-	if ( config( 'wpcom_user_bootstrap' ) ) {
+	if ( config.isEnabled( 'wpcom_user_bootstrap' ) ) {
 		this.data = window.currentUser || false;
 
 		// Store the current user in localStorage so that we can use it to determine
@@ -131,7 +131,7 @@ User.prototype.fetch = function() {
 
 	me.get( { meta: 'flags' }, function( error, data ) {
 		if ( error ) {
-			if ( ! config( 'wpcom_user_bootstrap' ) && error.error === 'authorization_required' ) {
+			if ( ! config.isEnabled( 'wpcom_user_bootstrap' ) && error.error === 'authorization_required' ) {
 				/**
 				 * if the user bootstrap is disabled (in development), we need to rely on a request to
 				 * /me to determine if the user is logged in.

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -39,7 +39,7 @@ export default {
 				stepSectionName = utils.getStepSectionName( context.params ),
 				urlWithoutLocale = utils.getStepUrl( flowName, stepName, stepSectionName );
 
-			if ( config( 'wpcom_user_bootstrap' ) ) {
+			if ( config.isEnabled( 'wpcom_user_bootstrap' ) ) {
 				return page.redirect( urlWithoutLocale );
 			}
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -39,7 +39,7 @@ export default {
 				stepSectionName = utils.getStepSectionName( context.params ),
 				urlWithoutLocale = utils.getStepUrl( flowName, stepName, stepSectionName );
 
-			if ( config.isEnabled( 'wpcom_user_bootstrap' ) ) {
+			if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 				return page.redirect( urlWithoutLocale );
 			}
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -179,6 +179,5 @@
 	"signup_url": false,
 	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/",
 	"wpcom_signup_id": false,
-	"wpcom_signup_key": false,
-	"wpcom_user_bootstrap": false
+	"wpcom_signup_key": false
 }

--- a/config/client.json
+++ b/config/client.json
@@ -36,6 +36,5 @@
   "sync-handler-defaults",
   "twemoji_cdn_url",
   "wpcom_signup_id",
-  "wpcom_signup_key",
-  "wpcom_user_bootstrap"
+  "wpcom_signup_key"
 ]

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -83,7 +83,7 @@
 		"upgrades/premium-themes": true,
 		"upgrades/presale-chat": true,
 		"upgrades/removal-survey": true,
-		"wpcom_user_bootstrap": false
+		"wpcom-user-bootstrap": false
 	},
 	"readerFollowingSource": "desktop",
 	"rtl": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -4,7 +4,6 @@
 	"client_slug": "desktop",
 	"hostname": "127.0.0.1",
 	"i18n_default_locale_slug": "en",
-	"wpcom_user_bootstrap": false,
 	"signup_url": "/start/desktop",
 	"login_url": "/oauth-login",
 	"logout_url": "/logout",
@@ -83,7 +82,8 @@
 		"upgrades/paypal": false,
 		"upgrades/premium-themes": true,
 		"upgrades/presale-chat": true,
-		"upgrades/removal-survey": true
+		"upgrades/removal-survey": true,
+		"wpcom_user_bootstrap": false
 	},
 	"readerFollowingSource": "desktop",
 	"rtl": false,

--- a/config/development.json
+++ b/config/development.json
@@ -7,7 +7,6 @@
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
-	"wpcom_user_bootstrap": false,
 	"rtl": false,
 	"jetpack_min_version": "3.3",
 	"siftscience_key": "e00e878351",
@@ -165,6 +164,7 @@
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-stats": false,
-		"wp-login": true
+		"wp-login": true,
+		"wpcom_user_bootstrap": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -165,6 +165,6 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-stats": false,
 		"wp-login": true,
-		"wpcom_user_bootstrap": false
+		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -94,7 +94,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"wpcom_user_bootstrap": true
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -4,7 +4,6 @@
 	"client_slug": "browser",
 	"hostname": "horizon.wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"wpcom_user_bootstrap": true,
 	"rtl": false,
 	"jetpack_min_version": "3.3-dev",
 	"signup_url": "/start",
@@ -94,7 +93,8 @@
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
-		"upgrades/presale-chat": true
+		"upgrades/presale-chat": true,
+		"wpcom_user_bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -4,7 +4,6 @@
 	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"wpcom_user_bootstrap": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
@@ -97,7 +96,8 @@
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
-		"upgrades/presale-chat": true
+		"upgrades/presale-chat": true,
+		"wpcom_user_bootstrap": true
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/production.json
+++ b/config/production.json
@@ -97,7 +97,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"wpcom_user_bootstrap": true
+		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/stage.json
+++ b/config/stage.json
@@ -102,7 +102,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"wpcom_user_bootstrap": true
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -5,7 +5,6 @@
 	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"wpcom_user_bootstrap": true,
 	"rtl": false,
 	"jetpack_min_version": "3.3",
 	"signup_url": "/start",
@@ -102,7 +101,8 @@
 		"upgrades/premium-themes": true,
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
-		"upgrades/presale-chat": true
+		"upgrades/presale-chat": true,
+		"wpcom_user_bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -5,7 +5,6 @@
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
-	"wpcom_user_bootstrap": false,
 	"rtl": false,
 	"jetpack_min_version": "3.3",
 	"siftscience_key": "e00e878351",
@@ -101,6 +100,7 @@
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
-		"upgrades/premium-themes": true
+		"upgrades/premium-themes": true,
+		"wpcom_user_bootstrap": false
 	}
 }

--- a/config/test.json
+++ b/config/test.json
@@ -101,6 +101,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"wpcom_user_bootstrap": false
+		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -5,7 +5,6 @@
 	"directly_rtm_widget_environment": "sandbox",
 	"hostname": "wpcalypso.wordpress.com",
 	"i18n_default_locale_slug": "en",
-	"wpcom_user_bootstrap": true,
 	"rtl": false,
 	"jetpack_min_version": "3.3-dev",
 	"signup_url": "/start",
@@ -125,7 +124,8 @@
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-stats": false,
-		"wp-login": true
+		"wp-login": true,
+		"wpcom_user_bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,7 +125,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-stats": false,
 		"wp-login": true,
-		"wpcom_user_bootstrap": true
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -203,7 +203,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 	const context = getDefaultContext( req );
 
-	if ( config( 'wpcom_user_bootstrap' ) ) {
+	if ( config.isEnabled( 'wpcom_user_bootstrap' ) ) {
 		const user = require( 'user-bootstrap' );
 
 		protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -203,7 +203,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 	const context = getDefaultContext( req );
 
-	if ( config.isEnabled( 'wpcom_user_bootstrap' ) ) {
+	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		const user = require( 'user-bootstrap' );
 
 		protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';


### PR DESCRIPTION
This PR makes `wpcom_user_bootstrap` a feature so we can enable/disable it from the command line using the `ENABLE_FEATURES`/`DISABLE_FEATURES` environment variables.
The primary use for this is to test other environments locally without needing a valid `wpcom_calypso_rest_api_key`.

Test it by running the following command locally:
```
NODE_ENV=production CALYPSO_ENV=wpcalypso DISABLE_FEATURES=wpcom_user_bootstrap npm run start
```

The secondary use is for `calypso.live` so we can bootstrap other environments than `development` which consumes a lot of memory and watches too many files.

Pinging people who have experience on the server part of calypso for a review in case there is a security concern with this approach.