### PR TITLE
Media library: add a data source parameter

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -26,6 +26,7 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		siteId: React.PropTypes.number.isRequired,
+		source: React.PropTypes.string,
 		filter: React.PropTypes.string,
 		search: React.PropTypes.string
 	},

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -32,6 +32,7 @@ const MediaLibraryContent = React.createClass( {
 		filter: React.PropTypes.string,
 		filterRequiresUpgrade: React.PropTypes.bool,
 		search: React.PropTypes.string,
+		source: React.PropTypes.string,
 		containerWidth: React.PropTypes.number,
 		single: React.PropTypes.bool,
 		scrollable: React.PropTypes.bool,
@@ -166,7 +167,11 @@ const MediaLibraryContent = React.createClass( {
 		}
 
 		return (
-			<MediaListData siteId={ this.props.site.ID } filter={ this.props.filter } search={ this.props.search }>
+			<MediaListData
+				siteId={ this.props.site.ID }
+				filter={ this.props.filter }
+				search={ this.props.search }
+				source={ this.props.source }>
 				<MediaLibrarySelectedData siteId={ this.props.site.ID }>
 					<MediaLibraryList
 						key={ 'list-' + ( [ this.props.site.ID, this.props.search, this.props.filter ].join() ) }
@@ -191,6 +196,7 @@ const MediaLibraryContent = React.createClass( {
 					<MediaLibraryHeader
 						site={ this.props.site }
 						filter={ this.props.filter }
+						source={ this.props.source }
 						onMediaScaleChange={ this.props.onMediaScaleChange }
 						onAddMedia={ this.props.onAddMedia }
 						onAddAndEditImage={ this.props.onAddAndEditImage }

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -25,6 +25,7 @@ export default React.createClass( {
 	propTypes: {
 		site: PropTypes.object,
 		filter: PropTypes.string,
+		source: PropTypes.string,
 		sliderPositionCount: PropTypes.number,
 		onMediaScaleChange: React.PropTypes.func,
 		onAddMedia: PropTypes.func,

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -30,6 +30,8 @@ module.exports = React.createClass( {
 		filter: React.PropTypes.string,
 		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
 		search: React.PropTypes.string,
+		source: React.PropTypes.string,
+		onSourceChange: React.PropTypes.func,
 		onAddMedia: React.PropTypes.func,
 		onFilterChange: React.PropTypes.func,
 		onSearch: React.PropTypes.func,
@@ -124,6 +126,7 @@ module.exports = React.createClass( {
 				filter={ this.props.filter }
 				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 				search={ this.props.search }
+				source={ this.props.source }
 				containerWidth={ this.props.containerWidth }
 				single={ this.props.single }
 				scrollable={ this.props.scrollable }
@@ -161,6 +164,7 @@ module.exports = React.createClass( {
 					enabledFilters={ this.props.enabledFilters }
 					search={ this.props.search }
 					onFilterChange={ this.props.onFilterChange }
+					source={ this.props.source }
 					onSearch={ this.doSearch } />
 				{ content }
 			</div>

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -125,6 +125,7 @@ export class EditorMediaModal extends Component {
 		return {
 			filter: '',
 			detailSelectedIndex: 0,
+			source: '',
 			gallerySettings: props.initialGallerySettings
 		};
 	}
@@ -301,6 +302,10 @@ export class EditorMediaModal extends Component {
 		}
 	};
 
+	onSourceChange = source => {
+		this.setState( { source } );
+	};
+
 	onClose = () => {
 		this.props.onClose();
 	};
@@ -434,11 +439,13 @@ export class EditorMediaModal extends Component {
 						filter={ this.state.filter || this.props.defaultFilter || this.getFirstEnabledFilter() }
 						enabledFilters={ this.props.enabledFilters }
 						search={ this.state.search }
+						source={ this.state.source }
 						onAddMedia={ this.onAddMedia }
 						onAddAndEditImage={ this.onAddAndEditImage }
 						onFilterChange={ this.onFilterChange }
 						onScaleChange={ this.onScaleChange }
 						onSearch={ this.onSearch }
+						onSourceChange={ this.onSourceChange }
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }
 						single={ this.props.single }


### PR DESCRIPTION
Adds a 'source' value to the media library which will be used to determine the data source for the media library - WordPress or something else (Google Photos, for example).

In an effort to keep this PR small it just threads the parameter through all the appropriate places but doesn't actually do anything with it - UI will be added in a future PR to use the source. It also adds a callback `onSourceChange` which can be called to change the source.

## Testing

There should be no noticeable impact from this PR  and the media library should continue to function normally.