### PR TITLE
Login: Provide `code` with error object in `getErrorFromHTTPError`

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -37,7 +37,7 @@ class SocialLoginForm extends Component {
 		this.props.loginSocialUser( 'google', response.Zi.id_token ).then( () => {
 			this.props.onSuccess();
 		} ).catch( error => {
-			if ( error === 'unknown_user' ) {
+			if ( error.code === 'unknown_user' ) {
 				const { notice } = this.props.infoNotice( this.props.translate( 'Creating your account' ) );
 				wpcom.undocumented().usersSocialNew( 'google', response.Zi.id_token, 'login', ( wpcomError, wpcomResponse ) => {
 					this.props.removeNotice( notice.noticeId );
@@ -51,7 +51,7 @@ class SocialLoginForm extends Component {
 					}
 				} );
 			} else {
-				this.props.errorNotice( error );
+				this.props.errorNotice( error.message );
 			}
 		} );
 	};

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -65,29 +65,29 @@ const errorFields = {
  * Retrieves the first error message from the specified HTTP error.
  *
  * @param {Object} httpError HTTP error
- * @returns {{message: string, field: string}} an error message and the id of the corresponding field, if not global
+ * @returns {{code: string?, message: string, field: string}} an error message and the id of the corresponding field, if not global
  */
 function getErrorFromHTTPError( httpError ) {
 	let message;
 	let field = 'global';
 
-	const errorKey = get( httpError, 'response.body.data.errors[0]' );
+	const code = get( httpError, 'response.body.data.errors[0]' );
 
-	if ( errorKey ) {
-		if ( errorKey in errorMessages ) {
-			message = errorMessages[ errorKey ];
+	if ( code ) {
+		if ( code in errorMessages ) {
+			message = errorMessages[ code ];
 
-			if ( errorKey in errorFields ) {
-				field = errorFields[ errorKey ];
+			if ( code in errorFields ) {
+				field = errorFields[ code ];
 			}
 		} else {
-			message = errorKey;
+			message = code;
 		}
 	} else {
 		message = get( httpError, 'response.body.data', httpError.message );
 	}
 
-	return { message, field };
+	return { code, message, field };
 }
 
 /**


### PR DESCRIPTION
This fixes [a regression](https://github.com/Automattic/wp-calypso/pull/14214#discussion_r120285863) in `SocialLoginForm`.

**Testing**
*Error code*
- Visit `/log-in`.
- Attempt to log in using a Google account not associated with a WordPress.com user.
- Assert that a new account is created and that you are redirected to `/start`.

*Error message*
- Apply the patch in pb-1a0e4
- Visit `/log-in`.
- Attempt to log in using a Google account.
- Assert that you see an error notice.

- [x] Code
- [x] Product