### PR TITLE
WCS: Update Table Progress

### DIFF
--- a/client/extensions/woocommerce/components/table/docs/example.js
+++ b/client/extensions/woocommerce/components/table/docs/example.js
@@ -23,10 +23,6 @@ class Example extends Component {
 		this.setState( { isCompact: ! this.state.isCompact } );
 	}
 
-	onToggleBorder = () => {
-		this.setState( { hasBorder: ! this.state.hasBorder } );
-	}
-
 	render() {
 		const titles = (
 			<TableRow isHeader>
@@ -64,11 +60,8 @@ class Example extends Component {
 					<Button onClick={ this.onToggleCompact }>
 						{ this.state.isCompact ? 'Expanded' : 'Compact' }
 					</Button>
-					<Button onClick={ this.onToggleBorder }>
-						{ this.state.hasBorder ? 'Remove Border' : 'Add Border' }
-					</Button>
 				</div>
-				<Table header={ titles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+				<Table header={ titles } compact={ this.state.isCompact }>
 					{ values.map( ( row, i ) => (
 						<TableRow key={ i }>
 							{ row.map( ( item, j ) => (
@@ -77,7 +70,7 @@ class Example extends Component {
 						</TableRow>
 					) ) }
 				</Table>
-				<Table header={ middleColTitles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+				<Table header={ middleColTitles } compact={ this.state.isCompact }>
 					{ middleColValues.map( ( row, i ) => (
 						<TableRow key={ i }>
 							{ row.map( ( item, j ) => (
@@ -87,7 +80,7 @@ class Example extends Component {
 					) ) }
 				</Table>
 				<div style={ { width: '50%' } }>
-					<Table header={ titles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+					<Table header={ titles } compact={ this.state.isCompact }>
 						{ values.map( ( row, i ) => (
 							<TableRow key={ i }>
 								{ row.map( ( item, j ) => (
@@ -98,7 +91,7 @@ class Example extends Component {
 					</Table>
 				</div>
 				<div style={ { width: '33%' } }>
-					<Table header={ titles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+					<Table header={ titles } compact={ this.state.isCompact }>
 						{ values.map( ( row, i ) => (
 							<TableRow key={ i }>
 								{ row.map( ( item, j ) => (

--- a/client/extensions/woocommerce/components/table/docs/example.js
+++ b/client/extensions/woocommerce/components/table/docs/example.js
@@ -1,54 +1,97 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Table from 'woocommerce/components/table';
-import Row from 'woocommerce/components/table/table-row';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
 import Gridicon from 'gridicons';
 
-const Example = () => {
-	const titles = [ 'Title', '', 'Qty', 'Total' ];
-	const link = <a href="#">An internal Link!</a>;
-	const externalLink = (
-		<a href="#">
-			<Gridicon icon="external" size={ 18 } />
-		</a>
-	);
-	const placeholder = '';
-	const values = [
-		[ 'one', placeholder, <a href="#">222</a>, 45 ],
-		[ 'really really really really really really long name', placeholder, 55, 777 ],
-		[ 'three', externalLink, <div>9</div>, 45 ],
-		[ link, externalLink, <Gridicon icon="cog" size={ 18 } />, 8 ],
-	];
+class Example extends Component {
+	state = {
+		hasBorder: false,
+		isCompact: false,
+	};
 
-	return (
-		<div>
-			<Table values={ titles }>
-				{ values.map( v => (
-					<Row key={ v } values={ v }/>
-				) ) }
-			</Table>
-			<div style={ { width: '50%' } }>
-				<Table values={ titles }>
-					{ values.map( v => (
-						<Row key={ v } values={ v }/>
+	onToggleCompact = () => {
+		this.setState( { isCompact: ! this.state.isCompact } );
+	}
+
+	onToggleBorder = () => {
+		this.setState( { hasBorder: ! this.state.hasBorder } );
+	}
+
+	render() {
+		const titles = (
+			<TableRow isHeader>
+				{ [ 'Title', '', 'Qty', 'Total' ].map( ( item, i ) => <TableItem isHeader isTitle={ 0 == i }>{ item }</TableItem> ) }
+			</TableRow>
+		);
+		const link = <a href="#">An internal Link!</a>;
+		const externalLink = (
+			<a href="#">
+				<Gridicon icon="external" size={ 18 } />
+			</a>
+		);
+		const placeholder = '';
+		const values = [
+			[ 'one', placeholder, <a href="#">222</a>, 45 ],
+			[ 'really really really really really really long name', placeholder, 55, 777 ],
+			[ 'three', externalLink, <div>9</div>, 45 ],
+			[ link, externalLink, <Gridicon icon="cog" size={ 18 } />, 8 ],
+		];
+
+		return (
+			<div className="woocommerce">
+				<div className="docs__design-toggle">
+					<Button onClick={ this.onToggleCompact }>
+						{ this.state.isCompact ? 'Expanded' : 'Compact' }
+					</Button>
+					<Button onClick={ this.onToggleBorder }>
+						{ this.state.hasBorder ? 'Remove Border' : 'Add Border' }
+					</Button>
+				</div>
+				<Table header={ titles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+					{ values.map( ( row, i ) => (
+						<TableRow key={ i }>
+							{ row.map( ( item, j ) => (
+								<TableItem key={ j } isTitle={ 0 == j }>{ item }</TableItem>
+							) ) }
+						</TableRow>
 					) ) }
 				</Table>
+				<div style={ { width: '50%' } }>
+					<Table header={ titles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+						{ values.map( ( row, i ) => (
+							<TableRow key={ i }>
+								{ row.map( ( item, j ) => (
+									<TableItem key={ j } isTitle={ 0 == j }>{ item }</TableItem>
+								) ) }
+							</TableRow>
+						) ) }
+					</Table>
+				</div>
+				<div style={ { width: '33%' } }>
+					<Table header={ titles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+						{ values.map( ( row, i ) => (
+							<TableRow key={ i }>
+								{ row.map( ( item, j ) => (
+									<TableItem key={ j } isTitle={ 0 == j }>{ item }</TableItem>
+								) ) }
+							</TableRow>
+						) ) }
+					</Table>
+				</div>
 			</div>
-			<div style={ { width: '33%' } }>
-				<Table values={ titles }>
-					{ values.map( v => (
-						<Row key={ v } values={ v }/>
-					) ) }
-				</Table>
-			</div>
-		</div>
-	);
-};
+		);
+	};
+}
+
+Example.displayName = 'WooTable';
 
 export default Example;

--- a/client/extensions/woocommerce/components/table/docs/example.js
+++ b/client/extensions/woocommerce/components/table/docs/example.js
@@ -11,6 +11,7 @@ import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
 import Gridicon from 'gridicons';
+import FormInputCheckbox from 'components/forms/form-checkbox';
 
 class Example extends Component {
 	state = {
@@ -29,7 +30,7 @@ class Example extends Component {
 	render() {
 		const titles = (
 			<TableRow isHeader>
-				{ [ 'Title', '', 'Qty', 'Total' ].map( ( item, i ) => <TableItem isHeader isTitle={ 0 == i }>{ item }</TableItem> ) }
+				{ [ 'Title', '', 'Qty', 'Total' ].map( ( item, i ) => <TableItem isHeader key={ i } isTitle={ 0 === i }>{ item }</TableItem> ) }
 			</TableRow>
 		);
 		const link = <a href="#">An internal Link!</a>;
@@ -45,6 +46,17 @@ class Example extends Component {
 			[ 'three', externalLink, <div>9</div>, 45 ],
 			[ link, externalLink, <Gridicon icon="cog" size={ 18 } />, 8 ],
 		];
+		const middleColValues = [
+			[ <FormInputCheckbox/>, placeholder, 'Thing 1', 65 ],
+			[ <FormInputCheckbox/>, placeholder, 'Thing 2', 66 ],
+			[ <FormInputCheckbox/>, placeholder, 'Thing 3', 67 ],
+			[ <FormInputCheckbox/>, placeholder, 'Thing 4', 68 ],
+		];
+		const middleColTitles = (
+			<TableRow isHeader>
+				{ [ <FormInputCheckbox/>, placeholder, 'Description', 'Total' ].map( ( item, i ) => <TableItem isHeader key={ i } isTitle={ 2 === i }>{ item }</TableItem> ) }
+			</TableRow>
+		);
 
 		return (
 			<div className="woocommerce">
@@ -65,12 +77,21 @@ class Example extends Component {
 						</TableRow>
 					) ) }
 				</Table>
+				<Table header={ middleColTitles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
+					{ middleColValues.map( ( row, i ) => (
+						<TableRow key={ i }>
+							{ row.map( ( item, j ) => (
+								<TableItem key={ j } isRowHeader={ 2 === j } isTitle={ 2 === j }>{ item }</TableItem>
+							) ) }
+						</TableRow>
+					) ) }
+				</Table>
 				<div style={ { width: '50%' } }>
 					<Table header={ titles } hasBorder={ this.state.hasBorder } compact={ this.state.isCompact }>
 						{ values.map( ( row, i ) => (
 							<TableRow key={ i }>
 								{ row.map( ( item, j ) => (
-									<TableItem key={ j } isTitle={ 0 == j }>{ item }</TableItem>
+									<TableItem key={ j } isRowHeader={ 0 === j } isTitle={ 0 === j }>{ item }</TableItem>
 								) ) }
 							</TableRow>
 						) ) }
@@ -81,7 +102,7 @@ class Example extends Component {
 						{ values.map( ( row, i ) => (
 							<TableRow key={ i }>
 								{ row.map( ( item, j ) => (
-									<TableItem key={ j } isTitle={ 0 == j }>{ item }</TableItem>
+									<TableItem key={ j } isTitle={ 0 === j }>{ item }</TableItem>
 								) ) }
 							</TableRow>
 						) ) }

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -9,10 +9,9 @@ import classnames from 'classnames';
  */
 import Card from 'components/card';
 
-const Table = ( { className, compact, header, hasBorder, children, ...props } ) => {
+const Table = ( { className, compact, header, children, ...props } ) => {
 	const classes = classnames( {
 		table: true,
-		'has-border': hasBorder,
 		'is-compact-table': compact,
 	}, className );
 	return (
@@ -35,7 +34,6 @@ Table.propTypes = {
 	children: PropTypes.node,
 	compact: PropTypes.bool,
 	header: PropTypes.node,
-	hasBorder: PropTypes.bool,
 };
 
 export default Table;

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -13,7 +13,7 @@ const Table = ( { className, compact, header, hasBorder, children, ...props } ) 
 	const classes = classnames( {
 		table: true,
 		'has-border': hasBorder,
-		'is-compact': compact,
+		'is-compact-table': compact,
 	}, className );
 	return (
 		<Card className={ classes }>

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -8,15 +8,20 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
-import Row from './table-row';
 
-const Table = ( { values, className, children } ) => {
+const Table = ( { className, compact, header, hasBorder, children, ...props } ) => {
+	const classes = classnames( {
+		table: true,
+		'has-border': hasBorder,
+		'is-compact': compact,
+	}, className );
 	return (
-		<Card className={ classnames( 'table', className ) }>
-			<table>
-				<thead>
-					<Row isHeader values={ values } />
-				</thead>
+		<Card className={ classes }>
+			<table { ...props }>
+				{ header
+					? <thead>{ header }</thead>
+					: null
+				}
 				<tbody>
 					{ children }
 				</tbody>
@@ -26,9 +31,11 @@ const Table = ( { values, className, children } ) => {
 };
 
 Table.propTypes = {
-	values: PropTypes.array,
 	className: PropTypes.string,
 	children: PropTypes.node,
+	compact: PropTypes.bool,
+	header: PropTypes.node,
+	hasBorder: PropTypes.bool,
 };
 
 export default Table;

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -17,10 +17,7 @@ const Table = ( { className, compact, header, children, ...props } ) => {
 	return (
 		<Card className={ classes }>
 			<table { ...props }>
-				{ header
-					? <thead>{ header }</thead>
-					: null
-				}
+				{ header && <thead>{ header }</thead> }
 				<tbody>
 					{ children }
 				</tbody>

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -5,26 +5,29 @@
 
 	padding: 0;
 
-	&.has-border {
-		thead .table-heading,
-		thead .table-item {
-			border-bottom: 1px solid lighten( $gray, 20% );
-		}
+	thead .table-heading,
+	thead .table-item {
+		border-bottom: 1px solid lighten( $gray, 20% );
+	}
 
-		tbody .table-heading,
-		tbody .table-item {
-			border-bottom: 1px solid lighten( $gray, 30% );
-		}
+	tbody .table-heading,
+	tbody .table-item {
+		border-bottom: 1px solid lighten( $gray, 30% );
+	}
 
-		// Remove the border from the last item in the body of the table.
-		tbody tr:last-child .table-heading,
-		tbody tr:last-child .table-item {
-			border: none;
-		}
+	// Remove the border from the last item in the body of the table.
+	tbody tr:last-child .table-heading,
+	tbody tr:last-child .table-item {
+		border: none;
 	}
 
 	&.is-compact-table {
 		padding: .5em 0;
+
+		.table-heading,
+		.table-item {
+			border-bottom: none;
+		}
 
 		.table-row {
 			&.is-header {
@@ -106,4 +109,3 @@
 		font-weight: normal;
 	}
 }
-

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -1,62 +1,97 @@
 .table {
 	table {
-		margin:	0;
+		margin: 0;
 	}
 
-	padding: .5em 0;
-}
+	.table-row {
+		line-height: 28px;
 
-.table-row {
-	line-height: 28px;
-
-	&.is-header {
-		color: $gray;
-		line-height: 40px;
-		&:hover {
-			background-color: initial;
-		}
-		.table-row__cell-title::after {
-			display: none;
+		&.is-header {
+			color: $gray-text-min;
+			line-height: 40px;
 		}
 	}
-	&:hover {
-		background-color: $gray-light;
 
-		.table-row__cell-title:after {
-			background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, $gray-light 90%);
+	.table-heading,
+	.table-item {
+		padding: 16px 16px 14px;
+		vertical-align: middle;
+	}
+
+	&.is-compact {
+		margin-bottom: 16px;
+
+		.table-row {
+			&.is-header {
+				.table-item__cell-title::after {
+					display: none;
+				}
+
+				&:hover {
+					background-color: initial;
+				}
+			}
+
+			&:hover {
+				background-color: $gray-light;
+
+				.table-item__cell-title:after {
+					background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, $gray-light 90%);
+				}
+			}
+		}
+
+		.table-heading,
+		.table-item {
+			text-align: right;
+			padding: 0 24px 0 0;
+			white-space: nowrap;
+			font-size: 14px;
+
+			&.is-title-cell {
+				padding: 0 0 0 24px;
+				text-align: left;
+				width: 100%;
+				// https://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
+				max-width: 0;
+			}
+		}
+
+		.table-item__cell-title {
+			width: 100%;
+			position: relative;
+			overflow: hidden;
+
+			&::after {
+				background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, $white 90%);
+				position: absolute;
+				z-index: 1;
+				right: 0;
+				top: 0;
+				bottom: 0;
+				content: "";
+				width: 48px;
+			}
 		}
 	}
-}
 
-.table-row__cell {
-	text-align: right;
-	padding: 0 24px 0 0;
-	white-space: nowrap;
-	font-size: 14px;
-	vertical-align: middle;
+	&.has-border {
+		padding: 0;
 
-	&.is-title-cell {
-		padding: 0 0 0 24px;
-		text-align: left;
-		width: 100%;
-		// https://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
-		max-width: 0;
-	}
-}
+		thead .table-heading,
+		thead .table-item {
+			border-bottom: 1px solid lighten( $gray, 20% );
+		}
 
-.table-row__cell-title {
-	width: 100%;
-	position: relative;
-	overflow: hidden;
+		tbody .table-heading,
+		tbody .table-item {
+			border-bottom: 1px solid lighten( $gray, 30% );
+		}
 
-	&::after {
-		background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, $white 90%);
-		position: absolute;
-		z-index: 1;
-		right: 0;
-		top: 0;
-		bottom: 0;
-		content: "";
-		width: 48px;
+		// Remove the border from the last item in the body of the table.
+		tbody tr:last-child .table-heading,
+		tbody tr:last-child .table-item {
+			border: none;
+		}
 	}
 }

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -3,23 +3,28 @@
 		margin: 0;
 	}
 
-	.table-row {
-		line-height: 28px;
+	padding: 0;
 
-		&.is-header {
-			color: $gray-text-min;
-			line-height: 40px;
+	&.has-border {
+		thead .table-heading,
+		thead .table-item {
+			border-bottom: 1px solid lighten( $gray, 20% );
+		}
+
+		tbody .table-heading,
+		tbody .table-item {
+			border-bottom: 1px solid lighten( $gray, 30% );
+		}
+
+		// Remove the border from the last item in the body of the table.
+		tbody tr:last-child .table-heading,
+		tbody tr:last-child .table-item {
+			border: none;
 		}
 	}
 
-	.table-heading,
-	.table-item {
-		padding: 16px 16px 14px;
-		vertical-align: middle;
-	}
-
-	&.is-compact {
-		margin-bottom: 16px;
+	&.is-compact-table {
+		padding: .5em 0;
 
 		.table-row {
 			&.is-header {
@@ -44,12 +49,19 @@
 		.table-heading,
 		.table-item {
 			text-align: right;
-			padding: 0 24px 0 0;
+			padding: 0 12px;
 			white-space: nowrap;
 			font-size: 14px;
 
+			&:first-child {
+				padding: 0 12px 0 24px;
+			}
+
+			&:last-child {
+				padding: 0 24px 0 12px;
+			}
+
 			&.is-title-cell {
-				padding: 0 0 0 24px;
 				text-align: left;
 				width: 100%;
 				// https://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
@@ -74,24 +86,24 @@
 			}
 		}
 	}
+}
 
-	&.has-border {
-		padding: 0;
+.table-row {
+	line-height: 28px;
 
-		thead .table-heading,
-		thead .table-item {
-			border-bottom: 1px solid lighten( $gray, 20% );
-		}
-
-		tbody .table-heading,
-		tbody .table-item {
-			border-bottom: 1px solid lighten( $gray, 30% );
-		}
-
-		// Remove the border from the last item in the body of the table.
-		tbody tr:last-child .table-heading,
-		tbody tr:last-child .table-item {
-			border: none;
-		}
+	&.is-header {
+		color: $gray-text-min;
+		line-height: 40px;
 	}
 }
+
+.table-heading,
+.table-item {
+	padding: 16px 16px 14px;
+	vertical-align: middle;
+
+	&.is-row-heading {
+		font-weight: normal;
+	}
+}
+

--- a/client/extensions/woocommerce/components/table/table-item/index.js
+++ b/client/extensions/woocommerce/components/table/table-item/index.js
@@ -4,21 +4,30 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 
-const TableItem = ( { className, isHeader, isTitle, children, ...props } ) => {
+function getScope( isHeader, isRowHeader ) {
+	if ( isHeader ) {
+		return 'col';
+	}
+	if ( isRowHeader ) {
+		return 'row';
+	}
+	return null;
+}
+
+const TableItem = ( { className, isHeader, isRowHeader, isTitle, children, ...props } ) => {
+	const isHeading = isHeader || isRowHeader;
 	const classes = classNames( {
 		'table-heading': isHeader,
 		'table-item': ! isHeader,
 		'is-title-cell': isTitle,
+		'is-row-heading': isRowHeader,
 	}, className );
 
-	const Cell = isHeader ? 'th' : 'td';
-
-	if ( isHeader ) {
-		props.scope = props.scope || 'col';
-	}
+	const Cell = isHeading ? 'th' : 'td';
+	const scope = getScope( isHeader, isRowHeader );
 
 	return (
-		<Cell className={ classes } { ...props }>
+		<Cell className={ classes } scope={ scope } { ...props }>
 			{ isTitle
 				? <div className="table-item__cell-title" >{ children }</div>
 				: children
@@ -30,8 +39,10 @@ const TableItem = ( { className, isHeader, isTitle, children, ...props } ) => {
 TableItem.propTypes = {
 	className: PropTypes.string,
 	isHeader: PropTypes.bool,
+	isRowHeader: PropTypes.bool,
 	isTitle: PropTypes.bool,
 	children: PropTypes.node,
+	scope: PropTypes.string,
 };
 
 export default TableItem;

--- a/client/extensions/woocommerce/components/table/table-item/index.jsx
+++ b/client/extensions/woocommerce/components/table/table-item/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const TableItem = ( { className, isHeader, isTitle, children, ...props } ) => {
+	const classes = classNames( {
+		'table-heading': isHeader,
+		'table-item': ! isHeader,
+		'is-title-cell': isTitle,
+	}, className );
+
+	const Cell = isHeader ? 'th' : 'td';
+
+	if ( isHeader ) {
+		props.scope = props.scope || 'col';
+	}
+
+	return (
+		<Cell className={ classes } { ...props }>
+			{ isTitle
+				? <div className="table-item__cell-title" >{ children }</div>
+				: children
+			}
+		</Cell>
+	);
+};
+
+TableItem.propTypes = {
+	className: PropTypes.string,
+	isHeader: PropTypes.bool,
+	isTitle: PropTypes.bool,
+	children: PropTypes.node,
+};
+
+export default TableItem;

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -4,34 +4,22 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-const Row = ( { values, className, isHeader } ) => {
-	const El = isHeader ? 'th' : 'td';
+const TableRow = ( { className, isHeader, children, ...props } ) => {
 	const rowClasses = classnames( 'table-row', className, {
 		'is-header': isHeader,
 	} );
 
 	return (
-		<tr className={ rowClasses }>
-			{ values.map( ( value, index ) => {
-				if ( index === 0 ) {
-					return (
-						<El className={ 'table-row__cell is-title-cell' } key={ value + index }>
-							<div className="table-row__cell-title" >{ value }</div>
-						</El>
-					);
-				}
-				return (
-					<El className={ 'table-row__cell' } key={ value + index }>{ value }</El>
-				);
-			} ) }
+		<tr className={ rowClasses } { ...props }>
+			{ children }
 		</tr>
 	);
 };
 
-Row.propTypes = {
-	isHeader: PropTypes.bool,
-	values: PropTypes.array,
+TableRow.propTypes = {
+	children: PropTypes.node,
 	className: PropTypes.string,
+	isHeader: PropTypes.bool,
 };
 
-export default Row;
+export default TableRow;


### PR DESCRIPTION
@ryelle I'm creating this pull request onto the `add/woo-stats-table` branch to keep track of discussion surrounding these changes.

I do like your inclusion of `<TableItem />` because it gives more control to the consuming app for things like identifying row and column headers.

### Changes I made 
https://github.com/Automattic/wp-calypso/commit/2dad6012e94877a5ed284a50c2ed3358ea3506eb
* `is-compact` class -> `is-compact-table`. The Card component already uses that class.
* Added `isRowHeader` prop so that a row header can be specified and the scope reflects this prop.
* Moved some CSS around.
* For the `compact` table, I wanted to allow the `is-title-cell` cell to be anywhere in the row, not just the first. This way any column can be designated as having the most room.
![screen shot 2017-06-09 at 2 18 02 pm](https://user-images.githubusercontent.com/1922453/26958398-8bb2c692-4d1e-11e7-94d4-470d4d592b34.png)

I'm happy to go in this direction. Feel free to merge this and continue working on the `add/woo-stats-table` branch (or here if you prefer). We could benefit from a README I think (I can do Monday).