### PR TITLE
Replace the WordPress.org API featured plugins results with a curated list.

### DIFF
--- a/client/lib/plugins/wporg-data/actions.js
+++ b/client/lib/plugins/wporg-data/actions.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -58,14 +57,7 @@ const PluginsDataActions = {
 		} );
 
 		if ( 'featured' === category ) {
-			this.fetchCuratedList( 'featured', [
-				'woocommerce',
-				'jetpack',
-				'bbpress',
-				'buddypress',
-				'akismet',
-				'vaultpress',
-			] );
+			this.fetchCuratedList();
 			return;
 		}
 
@@ -92,20 +84,17 @@ const PluginsDataActions = {
 		} );
 	}, 25 ),
 
-	fetchCuratedList: function( category, slugs ) {
-		const data = CuratedPlugins.filter( function( plugin ) {
-			return includes( slugs, plugin.slug );
-		} );
-		debug( 'curated plugin list', category, slugs );
-		_fetchingLists[ category ] = null;
-		_lastFetchedPagePerCategory[ category ] = 1;
-		_totalPagesPerCategory[ category ] = 1;
+	fetchCuratedList: function() {
+		debug( 'curated plugin list', CuratedPlugins );
+		_fetchingLists.featured = null;
+		_lastFetchedPagePerCategory.featured = 1;
+		_totalPagesPerCategory.featured = 1;
 		Dispatcher.handleServerAction( {
 			type: 'RECEIVE_WPORG_PLUGINS_LIST',
 			action: 'FETCH_WPORG_PLUGINS_LIST',
 			page: 1,
-			category: category,
-			data: utils.normalizePluginsList( data ),
+			category: 'featured',
+			data: utils.normalizePluginsList( CuratedPlugins ),
 			error: null
 		} );
 	},

--- a/client/lib/plugins/wporg-data/actions.js
+++ b/client/lib/plugins/wporg-data/actions.js
@@ -1,33 +1,34 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:wporg-data:actions' );
+import debugFactory from 'debug';
 import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var Dispatcher = require( 'dispatcher' ),
-	wporg = require( 'lib/wporg' ),
-	debounce = require( 'lodash/debounce' ),
-	utils = require( 'lib/plugins/utils' );
+import Dispatcher from 'dispatcher';
+import wporg from 'lib/wporg';
+import debounce from 'lodash/debounce';
+import utils from 'lib/plugins/utils';
 import CuratedPlugins from 'lib/plugins/wporg-data/curated.json';
 
 /**
  * Constants
  */
-var _LIST_DEFAULT_SIZE = 24,
-	_DEFAULT_FIRST_PAGE = 0;
+const debug = debugFactory( 'calypso:wporg-data:actions' );
+const _LIST_DEFAULT_SIZE = 24;
+const _DEFAULT_FIRST_PAGE = 0;
 
 /**
  *  Local variables;
  */
-var _fetchingLists = {},
-	_currentSearchTerm = null,
-	_lastFetchedPagePerCategory = {},
-	_totalPagesPerCategory = {};
+let _fetchingLists = {};
+let _currentSearchTerm = null;
+let _lastFetchedPagePerCategory = {};
+let _totalPagesPerCategory = {};
 
-var PluginsDataActions = {
+const PluginsDataActions = {
 	fetchPluginsList: debounce( function( category, page, searchTerm ) {
 		// We need to debounce this method to avoid mixing diferent dispatch batches (and get an invariant violation from react)
 		// Since the infinite scroll mixin is launching a bunch of fetch requests at the same time, without debounce is too easy
@@ -110,7 +111,7 @@ var PluginsDataActions = {
 	},
 
 	fetchNextCategoryPage: function( category, searchTerm ) {
-		var lastPage = _DEFAULT_FIRST_PAGE - 1;
+		let lastPage = _DEFAULT_FIRST_PAGE - 1;
 		if ( typeof _lastFetchedPagePerCategory[ category ] !== 'undefined' ) {
 			lastPage = _lastFetchedPagePerCategory[ category ];
 		}

--- a/client/lib/plugins/wporg-data/actions.js
+++ b/client/lib/plugins/wporg-data/actions.js
@@ -54,6 +54,11 @@ var PluginsDataActions = {
 			searchTerm: searchTerm
 		} );
 
+		if ( 'featured' === category ) {
+			this.fetchCuratedList( 'featured', 'woocommerce' );
+			return;
+		}
+
 		wporg.fetchPluginsList( {
 			pageSize: _LIST_DEFAULT_SIZE,
 			page: page,
@@ -76,6 +81,23 @@ var PluginsDataActions = {
 			}
 		} );
 	}, 25 ),
+
+	fetchCuratedList: function( category, slugs ) {
+		wporg.fetchPluginInformation( slugs, function( error, data ) {
+			debug( 'curated plugin list fetched from .org', category, slugs, error, data );
+			_fetchingLists[ category ] = null;
+			// _lastFetchedPagePerCategory[ category ] = page;
+			// _totalPagesPerCategory[ category ] = data.info.pages;
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_WPORG_PLUGINS_LIST',
+				action: 'FETCH_WPORG_PLUGINS_LIST',
+				page: 1,
+				category: category,
+				data: data ? utils.normalizePluginsList( [ data ] ) : null,
+				error: error
+			} );
+		} );
+	},
 
 	fetchNextCategoryPage: function( category, searchTerm ) {
 		var lastPage = _DEFAULT_FIRST_PAGE - 1;

--- a/client/lib/plugins/wporg-data/curated.json
+++ b/client/lib/plugins/wporg-data/curated.json
@@ -58,15 +58,5 @@
 			"2x": "https://ps.w.org/vaultpress/assets/icon-256x256.png?rev=986513"
 		},
 		"slug": "vaultpress"
-	},
-	{
-		"name": "Hello Dolly",
-		"author": "<a href=\"http://ma.tt/\">Matt Mullenweg</a>",
-		"rating": 52,
-		"icons": {
-			"1x": "https://ps.w.org/hello-dolly/assets/icon-128x128.jpg?rev=969907",
-			"2x": "https://ps.w.org/hello-dolly/assets/icon-256x256.jpg?rev=969907"
-		},
-		"slug": "hello-dolly"
 	}
 ]

--- a/client/lib/plugins/wporg-data/curated.json
+++ b/client/lib/plugins/wporg-data/curated.json
@@ -1,0 +1,62 @@
+[
+	{
+		"name": "WooCommerce",
+		"author": "<a href=\"https://woocommerce.com\">Automattic</a>",
+		"rating": 92,
+		"icons": {
+			"1x": "https://ps.w.org/woocommerce/assets/icon-128x128.png?rev=144083",
+			"2x": "https://ps.w.org/woocommerce/assets/icon-256x256.png?rev=144083"
+		},
+		"slug": "woocommerce"
+	},
+	{
+		"name": "Jetpack by WordPress.com",
+		"author": "<a href=\"https://jetpack.com\">Automattic</a>",
+		"rating": 82,
+		"icons": {
+			"1x": "https://ps.w.org/jetpack/assets/icon-128x128.png?rev=969908",
+			"2x": "https://ps.w.org/jetpack/assets/icon-256x256.png?rev=969908"
+		},
+		"slug": "jetpack"
+	},
+	{
+		"name": "Akismet",
+		"author": "<a href=\"https://automattic.com/wordpress-plugins/\">Automattic</a>",
+		"rating": 96,
+		"icons": {
+			"1x": "https://ps.w.org/akismet/assets/icon-128x128.png?rev=969272",
+			"2x": "https://ps.w.org/akismet/assets/icon-256x256.png?rev=969272"
+		},
+		"slug": "akismet"
+	},
+	{
+		"name": "bbPress",
+		"author": "<a href=\"https://bbpress.org\">The bbPress Community</a>",
+		"rating": 84,
+		"icons": {
+			"1x": "https://ps.w.org/bbpress/assets/icon-128x128.png?rev=1534011",
+			"2x": "https://ps.w.org/bbpress/assets/icon-256x256.png?rev=1534011"
+		},
+		"slug": "bbpress"
+	},
+	{
+		"name": "BuddyPress",
+		"author": "<a href=\"https://buddypress.org/\">The BuddyPress Community</a>",
+		"rating": 88,
+		"icons": {
+			"1x": "https://ps.w.org/buddypress/assets/icon-128x128.png?rev=1309232",
+			"2x": "https://ps.w.org/buddypress/assets/icon-256x256.png?rev=1309232"
+		},
+		"slug": "buddypress"
+	},
+	{
+		"name": "VaultPress",
+		"author": "<a href=\"http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0\">Automattic</a>",
+		"rating": 88,
+		"icons": {
+			"1x": "https://ps.w.org/vaultpress/assets/icon-128x128.png?rev=986513",
+			"2x": "https://ps.w.org/vaultpress/assets/icon-256x256.png?rev=986513"
+		},
+		"slug": "woocommerce"
+	}
+]

--- a/client/lib/plugins/wporg-data/curated.json
+++ b/client/lib/plugins/wporg-data/curated.json
@@ -10,53 +10,53 @@
 		"slug": "woocommerce"
 	},
 	{
-		"name": "Jetpack by WordPress.com",
-		"author": "<a href=\"https://jetpack.com\">Automattic</a>",
-		"rating": 82,
-		"icons": {
-			"1x": "https://ps.w.org/jetpack/assets/icon-128x128.png?rev=969908",
-			"2x": "https://ps.w.org/jetpack/assets/icon-256x256.png?rev=969908"
-		},
-		"slug": "jetpack"
-	},
-	{
-		"name": "Akismet",
-		"author": "<a href=\"https://automattic.com/wordpress-plugins/\">Automattic</a>",
+		"name": "Yoast SEO",
+		"author": "<a href=\"https://yoast.com/\">Team Yoast</a>",
 		"rating": 96,
 		"icons": {
-			"1x": "https://ps.w.org/akismet/assets/icon-128x128.png?rev=969272",
-			"2x": "https://ps.w.org/akismet/assets/icon-256x256.png?rev=969272"
+			"1x": "https://ps.w.org/wordpress-seo/assets/icon-128x128.png?rev=1550389",
+			"2x": "https://ps.w.org/wordpress-seo/assets/icon-256x256.png?rev=1550389"
 		},
-		"slug": "akismet"
+		"slug": "wordpress-seo"
 	},
 	{
-		"name": "bbPress",
-		"author": "<a href=\"https://bbpress.org\">The bbPress Community</a>",
-		"rating": 84,
+		"name": "Google XML Sitemaps",
+		"author": "<a href=\"http://www.arnebrachhold.de/\">Arne Brachhold</a>",
+		"rating": 98,
 		"icons": {
-			"1x": "https://ps.w.org/bbpress/assets/icon-128x128.png?rev=1534011",
-			"2x": "https://ps.w.org/bbpress/assets/icon-256x256.png?rev=1534011"
+			"1x": "https://ps.w.org/google-sitemap-generator/assets/icon-128x128.png?rev=976338",
+			"2x": "https://ps.w.org/google-sitemap-generator/assets/icon-256x256.png?rev=976338"
 		},
-		"slug": "bbpress"
+		"slug": "google-sitemap-generator"
 	},
 	{
-		"name": "BuddyPress",
-		"author": "<a href=\"https://buddypress.org/\">The BuddyPress Community</a>",
-		"rating": 88,
+		"name": "TinyMCE Advanced",
+		"author": "<a href=\"http://www.laptoptips.ca/\">Andrew Ozz</a>",
+		"rating": 92,
 		"icons": {
-			"1x": "https://ps.w.org/buddypress/assets/icon-128x128.png?rev=1309232",
-			"2x": "https://ps.w.org/buddypress/assets/icon-256x256.png?rev=1309232"
+			"1x": "https://ps.w.org/tinymce-advanced/assets/icon-128x128.png?rev=971511",
+			"2x": "https://ps.w.org/tinymce-advanced/assets/icon-256x256.png?rev=971511"
 		},
-		"slug": "buddypress"
+		"slug": "tinymce-advanced"
 	},
 	{
-		"name": "VaultPress",
-		"author": "<a href=\"http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0\">Automattic</a>",
-		"rating": 88,
+		"name": "Google Analytics for WordPress by MonsterInsights",
+		"author": "<a href=\"https://www.monsterinsights.com/\">MonsterInsights</a>",
+		"rating": 78,
 		"icons": {
-			"1x": "https://ps.w.org/vaultpress/assets/icon-128x128.png?rev=986513",
-			"2x": "https://ps.w.org/vaultpress/assets/icon-256x256.png?rev=986513"
+			"1x": "https://ps.w.org/google-analytics-for-wordpress/assets/icon-128x128.png?rev=1598927",
+			"2x": "https://ps.w.org/google-analytics-for-wordpress/assets/icon-256x256.png?rev=1598927"
 		},
-		"slug": "vaultpress"
+		"slug": "google-analytics-for-wordpress"
+	},
+	{
+		"name": "Page Builder by SiteOrigin",
+		"author": "<a href=\"https://siteorigin.com\">SiteOrigin</a>",
+		"rating": 98,
+		"icons": {
+			"1x": "https://ps.w.org/siteorigin-panels/assets/icon-128x128.png?rev=1044755",
+			"2x": "https://ps.w.org/siteorigin-panels/assets/icon-256x256.png?rev=1044755"
+		},
+		"slug": "siteorigin-panels"
 	}
 ]

--- a/client/lib/plugins/wporg-data/curated.json
+++ b/client/lib/plugins/wporg-data/curated.json
@@ -57,6 +57,16 @@
 			"1x": "https://ps.w.org/vaultpress/assets/icon-128x128.png?rev=986513",
 			"2x": "https://ps.w.org/vaultpress/assets/icon-256x256.png?rev=986513"
 		},
-		"slug": "woocommerce"
+		"slug": "vaultpress"
+	},
+	{
+		"name": "Hello Dolly",
+		"author": "<a href=\"http://ma.tt/\">Matt Mullenweg</a>",
+		"rating": 52,
+		"icons": {
+			"1x": "https://ps.w.org/hello-dolly/assets/icon-128x128.jpg?rev=969907",
+			"2x": "https://ps.w.org/hello-dolly/assets/icon-256x256.jpg?rev=969907"
+		},
+		"slug": "hello-dolly"
 	}
 ]

--- a/client/lib/plugins/wporg-data/test/actions.js
+++ b/client/lib/plugins/wporg-data/test/actions.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 
-import { assert } from 'chai';
-
+import { assert, expect } from 'chai';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -13,6 +13,7 @@ import mockedWporg from './mocks/wporg';
 
 describe( 'WPorg Data Actions', () => {
 	let WPorgActions;
+
 	useMockery( mockery => {
 		mockery.registerMock( 'lib/wporg', mockedWporg );
 		mockery.registerMock( 'lodash/debounce', cb => cb );
@@ -32,6 +33,10 @@ describe( 'WPorg Data Actions', () => {
 		assert.isFunction( WPorgActions.fetchPluginsList );
 	} );
 
+	it( 'Actions should have method fetchCuratedList', () => {
+		assert.isFunction( WPorgActions.fetchCuratedList );
+	} );
+
 	it( 'Actions should have method fetchNextCategoryPage', () => {
 		assert.isFunction( WPorgActions.fetchNextCategoryPage );
 	} );
@@ -41,6 +46,17 @@ describe( 'WPorg Data Actions', () => {
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		assert.equal( mockedWporg.getActivity().fetchPluginsList, 1 );
+	} );
+
+	it( 'should call fetchCuratedList for the "featured" category', () => {
+		const curatedSpy = spy( WPorgActions, 'fetchCuratedList' );
+		WPorgActions.fetchPluginsList( 'featured', 1 );
+		expect( curatedSpy.called ).to.be.true;
+	} );
+
+	it( 'should not call wporg.fetchPluginsList for the "featured" category', () => {
+		WPorgActions.fetchPluginsList( 'featured', 1 );
+		assert.equal( mockedWporg.getActivity().fetchPluginsList, 0 );
 	} );
 
 	it( 'when fetching for the next page, the next page number should be calculated automatically', () => {

--- a/client/lib/plugins/wporg-data/test/actions.js
+++ b/client/lib/plugins/wporg-data/test/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 import { spy } from 'sinon';
 
 /**
@@ -51,7 +51,7 @@ describe( 'WPorg Data Actions', () => {
 	it( 'should call fetchCuratedList for the "featured" category', () => {
 		const curatedSpy = spy( WPorgActions, 'fetchCuratedList' );
 		WPorgActions.fetchPluginsList( 'featured', 1 );
-		expect( curatedSpy.called ).to.be.true;
+		assert.isTrue( curatedSpy.called );
 	} );
 
 	it( 'should not call wporg.fetchPluginsList for the "featured" category', () => {

--- a/client/lib/plugins/wporg-data/test/actions.js
+++ b/client/lib/plugins/wporg-data/test/actions.js
@@ -48,13 +48,13 @@ describe( 'WPorg Data Actions', () => {
 		assert.equal( mockedWporg.getActivity().fetchPluginsList, 1 );
 	} );
 
-	it( 'should call fetchCuratedList for the "featured" category', () => {
+	it( 'should return our Calypso curated feature list', () => {
 		const curatedSpy = spy( WPorgActions, 'fetchCuratedList' );
 		WPorgActions.fetchPluginsList( 'featured', 1 );
 		assert.isTrue( curatedSpy.called );
 	} );
 
-	it( 'should not call wporg.fetchPluginsList for the "featured" category', () => {
+	it( 'does not return the community featured list', () => {
 		WPorgActions.fetchPluginsList( 'featured', 1 );
 		assert.equal( mockedWporg.getActivity().fetchPluginsList, 0 );
 	} );

--- a/client/lib/plugins/wporg-data/test/mocks/wporg.js
+++ b/client/lib/plugins/wporg-data/test/mocks/wporg.js
@@ -1,4 +1,4 @@
-var fetchPluginsListCalls = 0,
+let fetchPluginsListCalls = 0,
 	lastRequestParams = null;
 
 module.exports = {


### PR DESCRIPTION
To provide users with better value, the "featured" category of plugins at `https://wordpress.com/plugins/browse` should have the option of being curated, possibly by a hard-coded list in Calypso. This could allow better results based on context; for instance, WordPress.com users will be presented options other than plugins that already exist for their WordPress.com sites (like Jetpack).

![screen shot 2017-06-12 at 4 54 34 pm](https://user-images.githubusercontent.com/349751/27060478-fc606258-4f91-11e7-9404-008737b195b1.png)

![screen shot 2017-06-12 at 4 53 55 pm](https://user-images.githubusercontent.com/349751/27060482-0225a16c-4f92-11e7-835a-e97ab6ac83b9.png)

**Testing**
* Switch to this branch and go to `calypso.localhost:3000/plugin/browse`.
* You should see the six curated plugins with no missing info or errors.
* Click the various plugins, and you should see the single view of that plugin with no issues.
* Select a WordPress.com or Pressable site; Jetpack, Akismet, and VaultPress should be marked as "Installed".

cc/ @Automattic/lannister 