### PR TITLE
Comments: Update graphics

### DIFF
--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +13,13 @@ import CommentDetailActions from './comment-detail-actions';
 import ExternalLink from 'components/external-link';
 import FormCheckbox from 'components/forms/form-checkbox';
 
-const stopPropagation = event => event.stopPropagation();
+const controlExternalLink = isBulkEdit => event => {
+	if ( isBulkEdit ) {
+		event.preventDefault();
+	} else {
+		event.stopPropagation();
+	}
+};
 
 export const CommentDetailHeader = ( {
 	authorAvatarUrl,
@@ -63,14 +68,11 @@ export const CommentDetailHeader = ( {
 	return (
 		<div
 			className={ classNames( 'comment-detail__header', 'is-preview', { 'is-bulk-edit': isBulkEdit } ) }
-			onClick={ isBulkEdit ? noop : toggleExpanded }
+			onClick={ isBulkEdit ? toggleSelected : toggleExpanded }
 		>
 			{ isBulkEdit &&
 				<label className="comment-detail__checkbox">
-					<FormCheckbox
-						checked={ commentIsSelected }
-						onChange={ toggleSelected }
-					/>
+					<FormCheckbox checked={ commentIsSelected } />
 				</label>
 			}
 			<div className="comment-detail__author-preview">
@@ -90,7 +92,7 @@ export const CommentDetailHeader = ( {
 						{ translate( 'on {{postLink/}}', {
 							components: {
 								postLink:
-									<ExternalLink href={ postUrl } onClick={ stopPropagation }>
+									<ExternalLink href={ postUrl } onClick={ controlExternalLink( isBulkEdit ) }>
 										{ postTitle }
 									</ExternalLink>,
 							},

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 
@@ -24,12 +25,15 @@ export const CommentDetailHeader = ( {
 	edit,
 	isBulkEdit,
 	isExpanded,
+	postTitle,
+	postUrl,
 	toggleApprove,
 	toggleExpanded,
 	toggleLike,
 	toggleSelected,
 	toggleSpam,
 	toggleTrash,
+	translate,
 } ) => {
 	if ( isExpanded ) {
 		return (
@@ -66,16 +70,27 @@ export const CommentDetailHeader = ( {
 					/>
 				</label>
 			}
-			<div className="comment-detail__author-info">
+			<div className="comment-detail__author-preview">
 				<div className="comment-detail__author-avatar">
 					<img className="comment-detail__author-avatar-image" src={ authorAvatarUrl } />
 				</div>
-				<strong>
-					{ authorDisplayName }
-				</strong>
-				<span>
-					{ authorUrl }
-				</span>
+				<div className="comment-detail__author-info">
+					<div className="comment-detail__author-info-element">
+						<strong>
+							{ authorDisplayName }
+						</strong>
+						<span>
+							{ authorUrl }
+						</span>
+					</div>
+					<div className="comment-detail__author-info-element">
+						{ translate( 'on {{postLink/}}', {
+							components: {
+								postLink: <a href={ postUrl }>{ postTitle }</a>,
+							},
+						} ) }
+					</div>
+				</div>
 			</div>
 			<div className="comment-detail__comment-preview">
 				{ commentContent }
@@ -84,4 +99,4 @@ export const CommentDetailHeader = ( {
 	);
 };
 
-export default CommentDetailHeader;
+export default localize( CommentDetailHeader );

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,7 +73,7 @@ export const CommentDetailHeader = ( {
 		>
 			{ isBulkEdit &&
 				<label className="comment-detail__checkbox">
-					<FormCheckbox checked={ commentIsSelected } />
+					<FormCheckbox checked={ commentIsSelected } onChange={ noop } />
 				</label>
 			}
 			<div className="comment-detail__author-preview">

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -11,7 +11,10 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import CommentDetailActions from './comment-detail-actions';
+import ExternalLink from 'components/external-link';
 import FormCheckbox from 'components/forms/form-checkbox';
+
+const stopPropagation = event => event.stopPropagation();
 
 export const CommentDetailHeader = ( {
 	authorAvatarUrl,
@@ -86,7 +89,10 @@ export const CommentDetailHeader = ( {
 					<div className="comment-detail__author-info-element">
 						{ translate( 'on {{postLink/}}', {
 							components: {
-								postLink: <a href={ postUrl }>{ postTitle }</a>,
+								postLink:
+									<ExternalLink href={ postUrl } onClick={ stopPropagation }>
+										{ postTitle }
+									</ExternalLink>,
 							},
 						} ) }
 					</div>

--- a/client/blocks/comment-detail/docs/example.jsx
+++ b/client/blocks/comment-detail/docs/example.jsx
@@ -34,6 +34,7 @@ const mockComment = {
 	},
 	replied: true,
 	status: 'approved',
+	URL: 'http://discover.wordpress.com',
 }
 
 const mockSite = {

--- a/client/blocks/comment-detail/docs/example.jsx
+++ b/client/blocks/comment-detail/docs/example.jsx
@@ -69,7 +69,7 @@ const CommentListFake = CommentFaker( CommentList );
 export const CommentDetailExample = () =>
 	<div>
 		<CommentDetailPlaceholder />
-		<CommentListFake comments={ mockComments } />
+		<CommentListFake comments={ mockComments } status="all" />
 	</div>;
 
 CommentDetailExample.displayName = 'CommentDetail';

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -152,6 +152,8 @@ export class CommentDetail extends Component {
 					deleteCommentPermanently={ this.deleteCommentPermanently }
 					isBulkEdit={ isBulkEdit }
 					isExpanded={ isExpanded }
+					postTitle={ postTitle }
+					postUrl={ postUrl }
 					toggleApprove={ this.toggleApprove }
 					toggleExpanded={ this.toggleExpanded }
 					toggleLike={ this.toggleLike }
@@ -210,7 +212,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentStatus: comment.status,
 		postAuthorDisplayName: get( comment, 'post.author.name' ),
 		postTitle: get( comment, 'post.title' ),
-		postUrl: get( comment, 'post.link' ),
+		postUrl: get( comment, 'URL' ),
 		repliedToComment: comment.replied, // TODO: not available in the current data structure
 		siteId: comment.siteId,
 	} );

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -123,6 +123,14 @@
 		right: 0;
 		width: 30%;
 	}
+	@supports( -webkit-line-clamp: 2 ) {
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+		&:after {
+			background: transparent;
+		}
+	}
 }
 
 .comment-detail__actions {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -88,7 +88,7 @@
 			padding: 0 12px;
 			.external-link:hover,
 			.external-link:focus {
-				color: $blue-wordpress;
+				color: $gray;
 				outline: none;
 			}
 		}
@@ -102,6 +102,14 @@
 		box-sizing: border-box;
 		padding: 0 8px;
 		width: 40%;
+
+		.external-link {
+			color: $gray;
+			&:hover,
+			&:focus {
+				color: $link-highlight;
+			}
+		}
 	}
 }
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -73,13 +73,12 @@
 	flex-flow: row nowrap;
 	padding: 12px 8px;
 
-	&.is-preview:not( .is-bulk-edit ) {
+	&.is-preview {
 		cursor: pointer;
 	}
 
 	&.is-bulk-edit {
 		.comment-detail__checkbox {
-			cursor: pointer;
 			padding-left: 8px;
 			.form-checkbox {
 				margin: 0;
@@ -87,6 +86,11 @@
 		}
 		.comment-detail__author-preview {
 			padding: 0 12px;
+			.external-link:hover,
+			.external-link:focus {
+				color: $blue-wordpress;
+				outline: none;
+			}
 		}
 	}
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -25,23 +25,19 @@
 
 .comment-detail__transition-enter {
 	opacity: 0.01;
-	visibility: hidden;
 
 	&.comment-detail__transition-enter-active {
 		opacity: 1;
-		visibility: visible;
-		transition: all .15s linear;
+		transition: opacity .15s linear;
 		transition-delay: .15s;
 	}
 }
 .comment-detail__transition-leave {
 	opacity: 1;
-	visibility: visible;
 
 	&.comment-detail__transition-leave-active {
 		opacity: 0.01;
-		visibility: hidden;
-		transition: all .15s linear;
+		transition: opacity .15s linear;
 	}
 }
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -6,7 +6,12 @@
 
 	&.is-expanded {
 		margin: 16px auto;
+
+		.comment-detail__header {
+			justify-content: space-between;
+		}
 	}
+
 	&:not( .is-expanded ):hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
 		z-index: 1;
@@ -60,10 +65,16 @@
 	}
 }
 
+.comment-detail__author-info-element {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .comment-detail__header {
+	align-items: center;
 	display: flex;
 	flex-flow: row nowrap;
-	justify-content: space-between;
 	padding: 12px 8px;
 
 	&.is-preview:not( .is-bulk-edit ) {
@@ -71,22 +82,15 @@
 	}
 
 	&.is-bulk-edit {
-		padding: 0;
 		.comment-detail__checkbox {
 			cursor: pointer;
-			padding: 12px 16px;
+			padding-left: 8px;
 			.form-checkbox {
-				margin-top: 4px;
+				margin: 0;
 			}
 		}
-		.comment-detail__author-info {
-			padding: 12px 0;
-		}
-		.comment-detail__author-avatar {
-			padding-left: 0;
-		}
-		.comment-detail__comment-preview {
-			padding: 12px 8px;
+		.comment-detail__author-preview {
+			padding: 0 12px;
 		}
 	}
 
@@ -94,21 +98,31 @@
 		border-bottom: 1px solid lighten( $gray, 30% );
 	}
 
-	.comment-detail__author-avatar {
-		display: inline-block;
-		height: 24px;
+	.comment-detail__author-preview {
+		box-sizing: border-box;
 		padding: 0 8px;
-		vertical-align: middle;
-		width: 24px;
+		width: 40%;
 	}
 }
 
 .comment-detail__comment-preview {
+	box-sizing: border-box;
+	line-height: 1.4;
+	max-height: 38px;
 	overflow: hidden;
 	padding: 0 8px;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	position: relative;
 	width: 60%;
+
+	&:after {
+		background: linear-gradient(to right, rgba( $white, 0 ), rgba( $white, 1 ) 50%);
+		bottom: 0;
+		content: '';
+		height: 19px;
+		position: absolute;
+		right: 0;
+		width: 30%;
+	}
 }
 
 .comment-detail__actions {
@@ -227,17 +241,6 @@
 
 .comment-detail__author {
 	padding: 16px 0;
-
-	.comment-detail__author-info {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-	.comment-detail__author-info-element {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
 }
 
 .comment-detail__author-preview {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -255,6 +255,8 @@ export class CommentList extends Component {
 				</ReactCSSTransitionGroup>
 
 				<ReactCSSTransitionGroup
+					className="comment-list__transition-wrapper"
+					component="div"
 					transitionEnterTimeout={ 300 }
 					transitionLeaveTimeout={ 150 }
 					transitionName="comment-list__transition"

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -83,7 +83,7 @@ export class CommentNavigation extends Component {
 		if ( isBulkEdit ) {
 			return (
 			<SectionNav className="comment-navigation is-bulk-edit">
-				<CommentNavigationTab>
+				<CommentNavigationTab className="comment-navigation__bulk-count">
 					<FormCheckbox
 						checked={ isSelectedAll }
 						onChange={ toggleSelectAll }
@@ -164,7 +164,7 @@ export class CommentNavigation extends Component {
 					) }
 				</NavTabs>
 
-				<CommentNavigationTab className="comment-navigation__actions">
+				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
 					<Button compact onClick={ toggleBulkEdit }>
 						{ translate( 'Bulk Edit' ) }
 					</Button>

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -66,6 +66,7 @@ export class CommentNavigation extends Component {
 	render() {
 		const {
 			doSearch,
+			hasSearch,
 			isBulkEdit,
 			isSelectedAll,
 			query,
@@ -169,13 +170,15 @@ export class CommentNavigation extends Component {
 					</Button>
 				</CommentNavigationTab>
 
-				<Search
-					delaySearch
-					fitsContainer
-					initialValue={ query }
-					onSearch={ doSearch }
-					pinned
-				/>
+				{ hasSearch &&
+					<Search
+						delaySearch
+						fitsContainer
+						initialValue={ query }
+						onSearch={ doSearch }
+						pinned
+					/>
+				}
 			</SectionNav>
 		);
 	}

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -1,5 +1,41 @@
+.comment-navigation {
+	@include breakpoint( "<480px" ) {
+		.section-nav__mobile-header:after {
+			padding-left: 8px;
+		}
+		.section-nav__mobile-header-text {
+			flex: none;
+			width: auto;
+		}
+
+		.comment-navigation__open-bulk {
+			padding-top: 9px;
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
+	}
+}
+
 .comment-navigation.is-bulk-edit {
 	padding-right: 0;
+
+	@include breakpoint( "<480px" ) {
+		.section-nav__mobile-header {
+			display: none;
+		}
+
+		.comment-navigation__bulk-count {
+			width: calc( 100% - 70px );
+		}
+
+		.comment-navigation__close-bulk {
+			position: absolute;
+			right: 0;
+			top: 3px;
+			width: 55px;
+		}
+	}
 }
 
 .comment-navigation__tab {

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -24,25 +24,27 @@
 	}
 }
 
+.comment-list__transition-wrapper {
+	position: relative;
+}
+
 .comment-list__transition-enter {
 	opacity: 0.01;
-	visibility: hidden;
+	position: absolute;
 
 	&.comment-list__transition-enter-active {
 		opacity: 1;
-		visibility: visible;
-		transition: all .15s linear;
+		transition: opacity .15s linear;
 		transition-delay: .15s;
 	}
 }
 
 .comment-list__transition-leave {
 	opacity: 1;
-	visibility: visible;
+	position: absolute;
 
 	&.comment-list__transition-leave-active {
 		opacity: 0.01;
-		visibility: hidden;
-		transition: all 0.15s linear;
+		transition: opacity 0.15s linear;
 	}
 }


### PR DESCRIPTION
Fixes and updates the graphics of the Comment Management section.

## Changes

- Comment previews are now 2 liners.
Notice that the current "trick" employed here to truncate the text is a simple fade-out on the last line of the content excerpt. This means that its last bit is faded even if there's no need of truncation - and even on 1-line excerpts.
- The search bar is now hidden, as it's slated to m2 milestone.
- On small screens the section doesn't look weird anymore.
- Devdocs show (again) a list of comments after the n-th regression caused by changing the CommentList structure.

## Screenshots

**2-line comments**
<img width="549" alt="screen shot 2017-06-08 at 18 55 23" src="https://user-images.githubusercontent.com/2070010/26943046-2bfdc6fe-4c7c-11e7-90e0-0e0f20ce30b2.png">

**`<480px` normal view**
<img width="418" alt="screen shot 2017-06-08 at 18 55 35" src="https://user-images.githubusercontent.com/2070010/26943044-2bfad796-4c7c-11e7-888d-b30f4b7834c7.png">

**`<480px` bulk edit view**
<img width="417" alt="screen shot 2017-06-08 at 18 55 56" src="https://user-images.githubusercontent.com/2070010/26943068-3ad3442e-4c7c-11e7-9e73-f255c9c873c5.png">

_(please notice that the 100%-wide count "bubble" is apparently (maybe accidentally?) the intended behaviour)_

cc @Automattic/lannister 