### PR TITLE
Jetpack Connect: Fix redirect to checkout with preselected plans

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -249,7 +249,7 @@ class Plans extends Component {
 		addItem( cartItem );
 		this.redirecting = true;
 		this.props.completeFlow();
-		page( checkoutPath );
+		page.redirect( checkoutPath );
 	}
 
 	storeSelectedPlan( cartItem ) {


### PR DESCRIPTION
This PR fixes a bug with preselected plans, where users are not redirected to the checkout page with their selected plan, but rather are presented with a blank screen on /plans 😱 

Turns out all of our logic was correct, but the issue was caused by a `page()` instead of `page.redirect()` :man_facepalming: 

This was originally reported by @sirreal.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/connect/store
* Select a paid plan.
* Connect a brand new JP site and go through the connection flow.
* Verify you're redirected to the checkout page with your preselected plan after the authorization process has completed.