### PR TITLE
Editor: Images flickering on upload and not showing any progress of the upload process

### DIFF
--- a/assets/stylesheets/editor.scss
+++ b/assets/stylesheets/editor.scss
@@ -2,3 +2,5 @@
 @import 'shared/typography';
 
 @import 'components/tinymce/iframe';
+
+@import 'components/tinymce/plugins/media/style';

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -312,7 +312,7 @@ function mediaButton( editor ) {
 
 			// To avoid an undesirable flicker after the image uploads but
 			// hasn't yet been loaded, we preload the image before rendering.
-			const imageUrl = media.URL;
+			const imageUrl = event.resizedImageUrl || media.URL;
 			if ( ! loadedImages.isLoaded( imageUrl ) ) {
 				const preloadImage = new Image();
 				preloadImage.src = imageUrl;

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -226,6 +226,12 @@ function mediaButton( editor ) {
 			if ( current.media.transient ) {
 				transients++;
 				isTransientDetected = true;
+
+				// Mark the image as a transient in upload
+				editor.dom.$( img ).toggleClass( 'is-transient', true );
+			} else {
+				// Remove the transient flag if present
+				editor.dom.$( img ).toggleClass( 'is-transient', false );
 			}
 
 			if (

--- a/client/components/tinymce/plugins/media/restrict-size/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/index.js
@@ -36,8 +36,8 @@ function getResizedImgUrlFromImgString( img ) {
 	}
 
 	return {
-		originalURL: parsed.media.URL,
-		resizedURL: resize( parsed.media.URL, Math.min( parsed.media.width || Infinity, MAX_WIDTH ) )
+		originalUrl: parsed.media.URL,
+		resizedUrl: resize( parsed.media.URL, Math.min( parsed.media.width || Infinity, MAX_WIDTH ) )
 	};
 }
 
@@ -52,7 +52,7 @@ function setImageSrc( img, opening, src, closing ) {
 		return img;
 	}
 
-	return `${ opening }${ url.resizedURL }" data-wpmedia-src="${ url.originalURL }${ closing }`;
+	return `${ opening }${ url.resizedUrl }" data-wpmedia-src="${ url.originalUrl }${ closing }`;
 }
 
 export function resetImages( content ) {
@@ -77,7 +77,7 @@ export default function( editor ) {
 		const resizedUrl = getResizedImgUrlFromImgString( event.content );
 
 		if ( resizedUrl !== null ) {
-			event.resizedImageUrl = resizedUrl.resizedURL;
+			event.resizedImageUrl = resizedUrl.resizedUrl;
 		}
 	} );
 

--- a/client/components/tinymce/plugins/media/restrict-size/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/index.js
@@ -29,18 +29,30 @@ function resetImageSrc( img, opening, src, attributes, origAttr, origSrc, closin
 	return `${ opening }${ origSrc }${ attributes }${ closing }`;
 }
 
+function getResizedImgUrlFromImgString( img ) {
+	const parsed = deserialize( img );
+	if ( parsed.media.transient || ! parsed.media.ID ) {
+		return null;
+	}
+
+	return {
+		originalURL: parsed.media.URL,
+		resizedURL: resize( parsed.media.URL, Math.min( parsed.media.width || Infinity, MAX_WIDTH ) )
+	};
+}
+
 function setImageSrc( img, opening, src, closing ) {
 	if ( -1 !== img.indexOf( 'data-wpmedia-src' ) ) {
 		return img;
 	}
 
-	const parsed = deserialize( img );
-	if ( parsed.media.transient || ! parsed.media.ID ) {
+	const url = getResizedImgUrlFromImgString( img );
+
+	if ( url === null ) {
 		return img;
 	}
 
-	const url = resize( parsed.media.URL, Math.min( parsed.media.width || Infinity, MAX_WIDTH ) );
-	return `${ opening }${ url }" data-wpmedia-src="${ parsed.media.URL }${ closing }`;
+	return `${ opening }${ url.resizedURL }" data-wpmedia-src="${ url.originalURL }${ closing }`;
 }
 
 export function resetImages( content ) {
@@ -58,6 +70,15 @@ export default function( editor ) {
 		}
 
 		event.content = setImages( event.content );
+
+		/**
+		 * Also add the raw resized image URL so we can properly preload it in the editor
+		 */
+		const resizedUrl = getResizedImgUrlFromImgString( event.content );
+
+		if ( resizedUrl !== null ) {
+			event.resizedImageUrl = resizedUrl.resizedURL;
+		}
 	} );
 
 	editor.on( 'GetContent', ( event ) => {

--- a/client/components/tinymce/plugins/media/restrict-size/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/index.js
@@ -70,9 +70,11 @@ export default function( editor ) {
 		}
 
 		event.content = setImages( event.content );
+	} );
 
+	editor.on( 'BeforeSetWpcomMedia', ( event ) => {
 		/**
-		 * Also add the raw resized image URL so we can properly preload it in the editor
+		 * Add the resized image URL so we can properly preload it in the editor
 		 */
 		const resizedUrl = getResizedImgUrlFromImgString( event.content );
 

--- a/client/components/tinymce/plugins/media/style.scss
+++ b/client/components/tinymce/plugins/media/style.scss
@@ -1,5 +1,5 @@
 img.is-transient {
 	/**
-		This class is applied to images that are currently uploaded to the media library from the TinyMCE editor
+		This class is applied to images that are currently uploading to the media library from the TinyMCE editor
 	*/
 }

--- a/client/components/tinymce/plugins/media/style.scss
+++ b/client/components/tinymce/plugins/media/style.scss
@@ -1,0 +1,10 @@
+img.is-transient {
+	transform: translate3d(0,0,0);
+
+	animation: pulse-image 2.5s ease-in-out infinite;
+	opacity: 0.25;
+}
+
+@keyframes pulse-image {
+	50% { opacity: 0.5; }
+}

--- a/client/components/tinymce/plugins/media/style.scss
+++ b/client/components/tinymce/plugins/media/style.scss
@@ -1,10 +1,5 @@
 img.is-transient {
-	transform: translate3d(0,0,0);
-
-	animation: pulse-image 2.5s ease-in-out infinite;
-	opacity: 0.25;
-}
-
-@keyframes pulse-image {
-	50% { opacity: 0.5; }
+	/**
+		This class is applied to images that are currently uploaded to the media library from the TinyMCE editor
+	*/
 }


### PR DESCRIPTION
This PR aims to improve image flickering when they're uploaded. Reported in #14252 

### Current version

![old-version](https://user-images.githubusercontent.com/184938/26971193-eb99256a-4d14-11e7-87d4-7487da2ad8ee.gif)

### Why are the images flickering?

This is caused by the image not being preloaded when it's switched from transient image ( local `blob` ) to the one loaded from the server. If we look [tinymce/plugins/media/plugin.jsx](https://github.com/Automattic/wp-calypso/blob/b6db268109a867034a9d0fae23342f57c1cf6dc7/client/components/tinymce/plugins/media/plugin.jsx#L316) we can see that there's preload code there and with a bit of debugging we can see that it's working almost correctly. 

The problem is that when the switch from transient to server-loaded image happens, the preload block receives the wrong URL. 

This is caused by the `BeforeSetWpcomMedia` event that's fired right before the preloading. The event fires code in [tinymce/plugins/media/restrict-size/index.js](https://github.com/Automattic/wp-calypso/blob/b6db268109a867034a9d0fae23342f57c1cf6dc7/client/components/tinymce/plugins/media/restrict-size/index.js) which aims to limit the size of the image that will be fetched from the server, so we don't load images that are too big in size. The filter on its part replaces the image URL in the tag by adding a `?w=<width>` parameter. This causes the preloading break, since it has already started preloading the image without the `?w=<width>` parameter. 

After replacing the image, since it isn't properly preloaded, it loads it again from the server. This results the image being loaded twice - once the original size ( from the preloader ) and once from it actually rendering on the page. 

### No indication of uploading/loading

Currently there is no way for the user to know that the image is being uploaded and if it finished uploading.

This PR adds a simple animation that gives some sense of activity on the image. 

### New version

![editor-image-flicker-upload-animation](https://user-images.githubusercontent.com/184938/26970825-5ec96ba0-4d13-11e7-9af2-f533b5b74e32.gif)

### To test:

1. Checkout branch or use Calypso.live link
2. Go to editor
3. Type some text
4. Drag and drop an image in the Editor
5. Verify the image animates while being uploaded
6. Verify the image won't flicker/disappear for a moment when it finishes uploading
7. Verify image stopped animating when it finished uploading
8. Verify no JS errors in console
9. Verify the image is properly saved in the post when saving as draft or publishing

Todo: 
 - [x] Prevent image flickering when uploaded
 - [x] Research if it is possible to have some kind of a loader overlay on transient images. See how Featured image uploads handle this.

cc @designsimply 
