### PR TITLE
Add .ca TLD form

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -79,7 +79,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="legal-type">
-						{ translate( 'Cira Agreement' ) }
+						{ translate( 'CIRA Agreement' ) }
 					</FormLabel>
 					<FormLabel>
 						<FormCheckbox id="cira_acceptance" value={ ciraAccepted } />

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getContactDetailsCache } from 'state/selectors';
+import { updateContactDetailsCache } from 'state/domains/management/actions';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormCheckbox from 'components/forms/form-checkbox';
+
+const defaultValues = {
+	legalType: 'CCW',
+	isVisible: true,
+	agreementAccepted: false,
+	onSubmit: noop,
+};
+
+class RegistrantExtraInfoCaForm extends React.PureComponent {
+	static propTypes = {
+		agreementAccepted: PropTypes.bool,
+		legalType: PropTypes.string,
+		isVisible: PropTypes.bool,
+		onSubmit: PropTypes.func,
+	}
+
+	constructor( props ) {
+		super( props );
+
+		this.props.contactDetails.extra = {
+			...defaultValues,
+			...this.props.contactDetails.extra
+		};
+	}
+
+	handleChangeEvent = ( event ) => {
+		this.props.updateContactDetailsCache( {
+			extra: { [ event.target.id ]: event.target.value },
+		} );
+	}
+
+	render() {
+		const {
+			legalType,
+			translate,
+			ciraAccepted
+		} = { ...defaultValues, ...this.props };
+		const agreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
+
+		return (
+			<form className="registrant-extra-info__form">
+				<h1 className="registrant-extra-info__form-title">
+					{ translate(
+						'Registering a .CA domain'
+					) }
+				</h1>
+				<p className="registrant-extra-info__form-desciption">
+					{ translate(
+						'Almost done! We need some extra details to register domains ending in ".ca".'
+					) }
+				</p>
+				<FormFieldset>
+					<FormLabel htmlFor="legal-type">
+						{ translate( 'Choose the option that best describes you:' ) }
+					</FormLabel>
+					<FormSelect
+						id="legal-type"
+						value={ legalType }
+						countriesList={ this.props.countriesList }
+						className="registrant-extra-info__form-country-select"
+						onChange={ this.handleChangeEvent } />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="legal-type">
+						{ translate( 'Cira Agreement' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox id="cira_acceptance" value={ ciraAccepted } />
+						<span>{
+							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',
+								{
+									components: {
+										a: <a href={ agreementUrl} />
+									}
+								}
+							)
+						}</span>
+					</FormLabel>
+				</FormFieldset>
+
+				{ this.props.children }
+			</form>
+		);
+	}
+}
+
+export default connect(
+	state => ( { contactDetails: getContactDetailsCache( state ) } ),
+	{ updateContactDetailsCache }
+)( localize( RegistrantExtraInfoCaForm ) );

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -16,16 +16,37 @@ import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
 
+const legalTypes = {
+	ABO: 'Aboriginal',
+	ASS: 'Association',
+	CCO: 'CanadianCorporation',
+	CCT: 'CanadianCitizen',
+	EDU: 'Educational Institution',
+	GOV: 'Government',
+	HOP: 'Hospital',
+	INB: 'IndianBand',
+	LAM: 'Library, Archive, or Museum',
+	LGR: 'Legal Representative',
+	MAJ: 'Her Majesty the Queen',
+	OMK: 'Protected by Trademarks Act',
+	PLT: 'Political Party',
+	PRT: 'Partnership',
+	RES: 'Permanent Resident',
+	TDM: 'Trademark Owner',
+	TRD: 'Trade Union',
+	TRS: 'Trust'
+};
+
 const defaultValues = {
 	legalType: 'CCW',
 	isVisible: true,
-	agreementAccepted: false,
+	ciraAgreementAccepted: false,
 	onSubmit: noop,
 };
 
 class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
-		agreementAccepted: PropTypes.bool,
+		ciraAgreementAccepted: PropTypes.bool,
 		legalType: PropTypes.string,
 		isVisible: PropTypes.bool,
 		onSubmit: PropTypes.func,
@@ -50,7 +71,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		const {
 			legalType,
 			translate,
-			ciraAccepted
+			ciraAgreementAccepted
 		} = { ...defaultValues, ...this.props };
 		const agreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 
@@ -73,8 +94,8 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 					<FormSelect
 						id="legal-type"
 						value={ legalType }
-						countriesList={ this.props.countriesList }
-						className="registrant-extra-info__form-country-select"
+						legalTypes={ legalTypes }
+						className="registrant-extra-info__form-legal-type"
 						onChange={ this.handleChangeEvent } />
 				</FormFieldset>
 				<FormFieldset>
@@ -87,7 +108,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',
 								{
 									components: {
-										a: <a href={ agreementUrl} />
+										a: <a href={ agreementUrl } />
 									}
 								}
 							)

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -32,7 +32,7 @@ const defaultValues = {
 class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
 		contactDetailsExtra: PropTypes.object.isRequired,
-		translate: PropTypes.func,
+		translate: PropTypes.func.isRequired,
 	}
 
 	constructor( props ) {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -65,7 +65,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 		this.state = {
 			legalTypes,
-			legalTypeOptions
+			legalTypeOptions,
 		};
 	}
 

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -23,6 +23,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
 
+const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 const defaultValues = {
 	legalType: 'CCT',
 	ciraAgreementAccepted: false,
@@ -97,8 +98,6 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 			legalType,
 			ciraAgreementAccepted,
 		} = { ...defaultValues, ...this.props.contactDetails };
-
-		const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 
 		return (
 			<form className="registrant-extra-info__form">

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -31,9 +31,7 @@ const defaultValues = {
 
 class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
-		ciraAgreementAccepted: PropTypes.bool,
-		contactDetails: PropTypes.object,
-		legalType: PropTypes.string,
+		contactDetailsExtra: PropTypes.object.isRequired,
 		translate: PropTypes.function,
 	}
 
@@ -75,7 +73,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		// Add defaults to redux state to make accepting default values work.
 		const requiredDetailsNotInProps = difference(
 			[ 'legalType', 'ciraAgreementAccepted' ],
-			keys( this.props.contactDetails.extra ),
+			keys( this.props.contactDetailsExtra ),
 		);
 
 		if ( ! isEmpty( requiredDetailsNotInProps ) ) {
@@ -99,7 +97,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		const {
 			legalType,
 			ciraAgreementAccepted,
-		} = { ...defaultValues, ...this.props.contactDetails };
+		} = { ...defaultValues, ...this.props.contactDetailsExtra };
 
 		return (
 			<form className="registrant-extra-info__form">
@@ -149,6 +147,6 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 }
 
 export default connect(
-	state => ( { contactDetails: getContactDetailsExtraCache( state ) } ),
+	state => ( { contactDetailsExtra: getContactDetailsExtraCache( state ) } ),
 	{ updateContactDetailsCache }
 )( localize( RegistrantExtraInfoCaForm ) );

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -9,7 +9,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getContactDetailsCache } from 'state/selectors';
+import { getContactDetailsExtraCache } from 'state/selectors';
 import { updateContactDetailsCache } from 'state/domains/management/actions';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -124,6 +124,6 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 }
 
 export default connect(
-	state => ( { contactDetails: getContactDetailsCache( state ) } ),
+	state => ( { contactDetails: getContactDetailsExtraCache( state ) } ),
 	{ updateContactDetailsCache }
 )( localize( RegistrantExtraInfoCaForm ) );

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -4,7 +4,9 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import {
+	map,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,6 +39,10 @@ const legalTypes = {
 	TRD: 'Trade Union',
 	TRS: 'Trust',
 };
+
+const legalTypeOptions = map( legalTypes, ( text, optionValue ) =>
+	<option value={ optionValue } key={ optionValue }>{ text }</option>
+);
 
 const defaultValues = {
 	legalType: 'CCW',
@@ -95,9 +101,10 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 					<FormSelect
 						id="legal-type"
 						value={ legalType }
-						legalTypes={ legalTypes }
 						className="registrant-extra-info__form-legal-type"
-						onChange={ this.handleChangeEvent } />
+						onChange={ this.handleChangeEvent }>
+						{ legalTypeOptions }
+					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="legal-type">

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -133,7 +133,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 								{
 									components: {
 										a: <a href={ ciraAgreementUrl } />,
-									}
+									},
 								}
 							)
 						}</span>

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -18,23 +18,24 @@ import FormCheckbox from 'components/forms/form-checkbox';
 
 const legalTypes = {
 	ABO: 'Aboriginal',
-	ASS: 'Association',
-	CCO: 'CanadianCorporation',
-	CCT: 'CanadianCitizen',
+	ASS: 'Association (Unincorporated)',
+	CCO: 'Canadian Corporation',
+	CCT: 'Canadian Citizen',
 	EDU: 'Educational Institution',
 	GOV: 'Government',
 	HOP: 'Hospital',
-	INB: 'IndianBand',
+	INB: 'Indian Band',
 	LAM: 'Library, Archive, or Museum',
 	LGR: 'Legal Representative',
 	MAJ: 'Her Majesty the Queen',
-	OMK: 'Protected by Trademarks Act',
+	// An official mark is Canadian thing like a trademark for public authorities
+	OMK: 'Official Mark',
 	PLT: 'Political Party',
 	PRT: 'Partnership',
 	RES: 'Permanent Resident',
 	TDM: 'Trademark Owner',
 	TRD: 'Trade Union',
-	TRS: 'Trust'
+	TRS: 'Trust',
 };
 
 const defaultValues = {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -96,14 +96,10 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 		return (
 			<form className="registrant-extra-info__form">
-				<h1 className="registrant-extra-info__form-title">
-					{ translate(
-						'Registering a .CA domain'
-					) }
-				</h1>
 				<p className="registrant-extra-info__form-desciption">
 					{ translate(
-						'Almost done! We need some extra details to register domains ending in ".ca".'
+						'Almost done! We need some extra details to register your %(tld)s domain.',
+						{ args: { tld: '.ca' } }
 					) }
 				</p>
 				<FormFieldset>

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -6,7 +6,11 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {
 	camelCase,
+	difference,
+	isEmpty,
+	keys,
 	map,
+	pick,
 } from 'lodash';
 
 /**
@@ -61,10 +65,17 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 	constructor( props ) {
 		super( props );
 
-		this.props.contactDetails.extra = {
-			...defaultValues,
-			...this.props.contactDetails.extra
-		};
+		// Add defaults to redux state to make accepting default values work.
+		const requiredDetailsNotInProps = difference(
+			[ 'legalType', 'ciraAgreementAccepted' ],
+			keys( props.contactDetails.extra ),
+		);
+
+		if ( ! isEmpty( requiredDetailsNotInProps ) ) {
+			props.updateContactDetailsCache( {
+				extra: pick( defaultValues, requiredDetailsNotInProps ),
+			} );
+		}
 	}
 
 	handleChangeEvent = ( event ) => {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -39,29 +39,34 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 	constructor( props ) {
 		super( props );
 		const { translate } = props;
+		const legalTypes = {
+			ABO: translate( 'Aboriginal' ),
+			ASS: translate( 'Association (Unincorporated)' ),
+			CCO: translate( 'Canadian Corporation' ),
+			CCT: translate( 'Canadian Citizen' ),
+			EDU: translate( 'Educational Institution' ),
+			GOV: translate( 'Government' ),
+			HOP: translate( 'Hospital' ),
+			INB: translate( 'Indian Band' ),
+			LAM: translate( 'Library, Archive, or Museum' ),
+			LGR: translate( 'Legal Representative' ),
+			MAJ: translate( 'Her Majesty the Queen' ),
+			// An official mark is Canadian thing like a trademark for public authorities
+			OMK: translate( 'Official Mark' ),
+			PLT: translate( 'Political Party' ),
+			PRT: translate( 'Partnership' ),
+			RES: translate( 'Permanent Resident' ),
+			TDM: translate( 'Trademark Owner' ),
+			TRD: translate( 'Trade Union' ),
+			TRS: translate( 'Trust' ),
+		};
+		const legalTypeOptions = map( legalTypes, ( text, optionValue ) =>
+			<option value={ optionValue } key={ optionValue }>{ text }</option>
+		);
 
 		this.state = {
-			legalTypes: {
-				ABO: translate( 'Aboriginal' ),
-				ASS: translate( 'Association (Unincorporated)' ),
-				CCO: translate( 'Canadian Corporation' ),
-				CCT: translate( 'Canadian Citizen' ),
-				EDU: translate( 'Educational Institution' ),
-				GOV: translate( 'Government' ),
-				HOP: translate( 'Hospital' ),
-				INB: translate( 'Indian Band' ),
-				LAM: translate( 'Library, Archive, or Museum' ),
-				LGR: translate( 'Legal Representative' ),
-				MAJ: translate( 'Her Majesty the Queen' ),
-				// An official mark is Canadian thing like a trademark for public authorities
-				OMK: translate( 'Official Mark' ),
-				PLT: translate( 'Political Party' ),
-				PRT: translate( 'Partnership' ),
-				RES: translate( 'Permanent Resident' ),
-				TDM: translate( 'Trademark Owner' ),
-				TRD: translate( 'Trade Union' ),
-				TRS: translate( 'Trust' ),
-			}
+			legalTypes,
+			legalTypeOptions
 		};
 
 		// Add defaults to redux state to make accepting default values work.
@@ -87,6 +92,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 	render() {
 		const { translate } = this.props;
+		const { legalTypeOptions } = this.state;
 		const {
 			legalType,
 			ciraAgreementAccepted,
@@ -111,9 +117,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						value={ legalType }
 						className="registrant-extra-info__form-legal-type"
 						onChange={ this.handleChangeEvent }>
-						{ map( this.state.legalTypes, ( text, optionValue ) =>
-							<option value={ optionValue } key={ optionValue }>{ text }</option>
-						) }
+						{ legalTypeOptions }
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -40,24 +40,34 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		const { translate } = props;
 		const legalTypes = {
 			ABO: translate( 'Aboriginal' ),
-			ASS: translate( 'Association (Unincorporated)' ),
+			ASS: translate( 'Association (Unincorporated)', {
+				comment: 'Refers to Canadian legal concept -- encompasses entities ' +
+					'like religious congregations, social clubs, community groups, etc'
+			} ),
 			CCO: translate( 'Canadian Corporation' ),
 			CCT: translate( 'Canadian Citizen' ),
 			EDU: translate( 'Educational Institution' ),
 			GOV: translate( 'Government' ),
 			HOP: translate( 'Hospital' ),
-			INB: translate( 'Indian Band' ),
+			INB: translate( 'Indian Band', {
+				comment: 'Refers to Canadian legal concept -- Indian meaning the ' +
+					'indigeonous people of North America and band meaning a small ' +
+					'group or community'
+			} ),
 			LAM: translate( 'Library, Archive, or Museum' ),
 			LGR: translate( 'Legal Representative' ),
 			MAJ: translate( 'Her Majesty the Queen' ),
-			// An official mark is Canadian thing like a trademark for public authorities
-			OMK: translate( 'Official Mark' ),
+			OMK: translate( 'Official Mark', {
+				comment: 'Refers to a Canadian legal concept -- similar to a trademark'
+			} ),
 			PLT: translate( 'Political Party' ),
 			PRT: translate( 'Partnership' ),
 			RES: translate( 'Permanent Resident' ),
 			TDM: translate( 'Trademark Owner' ),
 			TRD: translate( 'Trade Union' ),
-			TRS: translate( 'Trust' ),
+			TRS: translate( 'Trust', {
+				comment: 'Refers to the legal concept of trust (noun)'
+			} ),
 		};
 		const legalTypeOptions = map( legalTypes, ( text, optionValue ) =>
 			<option value={ optionValue } key={ optionValue }>{ text }</option>

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -23,32 +23,6 @@ import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
 
-const legalTypes = {
-	ABO: 'Aboriginal',
-	ASS: 'Association (Unincorporated)',
-	CCO: 'Canadian Corporation',
-	CCT: 'Canadian Citizen',
-	EDU: 'Educational Institution',
-	GOV: 'Government',
-	HOP: 'Hospital',
-	INB: 'Indian Band',
-	LAM: 'Library, Archive, or Museum',
-	LGR: 'Legal Representative',
-	MAJ: 'Her Majesty the Queen',
-	// An official mark is Canadian thing like a trademark for public authorities
-	OMK: 'Official Mark',
-	PLT: 'Political Party',
-	PRT: 'Partnership',
-	RES: 'Permanent Resident',
-	TDM: 'Trademark Owner',
-	TRD: 'Trade Union',
-	TRS: 'Trust',
-};
-
-const legalTypeOptions = map( legalTypes, ( text, optionValue ) =>
-	<option value={ optionValue } key={ optionValue }>{ text }</option>
-);
-
 const defaultValues = {
 	legalType: 'CCT',
 	ciraAgreementAccepted: false,
@@ -64,6 +38,31 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 	constructor( props ) {
 		super( props );
+		const { translate } = props;
+
+		this.state = {
+			legalTypes: {
+				ABO: translate( 'Aboriginal' ),
+				ASS: translate( 'Association (Unincorporated)' ),
+				CCO: translate( 'Canadian Corporation' ),
+				CCT: translate( 'Canadian Citizen' ),
+				EDU: translate( 'Educational Institution' ),
+				GOV: translate( 'Government' ),
+				HOP: translate( 'Hospital' ),
+				INB: translate( 'Indian Band' ),
+				LAM: translate( 'Library, Archive, or Museum' ),
+				LGR: translate( 'Legal Representative' ),
+				MAJ: translate( 'Her Majesty the Queen' ),
+				// An official mark is Canadian thing like a trademark for public authorities
+				OMK: translate( 'Official Mark' ),
+				PLT: translate( 'Political Party' ),
+				PRT: translate( 'Partnership' ),
+				RES: translate( 'Permanent Resident' ),
+				TDM: translate( 'Trademark Owner' ),
+				TRD: translate( 'Trade Union' ),
+				TRS: translate( 'Trust' ),
+			}
+		};
 
 		// Add defaults to redux state to make accepting default values work.
 		const requiredDetailsNotInProps = difference(
@@ -116,7 +115,9 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						value={ legalType }
 						className="registrant-extra-info__form-legal-type"
 						onChange={ this.handleChangeEvent }>
-						{ legalTypeOptions }
+						{ map( this.state.legalTypes, ( text, optionValue ) =>
+							<option value={ optionValue } key={ optionValue }>{ text }</option>
+						) }
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -46,18 +46,16 @@ const legalTypeOptions = map( legalTypes, ( text, optionValue ) =>
 );
 
 const defaultValues = {
-	legalType: 'CCW',
-	isVisible: true,
+	legalType: 'CCT',
 	ciraAgreementAccepted: false,
-	onSubmit: noop,
 };
 
 class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
 		ciraAgreementAccepted: PropTypes.bool,
+		contactDetails: PropTypes.object,
 		legalType: PropTypes.string,
-		isVisible: PropTypes.bool,
-		onSubmit: PropTypes.func,
+		translate: PropTypes.function,
 	}
 
 	constructor( props ) {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -39,7 +39,9 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		super( props );
 		const { translate } = props;
 		const legalTypes = {
-			ABO: translate( 'Aboriginal' ),
+			ABO: translate( 'Aboriginal', {
+				comment: 'Refers to indigenous peoples, specifically of Canada.'
+			} ),
 			ASS: translate( 'Association (Unincorporated)', {
 				comment: 'Refers to Canadian legal concept -- encompasses entities ' +
 					'like religious congregations, social clubs, community groups, etc'

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -32,7 +32,7 @@ const defaultValues = {
 class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
 		contactDetailsExtra: PropTypes.object.isRequired,
-		translate: PropTypes.function,
+		translate: PropTypes.func,
 	}
 
 	constructor( props ) {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import {
+	camelCase,
 	map,
 } from 'lodash';
 
@@ -69,17 +70,20 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 	}
 
 	handleChangeEvent = ( event ) => {
+		const { target } = event;
+		const value = target.type === 'checkbox' ? target.checked : target.value;
 		this.props.updateContactDetailsCache( {
-			extra: { [ event.target.id ]: event.target.value },
+			extra: { [ camelCase( event.target.id ) ]: value },
 		} );
 	}
 
 	render() {
+		const { translate } = this.props;
 		const {
 			legalType,
-			translate,
-			ciraAgreementAccepted
-		} = { ...defaultValues, ...this.props };
+			ciraAgreementAccepted,
+		} = { ...defaultValues, ...this.props.contactDetails };
+
 		const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 
 		return (
@@ -111,12 +115,15 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						{ translate( 'CIRA Agreement' ) }
 					</FormLabel>
 					<FormLabel>
-						<FormCheckbox id="cira_acceptance" value={ ciraAgreementAccepted } />
+						<FormCheckbox
+							id="cira-agreement-accepted"
+							value={ ciraAgreementAccepted }
+							onChange={ this.handleChangeEvent } />
 						<span>{
 							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',
 								{
 									components: {
-										a: <a href={ ciraAgreementUrl } />
+										a: <a href={ ciraAgreementUrl } />,
 									}
 								}
 							)

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -69,15 +69,17 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 			legalTypes,
 			legalTypeOptions
 		};
+	}
 
+	componentWillMount() {
 		// Add defaults to redux state to make accepting default values work.
 		const requiredDetailsNotInProps = difference(
 			[ 'legalType', 'ciraAgreementAccepted' ],
-			keys( props.contactDetails.extra ),
+			keys( this.props.contactDetails.extra ),
 		);
 
 		if ( ! isEmpty( requiredDetailsNotInProps ) ) {
-			props.updateContactDetailsCache( {
+			this.props.updateContactDetailsCache( {
 				extra: pick( defaultValues, requiredDetailsNotInProps ),
 			} );
 		}

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -73,7 +73,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 			translate,
 			ciraAgreementAccepted
 		} = { ...defaultValues, ...this.props };
-		const agreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
+		const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 
 		return (
 			<form className="registrant-extra-info__form">
@@ -103,12 +103,12 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						{ translate( 'CIRA Agreement' ) }
 					</FormLabel>
 					<FormLabel>
-						<FormCheckbox id="cira_acceptance" value={ ciraAccepted } />
+						<FormCheckbox id="cira_acceptance" value={ ciraAgreementAccepted } />
 						<span>{
 							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',
 								{
 									components: {
-										a: <a href={ agreementUrl } />
+										a: <a href={ ciraAgreementUrl } />
 									}
 								}
 							)

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { isEqual, noop, toInteger } from 'lodash';
+import { get, isEqual, noop, toInteger } from 'lodash';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import debugFactory from 'debug';
@@ -120,7 +120,7 @@ class RegistrantExtraInfoForm extends React.PureComponent {
 
 	render() {
 		const translate = this.props.translate;
-		const registrantType = this.props.contactDetails.extra.registrantType;
+		const registrantType = get( this.props, 'contactDetails.extra.registrantType', 'individual' );
 		return (
 			<form className="registrant-extra-info__form">
 				<h1 className="registrant-extra-info__form-title">

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { get, isEqual, noop, toInteger } from 'lodash';
+import { isEqual, noop, toInteger } from 'lodash';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import debugFactory from 'debug';
@@ -120,7 +120,7 @@ class RegistrantExtraInfoForm extends React.PureComponent {
 
 	render() {
 		const translate = this.props.translate;
-		const registrantType = get( this.props, 'contactDetails.extra.registrantType', 'individual' );
+		const registrantType = this.props.contactDetails.extra.registrantType;
 		return (
 			<form className="registrant-extra-info__form">
 				<h1 className="registrant-extra-info__form-title">

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -42,7 +42,7 @@ const emptyValues = {
 	trademarkNumber: '',
 };
 
-class RegistrantExtraInfoForm extends React.PureComponent {
+class RegistrantExtraInfoFrForm extends React.PureComponent {
 	static propTypes = {
 		countriesList: PropTypes.object.isRequired,
 		isVisible: PropTypes.bool,
@@ -360,4 +360,4 @@ class RegistrantExtraInfoForm extends React.PureComponent {
 export default connect(
 	state => ( { contactDetails: getContactDetailsCache( state ) } ),
 	{ updateContactDetailsCache }
-)( localize( RegistrantExtraInfoForm ) );
+)( localize( RegistrantExtraInfoFrForm ) );

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -66,7 +66,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 		this.props.contactDetails.extra = {
 			...defaults,
-			...this.props.contactDetails.extra
+			...this.props.contactDetails.extra,
 		};
 	}
 
@@ -241,7 +241,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						translate( 'Year/Month/Day - e.g. 1970/12/31', {
 							comment: 'This is describing a date format with fixed fields, so please do not ' +
 								'alter the numbers (Year, Month, Day). Please translate e.g("For example") if appropriate and also ' +
-								'the words, Year, Month, Day, individually.'
+								'the words, Year, Month, Day, individually.',
 						} )
 					}</FormSettingExplanation>
 				</FormFieldset>
@@ -285,7 +285,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		const {
 			registrantVatId,
 			sirenSiret,
-			trademarkNumber
+			trademarkNumber,
 		} = { ...emptyValues, ...extra };
 
 		return (

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -123,14 +123,10 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		const registrantType = this.props.contactDetails.extra.registrantType;
 		return (
 			<form className="registrant-extra-info__form">
-				<h1 className="registrant-extra-info__form-title">
-					{ translate(
-						'Registering a .FR domain'
-					) }
-				</h1>
 				<p className="registrant-extra-info__form-desciption">
 					{ translate(
-						'Almost done! We need some extra details to register domains ending in ".fr".'
+						'Almost done! We need some extra details to register your %(tld)s domain.',
+						{ args: { tld: '.fr' } }
 					) }
 				</p>
 				<FormFieldset>

--- a/client/components/domains/registrant-extra-info/index.jsx
+++ b/client/components/domains/registrant-extra-info/index.jsx
@@ -1,0 +1,31 @@
+/**
+ * Extrenal dependencies
+ */
+import React, { PureComponent } from 'react';
+import { keys } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import fr from './fr-form';
+import ca from './ca-form';
+
+const tldSpecificForms = {
+	ca,
+	fr,
+};
+
+export const tldsWithAdditionalDetailsForms = keys( tldSpecificForms );
+
+export default class DomainDetailsForm extends PureComponent {
+	render() {
+		const { tld, ...props } = this.props;
+		const TldSpecificForm = tldSpecificForms[ tld ];
+
+		if ( ! TldSpecificForm ) {
+			throw new Error( 'unrecognized tld in extra info form:', tld );
+		}
+
+		return <TldSpecificForm { ...props } />;
+	}
+}

--- a/client/components/domains/registrant-extra-info/test/index.js
+++ b/client/components/domains/registrant-extra-info/test/index.js
@@ -1,0 +1,36 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import RegistrantExtraInfoFrForm from '../fr-form';
+import RegistrantExtraInfoCaForm from '../ca-form';
+
+/**
+ * Internal Dependencies
+ */
+import RegistrantExtraInfoForm from '../index';
+
+describe( 'Switcher Form', function() {
+	it( 'should render correct form for fr', () => {
+		const wrapper = shallow(
+			<RegistrantExtraInfoForm
+				tld="fr" />
+		);
+
+		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).to.have.length( 1 );
+		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).to.have.length( 0 );
+	} );
+
+	it( 'should render correct form for ca', () => {
+		const wrapper = shallow(
+			<RegistrantExtraInfoForm
+				tld="ca" />
+		);
+
+		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).to.have.length( 1 );
+		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).to.have.length( 0 );
+	} );
+} );

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1,8 +1,24 @@
 /**
  * External dependencies
  */
-var update = require( 'react-addons-update' );
-import { every, assign, flow, isEqual, merge, reject, tail, some, uniq, flatten, filter, find, get } from 'lodash';
+import update from 'react-addons-update';
+import {
+	assign,
+	every,
+	filter,
+	find,
+	flatten,
+	flow,
+	get,
+	isEqual,
+	map,
+	merge,
+	reject,
+	some,
+	trimStart,
+	tail,
+	uniq,
+} from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -228,6 +228,12 @@ function hasTld( cart, tld ) {
 	} );
 }
 
+export function getTlds( cart ) {
+	return uniq( map( getDomainRegistrations( cart ), function( cartItem ) {
+		return trimStart( getDomainRegistrationTld( cartItem ), '.' );
+	} ) );
+}
+
 function getDomainRegistrationTld( cartItem ) {
 	if ( ! isDomainRegistration( cartItem ) ) {
 		throw new Error( 'This function only works on domain registration cart ' +

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -244,7 +244,7 @@ function hasTld( cart, tld ) {
 	} );
 }
 
-export function getTlds( cart ) {
+function getTlds( cart ) {
 	return uniq( map( getDomainRegistrations( cart ), function( cartItem ) {
 		return trimStart( getDomainRegistrationTld( cartItem ), '.' );
 	} ) );
@@ -833,6 +833,7 @@ module.exports = {
 	getRenewalItemFromProduct,
 	getRenewalItems,
 	getSiteRedirects,
+	getTlds,
 	googleApps,
 	googleAppsExtraLicenses,
 	guidedTransferItem,

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -12,6 +12,7 @@ import {
 	first,
 	has,
 	head,
+	includes,
 	indexOf,
 	intersection,
 	isEqual,
@@ -498,14 +499,10 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	renderCurrentForm() {
-		switch ( this.state.currentStep ) {
-			// TODO: gather up tld specific stuff
-			case 'ca':
-			case 'fr':
-				return this.renderExtraDetailsForm( this.state.currentStep );
-			default:
-				return this.renderDetailsForm();
-		}
+		const { currentStep } = this.state;
+		return includes( tldsWithAdditionalDetailsForms, currentStep )
+			? this.renderExtraDetailsForm( this.state.currentStep )
+			: this.renderDetailsForm();
 	}
 
 	render() {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -65,7 +65,7 @@ export class DomainDetailsForm extends PureComponent {
 			'state',
 			'postalCode',
 			'countryCode',
-			'fax'
+			'fax',
 		];
 
 		const steps = [
@@ -91,7 +91,7 @@ export class DomainDetailsForm extends PureComponent {
 			sanitizerFunction: this.sanitize,
 			validatorFunction: this.validate,
 			onNewState: this.setFormState,
-			onError: this.handleFormControllerError
+			onError: this.handleFormControllerError,
 		} );
 	}
 
@@ -236,7 +236,7 @@ export class DomainDetailsForm extends PureComponent {
 			// kebab-case for HTML, so instead of using different variations all over the place, this accepts kebab-case and
 			// converts it to camelCase which is the format stored in the formState.
 			errorMessage: ( formState.getFieldErrorMessages( this.state.form, camelCase( name ) ) || [] ).join( '\n' ),
-			eventFormName: 'Checkout Form'
+			eventFormName: 'Checkout Form',
 		};
 	}
 
@@ -301,7 +301,7 @@ export class DomainDetailsForm extends PureComponent {
 				'Registering this domain for a company? + Add Organization Name',
 				'Registering these domains for a company? + Add Organization Name',
 				{
-					count: this.getNumberOfDomainRegistrations()
+					count: this.getNumberOfDomainRegistrations(),
 				}
 			) }
 			{ ...this.getFieldProps( 'organization' ) } />;

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -215,7 +215,7 @@ export class DomainDetailsForm extends PureComponent {
 			return [];
 		}
 
-		return cartItems.hasTld( this.props.cart, 'fr' ) ? [ 'fr' ] : [];
+		return cartItems.getTlds( this.props.cart );
 	}
 
 	getNumberOfDomainRegistrations() {
@@ -499,6 +499,7 @@ export class DomainDetailsForm extends PureComponent {
 	renderCurrentForm() {
 		switch ( this.state.currentStep ) {
 			// TODO: gather up tld specific stuff
+			case 'ca':
 			case 'fr':
 				return this.renderExtraDetailsForm();
 			default:

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -13,6 +13,7 @@ import {
 	has,
 	head,
 	indexOf,
+	intersection,
 	isEqual,
 	kebabCase,
 	last,
@@ -41,7 +42,7 @@ import { countries } from 'components/phone-input/data';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import wp from 'lib/wp';
-import ExtraInfoFrForm from 'components/domains/registrant-extra-info/fr-form';
+import ExtraInfoForm, { tldsWithAdditionalDetailsForms } from 'components/domains/registrant-extra-info';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:domain-details' );
@@ -69,8 +70,9 @@ export class DomainDetailsForm extends PureComponent {
 
 		const steps = [
 			'mainForm',
-			...this.getRequiredExtraSteps()
+			...this.getRequiredExtraSteps(),
 		];
+		debug( 'steps:', steps );
 
 		this.state = {
 			form: null,
@@ -214,8 +216,7 @@ export class DomainDetailsForm extends PureComponent {
 			// All we need to do to disable everything is not show the .FR form
 			return [];
 		}
-
-		return cartItems.getTlds( this.props.cart );
+		return intersection( cartItems.getTlds( this.props.cart ), tldsWithAdditionalDetailsForms );
 	}
 
 	getNumberOfDomainRegistrations() {
@@ -396,11 +397,11 @@ export class DomainDetailsForm extends PureComponent {
 		);
 	}
 
-	renderExtraDetailsForm() {
+	renderExtraDetailsForm( tld ) {
 		return (
-			<ExtraInfoFrForm countriesList={ countriesList } >
+			<ExtraInfoForm tld={ tld } countriesList={ countriesList } >
 				{ this.renderSubmitButton() }
-			</ExtraInfoFrForm>
+			</ExtraInfoForm>
 		);
 	}
 
@@ -501,7 +502,7 @@ export class DomainDetailsForm extends PureComponent {
 			// TODO: gather up tld specific stuff
 			case 'ca':
 			case 'fr':
-				return this.renderExtraDetailsForm();
+				return this.renderExtraDetailsForm( this.state.currentStep );
 			default:
 				return this.renderDetailsForm();
 		}

--- a/client/state/selectors/get-contact-details-cache.js
+++ b/client/state/selectors/get-contact-details-cache.js
@@ -10,5 +10,5 @@ import { get } from 'lodash';
  * @return {Object}              Contact details
  */
 export default function getContactDetailsCache( state ) {
-	return get( state, 'domains.management.items._contactDetailsCache', false );
+	return get( state, 'domains.management.items._contactDetailsCache', {} );
 }

--- a/client/state/selectors/get-contact-details-extra-cache.js
+++ b/client/state/selectors/get-contact-details-extra-cache.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns cached top-level-domain specific contact details if we've successfully requested them.
+ *
+ * @param  {Object}  state       Global state tree
+ * @return {Object}              TLD Specific Contact details
+ */
+export default function getContactDetailsExtraCache( state ) {
+	return get( state, 'domains.management.items._contactDetailsCache.extra', {} );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -31,6 +31,7 @@ export getActivityLogs from './get-activity-logs';
 export getBlockedSites from './get-blocked-sites';
 export getBillingTransactions from './get-billing-transactions';
 export getContactDetailsCache from './get-contact-details-cache';
+export getContactDetailsExtraCache from './get-contact-details-extra-cache';
 export getWhois from './get-whois';
 export getCurrentUserPaymentMethods from './get-current-user-payment-methods';
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';


### PR DESCRIPTION
This PR Adds the .CA specific form as per #13890
![ca form demo](https://user-images.githubusercontent.com/5952255/27212415-3eb3fcb4-52a3-11e7-9558-48c54ac7ad3c.gif)

In addition the form itself, it adds:

 - a switcher component to own the list of TLDs with specific forms and choose the right form for each TLD
- an additional selector to fetch TLD specific state.

This PR does not handle validation yet. As a note for when we do do validation, I've added the checkbox to the state so we can pass it to the back end for validation (and prevent users from submitting the form with the box unticked), but it's actually impossible to submit an invalid .CA form, so it might be worth looking into client-side validation logic specifically for the .CA form.