### PR TITLE
Jetpack Connect: Add queryObject arguments in URL passed as SignupForm prop

### DIFF
--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -100,14 +100,17 @@ class LoggedOutForm extends Component {
 		const {
 			isAuthorizing,
 			userData,
+			queryObject,
 		} = this.props.jetpackConnectAuthorize;
+
+		const redirectTo = addQueryArgs( queryObject, window.location.href );
 
 		return (
 			<div>
 				{ this.renderLocaleSuggestions() }
 				{ this.renderFormHeader() }
 				<SignupForm
-					getRedirectToAfterLoginUrl={ window.location.href }
+					getRedirectToAfterLoginUrl={ redirectTo }
 					disabled={ isAuthorizing }
 					submitting={ isAuthorizing }
 					submitForm={ this.handleSubmitSignup }

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -41,19 +41,24 @@ class LoggedOutForm extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
 	}
 
+	getRedirectAfterLoginUrl() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		return addQueryArgs( queryObject, window.location.href );
+	}
+
 	handleSubmitSignup = ( form, userData ) => {
 		debug( 'submiting new account', form, userData );
 		this.props.createAccount( userData );
 	}
 
 	renderLoginUser() {
-		const { queryObject, userData, bearerToken } = this.props.jetpackConnectAuthorize;
-		const redirectTo = addQueryArgs( queryObject, window.location.href );
+		const { userData, bearerToken } = this.props.jetpackConnectAuthorize;
+
 		return (
 			<WpcomLoginForm
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
-				redirectTo={ redirectTo } />
+				redirectTo={ this.getRedirectAfterLoginUrl() } />
 		);
 	}
 
@@ -83,8 +88,7 @@ class LoggedOutForm extends Component {
 	}
 
 	renderFooterLink() {
-		const { queryObject } = this.props.jetpackConnectAuthorize;
-		const redirectTo = addQueryArgs( queryObject, window.location.href );
+		const redirectTo = this.getRedirectAfterLoginUrl();
 
 		return (
 			<LoggedOutFormLinks>
@@ -100,17 +104,14 @@ class LoggedOutForm extends Component {
 		const {
 			isAuthorizing,
 			userData,
-			queryObject,
 		} = this.props.jetpackConnectAuthorize;
-
-		const redirectTo = addQueryArgs( queryObject, window.location.href );
 
 		return (
 			<div>
 				{ this.renderLocaleSuggestions() }
 				{ this.renderFormHeader() }
 				<SignupForm
-					getRedirectToAfterLoginUrl={ redirectTo }
+					getRedirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
 					disabled={ isAuthorizing }
 					submitting={ isAuthorizing }
 					submitForm={ this.handleSubmitSignup }


### PR DESCRIPTION
Fixes #14683.

Makes sure that the `getRedirectToAfterLoginUrl` prop passed to SignupForm has all the needed query arguments

#### Screenshot 
This PR makes sure that the two links pointed out in the screenshot have the same query string in the URL

![image](https://user-images.githubusercontent.com/746152/26929632-c3297a38-4c30-11e7-8ea3-27d7c0b84974.png)

#### Testing instructions

* You need to be sandboxed and to force the environment to `'development'` (`$env='development'`) there (Line 412 of `class.jetpack-server-version.php`)
* You need to be logged out from WordPress.com
* You need to restart your development version of calypso to take in account config keys changed in this PR.

1. Clone this branch and start calypso in localhost
1. Create a new WordPress installation. 
1. Install and activate Jetpack
1. From the wp-admin dashboard, click the "Connect Jetpack" button. 
1. You should be directed to `http://calypso.localhost:3000/jetpack/connect/authorize?etc=etc=etc` and prompted to **Sign Up**
1. Enter this email address `test@gmail.com`
1. You will be shown validation text reading `Choose a different email address. This one is not available. If this is you log in now.`. Click the "log in now" link.
1. Enter valid credentials
1. Expect to be redirected to the proper authorize page without seeing the weird screen reported in  #14683
 
