### PR TITLE
Add Gridicons to SelectDropdown

### DIFF
--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -51,6 +51,10 @@ Used for displaying the text on the dropdown header.
 
 Used for displaying the count on the dropdown header.
 
+`selectedIcon`
+
+Used for displaying the Gridicon on the dropdown header.
+
 `className`
 
 Optional extra class(es) to be applied to the `.select-dropdown`.
@@ -70,6 +74,10 @@ Boolean representing the selected visual state. `selected={ true }` creates a bl
 Optional number to show a Count next to the item text.
 
 ![selected example screenshot](https://cldup.com/BOZktaoqTT.png)
+
+`icon`
+
+Optional name of Gridicon to show in front of item text.
 
 `path`
 
@@ -167,6 +175,8 @@ var options = [
 		label: // *required* - (string) displayed to user
 		isLabel: // optional - (boolean) set this item like a static label
 		path: // optional - (string) URL to navigate when clicked
+		icon: // optional - (string) Gridicon name to display in front of label
+		count: // optional - (number) Count to show next to label
 	},
 	// ...
 ];

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -125,6 +125,28 @@ const SelectDropdownDemo = React.createClass( {
 					<DropdownItem count={ 3 }>Trashed</DropdownItem>
 				</SelectDropdown>
 
+				<h3 style={ { marginTop: 20 } }>With Gridicons on options prop</h3>
+				<SelectDropdown
+					compact={ this.state.compactButtons }
+					onSelect={ this.onDropdownSelect }
+					options={ [
+						{ value: 'posts', label: 'Posts', icon: 'posts', count: 12 },
+						{ value: 'images', label: 'Images', icon: 'image-multiple', count: 5 },
+						{ value: 'mentions', label: 'Mentions', icon: 'mention', count: 1 },
+						{ value: 'sales', label: 'Sales', icon: 'money', count: 999 },
+					] }
+				/>
+
+				<h3 style={ { marginTop: 20 } }>With Gridicons on children</h3>
+				<SelectDropdown
+					compact={ this.state.compactButtons }
+					selectedText="Tablet"
+					selectedIcon="tablet"
+				>
+					<DropdownItem icon="computer">Desktop</DropdownItem>
+					<DropdownItem icon="tablet" selected={ true }>Tablet</DropdownItem>
+					<DropdownItem icon="phone">Mobile</DropdownItem>
+				</SelectDropdown>
 			</div>
 		);
 	},

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -25,6 +25,7 @@ class SelectDropdown extends Component {
 	static propTypes = {
 		selectedText: PropTypes.string,
 		selectedCount: PropTypes.number,
+		selectedIcon: PropTypes.string,
 		initialSelected: PropTypes.string,
 		className: PropTypes.string,
 		style: PropTypes.object,

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -7,7 +7,6 @@ import find from 'lodash/find';
 import filter from 'lodash/filter';
 import findIndex from 'lodash/findIndex';
 import map from 'lodash/map';
-import result from 'lodash/result';
 import classNames from 'classnames';
 
 /**
@@ -17,6 +16,7 @@ import DropdownItem from 'components/select-dropdown/item';
 import DropdownSeparator from 'components/select-dropdown/separator';
 import DropdownLabel from 'components/select-dropdown/label';
 import Count from 'components/count';
+import Gridicon from 'gridicons';
 
 /**
  * SelectDropdown
@@ -121,7 +121,7 @@ class SelectDropdown extends Component {
 		return selectedItem && selectedItem.value;
 	}
 
-	getSelectedText() {
+	getSelectedObject() {
 		const { options, selectedText } = this.props;
 		const { selected } = this.state;
 
@@ -131,7 +131,7 @@ class SelectDropdown extends Component {
 
 		// return currently selected text
 		const selectedValue = selected ? selected : this.getInitialSelectedItem( this.props );
-		return result( find( options, { value: selectedValue } ), 'label' );
+		return find( options, { value: selectedValue } );
 	}
 
 	dropdownOptions() {
@@ -192,6 +192,8 @@ class SelectDropdown extends Component {
 					selected={ this.state.selected === item.value }
 					onClick={ this.onSelectItem( item ) }
 					path={ item.path }
+					icon={ item.icon }
+					count={ item.count }
 				>
 					{ item.label }
 				</DropdownItem>
@@ -218,7 +220,10 @@ class SelectDropdown extends Component {
 
 		const dropdownClassName = classNames( dropdownClasses );
 
-		const selectedText = this.getSelectedText();
+		const selectedItem = this.getSelectedObject();
+		const selectedIcon = this.props.selectedIcon || selectedItem.icon;
+		const selectedCount = this.props.selectedCount || selectedItem.count;
+		const selectedText = this.props.selectedText || selectedItem.label;
 
 		return (
 			<div style={ this.props.style } className={ dropdownClassName }>
@@ -240,11 +245,19 @@ class SelectDropdown extends Component {
 						className="select-dropdown__header"
 					>
 						<span className="select-dropdown__header-text">
+							{
+								selectedIcon &&
+								<Gridicon
+									icon={ selectedIcon }
+									size={ this.props.compact ? 18 : 24 }
+									className="select-dropdown__icon"
+								/>
+							}
 							{ selectedText }
 						</span>
 						{
-							'number' === typeof this.props.selectedCount &&
-							<Count count={ this.props.selectedCount } />
+							'number' === typeof selectedCount &&
+							<Count count={ selectedCount } />
 						}
 					</div>
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -7,6 +7,7 @@ import find from 'lodash/find';
 import filter from 'lodash/filter';
 import findIndex from 'lodash/findIndex';
 import map from 'lodash/map';
+import get from 'lodash/get';
 import classNames from 'classnames';
 
 /**
@@ -123,16 +124,17 @@ class SelectDropdown extends Component {
 	}
 
 	getSelectedObject() {
-		const { options, selectedText } = this.props;
+		const { options } = this.props;
 		const { selected } = this.state;
 
-		if ( selectedText ) {
-			return selectedText;
-		}
-
-		// return currently selected text
+		// return currently selected object
 		const selectedValue = selected ? selected : this.getInitialSelectedItem( this.props );
 		return find( options, { value: selectedValue } );
+	}
+
+	getSelectedText() {
+		const { selectedText } = this.props;
+		return selectedText ? selectedText : get( this.getSelectedObject(), 'label' );
 	}
 
 	dropdownOptions() {
@@ -222,9 +224,9 @@ class SelectDropdown extends Component {
 		const dropdownClassName = classNames( dropdownClasses );
 
 		const selectedItem = this.getSelectedObject();
-		const selectedIcon = this.props.selectedIcon || selectedItem.icon;
-		const selectedCount = this.props.selectedCount || selectedItem.count;
-		const selectedText = this.props.selectedText || selectedItem.label;
+		const selectedIcon = this.props.selectedIcon || get( selectedItem, 'icon' );
+		const selectedCount = this.props.selectedCount || get( selectedItem, 'count' );
+		const selectedText = this.props.selectedText || get( selectedItem, 'label' );
 
 		return (
 			<div style={ this.props.style } className={ dropdownClassName }>

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -32,8 +32,7 @@ class SelectDropdownItem extends Component {
 		const optionClassName = classNames( this.props.className, {
 			'select-dropdown__item': true,
 			'is-selected': this.props.selected,
-			'is-disabled': this.props.disabled,
-			'has-icon': this.props.icon
+			'is-disabled': this.props.disabled
 		} );
 
 		return (

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Count from 'components/count';
+import Gridicon from 'gridicons';
 
 class SelectDropdownItem extends Component {
 	static propTypes = {
@@ -15,20 +16,24 @@ class SelectDropdownItem extends Component {
 		path: React.PropTypes.string,
 		isDropdownOpen: React.PropTypes.bool,
 		selected: React.PropTypes.bool,
+		disabled: React.PropTypes.bool,
 		onClick: React.PropTypes.func,
-		count: React.PropTypes.number
+		count: React.PropTypes.number,
+		icon: React.PropTypes.string
 	}
 
 	static defaultProps = {
 		isDropdownOpen: false,
-		selected: false
+		selected: false,
+		disabled: false
 	}
 
 	render() {
 		const optionClassName = classNames( this.props.className, {
 			'select-dropdown__item': true,
 			'is-selected': this.props.selected,
-			'is-disabled': this.props.disabled
+			'is-disabled': this.props.disabled,
+			'has-icon': this.props.icon
 		} );
 
 		return (
@@ -43,6 +48,9 @@ class SelectDropdownItem extends Component {
 					tabIndex={ this.props.isDropdownOpen ? 0 : '' }
 					aria-selected={ this.props.selected } >
 					<span className="select-dropdown__item-text">
+						{ this.props.icon &&
+							<Gridicon icon={ this.props.icon } className="select-dropdown__icon" />
+						}
 						{ this.props.children }
 					</span>
 					{

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -53,7 +53,7 @@ $compact-header-height: 35;
 .select-dropdown__header {
 	height: #{ $header-height }px;
 	line-height: #{ $header-height - 3 }px;
-	padding: 0 75px 0 #{ $side-margin }px;
+	padding: 0 85px 0 #{ $side-margin }px;
 	box-sizing: border-box;
 
 	border-style: solid;
@@ -258,5 +258,16 @@ $compact-header-height: 35;
 		font-size: 12px;
 		text-transform: uppercase;
 		padding: 0px #{ $side-margin }px;
+	}
+}
+
+.select-dropdown__icon {
+	position: relative;
+	top: 7px;
+	margin-right: 8px;
+
+	.is-compact .select-dropdown__header-text & {
+		margin-right: 4px;
+		top: 5px;
 	}
 }


### PR DESCRIPTION
This PR adds an option to add Gridicon to SelectDropdown items. 

| Normal size | Compact |
| - | - |
| <img width="304" alt="screen shot 2017-06-06 at 13 25 24" src="https://cloud.githubusercontent.com/assets/156676/26827036/a7a0ab22-4abb-11e7-990a-ce4807a3b746.png"> | <img width="308" alt="screen shot 2017-06-06 at 13 25 15" src="https://cloud.githubusercontent.com/assets/156676/26827043/b162226c-4abb-11e7-9219-4c668ecfa663.png"> |


New examples were added to devdocs so we can easily test and review this new addition: 

https://calypso.live/devdocs/design/select-dropdown?branch=add/icons-to-select-dropdown

