### PR TITLE
WooCommerce: Update paths to keep site at the end, add child items to settings nav

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup.js
+++ b/client/extensions/woocommerce/app/dashboard/setup.js
@@ -125,7 +125,7 @@ class Setup extends Component {
 				actions: [
 					{
 						label: translate( 'Set up taxes' ),
-						path: getLink( '/store/settings/tax/:site', site ),
+						path: getLink( '/store/settings/taxes/:site', site ),
 					},
 					{
 						label: translate( 'I\'m not charging sales tax' ),

--- a/client/extensions/woocommerce/app/dashboard/setup.js
+++ b/client/extensions/woocommerce/app/dashboard/setup.js
@@ -76,12 +76,12 @@ class Setup extends Component {
 				actions: [
 					{
 						label: translate( 'Import' ),
-						path: getLink( '/store/products/:site/import', site ),
+						path: getLink( '/store/products/import/:site', site ),
 						slug: 'add-products-import',
 					},
 					{
 						label: 'Add a product',
-						path: getLink( '/store/products/:site/add', site ),
+						path: getLink( '/store/product/:site', site ),
 					}
 				]
 			},
@@ -94,7 +94,7 @@ class Setup extends Component {
 				actions: [
 					{
 						label: translate( 'Set up shipping' ),
-						path: getLink( '/store/settings/:site/shipping', site ),
+						path: getLink( '/store/settings/shipping/:site', site ),
 					},
 					{
 						label: translate( 'I won\'t be shipping' ),
@@ -112,7 +112,7 @@ class Setup extends Component {
 				actions: [
 					{
 						label: translate( 'Set up payments' ),
-						path: getLink( '/store/settings/:site/payments', site ),
+						path: getLink( '/store/settings/payments/:site', site ),
 					}
 				]
 			},
@@ -125,7 +125,7 @@ class Setup extends Component {
 				actions: [
 					{
 						label: translate( 'Set up taxes' ),
-						path: getLink( '/store/settings/:site/tax', site ),
+						path: getLink( '/store/settings/tax/:site', site ),
 					},
 					{
 						label: translate( 'I\'m not charging sales tax' ),

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -45,7 +45,7 @@ const getStorePages = () => {
 		{
 			container: ProductCreate,
 			configKey: 'woocommerce/extension-products',
-			path: '/store/products/:site/add',
+			path: '/store/product/:site',
 			sidebarItemButton: {
 				label: translate( 'Add' ),
 				parentSlug: 'products',
@@ -55,7 +55,7 @@ const getStorePages = () => {
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
 			configKey: 'woocommerce/extension-products-import',
-			path: '/store/products/:site/import',
+			path: '/store/products/import/:site',
 		},
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
@@ -71,7 +71,7 @@ const getStorePages = () => {
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
 			configKey: 'woocommerce/extension-orders',
-			path: '/store/orders/:site/add',
+			path: '/store/order/:site',
 			sidebarItemButton: {
 				label: translate( 'Add' ),
 				parentSlug: 'orders',
@@ -91,17 +91,6 @@ const getStorePages = () => {
 		},
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-extensions',
-			path: '/store/extensions/:site',
-			sidebarItem: {
-				icon: 'plugins',
-				isPrimary: false,
-				label: translate( 'Extensions' ),
-				slug: 'extensions',
-			},
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
 			configKey: 'woocommerce/extension-settings',
 			path: '/store/settings/:site',
 			sidebarItem: {
@@ -114,17 +103,46 @@ const getStorePages = () => {
 		{
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings-payments',
-			path: '/store/settings/:site/payments',
+			path: '/store/settings/payments/:site',
+			sidebarItem: {
+				isPrimary: false,
+				label: translate( 'Payments' ),
+				parentSlug: 'settings',
+				slug: 'settings-payments',
+			},
 		},
 		{
 			container: Shipping,
 			configKey: 'woocommerce/extension-settings-shipping',
-			path: '/store/settings/:site/shipping',
+			path: '/store/settings/shipping/:site',
+			sidebarItem: {
+				isPrimary: false,
+				label: translate( 'Shipping' ),
+				parentSlug: 'settings',
+				slug: 'settings-shipping',
+			},
 		},
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
 			configKey: 'woocommerce/extension-settings-tax',
-			path: '/store/settings/:site/tax',
+			path: '/store/settings/tax/:site',
+			sidebarItem: {
+				isPrimary: false,
+				label: translate( 'Tax' ),
+				parentSlug: 'settings',
+				slug: 'settings-tax',
+			},
+		},
+		{
+			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			configKey: 'woocommerce/extension-extensions',
+			path: '/store/extensions/:site',
+			sidebarItem: {
+				icon: 'plugins',
+				isPrimary: false,
+				label: translate( 'Extensions' ),
+				slug: 'extensions',
+			},
 		},
 	];
 };

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -125,10 +125,10 @@ const getStorePages = () => {
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
 			configKey: 'woocommerce/extension-settings-tax',
-			path: '/store/settings/tax/:site',
+			path: '/store/settings/taxes/:site',
 			sidebarItem: {
 				isPrimary: false,
-				label: translate( 'Tax' ),
+				label: translate( 'Taxes' ),
 				parentSlug: 'settings',
 				slug: 'settings-tax',
 			},

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -42,32 +42,6 @@ class StoreSidebar extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
-	itemLinkClass = ( path, existingClasses, isChild, isDisabled ) => {
-		const classSet = {};
-
-		if ( typeof existingClasses !== 'undefined' ) {
-			if ( ! Array.isArray( existingClasses ) ) {
-				existingClasses = [ existingClasses ];
-			}
-
-			existingClasses.forEach( function( className ) {
-				classSet[ className ] = true;
-			} );
-		}
-
-		if ( isDisabled ) {
-			classSet[ 'is-placeholder' ] = true;
-		}
-
-		if ( isChild ) {
-			classSet[ 'is-child-item' ] = true;
-		}
-
-		classSet.selected = this.isItemLinkSelected( path );
-
-		return classNames( classSet );
-	}
-
 	isItemLinkSelected = ( paths ) => {
 		if ( ! Array.isArray( paths ) ) {
 			paths = [ paths ];
@@ -79,14 +53,16 @@ class StoreSidebar extends Component {
 	}
 
 	renderSidebarMenuItems = ( items, buttons, isDisabled ) => {
+		const { site } = this.props;
+
 		return items.map( function( item, index ) {
 			const isChild = ( 'undefined' !== typeof item.parentSlug );
-			const itemLink = getLink( item.path, this.props.site );
+			const itemLink = getLink( item.path, site );
 			const itemButton = buttons.filter( button => button.parentSlug === item.slug ).map( button => {
 				return (
 					<SidebarButton
 						disabled={ isDisabled }
-						href={ getLink( button.path, this.props.site ) }
+						href={ getLink( button.path, site ) }
 						key={ button.slug }
 					>
 						{ button.label }
@@ -100,10 +76,10 @@ class StoreSidebar extends Component {
 			if ( 'undefined' !== typeof item.parentSlug ) {
 				const links = [];
 				const parentItem = find( items, { slug: item.parentSlug } );
-				links.push( getLink( parentItem.path, this.props.site ) );
+				links.push( getLink( parentItem.path, site ) );
 
 				filter( items, { parentSlug: item.parentSlug } ).map( child => {
-					links.push( getLink( child.path, this.props.site ) );
+					links.push( getLink( child.path, site ) );
 				} );
 
 				if ( ! this.isItemLinkSelected( links ) ) {
@@ -111,9 +87,27 @@ class StoreSidebar extends Component {
 				}
 			}
 
+			// If we reach this point, this is not a child item
+			// lets see if its children, if any, are selected
+			const childLinks = [];
+			filter( items, { parentSlug: item.slug } ).map( child => {
+				childLinks.push( getLink( child.path, site ) );
+			} );
+
+			// Build the classnames for the item
+			const itemClasses = classNames( item.slug,
+				{
+					'has-selected-child': this.isItemLinkSelected( childLinks ),
+					'is-child-item': isChild,
+					'is-placeholder': isDisabled,
+					selected: this.isItemLinkSelected( itemLink ),
+				}
+			);
+
+			// Render the item
 			return (
 				<SidebarItem
-					className={ this.itemLinkClass( itemLink, item.slug, isChild, isDisabled ) }
+					className={ itemClasses }
 					icon={ isChild ? '' : item.icon }
 					key={ index }
 					label={ item.label }

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -3,6 +3,7 @@
  */
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { find, filter } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 
 /**
@@ -92,6 +93,24 @@ class StoreSidebar extends Component {
 					</SidebarButton>
 				);
 			} );
+
+			// If this item has a parentSlug, only render it if 1) the parent is
+			// currently selected, 2) it is currently selected, or 3) any of its
+			// siblings are selected
+			if ( 'undefined' !== typeof item.parentSlug ) {
+				const links = [];
+				const parentItem = find( items, { slug: item.parentSlug } );
+				links.push( getLink( parentItem.path, this.props.site ) );
+
+				filter( items, { parentSlug: item.parentSlug } ).map( child => {
+					links.push( getLink( child.path, this.props.site ) );
+				} );
+
+				if ( ! this.isItemLinkSelected( links ) ) {
+					return null;
+				}
+			}
+
 			return (
 				<SidebarItem
 					className={ this.itemLinkClass( itemLink, item.slug, isChild, isDisabled ) }

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -21,9 +21,10 @@ class StoreSidebar extends Component {
 	static propTypes = {
 		path: PropTypes.string.isRequired,
 		sidebarItems: PropTypes.arrayOf( PropTypes.shape( {
-			icon: PropTypes.string.isRequired,
+			icon: PropTypes.string,
 			isPrimary: PropTypes.bool.isRequired,
 			label: PropTypes.string.isRequired,
+			parentSlug: PropTypes.string,
 			path: PropTypes.string.isRequired,
 			slug: PropTypes.string.isRequired,
 		} ) ),
@@ -40,7 +41,7 @@ class StoreSidebar extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
-	itemLinkClass = ( path, existingClasses, disabled ) => {
+	itemLinkClass = ( path, existingClasses, isChild, isDisabled ) => {
 		const classSet = {};
 
 		if ( typeof existingClasses !== 'undefined' ) {
@@ -53,8 +54,12 @@ class StoreSidebar extends Component {
 			} );
 		}
 
-		if ( disabled ) {
+		if ( isDisabled ) {
 			classSet[ 'is-placeholder' ] = true;
+		}
+
+		if ( isChild ) {
+			classSet[ 'is-child-item' ] = true;
 		}
 
 		classSet.selected = this.isItemLinkSelected( path );
@@ -72,13 +77,14 @@ class StoreSidebar extends Component {
 		}, this );
 	}
 
-	renderSidebarMenuItems = ( items, buttons, disabled ) => {
+	renderSidebarMenuItems = ( items, buttons, isDisabled ) => {
 		return items.map( function( item, index ) {
+			const isChild = ( 'undefined' !== typeof item.parentSlug );
 			const itemLink = getLink( item.path, this.props.site );
 			const itemButton = buttons.filter( button => button.parentSlug === item.slug ).map( button => {
 				return (
 					<SidebarButton
-						disabled={ disabled }
+						disabled={ isDisabled }
 						href={ getLink( button.path, this.props.site ) }
 						key={ button.slug }
 					>
@@ -88,8 +94,8 @@ class StoreSidebar extends Component {
 			} );
 			return (
 				<SidebarItem
-					className={ this.itemLinkClass( itemLink, item.slug, disabled ) }
-					icon={ item.icon }
+					className={ this.itemLinkClass( itemLink, item.slug, isChild, isDisabled ) }
+					icon={ isChild ? '' : item.icon }
 					key={ index }
 					label={ item.label }
 					link={ itemLink }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -57,4 +57,17 @@
 		display: inline-block;
 		flex-grow: 1;
 	}
+
+	li {
+		&.is-child-item {
+			a {
+				font-size: 12px;
+				padding: 8px 16px 8px 55px;
+			}
+
+			svg {
+				display: none;
+			}
+		}
+	}
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -59,6 +59,15 @@
 	}
 
 	li {
+
+		&.has-selected-child a {
+			font-weight: bold;
+		}
+
+		&.has-selected-child svg {
+			fill: $gray-text-min;
+		}
+
 		&.is-child-item {
 			a {
 				font-size: 12px;
@@ -70,4 +79,8 @@
 			}
 		}
 	}
+}
+
+.settings-tax.is-child-item {
+	border-bottom: 1px solid lighten( $gray, 20% );
 }


### PR DESCRIPTION
Fixes #14678 
Fixes #14729 

To Test

1. Navigate to /store/:site
2. Make sure each sidebar menu item works (note that everything will display the Dashboard except for Products-Add, Settings-Payments, and Settings-Shipping at this time, but the routes should be correct nonetheless)
3. Make sure each dashboard button works (see caveat in 2)
4. Make sure that the settings child items (Payments, Shipping and Taxes) are only displayed when Settings itself or one of them is selected

Note: Some routes change as a result of this PR:

```
FROM						TO
/store/products/:site			no change
/store/products/:site/add		/store/product/:site (note the singular here)
/store/products/:site/import		/store/products/import/:site

/store/orders/:site				no change
/store/orders/:site/add			/store/order/:site (note the singular here)

/store/settings/:site			no change (this corresponds to general settings)
/store/settings/:site/shipping	/store/settings/shipping/:site
/store/settings/:site/payments	/store/settings/payments/:site
/store/settings/:site/tax			/store/settings/tax/:site
```