### PR TITLE
Media Library: move media library secondary buttons into a function

### DIFF
--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -110,6 +110,18 @@ export default React.createClass( {
 		);
 	},
 
+	renderSecondaryButtons() {
+		return (
+			<MediaModalSecondaryActions
+				selectedItems={ this.props.selectedItems }
+				onViewDetails={ this.props.onViewDetails }
+				onDelete={ this.props.onDeleteItem }
+				site={ this.props.site }
+				view={ 'LIST' }
+			/>
+		);
+	},
+
 	render() {
 		const { site, onAddMedia } = this.props;
 
@@ -126,13 +138,8 @@ export default React.createClass( {
 		const card = (
 			<Card className="media-library__header">
 				{ this.renderUploadButtons() }
-				<MediaModalSecondaryActions
-					selectedItems={ this.props.selectedItems }
-					onViewDetails={ this.props.onViewDetails }
-					onDelete={ this.props.onDeleteItem }
-					site={ this.props.site }
-					view={ 'LIST' }
-				/>
+				{ this.renderSecondaryButtons() }
+
 				<MediaLibraryScale
 					onChange={ this.props.onMediaScaleChange } />
 			</Card>


### PR DESCRIPTION
Moves the secondary buttons into a separate function, similar to `renderUploadButtons`.

Allow this may seem a pointless it change it allows additional logic to be added to the display of buttons (getting my ducks all lined up!)

## Testing

Check secondary buttons still render

<img width="282" alt="secondary" src="https://cloud.githubusercontent.com/assets/1277682/26830593/410ba8d4-4ac1-11e7-9214-42a52bf36593.png">
