### PR TITLE
Fix small but annoying "Makefile" bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@
 .DEFAULT_GOAL := install
 
 install:
-	npm run install-if-needed
+	@npm run install-if-needed
 
 run:
-	npm start
+	@npm start
 
 dashboard:
 	@npm run dashboard
@@ -68,3 +68,5 @@ docker-build:
 
 docker-run:
 	@npm run docker
+
+.PHONY: build test

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ docker-build:
 docker-run:
 	@npm run docker
 
-.PHONY: build test
+.PHONY: install run dashboard test lint eslint eslint-branch mixedindentlint config-defaults-lint build-server build build-desktop clean distclean translate shrinkwrap analyze-bundles urn docker-build docker-run

--- a/bin/install-if-needed.js
+++ b/bin/install-if-needed.js
@@ -27,6 +27,21 @@ if ( needsInstall() ) {
 	const installResult = spawnSync( 'npm', [ 'install' ], {
 		shell: true,
 		stdio: 'inherit',
-	});
-	process.exit( installResult.status );
+	} ).status;
+	if ( installResult ) {
+		process.exit( installResult );
+	}
+
+	// Cleanup old Githooks (remove in a few months from June 2017)
+	const path = require( 'path' );
+	const rm = file => fs.existsSync( file ) && fs.unlinkSync( file );
+	rm( path.join( '.git', 'hooks', 'pre-push' ) );
+	rm( path.join( '.git', 'hooks', 'pre-commit' ) );
+	rm( path.join( 'bin', 'pre-push' ) );
+	rm( path.join( 'bin', 'pre-commit' ) );
+	process.exit( spawnSync( 'npm', [ 'run', 'install' ], {
+		shell: true,
+		stdio: 'inherit',
+		cwd: path.join( 'node_modules', 'husky' ),
+	} ).status );
 }

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "postshrinkwrap": "node bin/trim-shrinkwrap.js && touch node_modules",
     "prestart": "npm run -s install-if-needed && node bin/welcome.js && ( check-node-version --package || exit 0 )",
     "start": "npm run -s build",
-    "poststart": "npm run -s env -- node build/bundle.js",
+    "poststart": "npm run -s env -- cross-env node $NODE_ARGS build/bundle.js",
     "pretest": "npm run -s install-if-needed",
     "test": "run-s -s test-client test-server test-test",
     "test-client": "cross-env NODE_ENV=test NODE_PATH=test:client:client/extensions TEST_ROOT=client node test/runner.js",


### PR DESCRIPTION
This PR fixes 3 small bugs related to the `Makefile`.

First, https://github.com/Automattic/wp-calypso/commit/08bc534618ad617a510c1bd876ff57e98b7d4ce0 fixed `make test` and `make build` commands, adding them to the `.PHONY` list.

Second, https://github.com/Automattic/wp-calypso/commit/41945c54758ed8d2bddb900d4fea197e748c3259 adds back `NODE_ARGS` support to `npm start`. It was implemented in https://github.com/Automattic/wp-calypso/commit/293670f97ab8ecf7d98c33c64a795284bd936891 but it got lost in all the rebases / merges.

Last but not least, https://github.com/Automattic/wp-calypso/commit/a53ab2cfaa4fe65a7f0d95d743f7431f3f09ba07 cleans up the old `.git/hooks` symbolic links so they can be replaced with the new `husky` Githooks. Turns out (it wasn't clear in their documentation) that `husky` doesn't do anything if it finds there are already Githooks installed. Removing them and then forcing `husky` to run again (executing `npm run install` in its directory) is a way to fix that. It's hacky, and it should be removed in a few weeks (months?).

To test:
* Run `make test`, check that it works (before, it would fail instantly).
* Run `NODE_ARGS="--inspect --debug-brk" npm start`, check that you eventually see this in the console: `Debugger listening on port 9229.`
* The `husky` fix only works if you run `npm start` after switching from a branch where `npm-shrinkwrap.json` is different than `master`. To check it worked, check that `.git/hooks/pre-commit` is a Bash script with a `# husky` header (instead of a symlink).