### PR TITLE
WebPreview: Remove "Beep beep boop..." message from post preview modal

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -161,7 +161,6 @@ class StatsPostDetail extends Component {
 					previewUrl={ `${ previewUrl }?demo=true&iframe=true&theme_preview=true` }
 					externalUrl={ previewUrl }
 					onClose={ this.closePreview }
-					loadingMessage="Beep beep boop…"
 				>
 					<Button href={ `/post/${ siteSlug }/${ postId }` }>
 						{ translate( 'Edit' ) }

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -98,7 +98,6 @@ const EditorPreview = React.createClass( {
 				onClose={ this.props.onClose }
 				previewUrl={ this.state.iframeUrl }
 				externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }
-				loadingMessage="Beep beep boop…"
 			/>
 		);
 	}


### PR DESCRIPTION
This PR removes the "Beep beep boop..." message from the `WebPreview` modal which appears when previewing a post from the post editor and from the stats page.

To test:

1. Checkout branch or use Calypso.live branch
2. Open a post for editing
3. Click Preview Post
4. Verify that you see only the spinner, without "Beep beep boop..."
5. Go to Stats
6. Choose a post to see the stats for
7. Click Preview post on the top right
8. Verify that you see only the spinner, without "Beep beep boop..."
9. Verify no JS errors and nothing unexpected pops up