### PR TITLE
Reader: release intro banner to everyone

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -28,12 +28,7 @@ class FollowingIntro extends React.Component {
 
 	recordRenderTrack = ( props = this.props ) => {
 		if ( props.isNewReader === true ) {
-			// This is incorrect, but keeping the name for consistency.
-			// This event is more like `calypso_reader_following_rendered_for_new_reader`.
 			recordTrack( 'calypso_reader_following_intro_render' );
-
-			// Added _actual because the original event was fired incorrectly during A/B test
-			recordTrack( 'calypso_reader_following_intro_render_actual' );
 		}
 	};
 

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -61,7 +61,7 @@ class FollowingIntro extends React.Component {
 									strong: <strong />,
 									span: <span className="following__intro-copy-hidden" />,
 								},
-							}
+							},
 						) }
 					</div>
 
@@ -88,7 +88,7 @@ class FollowingIntro extends React.Component {
 export default connect(
 	state => {
 		return {
-			isNewReader: getPreference( state, 'is_new_reader' )
+			isNewReader: getPreference( state, 'is_new_reader' ),
 		};
 	},
 	dispatch =>
@@ -103,6 +103,6 @@ export default connect(
 					return savePreference( 'is_new_reader', false );
 				},
 			},
-			dispatch
-		)
+			dispatch,
+		),
 )( localize( FollowingIntro ) );

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -14,9 +14,6 @@ import QueryPreferences from 'components/data/query-preferences';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import { recordTrack } from 'reader/stats';
-import { getCurrentUserId } from 'state/current-user/selectors';
-
-const isEven = number => number % 2 === 0;
 
 class FollowingIntro extends React.Component {
 	componentDidMount() {
@@ -34,19 +31,17 @@ class FollowingIntro extends React.Component {
 			// This is incorrect, but keeping the name for consistency.
 			// This event is more like `calypso_reader_following_rendered_for_new_reader`.
 			recordTrack( 'calypso_reader_following_intro_render' );
-		}
-		if ( props.isNewReader === true && ! isEven( props.userId ) ) {
-			// Added _actual for when a new Reader and odd userid sees the intro card
+
+			// Added _actual because the original event was fired incorrectly during A/B test
 			recordTrack( 'calypso_reader_following_intro_render_actual' );
 		}
 	};
 
 	render() {
-		const { isNewReader, translate, dismiss, userId } = this.props;
+		const { isNewReader, translate, dismiss } = this.props;
 		const linkElement = <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />;
 
-		// Only show the banner to new Readers with an odd user ID (simple A/B test)
-		if ( ! isNewReader || ! userId || isEven( userId ) ) {
+		if ( ! isNewReader ) {
 			return null;
 		}
 
@@ -93,8 +88,7 @@ class FollowingIntro extends React.Component {
 export default connect(
 	state => {
 		return {
-			isNewReader: getPreference( state, 'is_new_reader' ),
-			userId: getCurrentUserId( state ),
+			isNewReader: getPreference( state, 'is_new_reader' )
 		};
 	},
 	dispatch =>


### PR DESCRIPTION
The Reader intro banner was previously released to users with an odd-numbered user ID as an A/B test. Following a successful trial, we're now releasing it to all new users.

<img width="859" alt="screen shot 2017-06-13 at 10 01 20" src="https://user-images.githubusercontent.com/17325/27074684-bc56d26c-501f-11e7-878b-05c5b26c568c.png">

## To test

Create a brand new user account and visit your Following stream at http://calypso.localhost:3000/. You should always see the intro banner until you dismiss it or click the Manage Following link within it.