### PR TITLE
restoreLastLocation: route whitelist, no redirect with query args

### DIFF
--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -36,6 +36,7 @@ export const restoreLastLocation = () => {
 						isWhitelistedForRestoring( lastPath ) ) {
 					debug( 'redir to', lastPath );
 					page( lastPath );
+					return;
 				} else if ( action.path !== lastPath &&
 						! isOutsideCalypso( action.path ) ) {
 					debug( 'saving', action.path );

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -13,10 +13,10 @@ import { ROUTE_SET } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:restore-last-location' );
 const LAST_PATH = 'last_path';
-const ALLOWED_PATHS = /^\/(stats|plans|view|posts|pages|media|types|themes|sharing|people|plugins|domains)/i;
+const ALLOWED_PATHS_FOR_RESTORING = /^\/(stats|plans|view|posts|pages|media|types|themes|sharing|people|plugins|domains)/i;
 
 const isWhitelistedForRestoring = ( path ) => {
-	return !! path.match( ALLOWED_PATHS );
+	return !! path.match( ALLOWED_PATHS_FOR_RESTORING );
 };
 
 export const restoreLastLocation = () => {

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -13,6 +13,11 @@ import { ROUTE_SET } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:restore-last-location' );
 const LAST_PATH = 'last_path';
+const ALLOWED_PATHS = /^\/(stats|plans|view|posts|pages|media|types|themes|sharing|people|plugins|domains)/i;
+
+const isWhitelistedForRestoring = ( path ) => {
+	return !! path.match( ALLOWED_PATHS );
+};
 
 export const restoreLastLocation = () => {
 	let hasInitialized = false;
@@ -26,8 +31,9 @@ export const restoreLastLocation = () => {
 			( lastPath ) => {
 				if ( ! hasInitialized &&
 						lastPath && lastPath !== '/' &&
-						action.path === '/' &&
-						! isOutsideCalypso( lastPath ) ) {
+						action.path === '/' && Object.keys( action.query ).length === 0 &&
+						! isOutsideCalypso( lastPath ) &&
+						isWhitelistedForRestoring( lastPath ) ) {
 					debug( 'redir to', lastPath );
 					page( lastPath );
 				} else if ( action.path !== lastPath &&

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -36,7 +36,6 @@ export const restoreLastLocation = () => {
 						isWhitelistedForRestoring( lastPath ) ) {
 					debug( 'redir to', lastPath );
 					page( lastPath );
-					return;
 				} else if ( action.path !== lastPath &&
 						! isOutsideCalypso( action.path ) ) {
 					debug( 'saving', action.path );

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -23,7 +23,7 @@ export const restoreLastLocation = () => {
 	let hasInitialized = false;
 
 	return ( next ) => ( action ) => {
-		if ( action.type !== ROUTE_SET || ! action.path ) {
+		if ( action.type !== ROUTE_SET || ! action.path || ! action.query ) {
 			return next( action );
 		}
 


### PR DESCRIPTION
This PR adds a whitelist for restoring the path. For now, the routes are basic management ones from My Sites, we can iterate on the list further. This PR also prevents restoring path when user visits `/` with query arguments present (typical for calypso.live)