### PR TITLE
Include existing users in domainToPaidPlanUpsellNudge test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -51,12 +51,13 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	domainToPaidPlanUpsellNudge: {
-		datestamp: '20170429',
+		datestamp: '20170607',
 		variations: {
 			skip: 50,
 			show: 50,
 		},
 		defaultVariation: 'skip',
+		allowExistingUsers: true,
 	},
 	ATPromptOnCancel: {
 		datestamp: '20170515',


### PR DESCRIPTION
The current incarnation of the domainToPaidPlanUpsellNudge a/b test excludes existing users.

Given that domains can only be purchased as part of a plan now, this needlessly limits the participants in the test.