### PR TITLE
Upgrades: fix plans with duplicate slugs

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -20,6 +20,7 @@ import {
 } from 'lib/products-values';
 import {
 	FEATURES_LIST,
+	JETPACK_PLANS,
 	PLANS_LIST,
 	PLAN_FREE,
 	PLAN_JETPACK_FREE,
@@ -60,10 +61,10 @@ export function canUpgradeToPlan( planKey, site ) {
 	return get( getPlan( planKey ), 'availableFor', () => false )( plan );
 }
 
-export function getUpgradePlanSlugFromPath( path, site ) {
-	return find( Object.keys( PLANS_LIST ), planKey => (
-		( planKey === path || getPlanPath( planKey ) === path ) &&
-		canUpgradeToPlan( planKey, site )
+export function getUpgradePlanSlugFromPath( path, isJetpack ) {
+	const planSlugs = Object.keys( PLANS_LIST );
+	return find( isJetpack ? JETPACK_PLANS : planSlugs, planKey => (
+		planKey === path || getPlanPath( planKey ) === path
 	) );
 }
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, find, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import { flatten, find, isEmpty, isEqual, reduce } from 'lodash';
 import i18n, { localize } from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
@@ -15,7 +15,6 @@ const analytics = require( 'lib/analytics' ),
 	clearSitePlans = require( 'state/sites/plans/actions' ).clearSitePlans,
 	clearPurchases = require( 'state/purchases/actions' ).clearPurchases,
 	DomainDetailsForm = require( './domain-details-form' ),
-	domainMapping = require( 'lib/cart-values/cart-items' ).domainMapping,
 	fetchReceiptCompleted = require( 'state/receipts/actions' ).fetchReceiptCompleted,
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	hasDomainDetails = require( 'lib/store-transactions' ).hasDomainDetails,
@@ -27,9 +26,13 @@ const analytics = require( 'lib/analytics' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
 	SecurePaymentFormPlaceholder = require( './secure-payment-form-placeholder' ),
 	supportPaths = require( 'lib/url/support' ),
-	themeItem = require( 'lib/cart-values/cart-items' ).themeItem,
 	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
 	upgradesActions = require( 'lib/upgrades/actions' );
+import {
+	domainMapping,
+	noAdsItem,
+	themeItem
+} from 'lib/cart-values/cart-items';
 import { getStoredCards } from 'state/stored-cards/selectors';
 import {
 	isValidFeatureKey,
@@ -118,23 +121,27 @@ const Checkout = React.createClass( {
 	},
 
 	addProductToCart: function() {
-		const planSlug = getUpgradePlanSlugFromPath( this.props.product, this.props.selectedSite );
+		const { product, productsList, purchaseId, selectedSite, selectedSiteSlug } = this.props;
+		const meta = product.split( ':' )[ 1 ];
+		const productSlug = getUpgradePlanSlugFromPath( product, selectedSite.jetpack ) || product.split( ':' )[ 0 ];
 
-		let cartItem,
-			cartMeta;
+		let cartItem = getCartItemForPlan( productSlug );
 
-		if ( planSlug ) {
-			cartItem = getCartItemForPlan( planSlug );
+		if ( 'theme' === productSlug ) {
+			cartItem = themeItem( meta );
+		} else if ( 'domain-mapping' === productSlug ) {
+			cartItem = domainMapping( { domain: meta } );
+		} else if ( 'no-ads' === productSlug ) {
+			cartItem = noAdsItem();
+		} else if ( meta ) {
+			cartItem = Object.assign( { meta }, productsList.data[ productSlug ] );
 		}
 
-		if ( startsWith( this.props.product, 'theme' ) ) {
-			cartMeta = this.props.product.split( ':' )[ 1 ];
-			cartItem = themeItem( cartMeta );
-		}
-
-		if ( startsWith( this.props.product, 'domain-mapping' ) ) {
-			cartMeta = this.props.product.split( ':' )[ 1 ];
-			cartItem = domainMapping( { domain: cartMeta } );
+		if ( cartItem && purchaseId ) {
+			cartItem = cartItems.getRenewalItemFromCartItem( cartItem, {
+				id: purchaseId,
+				domain: selectedSiteSlug
+			} );
 		}
 
 		if ( cartItem ) {

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -196,6 +196,7 @@ module.exports = {
 					<Checkout
 						product={ product }
 						productsList={ productsList }
+						purchaseId={ context.params.purchaseId }
 						selectedFeature={ selectedFeature }
 					/>
 				</CheckoutData>

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -275,6 +275,12 @@ module.exports = function() {
 			upgradesController.checkout
 		);
 
+		page(
+			'/checkout/:product/renew/:purchaseId/:domain',
+			controller.siteSelection,
+			upgradesController.checkout
+		);
+
 		// Visting /checkout without a plan or product should be redirected to /plans
 		page( '/checkout', '/plans' );
 	}


### PR DESCRIPTION
Second attempt on #14759. The original PR was reverted because Jetpack is using duplicate plan slugs.
----

This adds support for links to plan, mapping, and registration renewals

Domain Registration renewals require server changes ( D5878, D5875 )

To test:

Add an expiring subscription from SA
The link that is expected to add that subscription to cart has the following format:
/checkout/productSlug:meta/renew/123456/mytestsite.wordpress.com
addProductToCart in the checkout works with some non-standard pretty-slugs that replace the server slugs for plans with the pretty ones, and I add a pretty slug for the legacy no-ads upgrade because the default one is is long and has /.

Also test links to checkout for plans:
/checkout/mytestsite.wordpress.com/premium
/checkout/mytestsite.wordpress.com/business
/checkout/mytestsite.wordpress.com/personal

Test these with both Jetpack and WPCOM plans