### PR TITLE
Components: add displayName to SelectDropdown example

### DIFF
--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -12,7 +12,7 @@ import DropdownItem from 'components/select-dropdown/item';
 import DropdownLabel from 'components/select-dropdown/label';
 import DropdownSeparator from 'components/select-dropdown/separator';
 
-class SelectDropdownDemo extends React.PureComponent {
+class SelectDropdownExample extends React.PureComponent {
 	static displayName = 'SelectDropdownExample';
 
 	static defaultProps = {
@@ -209,4 +209,4 @@ class SelectDropdownDemo extends React.PureComponent {
 	}
 }
 
-export default SelectDropdownDemo;
+export default SelectDropdownExample;

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -12,7 +12,9 @@ import DropdownItem from 'components/select-dropdown/item';
 import DropdownLabel from 'components/select-dropdown/label';
 import DropdownSeparator from 'components/select-dropdown/separator';
 
-class SelectDropdownDemo extends React.Component {
+class SelectDropdownDemo extends React.PureComponent {
+	static displayName = 'SelectDropdownExample';
+
 	static defaultProps = {
 		options: [
 			{ value: 'status-options', label: 'Statuses', isLabel: true },


### PR DESCRIPTION
This PR returns a `displayName` to the `SelectDropdownDemo` component, which was accidentally removed in #14617.