### PR TITLE
WooCommerce Store Stats: Update BarChart getYAxisMax to Support Decimals

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -77,7 +77,7 @@ module.exports = React.createClass( {
 
 	getYAxisMax: function( values ) {
 		const max = Math.max.apply( null, values ),
-			operand = Math.pow( 10, ( max.toString().length - 1 ) );
+			operand = Math.pow( 10, ( Math.floor( max ).toString().length - 1 ) );
 		let rounded = ( Math.ceil( ( max + 1 ) / operand ) * operand );
 
 		if ( rounded < 10 ) {


### PR DESCRIPTION
I think the intention of the code here - https://github.com/Automattic/wp-calypso/blob/master/client/components/chart/index.jsx#L80 - is to round values up to the nearest ten, hundred, thousand etc. For example:

45 => 50
567 => 600
1,234 => 2,000
11,234 => 20,000
91,234 => 100,000
1 => 10

However, if the max value is a decimal then the operand here throws the calculation off. For example:

6.67 => 1,000

To fix this so that we can use the bar chart for series, which include decimal values, I've rounded the max value down before converting it to a string.

45 => 50
6.67 => 10
3,333.37 => 4,000
0.67 => 10

Fixes #14561 