### PR TITLE
Activitylog: Update reducer activation success

### DIFF
--- a/client/state/activity-log/activation/reducer.js
+++ b/client/state/activity-log/activation/reducer.js
@@ -13,6 +13,9 @@ import {
 	REWIND_ACTIVATE_FAILURE,
 	REWIND_ACTIVATE_REQUEST,
 	REWIND_ACTIVATE_SUCCESS,
+	REWIND_DEACTIVATE_FAILURE,
+	REWIND_DEACTIVATE_REQUEST,
+	REWIND_DEACTIVATE_SUCCESS,
 } from 'state/action-types';
 import {
 	createReducer,
@@ -23,4 +26,7 @@ export const activationRequesting = keyedReducer( 'siteId', createReducer( {}, {
 	[ REWIND_ACTIVATE_REQUEST ]: stubTrue,
 	[ REWIND_ACTIVATE_FAILURE ]: stubFalse,
 	[ REWIND_ACTIVATE_SUCCESS ]: stubFalse,
+	[ REWIND_DEACTIVATE_REQUEST ]: stubTrue,
+	[ REWIND_DEACTIVATE_FAILURE ]: stubFalse,
+	[ REWIND_DEACTIVATE_SUCCESS ]: stubFalse,
 } ) );

--- a/client/state/activity-log/activation/test/reducer.js
+++ b/client/state/activity-log/activation/test/reducer.js
@@ -12,6 +12,9 @@ import {
 	REWIND_ACTIVATE_FAILURE,
 	REWIND_ACTIVATE_REQUEST,
 	REWIND_ACTIVATE_SUCCESS,
+	REWIND_DEACTIVATE_FAILURE,
+	REWIND_DEACTIVATE_REQUEST,
+	REWIND_DEACTIVATE_SUCCESS,
 } from 'state/action-types';
 
 /**
@@ -21,18 +24,33 @@ const SITE_ID = 123456;
 const OTHER_SITE_ID = 987654;
 
 describe( '#activationRequesting()', () => {
-	it( 'should be true on request', () => {
+	it( 'should be true on activation request', () => {
 		const state = activationRequesting( undefined, createSiteAction( REWIND_ACTIVATE_REQUEST ) );
 		expect( state[ SITE_ID ] ).to.be.true;
 	} );
 
-	it( 'should be false on success', () => {
+	it( 'should be false on activation success', () => {
 		const state = activationRequesting( undefined, createSiteAction( REWIND_ACTIVATE_SUCCESS ) );
 		expect( state[ SITE_ID ] ).to.be.false;
 	} );
 
-	it( 'should be false on failure', () => {
+	it( 'should be false on activation failure', () => {
 		const state = activationRequesting( undefined, createSiteAction( REWIND_ACTIVATE_FAILURE ) );
+		expect( state[ SITE_ID ] ).to.be.false;
+	} );
+
+	it( 'should be true on deactivation request', () => {
+		const state = activationRequesting( undefined, createSiteAction( REWIND_DEACTIVATE_REQUEST ) );
+		expect( state[ SITE_ID ] ).to.be.true;
+	} );
+
+	it( 'should be false on deactivation success', () => {
+		const state = activationRequesting( undefined, createSiteAction( REWIND_DEACTIVATE_SUCCESS ) );
+		expect( state[ SITE_ID ] ).to.be.false;
+	} );
+
+	it( 'should be false on deactivation failure', () => {
+		const state = activationRequesting( undefined, createSiteAction( REWIND_DEACTIVATE_FAILURE ) );
 		expect( state[ SITE_ID ] ).to.be.false;
 	} );
 
@@ -47,6 +65,10 @@ describe( '#activationRequesting()', () => {
 			REWIND_ACTIVATE_FAILURE,
 			REWIND_ACTIVATE_REQUEST,
 			REWIND_ACTIVATE_SUCCESS,
+			REWIND_DEACTIVATE_REQUEST,
+			REWIND_DEACTIVATE_FAILURE,
+			REWIND_DEACTIVATE_REQUEST,
+			REWIND_DEACTIVATE_SUCCESS,
 		].forEach( type => {
 			state = activationRequesting( state, createSiteAction( type ) );
 			expect( state[ OTHER_SITE_ID ] ).to.be.false;

--- a/client/state/activity-log/rewind-status/reducer.js
+++ b/client/state/activity-log/rewind-status/reducer.js
@@ -3,6 +3,8 @@
  */
 import { rewindStatusSchema } from './schema';
 import {
+	REWIND_ACTIVATE_SUCCESS,
+	REWIND_DEACTIVATE_SUCCESS,
 	REWIND_STATUS_ERROR,
 	REWIND_STATUS_UPDATE,
 } from 'state/action-types';
@@ -16,6 +18,15 @@ const stubNull = () => null;
 export const rewindStatus = keyedReducer( 'siteId', createReducer( {}, {
 	[ REWIND_STATUS_ERROR ]: stubNull,
 	[ REWIND_STATUS_UPDATE ]: ( state, { status } ) => status,
+	[ REWIND_ACTIVATE_SUCCESS ]: ( state ) => ( {
+		...state,
+		active: true,
+	} ),
+	[ REWIND_DEACTIVATE_SUCCESS ]: ( state ) => ( {
+		...state,
+		active: false,
+	} ),
+
 }, rewindStatusSchema ) );
 
 export const rewindStatusError = keyedReducer( 'siteId', createReducer( {}, {

--- a/client/state/activity-log/rewind-status/test/reducer.js
+++ b/client/state/activity-log/rewind-status/test/reducer.js
@@ -12,9 +12,11 @@ import {
 	rewindStatusError,
 } from '../reducer';
 import {
+	rewindActivateSuccess,
+	rewindDeactivateSuccess,
 	rewindStatusError as rewindStatusErrorAction,
 	updateRewindStatus,
-} from '../../actions';
+} from 'state/activity-log/actions';
 
 /**
  * Constants
@@ -36,6 +38,44 @@ describe( '#rewindStatus()', () => {
 	it( 'should update site item', () => {
 		const state = rewindStatus( undefined, STATUS_ACTION );
 		expect( state[ SITE_ID ] ).to.deep.equal( STATUS_ACTION.status );
+	} );
+
+	it( 'should update on activation success', () => {
+		const prevState = deepFreeze( {
+			[ SITE_ID ]: { active: false }
+		} );
+		const state = rewindStatus( prevState, rewindActivateSuccess( SITE_ID ) );
+		expect( state[ SITE_ID ].active ).to.be.true;
+	} );
+
+	it( 'should maintain other props on activation success', () => {
+		const prevState = deepFreeze( {
+			[ SITE_ID ]: {
+				active: false,
+				other: 'prop',
+			}
+		} );
+		const state = rewindStatus( prevState, rewindActivateSuccess( SITE_ID ) );
+		expect( state[ SITE_ID ].other ).to.equal( 'prop' );
+	} );
+
+	it( 'should update on deactivation success', () => {
+		const prevState = deepFreeze( {
+			[ SITE_ID ]: { active: true }
+		} );
+		const state = rewindStatus( prevState, rewindDeactivateSuccess( SITE_ID ) );
+		expect( state[ SITE_ID ].active ).to.be.false;
+	} );
+
+	it( 'should maintain other props on activation success', () => {
+		const prevState = deepFreeze( {
+			[ SITE_ID ]: {
+				active: true,
+				other: 'prop',
+			}
+		} );
+		const state = rewindStatus( prevState, rewindDeactivateSuccess( SITE_ID ) );
+		expect( state[ SITE_ID ].other ).to.equal( 'prop' );
 	} );
 
 	it( 'should preserve other site\'s status', () => {


### PR DESCRIPTION
This makes 2 significant reducer changes:

* Handle DEACTIVATE actions properly in the `activationRequesting` reducer
* Handle `[DE]ACTIVATION_SUCCESS` actions in the `rewindStatus` reducer so that toggling rewind on/off will update it's activation state with no further requests required.

To test
* Ensure tests pass
* Ensure the toggles work correctly in #14730 

Included in #14730 
