### PR TITLE
Checkout/domains/fix unknown prop error

### DIFF
--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -34,7 +34,7 @@ export default localize( React.createClass( {
 
 		return (
 			<select
-				{ ...omit( this.props, 'className' ) }
+				{ ...omit( this.props, [ 'className', 'countriesList', 'translate', 'moment', 'numberFormat' ] ) }
 				className={ classnames( this.props.className, 'form-country-select' ) }
 				onChange={ this.props.onChange }
 			>


### PR DESCRIPTION
This PR fixes an "Unknown prop" warning on the domain contact page: 
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/26862207-b3899724-4b8c-11e7-892e-9cfe462a5dff.jpg)

Test/Reproduce: In a debug build, open the console, add a new domain, and go through the process to the contact details page and verify that the warnings are there and then fixed with the  patch. The warnings are coming from the country select associated with the phone number:
1. ![stats_ _my_test_blog_ _wordpress_com](https://user-images.githubusercontent.com/5952255/26862502-150bf670-4b8f-11e7-8085-633238e51a66.jpg)

2. ![checkout_ _my_test_blog_ _wordpress_com](https://user-images.githubusercontent.com/5952255/26862537-7df6fd24-4b8f-11e7-84a2-7d15a0dcd0f6.jpg)

The `countriesList` prop was passed in and intended for the parent, and the other three props come from the `localize()`, so we should just exclude them all from the props passed to the child.

I'm aware of the lint warnings about using `React.createClass()` and `'lib/mixins/data-observe`, but I don't want to update the class right now (it works fine, apart from the warnings), just fix the annoying warnings.

I'd totally welcome the refactor patch.

This should also fix the test warning for this component mentioned in #8274