### PR TITLE
Media library: add thumbnail media library type

### DIFF
--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -196,5 +196,6 @@ export const MimeTypes = {
 	pages: 'application/vnd.apple.pages',
 };
 
+export const MEDIA_IMAGE_THUMBNAIL = 'MEDIA_IMAGE_THUMBNAIL';
 export const MEDIA_IMAGE_PHOTON = 'MEDIA_IMAGE_PHOTON';
 export const MEDIA_IMAGE_RESIZER = 'MEDIA_IMAGE_RESIZER';

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -9,7 +9,7 @@ var React = require( 'react' );
 var MediaUtils = require( 'lib/media/utils' ),
 	MediaLibraryListItemFileDetails = require( './list-item-file-details' );
 
-import { MEDIA_IMAGE_PHOTON } from 'lib/media/constants';
+import { MEDIA_IMAGE_PHOTON, MEDIA_IMAGE_THUMBNAIL } from 'lib/media/constants';
 
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryListItemImage',
@@ -80,6 +80,7 @@ module.exports = React.createClass( {
 		var url = MediaUtils.url( this.props.media, {
 			photon: this.props.thumbnailType === MEDIA_IMAGE_PHOTON,
 			maxWidth: this.props.maxImageWidth,
+			size: this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL ? 'medium' : false,
 		} );
 
 		if ( ! url ) {

--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -10,6 +10,8 @@ var React = require( 'react' ),
 var ListItemFileDetails = require( './list-item-file-details' ),
 	Gridicon = require( 'gridicons' );
 
+import { MEDIA_IMAGE_THUMBNAIL, MEDIA_IMAGE_PHOTON } from 'lib/media/constants';
+
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryListItemVideo',
 
@@ -21,7 +23,8 @@ module.exports = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
-			maxImageWidth: 450
+			maxImageWidth: 450,
+			thumbnailType: MEDIA_IMAGE_PHOTON,
 		};
 	},
 
@@ -37,9 +40,10 @@ module.exports = React.createClass( {
 		const thumbnail = this.getHighestQualityThumbnail();
 
 		if ( thumbnail ) {
-			// All thumbnails extracted from the media should be accessible via
-			// Photon, so we don't concern ourselves with the boolean prop
-			const url = photon( thumbnail, { width: this.props.maxImageWidth } );
+			// Non MEDIA_IMAGE_THUMBNAIL video media is accessible via Photon
+			const url = this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL
+							? thumbnail
+							: photon( thumbnail, { width: this.props.maxImageWidth } );
 
 			return (
 				<div className="media-library__list-item-video" style={ { backgroundImage: 'url(' + url + ')' } }>

--- a/client/my-sites/media-library/test/fixtures/index.js
+++ b/client/my-sites/media-library/test/fixtures/index.js
@@ -44,6 +44,9 @@ module.exports = {
 			ID: 1009,
 			guid: 'http://example.files.wordpress.com/2015/05/g1009.gif',
 			URL: 'http://example.files.wordpress.com/2015/05/g1009.gif',
+			thumbnails: {
+				medium: 'http://example.files.wordpress.com/2015/05/g1009-medium.gif'
+			}
 		}, {
 			ID: 1008,
 			guid: 'http://example.files.wordpress.com/2015/05/g1008.gif',

--- a/client/my-sites/media-library/test/list-item-image.jsx
+++ b/client/my-sites/media-library/test/list-item-image.jsx
@@ -59,5 +59,17 @@ describe( 'MediaLibraryListItem image', function() {
 
 			expect( wrapper.props().src ).to.be.equal( getResizedUrl() );
 		} );
+
+		it( 'returns existing medium thumbnail for type MEDIA_IMAGE_THUMBNAIL', function() {
+			wrapper = shallow( getItem( 0, 'MEDIA_IMAGE_THUMBNAIL' ) );
+
+			expect( wrapper.props().src ).to.be.equal( fixtures.media[ 0 ].thumbnails.medium );
+		} );
+
+		it( 'returns resized thumbnail for type MEDIA_IMAGE_THUMBNAIL when no medium thumbnail', function() {
+			wrapper = shallow( getItem( 1, 'MEDIA_IMAGE_THUMBNAIL' ) );
+
+			expect( wrapper.props().src ).to.be.equal( getResizedUrl() );
+		} );
 	} );
 } );

--- a/client/my-sites/media-library/test/list-item-video.jsx
+++ b/client/my-sites/media-library/test/list-item-video.jsx
@@ -54,5 +54,11 @@ describe( 'MediaLibraryListItem video', function() {
 
 			expect( wrapper.props().style.backgroundImage ).to.be.equal( expectedBackground() );
 		} );
+
+		it( 'returns existing fmt_hd thumbnail for type MEDIA_IMAGE_THUMBNAIL', function() {
+			wrapper = shallow( getItem( 'MEDIA_IMAGE_THUMBNAIL' ) );
+
+			expect( wrapper.props().style.backgroundImage ).to.be.equal( styleUrl( fixtures.media[ 1 ].thumbnails.fmt_hd ) );
+		} );
 	} );
 } );


### PR DESCRIPTION
Adds `MEDIA_IMAGE_THUMBNAIL` to the media library thumbnails. This is a new display mode that uses the `thumbnails` value from a media items data.

Existing media library display types are unaffected.

Note that the thumbnail display type is not enabled in this PR.

## Testing

Run supplied unit tests to verify that thumbnails aren't changed for private/public blogs, and that when MEDIA_IMAGE_THUMBNAIL mode is enabled it returns the correct URL.

Also worth manually verifying that media library thumbnails use photon for public blogs and the resizer for private ones.