### PR TITLE
Media library: add data source

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -26,6 +26,7 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		siteId: React.PropTypes.number.isRequired,
+		source: React.PropTypes.string,
 		filter: React.PropTypes.string,
 		search: React.PropTypes.string
 	},

--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -134,7 +134,7 @@ MediaListStore.isItemMatchingQuery = function( siteId, item ) {
 
 	matches = true;
 
-	if ( query.search ) {
+	if ( query.search && ! query.source ) {
 		// WP_Query tests a post's title and content when performing a search.
 		// Since we're testing binary data, we match the title only.
 		//

--- a/client/lib/media/test/list-store.js
+++ b/client/lib/media/test/list-store.js
@@ -11,7 +11,7 @@ import sinon from 'sinon';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
 
-var DUMMY_SITE_ID = 1,
+const DUMMY_SITE_ID = 1,
 	DUMMY_MEDIA_ID = 10,
 	DUMMY_MEDIA_OBJECT = { ID: DUMMY_MEDIA_ID, title: 'Image', date: '2015-06-19T09:36:09-04:00', mime_type: 'image/png' },
 	DUMMY_MEDIA_RESPONSE = {
@@ -316,6 +316,14 @@ describe( 'MediaListStore', function() {
 			dispatchSetQuery( { query: { mime_type: 'image/' } } );
 
 			matches = isItemMatchingQuery( DUMMY_SITE_ID, DUMMY_MEDIA_OBJECT );
+
+			expect( matches ).to.be.true;
+		} );
+
+		it( 'should return true if item matches an external source but doesnt match title', function() {
+			dispatchSetQuery( { query: { search: 'monkey', source: 'external' } } );
+
+			const matches = isItemMatchingQuery( DUMMY_SITE_ID, DUMMY_MEDIA_OBJECT );
 
 			expect( matches ).to.be.true;
 		} );

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -27,6 +27,7 @@ import {
 } from 'lib/media/constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import MediaLibraryHeader from './header';
+import MediaLibraryScaleHeader from './empty-header';
 import MediaLibraryList from './list';
 
 const MediaLibraryContent = React.createClass( {
@@ -48,7 +49,8 @@ const MediaLibraryContent = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			mediaValidationErrors: Object.freeze( {} ),
-			onAddMedia: noop
+			onAddMedia: noop,
+			source: '',
 		};
 	},
 
@@ -201,22 +203,36 @@ const MediaLibraryContent = React.createClass( {
 		);
 	},
 
+	renderHeader() {
+		if ( this.props.source !== '' ) {
+			return (
+				<MediaLibraryScaleHeader onMediaScaleChange={ this.props.onMediaScaleChange } />
+			);
+		}
+
+		if ( ! this.props.filterRequiresUpgrade ) {
+			return (
+				<MediaLibraryHeader
+					site={ this.props.site }
+					filter={ this.props.filter }
+					onMediaScaleChange={ this.props.onMediaScaleChange }
+					onAddMedia={ this.props.onAddMedia }
+					onAddAndEditImage={ this.props.onAddAndEditImage }
+					selectedItems={ this.props.selectedItems }
+					onViewDetails={ this.props.onViewDetails }
+					onDeleteItem={ this.props.onDeleteItem }
+					sticky={ ! this.props.scrollable }
+				/>
+			);
+		}
+
+		return null;
+	},
+
 	render: function() {
 		return (
 			<div className="media-library__content">
-				{ ! this.props.filterRequiresUpgrade &&
-					<MediaLibraryHeader
-						site={ this.props.site }
-						filter={ this.props.filter }
-						onMediaScaleChange={ this.props.onMediaScaleChange }
-						onAddMedia={ this.props.onAddMedia }
-						onAddAndEditImage={ this.props.onAddAndEditImage }
-						selectedItems={ this.props.selectedItems }
-						onViewDetails={ this.props.onViewDetails }
-						onDeleteItem={ this.props.onDeleteItem }
-						sticky={ ! this.props.scrollable }
-					/>
-				}
+				{ this.renderHeader() }
 				{ this.renderErrors() }
 				{ this.renderMediaList() }
 			</div>

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -36,6 +36,7 @@ const MediaLibraryContent = React.createClass( {
 		filter: React.PropTypes.string,
 		filterRequiresUpgrade: React.PropTypes.bool,
 		search: React.PropTypes.string,
+		source: React.PropTypes.string,
 		containerWidth: React.PropTypes.number,
 		single: React.PropTypes.bool,
 		scrollable: React.PropTypes.bool,
@@ -178,7 +179,11 @@ const MediaLibraryContent = React.createClass( {
 		}
 
 		return (
-			<MediaListData siteId={ this.props.site.ID } filter={ this.props.filter } search={ this.props.search }>
+			<MediaListData
+				siteId={ this.props.site.ID }
+				filter={ this.props.filter }
+				search={ this.props.search }
+				source={ this.props.source }>
 				<MediaLibrarySelectedData siteId={ this.props.site.ID }>
 					<MediaLibraryList
 						key={ 'list-' + ( [ this.props.site.ID, this.props.search, this.props.filter ].join() ) }

--- a/client/my-sites/media-library/empty-header.jsx
+++ b/client/my-sites/media-library/empty-header.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import MediaLibraryScale from './scale';
+import Card from 'components/card';
+
+const MediaLibraryScaleHeader = props => {
+	return (
+		<Card className="media-library__header">
+			<MediaLibraryScale onChange={ props.onMediaScaleChange } />
+		</Card>
+	);
+};
+
+export default MediaLibraryScaleHeader;

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -86,7 +86,7 @@ export class MediaLibraryFilterBar extends Component {
 	};
 
 	renderTabItems() {
-		const tabs = [ '', 'images', 'documents', 'videos', 'audio' ];
+		const tabs = this.props.source === '' ? [ '', 'images', 'documents', 'videos', 'audio' ] : [];
 
 		return map( tabs, filter =>
 			<FilterItem

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -27,6 +27,7 @@ export class MediaLibraryFilterBar extends Component {
 		filter: React.PropTypes.string,
 		filterRequiresUpgrade: React.PropTypes.bool,
 		search: React.PropTypes.string,
+		source: React.PropTypes.string,
 		site: React.PropTypes.object,
 		onFilterChange: React.PropTypes.func,
 		onSearch: React.PropTypes.func,
@@ -38,7 +39,8 @@ export class MediaLibraryFilterBar extends Component {
 		basePath: '/media',
 		onFilterChange: noop,
 		onSearch: noop,
-		translate: identity
+		translate: identity,
+		source: '',
 	};
 
 	getSearchPlaceholderText() {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -30,11 +30,13 @@ module.exports = React.createClass( {
 		filter: React.PropTypes.string,
 		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
 		search: React.PropTypes.string,
+		source: React.PropTypes.string,
 		onAddMedia: React.PropTypes.func,
 		onFilterChange: React.PropTypes.func,
 		onSearch: React.PropTypes.func,
 		onScaleChange: React.PropTypes.func,
 		onEditItem: React.PropTypes.func,
+		onSourceChange: React.PropTypes.func,
 		fullScreenDropZone: React.PropTypes.bool,
 		containerWidth: React.PropTypes.number,
 		single: React.PropTypes.bool,
@@ -46,7 +48,9 @@ module.exports = React.createClass( {
 			fullScreenDropZone: true,
 			onAddMedia: () => {},
 			onScaleChange: () => {},
+			onSourceChange: () => {},
 			scrollable: false,
+			source: '',
 		};
 	},
 
@@ -124,6 +128,7 @@ module.exports = React.createClass( {
 				filter={ this.props.filter }
 				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 				search={ this.props.search }
+				source={ this.props.source }
 				containerWidth={ this.props.containerWidth }
 				single={ this.props.single }
 				scrollable={ this.props.scrollable }
@@ -161,6 +166,8 @@ module.exports = React.createClass( {
 					enabledFilters={ this.props.enabledFilters }
 					search={ this.props.search }
 					onFilterChange={ this.props.onFilterChange }
+					source={ this.props.source }
+					onSourceChange={ this.props.onSourceChange }
 					onSearch={ this.doSearch } />
 				{ content }
 			</div>

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -110,6 +110,10 @@ module.exports = React.createClass( {
 	},
 
 	renderDropZone: function() {
+		if ( this.props.source !== '' ) {
+			return null;
+		}
+
 		return (
 			<MediaLibraryDropZone
 				site={ this.props.site }

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -379,7 +379,15 @@ export class EditorMediaModal extends Component {
 			}
 		];
 
-		if ( ModalViews.GALLERY !== this.props.view && selectedItems.length > 1 &&
+		if ( this.state.source !== '' ) {
+			buttons.push( {
+				action: 'confirm',
+				label: this.props.labels.confirm || this.props.translate( 'Copy to media library' ),
+				isPrimary: true,
+				disabled: isDisabled || 0 === selectedItems.length,
+				onClick: this.confirmSelection
+			} );
+		} else if ( ModalViews.GALLERY !== this.props.view && selectedItems.length > 1 &&
 				! some( selectedItems, ( item ) => MediaUtils.getMimePrefix( item ) !== 'image' ) ) {
 			buttons.push( {
 				action: 'confirm',

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -127,6 +127,7 @@ export class EditorMediaModal extends Component {
 		return {
 			filter: '',
 			detailSelectedIndex: 0,
+			source: '',
 			gallerySettings: props.initialGallerySettings
 		};
 	}
@@ -325,6 +326,9 @@ export class EditorMediaModal extends Component {
 		}
 	};
 
+	onSourceChange = () => {
+	};
+
 	onClose = () => {
 		this.props.onClose();
 	};
@@ -470,11 +474,13 @@ export class EditorMediaModal extends Component {
 						filter={ this.state.filter || this.props.defaultFilter || this.getFirstEnabledFilter() }
 						enabledFilters={ this.props.enabledFilters }
 						search={ this.state.search }
+						source={ this.state.source }
 						onAddMedia={ this.onAddMedia }
 						onAddAndEditImage={ this.onAddAndEditImage }
 						onFilterChange={ this.onFilterChange }
 						onScaleChange={ this.onScaleChange }
 						onSearch={ this.onSearch }
+						onSourceChange={ this.onSourceChange }
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }
 						single={ this.props.single }

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -20,8 +20,8 @@ import { ModalViews } from 'state/ui/media-modal/constants';
  */
 const DUMMY_SITE = { ID: 1 };
 const DUMMY_MEDIA = [
-	{ ID: 100, date: '2015-06-19T11:36:09-04:00' },
-	{ ID: 200, date: '2015-06-19T09:36:09-04:00' }
+	{ ID: 100, date: '2015-06-19T11:36:09-04:00', mime_type: 'image/jpeg' },
+	{ ID: 200, date: '2015-06-19T09:36:09-04:00', mime_type: 'image/jpeg' }
 ];
 const EMPTY_COMPONENT = React.createClass( {
 	render: function() {
@@ -158,5 +158,61 @@ describe( 'EditorMediaModal', function() {
 			expect( tree.state.detailSelectedIndex ).to.equal( 0 );
 			done();
 		} );
+	} );
+
+	it( 'should show no buttons if editing an image', () => {
+		const tree = shallow(
+			<EditorMediaModal
+				site={ DUMMY_SITE }
+				mediaLibrarySelectedItems={ [] }
+				view={ ModalViews.IMAGE_EDITOR }
+				setView={ spy } />
+		).instance();
+
+		const buttons = tree.getModalButtons();
+
+		expect( buttons ).to.be.undefined;
+	} );
+
+	it( 'should show a copy button when viewing external media', () => {
+		const tree = shallow(
+			<EditorMediaModal
+				site={ DUMMY_SITE }
+				view={ ModalViews.DETAIL }
+				setView={ spy } />
+		).instance();
+
+		tree.setState( { source: 'external' } );
+		const buttons = tree.getModalButtons();
+
+		expect( buttons.length ).to.be.equals( 2 );
+		expect( buttons[ 1 ].label ).to.be.equals( 'Copy to media library' );
+	} );
+
+	it( 'should show a continue button when multiple images are selected', () => {
+		const tree = shallow(
+			<EditorMediaModal
+				site={ DUMMY_SITE }
+				mediaLibrarySelectedItems={ DUMMY_MEDIA }
+				view={ ModalViews.DETAIL }
+				setView={ spy } />
+		).instance();
+
+		const buttons = tree.getModalButtons();
+
+		expect( buttons[ 1 ].label ).to.be.equals( 'Continue' );
+	} );
+
+	it( 'should show an insert button if none or one local items are selected', () => {
+		const tree = shallow(
+			<EditorMediaModal
+				site={ DUMMY_SITE }
+				view={ ModalViews.DETAIL }
+				setView={ spy } />
+		).instance();
+
+		const buttons = tree.getModalButtons();
+
+		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
 	} );
 } );


### PR DESCRIPTION
Adds a 'source' value to the media library which will be used to determine the data source for the media library - WordPress or something else (Google Photos, for example).

This data source will then be used to determine whether certain bits of UI appear in the media modal (as well as other things in the future).

<img src="https://cloud.githubusercontent.com/assets/1277682/26830593/410ba8d4-4ac1-11e7-9214-42a52bf36593.png"/>

Note this PR doesn't change the current media modal, and doesn't introduce other data sources.

## Testing

Run included unit tests which verifies that the current media modal shows the same buttons, and that changing the data source will also change the buttons.

Also manually verify that the media library buttons remain the same as before. Likewise for the media menu.