### PR TITLE
Purchases: improving expired purchase styles

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -15,7 +15,7 @@
 		.manage-purchase__detail-label,
 		.manage-purchase__detail,
 		.manage-purchase__detail .user {
-			opacity: .6;
+			opacity: .7;
 		}
 	}
 
@@ -257,6 +257,10 @@
 		display: block;
 		cursor: pointer;
 	}
+}
+
+.manage-purchase__detail .user__name {
+	margin-right: 0;
 }
 
 .manage-purchase__expiring-credit-card-notice.notice,

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -63,11 +63,16 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isExpired( purchase ) ) {
+			const expiredToday = purchase.expiryMoment < moment().add( 1, 'day' );
+			const expiredText = expiredToday
+				? purchase.expiryMoment.format( '[today]' )
+				: purchase.expiryMoment.fromNow();
+
 			return (
 				<Notice isCompact status="is-error" icon="notice">
 					{ translate( 'Expired %(timeSinceExpiry)s', {
 						args: {
-							timeSinceExpiry: purchase.expiryMoment.fromNow(),
+							timeSinceExpiry: expiredText,
 						},
 						context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
 					} ) }

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -63,7 +63,7 @@ class PurchaseItem extends Component {
 		}
 
 		if ( isExpired( purchase ) ) {
-			const expiredToday = purchase.expiryMoment < moment().add( 1, 'day' );
+			const expiredToday = moment().diff( purchase.expiryMoment, 'hours' ) < 24;
 			const expiredText = expiredToday
 				? purchase.expiryMoment.format( '[today]' )
 				: purchase.expiryMoment.fromNow();

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -1,10 +1,10 @@
 .purchase-item.card {
 	&.is-expired {
-		background: $gray-light;
 
+		.purchase-item__plan-icon,
 		.purchase-item__title,
 		.purchase-item__purchase-type {
-			opacity: 0.6;
+			opacity: 0.7;
 		}
 	}
 


### PR DESCRIPTION
@ranh mentioned that the expired state of a purchase could look as though that purchase was simply information pertaining to the previous purchase. 

more info p58i-62z

**Before:**
![image](https://user-images.githubusercontent.com/437258/26885673-4ae22580-4b71-11e7-975a-aa2e8e0a937d.png)

**After:**
![image](https://user-images.githubusercontent.com/437258/26885581-081768b4-4b71-11e7-9562-e66561ec1ffa.png)

Still to-do:

- [x] Improve the 'fuzzy time' so that it says 'expired today' rather than 'expired 16 hours ago' which is too specific
- [x] Fix padding around purchase owner

cc @tyxla for help with fuzzy time