### PR TITLE
Upgrades: add ability to link to renewal checkout

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -117,6 +117,13 @@ const Checkout = React.createClass( {
 		recordViewCheckout( props.cart );
 	},
 
+	getProductSlugFromSynonym( slug ) {
+		if ( 'no-ads' === slug ) {
+			return 'no-adverts/no-adverts.php';
+		}
+		return slug;
+	},
+
 	addProductToCart() {
 		if ( this.props.purchaseId ) {
 			this.addRenewItemToCart();
@@ -126,10 +133,11 @@ const Checkout = React.createClass( {
 	},
 
 	addRenewItemToCart() {
-		const { product, productsList, purchaseId, selectedSiteSlug } = this.props;
-		const [ productSlug, meta ] = product.split( ':' );
+		const { product, purchaseId, selectedSiteSlug } = this.props;
+		const [ slug, meta ] = product.split( ':' );
+		const productSlug = this.getProductSlugFromSynonym( slug );
 
-		if ( ! purchaseId || ! productsList.data[ productSlug ] ) {
+		if ( ! purchaseId ) {
 			return;
 		}
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -127,7 +127,7 @@ const Checkout = React.createClass( {
 
 	addRenewItemToCart() {
 		const { product, productsList, purchaseId, selectedSiteSlug } = this.props;
-		const { productSlug, meta } = product.split( ':' );
+		const [ productSlug, meta ] = product.split( ':' );
 
 		let cartItem = Object.assign( { meta }, productsList.data[ productSlug ] );
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -117,7 +117,31 @@ const Checkout = React.createClass( {
 		recordViewCheckout( props.cart );
 	},
 
-	addProductToCart: function() {
+	addProductToCart() {
+		if ( this.props.purchaseId ) {
+			this.addRenewItemToCart();
+		} else {
+			this.addNewItemToCart();
+		}
+	},
+
+	addRenewItemToCart() {
+		const { product, productsList, purchaseId, selectedSiteSlug } = this.props;
+		const { productSlug, meta } = product.split( ':' );
+
+		let cartItem = Object.assign( { meta }, productsList.data[ productSlug ] );
+
+		if ( purchaseId ) {
+			cartItem = cartItems.getRenewalItemFromCartItem( cartItem, {
+				id: purchaseId,
+				domain: selectedSiteSlug
+			} );
+		}
+
+		upgradesActions.addItem( cartItem );
+	},
+
+	addNewItemToCart() {
 		const planSlug = getUpgradePlanSlugFromPath( this.props.product, this.props.selectedSite );
 
 		let cartItem,

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -129,14 +129,17 @@ const Checkout = React.createClass( {
 		const { product, productsList, purchaseId, selectedSiteSlug } = this.props;
 		const [ productSlug, meta ] = product.split( ':' );
 
-		let cartItem = Object.assign( { meta }, productsList.data[ productSlug ] );
-
-		if ( purchaseId ) {
-			cartItem = cartItems.getRenewalItemFromCartItem( cartItem, {
-				id: purchaseId,
-				domain: selectedSiteSlug
-			} );
+		if ( ! purchaseId || ! productsList.data[ productSlug ] ) {
+			return;
 		}
+
+		const cartItem = cartItems.getRenewalItemFromCartItem( {
+			meta,
+			product_slug: productSlug
+		}, {
+			id: purchaseId,
+			domain: selectedSiteSlug
+		} );
 
 		upgradesActions.addItem( cartItem );
 	},

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -196,6 +196,7 @@ module.exports = {
 					<Checkout
 						product={ product }
 						productsList={ productsList }
+						purchaseId={ context.params.purchaseId }
 						selectedFeature={ selectedFeature }
 					/>
 				</CheckoutData>

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -275,6 +275,12 @@ module.exports = function() {
 			upgradesController.checkout
 		);
 
+		page(
+			'/checkout/:product/renew/:purchaseId/:domain',
+			controller.siteSelection,
+			upgradesController.checkout
+		);
+
 		// Visting /checkout without a plan or product should be redirected to /plans
 		page( '/checkout', '/plans' );
 	}


### PR DESCRIPTION
This is another approach to add checkout links for products that need to be renewed. The approach in #14942 received too much feedback, requiring it to guarantee it doesn't break existing functionality that has no tests. This would not change adding a new product to cart. It creates a new and simpler function that relies on the unique product slugs coming from the server and ignores the non-standard plan slugs from Calypso.

There is an edge case with the legacy 'No Ads' product which I resolved with a synonym.

The format for the links is the following:
http://calypso.localhost:3000/checkout/value_bundle/renew/212/dzverbg400.wordpress.com
http://calypso.localhost:3000/checkout/domain_reg:dzverbg404.com/renew/202/dzverbg404.wordpress.com

Where 'value_bundle' is the slug and '212' is the subscription ID.

###To test, repeat these steps with a few products
1. Expire a product 
2. Visit the renew link with the proper slug - 'value_bundle' for Premium, 'offsite_redirect' for Site Redirect etc.

You should see a checkout page with that product in the cart.

To test with an expiring domain, always use `domain_map` product slug. The format is like this:
`http://calypso.localhost:3000/checkout/domain_reg:dzverbg404.com/renew/202/dzverbg404.wordpress.com`