### PR TITLE
View Site: renamed route

### DIFF
--- a/client/my-sites/preview/index.js
+++ b/client/my-sites/preview/index.js
@@ -6,6 +6,6 @@ import { siteSelection, sites, makeNavigation } from 'my-sites/controller';
 import { preview } from './controller';
 
 export default function( router ) {
-	router( '/preview', siteSelection, sites );
-	router( '/preview/:site', siteSelection, makeNavigation, preview, makeLayout );
+	router( '/view', siteSelection, sites );
+	router( '/view/:site', siteSelection, makeNavigation, preview, makeLayout );
 }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -155,8 +155,8 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				tipTarget="sitePreview"
 				label={ this.props.translate( 'View Site' ) }
-				className={ this.itemLinkClass( [ '/preview' ], 'preview' ) }
-				link={ '/preview' + this.props.siteSuffix }
+				className={ this.itemLinkClass( [ '/view' ], 'preview' ) }
+				link={ '/view' + this.props.siteSuffix }
 				onNavigate={ this.onNavigate }
 				icon="computer"
 				preloadSectionName="preview"

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -363,7 +363,7 @@ sections.push( {
 
 sections.push( {
 	name: 'preview',
-	paths: [ '/preview' ],
+	paths: [ '/view' ],
 	module: 'my-sites/preview',
 	group: 'sites',
 	secondary: true


### PR DESCRIPTION
This renames route `/preview/:slug` to just `/view/:slug` as per our discussions in Samus and with @shaunandrews.

Note: this route is not being linked to from anywhere. We currently iterate on it before we replace the current modal window preview by this page. 

To test:
1. Go to /view/somesite.wordpress.com
2. Confirm you see the page

After merging:
- ask systems to whitelist this route in nginx for Calypso