### PR TITLE
Media library: modify UI for external media sources

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -84,7 +84,7 @@ export class MediaLibraryFilterBar extends Component {
 	};
 
 	renderTabItems() {
-		const tabs = [ '', 'images', 'documents', 'videos', 'audio' ];
+		const tabs = this.props.source === '' ? [ '', 'images', 'documents', 'videos', 'audio' ] : [];
 
 		return map( tabs, filter =>
 			<FilterItem

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -72,7 +72,7 @@ export default React.createClass( {
 	renderUploadButtons() {
 		const { site, filter, onAddMedia } = this.props;
 
-		if ( ! userCan( 'upload_files', site ) ) {
+		if ( ! userCan( 'upload_files', site ) || this.props.source !== '' ) {
 			return;
 		}
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -351,7 +351,15 @@ export class EditorMediaModal extends Component {
 			}
 		];
 
-		if ( ModalViews.GALLERY !== this.props.view && selectedItems.length > 1 &&
+		if ( this.state.source !== '' ) {
+			buttons.push( {
+				action: 'confirm',
+				label: this.props.labels.confirm || this.props.translate( 'Copy to media library' ),
+				isPrimary: true,
+				disabled: isDisabled || 0 === selectedItems.length,
+				onClick: this.confirmSelection
+			} );
+		} else if ( ModalViews.GALLERY !== this.props.view && selectedItems.length > 1 &&
 				! some( selectedItems, ( item ) => MediaUtils.getMimePrefix( item ) !== 'image' ) ) {
 			buttons.push( {
 				action: 'confirm',


### PR DESCRIPTION
Remove certain media library UI for external media

Includes the filter bar, and the add new / edit / delete buttons.

<img width="391" alt="remove" src="https://user-images.githubusercontent.com/1277682/26968031-79f85e2e-4cf8-11e7-8e8d-e60448cd1318.png">

This PR just provides the ability to show/hide the bits of UI, it doesn't enable that.

## Testing

Verify that the media library UI indicated in the screenshot continues to work.