### PR TITLE
FacebookSharePreview: fix username value

### DIFF
--- a/client/blocks/sharing-preview-pane/docs/example.jsx
+++ b/client/blocks/sharing-preview-pane/docs/example.jsx
@@ -11,28 +11,35 @@ import { connect } from 'react-redux';
 import SharingPreviewPane from 'blocks/sharing-preview-pane';
 import { getCurrentUser } from 'state/current-user/selectors';
 import QueryPosts from 'components/data/query-posts';
+import QueryPublicizeConnections from 'components/data/query-publicize-connections';
 import { getSitePosts } from 'state/posts/selectors';
+import { getSite } from 'state/sites/selectors';
 import Card from 'components/card';
 import QuerySites from 'components/data/query-sites';
 
-const SharingPreviewPaneExample = ( { siteId, postId } ) => (
-	<Card>
-		<QuerySites siteId={ siteId } />
-		{ siteId && (
-			<QueryPosts
-				siteId={ siteId }
-				query={ { number: 1, type: 'post' } } />
-		) }
-		<SharingPreviewPane
-			message="Do you have a trip coming up?"
-			postId={ postId }
-			siteId={ siteId } />
-	</Card>
+const SharingPreviewPaneExample = ( { postId, site, siteId } ) => (
+	<div>
+		{ site && <p>Site: <strong>{ site.name } ({ siteId })</strong></p> }
+		<Card>
+			<QuerySites siteId={ siteId } />
+			<QueryPublicizeConnections siteId={ siteId } />
+			{ siteId && (
+				<QueryPosts
+					siteId={ siteId }
+					query={ { number: 1, type: 'post' } } />
+			) }
+			<SharingPreviewPane
+				message="Do you have a trip coming up?"
+				postId={ postId }
+				siteId={ siteId } />
+		</Card>
+	</div>
 );
 
 const ConnectedSharingPreviewPaneExample = connect( ( state ) => {
 	const user = getCurrentUser( state );
 	const siteId = get( user, 'primary_blog' );
+	const site = getSite( state, siteId );
 	const posts = getSitePosts( state, siteId );
 	const post = posts && posts[ posts.length - 1 ];
 	const postId = get( post, 'ID' );
@@ -40,6 +47,7 @@ const ConnectedSharingPreviewPaneExample = connect( ( state ) => {
 	return {
 		siteId,
 		postId,
+		site,
 	};
 } )( SharingPreviewPaneExample );
 

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -20,7 +20,7 @@ export class FacebookSharePreview extends PureComponent {
 			articleUrl,
 			externalProfilePicture,
 			externalProfileUrl,
-			externalName,
+			externalDisplay,
 			imageUrl,
 			message,
 			translate
@@ -35,10 +35,11 @@ export class FacebookSharePreview extends PureComponent {
 								src={ externalProfilePicture }
 							/>
 						</div>
+
 						<div className="facebook-share-preview__profile-line-part">
 							<div className="facebook-share-preview__profile-line">
 								<a className="facebook-share-preview__profile-name" href={ externalProfileUrl }>
-									{ externalName }
+									{ externalDisplay }
 								</a>
 								<span>
 									{


### PR DESCRIPTION
This PR fixes the bug trying to get the username value. Also, improve the preview pane example getting the connections and shows the title of the current site.

![image](https://user-images.githubusercontent.com/77539/27087654-f62f29ba-502b-11e7-8dac-4dddd5140578.png)


### Testing

1) Go to devdocs testing page: http://calypso.localhost:3000/devdocs/blocks/sharing-preview-pane.
Keep in mind that the testing the site is your primary site in WordPress.com and it needs connections. To add them go to `http://calypso.localhost:3000/sharing/<your-primary-blog>`

2) Take a look at the Facebook preview activating its tab:
![image](https://user-images.githubusercontent.com/77539/27087829-6e6e068a-502c-11e7-952c-1ba838e10b53.png)
