### PR TITLE
Publicize scheduling: add stats

### DIFF
--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -66,6 +66,7 @@ import formatCurrency from 'lib/format-currency';
 import SectionHeader from 'components/section-header';
 import Tooltip from 'components/tooltip';
 import analytics from 'lib/analytics';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 class PostShare extends Component {
 	static propTypes = {
@@ -520,6 +521,7 @@ class PostShare extends Component {
 
 		return (
 			<div className="post-share">
+				<TrackComponentView eventName="calypso_publicize_post_share_view" />
 				<QueryPostTypes siteId={ siteId } />
 				<QueryPublicizeConnections siteId={ siteId } />
 

--- a/client/my-sites/post-share/index.jsx
+++ b/client/my-sites/post-share/index.jsx
@@ -135,6 +135,7 @@ class PostShare extends Component {
 
 	toggleSharingPreview = () => {
 		const showSharingPreview = ! this.state.showSharingPreview;
+		analytics.tracks.recordEvent( 'calypso_publicize_share_preview_toggle', { show: showSharingPreview } );
 		this.setState( { showSharingPreview } );
 	}
 

--- a/client/my-sites/post-share/publicize-actions-list.jsx
+++ b/client/my-sites/post-share/publicize-actions-list.jsx
@@ -28,6 +28,7 @@ import NavItem from 'components/section-nav/item';
 import { isEnabled } from 'config';
 import Dialog from 'components/dialog';
 import { deletePostShareAction } from 'state/sharing/publicize/publicize-actions/actions';
+import analytics from 'lib/analytics';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {
@@ -43,7 +44,10 @@ class PublicizeActionsList extends PureComponent {
 		selectedScheduledShareId: null
 	};
 
-	setFooterSection = selectedShareTab => () => this.setState( { selectedShareTab } );
+	setFooterSection = selectedShareTab => () => {
+		analytics.tracks.recordEvent( 'calypso_publicize_action_tab_click', { tab: selectedShareTab } );
+		this.setState( { selectedShareTab } );
+	};
 
 	renderFooterSectionItem( {
 		ID: actionId,
@@ -109,6 +113,7 @@ class PublicizeActionsList extends PureComponent {
 	}
 
 	deleteScheduledAction( actionId ) {
+		analytics.tracks.recordEvent( 'calypso_publicize_scheduled_delete' );
 		return () => {
 			this.setState( {
 				showDeleteDialog: true,

--- a/client/my-sites/post-share/publicize-actions-list.jsx
+++ b/client/my-sites/post-share/publicize-actions-list.jsx
@@ -113,7 +113,6 @@ class PublicizeActionsList extends PureComponent {
 	}
 
 	deleteScheduledAction( actionId ) {
-		analytics.tracks.recordEvent( 'calypso_publicize_scheduled_delete' );
 		return () => {
 			this.setState( {
 				showDeleteDialog: true,
@@ -128,7 +127,7 @@ class PublicizeActionsList extends PureComponent {
 				siteId,
 				postId
 			} = this.props;
-
+			analytics.tracks.recordEvent( 'calypso_publicize_scheduled_delete' );
 			this.props.deletePostShareAction( siteId, postId, this.state.selectedScheduledShareId );
 		}
 


### PR DESCRIPTION
This adds various stats for publicize scheduling usage.

- calypso_publicize_share_schedule for scheduling shares
- calypso_publicize_share_instantly for instant republicize action
- calypso_publicize_post_share_view for opening share component
- calypso_publicize_action_tab_click for clicking tabs with sheduled / publithed
- calypso_publicize_scheduled_delete for deleting a share
- calypso_publicize_share_preview_toggle for opening preview window

## Testing

Set logging in calypso:
```javascript
localStorage.setItem('debug', 'calypso:analytics:*');
```

Perform the above actions and see if stats come in console.
