### PR TITLE
Post Types: Enable more Post Types

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -133,6 +133,8 @@ class PostTypeList extends Component {
 			'is-empty': isEmpty
 		} );
 
+		console.log( siteId, query );
+
 		return (
 			<div className={ classes }>
 				{ query && this.state.requestedPages.map( ( page ) => (

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -57,12 +57,11 @@ Types.propTypes = {
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	const postType = getPostType( state, siteId, ownProps.query.type );
-	const capability = get( postType, [ 'capabilities', 'edit_posts' ], null );
 
 	return {
 		siteId,
 		postType,
 		postTypeSupported: isPostTypeSupported( state, siteId, ownProps.query.type ),
-		userCanEdit: canCurrentUser( state, siteId, capability )
+		userCanEdit: canCurrentUser( state, siteId, 'edit_posts' )
 	};
 } )( Types );


### PR DESCRIPTION
WIP.

So far, we've been checking for each individual [post type's capability that corresponds to `edit_posts`](https://codex.wordpress.org/Function_Reference/register_post_type#capabilities) to be present in the list of the current user's capabilities. However, this doesn't quite work for CPTs such as WP Job Manager's `job_listing` CPT (where `edit_job_listings` corresponds to `edit_posts`).

AFAICT, those custom capabilities don't get added to the list of a user's capabilities; instead, the idea is to just check for the "normal" capability. So this PR removes the individual checks (which would fail for those custom capabilities) and instead just hides the entire `PublishMenu` component from the sidebar if the current user doesn't have the `edit_posts` capability.

To test:
* Verify that there's a _Job Listings_ menu item in the _Publish_ section.

TODO:
* Make actual CPT screen work for `job_listing`

cc @donnapep @jom 