### PR TITLE
Reader: fix Intro Card render stat

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -31,7 +31,13 @@ class FollowingIntro extends React.Component {
 
 	recordRenderTrack = ( props = this.props ) => {
 		if ( props.isNewReader === true ) {
+			// This is incorrect, but keeping the name for consistency.
+			// This event is more like `calypso_reader_following_rendered_for_new_reader`.
 			recordTrack( 'calypso_reader_following_intro_render' );
+		}
+		if ( props.isNewReader === true && ! isEven( userId ) ) {
+			// Added _actual for when a new Reader and odd userid sees the intro card
+			recordTrack( 'calypso_reader_following_intro_render_actual' );
 		}
 	};
 

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -35,7 +35,7 @@ class FollowingIntro extends React.Component {
 			// This event is more like `calypso_reader_following_rendered_for_new_reader`.
 			recordTrack( 'calypso_reader_following_intro_render' );
 		}
-		if ( props.isNewReader === true && ! isEven( userId ) ) {
+		if ( props.isNewReader === true && ! isEven( props.userId ) ) {
 			// Added _actual for when a new Reader and odd userid sees the intro card
 			recordTrack( 'calypso_reader_following_intro_render_actual' );
 		}


### PR DESCRIPTION
Currently triggers `calypso_reader_following_intro_render` for every new Reader. We need another stat to trigger for new Readers and those shown the Intro Card (odd userids).