### PR TITLE
Reader: fix proptype for reader search date-sort 

### DIFF
--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -18,8 +18,6 @@ import { SEARCH_RESULTS_SITES } from 'reader/follow-button/follow-sources';
 import { siteRowRenderer } from 'components/reader-infinite-stream/row-renderers';
 import withWidth from 'lib/with-width';
 
-const pickSort = sort => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
-
 class SiteResults extends React.Component {
 	static propTypes = {
 		query: PropTypes.string,
@@ -36,22 +34,18 @@ class SiteResults extends React.Component {
 			query: this.props.query,
 			offset,
 			excludeFollowed: false,
-			sort: pickSort( this.props.sort ),
+			sort: this.props.sort,
 		} );
 	};
 
 	hasNextPage = offset => offset < this.props.searchResultsCount;
 
 	render() {
-		const { query, searchResults, width, showLastUpdatedDate } = this.props;
+		const { query, searchResults, width, sort, showLastUpdatedDate } = this.props;
 
 		return (
 			<div>
-				<QueryReaderFeedsSearch
-					query={ query }
-					excludeFollowed={ false }
-					sort={ pickSort( this.props.sort ) }
-				/>
+				<QueryReaderFeedsSearch query={ query } excludeFollowed={ false } sort={ sort } />
 				<ReaderInfiniteStream
 					items={ searchResults || [ {}, {}, {}, {}, {} ] }
 					width={ width }
@@ -70,11 +64,11 @@ export default connect(
 	( state, ownProps ) => ( {
 		searchResults: getReaderFeedsForQuery(
 			state,
-			{ query: ownProps.query, excludeFollowed: false, sort: pickSort( ownProps.sort ) },
+			{ query: ownProps.query, excludeFollowed: false, sort: ownProps.sort },
 		),
 		searchResultsCount: getReaderFeedsCountForQuery(
 			state,
-			{ query: ownProps.query, excludeFollowed: false, sort: pickSort( ownProps.sort ) },
+			{ query: ownProps.query, excludeFollowed: false, sort: ownProps.sort },
 		),
 	} ),
 	{ requestFeedSearch },

--- a/client/reader/search-stream/with-sites.jsx
+++ b/client/reader/search-stream/with-sites.jsx
@@ -16,14 +16,13 @@ import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import SearchInput from 'components/search';
 import { recordAction, recordTrack } from 'reader/stats';
-// import { SEARCH_RESULTS } from 'reader/follow-button/follow-sources';
 import SiteResults from './site-results';
 import PostResults from './post-results';
 import ReaderMain from 'components/reader-main';
 import { addQueryArgs } from 'lib/url';
 import SearchStreamHeader, { POSTS } from './search-stream-header';
 import withWidth from 'lib/with-width';
-import { SORT_BY_LAST_UPDATED, SORT_BY_RELEVANCE } from './site-results';
+import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
 
 const WIDE_DISPLAY_CUTOFF = 660;
 
@@ -100,7 +99,6 @@ class SearchStream extends React.Component {
 
 	render() {
 		const { query, translate, searchType } = this.props;
-		// const emptyContent = <EmptyContent query={ query } />;
 		const sortOrder = this.props.postsStore && this.props.postsStore.sortOrder;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 

--- a/client/reader/search-stream/with-sites.jsx
+++ b/client/reader/search-stream/with-sites.jsx
@@ -23,11 +23,14 @@ import ReaderMain from 'components/reader-main';
 import { addQueryArgs } from 'lib/url';
 import SearchStreamHeader, { POSTS } from './search-stream-header';
 import withWidth from 'lib/with-width';
+import { SORT_BY_LAST_UPDATED, SORT_BY_RELEVANCE } from './site-results';
 
 const WIDE_DISPLAY_CUTOFF = 660;
 
 const updateQueryArg = params =>
 	page.replace( addQueryArgs( params, window.location.pathname + window.location.search ) );
+
+const pickSort = sort => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
 class SearchStream extends React.Component {
 	static propTypes = {
@@ -161,13 +164,21 @@ class SearchStream extends React.Component {
 						</div>
 						{ query &&
 							<div className="search-stream__site-results">
-								<SiteResults query={ query } sort={ sortOrder } showLastUpdatedDate={ false } />
+								<SiteResults
+									query={ query }
+									sort={ pickSort( sortOrder ) }
+									showLastUpdatedDate={ false }
+								/>
 							</div> }
 					</div> }
 				{ ! wideDisplay &&
 					<div className="search-stream__single-column-results">
 						{ ( ( searchType === POSTS || ! query ) && <PostResults { ...this.props } /> ) ||
-							<SiteResults query={ query } sort={ sortOrder } showLastUpdatedDate={ true } /> }
+							<SiteResults
+								query={ query }
+								sort={ pickSort( sortOrder ) }
+								showLastUpdatedDate={ true }
+							/> }
 					</div> }
 			</div>
 		);


### PR DESCRIPTION
Currently SiteResults expects PropTypes.oneOf( [ 'last_updated', 'relevance' ] ).   
e don't actually get it that way from the url though. Within the url it is "date" or "relevance".

 This pr handles the mapping from query param to calypso var one component higher up so that we can keep the nicer proptype without a warning

To Test
-----

- Make sure that there is no longer any proptype warning when loading up reader search and changing the sorts.
- date sorting should still work