### PR TITLE
Seo upgrade nudge new style

### DIFF
--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -4,59 +4,22 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
 import QueryPlans from 'components/data/query-plans';
-import FeatureExample from 'components/feature-example';
-import FeatureComparison from 'my-sites/feature-comparison';
-import PlanCompareCard from 'my-sites/plan-compare-card';
-import PlanCompareCardItem from 'my-sites/plan-compare-card/item';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { preventWidows } from 'lib/formatting';
-import formatCurrency from 'lib/format-currency';
-import { getFeatureTitle, planHasFeature } from 'lib/plans';
-import { isFreePlan, isFreeJetpackPlan } from 'lib/products-values';
 import { isJetpackSite } from 'state/sites/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getPlanBySlug } from 'state/plans/selectors';
-import { getPlan } from 'lib/plans';
+import Banner from 'components/banner';
 import {
 	PLAN_BUSINESS,
-	PLAN_JETPACK_BUSINESS,
-	FEATURE_ADVANCED_SEO
+	PLAN_JETPACK_BUSINESS
 } from 'lib/plans/constants';
 
-const SeoPreviewNudge = ( { translate, domain, plan = {}, businessPlan = {}, isJetpack = false, planFeatures = [] } ) => {
-	let planPrice = translate( 'Free for life' );
-	if ( ! ( isFreePlan( plan ) || isFreeJetpackPlan( plan ) ) ) {
-		planPrice = isJetpack
-			? translate( '%(price)s per year', {
-				args: {
-					price: formatCurrency( plan.raw_price, plan.currency_code )
-				}
-			} )
-			: translate( '%(price)s per month, billed yearly', {
-				args: {
-					price: formatCurrency( plan.raw_price / 12, plan.currency_code )
-				}
-			} );
-	}
-	const businessPlanPrice = isJetpack
-		? formatCurrency( businessPlan.raw_price, businessPlan.currency_code )
-		: formatCurrency( businessPlan.raw_price / 12, businessPlan.currency_code );
-	const priceInfo = isJetpack
-		? translate( '%(price)s per year', { args: { price: businessPlanPrice } } )
-		: translate( '%(price)s per month, billed yearly', { args: { price: businessPlanPrice } } );
-
-	const featuresToShow = planFeatures.filter(
-		feature =>
-			! planHasFeature( plan.product_slug, feature ) &&
-			feature !== FEATURE_ADVANCED_SEO
-	);
+const SeoPreviewNudge = ( { translate, isJetpack = false } ) => {
 	return (
 		<div className="preview-upgrade-nudge">
 			<QueryPlans />
@@ -89,56 +52,18 @@ const SeoPreviewNudge = ( { translate, domain, plan = {}, businessPlan = {}, isJ
 					</ul>
 				</div>
 			</div>
-			<FeatureComparison className="preview-upgrade-nudge__feature-comparison">
-				<PlanCompareCard
-					title={ plan.product_name_short || '' }
-					line={ planPrice }
-					buttonName={ translate( 'Your Plan' ) }
-					currentPlan={ true } >
-					<PlanCompareCardItem unavailable={ true } >
-						{ getFeatureTitle( FEATURE_ADVANCED_SEO ) }
-					</PlanCompareCardItem>
-					{ featuresToShow.map( feature => (
-						<PlanCompareCardItem
-							key={ feature }
-							unavailable={ ! planHasFeature( plan.product_slug, feature ) } >
-							{ getFeatureTitle( feature ) }
-						</PlanCompareCardItem>
-					) ) }
-				</PlanCompareCard>
-				<PlanCompareCard
-					title={ businessPlan.product_name_short || '' }
-					line={ priceInfo }
-					buttonName={ translate( 'Upgrade' ) }
-					onClick={ () => {
-						recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
-							cta_size: 'expanded',
-							cta_name: 'calypso_seo_preview_upgrade_nudge',
-							cta_feature: FEATURE_ADVANCED_SEO
-						} );
-						page( '/checkout/' + domain + ( isJetpack ? '/professional' : '/business' ) );
-					} }
-					currentPlan={ false }
-					popularRibbon={ true } >
-					<PlanCompareCardItem highlight={ true } >
-						{ getFeatureTitle( FEATURE_ADVANCED_SEO ) }
-					</PlanCompareCardItem>
-					{ featuresToShow.map( feature => (
-						<PlanCompareCardItem key={ feature }>
-							{ getFeatureTitle( feature ) }
-						</PlanCompareCardItem>
-					) ) }
-				</PlanCompareCard>
-			</FeatureComparison>
+			<Banner
+					plan={ isJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS }
+					title={ translate( 'Upgrade to a Business Plan to unlock the power of our SEO tools!' ) }
+					event="site_preview_seo_plan_upgrade"
+					className="preview-upgrade-nudge__banner"
+				/>
 		</div>
 	);
 };
 
 SeoPreviewNudge.propTypes = {
 	translate: PropTypes.func.isRequired,
-	domain: PropTypes.string.isRequired,
-	plan: PropTypes.object,
-	businessPlan: PropTypes.object
 };
 
 const mapStateToProps = ( state, ownProps ) => {
@@ -146,11 +71,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const isJetpack = isJetpackSite( state, site.ID );
 
 	return {
-		domain: site.domain,
-		plan: getPlanBySlug( state, site.plan.product_slug ),
-		businessPlan: getPlanBySlug( state, isJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS ),
 		isJetpack,
-		planFeatures: getPlan( isJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS ).getFeatures()
 	};
 };
 

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -13,6 +13,7 @@ import QueryPlans from 'components/data/query-plans';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { preventWidows } from 'lib/formatting';
 import { isJetpackSite } from 'state/sites/selectors';
+import FeatureExample from 'components/feature-example';
 import Banner from 'components/banner';
 import {
 	PLAN_BUSINESS,

--- a/client/components/seo/preview-upgrade-nudge/style.scss
+++ b/client/components/seo/preview-upgrade-nudge/style.scss
@@ -72,4 +72,15 @@
 	.feature-example__gradient {
 		background: linear-gradient( to bottom, rgba(243, 246, 248, 0), rgba( 243, 246, 248, 1) );
 	}
+
+	.preview-upgrade-nudge__banner {
+		bottom: 0;
+		margin: 0;
+		position: absolute;
+		width: 100%;
+
+		.banner__title {
+			text-decoration: none !important;
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/14735

This  PR changes how we prompt non-business users to upgrade in the site preview when they try to use the SEO tab. This was how it looked before:

![image](https://user-images.githubusercontent.com/1554855/26865630-d97bfcc6-4b5d-11e7-81c0-a948d8b9d050.png)

And this is how it looks after applying this PR:
![image](https://user-images.githubusercontent.com/1554855/26865654-f5feee94-4b5d-11e7-916e-af3caeb4aec3.png)

The banner in the bottom may look a little odd since the modal window goes all the way down to `bottom: 0`, so maybe @rickybanister  or @MichaelArestad want to step in and do some suggestion (or even play with the css in this PR ;D )

How to test
======
0. You need a site that is not business or a jetpack site that is not professional
1. Click on site preview in the left side menu
2. Click on the SEO tab
3. You should see the new banner instead of the plans comparisson 