### PR TITLE
Framework: add back some site options for nudges

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -94,7 +94,7 @@ export function requestSites() {
 			include_domain_only: true,
 			site_activity: 'active',
 			fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
-			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads' //eslint-disable-line max-len
+			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled' //eslint-disable-line max-len
 		} ).then( ( response ) => {
 			dispatch( receiveSites( response.sites ) );
 			dispatch( {


### PR DESCRIPTION
Fixes #14879 where we would prompt users to upgrade when they already had a plan. Follow up to #14885 since I missed a me/sites call. Regression caused by #14096

#### Testing Instructions
1. Navigate to http://calypso.localhost:3000/media/audio/:siteId: or /media/videos/:siteId: on a site with a Premium or Business plan
2. We should see the video/audio tab without being prompted to upgrade