### PR TITLE
Revert "Upgrades: add ability to link to renewal checkout"

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -60,9 +60,10 @@ export function canUpgradeToPlan( planKey, site ) {
 	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
 }
 
-export function getUpgradePlanSlugFromPath( path ) {
+export function getUpgradePlanSlugFromPath( path, site ) {
 	return find( Object.keys( PLANS_LIST ), planKey => (
-		planKey === path || getPlanPath( planKey ) === path
+		( planKey === path || getPlanPath( planKey ) === path ) &&
+		canUpgradeToPlan( planKey, site )
 	) );
 }
 

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -196,7 +196,6 @@ module.exports = {
 					<Checkout
 						product={ product }
 						productsList={ productsList }
-						purchaseId={ context.params.purchaseId }
 						selectedFeature={ selectedFeature }
 					/>
 				</CheckoutData>

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -275,12 +275,6 @@ module.exports = function() {
 			upgradesController.checkout
 		);
 
-		page(
-			'/checkout/:product/renew/:purchaseId/:domain',
-			controller.siteSelection,
-			upgradesController.checkout
-		);
-
 		// Visting /checkout without a plan or product should be redirected to /plans
 		page( '/checkout', '/plans' );
 	}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#14759

Jetpack plans relies on canUpgradeToPlan in getUpgradePlanSlugFromPath