### PR TITLE
Magic Login: Style improvements

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -226,6 +226,7 @@
 @import 'lib/directly/style';
 @import 'lib/keyboard-shortcuts/style';
 @import 'lib/abtest/test-helper/style';
+@import 'login/magic-login/style';
 @import 'login/wp-login/style';
 @import 'mailing-lists/style';
 @import 'me/account-password/style';

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -85,11 +85,14 @@ class MagicLogin extends React.Component {
 
 	render() {
 		const {
+			magicLoginView,
 			translate,
 		} = this.props;
-
 		return (
-			<Main className="magic-login">
+			<Main className={ {
+				'magic-login': true,
+				'magic-login__request_link': ! magicLoginView,
+			} }>
 				<PageViewTracker path="/login" title="Login" />
 
 				<GlobalNotices id="notices" notices={ notices.list } />

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -1,0 +1,39 @@
+.magic-login__request_link {
+	max-width: 400px;
+}
+
+.magic-login__formheader {
+	font-size: 22px;
+	margin-bottom: 24px;
+	margin-top: 16px;
+	text-align: center;
+}
+
+.magic-login__form-action {
+	margin-top: 10px;
+	overflow: auto;
+
+	button {
+		width: 100%;
+	}
+}
+
+.magic-login__footer {
+	border-bottom: 1px solid #c8d7e1;
+	color: #87a6bc;
+	display: block;
+	font-weight: 500;
+	line-height: 4em;
+	padding: 0 24px;
+	text-decoration: none;
+	a {
+		font-size: 14px;
+
+		&:hover {
+			color: $blue-medium;
+		}
+	}
+	.gridicon {
+		vertical-align: text-bottom;
+	}
+}


### PR DESCRIPTION
An iteration toward improving the styling of the Magic Login components.

This mainly touches one place, the Email Request Screen:

| Before | After |
| ------- | ----- |
| <img width="584" alt="screen shot 2017-06-13 at 5 09 00 pm" src="https://user-images.githubusercontent.com/1587282/27105056-26d250b2-505c-11e7-89bb-5ad1d8a2dd2b.png"> | <img width="421" alt="screen shot 2017-06-13 at 5 09 07 pm" src="https://user-images.githubusercontent.com/1587282/27105067-323667cc-505c-11e7-867a-f13ca89ab36e.png"> |

## To Test

* Browse to http://calypso.localhost:3000/log-in/link?action=handleLoginEmail&client_id=39911&email=address%40example.com&token=1&tt=1
  * Style should resemble the screen shot
* In your console: `dispatch( { type: 'MAGIC_LOGIN_SHOW_INTERSTITIAL_PAGE' } );`
  * Style should be unaffected (compared to the same path at https://calypso.live/)

Pulled from #14949. This is not functional and behind a feature flag, this just sets the stage for properly styling all this :)