### PR TITLE
Revisions #4: Add revisions list and revisions diff viewer

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -454,6 +454,7 @@
 @import 'post-editor/editor-categories-tags/style';
 @import 'post-editor/editor-confirmation-sidebar/style';
 @import 'post-editor/editor-delete-post/style';
+@import 'post-editor/editor-diff-viewer/style';
 @import 'post-editor/editor-discussion/style';
 @import 'post-editor/editor-drawer/style';
 @import 'post-editor/editor-drawer-well/style';
@@ -476,6 +477,7 @@
 @import 'post-editor/editor-preview/style';
 @import 'post-editor/editor-publish-date/style';
 @import 'post-editor/editor-revisions/style';
+@import 'post-editor/editor-revisions-list/style';
 @import 'post-editor/editor-seo-accordion/style';
 @import 'post-editor/editor-sharing/style';
 @import 'post-editor/editor-sidebar/style';

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -48,6 +48,7 @@ export class EditPostStatus extends Component {
 		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 		setNestedSidebar: PropTypes.func,
+		selectRevision: PropTypes.func,
 	};
 
 	constructor( props ) {
@@ -182,6 +183,7 @@ export class EditPostStatus extends Component {
 					revisions={ this.props.post && this.props.post.revisions }
 					adminUrl={ adminUrl }
 					setNestedSidebar={ this.props.setNestedSidebar }
+					selectRevision={ this.props.selectRevision }
 				/>
 			</div>
 		);

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -10,8 +10,7 @@ import { get, map } from 'lodash';
 /**
  * Internal dependencies
  */
-import getPostRevision from 'state/selectors/get-post-revision';
-import getPostRevisionChanges from 'state/selectors/get-post-revision-changes';
+import { getPostRevision, getPostRevisionChanges } from 'state/selectors';
 
 const EditorDiffViewer = ( { contentChanges, revision } ) => (
 	<div className="editor-diff-viewer">
@@ -43,8 +42,8 @@ EditorDiffViewer.propTypes = {
 };
 
 export default connect(
-	( state, ownProps ) => ( {
-		contentChanges: getPostRevisionChanges( state, ownProps.siteId, ownProps.postId, ownProps.selectedRevisionId ),
-		revision: getPostRevision( state, ownProps.siteId, ownProps.postId, ownProps.selectedRevisionId, 'editing' ),
+	( state, { siteId, postId, selectedRevisionId } ) => ( {
+		contentChanges: getPostRevisionChanges( state, siteId, postId, selectedRevisionId ),
+		revision: getPostRevision( state, siteId, postId, selectedRevisionId, 'editing' ),
 	} )
 )( EditorDiffViewer );

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { get, map } from 'lodash';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import getPostRevision from 'state/selectors/get-post-revision';
+import getPostRevisionChanges from 'state/selectors/get-post-revision-changes';
+import { normalizeForEditing } from 'state/selectors/utils/revisions';
+
+const EditorDiffViewer = ( { contentChanges, revision } ) => (
+	<div className="editor-diff-viewer">
+		<h1 className="editor-diff-viewer__title">
+			{ get( revision, 'title' ) }
+		</h1>
+		<div className="editor-diff-viewer__content">
+			{ map( contentChanges, ( change, changeIndex ) => {
+				const changeClassNames = classNames( {
+					'editor-diff-viewer__additions': change.added,
+					'editor-diff-viewer__deletions': change.removed,
+				} );
+				return (
+					<span className={ changeClassNames } key={ changeIndex }>
+						{ change.value }
+					</span>
+				);
+			} ) }
+		</div>
+	</div>
+);
+
+EditorDiffViewer.propTypes = {
+	contentChanges: PropTypes.array,
+	postId: PropTypes.number,
+	revision: PropTypes.object,
+	selectedRevisionId: PropTypes.number,
+	siteId: PropTypes.number,
+};
+
+export default connect(
+	( state, ownProps ) => ( {
+		contentChanges: getPostRevisionChanges( state, ownProps.siteId, ownProps.postId, ownProps.selectedRevisionId ),
+		revision: normalizeForEditing(
+			getPostRevision( state, ownProps.siteId, ownProps.postId, ownProps.selectedRevisionId )
+		),
+	} )
+)( EditorDiffViewer );

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -35,7 +35,7 @@ const EditorDiffViewer = ( { contentChanges, revision } ) => (
 );
 
 EditorDiffViewer.propTypes = {
-	contentChanges: PropTypes.array,
+	contentChanges: PropTypes.array.isRequired,
 	postId: PropTypes.number,
 	revision: PropTypes.object,
 	selectedRevisionId: PropTypes.number,

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get, map } from 'lodash';
-import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { get, map } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
  */
 import getPostRevision from 'state/selectors/get-post-revision';
 import getPostRevisionChanges from 'state/selectors/get-post-revision-changes';
-import { normalizeForEditing } from 'state/selectors/utils/revisions';
 
 const EditorDiffViewer = ( { contentChanges, revision } ) => (
 	<div className="editor-diff-viewer">
@@ -45,8 +44,6 @@ EditorDiffViewer.propTypes = {
 export default connect(
 	( state, ownProps ) => ( {
 		contentChanges: getPostRevisionChanges( state, ownProps.siteId, ownProps.postId, ownProps.selectedRevisionId ),
-		revision: normalizeForEditing(
-			getPostRevision( state, ownProps.siteId, ownProps.postId, ownProps.selectedRevisionId )
-		),
+		revision: getPostRevision( state, ownProps.siteId, ownProps.postId, ownProps.selectedRevisionId, 'editing' ),
 	} )
 )( EditorDiffViewer );

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -1,0 +1,31 @@
+.editor-diff-viewer__title {
+	padding-left: 10px; /* Intentionally non-standard to align editor body margin (10px) */
+	padding-right: 10px;
+	font-family: $serif;
+	font-size: 28px;
+	color: $gray-dark;
+	font-weight: 600;
+
+	@include breakpoint( '>480px' ) {
+		font-size: 32px;
+	}
+}
+
+.editor-diff-viewer {
+	margin: 0 auto;
+	max-width: 700px;
+	width: 100%;
+}
+
+.editor-diff-viewer__content {
+	padding: 11px;
+}
+
+.editor-diff-viewer__additions {
+	background: #e9f9fe;
+}
+
+.editor-diff-viewer__deletions {
+	color: #c83240;
+	text-decoration: line-through;
+}

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -85,6 +85,7 @@ const EditorDrawer = React.createClass( {
 		isPostPrivate: PropTypes.bool,
 		confirmationSidebarStatus: PropTypes.string,
 		setNestedSidebar: PropTypes.func,
+		selectRevision: PropTypes.func,
 	},
 
 	onExcerptChange: function( event ) {
@@ -335,6 +336,7 @@ const EditorDrawer = React.createClass( {
 					isPostPrivate={ this.props.isPostPrivate }
 					confirmationSidebarStatus={ this.props.confirmationSidebarStatus }
 					setNestedSidebar={ this.props.setNestedSidebar }
+					selectRevision={ this.props.selectRevision }
 				/>
 			</Accordion>
 		);

--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -25,7 +25,7 @@ const EditorRevisionsListHeader = ( { loadRevision, selectedRevisionId, translat
 EditorRevisionsListHeader.propTypes = {
 	loadRevision: PropTypes.func,
 	selectedRevisionId: PropTypes.number,
-	translate: PropTypes.func,
+	translate: PropTypes.func.isRequired,
 };
 
 export default localize( EditorRevisionsListHeader );

--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const EditorRevisionsListHeader = ( { loadRevision, selectedRevisionId, translate } ) => (
+	<div className="editor-revisions-list__header">
+		<Button
+			className="editor-revisions-list__load-revision"
+			compact={ true }
+			disabled={ selectedRevisionId === null }
+			onClick={ loadRevision }
+		>
+			{ translate( 'Load revision in the editor' ) }
+		</Button>
+	</div>
+);
+
+EditorRevisionsListHeader.propTypes = {
+	loadRevision: PropTypes.func,
+	selectedRevisionId: PropTypes.number,
+	translate: PropTypes.func,
+};
+
+export default localize( EditorRevisionsListHeader );

--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
+import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -13,8 +13,8 @@ import Button from 'components/button';
 const EditorRevisionsListHeader = ( { loadRevision, selectedRevisionId, translate } ) => (
 	<div className="editor-revisions-list__header">
 		<Button
+			compact
 			className="editor-revisions-list__load-revision"
-			compact={ true }
 			disabled={ selectedRevisionId === null }
 			onClick={ loadRevision }
 		>

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -80,12 +80,12 @@ class EditorRevisionsList extends PureComponent {
 }
 
 EditorRevisionsList.propTypes = {
-	loadRevision: PropTypes.func,
+	loadRevision: PropTypes.func.isRequired,
 	postId: PropTypes.number,
-	revisions: PropTypes.array,
+	revisions: PropTypes.array.isRequired,
 	selectedRevision: PropTypes.object,
 	selectedRevisionId: PropTypes.number,
-	selectRevision: PropTypes.func,
+	selectRevision: PropTypes.func.isRequired,
 	siteId: PropTypes.number,
 };
 

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map, orderBy } from 'lodash';
+import { map } from 'lodash';
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
@@ -91,11 +91,7 @@ export default connect(
 		const postId = getEditorPostId( state );
 		return {
 			postId,
-			revisions: orderBy(
-				getPostRevisions( state, siteId, postId, 'display' ),
-				'date',
-				'desc'
-			),
+			revisions: getPostRevisions( state, siteId, postId, 'display' ),
 			selectedRevision: getPostRevision(
 				state, siteId, postId, ownProps.selectedRevisionId, 'editing'
 			),

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -13,11 +13,10 @@ import { map } from 'lodash';
 import EditorRevisionsListHeader from './header';
 import EditorRevisionsListItem from './item';
 import QueryPostRevisions from 'components/data/query-post-revisions';
-import getPostRevision from 'state/selectors/get-post-revision';
-import getPostRevisions from 'state/selectors/get-post-revisions';
+import { getPostRevision, getPostRevisions } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import viewport from 'lib/viewport';
+import { isWithinBreakpoint } from 'lib/viewport';
 
 class EditorRevisionsList extends PureComponent {
 	loadRevision = () => {
@@ -28,7 +27,7 @@ class EditorRevisionsList extends PureComponent {
 		if (
 			this.props.selectedRevisionId === null &&
 			this.props.revisions.length > 0 &&
-			viewport.isWithinBreakpoint( '>660px' )
+			isWithinBreakpoint( '>660px' )
 		) {
 			this.props.selectRevision( this.props.revisions[ 0 ].id );
 		}
@@ -87,14 +86,14 @@ EditorRevisionsList.propTypes = {
 };
 
 export default connect(
-	( state, ownProps ) => {
+	( state, { selectedRevisionId } ) => {
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
 		return {
 			postId,
 			revisions: getPostRevisions( state, siteId, postId, 'display' ),
 			selectedRevision: getPostRevision(
-				state, siteId, postId, ownProps.selectedRevisionId, 'editing'
+				state, siteId, postId, selectedRevisionId, 'editing'
 			),
 			siteId,
 		};

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { map, orderBy } from 'lodash';
+import React, { PureComponent, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import EditorRevisionsListHeader from './header';
+import EditorRevisionsListItem from './item';
+import QueryPostRevisions from 'components/data/query-post-revisions';
+import getPostRevision from 'state/selectors/get-post-revision';
+import getPostRevisions from 'state/selectors/get-post-revisions';
+import {
+	normalizeForDisplay,
+	normalizeForEditing
+} from 'state/selectors/utils/revisions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import viewport from 'lib/viewport';
+
+class EditorRevisionsList extends PureComponent {
+	loadRevision = () => {
+		this.props.loadRevision( this.props.selectedRevision );
+	}
+
+	trySelectingRevision() {
+		if (
+			this.props.selectedRevisionId === null &&
+			this.props.revisions.length > 0 &&
+			viewport.isWithinBreakpoint( '>660px' )
+		) {
+			this.props.selectRevision( this.props.revisions[ 0 ].id );
+		}
+	}
+
+	componentWillMount() {
+		this.trySelectingRevision();
+	}
+
+	componentDidMount() {
+		// Make sure that scroll position in the editor is not preserved.
+		window.scrollTo( 0, 0 );
+	}
+
+	componentDidUpdate() {
+		this.trySelectingRevision();
+	}
+
+	render() {
+		return (
+			<div>
+				<QueryPostRevisions postId={ this.props.postId } siteId={ this.props.siteId } />
+				<EditorRevisionsListHeader
+					loadRevision={ this.loadRevision }
+					selectedRevisionId={ this.props.selectedRevisionId }
+				/>
+				<ul className="editor-revisions-list__list">
+					{ map( this.props.revisions, revision => {
+						const itemClasses = classNames(
+							'editor-revisions-list__revision',
+							{ 'is-selected': revision.id === this.props.selectedRevisionId }
+						);
+						return (
+							<li className={ itemClasses } key={ revision.id }>
+								<EditorRevisionsListItem
+									revision={ revision }
+									selectRevision={ this.props.selectRevision }
+								/>
+							</li>
+						);
+					} ) }
+				</ul>
+			</div>
+		);
+	}
+}
+
+EditorRevisionsList.propTypes = {
+	loadRevision: PropTypes.func,
+	postId: PropTypes.number,
+	revisions: PropTypes.array,
+	selectedRevision: PropTypes.object,
+	selectedRevisionId: PropTypes.number,
+	selectRevision: PropTypes.func,
+	siteId: PropTypes.number,
+};
+
+export default connect(
+	( state, ownProps ) => {
+		const siteId = getSelectedSiteId( state );
+		const postId = getEditorPostId( state );
+		return {
+			postId,
+			revisions: orderBy(
+				map(
+					getPostRevisions( state, siteId, postId ),
+					normalizeForDisplay
+				),
+				'date',
+				'desc'
+			),
+			selectedRevision: normalizeForEditing(
+				getPostRevision(
+					state, siteId, postId, ownProps.selectedRevisionId
+				)
+			),
+			siteId,
+		};
+	},
+)( EditorRevisionsList );

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
-import React, { PureComponent, PropTypes } from 'react';
-import { connect } from 'react-redux';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -14,10 +14,6 @@ import EditorRevisionsListItem from './item';
 import QueryPostRevisions from 'components/data/query-post-revisions';
 import getPostRevision from 'state/selectors/get-post-revision';
 import getPostRevisions from 'state/selectors/get-post-revisions';
-import {
-	normalizeForDisplay,
-	normalizeForEditing
-} from 'state/selectors/utils/revisions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import viewport from 'lib/viewport';
@@ -96,17 +92,12 @@ export default connect(
 		return {
 			postId,
 			revisions: orderBy(
-				map(
-					getPostRevisions( state, siteId, postId ),
-					normalizeForDisplay
-				),
+				getPostRevisions( state, siteId, postId, 'display' ),
 				'date',
 				'desc'
 			),
-			selectedRevision: normalizeForEditing(
-				getPostRevision(
-					state, siteId, postId, ownProps.selectedRevisionId
-				)
+			selectedRevision: getPostRevision(
+				state, siteId, postId, ownProps.selectedRevisionId, 'editing'
 			),
 			siteId,
 		};

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import { isObject } from 'lodash';
+import React, { PureComponent, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PostTime from 'reader/post-time';
+
+class EditorRevisionsListItem extends PureComponent {
+	selectRevision = event => {
+		const revisionId = parseInt( event.currentTarget.dataset.revisionId, 10 );
+		this.props.selectRevision( revisionId );
+	}
+
+	render() {
+		return (
+			<button
+				className="editor-revisions-list__button"
+				data-revision-id={ this.props.revision.id }
+				onClick={ this.selectRevision }
+				type="button"
+			>
+				<span className="editor-revisions-list__date">
+					<PostTime date={ this.props.revision.date } />
+				</span>
+				&nbsp;
+				<span className="editor-revisions-list__author">
+					{ isObject( this.props.revision.author ) && (
+						this.props.translate( 'by %(author)s', {
+							args: { author: this.props.revision.author.display_name },
+						} )
+					) }
+				</span>
+
+				<div className="editor-revisions-list__changes">
+					{ this.props.revision.changes.added > 0 && (
+						<span className="editor-revisions-list__additions">
+							{ this.props.translate(
+								'%(changes)d word added',
+								'%(changes)d words added',
+								{
+									args: { changes: this.props.revision.changes.added },
+									count: this.props.revision.changes.added,
+								}
+							) }
+						</span>
+					) }
+
+					{ this.props.revision.changes.added > 0 && this.props.revision.changes.removed > 0 && ', ' }
+
+					{ this.props.revision.changes.removed > 0 && (
+						<span className="editor-revisions-list__deletions">
+							{ this.props.translate(
+								'%(changes)d word removed',
+								'%(changes)d words removed',
+								{
+									args: { changes: this.props.revision.changes.removed },
+									count: this.props.revision.changes.removed,
+								}
+							) }
+						</span>
+					) }
+
+					{ this.props.revision.changes.added === 0 && this.props.revision.changes.removed === 0 && (
+						<span className="editor-revisions-list__minor-changes">
+							{ this.props.translate( 'minor changes' ) }
+						</span>
+					) }
+				</div>
+			</button>
+		);
+	}
+}
+
+EditorRevisionsListItem.propTypes = {
+	revision: PropTypes.object,
+	selectRevision: PropTypes.func,
+	translate: PropTypes.func,
+};
+
+export default localize( EditorRevisionsListItem );

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { isObject } from 'lodash';
-import React, { PureComponent, PropTypes } from 'react';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -11,16 +11,14 @@ import React, { PureComponent, PropTypes } from 'react';
 import PostTime from 'reader/post-time';
 
 class EditorRevisionsListItem extends PureComponent {
-	selectRevision = event => {
-		const revisionId = parseInt( event.currentTarget.dataset.revisionId, 10 );
-		this.props.selectRevision( revisionId );
+	selectRevision = () => {
+		this.props.selectRevision( this.props.revision.id );
 	}
 
 	render() {
 		return (
 			<button
 				className="editor-revisions-list__button"
-				data-revision-id={ this.props.revision.id }
 				onClick={ this.selectRevision }
 				type="button"
 			>

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -75,9 +75,9 @@ class EditorRevisionsListItem extends PureComponent {
 }
 
 EditorRevisionsListItem.propTypes = {
-	revision: PropTypes.object,
-	selectRevision: PropTypes.func,
-	translate: PropTypes.func,
+	revision: PropTypes.object.isRequired,
+	selectRevision: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
 };
 
 export default localize( EditorRevisionsListItem );

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -1,0 +1,68 @@
+.editor-revisions-list__button {
+	// NOTE: this is imitating the style of an accordion (with subtitle), with
+	// support for being "selected" and no right arrow
+	background-color: $accordion-background-collapsed;
+	border-top: 1px solid darken( $sidebar-bg-color, 5% );
+	color: $gray-dark;
+	cursor: pointer;
+	display: block;
+	font-size: 13px;
+	margin: 0;
+	padding: ( $accordion-padding - $accordion-subtitle-height / 2 ) $accordion-padding;
+	text-align: left;
+	width: 100%;
+
+	&:hover {
+		background: $accordion-background-hover;
+		color: $blue-medium;
+	}
+
+	.editor-revisions-list__revision.is-selected > &,
+	.editor-revisions-list__revision.is-selected > &:hover {
+		background: $blue-medium;
+
+		// NOTE: force with a heavy specificity white text, see discussion on
+		// https://github.com/Automattic/wp-calypso/pull/13367#discussion_r114108253
+		* {
+			color: $white;
+		}
+	}
+}
+
+.editor-revisions-list__date {
+	font-weight: bold;
+}
+
+.editor-revisions-list__changes {
+	padding-top: 5px;
+	font-size: 11px;
+}
+
+.editor-revisions-list__additions {
+	color: $blue-medium;
+}
+
+.editor-revisions-list__deletions {
+	color: $alert-red;
+}
+
+.editor-revisions-list__minor-changes {
+	color: $gray-text-min;
+}
+
+.editor-revisions-list__list,
+.editor-revisions-list__header {
+	background: $white;
+	border-top: 1px solid darken( $sidebar-bg-color, 5% );
+	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
+	font-size: 13px;
+}
+
+.editor-revisions-list__header {
+	margin-bottom: 10px;
+	padding: 1rem;
+}
+
+.editor-revisions-list__load-revision {
+	width: 100%;
+}

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -14,6 +14,7 @@ import { NESTED_SIDEBAR_REVISIONS } from 'post-editor/editor-sidebar/constants';
 
 class EditorRevisions extends Component {
 	showRevisionsNestedSidebar = () => {
+		this.props.selectRevision( null );
 		this.props.setNestedSidebar( NESTED_SIDEBAR_REVISIONS );
 	}
 
@@ -70,7 +71,8 @@ EditorRevisions.propTypes = {
 	adminUrl: PropTypes.string,
 	revisions: PropTypes.array,
 	translate: PropTypes.func,
-	setNestedSidebar: PropTypes.func,
+	setNestedSidebar: PropTypes.func.isRequired,
+	selectRevision: PropTypes.func.isRequired,
 };
 
 export default localize( EditorRevisions );

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -51,7 +51,7 @@ const EditorSidebarHeader = ( { nestedSidebar = NESTED_SIDEBAR_NONE, toggleSideb
 );
 
 EditorSidebarHeader.propTypes = {
-	translate: PropTypes.func,
+	translate: PropTypes.func.isRequired,
 	toggleSidebar: PropTypes.func,
 	nestedSidebar: NestedSidebarPropType
 };

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -14,7 +14,8 @@ import SidebarFooter from 'layout/sidebar/footer';
 import SidebarRegion from 'layout/sidebar/region';
 import EditorActionBar from 'post-editor/editor-action-bar';
 import EditorDeletePost from 'post-editor/editor-delete-post';
-import { NESTED_SIDEBAR_NONE, NestedSidebarPropType } from './constants';
+import EditorRevisionsList from 'post-editor/editor-revisions-list';
+import { NESTED_SIDEBAR_NONE, NESTED_SIDEBAR_REVISIONS, NestedSidebarPropType } from './constants';
 
 export default class EditorSidebar extends Component {
 	static propTypes = {
@@ -32,6 +33,9 @@ export default class EditorSidebar extends Component {
 		confirmationSidebarStatus: PropTypes.string,
 		nestedSidebar: NestedSidebarPropType,
 		setNestedSidebar: PropTypes.func,
+		loadRevision: PropTypes.func,
+		selectedRevisionId: PropTypes.number,
+		selectRevision: PropTypes.func,
 	}
 
 	headerToggleSidebar = () => {
@@ -57,6 +61,9 @@ export default class EditorSidebar extends Component {
 			confirmationSidebarStatus,
 			nestedSidebar,
 			setNestedSidebar,
+			loadRevision,
+			selectedRevisionId,
+			selectRevision,
 		} = this.props;
 
 		const sidebarClassNames = classNames(
@@ -89,7 +96,17 @@ export default class EditorSidebar extends Component {
 						setNestedSidebar={ setNestedSidebar }
 					/>
 				</SidebarRegion>
-				<SidebarRegion className="editor-sidebar__nested-region" />
+				<SidebarRegion className="editor-sidebar__nested-region">
+					{
+						nestedSidebar === NESTED_SIDEBAR_REVISIONS
+							? <EditorRevisionsList
+								loadRevision={ loadRevision }
+								selectedRevisionId={ selectedRevisionId }
+								selectRevision={ selectRevision }
+							/>
+							: null
+					}
+				</SidebarRegion>
 				<SidebarFooter>
 					{ nestedSidebar === NESTED_SIDEBAR_NONE && (
 						<EditorDeletePost post={ post } onTrashingPost={ onTrashingPost } />

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -97,14 +97,12 @@ export default class EditorSidebar extends Component {
 					/>
 				</SidebarRegion>
 				<SidebarRegion className="editor-sidebar__nested-region">
-					{
-						nestedSidebar === NESTED_SIDEBAR_REVISIONS
-							? <EditorRevisionsList
-								loadRevision={ loadRevision }
-								selectedRevisionId={ selectedRevisionId }
-								selectRevision={ selectRevision }
-							/>
-							: null
+					{ nestedSidebar === NESTED_SIDEBAR_REVISIONS &&
+						<EditorRevisionsList
+							loadRevision={ loadRevision }
+							selectedRevisionId={ selectedRevisionId }
+							selectRevision={ selectRevision }
+						/>
 					}
 				</SidebarRegion>
 				<SidebarFooter>

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -94,6 +94,7 @@ export default class EditorSidebar extends Component {
 						isPostPrivate={ isPostPrivate }
 						confirmationSidebarStatus={ confirmationSidebarStatus }
 						setNestedSidebar={ setNestedSidebar }
+						selectRevision={ selectRevision }
 					/>
 				</SidebarRegion>
 				<SidebarRegion className="editor-sidebar__nested-region">

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -59,7 +59,7 @@ import Site from 'blocks/site';
 import StatusLabel from 'post-editor/editor-status-label';
 import { editedPostHasContent } from 'state/selectors';
 import EditorGroundControl from 'post-editor/editor-ground-control';
-import { isWithinBreakpoint, isMobile } from 'lib/viewport';
+import { isWithinBreakpoint } from 'lib/viewport';
 import { isSitePreviewable } from 'state/sites/selectors';
 import EditorDiffViewer from 'post-editor/editor-diff-viewer';
 import { NESTED_SIDEBAR_NONE, NESTED_SIDEBAR_REVISIONS } from 'post-editor/editor-sidebar/constants';
@@ -285,7 +285,7 @@ export const PostEditor = React.createClass( {
 	},
 
 	loadRevision: function( revision ) {
-		this.toggleNestedSidebar( NESTED_SIDEBAR_NONE );
+		this.setNestedSidebar( NESTED_SIDEBAR_NONE );
 		this.setState( { selectedRevisionId: null } );
 		this.restoreRevision( {
 			content: revision.content,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -264,13 +264,6 @@ export const PostEditor = React.createClass( {
 	},
 
 	setNestedSidebar: function( nestedSidebar ) {
-		if (
-			this.state.nestedSidebar === NESTED_SIDEBAR_REVISIONS &&
-			this.state.nestedSidebar !== nestedSidebar
-		) {
-			this.selectRevision( null );
-		}
-
 		this.setState( { nestedSidebar } );
 	},
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -511,7 +511,7 @@ export const PostEditor = React.createClass( {
 
 	restoreAutosave: function() {
 		this.setState( { showAutosaveDialog: false } );
-		this.restoreRevision( this.state.post.meta.data.autosave );
+		this.restoreRevision( get( this.state, 'post.meta.data.autosave' ) );
 	},
 
 	restoreRevision: function( revision ) {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -247,3 +247,11 @@
 		max-height: 400px;
 	}
 }
+
+.post-editor__inner-content {
+	display: none;
+
+	&.is-shown {
+		display: block;
+	}
+}

--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { findIndex, get, isUndefined, map, omitBy, orderBy } from 'lodash';
+import { findIndex, get, isUndefined, map, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,10 +12,7 @@ import getPostRevisions from 'state/selectors/get-post-revisions';
 
 const getPostRevisionChanges = createSelector(
 	( state, siteId, postId, revisionId ) => {
-		const orderedRevisions = orderBy(
-			getPostRevisions( state, siteId, postId ),
-			'date', 'desc',
-		);
+		const orderedRevisions = getPostRevisions( state, siteId, postId );
 		const revisionIndex = findIndex( orderedRevisions, { id: revisionId } );
 		if ( revisionIndex === -1 ) {
 			return [];

--- a/client/state/selectors/get-post-revision.js
+++ b/client/state/selectors/get-post-revision.js
@@ -7,12 +7,15 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { hydrateRevision } from 'state/selectors/utils/revisions';
+import { hydrateRevision, normalizeRevision } from 'state/selectors/utils/revisions';
 
 const getPostRevision = createSelector(
-	( state, siteId, postId, revisionId ) => hydrateRevision(
-		state,
-		get( state.posts.revisions.revisions, [ siteId, postId, revisionId ], null )
+	( state, siteId, postId, revisionId, normalizerName = null ) => normalizeRevision(
+		normalizerName,
+		hydrateRevision(
+			state,
+			get( state.posts.revisions.revisions, [ siteId, postId, revisionId ], null )
+		)
 	),
 	( state ) => [ state.posts.revisions.revisions, state.users.items ]
 );

--- a/client/state/selectors/get-post-revisions.js
+++ b/client/state/selectors/get-post-revisions.js
@@ -1,18 +1,18 @@
 /**
  * External dependencies
  */
-import { get, map, partial } from 'lodash';
+import { get, map } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { hydrateRevision } from 'state/selectors/utils/revisions';
+import { hydrateRevision, normalizeRevision } from 'state/selectors/utils/revisions';
 
 const getPostRevisions = createSelector(
-	( state, siteId, postId ) => map(
+	( state, siteId, postId, normalizerName = null ) => map(
 		get( state.posts.revisions.revisions, [ siteId, postId ], {} ),
-		partial( hydrateRevision, state )
+		revision => normalizeRevision( normalizerName, hydrateRevision( state, revision ) )
 	),
 	( state ) => [ state.posts.revisions.revisions, state.users.items ]
 );

--- a/client/state/selectors/get-post-revisions.js
+++ b/client/state/selectors/get-post-revisions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, map } from 'lodash';
+import { get, map, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,9 +10,13 @@ import createSelector from 'lib/create-selector';
 import { hydrateRevision, normalizeRevision } from 'state/selectors/utils/revisions';
 
 const getPostRevisions = createSelector(
-	( state, siteId, postId, normalizerName = null ) => map(
-		get( state.posts.revisions.revisions, [ siteId, postId ], {} ),
-		revision => normalizeRevision( normalizerName, hydrateRevision( state, revision ) )
+	( state, siteId, postId, normalizerName = null ) => orderBy(
+		map(
+			get( state.posts.revisions.revisions, [ siteId, postId ], {} ),
+			revision => normalizeRevision( normalizerName, hydrateRevision( state, revision ) )
+		),
+		'date',
+		'desc'
 	),
 	( state ) => [ state.posts.revisions.revisions, state.users.items ]
 );

--- a/client/state/selectors/test/get-post-revision.js
+++ b/client/state/selectors/test/get-post-revision.js
@@ -102,4 +102,29 @@ describe( 'getPostRevision', () => {
 			author: 1,
 		} );
 	} );
+
+	it( 'should normalize the revision', () => {
+		expect( getPostRevision( {
+			posts: {
+				revisions: {
+					revisions: {
+						12345678: {
+							10: {
+								11: {
+									id: 11,
+									title: '&acute;',
+								},
+							},
+						},
+					},
+				},
+			},
+			users: {
+				items: {},
+			},
+		}, 12345678, 10, 11, 'editing' ) ).to.eql( {
+			id: 11,
+			title: '´',
+		} );
+	} );
 } );

--- a/client/state/selectors/test/get-post-revisions.js
+++ b/client/state/selectors/test/get-post-revisions.js
@@ -129,4 +129,39 @@ describe( 'getPostRevisions', () => {
 			}
 		] );
 	} );
+
+	it( 'should normalize all revisions', () => {
+		expect( getPostRevisions( {
+			posts: {
+				revisions: {
+					revisions: {
+						12345678: {
+							10: {
+								11: {
+									id: 11,
+									title: '&acute;',
+								},
+								12: {
+									id: 12,
+									title: '&grave;',
+								}
+							},
+						},
+					},
+				},
+			},
+			users: {
+				items: {},
+			},
+		}, 12345678, 10, 'editing' ) ).to.eql( [
+			{
+				id: 11,
+				title: '´',
+			},
+			{
+				id: 12,
+				title: '`',
+			}
+		] );
+	} );
 } );

--- a/client/state/selectors/test/get-post-revisions.js
+++ b/client/state/selectors/test/get-post-revisions.js
@@ -164,4 +164,39 @@ describe( 'getPostRevisions', () => {
 			}
 		] );
 	} );
+
+	it( 'should order revisions by date (recent first)', () => {
+		expect( getPostRevisions( {
+			posts: {
+				revisions: {
+					revisions: {
+						12345678: {
+							10: {
+								12: {
+									id: 12,
+									date: '2017-07-07T12:44:00Z',
+								},
+								11: {
+									id: 11,
+									date: '2017-07-06T12:44:00Z',
+								},
+							},
+						},
+					},
+				},
+			},
+			users: {
+				items: {},
+			},
+		}, 12345678, 10 ) ).to.eql( [
+			{
+				id: 12,
+				date: '2017-07-07T12:44:00Z',
+			},
+			{
+				id: 11,
+				date: '2017-07-06T12:44:00Z',
+			}
+		] );
+	} );
 } );

--- a/client/state/selectors/utils/revisions/index.js
+++ b/client/state/selectors/utils/revisions/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep, get } from 'lodash';
+import { cloneDeep, get, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -9,14 +9,18 @@ import { cloneDeep, get } from 'lodash';
 import decodeEntities from 'lib/post-normalizer/rule-decode-entities';
 import { normalizePostForDisplay } from 'state/posts/utils';
 
-export const normalizeForDisplay = normalizePostForDisplay;
-export function normalizeForEditing( revision ) {
+function normalizeForEditing( revision ) {
 	if ( ! revision ) {
 		return null;
 	}
 
 	return decodeEntities( cloneDeep( revision ) );
 }
+
+const NORMALIZER_MAPPING = {
+	display: normalizePostForDisplay,
+	editing: normalizeForEditing,
+};
 
 export function hydrateRevision( state, revision ) {
 	if ( ! revision ) {
@@ -32,4 +36,8 @@ export function hydrateRevision( state, revision ) {
 		...revision,
 		author,
 	};
+}
+
+export function normalizeRevision( normalizerName, revision ) {
+	return get( NORMALIZER_MAPPING, normalizerName, identity )( revision );
 }


### PR DESCRIPTION
~**Note: This builds on top of #14242, so it's not merge-able yet**~

4th chunk coming from my WIP PR to introduce post revisions in calypso: #13367, this is mostly UI code to introduce a list of revisions in the post editor sidebar, a diff viewer replacing the main editor with a diff view of the revision currently selected and some code to enable "loading" a revision in the editor.

### testing

- Tap on "x revisions" in the post editor sidebar (shown only on posts with multiple revisions)
- It should automatically fetch the revisions for the post you're currently editing
- On desktop, once the revisions are fetched, it should automatically display the latest revision in the diff viewer
- On mobile, once the revisions are fetched, it should NOT automatically select a revision.
- On mobile, selecting a revision should switch focus to the diff viewer, you can then reopen the revisions sidebar by tap-ing the "history" icon in the editor ground control.
- Once you have a revision selected in the list, you can "load the revision in the editor", on mobile, this should dismiss the entire sidebar.

### screenshots

<img width="400" alt="desktop" src="https://user-images.githubusercontent.com/1145270/27355149-3657c4a0-560a-11e7-8bd1-bc4c6f4df4c0.png">

<img width="400" alt="mobile" src="https://user-images.githubusercontent.com/1145270/27355014-c4c512a2-5609-11e7-9bc1-3e1a8c0beea2.png">