### PR TITLE
ABTests: Add tests to catch issue if userLocale is not set

### DIFF
--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -197,7 +197,23 @@ describe( 'abtest', () => {
 				} );
 			} );
 		} );
-
+		describe( 'new-user-no-locale', () => {
+			beforeEach( () => {
+				mockedUser = {
+					localeSlug: false,
+					date: DATE_AFTER
+				};
+			} );
+			it( 'should call store.set for new users with no locale for en only test', () => {
+				abtest( 'mockedTest' );
+				expect( setSpy ).to.have.been.calledOnce;
+			} );
+			it( 'show return default and skip store.set for new users with no locale for fr test', () => {
+				navigator.language = 'de';
+				expect( abtest( 'mockedTestFrLocale' ) ).to.equal( 'hide' );
+				expect( setSpy ).not.to.have.been.called;
+			} );
+		} );
 		describe( 'logged-out users', () => {
 			beforeEach( () => {
 				mockedUser = false;


### PR DESCRIPTION
After #13402 was merged, automated testing caught an issue in some cases where userLocale is not set: see #14825

#14826 fixes that issue, and this PR contains additional unit tests to prevent future regressions.

Testing:
`NODE_ENV=test NODE_PATH=test:client TEST_ROOT=client  test/runner.js  client/lib/abtest/test/index.js`
This will fail if #14826 is reverted.


