### PR TITLE
Revisions #6: Fetch authors

### DIFF
--- a/client/components/data/query-users/README.md
+++ b/client/components/data/query-users/README.md
@@ -1,0 +1,46 @@
+Query Users
+================
+
+`<QueryUsers />` is a React component used to request users data.
+
+## Usage
+
+Render the component, passing `siteId` and `usersId`. It does not accept any children, nor does it render any element to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryUsers from 'components/data/query-users';
+
+export default function Users( { users } ) {
+	return (
+		<div>
+			<QueryUsers
+				siteId={ 12345678 }
+				usersId={ usersId }
+			/>
+			<div>{ users }</div>
+		</div>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which we request post revisions.
+
+
+### `usersId`
+
+<table>
+	<tr><th>Type</th><td>Array[Number]</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Limit result set to specific IDs.

--- a/client/components/data/query-users/README.md
+++ b/client/components/data/query-users/README.md
@@ -1,11 +1,11 @@
 Query Users
-================
+===========
 
 `<QueryUsers />` is a React component used to request users data.
 
 ## Usage
 
-Render the component, passing `siteId` and `usersId`. It does not accept any children, nor does it render any element to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+Render the component, passing `siteId` and `userIds`. It does not accept any children, nor does it render any element to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
 
 ```jsx
 import React from 'react';
@@ -16,7 +16,7 @@ export default function Users( { users } ) {
 		<div>
 			<QueryUsers
 				siteId={ 12345678 }
-				usersId={ usersId }
+				userIds={ userIds }
 			/>
 			<div>{ users }</div>
 		</div>
@@ -36,7 +36,7 @@ export default function Users( { users } ) {
 The site ID for which we request post revisions.
 
 
-### `usersId`
+### `userIds`
 
 <table>
 	<tr><th>Type</th><td>Array[Number]</td></tr>

--- a/client/components/data/query-users/index.jsx
+++ b/client/components/data/query-users/index.jsx
@@ -12,13 +12,19 @@ import shallowEqual from 'react-pure-render/shallowEqual';
 import { requestUsers } from 'state/users/actions';
 
 class QueryUsers extends Component {
+	static propTypes = {
+		requestUsers: PropTypes.func,
+		siteId: PropTypes.number,
+		userIds: PropTypes.arrayOf( PropTypes.number ),
+	}
+
 	componentWillMount() {
 		this.request();
 	}
 
 	componentDidUpdate( prevProps ) {
 		if (
-			shallowEqual( this.props.usersId, prevProps.usersId ) &&
+			shallowEqual( this.props.userIds, prevProps.userIds ) &&
 			this.props.siteId === prevProps.siteId
 		) {
 			return;
@@ -28,19 +34,13 @@ class QueryUsers extends Component {
 	}
 
 	request() {
-		this.props.requestUsers( this.props.siteId, this.props.usersId );
+		this.props.requestUsers( this.props.siteId, this.props.userIds );
 	}
 
 	render() {
 		return null;
 	}
 }
-
-QueryUsers.propTypes = {
-	requestUsers: PropTypes.func,
-	siteId: PropTypes.number,
-	usersId: PropTypes.arrayOf( PropTypes.number ),
-};
 
 export default connect(
 	() => ( {} ),

--- a/client/components/data/query-users/index.jsx
+++ b/client/components/data/query-users/index.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import shallowEqual from 'react-pure-render/shallowEqual';
+
+/**
+ * Internal dependencies
+ */
+import { requestUsers } from 'state/users/actions';
+
+class QueryUsers extends Component {
+	componentWillMount() {
+		this.request();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			shallowEqual( this.props.usersId, prevProps.usersId ) &&
+			this.props.siteId === prevProps.siteId
+		) {
+			return;
+		}
+
+		this.request();
+	}
+
+	request() {
+		this.props.requestUsers( this.props.siteId, this.props.usersId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryUsers.propTypes = {
+	requestUsers: PropTypes.func,
+	siteId: PropTypes.number,
+	usersId: PropTypes.arrayOf( PropTypes.number ),
+};
+
+export default connect(
+	() => ( {} ),
+	{ requestUsers }
+)( QueryUsers );

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
+import { get, map, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +13,7 @@ import { map } from 'lodash';
 import EditorRevisionsListHeader from './header';
 import EditorRevisionsListItem from './item';
 import QueryPostRevisions from 'components/data/query-post-revisions';
+import QueryUsers from 'components/data/query-users';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostRevision, getPostRevisions } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -48,12 +49,20 @@ class EditorRevisionsList extends PureComponent {
 	}
 
 	render() {
+		// NOTE: This supports revisions that have been hydrated with author
+		// info (`author` is an object) and the ones that haven't (author is a
+		// string, containing just the ID ).
+		const usersId = uniq( map( this.props.revisions, r => get( r, 'author.ID', r.author ) ) );
 		return (
 			<div>
 				<QueryPostRevisions
 					postId={ this.props.postId }
 					postType={ this.props.type }
 					siteId={ this.props.siteId }
+				/>
+				<QueryUsers
+					siteId={ this.props.siteId }
+					usersId={ usersId }
 				/>
 				<EditorRevisionsListHeader
 					loadRevision={ this.loadRevision }

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -26,7 +26,7 @@ import { isWithinBreakpoint } from 'lib/viewport';
 
 class EditorRevisionsList extends PureComponent {
 	static propTypes = {
-		authorsId: PropTypes.array.isRequired,
+		authorsIds: PropTypes.array.isRequired,
 		loadRevision: PropTypes.func.isRequired,
 		postId: PropTypes.number,
 		revisions: PropTypes.array.isRequired,
@@ -74,7 +74,7 @@ class EditorRevisionsList extends PureComponent {
 				/>
 				<QueryUsers
 					siteId={ this.props.siteId }
-					usersId={ this.props.authorsId }
+					userIds={ this.props.authorsIds }
 				/>
 				<EditorRevisionsListHeader
 					loadRevision={ this.loadRevision }
@@ -107,7 +107,7 @@ export default connect(
 		const postId = getEditorPostId( state );
 		const type = getEditedPostValue( state, siteId, postId, 'type' );
 		return {
-			authorsId: getPostRevisionsAuthorsId( state, siteId, postId ),
+			authorsIds: getPostRevisionsAuthorsId( state, siteId, postId ),
 			postId,
 			revisions: getPostRevisions( state, siteId, postId, 'display' ),
 			selectedRevision: getPostRevision(

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, map, uniq } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,13 +15,18 @@ import EditorRevisionsListItem from './item';
 import QueryPostRevisions from 'components/data/query-post-revisions';
 import QueryUsers from 'components/data/query-users';
 import { getEditedPostValue } from 'state/posts/selectors';
-import { getPostRevision, getPostRevisions } from 'state/selectors';
+import {
+	getPostRevision,
+	getPostRevisions,
+	getPostRevisionsAuthorsId,
+} from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { isWithinBreakpoint } from 'lib/viewport';
 
 class EditorRevisionsList extends PureComponent {
 	static propTypes = {
+		authorsId: PropTypes.array.isRequired,
 		loadRevision: PropTypes.func.isRequired,
 		postId: PropTypes.number,
 		revisions: PropTypes.array.isRequired,
@@ -60,10 +65,6 @@ class EditorRevisionsList extends PureComponent {
 	}
 
 	render() {
-		// NOTE: This supports revisions that have been hydrated with author
-		// info (`author` is an object) and the ones that haven't (author is a
-		// string, containing just the ID ).
-		const usersId = uniq( map( this.props.revisions, r => get( r, 'author.ID', r.author ) ) );
 		return (
 			<div>
 				<QueryPostRevisions
@@ -73,7 +74,7 @@ class EditorRevisionsList extends PureComponent {
 				/>
 				<QueryUsers
 					siteId={ this.props.siteId }
-					usersId={ usersId }
+					usersId={ this.props.authorsId }
 				/>
 				<EditorRevisionsListHeader
 					loadRevision={ this.loadRevision }
@@ -106,6 +107,7 @@ export default connect(
 		const postId = getEditorPostId( state );
 		const type = getEditedPostValue( state, siteId, postId, 'type' );
 		return {
+			authorsId: getPostRevisionsAuthorsId( state, siteId, postId ),
 			postId,
 			revisions: getPostRevisions( state, siteId, postId, 'display' ),
 			selectedRevision: getPostRevision(

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -21,6 +21,17 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { isWithinBreakpoint } from 'lib/viewport';
 
 class EditorRevisionsList extends PureComponent {
+	static propTypes = {
+		loadRevision: PropTypes.func.isRequired,
+		postId: PropTypes.number,
+		revisions: PropTypes.array.isRequired,
+		selectedRevision: PropTypes.object,
+		selectedRevisionId: PropTypes.number,
+		selectRevision: PropTypes.func.isRequired,
+		siteId: PropTypes.number,
+		type: PropTypes.string,
+	}
+
 	loadRevision = () => {
 		this.props.loadRevision( this.props.selectedRevision );
 	}
@@ -88,17 +99,6 @@ class EditorRevisionsList extends PureComponent {
 		);
 	}
 }
-
-EditorRevisionsList.propTypes = {
-	loadRevision: PropTypes.func.isRequired,
-	postId: PropTypes.number,
-	revisions: PropTypes.array.isRequired,
-	selectedRevision: PropTypes.object,
-	selectedRevisionId: PropTypes.number,
-	selectRevision: PropTypes.func.isRequired,
-	siteId: PropTypes.number,
-	type: PropTypes.string,
-};
 
 export default connect(
 	( state, { selectedRevisionId } ) => {

--- a/client/state/selectors/get-post-revisions-authors-id.js
+++ b/client/state/selectors/get-post-revisions-authors-id.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { get, map, uniq } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+const getPostRevisionsAuthorsId = createSelector(
+	( state, siteId, postId ) => uniq( map(
+		get( state.posts.revisions.revisions, [ siteId, postId ], {} ),
+		'author'
+	) ),
+	( state ) => [ state.posts.revisions.revisions ]
+);
+
+export default getPostRevisionsAuthorsId;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -72,6 +72,7 @@ export getPostLikes from './get-post-likes';
 export getPostRevision from './get-post-revision';
 export getPostRevisionChanges from './get-post-revision-changes';
 export getPostRevisions from './get-post-revisions';
+export getPostRevisionsAuthorsId from './get-post-revisions-authors-id';
 export getPostSharePublishedActions from './get-post-share-published-actions';
 export getPostShareScheduledActions from './get-post-share-scheduled-actions';
 export getPrimarySiteId from './get-primary-site-id';

--- a/client/state/selectors/test/get-post-revisions-authors-id.js
+++ b/client/state/selectors/test/get-post-revisions-authors-id.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPostRevisionsAuthorsId from 'state/selectors/get-post-revisions-authors-id';
+
+describe( 'getPostRevisionsAuthorsId', () => {
+	it( 'should return an empty array if there is no revision in the state for `siteId, postId`', () => {
+		expect( getPostRevisionsAuthorsId( {
+			posts: {
+				revisions: {
+					revisions: {},
+				},
+			},
+		}, 12345678, 10 ) ).to.eql( [] );
+	} );
+
+	it( 'should return an array of post revisions authors ID', () => {
+		expect( getPostRevisionsAuthorsId( {
+			posts: {
+				revisions: {
+					revisions: {
+						12345678: {
+							10: {
+								11: {
+									author: 123,
+								},
+							},
+						},
+					},
+				},
+			},
+		}, 12345678, 10 ) ).to.eql( [ 123 ] );
+	} );
+} );


### PR DESCRIPTION
~**Note: This builds on top of #14928, so it's not merge-able yet**~

6th (and last? :tada: ) chunk coming from my WIP PR to introduce post revisions in calypso: #13367. This simply fetches authors name to display them in the revisions list using a query component following #14241 review.

### testing

* On a post with multiple authors - after fetching the revisions - you should see a list without the "by <author name>" information, this silently loads the relevant users to display that information.