### PR TITLE
Editor: add Tracks to visibility dropdown

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -208,7 +208,8 @@ export class EditPostStatus extends Component {
 			type,
 			password,
 			savedStatus,
-			savedPassword
+			savedPassword,
+			context: 'post-settings',
 		};
 
 		return (

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -97,7 +97,8 @@ class EditorConfirmationSidebar extends React.Component {
 			password,
 			status,
 			savedStatus,
-			savedPassword
+			savedPassword,
+			context: 'confirmation-sidebar',
 		};
 
 		return (

--- a/client/post-editor/editor-visibility/README.md
+++ b/client/post-editor/editor-visibility/README.md
@@ -38,3 +38,4 @@ The following props are used with the Editor Visibility component:
 - `password`: (string) A password for 'password' protected post. An empty string if not password protected.
 - `savedStatus`: (string) Auto-save post status.
 - `savedPassword`: (string) Auto-save post password for 'password' protected post.
+- `context`: (string) A string describing the context in which the component is being rendered. (Ex: 'post-settings', 'confirmation-sidebar')

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -43,6 +43,7 @@ const EditorVisibility = React.createClass( {
 	},
 
 	propTypes: {
+		context: React.PropTypes.string,
 		onPrivatePublish: React.PropTypes.func,
 		isPrivateSite: React.PropTypes.bool,
 		type: React.PropTypes.string,
@@ -179,7 +180,7 @@ const EditorVisibility = React.createClass( {
 
 		recordStat( 'visibility-set-' + newVisibility );
 		recordEvent( 'Changed visibility', newVisibility );
-		tracks.recordEvent( 'calypso_editor_visibility_set', { visibility: newVisibility } );
+		tracks.recordEvent( 'calypso_editor_visibility_set', { context: this.props.context, visibility: newVisibility } );
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( postEdits );
@@ -204,6 +205,10 @@ const EditorVisibility = React.createClass( {
 				this.setState( { passwordIsValid: true } );
 				break;
 		}
+
+		recordStat( 'visibility-set-' + newVisibility );
+		recordEvent( 'Changed visibility', newVisibility );
+		tracks.recordEvent( 'calypso_editor_visibility_set', { context: this.props.context, visibility: newVisibility } );
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( postEdits );
@@ -233,7 +238,7 @@ const EditorVisibility = React.createClass( {
 
 		recordStat( 'visibility-set-private' );
 		recordEvent( 'Changed visibility', 'private' );
-		tracks.recordEvent( 'calypso_editor_visibility_set', { visibility: 'private' } );
+		tracks.recordEvent( 'calypso_editor_visibility_set', { context: this.props.context, visibility: 'private' } );
 	},
 
 	onPrivatePublish() {

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -27,6 +27,7 @@ import DropdownItem from 'components/select-dropdown/item';
 import touchDetect from 'lib/touch-detect';
 import postActions from 'lib/posts/actions';
 import { recordEvent, recordStat } from 'lib/posts/stats';
+import { tracks } from 'lib/analytics';
 import accept from 'lib/accept';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -178,6 +179,7 @@ const EditorVisibility = React.createClass( {
 
 		recordStat( 'visibility-set-' + newVisibility );
 		recordEvent( 'Changed visibility', newVisibility );
+		tracks.recordEvent( 'calypso_editor_visibility_set', { visibility: newVisibility } );
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( postEdits );
@@ -231,6 +233,7 @@ const EditorVisibility = React.createClass( {
 
 		recordStat( 'visibility-set-private' );
 		recordEvent( 'Changed visibility', 'private' );
+		tracks.recordEvent( 'calypso_editor_visibility_set', { visibility: 'private' } );
 	},
 
 	onPrivatePublish() {


### PR DESCRIPTION
This PR adds Tracks events when the visibility is changed via the dropdown.

To test:

* Checkout branch and `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Set your console to log Tracks events: `localStorage.setItem('debug', 'calypso:analytics:tracks');`
* Draft a new post.
* Change the visibility from the post settings sidebar. Make sure the `calypso_editor_visibility_set` is recorded with a context indicating that it was triggered from post settings
* Click "Publish..." to trigger the confirmation sidebar
* Change the visibility from the confirmation sidebar. Make sure the `calypso_editor_visibility_set` is recorded with a context indicating that it was triggered from the confirmation sidebar.