### PR TITLE
Domains: Add view for transfering a domain between sites v2

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1853,6 +1853,19 @@ Undocumented.prototype.transferToUser = function( siteId, domainName, targetUser
 	return this.wpcom.req.post( '/sites/' + siteId + '/domains/' + domainName + '/transfer-to-user/' + targetUserId, fn );
 };
 
+/**
+ * Transfers a domain to the specified site
+ *
+ * @param {int} [siteId] The site ID
+ * @param {string} [domainName] Name of the domain
+ * @param {int} [targetSiteId] The target site ID
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ */
+Undocumented.prototype.transferToSite = function( siteId, domainName, targetSiteId, fn ) {
+	return this.wpcom.req.post( `/sites/${ siteId }/domains/${ domainName }/transfer-to-site/${ targetSiteId }`, fn );
+};
+
 /*
  * Retrieves WHOIS data for given domain.
  *

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -312,6 +312,30 @@ export default {
 		);
 	},
 
+	domainManagementTransferToOtherSite( pageContext ) {
+		const state = pageContext.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
+		if ( isAutomatedTransfer ) {
+			const siteSlug = getSelectedSiteSlug( state );
+			page.redirect( `/domains/manage/${ siteSlug }` );
+			return;
+		}
+
+		setTitle(
+			i18n.translate( 'Transfer Domain' ),
+			pageContext
+		);
+
+		renderWithReduxStore(
+			<TransferData
+				component={ DomainManagement.TransferToOtherSite }
+				selectedDomainName={ pageContext.params.domain } />,
+			document.getElementById( 'primary' ),
+			pageContext.store
+		);
+	},
+
 	domainManagementTransferToOtherUser( pageContext ) {
 		const state = pageContext.store.getState();
 		const siteId = getSelectedSiteId( state );

--- a/client/my-sites/upgrades/domain-management/domain-management.jsx
+++ b/client/my-sites/upgrades/domain-management/domain-management.jsx
@@ -12,6 +12,7 @@ module.exports = {
 	PrivacyProtection: require( './privacy-protection' ),
 	SiteRedirect: require( './site-redirect' ),
 	TransferOut: require( './transfer/transfer-out' ),
+	TransferToOtherSite: require( './transfer/transfer-to-other-site' ),
 	TransferToOtherUser: require( './transfer/transfer-to-other-user' ),
 	Transfer: require( './transfer' )
 };

--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -29,15 +29,19 @@ function Transfer( props ) {
 				{ translate( 'Transfer Domain' ) }
 			</Header>
 			<VerticalNav>
-				<VerticalNavItem path={
-					paths.domainManagementTransferOut( slug, selectedDomainName )
-				}>
+				<VerticalNavItem path={ paths.domainManagementTransferOut( slug, selectedDomainName ) }>
 					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
-					{ ! isAutomatedTransfer && ! isDomainOnly &&
-						<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, selectedDomainName ) }>
-							{ translate( 'Transfer to another user' ) }
-						</VerticalNavItem> }
+				{ ! isAutomatedTransfer && ! isDomainOnly &&
+					<VerticalNavItem path={ paths.domainManagementTransferToAnotherUser( slug, selectedDomainName ) }>
+						{ translate( 'Transfer to another user' ) }
+					</VerticalNavItem>
+				}
+				{ ! isAutomatedTransfer && ! isDomainOnly &&
+					<VerticalNavItem path={ paths.domainManagementTransferToOtherSite( slug, selectedDomainName ) }>
+						{ translate( 'Transfer to another WordPress.com site' ) }
+					</VerticalNavItem>
+				}
 			</VerticalNav>
 		</Main>
 	);

--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -37,7 +37,7 @@ function Transfer( props ) {
 						{ translate( 'Transfer to another user' ) }
 					</VerticalNavItem>
 				}
-				{ ! isAutomatedTransfer && ! isDomainOnly &&
+				{ ! isAutomatedTransfer &&
 					<VerticalNavItem path={ paths.domainManagementTransferToOtherSite( slug, selectedDomainName ) }>
 						{ translate( 'Transfer to another WordPress.com site' ) }
 					</VerticalNavItem>

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -1,0 +1,66 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import {
+	get,
+} from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { getSiteBySlug } from 'state/sites/selectors';
+import Dialog from 'components/dialog';
+
+class TransferConfirmationDialog extends React.PureComponent {
+	static propTypes = {
+		isVisible: React.PropTypes.bool.isRequired,
+		targetSiteSlug: React.PropTypes.string.isRequired,
+		disableDialogButtons: React.PropTypes.bool.isRequired,
+		domainName: React.PropTypes.string.isRequired,
+		onConfirmTransfer: React.PropTypes.func.isRequired,
+		onClose: React.PropTypes.func.isRequired,
+	};
+
+	onConfirm = ( closeDialog ) => {
+		this.props.onConfirmTransfer( this.props.targetSite, closeDialog );
+	}
+
+	render() {
+		const { domainName, translate } = this.props,
+			buttons = [
+				{
+					action: 'cancel',
+					label: translate( 'Cancel' ),
+					disabled: this.props.disableDialogButtons
+				},
+				{
+					action: 'confirm',
+					label: translate( 'Confirm Transfer' ),
+					onClick: this.onConfirm,
+					disabled: this.props.disableDialogButtons,
+					isPrimary: true
+				}
+			],
+			targetSiteName = get( this.props.targetSite, 'name', '' );
+
+		return (
+			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
+				<h1>{ translate( 'Confirm Transfer' ) }</h1>
+				<p>{ translate( 'Do you want to transfer {{strong}}%(domainName)s{{/strong}} ' +
+					'to site {{strong}}%(targetSiteName)s{{/strong}}?', {
+						args: { domainName, targetSiteName }, components: { strong: <strong /> }
+					} ) }</p>
+			</Dialog>
+		);
+	}
+
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		targetSite: getSiteBySlug( state, ownProps.targetSiteSlug )
+	} )
+)( localize( TransferConfirmationDialog ) );

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -11,13 +11,13 @@ import {
 /**
  * Internal Dependencies
  */
-import { getSiteBySlug } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
 import Dialog from 'components/dialog';
 
 class TransferConfirmationDialog extends React.PureComponent {
 	static propTypes = {
 		isVisible: React.PropTypes.bool.isRequired,
-		targetSiteSlug: React.PropTypes.string.isRequired,
+		targetSiteId: React.PropTypes.string.isRequired,
 		disableDialogButtons: React.PropTypes.bool.isRequired,
 		domainName: React.PropTypes.string.isRequired,
 		onConfirmTransfer: React.PropTypes.func.isRequired,
@@ -60,6 +60,6 @@ class TransferConfirmationDialog extends React.PureComponent {
 
 export default connect(
 	( state, ownProps ) => ( {
-		targetSite: getSiteBySlug( state, ownProps.targetSiteSlug )
+		targetSite: getSite( state, ownProps.targetSiteId )
 	} )
 )( localize( TransferConfirmationDialog ) );

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -29,22 +29,22 @@ class TransferConfirmationDialog extends React.PureComponent {
 	}
 
 	render() {
-		const { domainName, translate } = this.props,
-			buttons = [
-				{
-					action: 'cancel',
-					label: translate( 'Cancel' ),
-					disabled: this.props.disableDialogButtons
-				},
-				{
-					action: 'confirm',
-					label: translate( 'Confirm Transfer' ),
-					onClick: this.onConfirm,
-					disabled: this.props.disableDialogButtons,
-					isPrimary: true
-				}
-			],
-			targetSiteName = get( this.props.targetSite, 'name', '' );
+		const { domainName, translate } = this.props;
+		const buttons = [
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' ),
+				disabled: this.props.disableDialogButtons
+			},
+			{
+				action: 'confirm',
+				label: translate( 'Confirm Transfer' ),
+				onClick: this.onConfirm,
+				disabled: this.props.disableDialogButtons,
+				isPrimary: true
+			}
+		];
+		const targetSiteName = get( this.props.targetSite, 'name', '' );
 
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
@@ -56,7 +56,6 @@ class TransferConfirmationDialog extends React.PureComponent {
 			</Dialog>
 		);
 	}
-
 }
 
 export default connect(

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -1,0 +1,181 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import {
+	get,
+	omit,
+} from 'lodash';
+import page from 'page';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import Card from 'components/card';
+import SiteSelector from 'components/site-selector';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { getSites } from 'state/selectors';
+import { getSiteBySlug } from 'state/sites/selectors';
+import Header from 'my-sites/upgrades/domain-management/components/header';
+import Main from 'components/main';
+import paths from 'my-sites/upgrades/paths';
+import { getSelectedDomain } from 'lib/domains';
+import NonOwnerCard from 'my-sites/upgrades/domain-management/components/domain/non-owner-card';
+import SectionHeader from 'components/section-header';
+import Dialog from 'components/dialog';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import wp from 'lib/wp';
+
+const wpcom = wp.undocumented();
+
+class TransferToOtherSite extends React.Component {
+
+	static propTypes = {
+		selectedDomainName: React.PropTypes.string.isRequired,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ).isRequired,
+		currentUser: React.PropTypes.object.isRequired
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			targetSite: null,
+			showConfirmationDialog: false,
+			disableDialogButtons: false
+		};
+	}
+
+	handleSiteSelect = ( siteSlug ) => {
+		const targetSite = this.props.siteBySlug( siteSlug );
+
+		if ( targetSite ) {
+			this.setState( {
+				targetSite,
+				showConfirmationDialog: true,
+			} );
+		}
+	}
+
+	handleConfirmTransferDomain = ( closeDialog ) => {
+		const { selectedDomainName } = this.props,
+			targetSiteName = this.state.targetSite.name,
+			successMessage = this.props.translate(
+				'%(selectedDomainName)s has been transferred to site: %(targetSiteName)s',
+				{ args: { selectedDomainName, targetSiteName } } ),
+			defaultErrorMessage = this.props.translate(
+				'Failed to transfer %(selectedDomainName)s, please try again or contact support.', {
+					args: { selectedDomainName } } );
+		this.setState( { disableDialogButtons: true } );
+		wpcom.transferToSite( this.props.selectedSite.ID, this.props.selectedDomainName, this.state.targetSite.ID )
+			.then( () => {
+				this.setState( { disableDialogButtons: false } );
+				this.props.successNotice( successMessage, { duration: 10000, isPersistent: true } );
+				closeDialog();
+				page( paths.domainManagementList( this.props.selectedSite.slug ) );
+			}, error => {
+				this.setState( { disableDialogButtons: false } );
+				this.props.errorNotice( error.message || defaultErrorMessage );
+				closeDialog();
+			} );
+	}
+
+	handleDialogClose = () => {
+		if ( ! this.state.disableDialogButtons ) {
+			this.setState( { showConfirmationDialog: false } );
+		}
+	}
+
+	render() {
+		const { selectedSite, selectedDomainName } = this.props,
+			{ slug } = selectedSite;
+
+		return (
+			<Main className="transfer-to-other-site">
+				<Header
+					selectedDomainName={ selectedDomainName }
+					backHref={ paths.domainManagementTransfer( slug, selectedDomainName ) }>
+					{ this.props.translate( 'Transfer Domain To Another Site' ) }
+				</Header>
+				{ this.renderSection() }
+			</Main>
+		);
+	}
+
+	renderDialog() {
+		const { selectedDomainName: domainName, translate } = this.props,
+			buttons = [
+				{
+					action: 'cancel',
+					label: translate( 'Cancel' ),
+					disabled: this.state.disableDialogButtons
+				},
+				{
+					action: 'confirm',
+					label: translate( 'Confirm Transfer' ),
+					onClick: this.handleConfirmTransferDomain,
+					disabled: this.state.disableDialogButtons,
+					isPrimary: true
+				}
+			],
+			targetSiteName = get( this.state.targetSite, 'name', '' );
+
+		return (
+			<Dialog isVisible={ this.state.showConfirmationDialog } buttons={ buttons } onClose={ this.handleDialogClose }>
+				<h1>{ translate( 'Confirm Transfer' ) }</h1>
+				<p>{ translate( 'Do you want to transfer {{strong}}%(domainName)s{{/strong}} ' +
+					'to site {{strong}}%(targetSiteName)s{{/strong}}?', {
+						args: { domainName, targetSiteName }, components: { strong: <strong /> }
+					} ) }</p>
+			</Dialog>
+		);
+	}
+
+	renderSection() {
+		const { selectedDomainName: domainName, translate } = this.props,
+			{ currentUserCanManage } = getSelectedDomain( this.props );
+
+		if ( ! currentUserCanManage ) {
+			return <NonOwnerCard { ...omit( this.props, [ 'children' ] ) } />;
+		}
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Transfer Domain To Another Site' ) } />
+				<Card className="transfer-to-other-site__card">
+					<p>
+						{ translate( 'Please choose a site you\'re an administrator on to transfer {{strong}}%(domainName)s{{/strong}} to:',
+							{ args: { domainName }, components: { strong: <strong /> } } ) }
+					</p>
+					<SiteSelector
+						filter={ this.checkSiteEligibility }
+						sites={ this.props.sites }
+						onSiteSelect={ this.handleSiteSelect }
+					/>
+				</Card>
+				{ this.renderDialog() }
+			</div>
+		);
+	}
+
+	checkSiteEligibility = ( site ) => {
+		return site.capabilities.manage_options && ! site.jetpack && site.ID !== this.props.selectedSite.ID;
+	}
+}
+
+export default connect(
+	state => ( {
+		currentUser: getCurrentUser( state ),
+		sites: getSites( state ),
+		siteBySlug: ( siteSlug ) => getSiteBySlug( state, siteSlug ),
+	} ),
+	{
+		successNotice,
+		errorNotice
+	}
+)( localize( TransferToOtherSite ) );

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -23,6 +23,7 @@ import Main from 'components/main';
 import paths from 'my-sites/upgrades/paths';
 import { getSelectedDomain } from 'lib/domains';
 import NonOwnerCard from 'my-sites/upgrades/domain-management/components/domain/non-owner-card';
+import DomainMainPlaceholder from 'my-sites/upgrades/domain-management/components/domain/main-placeholder';
 import SectionHeader from 'components/section-header';
 import Dialog from 'components/dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
@@ -49,6 +50,17 @@ class TransferToOtherSite extends React.Component {
 			showConfirmationDialog: false,
 			disableDialogButtons: false
 		};
+	}
+
+	isDataReady() {
+		return this.props.domains.hasLoadedFromServer;
+	}
+
+	checkSiteEligibility = ( site ) => {
+		return site.capabilities.manage_options &&
+			! site.jetpack &&
+			! get( site, 'options.is_domain_only', false ) &&
+			site.ID !== this.props.selectedSite.ID;
 	}
 
 	handleSiteSelect = ( siteSlug ) => {
@@ -92,6 +104,10 @@ class TransferToOtherSite extends React.Component {
 	}
 
 	render() {
+		if ( ! this.isDataReady() ) {
+			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
+		}
+
 		const { selectedSite, selectedDomainName } = this.props,
 			{ slug } = selectedSite;
 
@@ -161,13 +177,6 @@ class TransferToOtherSite extends React.Component {
 				{ this.renderDialog() }
 			</div>
 		);
-	}
-
-	checkSiteEligibility = ( site ) => {
-		return site.capabilities.manage_options &&
-			! site.jetpack &&
-			! get( site, 'options.is_domain_only', false ) &&
-			site.ID !== this.props.selectedSite.ID;
 	}
 }
 

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -164,7 +164,10 @@ class TransferToOtherSite extends React.Component {
 	}
 
 	checkSiteEligibility = ( site ) => {
-		return site.capabilities.manage_options && ! site.jetpack && site.ID !== this.props.selectedSite.ID;
+		return site.capabilities.manage_options &&
+			! site.jetpack &&
+			! get( site, 'options.is_domain_only', false ) &&
+			site.ID !== this.props.selectedSite.ID;
 	}
 }
 

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -40,7 +40,7 @@ class TransferToOtherSite extends React.Component {
 	};
 
 	state = {
-		targetSiteSlug: '',
+		targetSiteId: null,
 		showConfirmationDialog: false,
 		disableDialogButtons: false
 	};
@@ -57,9 +57,9 @@ class TransferToOtherSite extends React.Component {
 			site.ID !== this.props.selectedSite.ID;
 	}
 
-	handleSiteSelect = ( targetSiteSlug ) => {
+	handleSiteSelect = ( targetSiteId ) => {
 		this.setState( {
-			targetSiteSlug,
+			targetSiteId,
 			showConfirmationDialog: true,
 		} );
 	}
@@ -143,7 +143,7 @@ class TransferToOtherSite extends React.Component {
 					/>
 				</Card>
 				<TransferConfirmationDialog
-					targetSiteSlug={ this.state.targetSiteSlug }
+					targetSiteId={ this.state.targetSiteId }
 					domainName={ this.props.selectedDomainName }
 					onConfirmTransfer={ this.handleConfirmTransfer }
 					onClose={ this.handleDialogClose }

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -33,10 +33,7 @@ const wpcom = wp.undocumented();
 class TransferToOtherSite extends React.Component {
 	static propTypes = {
 		selectedDomainName: React.PropTypes.string.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
-		] ).isRequired,
+		selectedSite: React.PropTypes.object.isRequired,
 		currentUser: React.PropTypes.object.isRequired
 	};
 

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -50,7 +50,7 @@ class TransferToOtherSite extends React.Component {
 		return this.props.domains.hasLoadedFromServer;
 	}
 
-	checkSiteEligibility = ( site ) => {
+	isSiteEligible = ( site ) => {
 		return site.capabilities.manage_options &&
 			! site.jetpack &&
 			! get( site, 'options.is_domain_only', false ) &&
@@ -65,14 +65,15 @@ class TransferToOtherSite extends React.Component {
 	}
 
 	handleConfirmTransfer = ( targetSite, closeDialog ) => {
-		const { selectedDomainName } = this.props,
-			targetSiteName = targetSite.name,
-			successMessage = this.props.translate(
+		const { selectedDomainName } = this.props;
+		const targetSiteName = targetSite.name;
+		const successMessage = this.props.translate(
 				'%(selectedDomainName)s has been transferred to site: %(targetSiteName)s',
-				{ args: { selectedDomainName, targetSiteName } } ),
-			defaultErrorMessage = this.props.translate(
+				{ args: { selectedDomainName, targetSiteName } } );
+		const defaultErrorMessage = this.props.translate(
 				'Failed to transfer %(selectedDomainName)s, please try again or contact support.', {
 					args: { selectedDomainName } } );
+
 		this.setState( { disableDialogButtons: true } );
 		wpcom.transferToSite( this.props.selectedSite.ID, this.props.selectedDomainName, targetSite.ID )
 			.then( () => {
@@ -98,8 +99,8 @@ class TransferToOtherSite extends React.Component {
 			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
 		}
 
-		const { selectedSite, selectedDomainName } = this.props,
-			{ slug } = selectedSite;
+		const { selectedSite, selectedDomainName } = this.props;
+		const { slug } = selectedSite;
 
 		return (
 			<Main className="transfer-to-other-site">
@@ -114,12 +115,12 @@ class TransferToOtherSite extends React.Component {
 	}
 
 	renderSection() {
-		const { selectedDomainName: domainName, translate } = this.props,
-			{ currentUserCanManage } = getSelectedDomain( this.props );
-
+		const { currentUserCanManage } = getSelectedDomain( this.props );
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...omit( this.props, [ 'children' ] ) } />;
 		}
+
+		const { selectedDomainName: domainName, translate } = this.props;
 
 		return (
 			<div>
@@ -130,7 +131,7 @@ class TransferToOtherSite extends React.Component {
 							{ args: { domainName }, components: { strong: <strong /> } } ) }
 					</p>
 					<SiteSelector
-						filter={ this.checkSiteEligibility }
+						filter={ this.isSiteEligible }
 						sites={ this.props.sites }
 						onSiteSelect={ this.handleSiteSelect }
 					/>

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -78,12 +78,11 @@ class TransferToOtherSite extends React.Component {
 					this.props.successNotice( successMessage, { duration: 10000, isPersistent: true } );
 					page( paths.domainManagementList( this.props.selectedSite.slug ) );
 				}, ( error ) => {
+					this.setState( { disableDialogButtons: false } );
+					closeDialog();
 					this.props.errorNotice( error.message || defaultErrorMessage );
-				} )
-			.then( () => {
-				this.setState( { disableDialogButtons: false } );
-				closeDialog();
-			} );
+				}
+			);
 	}
 
 	handleDialogClose = () => {

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -31,7 +31,6 @@ import wp from 'lib/wp';
 const wpcom = wp.undocumented();
 
 class TransferToOtherSite extends React.Component {
-
 	static propTypes = {
 		selectedDomainName: React.PropTypes.string.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
@@ -41,15 +40,11 @@ class TransferToOtherSite extends React.Component {
 		currentUser: React.PropTypes.object.isRequired
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			targetSiteSlug: '',
-			showConfirmationDialog: false,
-			disableDialogButtons: false
-		};
-	}
+	state = {
+		targetSiteSlug: '',
+		showConfirmationDialog: false,
+		disableDialogButtons: false
+	};
 
 	isDataReady() {
 		return this.props.domains.hasLoadedFromServer;

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -76,14 +76,15 @@ class TransferToOtherSite extends React.Component {
 
 		this.setState( { disableDialogButtons: true } );
 		wpcom.transferToSite( this.props.selectedSite.ID, this.props.selectedDomainName, targetSite.ID )
+			.then(
+				() => {
+					this.props.successNotice( successMessage, { duration: 10000, isPersistent: true } );
+					page( paths.domainManagementList( this.props.selectedSite.slug ) );
+				}, ( error ) => {
+					this.props.errorNotice( error.message || defaultErrorMessage );
+				} )
 			.then( () => {
 				this.setState( { disableDialogButtons: false } );
-				this.props.successNotice( successMessage, { duration: 10000, isPersistent: true } );
-				closeDialog();
-				page( paths.domainManagementList( this.props.selectedSite.slug ) );
-			}, error => {
-				this.setState( { disableDialogButtons: false } );
-				this.props.errorNotice( error.message || defaultErrorMessage );
 				closeDialog();
 			} );
 	}

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/style.scss
@@ -1,8 +1,0 @@
-.transfer-to-other-site__select {
-	margin-top: 20px;
-	width: 100%;
-	@include breakpoint('>480px') {
-		width: 300px;
-	}
-
-}

--- a/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/style.scss
+++ b/client/my-sites/upgrades/domain-management/transfer/transfer-to-other-site/style.scss
@@ -1,0 +1,8 @@
+.transfer-to-other-site__select {
+	margin-top: 20px;
+	width: 100%;
+	@include breakpoint('>480px') {
+		width: 300px;
+	}
+
+}

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -120,6 +120,12 @@ module.exports = function() {
 	);
 
 	page(
+		paths.domainManagementTransferToOtherSite( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementTransferToOtherSite
+	);
+
+	page(
 		paths.domainManagementRoot(),
 		controller.siteSelection,
 		controller.sites

--- a/client/my-sites/upgrades/paths.js
+++ b/client/my-sites/upgrades/paths.js
@@ -95,6 +95,10 @@ function domainManagementTransferToAnotherUser( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'other-user' );
 }
 
+function domainManagementTransferToOtherSite( siteName, domainName ) {
+	return domainManagementTransfer( siteName, domainName, 'other-site' );
+}
+
 function getSectionName( pathname ) {
 	const regExp = new RegExp( '^' + domainManagementRoot() + '/[^/]+/([^/]+)', 'g' ),
 		matches = regExp.exec( pathname );
@@ -119,5 +123,6 @@ module.exports = {
 	domainManagementTransfer,
 	domainManagementTransferOut,
 	domainManagementTransferToAnotherUser,
+	domainManagementTransferToOtherSite,
 	getSectionName
 };


### PR DESCRIPTION
Based on https://github.com/Automattic/wp-calypso/pull/14029, but this time working ;)

----

Adds a view for transferring a domain between sites.
This complements our existing tool for transferring a domain between users of the same site. Now, the user should be able to move around the domain freely, without Happiness Engineer's intervention 🎉 

New entry in the Transfers section:
<img width="752" alt="screen shot 2017-05-14 at 20 00 54" src="https://cloud.githubusercontent.com/assets/3392497/26036571/53012d86-38e0-11e7-9cca-cd4e1e854e96.png">

New view:
<img width="762" alt="screen shot 2017-05-14 at 20 01 29" src="https://cloud.githubusercontent.com/assets/3392497/26036573/533ac726-38e0-11e7-9443-97d3fe6d966b.png">

Confirmation after clicking on the selected site:
<img width="554" alt="screen shot 2017-05-14 at 20 01 50" src="https://cloud.githubusercontent.com/assets/3392497/26036572/53358f0e-38e0-11e7-8ce5-6d74b77636f1.png">


## Testing
~Requires `D5603-code` on the backend.~ Backend patch already merged.

Test a few scenarios:
* Moving a domain between sites you're admin on.
* Moving a domain to a site you're not an admin on (the site should not be visible on the site picker and the backend should reject such a request).
* Moving a domain you don't own (should show the `NonOwnerCard` component.

When the domain is moved, it will _not_ become the primary domain on the target site. The user can set it as the primary one using the usual means.

There should be no WHOIS changes with this move, of course, so no emails from Tucows/WWD are expected as a result.