### PR TITLE
Publicize: open publicize scheduling to wpcalypso.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -177,7 +177,7 @@ export const PLANS_LIST = {
 			FEATURE_NO_ADS,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 		] ),
 		getPromotedFeatures: () => [
 			FEATURE_CUSTOM_DOMAIN,
@@ -285,7 +285,6 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' )
 	},
@@ -312,7 +311,6 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -177,8 +177,7 @@ export const PLANS_LIST = {
 			FEATURE_NO_ADS,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
-			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE
 		] ),
 		getPromotedFeatures: () => [
 			FEATURE_CUSTOM_DOMAIN,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,6 +82,7 @@
 		"post-editor/image-editor": true,
 		"press-this": true,
 		"preview-layout": true,
+		"publicize-scheduling": false,
 		"reader": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,7 +82,7 @@
 		"post-editor/image-editor": true,
 		"press-this": true,
 		"preview-layout": true,
-		"publicize-scheduling": false,
+		"publicize-scheduling": true,
 		"reader": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,


### PR DESCRIPTION
This opens up publicize scheduling to wpcalypso users letting other a12s and wpcalypso users test this.
It also enables it ONLY for business users

## Testing instructions

1. Build with flag on development `ENABLE_FEATURES=publicize-scheduling make run` 
2. Test on free and business site
3. On business site you should have calendar icon and scheduled list
4. Test everythiong, see if you have any errors

### Published tab is not working yet, we're working on it