### PR TITLE
Framework: Add custom scrollbar component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -165,6 +165,7 @@
 @import 'components/reader-infinite-stream/style';
 @import 'components/ribbon/style';
 @import 'components/screen-reader-text/style';
+@import 'components/scroll-container/style';
 @import 'components/search/style';
 @import 'components/search-card/style';
 @import 'components/section-header/style';

--- a/client/components/scroll-container/ScrollTrack.jsx
+++ b/client/components/scroll-container/ScrollTrack.jsx
@@ -1,0 +1,67 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal Dependencies
+ */
+import { BASE_CLASS } from './helpers/constants';
+import { scrollbarHasLayout, getScrollbarClipWidth } from './helpers/dimensions';
+
+export default class ScrollTrack extends PureComponent {
+	render() {
+		const { className, direction, puckHovered, puckOffset, puckSize, trackHovered } = this.props;
+		const isVertical = direction === 'vertical';
+		const isHorizontal = direction === 'horizontal';
+		const hoverClass = `${ BASE_CLASS }-is-hovered`;
+		let transform = null;
+		if ( isVertical && puckOffset != null ) {
+			transform = `translateY(${ puckOffset }px)`;
+		} else if ( isHorizontal && puckOffset != null ) {
+			transform = `translateX(${ puckOffset }px)`;
+		}
+
+		let trackStyles = null;
+		if ( ! scrollbarHasLayout() ) {
+			trackStyles = {
+				right: `${ getScrollbarClipWidth() }px`,
+			};
+		}
+		const puckStyles = {
+			height: isVertical && puckSize != null ? `${ puckSize }px` : null,
+			width: isHorizontal && puckSize != null ? `${ puckSize }px` : null,
+			transform,
+		};
+		const trackClasses = classnames( `${ BASE_CLASS }__track ${ BASE_CLASS }__track-${ direction }`, className, {
+			[ hoverClass ]: trackHovered,
+		} );
+		const puckClasses = classnames( `${ BASE_CLASS }__puck ${ BASE_CLASS }__puck-${ direction }`, {
+			[ hoverClass ]: puckHovered,
+		} );
+		return (
+			<div ref={ this.props.refFn } className={ trackClasses } style={ trackStyles }>
+				<div
+					className={ puckClasses }
+					style={ puckStyles }
+				/>
+			</div>
+		);
+	}
+}
+
+ScrollTrack.propTypes = {
+	className: PropTypes.string,
+	direction: PropTypes.oneOf( [ 'vertical', 'horizontal' ] ),
+	refFn: PropTypes.func,
+	puckHovered: PropTypes.bool,
+	puckOffset: PropTypes.number.isRequired,
+	puckSize: PropTypes.number.isRequired,
+	trackHovered: PropTypes.bool,
+};
+
+ScrollTrack.defaultProps = {
+	puckHovered: false,
+	trackHovered: false,
+};

--- a/client/components/scroll-container/helpers/constants.js
+++ b/client/components/scroll-container/helpers/constants.js
@@ -1,0 +1,1 @@
+export const BASE_CLASS = 'scroll-container';

--- a/client/components/scroll-container/helpers/dimensions.js
+++ b/client/components/scroll-container/helpers/dimensions.js
@@ -1,0 +1,90 @@
+let scrollbarWidth = null;
+
+/**
+ * Calculate the width of the browser's scrollbar.  If the scrollbar width can't be calculated
+ * for some reason, zero is returned, but not cached.  If you want to force this function to
+ * recalcuate the scrollbar width, pass true into the function.
+ *
+ * @export
+ * @param {Boolean} recalculate - Pass true to force recalculation of the scrollbar width
+ * @returns {Number} Width of the browser scrollbar or 0 if it can't be calculated
+ */
+export const getScrollbarWidth = recalculate => {
+	if ( typeof window !== 'undefined' ) {
+		if ( recalculate == null ) {
+			recalculate = false;
+		}
+		if ( ( scrollbarWidth != null ) && ! recalculate ) {
+			return scrollbarWidth;
+		}
+		if ( document.readyState === 'loading' ) {
+			return 0;
+		}
+		const div1 = document.createElement( 'div' );
+		const div2 = document.createElement( 'div' );
+		div1.style.width = div2.style.width = div1.style.height = div2.style.height = '100px';
+		div1.style.overflowY = 'scroll';
+		div2.style.overflow = 'hidden';
+		document.body.appendChild( div1 );
+		document.body.appendChild( div2 );
+		scrollbarWidth = Math.abs( div1.scrollWidth - div2.scrollWidth );
+		document.body.removeChild( div1 );
+		document.body.removeChild( div2 );
+		return scrollbarWidth;
+	}
+	return 0;
+};
+
+/**
+ * Determine if the scrollbar actually affects layout.
+ *
+ * @export
+ * @returns {Boolean} Whether or not the vertical scrollbar has any width.
+ */
+export const scrollbarHasLayout = () => !! getScrollbarWidth();
+
+/**
+ * Determine the amount of the content container needs to be clipped in order for the vertical
+ * scrollbar hidden from view.
+ *
+ * @export
+ * @returns {Number} The amount of clipping necessary to hide a scrollbar
+ */
+export const getScrollbarClipWidth = () => getScrollbarWidth() || 15;
+
+/**
+ * Determine the size of the scroll puck (draggable element of the scroll bar) given the
+ * amount of visible space and total size of content along a dimension.  The direction the
+ * user is allowed to scroll is also needed, due to the restricted amount of available space
+ * for the puck to traverse on the track if the user is allowed to scroll in both dimensions.
+ *
+ * @export
+ * @param {Number} visibleSize - The number of visible pixels in the direction you care about
+ * @param {Number} totalSize - The total number of pixels that the content takes up
+ * @param {Number} trackMargin - The amount of space between the track and the edge of the scrollable area
+ * @returns {Number} The size of the puck in pixels
+ */
+export function calcPuckSize( visibleSize, totalSize, trackMargin ) {
+	return Math.max( Math.min( Math.round( ( visibleSize - ( trackMargin * 2 ) ) / totalSize * visibleSize ), visibleSize ), 0 );
+}
+
+/**
+ * Determine the pixel offset of the puck from the base of the track given how much the
+ * user has scrolled.  The direction the user is allowed to scroll is also needed, due to
+ * the restricted amount of available space for the puck to traverse on the track if the
+ * user is allowed to scroll in both dimensions.
+ *
+ * @export
+ * @param {Number} visibleSize - The number of visible pixels in the direction you care about
+ * @param {Number} totalSize - The total number of pixels that the content takes up
+ * @param {Number} scrollAmount - The number of pixels the user has scrolled in a given dimension
+ * @param {Number} trackMargin - The amount of space between the track and the edge of the scrollable area
+ * @returns {Number} The offset of the puck from the track base in pixels
+ */
+export function calcPuckOffset( visibleSize, totalSize, scrollAmount, trackMargin ) {
+	const puckSize = calcPuckSize( visibleSize, totalSize, trackMargin );
+	const visibleSizeAvailable = visibleSize - trackMargin * 2;
+	const maxOffset = visibleSizeAvailable - puckSize;
+	const proportionScrolled = scrollAmount / totalSize;
+	return Math.max( Math.min( Math.round( visibleSizeAvailable * proportionScrolled ), maxOffset ), 0 );
+}

--- a/client/components/scroll-container/helpers/events.js
+++ b/client/components/scroll-container/helpers/events.js
@@ -1,0 +1,34 @@
+
+/**
+ * Curry a function which will ensure that the passed function is only executed once per
+ * animation frame.
+ *
+ * @private
+ * @param {Function} fn - The function which needs to be executed in the animation frame
+ * @returns {Function} A function that can be called any number of times
+ */
+export function throttleToFrame( fn ) {
+	let requestingFrame = false;
+	return ( ...args ) => {
+		if ( ! requestingFrame && typeof window !== 'undefined' ) {
+			window.requestAnimationFrame( () => {
+				requestingFrame = false;
+				fn.apply( null, args );
+			} );
+			requestingFrame = true;
+		}
+	};
+}
+
+/**
+ * Determine if an event occured at a point on the screen inside the given client rectangle.
+ *
+ * @private
+ * @param {UIEvent} event - The event which occurred.
+ * @param {any} rect - The client rectangle being tested
+ * @returns {Boolean} Whether the event occurred in the client rect
+ */
+export function eventInsideRect( event, rect ) {
+	const { clientX, clientY } = event;
+	return rect.left < clientX && rect.right > clientX && rect.top < clientY && rect.bottom > clientY;
+}

--- a/client/components/scroll-container/index.jsx
+++ b/client/components/scroll-container/index.jsx
@@ -1,0 +1,454 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes, PureComponent } from 'react';
+import classnames from 'classnames';
+import { debounce, throttle } from 'lodash';
+
+// tween.js has references to window on its initial run. So, if that doesn't exist,
+// we don't want to import that library.
+let TWEEN = {};
+if ( typeof window !== 'undefined' ) {
+	TWEEN = require( 'tween.js' );
+}
+
+/**
+ * Internal Dependencies
+ */
+import ScrollTrack from './ScrollTrack';
+import { BASE_CLASS } from './helpers/constants';
+import { throttleToFrame, eventInsideRect } from './helpers/events';
+import { calcPuckSize, calcPuckOffset, getScrollbarClipWidth, scrollbarHasLayout } from './helpers/dimensions';
+
+/**
+ * This component will wrap content and create custom scroll bars for said content.  Due to requirements
+ * for automatically fading content in and out, Webkit's CSS customization for scroll bars can not be
+ * used.
+ *
+ * @export
+ * @class ScrollContainer
+ * @extends {PureComponent}
+ */
+export default class ScrollContainer extends PureComponent {
+	static propTypes = {
+		autoHide: PropTypes.bool,
+		children: PropTypes.node,
+		className: PropTypes.string,
+	};
+
+	static defaultProps = {
+		autoHide: false,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			canScrollVertical: false,
+			draggingPuck: false,
+			forceVisible: ! this.props.autoHide,
+			isVerticalPuckHovered: false,
+			verticalPuckOffset: 0,
+			verticalPuckSize: 0,
+			isVerticalTrackHovered: false,
+		};
+		this.verticalTrackRect = null;
+		this.verticalTrackMargin = 0;
+
+		this.contentContainerRefFn = n => this.contentContainer = n;
+		this.horizontalTrackRefFn = c => this.horizontalTrack = c;
+		this.rootNodeRefFn = n => this.rootNode = n;
+		this.verticalTrackRefFn = c => this.verticalTrack = c;
+
+		this.contentScrollHandler = throttleToFrame( () => {
+			this.updatePuckPosition();
+			this.scrollComplete();
+		} );
+		this.contentUpdateHandler = throttle( () => {
+			this.canScroll();
+			this.calculateTrackRectangles();
+			this.updatePuck();
+		}, 100, { leading: false } );
+		this.coordinatesOverTrack = throttleToFrame( this.coordinatesOverTrack );
+		this.scrollByDragging = throttleToFrame( this.scrollByDragging );
+		this.scrollComplete = debounce( this.autoHideAfterScroll, 333, { leading: true, trailing: true } );
+		this.windowResizeHandler = throttleToFrame( () => {
+			this.canScroll();
+			this.calculateTrackRectangles();
+			this.updatePuck();
+		} );
+		this.windowScrollHandler = debounce( () => {
+			if ( this.verticalTrackRect != null ) {
+				this.updateScrollbar();
+			}
+		}, 100 );
+
+		this.dragPuck = event => {
+			const { clientX, clientY } = event;
+			this.scrollByDragging( clientX, clientY );
+		};
+		this.trackMouseOnHover = event => {
+			const { clientX, clientY } = event;
+			this.coordinatesOverTrack( clientX, clientY );
+		};
+	}
+
+	componentDidMount = () => {
+		if ( typeof window !== 'undefined' ) {
+			window.addEventListener( 'resize', this.windowResizeHandler );
+		}
+		this.updateScrollbar();
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if (
+			prevState.isVerticalTrackHovered !== this.state.isVerticalTrackHovered ||
+			prevState.horizontalTrackHovered !== this.state.horizontalTrackHovered
+		) {
+			this.calculateTrackRectangles();
+		}
+
+		if ( typeof window !== 'undefined' && prevState.draggingPuck !== this.state.draggingPuck ) {
+			if ( this.state.draggingPuck ) {
+				window.addEventListener( 'mousemove', this.dragPuck );
+				window.addEventListener( 'mouseup', this.stopDragging );
+			} else {
+				window.removeEventListener( 'mousemove', this.dragPuck );
+				window.removeEventListener( 'mouseup', this.stopDragging );
+			}
+		}
+
+		if ( prevProps.children !== this.props.children ) {
+			this.updateScrollbar();
+		}
+	}
+
+	componentWillUnmount = () => {
+		if ( typeof window !== 'undefined' ) {
+			window.removeEventListener( 'mousemove', this.dragPuck );
+			window.removeEventListener( 'mouseup', this.stopDragging );
+			window.removeEventListener( 'resize', this.windowResizeHandler );
+		}
+
+		// Just to be safe
+		this.stopScrolling();
+
+		/*
+		There's a possibility that since these functions are the result of currying
+		another function which has the initial function which is boudn to the component
+		instance in the scope chain, the curried function will keep the component in
+		memory even after the component is unmounted.  Since this is inexpensive,
+		let's just cancel (if possible) and assign over these to prevent memory leaks.
+		*/
+		this.contentScrollHandler = null;
+		this.contentUpdateHandler.cancel();
+		this.contentUpdateHandler = null;
+		this.coordinatesOverTrack = null;
+		this.scrollByDragging = null;
+		this.scrollComplete.cancel();
+		this.scrollComplete = null;
+		this.windowResizeHandler = null;
+		this.windowScrollHandler.cancel();
+		this.windowScrollHandler = null;
+	}
+
+	autoHideAfterScroll = () => {
+		if ( this.props.autoHide && ! this.state.draggingPuck ) {
+			this.setState( () => ( { forceVisible: false } ) );
+		}
+	}
+
+	calculateTrackRectangles = () => {
+		if ( this.state.canScrollVertical && this.verticalTrack != null ) {
+			const verticalTrackRect = this.verticalTrack.getBoundingClientRect();
+			if ( verticalTrackRect.width > 0 ) {
+				const margin = parseInt( window.getComputedStyle( this.verticalTrack ).marginTop, 10 );
+				this.verticalTrackRect = verticalTrackRect;
+				this.verticalTrackMargin = ! isNaN( margin ) && isFinite( margin ) ? margin : 0;
+			}
+			this.clientHeight = this.contentContainer.clientHeight;
+			this.scrollHeight = this.contentContainer.scrollHeight;
+		}
+	}
+
+	canScroll = () => {
+		const content = this.contentContainer;
+		this.setState( () => ( {
+			canScrollVertical: content.clientHeight < content.scrollHeight,
+		} ) );
+	}
+
+	clearTrackState = () => {
+		this.clientHeight = null;
+		this.scrollHeight = null;
+		this.verticalTrackMargin = null;
+		this.verticalTrackRect = null;
+		this.setState( () => ( {
+			draggingPuck: false,
+			isVerticalPuckHovered: false,
+			isVerticalTrackHovered: false,
+		} ) );
+	}
+
+	/**
+	 * Determine if a given set of X/Y client coordinates is on top of a visible scrollbar track.
+	 *
+	 * @private
+	 * @param {Number} x - X Coordinate
+	 * @param {Number} y - Y Coordinate
+	 * @memberof ScrollContainer
+	 */
+	coordinatesOverTrack = ( x, y ) => {
+		this.setState( state => {
+			if ( this.verticalTrackRect == null ) {
+				this.calculateTrackRectangles();
+			}
+			const { verticalTrackRect } = this;
+			const fakeEvent = { clientX: x, clientY: y };
+			const newState = {};
+			if ( state.canScrollVertical ) {
+				newState.isVerticalTrackHovered = verticalTrackRect == null ? false : eventInsideRect( fakeEvent, verticalTrackRect );
+				newState.isVerticalPuckHovered = false;
+				if ( newState.isVerticalTrackHovered ) {
+					const puckTop = verticalTrackRect.top + state.verticalPuckOffset;
+					newState.isVerticalPuckHovered = y >= puckTop && y <= puckTop + state.verticalPuckSize;
+				}
+			}
+
+			if ( state.isVerticalTrackHovered !== newState.isVerticalTrackHovered ) {
+				this.calculateTrackRectangles();
+			}
+			return newState;
+		} );
+	}
+
+	/**
+	 * Scroll the content based on the current clientX and clientY of the mouse.
+	 *
+	 * @param {Number} clientX - X coordinate of the mouse with (0, 0) at the top left of the window
+	 * @param {Number} clientY - Y coordinate of the mouse with (0, 0) at the top left of the window
+	 * @memberof ScrollContainer
+	 */
+	scrollByDragging = ( clientX, clientY ) => {
+		const { clientHeight, scrollHeight } = this;
+		const trackDiff = clientY - this.state.dragStartPosition;
+		const scrollDiff = scrollHeight / clientHeight * trackDiff;
+		this.contentContainer.scrollTop = this.state.startingScrollPosition + scrollDiff;
+	}
+
+	/**
+	 * After scrolling has completed, prevent a click event from landing on the content,
+	 * reset dragging state, and execute mouseleave handlers if the mouse is no longer
+	 * inside of this container.
+	 *
+	 * @param {MouseEvent} event - The mouseup event which caused scrolling to stop.
+	 * @memberof ScrollContainer
+	 */
+	stopDragging = event => {
+		event.preventDefault();
+		event.stopPropagation();
+		if ( ! this.rootNode.contains( event.target ) ) {
+			this.clearTrackState();
+		}
+		this.setState( {
+			draggingPuck: false,
+			dragStartPosition: null,
+			forceVisible: false,
+			startingScrollPosition: null,
+		} );
+	}
+
+	/**
+	 * If the user clicks on a scroll track, but outside of its associated scroll puck,
+	 * we need to either increase or decrease the amount of scrolling by a single "page".
+	 *
+	 * @private
+	 * @param {MouseEvent} event - The mouse event triggered in the UI
+	 * @memberof ScrollContainer
+	 */
+	scrollIfClickOnTrack = event => {
+		const { clientY } = event;
+		const { verticalTrackRect } = this;
+
+		if ( verticalTrackRect != null && eventInsideRect( event, verticalTrackRect ) ) {
+			event.preventDefault();
+			event.stopPropagation();
+			const { scrollLeft, scrollTop } = this.contentContainer;
+			const { verticalPuckOffset, verticalPuckSize } = this.state;
+			const clickedBelowPuck = clientY > verticalTrackRect.top + verticalPuckOffset + verticalPuckSize;
+			const clickedAbovePuck = clientY < verticalTrackRect.top + verticalPuckOffset;
+			if ( clickedAbovePuck || clickedBelowPuck ) {
+				const scrollYTarget = clickedAbovePuck ? scrollTop - this.clientHeight : scrollTop + this.clientHeight;
+				this.scrollTo( scrollLeft, scrollYTarget, () => this.setState( () => ( { isVerticalPuckHovered: true } ) ) );
+			} else {
+				this.setState( () => ( {
+					draggingPuck: true,
+					dragStartPosition: clientY,
+					forceVisible: true,
+					startingScrollPosition: scrollTop,
+				} ) );
+			}
+		}
+	}
+
+	/**
+	 * Scroll the contentes of this container to the given x/y coordinates.
+	 *
+	 * @public
+	 * @param {Number} x - The amount of desired horizontal scrolling
+	 * @param {Number} y - The amount of desired vertical scrolling
+	 * @param {Function} [cb] - Callback to execute after scrolling
+	 * @memberof ScrollContainer
+	 */
+	scrollTo = ( x, y, cb ) => {
+		if ( this.scrollTween != null ) {
+			this.scrollTween.stop();
+		}
+		this.setState( () => ( { scrolling: true } ), () => {
+			const scrollContainer = this;
+			this.scrollTween = new TWEEN.Tween( {
+				x: this.contentContainer.scrollLeft || 0,
+				y: this.contentContainer.scrollTop || 0,
+			} )
+			.to( {
+				x: Math.max( x || 0, 0 ),
+				y: Math.max( y || 0, 0 ),
+			}, 75 )
+			.onUpdate( function() {
+				scrollContainer.contentContainer.scrollTop = this.y;
+				scrollContainer.contentContainer.scrollLeft = this.x;
+			} )
+			.easing( TWEEN.Easing.Linear.None )
+			.interpolation( TWEEN.Interpolation.Bezier )
+			.onComplete( () => {
+				this.stopScrolling();
+				if ( typeof cb === 'function' ) {
+					cb();
+				}
+			} )
+			.start();
+			const tweenUpdateFn = time => {
+				if ( this.state.scrolling ) {
+					TWEEN.update( time );
+					requestAnimationFrame( tweenUpdateFn );
+				}
+			};
+			requestAnimationFrame( tweenUpdateFn );
+		} );
+	}
+
+	/**
+	 * If the mouse is on top of the track, we have to manually stop the event from
+	 * landing on the underlying content since the track doesn't accept pointer events.
+	 *
+	 * @param {MouseEvent} event - The click event we might need to kill.
+	 * @memberof ScrollContainer
+	 */
+	stopClickOnTrackOver = event => {
+		if ( this.state.isVerticalTrackHovered ) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+	}
+
+	stopScrolling = () => {
+		if ( this.scrollTween != null ) {
+			this.scrollTween.stop();
+		}
+		this.setState( () => ( { scrolling: false } ) );
+	}
+
+	updateScrollbar = () => {
+		this.canScroll();
+		this.calculateTrackRectangles();
+		this.updatePuck();
+	}
+
+	updatePuck = () => {
+		this.updatePuckSize();
+		this.updatePuckPosition();
+	}
+
+	updatePuckPosition = () => {
+		this.setState( state => {
+			if ( state.canScrollVertical ) {
+				const { scrollHeight, clientHeight, scrollTop } = this.contentContainer;
+				return {
+					verticalPuckOffset: calcPuckOffset( clientHeight, scrollHeight, scrollTop, this.verticalTrackMargin ),
+				};
+			}
+			return null;
+		} );
+	}
+
+	updatePuckSize = () => {
+		this.setState( state => {
+			if ( state.canScrollVertical ) {
+				const { scrollHeight, clientHeight } = this.contentContainer;
+				return {
+					verticalPuckSize: calcPuckSize( clientHeight, scrollHeight, this.verticalTrackMargin ),
+				};
+			}
+			return null;
+		} );
+	}
+
+	render() {
+		const { className, autoHide, children } = this.props;
+		const { canScrollVertical } = this.state;
+		const {
+			draggingPuck,
+			forceVisible,
+			scrolling,
+			isVerticalPuckHovered,
+			verticalPuckOffset,
+			verticalPuckSize,
+			isVerticalTrackHovered,
+		} = this.state;
+
+		const scrollbarCipWidth = `${ getScrollbarClipWidth() }px`;
+		const scrollbarClipStyles = {
+			marginRight: `-${ scrollbarCipWidth }`,
+			paddingRight: scrollbarHasLayout() ? null : scrollbarCipWidth,
+		};
+
+		const classes = classnames( BASE_CLASS, `${ BASE_CLASS }__vertical`, className, {
+			[ `${ BASE_CLASS }-autohide` ]: autoHide,
+			[ `${ BASE_CLASS }-dragging` ]: draggingPuck,
+			[ `${ BASE_CLASS }__force-visible` ]: forceVisible,
+		} );
+		return (
+			<div
+				ref={ this.rootNodeRefFn }
+				className={ classes }
+				onMouseEnter={ this.calculateTrackRectangles }
+				onMouseLeave={ draggingPuck ? null : this.clearTrackState }
+			>
+				<div
+					ref={ this.contentContainerRefFn }
+					className={ `${ BASE_CLASS }__content-container` }
+					onScroll={ this.contentScrollHandler }
+					onClick={ this.contentUpdateHandler }
+					onClickCapture={ this.stopClickOnTrackOver }
+					onKeyDown={ this.contentUpdateHandler }
+					onMouseDownCapture={ this.scrollIfClickOnTrack }
+					onMouseMove={ scrolling || draggingPuck ? null : this.trackMouseOnHover }
+					style={ scrollbarClipStyles }
+				>
+					{ children }
+				</div>
+				{
+					canScrollVertical
+					? <ScrollTrack
+						direction="vertical"
+						refFn={ this.verticalTrackRefFn }
+						puckHovered={ isVerticalPuckHovered }
+						puckOffset={ verticalPuckOffset }
+						puckSize={ verticalPuckSize }
+						trackHovered={ isVerticalTrackHovered }
+					/>
+					: null
+				}
+			</div>
+		);
+	}
+}

--- a/client/components/scroll-container/style.scss
+++ b/client/components/scroll-container/style.scss
@@ -1,0 +1,95 @@
+$scroll-ns: 'scroll-container';
+$scroll-border-radius: 10px;
+$scroll-puck-min-size: 36px;
+$scroll-track-size: 10px;
+$scroll-opacity-transition: opacity 0.4s ease;
+$scroll-width-transition: width 0.1s linear 0.2s;
+
+.#{$scroll-ns} {
+	overflow: hidden;
+	position: relative;
+
+	// Smooth scroll related properties
+	&__content-container {
+		transform: translateX( 0 ); /* workaround for safari scrollbar rendering bug */
+		-webkit-overflow-scrolling: touch;
+	}
+
+	// Scroll direction helpers
+	&__vertical .#{$scroll-ns}__content-container {
+		min-height: 100%;
+		overflow-x: hidden;
+		overflow-y: scroll;
+	}
+
+	&-dragging {
+		cursor: pointer !important;
+		user-select: none;
+	}
+
+    // Autohide functionality
+    &-autohide .#{$scroll-ns}__track {
+        opacity: 0;
+		transition: $scroll-opacity-transition, $scroll-width-transition;
+    }
+    &-autohide:hover, &__force-visible {
+		.#{$scroll-ns}__track {
+			opacity: 1;
+			transition: $scroll-width-transition;
+		}
+	}
+
+    // Puck (draggable element)
+    &__puck {
+		background: transparentize( darken( $gray, 10% ), 0.7);
+		background-clip: padding-box;
+		border-radius: $scroll-border-radius;
+		box-sizing: border-box;
+		position: relative;
+
+		&.#{$scroll-ns}-is-hovered {
+			background: transparentize( darken( $gray, 10% ), 0.2 );
+		}
+
+		.#{$scroll-ns}-dragging & {
+			background: darken( $gray, 10% );
+		}
+
+		&-vertical {
+			min-height: $scroll-puck-min-size;
+			padding: $scroll-border-radius 0;
+			top: 0;
+			width: 100%;
+		}
+    }
+
+    // Track (clickable background)
+    &__track {
+		background-clip: padding-box;
+		border-radius: $scroll-border-radius;
+		box-sizing: border-box;
+		margin: 2px;
+		pointer-events: none;
+		position: absolute;
+
+		// Since the track has "pointer-events: none", a class gets added for the
+		// "hover" state
+		&.#{$scroll-ns}-is-hovered {
+			background-color: transparentize( lighten( $gray, 20% ), 0.5 );
+		}
+
+		&-vertical {
+			bottom: 0;
+			right: 0;
+			transition: background-color 0.25s linear, width 0.3s linear;
+			top: 0;
+			width: $scroll-track-size - 4;
+
+			// Since the track has "pointer-events: none", a class gets added for the
+			// "hover" state
+			&.#{$scroll-ns}-is-hovered {
+				width: $scroll-track-size;
+			}
+		}
+    }
+}

--- a/client/components/scroll-container/test/ScrollTrack-test.jsx
+++ b/client/components/scroll-container/test/ScrollTrack-test.jsx
@@ -1,0 +1,64 @@
+/**
+ * External Dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal Dependencies
+ */
+import ScrollTrack from '../ScrollTrack';
+import { BASE_CLASS } from '../helpers/constants';
+
+const hoverClass = `${ BASE_CLASS }-is-hovered`;
+const puckClass = `${ BASE_CLASS }__puck`;
+const trackClass = `${ BASE_CLASS }__track`;
+
+describe( '<ScrollTrack />', () => {
+	it( 'should render with the proper track classes based on direction', () => {
+		const horizontalWrapper = shallow( <ScrollTrack direction="horizontal" puckOffset={ 0 } puckSize={ 0 } /> );
+		expect( horizontalWrapper ).to.have.className( `${ trackClass } ${ trackClass }-horizontal` );
+		const verticalWrapper = shallow( <ScrollTrack direction="vertical" puckOffset={ 10 } puckSize={ 10 } /> );
+		expect( verticalWrapper ).to.have.className( `${ trackClass } ${ trackClass }-vertical` );
+	} );
+
+	it( 'should render a puck with the proper puck classes based on direction', () => {
+		const horizontalWrapper = shallow( <ScrollTrack direction="horizontal" puckOffset={ 10 } puckSize={ 10 } /> );
+		expect( horizontalWrapper.find( `.${ puckClass }.${ puckClass }-horizontal` ) ).to.have.length( 1 );
+		const verticalWrapper = shallow( <ScrollTrack direction="vertical" puckOffset={ 10 } puckSize={ 10 } /> );
+		expect( verticalWrapper.find( `.${ puckClass }.${ puckClass }-vertical` ) ).to.have.length( 1 );
+	} );
+
+	it( 'should add the hover class to the track when trackHovered is set', () => {
+		const horizontalWrapper = shallow( <ScrollTrack direction="horizontal" trackHovered puckOffset={ 10 } puckSize={ 10 } /> );
+		expect( horizontalWrapper ).to.have.className( `${ trackClass } ${ trackClass }-horizontal ${ hoverClass }` );
+		const verticalWrapper = shallow( <ScrollTrack direction="vertical" trackHovered puckOffset={ 10 } puckSize={ 10 } /> );
+		expect( verticalWrapper ).to.have.className( `${ trackClass } ${ trackClass }-vertical ${ hoverClass }` );
+	} );
+
+	it( 'should add the hover class to the puck when puckHovered is set', () => {
+		const horizontalWrapper = shallow( <ScrollTrack direction="horizontal" puckHovered puckOffset={ 10 } puckSize={ 10 } /> );
+		expect( horizontalWrapper.find( `.${ puckClass }.${ puckClass }-horizontal.${ hoverClass }` ) ).to.have.length( 1 );
+		const verticalWrapper = shallow( <ScrollTrack direction="vertical" puckHovered puckOffset={ 10 } puckSize={ 10 } /> );
+		expect( verticalWrapper.find( `.${ puckClass }.${ puckClass }-vertical.${ hoverClass }` ) ).to.have.length( 1 );
+	} );
+
+	it( 'should set the height or width as appropriate when the puckSize is set', () => {
+		const horizontalWrapper = shallow( <ScrollTrack direction="horizontal" puckOffset={ 10 } puckSize={ 10 } /> );
+		const horizontalPuck = horizontalWrapper.find( `.${ puckClass }` ).at( 0 );
+		expect( horizontalPuck.prop( 'style' ).width ).to.be.equal( '10px' );
+		const verticalWrapper = shallow( <ScrollTrack direction="vertical" puckOffset={ 10 } puckSize={ 10 } /> );
+		const verticalPuck = verticalWrapper.find( `.${ puckClass }` ).at( 0 );
+		expect( verticalPuck.prop( 'style' ).height ).to.be.equal( '10px' );
+	} );
+
+	it( 'should set the proper styles to move the puck on the screen when the puckOffset is set', () => {
+		const horizontalWrapper = shallow( <ScrollTrack direction="horizontal" puckOffset={ 10 } puckSize={ 10 } /> );
+		const horizontalPuck = horizontalWrapper.find( `.${ puckClass }` ).at( 0 );
+		expect( horizontalPuck.prop( 'style' ).transform ).to.be.equal( 'translateX(10px)' );
+		const verticalWrapper = shallow( <ScrollTrack direction="vertical" puckOffset={ 10 } puckSize={ 10 } /> );
+		const verticalPuck = verticalWrapper.find( `.${ puckClass }` ).at( 0 );
+		expect( verticalPuck.prop( 'style' ).transform ).to.be.equal( 'translateY(10px)' );
+	} );
+} );

--- a/client/components/scroll-container/test/dimensions-test.js
+++ b/client/components/scroll-container/test/dimensions-test.js
@@ -1,0 +1,70 @@
+/**
+ * External Dependencies
+ */
+import { assert } from 'chai';
+
+/**
+ * Internal Dependencies
+ */
+import { calcPuckSize, calcPuckOffset } from '../helpers/dimensions';
+
+describe( 'scroll-container helpers', () => {
+	describe( 'calcPuckSize', () => {
+		it( 'should return a minimum size of zero', () => {
+			const size = calcPuckSize( -100, 1, 0 );
+			assert.isAtLeast( size, 0 );
+		} );
+
+		it( 'should return a maximum size of the total visible size', () => {
+			const size = calcPuckSize( 100, 99, 0 );
+			assert.isAtMost( size, 100 );
+		} );
+
+		// eslint-disable-next-line max-len
+		it( 'should ensure that the porpotion of visible space to puck size is the same as the proportion of visible space to total space', () => {
+			const visibleSpace = 100;
+			const totalSpace = 1000;
+			const size = calcPuckSize( visibleSpace, totalSpace, 0 );
+			assert.strictEqual( size, 10 );
+		} );
+
+		it( "should remove the track's margin from the visible space when accounting for the puck size", () => {
+			const visibleSpace = 104;
+			const totalSpace = 1000;
+			const size = calcPuckSize( visibleSpace, totalSpace, 2 );
+			assert.strictEqual( size, 10 );
+		} );
+	} );
+
+	describe( 'calcPuckOffset', () => {
+		it( 'should return a minimum offset of zero', () => {
+			const offset = calcPuckOffset( -100, 1, -100, 0 );
+			assert.isAtLeast( offset, 0 );
+		} );
+
+		it( 'should return a maximum offset of the visible size minus the puck size', () => {
+			const visibleSpace = 10;
+			const totalSpace = 100;
+			const scrollAmount = 100;
+			const size = calcPuckSize( visibleSpace, totalSpace, 0 );
+			const offset = calcPuckOffset( visibleSpace, totalSpace, scrollAmount, 0 );
+			assert.isAtMost( offset, visibleSpace - size );
+		} );
+
+		it( 'should return an offset that is proportional to the amound scrolled', () => {
+			const visibleSpace = 100;
+			const totalSpace = 1000;
+			const scrollAmount = 250;
+			const offset = calcPuckOffset( visibleSpace, totalSpace, scrollAmount, 0 );
+			assert.strictEqual( offset, 25 );
+		} );
+
+		it( "should remove the track's margin from the visible space when accounting for the puck offset", () => {
+			const visibleSpace = 100;
+			const totalSpace = 1000;
+			const scrollAmount = 250;
+			const offset = calcPuckOffset( visibleSpace, totalSpace, scrollAmount, 5 );
+			assert.strictEqual( offset, 23 );
+		} );
+	} );
+} );

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -1,25 +1,30 @@
 /**
- * External dependencies
+ * External Dependencies
  */
-import React from 'react';
+import React, { Children, Component } from 'react';
 import classNames from 'classnames';
+
+/**
+ * Internal Dependencies
+ */
 import SidebarRegion from './region';
 
-export default React.createClass( {
-	displayName: 'Sidebar',
-
-	propTypes: {
-		className: React.PropTypes.string,
-		onClick: React.PropTypes.func
-	},
-
-	render: function() {
-		const hasRegions = React.Children.toArray( this.props.children ).some( el => el.type === SidebarRegion );
+export default class Sidebar extends Component {
+	render() {
+		const hasRegions = Children.toArray( this.props.children ).some( el => el.type === SidebarRegion );
+		const classes = classNames( 'sidebar', this.props.className, {
+			'has-regions': hasRegions
+		} );
 
 		return (
-			<ul className={ classNames( 'sidebar', this.props.className, { 'has-regions': hasRegions } ) } onClick={ this.props.onClick } data-tip-target="sidebar">
+			<ul className={ classes } onClick={ this.props.onClick } data-tip-target="sidebar">
 				{ this.props.children }
 			</ul>
 		);
 	}
-} );
+}
+
+Sidebar.propTypes = {
+	className: React.PropTypes.string,
+	onClick: React.PropTypes.func
+};

--- a/client/layout/sidebar/region.jsx
+++ b/client/layout/sidebar/region.jsx
@@ -4,8 +4,28 @@
 import React from 'react';
 import classNames from 'classnames';
 
-const SidebarRegion = ( { children, className } ) => (
-	<div className={ classNames( 'sidebar__region', className ) }>{ children }</div>
-);
+/**
+ * Internal Dependencies
+ */
+import ScrollContainer from 'components/scroll-container';
+
+const config = require( 'config' );
+
+const SidebarRegion = ( { children, className } ) => {
+	const useCustomScrollbars = config.isEnabled( 'custom-scrollbars' );
+	const region = (
+		<div className={ classNames( 'sidebar__region', className, { 'sidebar__region-scrolls': ! useCustomScrollbars } ) }>
+			{ children }
+		</div>
+	);
+	if ( useCustomScrollbars ) {
+		return (
+			<ScrollContainer autoHide>
+				{ region }
+			</ScrollContainer>
+		);
+	}
+	return region;
+};
 
 export default SidebarRegion;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -418,15 +418,24 @@ form.sidebar__button {
 
 .sidebar__region {
 	flex-shrink: 0;
+
 	@include breakpoint( ">660px" ) {
 		display: flex;
 		flex-direction: column;
-		overflow-y: auto;
-		overflow-x: hidden;
 		flex: 1;
-		transform: translateX( 0 ); /* workaround for safari scrollbar rendering bug */
-		-webkit-overflow-scrolling: touch;
+		&-scrolls {
+			overflow-y: auto;
+			overflow-x: hidden;
+			transform: translateX( 0 ); /* workaround for safari scrollbar rendering bug */
+			-webkit-overflow-scrolling: touch;
+		}
 	}
+}
+
+.sidebar .scroll-container {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
 }
 
 .sidebar__menu {

--- a/config/development.json
+++ b/config/development.json
@@ -45,6 +45,7 @@
 		"manage/comments/bulk-actions": false,
 		"community-translator": true,
 		"css-hot-reload": true,
+		"custom-scrollbars": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,


### PR DESCRIPTION
**Feature:**
As noted in #1050, we would like to have the ability to create custom scrollbars for components on our site.  Requirements of this include:
- The scrollbars must be able to to fade in/out.
- Should not interfere with the user being able to scroll.
- Skinnable
- Should respect system settings about what happens when you click on the track if possible

Unfortunately, I have not been able to find any way to respect the system settings about scroll behavior when clicking on the track.  If anyone has any suggestions, I'd be happy to have a look.

**TODO:**
- [x] Put this work behind a feature flag in the sidebar
- [x] Clicking on the track should scroll the content
- [x] Dragging the thumb should scroll the content
- [x] Expand on mouseover
- [x] Hide scrollbars if they are not needed (ie content is not large enough to require scrolling)
- [ ] Look into more efficient ways to determine if the thumb needs to be resized due to content changes
- [x] Get design feedback on default scrollbar styling
- [x] ~~Window scroll lock on hover~~ On hold pending conversation with design.
- [ ] A ton more testing in the browser
- [x] Write unit tests for scroll calculation logic
- [ ] README docs

**Research:**
Several existing implementations are mentioned in the conversation thread of the aforementioned issue.  I've decided to try and write my own implementation for a variety of reasons.  The excellent implementations don't have a public shared component, and the existing public shared components have issues.  Here are some that I found:

- Poor performance on mobile
- Not updating the scrollbar thumb size/position when content changes (show/hide)
- Not being able to scroll via mouse wheel while on the mouse is on top of the scrollbar
- Notably, one implementation makes it very difficult to skin by not accepting any className prop at all

Upon starting, my first instinct was to use -webkit- prefixed pseudo-selectors to style the scrollbar in browsers that support that with a React component as a fallback.  However, any animation applied to the scrollbar was simply ignored, so that was not an option.

After that, I had a look at the parallax scrolling based example mentioned in the issue discussion.  However, CSS parallax scrolling has serious issues in Edge.  It needs a fixed positioned container with a transform applied in order for that to work, which I didn't think was flexible enough.

cc: @folletto @nb @jasmussen @shaunandrews 

---

Live Demo: https://calypso.live/?branch=add/custom-scrollbar 