### PR TITLE
Export: enable in desktop app

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -26,6 +26,7 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
+		"manage/export": true,
 		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/media": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-desktop/issues/306

Enable the export feature on the Desktop app.

![export](https://user-images.githubusercontent.com/7767559/27042565-a665156e-4f97-11e7-9ba4-53e3a5ab4214.gif)

Works fine. The only slight oddity is that the download link downloads the file in the system default browser instead of the app.

**To Test**
* Build the desktop app with this PR
* Go to _Site Settings->General->Site Tools->Export_
* Export site contents
