### PR TITLE
Jetpack Connect: Use correct prop name for interval in PlansGrid

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -65,7 +65,7 @@ class JetpackPlansGrid extends Component {
 							isLandingPage={ ! this.props.selectedSite }
 							basePlansPath={ this.props.basePlansPath }
 							onUpgradeClick={ this.props.onSelect }
-							interval={ this.props.interval }
+							intervalType={ this.props.interval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true } />
 					</div>


### PR DESCRIPTION
This PR fixes a wrong prop name in Jetpack Connect's plan grid. This fixes a bad issue, where on /jetpack/connect/store switching between intervals does not affect any of the plans appearance.

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/jetpack/connect/store`
* Verify switching to monthly interval works as expected.
* Go to `http://calypso.localhost:3000/jetpack/connect/store/monthly`
* Verify it loads correctly the monthly prices, and switching to yearly still works.