### PR TITLE
Reader: Sites in Search nits

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -53,11 +53,10 @@
 	z-index: z-index( 'root', '.search-stream__input-card' );
 }
 
-// Top margins for Sites in Search
-// Post recs and post results with suggested terms
+// Top margins
+// Top margin for post recs and post results with suggested terms
 .search-stream .search-stream__recommendation-list-item:nth-child(2),
-.search-stream .search-stream__recommendation-list-item:nth-child(3),
-.search-stream .reader-post-card:nth-child(2) {
+.search-stream .search-stream__recommendation-list-item:nth-child(3) {
 	margin-top: 100px;
 }
 
@@ -72,7 +71,7 @@
 	}
 }
 
-// Post recs in Site Results
+// Top margin for post recs without suggested terms
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(2),
 .search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(3) {
 	margin-top: 70px;
@@ -102,7 +101,7 @@
 	}
 }
 
-// Site results
+// Top margin for site results
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__post-results .reader-post-card:nth-child(2),
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__site-results {
 	margin-top: 150px;
@@ -116,7 +115,8 @@
 	padding-bottom: 15px;
 	text-align:left;
 
-	a, a:visited {
+	a,
+	a:visited {
 		color: $blue-medium;
 	}
 
@@ -129,12 +129,12 @@
 	}
 }
 
-// Post recommendations in Search
-// Custom breakpoints needed to match Related Posts
-$reader-post-card-breakpoint: "( min-width: 1012px )";
-$reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
-$reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
+// Custom breakpoints
+$reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040px )";
+$reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
+$reader-post-card-breakpoint-small: "( max-width: 550px )";
 
+// Post recommendations in Search
 .is-reader-page .search-stream .reader__content {
 	display: flex;
 	flex-flow: wrap;
@@ -277,9 +277,9 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 // Post and Sites static headers
 .search-stream__headers {
 	color: $gray;
+	font-size: 14px;
 	display: flex;
 	font-weight: 600;
-	letter-spacing: .1em;
 	list-style-type: none;
 	margin: 0;
 	padding-top: 20px;
@@ -292,13 +292,65 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	width: 100%;
 }
 
-.search-stream .search-stream__post-header,
-.search-stream .search-stream__site-header {
-	border-bottom: 2px solid lighten( $gray, 30% );
+.search-stream__post-header,
+.search-stream__site-header {
+	border-bottom: 1px solid lighten( $gray, 30% );
 	padding-bottom: 10px;
 	width: 100%;
 }
 
+// Posts and Sites tabbed headers
+.search-stream__header .section-nav-tabs__dropdown,
+.search-stream__header .section-nav__mobile-header {
+	display: none;
+}
+
+.search-stream__header .section-nav {
+	background: inherit;
+	border-bottom: 2px solid lighten( $gray, 30% );
+	box-shadow: none;
+	margin-bottom: 0;
+	padding-bottom: 0;
+}
+
+.search-stream__header .section-nav-group {
+	display: flex;
+	flex: 1 0 0%;
+	margin-top: 5px;
+	width: 0;
+}
+
+.search-stream__header .section-nav-tabs__list {
+	display: flex;
+
+	.section-nav-tab.is-selected {
+		border-bottom: 2px solid $gray-dark;
+	}
+
+	.is-selected .section-nav-tab__link {
+		color: $gray-dark;
+	}
+
+	.section-nav-tab__link {
+		background-color: transparent;
+		color: $blue-wordpress;
+		padding: 16px;
+
+		&:hover {
+			color: $blue-medium;
+		}
+	}
+
+	.section-nav-tab__text {
+		font-weight: 600;
+		font-size: 13px;
+		letter-spacing: .04em;
+		text-transform: uppercase;
+		width: 100%;
+	}
+}
+
+// Site results
 .search-stream .search-stream__site-results {
 	max-width: 265px;
 	min-width: 265px;
@@ -314,79 +366,74 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 }
 
-// Posts and Sites segmented control
-.search-stream__header .section-nav {
-	background: inherit;
-	border-bottom: 2px solid lighten( $gray, 30% );
-	box-shadow: none;
-	margin-bottom: 0;
-	padding-bottom: 0;
-}
-
-.search-stream__header .section-nav-group {
+// Custom styling for cards in post results
+.search-stream__results.is-two-columns {
 	display: flex;
-	flex: 1 0 0%;
-	width: 0;
-
-	@include breakpoint( "<480px" ) {
-		margin-top: 0;
-	}
 }
 
-.search-stream__header .section-nav-tabs__dropdown,
-.search-stream__header .section-nav__mobile-header {
-	display: none;
-}
+.search-stream__results.is-two-columns .search-stream__post-results {
+	max-width: 660px;
 
-.search-stream__header .section-nav-tabs__list {
-	display: flex;
+	.reader-post-card__post {
 
-	.section-nav-tab.is-selected {
-		border-bottom: 2px solid $gray-dark;
-	}
+		@media #{$reader-post-card-breakpoint-large} {
+			flex-direction: column;
+		}
 
-	.section-nav-tab__link {
-		background-color: transparent;
-		color: $blue-wordpress;
-		padding: 16px;
-
-		&:hover {
-			color: $blue-medium;
+		@include breakpoint( "<960px" ) {
+			flex-direction: column;
 		}
 	}
 
-	.is-selected .section-nav-tab__link {
-		color: $gray-dark;
+	.reader-post-card.card.has-thumbnail .reader-featured-image {
+
+		@media #{$reader-post-card-breakpoint-large} {
+			height: 80px;
+			margin: 0 0 20px;
+			max-width: 100%;
+		}
+
+		@include breakpoint( "<960px" ) {
+			height: 80px;
+			margin: 0 0 20px;
+			max-width: 100%;
+		}
+	}
+
+	.reader-post-card.is-photo .reader-post-card__title {
+		white-space: normal;
+	}
+
+	.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
+
+		@media #{$reader-post-card-breakpoint-large} {
+			display: none;
+		}
+
+		@include breakpoint( "<960px" ) {
+			display: block;
+		}
+	}
+
+	.reader-share__button-label,
+	.comment-button__label-status,
+	.like-button__label-status {
+		display: none;
+	}
+
+	.reader-share__button {
+		top: 2px;
 	}
 }
 
-.search-stream__header .section-nav-tab__text {
-	font-weight: 600;
-	font-size: 13px;
-	letter-spacing: .04em;
-	text-transform: uppercase;
-	width: 100%;
+.search-stream__results.is-two-columns .search-stream__site-results .gridicons-cog {
+	left: -3px;
+	top: 15px;
 }
 
-.search-stream__headers {
-	color: $gray;
-	display: flex;
-	font-weight: 600;
-	list-style-type: none;
-	margin: 0;
-	padding-top: 20px;
-	text-transform: uppercase;
-}
+.card.reader-search-card.is-photo {
 
-.search-stream__site-header {
-	margin-left: 40px;
-	max-width: 265px;
-	width: 100%;
-}
-
-.search-stream__post-header,
-.search-stream__site-header {
-	border-bottom: 2px solid lighten( $gray, 30% );
-	padding-bottom: 10px;
-	width: 100%;
+	@include breakpoint( "<660px" ) {
+		z-index: z-index( 'root', '.reader-search-card' );
+	}
 }

--- a/client/reader/search-stream/without-sites.jsx
+++ b/client/reader/search-stream/without-sites.jsx
@@ -145,8 +145,8 @@ class SearchStream extends Component {
 						railcar={ suggestion.railcar }
 					/>,
 					', ',
-				]
-			)
+				],
+			),
 		);
 
 		const documentTitle = this.props.translate( '%s ‹ Reader', {
@@ -175,7 +175,10 @@ class SearchStream extends Component {
 			>
 				{ this.props.showBack && <HeaderBack /> }
 				<div ref={ this.handleStreamMounted } />
-				<div style={ { height: '100px' } } />
+				{/* for non-recs add more margin-top.  this is a soon-to-be-deleted hack */}
+				{ this.props.postsStore &&
+					! this.props.postsStore.algorithm &&
+					<div style={ { height: '100px' } } /> }
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<DocumentHead title={ documentTitle } />
 					<MobileBackToSidebar>

--- a/client/reader/search-stream/without-sites.jsx
+++ b/client/reader/search-stream/without-sites.jsx
@@ -175,6 +175,7 @@ class SearchStream extends Component {
 			>
 				{ this.props.showBack && <HeaderBack /> }
 				<div ref={ this.handleStreamMounted } />
+				<div style={ { height: '100px' } } />
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<DocumentHead title={ documentTitle } />
 					<MobileBackToSidebar>

--- a/client/reader/search-stream/without-sites.jsx
+++ b/client/reader/search-stream/without-sites.jsx
@@ -177,7 +177,7 @@ class SearchStream extends Component {
 				<div ref={ this.handleStreamMounted } />
 				{/* for non-recs add more margin-top.  this is a soon-to-be-deleted hack */}
 				{ this.props.postsStore &&
-					! this.props.postsStore.algorithm &&
+					this.props.postsStore.id !== 'custom_recs_posts_with_images' &&
 					<div style={ { height: '100px' } } /> }
 				<div className="search-stream__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<DocumentHead title={ documentTitle } />


### PR DESCRIPTION
This supersedes: https://github.com/Automattic/wp-calypso/pull/14881

Relevance/Date sorter is working in this branch, but the additional nits mentioned in: https://github.com/Automattic/wp-calypso/pull/14881#issuecomment-308256084 are to be addressed in separate PRs.