### PR TITLE
WooCommerce Promotions: remove from nav for v1

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -80,17 +80,6 @@ const getStorePages = () => {
 		},
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-promotions',
-			path: '/store/promotions/:site',
-			sidebarItem: {
-				icon: 'money',
-				isPrimary: true,
-				label: translate( 'Promotions' ),
-				slug: 'promotions',
-			},
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
 			configKey: 'woocommerce/extension-settings',
 			path: '/store/settings/:site',
 			sidebarItem: {

--- a/config/development.json
+++ b/config/development.json
@@ -158,7 +158,6 @@
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-products-import": true,
-		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,6 @@
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-products-import": true,
-		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/14705

To test, visit `http://calypso.localhost:3000/store/SITEURL` and ensure that Promotions navigation item is no longer present. 

cc @allendav to make sure I did this right. 