### PR TITLE
WooCommerce: Fix the weight and dimensions inputs by displaying the correct unit.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -17,7 +17,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import FormWeightInput from 'woocommerce/components/form-weight-input';
 
 const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 	const setDimension = ( e ) => {
@@ -60,28 +60,21 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 		</Card>
 	);
 
-	// TODO pull in dimension and weight units.
 	const renderDeliveryDetails = () => (
 		<Card className="products__product-form-delivery-details">
 			<div className="products__product-dimensions-weight">
 				<FormFieldSet className="products__product-dimensions-input">
 					<FormLabel>{ translate( 'Dimensions' ) }</FormLabel>
 					<FormDimensionsInput
-						unit={ translate( 'in' ) }
 						dimensions={ product.dimensions }
 						onChange={ setDimension }
 					/>
 				</FormFieldSet>
 				<FormFieldSet className="products__product-weight-input">
 					<FormLabel>{ translate( 'Weight' ) }</FormLabel>
-					<FormTextInputWithAffixes
-						name="weight"
-						type="number"
-						min="0"
-						suffix="g"
-						value={ product.weight || '' }
+					<FormWeightInput
+						value={ product.weight }
 						onChange={ setWeight }
-						size="4"
 					/>
 				</FormFieldSet>
 			</div>

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -15,7 +15,7 @@ import Button from 'components/button';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import FormWeightInput from 'woocommerce/components/form-weight-input';
 import ImagePreloader from 'components/image-preloader';
 import ProductImageUploader from 'woocommerce/components/product-image-uploader';
 import Spinner from 'components/spinner';
@@ -194,19 +194,14 @@ class ProductFormVariationsRow extends Component {
 					<div className="products__product-dimensions-weight">
 						<FormDimensionsInput
 							className="products__product-dimensions-input"
-							unit="in"
 							dimensions={ variation.dimensions }
 							onChange={ this.setDimension }
 							noWrap
 						/>
 						<div className="products__product-weight-input">
-							<FormTextInputWithAffixes
-								name="weight"
-								type="number"
-								suffix="g"
-								value={ variation.weight || '' }
+							<FormWeightInput
+								value={ variation.weight }
 								onChange={ this.setWeight }
-								size="4"
 								noWrap
 							/>
 						</div>

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -8,12 +8,12 @@ import { find, isNumber } from 'lodash';
 /**
  * Internal dependencies
  */
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import Dialog from 'components/dialog';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
-import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormWeightInput from 'woocommerce/components/form-weight-input';
 import ProductFormVariationsModal from './product-form-variations-modal';
 import ProductFormVariationsRow from './product-form-variations-row';
 
@@ -160,20 +160,15 @@ class ProductFormVariationsTable extends React.Component {
 					<div className="products__product-dimensions-weight">
 						<FormDimensionsInput
 							className="products__product-dimensions-input"
-							unit="in"
 							noWrap
 							dimensions={ dimensions }
 							onChange={ this.setDimension }
 						/>
 						<div className="products__product-weight-input">
-							<FormTextInputWithAffixes
-								name="weight"
-								type="number"
-								suffix="g"
+							<FormWeightInput
 								value={ weight }
-								size="4"
-								noWrap
 								onChange={ this.setWeight }
+								noWrap
 							/>
 						</div>
 					</div>

--- a/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
+++ b/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
@@ -1,9 +1,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,46 +14,99 @@ import { localize } from 'i18n-calypso';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 
-function FormDimensionsInput( {
-	className,
-	dimensions,
-	unit,
-	onChange,
-	translate,
-	noWrap,
-} ) {
-	const classes = classNames( 'form-dimensions-input', className, { 'no-wrap': noWrap } );
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getDimensionsUnitSetting } from 'woocommerce/state/sites/settings/products/selectors';
+import { fetchSettingsProducts } from 'woocommerce/state/sites/settings/products/actions';
 
-	return (
-		<div className={ classes }>
-			<FormTextInput
-				name="length"
-				placeholder={ translate( 'L' ) }
-				type="number"
-				value={ dimensions && dimensions.length || '' }
-				onChange={ onChange }
-				className="form-dimensions-input__length"
-			/>
-			<FormTextInput
-				name="width"
-				placeholder={ translate( 'W' ) }
-				type="number"
-				value={ dimensions && dimensions.width || '' }
-				onChange={ onChange }
-				className="form-dimensions-input__width"
-			/>
-			<FormTextInputWithAffixes
-				name="height"
-				placeholder={ translate( 'H' ) }
-				suffix={ unit }
-				type="number"
-				noWrap={ noWrap }
-				value={ dimensions && dimensions.height || '' }
-				onChange={ onChange }
-				className="form-dimensions-input__height"
-			/>
-		</div>
+class FormDimensionsInput extends Component {
+
+	static propTypes = {
+		className: PropTypes.string,
+		dimensions: PropTypes.shape( {
+			width: PropTypes.string,
+			height: PropTypes.sting,
+			length: PropTypes.string,
+		} ),
+		onChange: PropTypes.func.isRequired,
+		noWrap: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		value: '',
+		className: '',
+		onChange: noop,
+		noWrap: false,
+	}
+
+	componentDidMount() {
+		const { siteId } = this.props;
+
+		if ( siteId ) {
+			this.props.fetchSettingsProducts( siteId );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.siteId !== this.props.siteId ) {
+			this.props.fetchSettingsProducts( newProps.siteId );
+		}
+	}
+
+	render() {
+		const { className, noWrap, dimensions, onChange, translate, dimensionsUnit } = this.props;
+		const classes = classNames( 'form-dimensions-input', className, { 'no-wrap': noWrap } );
+
+		return (
+			<div className={ classes }>
+				<FormTextInput
+					name="length"
+					placeholder={ translate( 'L', { comment: 'Length placeholder for dimensions input' } ) }
+					type="number"
+					value={ dimensions && dimensions.length || '' }
+					onChange={ onChange }
+					className="form-dimensions-input__length"
+				/>
+				<FormTextInput
+					name="width"
+					placeholder={ translate( 'W', { comment: 'Width placeholder for dimensions input' } ) }
+					type="number"
+					value={ dimensions && dimensions.width || '' }
+					onChange={ onChange }
+					className="form-dimensions-input__width"
+				/>
+				<FormTextInputWithAffixes
+					name="height"
+					placeholder={ translate( 'H', { comment: 'Height placeholder for dimensions input' } ) }
+					suffix={ dimensionsUnit }
+					type="number"
+					noWrap={ noWrap }
+					value={ dimensions && dimensions.height || '' }
+					onChange={ onChange }
+					className="form-dimensions-input__height"
+				/>
+			</div>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const dimensionsUnitSetting = site && getDimensionsUnitSetting( state, site.ID );
+	const dimensionsUnit = dimensionsUnitSetting && dimensionsUnitSetting.value || 'in';
+
+	return {
+		siteId: site && site.ID,
+		dimensionsUnit,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSettingsProducts,
+		},
+		dispatch
 	);
 }
 
-export default localize( FormDimensionsInput );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( FormDimensionsInput ) );

--- a/client/extensions/woocommerce/components/form-weight-input/index.js
+++ b/client/extensions/woocommerce/components/form-weight-input/index.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getWeightUnitSetting } from 'woocommerce/state/sites/settings/products/selectors';
+import { fetchSettingsProducts } from 'woocommerce/state/sites/settings/products/actions';
+
+class FormWeightInput extends Component {
+
+	static propTypes = {
+		className: PropTypes.string,
+		value: PropTypes.string.isRequired,
+		onChange: PropTypes.func.isRequired,
+		noWrap: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		value: '',
+		className: '',
+		onChange: noop,
+		noWrap: false,
+	}
+
+	componentDidMount() {
+		const { siteId } = this.props;
+
+		if ( siteId ) {
+			this.props.fetchSettingsProducts( siteId );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.siteId !== this.props.siteId ) {
+			this.props.fetchSettingsProducts( newProps.siteId );
+		}
+	}
+
+	render() {
+		const { className, weightUnit, value, onChange, noWrap } = this.props;
+		const classes = classNames( 'form-weight-input', className, { 'no-wrap': noWrap } );
+
+		return (
+			<FormTextInputWithAffixes
+				name="weight"
+				min="0"
+				suffix={ weightUnit }
+				type="number"
+				value={ value || '' }
+				onChange={ onChange }
+				className={ classes }
+				size="4"
+			/>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const weightUnitSetting = site && getWeightUnitSetting( state, site.ID );
+	const weightUnit = weightUnitSetting && weightUnitSetting.value || 'lbs';
+
+	return {
+		siteId: site && site.ID,
+		weightUnit,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSettingsProducts,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( FormWeightInput );


### PR DESCRIPTION
This PR builds on #14827 and actually displays the correct units for weight and dimensions. I converted the various weight inputs (variations, global row, product) to use a new component instead that would load the correct unit, and made the existing dimensions do the same thing. I've defaulted to inches and pounds when nothing is loaded since our MVP is US stores.

To Test:
* Go to `http://calypso.localhost:3000/store/product/:site`
* Make sure the weight and dimensions inputs display correctly both in variations view and normal product view.
* Go to `wp-admin` and `Settings > Products` and change your weight and dimensions units.
* Refresh the product form and see the new units loaded correctly into the component.

See #14185.