### PR TITLE
PostShare: Improve/publicize connection issue

### DIFF
--- a/client/my-sites/post-share/connections-list.jsx
+++ b/client/my-sites/post-share/connections-list.jsx
@@ -91,8 +91,6 @@ class ConnectionsList extends PureComponent {
 
 		return (
 			<div className="post-share__connections">
-				{ this.renderWarnings() }
-
 				{ connections.map( connection =>
 					<Connection { ...{
 						connection,

--- a/client/my-sites/post-share/connections-list.jsx
+++ b/client/my-sites/post-share/connections-list.jsx
@@ -37,42 +37,6 @@ class ConnectionsList extends PureComponent {
 		);
 	}
 
-	renderWarnings() {
-		const {
-			connections,
-			hasFetchedConnections,
-			siteSlug,
-			translate,
-		} = this.props;
-
-		if ( ! hasFetchedConnections || ! connections.length ) {
-			return null;
-		}
-
-		const brokenConnections = connections.filter( connection => connection.status === 'broken' );
-
-		if ( ! brokenConnections.length ) {
-			return null;
-		}
-
-		return (
-			<div>
-				{ brokenConnections
-					.map( connection => <Notice
-						key={ connection.keyring_connection_ID }
-						status="is-warning"
-						showDismiss={ false }
-						text={ translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
-					>
-						<NoticeAction href={ `/sharing/${ siteSlug }` }>
-							{ translate( 'Reconnect' ) }
-						</NoticeAction>
-					</Notice> )
-				}
-			</div>
-		);
-	}
-
 	render() {
 		const { connections, onToggle, siteId } = this.props;
 
@@ -99,6 +63,40 @@ class ConnectionsList extends PureComponent {
 		);
 	}
 }
+
+export const ConnectionsWarning = ( {
+	connections,
+	hasFetchedConnections,
+	siteSlug,
+	translate,
+} ) => {
+	if ( ! hasFetchedConnections || ! connections.length ) {
+		return null;
+	}
+
+	const brokenConnections = connections.filter( connection => connection.status === 'broken' );
+
+	if ( ! brokenConnections.length ) {
+		return null;
+	}
+
+	return (
+		<div>
+			{ brokenConnections
+				.map( connection => <Notice
+					key={ connection.keyring_connection_ID }
+					status="is-warning"
+					showDismiss={ false }
+					text={ translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
+				>
+					<NoticeAction href={ `/sharing/${ siteSlug }` }>
+						{ translate( 'Reconnect' ) }
+					</NoticeAction>
+				</Notice> )
+			}
+		</div>
+	);
+};
 
 export const NoConnectionsNotice = ( { siteSlug, translate } ) => (
 	<Notice

--- a/client/my-sites/post-share/connections-list.jsx
+++ b/client/my-sites/post-share/connections-list.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PureComponent, PropTypes } from 'react';
-import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -29,10 +28,6 @@ class ConnectionsList extends PureComponent {
 		connections: [],
 	};
 
-	hasConnections() {
-		return !! get( this.props, 'connections.length' );
-	}
-
 	renderEmptyPlaceholder() {
 		return (
 			<div className="post-share__main">
@@ -50,7 +45,7 @@ class ConnectionsList extends PureComponent {
 			translate,
 		} = this.props;
 
-		if ( ! hasFetchedConnections || ! this.hasConnections() ) {
+		if ( ! hasFetchedConnections || ! connections.length ) {
 			return null;
 		}
 
@@ -81,7 +76,7 @@ class ConnectionsList extends PureComponent {
 	render() {
 		const { connections, onToggle, siteId } = this.props;
 
-		if ( ! siteId || ! this.hasConnections() ) {
+		if ( ! siteId || ! connections.length ) {
 			return null;
 		}
 

--- a/client/my-sites/post-share/connections-list.jsx
+++ b/client/my-sites/post-share/connections-list.jsx
@@ -64,40 +64,6 @@ class ConnectionsList extends PureComponent {
 	}
 }
 
-export const ConnectionsWarning = ( {
-	connections,
-	hasFetchedConnections,
-	siteSlug,
-	translate,
-} ) => {
-	if ( ! hasFetchedConnections || ! connections.length ) {
-		return null;
-	}
-
-	const brokenConnections = connections.filter( connection => connection.status === 'broken' );
-
-	if ( ! brokenConnections.length ) {
-		return null;
-	}
-
-	return (
-		<div>
-			{ brokenConnections
-				.map( connection => <Notice
-					key={ connection.keyring_connection_ID }
-					status="is-warning"
-					showDismiss={ false }
-					text={ translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
-				>
-					<NoticeAction href={ `/sharing/${ siteSlug }` }>
-						{ translate( 'Reconnect' ) }
-					</NoticeAction>
-				</Notice> )
-			}
-		</div>
-	);
-};
-
 export const NoConnectionsNotice = ( { siteSlug, translate } ) => (
 	<Notice
 		status="is-warning"

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -17,6 +17,7 @@ import QueryPosts from 'components/data/query-posts';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
+import NoticeAction from 'components/notice/notice-action';
 import {
 	isPublicizeEnabled,
 	isSchedulingPublicizeShareAction,
@@ -56,10 +57,7 @@ import {
 
 import Banner from 'components/banner';
 import SharingPreviewModal from './sharing-preview-modal';
-import ConnectionsList, {
-	NoConnectionsNotice,
-	ConnectionsWarning,
-} from './connections-list';
+import ConnectionsList, { NoConnectionsNotice } from './connections-list';
 
 import ActionsList from './publicize-actions-list';
 import CalendarButton from 'blocks/calendar-button';
@@ -301,8 +299,38 @@ class PostShare extends Component {
 	}
 
 	renderConnectionsWarning() {
+		const {
+			connections,
+			hasFetchedConnections,
+			siteSlug,
+			translate,
+		} = this.props;
+
+		if ( ! hasFetchedConnections || ! connections.length ) {
+			return null;
+		}
+
+		const brokenConnections = connections.filter( connection => connection.status === 'broken' );
+
+		if ( ! brokenConnections.length ) {
+			return null;
+		}
+
 		return (
-			<ConnectionsWarning { ...this.props } />
+			<div>
+				{ brokenConnections
+					.map( connection => <Notice
+						key={ connection.keyring_connection_ID }
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate( 'There is an issue connecting to %s.', { args: connection.label } ) }
+					>
+						<NoticeAction href={ `/sharing/${ siteSlug }` }>
+							{ translate( 'Reconnect' ) }
+						</NoticeAction>
+					</Notice> )
+				}
+			</div>
 		);
 	}
 

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -56,7 +56,11 @@ import {
 
 import Banner from 'components/banner';
 import SharingPreviewModal from './sharing-preview-modal';
-import ConnectionsList, { NoConnectionsNotice } from './connections-list';
+import ConnectionsList, {
+	NoConnectionsNotice,
+	ConnectionsWarning,
+} from './connections-list';
+
 import ActionsList from './publicize-actions-list';
 import CalendarButton from 'blocks/calendar-button';
 import formatCurrency from 'lib/format-currency';
@@ -296,6 +300,12 @@ class PostShare extends Component {
 		);
 	}
 
+	renderConnectionsWarning() {
+		return (
+			<ConnectionsWarning { ...this.props } />
+		);
+	}
+
 	renderRequestSharingNotice() {
 		const {
 			failure,
@@ -488,7 +498,7 @@ class PostShare extends Component {
 						</div>
 					</div>
 					{ this.renderRequestSharingNotice() }
-
+					{ this.renderConnectionsWarning() }
 					{ this.renderPrimarySection() }
 				</div>
 				<QueryPosts { ...{ siteId, postId } } />


### PR DESCRIPTION
This PR moves the connections warning outside of the connections box.

It fixes #14999

*before*
![image](https://user-images.githubusercontent.com/77539/27037070-335d9ada-4f5d-11e7-8af3-18eb5698aa1d.png)

*after*
![image](https://user-images.githubusercontent.com/77539/27048711-3d1a7b26-4f83-11e7-82a9-80329303845f.png)


### Testing

You will need _create_ an issue with your connection in order to reproduce this visual issue. What I did was change the password of the account. Then ...

1) Go to posts list section: `http://calypso.localhost:3000/posts/my/<your-testing-site>`
2) Click on the `Share` tab:
![image](https://user-images.githubusercontent.com/77539/27048936-0ccb8248-4f84-11e7-943a-589d1d1ec15f.png)

You should be able to see the warning notice right there