### PR TITLE
Revisions #5: Add support for `page` postTypes

### DIFF
--- a/client/components/data/query-post-revisions/index.jsx
+++ b/client/components/data/query-post-revisions/index.jsx
@@ -26,7 +26,7 @@ class QueryPostRevisions extends Component {
 	}
 
 	request() {
-		this.props.requestPostRevisions( this.props.siteId, this.props.postId );
+		this.props.requestPostRevisions( this.props.siteId, this.props.postId, this.props.postType );
 	}
 
 	render() {
@@ -36,6 +36,7 @@ class QueryPostRevisions extends Component {
 
 QueryPostRevisions.propTypes = {
 	postId: PropTypes.number,
+	postType: PropTypes.string,
 	siteId: PropTypes.number,
 	requestPostRevisions: PropTypes.func,
 };

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -13,6 +13,7 @@ import { map } from 'lodash';
 import EditorRevisionsListHeader from './header';
 import EditorRevisionsListItem from './item';
 import QueryPostRevisions from 'components/data/query-post-revisions';
+import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostRevision, getPostRevisions } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -49,7 +50,11 @@ class EditorRevisionsList extends PureComponent {
 	render() {
 		return (
 			<div>
-				<QueryPostRevisions postId={ this.props.postId } siteId={ this.props.siteId } />
+				<QueryPostRevisions
+					postId={ this.props.postId }
+					postType={ this.props.type }
+					siteId={ this.props.siteId }
+				/>
 				<EditorRevisionsListHeader
 					loadRevision={ this.loadRevision }
 					selectedRevisionId={ this.props.selectedRevisionId }
@@ -83,12 +88,14 @@ EditorRevisionsList.propTypes = {
 	selectedRevisionId: PropTypes.number,
 	selectRevision: PropTypes.func.isRequired,
 	siteId: PropTypes.number,
+	type: PropTypes.string,
 };
 
 export default connect(
 	( state, { selectedRevisionId } ) => {
 		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
+		const type = getEditedPostValue( state, siteId, postId, 'type' );
 		return {
 			postId,
 			revisions: getPostRevisions( state, siteId, postId, 'display' ),
@@ -96,6 +103,7 @@ export default connect(
 				state, siteId, postId, selectedRevisionId, 'editing'
 			),
 			siteId,
+			type,
 		};
 	},
 )( EditorRevisionsList );

--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -19,7 +19,7 @@ import {
 } from 'state/posts/revisions/actions';
 
 /**
- * Normalize a WP REST API Post Revisions ressource for consumption in Calypso
+ * Normalize a WP REST API Post Revisions resource for consumption in Calypso
  *
  * @param {Object} revision Raw revision from the API
  * @returns {Object} the normalized revision
@@ -85,9 +85,10 @@ export const receiveSuccess = ( { dispatch }, { siteId, postId }, revisions ) =>
  * @param {Object} action Redux action
  */
 export const fetchPostRevisions = ( { dispatch }, action ) => {
-	const { siteId, postId } = action;
+	const { siteId, postId, postType } = action;
+	const resourceName = postType === 'page' ? 'pages' : 'posts';
 	dispatch( http( {
-		path: `/sites/${ siteId }/posts/${ postId }/revisions`,
+		path: `/sites/${ siteId }/${ resourceName }/${ postId }/revisions`,
 		method: 'GET',
 		query: {
 			apiNamespace: 'wp/v2',

--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -108,6 +108,22 @@ describe( '#fetchPostRevisions', () => {
 			},
 		}, action ) );
 	} );
+
+	it( 'should dispatch HTTP request to page revisions endpoint', () => {
+		const action = requestPostRevisions( 12345678, 10, 'page' );
+		const dispatch = sinon.spy();
+
+		fetchPostRevisions( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWith( http( {
+			method: 'GET',
+			path: '/sites/12345678/pages/10/revisions',
+			query: {
+				apiNamespace: 'wp/v2',
+			},
+		}, action ) );
+	} );
 } );
 
 describe( '#receiveSuccess', () => {

--- a/client/state/posts/revisions/actions.js
+++ b/client/state/posts/revisions/actions.js
@@ -13,11 +13,14 @@ import {
  *
  * @param {String} siteId of the revisions
  * @param {String} postId of the revisions
+ * @param {String} [postType='post'] post type of the revisions
  * @return {Object} action object
  */
-export const requestPostRevisions = ( siteId, postId ) => ( {
+export const requestPostRevisions = ( siteId, postId, postType = 'post' ) => ( {
 	type: POST_REVISIONS_REQUEST,
-	siteId, postId,
+	postId,
+	postType,
+	siteId
 } );
 
 /**


### PR DESCRIPTION
~**Note: This builds on top of #14927, so it's not merge-able yet**~

5th chunk coming from my WIP PR to introduce post revisions in calypso: #13367. This simply adds support for pages. It's mostly code to hit a different endpoint based on the `postType`.

### testing

* The unit tests for the data-layer part have been updated to test this use case as well
* Manual testing: Tap on "x revisions" in the post editor sidebar of a page (shown only on pages with multiple revisions)
