### PR TITLE
Extensions: WPSC - Add new preload notices

### DIFF
--- a/client/extensions/wp-super-cache/preload-tab.jsx
+++ b/client/extensions/wp-super-cache/preload-tab.jsx
@@ -18,11 +18,13 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormToggle from 'components/forms/form-toggle/compact';
 import Notice from 'components/notice';
+import QueryNotices from './data/query-notices';
 import SectionHeader from 'components/section-header';
 import WrapSettingsForm from './wrap-settings-form';
 import { cancelPreloadCache, preloadCache } from './state/cache/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isPreloadingCache } from './state/cache/selectors';
+import { getNotices } from './state/notices/selectors';
 
 /**
  * Render cache preload interval number input
@@ -85,14 +87,17 @@ class PreloadTab extends Component {
 			isPreloading,
 			isRequesting,
 			isSaving,
+			notices: {
+				preload_disabled_by_admin,
+				preload_disabled_cache_off,
+				preload_disabled_supercache_off,
+			},
+			siteId,
 			translate,
 		} = this.props;
 
 		const {
-			is_cache_enabled,
-			is_preload_enabled,
 			is_preloading,
-			is_super_cache_enabled,
 			minimum_preload_interval,
 			post_count,
 			preload_email_volume,
@@ -109,25 +114,34 @@ class PreloadTab extends Component {
 			{ value: 'less', description: translate( 'Low (one email at the start and one at the end of preloading all posts)' ) },
 		];
 
-		if ( ! is_cache_enabled ) {
+		if ( preload_disabled_by_admin ) {
 			return (
 				<Notice
-					text={ translate( 'Caching must be enabled to use this feature.' ) }
-					showDismiss={ false } />
+					showDismiss={ false }
+					text={ translate( 'Preloading is disabled by the administrator of your site.' ) } />
 			);
 		}
 
-		if ( is_super_cache_enabled && ! is_preload_enabled ) {
+		if ( preload_disabled_cache_off ) {
 			return (
 				<Notice
-					text={ translate( 'Preloading of cache disabled. Please disable legacy page caching or talk to ' +
-						'your host administrator.' ) }
-					showDismiss={ false } />
+					showDismiss={ false }
+					text={ translate( 'Preloading is disabled as caching is disabled.' ) } />
+			);
+		}
+
+		if ( preload_disabled_supercache_off ) {
+			return (
+				<Notice
+					showDismiss={ false }
+					text={ translate( 'Preloading is disabled as supercaching is disabled.' ) } />
 			);
 		}
 
 		return (
 			<div>
+				<QueryNotices siteId={ siteId } />
+
 				<SectionHeader label={ ( 'Preload' ) }>
 					<Button
 						compact
@@ -270,6 +284,7 @@ const connectComponent = connect(
 
 		return {
 			isPreloading: isPreloadingCache( state, siteId ),
+			notices: getNotices( state, siteId ),
 		};
 	},
 	{
@@ -280,10 +295,7 @@ const connectComponent = connect(
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'is_cache_enabled',
-		'is_preload_enabled',
 		'is_preloading',
-		'is_super_cache_enabled',
 		'minimum_preload_interval',
 		'post_count',
 		'preload_email_volume',

--- a/client/extensions/wp-super-cache/state/settings/utils.js
+++ b/client/extensions/wp-super-cache/state/settings/utils.js
@@ -41,7 +41,6 @@ export const sanitizeSettings = settings => {
 			case 'cache_mobile_prefixes':
 			case 'cache_mod_rewrite':
 			case 'cache_next_gc':
-			case 'is_preload_enabled':
 			case 'is_preloading':
 			case 'minimum_preload_interval':
 			case 'post_count':


### PR DESCRIPTION
This PR adds the following notices to the _Preload_ tab:

## Preload Disabled By Admin

![preload-admin](https://cloud.githubusercontent.com/assets/1190420/26827376/f5398434-4a8a-11e7-89dc-b94ab40ec714.jpg)

## Caching Disabled

![preload-caching-disabled](https://cloud.githubusercontent.com/assets/1190420/26827416/2c82395e-4a8b-11e7-9b9b-f035aa2d7d88.jpg)

## Supercaching Disabled

![preload-supercaching-disabled](https://cloud.githubusercontent.com/assets/1190420/26827420/32126d94-4a8b-11e7-9a19-fa85deebe715.jpg)

### Testing
Use [this branch](https://github.com/Automattic/wp-super-cache/tree/preload_enabled_setting) of WPSC (may already be merged).
- _Preload Disabled By Admin_: Add the following line to `wp-cache-config.php`:
`define( 'DISABLESUPERCACHEPRELOADING', true );`
- _Caching Disabled_: Toggle the "Enable Page Caching" switch to off on the _Easy_ or _Advanced_ tab.
- _Supercaching Disabled_: Check the "Legacy page caching" radio button on the _Advanced_ tab.