### PR TITLE
Activity Log: Add error messages for activity log internal testing

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -28,10 +28,14 @@ class ActivityLog extends Component {
 		siteId: PropTypes.number,
 		slug: PropTypes.string,
 
+		// FIXME: Testing only
+		isPressable: PropTypes.bool,
+
 		// localize
 		moment: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
+
 	componentDidMount() {
 		window.scrollTo( 0, 0 );
 	}
@@ -283,16 +287,15 @@ class ActivityLog extends Component {
 		</div>;
 	}
 
+	// FIXME: This is for internal testing
 	renderErrorMessage() {
 		const {
-			siteId,
+			isPressable,
 			rewindStatusError,
-			translate
+			translate,
 		} = this.props;
 		const rewindError = get( rewindStatusError, [ 'message' ], false );
 
-		// FIXME: check if on pressable for testing only
-		const isPressable = get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], false );
 		if ( ! isPressable && ! rewindError ) {
 			return translate( 'Currently only available for Pressable sites' );
 		}
@@ -363,6 +366,9 @@ export default connect(
 			siteId,
 			slug: getSiteSlug( state, siteId ),
 			rewindStatusError: getRewindStatusError( state, siteId ),
+
+			// FIXME: Testing only
+			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], false ),
 		};
 	}
 )( localize( ActivityLog ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -27,6 +27,10 @@ class ActivityLog extends Component {
 		isJetpack: PropTypes.bool,
 		siteId: PropTypes.number,
 		slug: PropTypes.string,
+		rewindStatusError: PropTypes.shape( {
+			error: PropTypes.string.isRequired,
+			message: PropTypes.string.isRequired,
+		} ),
 
 		// FIXME: Testing only
 		isPressable: PropTypes.bool,
@@ -294,13 +298,14 @@ class ActivityLog extends Component {
 			rewindStatusError,
 			translate,
 		} = this.props;
-		const rewindError = get( rewindStatusError, [ 'message' ], false );
 
-		if ( ! isPressable && ! rewindError ) {
+		// FIXME: Do something nicer with the error
+		if ( rewindStatusError ) {
+			return translate( 'Rewind error: %s', { args: rewindStatusError.message } );
+		}
+		if ( ! isPressable ) {
 			return translate( 'Currently only available for Pressable sites' );
 		}
-
-		return rewindError && rewindError + translate( ' Are you on a Premium or Pro plan?' );
 	}
 
 	renderContent() {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { groupBy, map } from 'lodash';
+import { groupBy, map, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +12,7 @@ import { groupBy, map } from 'lodash';
 import Main from 'components/main';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { getRewindStatusError } from 'state/selectors';
 import StatsFirstView from '../stats-first-view';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from '../stats-navigation';
@@ -282,12 +283,27 @@ class ActivityLog extends Component {
 		</div>;
 	}
 
-	render() {
+	renderErrorMessage() {
 		const {
-			isJetpack,
+			siteId,
+			rewindStatusError,
+			translate
+		} = this.props;
+		const rewindError = get( rewindStatusError, [ 'message' ], false );
+
+		// FIXME: check if on pressable for testing only
+		const isPressable = get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], false );
+		if ( ! isPressable && ! rewindError ) {
+			return translate( 'Currently only available for Pressable sites' );
+		}
+
+		return rewindError && rewindError + translate( ' Are you on a Premium or Pro plan?' );
+	}
+
+	renderContent() {
+		const {
 			moment,
 			siteId,
-			slug,
 		} = this.props;
 		const logs = this.logs();
 		const logsGroupedByDate = map(
@@ -307,6 +323,23 @@ class ActivityLog extends Component {
 		);
 
 		return (
+			<div>
+				{ this.renderBanner() }
+				<section className="activity-log__wrapper">
+					{ logsGroupedByDate }
+				</section>
+			</div>
+		);
+	}
+
+	render() {
+		const {
+			isJetpack,
+			siteId,
+			slug,
+		} = this.props;
+
+		return (
 			<Main wideLayout={ true }>
 				<QueryRewindStatus siteId={ siteId } />
 				<StatsFirstView />
@@ -316,10 +349,7 @@ class ActivityLog extends Component {
 					slug={ slug }
 					section="activity"
 				/>
-				{ this.renderBanner() }
-				<section className="activity-log__wrapper">
-					{ logsGroupedByDate }
-				</section>
+				{ this.renderErrorMessage() || this.renderContent() }
 			</Main>
 		);
 	}
@@ -331,7 +361,8 @@ export default connect(
 		return {
 			isJetpack: isJetpackSite( state, siteId ),
 			siteId,
-			slug: getSiteSlug( state, siteId )
+			slug: getSiteSlug( state, siteId ),
+			rewindStatusError: getRewindStatusError( state, siteId ),
 		};
 	}
 )( localize( ActivityLog ) );


### PR DESCRIPTION
This PR is meant to make testing the UI less confusing for internal testers, as it will render an error message if testing requirements are not met. It will render the error message from the `getRewindStatusError` selector if found.  

It does not have any nice UI yet, as this will not be in production and there is no error state designs as of yet.

**For sites not on Pressable, you should see this:**
![screen shot 2017-06-09 at 11 39 27 am](https://user-images.githubusercontent.com/7129409/26983277-3bc80422-4d09-11e7-8572-16346a83cf47.png)

For Pressable sites without a premium/pro plan: 
![screen shot 2017-06-09 at 11 39 00 am 1](https://user-images.githubusercontent.com/7129409/26983298-511a616c-4d09-11e7-934f-4beda5dd6745.png)

