### PR TITLE
Tools: Update editorconfig to make github diffs easier to read

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,13 @@
 root = true
 
 [*]
+# yes, we use tabs
 indent_style = tab
+
+# To control tab size in github diffs
+# See https://github.com/isaacs/github/issues/170#issuecomment-150489692
+indent_size = 2
+
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
Github uses the [`.editorconfig` file, if present](https://github.com/isaacs/github/issues/170#issuecomment-150489692), to determine how wide the tab character should be in diffs. Right now, it's using the default of `8`, which makes diffs a pain to read.

This changes the value to `2`, which should make diffs easier to read by letting more of the diff appear on screen. Arguments could be made (and will be, I bet) about the correct value (`4! 2! 3!`) but getting off `8` would be nice.