### PR TITLE
Editor: add preview button to preview after publish

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -256,6 +256,10 @@ WebPreviewContent.propTypes = {
 	showSEO: PropTypes.bool,
 	// Show device viewport switcher
 	showDeviceSwitcher: PropTypes.bool,
+	// Show edit button
+	showEdit: PropTypes.bool,
+	// The URL for the edit button
+	editUrl: PropTypes.string,
 	// The URL that should be displayed in the iframe
 	previewUrl: PropTypes.string,
 	// The URL for the external link button
@@ -288,6 +292,8 @@ WebPreviewContent.defaultProps = {
 	showClose: true,
 	showSEO: true,
 	showDeviceSwitcher: true,
+	showEdit: false,
+	editUrl: null,
 	previewUrl: null,
 	previewMarkup: null,
 	onLoad: noop,

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -123,6 +123,10 @@ WebPreview.propTypes = {
 	showSEO: PropTypes.bool,
 	// Show device viewport switcher
 	showDeviceSwitcher: PropTypes.bool,
+	// Show edit button
+	showEdit: PropTypes.bool,
+	// The URL for the edit button
+	editUrl: PropTypes.string,
 	// The URL that should be displayed in the iframe
 	previewUrl: PropTypes.string,
 	// The URL for the external link button
@@ -151,6 +155,8 @@ WebPreview.defaultProps = {
 	showClose: true,
 	showSEO: true,
 	showDeviceSwitcher: true,
+	showEdit: false,
+	editUrl: null,
 	previewUrl: null,
 	previewMarkup: null,
 	onLoad: noop,

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -116,10 +116,26 @@ a.web-preview__external {
 	cursor: pointer;
 }
 
-.web-preview__external {
-	display: flex;
-	align-items: center;
+.web-preview__edit {
+	color: $gray;
+	border: none;
+	padding: 15px 12px;
+
+	&:visited {
+		color: $gray;
+	}
+
+	&:hover {
+		color: $gray-dark;
+	}
+
+}
+
+.web-preview__toolbar-actions {
 	margin-left: auto;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
 }
 
 .web-preview__device-switcher {
@@ -171,15 +187,6 @@ a.web-preview__external {
 }
 
 .web-preview__toolbar-tray {
-	margin-left: auto;
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-end;
-
-	a.web-preview__external + & {
-		margin-left: 0;
-	}
-
 	.button {
 		margin: 4px;
 		&:not(:last-child) {

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
+import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 
@@ -28,6 +29,10 @@ class PreviewToolbar extends Component {
 		showClose: PropTypes.bool,
 		// Show SEO button
 		showSEO: PropTypes.bool,
+		// Show edit button
+		showEdit: PropTypes.bool,
+		// The URL for the edit button
+		editUrl: PropTypes.string,
 		// The device to display, used for setting preview dimensions
 		device: PropTypes.string,
 		// Elements to render on the right side of the toolbar
@@ -56,12 +61,14 @@ class PreviewToolbar extends Component {
 	render() {
 		const {
 			device: currentDevice,
+			editUrl,
 			externalUrl,
 			onClose,
 			previewUrl,
 			setDeviceViewport,
 			showClose,
 			showDeviceSwitcher,
+			showEdit,
 			showExternal,
 			showSEO,
 			translate
@@ -100,6 +107,15 @@ class PreviewToolbar extends Component {
 							</DropdownItem>
 						) ) }
 					</SelectDropdown>
+				}
+				{ showEdit &&
+					<Button
+						borderless
+						className="web-preview__edit"
+						href={ editUrl }
+					>
+						<Gridicon icon="pencil" /> { translate( 'Edit' ) }
+					</Button>
 				}
 				{ showExternal &&
 					<a

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -108,27 +108,29 @@ class PreviewToolbar extends Component {
 						) ) }
 					</SelectDropdown>
 				}
-				{ showEdit &&
-					<Button
-						borderless
-						className="web-preview__edit"
-						href={ editUrl }
-					>
-						<Gridicon icon="pencil" /> { translate( 'Edit' ) }
-					</Button>
-				}
-				{ showExternal &&
-					<a
-						className="web-preview__external"
-						href={ externalUrl || previewUrl }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<Gridicon icon="external" />
-					</a>
-				}
-				<div className="web-preview__toolbar-tray">
-					{ this.props.children }
+				<div className="web-preview__toolbar-actions">
+					{ showEdit &&
+						<Button
+							className="web-preview__edit"
+							href={ editUrl }
+							onClick={ onClose }
+						>
+							<Gridicon icon="pencil" /> { translate( 'Edit' ) }
+						</Button>
+					}
+					{ showExternal &&
+						<a
+							className="web-preview__external"
+							href={ externalUrl || previewUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<Gridicon icon="external" />
+						</a>
+					}
+					<div className="web-preview__toolbar-tray">
+						{ this.props.children }
+					</div>
 				</div>
 			</div>
 		);

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -104,10 +104,11 @@ const EditorPreview = React.createClass( {
 				{ previewFlow
 					? <WebPreviewContent
 							showPreview={ this.props.showPreview }
+							showEdit={ true }
+							showExternal={ false }
 							defaultViewportDevice={ this.props.defaultViewportDevice }
 							onClose={ this.props.onClose }
 							previewUrl={ this.state.iframeUrl }
-							externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }
 						/>
 					: <WebPreview
 							showPreview={ this.props.showPreview }

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -22,6 +22,7 @@ const EditorPreview = React.createClass( {
 		isSaving: React.PropTypes.bool,
 		isLoading: React.PropTypes.bool,
 		previewUrl: React.PropTypes.string,
+		editUrl: React.PropTypes.string,
 		onClose: React.PropTypes.func,
 		postId: React.PropTypes.number
 	},
@@ -109,6 +110,7 @@ const EditorPreview = React.createClass( {
 							defaultViewportDevice={ this.props.defaultViewportDevice }
 							onClose={ this.props.onClose }
 							previewUrl={ this.state.iframeUrl }
+							editUrl={ this.props.editUrl }
 						/>
 					: <WebPreview
 							showPreview={ this.props.showPreview }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -368,6 +368,7 @@ export const PostEditor = React.createClass( {
 							isLoading={ this.state.isLoading }
 							previewUrl={ this.state.previewUrl }
 							externalUrl={ this.state.previewUrl }
+							editUrl={ this.props.editPath }
 							defaultViewportDevice={ config.isEnabled( 'post-editor/delta-post-publish-preview' ) ? 'computer' : 'tablet' }
 						/>
 						: null }


### PR DESCRIPTION
This PR adds an edit button to the preview shown after publishing a post.

![editbutton](https://user-images.githubusercontent.com/363749/27102059-87befe06-5049-11e7-8bc8-fa957ce12c70.gif)

This PR is part of a larger epic, see p8F9tW-3F-p2.

**To Test:**
- Check out branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Publish a new post. 
- After the post is published, the full-screen view of the post that is displayed should have an "Edit" button. Clicking on "Edit" should close the modal, allowing you to edit the post.