### PR TITLE
Sites Selector: sort sites alphabetically

### DIFF
--- a/client/state/selectors/get-sites.js
+++ b/client/state/selectors/get-sites.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { concat, partition, map, sortBy } from 'lodash';
+import { partition, sortBy } from 'lodash/fp';
 
 /**
  * Internal dependencies
@@ -9,6 +9,8 @@ import { concat, partition, map, sortBy } from 'lodash';
 import createSelector from 'lib/create-selector';
 import { getSite } from 'state/sites/selectors';
 import { getPrimarySiteId } from 'state/selectors';
+
+const sortByNameAndUrl = sortBy( [ 'name', 'URL' ] );
 
 /**
  * Get all sites
@@ -19,8 +21,12 @@ import { getPrimarySiteId } from 'state/selectors';
 export default createSelector(
 	( state ) => {
 		const primarySiteId = getPrimarySiteId( state );
-		const [ primarySite, sites ] = partition( state.sites.items, { ID: primarySiteId } );
-		return map( concat( primarySite, sortBy( sites, [ 'name', 'URL' ] ) ), site => getSite( state, site.ID ) );
+		const [ primarySite, sites ] = partition( { ID: primarySiteId } )( state.sites.items );
+
+		return [
+			...primarySite,
+			...sortByNameAndUrl( sites )
+		].map( site => getSite( state, site.ID ) );
 	},
 	( state ) => state.sites.items
 );

--- a/client/state/selectors/get-sites.js
+++ b/client/state/selectors/get-sites.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { concat, partition, map } from 'lodash';
+import { concat, partition, map, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ export default createSelector(
 	( state ) => {
 		const primarySiteId = getPrimarySiteId( state );
 		const [ primarySite, sites ] = partition( state.sites.items, { ID: primarySiteId } );
-		return map( concat( primarySite, sites ), site => getSite( state, site.ID ) );
+		return map( concat( primarySite, sortBy( sites, [ 'name', 'URL' ] ) ), site => getSite( state, site.ID ) );
 	},
 	( state ) => state.sites.items
 );

--- a/client/state/selectors/test/get-sites.js
+++ b/client/state/selectors/test/get-sites.js
@@ -33,29 +33,42 @@ describe( 'getSites()', () => {
 		expect( sites ).to.eql( [] );
 	} );
 
+	it( 'should return the primary site if the user has only one site', () => {
+		const state = {
+			...currentUserState,
+			sites: {
+				items: {
+					2916288: { ID: 2916288, name: 'WordPress.com Example Blog' }
+				}
+			}
+		};
+
+		const sites = getSites( state );
+		expect( sites ).to.have.length( 1 );
+	} );
+
+	it( 'should return the sites lists if the user has no primary site', () => {
+		const state = {
+			...currentUserState,
+			sites: {
+				items: {
+					2916287: { ID: 2916287, name: 'WordPress.com Example Blog' },
+					2916286: { ID: 2916286, name: 'WordPress.com Example Blog' }
+				}
+			}
+		};
+
+		const sites = getSites( state );
+		expect( sites ).to.have.length( 2 );
+	} );
+
 	it( 'should return all the sites in state', () => {
 		const state = {
 			...currentUserState,
 			sites: {
 				items: {
-					2916284: {
-						ID: 2916284,
-						visible: true,
-						name: 'WordPress.com Example Blog',
-						URL: 'https://example.wordpress.com',
-						options: {
-							unmapped_url: 'https://example.wordpress.com'
-						}
-					},
-					2916285: {
-						ID: 2916285,
-						visible: false,
-						name: 'WordPress.com Way Better Example Blog',
-						URL: 'https://example2.wordpress.com',
-						options: {
-							unmapped_url: 'https://example2.wordpress.com'
-						}
-					}
+					2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+					2916285: { ID: 2916285, name: 'WordPress.com Way Better Example Blog' }
 				}
 			},
 			siteSettings: {
@@ -73,18 +86,9 @@ describe( 'getSites()', () => {
 			...currentUserState,
 			sites: {
 				items: {
-					2916287: {
-						ID: 2916287,
-						name: 'WordPress.com Example Blog',
-					},
-					2916288: {
-						ID: 2916288,
-						name: 'WordPress.com Way Better Example Blog',
-					},
-					2916289: {
-						ID: 2916289,
-						name: 'WordPress.com Another Example Blog',
-					}
+					2916287: { ID: 2916287, name: 'WordPress.com Example Blog' },
+					2916288: { ID: 2916288, name: 'WordPress.com Way Better Example Blog' },
+					2916289: { ID: 2916289, name: 'WordPress.com Another Example Blog' }
 				}
 			},
 			siteSettings: {

--- a/client/state/selectors/test/get-sites.js
+++ b/client/state/selectors/test/get-sites.js
@@ -95,7 +95,39 @@ describe( 'getSites()', () => {
 
 		expect( sites ).to.have.length( 3 );
 		expect( sites[ 0 ] ).to.have.property( 'ID', 2916288 );
-		expect( sites[ 1 ] ).to.have.property( 'ID', 2916287 );
-		expect( sites[ 2 ] ).to.have.property( 'ID', 2916289 );
+	} );
+
+	it( 'should returns sites in alphabetical order by name and url', () => {
+		const state = {
+			...currentUserState,
+			sites: {
+				items: {
+					2916287: { ID: 2916287, name: 'WordPress.com B Site', URL: '' },
+					2916288: { ID: 2916288, name: 'WordPress.com Z Site', URL: '' },
+					2916289: { ID: 2916289, name: 'WordPress.com A Site', URL: '' },
+					2916290: { ID: 2916290, name: 'WordPress.com C Site', URL: '' },
+					2916291: { ID: 2916291, name: 'WordPress.com 0 Site', URL: '' },
+					2916292: { ID: 2916292, name: '', URL: 'https://z-site-with-no-name.wordpress.com' },
+					2916293: { ID: 2916293, name: '', URL: 'https://0-site-with-no-name.wordpress.com' },
+					2916294: { ID: 2916294, name: 'WordPress.com B Site', URL: 'https://site-with-same-name-2.wordpress.com' },
+					2916295: { ID: 2916295, name: 'WordPress.com B Site', URL: 'https://site-with-same-name-1.wordpress.com' }
+				}
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getSites( state );
+
+		expect( sites ).to.have.length( 9 );
+		expect( sites[ 0 ] ).to.have.property( 'ID', 2916288 ); // WordPress.com Z Blog - Primary Site
+		expect( sites[ 1 ] ).to.have.property( 'ID', 2916293 ); // https://0-site-with-no-name.wordpress.com
+		expect( sites[ 2 ] ).to.have.property( 'ID', 2916292 ); // https://z-site-with-no-name.wordpress.com
+		expect( sites[ 3 ] ).to.have.property( 'ID', 2916291 ); // WordPress.com 0 Site
+		expect( sites[ 4 ] ).to.have.property( 'ID', 2916289 ); // WordPress.com A Site
+		expect( sites[ 5 ] ).to.have.property( 'ID', 2916287 ); // WordPress.com B Site
+		expect( sites[ 6 ] ).to.have.property( 'ID', 2916295 ); // WordPress.com B Site - https://site-with-same-name-1.wordpress.com
+		expect( sites[ 7 ] ).to.have.property( 'ID', 2916294 ); // WordPress.com B Site - https://site-with-same-name-2.wordpress.com
+		expect( sites[ 8 ] ).to.have.property( 'ID', 2916290 ); // WordPress.com C Site
 	} );
 } );

--- a/client/state/selectors/test/get-sites.js
+++ b/client/state/selectors/test/get-sites.js
@@ -101,7 +101,7 @@ describe( 'getSites()', () => {
 		expect( sites[ 0 ] ).to.have.property( 'ID', 2916288 );
 	} );
 
-	it( 'should returns sites in alphabetical order by name and url', () => {
+	it( 'should return sites in alphabetical order by name and url', () => {
 		const state = {
 			...currentUserState,
 			sites: {


### PR DESCRIPTION
This PR forces the `getSites` selector to sort the sites alphabetically by `name` and `url`.

Fixes #14023

To run tests:
```sh
npm run test-client client/state/selectors/test/get-sites.js
```