### PR TITLE
SSR: Render logged out layout by sections definition

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -9,19 +9,20 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import MasterbarLoggedOut from 'layout/masterbar/logged-out';
-import { getSection } from 'state/ui/selectors';
+import { getSection, hasSidebar } from 'state/ui/selectors';
 
 const LayoutLoggedOut = ( {
 	primary,
 	secondary,
 	section,
+	hasNoSidebar,
 	redirectUri,
 } ) => {
 	const classes = classNames( 'layout', {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
-		'has-no-sidebar': true, // Logged-out never has a sidebar
+		'has-no-sidebar': hasNoSidebar,
 		'wp-singletree-layout': !! primary,
 	} );
 
@@ -53,6 +54,7 @@ LayoutLoggedOut.propTypes = {
 
 export default connect(
 	state => ( {
-		section: getSection( state )
+		section: getSection( state ),
+		hasNoSidebar: ! hasSidebar( state )
 	} )
 )( LayoutLoggedOut );

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -76,6 +76,7 @@ export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getSelectedOrAllSites from './get-selected-or-all-sites';
 export getScheduledPublicizeShareActionTime from './get-scheduled-publicize-share-action-time';
+export isLoggedOut from './is-logged-out';
 export isSchedulingPublicizeShareActionError from './is-scheduling-publicize-share-action-error';
 export getSharingButtons from './get-sharing-buttons';
 export getSiteComments from './get-site-comments';

--- a/client/state/selectors/is-logged-out.js
+++ b/client/state/selectors/is-logged-out.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserId } from 'state/current-user/selectors';
+
+export default function isLoggedOut( state ) {
+	return ! getCurrentUserId( state );
+}

--- a/client/state/selectors/test/is-logged-out.js
+++ b/client/state/selectors/test/is-logged-out.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isLoggedOut } from '../';
+
+describe( 'isLoggedOut()', () => {
+	it( 'should return false if user exists', () => {
+		const result = isLoggedOut( {
+			currentUser: {
+				id: 73705554
+			}
+		} );
+
+		expect( result ).to.be.false;
+	} );
+
+	it( 'should return true if user does not exist', () => {
+		const result = isLoggedOut( {
+			currentUser: {
+				id: null
+			}
+		} );
+
+		expect( result ).to.be.true;
+	} );
+} );

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { includes, get } from 'lodash';
+import { includes, has, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { isLoggedOut } from 'state/selectors';
 
 /**
  * Returns the site object for the currently selected site.
@@ -137,5 +138,12 @@ export function hasSidebar( state ) {
 	if ( val === false ) {
 		return false;
 	}
-	return get( getSection( state ), 'secondary', true );
+
+	// Presence of sidebar may vary depending on logged-in state.
+	const section = getSection( state );
+	if ( has( section, 'secondaryLoggedOut' ) && isLoggedOut( state ) ) {
+		return section.secondaryLoggedOut;
+	}
+
+	return get( section, 'secondary', true );
 }

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -281,6 +281,9 @@ describe( 'selectors', () => {
 
 		it( 'should be true if true and secondary does not override it', () => {
 			expect( hasSidebar( {
+				currentUser: {
+					id: 73705554
+				},
 				ui: {
 					hasSidebar: true,
 					section: {}
@@ -290,10 +293,41 @@ describe( 'selectors', () => {
 
 		it( 'should fall back to the secondary prop on the current section when hasSidebar is true', () => {
 			expect( hasSidebar( {
+				currentUser: {
+					id: 73705554
+				},
 				ui: {
 					hasSidebar: true,
 					section: {
 						secondary: false
+					}
+				}
+			} ) ).to.be.false;
+		} );
+
+		it( 'should vary by logged in', () => {
+			expect( hasSidebar( {
+				currentUser: {
+					id: null
+				},
+				ui: {
+					hasSidebar: true,
+					section: {
+						secondary: false,
+						secondaryLoggedOut: true
+					}
+				}
+			} ) ).to.be.true;
+
+			expect( hasSidebar( {
+				currentUser: {
+					id: 73705554
+				},
+				ui: {
+					hasSidebar: true,
+					section: {
+						secondary: false,
+						secondaryLoggedOut: true
 					}
 				}
 			} ) ).to.be.false;

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -165,6 +165,7 @@ const sections = [
 		module: 'my-sites/themes',
 		enableLoggedOut: true,
 		secondary: true,
+		secondaryLoggedOut: false,
 		group: 'sites',
 		isomorphic: true,
 		title: 'Themes'

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -373,8 +373,13 @@ module.exports = function() {
 						req.context = Object.assign( {}, req.context, { chunk: section.name } );
 					}
 
-					if ( section.secondary && req.context ) {
-						req.context.hasSecondary = true;
+					if ( req.context ) {
+						const isLoggedIn = !! req.cookies.wordpress_logged_in;
+						if ( isLoggedIn ) {
+							req.context.hasSecondary = !! section.secondary;
+						} else if ( 'secondaryLoggedOut' in section ) {
+							req.context.hasSecondary = !! section.secondaryLoggedOut;
+						}
 					}
 
 					if ( section.group && req.context ) {


### PR DESCRIPTION
Fixes #8789
Related: #8815, #8454

This pull request seeks to resolve layout behavior for the DevDocs section whilst logged out. Previously we assumed that no logged out pages would have a sidebar. Instead, we should consider the `secondary` value defined per section, same as logged in. This is made more difficult by Themes section needing sidebar while logged in, but not while logged out. Ideally it would not be the place of the sections configuration to define the presence of a sidebar but instead the render behavior. Alas, the solution here is to define an additional property `secondaryLoggedOut` which is preferred when generating the section while logged out.

__Implementation notes:__

An initial approach I'd taken was to define `secondary` as a function accepting options including `isLoggedOut`. However, because these sections are serialized by `JSON.stringify`, it is not possible to define behavior as functions to be invoked at runtime.

__Testing instructions:__

Confirm both of the behaviors below, both while logged in, and while logged out (Incognito):

1. Navigate to http://calypso.localhost:3000/themes
   - If logged out, there should be no sidebar
   - If logged in, there should be a sidebar
      - NOTE: The initial server render does not appear to be working correctly as it considers the user to be logged out even if they're in-fact logged in. I could use some clarification here, but I suspect that the auth cookies that we test server-side are not available in development environments but that this would work correctly in production.
2. Navigate to http://calypso.localhost:3000/devdocs
   - There should be a sidebar regardless of logged in or logged out