### PR TITLE
Posts: Open posts in new tab if no site is selected

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -282,7 +282,7 @@ const Post = React.createClass( {
 
 	viewPost( event ) {
 		event.preventDefault();
-		const { isPreviewable, previewUrl } = this.props;
+		const { isPreviewable, previewUrl, selectedSiteId } = this.props;
 
 		if ( this.props.post.status && this.props.post.status === 'future' ) {
 			this.analyticsEvents.previewPost;
@@ -290,7 +290,7 @@ const Post = React.createClass( {
 			this.analyticsEvents.viewPost;
 		}
 
-		if ( ! isPreviewable ) {
+		if ( ! isPreviewable || ! selectedSiteId ) {
 			return window.open( previewUrl );
 		}
 


### PR DESCRIPTION
Currently, when you visit `/posts` with no site is selected, previewing posts does not work.

This is because previewing currently requires a selected site. In this case, debugging pointed to `DesignPreview`:

```js
render() {
  if ( ! this.props.selectedSite || ! this.props.selectedSite.is_previewable ) {
    debug( 'a preview is not available for this site' );
    return null;
  }
```

As an interim fix, this opens the posts as a new window if a preview is not possible.

# To test

- Make sure single-site views in `/posts` are unaffected by this change and that tapping _View_ on an item opens a preview (unless the site itself doesn't support it).
- In all-sites views, which includes `/posts`, `/posts/my`, and their drafts/scheduled/trash variants, tapping _View_ should open a new window showing that particular post.