### PR TITLE
Framework: Switch to 4 space tabs for GitHub diffs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = tab
 
 # To control tab size in github diffs
 # See https://github.com/isaacs/github/issues/170#issuecomment-150489692
-indent_size = 2
+indent_size = 4
 
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
2 spaces was just too hard to read given how github does diffs. It made many indented lines appear like they were not indented at all.