### PR TITLE
WooCommerce: Make description fields TinyMCE components

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -3,16 +3,16 @@
  */
 import React, { Component, PropTypes } from 'react';
 import i18n from 'i18n-calypso';
-import { trim } from 'lodash';
+import { trim, debounce } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import CompactTinyMCE from 'woocommerce/components/compact-tinymce';
 import FormClickToEditInput from 'woocommerce/components/form-click-to-edit-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormTextArea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import ProductFormImages from './product-form-images';
 
@@ -37,6 +37,7 @@ export default class ProductFormDetailsCard extends Component {
 
 		this.setName = this.setName.bind( this );
 		this.setDescription = this.setDescription.bind( this );
+		this.debouncedSetDescription = debounce( this.setDescription, 200 );
 	}
 
 	// TODO: Consider consolidating the following set functions
@@ -63,9 +64,9 @@ export default class ProductFormDetailsCard extends Component {
 		}
 	}
 
-	setDescription( e ) {
+	setDescription( description ) {
 		const { product, editProduct } = this.props;
-		editProduct( product, { description: e.target.value } );
+		editProduct( product, { description } );
 	}
 
 	onImageUpload = ( image ) => {
@@ -120,11 +121,10 @@ export default class ProductFormDetailsCard extends Component {
 						</FormFieldSet>
 						<FormFieldSet className="products__product-form-details-basic-description">
 							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>
-							<FormTextArea
-								id="description"
+							<CompactTinyMCE
 								value={ product.description || '' }
-								onChange={ this.setDescription }
-								rows="8" />
+								onContentsChange={ this.debouncedSetDescription }
+							/>
 						</FormFieldSet>
 					</div>
 				</div>

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -4,17 +4,17 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
+import { find, debounce } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import CompactTinyMCE from 'woocommerce/components/compact-tinymce';
 import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
 import FormClickToEditInput from 'woocommerce/components/form-click-to-edit-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormTextArea from 'components/forms/form-textarea';
 import FormToggle from 'components/forms/form-toggle';
 import VerticalMenu from 'components/vertical-menu';
 
@@ -29,25 +29,38 @@ class ProductFormVariationsModal extends React.Component {
 	constructor( props ) {
 		super( props );
 
+		const { selectedVariation } = props;
+
 		this.state = {
-			selectedVariation: this.props.selectedVariation,
+			selectedVariation: selectedVariation,
+			editor: () => this.editorComponent( selectedVariation ),
 		};
 
 		this.switchVariation = this.switchVariation.bind( this );
-		this.setDescription = this.setDescription.bind( this );
 		this.toggleVisible = this.toggleVisible.bind( this );
+	}
+
+	/*
+	 * Initialize an editor when loading a different variation so we can
+	 * make sure the correct event handler runs, and that we don't share the
+	 * same TinyMCE instance for different descriptions.
+	 */
+	editorComponent = ( variationId ) => {
+		const { product, variations, editProductVariation } = this.props;
+		const variation = find( variations, ( v ) => variationId === v.id );
+		const setDescription = debounce( ( description ) => {
+			editProductVariation( product, variation, { description } );
+		}, 200 );
+		return <CompactTinyMCE
+				value={ variation.description || '' }
+				onContentsChange={ setDescription }
+			/>;
 	}
 
 	selectedVariation() {
 		const { selectedVariation } = this.state;
 		const { variations } = this.props;
 		return find( variations, ( v ) => selectedVariation === v.id );
-	}
-
-	setDescription( e ) {
-		const { product, editProductVariation } = this.props;
-		const variation = this.selectedVariation();
-		editProductVariation( product, variation, { description: e.target.value } );
 	}
 
 	setSku = ( sku ) => {
@@ -65,7 +78,8 @@ class ProductFormVariationsModal extends React.Component {
 
 	switchVariation( selectedVariation ) {
 		this.setState( {
-			selectedVariation
+			selectedVariation,
+			editor: () => this.editorComponent( selectedVariation ),
 		} );
 	}
 
@@ -79,6 +93,8 @@ class ProductFormVariationsModal extends React.Component {
 				<ModalNavItem key={ i } variation={ v } selected={ selectedVariation } />
 			);
 		} );
+
+		const Editor = this.state.editor;
 
 		return (
 			<div className="products__product-form-modal-wrapper">
@@ -104,11 +120,7 @@ class ProductFormVariationsModal extends React.Component {
 
 					<FormFieldSet className="products__product-form-variation-description">
 						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
-						<FormTextArea
-							id="description"
-							value={ variation.description || '' }
-							onChange={ this.setDescription }
-						/>
+						<Editor />
 						<FormSettingExplanation>{ translate(
 								'This will be displayed in addition to the main product description when this variation is selected.'
 						) }</FormSettingExplanation>

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -32,7 +32,7 @@ class ProductFormVariationsModal extends React.Component {
 		const { selectedVariation } = props;
 
 		this.state = {
-			selectedVariation: selectedVariation,
+			selectedVariation,
 			editor: () => this.editorComponent( selectedVariation ),
 		};
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -553,7 +553,8 @@
 
 		.compact-tinymce {
 			padding: 16px;
-			margin-left: -136px;
+			padding-left: 0px;
+			max-width: 700px;
 		}
 	}
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -550,6 +550,11 @@
 		padding: 16px;
 		max-height: 80vh;
 		overflow-y: hidden;
+
+		.compact-tinymce {
+			padding: 16px;
+			margin-left: -136px;
+		}
 	}
 
 	h1 {

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { assign, uniqueId, noop } from 'lodash';
+import classNames from 'classnames';
+import tinymce from 'tinymce/tinymce';
+
+/**
+ * Internal dependencies
+ */
+import i18n from 'components/tinymce/i18n';
+import userFactory from 'lib/user';
+import { wpautop } from 'lib/formatting';
+// TinyMCE plugins & dependencies
+import wplinkPlugin from 'components/tinymce/plugins/wplink/plugin';
+import 'tinymce/themes/modern/theme.js';
+import 'tinymce/plugins/lists/plugin.js';
+
+class CompactTinyMCE extends Component {
+	static contextTypes = {
+		store: PropTypes.object,
+	}
+
+	static propTypes = {
+		height: PropTypes.number,
+		className: PropTypes.string,
+		value: PropTypes.string,
+		onContentsChange: PropTypes.func,
+	}
+
+	static defaultProps = {
+		height: 250,
+		className: '',
+		value: '',
+		onContentsChange: noop,
+	}
+
+	// See this.localize()
+	DUMMY_LANG_URL = '/do-not-load/';
+
+	componentWillMount() {
+		this._id = uniqueId( 'woocommerce-tinymce-' );
+		// Init any plugins we need
+		wplinkPlugin();
+	}
+
+	componentDidMount() {
+		this.mounted = true;
+
+		const setup = function( editor ) {
+			this._editor = editor;
+
+			if ( ! this.mounted ) {
+				this.destroyEditor();
+				return;
+			}
+
+			const { value, onContentsChange } = this.props;
+			editor.on( 'init', () => {
+				this._editor.setContent( wpautop( value ) );
+			} );
+			if ( onContentsChange ) {
+				editor.on( 'change', () => {
+					onContentsChange( this._editor.getContent() );
+				} );
+				editor.on( 'keyup', () => {
+					onContentsChange( this._editor.getContent() );
+				} );
+			}
+		}.bind( this );
+
+		this.localize();
+		const user = userFactory();
+
+		tinymce.init( {
+			selector: '#' + this._id,
+			skin_url: '//s1.wp.com/wp-includes/js/tinymce/skins/lightgray',
+			skin: 'lightgray',
+			body_class: 'description',
+			content_css: '/calypso/tinymce/skins/woocommerce/content.css',
+			language: user.get() ? user.get().localeSlug : 'en',
+			language_url: this.DUMMY_LANG_URL,
+			directionality: user.isRTL() ? 'rtl' : 'ltr',
+			relative_urls: false,
+			remove_script_host: false,
+			convert_urls: false,
+			browser_spellcheck: true,
+			fix_list_elements: true,
+			keep_styles: false,
+			textarea: this.refs.text,
+			preview_styles: 'font-family font-size font-weight font-style text-decoration text-transform',
+			end_container_on_empty_block: true,
+			statusbar: false,
+			resize: false,
+			menubar: false,
+			indent: false,
+			plugins: 'lists,wplink',
+			redux_store: this.context.store,
+			height: this.props.height + 'px',
+			toolbar1: 'formatselect,bold,italic,bullist,numlist,link,blockquote',
+			toolbar2: '',
+			toolbar3: '',
+			toolbar4: '',
+			branding: false,
+			add_unload_trigger: false,
+			setup: setup,
+		} );
+
+		// TODO Investigate if there is a better way to do this in the future.
+		// The post editor adds a bunch of CSS rules that affect TinyMCE, in root components.
+		// To avoid making changes that affect the post editor at this time, we can load a small set of CSS.
+		tinymce.DOM.loadCSS( '/calypso/tinymce/skins/woocommerce/editor.css' );
+	}
+
+	componentWillUnmount() {
+		this.mounted = false;
+		if ( this._editor ) {
+			this.destroyEditor();
+		}
+	}
+
+	destroyEditor() {
+		tinymce.remove( this._editor );
+		this._editor = null;
+	}
+
+	localize() {
+		const user = userFactory();
+		const userData = user.get();
+		let i18nStrings = i18n;
+
+		if ( ! userData ) {
+			return;
+		}
+
+		if ( user.isRTL() ) {
+			i18nStrings = assign( { _dir: 'rtl' }, i18nStrings );
+		}
+
+		tinymce.addI18n( userData.localeSlug, i18nStrings );
+
+		// Stop TinyMCE from trying to load the lang script by marking as done
+		tinymce.ScriptLoader.markDone( this.DUMMY_LANG_URL );
+	}
+
+	render() {
+		const tinyMCEClassName = classNames( 'tinymce' );
+		const className = classNames( 'compact-tinymce', this.props.className );
+		return (
+			<div className={ className }>
+				<textarea
+					ref="text"
+					className={ tinyMCEClassName }
+					id={ this._id }
+				/>
+			</div>
+		);
+	}
+}
+
+export default CompactTinyMCE;

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -110,6 +110,7 @@ class CompactTinyMCE extends Component {
 		// TODO Investigate if there is a better way to do this in the future.
 		// The post editor adds a bunch of CSS rules that affect TinyMCE, in root components.
 		// To avoid making changes that affect the post editor at this time, we can load a small set of CSS.
+		// This mainly affects the text format drop down which renders outside of any elements that we can target.
 		tinymce.DOM.loadCSS( '/calypso/tinymce/skins/woocommerce/editor.css' );
 	}
 

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -5,6 +5,8 @@ import React, { Component, PropTypes } from 'react';
 import { assign, uniqueId, noop } from 'lodash';
 import classNames from 'classnames';
 import tinymce from 'tinymce/tinymce';
+import 'tinymce/themes/modern/theme.js';
+import 'tinymce/plugins/lists/plugin.js';
 
 /**
  * Internal dependencies
@@ -14,8 +16,6 @@ import userFactory from 'lib/user';
 import { wpautop } from 'lib/formatting';
 // TinyMCE plugins & dependencies
 import wplinkPlugin from 'components/tinymce/plugins/wplink/plugin';
-import 'tinymce/themes/modern/theme.js';
-import 'tinymce/plugins/lists/plugin.js';
 
 class CompactTinyMCE extends Component {
 	static contextTypes = {
@@ -23,10 +23,10 @@ class CompactTinyMCE extends Component {
 	}
 
 	static propTypes = {
+		onContentsChange: PropTypes.func.isRequired,
 		height: PropTypes.number,
 		className: PropTypes.string,
 		value: PropTypes.string,
-		onContentsChange: PropTypes.func,
 	}
 
 	static defaultProps = {
@@ -49,7 +49,7 @@ class CompactTinyMCE extends Component {
 		this.mounted = true;
 
 		const setup = function( editor ) {
-			this._editor = editor;
+			this.editor = editor;
 
 			if ( ! this.mounted ) {
 				this.destroyEditor();
@@ -58,14 +58,14 @@ class CompactTinyMCE extends Component {
 
 			const { value, onContentsChange } = this.props;
 			editor.on( 'init', () => {
-				this._editor.setContent( wpautop( value ) );
+				this.editor.setContent( wpautop( value ) );
 			} );
 			if ( onContentsChange ) {
 				editor.on( 'change', () => {
-					onContentsChange( this._editor.getContent() );
+					onContentsChange( this.editor.getContent() );
 				} );
 				editor.on( 'keyup', () => {
-					onContentsChange( this._editor.getContent() );
+					onContentsChange( this.editor.getContent() );
 				} );
 			}
 		}.bind( this );
@@ -116,14 +116,14 @@ class CompactTinyMCE extends Component {
 
 	componentWillUnmount() {
 		this.mounted = false;
-		if ( this._editor ) {
+		if ( this.editor ) {
 			this.destroyEditor();
 		}
 	}
 
 	destroyEditor() {
-		tinymce.remove( this._editor );
-		this._editor = null;
+		tinymce.remove( this.editor );
+		this.editor = null;
 	}
 
 	localize() {

--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -1,0 +1,53 @@
+.compact-tinymce {
+	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox:hover {
+		border-left-color: lighten( $gray, 20% );
+		border-right-color: lighten( $gray, 20% );
+	}
+
+	.mce-edit-area {
+		border: 1px solid lighten( $gray, 20% ) !important;
+		margin-bottom: 4px;
+		padding-top: 36px;
+		padding-left: 8px;
+	}
+
+	.mce-tinymce .mce-stack-layout-item.mce-last {
+		border-top: 1px solid lighten( $gray, 20% );
+	}
+
+	div.mce-toolbar-grp {
+		background-color: rgba( $white, 0.92 );
+		border-color: lighten( $gray, 20% );
+		border-style: solid;
+		border-right-width: 1px;
+		padding: 0;
+		overflow-x: auto;
+		margin: 0 auto;
+	}
+
+	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox {
+		margin: 0 2px 0 0;
+		padding: 0 8px;
+		vertical-align: top;
+		border-left: 1px solid lighten( $gray, 20% );
+		border-right: 1px solid lighten( $gray, 20% );
+		height: 36px;
+	}
+
+	.mce-toolbar .mce-btn-group .mce-btn:hover,
+	.mce-toolbar .mce-btn-group .mce-btn:focus,
+	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox:hover,
+	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox:focus {
+		box-shadow: none;
+	}
+
+	.mce-toolbar .mce-btn-group .mce-btn:hover .mce-ico,
+	.mce-toolbar .mce-btn-group .mce-btn:focus .mce-ico {
+		color: $gray-dark;
+	}
+
+	.mce-toolbar .mce-btn-group .mce-btn:hover .gridicon,
+	.mce-toolbar .mce-btn-group .mce-btn:focus .gridicon {
+		fill: $gray-dark;
+	}
+}

--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -41,6 +41,14 @@
 		box-shadow: none;
 	}
 
+	.mce-toolbar .mce-btn-group .mce-ico {
+		color: darken( $gray, 20% );
+	}
+
+	.mce-toolbar .mce-btn-group .mce-btn .gridicon {
+		fill: darken( $gray, 20% );
+	}
+
 	.mce-toolbar .mce-btn-group .mce-btn:hover .mce-ico,
 	.mce-toolbar .mce-btn-group .mce-btn:focus .mce-ico {
 		color: $gray-dark;

--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -1,6 +1,6 @@
 .compact-tinymce {
 	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox:hover {
-		border-left-color: lighten( $gray, 20% );
+		border-left-color: transparent;
 		border-right-color: lighten( $gray, 20% );
 	}
 
@@ -11,15 +11,11 @@
 		padding-left: 8px;
 	}
 
-	.mce-tinymce .mce-stack-layout-item.mce-last {
-		border-top: 1px solid lighten( $gray, 20% );
-	}
-
 	div.mce-toolbar-grp {
 		background-color: rgba( $white, 0.92 );
 		border-color: lighten( $gray, 20% );
 		border-style: solid;
-		border-right-width: 1px;
+		border-width: 1px;
 		padding: 0;
 		overflow-x: auto;
 		margin: 0 auto;
@@ -29,9 +25,30 @@
 		margin: 0 2px 0 0;
 		padding: 0 8px;
 		vertical-align: top;
-		border-left: 1px solid lighten( $gray, 20% );
 		border-right: 1px solid lighten( $gray, 20% );
 		height: 36px;
+
+		@include breakpoint( "<660px" ) {
+			height: 44px;
+		}
+	}
+
+	.mce-tinymce .mce-stack-layout-item.mce-last {
+		border-top-width: 0px;
+	}
+
+	.mce-container.mce-tinymce {
+		& > .mce-container-body {
+			&:after {
+				@include breakpoint( "<660px" ) {
+					@include long-content-fade( $size: 0px );
+				}
+
+				@include breakpoint( "660px-960px" ) {
+					@include long-content-fade( $size: 0px );
+				}
+			}
+		}
 	}
 
 	.mce-toolbar .mce-btn-group .mce-btn:hover,

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -12,6 +12,7 @@
 	@import 'app/settings/payments/style';
 	@import 'components/action-header/style';
 	@import 'components/address-view/style';
+	@import 'components/compact-tinymce/style';
 	@import 'components/extended-header/style';
 	@import 'components/form-click-to-edit-input/style';
 	@import 'components/form-dimensions-input/style';

--- a/public/tinymce/skins/woocommerce/content.css
+++ b/public/tinymce/skins/woocommerce/content.css
@@ -1,0 +1,5 @@
+.description {
+	font-size: 16px;
+	color: #2e4453;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+}

--- a/public/tinymce/skins/woocommerce/editor.css
+++ b/public/tinymce/skins/woocommerce/editor.css
@@ -1,0 +1,8 @@
+.mce-container.mce-menu,
+.mce-container .mce-floatpanel.mce-popover {
+	z-index: 25 !important;
+}
+
+.mce-tinymce .mce-btn-group .mce-btn.mce-last {
+	position: initial;
+}

--- a/public/tinymce/skins/woocommerce/editor.css
+++ b/public/tinymce/skins/woocommerce/editor.css
@@ -6,3 +6,7 @@
 .mce-tinymce .mce-btn-group .mce-btn.mce-last {
 	position: initial;
 }
+
+.mce-container.mce-menu {
+	margin-left: -1px;
+}

--- a/public/tinymce/skins/woocommerce/editor.css
+++ b/public/tinymce/skins/woocommerce/editor.css
@@ -1,6 +1,6 @@
 .mce-container.mce-menu,
 .mce-container .mce-floatpanel.mce-popover {
-	z-index: 25 !important;
+	z-index: 999999 !important;
 }
 
 .mce-tinymce .mce-btn-group .mce-btn.mce-last {


### PR DESCRIPTION
This PR adds a new `<CompactTinyMCE />` component to `woocommerce/components` so that we can display basic TinyMCE text areas. The existing `<TinyMCE />` component is heavily tied to the post form, post styles, and contains a lot things we don't need and can't disable like pinned toolbars.

This PR also converts the product description field and variation description fields to TinyMCE instances.

To Test:
* Go to `http://calypso.localhost:3000/store/product/:site`
* Make sure that TinyMCE loads and you see an editing toolbar.
* Type in the field and make sure you can see your description as you type.
* Try different toolbar options/buttons.
* Create some variations and test out the description inputs there as well.

<img width="420" alt="screen shot 2017-06-08 at 3 17 05 pm" src="https://user-images.githubusercontent.com/689165/26953149-908ac12c-4c5d-11e7-9d9a-90aeddb70c67.png">

cc @kellychoffman @jameskoster this PR contains UI elements.

Closes #13631.
Closes #13248.