### PR TITLE
Text Utils: Fix default exporting an object, preventing tree shaking

### DIFF
--- a/client/lib/text-utils/index.js
+++ b/client/lib/text-utils/index.js
@@ -1,10 +1,11 @@
 /**
  * External Dependencies
  */
-import { diffWords } from 'diff';
 import { reduce } from 'lodash';
 
-function countWords( content ) {
+export { diffWords } from 'diff';
+
+export function countWords( content ) {
 	// Adapted from TinyMCE wordcount plugin:
 	// https://github.com/tinymce/tinymce/blob/4.2.6/js/tinymce/plugins/wordcount/plugin.js
 
@@ -30,7 +31,7 @@ function countWords( content ) {
 	return 0;
 }
 
-function countDiffWords( diffChanges ) {
+export function countDiffWords( diffChanges ) {
 	return reduce(
 		diffChanges,
 		( accumulator, change ) => {
@@ -49,9 +50,3 @@ function countDiffWords( diffChanges ) {
 		},
 	);
 }
-
-export default {
-	countDiffWords,
-	countWords,
-	diffWords,
-};

--- a/client/lib/text-utils/test/index.js
+++ b/client/lib/text-utils/test/index.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import textUtils from '../';
+import { countDiffWords, countWords } from '../';
 
 // Adapted from TinyMCE word count tests:
 // https://github.com/tinymce/tinymce/blob/4.2.6/tests/plugins/wordcount.js
@@ -14,49 +14,49 @@ import textUtils from '../';
 describe( 'index', () => {
 	describe( '#wordCount', () => {
 		it( 'should return 0 for blank content', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				''
 			) ).to.equal( 0 );
 		} );
 
 		it( 'should strip HTML tags and count words for a simple sentence', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				'<p>My sentence is this.</p>'
 			) ).to.equal( 4 );
 		} );
 
 		it( 'should not count dashes', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				'<p>Something -- ok</p>'
 			) ).to.equal( 2 );
 		} );
 
 		it( 'should not count asterisks or other non-word characters', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				'<p>* something\n\u00b7 something else</p>'
 			) ).to.equal( 3 );
 		} );
 
 		it( 'should not count numbers', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				'<p>Something 123 ok</p>'
 			) ).to.equal( 2 );
 		} );
 
 		it( 'should not count HTML entities', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				'<p>It&rsquo;s my life &ndash; &#8211; &#x2013; don\'t you forget.</p>'
 			) ).to.equal( 6 );
 		} );
 
 		it( 'should count hyphenated words as one word', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				'<p>Hello some-word here.</p>'
 			) ).to.equal( 3 );
 		} );
 
 		it( 'should count words between blocks as two words', () => {
-			expect( textUtils.countWords(
+			expect( countWords(
 				'<p>Hello</p><p>world</p>'
 			) ).to.equal( 2 );
 		} );
@@ -64,7 +64,7 @@ describe( 'index', () => {
 
 	describe( '#countDiffWords', () => {
 		it( 'should return (0, 0) if input is empty', () => {
-			expect( textUtils.countDiffWords( [] ) )
+			expect( countDiffWords( [] ) )
 				.to.eql( {
 					added: 0,
 					removed: 0,
@@ -72,7 +72,7 @@ describe( 'index', () => {
 		} );
 
 		it( 'should count words in each change', () => {
-			expect( textUtils.countDiffWords( [
+			expect( countDiffWords( [
 				{
 					value: 'Hello World',
 					removed: true,
@@ -89,7 +89,7 @@ describe( 'index', () => {
 		} );
 
 		it( 'should accumulate additions and deletions', () => {
-			expect( textUtils.countDiffWords( [
+			expect( countDiffWords( [
 				{
 					value: 'Hello',
 					removed: true,

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -9,7 +9,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
  */
 import PostEditStore from 'lib/posts/post-edit-store';
 import userModule from 'lib/user';
-import textUtils from 'lib/text-utils';
+import { countWords } from 'lib/text-utils';
 
 /**
  * Module variables
@@ -64,7 +64,7 @@ export default React.createClass( {
 				return null;
 		}
 
-		const wordCount = textUtils.countWords( this.state.rawContent );
+		const wordCount = countWords( this.state.rawContent );
 
 		return (
 			<div className="editor-word-count">


### PR DESCRIPTION
Spin off from #14241 to fix a comment from @aduth about default exporting objects preventing proper tree shaking.