### PR TITLE
A/B Test: Deploy 'select' variation

### DIFF
--- a/client/components/domains/domain-mapping-suggestion/index.jsx
+++ b/client/components/domains/domain-mapping-suggestion/index.jsx
@@ -8,7 +8,6 @@ import React from 'react';
  */
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import { shouldBundleDomainWithPlan, getDomainPriceRule } from 'lib/cart-values/cart-items';
-import { abtest } from 'lib/abtest';
 
 var DomainMappingSuggestion = React.createClass( {
 	propTypes: {
@@ -25,10 +24,10 @@ var DomainMappingSuggestion = React.createClass( {
 				cost: this.props.products.domain_map.cost_display
 			},
 			{ cart, domainsWithPlansOnly, isSignupStep, selectedSite } = this.props,
-			allowUpgradeCta = ! isSignupStep || abtest( 'selectCtaInDomainsSignup' ) === 'original',
-			buttonContent = allowUpgradeCta && shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
+			buttonContent = ! isSignupStep && shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
 				? this.translate( 'Upgrade', { context: 'Domain mapping suggestion button with plan upgrade' } )
 				: this.translate( 'Map it', { context: 'Domain mapping suggestion button' } );
+
 		return (
 				<DomainSuggestion
 					priceRule={ getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion ) }

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -12,7 +12,6 @@ import DomainSuggestion from 'components/domains/domain-suggestion';
 import Gridicon from 'gridicons';
 import DomainSuggestionFlag from 'components/domains/domain-suggestion-flag';
 import { shouldBundleDomainWithPlan, getDomainPriceRule, hasDomainInCart } from 'lib/cart-values/cart-items';
-import { abtest } from 'lib/abtest';
 
 const DomainRegistrationSuggestion = React.createClass( {
 	propTypes: {
@@ -89,8 +88,7 @@ const DomainRegistrationSuggestion = React.createClass( {
 			buttonContent = <Gridicon icon="checkmark" />;
 		} else {
 			buttonClasses = 'add is-primary';
-			const allowUpgradeCta = ! isSignupStep || abtest( 'selectCtaInDomainsSignup' ) === 'original';
-			buttonContent = allowUpgradeCta && shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
+			buttonContent = ! isSignupStep && shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
 				? translate( 'Upgrade', { context: 'Domain mapping suggestion button with plan upgrade' } )
 				: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -101,14 +101,6 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	selectCtaInDomainsSignup: {
-		datestamp: '20170529',
-		variations: {
-			original: 50,
-			select: 50,
-		},
-		defaultVariation: 'original',
-	},
 	pulsingCartTestingAB: {
 		datestamp: '20170601',
 		variations: {


### PR DESCRIPTION
Select variation has better conversion rates as per p8kIbR-4e-p2.

Make sure that on the domain search step in signup you're seeing `Select` for all domains.

Test PR: https://github.com/Automattic/wp-calypso/pull/14401