### PR TITLE
Magic Login: Improved internationalization

### DIFF
--- a/client/login/index.js
+++ b/client/login/index.js
@@ -7,7 +7,7 @@ import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
 
 export default router => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
-		router( '/log-in/link', redirectLoggedIn, magicLogin, makeLayout );
+		router( '/log-in/link/:lang?', setUpLocale, redirectLoggedIn, magicLogin, makeLayout );
 	}
 
 	if ( config.isEnabled( 'login/wp-login' ) ) {

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -94,7 +94,7 @@ class RequestLoginEmailForm extends React.Component {
 							autoFocus="true"
 							disabled={ isFetching || emailRequested }
 							name="emailAddress"
-							placeholder="Email address"
+							placeholder={ translate( 'Email address' ) }
 							value={ this.props.emailAddress }
 							onChange={ this.onEmailAddressFieldChange }
 						/>


### PR DESCRIPTION
* Localize the Email address placeholder string (previously missed wrapping w/ the `translate` function)
* Set up the locale with a trailing local slug path part

## To Test
* Open http://calypso.localhost:3000/log-in/link/fr in an incognito / logged out window
  * You should see French strings
* Repeat with another trailing locale slug
  * You should see appropriately localized strings

Partially pulled out of #14949