### PR TITLE
Woo: Add onSuccessAction and onFailureAction to request

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/request/actions.js
+++ b/client/extensions/woocommerce/state/data-layer/request/actions.js
@@ -18,14 +18,9 @@ function _createRequestAction( method, siteId, path, body, onSuccessAction, onFa
 		siteId,
 		path,
 		body,
+		onSuccessAction,
+		onFailureAction,
 	};
-
-	if ( onSuccessAction ) {
-		action.onSuccessAction = onSuccessAction;
-	}
-	if ( onFailureAction ) {
-		action.onFailureAction = onFailureAction;
-	}
 
 	return action;
 }

--- a/client/extensions/woocommerce/state/data-layer/request/actions.js
+++ b/client/extensions/woocommerce/state/data-layer/request/actions.js
@@ -10,8 +10,8 @@ import {
 	WOOCOMMERCE_API_REQUEST,
 } from 'woocommerce/state/action-types';
 
-function _createRequestAction( method, siteId, path, body ) {
-	return {
+function _createRequestAction( method, siteId, path, body, onSuccessAction, onFailureAction ) {
+	const action = {
 		type: WOOCOMMERCE_API_REQUEST,
 		requestId: uniqueId( 'request_' ),
 		method,
@@ -19,21 +19,64 @@ function _createRequestAction( method, siteId, path, body ) {
 		path,
 		body,
 	};
+
+	if ( onSuccessAction ) {
+		action.onSuccessAction = onSuccessAction;
+	}
+	if ( onFailureAction ) {
+		action.onFailureAction = onFailureAction;
+	}
+
+	return action;
 }
 
-export function get( siteId, path ) {
-	return _createRequestAction( 'get', siteId, path );
+/**
+ * Performs HTTP GET in data-layer handlers and dispatches appropriate success/failure actions.
+ * @param {Number} siteId id for the WooCommerce site.
+ * @param {String} path API endpoint
+ * @param {Object} [onSuccessAction] Action will have `data` property assigned to it and be dispatched upon success.
+ * @param {Object} [onFailureAction] Action will have `error` property assigned to it and be dispatched upon failure.
+ * @return {Promise<Object>} A promise to the action (only used for testing)
+ */
+export function get( siteId, path, onSuccessAction, onFailureAction ) {
+	return _createRequestAction( 'get', siteId, path, undefined, onSuccessAction, onFailureAction );
 }
 
-export function post( siteId, path, body ) {
-	return _createRequestAction( 'post', siteId, path, body );
+/**
+ * Performs HTTP POST in data-layer handlers and dispatches appropriate success/failure actions.
+ * @param {Number} siteId id for the WooCommerce site.
+ * @param {String} path API endpoint
+ * @param {Object} body JS Object that will be converted to JSON for the HTTP Body
+ * @param {Object} [onSuccessAction] Action will have `data` property assigned to it and be dispatched upon success.
+ * @param {Object} [onFailureAction] Action will have `error` property assigned to it and be dispatched upon failure.
+ * @return {Promise<Object>} A promise to the action (only used for testing)
+ */
+export function post( siteId, path, body, onSuccessAction, onFailureAction ) {
+	return _createRequestAction( 'post', siteId, path, body, onSuccessAction, onFailureAction );
 }
 
-export function put( siteId, path, body ) {
-	return _createRequestAction( 'put', siteId, path, body );
+/**
+ * Performs HTTP PUT in data-layer handlers and dispatches appropriate success/failure actions.
+ * @param {Number} siteId id for the WooCommerce site.
+ * @param {String} path API endpoint
+ * @param {Object} body JS Object that will be converted to JSON for the HTTP Body
+ * @param {Object} [onSuccessAction] Action will have `data` property assigned to it and be dispatched upon success.
+ * @param {Object} [onFailureAction] Action will have `error` property assigned to it and be dispatched upon failure.
+ * @return {Promise<Object>} A promise to the action (only used for testing)
+ */
+export function put( siteId, path, body, onSuccessAction, onFailureAction ) {
+	return _createRequestAction( 'put', siteId, path, body, onSuccessAction, onFailureAction );
 }
 
-export function del( siteId, path ) {
-	return _createRequestAction( 'del', siteId, path );
+/**
+ * Performs HTTP DELETE in data-layer handlers and dispatches appropriate success/failure actions.
+ * @param {Number} siteId id for the WooCommerce site.
+ * @param {String} path API endpoint
+ * @param {Object} [onSuccessAction] Action will have `data` property assigned to it and be dispatched upon success.
+ * @param {Object} [onFailureAction] Action will have `error` property assigned to it and be dispatched upon failure.
+ * @return {Promise<Object>} A promise to the action (only used for testing)
+ */
+export function del( siteId, path, onSuccessAction, onFailureAction ) {
+	return _createRequestAction( 'del', siteId, path, undefined, onSuccessAction, onFailureAction );
 }
 

--- a/client/extensions/woocommerce/state/data-layer/request/index.js
+++ b/client/extensions/woocommerce/state/data-layer/request/index.js
@@ -20,6 +20,12 @@ export function handleRequest( { dispatch }, action ) {
 				action,
 				data,
 			} );
+
+			if ( action.onSuccessAction ) {
+				// Append data and dispatch.
+				const onSuccess = { ...action.onSuccessAction, data };
+				dispatch( onSuccess );
+			}
 		} )
 		.catch( error => {
 			// TODO: Maybe phase out usage of this in favor of the failure action?
@@ -29,6 +35,12 @@ export function handleRequest( { dispatch }, action ) {
 				action,
 				error,
 			} );
+
+			if ( action.onFailureAction ) {
+				// Append error and dispatch.
+				const onFailure = { ...action.onFailureAction, error };
+				dispatch( onFailure );
+			}
 		} );
 }
 

--- a/client/extensions/woocommerce/state/data-layer/request/index.js
+++ b/client/extensions/woocommerce/state/data-layer/request/index.js
@@ -23,8 +23,7 @@ export function handleRequest( { dispatch }, action ) {
 
 			if ( action.onSuccessAction ) {
 				// Append data and dispatch.
-				const onSuccess = { ...action.onSuccessAction, data };
-				dispatch( onSuccess );
+				dispatch( { ...action.onSuccessAction, data } );
 			}
 		} )
 		.catch( error => {
@@ -38,8 +37,7 @@ export function handleRequest( { dispatch }, action ) {
 
 			if ( action.onFailureAction ) {
 				// Append error and dispatch.
-				const onFailure = { ...action.onFailureAction, error };
-				dispatch( onFailure );
+				dispatch( { ...action.onFailureAction, error } );
 			}
 		} );
 }

--- a/client/extensions/woocommerce/state/data-layer/request/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/request/test/index.js
@@ -36,12 +36,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = get( siteId, 'placeholder_endpoint' );
+			const onSuccessAction = {
+				type: '%%ON_SUCCESS_ACTION%%',
+			};
+
+			const action = get( siteId, 'placeholder_endpoint', onSuccessAction );
 
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledOnce;
+				expect( store.dispatch ).to.have.been.calledTwice;
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: getResponse } )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onSuccessAction.type } )
+						.and( match.has( 'data' ) )
 				);
 			} );
 		} );
@@ -51,12 +59,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = get( siteId, 'bad_placeholder_endpoint' );
+			const onFailureAction = {
+				type: '%%ON_FAILURE_ACTION%%',
+			};
+
+			const action = get( siteId, 'bad_placeholder_endpoint', null, onFailureAction );
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledTwice;
+				expect( store.dispatch ).to.have.been.calledThrice;
 				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onFailureAction.type } )
 						.and( match.has( 'error' ) )
 				);
 			} );
@@ -81,12 +97,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = post( siteId, 'placeholder_endpoint', body );
+			const onSuccessAction = {
+				type: '%%ON_SUCCESS_ACTION%%',
+			};
+
+			const action = post( siteId, 'placeholder_endpoint', body, onSuccessAction );
 
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledOnce;
+				expect( store.dispatch ).to.have.been.calledTwice;
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: postResponse } )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onSuccessAction.type } )
+						.and( match.has( 'data' ) )
 				);
 			} );
 		} );
@@ -96,12 +120,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = post( siteId, 'bad_placeholder_endpoint', body );
+			const onFailureAction = {
+				type: '%%ON_FAILURE_ACTION%%',
+			};
+
+			const action = post( siteId, 'bad_placeholder_endpoint', body, null, onFailureAction );
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledTwice;
+				expect( store.dispatch ).to.have.been.calledThrice;
 				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onFailureAction.type } )
 						.and( match.has( 'error' ) )
 				);
 			} );
@@ -126,12 +158,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = put( siteId, 'placeholder_endpoint', body );
+			const onSuccessAction = {
+				type: '%%ON_SUCCESS_ACTION%%',
+			};
+
+			const action = put( siteId, 'placeholder_endpoint', body, onSuccessAction );
 
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledOnce;
+				expect( store.dispatch ).to.have.been.calledTwice;
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: putResponse } )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onSuccessAction.type } )
+						.and( match.has( 'data' ) )
 				);
 			} );
 		} );
@@ -141,12 +181,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = put( siteId, 'bad_placeholder_endpoint', body );
+			const onFailureAction = {
+				type: '%%ON_FAILURE_ACTION%%',
+			};
+
+			const action = put( siteId, 'bad_placeholder_endpoint', body, null, onFailureAction );
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledTwice;
+				expect( store.dispatch ).to.have.been.calledThrice;
 				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onFailureAction.type } )
 						.and( match.has( 'error' ) )
 				);
 			} );
@@ -169,12 +217,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = del( siteId, 'placeholder_endpoint' );
+			const onSuccessAction = {
+				type: '%%ON_SUCCESS_ACTION%%',
+			};
+
+			const action = del( siteId, 'placeholder_endpoint', onSuccessAction );
 
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledOnce;
+				expect( store.dispatch ).to.have.been.calledTwice;
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: deleteResponse } )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onSuccessAction.type } )
+						.and( match.has( 'data' ) )
 				);
 			} );
 		} );
@@ -184,12 +240,20 @@ describe( 'handlers', () => {
 				dispatch: spy(),
 			};
 
-			const action = del( siteId, 'bad_placeholder_endpoint' );
+			const onFailureAction = {
+				type: '%%ON_FAILURE_ACTION%%',
+			};
+
+			const action = del( siteId, 'bad_placeholder_endpoint', null, onFailureAction );
 			return handleRequest( store, action ).then( () => {
-				expect( store.dispatch ).to.have.been.calledTwice;
+				expect( store.dispatch ).to.have.been.calledThrice;
 				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
 				expect( store.dispatch ).to.have.been.calledWith(
 					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: onFailureAction.type } )
 						.and( match.has( 'error' ) )
 				);
 			} );

--- a/client/extensions/woocommerce/state/data-layer/request/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/request/test/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, match } from 'sinon';
 
 /**
  * Internal dependencies
@@ -37,15 +37,12 @@ describe( 'handlers', () => {
 			};
 
 			const action = get( siteId, 'placeholder_endpoint' );
-			const successAction = {
-				type: WOOCOMMERCE_API_REQUEST_SUCCESS,
-				action,
-				data: getResponse,
-			};
 
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledOnce;
-				expect( store.dispatch ).to.have.been.calledWith( successAction );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: getResponse } )
+				);
 			} );
 		} );
 
@@ -57,14 +54,11 @@ describe( 'handlers', () => {
 			const action = get( siteId, 'bad_placeholder_endpoint' );
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledTwice;
-
-				const errorSetAction = store.dispatch.getCall( 0 ).args[ 0 ];
-				expect( errorSetAction.type ).to.equal( WOOCOMMERCE_ERROR_SET );
-
-				const failureAction = store.dispatch.getCall( 1 ).args[ 0 ];
-				expect( failureAction.type ).to.equal( WOOCOMMERCE_API_REQUEST_FAILURE );
-				expect( failureAction.action ).to.equal( action );
-				expect( failureAction.error ).to.exist;
+				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
 			} );
 		} );
 	} );
@@ -88,15 +82,12 @@ describe( 'handlers', () => {
 			};
 
 			const action = post( siteId, 'placeholder_endpoint', body );
-			const successAction = {
-				type: WOOCOMMERCE_API_REQUEST_SUCCESS,
-				action,
-				data: postResponse,
-			};
 
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledOnce;
-				expect( store.dispatch ).to.have.been.calledWith( successAction );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: postResponse } )
+				);
 			} );
 		} );
 
@@ -108,14 +99,11 @@ describe( 'handlers', () => {
 			const action = post( siteId, 'bad_placeholder_endpoint', body );
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledTwice;
-
-				const errorSetAction = store.dispatch.getCall( 0 ).args[ 0 ];
-				expect( errorSetAction.type ).to.equal( WOOCOMMERCE_ERROR_SET );
-
-				const failureAction = store.dispatch.getCall( 1 ).args[ 0 ];
-				expect( failureAction.type ).to.equal( WOOCOMMERCE_API_REQUEST_FAILURE );
-				expect( failureAction.action ).to.equal( action );
-				expect( failureAction.error ).to.exist;
+				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
 			} );
 		} );
 	} );
@@ -139,15 +127,12 @@ describe( 'handlers', () => {
 			};
 
 			const action = put( siteId, 'placeholder_endpoint', body );
-			const successAction = {
-				type: WOOCOMMERCE_API_REQUEST_SUCCESS,
-				action,
-				data: putResponse,
-			};
 
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledOnce;
-				expect( store.dispatch ).to.have.been.calledWith( successAction );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: putResponse } )
+				);
 			} );
 		} );
 
@@ -159,14 +144,11 @@ describe( 'handlers', () => {
 			const action = put( siteId, 'bad_placeholder_endpoint', body );
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledTwice;
-
-				const errorSetAction = store.dispatch.getCall( 0 ).args[ 0 ];
-				expect( errorSetAction.type ).to.equal( WOOCOMMERCE_ERROR_SET );
-
-				const failureAction = store.dispatch.getCall( 1 ).args[ 0 ];
-				expect( failureAction.type ).to.equal( WOOCOMMERCE_API_REQUEST_FAILURE );
-				expect( failureAction.action ).to.equal( action );
-				expect( failureAction.error ).to.exist;
+				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
 			} );
 		} );
 	} );
@@ -188,15 +170,12 @@ describe( 'handlers', () => {
 			};
 
 			const action = del( siteId, 'placeholder_endpoint' );
-			const successAction = {
-				type: WOOCOMMERCE_API_REQUEST_SUCCESS,
-				action,
-				data: deleteResponse,
-			};
 
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledOnce;
-				expect( store.dispatch ).to.have.been.calledWith( successAction );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_SUCCESS, action, data: deleteResponse } )
+				);
 			} );
 		} );
 
@@ -208,14 +187,11 @@ describe( 'handlers', () => {
 			const action = del( siteId, 'bad_placeholder_endpoint' );
 			return handleRequest( store, action ).then( () => {
 				expect( store.dispatch ).to.have.been.calledTwice;
-
-				const errorSetAction = store.dispatch.getCall( 0 ).args[ 0 ];
-				expect( errorSetAction.type ).to.equal( WOOCOMMERCE_ERROR_SET );
-
-				const failureAction = store.dispatch.getCall( 1 ).args[ 0 ];
-				expect( failureAction.type ).to.equal( WOOCOMMERCE_API_REQUEST_FAILURE );
-				expect( failureAction.action ).to.equal( action );
-				expect( failureAction.error ).to.exist;
+				expect( store.dispatch ).to.have.been.calledWith( match( { type: WOOCOMMERCE_ERROR_SET } ) );
+				expect( store.dispatch ).to.have.been.calledWith(
+					match( { type: WOOCOMMERCE_API_REQUEST_FAILURE, action: action } )
+						.and( match.has( 'error' ) )
+				);
 			} );
 		} );
 	} );


### PR DESCRIPTION
This adds an optional onSuccessAction and onFailureAction to the request
functions. This allows the calling code to add an optional action for
each of these to be dispatched for an individual request. This will help
track individual requests all the way through to the UI.

To Test: Run `npm test` and verify all tests pass.