### PR TITLE
Activity log: Add and use QueryRewindStatus component

### DIFF
--- a/client/components/data/query-rewind-status/index.jsx
+++ b/client/components/data/query-rewind-status/index.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getRewindStatus as getRewindStatusAction } from 'state/activity-log/actions';
+
+class QueryRewindStatus extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+	};
+
+	componentWillMount() {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId === nextProps.siteId ) {
+			return;
+		}
+
+		this.request( nextProps );
+	}
+
+	request( { siteId } ) {
+		if ( siteId ) {
+			this.props.getRewindStatus( siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, {
+	getRewindStatus: getRewindStatusAction,
+} )( QueryRewindStatus );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { groupBy, map } from 'lodash';
@@ -19,8 +19,18 @@ import ActivityLogDay from '../activity-log-day';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import SuccessBanner from '../activity-log-banner/success-banner';
+import QueryRewindStatus from 'components/data/query-rewind-status';
 
 class ActivityLog extends Component {
+	static propTypes = {
+		isJetpack: PropTypes.bool,
+		siteId: PropTypes.number,
+		slug: PropTypes.string,
+
+		// localize
+		moment: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
 	componentDidMount() {
 		window.scrollTo( 0, 0 );
 	}
@@ -298,6 +308,7 @@ class ActivityLog extends Component {
 
 		return (
 			<Main wideLayout={ true }>
+				<QueryRewindStatus siteId={ siteId } />
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation
@@ -317,9 +328,9 @@ class ActivityLog extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
 		return {
-			isJetpack,
+			isJetpack: isJetpackSite( state, siteId ),
+			siteId,
 			slug: getSiteSlug( state, siteId )
 		};
 	}


### PR DESCRIPTION
Add QueryRewindStatus component
Use it in the stats/activity view

To test:
1. Visit one:
   * https://calypso.live/stats/activity?branch=update/activitylog-use-rewindstatusquerycomponent
   * http://calypso.localhost:3000/stats/activity
1. Select a Jetpack site
1. Ensure you see network requests fire for the rewind endpoint.
1. Switch sites and ensure you see a new request fire.

Fixes #14675
Replaces #14954