### PR TITLE
Happychat: Rework selected site logic to send proper site info to happychat and kayako

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -22,8 +22,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import ChatClosureNotice from '../chat-closure-notice';
-import { getSelectedOrPrimarySiteId } from 'state/selectors';
-import { getHelpSelectedSiteId } from 'state/help/selectors';
 import { selectSiteId } from 'state/help/actions';
 
 export const HelpContactForm = React.createClass( {
@@ -38,6 +36,7 @@ export const HelpContactForm = React.createClass( {
 		showSubjectField: PropTypes.bool,
 		showSiteField: PropTypes.bool,
 		showHelpLanguagePrompt: PropTypes.bool,
+		selectedSite: PropTypes.object,
 		siteFilter: PropTypes.func,
 		siteList: PropTypes.object,
 		disabled: PropTypes.bool,
@@ -224,7 +223,7 @@ export const HelpContactForm = React.createClass( {
 					<div className="help-contact-form__site-selection">
 						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
 						<SitesDropdown
-							selectedSiteId={ this.props.selectedSiteId }
+							selectedSiteId={ this.props.selectedSite.ID }
 							onSiteSelect={ this.props.onChangeSite } />
 					</div>
 				) }
@@ -250,14 +249,8 @@ export const HelpContactForm = React.createClass( {
 	}
 } );
 
-const mapStateToProps = ( state ) => {
-	return {
-		selectedSiteId: getHelpSelectedSiteId( state ) || getSelectedOrPrimarySiteId( state )
-	};
-};
-
 const mapDispatchToProps = {
 	onChangeSite: selectSiteId
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( HelpContactForm ) );
+export default connect( null, mapDispatchToProps )( localize( HelpContactForm ) );

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -36,7 +36,7 @@ export const HelpContactForm = React.createClass( {
 		showSubjectField: PropTypes.bool,
 		showSiteField: PropTypes.bool,
 		showHelpLanguagePrompt: PropTypes.bool,
-		selectedSite: PropTypes.object,
+		selectedSiteId: PropTypes.number,
 		siteFilter: PropTypes.func,
 		siteList: PropTypes.object,
 		disabled: PropTypes.bool,
@@ -223,7 +223,7 @@ export const HelpContactForm = React.createClass( {
 					<div className="help-contact-form__site-selection">
 						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
 						<SitesDropdown
-							selectedSiteId={ this.props.selectedSite.ID }
+							selectedSiteId={ this.props.selectedSiteId }
 							onSiteSelect={ this.props.onChangeSite } />
 					</div>
 				) }

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -23,6 +23,7 @@ import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import ChatClosureNotice from '../chat-closure-notice';
 import { selectSiteId } from 'state/help/actions';
+import { getHelpSelectedSite } from 'state/help/selectors';
 
 export const HelpContactForm = React.createClass( {
 	mixins: [ LinkedStateMixin, PureRenderMixin ],
@@ -36,7 +37,7 @@ export const HelpContactForm = React.createClass( {
 		showSubjectField: PropTypes.bool,
 		showSiteField: PropTypes.bool,
 		showHelpLanguagePrompt: PropTypes.bool,
-		selectedSiteId: PropTypes.number,
+		selectedSite: PropTypes.object,
 		siteFilter: PropTypes.func,
 		siteList: PropTypes.object,
 		disabled: PropTypes.bool,
@@ -164,7 +165,20 @@ export const HelpContactForm = React.createClass( {
 	 * @param  {object} event Event object
 	 */
 	submitForm() {
-		this.props.onSubmit( this.state );
+		const {
+			howCanWeHelp,
+			howYouFeel,
+			message,
+			subject
+		} = this.state;
+
+		this.props.onSubmit( {
+			howCanWeHelp,
+			howYouFeel,
+			message,
+			subject,
+			site: this.props.selectedSite,
+		} );
 	},
 
 	/**
@@ -223,7 +237,7 @@ export const HelpContactForm = React.createClass( {
 					<div className="help-contact-form__site-selection">
 						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
 						<SitesDropdown
-							selectedSiteId={ this.props.selectedSiteId }
+							selectedSiteId={ this.props.selectedSite.ID }
 							onSiteSelect={ this.props.onChangeSite } />
 					</div>
 				) }
@@ -249,8 +263,12 @@ export const HelpContactForm = React.createClass( {
 	}
 } );
 
+const mapStateToProps = ( state ) => ( {
+	selectedSite: getHelpSelectedSite( state ),
+} );
+
 const mapDispatchToProps = {
 	onChangeSite: selectSiteId
 };
 
-export default connect( null, mapDispatchToProps )( localize( HelpContactForm ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( HelpContactForm ) );

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -35,7 +35,6 @@ import QueryTicketSupportConfiguration from 'components/data/query-ticket-suppor
 import HelpUnverifiedWarning from '../help-unverified-warning';
 import { sendChatMessage as sendHappychatMessage, sendUserInfo } from 'state/happychat/actions';
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
-import { getHelpSelectedSite } from 'state/help/selectors';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 import { askQuestion as askDirectlyQuestion, initialize as initializeDirectly } from 'state/help/directly/actions';
 import {
@@ -133,8 +132,7 @@ const HelpContact = React.createClass( {
 
 	startHappychat: function( contactForm ) {
 		this.props.openHappychat();
-		const { message } = contactForm;
-		const { selectedSite: site } = this.props;
+		const { message, site } = contactForm;
 
 		this.props.sendUserInfo( site.URL );
 		this.props.sendHappychatMessage( message );
@@ -148,8 +146,7 @@ const HelpContact = React.createClass( {
 	},
 
 	startChat: function( contactForm ) {
-		const { message, howCanWeHelp, howYouFeel } = contactForm;
-		const { selectedSite: site } = this.props;
+		const { message, howCanWeHelp, howYouFeel, site } = contactForm;
 
 		// Intentionally not translated since only HE's will see this in the olark console as a notification.
 		const notifications = [
@@ -195,8 +192,8 @@ const HelpContact = React.createClass( {
 	},
 
 	submitKayakoTicket: function( contactForm ) {
-		const { subject, message, howCanWeHelp, howYouFeel } = contactForm;
-		const { currentUserLocale, selectedSite: site } = this.props;
+		const { subject, message, howCanWeHelp, howYouFeel, site } = contactForm;
+		const { currentUserLocale } = this.props;
 
 		const ticketMeta = [
 			'How can you help: ' + howCanWeHelp,
@@ -537,7 +534,7 @@ const HelpContact = React.createClass( {
 
 	getContactFormCommonProps: function( variationSlug ) {
 		const { isSubmitting } = this.state;
-		const { currentUserLocale, selectedSite } = this.props;
+		const { currentUserLocale } = this.props;
 
 		// Let the user know we only offer support in English.
 		// We only need to show the message if:
@@ -552,7 +549,6 @@ const HelpContact = React.createClass( {
 		return {
 			disabled: isSubmitting,
 			showHelpLanguagePrompt: showHelpLanguagePrompt,
-			selectedSiteId: selectedSite.ID,
 			valueLink: { value: savedContactForm, requestChange: ( contactForm ) => savedContactForm = contactForm }
 		};
 	},
@@ -698,7 +694,6 @@ export default connect(
 			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			ticketSupportEligible: isTicketSupportEligible( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
-			selectedSite: getHelpSelectedSite( state ),
 		};
 	},
 	{

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -35,6 +35,7 @@ import QueryTicketSupportConfiguration from 'components/data/query-ticket-suppor
 import HelpUnverifiedWarning from '../help-unverified-warning';
 import { sendChatMessage as sendHappychatMessage, sendUserInfo } from 'state/happychat/actions';
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
+import { getHelpSelectedSite } from 'state/help/selectors';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 import { askQuestion as askDirectlyQuestion, initialize as initializeDirectly } from 'state/help/directly/actions';
 import {
@@ -132,8 +133,8 @@ const HelpContact = React.createClass( {
 
 	startHappychat: function( contactForm ) {
 		this.props.openHappychat();
-		const { message, siteId } = contactForm;
-		const site = sites.getSite( siteId );
+		const { message } = contactForm;
+		const { selectedSite: site } = this.props;
 
 		this.props.sendUserInfo( site.URL );
 		this.props.sendHappychatMessage( message );
@@ -147,8 +148,8 @@ const HelpContact = React.createClass( {
 	},
 
 	startChat: function( contactForm ) {
-		const { message, howCanWeHelp, howYouFeel, siteId } = contactForm;
-		const site = sites.getSite( siteId );
+		const { message, howCanWeHelp, howYouFeel } = contactForm;
+		const { selectedSite: site } = this.props;
 
 		// Intentionally not translated since only HE's will see this in the olark console as a notification.
 		const notifications = [
@@ -194,9 +195,8 @@ const HelpContact = React.createClass( {
 	},
 
 	submitKayakoTicket: function( contactForm ) {
-		const { subject, message, howCanWeHelp, howYouFeel, siteId } = contactForm;
-		const { currentUserLocale } = this.props;
-		const site = sites.getSite( siteId );
+		const { subject, message, howCanWeHelp, howYouFeel } = contactForm;
+		const { currentUserLocale, selectedSite: site } = this.props;
 
 		const ticketMeta = [
 			'How can you help: ' + howCanWeHelp,
@@ -537,7 +537,7 @@ const HelpContact = React.createClass( {
 
 	getContactFormCommonProps: function( variationSlug ) {
 		const { isSubmitting } = this.state;
-		const { currentUserLocale } = this.props;
+		const { currentUserLocale, selectedSite } = this.props;
 
 		// Let the user know we only offer support in English.
 		// We only need to show the message if:
@@ -552,6 +552,7 @@ const HelpContact = React.createClass( {
 		return {
 			disabled: isSubmitting,
 			showHelpLanguagePrompt: showHelpLanguagePrompt,
+			selectedSite: selectedSite,
 			valueLink: { value: savedContactForm, requestChange: ( contactForm ) => savedContactForm = contactForm }
 		};
 	},
@@ -697,6 +698,7 @@ export default connect(
 			ticketSupportConfigurationReady: isTicketSupportConfigurationReady( state ),
 			ticketSupportEligible: isTicketSupportEligible( state ),
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
+			selectedSite: getHelpSelectedSite( state ),
 		};
 	},
 	{

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -552,7 +552,7 @@ const HelpContact = React.createClass( {
 		return {
 			disabled: isSubmitting,
 			showHelpLanguagePrompt: showHelpLanguagePrompt,
-			selectedSite: selectedSite,
+			selectedSiteId: selectedSite.ID,
 			valueLink: { value: savedContactForm, requestChange: ( contactForm ) => savedContactForm = contactForm }
 		};
 	},

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -64,6 +64,7 @@ import {
 	getCurrentUser,
 	getCurrentUserLocale,
 } from 'state/current-user/selectors';
+import { getHelpSelectedSite } from 'state/help/selectors';
 
 const debug = require( 'debug' )( 'calypso:happychat:actions' );
 
@@ -99,9 +100,10 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 		return;
 	}
 
+	const selectedSite = getHelpSelectedSite( state );
 	const user = getCurrentUser( state );
 	const locale = getCurrentUserLocale( state );
-	const groups = getGroups( state );
+	const groups = getGroups( state, selectedSite.ID );
 
 	// Notify that a new connection is being established
 	dispatch( setConnecting() );
@@ -135,7 +137,6 @@ export const connectChat = ( connection, { getState, dispatch } ) => {
 		.then( ( { jwt } ) => connection.open( user.ID, jwt, locale, groups ) )
 		.catch( e => debug( 'failed to start happychat session', e, e.stack ) );
 };
-
 
 export const updateChatPreferences = ( connection, { getState }, siteId ) => {
 	const state = getState();

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getPrimarySiteId } from 'state/selectors';
+import { getSelectedOrPrimarySiteId } from 'state/selectors';
 import { getRawSite } from 'state/sites/selectors';
 import createSelector from 'lib/create-selector';
 
@@ -10,7 +10,7 @@ export const getHelpSelectedSiteId = createSelector(
 );
 
 export const getHelpSelectedSite = ( state ) => {
-	const siteId = getHelpSelectedSiteId( state ) || getPrimarySiteId( state );
+	const siteId = getHelpSelectedSiteId( state ) || getSelectedOrPrimarySiteId( state );
 
 	return getRawSite( state, siteId );
 };

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -1,8 +1,16 @@
 /**
  * Internal dependencies
  */
+import { getPrimarySiteId } from 'state/selectors';
+import { getRawSite } from 'state/sites/selectors';
 import createSelector from 'lib/create-selector';
 
 export const getHelpSelectedSiteId = createSelector(
 	state => state.help.selectedSiteId
 );
+
+export const getHelpSelectedSite = ( state ) => {
+	const siteId = getHelpSelectedSiteId( state ) || getPrimarySiteId( state );
+
+	return getRawSite( state, siteId );
+};

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getSelectedOrPrimarySiteId } from 'state/selectors';
-import { getRawSite } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
 import createSelector from 'lib/create-selector';
 
 export const getHelpSelectedSiteId = createSelector(
@@ -12,5 +12,5 @@ export const getHelpSelectedSiteId = createSelector(
 export const getHelpSelectedSite = ( state ) => {
 	const siteId = getHelpSelectedSiteId( state ) || getSelectedOrPrimarySiteId( state );
 
-	return getRawSite( state, siteId );
+	return getSite( state, siteId );
 };


### PR DESCRIPTION
This PR moves selected site logic to an upper level as prop of the `help` component. This will provide us with the selected site info which are sent when initializing a new chat or creating a kayako 

### Testing steps
1. Starting a new chat or kayako ticket should have proper site url 
2. Unit tests should not fail

### Implementation description
- `redux/help.selectedSiteId` was connected to `help` component as a prop
- A new selector was added to `help/selectors` that will provide site info for the selected site or if a site is not selected for the primary site.
- `selectedSite` is passed down as a common prop to `help-contact-form`

Fixes: https://github.com/Automattic/wp-calypso/issues/14997

