### PR TITLE
SEO Settings: Preview meta description without requiring save

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -104,12 +104,13 @@ const ComingSoonMessage = translate => (
 	</div>
 );
 
-const ReaderPost = ( site, post ) => {
+const ReaderPost = ( site, post, frontPageMetaDescription ) => {
 	return (
 		<ReaderPreview
 			site={ site }
 			post={ post }
 			postExcerpt={ formatExcerpt(
+				frontPageMetaDescription ||
 				get( post, 'excerpt', false ) ||
 				get( post, 'content', false )
 			) }
@@ -118,59 +119,59 @@ const ReaderPost = ( site, post ) => {
 	);
 };
 
-const GoogleSite = site => (
+const GoogleSite = ( site, frontPageMetaDescription ) => (
 	<SearchPreview
 		title={ site.name }
 		url={ site.URL }
-		snippet={ getSeoExcerptForSite( site ) }
+		snippet={ frontPageMetaDescription || getSeoExcerptForSite( site ) }
 	/>
 );
 
-const GooglePost = ( site, post ) => (
+const GooglePost = ( site, post, frontPageMetaDescription ) => (
 	<SearchPreview
 		title={ get( post, 'seoTitle', '' ) }
 		url={ get( post, 'URL', '' ) }
-		snippet={ getSeoExcerptForPost( post ) }
+		snippet={ frontPageMetaDescription || getSeoExcerptForPost( post ) }
 	/>
 );
 
-const FacebookSite = site => (
+const FacebookSite = ( site, frontPageMetaDescription ) => (
 	<FacebookPreview
 		title={ site.name }
 		url={ site.URL }
 		type="website"
-		description={ getSeoExcerptForSite( site ) }
+		description={ frontPageMetaDescription || getSeoExcerptForSite( site ) }
 		image={ largeBlavatar( site ) }
 	/>
 );
 
-const FacebookPost = ( site, post ) => (
+const FacebookPost = ( site, post, frontPageMetaDescription ) => (
 	<FacebookPreview
 		title={ get( post, 'seoTitle', '' ) }
 		url={ get( post, 'URL', '' ) }
 		type="article"
-		description={ getSeoExcerptForPost( post ) }
+		description={ frontPageMetaDescription || getSeoExcerptForPost( post ) }
 		image={ getPostImage( post ) }
 		author={ get( post, 'author.name', '' ) }
 	/>
 );
 
-const TwitterSite = site => (
+const TwitterSite = ( site, frontPageMetaDescription ) => (
 	<TwitterPreview
 		title={ site.name }
 		url={ site.URL }
 		type="summary"
-		description={ getSeoExcerptForSite( site ) }
+		description={ frontPageMetaDescription || getSeoExcerptForSite( site ) }
 		image={ largeBlavatar( site ) }
 	/>
 );
 
-const TwitterPost = ( site, post ) => (
+const TwitterPost = ( site, post, frontPageMetaDescription ) => (
 	<TwitterPreview
 		title={ get( post, 'seoTitle', '' ) }
 		url={ get( post, 'URL', '' ) }
 		type="large_image_summary"
-		description={ getSeoExcerptForPost( post ) }
+		description={ frontPageMetaDescription || getSeoExcerptForPost( post ) }
 		image={ getPostImage( post ) }
 	/>
 );
@@ -206,7 +207,8 @@ export class SeoPreviewPane extends PureComponent {
 			post,
 			site,
 			translate,
-			showNudge
+			showNudge,
+			frontPageMetaDescription,
 		} = this.props;
 
 		const { selectedService } = this.state;
@@ -247,15 +249,15 @@ export class SeoPreviewPane extends PureComponent {
 				<div className="seo-preview-pane__preview-area">
 					<div className="seo-preview-pane__preview">
 						{ post && get( {
-							wordpress: ReaderPost( site, post ),
-							facebook: FacebookPost( site, post ),
-							google: GooglePost( site, post ),
-							twitter: TwitterPost( site, post )
+							wordpress: ReaderPost( site, post, frontPageMetaDescription ),
+							facebook: FacebookPost( site, post, frontPageMetaDescription ),
+							google: GooglePost( site, post, frontPageMetaDescription ),
+							twitter: TwitterPost( site, post, frontPageMetaDescription )
 						}, selectedService, ComingSoonMessage( translate ) ) }
 						{ ! post && get( {
-							facebook: FacebookSite( site ),
-							google: GoogleSite( site ),
-							twitter: TwitterSite( site )
+							facebook: FacebookSite( site, frontPageMetaDescription ),
+							google: GoogleSite( site, frontPageMetaDescription ),
+							twitter: TwitterSite( site, frontPageMetaDescription )
 						}, selectedService, ComingSoonMessage( translate ) ) }
 					</div>
 				</div>

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -237,7 +237,9 @@ export class WebPreviewContent extends Component {
 						/>
 					</div>
 					{ 'seo' === this.state.device &&
-						<SeoPreviewPane />
+						<SeoPreviewPane
+							frontPageMetaDescription={ this.props.frontPageMetaDescription }
+						/>
 					}
 				</div>
 			</div>
@@ -288,7 +290,9 @@ WebPreviewContent.propTypes = {
 	// Called after user switches device
 	onDeviceUpdate: React.PropTypes.func,
 	// Flag that differentiates modal window from inline embeds
-	isModalWindow: React.PropTypes.bool
+	isModalWindow: React.PropTypes.bool,
+	// The site/post description passed to the SeoPreviewPane
+	frontPageMetaDescription: React.PropTypes.string,
 };
 
 WebPreviewContent.defaultProps = {

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -104,6 +104,7 @@ export class WebPreview extends Component {
 							{ ...this.props }
 							onDeviceUpdate={ this.setDeviceViewport }
 							isModalWindow={ true }
+							frontPageMetaDescription={ this.props.frontPageMetaDescription || null }
 						/>
 					</div>
 				</div>
@@ -152,6 +153,8 @@ WebPreview.propTypes = {
 	iframeTitle: PropTypes.string,
 	// Makes room for a sidebar if desired
 	hasSidebar: React.PropTypes.bool,
+	// The site/post description passed to the SeoPreviewPane
+	frontPageMetaDescription: React.PropTypes.string,
 };
 
 WebPreview.defaultProps = {

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -771,6 +771,7 @@ export const SeoForm = React.createClass( {
 					showDeviceSwitcher={ false }
 					showExternal={ false }
 					defaultViewportDevice="seo"
+					frontPageMetaDescription={ this.state.frontPageMetaDescription || null }
 				/>
 			</div>
 		);

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -87,6 +87,7 @@ class EditorSeoAccordion extends Component {
 								showDeviceSwitcher={ false }
 								showExternal={ false }
 								defaultViewportDevice="seo"
+								frontPageMetaDescription={ metaDescription }
 							/>
 						</div>
 					}


### PR DESCRIPTION
Currently, if you enter a new SEO meta description for a post or page, you have to save that setting (on /settings/traffic) or update the post/page to preview the new meta description. This isn't immediately obvious to users. If I had text typed into the meta description area, I would expect to see that text in the preview.

This updates the behavior in two spots:
- For settings/traffic, we're passing the value of `this.state.frontPageMetaDescription` into the `WebPreview` component and then into `SeoPreviewPane`
- For the post editor, we're passing the value of `this.props.metaDescription` to the `WebPreview` and into `SeoPreviewPane`

In both instances, you should no longer need to save the changes to view the preview.

### To test
**Settings**
1. On a site with a Business plan, visit wordpress.com/settings/traffic
2. In the section for "Website Meta," type some content into the meta description field. 
3. Click "Show Preview." You should see the content you have typed. On production, you would need to save those settings first.

**Editor**
1. Start a new post or page on a Jetpack site.
2. On the right-hand side under SEO Description, enter a meta description.
3. Click "Show Preview." You should see the content you typed in all previews including the WordPress.com Reader.

## GIFs
**Settings**
![websitemeta](https://user-images.githubusercontent.com/7240478/26879867-d2f9ea6a-4b4f-11e7-9909-8161c5aa5cf6.gif)

**Editor**
![metapost](https://user-images.githubusercontent.com/7240478/26879872-d760f774-4b4f-11e7-935b-012657e6df1c.gif)

Resolves: #9466