### PR TITLE
Login: Remove context.renderCacheKey from login & magicLogin

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -11,16 +11,12 @@ import MagicLogin from './magic-login';
 
 export default {
 	login( context, next ) {
-		context.renderCacheKey = 'login';
 		context.primary = <WPLogin twoFactorAuthType={ context.params.twoFactorAuthType } />;
-
 		next();
 	},
 
 	magicLogin( context, next ) {
-		context.renderCacheKey = 'magiclogin';
 		context.primary = <MagicLogin />;
-
 		next();
 	}
 };


### PR DESCRIPTION
As @mcsf [pointed out](https://github.com/Automattic/wp-calypso/pull/14592#discussion_r120844473), It's no longer used as of #13339.

This stops setting it on the `context` in the `login/controller` needlessly.

## To Test
TBD
