### PR TITLE
Reader: only show following intro banner to users < 2 weeks old

### DIFF
--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -14,6 +14,7 @@ import QueryPreferences from 'components/data/query-preferences';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import { recordTrack } from 'reader/stats';
+import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'state/ui/guided-tours/contexts';
 
 class FollowingIntro extends React.Component {
 	componentDidMount() {
@@ -33,10 +34,10 @@ class FollowingIntro extends React.Component {
 	};
 
 	render() {
-		const { isNewReader, translate, dismiss } = this.props;
+		const { isNewReader, translate, dismiss, isNewUser } = this.props;
 		const linkElement = <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />;
 
-		if ( ! isNewReader ) {
+		if ( ! isNewReader || ! isNewUser ) {
 			return null;
 		}
 
@@ -84,6 +85,7 @@ export default connect(
 	state => {
 		return {
 			isNewReader: getPreference( state, 'is_new_reader' ),
+			isNewUser: isUserNewerThan( state, WEEK_IN_MILLISECONDS * 2 ),
 		};
 	},
 	dispatch =>

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -85,7 +85,7 @@ export default connect(
 	state => {
 		return {
 			isNewReader: getPreference( state, 'is_new_reader' ),
-			isNewUser: isUserNewerThan( state, WEEK_IN_MILLISECONDS * 2 ),
+			isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS * 2 )( state ),
 		};
 	},
 	dispatch =>

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -56,16 +56,6 @@ const timeSinceUserRegistration = state => {
 };
 
 /**
- * Returns true if the user is considered "new" (less than a week since registration)
- *
- * @param {Object} state Global state tree
- * @return {Boolean} True if user is new, false otherwise
- */
-export const isNewUser = state => {
-	return isUserNewerThan( state, WEEK_IN_MILLISECONDS );
-};
-
-/**
  * Returns a selector that tests if the user is newer than a given time
  *
  * @param {Number} age Number of milliseconds
@@ -74,6 +64,16 @@ export const isNewUser = state => {
 export const isUserNewerThan = age => state => {
 	const userAge = timeSinceUserRegistration( state );
 	return userAge !== false ? userAge <= age : false;
+};
+
+/**
+ * Returns true if the user is considered "new" (less than a week since registration)
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if user is new, false otherwise
+ */
+export const isNewUser = state => {
+	return isUserNewerThan( state, WEEK_IN_MILLISECONDS );
 };
 
 /**

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -23,7 +23,7 @@ import {
 	isCurrentPlanPaid,
 } from 'state/sites/selectors';
 
-const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
+export const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 
 /**
  * Returns a selector that tests if the current user is in a given section

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -73,7 +73,7 @@ export const isUserNewerThan = age => state => {
  * @return {Boolean} True if user is new, false otherwise
  */
 export const isNewUser = state => {
-	return isUserNewerThan( state, WEEK_IN_MILLISECONDS );
+	return isUserNewerThan( WEEK_IN_MILLISECONDS )( state );
 };
 
 /**

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -62,8 +62,18 @@ const timeSinceUserRegistration = state => {
  * @return {Boolean} True if user is new, false otherwise
  */
 export const isNewUser = state => {
+	return isUserNewerThan( state, WEEK_IN_MILLISECONDS );
+};
+
+/**
+ * Returns a selector that tests if the user is newer than a given time
+ *
+ * @param {Number} age Number of milliseconds
+ * @return {Function} Selector function
+ */
+export const isUserNewerThan = age => state => {
 	const userAge = timeSinceUserRegistration( state );
-	return userAge !== false ? userAge <= WEEK_IN_MILLISECONDS : false;
+	return userAge !== false ? userAge <= age : false;
 };
 
 /**

--- a/client/state/ui/guided-tours/test/contexts.js
+++ b/client/state/ui/guided-tours/test/contexts.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,7 +15,10 @@ import {
 	SOURCE_UNKNOWN,
 } from 'components/tinymce/plugins/wpcom-track-paste/sources';
 
+const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24
+
 describe( 'selectors', () => {
+	let isUserNewerThan;
 	let hasUserRegisteredBefore;
 	let hasUserPastedFromGoogleDocs;
 	let hasAnalyticsEventFired;
@@ -28,10 +32,43 @@ describe( 'selectors', () => {
 				'state/ui/guided-tours/test/fixtures/config' );
 
 		const contexts = require( '../contexts' );
+		isUserNewerThan = contexts.isUserNewerThan;
 		hasUserRegisteredBefore = contexts.hasUserRegisteredBefore;
 		hasUserPastedFromGoogleDocs = contexts.hasUserPastedFromGoogleDocs;
 		hasAnalyticsEventFired = contexts.hasAnalyticsEventFired;
 		hasUserClicked = hasAnalyticsEventFired( 'calypso_themeshowcase_theme_click' );
+	} );
+
+	describe( '#isUserNewerThan', () => {
+		const oldUser = {
+			currentUser: {
+				id: 73705554
+			},
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2016', date: moment().subtract( 8, 'days' ) }
+				}
+			},
+		};
+
+		const newUser = {
+			currentUser: {
+				id: 73705554
+			},
+			users: {
+				items: {
+					73705554: { ID: 73705554, login: 'testonesite2016', date: moment() }
+				}
+			},
+		};
+
+		it( 'should return false for users registered before a week ago', () => {
+			expect( isUserNewerThan( WEEK_IN_MILLISECONDS )( oldUser ) ).to.be.false;
+		} );
+
+		it( 'should return true for users registered in the last week', () => {
+			expect( isUserNewerThan( WEEK_IN_MILLISECONDS )( newUser ) ).to.be.true;
+		} );
 	} );
 
 	describe( '#hasUserRegisteredBefore', () => {

--- a/client/state/ui/guided-tours/test/contexts.js
+++ b/client/state/ui/guided-tours/test/contexts.js
@@ -15,7 +15,7 @@ import {
 	SOURCE_UNKNOWN,
 } from 'components/tinymce/plugins/wpcom-track-paste/sources';
 
-const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24
+const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 
 describe( 'selectors', () => {
 	let isUserNewerThan;


### PR DESCRIPTION
The Reader following intro banner is currently shown to all users until they dismiss it or use the Manage Following link within it.

This PR autohides the banner if the user has been registered for more than two weeks.

<img src="https://user-images.githubusercontent.com/17325/27074684-bc56d26c-501f-11e7-878b-05c5b26c568c.png" />

Fixes #14824.

Pre-requisite: https://github.com/Automattic/wp-calypso/pull/15029

