### PR TITLE
Update action button label on the editor sidebar.

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -23,6 +23,8 @@ import AsyncLoad from 'components/async-load';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
+import config from 'config';
+import classNames from 'classnames';
 
 export default React.createClass( {
 	displayName: 'EditorGroundControl',
@@ -285,6 +287,75 @@ export default React.createClass( {
 		}
 	},
 
+	renderGroundControlActionButtons: function() {
+		const publishComboClasses = classNames( 'editor-ground-control__publish-combo', {
+			'is-standalone': config.isEnabled( 'post-editor/delta-post-publish-flow' )
+		} );
+
+		return ( <div className="editor-ground-control__action-buttons">
+			<Button
+				borderless
+				className="editor-ground-control__preview-button"
+				disabled={ ! this.isPreviewEnabled() }
+				onClick={ this.onPreviewButtonClick }
+				tabIndex={ 4 }
+			>
+				<Gridicon icon="visible" /> <span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
+			</Button>
+			<Button
+				borderless
+				className="editor-ground-control__toggle-sidebar"
+				onClick={ this.props.toggleSidebar }
+			>
+				<Gridicon icon="cog" /> <span className="editor-ground-control__button-label"><EditorPostType isSettings /></span>
+			</Button>
+			<div className={ publishComboClasses }>
+				<EditorPublishButton
+					site={ this.props.site }
+					post={ this.props.post }
+					savedPost={ this.props.savedPost }
+					onSave={ this.props.onSave }
+					onPublish={ this.props.onPublish }
+					tabIndex={ 5 }
+					isPublishing={ this.props.isPublishing }
+					isSaveBlocked={ this.props.isSaveBlocked }
+					hasContent={ this.props.hasContent }
+					needsVerification={ this.state.needsVerification }
+					busy={ this.props.isPublishing || ( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving ) }
+				/>
+				{ this.canPublishPost() &&
+				! config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+				<Button
+					primary
+					compact
+					ref="schedulePost"
+					className="editor-ground-control__time-button"
+					onClick={ this.toggleSchedulePopover }
+					aria-label={ this.translate( 'Schedule date and time to publish post.' ) }
+					aria-pressed={ !! this.state.showSchedulePopover }
+					title={ this.translate( 'Set date and time' ) }
+					tabIndex={ 6 }
+				>
+					{ postUtils.isFutureDated( this.props.post )
+						? <Gridicon icon="scheduled" />
+						: <Gridicon icon="calendar" />
+					}
+					<span className="editor-ground-control__time-button-label">
+									{ postUtils.isFutureDated( this.props.post )
+										? this.moment( this.props.post.date ).calendar()
+										: this.translate( 'Choose Date' )
+									}
+								</span>
+				</Button>
+				}
+			</div>
+			{ this.canPublishPost() &&
+			! config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+			this.schedulePostPopover()
+			}
+		</div> );
+	},
+
 	render: function() {
 		return (
 			<Card className="editor-ground-control">
@@ -332,66 +403,7 @@ export default React.createClass( {
 						</span>
 					}
 				</div>
-				<div className="editor-ground-control__action-buttons">
-					<Button
-						borderless
-						className="editor-ground-control__preview-button"
-						disabled={ ! this.isPreviewEnabled() }
-						onClick={ this.onPreviewButtonClick }
-						tabIndex={ 4 }
-					>
-						<Gridicon icon="visible" /> <span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
-					</Button>
-					<Button
-						borderless
-						className="editor-ground-control__toggle-sidebar"
-						onClick={ this.props.toggleSidebar }
-					>
-						<Gridicon icon="cog" /> <span className="editor-ground-control__button-label"><EditorPostType isSettings /></span>
-					</Button>
-					<div className="editor-ground-control__publish-combo">
-						<EditorPublishButton
-							site={ this.props.site }
-							post={ this.props.post }
-							savedPost={ this.props.savedPost }
-							onSave={ this.props.onSave }
-							onPublish={ this.props.onPublish }
-							tabIndex={ 5 }
-							isPublishing={ this.props.isPublishing }
-							isSaveBlocked={ this.props.isSaveBlocked }
-							hasContent={ this.props.hasContent }
-							needsVerification={ this.state.needsVerification }
-							busy={ this.props.isPublishing || ( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving ) }
-						/>
-						{ this.canPublishPost() &&
-							<Button
-								primary
-								compact
-								ref="schedulePost"
-								className="editor-ground-control__time-button"
-								onClick={ this.toggleSchedulePopover }
-								aria-label={ this.translate( 'Schedule date and time to publish post.' ) }
-								aria-pressed={ !! this.state.showSchedulePopover }
-								title={ this.translate( 'Set date and time' ) }
-								tabIndex={ 6 }
-							>
-								{ postUtils.isFutureDated( this.props.post )
-									? <Gridicon icon="scheduled" />
-									: <Gridicon icon="calendar" />
-								}
-								<span className="editor-ground-control__time-button-label">
-									{ postUtils.isFutureDated( this.props.post )
-										? this.moment( this.props.post.date ).calendar()
-										: this.translate( 'Choose Date' )
-									}
-								</span>
-							</Button>
-						}
-					</div>
-					{ this.canPublishPost() &&
-						this.schedulePostPopover()
-					}
-				</div>
+				{ this.renderGroundControlActionButtons() }
 			</Card>
 		);
 	}

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -101,12 +101,21 @@
 	flex-grow: 1;
 	display: flex;
 	margin: 0 4px;
+
+	&.is-standalone {
+		margin: 0 12px;
+	}
 }
 
 .editor-ground-control .editor-publish-button {
 	border-radius: 4px 0 0 4px;
 	flex-grow: 1;
 	padding: 5px 14px 7px;
+}
+
+.editor-ground-control .is-standalone .editor-publish-button {
+	border-radius: 4px;
+	padding: 7px 16px;
 }
 
 .editor-ground-control__time-button {

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -11,6 +11,7 @@ import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
 import Button from 'components/button';
 import { localize } from 'i18n-calypso';
+import config from 'config';
 
 export const getPublishButtonStatus = ( site, post, savedPost ) => {
 	if (
@@ -87,8 +88,16 @@ export class EditorPublishButton extends Component {
 			case 'update':
 				return this.props.translate( 'Update' );
 			case 'schedule':
+				if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+					return this.props.translate( 'Schedule…',
+						{ comment: 'Button label on the editor sidebar - a confirmation step will follow' } );
+				}
 				return this.props.translate( 'Schedule' );
 			case 'publish':
+				if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+					return this.props.translate( 'Publish…',
+						{ context: 'Button label on the editor sidebar - a confirmation step will follow' } );
+				}
 				return this.props.translate( 'Publish' );
 			case 'requestReview':
 				return this.props.translate( 'Submit for Review' );


### PR DESCRIPTION
This pull request updates the existing Publish button on the editor sidebar.

- Publish/Schedule steps are followed by a confirmation step now so the action button label on the editor sidebar indicates this with an ellipsis (…)
- Calendar dropdown is redundant so it's been removed

These changes are only visible if the 'post-editor/delta-post-publish-flow' feature flag is enabled.

![fqejowpxyx](https://user-images.githubusercontent.com/1017839/26898641-f86604d2-4bcc-11e7-8e20-85f9cacb06d8.gif)

### To test:

#### Existing behavior:

- Checkout branch and run *without* the feature-flag enabled: `make run`
- Load the editor and draft a post. Do not change the date.
- Verify that the look & feel and the behavior have not changed (hit Publish to publish your post)
- Change the date of the post, and verify that the look & feel and the behavior have not changed (hit Schedule to schedule your post)

#### New flow behind the feature flag:
- Checkout branch and run with the feature-flag enabled: ENABLE_FEATURES=post-editor/delta-post-publish-flow make run
- Load the editor and draft a post. Do not change the date.
- Verify that the Publish button has the ellipsis in its label, and it's functional
- Change the date of the post, and verify that the Schedule button has the ellipsis in its label, and it's functional