### PR TITLE
Social signup: Google OAuth credentials

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -29,7 +29,7 @@
 	"olark": {},
 	"port": false,
 	"happychat_url": "https://happychat.io/customer",
-	"google_oauth_client_id": "543610697398-l287fumouns096o4os9l9fs1svh5esjc.apps.googleusercontent.com",
+	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"languages": [


### PR DESCRIPTION
This pull request update the google OAuth client ID to match the Highlander one.

Also needs D5974-code.
  
#### Testing instructions
  
1. Run `git checkout update/google-cred` and start your server
2. Apply the patch D5974-code.
2. Open the [`Social signup` page](http://calypso.localhost:3000/start/social)
3. Check that you can create an account with a Google account
4. Check that you can log into an account with a Google account
  
#### Reviews
  
- [x] Code
- [x] Product
