### PR TITLE
WebPreview: Don't show loading spinner while WebPreview isn't visible

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -197,7 +197,7 @@ export class WebPreview extends Component {
 							selectSeoPreview={ this.setDeviceViewport.bind( null, 'seo' ) }
 						/>
 						<div className="web-preview__placeholder">
-							{ ! this.state.loaded && 'seo' !== this.state.device &&
+							{ this.props.showPreview && ! this.state.loaded && 'seo' !== this.state.device &&
 								<div>
 									<Spinner />
 									{ this.props.loadingMessage &&


### PR DESCRIPTION
Today I noticed that the `WebPreview` component is kept always rendered, since it's only hidden by CSS with `opacity: 0`. This made the Loading spinner continuously animate, even though it wasn't visible and that resulted in constant CPU usage ( 20%+ ) on my laptop.

This PR aims to hide the spinner while the WebPreview is not visible in order to reduce page redraws. After being hidden, the CPU usage drops normal levels. 

To test:
1. Checkout branch or use Calypso.live link
2. Go to Settings tab ( since nothing there should animate continuously )
3. Check CPU usage - should be close to 0%
4. Click Preview site in the sidebar
5. Verify you see the spinner while the site loads
6. Verify no JS errors appear in the console
7. Do steps 2 and 3 on `master` to verify CPU usage is high.