### PR TITLE
Desktop: Don't crash on right click in Editor

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -831,8 +831,8 @@ function mediaButton( editor ) {
 	// send contextmenu event up to desktop app
 	if ( config.isEnabled( 'desktop' ) ) {
 		const ipc = require( 'electron' ).ipcRenderer; // From Electron
-		editor.on( 'contextmenu', function( ev ) {
-			ipc.send( 'mce-contextmenu', ev );
+		editor.on( 'contextmenu', function() {
+			ipc.send( 'mce-contextmenu', { sender: true } );
 		} );
 	}
 


### PR DESCRIPTION
One of the most annoying bugs in the desktop app: https://github.com/Automattic/wp-desktop/issues/241

Problem was that a complex object like the event just cannot be passed over the IPC. Code tried hard to serialize it but failed for some reason (my guess is that it got stuck on circular `window` property and entered an infinite loop).

This PR replaces the event object by a simple mock that contains just enough data that the receiver needs, as will only be testing for the presence of `sender` property to identify that event comes from the editor.

To test:
1. run wp-desktop with this branch
2. go to the editor
3. right click the content

![right-click](https://user-images.githubusercontent.com/156676/26905148-e495bdee-4be5-11e7-9251-9e5df569cf7a.gif)
