### PR TITLE
Framework: Extract Layout out of the main bundle

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -84,13 +84,17 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		analytics.setSuperProps( superProps );
 	}
 
-	// Render Layout only for non-isomorphic sections.
+	// Ensure Layout is rendered.
 	// Isomorphic sections will take care of rendering their Layout last themselves.
-	if ( ! document.getElementById( 'primary' ) ) {
-		page( '*', function( context, next ) {
+	page( '*', function( context, next ) {
+		if ( ! document.getElementById( 'primary' ) ) {
 			renderLayoutAsync( reduxStore ).then( next );
-		} );
+		} else {
+			next();
+		}
+	} );
 
+	if ( ! document.getElementById( 'primary' ) ) {
 		if ( config.isEnabled( 'catch-js-errors' ) ) {
 			const Logger = require( 'lib/catch-js-errors' );
 			const errorLogger = new Logger();

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -32,7 +32,7 @@ const config = require( 'config' ),
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 
-function renderLayout( reduxStore ) {
+function renderLayoutAsync( reduxStore ) {
 	return require( 'controller' ).getReduxWrappedLayout( reduxStore ).then(
 		Layout => {
 			const layoutElement = React.createElement( Layout, {
@@ -88,7 +88,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	// Isomorphic sections will take care of rendering their Layout last themselves.
 	if ( ! document.getElementById( 'primary' ) ) {
 		page( '*', function( context, next ) {
-			renderLayout( reduxStore ).then( next );
+			renderLayoutAsync( reduxStore ).then( next );
 		} );
 
 		if ( config.isEnabled( 'catch-js-errors' ) ) {
@@ -251,7 +251,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		if ( isMultiTreeLayout && previousLayoutIsSingleTree ) {
 			debug( 'Re-rendering multi-tree layout' );
 			ReactDom.unmountComponentAtNode( document.getElementById( 'wpcom' ) );
-			renderLayout( context.store ).then( next );
+			renderLayoutAsync( context.store ).then( next );
 		} else if ( ! isMultiTreeLayout && ! previousLayoutIsSingleTree ) {
 			debug( 'Unmounting multi-tree layout' );
 			ReactDom.unmountComponentAtNode( document.getElementById( 'primary' ) );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -9,7 +9,6 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
 import nuxWelcome from 'layout/nux-welcome';
 import translatorInvitation from 'layout/community-translator/invitation-utils';
@@ -24,25 +23,64 @@ export { setSection, setUpLocale } from './shared.js';
 
 const user = userFactory();
 
-export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => (
-	<ReduxProvider store={ store }>
-		{ getCurrentUser( store.getState() )
-			? <Layout primary={ primary }
-				secondary={ secondary }
-				user={ user }
-				nuxWelcome={ nuxWelcome }
-				translatorInvitation={ translatorInvitation }
-			/>
-			: <LayoutLoggedOut
-				primary={ primary }
-				secondary={ secondary }
-				redirectUri={ redirectUri }
-			/>
-		}
-	</ReduxProvider>
-);
+/**
+ * Fetch the correct Layout based on whether or not the user is logged-in.
+ *
+ * @param {bool} loggedIn true if the user is logged-in, false otherwise
+ * @returns {Promise} a Promise that resolves to the Layout component
+ */
+function getLayout( loggedIn ) {
+	return new Promise( ( resolve ) => {
+		if ( loggedIn ) {
+			// If user is logged in, async load the main layout
+			require.ensure( [], () => {
+				const Layout = require( 'layout' );
 
-export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
+				resolve(
+					( { primary, secondary } ) => (
+						<Layout
+							primary={ primary }
+							secondary={ secondary }
+							user={ user }
+							nuxWelcome={ nuxWelcome }
+							translatorInvitation={ translatorInvitation }
+						/>
+					)
+				);
+			}, 'async-load-layout' );
+		} else {
+			resolve(
+				( { primary, secondary, redirectUri } ) => (
+					<LayoutLoggedOut
+						primary={ primary }
+						secondary={ secondary }
+						redirectUri={ redirectUri }
+					/>
+				)
+			);
+		}
+	} );
+}
+
+export function getReduxWrappedLayout( reduxStore ) {
+	const loggedIn = getCurrentUser( reduxStore.getState() );
+
+	return getLayout( loggedIn ).then( ( InnerLayout ) => (
+		// Wrap the InnerLayout
+		( { store, primary, secondary, redirectUri } ) => (
+			<ReduxProvider store={ store }>
+				<InnerLayout
+					store={ store }
+					primary={ primary }
+					secondary={ secondary }
+					redirectUri={ redirectUri }
+				/>
+			</ReduxProvider>
+		)
+	) );
+}
+
+export const makeLayout = makeLayoutMiddleware( getReduxWrappedLayout );
 
 /**
  * Isomorphic routing helper, client side

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -33,9 +33,7 @@ function getLayout( loggedIn ) {
 	return new Promise( ( resolve ) => {
 		if ( loggedIn ) {
 			// If user is logged in, async load the main layout
-			require.ensure( [], () => {
-				const Layout = require( 'layout' );
-
+			asyncRequire( 'layout', ( Layout ) => {
 				resolve(
 					( { primary, secondary } ) => (
 						<Layout
@@ -47,7 +45,7 @@ function getLayout( loggedIn ) {
 						/>
 					)
 				);
-			}, 'async-load-layout' );
+			} );
 		} else {
 			resolve(
 				( { primary, secondary, redirectUri } ) => (

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -12,26 +12,30 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getLanguage } from 'lib/i18n-utils';
 import { setSection as setSectionAction } from 'state/ui/actions';
 
-export function makeLayoutMiddleware( LayoutComponent ) {
+export function makeLayoutMiddleware( getLayoutComponent ) {
 	return ( context, next ) => {
 		const { store, primary, secondary } = context;
 
-		// On server, only render LoggedOutLayout when logged-out.
-		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
-			let redirectUri;
-			if ( context.isServerSide ) {
-				redirectUri = `${ context.protocol }://${ context.host }${ context.originalUrl }`;
+		getLayoutComponent( store ).then( ( LayoutComponent ) => {
+			// On server, only render LoggedOutLayout when logged-out.
+			if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
+				let redirectUri;
+				if ( context.isServerSide ) {
+					redirectUri = `${ context.protocol }://${ context.host }${ context.originalUrl }`;
+				}
+
+				context.layout = (
+					<LayoutComponent
+						store={ store }
+						primary={ primary }
+						secondary={ secondary }
+						redirectUri={ redirectUri }
+					/>
+				);
 			}
-			context.layout = (
-				<LayoutComponent
-					store={ store }
-					primary={ primary }
-					secondary={ secondary }
-					redirectUri={ redirectUri }
-				/>
-			);
-		}
-		next();
+
+			next();
+		} );
 	};
 }
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -132,12 +132,18 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(src=urls[ 'manifest' ])
 			script(src=urls[ 'vendor' ])
 			script(src=urls[ jsFile ])
+			if user
+				// Load the Layout up front if user is logged-in
+				script(src=urls[ 'async-load-layout' ])
 			if chunk
 				script(src=urls[ chunk ])
 		else
 			script(src=urls[ 'manifest-min' ])
 			script(src=urls[ 'vendor-min' ])
 			script(src=urls[ jsFile + '-min' ])
+			if user
+				// Load the Layout up front if user is logged-in
+				script(src=urls[ 'async-load-layout-min' ])
 			if chunk
 				script(src=urls[ chunk + '-min' ])
 		script(type='text/javascript')!='window.AppBoot();'


### PR DESCRIPTION
The `Layout` component is only used for logged-in users. It also has many dependencies which contribute significantly to the size of the main JavaScript bundle. By extracting it and loading it asynchronously, we reduce the size of the main bundle, and avoid loading the unneeded Layout for logged-out users.

Before extracting `Layout`:

<img width="210" alt="2017-06-10_1312 before" src="https://user-images.githubusercontent.com/842193/27004363-97f4a932-4dde-11e7-80b0-672bdce5dac3.png">

After extracting `Layout`:

<img width="210" alt="2017-06-10_1312 after-build" src="https://user-images.githubusercontent.com/842193/27004365-a25a1c5e-4dde-11e7-8705-b4123b68489d.png">

<img width="270" alt="2017-06-10_1312 after-layout" src="https://user-images.githubusercontent.com/842193/27004366-a405e6be-4dde-11e7-898b-982554270b92.png">

_**Update - Here are the full bundle reports**_

_Note: the numbers are different from above because I rebased after the initial reports were made_

- [Before extracting `Layout`](https://alexsanford.gitlab.io/calypso-performance/report-before-extract-layout-0316d6b7.html)

- [After extracting `Layout`](https://alexsanford.gitlab.io/calypso-performance/report-after-extract-layout-28922e7c.html)

Things to discuss/investigate:

- Is the async load going to have a negative effect on logged-in users? On one hand, the smaller `build.js` bundle should load more quickly, which will give an indication of progress sooner. On the other hand, the `Layout` itself might be rendered later because of the async load. If this is a problem, we could add a `script` tag in the HTML to load `Layout` right away for logged-in users.

- I changed a few places where `Layout` was rendered in order to render it asynchronously. It looks like everything still works (logging out, logging in, navigating, tests all pass), but I would like some more eyes on that code to be sure.

- Theoretically, we could also extract the `LayoutLoggedOut` component very easily. I didn't do so for a couple of reasons:

  1. It contributes much less size to the bundle. Using the [Bonsai](https://pinterest.github.io/bonsai/analyze/) analysis tool, `Layout` has a "Weighted Size" of `2.29 MB`, whereas `LayoutLoggedOut` has a "Weighted Size" of only `10.98 KB`.

  2. In the interest of keeping logged-out pages fast, I felt that loading `LayoutLoggedOut` async might have too much overhead. It is probably faster if we leave it in `build.js`.