### PR TITLE
Emoji: Fix twemoji incorrectly parsing characters in a few places.

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -393,14 +393,18 @@ export class FullPostView extends React.Component {
 											siteLink: (
 												<a
 													href={ getStreamUrlFromPost( post ) }
+													/* eslint-disable wpcalypso/jsx-classname-namespace */
 													className="reader-related-card-v2__link"
+													/* eslint-enable wpcalypso/jsx-classname-namespace */
 												>
 													{ siteName }
 												</a>
 											),
 										},
 									} ) }
+									/* eslint-disable wpcalypso/jsx-classname-namespace */
 									className="is-same-site"
+									/* eslint-enable wpcalypso/jsx-classname-namespace */
 									onPostClick={ this.handleRelatedPostFromSameSiteClicked }
 								/> }
 
@@ -421,7 +425,9 @@ export class FullPostView extends React.Component {
 									siteId={ +post.site_ID }
 									postId={ +post.ID }
 									title={ relatedPostsFromOtherSitesTitle }
+									/* eslint-disable wpcalypso/jsx-classname-namespace */
 									className="is-other-site"
+									/* eslint-enable wpcalypso/jsx-classname-namespace */
 									onPostClick={ this.handleRelatedPostFromOtherSiteClicked }
 								/> }
 						</article>

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -33,7 +33,16 @@ export default class Emojify extends PureComponent {
 		twemoji.parse( this.refs.emojified, {
 			base: config( 'twemoji_cdn_url' ),
 			size: '72x72',
-			className: className
+			className: className,
+			callback: function( icon, options ) {
+				const ignored = [ 'a9', 'ae', '2122', '2194', '2660', '2663', '2665', '2666' ];
+
+				if ( -1 !== ignored.indexOf( icon ) ) {
+					return false;
+				}
+
+				return ''.concat( options.base, options.size, '/', icon, options.ext );
+			}
 		} );
 	}
 

--- a/client/components/emojify/style.scss
+++ b/client/components/emojify/style.scss
@@ -4,7 +4,7 @@
 
 // Styles recommended by twemoji
 // https://github.com/twitter/twemoji#inline-styles
-.emojify__emoji {
+img.emojify__emoji {
 	height: 1em;
 	width: 1em;
 	margin: 0 .05em 0 .1em;

--- a/client/components/tinymce/plugins/wpemoji/plugin.js
+++ b/client/components/tinymce/plugins/wpemoji/plugin.js
@@ -3,6 +3,7 @@
  */
 import tinymce from 'tinymce/tinymce';
 import twemoji from 'twemoji';
+import config from 'config';
 
 /**
  * TinyMCE plugin tweaking Markdown behaviour.
@@ -32,13 +33,26 @@ function wpemoji( editor ) {
 	}
 
 	function replaceEmoji( node ) {
-		const imgAttr = {
-			'data-mce-resize': 'false',
-			'data-mce-placeholder': '1',
-			'data-wp-emoji': '1'
-		};
+		twemoji.parse( node, {
+			base: config( 'twemoji_cdn_url' ),
+			size: '72x72',
+			attributes: () => {
+				return {
+					'data-mce-resize': 'false',
+					'data-mce-placeholder': '1',
+					'data-wp-emoji': '1'
+				};
+			},
+			callback: ( icon, options ) => {
+				const ignored = [ 'a9', 'ae', '2122', '2194', '2660', '2663', '2665', '2666' ];
 
-		twemoji.parse( node, { imgAttr: imgAttr } );
+				if ( -1 !== ignored.indexOf( icon ) ) {
+					return false;
+				}
+
+				return ''.concat( options.base, options.size, '/', icon, options.ext );
+			},
+		} );
 	}
 
 	// Test if the node text contains emoji char(s) and replace.


### PR DESCRIPTION
- In the Editor: Image attributes were not begin correctly set, so the editor was saving emoji as images, instead of characters.
- In Emojify and the Editor: Overly aggressive character replacements were replacing basic characters that can be handled by all browsers.
- Reader: The full post view was using a custom emoji parser, instead of Emojify, so couldn't use the fixes from Emojify.

See #14887.