### PR TITLE
WooCommerce: Update variation visible toggle to set post status.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -59,7 +59,8 @@ class ProductFormVariationsModal extends React.Component {
 	toggleVisible() {
 		const { product, editProductVariation } = this.props;
 		const variation = this.selectedVariation();
-		editProductVariation( product, variation, { visible: ! variation.visible } );
+		const status = 'publish' === variation.status ? 'private' : 'publish';
+		editProductVariation( product, variation, { status } );
 	}
 
 	switchVariation( selectedVariation ) {
@@ -117,7 +118,7 @@ class ProductFormVariationsModal extends React.Component {
 						{ translate( 'Visible' ) }
 						<FormToggle
 							onChange={ this.toggleVisible }
-							checked={ variation.visible }
+							checked={ 'publish' === variation.status }
 						/>
 					</FormLabel>
 					<FormSettingExplanation>{ translate(

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -131,7 +131,7 @@ function editProductVariations( productEdits, variations ) {
 				id: { index: Number( uniqueId() ) },
 				attributes: variation.attributes,
 				sku: variation.sku,
-				visible: true,
+				status: 'publish',
 			} );
 		}
 	} );


### PR DESCRIPTION
Previously when toggling the variation 'visible' toggle, a true/false 'visible' field was stored in Redux state. This is removed from v3 of the REST API because it was broken. Instead, a 'private' post status should be used (which is what WooCommerce actually uses to hide variations).

This tiny PR updates the code to use the correct field.

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site/add`.
* Toggle the variation card.
* Type in a type with a few options (like `Color` and `Red`, `Green`, `Blue`).
* Click on the linked variation name to open the modal for that variation.
* Toggle the 'visible' toggle and make sure it updates. (`status` will also update in Redux state).
* There is a single line change to the variations-reducer for when we generate new variations, so to be safe: `make test` and make sure all tests pass.