### PR TITLE
Editor: view published post after publishing.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -453,6 +453,7 @@
 @import 'post-editor/editor-post-formats/style';
 @import 'post-editor/editor-post-type/style';
 @import 'post-editor/editor-post-type-unsupported/style';
+@import 'post-editor/editor-preview/style';
 @import 'post-editor/editor-revisions/style';
 @import 'post-editor/editor-seo-accordion/style';
 @import 'post-editor/editor-sharing/style';

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import url from 'url';
 import omit from 'lodash/omit';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -93,9 +94,14 @@ const EditorPreview = React.createClass( {
 	},
 
 	render() {
+		const previewFlow = config.isEnabled( 'post-editor/delta-post-publish-preview' );
+		const className = classNames( 'editor-preview', {
+			'is-fullscreen': previewFlow,
+		} );
+
 		return (
-			<div className="editor-preview">
-				{ config.isEnabled( 'post-editor/delta-post-publish-preview' )
+			<div className={ className }>
+				{ previewFlow
 					? <WebPreviewContent
 							showPreview={ this.props.showPreview }
 							defaultViewportDevice={ this.props.defaultViewportDevice }

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -8,7 +8,9 @@ import omit from 'lodash/omit';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import WebPreview from 'components/web-preview';
+import WebPreviewContent from 'components/web-preview/content';
 
 const EditorPreview = React.createClass( {
 
@@ -92,13 +94,24 @@ const EditorPreview = React.createClass( {
 
 	render() {
 		return (
-			<WebPreview
-				showPreview={ this.props.showPreview }
-				defaultViewportDevice="tablet"
-				onClose={ this.props.onClose }
-				previewUrl={ this.state.iframeUrl }
-				externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }
-			/>
+			<div className="editor-preview">
+				{ config.isEnabled( 'post-editor/delta-post-publish-preview' )
+					? <WebPreviewContent
+							showPreview={ this.props.showPreview }
+							defaultViewportDevice={ this.props.defaultViewportDevice }
+							onClose={ this.props.onClose }
+							previewUrl={ this.state.iframeUrl }
+							externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }
+						/>
+					: <WebPreview
+							showPreview={ this.props.showPreview }
+							defaultViewportDevice={ this.props.defaultViewportDevice }
+							onClose={ this.props.onClose }
+							previewUrl={ this.state.iframeUrl }
+							externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }
+						/>
+				}
+			</div>
 		);
 	}
 } );

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -1,10 +1,16 @@
 .editor-preview .web-preview__inner {
+	display: none;
+	opacity: 0;
+	transition: opacity 0.3s ease-in-out;
 	width: 100%;
 
 	&.is-visible {
+		display: flex;
+		opacity: 1;
         position: absolute;
-		top: -46px;
-		left: 0;
-		z-index: z-index( 'root', '.web-preview' );
+			top: -46px;
+			left: 0;
+			z-index: z-index( 'root', '.web-preview' );
+		visibility: visible;
     }
 }

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -1,0 +1,10 @@
+.editor-preview .web-preview__inner {
+	width: 100%;
+
+	&.is-visible {
+        position: absolute;
+		top: -46px;
+		left: 0;
+		z-index: z-index( 'root', '.web-preview' );
+    }
+}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -359,6 +359,7 @@ export const PostEditor = React.createClass( {
 							isLoading={ this.state.isLoading }
 							previewUrl={ this.state.previewUrl }
 							externalUrl={ this.state.previewUrl }
+							defaultViewportDevice={ config.isEnabled( 'post-editor/delta-post-publish-preview' ) ? 'computer' : 'tablet' }
 						/>
 						: null }
 				</div>
@@ -817,6 +818,10 @@ export const PostEditor = React.createClass( {
 			};
 
 			window.scrollTo( 0, 0 );
+
+			if ( config.isEnabled( 'post-editor/delta-post-publish-preview' ) && this.props.isSitePreviewable ) {
+				this.iframePreview();
+			}
 		} else {
 			nextState.notice = null;
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -111,6 +111,7 @@
 		"plans/personal-plan": true,
 		"plans/jetpack-config-v2": true,
 		"post-editor/delta-post-publish-flow": false,
+		"post-editor/delta-post-publish-preview": false,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
This PR adds a full-screen view of newly published posts, using the `WebPreviewContent` component from #14330.

**Mock:**
![preview](https://user-images.githubusercontent.com/942359/27043122-2092f7ce-4f67-11e7-9b5e-081e5bb76557.png)

This is part of a larger epic (See p3Ex-2ri-p2)

**To Test:**
- Check out branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Publish a new post. 
- After the post is published, a full-screen view of the post should be displayed.
- Run the branch again without the feature flag enabled and make sure the "View post" link in the confirmation message renders the post inside a modal.