### PR TITLE
Fix cart items lint errors and ES6ify

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -60,7 +60,7 @@ import {
  * @param {Object} newCartItem - new item as `CartItemValue` object
  * @returns {Function} the function that adds the item to a shopping cart
  */
-function add( newCartItem ) {
+export function add( newCartItem ) {
 	function appendItem( products ) {
 		products = products || [];
 
@@ -121,7 +121,7 @@ function cartItemShouldReplaceCart( cartItem, cart ) {
  * @param {Object} cartItemToRemove - item as `CartItemValue` object
  * @returns {Function} the function that removes the item from a shopping cart
  */
-function remove( cartItemToRemove ) {
+export function remove( cartItemToRemove ) {
 	function rejectItem( products ) {
 		return reject( products, function( existingCartItem ) {
 			return (
@@ -144,7 +144,7 @@ function remove( cartItemToRemove ) {
  * @param {bool} domainsWithPlansOnly - Whether we should consider domains as dependents of products
  * @returns {Function} the function that removes the items from a shopping cart
  */
-function removeItemAndDependencies( cartItemToRemove, cart, domainsWithPlansOnly ) {
+export function removeItemAndDependencies( cartItemToRemove, cart, domainsWithPlansOnly ) {
 	const dependencies = getDependentProducts( cartItemToRemove, cart, domainsWithPlansOnly ),
 		changes = dependencies.map( remove ).concat( remove( cartItemToRemove ) );
 
@@ -177,7 +177,7 @@ function getDependentProducts( cartItem, cart, domainsWithPlansOnly ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Object[]} the list of items in the shopping cart as `CartItemValue` objects
  */
-function getAll( cart ) {
+export function getAll( cart ) {
 	return cart && cart.products || [];
 }
 
@@ -188,7 +188,7 @@ function getAll( cart ) {
  *
  * @returns {Object[]} the sorted list of items in the shopping cart
  */
-function getAllSorted( cart ) {
+export function getAllSorted( cart ) {
 	return sortProducts( getAll( cart ) );
 }
 
@@ -198,7 +198,7 @@ function getAllSorted( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Array} an array of renewal items
  */
-function getRenewalItems( cart ) {
+export function getRenewalItems( cart ) {
 	return getAll( cart ).filter( isRenewal );
 }
 
@@ -208,7 +208,7 @@ function getRenewalItems( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one item with free trial, false otherwise
  */
-function hasFreeTrial( cart ) {
+export function hasFreeTrial( cart ) {
 	return some( getAll( cart ), 'free_trial' );
 }
 
@@ -218,15 +218,15 @@ function hasFreeTrial( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one plan, false otherwise
  */
-function hasPlan( cart ) {
+export function hasPlan( cart ) {
 	return cart && some( getAll( cart ), isPlan );
 }
 
-function hasPremiumPlan( cart ) {
+export function hasPremiumPlan( cart ) {
 	return some( getAll( cart ), isPremium );
 }
 
-function hasDomainCredit( cart ) {
+export function hasDomainCredit( cart ) {
 	return cart.has_bundle_credit || hasPlan( cart );
 }
 
@@ -238,13 +238,13 @@ function hasDomainCredit( cart ) {
  *
  * @returns {Boolean} - Whether or not the cart contains a domain with that TLD
  */
-function hasTld( cart, tld ) {
+export function hasTld( cart, tld ) {
 	return some( getDomainRegistrations( cart ), function( cartItem ) {
 		return getDomainRegistrationTld( cartItem ) === '.' + tld;
 	} );
 }
 
-function getDomainRegistrationTld( cartItem ) {
+export function getDomainRegistrationTld( cartItem ) {
 	if ( ! isDomainRegistration( cartItem ) ) {
 		throw new Error( 'This function only works on domain registration cart ' +
 											'items.' );
@@ -260,7 +260,7 @@ function getDomainRegistrationTld( cartItem ) {
  * @returns {boolean} true if all items have free trial, false otherwise
  * @todo This will fail when a domain is purchased with a plan, as the domain will be included in the free trial
  */
-function hasOnlyFreeTrial( cart ) {
+export function hasOnlyFreeTrial( cart ) {
 	return cart.products && findFreeTrial( cart ) && every( getAll( cart ), { cost: 0 } );
 }
 
@@ -271,7 +271,7 @@ function hasOnlyFreeTrial( cart ) {
  * @param {Object} productSlug - the unique string that identifies the product
  * @returns {boolean} true if there is at least one item of the specified product type, false otherwise
  */
-function hasProduct( cart, productSlug ) {
+export function hasProduct( cart, productSlug ) {
 	return getAll( cart ).some( function( cartItem ) {
 		return cartItem.product_slug === productSlug;
 	} );
@@ -285,7 +285,7 @@ function hasProduct( cart, productSlug ) {
  * @param {Object} productSlug - the unique string that identifies the product
  * @returns {boolean} true if all the products in the cart are of the productSlug type
  */
-function hasOnlyProductsOf( cart, productSlug ) {
+export function hasOnlyProductsOf( cart, productSlug ) {
 	return cart.products && every( getAll( cart ), { product_slug: productSlug } );
 }
 
@@ -295,11 +295,11 @@ function hasOnlyProductsOf( cart, productSlug ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one domain registration item, false otherwise
  */
-function hasDomainRegistration( cart ) {
+export function hasDomainRegistration( cart ) {
 	return some( getAll( cart ), isDomainRegistration );
 }
 
-function hasDomainMapping( cart ) {
+export function hasDomainMapping( cart ) {
 	return some( getAll( cart ), productsValues.isDomainMapping );
 }
 
@@ -309,7 +309,7 @@ function hasDomainMapping( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one renewal item, false otherwise
  */
-function hasRenewalItem( cart ) {
+export function hasRenewalItem( cart ) {
 	return some( getAll( cart ), isRenewal );
 }
 
@@ -319,7 +319,7 @@ function hasRenewalItem( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {boolean} true if there are only renewal items, false otherwise
  */
-function hasOnlyRenewalItems( cart ) {
+export function hasOnlyRenewalItems( cart ) {
 	return every( getAll( cart ), isRenewal );
 }
 
@@ -330,7 +330,7 @@ function hasOnlyRenewalItems( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {boolean} true if any product in the cart renews
  */
-function hasRenewableSubscription( cart ) {
+export function hasRenewableSubscription( cart ) {
 	return cart.products && some( getAll( cart ), cartItem => cartItem.bill_period > 0 );
 }
 
@@ -341,7 +341,7 @@ function hasRenewableSubscription( cart ) {
  * @param {boolean} isFreeTrial - optionally specifies if this is a free trial or not
  * @returns {Object} the new item as `CartItemValue` object
  */
-function planItem( productSlug, isFreeTrial = false ) {
+export function planItem( productSlug, isFreeTrial = false ) {
 	// Free plan doesn't have shopping cart.
 	if ( productSlug === PLAN_FREE ) {
 		return null;
@@ -371,7 +371,7 @@ function personalPlan( slug, properties ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function premiumPlan( slug, properties ) {
+export function premiumPlan( slug, properties ) {
 	return planItem( slug, properties.isFreeTrial );
 }
 
@@ -382,7 +382,7 @@ function premiumPlan( slug, properties ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function businessPlan( slug, properties ) {
+export function businessPlan( slug, properties ) {
 	return planItem( slug, properties.isFreeTrial );
 }
 
@@ -403,7 +403,7 @@ function domainItem( productSlug, domain, source ) {
 	}, extra );
 }
 
-function themeItem( themeSlug, source ) {
+export function themeItem( themeSlug, source ) {
 	return {
 		product_slug: 'premium_theme',
 		meta: themeSlug,
@@ -419,7 +419,7 @@ function themeItem( themeSlug, source ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function domainRegistration( properties ) {
+export function domainRegistration( properties ) {
 	return assign( domainItem( properties.productSlug, properties.domain, properties.source ), { is_domain_registration: true } );
 }
 
@@ -429,7 +429,7 @@ function domainRegistration( properties ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function domainMapping( properties ) {
+export function domainMapping( properties ) {
 	return domainItem( 'domain_map', properties.domain, properties.source );
 }
 
@@ -439,7 +439,7 @@ function domainMapping( properties ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function siteRedirect( properties ) {
+export function siteRedirect( properties ) {
 	return domainItem( 'offsite_redirect', properties.domain, properties.source );
 }
 
@@ -449,7 +449,7 @@ function siteRedirect( properties ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function domainPrivacyProtection( properties ) {
+export function domainPrivacyProtection( properties ) {
 	return domainItem( 'private_whois', properties.domain, properties.source );
 }
 
@@ -459,24 +459,24 @@ function domainPrivacyProtection( properties ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function domainRedemption( properties ) {
+export function domainRedemption( properties ) {
 	return domainItem( 'domain_redemption', properties.domain, properties.source );
 }
 
-function googleApps( properties ) {
+export function googleApps( properties ) {
 	const productSlug = properties.product_slug || 'gapps',
 		item = domainItem( productSlug, properties.meta ? properties.meta : properties.domain );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }
 
-function googleAppsExtraLicenses( properties ) {
+export function googleAppsExtraLicenses( properties ) {
 	const item = domainItem( 'gapps_extra_license', properties.domain, properties.source );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }
 
-function fillGoogleAppsRegistrationData( cart, registrationData ) {
+export function fillGoogleAppsRegistrationData( cart, registrationData ) {
 	const googleAppsItems = filter( getAll( cart ), isGoogleApps );
 	return flow.apply( null, googleAppsItems.map( function( item ) {
 		item.extra = assign( item.extra, { google_apps_registration_data: registrationData } );
@@ -484,47 +484,47 @@ function fillGoogleAppsRegistrationData( cart, registrationData ) {
 	} ) );
 }
 
-function hasGoogleApps( cart ) {
+export function hasGoogleApps( cart ) {
 	return some( getAll( cart ), isGoogleApps );
 }
 
-function customDesignItem() {
+export function customDesignItem() {
 	return {
 		product_slug: 'custom-design'
 	};
 }
 
-function guidedTransferItem() {
+export function guidedTransferItem() {
 	return {
 		product_slug: 'guided_transfer',
 	};
 }
 
-function noAdsItem() {
+export function noAdsItem() {
 	return {
 		product_slug: 'no-adverts/no-adverts.php'
 	};
 }
 
-function videoPressItem() {
+export function videoPressItem() {
 	return {
 		product_slug: 'videopress'
 	};
 }
 
-function unlimitedSpaceItem() {
+export function unlimitedSpaceItem() {
 	return {
 		product_slug: 'unlimited_space'
 	};
 }
 
-function unlimitedThemesItem() {
+export function unlimitedThemesItem() {
 	return {
 		product_slug: 'unlimited_themes'
 	};
 }
 
-function spaceUpgradeItem( slug ) {
+export function spaceUpgradeItem( slug ) {
 	return {
 		product_slug: slug
 	};
@@ -537,7 +537,7 @@ function spaceUpgradeItem( slug ) {
  * @param {Object} properties - list of properties
  * @returns {Object} the new item as `CartItemValue` object
  */
-function getItemForPlan( plan, properties ) {
+export function getItemForPlan( plan, properties ) {
 	properties = properties || {};
 
 	switch ( plan.product_slug ) {
@@ -568,7 +568,7 @@ function getItemForPlan( plan, properties ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Object} the corresponding item in the shopping cart as `CartItemValue` object
  */
-function findFreeTrial( cart ) {
+export function findFreeTrial( cart ) {
 	return find( getAll( cart ), { free_trial: true } );
 }
 
@@ -578,7 +578,7 @@ function findFreeTrial( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
-function getDomainRegistrations( cart ) {
+export function getDomainRegistrations( cart ) {
 	return filter( getAll( cart ), { is_domain_registration: true } );
 }
 
@@ -588,7 +588,7 @@ function getDomainRegistrations( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
-function getDomainMappings( cart ) {
+export function getDomainMappings( cart ) {
 	return filter( getAll( cart ), { product_slug: 'domain_map' } );
 }
 
@@ -599,7 +599,7 @@ function getDomainMappings( cart ) {
  * @param {Object} [properties] - properties to be included in the new CartItem object
  * @returns {Object} a CartItem object
  */
-function getRenewalItemFromProduct( product, properties ) {
+export function getRenewalItemFromProduct( product, properties ) {
 	product = formatProduct( product );
 
 	let cartItem;
@@ -658,7 +658,7 @@ function getRenewalItemFromProduct( product, properties ) {
  * @param {Object} properties - properties to be included in the new CartItem object
  * @returns {Object} a CartItem object
  */
-function getRenewalItemFromCartItem( cartItem, properties ) {
+export function getRenewalItemFromCartItem( cartItem, properties ) {
 	return merge( {}, cartItem, { extra: {
 		purchaseId: properties.id,
 		purchaseDomain: properties.domain,
@@ -673,11 +673,11 @@ function getRenewalItemFromCartItem( cartItem, properties ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
-function getSiteRedirects( cart ) {
+export function getSiteRedirects( cart ) {
 	return filter( getAll( cart ), { product_slug: 'offsite_redirect' } );
 }
 
-function hasDomainInCart( cart, domain ) {
+export function hasDomainInCart( cart, domain ) {
 	return some( getAll( cart ), { is_domain_registration: true, meta: domain } );
 }
 
@@ -688,7 +688,7 @@ function hasDomainInCart( cart, domain ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
-function getDomainRegistrationsWithoutPrivacy( cart ) {
+export function getDomainRegistrationsWithoutPrivacy( cart ) {
 	return getDomainRegistrations( cart ).filter( function( cartItem ) {
 		return ! some( cart.products, {
 			meta: cartItem.meta,
@@ -711,11 +711,11 @@ function changePrivacyForDomains( cart, domainItems, changeFunction ) {
 	} ) );
 }
 
-function addPrivacyToAllDomains( cart ) {
+export function addPrivacyToAllDomains( cart ) {
 	return changePrivacyForDomains( cart, getDomainRegistrationsWithoutPrivacy( cart ), add );
 }
 
-function removePrivacyFromAllDomains( cart ) {
+export function removePrivacyFromAllDomains( cart ) {
 	return changePrivacyForDomains( cart, getDomainRegistrations( cart ), remove );
 }
 
@@ -735,15 +735,15 @@ function isRenewal( cartItem ) {
  * @param {Object} cartItem - `CartItemValue` object
  * @returns {string} the included domain
  */
-function getIncludedDomain( cartItem ) {
+export function getIncludedDomain( cartItem ) {
 	return cartItem.extra && cartItem.extra.includedDomain;
 }
 
-function isNextDomainFree( cart ) {
+export function isNextDomainFree( cart ) {
 	return !! ( cart && cart.next_domain_is_free );
 }
 
-function isDomainBeingUsedForPlan( cart, domain ) {
+export function isDomainBeingUsedForPlan( cart, domain ) {
 	if ( cart && domain && hasPlan( cart ) ) {
 		const domainProducts = getDomainRegistrations( cart ).concat( getDomainMappings( cart ) ),
 			domainProduct = ( domainProducts.shift() || {} );
@@ -753,7 +753,7 @@ function isDomainBeingUsedForPlan( cart, domain ) {
 	return false;
 }
 
-function shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggestionOrCartItem ) {
+export function shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggestionOrCartItem ) {
 	return withPlansOnly &&
 		// not free or a cart item
 		( isDomainRegistration( suggestionOrCartItem ) ||
@@ -765,7 +765,7 @@ function shouldBundleDomainWithPlan( withPlansOnly, selectedSite, cart, suggesti
 		( ! selectedSite || ( selectedSite && selectedSite.plan.product_slug === 'free_plan' ) ); // site has a plan
 }
 
-function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {
+export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {
 	if ( ! suggestion.product_slug || suggestion.cost === 'Free' ) {
 		return 'FREE_DOMAIN';
 	}
@@ -784,62 +784,3 @@ function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {
 
 	return 'PRICE';
 }
-
-module.exports = {
-	add,
-	addPrivacyToAllDomains,
-	businessPlan,
-	customDesignItem,
-	domainMapping,
-	domainPrivacyProtection,
-	domainRedemption,
-	domainRegistration,
-	fillGoogleAppsRegistrationData,
-	findFreeTrial,
-	getAll,
-	getAllSorted,
-	getDomainMappings,
-	getDomainPriceRule,
-	getDomainRegistrations,
-	getDomainRegistrationsWithoutPrivacy,
-	getDomainRegistrationTld,
-	getIncludedDomain,
-	getItemForPlan,
-	getRenewalItemFromCartItem,
-	getRenewalItemFromProduct,
-	getRenewalItems,
-	getSiteRedirects,
-	googleApps,
-	googleAppsExtraLicenses,
-	guidedTransferItem,
-	isNextDomainFree,
-	isDomainBeingUsedForPlan,
-	hasDomainCredit,
-	hasDomainInCart,
-	hasDomainMapping,
-	hasDomainRegistration,
-	hasFreeTrial,
-	hasGoogleApps,
-	hasOnlyFreeTrial,
-	hasOnlyProductsOf,
-	hasOnlyRenewalItems,
-	hasPlan,
-	hasPremiumPlan,
-	hasProduct,
-	hasRenewableSubscription,
-	hasRenewalItem,
-	hasTld,
-	noAdsItem,
-	planItem,
-	premiumPlan,
-	remove,
-	removeItemAndDependencies,
-	removePrivacyFromAllDomains,
-	siteRedirect,
-	shouldBundleDomainWithPlan,
-	spaceUpgradeItem,
-	themeItem,
-	unlimitedSpaceItem,
-	unlimitedThemesItem,
-	videoPressItem
-};

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -44,7 +44,6 @@ import productsValues, {
 import sortProducts from 'lib/products-values/sort';
 import { PLAN_PERSONAL } from 'lib/plans/constants';
 
-
 import {
 	PLAN_FREE,
 	PLAN_JETPACK_PREMIUM,
@@ -63,11 +62,9 @@ import {
  */
 function add( newCartItem ) {
 	function appendItem( products ) {
-		var isDuplicate;
-
 		products = products || [];
 
-		isDuplicate = products.some( function( existingCartItem ) {
+		const isDuplicate = products.some( function( existingCartItem ) {
 			return isEqual( newCartItem, existingCartItem );
 		} );
 
@@ -148,7 +145,7 @@ function remove( cartItemToRemove ) {
  * @returns {Function} the function that removes the items from a shopping cart
  */
 function removeItemAndDependencies( cartItemToRemove, cart, domainsWithPlansOnly ) {
-	var dependencies = getDependentProducts( cartItemToRemove, cart, domainsWithPlansOnly ),
+	const dependencies = getDependentProducts( cartItemToRemove, cart, domainsWithPlansOnly ),
 		changes = dependencies.map( remove ).concat( remove( cartItemToRemove ) );
 
 	return flow.apply( null, changes );
@@ -167,7 +164,11 @@ function getDependentProducts( cartItem, cart, domainsWithPlansOnly ) {
 		return isDependentProduct( cartItem, existingCartItem, domainsWithPlansOnly );
 	} );
 
-	return uniq( flatten( dependentProducts.concat( dependentProducts.map( dependentProduct => getDependentProducts( dependentProduct, cart ) ) ) ) );
+	return uniq( flatten(
+		dependentProducts.concat(
+			dependentProducts.map( dependentProduct => getDependentProducts( dependentProduct, cart ) )
+		)
+	) );
 }
 
 /**
@@ -394,7 +395,7 @@ function businessPlan( slug, properties ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function domainItem( productSlug, domain, source ) {
-	var extra = source ? { extra: { source: source } } : undefined;
+	const extra = source ? { extra: { source: source } } : undefined;
 
 	return Object.assign( {
 		product_slug: productSlug,
@@ -470,7 +471,7 @@ function googleApps( properties ) {
 }
 
 function googleAppsExtraLicenses( properties ) {
-	var item = domainItem( 'gapps_extra_license', properties.domain, properties.source );
+	const item = domainItem( 'gapps_extra_license', properties.domain, properties.source );
 
 	return assign( item, { extra: { google_apps_users: properties.users } } );
 }
@@ -479,7 +480,7 @@ function fillGoogleAppsRegistrationData( cart, registrationData ) {
 	const googleAppsItems = filter( getAll( cart ), isGoogleApps );
 	return flow.apply( null, googleAppsItems.map( function( item ) {
 		item.extra = assign( item.extra, { google_apps_registration_data: registrationData } );
-		return add( item )
+		return add( item );
 	} ) );
 }
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1,34 +1,49 @@
 /**
  * External dependencies
  */
-var update = require( 'react-addons-update' );
-import { every, assign, flow, isEqual, merge, reject, tail, some, uniq, flatten, filter, find } from 'lodash';
+import update from 'react-addons-update';
+import {
+	assign,
+	every,
+	filter,
+	find,
+	flatten,
+	flow,
+	isEqual,
+	merge,
+	reject,
+	some,
+	tail,
+	uniq,
+} from 'lodash';
 
 /**
  * Internal dependencies
  */
-var productsValues = require( 'lib/products-values' ),
-	formatProduct = productsValues.formatProduct,
-	isCustomDesign = productsValues.isCustomDesign,
-	isDependentProduct = productsValues.isDependentProduct,
-	isDomainMapping = productsValues.isDomainMapping,
-	isDomainProduct = productsValues.isDomainProduct,
-	isDomainRedemption = productsValues.isDomainRedemption,
-	isDomainRegistration = productsValues.isDomainRegistration,
-	isGoogleApps = productsValues.isGoogleApps,
-	isNoAds = productsValues.isNoAds,
-	isPlan = productsValues.isPlan,
-	isPremium = productsValues.isPremium,
-	isPrivacyProtection = productsValues.isPrivacyProtection,
-	isSiteRedirect = productsValues.isSiteRedirect,
-	isSpaceUpgrade = productsValues.isSpaceUpgrade,
-	isUnlimitedSpace = productsValues.isUnlimitedSpace,
-	isUnlimitedThemes = productsValues.isUnlimitedThemes,
-	isVideoPress = productsValues.isVideoPress,
-	isJetpackPlan = productsValues.isJetpackPlan,
-	isFreeWordPressComDomain = productsValues.isFreeWordPressComDomain,
-	sortProducts = require( 'lib/products-values/sort' ),
-	PLAN_PERSONAL = require( 'lib/plans/constants' ).PLAN_PERSONAL;
+import productsValues, {
+	formatProduct,
+	isCustomDesign,
+	isDependentProduct,
+	isDomainMapping,
+	isDomainProduct,
+	isDomainRedemption,
+	isDomainRegistration,
+	isGoogleApps,
+	isNoAds,
+	isPlan,
+	isPremium,
+	isPrivacyProtection,
+	isSiteRedirect,
+	isSpaceUpgrade,
+	isUnlimitedSpace,
+	isUnlimitedThemes,
+	isVideoPress,
+	isJetpackPlan,
+	isFreeWordPressComDomain
+} from 'lib/products-values';
+import sortProducts from 'lib/products-values/sort';
+import { PLAN_PERSONAL } from 'lib/plans/constants';
+
 
 import {
 	PLAN_FREE,


### PR DESCRIPTION
This PR addresses all the linting errors and es6-ifies `lib/cart-values/cart-items.js`.

I wanted to break this PR off and before I started making semantic changes.

P.s. https://xkcd.com/208/

![**PERL**](https://imgs.xkcd.com/comics/regular_expressions.png)
`s/^function (addPrivacyToAllDomains|businessPlan|customDesignItem|domainMapping|domainPrivacyProtection|domainRedemption|domainRegistration|fillGoogleAppsRegistrationData|findFreeTrial|getDomainMappings|getDomainPriceRule|getDomainRegistrations|getDomainRegistrationsWithoutPrivacy|getIncludedDomain|getItemForPlan|getRenewalItemFromCartItem|getRenewalItemFromProduct|getSiteRedirects|googleApps|googleAppsExtraLicenses|guidedTransferItem|hasDomainCredit|hasDomainInCart|hasDomainMapping|hasDomainRegistration|hasGoogleApps|hasOnlyProductsOf|hasOnlyRenewalItems|hasProduct|hasRenewableSubscription|hasRenewalItem|hasTld|isDomainBeingUsedForPlan|isNextDomainFree|noAdsItem|planItem|premiumPlan|removePrivacyFromAllDomains|shouldBundleDomainWithPlan|siteRedirect|spaceUpgradeItem|themeItem|unlimitedSpaceItem|unlimitedThemesItem|videoPressItem)/export function $1/`