### PR TITLE
Editor: display EditorNotice over full-screen preview.

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -148,6 +148,7 @@ $z-layers: (
 		'.dialog__backdrop': 100200,
 		'.wplink__dialog.dialog.card': 100200,
 		'.web-preview': 100200,
+		'.web-preview .editor-notice': 100201,
 		'.design-menu.is-visible': 100201,
 		'.popover.gallery__order-popover': 100300,
 		'popover.is-dialog-visible': 100300,

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -4,10 +4,12 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import config from 'config';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
@@ -224,18 +226,22 @@ export class EditorNotice extends Component {
 	}
 
 	render() {
-		const { siteId, message, status, onDismissClick } = this.props;
+		const { siteId, message, status, onDismissClick, isPreviewable } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
+		const previewFlow = config.isEnabled( 'post-editor/delta-post-publish-preview' ) && isPreviewable;
+		const classes = classNames( 'editor-notice', {
+			'is-global': previewFlow
+		} );
 
 		return (
-			<div className="editor-notice">
+			<div className={ classes }>
 				{ siteId && <QueryPostTypes siteId={ siteId } /> }
 				{ text && (
 					<Notice
 						{ ...{ status, text, onDismissClick } }
 						showDismiss={ true }
 					>
-						{ this.renderNoticeAction() }
+						{ ! previewFlow && this.renderNoticeAction() }
 					</Notice>
 				) }
 			</div>

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -204,8 +204,8 @@ export class EditorNotice extends Component {
 	renderNoticeAction() {
 		const {
 			action,
-			isSitePreviewable: isPreviewable,
 			link,
+			isPreviewable,
 			onViewClick,
 		} = this.props;
 		if ( onViewClick && isPreviewable && link ) {
@@ -226,7 +226,7 @@ export class EditorNotice extends Component {
 	}
 
 	render() {
-		const { siteId, message, status, onDismissClick, isPreviewable } = this.props;
+		const { siteId, message, status, onDismissClick, isSitePreviewable: isPreviewable, } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
 		const previewFlow = config.isEnabled( 'post-editor/delta-post-publish-preview' ) && isPreviewable;
 		const classes = classNames( 'editor-notice', {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -33,7 +33,7 @@ export class EditorNotice extends Component {
 		action: PropTypes.string,
 		link: PropTypes.string,
 		onViewClick: PropTypes.func,
-		isSitePreviewable: PropTypes.bool,
+		isPreviewable: PropTypes.bool,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object
 	}
@@ -226,7 +226,7 @@ export class EditorNotice extends Component {
 	}
 
 	render() {
-		const { siteId, message, status, onDismissClick, isSitePreviewable: isPreviewable, } = this.props;
+		const { siteId, message, status, onDismissClick, isPreviewable } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
 		const classes = classNames( 'editor-notice', {
 			'is-global': config.isEnabled( 'post-editor/delta-post-publish-preview' ) && isPreviewable,
@@ -260,6 +260,6 @@ export default connect( ( state ) => {
 		site: getSelectedSite( state ),
 		type: post.type,
 		typeObject: getPostType( state, siteId, post.type ),
-		isSitePreviewable: isSitePreviewable( state, siteId ),
+		isPreviewable: isSitePreviewable( state, siteId ),
 	};
 }, { setLayoutFocus } )( localize( EditorNotice ) );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -228,9 +228,8 @@ export class EditorNotice extends Component {
 	render() {
 		const { siteId, message, status, onDismissClick, isSitePreviewable: isPreviewable, } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
-		const previewFlow = config.isEnabled( 'post-editor/delta-post-publish-preview' ) && isPreviewable;
 		const classes = classNames( 'editor-notice', {
-			'is-global': previewFlow
+			'is-global': config.isEnabled( 'post-editor/delta-post-publish-preview' ) && isPreviewable,
 		} );
 
 		return (
@@ -241,7 +240,7 @@ export class EditorNotice extends Component {
 						{ ...{ status, text, onDismissClick } }
 						showDismiss={ true }
 					>
-						{ ! previewFlow && this.renderNoticeAction() }
+						{ this.renderNoticeAction() }
 					</Notice>
 				) }
 			</div>

--- a/client/post-editor/editor-notice/style.scss
+++ b/client/post-editor/editor-notice/style.scss
@@ -23,11 +23,11 @@
 		z-index: z-index( 'root', '.web-preview .editor-notice' );
 
 		@include breakpoint( ">660px" ) {
-				top: 47px + 49px + 16px;
+			top: 47px + 49px + 16px;
 		}
 
 		@include breakpoint( ">960px" ) {
-				top: 47px + 49px + 24px;
+			top: 47px + 49px + 24px;
 		}
 
 		.notice {

--- a/client/post-editor/editor-notice/style.scss
+++ b/client/post-editor/editor-notice/style.scss
@@ -17,4 +17,54 @@
 			background-image: none;
 		}
 	}
+
+	&.is-global {
+		@extend .global-notices;
+		z-index: z-index( 'root', '.web-preview .editor-notice' );
+
+		@include breakpoint( ">660px" ) {
+				top: 47px + 49px + 16px;
+		}
+
+		@include breakpoint( ">960px" ) {
+				top: 47px + 49px + 24px;
+		}
+
+		.notice {
+			flex-wrap: nowrap;
+			margin-bottom: 0;
+			text-align: left;
+			pointer-events: auto;
+
+			@include breakpoint( ">660px" ) {
+				display: flex;
+				border-radius: 20px;
+				overflow: hidden;
+				margin-bottom: 24px;
+			}
+		}
+
+		.notice__icon {
+			@include breakpoint( ">660px" ) {
+				padding: 8px 0 8px 16px;
+			}
+		}
+
+		.notice__content {
+			flex-basis: auto;
+			flex-grow: 1;
+
+			@include breakpoint( ">660px" ) {
+				padding: 9px 13px;
+			}
+		}
+
+		.notice__dismiss {
+			flex-shrink: 0;
+
+			@include breakpoint( ">660px" ) {
+				padding: 8px 16px;
+			}
+		}
+	}
 }

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -29,7 +29,7 @@ describe( 'EditorNotice', () => {
 				translate={ translate }
 				status="is-error"
 				message="publishFailure"
-				isSitePreviewable={ true }
+				isPreviewable={ true }
 				onViewClick={ spy }
 				error={ new Error( 'NO_CONTENT' ) } />
 		);
@@ -128,7 +128,7 @@ describe( 'EditorNotice', () => {
 				type="page"
 				link="https://example.wordpress.com/published-page"
 				action="view"
-				isSitePreviewable={ true }
+				isPreviewable={ true }
 				onViewClick={ spy }
 				site={ {
 					URL: 'https://example.wordpress.com',

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -1,4 +1,5 @@
 .editor-preview .web-preview__inner {
+	background: $gray-light;
 	display: none;
 	opacity: 0;
 	transition: opacity 0.3s ease-in-out;

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -1,17 +1,24 @@
-.editor-preview .web-preview__inner {
+.editor-preview {
+	display: flex;
+	flex-direction: column;
+}
+
+.editor-preview.is-fullscreen .web-preview__inner {
 	background: $gray-light;
 	display: none;
 	opacity: 0;
+	position: fixed;
+		top: 46px;
+		right: 0;
+		left: 0;
+		z-index: z-index( 'root', '.web-preview' );
 	transition: opacity 0.3s ease-in-out;
 	width: 100%;
+	height: calc( 100% - 46px );
 
 	&.is-visible {
 		display: flex;
 		opacity: 1;
-        position: absolute;
-			top: -46px;
-			left: 0;
-			z-index: z-index( 'root', '.web-preview' );
 		visibility: visible;
     }
 }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -823,7 +823,7 @@ export const PostEditor = React.createClass( {
 				status: 'is-success',
 				message,
 				action,
-				link
+				link: config.isEnabled( 'post-editor/delta-post-publish-preview' ) ? null : link,
 			};
 
 			window.scrollTo( 0, 0 );


### PR DESCRIPTION
In #15004, a full-screen preview is shown after publishing a post with the `post-editor/delta-post-publish-preview` flag enabled. This PR updates the styles of `EditorNotice` to be shown on top of the preview and to match the styling of global notices.

**Mock:**
<img width="1096" alt="screen shot 2017-06-13 at 3 52 47 pm" src="https://user-images.githubusercontent.com/942359/27101602-6c023de8-5050-11e7-8f52-6871865244ca.png">

This is part of a larger epic (See p3Ex-2ri-p2).

**To Test:**
- Check out branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Publish a new post. 
- After the post is published, a full-screen view of the post should be displayed with a success EditorNotice in the top right, below the preview toolbar, without a "Visit post" action.
- Run the branch again without the feature flag enabled and make sure the notices match their current editor-width, square style, with "Visit post" action.