### PR TITLE
Comments: show comment content as html

### DIFF
--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CommentDetailAuthor from './comment-detail-author';
+import AutoDirection from 'components/auto-direction';
 
 export class CommentDetailComment extends Component {
 	static propTypes = {
@@ -55,10 +56,11 @@ export class CommentDetailComment extends Component {
 						blockUser={ blockUser }
 						commentDate={ commentDate }
 					/>
-
-					<div className="comment-detail__comment-body">
-						{ commentContent }
-					</div>
+					<AutoDirection>
+						<div className="comment-detail__comment-body"
+							dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
+						/>
+					</AutoDirection>
 
 					{ repliedToComment &&
 						<div className="comment-detail__comment-reply">

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -14,7 +14,7 @@ import CommentDetailActions from './comment-detail-actions';
 import ExternalLink from 'components/external-link';
 import FormCheckbox from 'components/forms/form-checkbox';
 import AutoDirection from 'components/auto-direction';
-import { stripHTML } from 'lib/formatting';
+import { stripHTML, decodeEntities } from 'lib/formatting';
 
 const controlExternalLink = isBulkEdit => event => {
 	if ( isBulkEdit ) {
@@ -105,7 +105,7 @@ export const CommentDetailHeader = ( {
 			</div>
 			<AutoDirection>
 				<div className="comment-detail__comment-preview">
-					{ stripHTML( commentContent ) }
+					{ decodeEntities( stripHTML( commentContent ) ) }
 				</div>
 			</AutoDirection>
 		</div>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -13,6 +13,7 @@ import { noop } from 'lodash';
 import CommentDetailActions from './comment-detail-actions';
 import ExternalLink from 'components/external-link';
 import FormCheckbox from 'components/forms/form-checkbox';
+import AutoDirection from 'components/auto-direction';
 
 const controlExternalLink = isBulkEdit => event => {
 	if ( isBulkEdit ) {
@@ -101,9 +102,11 @@ export const CommentDetailHeader = ( {
 					</div>
 				</div>
 			</div>
-			<div className="comment-detail__comment-preview">
-				{ commentContent }
-			</div>
+			<AutoDirection>
+				<div className="comment-detail__comment-preview"
+					dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
+				/>
+			</AutoDirection>
 		</div>
 	);
 };

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -14,6 +14,7 @@ import CommentDetailActions from './comment-detail-actions';
 import ExternalLink from 'components/external-link';
 import FormCheckbox from 'components/forms/form-checkbox';
 import AutoDirection from 'components/auto-direction';
+import { stripHTML } from 'lib/formatting';
 
 const controlExternalLink = isBulkEdit => event => {
 	if ( isBulkEdit ) {
@@ -103,9 +104,9 @@ export const CommentDetailHeader = ( {
 				</div>
 			</div>
 			<AutoDirection>
-				<div className="comment-detail__comment-preview"
-					dangerouslySetInnerHTML={ { __html: commentContent } } //eslint-disable-line react/no-danger
-				/>
+				<div className="comment-detail__comment-preview">
+					{ stripHTML( commentContent ) }
+				</div>
 			</AutoDirection>
 		</div>
 	);


### PR DESCRIPTION
This PR inserts comment content as html, and also adds updates the component to use `AutoDirection` to help with text direction when using a RTL language.

### Testing Instructions

1. Navigate to http://calypso.localhost:3000/comments/all
2. Select a site
3. Comment previews and details look correct

cc @Automattic/lannister 