### PR TITLE
Reader: Limit the fields and options we fetch for sites

### DIFF
--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -17,25 +17,45 @@ export function requestSite( siteId ) {
 				ID: siteId,
 			},
 		} );
-		return wpcom.undocumented().readSite( { site: siteId } ).then(
-			function success( data ) {
-				dispatch( {
-					type: READER_SITE_REQUEST_SUCCESS,
-					payload: data,
-				} );
-				return data;
-			},
-			function failure( err ) {
-				dispatch( {
-					type: READER_SITE_REQUEST_FAILURE,
-					payload: {
-						ID: siteId,
-					},
-					error: err,
-				} );
-				throw err;
-			}
-		);
+		return wpcom
+			.undocumented()
+			.readSite( {
+				site: siteId,
+				fields: [
+					'ID',
+					'name',
+					'title',
+					'URL',
+					'icon',
+					'is_jetpack',
+					'description',
+					'is_private',
+					'feed_ID',
+					'feed_URL',
+					'capabilities',
+					'prefer_feed',
+				].join( ',' ),
+				options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
+			} )
+			.then(
+				function success( data ) {
+					dispatch( {
+						type: READER_SITE_REQUEST_SUCCESS,
+						payload: data,
+					} );
+					return data;
+				},
+				function failure( err ) {
+					dispatch( {
+						type: READER_SITE_REQUEST_FAILURE,
+						payload: {
+							ID: siteId,
+						},
+						error: err,
+					} );
+					throw err;
+				},
+			);
 	};
 }
 

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -1,5 +1,11 @@
-import isArray from 'lodash/isArray';
+/**
+ * External Dependencies
+ */
+import { isArray } from 'lodash';
 
+/**
+ * Internal Dependencies
+ */
 import wpcom from 'lib/wp';
 
 import {
@@ -34,6 +40,7 @@ export function requestSite( siteId ) {
 					'feed_URL',
 					'capabilities',
 					'prefer_feed',
+					'options',  // have to include this to get options at all
 				].join( ',' ),
 				options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
 			} )

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -21,10 +21,30 @@ describe( 'actions', () => {
 		let request;
 
 		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/read/sites/1' ).reply( 200, {
-				ID: 1,
-				name: 'My test site',
-			} );
+			nock( 'https://public-api.wordpress.com:443' )
+				.get( '/rest/v1.1/read/sites/1' )
+				.query( {
+					fields: [
+						'ID',
+						'name',
+						'title',
+						'URL',
+						'icon',
+						'is_jetpack',
+						'description',
+						'is_private',
+						'feed_ID',
+						'feed_URL',
+						'capabilities',
+						'prefer_feed',
+						'options',  // have to include this to get options at all
+					].join( ',' ),
+					options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
+				} )
+				.reply( 200, {
+					ID: 1,
+					name: 'My test site',
+				} );
 			request = requestSite( 1 )( spy );
 		} );
 
@@ -51,7 +71,7 @@ describe( 'actions', () => {
 				err => {
 					assert.fail( 'Errback should not be invoked!', err );
 					return err;
-				}
+				},
 			);
 		} );
 	} );
@@ -88,7 +108,7 @@ describe( 'actions', () => {
 						},
 						error: sinon.match.instanceOf( Error ),
 					} );
-				}
+				},
 			);
 		} );
 	} );


### PR DESCRIPTION
This should speed up site requests, and even more importantly, cut down on the bandwidth required since we don't really need a lot of the default options and fields.