### PR TITLE
Jetpack Plans: Allow upgrading from monthly to the corresponding yearly plan

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -366,7 +366,12 @@ export const PLANS_LIST = {
 		getSubtitle: () => i18n.translate( 'Protection, speed, and revenue.' ),
 		getProductId: () => 2000,
 		getStoreSlug: () => PLAN_JETPACK_PREMIUM,
-		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
+		availableFor: ( plan ) => includes( [
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_PERSONAL,
+			PLAN_JETPACK_PERSONAL_MONTHLY,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+		], plan ),
 		getPathSlug: () => 'premium',
 		getDescription: () => i18n.translate(
 				'Generate income and save on video hosting costs. ' +
@@ -434,7 +439,7 @@ export const PLANS_LIST = {
 		getAudience: () => 'Best for hobbyists', //PLANS A/B TEST: Translate if test passes
 		getProductId: () => 2005,
 		getStoreSlug: () => PLAN_JETPACK_PERSONAL,
-		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE ], plan ),
+		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
 		getPathSlug: () => 'jetpack-personal',
 		getDescription: () => i18n.translate(
 				'Essentials for every site. The most affordable solution to keep your' +
@@ -494,6 +499,7 @@ export const PLANS_LIST = {
 		getAudience: () => 'Best for organizations', //PLANS A/B TEST: Translate if test passes
 		getProductId: () => 2001,
 		availableFor: ( plan ) => includes( [
+			PLAN_JETPACK_BUSINESS_MONTHLY,
 			PLAN_JETPACK_FREE,
 			PLAN_JETPACK_PREMIUM,
 			PLAN_JETPACK_PREMIUM_MONTHLY,

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
@@ -10,6 +11,9 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPlanClass, isMonthly } from 'lib/plans/constants';
 
 const PlanFeaturesActions = ( {
 	canPurchase,
@@ -25,7 +29,9 @@ const PlanFeaturesActions = ( {
 	translate,
 	manageHref,
 	isLandingPage,
-	planName
+	planName,
+	currentSitePlan,
+	planType,
 } ) => {
 	let upgradeButton;
 	const classes = classNames(
@@ -57,6 +63,10 @@ const PlanFeaturesActions = ( {
 				}
 			} );
 		}
+		const isCurrentPlanMonthly = currentSitePlan && isMonthly( currentSitePlan.productSlug );
+		if ( isCurrentPlanMonthly && getPlanClass( planType ) === getPlanClass( currentSitePlan.productSlug ) ) {
+			buttonText = translate( 'Upgrade to Yearly' );
+		}
 
 		upgradeButton = (
 			<Button
@@ -87,7 +97,17 @@ PlanFeaturesActions.propTypes = {
 	onUpgradeClick: PropTypes.func,
 	freePlan: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
-	isLandingPage: PropTypes.bool
+	isLandingPage: PropTypes.bool,
+	planType: PropTypes.string,
 };
 
-export default localize( PlanFeaturesActions );
+export default connect(
+	( state, ownProps ) => {
+		const { isInSignup } = ownProps;
+		const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
+		const currentSitePlan = getCurrentPlan( state, selectedSiteId );
+		return {
+			currentSitePlan,
+		};
+	}
+)( localize( PlanFeaturesActions ) );

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -14,6 +14,7 @@ import Button from 'components/button';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPlanClass, isMonthly } from 'lib/plans/constants';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const PlanFeaturesActions = ( {
 	canPurchase,
@@ -32,6 +33,7 @@ const PlanFeaturesActions = ( {
 	planName,
 	currentSitePlan,
 	planType,
+	recordTracksEvent: trackTracksEvent,
 } ) => {
 	let upgradeButton;
 	const classes = classNames(
@@ -68,10 +70,23 @@ const PlanFeaturesActions = ( {
 			buttonText = translate( 'Upgrade to Yearly' );
 		}
 
+		const handleUpgradeButtonClick = () => {
+			if ( isPlaceholder ) {
+				return noop();
+			}
+
+			trackTracksEvent( 'calypso_plan_features_upgrade_click', {
+				currentPlan: currentSitePlan && currentSitePlan.productSlug,
+				upgradingTo: planType,
+			} );
+
+			onUpgradeClick();
+		};
+
 		upgradeButton = (
 			<Button
 				className={ classes }
-				onClick={ isPlaceholder ? noop : onUpgradeClick }
+				onClick={ handleUpgradeButtonClick }
 				disabled={ isPlaceholder }
 			>
 				{ buttonText }
@@ -109,5 +124,8 @@ export default connect(
 		return {
 			currentSitePlan,
 		};
+	},
+	{
+		recordTracksEvent
 	}
 )( localize( PlanFeaturesActions ) );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -26,7 +26,8 @@ import {
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_PERSONAL,
-	getPlanClass
+	getPlanClass,
+	isMonthly,
 } from 'lib/plans/constants';
 import PlanIcon from 'components/plans/plan-icon';
 import { plansLink } from 'lib/plans';
@@ -174,12 +175,15 @@ class PlanFeaturesHeader extends Component {
 			intervalType,
 			site,
 			basePlansPath,
-			hideMonthly
+			hideMonthly,
+			currentSitePlan,
 		} = this.props;
 
 		if ( hideMonthly ||
 			! rawPrice ||
-			this.isPlanCurrent() ) {
+			// Only monthly to yearly upgrades for the same plan are supported
+			( this.isPlanCurrent() && currentSitePlan && ! isMonthly( currentSitePlan.productSlug ) )
+		) {
 			return (
 				<div className="plan-features__interval-type is-placeholder">
 				</div>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -216,6 +216,7 @@ class PlanFeatures extends Component {
 						isLandingPage={ isLandingPage }
 						isPopular = { popular }
 						planName ={ planConstantObj.getTitle() }
+						planType={ planName }
 					/>
 					<FoldableCard
 						header={ translate( 'Show features' ) }
@@ -374,6 +375,7 @@ class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
+						planType={ planName }
 					/>
 				</td>
 			);
@@ -486,6 +488,7 @@ class PlanFeatures extends Component {
 						isLandingPage={ isLandingPage }
 						isPopular = { popular }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
+						planType={ planName }
 					/>
 				</td>
 			);


### PR DESCRIPTION
### Purpose

This PR updates the .org plans to allow upgrading from monthly to the corresponding yearly plan, right within the plans page. Implements part of #6499. To be landed together with D5920-code.

### Testing

* Checkout this branch or get it going on calypso.live.
* Go to `/plans/$site`, where `$site` is one of your Jetpack sites with a paid Jetpack monthly plan.
* Verify you see the interval type toggle in the header of your current plan (see previews A and B below).
* Verify the interval type toggle works as expected.
* Verify see the "Upgrade" button above the plan features of your current plan (see previews A and B below).
* Go to `/plans/$site`, where `$site` is one of your Jetpack sites with a paid Jetpack yearly plan.
* Verify you don't see the interval type toggle in the header of your current plan (see previews C and D below).
* Verify you don't see the "Upgrade" button above the plan features of your current plan (see previews C and D below).

### Previews

**Preview A** (Current plan: JP Personal monthly, selected interval type: monthly)
![](https://cldup.com/SYUdEzc3JO.png)

**Preview B** (Current plan: JP Personal monthly, selected interval type: yearly)
![](https://cldup.com/HbD85UPV1o.png)

**Preview C** (Current plan: JP Premium yearly, selected interval type: monthly)
![](https://cldup.com/pGUlasuFSV.png)

**Preview D** (Current plan: JP Premium yearly, selected interval type: yearly)
![](https://cldup.com/yFgQM0ZrqX.png)

### Notes
* DO NOT MERGE: Additional work is in progress to provide this upgrade case with a relevant discount.
* Don't mind any price differences on the previews, I'm working on D5920-code simultaneously to introduce discounts when upgrading from a monthly to an equivalent or higher-tier yearly plan.