### PR TITLE
Components: Add icon to closed state of SelectDropdown

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -221,19 +221,12 @@ class SelectDropdown extends Component {
 	}
 
 	render() {
-		const dropdownClasses = {
+		const dropdownClassName = classNames( this.props.className, {
 			'select-dropdown': true,
 			'is-compact': this.props.compact,
-			'is-open': this.state.isOpen
-		};
-
-		if ( this.props.className ) {
-			this.props.className.split( ' ' ).forEach( function( className ) {
-				dropdownClasses[ className ] = true;
-			} );
-		}
-
-		const dropdownClassName = classNames( dropdownClasses );
+			'is-open': this.state.isOpen,
+			'has-count': 'number' === typeof this.props.selectedCount
+		} );
 
 		const selectedText = this.getSelectedText();
 		const selectedIcon = this.getSelectedIcon();

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -53,7 +53,7 @@ $compact-header-height: 35;
 .select-dropdown__header {
 	height: #{ $header-height }px;
 	line-height: #{ $header-height - 3 }px;
-	padding: 0 75px 0 #{ $side-margin }px;
+	padding: 0 32px 0 #{ $side-margin }px;
 	box-sizing: border-box;
 
 	border-style: solid;
@@ -85,6 +85,10 @@ $compact-header-height: 35;
 			right: 5px;
 			line-height: #{ $compact-header-height }px;
 		}
+	}
+
+	.has-count & {
+		padding-right: 75px;
 	}
 
 	.is-compact & {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -125,7 +125,8 @@ $compact-header-height: 35;
 		vertical-align: text-bottom;
 
 		.is-compact & {
-			display: none;
+			position: relative;
+			top: 2px;
 		}
 	}
 }


### PR DESCRIPTION
This PR adds an icon to the closed state of `SelectDropdown` component. It also updates the color and text-transform of the compact state to the same style as the non-compact version, based on designs from @shaunandrews.

**To test:**
- https://calypso.live/devdocs/design/select-dropdown
- or you can open any preview in My Sites and look at the mode switcher

**New look:**

| Normal | Compact |
| --- | --- |
| <img width="400" alt="screen shot 2017-06-13 at 19 13 23" src="https://user-images.githubusercontent.com/156676/27095027-7ac9c6e0-506c-11e7-9d6d-ea4302f31085.png"> | <img width="419" alt="screen shot 2017-06-13 at 19 14 57" src="https://user-images.githubusercontent.com/156676/27095063-a3417a96-506c-11e7-8e2d-153a9ecdcda0.png"> |

**Usage in Preview:**

<img width="483" alt="screen shot 2017-06-13 at 19 15 48" src="https://user-images.githubusercontent.com/156676/27095103-d70f2e40-506c-11e7-8d67-38beb4a276d7.png">
