### PR TITLE
Reader: Keep the feed image when getting feed data

### DIFF
--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -66,6 +66,7 @@ function adaptFeed( feed ) {
 		subscribers_count: feed.subscribers_count,
 		description: feed.description && decodeEntities( feed.description ),
 		last_update: feed.last_update,
+		image: feed.image,
 	};
 }
 

--- a/client/state/reader/feeds/schema.js
+++ b/client/state/reader/feeds/schema.js
@@ -15,6 +15,7 @@ export const itemsSchema = {
 				subscribers_count: { type: [ 'integer', 'null' ] },
 				description: { type: [ 'string', 'null' ] },
 				last_update: { type: [ 'string', 'null' ] },
+				image: { type: [ 'string', null ] },
 			},
 		},
 	},

--- a/client/state/reader/feeds/test/reducer.js
+++ b/client/state/reader/feeds/test/reducer.js
@@ -37,8 +37,8 @@ describe( 'reducer', () => {
 							feed_URL: 'http://example.com',
 							is_following: true,
 						},
-					}
-				)[ 1 ]
+					},
+				)[ 1 ],
 			).to.deep.equal( {
 				feed_ID: 1,
 				blog_ID: 2,
@@ -49,6 +49,7 @@ describe( 'reducer', () => {
 				subscribers_count: undefined,
 				description: undefined,
 				last_update: undefined,
+				image: undefined,
 			} );
 		} );
 
@@ -64,8 +65,8 @@ describe( 'reducer', () => {
 							name: 'ben &amp; jerries',
 							description: 'peaches &amp; cream',
 						},
-					}
-				)[ 1 ]
+					},
+				)[ 1 ],
 			).to.deep.equal( {
 				feed_ID: 1,
 				blog_ID: 2,
@@ -76,6 +77,7 @@ describe( 'reducer', () => {
 				is_following: undefined,
 				subscribers_count: undefined,
 				last_update: undefined,
+				image: undefined,
 			} );
 		} );
 
@@ -103,7 +105,7 @@ describe( 'reducer', () => {
 				const unvalidatedObject = deepFreeze( { hi: 'there' } );
 				this.stub( console, 'warn' ); // stub warn to suppress the warning that validation failure emits
 				expect( items( unvalidatedObject, { type: DESERIALIZE } ) ).to.deep.equal( {} );
-			} )
+			} ),
 		);
 
 		it( 'should deserialize good things', () => {
@@ -117,6 +119,7 @@ describe( 'reducer', () => {
 					subscribers_count: 10,
 					is_following: false,
 					last_update: undefined,
+					image: 'http://example.com/favicon',
 				},
 			} );
 			expect( items( validState, { type: DESERIALIZE } ) ).to.deep.equal( validState );
@@ -130,8 +133,8 @@ describe( 'reducer', () => {
 						type: READER_FEED_REQUEST_FAILURE,
 						error: new Error( 'request failed' ),
 						payload: { feed_ID: 666 },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 666: { feed_ID: 666, is_error: true } } );
 		} );
 
@@ -145,8 +148,9 @@ describe( 'reducer', () => {
 						blog_ID: 888,
 						name: 'new',
 						subscribers_count: 10,
+						image: 'http://example.com/image',
 					},
-				} )
+				} ),
 			).to.deep.equal( {
 				666: {
 					feed_ID: 666,
@@ -158,6 +162,7 @@ describe( 'reducer', () => {
 					is_following: undefined,
 					description: undefined,
 					last_update: undefined,
+					image: 'http://example.com/image',
 				},
 			} );
 		} );
@@ -169,7 +174,7 @@ describe( 'reducer', () => {
 					type: READER_FEED_REQUEST_FAILURE,
 					error: new Error( 'request failed' ),
 					payload: { feed_ID: 666 },
-				} )
+				} ),
 			).to.deep.equal( startingState );
 		} );
 
@@ -183,7 +188,7 @@ describe( 'reducer', () => {
 						{ feed_ID: 1, blog_ID: 777, name: 'first &amp; one', is_following: true },
 						{ feed_ID: 2, blog_ID: 999, name: 'second', is_following: true },
 					],
-				} )
+				} ),
 			).to.deep.equal( {
 				666: {
 					feed_ID: 666,
@@ -195,6 +200,7 @@ describe( 'reducer', () => {
 					subscribers_count: undefined,
 					description: undefined,
 					last_update: undefined,
+					image: undefined,
 				},
 				1: {
 					feed_ID: 1,
@@ -206,6 +212,7 @@ describe( 'reducer', () => {
 					subscribers_count: undefined,
 					description: undefined,
 					last_update: undefined,
+					image: undefined,
 				},
 				2: {
 					feed_ID: 2,
@@ -217,6 +224,7 @@ describe( 'reducer', () => {
 					subscribers_count: undefined,
 					description: undefined,
 					last_update: undefined,
+					image: undefined,
 				},
 			} );
 		} );
@@ -230,8 +238,8 @@ describe( 'reducer', () => {
 					{
 						type: READER_FEED_REQUEST,
 						payload: { feed_ID: 1 },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 1: true } );
 		} );
 
@@ -240,7 +248,7 @@ describe( 'reducer', () => {
 				queuedRequests( deepFreeze( { 1: true } ), {
 					type: READER_FEED_REQUEST_SUCCESS,
 					payload: { feed_ID: 1 },
-				} )
+				} ),
 			).to.deep.equal( {} );
 		} );
 	} );


### PR DESCRIPTION
We use the feed image as a backup for the site icon when displaying site icons on post cards. Prior to this, we were throwing away the image.