### PR TITLE
WooCommerce: Add the order list view

### DIFF
--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -23,7 +23,7 @@ class Orders extends Component {
 			<Main className={ className }>
 				<OrderHeader siteSlug={ site.slug } />
 
-				<div className="orders__list">
+				<div className="orders__container">
 					<SectionNav>
 						<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
 							<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -10,28 +10,16 @@ import React, { Component } from 'react';
  */
 import { getSelectedSite } from 'state/ui/selectors';
 import Main from 'components/main';
-import NavItem from 'components/section-nav/item';
-import NavTabs from 'components/section-nav/tabs';
 import OrderHeader from './order-header';
 import OrdersList from './orders-list';
-import SectionNav from 'components/section-nav';
 
 class Orders extends Component {
 	render() {
-		const { className, site, translate } = this.props;
+		const { className, site } = this.props;
 		return (
 			<Main className={ className }>
 				<OrderHeader siteSlug={ site.slug } />
-
-				<div className="orders__container">
-					<SectionNav>
-						<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
-							<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>
-						</NavTabs>
-					</SectionNav>
-
-					<OrdersList />
-				</div>
+				<OrdersList />
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import Main from 'components/main';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import OrderHeader from './order-header';
+import OrdersList from './orders-list';
+import SectionNav from 'components/section-nav';
+
+class Orders extends Component {
+	render() {
+		const { className, site, translate } = this.props;
+		return (
+			<Main className={ className }>
+				<OrderHeader siteSlug={ site.slug } />
+
+				<SectionNav>
+					<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
+						<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>
+						<NavItem path="/orders/new" selected={ false }>{ translate( 'New' ) }</NavItem>
+						<NavItem path="/orders/pending" selected={ false }>{ translate( 'Pending' ) }</NavItem>
+						<NavItem path="/orders/processing" selected={ false }>{ translate( 'Processing' ) }</NavItem>
+						<NavItem path="/orders/failed" selected={ false }>{ translate( 'Failed' ) }</NavItem>
+					</NavTabs>
+				</SectionNav>
+
+				<OrdersList />
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const site = getSelectedSite( state );
+
+		return {
+			site,
+		};
+	}
+)( localize( Orders ) );

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -27,10 +27,6 @@ class Orders extends Component {
 					<SectionNav>
 						<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
 							<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>
-							<NavItem path="/orders/new" selected={ false }>{ translate( 'New' ) }</NavItem>
-							<NavItem path="/orders/pending" selected={ false }>{ translate( 'Pending' ) }</NavItem>
-							<NavItem path="/orders/processing" selected={ false }>{ translate( 'Processing' ) }</NavItem>
-							<NavItem path="/orders/failed" selected={ false }>{ translate( 'Failed' ) }</NavItem>
 						</NavTabs>
 					</SectionNav>
 

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import OrderHeader from './order-header';
 import OrdersList from './orders-list';
@@ -18,7 +18,7 @@ class Orders extends Component {
 		const { className, site } = this.props;
 		return (
 			<Main className={ className }>
-				<OrderHeader siteSlug={ site.slug } />
+				<OrderHeader siteSlug={ site ? site.slug : false } />
 				<OrdersList />
 			</Main>
 		);
@@ -27,7 +27,7 @@ class Orders extends Component {
 
 export default connect(
 	state => {
-		const site = getSelectedSite( state );
+		const site = getSelectedSiteWithFallback( state );
 
 		return {
 			site,

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -23,17 +23,19 @@ class Orders extends Component {
 			<Main className={ className }>
 				<OrderHeader siteSlug={ site.slug } />
 
-				<SectionNav>
-					<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
-						<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>
-						<NavItem path="/orders/new" selected={ false }>{ translate( 'New' ) }</NavItem>
-						<NavItem path="/orders/pending" selected={ false }>{ translate( 'Pending' ) }</NavItem>
-						<NavItem path="/orders/processing" selected={ false }>{ translate( 'Processing' ) }</NavItem>
-						<NavItem path="/orders/failed" selected={ false }>{ translate( 'Failed' ) }</NavItem>
-					</NavTabs>
-				</SectionNav>
+				<div className="orders__list">
+					<SectionNav>
+						<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
+							<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>
+							<NavItem path="/orders/new" selected={ false }>{ translate( 'New' ) }</NavItem>
+							<NavItem path="/orders/pending" selected={ false }>{ translate( 'Pending' ) }</NavItem>
+							<NavItem path="/orders/processing" selected={ false }>{ translate( 'Processing' ) }</NavItem>
+							<NavItem path="/orders/failed" selected={ false }>{ translate( 'Failed' ) }</NavItem>
+						</NavTabs>
+					</SectionNav>
 
-				<OrdersList />
+					<OrdersList />
+				</div>
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/orders/order-header.js
+++ b/client/extensions/woocommerce/app/orders/order-header.js
@@ -11,7 +11,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 
 const OrderHeader = ( { translate, siteSlug } ) => {
-	const addLink = `/store/orders/${ siteSlug }/add`;
+	const addLink = `/store/order/${ siteSlug }`;
 
 	return (
 		<ActionHeader>

--- a/client/extensions/woocommerce/app/orders/order-header.js
+++ b/client/extensions/woocommerce/app/orders/order-header.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+
+const OrderHeader = ( { translate, siteSlug } ) => {
+	const addLink = `/store/orders/${ siteSlug }/add`;
+
+	return (
+		<ActionHeader>
+			<Button primary href={ addLink }>{ translate( 'Add Order' ) }</Button>
+		</ActionHeader>
+	);
+};
+
+export default localize( OrderHeader );

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import orders from './orders.json';
+
+class Orders extends Component {
+	getOrderStatus = ( status ) => {
+		const { translate } = this.props;
+		const classes = `orders__item-status is-${ status }`;
+		switch ( status ) {
+			case 'pending':
+				return <span className={ classes }>{ translate( 'Pending payment' ) }</span>;
+			case 'processing':
+				return <span className={ classes }>{ translate( 'Processing' ) }</span>;
+			case 'on-hold':
+				return <span className={ classes }>{ translate( 'On hold' ) }</span>;
+			case 'completed':
+				return <span className={ classes }>{ translate( 'Completed' ) }</span>;
+			case 'cancelled':
+				return <span className={ classes }>{ translate( 'Cancelled' ) }</span>;
+			case 'refunded':
+				return <span className={ classes }>{ translate( 'Refunded' ) }</span>;
+			case 'failed':
+				return <span className={ classes }>{ translate( 'Failed' ) }</span>;
+		}
+	}
+
+	renderOrderItems = ( order, i ) => {
+		const { translate, moment } = this.props;
+		return (
+			<tr key={ i }>
+				<td className="orders__table-item orders__table-checkbox">
+					<FormInputCheckbox aria-label={ translate( 'Select order %(order)s', {
+						context: 'Label for checkbox',
+						args: {
+							order: order.number,
+						}
+					} ) } />
+				</td>
+				<th className="orders__table-item orders__table-name" scope="row">
+					<a className="orders__item-link" href="#">#{ order.number }</a>
+					<span className="orders__item-name">
+						{ `${ order.billing.first_name } ${ order.billing.last_name }` }
+					</span>
+				</th>
+				<td className="orders__table-item orders__table-date">
+					{ moment( order.date_modified ).format( 'LLL' ) }
+				</td>
+				<td className="orders__table-item orders__table-status">
+					{ this.getOrderStatus( order.status ) }
+				</td>
+				<td className="orders__table-item orders__table-total">
+					{ order.total }
+				</td>
+			</tr>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<table className="orders__table">
+				<thead>
+					<tr>
+						<th className="orders__table-heading" scope="col">
+							<FormInputCheckbox aria-label={ translate( 'Select All', {
+								context: 'Label for checkbox'
+							} ) } />
+						</th>
+						<th className="orders__table-heading" scope="col">Order</th>
+						<th className="orders__table-heading" scope="col">Date</th>
+						<th className="orders__table-heading" scope="col">Fulfillment Status</th>
+						<th className="orders__table-heading" scope="col">Total</th>
+					</tr>
+				</thead>
+				<tbody>
+					{ orders.map( this.renderOrderItems ) }
+				</tbody>
+			</table>
+		);
+	}
+}
+
+export default localize( Orders );

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -136,7 +136,7 @@ class Orders extends Component {
 				</TableItem>
 				<TableItem isHeader>{ translate( 'Order' ) }</TableItem>
 				<TableItem isHeader>{ translate( 'Date' ) }</TableItem>
-				<TableItem isHeader>{ translate( 'Fulfillment Status' ) }</TableItem>
+				<TableItem isHeader>{ translate( 'Status' ) }</TableItem>
 				<TableItem isHeader>{ translate( 'Total' ) }</TableItem>
 			</TableRow>
 		);

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -20,7 +20,7 @@ import {
 	getTotalOrdersPages
 } from 'woocommerce/state/sites/orders/selectors';
 import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getSiteAdminUrl } from 'state/sites/selectors';
 import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
 import NavItem from 'components/section-nav/item';
@@ -183,7 +183,8 @@ class Orders extends Component {
 
 export default connect(
 	state => {
-		const siteId = getSelectedSiteId( state );
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
 		const createOrderLink = getSiteAdminUrl( state, siteId, 'post-new.php?post_type=shop_order' );
 		const currentPage = getOrdersCurrentPage( state, siteId );
 		const orders = getOrders( state, currentPage, siteId );

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -14,7 +14,12 @@ import Button from 'components/button';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
 import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
-import { getOrders, getTotalOrdersPages } from 'woocommerce/state/sites/orders/selectors';
+import {
+	areOrdersLoading,
+	areOrdersLoaded,
+	getOrders,
+	getTotalOrdersPages
+} from 'woocommerce/state/sites/orders/selectors';
 import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Table from 'woocommerce/components/table';
@@ -107,7 +112,7 @@ class Orders extends Component {
 	}
 
 	render() {
-		const { orders, totalPages, translate } = this.props;
+		const { orders, ordersLoading, ordersLoaded, totalPages, translate } = this.props;
 		const headers = (
 			<TableRow>
 				<TableItem isHeader>
@@ -122,10 +127,16 @@ class Orders extends Component {
 			</TableRow>
 		);
 
+		// @todo Designer needed :)
+		const placeholder = ( ordersLoading && ! ordersLoaded ) ? translate( 'Loading orders' ) : translate( 'No orders found.' );
+
 		return (
 			<div>
 				<Table className="orders__table" header={ headers }>
-					{ orders.map( this.renderOrderItems ) }
+					{ orders.length
+						? orders.map( this.renderOrderItems )
+						: <TableRow><TableItem colSpan="5">{ placeholder }</TableItem></TableRow>
+					}
 				</Table>
 				<ul>
 					{ times( totalPages, this.renderPageLink ) }
@@ -140,11 +151,15 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const currentPage = getOrdersCurrentPage( state, siteId );
 		const orders = getOrders( state, currentPage, siteId );
+		const ordersLoading = areOrdersLoading( state, currentPage, siteId );
+		const ordersLoaded = areOrdersLoaded( state, currentPage, siteId );
 		const totalPages = getTotalOrdersPages( state, siteId );
 
 		return {
 			currentPage,
 			orders,
+			ordersLoading,
+			ordersLoaded,
 			siteId,
 			totalPages,
 		};

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -11,8 +11,8 @@ import { times } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import EmptyContent from 'components/empty-content';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
-import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
 import {
 	areOrdersLoading,
 	areOrdersLoaded,
@@ -21,6 +21,8 @@ import {
 } from 'woocommerce/state/sites/orders/selectors';
 import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteAdminUrl } from 'state/sites/selectors';
+import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -138,7 +140,16 @@ class Orders extends Component {
 	}
 
 	render() {
-		const { orders, ordersLoading, ordersLoaded, translate } = this.props;
+		const { createOrderLink, orders, translate } = this.props;
+		if ( ! orders.length ) {
+			return (
+				<EmptyContent
+					title={ translate( 'Orders will appear here as they come in.' ) }
+					action={ translate( 'Manually add an order' ) }
+					actionURL={ createOrderLink } />
+			);
+		}
+
 		const headers = (
 			<TableRow>
 				<TableItem isHeader>{ translate( 'Order' ) }</TableItem>
@@ -148,16 +159,10 @@ class Orders extends Component {
 			</TableRow>
 		);
 
-		// @todo Designer needed :)
-		const placeholder = ( ordersLoading && ! ordersLoaded ) ? translate( 'Loading orders' ) : translate( 'No orders found.' );
-
 		return (
 			<div>
 				<Table className="orders__table" header={ headers }>
-					{ orders.length
-						? orders.map( this.renderOrderItems )
-						: <TableRow><TableItem colSpan="5">{ placeholder }</TableItem></TableRow>
-					}
+					{ orders.map( this.renderOrderItems ) }
 				</Table>
 				{ this.renderPagination() }
 			</div>
@@ -168,6 +173,7 @@ class Orders extends Component {
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
+		const createOrderLink = getSiteAdminUrl( state, siteId, 'post-new.php?post_type=shop_order' );
 		const currentPage = getOrdersCurrentPage( state, siteId );
 		const orders = getOrders( state, currentPage, siteId );
 		const ordersLoading = areOrdersLoading( state, currentPage, siteId );
@@ -175,6 +181,7 @@ export default connect(
 		const totalPages = getTotalOrdersPages( state, siteId );
 
 		return {
+			createOrderLink,
 			currentPage,
 			orders,
 			ordersLoading,

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -98,7 +98,10 @@ class Orders extends Component {
 		i++;
 		return (
 			<li key={ i }>
-				<Button compact borderless onClick={ this.onPageClick( i ) }>{ i }</Button>
+				{ ( i !== this.props.currentPage )
+					? <Button compact borderless onClick={ this.onPageClick( i ) }>{ i }</Button>
+					: <span>{ i }</span>
+				}
 			</li>
 		);
 	}

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -11,7 +11,6 @@ import { times } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
-import FormInputCheckbox from 'components/forms/form-checkbox';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
 import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
 import {
@@ -63,16 +62,9 @@ class Orders extends Component {
 	}
 
 	renderOrderItems = ( order, i ) => {
-		const { translate, moment, siteId } = this.props;
+		const { moment, siteId } = this.props;
 		return (
 			<TableRow key={ i }>
-				<TableItem className="orders__table-checkbox">
-					<FormInputCheckbox aria-label={ translate( 'Select order %(order)s', {
-						args: {
-							order: order.number,
-						}
-					} ) } />
-				</TableItem>
 				<TableItem className="orders__table-name" isRowHeader>
 					<a className="orders__item-link" href={ `/store/order/${ siteId }/${ order.number }` }>#{ order.number }</a>
 					<span className="orders__item-name">
@@ -129,9 +121,6 @@ class Orders extends Component {
 		const { orders, ordersLoading, ordersLoaded, translate } = this.props;
 		const headers = (
 			<TableRow>
-				<TableItem isHeader>
-					<FormInputCheckbox aria-label={ translate( 'Select All' ) } />
-				</TableItem>
 				<TableItem isHeader>{ translate( 'Order' ) }</TableItem>
 				<TableItem isHeader>{ translate( 'Date' ) }</TableItem>
 				<TableItem isHeader>{ translate( 'Status' ) }</TableItem>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -114,7 +114,8 @@ class Orders extends Component {
 
 	renderPagination = () => {
 		const { totalPages } = this.props;
-		if ( totalPages < 2 ) {
+		// @todo Bring back pagination
+		if ( true || totalPages < 2 ) {
 			return null;
 		}
 

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 
@@ -8,9 +10,25 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import FormInputCheckbox from 'components/forms/form-checkbox';
-import orders from './orders.json';
+import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
+import { getOrders } from 'woocommerce/state/sites/orders/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class Orders extends Component {
+	componentDidMount() {
+		const { siteId } = this.props;
+
+		if ( siteId ) {
+			this.props.fetchOrders( siteId );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.siteId !== this.props.siteId ) {
+			this.props.fetchOrders( newProps.siteId );
+		}
+	}
+
 	getOrderStatus = ( status ) => {
 		const { translate } = this.props;
 		const classes = `orders__item-status is-${ status }`;
@@ -64,7 +82,7 @@ class Orders extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, orders } = this.props;
 		return (
 			<table className="orders__table">
 				<thead>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -13,6 +13,9 @@ import FormInputCheckbox from 'components/forms/form-checkbox';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
 import { getOrders } from 'woocommerce/state/sites/orders/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import Table from 'woocommerce/components/table';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
 
 class Orders extends Component {
 	componentDidMount() {
@@ -51,59 +54,69 @@ class Orders extends Component {
 	}
 
 	renderOrderItems = ( order, i ) => {
-		const { translate, moment } = this.props;
+		const { translate, moment, siteId } = this.props;
 		return (
-			<tr key={ i }>
-				<td className="orders__table-item orders__table-checkbox">
+			<TableRow key={ i }>
+				<TableItem className="orders__table-checkbox">
 					<FormInputCheckbox aria-label={ translate( 'Select order %(order)s', {
 						context: 'Label for checkbox',
 						args: {
 							order: order.number,
 						}
 					} ) } />
-				</td>
-				<th className="orders__table-item orders__table-name" scope="row">
-					<a className="orders__item-link" href="#">#{ order.number }</a>
+				</TableItem>
+				<TableItem className="orders__table-name" isRowHeader>
+					<a className="orders__item-link" href={ `/store/order/${ siteId }/${ order.number }` }>#{ order.number }</a>
 					<span className="orders__item-name">
 						{ `${ order.billing.first_name } ${ order.billing.last_name }` }
 					</span>
-				</th>
-				<td className="orders__table-item orders__table-date">
+				</TableItem>
+				<TableItem className="orders__table-date">
 					{ moment( order.date_modified ).format( 'LLL' ) }
-				</td>
-				<td className="orders__table-item orders__table-status">
+				</TableItem>
+				<TableItem className="orders__table-status">
 					{ this.getOrderStatus( order.status ) }
-				</td>
-				<td className="orders__table-item orders__table-total">
+				</TableItem>
+				<TableItem className="orders__table-total">
 					{ order.total }
-				</td>
-			</tr>
+				</TableItem>
+			</TableRow>
 		);
 	}
 
 	render() {
 		const { translate, orders } = this.props;
+		const headers = (
+			<TableRow>
+				<TableItem isHeader>
+					<FormInputCheckbox aria-label={ translate( 'Select All', {
+						context: 'Label for checkbox'
+					} ) } />
+				</TableItem>
+				<TableItem isHeader>{ translate( 'Order' ) }</TableItem>
+				<TableItem isHeader>{ translate( 'Date' ) }</TableItem>
+				<TableItem isHeader>{ translate( 'Fulfillment Status' ) }</TableItem>
+				<TableItem isHeader>{ translate( 'Total' ) }</TableItem>
+			</TableRow>
+		);
+
 		return (
-			<table className="orders__table">
-				<thead>
-					<tr>
-						<th className="orders__table-heading" scope="col">
-							<FormInputCheckbox aria-label={ translate( 'Select All', {
-								context: 'Label for checkbox'
-							} ) } />
-						</th>
-						<th className="orders__table-heading" scope="col">Order</th>
-						<th className="orders__table-heading" scope="col">Date</th>
-						<th className="orders__table-heading" scope="col">Fulfillment Status</th>
-						<th className="orders__table-heading" scope="col">Total</th>
-					</tr>
-				</thead>
-				<tbody>
-					{ orders.map( this.renderOrderItems ) }
-				</tbody>
-			</table>
+			<Table className="orders__table" header={ headers }>
+				{ orders.map( this.renderOrderItems ) }
+			</Table>
 		);
 	}
 }
 
-export default localize( Orders );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const orders = getOrders( state, siteId );
+
+		return {
+			siteId,
+			orders,
+		};
+	},
+	dispatch => bindActionCreators( { fetchOrders }, dispatch )
+)( localize( Orders ) );

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -100,6 +100,7 @@ class Orders extends Component {
 	}
 
 	renderPageLink = ( i ) => {
+		// We want this to start at 1, not 0
 		i++;
 		return (
 			<li key={ i }>
@@ -111,8 +112,21 @@ class Orders extends Component {
 		);
 	}
 
+	renderPagination = () => {
+		const { totalPages } = this.props;
+		if ( totalPages < 2 ) {
+			return null;
+		}
+
+		return (
+			<ul>
+				{ times( totalPages, this.renderPageLink ) }
+			</ul>
+		);
+	}
+
 	render() {
-		const { orders, ordersLoading, ordersLoaded, totalPages, translate } = this.props;
+		const { orders, ordersLoading, ordersLoaded, translate } = this.props;
 		const headers = (
 			<TableRow>
 				<TableItem isHeader>
@@ -138,9 +152,7 @@ class Orders extends Component {
 						: <TableRow><TableItem colSpan="5">{ placeholder }</TableItem></TableRow>
 					}
 				</Table>
-				<ul>
-					{ times( totalPages, this.renderPageLink ) }
-				</ul>
+				{ this.renderPagination() }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -68,7 +68,6 @@ class Orders extends Component {
 			<TableRow key={ i }>
 				<TableItem className="orders__table-checkbox">
 					<FormInputCheckbox aria-label={ translate( 'Select order %(order)s', {
-						context: 'Label for checkbox',
 						args: {
 							order: order.number,
 						}
@@ -131,9 +130,7 @@ class Orders extends Component {
 		const headers = (
 			<TableRow>
 				<TableItem isHeader>
-					<FormInputCheckbox aria-label={ translate( 'Select All', {
-						context: 'Label for checkbox'
-					} ) } />
+					<FormInputCheckbox aria-label={ translate( 'Select All' ) } />
 				</TableItem>
 				<TableItem isHeader>{ translate( 'Order' ) }</TableItem>
 				<TableItem isHeader>{ translate( 'Date' ) }</TableItem>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -23,6 +23,9 @@ import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteAdminUrl } from 'state/sites/selectors';
 import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import SectionNav from 'components/section-nav';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -143,10 +146,12 @@ class Orders extends Component {
 		const { createOrderLink, orders, translate } = this.props;
 		if ( ! orders.length ) {
 			return (
-				<EmptyContent
-					title={ translate( 'Orders will appear here as they come in.' ) }
-					action={ translate( 'Manually add an order' ) }
-					actionURL={ createOrderLink } />
+				<div className="orders__container">
+					<EmptyContent
+						title={ translate( 'Orders will appear here as they come in.' ) }
+						action={ translate( 'Manually add an order' ) }
+						actionURL={ createOrderLink } />
+				</div>
 			);
 		}
 
@@ -160,7 +165,13 @@ class Orders extends Component {
 		);
 
 		return (
-			<div>
+			<div className="orders__container">
+				<SectionNav>
+					<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
+						<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>
+					</NavTabs>
+				</SectionNav>
+
 				<Table className="orders__table" header={ headers }>
 					{ orders.map( this.renderOrderItems ) }
 				</Table>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -98,7 +98,7 @@ class Orders extends Component {
 					{ this.getOrderStatus( order.status ) }
 				</TableItem>
 				<TableItem className="orders__table-total">
-					{ order.total }
+					{ 'USD' === order.currency ? `$${ order.total }` : order.total }
 				</TableItem>
 			</TableRow>
 		);

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -43,22 +43,42 @@ class Orders extends Component {
 	getOrderStatus = ( status ) => {
 		const { translate } = this.props;
 		const classes = `orders__item-status is-${ status }`;
+		let paymentLabel;
+		let shippingLabel;
 		switch ( status ) {
 			case 'pending':
-				return <span className={ classes }>{ translate( 'Pending payment' ) }</span>;
+				shippingLabel = translate( 'New order' );
+				paymentLabel = translate( 'Payment pending' );
+				break;
 			case 'processing':
-				return <span className={ classes }>{ translate( 'Processing' ) }</span>;
+				shippingLabel = translate( 'New order' );
+				paymentLabel = translate( 'Paid in full' );
+				break;
 			case 'on-hold':
-				return <span className={ classes }>{ translate( 'On hold' ) }</span>;
+				shippingLabel = translate( 'On hold' );
+				paymentLabel = translate( 'Payment pending' );
+				break;
 			case 'completed':
-				return <span className={ classes }>{ translate( 'Completed' ) }</span>;
+				shippingLabel = translate( 'Fulfilled' );
+				paymentLabel = translate( 'Paid in full' );
+				break;
 			case 'cancelled':
-				return <span className={ classes }>{ translate( 'Cancelled' ) }</span>;
+				paymentLabel = translate( 'Cancelled' );
+				break;
 			case 'refunded':
-				return <span className={ classes }>{ translate( 'Refunded' ) }</span>;
+				paymentLabel = translate( 'Refunded' );
+				break;
 			case 'failed':
-				return <span className={ classes }>{ translate( 'Failed' ) }</span>;
+				paymentLabel = translate( 'Payment Failed' );
+				break;
 		}
+
+		return (
+			<span className={ classes }>
+				{ shippingLabel ? <span className="orders__shipping-status">{ shippingLabel }</span> : null }
+				<span className="orders__payment-status">{ paymentLabel }</span>
+			</span>
+		);
 	}
 
 	renderOrderItems = ( order, i ) => {

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -17,7 +17,7 @@
 
 .orders__item-status {
 	display: inline-block;
-	padding: 6px 8px;
+	padding: 0px 8px;
 	background: lighten( $gray, 20% );
 	border-radius: 4px;
 }

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -1,39 +1,20 @@
-.orders__table {
-	background: $white;
-	box-sizing: border-box;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+.orders__item-link,
+.orders__item-name {
+	display: inline-block;
+	font-weight: normal;
+}
 
-	th, td {
-		padding: 16px 16px 14px;
-	}
+.orders__item-link {
+	margin-right: 5px;
+}
 
-	.orders__table-heading {
-		border-bottom: 1px solid lighten( $gray, 20% );
-	}
+.orders__item-status {
+	display: inline-block;
+	padding: 6px 8px;
+	background: lighten( $gray, 20% );
+	border-radius: 4px;
+}
 
-	.orders__table-item {
-		border-bottom: 1px solid lighten( $gray, 30% );
-	}
-
-	.orders__item-link,
-	.orders__item-name {
-		display: inline-block;
-		font-weight: normal;
-	}
-
-	.orders__item-link {
-		margin-right: 5px;
-	}
-
-	.orders__item-status {
-		display: inline-block;
-		padding: 6px 8px;
-		background: lighten( $gray, 20% );
-		border-radius: 4px;
-	}
-
-	.orders__table-total {
-		text-align: right;
-	}
+.orders__table-total {
+	text-align: right;
 }

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -1,5 +1,5 @@
 
-.orders__list {
+.orders__container {
 	@include breakpoint( ">660px" ) {
 		margin-top: 58px;
 	}

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -1,0 +1,39 @@
+.orders__table {
+	background: $white;
+	box-sizing: border-box;
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+
+	th, td {
+		padding: 16px 16px 14px;
+	}
+
+	.orders__table-heading {
+		border-bottom: 1px solid lighten( $gray, 20% );
+	}
+
+	.orders__table-item {
+		border-bottom: 1px solid lighten( $gray, 30% );
+	}
+
+	.orders__item-link,
+	.orders__item-name {
+		display: inline-block;
+		font-weight: normal;
+	}
+
+	.orders__item-link {
+		margin-right: 5px;
+	}
+
+	.orders__item-status {
+		display: inline-block;
+		padding: 6px 8px;
+		background: lighten( $gray, 20% );
+		border-radius: 4px;
+	}
+
+	.orders__table-total {
+		text-align: right;
+	}
+}

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -1,3 +1,10 @@
+
+.orders__list {
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
+	}
+}
+
 .orders__item-link,
 .orders__item-name {
 	display: inline-block;

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -3,6 +3,14 @@
 	@include breakpoint( ">660px" ) {
 		margin-top: 58px;
 	}
+
+	thead {
+		.table-row {
+			&:hover {
+				background: transparent;
+			}
+		}
+	}
 }
 
 .orders__item-link,
@@ -21,30 +29,30 @@
 	line-height: 32px;
 	background: lighten( $gray, 20% );
 	border-radius: 4px;
-	
+
 	&.is-cancelled,
 	&.is-failed {
 		background: lighten( $alert-red, 20% );
 		color: darken( $alert-red, 30% );
-		
+
 		span + span {
 			border-color: $alert-red;
 		}
 	}
-	
+
 	&.is-on-hold {
 		background: lighten( $alert-yellow, 20% );
 		color: darken( $alert-yellow, 30% );
-		
+
 		span + span {
 			border-color: $alert-yellow;
 		}
 	}
-	
+
 	&.is-completed {
 		background: lighten( $alert-green, 20% );
-		color: darken( $alert-green, 30% );	
-		
+		color: darken( $alert-green, 30% );
+
 		span + span {
 			border-color: $alert-green;
 		}
@@ -52,8 +60,8 @@
 
 	&.is-refunded {
 		background: lighten( $alert-purple, 20% );
-		color: darken( $alert-purple, 30% );	
-		
+		color: darken( $alert-purple, 30% );
+
 		span + span {
 			border-color: $alert-purple;
 		}

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -20,6 +20,16 @@
 	padding: 0px 8px;
 	background: lighten( $gray, 20% );
 	border-radius: 4px;
+
+	span {
+		display: inline-block;
+	}
+
+	span + span {
+		margin-left: 8px;
+		padding-left: 8px;
+		border-left: 1px solid $gray;
+	}
 }
 
 .orders__table-total {

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -16,13 +16,47 @@
 }
 
 .orders__item-status {
-	display: inline-block;
+	display: inline-flex;
 	padding: 0px 8px;
+	line-height: 32px;
 	background: lighten( $gray, 20% );
 	border-radius: 4px;
+	
+	&.is-cancelled,
+	&.is-failed {
+		background: lighten( $alert-red, 20% );
+		color: darken( $alert-red, 30% );
+		
+		span + span {
+			border-color: $alert-red;
+		}
+	}
+	
+	&.is-on-hold {
+		background: lighten( $alert-yellow, 20% );
+		color: darken( $alert-yellow, 30% );
+		
+		span + span {
+			border-color: $alert-yellow;
+		}
+	}
+	
+	&.is-completed {
+		background: lighten( $alert-green, 20% );
+		color: darken( $alert-green, 30% );	
+		
+		span + span {
+			border-color: $alert-green;
+		}
+	}
 
-	span {
-		display: inline-block;
+	&.is-refunded {
+		background: lighten( $alert-purple, 20% );
+		color: darken( $alert-purple, 30% );	
+		
+		span + span {
+			border-color: $alert-purple;
+		}
 	}
 
 	span + span {
@@ -32,6 +66,7 @@
 	}
 }
 
-.orders__table-total {
+.orders__table-total,
+.table-heading:last-child {
 	text-align: right;
 }

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -1,5 +1,6 @@
 .action-header__header {
 	width: 100%;
+	min-height: 58px;
 	padding: 8px 16px 7px;
 	display: flex;
 	flex-direction: row;

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import Card from 'components/card';
 
-const Table = ( { className, compact, header, children, ...props } ) => {
+const Table = ( { className, compact = false, header, children, ...props } ) => {
 	const classes = classnames( {
 		table: true,
 		'is-compact-table': compact,

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,6 +12,7 @@ import { translate } from 'i18n-calypso';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
+import Orders from './app/orders';
 import Products from './app/products';
 import ProductCreate from './app/products/product-create';
 import Dashboard from './app/dashboard';
@@ -64,7 +65,7 @@ const getStorePages = () => {
 			path: '/store/products/import/:site',
 		},
 		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			container: Orders,
 			configKey: 'woocommerce/extension-orders',
 			path: '/store/orders/:site',
 			sidebarItem: {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -22,6 +22,7 @@
 	@import 'components/list/style';
 	@import 'components/table/style';
 	@import 'app/dashboard/style';
+	@import 'app/orders/style';
 	@import 'components/basic-widget/style';
 	@import 'components/share-widget/style';
 	@import 'components/reading-widget/style';


### PR DESCRIPTION
Fixes #13654 

<img width="1180" alt="screen shot 2017-06-20 at 9 47 49 am" src="https://user-images.githubusercontent.com/541093/27336461-a1d8291c-559d-11e7-94c0-5abb4f7f5c32.png">

This adds the basic orders list view. We've decided pagination will be part of v2, so right now you can only see a max of 100 orders. This particular PR just gets the basic display in, I'll add follow-ups for better currency display, and for the split status bar (in https://github.com/Automattic/wp-calypso/issues/13654#issuecomment-306613311).

To test:

- Visit `https://calypso.live/store/orders/$site`
- You should see the list of orders on your site