### PR TITLE
Login: Allow users to log in to a different account when logged in

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -26,6 +26,7 @@ import WaitingTwoFactorNotificationApproval from './two-factor-authentication/wa
 import { login } from 'lib/paths';
 import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
+import store from 'store';
 
 class Login extends Component {
 	static propTypes = {
@@ -79,6 +80,10 @@ class Login extends Component {
 		// Redirects to / if no redirect url is available
 		const url = redirectTo ? redirectTo : window.location.origin;
 
+		// user data is persisted in localstorage at `lib/user/user` line 157
+		// therefor we need to reset it before we redirect, otherwise we'll get
+		// mixed data from old and new user
+		store.clear();
 		window.location.href = url;
 	};
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -26,7 +26,9 @@ import WaitingTwoFactorNotificationApproval from './two-factor-authentication/wa
 import { login } from 'lib/paths';
 import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
-import store from 'store';
+import userFactory from 'lib/user';
+
+const user = userFactory();
 
 class Login extends Component {
 	static propTypes = {
@@ -80,10 +82,7 @@ class Login extends Component {
 		// Redirects to / if no redirect url is available
 		const url = redirectTo ? redirectTo : window.location.origin;
 
-		// user data is persisted in localstorage at `lib/user/user` line 157
-		// therefor we need to reset it before we redirect, otherwise we'll get
-		// mixed data from old and new user
-		store.clear();
+		user.clear();
 		window.location.href = url;
 	};
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -82,7 +82,11 @@ class Login extends Component {
 		// Redirects to / if no redirect url is available
 		const url = redirectTo ? redirectTo : window.location.origin;
 
+		// user data is persisted in localstorage at `lib/user/user` line 157
+		// therefor we need to reset it before we redirect, otherwise we'll get
+		// mixed data from old and new user
 		user.clear();
+
 		window.location.href = url;
 	};
 

--- a/client/login/index.js
+++ b/client/login/index.js
@@ -14,7 +14,6 @@ export default router => {
 		router(
 			'/log-in/:twoFactorAuthType(authenticator|backup|sms|push)?/:lang?',
 			setUpLocale,
-			redirectLoggedIn,
 			login,
 			makeLayout,
 		);


### PR DESCRIPTION
This change enables the possibility to load Login page when user is logged in. It redirects to the homepage without this change.

Users can access `/wp-login.php` when logged out. So this PR tries to copy that behavior.

### Known issues

* [x] ~~It shows masterbar for logged in users when accessing Login page. The existing Login page shows logged out version of masterbar~~ we agreed it's an expected behavior :)

### Testing

1. Open http://calypso.localhost:3000/log-in when logged in.
2. Try to log in as a different user.
3. You should get logged in as a different user and get redirect to homepage.
4. Open http://calypso.localhost:3000/log-in?redirect_to=/me/purchases when logged in.
5. Try to log in as a different user.
6. You should get logged in as a different user and get redirect to `/me/purchases`.

### Review

* [x] Code
* [ ] Product