### PR TITLE
Jetpack Connect: Handle prefilled URL on plans landing

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -192,6 +192,7 @@ export default {
 				destinationType={ context.params.destinationType }
 				interval={ context.params.interval }
 				basePlansPath={ '/jetpack/connect/store' }
+				url={ context.query.site }
 			/>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -14,6 +14,7 @@ import { selectPlanInAdvance } from 'state/jetpack-connect/actions';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getSite } from 'state/sites/selectors';
 import QueryPlans from 'components/data/query-plans';
+import addQueryArgs from 'lib/route/add-query-args';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 
@@ -53,7 +54,7 @@ class PlansLanding extends Component {
 		let redirectUrl = CALYPSO_JETPACK_CONNECT;
 
 		if ( url ) {
-			redirectUrl += '?url=' + url;
+			redirectUrl = addQueryArgs( { url }, redirectUrl );
 		}
 
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -49,13 +49,20 @@ class PlansLanding extends Component {
 	}
 
 	storeSelectedPlan = ( cartItem ) => {
+		const { url } = this.props;
+		let redirectUrl = CALYPSO_JETPACK_CONNECT;
+
+		if ( url ) {
+			redirectUrl += '?url=' + url;
+		}
+
 		this.props.recordTracksEvent( 'calypso_jpc_plans_store_plan', {
 			plan: cartItem ? cartItem.product_slug : 'free'
 		} );
 		this.props.selectPlanInAdvance( cartItem ? cartItem.product_slug : 'free', '*' );
 
 		setTimeout( () => {
-			page.redirect( CALYPSO_JETPACK_CONNECT );
+			page.redirect( redirectUrl );
 		}, 25 );
 	}
 


### PR DESCRIPTION
This PR implements correct handling for the `site` query parameter in Jetpack Connect store URLs like this one:

https://wordpress.com/jetpack/connect/store?site=example.com

There are two cases this PR is addressing:
* If the `site` is already connected, let's redirect to the plans page.
* If the `site` is not connected, let's persist it throughout the connection flow.

To test:
* Checkout this branch
* Test with an already connected site and clean cache
  * Clean up your Redux store
  * Let `$site` is the slug of one of your already connected Jetpack sites.
  * Go to `http://calypso.localhost:3000/jetpack/connect/store?site=$site`
  * Wait for the sites to be loaded.
  * Verify you're redirected to http://calypso.localhost:3000/plans/$site
* Test with an already connected site and cached sites
  * Make sure you're testing with cached sites (if you see the `Skipping initial state rehydration to recreate first-load experience.` message in your console, you'll need to try again).
  * Let `$site` is the slug of one of your already connected Jetpack sites.
  * Go to `http://calypso.localhost:3000/jetpack/connect/store?site=$site`
  * Verify you're immediately redirected to http://calypso.localhost:3000/plans/$site
* Test with a non-connected site
  * Let `$site` is the slug of one of a non-connected site.
  * Go to `http://calypso.localhost:3000/jetpack/connect/store?site=$site`
  * Pick a random plan.
  * Verify you're redirected to http://calypso.localhost:3000/jetpack/connect?url=$site so the URL is preserved throughout the connection flow.