### PR TITLE
Publicize: update published actions endpoint

### DIFF
--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -62,13 +62,13 @@ export function fetchPostShareActionsPublished( siteId, postId ) {
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
 			}, ( error, data ) => {
-				if ( error || ! data.items ) {
-					return dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_FAILURE, siteId, postId, error } );
-				}
+			if ( error || ! data.items ) {
+				return dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_FAILURE, siteId, postId, error } );
+			}
 
-				const actions = {};
-				data.items.forEach( action => ( actions[ action.ID ] = action ) );
-				dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS, siteId, postId, actions } );
+			const actions = {};
+			data.items.forEach( action => ( actions[ action.ID ] = action ) );
+			dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS, siteId, postId, actions } );
 		} );
 	};
 }

--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -55,15 +55,20 @@ export function fetchPostShareActionsPublished( siteId, postId ) {
 			postId,
 		} );
 
-		const getPublishedPath = `/sites/${ siteId }/post/${ postId }/publicize/published`;
-		return wpcom.req.get( getPublishedPath, ( error, data ) => {
-			if ( error || ! data.items ) {
-				return dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_FAILURE, siteId, postId, error } );
-			}
+		const getPublishedPath = `/sites/${ siteId }/posts/${ postId }/publicize/published-actions`;
+		return wpcom.req.get(
+			{
+				path: getPublishedPath,
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			}, ( error, data ) => {
+				if ( error || ! data.items ) {
+					return dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_FAILURE, siteId, postId, error } );
+				}
 
-			const actions = {};
-			data.items.forEach( action => ( actions[ action.ID ] = action ) );
-			dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS, siteId, postId, actions } );
+				const actions = {};
+				data.items.forEach( action => ( actions[ action.ID ] = action ) );
+				dispatch( { type: PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS, siteId, postId, actions } );
 		} );
 	};
 }


### PR DESCRIPTION
This updates the published actions endpoint to v2.

**Testing**
- Open up dev tools
- visit http://calypso.localhost:3000/posts/:site_id and open the sharing tab on a post
- look for the `publicize/published-actions` endpoint in the dev tools network tab
- the response shape should be `{ total: 0, items: [] }` for any post without published actions

To test with published actions you will need a site that is whitelisted to save published actions or try accessing this test site: jhnstntest2.wordpress.com
