### PR TITLE
Framework: enable `publicize-scheduling` on development

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,7 @@
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
 		"press-this": true,
-		"publicize-preview": false,
+		"publicize-preview": true,
 		"publicize-scheduling": true,
 		"push-notifications": true,
 		"reader": true,

--- a/config/development.json
+++ b/config/development.json
@@ -117,7 +117,7 @@
 		"post-editor/media-advanced": false,
 		"press-this": true,
 		"publicize-preview": false,
-		"publicize-scheduling": false,
+		"publicize-scheduling": true,
 		"push-notifications": true,
 		"reader": true,
 		"reader/following-intro": true,


### PR DESCRIPTION
It enables `publicize-scheduling` on the development environment.