### PR TITLE
Fix usages of `editor` as a CSS namespace, replaced by `post-editor`

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -61,7 +61,7 @@ $z-layers: (
 		'.wp-editor-tools': 1,
 		'.plan .gridicons-checkmark-circle': 1,
 		'.plan-discount-message': 1,
-		'.editor__switch-mode': 1,
+		'.post-editor__switch-mode': 1,
 		'.auth__form .form-fieldset input': 1,
 		'.chart__empty': 1,
 		'.chart__bar-marker': 1,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -274,7 +274,7 @@ export const PostEditor = React.createClass( {
 						allPostsUrl={ this.getAllPostsUrl() }
 					/>
 					<div className="post-editor__content">
-						<div className="editor">
+						<div className="post-editor__content-editor">
 							{ ! config.isEnabled( 'post-editor/delta-post-publish-preview' )
 								? <EditorNotice
 									{ ...this.state.notice }
@@ -307,7 +307,7 @@ export const PostEditor = React.createClass( {
 								site={ site }
 								post={ this.state.post }
 								maxWidth={ 1462 } />
-							<div className="editor__header">
+							<div className="post-editor__header">
 								<EditorTitle
 									onChange={ this.debouncedAutosave }
 									tabIndex={ 1 } />
@@ -320,7 +320,7 @@ export const PostEditor = React.createClass( {
 										/>
 									: null
 								}
-								<SegmentedControl className="editor__switch-mode" compact={ true }>
+								<SegmentedControl className="post-editor__switch-mode" compact={ true }>
 									<SegmentedControlItem
 										selected={ mode === 'tinymce' }
 										onClick={ this.switchEditorVisualMode }
@@ -335,7 +335,7 @@ export const PostEditor = React.createClass( {
 									</SegmentedControlItem>
 								</SegmentedControl>
 							</div>
-							<hr className="editor__header-divider" />
+							<hr className="post-editor__header-divider" />
 							<TinyMCE
 								ref={ this.storeEditor }
 								mode={ mode }

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -99,22 +99,22 @@
 	}
 }
 
-.editor__header,
-.editor .mce-container-body,
-.editor .tinymce {
+.post-editor__header,
+.post-editor .mce-container-body,
+.post-editor .tinymce {
 	width: 100%;
 	max-width: 700px;
 	margin: 0 auto;
 }
 
-.focus-content .editor__header {
+.focus-content .post-editor__header {
 	@include breakpoint( ">660px" ) {
 		width: 700px;
 	}
 }
 
-.editor__header,
-.editor .mce-edit-area {
+.post-editor__header,
+.post-editor .mce-edit-area {
 	box-sizing: border-box;
 	padding: 0 16px;
 
@@ -128,17 +128,17 @@
 }
 
 // Component <Editor>
-.editor {
+.post-editor__content-editor {
 	position: relative;
 }
 
-.editor .editor-notice .notice {
+.post-editor__content-editor .editor-notice .notice {
 	@include breakpoint( ">660px" ) {
 		margin: 0;
 	}
 }
 
-.editor .tinymce {
+.post-editor .tinymce {
 	min-height: 100vh;
 	resize: none;
 	border-width: 0;
@@ -160,16 +160,16 @@
 	}
 }
 
-.editor__header {
+.post-editor__header {
 	position: relative;
 	padding-bottom: 27px;
 }
 
-.editor__switch-mode {
+.post-editor__switch-mode {
 	position: absolute;
 		right: 16px;
 	width: 160px;
-	z-index: z-index( 'root', '.editor__switch-mode' );
+	z-index: z-index( 'root', '.post-editor__switch-mode' );
 
 	@include breakpoint( ">960px" ) {
 		right: 32px;
@@ -180,7 +180,7 @@
 	}
 }
 
-.editor__switch-mode .segmented-control__item {
+.post-editor__switch-mode .segmented-control__item {
 	&:first-of-type {
 		.segmented-control__link {
 			border-bottom-left-radius: 0;
@@ -201,18 +201,18 @@
 	}
 }
 
-.editor__switch-mode .segmented-control__link {
+.post-editor__switch-mode .segmented-control__link {
 	background: $gray-light;
 	border-color: lighten( $gray, 20% );
 }
 
-.editor__switch-mode .segmented-control__item.is-selected .segmented-control__link {
+.post-editor__switch-mode .segmented-control__item.is-selected .segmented-control__link {
 	border-color: lighten( $gray, 20% );
 	border-bottom-color: $white;
 	background-color: $white;
 }
 
-.editor__header-divider {
+.post-editor__header-divider {
 	background-color: lighten( $gray, 25% );
 	max-width: 700px;
 	margin: 0 auto;
@@ -230,7 +230,7 @@
 	padding: 16px;
 }
 
-.editor .editor-featured-image {
+.post-editor__content-editor .editor-featured-image {
 	display: none;
 	border-bottom: 1px solid lighten( $gray, 20 );
 	border-top: 1px solid lighten( $gray, 20 );


### PR DESCRIPTION
This is to have a consistent CSS namespace usage in `post-editor.jsx` (mainly to simplify PRs that are updating that file).

Further down the line, @aduth had some great suggestions to increase even further the consistency for the entire folder:
1- rename `post-editor` folder to `editor`, making it consistent with the subdirs naming scheme.
2- prefix all subdirs by `post-`, and update all the subdirs CSS to the `post-editor` prefix.

After a bit of grepping:
1- less edits but they are riskier (renaming chunks, section names ... )
2- more edits, but they are mostly in CSS classnames and are contained in the editor which makes them a bit safer.

Anyway - for now - this will unblock my usage in #14927 (and follow ups) while still making `post-editor.jsx` a tiny bit more consistent (even if we end up going with 1- in the future)