### PR TITLE
Media library: change what is searched in the media library for external media

### DIFF
--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -134,7 +134,7 @@ MediaListStore.isItemMatchingQuery = function( siteId, item ) {
 
 	matches = true;
 
-	if ( query.search ) {
+	if ( query.search && query.source === '' ) {
 		// WP_Query tests a post's title and content when performing a search.
 		// Since we're testing binary data, we match the title only.
 		//


### PR DESCRIPTION
Internal media searches happen on the file title. External media searches don’t. Restrict the extract search match to internal media only otherwise external media may not match

## Testing

Search function in media library continues to operate