### PR TITLE
Posts list: Post Preview button shows the front page of the site, instead of the post itself (take 2)

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -356,8 +356,25 @@ export default connect(
 			editUrl: getEditorPath( state, post.site_ID, post.ID, 'post' ),
 			isPostFromSingleUserSite: isSingleUserSite( state, post.site_ID ),
 			isPreviewable: false !== isSitePreviewable( state, post.site_ID ),
-			previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
-			selectedSiteId
+			selectedSiteId,
+
+			/*
+			 * getPostPreviewUrl() relies on the post to be in Redux.
+			 *
+			 * There is an out of sync issue, because the posts list is fetched
+			 * through Flux and the Redux store is not filled with the proper
+			 * Posts data.
+			 *
+			 * This is a hack to work around that issue for the moment. It must
+			 * be removed when the posts list is updated to fetch the posts
+			 * through the newer QueryPosts component.
+			 *
+			 * FIXME(biskobe,mcsf): undo hack
+			 * //previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID ),
+			 */
+			previewUrl: getPostPreviewUrl( state, post.site_ID, post.ID,
+				{ __forceUseRawPost: post }
+			)
 		};
 	},
 	{ setPreviewUrl, setLayoutFocus }

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -421,13 +421,20 @@ export function getEditedPostSlug( state, siteId, postId ) {
  * Returns the most reliable preview URL for the post by site ID, post ID pair,
  * or null if a preview URL cannot be determined.
  *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @param  {Number}  postId Post ID
- * @return {?String}        Post preview URL
+ * @param  {Object}  state     Global state tree
+ * @param  {Number}  siteId    Site ID
+ * @param  {Number}  postId    Post ID
+ * @param  {Object}  [options] Special options. See wp-calypso#14456
+ * @return {?String}           Post preview URL
  */
-export function getPostPreviewUrl( state, siteId, postId ) {
-	const post = getSitePost( state, siteId, postId );
+export function getPostPreviewUrl( state, siteId, postId, options = false ) {
+	const rawPost = options.__forceUseRawPost;
+	const shouldUseRawPost = !! rawPost;
+
+	const post = shouldUseRawPost
+		? rawPost
+		: getSitePost( state, siteId, postId );
+
 	if ( ! post ) {
 		return null;
 	}


### PR DESCRIPTION
Take two, after reverting #14456 

Props @bisko for the original fix.