### PR TITLE
Reader: ReaderFeedSearch QueryComponent sort support

### DIFF
--- a/client/components/data/query-reader-feeds-search/index.jsx
+++ b/client/components/data/query-reader-feeds-search/index.jsx
@@ -7,19 +7,20 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { requestFeedSearch } from 'state/reader/feed-searches/actions';
+import { requestFeedSearch, SORT_BY_LAST_UPDATED, SORT_BY_RELEVANCE } from 'state/reader/feed-searches/actions';
 
 class QueryFeedSearch extends Component {
 	static propTypes = {
 		query: PropTypes.string,
 		excludeFollowed: PropTypes.bool,
-		searchFeeds: PropTypes.func,
+		sort: PropTypes.oneOf( [ SORT_BY_LAST_UPDATED, SORT_BY_RELEVANCE ] ),
 	};
 
 	componentWillMount() {
 		this.props.requestFeedSearch( {
 			query: this.props.query,
 			excludeFollowed: this.props.excludeFollowed,
+			sort: this.props.sort,
 		} );
 	}
 
@@ -27,6 +28,7 @@ class QueryFeedSearch extends Component {
 		nextProps.requestFeedSearch( {
 			query: nextProps.query,
 			excludeFollowed: nextProps.excludeFollowed,
+			sort: nextProps.sort,
 		} );
 	}
 

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -58,6 +58,7 @@ class SiteResults extends React.Component {
 					hasNextPage={ this.hasNextPage }
 					rowRenderer={ siteRowRenderer }
 					renderEventName={ 'search_stream_sites' }
+					passthroughProp={ this.props.sort }
 				/>
 			</div>
 		);


### PR DESCRIPTION
Current brokenness:
1. go to wpcalypso.wordpress.com
2. do a regular search. then try to switch to a date search.  you will see placeholders forever.  

Why is it broken?
- We expect a qc to handle the first page request and it doesn't understand sort yet
- We also aren't informing rv list in any way that the items have changed in a meaningful way since it doesn't get the array ever

To Test:
- try to do the initial switch from relevance to date sort on this branch