### PR TITLE
Editor Confirmation Sidebar: Record tracks events

### DIFF
--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -57,6 +57,7 @@ export function recordSaveEvent() {
 	let statName = false;
 	let statEvent = false;
 	let usageAction = false;
+	let eventContext = null;
 
 	if ( ! post.ID && ! utils.isPublished( post ) ) {
 		tracksEventName += 'savedraft';
@@ -68,12 +69,18 @@ export function recordSaveEvent() {
 	} else if ( 'publish' === nextStatus || 'private' === nextStatus ) {
 		tracksEventName += 'publish';
 		usageAction = 'new';
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+			eventContext = 'confirmation_sidebar';
+		}
 	} else if ( 'pending' === nextStatus ) {
 		tracksEventName += 'pending';
 	} else if ( 'future' === nextStatus ) {
 		tracksEventName += 'schedule';
 		statName = 'status-schedule';
 		statEvent = 'Scheduled Post';
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+			eventContext = 'confirmation_sidebar';
+		}
 	}
 
 	if ( usageAction ) {
@@ -100,7 +107,8 @@ export function recordSaveEvent() {
 		post_type: post.type,
 		visibility: utils.getVisibility( post ),
 		current_status: currentStatus,
-		next_status: nextStatus
+		next_status: nextStatus,
+		context: eventContext,
 	} );
 }
 

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -26,15 +26,15 @@ class EditorConfirmationSidebar extends React.Component {
 		onPublish: React.PropTypes.func,
 		post: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
-		setState: React.PropTypes.func,
+		setStatus: React.PropTypes.func,
 		site: React.PropTypes.object,
-		state: React.PropTypes.string,
+		status: React.PropTypes.string,
 	};
 
-	getCloseOverlayHandler = ( context ) => () => this.props.setState( { state: 'closed', context } );
+	getCloseOverlayHandler = ( context ) => () => this.props.setStatus( { status: 'closed', context } );
 
 	closeAndPublish = () => {
-		this.props.setState( { state: 'closed', context: 'publish' } );
+		this.props.setStatus( { status: 'closed', context: 'publish' } );
 		this.props.onPublish( true );
 	};
 
@@ -104,7 +104,7 @@ class EditorConfirmationSidebar extends React.Component {
 	}
 
 	renderPublishingBusyButton() {
-		if ( 'publishing' !== this.props.state ) {
+		if ( 'publishing' !== this.props.status ) {
 			return;
 		}
 
@@ -121,8 +121,8 @@ class EditorConfirmationSidebar extends React.Component {
 	}
 
 	render() {
-		const isSidebarActive = this.props.state === 'open';
-		const isOverlayActive = this.props.state !== 'closed';
+		const isSidebarActive = this.props.status === 'open';
+		const isOverlayActive = this.props.status !== 'closed';
 
 		return (
 			<RootChild>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -31,12 +31,10 @@ class EditorConfirmationSidebar extends React.Component {
 		state: React.PropTypes.string,
 	};
 
-	closeOverlay = () => {
-		this.props.setState( 'closed' );
-	};
+	getCloseOverlayHandler = ( context ) => () => this.props.setState( { state: 'closed', context } );
 
 	closeAndPublish = () => {
-		this.closeOverlay();
+		this.props.setState( { state: 'closed', context: 'publish' } );
 		this.props.onPublish( true );
 	};
 
@@ -135,7 +133,7 @@ class EditorConfirmationSidebar extends React.Component {
 					<div className={ classnames( {
 						'editor-confirmation-sidebar__overlay': true,
 						'is-active': isOverlayActive,
-					} ) } onClick={ this.closeOverlay }>
+					} ) } onClick={ this.getCloseOverlayHandler( 'dismiss_overlay' ) }>
 						{ this.renderPublishingBusyButton() }
 					</div>
 					<div className={ classnames( {
@@ -146,7 +144,7 @@ class EditorConfirmationSidebar extends React.Component {
 							<div className="editor-confirmation-sidebar__close">
 								<Button
 									borderless
-									onClick={ this.closeOverlay }
+									onClick={ this.getCloseOverlayHandler( 'dismiss_x' ) }
 									title={ this.props.translate( 'Close sidebar' ) }
 									aria-label={ this.props.translate( 'Close sidebar' ) }>
 									<Gridicon icon="cross" />

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -189,10 +189,19 @@ export const PostEditor = React.createClass( {
 		return this.props.setLayoutFocus( 'content' );
 	},
 
-	setConfirmationSidebar: function( state ) {
+	setConfirmationSidebar: function( { state, context = null } ) {
 		const allowedStates = [ 'closed', 'open', 'publishing' ];
 		const confirmationSidebar = allowedStates.indexOf( state ) > -1 ? state : 'closed';
 		this.setState( { confirmationSidebar } );
+
+		switch ( confirmationSidebar ) {
+			case 'closed':
+				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_close', { context } );
+				break;
+			case 'open':
+				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_open' );
+				break;
+		}	
 	},
 
 	toggleSidebar: function() {
@@ -666,12 +675,12 @@ export const PostEditor = React.createClass( {
 		};
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) && false === isConfirmed ) {
-			this.setConfirmationSidebar( 'open' );
+			this.setConfirmationSidebar( { state: 'open' } );
 			return;
 		}
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( 'publishing' );
+			this.setConfirmationSidebar( { state: 'publishing' } );
 		}
 
 		// determine if this is a private publish
@@ -703,7 +712,7 @@ export const PostEditor = React.createClass( {
 		this.onSaveFailure( error, 'publishFailure' );
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( 'closed' );
+			this.setConfirmationSidebar( { state: 'closed', context: 'publish_failure' } );
 		}
 	},
 
@@ -720,7 +729,7 @@ export const PostEditor = React.createClass( {
 		}
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( 'closed' );
+			this.setConfirmationSidebar( { state: 'closed', context: 'publish_success' } );
 		}
 
 		this.onSaveSuccess( message, ( message === 'published' ? 'view' : 'preview' ), savedPost.URL );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -189,9 +189,9 @@ export const PostEditor = React.createClass( {
 		return this.props.setLayoutFocus( 'content' );
 	},
 
-	setConfirmationSidebar: function( { state, context = null } ) {
-		const allowedStates = [ 'closed', 'open', 'publishing' ];
-		const confirmationSidebar = allowedStates.indexOf( state ) > -1 ? state : 'closed';
+	setConfirmationSidebar: function( { status, context = null } ) {
+		const allowedStatuses = [ 'closed', 'open', 'publishing' ];
+		const confirmationSidebar = allowedStatuses.indexOf( status ) > -1 ? status : 'closed';
 		this.setState( { confirmationSidebar } );
 
 		switch ( confirmationSidebar ) {
@@ -201,7 +201,7 @@ export const PostEditor = React.createClass( {
 			case 'open':
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_open' );
 				break;
-		}	
+		}
 	},
 
 	toggleSidebar: function() {
@@ -243,9 +243,9 @@ export const PostEditor = React.createClass( {
 					onPublish={ this.onPublish }
 					post={ this.state.post }
 					savedPost={ this.state.savedPost }
-					setState={ this.setConfirmationSidebar }
+					setStatus={ this.setConfirmationSidebar }
 					site={ site }
-					state={ this.state.confirmationSidebar }
+					status={ this.state.confirmationSidebar }
 				/>
 				<EditorDocumentHead />
 				<EditorPostTypeUnsupported />
@@ -675,12 +675,12 @@ export const PostEditor = React.createClass( {
 		};
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) && false === isConfirmed ) {
-			this.setConfirmationSidebar( { state: 'open' } );
+			this.setConfirmationSidebar( { status: 'open' } );
 			return;
 		}
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( { state: 'publishing' } );
+			this.setConfirmationSidebar( { status: 'publishing' } );
 		}
 
 		// determine if this is a private publish
@@ -712,7 +712,7 @@ export const PostEditor = React.createClass( {
 		this.onSaveFailure( error, 'publishFailure' );
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( { state: 'closed', context: 'publish_failure' } );
+			this.setConfirmationSidebar( { status: 'closed', context: 'publish_failure' } );
 		}
 	},
 
@@ -729,7 +729,7 @@ export const PostEditor = React.createClass( {
 		}
 
 		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( { state: 'closed', context: 'publish_success' } );
+			this.setConfirmationSidebar( { status: 'closed', context: 'publish_success' } );
 		}
 
 		this.onSaveSuccess( message, ( message === 'published' ? 'view' : 'preview' ), savedPost.URL );


### PR DESCRIPTION
This PR adds Tracks events for state changes to the confirmation sidebar, allowing for an optional context for the state change (which is currently used to record what triggered the sidebar closure). It also adds a context to the existing publish event to record when the publish occurred as a result of the sidebar.

A switch statement is used as opposed to programmatically generating the event name per: PCYsg-4S2-p2

> Don’t programmatically create event names. They should be hardcoded so they are easily searchable in the code base.

This PR is part of a larger epic and is behind the `post-editor/delta-post-publish-flow` feature flag. See p8F9tW-3F-p2.

To test:
* Checkout branch and `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Set your console to log Tracks events: `localStorage.setItem('debug', 'calypso:analytics:tracks');`
* Draft a post in the editor and then click on "Publish...". Verify that a debug statement for the Tracks event is shown in the console when the sidebar opens.
* Close the sidebar by clicking within the overlay. Verify that a debug statement for the Tracks event is shown in the console when the sidebar closes. Verify that the context for that statement indicates that the closure occurred from the overlay.
* Open the sidebar again by clicking "Publish..." and then close the sidebar, this time by clicking on the "X". Verify that a debug statement for the Tracks event is shown in the console when the sidebar closes. Verify that the context for that statement indicates that the closure occurred from the x.
* Open the sidebar again by clicking on "Publish...". Publish the post. You should see 2 events: one for the closure of the sidebar with a context indicating successful publishing, and another for the successful publishing of the post and a context indicating it was triggered via the sidebar.
* Failure state also results in the closure of the sidebar, and an event recorded with a context indicating failure. You can simulate this by attempting to publish while offline (or while throttling "offline" with Chrome's network tools).