### PR TITLE
Comments: design tweaks

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -76,8 +76,8 @@ export const CommentDetailActions = ( {
 					<Gridicon icon="spam" />
 					<span>{
 						isSpam
-							? translate( 'Spam' )
-							: translate( 'Mark as Spam' )
+							? translate( 'Spammed' )
+							: translate( 'Spam' )
 					}</span>
 				</a>
 			}

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -132,8 +132,10 @@ export class CommentDetail extends Component {
 		const classes = classNames( 'comment-detail', {
 			'author-is-blocked': authorIsBlocked,
 			'is-approved': 'approved' === commentStatus,
+			'is-unapproved': 'unapproved' === commentStatus,
 			'is-bulk-edit': isBulkEdit,
 			'is-expanded': isExpanded,
+			'is-collapsed': ! isExpanded,
 			'is-liked': commentIsLiked,
 			'is-spam': 'spam' === commentStatus,
 			'is-trash': 'trash' === commentStatus,

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -147,13 +147,11 @@
 	a {
 		color: $gray-text-min;
 		cursor: pointer;
-		fill: $gray;
 		padding: 8px;
 		white-space: nowrap;
 		&:focus,
 		&:hover {
 			color: $blue-wordpress;
-			fill: $blue-wordpress;
 		}
 	}
 	span {
@@ -166,11 +164,9 @@
 
 	.is-approved .gridicon {
 		color: $alert-green;
-		fill: $alert-green;
 	}
 	.is-liked .gridicon {
 		color: $alert-yellow;
-		fill: $alert-yellow;
 	}
 	.is-spam .gridicon {
 		color: $alert-red;
@@ -216,7 +212,6 @@
 	a {
 		color: $gray-text-min;
 		cursor: pointer;
-		fill: $gray;
 		&:focus,
 		&:hover {
 			color: $blue-wordpress;
@@ -244,11 +239,9 @@
 	a {
 		color: $gray-text-min;
 		cursor: pointer;
-		fill: $gray;
 		&:focus,
 		&:hover {
 			color: $blue-wordpress;
-			fill: $blue-wordpress;
 		}
 	}
 }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -162,19 +162,40 @@
 		}
 	}
 
-	.is-approved .gridicon {
+	.comment-detail__action-like {
+		&:focus,
+		&:hover {
+			color: $orange-jazzy;
+		}
+	}
+
+	.comment-detail__action-approve {
+		&:focus,
+		&:hover {
+			color: $alert-green;
+		}
+	}
+
+	.comment-detail__action-spam,
+	.comment-detail__action-trash,
+	.comment-detail__action-delete {
+		&:focus,
+		&:hover {
+			color: $alert-red;
+		}
+	}
+
+	.is-approved {
 		color: $alert-green;
 	}
-	.is-liked .gridicon {
-		color: $alert-yellow;
+	.is-liked {
+		color: $orange-jazzy;
 	}
-	.is-spam .gridicon {
+	.is-spam {
 		color: $alert-red;
-		fill: $alert-red;
 	}
-	.is-trash .gridicon {
+	.is-trash {
 		color: $gray-dark;
-		fill: $gray-dark;
 	}
 }
 
@@ -215,7 +236,6 @@
 		&:focus,
 		&:hover {
 			color: $blue-wordpress;
-			fill: $blue-wordpress;
 		}
 	}
 }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -284,7 +284,7 @@
 }
 
 .comment-detail__author {
-	padding: 16px 0;
+	padding: 16px 0 0;
 }
 
 .comment-detail__author-preview {
@@ -295,8 +295,8 @@
 	transition: padding-bottom .3s linear;
 
 	.comment-detail__author-avatar {
-		height: 40px;
-		width: 40px;
+		height: 32px;
+		width: 32px;
 	}
 
 	.comment-detail__author-info {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -50,7 +50,7 @@
 }
 
 .comment-detail__author-info {
-	color: $gray;
+	color: $gray-text-min;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -88,7 +88,6 @@
 			padding: 0 12px;
 			.external-link:hover,
 			.external-link:focus {
-				color: $gray;
 				outline: none;
 			}
 		}
@@ -104,7 +103,7 @@
 		width: 40%;
 
 		.external-link {
-			color: $gray;
+			color: $gray-text-min;
 			&:hover,
 			&:focus {
 				color: $link-highlight;
@@ -146,7 +145,7 @@
 	user-select: none;
 
 	a {
-		color: $gray;
+		color: $gray-text-min;
 		cursor: pointer;
 		fill: $gray;
 		padding: 8px;
@@ -204,7 +203,6 @@
 }
 
 .comment-detail__post-info {
-	color: $gray;
 	overflow: hidden;
 	padding-left: 8px;
 	text-overflow: ellipsis;
@@ -216,7 +214,7 @@
 	}
 
 	a {
-		color: $gray;
+		color: $gray-text-min;
 		cursor: pointer;
 		fill: $gray;
 		&:focus,
@@ -244,7 +242,7 @@
 	padding: 16px;
 
 	a {
-		color: $gray;
+		color: $gray-text-min;
 		cursor: pointer;
 		fill: $gray;
 		&:focus,

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -17,6 +17,14 @@
 		z-index: 1;
 	}
 
+	// If the comment is pending and collapsed, color it yellow.
+	&:not( .is-approved ):not( .is-expanded ) {
+		.comment-detail__header {
+			background: rgba( $alert-yellow, 0.085 );
+			box-shadow: inset 4px 0 0 0 $alert-yellow;
+		}
+	}
+
 	.gridicon {
 		margin-right: 4px;
 		vertical-align: middle;
@@ -246,7 +254,16 @@
 }
 
 .comment-detail__comment-content {
-	border-left: 3px solid lighten( $gray, 30% );
+	border-left: 4px solid lighten( $gray, 30% );
+}
+
+// If the comment is pending and expanded, color it yellow.
+.comment-detail:not( .is-approved ) .comment-detail__comment {
+	background: rgba( $alert-yellow, 0.085 );
+}
+
+.comment-detail:not( .is-approved ) .comment-detail__comment-content {
+	border-color: $alert-yellow;
 }
 
 .comment-detail__comment-body {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -267,7 +267,11 @@
 }
 
 .comment-detail__comment-body {
-	padding: 0 16px;
+	padding: 0 16px 16px;
+
+	> :last-child {
+		margin-bottom: 0;
+	}
 }
 
 .comment-detail__comment-reply {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -257,15 +257,6 @@
 	border-left: 4px solid lighten( $gray, 30% );
 }
 
-// If the comment is pending and expanded, color it yellow.
-.comment-detail:not( .is-approved ) .comment-detail__comment {
-	background: rgba( $alert-yellow, 0.085 );
-}
-
-.comment-detail:not( .is-approved ) .comment-detail__comment-content {
-	border-color: $alert-yellow;
-}
-
 .comment-detail__comment-body {
 	padding: 0 16px 16px;
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -12,13 +12,13 @@
 		}
 	}
 
-	&:not( .is-expanded ):hover {
+	&.is-collapsed:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
 		z-index: 1;
 	}
 
-	// If the comment is pending and collapsed, color it yellow.
-	&:not( .is-approved ):not( .is-expanded ) {
+	// If the comment is unapproved and collapsed, color it yellow.
+	&.is-unapproved.is-collapsed {
 		.comment-detail__header {
 			background: rgba( $alert-yellow, 0.085 );
 			box-shadow: inset 4px 0 0 0 $alert-yellow;

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -115,6 +115,7 @@ export class CommentNavigation extends Component {
 						{ this.statusHasAction( 'spam' ) &&
 							<Button
 								compact
+								scary
 								disabled={ ! selectedCount }
 								onClick={ setBulkStatus( 'spam' ) }
 							>
@@ -124,6 +125,7 @@ export class CommentNavigation extends Component {
 						{ this.statusHasAction( 'trash' ) &&
 							<Button
 								compact
+								scary
 								disabled={ ! selectedCount }
 								onClick={ setBulkStatus( 'trash' ) }
 							>
@@ -133,6 +135,7 @@ export class CommentNavigation extends Component {
 						{ this.statusHasAction( 'delete' ) &&
 							<Button
 								compact
+								scary
 								disabled={ ! selectedCount }
 								onClick={ setBulkStatus( 'delete' ) }
 							>


### PR DESCRIPTION
A handful of tweaks including:

- Destructive buttons in bulk edit are now `scary`
- Pending comments are now yellow
- Updated action button colors, including :hover
- Increased contrast
- Removed `fill` CSS that wasn't necessary

To test:

- Check bulk edit buttons in multiple filters and confirm that the destructive actions are `scary`
- Check multiple filters and make sure pending comments are yellow

Before

![screen shot 2017-06-13 at 4 21 12 pm](https://user-images.githubusercontent.com/618551/27105213-5d6c7cf4-5054-11e7-9a03-34e8357a65c7.png)


After 

![screen shot 2017-06-13 at 4 20 00 pm](https://user-images.githubusercontent.com/618551/27105217-62261f52-5054-11e7-88c2-2427e4362dc5.png)

(screenshots are showing hover on the Spam button)

cc @Copons 