### PR TITLE
Reader: Sites in Search visual updates

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -276,7 +276,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	position: relative;
 	height: 20px;
 	overflow: hidden;
-	white-space: nowrap;
 	margin-left: 10px;
 	color: $gray;
 
@@ -286,7 +285,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__tag {
-	white-space: nowrap;
 
 	&::after {
 		content: ', '

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -280,7 +280,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	color: $gray;
 
 	&::after {
-		@include long-content-fade( $size: 10% );
+		@include long-content-fade( $size: 20% );
 	}
 }
 
@@ -290,7 +290,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		content: ', '
 	}
 
-	&:last-child:after {
+	&:last-child::after {
 		display: none;
 	}
 }

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -23,7 +23,6 @@
 .is-reader-page .follow-button {
 	border: 0;
 	border-radius: 0;
-	float: right;
 }
 
 .is-reader-page .reader-full-post__story-content {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -74,10 +74,10 @@
 // Post recs
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(2),
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(3) {
-	margin-top: 90px;
+	margin-top: 70px;
 
-	@include breakpoint( "<660px" ) {
-		margin-top: 70px;
+	@include breakpoint( ">660px" ) {
+		margin-top: 90px;
 	}
 }
 
@@ -282,44 +282,29 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 }
 
-// Post and Sites static headers
+// Posts and Sites static headers
 .search-stream__headers {
 	color: $gray;
+	font-size: 14px;
 	display: flex;
 	font-weight: 600;
-	letter-spacing: .1em;
 	list-style-type: none;
 	margin: 0;
 	padding-top: 20px;
 	text-transform: uppercase;
 }
 
-.search-stream .search-stream__site-header {
+.search-stream__site-header {
 	margin-left: 40px;
 	max-width: 265px;
 	width: 100%;
 }
 
-.search-stream .search-stream__post-header,
-.search-stream .search-stream__site-header {
-	border-bottom: 2px solid lighten( $gray, 30% );
+.search-stream__post-header,
+.search-stream__site-header {
+	border-bottom: 1px solid lighten( $gray, 30% );
 	padding-bottom: 10px;
 	width: 100%;
-}
-
-.search-stream .search-stream__site-results {
-	max-width: 265px;
-	min-width: 265px;
-	margin-left: 40px;
-
-	.reader-infinite-stream__row-wrapper {
-		border: 0;
-	}
-
-	.reader-subscription-list-item .follow-button__label,
-	.reader-subscription-list-item__settings-label {
-		display: none;
-	}
 }
 
 // Posts and Sites tabbed headers

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -53,8 +53,8 @@
 	z-index: z-index( 'root', '.search-stream__input-card' );
 }
 
-// Top margins for Sites in Search
-// Post recs and post results with suggested terms
+// Top margins
+// Top margin for post recs and post results with suggested terms
 .search-stream .search-stream__recommendation-list-item:nth-child(2),
 .search-stream .search-stream__recommendation-list-item:nth-child(3) {
 	margin-top: 100px;
@@ -71,7 +71,7 @@
 	}
 }
 
-// Post recs
+// Top margin for post recs without suggested terms
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(2),
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(3) {
 	margin-top: 70px;
@@ -101,7 +101,7 @@
 	}
 }
 
-// Site results
+// Top margin for site results
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__post-results .reader-post-card:nth-child(2),
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__site-results {
 	margin-top: 150px;
@@ -294,12 +294,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	text-transform: uppercase;
 }
 
-.search-stream__site-header, .search-stream__site-results {
-	margin-left: 40px;
-	max-width: 265px;
-	width: 100%;
-}
-
 .search-stream__post-header,
 .search-stream__site-header {
 	border-bottom: 1px solid lighten( $gray, 30% );
@@ -326,10 +320,6 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	flex: 1 0 0%;
 	margin-top: 5px;
 	width: 0;
-}
-
-.search-stream__header .section-nav__panel {
-	height: 58px;
 }
 
 .search-stream__header .section-nav-tabs__list {
@@ -360,6 +350,18 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		text-transform: uppercase;
 		width: 100%;
 	}
+}
+
+// Site results
+.search-stream__site-header, .search-stream__site-results {
+	margin-left: 40px;
+	max-width: 265px;
+	width: 100%;
+}
+
+.reader-subscription-list-item .follow-button__label,
+.reader-subscription-list-item__settings-label {
+	display: none;
 }
 
 // Custom styling for cards in post results

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -53,7 +53,7 @@
 	z-index: z-index( 'root', '.search-stream__input-card' );
 }
 
-// Top margins for Sites in Search
+// Top margins
 // Post recs and post results with suggested terms
 .search-stream .search-stream__recommendation-list-item:nth-child(2),
 .search-stream .search-stream__recommendation-list-item:nth-child(3),
@@ -72,7 +72,11 @@
 	}
 }
 
-// Post recs in Site Results
+.search-stream .search-stream__single-column-results .reader-post-card:nth-child(2) {
+	margin-top: 0;
+}
+
+// Post recs
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(2),
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(3) {
 	margin-top: 70px;
@@ -116,7 +120,8 @@
 	padding-bottom: 15px;
 	text-align:left;
 
-	a, a:visited {
+	a,
+	a:visited {
 		color: $blue-medium;
 	}
 
@@ -131,7 +136,7 @@
 
 // Post recommendations in Search
 // Custom breakpoints needed to match Related Posts
-$reader-post-card-breakpoint: "( min-width: 1012px )";
+$reader-post-results-breakpoint: "( min-width: 1012px ) and ( max-width: 1080px )";
 $reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
 $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
@@ -261,6 +266,15 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
+.is-reader-page .search-stream__input-card.card {
+	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 30% );
+	margin-bottom: 0;
+ }
+
+.is-reader-page .search-stream__blank-suggestions {
+	 margin-bottom: -15px;
+ }
+
 // Date and Relevance sorter
 .search-stream__sort-picker {
 	position: absolute;
@@ -269,7 +283,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	z-index: z-index( 'root', '.search-stream__sort-picker' );
 }
 
-// Posts and Sites results
 .search-stream .search-stream__results.is-two-columns {
 	display: flex;
 }
@@ -389,4 +402,37 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	border-bottom: 2px solid lighten( $gray, 30% );
 	padding-bottom: 10px;
 	width: 100%;
+}
+
+// Custom card styling for post results
+.search-stream .search-stream__results {
+	display: flex;
+
+	&.is-two-columns .search-stream__post-results {
+		max-width: 660px;
+
+		.reader-share__button-label,
+		.comment-button__label-status,
+		.like-button__label-status {
+			display: none;
+		}
+
+		.reader-share__button {
+			top: 2px;
+		}
+
+		.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
+
+			@media #{$reader-post-results-breakpoint} {
+				display: none;
+			}
+		}
+	}
+}
+
+.card.reader-search-card.is-photo {
+
+	@include breakpoint( "<660px" ) {
+		z-index: z-index( 'root', '.reader-search-card' );
+	}
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -294,7 +294,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	text-transform: uppercase;
 }
 
-.search-stream__site-header {
+.search-stream__site-header, .search-stream__site-results {
 	margin-left: 40px;
 	max-width: 265px;
 	width: 100%;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -353,7 +353,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 // Site results
-.search-stream__site-header, .search-stream__site-results {
+.search-stream__site-header,
+.search-stream__site-results {
 	margin-left: 40px;
 	max-width: 265px;
 	width: 100%;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -53,11 +53,10 @@
 	z-index: z-index( 'root', '.search-stream__input-card' );
 }
 
-// Top margins
+// Top margins for Sites in Search
 // Post recs and post results with suggested terms
 .search-stream .search-stream__recommendation-list-item:nth-child(2),
-.search-stream .search-stream__recommendation-list-item:nth-child(3),
-.search-stream .reader-post-card:nth-child(2) {
+.search-stream .search-stream__recommendation-list-item:nth-child(3) {
 	margin-top: 100px;
 }
 
@@ -72,22 +71,14 @@
 	}
 }
 
-.search-stream .search-stream__single-column-results .reader-post-card:nth-child(2) {
-	margin-top: 0;
-}
-
 // Post recs
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(2),
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(3) {
-	margin-top: 70px;
+	margin-top: 90px;
 
-	@include breakpoint( ">660px" ) {
-		margin-top: 90px;
+	@include breakpoint( "<660px" ) {
+		margin-top: 70px;
 	}
-}
-
-.search-stream.search-stream__with-sites .search-stream__single-column-results {
-	padding-top: 150px;
 }
 
 .search-stream.search-stream__with-sites .search-stream__single-column-results .search-stream__recommendation-list-item:nth-child(2) {
@@ -104,12 +95,6 @@
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		margin-top: 0;
 	}
-}
-
-// Site results
-.search-stream.search-stream__with-sites .is-two-columns .search-stream__post-results .reader-post-card:nth-child(2),
-.search-stream.search-stream__with-sites .is-two-columns .search-stream__site-results {
-	margin-top: 150px;
 }
 
 // Search term suggestions
@@ -134,12 +119,12 @@
 	}
 }
 
-// Post recommendations in Search
-// Custom breakpoints needed to match Related Posts
-$reader-post-results-breakpoint: "( min-width: 1012px ) and ( max-width: 1080px )";
-$reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
-$reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
+// Custom breakpoints
+$reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040px )";
+$reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
+$reader-post-card-breakpoint-small: "( max-width: 550px )";
 
+// Post recommendations in Search
 .is-reader-page .search-stream .reader__content {
 	display: flex;
 	flex-flow: wrap;
@@ -404,7 +389,23 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	width: 100%;
 }
 
-// Custom card styling for post results
+.search-stream__results.is-two-columns {
+	margin-top: 140px;
+}
+
+.search-stream__single-column-results {
+	padding-top: 140px;
+
+	.follow-button {
+		float: none;
+	}
+
+	.reader-subscription-list-item__options {
+		min-width: 90px;
+	}
+}
+
+// Custom styling for cards in post results
 .search-stream .search-stream__results {
 	display: flex;
 
@@ -421,11 +422,53 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 			top: 2px;
 		}
 
+		.reader-post-card__post {
+
+			@media #{$reader-post-card-breakpoint-large} {
+				flex-direction: column;
+			}
+
+			@include breakpoint( "<960px" ) {
+				flex-direction: column;
+			}
+		}
+
+		.reader-post-card.card.has-thumbnail .reader-featured-image {
+
+			@media #{$reader-post-card-breakpoint-large} {
+				height: 80px;
+				margin: 0 0 20px;
+				max-width: 100%;
+			}
+
+			@include breakpoint( "<960px" ) {
+				height: 80px;
+				margin: 0 0 20px;
+				max-width: 100%;
+			}
+		}
+
+		.reader-post-card.is-photo .reader-post-card__title {
+			white-space: normal;
+		}
+
 		.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
 
-			@media #{$reader-post-results-breakpoint} {
+			@media #{$reader-post-card-breakpoint-large} {
 				display: none;
 			}
+
+			@include breakpoint( "<960px" ) {
+				display: block;
+			}
+		}
+	}
+
+	&.is-two-columns .search-stream__site-results {
+
+		.reader-subscription-list-item .gridicons-cog {
+			left: -2px;
+			top: 15px;
 		}
 	}
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -81,6 +81,10 @@
 	}
 }
 
+.search-stream.search-stream__with-sites .search-stream__single-column-results {
+	padding-top: 150px;
+}
+
 .search-stream.search-stream__with-sites .search-stream__single-column-results .search-stream__recommendation-list-item:nth-child(2) {
 	margin-top: -60px;
 }
@@ -95,6 +99,12 @@
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		margin-top: 0;
 	}
+}
+
+// Site results
+.search-stream.search-stream__with-sites .is-two-columns .search-stream__post-results .reader-post-card:nth-child(2),
+.search-stream.search-stream__with-sites .is-two-columns .search-stream__site-results {
+	margin-top: 150px;
 }
 
 // Search term suggestions
@@ -312,7 +322,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 }
 
-// Posts and Sites segmented control
+// Posts and Sites tabbed headers
+.search-stream__header .section-nav-tabs__dropdown,
+.search-stream__header .section-nav__mobile-header {
+	display: none;
+}
+
 .search-stream__header .section-nav {
 	background: inherit;
 	border-bottom: 2px solid lighten( $gray, 30% );
@@ -324,16 +339,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .search-stream__header .section-nav-group {
 	display: flex;
 	flex: 1 0 0%;
+	margin-top: 5px;
 	width: 0;
-
-	@include breakpoint( "<480px" ) {
-		margin-top: 0;
-	}
 }
 
-.search-stream__header .section-nav-tabs__dropdown,
-.search-stream__header .section-nav__mobile-header {
-	display: none;
+.search-stream__header .section-nav__panel {
+	height: 58px;
 }
 
 .search-stream__header .section-nav-tabs__list {
@@ -341,6 +352,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	.section-nav-tab.is-selected {
 		border-bottom: 2px solid $gray-dark;
+	}
+
+	.is-selected .section-nav-tab__link {
+		color: $gray-dark;
 	}
 
 	.section-nav-tab__link {
@@ -353,124 +368,78 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 	}
 
-	.is-selected .section-nav-tab__link {
-		color: $gray-dark;
-	}
-}
-
-.search-stream__header .section-nav-tab__text {
-	font-weight: 600;
-	font-size: 13px;
-	letter-spacing: .04em;
-	text-transform: uppercase;
-	width: 100%;
-}
-
-.search-stream__headers {
-	color: $gray;
-	display: flex;
-	font-weight: 600;
-	list-style-type: none;
-	margin: 0;
-	padding-top: 20px;
-	text-transform: uppercase;
-}
-
-.search-stream__site-header {
-	margin-left: 40px;
-	max-width: 265px;
-	width: 100%;
-}
-
-.search-stream__post-header,
-.search-stream__site-header {
-	border-bottom: 2px solid lighten( $gray, 30% );
-	padding-bottom: 10px;
-	width: 100%;
-}
-
-.search-stream__results.is-two-columns {
-	margin-top: 140px;
-}
-
-.search-stream__single-column-results {
-	padding-top: 140px;
-
-	.follow-button {
-		float: none;
-	}
-
-	.reader-subscription-list-item__options {
-		min-width: 90px;
+	.section-nav-tab__text {
+		font-weight: 600;
+		font-size: 13px;
+		letter-spacing: .04em;
+		text-transform: uppercase;
+		width: 100%;
 	}
 }
 
 // Custom styling for cards in post results
-.search-stream .search-stream__results {
+.search-stream__results {
 	display: flex;
+}
 
-	&.is-two-columns .search-stream__post-results {
-		max-width: 660px;
+.search-stream__results.is-two-columns .search-stream__post-results {
+	max-width: 660px;
 
-		.reader-share__button-label,
-		.comment-button__label-status,
-		.like-button__label-status {
+	.reader-post-card__post {
+
+		@media #{$reader-post-card-breakpoint-large} {
+			flex-direction: column;
+		}
+
+		@include breakpoint( "<960px" ) {
+			flex-direction: column;
+		}
+	}
+
+	.reader-post-card.card.has-thumbnail .reader-featured-image {
+
+		@media #{$reader-post-card-breakpoint-large} {
+			height: 80px;
+			margin: 0 0 20px;
+			max-width: 100%;
+		}
+
+		@include breakpoint( "<960px" ) {
+			height: 80px;
+			margin: 0 0 20px;
+			max-width: 100%;
+		}
+	}
+
+	.reader-post-card.is-photo .reader-post-card__title {
+		white-space: normal;
+	}
+
+	.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
+
+		@media #{$reader-post-card-breakpoint-large} {
 			display: none;
 		}
 
-		.reader-share__button {
-			top: 2px;
-		}
-
-		.reader-post-card__post {
-
-			@media #{$reader-post-card-breakpoint-large} {
-				flex-direction: column;
-			}
-
-			@include breakpoint( "<960px" ) {
-				flex-direction: column;
-			}
-		}
-
-		.reader-post-card.card.has-thumbnail .reader-featured-image {
-
-			@media #{$reader-post-card-breakpoint-large} {
-				height: 80px;
-				margin: 0 0 20px;
-				max-width: 100%;
-			}
-
-			@include breakpoint( "<960px" ) {
-				height: 80px;
-				margin: 0 0 20px;
-				max-width: 100%;
-			}
-		}
-
-		.reader-post-card.is-photo .reader-post-card__title {
-			white-space: normal;
-		}
-
-		.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
-
-			@media #{$reader-post-card-breakpoint-large} {
-				display: none;
-			}
-
-			@include breakpoint( "<960px" ) {
-				display: block;
-			}
+		@include breakpoint( "<960px" ) {
+			display: block;
 		}
 	}
 
-	&.is-two-columns .search-stream__site-results {
-
-		.reader-subscription-list-item .gridicons-cog {
-			left: -2px;
-			top: 15px;
-		}
+	.reader-share__button-label,
+	.comment-button__label-status,
+	.like-button__label-status {
+		display: none;
 	}
+
+	.reader-share__button {
+		top: 2px;
+	}
+}
+
+.search-stream__results.is-two-columns .search-stream__site-results .gridicons-cog {
+	left: -3px;
+	top: 15px;
 }
 
 .card.reader-search-card.is-photo {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -359,8 +359,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	width: 100%;
 }
 
-.reader-subscription-list-item .follow-button__label,
-.reader-subscription-list-item__settings-label {
+.search-stream__site-results .reader-subscription-list-item .follow-button__label,
+.search-stream__site-results .reader-subscription-list-item__settings-label {
 	display: none;
 }
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -8,6 +8,7 @@
 }
 
 .tag-stream__header .follow-button {
+	float: right;
 	padding: 0;
 	position: relative;
 		top: 2px;


### PR DESCRIPTION
### Drop labels as Likes were wrapping when we have 2-cols:

**Before:**
<img width="655" alt="screenshot 2017-06-07 10 01 30" src="https://user-images.githubusercontent.com/4924246/26898637-8592479a-4b81-11e7-8026-d8e9dd47762f.png">

**After:**
![screenshot 2017-06-07 11 15 44](https://user-images.githubusercontent.com/4924246/26898642-8b7cccb6-4b81-11e7-90b8-4b62e78b38f8.png)

### Photo cards with long titles widen the posts column:

**Before:**
![screenshot 2017-06-07 11 11 48](https://user-images.githubusercontent.com/4924246/26900430-010cab2c-4b87-11e7-9e50-ee3411d3954f.png)

**After:**
![screenshot 2017-06-07 14 01 04](https://user-images.githubusercontent.com/4924246/26901207-c82899d0-4b89-11e7-8b52-e4e1fab7a600.png)

### Photo cards with long tags widen the posts column:

**Before:**
![screenshot 2017-06-07 14 03 37](https://user-images.githubusercontent.com/4924246/26901542-11cd61fa-4b8b-11e7-92b4-a1a538959775.png)

**After:**
![screenshot 2017-06-07 14 10 10](https://user-images.githubusercontent.com/4924246/26901544-15664660-4b8b-11e7-82cf-c068c1378573.png)

### At ~1012px, only show 3 thumbnails for gallery cards so images don't look squished when we have 2-cols:

**Before:**
![screenshot 2017-06-07 12 57 08](https://user-images.githubusercontent.com/4924246/26901244-f33491c4-4b89-11e7-8933-74af64d7f51e.png)

**After:**
![screenshot 2017-06-07 12 57 27](https://user-images.githubusercontent.com/4924246/26901249-f76da97e-4b89-11e7-86a5-3431f265194e.png)

