### PR TITLE
Adds toggle to be used with editing payment methods

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
@@ -2,13 +2,15 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormToggle from 'components/forms/form-toggle';
 
-const PaymentMethodEditFormToggle = ( { checked, name, onChange } ) => {
+const PaymentMethodEditFormToggle = ( props ) => {
+	const { checked, name, onChange } = props;
 	const onChangeHandler = () => {
 		const fakeEvent = {
 			target: {
@@ -21,6 +23,7 @@ const PaymentMethodEditFormToggle = ( { checked, name, onChange } ) => {
 
 	return (
 		<FormToggle
+			{ ...omit( props, [ 'updateAriaLabel', 'editAriaLabel' ] ) }
 			checked={ checked }
 			name={ name }
 			onChange={ onChangeHandler } />

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
@@ -23,7 +23,7 @@ const PaymentMethodEditFormToggle = ( props ) => {
 
 	return (
 		<FormToggle
-			{ ...omit( props, [ 'updateAriaLabel', 'editAriaLabel' ] ) }
+			{ ...omit( props, [ onChange ] ) }
 			checked={ checked }
 			name={ name }
 			onChange={ onChangeHandler } />

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
@@ -23,7 +23,7 @@ const PaymentMethodEditFormToggle = ( props ) => {
 
 	return (
 		<FormToggle
-			{ ...omit( props, [ onChange ] ) }
+			{ ...omit( props, [ 'onChange' ] ) }
 			checked={ checked }
 			name={ name }
 			onChange={ onChangeHandler } />

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-form-toggle.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormToggle from 'components/forms/form-toggle';
+
+const PaymentMethodEditFormToggle = ( { checked, name, onChange } ) => {
+	const onChangeHandler = () => {
+		const fakeEvent = {
+			target: {
+				name,
+				value: checked ? 'no' : 'yes'
+			}
+		};
+		onChange( fakeEvent );
+	};
+
+	return (
+		<FormToggle
+			checked={ checked }
+			name={ name }
+			onChange={ onChangeHandler } />
+	);
+};
+
+PaymentMethodEditFormToggle.propTypes = {
+	checked: PropTypes.bool,
+	name: PropTypes.string,
+	onChange: PropTypes.func,
+};
+
+export default PaymentMethodEditFormToggle;


### PR DESCRIPTION
Because the FormToggle component does not return an event when calling the onChange method I need to wrap it in a component that does.

This component mimics the event object structure so that it can be parsed by the same function as other inputs.

This can only be tested on its own since the code that requires this component is not part of this PR.  I have a PR up that has all of the code including the component that requires this here:  #14607