### PR TITLE
Login: Refactor handling of redirect url

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -38,10 +38,6 @@ class Login extends Component {
 		twoFactorNotificationSent: PropTypes.string,
 	};
 
-	state = {
-		rememberMe: false,
-	};
-
 	componentDidMount = () => {
 		if ( ! this.props.twoFactorEnabled && this.props.twoFactorAuthType ) {
 			// Disallow access to the 2FA pages unless the user has 2FA enabled
@@ -126,10 +122,6 @@ class Login extends Component {
 			twoFactorNotificationSent,
 		} = this.props;
 
-		const {
-			rememberMe,
-		} = this.state;
-
 		let poller;
 		if ( twoFactorEnabled && twoFactorAuthType && twoFactorNotificationSent === 'push' ) {
 			poller = <PushNotificationApprovalPoller onSuccess={ this.rebootAfterLogin } />;
@@ -140,7 +132,6 @@ class Login extends Component {
 				<div>
 					{ poller }
 					<VerificationCodeForm
-						rememberMe={ rememberMe }
 						onSuccess={ this.rebootAfterLogin }
 						twoFactorAuthType={ twoFactorAuthType }
 					/>

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -13,6 +13,7 @@ import page from 'page';
 import DocumentHead from 'components/data/document-head';
 import LoginForm from './login-form';
 import {
+	getRedirectTo,
 	getRequestError,
 	getRequestNotice,
 	getTwoFactorAuthRequestError,
@@ -29,7 +30,7 @@ import PushNotificationApprovalPoller from './two-factor-authentication/push-not
 class Login extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
-		redirectLocation: PropTypes.string,
+		redirectTo: PropTypes.string,
 		requestError: PropTypes.object,
 		requestNotice: PropTypes.object,
 		twoFactorAuthType: PropTypes.string,
@@ -69,22 +70,16 @@ class Login extends Component {
 	};
 
 	rebootAfterLogin = () => {
+		const { redirectTo } = this.props;
+
 		this.props.recordTracksEvent( 'calypso_login_success', {
 			two_factor_enabled: this.props.twoFactorEnabled
 		} );
 
-		const { redirectLocation } = this.props;
+		// Redirects to / if no redirect url is available
+		const url = redirectTo ? redirectTo : window.location.origin;
 
-		let newHref;
-
-		if ( redirectLocation && redirectLocation.match( /^(?!\/\/)[\/\-a-z0-9.]+$/i ) ) {
-			// only redirect to paths on the current domain
-			newHref = redirectLocation;
-		} else {
-			newHref = window.location.origin;
-		}
-
-		window.location.href = newHref;
+		window.location.href = url;
 	};
 
 	renderError() {
@@ -176,6 +171,7 @@ class Login extends Component {
 
 export default connect(
 	( state ) => ( {
+		redirectTo: getRedirectTo( state ),
 		requestError: getRequestError( state ),
 		requestNotice: getRequestNotice( state ),
 		twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -16,6 +16,7 @@ import Card from 'components/card';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormTextInput from 'components/forms/form-text-input';
 import FormCheckbox from 'components/forms/form-checkbox';
+import { getCurrentQueryArguments } from 'state/ui/selectors';
 import { loginUser } from 'state/login/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isRequesting, getRequestError } from 'state/login/selectors';
@@ -27,6 +28,7 @@ export class LoginForm extends Component {
 		loginError: PropTypes.string,
 		loginUser: PropTypes.func.isRequired,
 		onSuccess: PropTypes.func.isRequired,
+		redirectTo: PropTypes.string,
 		requestError: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 	};
@@ -55,11 +57,11 @@ export class LoginForm extends Component {
 		event.preventDefault();
 
 		const { password, rememberMe, usernameOrEmail } = this.state;
-		const { onSuccess } = this.props;
+		const { onSuccess, redirectTo } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
-		this.props.loginUser( usernameOrEmail, password, rememberMe ).then( () => {
+		this.props.loginUser( usernameOrEmail, password, rememberMe, redirectTo ).then( () => {
 			this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 
 			onSuccess();
@@ -157,6 +159,7 @@ export class LoginForm extends Component {
 
 export default connect(
 	( state ) => ( {
+		redirectTo: getCurrentQueryArguments( state ).redirect_to,
 		isRequesting: isRequesting( state ),
 		requestError: getRequestError( state ),
 	} ),

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -54,11 +54,15 @@ export class LoginForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
+		const { password, rememberMe, usernameOrEmail } = this.state;
+		const { onSuccess } = this.props;
+
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
-		this.props.loginUser( this.state.usernameOrEmail, this.state.password, this.state.rememberMe ).then( () => {
+		this.props.loginUser( usernameOrEmail, password, rememberMe ).then( () => {
 			this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
-			this.props.onSuccess( this.state );
+
+			onSuccess();
 		} ).catch( error => {
 			this.props.recordTracksEvent( 'calypso_login_block_login_form_failure', {
 				error_message: error.message

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
+import { getCurrentQueryArguments } from 'state/ui/selectors';
 import { loginSocialUser } from 'state/login/actions';
 import { errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -21,6 +22,7 @@ class SocialLoginForm extends Component {
 		errorNotice: PropTypes.func.isRequired,
 		infoNotice: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
+		redirectTo: PropTypes.string,
 		removeNotice: PropTypes.func.isRequired,
 		onSuccess: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -32,13 +34,13 @@ class SocialLoginForm extends Component {
 	};
 
 	handleGoogleResponse = ( response ) => {
-		const { onSuccess, translate } = this.props;
+		const { onSuccess, redirectTo, translate } = this.props;
 
 		if ( ! response.Zi || ! response.Zi.id_token ) {
 			return;
 		}
 
-		this.props.loginSocialUser( 'google', response.Zi.id_token ).then( () => {
+		this.props.loginSocialUser( 'google', response.Zi.id_token, redirectTo ).then( () => {
 			this.props.recordTracksEvent( 'calypso_social_login_form_login_success', {
 				social_account_type: 'google',
 			} );
@@ -106,7 +108,9 @@ class SocialLoginForm extends Component {
 }
 
 export default connect(
-	null,
+	( state ) => ( {
+		redirectTo: getCurrentQueryArguments( state ).redirect_to,
+	} ),
 	{
 		errorNotice,
 		infoNotice,

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -52,7 +52,7 @@ class SocialLoginForm extends Component {
 					this.props.removeNotice( notice.noticeId );
 
 					if ( wpcomError ) {
-						this.props.recordTracksEvent( 'calypso_social_login_form_signup_fail', {
+						this.props.recordTracksEvent( 'calypso_social_login_form_signup_failure', {
 							social_account_type: 'google',
 							error: wpcomError.message
 						} );
@@ -70,7 +70,7 @@ class SocialLoginForm extends Component {
 					}
 				} );
 			} else {
-				this.props.recordTracksEvent( 'calypso_social_login_form_login_fail', {
+				this.props.recordTracksEvent( 'calypso_social_login_form_login_failure', {
 					social_account_type: 'google',
 					error: error.message
 				} );

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -32,6 +32,8 @@ class SocialLoginForm extends Component {
 	};
 
 	handleGoogleResponse = ( response ) => {
+		const { onSuccess, translate } = this.props;
+
 		if ( ! response.Zi || ! response.Zi.id_token ) {
 			return;
 		}
@@ -41,12 +43,14 @@ class SocialLoginForm extends Component {
 				social_account_type: 'google',
 			} );
 
-			this.props.onSuccess();
+			onSuccess();
 		} ).catch( error => {
 			if ( error.code === 'unknown_user' ) {
-				const { notice } = this.props.infoNotice( this.props.translate( 'Creating your account' ) );
+				const { notice } = this.props.infoNotice( translate( 'Creating your account' ) );
+
 				wpcom.undocumented().usersSocialNew( 'google', response.Zi.id_token, 'login', ( wpcomError, wpcomResponse ) => {
 					this.props.removeNotice( notice.noticeId );
+
 					if ( wpcomError ) {
 						this.props.recordTracksEvent( 'calypso_social_login_form_signup_fail', {
 							social_account_type: 'google',

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -61,7 +61,7 @@ class VerificationCodeForm extends Component {
 		} );
 	};
 
-	onCodeSubmit = ( event ) => {
+	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
 		const { rememberMe, twoFactorAuthType } = this.props;
@@ -108,7 +108,7 @@ class VerificationCodeForm extends Component {
 		}
 
 		return (
-			<form onSubmit={ this.onCodeSubmit }>
+			<form onSubmit={ this.onSubmitForm }>
 				<Card className="two-factor-authentication__push-notification-screen is-compact">
 					<p>
 						{ helpText }
@@ -139,7 +139,6 @@ class VerificationCodeForm extends Component {
 
 					<FormButton
 						className="two-factor-authentication__form-button"
-						onClick={ this.onSubmit }
 						primary
 						disabled={ this.props.isRequestingTwoFactorAuth }
 					>{ translate( 'Continue' ) }</FormButton>

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -67,7 +67,11 @@ class VerificationCodeForm extends Component {
 		const { onSuccess, rememberMe, twoFactorAuthType } = this.props;
 		const { twoStepCode } = this.state;
 
+		this.props.recordTracksEvent( 'calypso_two_factor_verification_code_submit' );
+
 		this.props.loginUserWithTwoFactorVerificationCode( twoStepCode, rememberMe, twoFactorAuthType ).then( () => {
+			this.props.recordTracksEvent( 'calypso_two_factor_verification_code_success' );
+
 			onSuccess();
 		} ).catch( ( error ) => {
 			this.props.recordTracksEvent( 'calypso_two_factor_verification_code_failure', {

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -30,7 +30,6 @@ class VerificationCodeForm extends Component {
 		loginUserWithTwoFactorVerificationCode: PropTypes.func.isRequired,
 		onSuccess: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
-		rememberMe: PropTypes.bool.isRequired,
 		sendSmsCode: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthRequestError: PropTypes.string,
@@ -64,12 +63,12 @@ class VerificationCodeForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
-		const { onSuccess, rememberMe, twoFactorAuthType } = this.props;
+		const { onSuccess, twoFactorAuthType } = this.props;
 		const { twoStepCode } = this.state;
 
 		this.props.recordTracksEvent( 'calypso_two_factor_verification_code_submit' );
 
-		this.props.loginUserWithTwoFactorVerificationCode( twoStepCode, rememberMe, twoFactorAuthType ).then( () => {
+		this.props.loginUserWithTwoFactorVerificationCode( twoStepCode, twoFactorAuthType ).then( () => {
 			this.props.recordTracksEvent( 'calypso_two_factor_verification_code_success' );
 
 			onSuccess();

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -64,11 +64,11 @@ class VerificationCodeForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
-		const { rememberMe, twoFactorAuthType } = this.props;
+		const { onSuccess, rememberMe, twoFactorAuthType } = this.props;
 		const { twoStepCode } = this.state;
 
 		this.props.loginUserWithTwoFactorVerificationCode( twoStepCode, rememberMe, twoFactorAuthType ).then( () => {
-			this.props.onSuccess();
+			onSuccess();
 		} ).catch( ( error ) => {
 			this.props.recordTracksEvent( 'calypso_two_factor_verification_code_failure', {
 				error_message: error.message

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -12,7 +12,6 @@ import page from 'page';
  */
 import config, { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
-import { getCurrentQueryArguments } from 'state/ui/selectors';
 import Gridicon from 'gridicons';
 import Main from 'components/main';
 import LocaleSuggestions from 'components/locale-suggestions';
@@ -97,7 +96,7 @@ export class Login extends React.Component {
 	}
 
 	render() {
-		const { queryArguments, translate, twoFactorAuthType } = this.props;
+		const { translate, twoFactorAuthType } = this.props;
 
 		return (
 			<Main className="wp-login">
@@ -111,10 +110,10 @@ export class Login extends React.Component {
 					<div className="wp-login__container">
 						<LoginBlock
 							twoFactorAuthType={ twoFactorAuthType }
-							redirectLocation={ queryArguments.redirect_to }
 							title={ translate( 'Log in to your account.' ) }
 						/>
 					</div>
+
 					<div className="wp-login__footer">
 						{ this.footerLinks() }
 					</div>
@@ -124,15 +123,9 @@ export class Login extends React.Component {
 	}
 }
 
-const mapState = state => {
-	return {
-		queryArguments: getCurrentQueryArguments( state ),
-	};
-};
-
 const mapDispatch = {
 	recordTracksEvent,
 	resetMagicLoginRequestForm,
 };
 
-export default connect( mapState, mapDispatch )( localize( Login ) );
+export default connect( null, mapDispatch )( localize( Login ) );

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -14,11 +14,11 @@ import {
 	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START,
 } from 'state/action-types';
 import {
-  getTwoFactorAuthNonce,
-  getTwoFactorPushPollInProgress,
-  getTwoFactorPushToken,
-  getTwoFactorRememberMe,
-  getTwoFactorUserId,
+	getRememberMe,
+	getTwoFactorAuthNonce,
+	getTwoFactorPushPollInProgress,
+	getTwoFactorPushToken,
+	getTwoFactorUserId,
 } from 'state/login/selectors';
 
 /***
@@ -40,7 +40,7 @@ const doAppPushRequest = ( store ) => {
 		.send( {
 			user_id: getTwoFactorUserId( store.getState() ),
 			two_step_nonce: getTwoFactorAuthNonce( store.getState(), 'push' ),
-			remember_me: getTwoFactorRememberMe( store.getState() ),
+			remember_me: getRememberMe( store.getState() ),
 			two_step_push_token: getTwoFactorPushToken( store.getState() ),
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),

--- a/client/state/data-layer/wpcom/login-2fa/index.js
+++ b/client/state/data-layer/wpcom/login-2fa/index.js
@@ -14,11 +14,11 @@ import {
 	TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START,
 } from 'state/action-types';
 import {
-	getTwoFactorUserId,
-	getTwoFactorAuthNonce,
-	getTwoFactorPushToken,
-	getTwoFactorRememberMe,
-	getTwoFactorPushPollInProgress
+  getTwoFactorAuthNonce,
+  getTwoFactorPushPollInProgress,
+  getTwoFactorPushToken,
+  getTwoFactorRememberMe,
+  getTwoFactorUserId,
 } from 'state/login/selectors';
 
 /***

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -27,8 +27,9 @@ import {
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
 } from 'state/action-types';
 import {
-	getTwoFactorUserId,
+	getRememberMe,
 	getTwoFactorAuthNonce,
+	getTwoFactorUserId,
 } from 'state/login/selectors';
 
 const errorMessages = {
@@ -95,7 +96,7 @@ function getErrorFromHTTPError( httpError ) {
  *
  * @param  {String}    usernameOrEmail    Username or email of the user.
  * @param  {String}    password           Password of the user.
- * @param  {Boolean}   rememberMe         Whether to persist the logged in state of the user..
+ * @param  {Boolean}   rememberMe         Whether to persist the logged in state of the user.
  * @return {Function}                     Action thunk to trigger the login process.
  */
 export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch => {
@@ -135,11 +136,10 @@ export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch =
  * Attempt to login a user when a two factor verification code is sent.
  *
  * @param  {String}    twoStepCode  Verification code for the user.
- * @param  {Boolean}   rememberMe       Flag for remembering the user for a while after logging in.
  * @param {String}     twoFactorAuthType Two factor authentication method
  * @return {Function}                 Action thunk to trigger the login process.
  */
-export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, rememberMe, twoFactorAuthType ) => ( dispatch, getState ) => {
+export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAuthType ) => ( dispatch, getState ) => {
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 
 	return request.post( 'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint' )
@@ -150,7 +150,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, rememberMe,
 			user_id: getTwoFactorUserId( getState() ),
 			two_step_code: twoStepCode,
 			two_step_nonce: getTwoFactorAuthNonce( getState(), twoFactorAuthType ),
-			remember_me: rememberMe,
+			remember_me: getRememberMe( getState() ),
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
 		} )

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -101,7 +101,6 @@ function getErrorFromHTTPError( httpError ) {
 export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch => {
 	dispatch( {
 		type: LOGIN_REQUEST,
-		usernameOrEmail
 	} );
 
 	return request.post( 'https://wordpress.com/wp-login.php?action=login-endpoint' )
@@ -117,7 +116,6 @@ export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch =
 		} ).then( ( response ) => {
 			dispatch( {
 				type: LOGIN_REQUEST_SUCCESS,
-				usernameOrEmail,
 				rememberMe,
 				data: response.body && response.body.data,
 			} );
@@ -126,7 +124,6 @@ export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch =
 
 			dispatch( {
 				type: LOGIN_REQUEST_FAILURE,
-				usernameOrEmail,
 				error,
 			} );
 
@@ -238,11 +235,11 @@ export const sendSmsCode = () => ( dispatch, getState ) => {
 		.then( ( response ) => {
 			const phoneNumber = get( response, 'body.data.phone_number' );
 			const message = translate( 'Message sent to phone number ending in %(phoneNumber)s', {
-					args: {
-						phoneNumber
-					}
+				args: {
+					phoneNumber
 				}
-			);
+			} );
+
 			dispatch( {
 				type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
 				notice: {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -137,12 +137,12 @@ export const loginUser = ( usernameOrEmail, password, rememberMe ) => dispatch =
 /**
  * Attempt to login a user when a two factor verification code is sent.
  *
- * @param  {String}    two_step_code  Verification code for the user.
- * @param  {Boolean}   remember_me       Flag for remembering the user for a while after logging in.
+ * @param  {String}    twoStepCode  Verification code for the user.
+ * @param  {Boolean}   rememberMe       Flag for remembering the user for a while after logging in.
  * @param {String}     twoFactorAuthType Two factor authentication method
  * @return {Function}                 Action thunk to trigger the login process.
  */
-export const loginUserWithTwoFactorVerificationCode = ( two_step_code, remember_me, twoFactorAuthType ) => ( dispatch, getState ) => {
+export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, rememberMe, twoFactorAuthType ) => ( dispatch, getState ) => {
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 
 	return request.post( 'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint' )
@@ -151,9 +151,9 @@ export const loginUserWithTwoFactorVerificationCode = ( two_step_code, remember_
 		.accept( 'application/json' )
 		.send( {
 			user_id: getTwoFactorUserId( getState() ),
-			two_step_code,
+			two_step_code: twoStepCode,
 			two_step_nonce: getTwoFactorAuthNonce( getState(), twoFactorAuthType ),
-			remember_me,
+			remember_me: rememberMe,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
 		} )

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get, isEmpty, omit } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
@@ -7,6 +12,9 @@ import {
 	LOGIN_REQUEST,
 	LOGIN_REQUEST_FAILURE,
 	LOGIN_REQUEST_SUCCESS,
+	SOCIAL_LOGIN_REQUEST,
+	SOCIAL_LOGIN_REQUEST_FAILURE,
+	SOCIAL_LOGIN_REQUEST_SUCCESS,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS,
@@ -23,6 +31,15 @@ export const isRequesting = createReducer( false, {
 	[ LOGIN_REQUEST ]: () => true,
 	[ LOGIN_REQUEST_FAILURE ]: () => false,
 	[ LOGIN_REQUEST_SUCCESS ]: () => false,
+} );
+
+export const redirectTo = createReducer( null, {
+	[ LOGIN_REQUEST ]: () => null,
+	[ LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => get( data, 'redirect_to', null ),
+	[ LOGIN_REQUEST_FAILURE ]: () => null,
+	[ SOCIAL_LOGIN_REQUEST ]: () => null,
+	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: ( state, action ) => get( action, 'redirectTo', null ),
+	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => null,
 } );
 
 export const rememberMe = createReducer( null, {
@@ -57,7 +74,17 @@ const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) => Object.assi
 
 export const twoFactorAuth = createReducer( null, {
 	[ LOGIN_REQUEST ]: () => null,
-	[ LOGIN_REQUEST_SUCCESS ]: ( state, { data, rememberMe } ) => data ? { ...data } : null,
+	[ LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => {
+		if ( data ) {
+			const rest = omit( data, 'redirect_to' );
+
+			if ( ! isEmpty( rest ) ) {
+				return rest;
+			}
+		}
+
+		return null;
+	},
 	[ LOGIN_REQUEST_FAILURE ]: () => null,
 	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE ]: ( state, { twoStepNonce } ) =>
 		updateTwoStepNonce( state, { twoStepNonce, nonceType: 'sms' } ),
@@ -88,6 +115,7 @@ export default combineReducers( {
 	isRequesting,
 	isRequestingTwoFactorAuth,
 	magicLogin,
+	redirectTo,
 	rememberMe,
 	requestError,
 	requestNotice,

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -25,6 +25,12 @@ export const isRequesting = createReducer( false, {
 	[ LOGIN_REQUEST_SUCCESS ]: () => false,
 } );
 
+export const rememberMe = createReducer( null, {
+	[ LOGIN_REQUEST ]: () => null,
+	[ LOGIN_REQUEST_SUCCESS ]: ( state, action ) => action.rememberMe,
+	[ LOGIN_REQUEST_FAILURE ]: () => false,
+} );
+
 export const requestError = createReducer( null, {
 	[ LOGIN_REQUEST ]: () => null,
 	[ LOGIN_REQUEST_SUCCESS ]: () => null,
@@ -51,7 +57,7 @@ const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) => Object.assi
 
 export const twoFactorAuth = createReducer( null, {
 	[ LOGIN_REQUEST ]: () => null,
-	[ LOGIN_REQUEST_SUCCESS ]: ( state, { data, rememberMe } ) => data ? { ...data, remember_me: rememberMe } : null,
+	[ LOGIN_REQUEST_SUCCESS ]: ( state, { data, rememberMe } ) => data ? { ...data } : null,
 	[ LOGIN_REQUEST_FAILURE ]: () => null,
 	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE ]: ( state, { twoStepNonce } ) =>
 		updateTwoStepNonce( state, { twoStepNonce, nonceType: 'sms' } ),
@@ -82,6 +88,7 @@ export default combineReducers( {
 	isRequesting,
 	isRequestingTwoFactorAuth,
 	magicLogin,
+	rememberMe,
 	requestError,
 	requestNotice,
 	requestSuccess,

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -46,14 +46,6 @@ export const getTwoFactorNotificationSent = ( state ) => {
 export const getTwoFactorPushToken = state => get( state, 'login.twoFactorAuth.push_web_token', null );
 
 /***
- * Retrieve the remember me flag that was set when logging in
- *
- * @param  {Object}   state  Global state tree
- * @return {Boolean}         Remember me flag for authentication
- */
-export const getTwoFactorRememberMe = state => get( state, 'login.twoFactorAuth.remember_me', false );
-
-/***
  * Retrieve the progress status of polling for push authentication
  *
  * @param  {Object}   state  Global state tree
@@ -159,4 +151,14 @@ export const getRequestError = ( state ) => {
  */
 export const getRequestNotice = ( state ) => {
 	return get( state, 'login.requestNotice', null );
+};
+
+/***
+ * Retrieve the remember me flag that was set when logging in.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {Boolean}         Remember me flag for authentication
+ */
+export const getRememberMe = ( state ) => {
+	return get( state, 'login.rememberMe', false );
 };

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * Retrieve the user ID for the two factor authentication process.
@@ -62,21 +62,15 @@ export const getTwoFactorPushPollInProgress = state => get( state, 'login.twoFac
 export const getTwoFactorPushPollSuccess = state => get( state, 'login.twoFactorAuthPushPoll.success', false );
 
 /**
- * True if two factor authentication is enabled for the logging in user.
- * False if not, null if the information is not available yet.
+ * Determines whether two factor authentication is enabled for the logging in user.
  *
  * @param  {Object}   state  Global state tree
- * @return {?Boolean}        Whether 2FA is enabled
+ * @return {Boolean}        Whether 2FA is enabled
  */
 export const isTwoFactorEnabled = ( state ) => {
 	const twoFactorAuth = get( state, 'login.twoFactorAuth' );
-	if ( ! twoFactorAuth ) {
-		return null;
-	}
 
-	return (
-		twoFactorAuth.user_id !== ''
-	);
+	return ! isEmpty( twoFactorAuth );
 };
 
 /**
@@ -154,7 +148,17 @@ export const getRequestNotice = ( state ) => {
 };
 
 /***
- * Retrieve the remember me flag that was set when logging in.
+ * Retrieves the redirect url that was passed when logging in.
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?String}         Url to redirect the user to upon successful login
+ */
+export const getRedirectTo = ( state ) => {
+	return get( state, 'login.redirectTo', null );
+};
+
+/***
+ * Retrieves the remember me flag that was set when logging in.
  *
  * @param  {Object}   state  Global state tree
  * @return {Boolean}         Remember me flag for authentication

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -35,6 +35,7 @@ describe( 'reducer', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'isRequesting',
 			'magicLogin',
+			'rememberMe',
 			'requestError',
 			'requestNotice',
 			'requestSuccess',
@@ -372,7 +373,7 @@ describe( 'reducer', () => {
 				rememberMe: true
 			} );
 
-			expect( state ).to.eql( { ...data, remember_me: true } );
+			expect( state ).to.eql( { ...data } );
 		} );
 
 		it( 'should set twoFactorAuth to null value if a request is unsuccessful', () => {

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -35,6 +35,7 @@ describe( 'reducer', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'isRequesting',
 			'magicLogin',
+			'redirectTo',
 			'rememberMe',
 			'requestError',
 			'requestNotice',

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -8,19 +8,19 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	getTwoFactorAuthRequestError,
-	getTwoFactorUserId,
-	getTwoFactorAuthNonce,
-	getRequestError,
-	getTwoFactorSupportedAuthTypes,
-	isRequestingTwoFactorAuth,
-	isRequesting,
-	isTwoFactorEnabled,
-	isTwoFactorAuthTypeSupported,
-	getTwoFactorPushToken,
-	getTwoFactorRememberMe,
-	getTwoFactorPushPollInProgress,
-	getTwoFactorPushPollSuccess,
+  getRequestError,
+  getTwoFactorAuthNonce,
+  getTwoFactorAuthRequestError,
+  getTwoFactorPushPollInProgress,
+  getTwoFactorPushPollSuccess,
+  getTwoFactorPushToken,
+  getTwoFactorRememberMe,
+  getTwoFactorSupportedAuthTypes,
+  getTwoFactorUserId,
+  isRequesting,
+  isRequestingTwoFactorAuth,
+  isTwoFactorAuthTypeSupported,
+  isTwoFactorEnabled,
 } from '../selectors';
 
 describe( 'selectors', () => {

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -154,10 +154,10 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isTwoFactorEnabled()', () => {
-		it( 'should return null if there is no two factor information yet', () => {
+		it( 'should return false if there is no two factor information yet', () => {
 			const twoFactorEnabled = isTwoFactorEnabled( undefined );
 
-			expect( twoFactorEnabled ).to.be.null;
+			expect( twoFactorEnabled ).to.be.false;
 		} );
 
 		it( 'should return true if the request was successful and two-factor auth is enabled', () => {
@@ -166,40 +166,11 @@ describe( 'selectors', () => {
 					twoFactorAuth: {
 						user_id: 123456,
 						two_step_nonce: 'abcdef123456',
-						result: true,
 					}
 				}
 			} );
 
 			expect( twoFactorEnabled ).to.be.true;
-		} );
-
-		it( 'should return false if the request was successful and two-factor auth is not', () => {
-			const twoFactorEnabled = isTwoFactorEnabled( {
-				login: {
-					twoFactorAuth: {
-						user_id: '',
-						two_step_nonce: '',
-						result: true,
-					}
-				}
-			} );
-
-			expect( twoFactorEnabled ).to.be.false;
-		} );
-
-		it( 'should return false if the request was unsuccessful', () => {
-			const twoFactorEnabled = isTwoFactorEnabled( {
-				login: {
-					twoFactorAuth: {
-						user_id: '',
-						two_step_nonce: '',
-						result: false,
-					}
-				}
-			} );
-
-			expect( twoFactorEnabled ).to.be.false;
 		} );
 	} );
 

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -8,19 +8,19 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-  getRequestError,
-  getTwoFactorAuthNonce,
-  getTwoFactorAuthRequestError,
-  getTwoFactorPushPollInProgress,
-  getTwoFactorPushPollSuccess,
-  getTwoFactorPushToken,
-  getTwoFactorRememberMe,
-  getTwoFactorSupportedAuthTypes,
-  getTwoFactorUserId,
-  isRequesting,
-  isRequestingTwoFactorAuth,
-  isTwoFactorAuthTypeSupported,
-  isTwoFactorEnabled,
+	getRememberMe,
+	getRequestError,
+	getTwoFactorAuthNonce,
+	getTwoFactorAuthRequestError,
+	getTwoFactorPushPollInProgress,
+	getTwoFactorPushPollSuccess,
+	getTwoFactorPushToken,
+	getTwoFactorSupportedAuthTypes,
+	getTwoFactorUserId,
+	isRequesting,
+	isRequestingTwoFactorAuth,
+	isTwoFactorAuthTypeSupported,
+	isTwoFactorEnabled,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -260,18 +260,16 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getTwoFactorRememberMe()', () => {
+	describe( 'getRememberMe()', () => {
 		it( 'should return false by default', () => {
-			expect( getTwoFactorRememberMe( undefined ) ).to.be.false;
+			expect( getRememberMe( undefined ) ).to.be.false;
 		} );
 
 		it( "should return remember me flag when it's set", () => {
 			const rememberMe = true;
-			expect( getTwoFactorRememberMe( {
+			expect( getRememberMe( {
 				login: {
-					twoFactorAuth: {
-						remember_me: rememberMe
-					}
+					rememberMe
 				}
 			} ) ).to.eql( rememberMe );
 		} );


### PR DESCRIPTION
This pull request, together with patch D5959-code, updates the handling of the `redirect_to` parameter that can be passed to the new [`Login` page](http://calypso.localhost:3000/log-in). More specifically, it moves the sanitization and validation of the redirect url to the API in order to make it more robust. It also refactors how we store this url as well as the remember me flag in the global state tree, and makes it more consistent. Finally, it adds two Tracks events that were missing, and cleans some code.
 
#### Testing instructions

1. Apply patch D5959-code
2. Point `wordpress.com`to your sandbox
3. Run `git checkout update/login-redirect` and start your server
4. Open http://calypso.localhost:3000/log-in in incognito mode
5. Check that you can still log in, and are redirected to the [`Reader` page](http://calypso.localhost:3000/)
6. Open http://calypso.localhost:3000/log-in?redirect_to=https://www.yahoo.fr in incognito mode
7. Check that you can still log in, and are still redirected to the `Reader` page
8. Open http://calypso.localhost:3000/log-in?redirect_to=/me in incognito mode
9. Check that you can still log in, and are redirected to http://calypso.localhost:3000/me
10. Open http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans in incognito mode
11. Check that you can still log in, and are redirected to https://wordpress.com/plans
12. Open http://calypso.localhost:3000/log-in?redirect_to=https://haiku.blog/ in incognito mode
13. Check that you can still log in, and are redirected to https://haiku.blog/
14. Leave a comment there, it will make its author happy

Please repeat those steps with accounts that have **2FA enabled** or by **login with Google** as well.
 
#### Additional notes

We should probably still honor the `redirect_to` parameter when the user accesses the new `Login` page while already logged in. This is something that can be addressed in another pull request, unless someone object.

 
#### Reviews
 
- [x] Code
- [x] Product
- [x] Tests