### PR TITLE
Post Anniversaries

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -405,6 +405,7 @@
 @import 'my-sites/stats/stats-overview-placeholder/style';
 @import 'my-sites/stats/stats-page-placeholder/style';
 @import 'my-sites/stats/stats-period-navigation/style';
+@import 'my-sites/stats/stats-post-anniversaries/style';
 @import 'my-sites/stats/stats-post-likes/style';
 @import 'my-sites/stats/stats-post-summary/style';
 @import 'my-sites/stats/stats-site-overview/style';

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -250,7 +250,16 @@ module.exports = {
 		let period;
 
 		const validModules = [
-			'posts', 'referrers', 'clicks', 'countryviews', 'authors', 'videoplays', 'videodetails', 'podcastdownloads', 'searchterms'
+			'posts',
+			'referrers',
+			'clicks',
+			'countryviews',
+			'authors',
+			'videoplays',
+			'videodetails',
+			'podcastdownloads',
+			'searchterms',
+			'anniversaries',
 		];
 		let momentSiteZone = i18n.moment();
 		const basePath = route.sectionify( context.path );
@@ -277,6 +286,11 @@ module.exports = {
 				date = momentSiteZone.endOf( activeFilter.period );
 			}
 			period = rangeOfPeriod( activeFilter.period, date );
+
+			// Only show anniversaries for days, weeks and months
+			if ( contextModule === 'anniversaries' && period.period === 'year' ) {
+				return next();
+			}
 
 			const extraProps = context.params.module === 'videodetails' ? { postId: parseInt( queryOptions.post, 10 ) } : {};
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -17,6 +17,7 @@ import DatePicker from './stats-date-picker';
 import Countries from './stats-countries';
 import ChartTabs from './stats-chart-tabs';
 import StatsModule from './stats-module';
+import PostAnniversaries from './stats-post-anniversaries';
 import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
 import StatsFirstView from './stats-first-view';
@@ -186,6 +187,10 @@ class StatsSite extends Component {
 								className="stats__author-views"
 								showSummaryLink />
 							{ podcastList }
+							<PostAnniversaries
+								path="anniversaries"
+								period={ this.props.period }
+							/>
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -25,7 +25,6 @@ import StatsFirstView from '../stats-first-view';
 import SectionHeader from 'components/section-header';
 import StatsViews from '../stats-views';
 import Followers from '../stats-followers';
-import PostAnniversaries from '../stats-post-anniversaries';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
@@ -65,7 +64,6 @@ const StatsInsights = ( props ) => {
 							<LatestPostSummary />
 							<MostPopular />
 							{ tagsList }
-							<PostAnniversaries />
 						</div>
 						<div className="stats__module-column">
 							<Reach />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -64,8 +64,8 @@ const StatsInsights = ( props ) => {
 						<div className="stats__module-column">
 							<LatestPostSummary />
 							<MostPopular />
-							<PostAnniversaries />
 							{ tagsList }
+							<PostAnniversaries />
 						</div>
 						<div className="stats__module-column">
 							<Reach />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -25,6 +25,7 @@ import StatsFirstView from '../stats-first-view';
 import SectionHeader from 'components/section-header';
 import StatsViews from '../stats-views';
 import Followers from '../stats-followers';
+import PostAnniversaries from '../stats-post-anniversaries';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
@@ -63,6 +64,7 @@ const StatsInsights = ( props ) => {
 						<div className="stats__module-column">
 							<LatestPostSummary />
 							<MostPopular />
+							<PostAnniversaries />
 							{ tagsList }
 						</div>
 						<div className="stats__module-column">

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -210,6 +210,9 @@ module.exports = React.createClass( {
 		}
 
 		switch ( valueData.type ) {
+			case 'raw':
+				value = valueData.value;
+				break;
 			case 'relative-date':
 				value = this.moment( valueData.value ).fromNow( true );
 				break;

--- a/client/my-sites/stats/stats-post-anniversaries/grouped-posts.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/grouped-posts.jsx
@@ -50,7 +50,6 @@ const GroupedPosts = ( { translate, postsByYear, summary, period, siteSlug } ) =
 								{ type: 'link', data: post.URL },
 							],
 							label: post.title,
-							labelIcon: 'calendar',
 							value: {
 								type: 'raw',
 								value: moment().subtract( i + 1, 'years' ).format( 'YYYY' ),

--- a/client/my-sites/stats/stats-post-anniversaries/grouped-posts.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/grouped-posts.jsx
@@ -16,52 +16,52 @@ import { getSiteSlug } from 'state/sites/selectors';
 
 const label = ( translate, period ) => {
 	if ( period.period === 'day' ) {
-		return translate( 'Published on this day in the past years:', {
+		return translate( 'Published on this day in the past:', {
 			comment: 'Preceding a list of posts published in the previous years',
 		} );
 	}
 	if ( period.period === 'week' ) {
-		return translate( 'Published on this week in the past years:', {
+		return translate( 'Published on this week in the past:', {
 			comment: 'Preceding a list of posts published in the previous years',
 		} );
 	}
 	if ( period.period === 'month' ) {
-		return translate( 'Published on this month in the past years:', {
+		return translate( 'Published on this month in the past:', {
 			comment: 'Preceding a list of posts published in the previous years',
 		} );
 	}
 	return '';
 };
 
-const GroupedPosts = ( { translate, postsByYear, summary, period, siteSlug } ) => (
+// Converts posts to the data format expected by StatsList.
+const statsListData = ( postsByYear, siteSlug ) =>
+	postsByYear.reduce(
+		( allPosts, posts, i ) =>
+			allPosts.concat(
+				posts.map( post => ( {
+					page: `/stats/post/${ post.ID }/${ siteSlug }`,
+					actions: [ { type: 'link', data: post.URL } ],
+					label: post.title,
+					value: {
+						type: 'raw',
+						value: moment().subtract( i + 1, 'years' ).format( 'YYYY' ),
+					},
+				} ) ),
+			),
+		[],
+	);
+
+const GroupedPosts = ( { translate, postsByYear, summary, period, siteSlug } ) =>
 	<div>
 		<StatsContentText>
-			{ ! summary && <p>{ label( translate, period ) }</p> }
+			{ ! summary &&
+				<p>
+					{ label( translate, period ) }
+				</p> }
 		</StatsContentText>
 		<StatsListLegend label={ translate( 'Title' ) } value={ translate( 'Year' ) } />
-		<StatsList
-			moduleName={ 'postAnniversaries' }
-			data={ postsByYear.reduce(
-				( allPosts, posts, i ) =>
-					allPosts.concat(
-						posts.map( post => ( {
-							page: `/stats/post/${ post.ID }/${ siteSlug }`,
-							actions: [
-								{ type: 'link', data: post.URL },
-							],
-							label: post.title,
-							value: {
-								type: 'raw',
-								value: moment().subtract( i + 1, 'years' ).format( 'YYYY' ),
-							},
-						} ) ),
-					),
-				[],
-			) }
-		/>
-
-	</div>
-);
+		<StatsList moduleName={ 'postAnniversaries' } data={ statsListData( postsByYear, siteSlug ) } />
+	</div>;
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/stats/stats-post-anniversaries/grouped-posts.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/grouped-posts.jsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize, moment } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import StatsList from '../stats-list';
+import StatsListLegend from '../stats-list/legend';
+import StatsContentText from '../stats-module/content-text';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+
+const label = ( translate, period ) => {
+	if ( period.period === 'day' ) {
+		return translate( 'Published on this day in the past years:', {
+			comment: 'Preceding a list of posts published in the previous years',
+		} );
+	}
+	if ( period.period === 'week' ) {
+		return translate( 'Published on this week in the past years:', {
+			comment: 'Preceding a list of posts published in the previous years',
+		} );
+	}
+	if ( period.period === 'month' ) {
+		return translate( 'Published on this month in the past years:', {
+			comment: 'Preceding a list of posts published in the previous years',
+		} );
+	}
+	return '';
+};
+
+const GroupedPosts = ( { translate, postsByYear, summary, period, siteSlug } ) => (
+	<div>
+		<StatsContentText>
+			{ ! summary && <p>{ label( translate, period ) }</p> }
+		</StatsContentText>
+		<StatsListLegend label={ translate( 'Title' ) } value={ translate( 'Year' ) } />
+		<StatsList
+			moduleName={ 'postAnniversaries' }
+			data={ postsByYear.reduce(
+				( allPosts, posts, i ) =>
+					allPosts.concat(
+						posts.map( post => ( {
+							page: `/stats/post/${ post.ID }/${ siteSlug }`,
+							actions: [
+								{ type: 'link', data: post.URL },
+							],
+							label: post.title,
+							labelIcon: 'calendar',
+							value: {
+								type: 'raw',
+								value: moment().subtract( i + 1, 'years' ).format( 'YYYY' ),
+							},
+						} ) ),
+					),
+				[],
+			) }
+		/>
+
+	</div>
+);
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+
+	return {
+		siteSlug,
+	};
+} )( localize( GroupedPosts ) );

--- a/client/my-sites/stats/stats-post-anniversaries/index.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/index.jsx
@@ -1,0 +1,209 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import { localize, moment } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import ErrorPanel from '../stats-error';
+import StatsList from '../stats-list';
+import StatsListLegend from '../stats-list/legend';
+import SectionHeader from 'components/section-header';
+import StatsContentText from '../stats-module/content-text';
+import StatsModulePlaceholder from '../stats-module/placeholder';
+import Card from 'components/card';
+import QueryPosts from 'components/data/query-posts';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSitePostsForQuery, isRequestingSitePostsForQuery } from 'state/posts/selectors';
+
+// Maximum number of simultaneous queries to fetch the posts by year
+const MAX_POST_QUERIES = 10;
+
+const StatModulePostAnniversaries = props => {
+	const { oldestPostQuery, postsByYearQueries, postsByYear, requesting, siteId, translate } = props;
+
+	const allPosts = Array.prototype.concat( ...postsByYear );
+
+	const cardClasses = classNames( 'stats-module', 'is-expanded', 'summary', {
+		'is-loading': requesting,
+		'has-no-data': ! allPosts.length,
+		'is-showing-error': ! allPosts.length,
+	} );
+
+	return (
+		<div>
+			<SectionHeader
+				label={ translate( 'Anniversaries', {
+					comment: 'Title of the anniversaries module',
+				} ) }
+			/>
+			<Card className={ cardClasses }>
+				{ siteId && <QueryPosts siteId={ siteId } query={ oldestPostQuery } /> }
+				{ siteId &&
+					postsByYearQueries.map(
+						( query, i ) => <QueryPosts key={ i } siteId={ siteId } query={ query } />,
+					) }
+
+				<StatsModulePlaceholder isLoading={ requesting } />
+
+				{ ! requesting &&
+					allPosts &&
+					( allPosts.length === 0
+						? <EmptyMessage />
+						: <PostsList allPosts={ allPosts } postsByYear={ postsByYear } /> ) }
+			</Card>
+		</div>
+	);
+};
+
+const CalendarIcon = () => (
+	<span style={ { position: 'relative', top: '-2px' } }>
+		<Gridicon icon="calendar" size={ 18 } />
+	</span>
+);
+
+const PostsList = ( { allPosts, postsByYear } ) =>
+	( allPosts.length === 1
+		? <SinglePost post={ allPosts[ 0 ] } />
+		: <GroupedPosts postsByYear={ postsByYear } /> );
+
+const SinglePost = localize( ( { translate, post } ) => {
+	const yearsAgo = moment()
+		.startOf( 'year' )
+		.diff( moment( post.date ).startOf( 'year' ), 'years' );
+	return (
+		<StatsContentText>
+			<p>
+				<CalendarIcon />
+				{ translate(
+					'%(yearsAgo)d year ago on this day, {{href}}%(title)s{{/href}} was published.',
+					'%(yearsAgo)d years ago on this day, {{href}}%(title)s{{/href}} was published.',
+					{
+						count: yearsAgo,
+						args: { yearsAgo, title: post.title },
+						components: {
+							href: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
+						},
+						comment: 'Sentence showing what post was published some years ago',
+					},
+				) }
+			</p>
+		</StatsContentText>
+	);
+} );
+
+const GroupedPosts = localize( ( { translate, postsByYear } ) => (
+	<div>
+		<StatsContentText>
+			<p>
+				{ translate( 'Published on this day in the past years:', {
+					comment: 'Sentence preceding a list of posts published in the previous years',
+				} ) }
+			</p>
+		</StatsContentText>
+		<StatsListLegend label={ translate( 'Post' ) } value={ translate( 'Year' ) } />
+		<StatsList
+			moduleName={ 'postAnniversaries' }
+			data={ postsByYear.reduce(
+				( allPosts, posts, i ) =>
+					allPosts.concat(
+						posts.map( post => ( {
+							link: post.URL,
+							label: post.title,
+							labelIcon: 'calendar',
+							value: {
+								type: 'raw',
+								value: moment().subtract( i + 1, 'years' ).format( 'YYYY' ),
+							},
+						} ) ),
+					),
+				[],
+			) }
+		/>
+
+	</div>
+) );
+
+const EmptyMessage = localize( ( { translate } ) => (
+	<ErrorPanel
+		message={ translate( 'No anniversaries today!', {
+			comment: 'Label displayed when the anniversaries module is empty',
+		} ) }
+	/>
+) );
+
+const yearsAgoToday = ( years = 1, nextDay = false ) =>
+	moment().startOf( 'day' ).subtract( years, 'years' ).add( nextDay ? 1 : 0, 'day' );
+
+const yearsAgoQuery = ( yearsAgo = 1 ) => ( {
+	after: yearsAgoToday( yearsAgo ).format(),
+	before: yearsAgoToday( yearsAgo, true ).format(),
+	status: 'publish',
+} );
+
+export default connect( () => {
+	/*
+	 * Keep track of the posts queries and results.
+	 *
+	 * This is needed because <QueryPosts /> handles one query at a time and is
+	 * responsible of creating the data in the Redux store.
+	 *
+	 * Creating these arrays on the fly would create a new reference every time,
+	 * which would trigger a re-rendering of the component as we need to pass
+	 * them to it.
+	 */
+	let postsByYear = [];
+	let postsByYearQueries = [];
+
+	const oldestPostQuery = { number: 1, order: 'ASC' };
+
+	const mapStateToProps = state => {
+		const siteId = getSelectedSiteId( state );
+
+		const requestingOldestPost = isRequestingSitePostsForQuery( state, siteId, oldestPostQuery );
+		const oldestPostResult = getSitePostsForQuery( state, siteId, oldestPostQuery );
+		const oldestPost = oldestPostResult && oldestPostResult[ 0 ];
+
+		// After having received the oldest post date, an array of queries is
+		// created: one for each year preceding the current year.
+		if ( ! postsByYearQueries.length && oldestPost && oldestPost.date ) {
+			const years = Math.min(
+				MAX_POST_QUERIES,
+				moment().diff( moment( oldestPost.date ), 'years' ) + 1,
+			);
+			postsByYearQueries = [ ...Array( years ) ].map( ( v, i ) => yearsAgoQuery( i + 1 ) );
+		}
+
+		// Fill postsByYear if any item has been updated
+		postsByYearQueries.forEach( ( query, i ) => {
+			const result = getSitePostsForQuery( state, siteId, query );
+
+			// Create a new array when an item is updated, to invalidate the equality check
+			if ( postsByYear[ i ] !== result ) {
+				postsByYear[ i ] = result || [];
+				postsByYear = [ ...postsByYear ];
+			}
+		} );
+
+		// True if any of the requests is active
+		const requestingAnyPostsByYear = postsByYearQueries.some(
+			query => isRequestingSitePostsForQuery( state, siteId, query ),
+		);
+
+		return {
+			siteId,
+			requesting: requestingOldestPost || requestingAnyPostsByYear,
+			oldestPostQuery,
+			oldestPost,
+			postsByYearQueries,
+			postsByYear,
+		};
+	};
+
+	return mapStateToProps;
+} )( localize( StatModulePostAnniversaries ) );

--- a/client/my-sites/stats/stats-post-anniversaries/index.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/index.jsx
@@ -63,12 +63,6 @@ const StatModulePostAnniversaries = props => {
 	);
 };
 
-const CalendarIcon = () => (
-	<span style={ { position: 'relative', top: '-2px' } }>
-		<Gridicon icon="calendar" size={ 18 } />
-	</span>
-);
-
 const PostsList = ( { allPosts, postsByYear } ) =>
 	( allPosts.length === 1
 		? <SinglePost post={ allPosts[ 0 ] } />
@@ -81,7 +75,7 @@ const SinglePost = localize( ( { translate, post } ) => {
 	return (
 		<StatsContentText>
 			<p>
-				<CalendarIcon />
+				<Gridicon icon="calendar" size={ 18 } />
 				{ translate(
 					'%(yearsAgo)d year ago on this day, {{href}}%(title)s{{/href}} was published.',
 					'%(yearsAgo)d years ago on this day, {{href}}%(title)s{{/href}} was published.',

--- a/client/my-sites/stats/stats-post-anniversaries/index.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/index.jsx
@@ -199,12 +199,17 @@ export default connect( () => {
 		postsByYearQueries.forEach( ( query, i ) => {
 			const result = getSitePostsForQuery( state, siteId, query );
 
-			// Create a new array when an item is updated to invalidate
-			// the equality check and render the component.
-			if ( postsByYear[ i ] !== result ) {
-				postsByYear[ i ] = result || [];
-				postsByYear = [ ...postsByYear ];
+			// No need to update.
+			if ( postsByYear[ i ] === result ) {
+				return;
 			}
+
+			// Fill the year posts.
+			postsByYear[ i ] = result || [];
+
+			// A new array is created after an item is updated, to invalidate the
+			// equality check and re-render the component.
+			postsByYear = [ ...postsByYear ];
 		} );
 
 		// Get the number of views for each post, to get the top posts

--- a/client/my-sites/stats/stats-post-anniversaries/posts-list.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/posts-list.jsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import GroupedPosts from './grouped-posts';
+import SinglePost from './single-post';
+
+const PostsList = ( { postsByYear, summary, period } ) => {
+	const allPosts = Array.prototype.concat( ...postsByYear );
+	return ! summary && allPosts.length === 1
+		? <SinglePost post={ allPosts[ 0 ] } summary={ summary } period={ period } />
+		: <GroupedPosts postsByYear={ postsByYear } summary={ summary } period={ period } />;
+};
+
+export default PostsList;

--- a/client/my-sites/stats/stats-post-anniversaries/single-post.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/single-post.jsx
@@ -10,15 +10,44 @@ import { localize, moment } from 'i18n-calypso';
  */
 import StatsContentText from '../stats-module/content-text';
 
-const periodLabel = ( translate, period ) => {
+const label = ( translate, period, yearsAgo, post ) => {
+	const { URL: url, title } = post;
+	const link = <a href={ url } target="_blank" rel="noopener noreferrer" />;
 	if ( period.period === 'day' ) {
-		return translate( 'this day' );
+		return translate(
+			'%(yearsAgo)d year ago on this day, {{href}}%(title)s{{/href}} was published.',
+			'%(yearsAgo)d years ago on this day, {{href}}%(title)s{{/href}} was published.',
+			{
+				count: yearsAgo,
+				args: { yearsAgo, title },
+				components: { href: link },
+				comment: 'Sentence showing what post was published some years ago on this day',
+			},
+		);
 	}
 	if ( period.period === 'week' ) {
-		return translate( 'this week' );
+		return translate(
+			'%(yearsAgo)d year ago on this week, {{href}}%(title)s{{/href}} was published.',
+			'%(yearsAgo)d years ago on this week, {{href}}%(title)s{{/href}} was published.',
+			{
+				count: yearsAgo,
+				args: { yearsAgo, title },
+				components: { href: link },
+				comment: 'Sentence showing what post was published some years ago on this week',
+			},
+		);
 	}
 	if ( period.period === 'month' ) {
-		return translate( 'this month' );
+		return translate(
+			'%(yearsAgo)d year ago on this month, {{href}}%(title)s{{/href}} was published.',
+			'%(yearsAgo)d years ago on this month, {{href}}%(title)s{{/href}} was published.',
+			{
+				count: yearsAgo,
+				args: { yearsAgo, title },
+				components: { href: link },
+				comment: 'Sentence showing what post was published some years ago on this month',
+			},
+		);
 	}
 	return '';
 };
@@ -32,22 +61,7 @@ const SinglePost = localize( ( { translate, post, period } ) => {
 		<StatsContentText>
 			<p>
 				<Gridicon icon="calendar" size={ 18 } />
-				{ translate(
-					'%(yearsAgo)d year ago on %(period)s, {{href}}%(title)s{{/href}} was published.',
-					'%(yearsAgo)d years ago on %(period)s, {{href}}%(title)s{{/href}} was published.',
-					{
-						count: yearsAgo,
-						args: {
-							yearsAgo,
-							period: periodLabel( translate, period ),
-							title: post.title,
-						},
-						components: {
-							href: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
-						},
-						comment: 'Sentence showing what post was published some years ago',
-					},
-				) }
+				{ label( translate, period, yearsAgo, post ) }
 			</p>
 		</StatsContentText>
 	);

--- a/client/my-sites/stats/stats-post-anniversaries/single-post.jsx
+++ b/client/my-sites/stats/stats-post-anniversaries/single-post.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+import { localize, moment } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import StatsContentText from '../stats-module/content-text';
+
+const periodLabel = ( translate, period ) => {
+	if ( period.period === 'day' ) {
+		return translate( 'this day' );
+	}
+	if ( period.period === 'week' ) {
+		return translate( 'this week' );
+	}
+	if ( period.period === 'month' ) {
+		return translate( 'this month' );
+	}
+	return '';
+};
+
+const SinglePost = localize( ( { translate, post, period } ) => {
+	const yearsAgo = period.startOf
+		.clone()
+		.startOf( 'year' )
+		.diff( moment( post.date ).startOf( 'year' ), 'years' );
+	return (
+		<StatsContentText>
+			<p>
+				<Gridicon icon="calendar" size={ 18 } />
+				{ translate(
+					'%(yearsAgo)d year ago on %(period)s, {{href}}%(title)s{{/href}} was published.',
+					'%(yearsAgo)d years ago on %(period)s, {{href}}%(title)s{{/href}} was published.',
+					{
+						count: yearsAgo,
+						args: {
+							yearsAgo,
+							period: periodLabel( translate, period ),
+							title: post.title,
+						},
+						components: {
+							href: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
+						},
+						comment: 'Sentence showing what post was published some years ago',
+					},
+				) }
+			</p>
+		</StatsContentText>
+	);
+} );
+
+export default SinglePost;

--- a/client/my-sites/stats/stats-post-anniversaries/style.scss
+++ b/client/my-sites/stats/stats-post-anniversaries/style.scss
@@ -1,0 +1,4 @@
+.stats-post-anniversaries__card .stats-section-title {
+	margin: 0;
+	padding: 1em;
+}

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -21,6 +21,7 @@ import StatsFirstView from '../stats-first-view';
 import QueryMedia from 'components/data/query-media';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getMediaItem } from 'state/selectors';
+import PostAnniversaries from '../stats-post-anniversaries';
 
 const StatsStrings = statsStringsFactory();
 
@@ -185,6 +186,15 @@ class StatsSummary extends Component {
 					query={ merge( {}, statsQueryOptions, query ) }
 					statType="statsSearchTerms"
 					summary />;
+				break;
+
+			case 'anniversaries':
+				title = translate( 'Anniversaries' );
+				summaryView = <PostAnniversaries
+						key="anniversaries-summary"
+						path="anniversaries"
+						period={ this.props.period }
+						summary />;
 				break;
 		}
 


### PR DESCRIPTION
Hi!

This is my first pull request on the project, its goal is to add a module in the stats section that will display the post anniversaries corresponding to the current day. Please let me know what you think! 😊

## Screenshots

Here are some visuals of the module in its current state, including zero / one / two / more posts:

<p><img align="top" width="321" alt="empty" style="vertical-align:top" src="https://user-images.githubusercontent.com/36158/27012789-7e745254-4ecf-11e7-9bb9-8784a7dee6b7.png"> <img width="321" alt="one" align="top" src="https://user-images.githubusercontent.com/36158/27012790-8275ef02-4ecf-11e7-8c29-4cec12bcb7e1.png"> </p>

<p> <img width="321" alt="two" align="top" src="https://user-images.githubusercontent.com/36158/27012792-864d41d4-4ecf-11e7-8e1f-53c5857c3e3f.png"> <img width="321" alt="many" align="top" src="https://user-images.githubusercontent.com/36158/27012793-8b6b4c7e-4ecf-11e7-88d6-16fda48201f2.png"></p>

## Rationale

The first approach I followed was to provide a full completeness: the module displays all the posts found for the last ten years <a href="#footnote-1">[1]</a>.

Another approach that I would like to discuss would be to see this module as something more “entertaining” than informative, which would allow it to display only one (random) anniversary if several exist. It could also visually be identified as something special (e.g. using an icon representing a birthday cake), the same way “Best Views Ever” is using a cup icon with a yellow color.

## Display modes

I believe (maybe this information can be found somewhere?) that having only one or zero anniversaries would be the most common cases, and decided to display the single anniversary case as a simple sentence, following the pattern of the “Latest Post Summary” module:

<p> <img align="top" width="321" alt="latest-post-summary" src="https://user-images.githubusercontent.com/36158/27012940-f841c9e8-4ed1-11e7-850c-a445165e948e.png"> <img width="321" alt="one" align="top" src="https://user-images.githubusercontent.com/36158/27012790-8275ef02-4ecf-11e7-8c29-4cec12bcb7e1.png"> </p>

When several anniversaries exist, a table is used to display the list of posts, reusing a component found in other stats modules like “Posts & Pages”:

<p> <img width="321" align="top"  alt="posts-and-pages" src="https://user-images.githubusercontent.com/36158/27012967-592ea56e-4ed2-11e7-92c1-4b8123b87993.png"> <img width="321" alt="two" align="top" src="https://user-images.githubusercontent.com/36158/27012792-864d41d4-4ecf-11e7-8e1f-53c5857c3e3f.png"></p>

While having the advantage of reusing an existing component, I am not sure a table is the best way to display this data. Another way could be to only display the first year containing anniversaries, and to add buttons that would allow the user to navigate through the years containing anniversaries. The posts could also be grouped by year as a series of lists. If so, a solution could be to expand it vertically using a “more” button.

## Emplacement

At the moment, the module appears in the _Insights_ tab of the stats section. I am still unsure about this, as my first instinct was to put it in the _Days_ tab.

Some reasons for not displaying it in the _Days_ tab:

- It would be the only module in the _Days_ tab that wouldn’t be displayed in the Weeks, Months, and Years tabs.
- It would be the only module in the _Days_ tab not referring to the visits.
- The modules displayed in the _Insights_ tab are already about different aspects.

But an important reason for doing it would be to allow the user to display the post anniversaries of any day, not only today.

## Additional Notes

- I decided to not put it behind a feature flag as the project is small enough, but maybe I should do it, so the PR can be merged early?
- After thinking about the wording, I decided to use “Anniversaries” instead of “Post Anniversaries” in the module, as the context should be enough to understand that we are talking about posts. Please tell me if you think that it should be changed.
- I used calypso-prettier (#12260)  to format the code of the module. I had very good results with it, but it might be a bit premature. Please tell me if this is the case, and I will reformat it manually.
- I modified the module `stats/stats-list/stats-list-item.jsx` to allow it to display a year without formatting it as a number.
- I used a [wrapper](https://github.com/Automattic/wp-calypso/blob/be022e6fdd46ff7cd6ca4bcc8ceb0ee85d2aff24/client/my-sites/stats/stats-post-anniversaries/index.jsx#L65) around the `<Gridicon/>` component to fix its alignment. It is a temporary fix that I only applied to the single anniversary mode. The problem is present with other modules of the stats section and I will open a separate issue to discuss this, so this fix can be removed.

cc @ehg

<a name="footnote-1">[1]</a> This limitation exists because the WordPress.com API doesn’t allow a query on multiple date ranges, which means that each year need to be queried separately. The module tries to optimize this by fetching the oldest post first. Then, if the blog is younger than ten years, only the relevant years will be queried. This optimization can easily be removed in the future whenever / if the WordPress.com API implements the feature.