### PR TITLE
Reader: Allow the user to specify a search algorithm

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -14,6 +14,7 @@ import FeedStreamCache from './feed-stream-cache';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import { keyToString, keysAreEqual } from './post-key';
+import getDefaultSearchAlgorithm from 'reader/search-helper';
 
 const wpcomUndoc = wpcom.undocumented();
 
@@ -186,31 +187,34 @@ function getStoreForSearch( storeId ) {
 	const slug = idParts.slice( 2 ).join( ':' );
 	// We can use a feed stream when it's a strict date sort.
 	// This lets us go deeper than 20 pages and let's the results auto-update
-	let stream;
-	if ( sort === 'date' ) {
-		stream = new FeedStream( {
-			id: storeId,
-			fetcher: fetcher,
-			keyMaker: siteKeyMaker,
-			perPage: 5,
-			onGapFetch: limitSiteParams,
-			onUpdateFetch: limitSiteParams,
-			maxUpdates: 20,
-		} );
-	} else {
-		stream = new PagedStream( {
-			id: storeId,
-			fetcher: fetcher,
-			keyMaker: siteKeyMaker,
-			perPage: 5,
-		} );
-	}
+	const stream =
+		sort === 'date'
+			? new FeedStream( {
+					id: storeId,
+					fetcher: fetcher,
+					keyMaker: siteKeyMaker,
+					perPage: 5,
+					onGapFetch: limitSiteParams,
+					onUpdateFetch: limitSiteParams,
+					maxUpdates: 20,
+				} )
+			: new PagedStream( {
+					id: storeId,
+					fetcher: fetcher,
+					keyMaker: siteKeyMaker,
+					perPage: 5,
+				} );
+
 	stream.sortOrder = sort;
 
 	function fetcher( query, callback ) {
 		query.q = slug;
 		query.meta = 'site';
 		query.sort = sort;
+		const defaultAlg = getDefaultSearchAlgorithm();
+		if ( defaultAlg ) {
+			query.algorithm = defaultAlg;
+		}
 		wpcomUndoc.readSearch( query, trainTracksProxyForStream( stream, callback ) );
 	}
 

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -14,7 +14,7 @@ import FeedStreamCache from './feed-stream-cache';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import { keyToString, keysAreEqual } from './post-key';
-import getDefaultSearchAlgorithm from 'reader/search-helper';
+import { getDefaultSearchAlgorithm } from 'reader/search-helper';
 
 const wpcomUndoc = wpcom.undocumented();
 
@@ -316,6 +316,10 @@ function getStoreForRecommendedPosts( storeId ) {
 				break;
 			default:
 				query.algorithm = 'read:recommendations:posts/es/1';
+				break;
+		}
+		if ( getDefaultSearchAlgorithm() ) {
+			query.algorithm = getDefaultSearchAlgorithm();
 		}
 		wpcomUndoc.readRecommendedPosts( query, trainTracksProxyForStream( stream, callback ) );
 	}

--- a/client/reader/search-helper.js
+++ b/client/reader/search-helper.js
@@ -3,10 +3,17 @@
  */
 import querystring from 'querystring';
 
+/**
+ * Internal Dependencies
+ */
+import config from 'config';
+
 let algorithm;
 
 // try to pick the default algorithm up from the querystring
-if ( typeof window !== 'undefined' && window.location.search ) {
+if (
+	config( 'env_id' ) !== 'production' && typeof window !== 'undefined' && window.location.search
+) {
 	const query = querystring.parse( window.location.search.substring( 1 ) );
 	if ( query.algorithm ) {
 		algorithm = query.algorithm;

--- a/client/reader/search-helper.js
+++ b/client/reader/search-helper.js
@@ -1,0 +1,18 @@
+/**
+ * External Dependencies
+ */
+import querystring from 'querystring';
+
+let algorithm;
+
+// try to pick the default algorithm up from the querystring
+if ( typeof window !== 'undefined' && window.location.search ) {
+	const query = querystring.parse( window.location.search.substring( 1 ) );
+	if ( query.algorithm ) {
+		algorithm = query.algorithm;
+	}
+}
+
+export default function getDefaultSearchAlgorithm() {
+	return algorithm;
+}

--- a/client/reader/search-helper.js
+++ b/client/reader/search-helper.js
@@ -13,6 +13,6 @@ if ( typeof window !== 'undefined' && window.location.search ) {
 	}
 }
 
-export default function getDefaultSearchAlgorithm() {
+export function getDefaultSearchAlgorithm() {
 	return algorithm;
 }

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -14,7 +14,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 import queryKey from 'state/reader/feed-searches/query-key';
-import getDefaultSearchAlgorithm from 'reader/search-helper';
+import { getDefaultSearchAlgorithm } from 'reader/search-helper';
 
 export function initiateFeedSearch( store, action ) {
 	if ( ! ( action.payload && action.payload.query ) ) {

--- a/client/state/data-layer/wpcom/read/feed/index.js
+++ b/client/state/data-layer/wpcom/read/feed/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { map, truncate } from 'lodash';
+import { map, truncate, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 import queryKey from 'state/reader/feed-searches/query-key';
+import getDefaultSearchAlgorithm from 'reader/search-helper';
 
 export function initiateFeedSearch( store, action ) {
 	if ( ! ( action.payload && action.payload.query ) ) {
@@ -26,12 +27,16 @@ export function initiateFeedSearch( store, action ) {
 			path,
 			method: 'GET',
 			apiVersion: '1.1',
-			query: {
-				q: action.payload.query,
-				offset: action.payload.offset,
-				exclude_followed: action.payload.excludeFollowed,
-				sort: action.payload.sort,
-			},
+			query: pickBy(
+				{
+					q: action.payload.query,
+					offset: action.payload.offset,
+					exclude_followed: action.payload.excludeFollowed,
+					sort: action.payload.sort,
+					algorithm: getDefaultSearchAlgorithm(),
+				},
+				Boolean
+			),
 			onSuccess: action,
 			onFailure: action,
 		} )

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -22,12 +22,12 @@ export const requestRecommendedSites = ( { dispatch }, action ) => {
 			path: '/read/recommendations/sites',
 			query: pickBy(
 				{ number, offset, seed, posts_per_site: 0, algorithm: getDefaultSearchAlgorithm() },
-				Boolean,
+				Boolean
 			),
 			apiVersion: '1.2',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 };
 
@@ -56,7 +56,7 @@ export const receiveRecommendedSitesResponse = ( store, action, response ) => {
 			sites: fromApi( response ),
 			seed: action.payload.seed,
 			offset: action.payload.offset,
-		} ),
+		} )
 	);
 };
 

--- a/client/state/data-layer/wpcom/read/recommendations/sites/index.js
+++ b/client/state/data-layer/wpcom/read/recommendations/sites/index.js
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import { map, noop } from 'lodash';
+import { map, noop, pickBy } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -12,6 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { receiveRecommendedSites } from 'state/reader/recommended-sites/actions';
 import { decodeEntities } from 'lib/formatting';
+import getDefaultSearchAlgorithm from 'reader/search-helper';
 
 export const requestRecommendedSites = ( { dispatch }, action ) => {
 	const { seed = 1, number = 10, offset = 0 } = action.payload;
@@ -19,11 +20,14 @@ export const requestRecommendedSites = ( { dispatch }, action ) => {
 		http( {
 			method: 'GET',
 			path: '/read/recommendations/sites',
-			query: { number, offset, seed, posts_per_site: 0 },
+			query: pickBy(
+				{ number, offset, seed, posts_per_site: 0, algorithm: getDefaultSearchAlgorithm() },
+				Boolean,
+			),
 			apiVersion: '1.2',
 			onSuccess: action,
 			onFailure: action,
-		} )
+		} ),
 	);
 };
 
@@ -52,7 +56,7 @@ export const receiveRecommendedSitesResponse = ( store, action, response ) => {
 			sites: fromApi( response ),
 			seed: action.payload.seed,
 			offset: action.payload.offset,
-		} )
+		} ),
 	);
 };
 

--- a/client/state/reader/related-posts/actions.js
+++ b/client/state/reader/related-posts/actions.js
@@ -21,20 +21,9 @@ import { getDefaultSearchAlgorithm } from 'reader/search-helper';
 
 export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
 	return function( dispatch ) {
-		dispatch( {
-			type: READER_RELATED_POSTS_REQUEST,
-			payload: {
-				siteId,
-				postId,
-				scope,
-			},
-		} );
+		dispatch( { type: READER_RELATED_POSTS_REQUEST, payload: { siteId, postId, scope } } );
 
-		const query = {
-			site_id: siteId,
-			post_id: postId,
-			meta: 'site',
-		};
+		const query = { site_id: siteId, post_id: postId, meta: 'site' };
 
 		if ( scope === SCOPE_SAME ) {
 			query.size_local = 2;
@@ -48,24 +37,18 @@ export function requestRelatedPosts( siteId, postId, scope = SCOPE_ALL ) {
 			query.algorithm = getDefaultSearchAlgorithm();
 		}
 
-		return wpcom.undocumented().readSitePostRelated( query ).then(
-			response => {
-				dispatch( {
-					type: READER_RELATED_POSTS_REQUEST_SUCCESS,
-					payload: { siteId, postId, scope },
-				} );
-				const sites = filter( map( response && response.posts, 'meta.data.site' ), Boolean );
-				if ( sites && sites.length !== 0 ) {
+		return wpcom
+			.undocumented()
+			.readSitePostRelated( query )
+			.then(
+				response => {
 					dispatch( {
 						type: READER_RELATED_POSTS_REQUEST_SUCCESS,
 						payload: { siteId, postId, scope },
 					} );
 					const sites = filter( map( response && response.posts, 'meta.data.site' ), Boolean );
 					if ( sites && sites.length !== 0 ) {
-						dispatch( {
-							type: READER_SITE_UPDATE,
-							payload: sites,
-						} );
+						dispatch( { type: READER_SITE_UPDATE, payload: sites } );
 					}
 					// collect posts and dispatch
 					dispatch( receivePosts( response && response.posts ) ).then( () => {


### PR DESCRIPTION
Just add a algorithm=foo to the querystring when you first load calypso and all "search" requests will use that algorithm.

Works for post search, feed search, related posts, recommended sites.