### PR TITLE
Reader: Fix grav/excerpt site recs overlap in Manage

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -58,7 +58,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	flex-direction: column;
 	list-style-type: none;
 	margin-top: -40px;
-	min-width: 0;
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		flex-direction: row;


### PR DESCRIPTION
Happens in <960px.

**Before:**
![screenshot 2017-06-09 14 43 41](https://user-images.githubusercontent.com/4924246/26995547-2a1ec864-4d22-11e7-811c-3afb0ac4685b.png)

**After:**
![screenshot 2017-06-09 14 44 07](https://user-images.githubusercontent.com/4924246/26995549-2e47eace-4d22-11e7-9089-699ac69fe707.png)

