### PR TITLE
WooCommerce: Remove 'extensions' item from store nav

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -122,17 +122,6 @@ const getStorePages = () => {
 				slug: 'settings-tax',
 			},
 		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-extensions',
-			path: '/store/extensions/:site',
-			sidebarItem: {
-				icon: 'plugins',
-				isPrimary: false,
-				label: translate( 'Extensions' ),
-				slug: 'extensions',
-			},
-		},
 	];
 };
 


### PR DESCRIPTION
We are going to remove extensions items from the store navigation for version 1 until we have tailored the experience for wp.com. A few reasons:

- Most wp.com users have not used WordPress before and have no concept of plugins/extensions
- There is currently no way to manage extensions and their subscriptions in wp.com
- There is no way to purchase paid extensions through WP.com
- No extensions have been calypsoified
- Our current extension discovery and purchase flow is tailored for wp-admin