### PR TITLE
Signup: Rename Signup Form component's prop name to redirectToAfterLoginUrl

### DIFF
--- a/client/components/signup-form/README.md
+++ b/client/components/signup-form/README.md
@@ -7,7 +7,7 @@ This component renders a Signup Form. It magically handles email, username, and 
 
 A Signup Form instance expects `save` and `submitForm` properties, `save` is called `onBlur` of each field. `submitForm` is called when the form is submitted.
 Optional:
-getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
+redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 disabled={ this.isDisabled() }
 submitting={ this.isSubmitting() }
 
@@ -18,7 +18,7 @@ render: function() {
 	return (
 		<SignupForm
 			{ ...this.props }
-			getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
+			redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 			disabled={ this.isDisabled() }
 			submitting={ this.isSubmitting() }
 			save={ this.save }
@@ -31,7 +31,7 @@ render: function() {
 
 * `submitForm` function - Called when the form is submitted. It will receive the following parameters: `form`, `userData` and `analyticsData`
 * `submitButtonText` string: The text displayed inside the submit button
-* `getRedirectToAfterLoginUrl` string: Where the user should be redirected after being logged in
+* `redirectToAfterLoginUrl` string: Where the user should be redirected after being logged in
 * (optional) `save` function: Called `onBlur` of each field with `form` as parameter
 * (optional) `disabled` boolean: Sets the form as disabled
 * (optional) `submitting` boolean: Sets the state of the form as being submitted

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -54,7 +54,7 @@ class SignupForm extends Component {
 		email: PropTypes.string,
 		footerLink: PropTypes.node,
 		formHeader: PropTypes.node,
-		getRedirectToAfterLoginUrl: PropTypes.string.isRequired,
+		redirectToAfterLoginUrl: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
@@ -285,7 +285,7 @@ class SignupForm extends Component {
 
 		let link = login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
-			redirectTo: this.props.getRedirectToAfterLoginUrl
+			redirectTo: this.props.redirectToAfterLoginUrl
 		} );
 
 		return map( messages, ( message, error_code ) => {

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -111,12 +111,12 @@ class LoggedOutForm extends Component {
 				{ this.renderLocaleSuggestions() }
 				{ this.renderFormHeader() }
 				<SignupForm
-					getRedirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
 					disabled={ isAuthorizing }
+					footerLink={ this.renderFooterLink() }
 					submitting={ isAuthorizing }
 					submitForm={ this.handleSubmitSignup }
 					submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
-					footerLink={ this.renderFooterLink() }
+					redirectToAfterLoginUrl={ this.getRedirectAfterLoginUrl() }
 					suggestedUsername={ get( userData, 'username', '' ) }
 				/>
 				{ userData && this.renderLoginUser() }

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -153,7 +153,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 		return (
 			<div>
 				<SignupForm
-					getRedirectToAfterLoginUrl={ window.location.href }
+					redirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.state.submitting }
 					formHeader={ this.renderFormHeader() }
 					submitting={ this.state.submitting }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -152,7 +152,7 @@ export class UserStep extends Component {
 		return (
 			<SignupForm
 				{ ...omit( this.props, [ 'translate' ] ) }
-				getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
+				redirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 				disabled={ this.userCreationStarted() }
 				submitting={ this.userCreationStarted() }
 				save={ this.save }


### PR DESCRIPTION
Renames the `SignupForm` component's prop `getRedirectToAfterLoginUrl` to just `redirectToAfterLoginUrl`. At some point, a long time ago, this property stopped being used by the `SignUpForm` as a function and at some time after that, started being enforced as a required string. Using the verb in the name is confusing now.

#### Testing instructions

1. Expect that sign up forms still redirect to where is intended (i.e. no regression in the redirection behaviour).
1. Verify that no other usages of `getRedirectToAfterLoginUrl` as a prop to SignupForm exist in the codebase.