### PR TITLE
Accessibility: Remove all caps text on compact buttons

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -68,9 +68,8 @@ button {
 	&.is-compact {
 		padding: 7px;
 		color: $gray-text-min;
-		font-size: 11px;
+		font-size: 12px;
 		line-height: 1;
-		text-transform: uppercase;
 
 		&:disabled {
 			color: lighten( $gray, 30% );

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -91,8 +91,7 @@ $compact-header-height: 35;
 		height: #{$compact-header-height }px;
 		line-height: #{$compact-header-height - 3 }px;
 		color: $gray-text-min;
-		font-size: 11px;
-		text-transform: uppercase;
+		font-size: 12px;
 
 		.count {
 			border-width: 0;
@@ -270,7 +269,6 @@ $compact-header-height: 35;
 
 	label {
 		font-size: 12px;
-		text-transform: uppercase;
 		padding: 0px #{ $side-margin }px;
 	}
 }


### PR DESCRIPTION
All caps are hard to read. Contrast makes text easier to read; the contrast of color, size, and shape. When we read, we don't take in each letter, instead we read the actual shape of the word. When you use all caps, every word is the same shape and it takes us about 10% longer to read. AND IT CAN LOOK LIKE YOU'RE SHOUTING. Which feels unnecessary. 

Here's a before and after using the dev docs examples.
Before:
<img width="650" alt="screen shot 2017-06-12 at 4 49 04 pm" src="https://user-images.githubusercontent.com/5835847/27059204-76371b80-4f92-11e7-962e-03f94c41580d.png">
<img width="647" alt="screen shot 2017-06-12 at 4 49 11 pm" src="https://user-images.githubusercontent.com/5835847/27059205-7638c23c-4f92-11e7-8772-2f24dda434fe.png">
After:
<img width="645" alt="screen shot 2017-06-12 at 5 02 28 pm" src="https://user-images.githubusercontent.com/5835847/27059184-671f1ada-4f92-11e7-88b9-ffbd0fd195a4.png">
<img width="647" alt="screen shot 2017-06-12 at 5 02 21 pm" src="https://user-images.githubusercontent.com/5835847/27059183-670cccd6-4f92-11e7-8461-acd90bb14c60.png">

And how this new change looks on actual pages: 

<img width="483" alt="screen shot 2017-06-12 at 5 03 45 pm" src="https://user-images.githubusercontent.com/5835847/27059170-5cdf79b6-4f92-11e7-960d-144e0d0496dd.png">
<img width="967" alt="screen shot 2017-06-12 at 5 04 25 pm" src="https://user-images.githubusercontent.com/5835847/27059172-5cee28a8-4f92-11e7-9388-12c4b0dc38e5.png">
<img width="971" alt="screen shot 2017-06-12 at 5 04 51 pm" src="https://user-images.githubusercontent.com/5835847/27059169-5cbbd876-4f92-11e7-9128-d817794b3f4f.png">
<img width="752" alt="screen shot 2017-06-12 at 5 05 00 pm" src="https://user-images.githubusercontent.com/5835847/27059167-5cb30610-4f92-11e7-923b-75d98ff2bc64.png">
<img width="967" alt="screen shot 2017-06-12 at 5 05 17 pm" src="https://user-images.githubusercontent.com/5835847/27059168-5cb9fa06-4f92-11e7-8f60-8aae29aa6529.png">

To test, visit: http://calypso.localhost:3000/devdocs/design/buttons and toggle on the Compact button. Notice a less-shouty, easier to read group of buttons. You can also visit any of the pages noted above. 