### PR TITLE
Add all payment method types

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
@@ -14,7 +14,6 @@ import FormPasswordInput from 'components/forms/form-password-input';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
-import ListItem from 'woocommerce/components/list/list-item';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 
 class PaymentMethodEdit extends Component {
@@ -106,13 +105,13 @@ class PaymentMethodEdit extends Component {
 		const { method, translate } = this.props;
 		const settingsFieldsKeys = method.settings && Object.keys( method.settings );
 		return (
-			<ListItem>
+			<div className="payments__method-edit-pane">
 				{ settingsFieldsKeys.map( this.renderEditField ) }
 				<hr />
 				<Button primary onClick={ this.onSaveHandler }>
 					{ translate( 'Save' ) }
 				</Button>
-			</ListItem>
+			</div>
 		);
 	}
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
@@ -13,6 +13,7 @@ import FormLabel from 'components/forms/form-label';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
 import ListItem from 'woocommerce/components/list/list-item';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 
@@ -60,6 +61,7 @@ class PaymentMethodEdit extends Component {
 				{ 'email' === setting.type && this.renderEditTextbox( setting ) }
 				{ 'password' === setting.type && this.renderEditPassword( setting ) }
 				{ 'text' === setting.type && this.renderEditTextbox( setting ) }
+				{ 'textarea' === setting.type && this.renderEditTextarea( setting ) }
 				{ 'select' === setting.type && this.renderEditSelect( setting ) }
 			</FormFieldset>
 		);
@@ -85,6 +87,12 @@ class PaymentMethodEdit extends Component {
 	renderEditTextbox = ( setting ) => {
 		return (
 			<FormTextInput name={ setting.id } onChange={ this.onEditFieldHandler } value={ setting.value } />
+		);
+	}
+
+	renderEditTextarea = ( setting ) => {
+		return (
+			<FormTextarea name={ setting.id } onChange={ this.onEditFieldHandler } value={ setting.value } />
 		);
 	}
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
@@ -105,7 +105,7 @@ class PaymentMethodEdit extends Component {
 		const { method, translate } = this.props;
 		const settingsFieldsKeys = method.settings && Object.keys( method.settings );
 		return (
-			<div className="payments__method-edit-pane">
+			<div className="payments__method-edit-fields">
 				{ settingsFieldsKeys.map( this.renderEditField ) }
 				<Button primary onClick={ this.onSaveHandler }>
 					{ translate( 'Save' ) }

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit.js
@@ -107,7 +107,6 @@ class PaymentMethodEdit extends Component {
 		return (
 			<div className="payments__method-edit-pane">
 				{ settingsFieldsKeys.map( this.renderEditField ) }
-				<hr />
 				<Button primary onClick={ this.onSaveHandler }>
 					{ translate( 'Save' ) }
 				</Button>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -53,21 +53,19 @@ class PaymentMethodItem extends Component {
 	};
 
 	onCancel = () => {
-		const { method } = this.props;
-		this.props.closeEditingPaymentMethod( this.props.site.ID, method.id );
+		this.props.closeEditingPaymentMethod( this.props.site.ID, this.props.method.id );
 	}
 
-	onEdit = ( method ) => {
-		const { site } = this.props;
-		this.props.openPaymentMethodForEdit( site.ID, method.id );
+	onEdit = () => {
+		this.props.openPaymentMethodForEdit( this.props.site.ID, this.props.method.id );
 	}
 
 	onEditField = ( field, value ) => {
 		this.props.changePaymentMethodField( this.props.site.ID, field, value );
 	}
 
-	onSave = ( method ) => {
-		const { site, translate } = this.props;
+	onSave = () => {
+		const { method, site, translate } = this.props;
 
 		const successAction = () => {
 			this.props.closeEditingPaymentMethod( site.ID, method.id );

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -14,7 +14,6 @@ import { getPaymentMethodsGroup } from 'woocommerce/state/ui/payments/methods/se
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import List from 'woocommerce/components/list/list';
 import ListHeader from 'woocommerce/components/list/list-header';
-import ListItem from 'woocommerce/components/list/list-item';
 import ListItemField from 'woocommerce/components/list/list-item-field';
 import PaymentMethodItem from './payment-method-item';
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -1,0 +1,148 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	changePaymentMethodField,
+	closeEditingPaymentMethod,
+	openPaymentMethodForEdit,
+} from 'woocommerce/state/ui/payments/methods/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
+import { fetchPaymentMethods, savePaymentMethod } from 'woocommerce/state/sites/payment-methods/actions';
+import { getCurrentlyEditingPaymentMethod, getPaymentMethodsGroup } from 'woocommerce/state/ui/payments/methods/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import List from 'woocommerce/components/list/list';
+import ListHeader from 'woocommerce/components/list/list-header';
+import ListItemField from 'woocommerce/components/list/list-item-field';
+import PaymentMethodEdit from './payment-method-edit';
+import PaymentMethodItem from './payment-method-item';
+
+class SettingsPaymentsMethodList extends Component {
+	static propTypes = {
+		closeEditingPaymentMethod: PropTypes.func.isRequired,
+		currentlyEditingMethod: PropTypes.shape( {
+			id: PropTypes.string,
+		} ),
+		fetchPaymentMethods: PropTypes.func.isRequired,
+		methodType: PropTypes.string.isRequired,
+		openPaymentMethodForEdit: PropTypes.func.isRequired,
+		paymentMethods: PropTypes.array.isRequired,
+		savePaymentMethod: PropTypes.func.isRequired,
+		site: PropTypes.object,
+	};
+
+	componentDidMount() {
+		this.props.fetchPaymentMethods();
+	}
+
+	onCancel = ( method ) => {
+		this.props.closeEditingPaymentMethod( this.props.site.ID, method.id );
+	}
+
+	onEdit = ( method ) => {
+		const { site } = this.props;
+		this.props.openPaymentMethodForEdit( site.ID, method.id );
+	}
+
+	onEditField = ( field, value ) => {
+		this.props.changePaymentMethodField( this.props.site.ID, field, value );
+	}
+
+	onSave = ( method ) => {
+		const { site, translate } = this.props;
+
+		const successAction = () => {
+			this.props.closeEditingPaymentMethod( site.ID, method.id );
+			return successNotice(
+				translate( 'Payment method successfully saved.' ),
+				{ duration: 4000 }
+			);
+		};
+
+		const errorAction = () => {
+			return errorNotice(
+				translate( 'There was a problem saving the payment method. Please try again.' )
+			);
+		};
+
+		this.props.savePaymentMethod( site.ID, method, successAction, errorAction );
+	}
+
+	renderMethodItem = ( method ) => {
+		const currentlyEditingId = this.props.currentlyEditingMethod &&
+			this.props.currentlyEditingMethod.id;
+		const methodTypeClass = `payments__methods-${ this.props.methodType }`;
+		return (
+			<div className={ methodTypeClass } key={ method.title }>
+				<PaymentMethodItem
+					currentlyEditingId={ currentlyEditingId }
+					method={ method }
+					onCancel={ this.onCancel }
+					onEdit={ this.onEdit } />
+				{ currentlyEditingId === method.id && (
+					<PaymentMethodEdit
+						method={ this.props.currentlyEditingMethod }
+						onEditField={ this.onEditField }
+						onSave={ this.onSave } />
+				) }
+			</div>
+		);
+	}
+
+	render() {
+		const { translate, methodType, paymentMethods } = this.props;
+
+		return (
+			<List>
+				<ListHeader>
+					<ListItemField className="payments__methods-column-method">
+						{ translate( 'Method' ) }
+					</ListItemField>
+					{ methodType !== 'offline' && (
+						<ListItemField className="payments__methods-column-fees">
+							{ translate( 'Fees' ) }
+						</ListItemField>
+					) }
+					<ListItemField className="payments__methods-column-settings">
+					</ListItemField>
+				</ListHeader>
+				{ paymentMethods && paymentMethods.map( this.renderMethodItem ) }
+			</List>
+		);
+	}
+}
+
+function mapStateToProps( state, ownProps ) {
+	const currentlyEditingMethod = getCurrentlyEditingPaymentMethod( state );
+	const paymentMethods = getPaymentMethodsGroup( state, ownProps.methodType );
+	const site = getSelectedSiteWithFallback( state );
+	return {
+		currentlyEditingMethod,
+		paymentMethods,
+		site,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			changePaymentMethodField,
+			closeEditingPaymentMethod,
+			fetchPaymentMethods,
+			openPaymentMethodForEdit,
+			savePaymentMethod,
+		},
+		dispatch
+	);
+}
+
+export default localize(
+	connect( mapStateToProps, mapDispatchToProps )( SettingsPaymentsMethodList )
+);

--- a/client/extensions/woocommerce/app/settings/payments/payments-off-site.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-off-site.js
@@ -1,105 +1,22 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import {
-	changePaymentMethodField,
-	closeEditingPaymentMethod,
-	openPaymentMethodForEdit,
-} from 'woocommerce/state/ui/payments/methods/actions';
-import { errorNotice, successNotice } from 'state/notices/actions';
 import ExtendedHeader from 'woocommerce/components/extended-header';
-import { fetchPaymentMethods, savePaymentMethod } from 'woocommerce/state/sites/payment-methods/actions';
-import { getCurrentlyEditingPaymentMethod, getPaymentMethodsGroup } from 'woocommerce/state/ui/payments/methods/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import List from 'woocommerce/components/list/list';
-import ListHeader from 'woocommerce/components/list/list-header';
-import ListItemField from 'woocommerce/components/list/list-item-field';
-import PaymentMethodEdit from './payment-method-edit';
-import PaymentMethodItem from './payment-method-item';
+import PaymentMethodList from './payment-method-list';
 
-class SettingsPaymentsOffSite extends Component {
-	static propTypes = {
-		closeEditingPaymentMethod: PropTypes.func.isRequired,
-		currentlyEditingMethod: PropTypes.shape( {
-			id: PropTypes.string,
-		} ),
-		fetchPaymentMethods: PropTypes.func.isRequired,
-		openPaymentMethodForEdit: PropTypes.func.isRequired,
-		paymentMethods: PropTypes.array.isRequired,
-		savePaymentMethod: PropTypes.func.isRequired,
-		siteId: PropTypes.number.isRequired,
-	};
-
-	componentDidMount() {
-		this.props.fetchPaymentMethods();
-	}
-
-	onCancel = ( method ) => {
-		this.props.closeEditingPaymentMethod( this.props.siteId, method.id );
-	}
-
-	onEdit = ( method ) => {
-		const { siteId } = this.props;
-		this.props.openPaymentMethodForEdit( siteId, method.id );
-	}
-
-	onEditField = ( field, value ) => {
-		this.props.changePaymentMethodField( this.props.siteId, field, value );
-	}
-
-	onSave = ( method ) => {
-		const { siteId, translate } = this.props;
-
-		const successAction = () => {
-			this.props.closeEditingPaymentMethod( siteId, method.id );
-			return successNotice(
-				translate( 'Payment method successfully saved.' ),
-				{ duration: 4000 }
-			);
-		};
-
-		const errorAction = () => {
-			return errorNotice(
-				translate( 'There was a problem saving the payment method. Please try again.' )
-			);
-		};
-
-		this.props.savePaymentMethod( siteId, method, successAction, errorAction );
-	}
-
-	renderMethodItem = ( method ) => {
-		const currentlyEditingId = this.props.currentlyEditingMethod &&
-			this.props.currentlyEditingMethod.id;
-		return (
-			<div key={ method.title }>
-				<PaymentMethodItem
-					currentlyEditingId={ currentlyEditingId }
-					method={ method }
-					onCancel={ this.onCancel }
-					onEdit={ this.onEdit } />
-				{ currentlyEditingId === method.id && (
-					<PaymentMethodEdit
-						method={ this.props.currentlyEditingMethod }
-						onEditField={ this.onEditField }
-						onSave={ this.onSave } />
-				) }
-			</div>
-		);
-	}
+class SettingsPaymentsOnSite extends Component {
 
 	render() {
-		const { translate, paymentMethods } = this.props;
+		const { translate } = this.props;
 
 		return (
-			<div className="payments__off-site-container">
+			<div className="payments__type-container">
 				<ExtendedHeader
 					label={ translate( 'Off-site credit card payment methods' ) }
 					description={
@@ -109,48 +26,10 @@ class SettingsPaymentsOffSite extends Component {
 							'information'
 						)
 					} />
-					<List>
-						<ListHeader>
-							<ListItemField className="payments__methods-column-method">
-								{ translate( 'Method' ) }
-							</ListItemField>
-							<ListItemField className="payments__methods-column-fees">
-								{ translate( 'Fees' ) }
-							</ListItemField>
-							<ListItemField className="payments__methods-column-settings">
-							</ListItemField>
-						</ListHeader>
-						{ paymentMethods && paymentMethods.map( this.renderMethodItem ) }
-					</List>
+					<PaymentMethodList methodType="off-site" />
 			</div>
 		);
 	}
 }
 
-function mapStateToProps( state ) {
-	const currentlyEditingMethod = getCurrentlyEditingPaymentMethod( state );
-	const paymentMethods = getPaymentMethodsGroup( state, 'off-site' );
-	const siteId = getSelectedSiteId( state );
-	return {
-		currentlyEditingMethod,
-		paymentMethods,
-		siteId,
-	};
-}
-
-function mapDispatchToProps( dispatch ) {
-	return bindActionCreators(
-		{
-			changePaymentMethodField,
-			closeEditingPaymentMethod,
-			fetchPaymentMethods,
-			openPaymentMethodForEdit,
-			savePaymentMethod,
-		},
-		dispatch
-	);
-}
-
-export default localize(
-	connect( mapStateToProps, mapDispatchToProps )( SettingsPaymentsOffSite )
-);
+export default localize( SettingsPaymentsOnSite );

--- a/client/extensions/woocommerce/app/settings/payments/payments-offline.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-offline.js
@@ -7,15 +7,15 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
+import PaymentMethodList from './payment-method-list';
 
 class SettingsPaymentsOffline extends Component {
 
 	render() {
 		const { translate } = this.props;
 		return (
-			<div>
+			<div className="payments__type-container">
 				<ExtendedHeader
 					label={ translate( 'Offline payment methods' ) }
 					description={
@@ -24,7 +24,7 @@ class SettingsPaymentsOffline extends Component {
 							'transfer, check or cash on delivery.'
 						)
 					} />
-				<Card></Card>
+				<PaymentMethodList methodType="offline" />
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/settings/payments/payments-on-site.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-on-site.js
@@ -7,29 +7,29 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
+import PaymentMethodList from './payment-method-list';
 
 class SettingsPaymentsOnSite extends Component {
 
 	render() {
 		const { translate } = this.props;
+
 		return (
-			<div>
+			<div className="payments__type-container">
 				<ExtendedHeader
 					label={ translate( 'On-site credit card payment methods' ) }
 					description={
 						translate(
-							'On-site methods provide a seamless experience by keeping the ' +
-							'customer on your site to enter their credit card details and ' +
-							'complete checkout. More information'
+							'On-site payment methods involve sending the customer to a ' +
+							'third party web site to complete payment, like PayPal. More ' +
+							'information'
 						)
 					} />
-				<Card></Card>
+					<PaymentMethodList methodType="on-site" />
 			</div>
 		);
 	}
-
 }
 
 export default localize( SettingsPaymentsOnSite );

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -31,6 +31,14 @@
 		border-top: 1px solid lighten( $gray, 30% );
 	}
 
+	.payments__method-information {
+		font-size: 14px;
+	}
+
+	.payments__method-name {
+		font-size: 14px;
+	}
+
 	.list-item-field {
 		width: 30%;
 

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -2,6 +2,10 @@
 	width: 100%;
 }
 
+.payments__type-container .section-header__label:before {
+	display: none;
+}
+
 // PAYMENT-METHOD-ROW
 .payments__type-container {
 

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -3,7 +3,7 @@
 }
 
 // PAYMENT-METHOD-ROW
-.payments__off-site-container {
+.payments__type-container {
 
 	p.payments__method-suggested {
 		font-size: 11px;
@@ -27,8 +27,16 @@
 		width: 30%;
 	}
 
-	.list-item-field:nth-child( 2 ) {
+	.payments__methods-offline .list-item-field:first-child {
 		width: 50%;
+	}
+
+	.list-item-field:nth-child( 2 ) {
+		width: 40%;
+	}
+
+	.payments__methods-offline .list-item-field:nth-child( 2 ) {
+		width: 0;
 	}
 
 	.list-item-field:nth-child( 3 ) {
@@ -45,14 +53,14 @@
 	width: 100%;
 }
 
-.payments__off-site-container {
+.payments__type-container {
 	.list__ul {
 		> div {
-			li:nth-child(2) {
+			li:nth-child( 2 ) {
 				padding: 16px;
 				border-top: 1px solid $gray-light;
 
-				@include breakpoint( ">480px" ) {
+				@include breakpoint( '>480px' ) {
 					padding: 24px;
 				}
 			}

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -28,7 +28,7 @@
 	}
 
 	.list-item {
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $border-ultra-light-gray;
 	}
 
 	.payments__method-information {
@@ -65,7 +65,7 @@
 
 .payments__method-edit-pane {
 	padding: 16px;
-	border-top: 1px solid $gray-light;
+	border-top: 1px solid $border-ultra-light-gray;
 	width: 100%;
 
 	@include breakpoint( '>480px' ) {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -23,25 +23,27 @@
 		font-size: 15px;
 	}
 
-	.list-item-field:first-child {
+	.list-header + .list-item {
+		border-top: 0;
+	}
+
+	.list-item {
+		border-top: 1px solid lighten( $gray, 30% );
+	}
+
+	.list-item-field {
 		width: 30%;
-	}
 
-	.payments__methods-offline .list-item-field:first-child {
-		width: 50%;
-	}
+		&:nth-child(2) {
+			width: 45%;
+		}
 
-	.list-item-field:nth-child( 2 ) {
-		width: 40%;
-	}
-
-	.payments__methods-offline .list-item-field:nth-child( 2 ) {
-		width: 0;
+		&:nth-child(3) {
+			width: 25%;
+		}
 	}
 
 	.list-item-field:nth-child( 3 ) {
-		width: 20%;
-
 		.button {
 			align-self: flex-end;
 		}
@@ -56,6 +58,7 @@
 .payments__method-edit-pane {
 	padding: 16px;
 	border-top: 1px solid $gray-light;
+	width: 100%;
 
 	@include breakpoint( '>480px' ) {
 		padding: 24px;

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -32,7 +32,7 @@
 	}
 
 	.payments__method-information {
-		font-size: 14px;
+		font-size: 12px;
 	}
 
 	.payments__method-name {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -2,7 +2,7 @@
 	width: 100%;
 }
 
-.payments__type-container .section-header__label:before {
+.payments__type-container .section-header__label::before {
 	display: none;
 }
 
@@ -46,11 +46,11 @@
 	.list-item-field {
 		width: 30%;
 
-		&:nth-child(2) {
+		&:nth-child( 2 ) {
 			width: 45%;
 		}
 
-		&:nth-child(3) {
+		&:nth-child( 3 ) {
 			width: 25%;
 		}
 	}
@@ -67,7 +67,7 @@
 	width: 100%;
 }
 
-.payments__method-edit-pane {
+.payments__method-edit-fields {
 	padding: 16px;
 	border-top: 1px solid $border-ultra-light-gray;
 	width: 100%;

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -53,17 +53,11 @@
 	width: 100%;
 }
 
-.payments__type-container {
-	.list__ul {
-		> div {
-			li:nth-child( 2 ) {
-				padding: 16px;
-				border-top: 1px solid $gray-light;
+.payments__method-edit-pane {
+	padding: 16px;
+	border-top: 1px solid $gray-light;
 
-				@include breakpoint( '>480px' ) {
-					padding: 24px;
-				}
-			}
-		}
+	@include breakpoint( '>480px' ) {
+		padding: 24px;
 	}
 }

--- a/client/extensions/woocommerce/components/list/list-header/style.scss
+++ b/client/extensions/woocommerce/components/list/list-header/style.scss
@@ -1,11 +1,11 @@
 .list-header {
-	background: $gray-light;
 	border-bottom: 1px solid lighten( $gray, 20% );
 	display: flex;
 	flex-direction: row;
 	font-weight: normal;
 	font-size: 13px;
 	justify-content: space-between;
+	font-weight: 700;
 
 	.list-item-field {
 		padding-top: 8px;


### PR DESCRIPTION
- Adds all payment method types from API
- Allows editing of all payment method types
- Adds text area input since it is used by offline payment methods

You can test by going to:  http://calypso.localhost:3000/store/settings/payments/{storeUrl}

