### PR TITLE
Woocommerce Payment Method Edit: Limit Fields based on design

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -52,7 +53,15 @@ class PaymentMethodEdit extends Component {
 	}
 
 	renderEditField = ( editField ) => {
-		const setting = this.props.method.settings[ editField ];
+		const { method } = this.props;
+		if (
+			method.fields &&
+			isArray( method.fields ) &&
+			method.fields.indexOf( editField ) < 0
+		) {
+			return;
+		}
+		const setting = method.settings[ editField ];
 		return (
 			<FormFieldset className="payments__method-edit-field-container" key={ editField }>
 				<FormLabel>{ setting.label }</FormLabel>

--- a/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
+++ b/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
@@ -6,14 +6,14 @@
 		"methodType": "offline"
 	},
 	"cod": {
+		"fields": [
+			"title",
+			"instructions"
+		],
 		"methodType": "offline"
 	},
 	"paypal": {
 		"fees": "2.9% + 30c per transaction",
-		"fields": [
-			"email",
-			"paymentaction"
-		],
 		"informationUrl": "https://docs.woocommerce.com/document/paypal-standard/",
 		"isSuggested": true,
 		"methodType": "off-site"

--- a/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
+++ b/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
@@ -11,7 +11,8 @@
 	"paypal": {
 		"fees": "2.9% + 30c per transaction",
 		"fields": [
-			"email"
+			"email",
+			"paymentaction"
 		],
 		"informationUrl": "https://docs.woocommerce.com/document/paypal-standard/",
 		"isSuggested": true,

--- a/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
+++ b/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
@@ -10,6 +10,9 @@
 	},
 	"paypal": {
 		"fees": "2.9% + 30c per transaction",
+		"fields": [
+			"email"
+		],
 		"informationUrl": "https://docs.woocommerce.com/document/paypal-standard/",
 		"isSuggested": true,
 		"methodType": "off-site"

--- a/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
@@ -239,6 +239,7 @@ describe( 'actions', () => {
 						description: 'Pay via PayPal;',
 						enabled: false,
 						fees: '2.9% + 30c per transaction',
+						fields: [ 'email', 'paymentaction' ],
 						id: 'paypal',
 						informationUrl: 'https://docs.woocommerce.com/document/paypal-standard/',
 						isSuggested: true,

--- a/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
@@ -239,7 +239,6 @@ describe( 'actions', () => {
 						description: 'Pay via PayPal;',
 						enabled: false,
 						fees: '2.9% + 30c per transaction',
-						fields: [ 'email', 'paymentaction' ],
 						id: 'paypal',
 						informationUrl: 'https://docs.woocommerce.com/document/paypal-standard/',
 						isSuggested: true,


### PR DESCRIPTION
Based on the designs we are limiting the fields under each payment method.  I have added code that will limit the fields that are shown.

Test by clicking open COD and verify that the only fields shown are title and description.

You can test here: http://calypso.localhost:3000/store/settings/payments/belcher.mystagingwebsite.com