### PR TITLE
Reader: Teach feed searches about parameters, show sites you follow in main search

### DIFF
--- a/client/components/data/query-reader-feeds-search/index.jsx
+++ b/client/components/data/query-reader-feeds-search/index.jsx
@@ -12,15 +12,22 @@ import { requestFeedSearch } from 'state/reader/feed-searches/actions';
 class QueryFeedSearch extends Component {
 	static propTypes = {
 		query: PropTypes.string,
+		excludeFollowed: PropTypes.bool,
 		searchFeeds: PropTypes.func,
-	}
+	};
 
 	componentWillMount() {
-		this.props.requestFeedSearch( this.props.query );
+		this.props.requestFeedSearch( {
+			query: this.props.query,
+			excludeFollowed: this.props.excludeFollowed,
+		} );
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		nextProps.requestFeedSearch( nextProps.query );
+		nextProps.requestFeedSearch( {
+			query: nextProps.query,
+			excludeFollowed: nextProps.excludeFollowed,
+		} );
 	}
 
 	render() {

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -139,13 +139,18 @@ class FollowingManage extends Component {
 		return reject( recommendedSites, site => includes( blockedSites, site.blogId ) ).length <= 4;
 	};
 
-	fetchNextPage = offset => this.props.requestFeedSearch( this.props.sitesQuery, offset );
+	fetchNextPage = offset =>
+		this.props.requestFeedSearch( {
+			query: this.props.sitesQuery,
+			offset,
+			excludeFollowed: true,
+		} );
 
 	handleShowMoreClicked = () => {
 		recordTrack( 'calypso_reader_following_manage_search_more_click' );
 		recordAction( 'manage_feed_search_more' );
 		page.replace(
-			addQueryArgs( { showMoreResults: true }, window.location.pathname + window.location.search )
+			addQueryArgs( { showMoreResults: true }, window.location.pathname + window.location.search ),
 		);
 	};
 
@@ -191,7 +196,7 @@ class FollowingManage extends Component {
 		const isFollowByUrlWithNoSearchResults = showFollowByUrl && searchResultsCount === 0;
 		const filteredRecommendedSites = reject(
 			recommendedSites,
-			site => includes( blockedSites, site.blogId )
+			site => includes( blockedSites, site.blogId ),
 		);
 
 		return (
@@ -200,7 +205,8 @@ class FollowingManage extends Component {
 				<MobileBackToSidebar>
 					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
-				{ ! searchResults && <QueryReaderFeedsSearch query={ sitesQuery } /> }
+				{ ! searchResults &&
+					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } /> }
 				{ this.shouldRequestMoreRecs() &&
 					<QueryReaderRecommendedSites
 						seed={ recommendationsSeed }
@@ -267,16 +273,19 @@ class FollowingManage extends Component {
 
 export default connect(
 	( state, { sitesQuery } ) => ( {
-		searchResults: getReaderFeedsForQuery( state, sitesQuery ),
-		searchResultsCount: getReaderFeedsCountForQuery( state, sitesQuery ),
+		searchResults: getReaderFeedsForQuery( state, { query: sitesQuery, excludeFollowed: true } ),
+		searchResultsCount: getReaderFeedsCountForQuery(
+			state,
+			{ query: sitesQuery, excludeFollowed: true },
+		),
 		recommendedSites: getReaderRecommendedSites( state, recommendationsSeed ),
 		recommendedSitesPagingOffset: getReaderRecommendedSitesPagingOffset(
 			state,
-			recommendationsSeed
+			recommendationsSeed,
 		),
 		blockedSites: getBlockedSites( state ),
 		readerAliasedFollowFeedUrl: sitesQuery && getReaderAliasedFollowFeedUrl( state, sitesQuery ),
 		followsCount: getReaderFollowsCount( state ),
 	} ),
-	{ requestFeedSearch }
+	{ requestFeedSearch },
 )( localize( FollowingManage ) );

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -22,7 +22,11 @@ class SitesResults extends React.Component {
 	};
 
 	fetchNextPage = offset => {
-		this.props.requestFeedSearch( this.props.query, offset );
+		this.props.requestFeedSearch( {
+			query: this.props.query,
+			offset,
+			excludeFollowed: false,
+		} );
 	};
 
 	render() {
@@ -30,7 +34,7 @@ class SitesResults extends React.Component {
 
 		return (
 			<div>
-				<QueryReaderFeedsSearch query={ query } />
+				<QueryReaderFeedsSearch query={ query } excludeFollowed={ false } />
 				<ReaderInfiniteStream
 					itemType={ 'site' }
 					items={ searchResults || [ {}, {}, {}, {}, {} ] }
@@ -45,7 +49,10 @@ class SitesResults extends React.Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		searchResults: getReaderFeedsForQuery( state, ownProps.query ),
+		searchResults: getReaderFeedsForQuery(
+			state,
+			{ query: ownProps.query, excludeFollowed: false },
+		),
 	} ),
-	{ requestFeedSearch }
+	{ requestFeedSearch },
 )( localize( SitesResults ) );

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -12,6 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
+import queryKey from 'state/reader/feed-searches/query-key';
 
 export function initiateFeedSearch( store, action ) {
 	if ( ! ( action.payload && action.payload.query ) ) {
@@ -24,10 +25,14 @@ export function initiateFeedSearch( store, action ) {
 			path,
 			method: 'GET',
 			apiVersion: '1.1',
-			query: { q: action.payload.query, offset: action.payload.offset },
+			query: {
+				q: action.payload.query,
+				offset: action.payload.offset,
+				exclude_followed: action.payload.excludeFollowed,
+			},
 			onSuccess: action,
 			onFailure: action,
-		} )
+		} ),
 	);
 }
 
@@ -38,7 +43,7 @@ export function receiveFeeds( store, action, next, apiResponse ) {
 	} ) );
 
 	const total = apiResponse.total > 200 ? 200 : apiResponse.total;
-	store.dispatch( receiveFeedSearch( action.payload.query, feeds, total ) );
+	store.dispatch( receiveFeedSearch( queryKey( action.payload ), feeds, total ) );
 }
 
 export function receiveError( store, action, next, error ) {

--- a/client/state/data-layer/wpcom/read/feed/test/index.js
+++ b/client/state/data-layer/wpcom/read/feed/test/index.js
@@ -12,6 +12,7 @@ import { requestFeedSearch, receiveFeedSearch } from 'state/reader/feed-searches
 import { initiateFeedSearch, receiveFeeds, receiveError } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { NOTICE_CREATE } from 'state/action-types';
+import queryKey from 'state/reader/feed-searches/query-key';
 
 const feeds = freeze( [ { blog_ID: 'IM A BLOG', subscribe_URL: 'feedUrl' } ] );
 
@@ -20,8 +21,8 @@ const query = 'okapis r us';
 describe( 'wpcom-api', () => {
 	describe( 'search feeds', () => {
 		describe( '#initiateFeedSearch', () => {
-			it( 'should dispatch http request for feed search', () => {
-				const action = requestFeedSearch( query );
+			it( 'should dispatch http request for feed search with followed feeds excluded by default', () => {
+				const action = requestFeedSearch( { query } );
 				const dispatch = sinon.spy();
 
 				initiateFeedSearch( { dispatch }, action );
@@ -32,17 +33,55 @@ describe( 'wpcom-api', () => {
 						method: 'GET',
 						path: '/read/feed',
 						apiVersion: '1.1',
-						query: { q: query, offset: 0 },
+						query: { q: query, offset: 0, exclude_followed: true },
 						onSuccess: action,
 						onFailure: action,
-					} )
+					} ),
+				);
+			} );
+
+			it( 'should dispatch http request for feed search with followed feeds included if specified', () => {
+				const action = requestFeedSearch( { query, excludeFollowed: false } );
+				const dispatch = sinon.spy();
+
+				initiateFeedSearch( { dispatch }, action );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith(
+					http( {
+						method: 'GET',
+						path: '/read/feed',
+						apiVersion: '1.1',
+						query: { q: query, offset: 0, exclude_followed: false },
+						onSuccess: action,
+						onFailure: action,
+					} ),
+				);
+			} );
+
+			it( 'should dispatch http request for feed search with the offset specified', () => {
+				const action = requestFeedSearch( { query, offset: 10 } );
+				const dispatch = sinon.spy();
+
+				initiateFeedSearch( { dispatch }, action );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith(
+					http( {
+						method: 'GET',
+						path: '/read/feed',
+						apiVersion: '1.1',
+						query: { q: query, offset: 10, exclude_followed: true },
+						onSuccess: action,
+						onFailure: action,
+					} ),
 				);
 			} );
 		} );
 
 		describe( '#receiveFeeds', () => {
 			it( 'should dispatch an action with the feed results', () => {
-				const action = requestFeedSearch( query );
+				const action = requestFeedSearch( { query } );
 				const dispatch = sinon.spy();
 				const apiResponse = { feeds, total: 500 };
 
@@ -51,7 +90,7 @@ describe( 'wpcom-api', () => {
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWith(
 					receiveFeedSearch(
-						query,
+						queryKey( action.payload ),
 						[
 							{
 								blog_ID: 'IM A BLOG',
@@ -59,15 +98,15 @@ describe( 'wpcom-api', () => {
 								subscribe_URL: 'feedUrl',
 							},
 						],
-						200
-					)
+						200,
+					),
 				);
 			} );
 		} );
 
 		describe( '#receiveFeedsError', () => {
 			it( 'should dispatch error notice', () => {
-				const action = requestFeedSearch( query );
+				const action = requestFeedSearch( { query } );
 				const dispatch = sinon.spy();
 
 				receiveError( { dispatch }, action );

--- a/client/state/reader/feed-searches/actions.js
+++ b/client/state/reader/feed-searches/actions.js
@@ -3,16 +3,17 @@
  */
 import { READER_FEED_SEARCH_REQUEST, READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
-export const requestFeedSearch = ( query, offset = 0 ) => ( {
+export const requestFeedSearch = ( { query, offset = 0, excludeFollowed = true } ) => ( {
 	type: READER_FEED_SEARCH_REQUEST,
 	payload: {
 		query: query.substring( 0, 500 ),
 		offset,
+		excludeFollowed,
 	},
 } );
 
-export const receiveFeedSearch = ( query, feeds, total ) => ( {
+export const receiveFeedSearch = ( queryKey, feeds, total ) => ( {
 	type: READER_FEED_SEARCH_RECEIVE,
 	payload: { feeds, total },
-	query,
+	queryKey,
 } );

--- a/client/state/reader/feed-searches/query-key.js
+++ b/client/state/reader/feed-searches/query-key.js
@@ -1,0 +1,15 @@
+/**
+ * Build a key for feed search queries
+ *
+ * Key format is {literalQuery}-{X|A}.
+ *   X if we excluded followed sites,
+ *   A if we did not
+ * For example: a search for "halloween", excluding followed sites, would be
+ *   halloween-X
+ * @param  {object} query The feed search action
+ * @return {string} the key
+ */
+export default function keyBy( query ) {
+	const excludeFollowed = query.excludeFollowed ? 'X' : 'A';
+	return `${ query.query }-${ excludeFollowed }`;
+}

--- a/client/state/reader/feed-searches/reducer.js
+++ b/client/state/reader/feed-searches/reducer.js
@@ -12,10 +12,13 @@ import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
 
 /**
  * Tracks mappings between queries --> feed results
+ *
+ * A map of query to results, keyed by query key.
+ * The query key is supplied by the action, making it opaque to the reducer.
  * Here is what the state tree may look like:
  * feedSearches: {
 		items: {
-			'wordpress tavern': [ feed1, feed2, ],
+			'wordpress tavern-X': [ feed1, feed2, ],
 			...
 		},
 	}
@@ -25,21 +28,24 @@ import { READER_FEED_SEARCH_RECEIVE } from 'state/action-types';
  * @return {Array}        Updated state
  */
 export const items = keyedReducer(
-	'query',
+	'queryKey',
 	createReducer( null, {
 		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) =>
 			uniqBy( ( state || [] ).concat( action.payload.feeds ), 'feed_URL' ),
-	} )
+	} ),
 );
 
 /**
  * Tracks mappings between queries --> num results
+ *
+ * A of query counts to results, keyed by query key.
+ * The query key is supplied by the action, making it opaque to the reducer.
  * Here is what the state tree may look like:
  * feedSearches: {
 		total: {
-			'wordpress tavern': 4,
-			'thingsldkjflskjfsdf': 0,
-			'chickens': 4000,
+			'wordpress tavern-X': 4,
+			'thingsldkjflskjfsdf-A': 0,
+			'chickens-A': 4000,
 			...
 		},
 	}
@@ -49,10 +55,10 @@ export const items = keyedReducer(
  * @return {Array}         Updated state
  */
 export const total = keyedReducer(
-	'query',
+	'queryKey',
 	createReducer( null, {
 		[ READER_FEED_SEARCH_RECEIVE ]: ( state, action ) => action.payload.total,
-	} )
+	} ),
 );
 
 export default combineReducers( {

--- a/client/state/reader/feed-searches/test/query-key.js
+++ b/client/state/reader/feed-searches/test/query-key.js
@@ -1,0 +1,27 @@
+/**
+ * External Dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal Dependencies
+ */
+
+import { requestFeedSearch, SORT_BY_LAST_UPDATED } from '../actions';
+import queryKey from '../query-key';
+
+describe( 'query-key', () => {
+	it( 'should generate the expected query keys', () => {
+		[
+			[ requestFeedSearch( { query: 'one' } ), 'one-X' ],
+			[ requestFeedSearch( { query: 'one', offset: 10 } ), 'one-X' ],
+			[ requestFeedSearch( { query: 'one', excludeFollowed: false } ), 'one-A' ],
+			[
+				requestFeedSearch( { query: 'one', excludeFollowed: false, sort: SORT_BY_LAST_UPDATED } ),
+				'one-A',
+			],
+		].forEach( ( [ action, expectedKey ] ) => {
+			expect( queryKey( action.payload ) ).to.equal( expectedKey );
+		} );
+	} );
+} );

--- a/client/state/reader/feed-searches/test/reducer.js
+++ b/client/state/reader/feed-searches/test/reducer.js
@@ -10,7 +10,7 @@ import freeze from 'deep-freeze';
 import { receiveFeedSearch } from '../actions';
 import { items } from '../reducer';
 
-const query = 'macrumor';
+const queryKey = 'macrumor-F-ASC';
 const feeds = freeze( [
 	{
 		URL: 'http://www.macrumors.com/macrumors.xml',
@@ -39,11 +39,11 @@ describe( 'reducer', () => {
 
 		it( 'should add query results to an empty object', () => {
 			const prevState = {};
-			const action = receiveFeedSearch( query, feeds );
+			const action = receiveFeedSearch( queryKey, feeds );
 			const nextState = items( prevState, action );
 
 			expect( nextState ).to.eql( {
-				[ query ]: feeds,
+				[ queryKey ]: feeds,
 			} );
 		} );
 
@@ -51,11 +51,11 @@ describe( 'reducer', () => {
 			const prevState = {
 				chickens: [ { blogName: 'chickens R us' } ],
 			};
-			const action = receiveFeedSearch( query, feeds );
+			const action = receiveFeedSearch( queryKey, feeds );
 			const nextState = items( prevState, action );
 			expect( nextState ).to.eql( {
 				...prevState,
-				[ query ]: feeds,
+				[ queryKey ]: feeds,
 			} );
 		} );
 	} );

--- a/client/state/selectors/get-reader-feeds-count-for-query.js
+++ b/client/state/selectors/get-reader-feeds-count-for-query.js
@@ -1,4 +1,9 @@
 /**
+ * Internal Dependencies
+ */
+import queryKey from 'state/reader/feed-searches/query-key';
+
+/**
  * Returns the number of feed results for a given query. from 0 to 200.
  *
  * @param  {Object}  state  Global state tree
@@ -6,5 +11,6 @@
  * @return {Array} list of feeds that are the result of that query
  */
 export default function getReaderFeedsCountForQuery( state, query ) {
-	return state.reader.feedSearches.total[ query ];
+	const key = queryKey( query );
+	return state.reader.feedSearches.total[ key ];
 }

--- a/client/state/selectors/get-reader-feeds-for-query.js
+++ b/client/state/selectors/get-reader-feeds-for-query.js
@@ -1,4 +1,9 @@
 /**
+ * Internal Dependencies
+ */
+import queryKey from 'state/reader/feed-searches/query-key';
+
+/**
  * Returns the feeds result for a given query.
  *
  * @param  {Object}  state  Global state tree
@@ -6,5 +11,6 @@
  * @return {Array} list of feeds that are the result of that query
  */
 export default function getReaderFeedsForQuery( state, query ) {
-	return state.reader.feedSearches.items[ query ];
+	const key = queryKey( query );
+	return state.reader.feedSearches.items[ key ];
 }


### PR DESCRIPTION
This teaches the feed search reducer, actions, and data layer how to store data for queries that have parmeters. For now, this is just excludeFollowers, but going forward we'll be adding other parameters.

To test, pull up the new site search on /read/search and search for something you're following. It should appear in the results, marked as followed! Then search for it on /following/manage, using the "search for something new" box. It should not appear there.