### PR TITLE
Update rebootAfterLogin to allow full urls that match the origin

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -25,8 +25,9 @@ import WaitingTwoFactorNotificationApproval from './two-factor-authentication/wa
 import { login } from 'lib/paths';
 import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
+import { isExternal, resemblesUrl } from 'lib/url';
 
-class Login extends Component {
+export class Login extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectLocation: PropTypes.string,
@@ -81,10 +82,11 @@ class Login extends Component {
 
 		let newHref;
 
-		if ( redirectLocation && redirectLocation.match( /^(?!\/\/)[\/\-a-z0-9.]+$/i ) ) {
+		if ( redirectLocation && ! ( resemblesUrl( redirectLocation ) && isExternal( redirectLocation ) ) ) {
 			// only redirect to paths on the current domain
 			newHref = redirectLocation;
 		} else {
+			// redirect to / by default
 			newHref = window.location.origin;
 		}
 

--- a/client/blocks/login/test/index.jsx
+++ b/client/blocks/login/test/index.jsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { noop } from 'lodash';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import config from 'config';
+
+describe( 'Login', function() {
+	let Login;
+
+	useFakeDom();
+
+	before( () => {
+		Login = require( 'blocks/login' ).Login;
+	} );
+
+	context( '#rebootAfterLogin()', () => {
+		const defaultProps = {
+			twoFactorEnabled: false,
+			recordTracksEvent: noop,
+			translate: noop,
+		};
+		const origin = `https://${ config( 'hostname' ) }`;
+
+		beforeEach( () => {
+			// mock window.location
+			global.window = {
+				location: {
+					href: origin + '/log-in',
+					origin,
+				}
+			};
+		} );
+
+		it( 'should successfully redirect to an absolute route', () => {
+			const wrapper = shallow( <Login redirectLocation={ '/themes' } { ...defaultProps } /> );
+
+			wrapper.instance().rebootAfterLogin();
+
+			expect( window.location.href ).to.equal( '/themes' );
+		} );
+
+		it( 'should successfully redirect to a relative route', () => {
+			const wrapper = shallow( <Login redirectLocation={ 'themes' } { ...defaultProps } /> );
+
+			wrapper.instance().rebootAfterLogin();
+
+			expect( window.location.href ).to.equal( 'themes' );
+		} );
+
+		it( 'should successfully redirect to a valid url if it matches the origin', () => {
+			const wrapper = shallow( <Login redirectLocation={ origin + '/themes' } { ...defaultProps } /> );
+
+			wrapper.instance().rebootAfterLogin();
+
+			expect( window.location.href ).to.equal( origin + '/themes' );
+		} );
+
+		it( 'should redirect to / if the hostname does not match the origin', () => {
+			const wrapper = shallow( <Login redirectLocation={ '//suspicious-site.com/fishing' } { ...defaultProps } /> );
+
+			wrapper.instance().rebootAfterLogin();
+
+			expect( window.location.href ).to.equal( origin );
+		} );
+	} );
+} );

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -122,7 +122,7 @@ function resemblesUrl( query ) {
 
 	// Make sure the query has a protocol - hostname ends up blank otherwise
 	if ( ! parsedUrl.protocol ) {
-		parsedUrl = url.parse( 'http://' + query );
+		parsedUrl = url.parse( 'http:' + ( query.startsWith( '//' ) ? query : '//' + query ) );
 	}
 
 	if ( ! parsedUrl.hostname || parsedUrl.hostname.indexOf( '.' ) === -1 ) {


### PR DESCRIPTION
This change allows full urls to be given to `redirect_to` during Log in. This is required for jetpack auth flow for instance.

### Testing Instructions
- Boot the branch
- Go to http://calypso.localhost:3000/log-in?redirect_to=http://calypso.localhost:3000/themes
- Ensure that you are redirected to themes after log in

### Reviews
- [ ] Code
- [ ] Product