### PR TITLE
Separate concerns and display proper error message

### DIFF
--- a/client/blocks/global-notice/README.md
+++ b/client/blocks/global-notice/README.md
@@ -1,0 +1,23 @@
+Global Notice
+===========
+
+These components are used to display global notices.
+They allow you to use a component for your notice instead of calling the notices redux actions directly.
+
+#### How to use the container:
+
+```js
+import { InfoNotice } from 'blocks/global-notice';
+
+render() {
+	return (
+		<div>
+			{ this.state.processing && <InfoNotice text={ this.props.translate( 'Proccessing…' ) } /> }
+		</div>
+	);
+}
+```
+
+#### Props
+
+* `text`: The text that will be displayed while the notice is visible

--- a/client/blocks/global-notice/index.js
+++ b/client/blocks/global-notice/index.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { infoNotice, removeNotice } from 'state/notices/actions';
+
+export class GlobalNotice extends Component {
+	static propTypes = {
+		displayNotice: PropTypes.func.isRequired,
+		removeNotice: PropTypes.func.isRequired,
+		text: PropTypes.string.isRequired,
+	};
+
+	componentWillMount() {
+		const { notice } = this.props.displayNotice( this.props.text, { isPersistent: true } );
+		this.notice = notice;
+	}
+
+	componentWillUnmount() {
+		if ( this.notice ) {
+			this.props.removeNotice( this.notice.noticeId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export const InfoNotice = connect(
+	null,
+	{
+		displayNotice: infoNotice,
+		removeNotice,
+	}
+)( GlobalNotice );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -17,6 +17,8 @@ import {
 	getRequestNotice,
 	getTwoFactorAuthRequestError,
 	getTwoFactorNotificationSent,
+	getCreateSocialAccountError,
+	getRequestSocialAccountError,
 	isTwoFactorEnabled,
 } from 'state/login/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -90,9 +92,12 @@ class Login extends Component {
 	};
 
 	renderError() {
-		const error = this.props.requestError || this.props.twoFactorAuthRequestError;
+		const error = this.props.requestError ||
+			this.props.twoFactorAuthRequestError ||
+			this.props.requestAccountError ||
+			this.props.createAccountError && this.props.createAccountError.code !== 'unknown_user' ? this.props.createAccountError : null;
 
-		if ( ! error || error.field !== 'global' ) {
+		if ( ! error || ( error.field && error.field !== 'global' ) || ! error.message ) {
 			return null;
 		}
 
@@ -177,6 +182,8 @@ class Login extends Component {
 export default connect(
 	( state ) => ( {
 		redirectTo: getRedirectTo( state ),
+		createAccountError: getCreateSocialAccountError( state ),
+		requestAccountError: getRequestSocialAccountError( state ),
 		requestError: getRequestError( state ),
 		requestNotice: getRequestNotice( state ),
 		twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -95,6 +95,24 @@ function getErrorFromHTTPError( httpError ) {
 	return { code, message, field };
 }
 
+const wpcomErrorMessages = {
+	user_exists: translate( 'Your Google email address is already in use WordPress.com. ' +
+		'Log in to your account using your email address or username, and your password. ' +
+		'To create a new WordPress.com account, use a different Google account.' )
+};
+
+/**
+ * Transforms WPCOM error to the error object we use for login purposes
+ *
+ * @param {Object} wpcomError HTTP error
+ * @returns {{message: string, field: string, code: string}} an error message and the id of the corresponding field
+ */
+const getErrorFromWPCOMError = ( wpcomError ) => ( {
+	message: wpcomErrorMessages[ wpcomError.error ] || wpcomError.message,
+	code: wpcomError.error,
+	field: 'global',
+} );
+
 /**
  * Attempt to login a user.
  *
@@ -239,10 +257,14 @@ export const createSocialUser = ( service, token, flowName ) => dispatch => {
 	} );
 
 	return wpcom.undocumented().usersSocialNew( service, token, flowName ).then( wpcomResponse => {
-		dispatch( { type: SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS } );
-		return Promise.resolve( wpcomResponse );
-	} ).catch( wpcomError => {
-		const error = { ...wpcomError, field: 'global' };
+		const data = {
+			username: wpcomResponse.username,
+			bearerToken: wpcomResponse.bearer_token
+		};
+		dispatch( { type: SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS, data } );
+		return data;
+	}, wpcomError => {
+		const error = getErrorFromWPCOMError( wpcomError );
 
 		dispatch( {
 			type: SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -29,6 +29,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE,
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
+	USER_RECEIVE,
 } from 'state/action-types';
 
 export const isRequesting = createReducer( false, {
@@ -124,6 +125,22 @@ export const twoFactorAuthPushPoll = createReducer( { inProgress: false, success
 	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED ]: state => ( { ...state, inProgress: false, success: true } ),
 } );
 
+export const socialAccount = createReducer( { isCreating: false }, {
+	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: () => ( { isCreating: true } ),
+	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => ( { isCreating: false, createError: error } ),
+	[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: ( state, { data: { username, bearerToken } } ) => ( {
+		isCreating: false,
+		username,
+		bearerToken
+	} ),
+	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: ( state, { error } ) => ( {
+		...state,
+		requestError: error
+	} ),
+	[ USER_RECEIVE ]: state => ( { ...state, bearerToken: null, username: null } ),
+	[ LOGIN_REQUEST ]: state => ( { ...state, createError: false } ),
+} );
+
 export default combineReducers( {
 	isRequesting,
 	isRequestingTwoFactorAuth,
@@ -136,4 +153,5 @@ export default combineReducers( {
 	twoFactorAuth,
 	twoFactorAuthRequestError,
 	twoFactorAuthPushPoll,
+	socialAccount,
 } );

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -166,3 +166,43 @@ export const getRedirectTo = ( state ) => {
 export const getRememberMe = ( state ) => {
 	return get( state, 'login.rememberMe', false );
 };
+
+/***
+ * Tells us if we're in a process of creating a social account
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?Boolean}         Error for the request.
+ */
+export const isSocialAccountCreating = ( state ) => get( state, 'login.socialAccount.isCreating', null );
+
+/***
+ * Gets Username of the created social account
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?String}         Username of the created social account
+ */
+export const getCreatedSocialAccountUsername = ( state ) => get( state, 'login.socialAccount.username', null );
+
+/***
+ * Gets Bearer token of the created social account
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?String}         Bearer token of the created social account
+ */
+export const getCreatedSocialAccountBearerToken = ( state ) => get( state, 'login.socialAccount.bearerToken', null );
+
+/***
+ * Gets error for the create social account request.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?Object}         Error for the create social account request.
+ */
+export const getCreateSocialAccountError = ( state ) => get( state, 'login.socialAccount.createError', null );
+
+/***
+ * Gets error for the get social account request.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?Object}         Error for the get social account request.
+ */
+export const getRequestSocialAccountError = ( state ) => get( state, 'login.socialAccount.requestError', null );

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -41,6 +41,7 @@ describe( 'reducer', () => {
 			'requestError',
 			'requestNotice',
 			'requestSuccess',
+			'socialAccount',
 			'twoFactorAuth',
 			'isRequestingTwoFactorAuth',
 			'twoFactorAuthRequestError',


### PR DESCRIPTION
This pull request fixes #13954 by refactoring the error handling logic.

![log_in_error](https://user-images.githubusercontent.com/326402/27171660-f47cd8fc-51ba-11e7-9f69-466707eb3d14.gif)

#### Testing instructions
  
1. Run `git checkout update/error-existing-user` and start your server, or open a [live branch](https://calypso.live/?branch=update/error-existing-user)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Try to log-in with Google account that has an email that already has a WordPress.com account
4. Assert you see a correct error message
5. Repeat with a fresh email and assert the account is indeed created.
    
#### Reviews
  
- [x] Code
- [x] Product

