### PR TITLE
Purchases: Add a billing period switch to PurchasePlanDetails

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1246,3 +1246,16 @@ export function getMonthlyPlanByYearly( plan ) {
 			return '';
 	}
 }
+
+export function getYearlyPlanByMonthly( plan ) {
+	switch ( plan ) {
+		case PLAN_JETPACK_PREMIUM_MONTHLY:
+			return PLAN_JETPACK_PREMIUM;
+		case PLAN_JETPACK_BUSINESS_MONTHLY:
+			return PLAN_JETPACK_BUSINESS;
+		case PLAN_JETPACK_PERSONAL_MONTHLY:
+			return PLAN_JETPACK_PERSONAL;
+		default:
+			return '';
+	}
+}

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -1,0 +1,76 @@
+/**
+ * External Dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { isMonthly, getYearlyPlanByMonthly } from 'lib/plans/constants';
+import { planItem } from 'lib/cart-values/cart-items';
+import { addItem } from 'lib/upgrades/actions';
+
+class PlanBillingPeriod extends Component {
+	static propTypes = {
+		purchase: PropTypes.object,
+	};
+
+	handleBillingPeriodChange = ( event ) => {
+		if ( event.target.value === 'monthly' ) {
+			return;
+		}
+
+		const { purchase } = this.props;
+		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.productSlug );
+		if ( ! yearlyPlanSlug ) {
+			return;
+		}
+
+		addItem( planItem( yearlyPlanSlug ) );
+		page( '/checkout/' + purchase.domain );
+	};
+
+	renderBillingPeriodSelector() {
+		const { purchase, translate } = this.props;
+		if ( ! purchase ) {
+			return;
+		}
+
+		if ( ! isMonthly( purchase.productSlug ) ) {
+			return (
+				<FormSettingExplanation>
+					{ translate( 'yearly' ) }
+				</FormSettingExplanation>
+			);
+		}
+
+		return (
+			<FormSelect onChange={ this.handleBillingPeriodChange } defaultValue="monthly">
+				<option value="monthly">{ translate( 'monthly' ) }</option>
+				<option value="yearly">{ translate( 'yearly' ) }</option>
+			</FormSelect>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<FormFieldset>
+				<FormLabel htmlFor="plan-billing-period">
+					{ translate( 'Billing period' ) }
+				</FormLabel>
+
+				{ this.renderBillingPeriodSelector() }
+			</FormFieldset>
+		);
+	}
+}
+
+export default localize( PlanBillingPeriod );

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -45,15 +45,15 @@ class PlanBillingPeriod extends Component {
 		if ( ! isMonthly( purchase.productSlug ) ) {
 			return (
 				<FormSettingExplanation>
-					{ translate( 'yearly' ) }
+					{ translate( 'Yearly' ) }
 				</FormSettingExplanation>
 			);
 		}
 
 		return (
 			<FormSelect onChange={ this.handleBillingPeriodChange } defaultValue="monthly">
-				<option value="monthly">{ translate( 'monthly' ) }</option>
-				<option value="yearly">{ translate( 'yearly' ) }</option>
+				<option value="monthly">{ translate( 'Monthly' ) }</option>
+				<option value="yearly">{ translate( 'Yearly' ) }</option>
 			</FormSelect>
 		);
 	}

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -86,12 +86,16 @@ class PlanBillingPeriod extends Component {
 		}
 
 		return (
-			<Button
-				onClick={ this.handleMonthlyToYearlyButtonClick }
-				primary
-			>
-				{ translate( 'Upgrade to Yearly' ) }
-			</Button>
+			<FormSettingExplanation>
+				{ translate( 'Billed monthly' ) }
+				<Button
+					onClick={ this.handleMonthlyToYearlyButtonClick }
+					primary
+					compact
+				>
+					{ translate( 'Upgrade to yearly billing' ) }
+				</Button>
+			</FormSettingExplanation>
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -8,9 +8,9 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
+import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { isMonthly, getYearlyPlanByMonthly } from 'lib/plans/constants';
 import { planItem } from 'lib/cart-values/cart-items';
@@ -27,16 +27,9 @@ class PlanBillingPeriod extends Component {
 		purchase: PropTypes.object,
 	};
 
-	handleBillingPeriodChange = ( event ) => {
-		if ( event.target.value === 'monthly' ) {
-			return;
-		}
-
+	handleMonthlyToYearlyButtonClick = () => {
 		const { purchase } = this.props;
 		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.productSlug );
-		if ( ! yearlyPlanSlug ) {
-			return;
-		}
 
 		addItem( planItem( yearlyPlanSlug ) );
 		page( '/checkout/' + purchase.domain );
@@ -73,7 +66,7 @@ class PlanBillingPeriod extends Component {
 		return translate( 'Billed yearly' );
 	}
 
-	renderBillingPeriodSelector() {
+	renderBillingPeriod() {
 		const { purchase, translate } = this.props;
 		if ( ! purchase ) {
 			return;
@@ -87,11 +80,18 @@ class PlanBillingPeriod extends Component {
 			);
 		}
 
+		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.productSlug );
+		if ( ! yearlyPlanSlug ) {
+			return;
+		}
+
 		return (
-			<FormSelect onChange={ this.handleBillingPeriodChange } defaultValue="monthly">
-				<option value="monthly">{ translate( 'Monthly' ) }</option>
-				<option value="yearly">{ translate( 'Yearly' ) }</option>
-			</FormSelect>
+			<Button
+				onClick={ this.handleMonthlyToYearlyButtonClick }
+				primary
+			>
+				{ translate( 'Upgrade to Yearly' ) }
+			</Button>
 		);
 	}
 
@@ -104,7 +104,7 @@ class PlanBillingPeriod extends Component {
 					{ translate( 'Billing period' ) }
 				</FormLabel>
 
-				{ this.renderBillingPeriodSelector() }
+				{ this.renderBillingPeriod() }
 			</FormFieldset>
 		);
 	}

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -15,6 +15,12 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { isMonthly, getYearlyPlanByMonthly } from 'lib/plans/constants';
 import { planItem } from 'lib/cart-values/cart-items';
 import { addItem } from 'lib/upgrades/actions';
+import {
+	isExpired,
+	isExpiring,
+	isRenewing,
+	showCreditCardExpiringWarning,
+} from 'lib/purchases';
 
 class PlanBillingPeriod extends Component {
 	static propTypes = {
@@ -36,6 +42,37 @@ class PlanBillingPeriod extends Component {
 		page( '/checkout/' + purchase.domain );
 	};
 
+	renderYearlyBillingInformation() {
+		const { purchase, translate } = this.props;
+
+		if ( showCreditCardExpiringWarning( purchase ) ) {
+			return translate( 'Billed yearly, credit card expiring soon' );
+		}
+
+		if ( isRenewing( purchase ) ) {
+			return translate( 'Billed yearly, renews on %s', {
+				args: purchase.renewMoment.format( 'LL' ),
+			} );
+		}
+
+		if ( isExpiring( purchase ) ) {
+			return translate( 'Billed yearly, expires on %s', {
+				args: purchase.expiryMoment.format( 'LL' ),
+			} );
+		}
+
+		if ( isExpired( purchase ) ) {
+			return translate( 'Billed yearly, expired %(timeSinceExpiry)s', {
+				args: {
+					timeSinceExpiry: purchase.expiryMoment.fromNow(),
+				},
+				context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
+			} );
+		}
+
+		return translate( 'Billed yearly' );
+	}
+
 	renderBillingPeriodSelector() {
 		const { purchase, translate } = this.props;
 		if ( ! purchase ) {
@@ -45,7 +82,7 @@ class PlanBillingPeriod extends Component {
 		if ( ! isMonthly( purchase.productSlug ) ) {
 			return (
 				<FormSettingExplanation>
-					{ translate( 'Yearly' ) }
+					{ this.renderYearlyBillingInformation() }
 				</FormSettingExplanation>
 			);
 		}

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 
@@ -21,6 +22,7 @@ import {
 	isRenewing,
 	showCreditCardExpiringWarning,
 } from 'lib/purchases';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class PlanBillingPeriod extends Component {
 	static propTypes = {
@@ -32,6 +34,10 @@ class PlanBillingPeriod extends Component {
 		const yearlyPlanSlug = getYearlyPlanByMonthly( purchase.productSlug );
 
 		addItem( planItem( yearlyPlanSlug ) );
+		this.props.recordTracksEvent( 'calypso_purchase_details_plan_upgrade_click', {
+			currentPlan: purchase.productSlug,
+			upgradingTo: yearlyPlanSlug,
+		} );
 		page( '/checkout/' + purchase.domain );
 	};
 
@@ -114,4 +120,9 @@ class PlanBillingPeriod extends Component {
 	}
 }
 
-export default localize( PlanBillingPeriod );
+export default connect(
+	null,
+	{
+		recordTracksEvent
+	}
+)( localize( PlanBillingPeriod ) );

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -66,7 +66,7 @@ class PlanBillingPeriod extends Component {
 				args: {
 					timeSinceExpiry: purchase.expiryMoment.fromNow(),
 				},
-				context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
+				comment: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 			} );
 		}
 

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -14,6 +14,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import SectionHeader from 'components/section-header';
+import PlanBillingPeriod from './billing-period';
 import { isRequestingSites } from 'state/sites/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getPurchase, isDataLoading } from 'me/purchases/utils';
@@ -71,6 +72,8 @@ class PurchasePlanDetails extends Component {
 				<QueryPluginKeys siteId={ selectedSite.ID } />
 				<SectionHeader label={ headerText } />
 				<Card>
+					<PlanBillingPeriod purchase={ purchase } />
+
 					{ pluginList.map( ( plugin, i ) => {
 						return (
 							<FormFieldset key={ i }>

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -68,7 +68,7 @@ class PurchasePlanDetails extends Component {
 		} );
 
 		return (
-			<div>
+			<div className="plan-details">
 				<QueryPluginKeys siteId={ selectedSite.ID } />
 				<SectionHeader label={ headerText } />
 				<Card>

--- a/client/me/purchases/manage-purchase/plan-details/style.scss
+++ b/client/me/purchases/manage-purchase/plan-details/style.scss
@@ -1,3 +1,10 @@
+.plan-details {
+	.form-setting-explanation .button {
+		margin-left: 12px;
+		vertical-align: middle;
+	}
+}
+
 .plan-details__wrapper.is-placeholder {
 	.section-header__label-text,
 	.plan-details__plugin-key {


### PR DESCRIPTION
This PR introduces a Billing period switch to the plan details card for Jetpack plan purchases, as suggested in p6TEKc-17s-p2. It allows the user to switch from a monthly to yearly plan - after the user selects "yearly", they're redirected to the checkout page to complete the purchase. Downgrading from yearly to monthly is intentionally not supported for now.

This PR is intended to be landed together with D5920-code, which introduces discounts for the monthly-to-yearly upgrade case. Feel free to test with it to get a nice discount when upgrading from a monthly to an equivalent or higher tier yearly plan.

This PR implements part of #6499.

Preview (Jetpack monthly plan):
![](https://cldup.com/cRzrwjkHhr.png)

Preview (Jetpack yearly plan):
![](https://cldup.com/clWXZ-Pl3M.png)

To test:
* Checkout this branch or get it going on calypso.live
* Go to /me/purchases and click on a Jetpack monthly plan purchase.
* Verify you see a Billing period label with a select field in the plan details card.
* Select "yearly" and verify you're able to complete the purchase successfully. 
* Go to /me/purchases again and click on a Jetpack yearly plan purchase.
* Verify you see a Billing period label, but with a static "yearly" copy below.
* Go to /me/purchases again and select a WordPress.com plan.
* Verify plan details page is untouched and unaffected from this PR.