### PR TITLE
WooCommerce State: Always return an array for the product category list

### DIFF
--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get, isArray } from 'lodash';
+
+/**
  * Gets product categories from API data.
  *
  * @param {Object} state Global state tree
@@ -6,8 +11,9 @@
  * @return {Array} List of product categories
  */
 export function getProductCategories( state, siteId ) {
-	const sites = state.extensions.woocommerce.sites || {};
-	const siteData = sites[ siteId ] || {};
-
-	return siteData.productCategories || [];
+	const categories = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories' ], [] );
+	if ( ! isArray( categories ) ) {
+		return [];
+	}
+	return categories;
 }

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { getProductCategories } from '../selectors';
+import { LOADING } from 'woocommerce/state/constants';
 
 describe( 'selectors', () => {
 	describe( '#getProductCategories()', () => {
@@ -14,6 +15,22 @@ describe( 'selectors', () => {
 			const state = {
 				extensions: {
 					woocommerce: {}
+				}
+			};
+
+			expect( getProductCategories( state, 123 ) ).to.eql( [] );
+		} );
+
+		it( 'should return an empty array if data is still loading.', () => {
+			const state = {
+				extensions: {
+					woocommerce: {
+						sites: {
+							123: {
+								productCategories: LOADING,
+							}
+						}
+					}
 				}
 			};
 
@@ -35,10 +52,10 @@ describe( 'selectors', () => {
 				extensions: {
 					woocommerce: {
 						sites: {
-							[ 123 ]: {
+							123: {
 								productCategories: categories123,
 							},
-							[ 345 ]: {
+							345: {
 								productCategories: categories345,
 							},
 						}


### PR DESCRIPTION
This PR updates the `getProductCategories` selector to always return an array, even if the data is not available or is LOADING.

This fixes a `TypeError: productCategories.map is not a function` in the edit product screen, which happens when `productCategories == LOADING`, a string. I've also added a new test for the loading state. This was noted here: https://github.com/Automattic/wp-calypso/pull/14737#pullrequestreview-42179147

**To test**

- Run these tests: `npm run test-client client/extensions/woocommerce/state/sites/product-categories/`
- Visit the product edit screen, `http://calypso.localhost:3000/store/products/:site/add`, and verify no console errors.