### PR TITLE
Add callback style ref for wrapped state component

### DIFF
--- a/client/components/forms/form-select/index.jsx
+++ b/client/components/forms/form-select/index.jsx
@@ -12,13 +12,15 @@ const FormSelect = React.createClass( {
 	},
 
 	render() {
-		const { className, isError, ...props } = this.props,
-			classes = classNames( className, 'form-select', {
-				'is-error': isError,
-			} );
+		const { inputRef, className, isError, ...props } = this.props;
+		const classes = classNames( className, 'form-select', {
+			'is-error': isError,
+		} );
+
+		const ref = inputRef ? { ref: inputRef } : {};
 
 		return (
-			<select { ...props } className={ classes }>
+			<select { ...props } { ...ref } className={ classes }>
 				{ this.props.children }
 			</select>
 		);

--- a/client/components/forms/form-select/index.jsx
+++ b/client/components/forms/form-select/index.jsx
@@ -17,10 +17,8 @@ const FormSelect = React.createClass( {
 			'is-error': isError,
 		} );
 
-		const ref = inputRef ? { ref: inputRef } : {};
-
 		return (
-			<select { ...props } { ...ref } className={ classes }>
+			<select { ...props } ref={ inputRef } className={ classes }>
 				{ this.props.children }
 			</select>
 		);

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -30,10 +30,9 @@ export default class FormTextInput extends PureComponent {
 	}
 
 	render() {
-		const {
-			inputRef,
-			...props
-		} = omit( this.props, 'isError', 'isValid', 'selectOnFocus' );
+		const { inputRef } = this.props;
+		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus', 'inputRef' );
+
 		const classes = classNames( 'form-text-input', this.props.className, {
 			'is-error': this.props.isError,
 			'is-valid': this.props.isValid

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -30,7 +30,10 @@ export default class FormTextInput extends PureComponent {
 	}
 
 	render() {
-		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus' );
+		const {
+			inputRef,
+			...props
+		} = omit( this.props, 'isError', 'isValid', 'selectOnFocus' );
 		const classes = classNames( 'form-text-input', this.props.className, {
 			'is-error': this.props.isError,
 			'is-valid': this.props.isValid
@@ -40,7 +43,7 @@ export default class FormTextInput extends PureComponent {
 			<input
 				type="text"
 				{ ...props }
-				ref="textField"
+				ref={ inputRef || 'textField' }
 				className={ classes }
 				onClick={ this.selectOnFocus } />
 		);

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -80,6 +80,8 @@ export class DomainDetailsForm extends PureComponent {
 			steps,
 			currentStep: first( steps ),
 		};
+
+		this.inputRefs = {};
 	}
 
 	componentWillMount() {
@@ -223,9 +225,12 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	getFieldProps( name ) {
+		const ref = name === 'state'
+			? { inputRef: el => this.inputRefs[ name ] = el }
+			: { ref: name };
 		return {
 			name,
-			ref: name,
+			...ref,
 			additionalClasses: 'checkout-field',
 			value: formState.getFieldValue( this.state.form, name ) || '',
 			isError: formState.isFieldInvalid( this.state.form, name ),
@@ -417,7 +422,8 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	focusFirstError() {
-		this.refs[ kebabCase( head( map( formState.getInvalidFields( this.state.form ), 'name' ) ) ) ].focus();
+		const firstErrorName = kebabCase( head( formState.getInvalidFields( this.state.form ) ).name );
+		( this.inputRefs[ firstErrorName ] || this.refs[ firstErrorName ] ).focus();
 	}
 
 	handleSubmitButtonClick = ( event ) => {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -82,6 +82,7 @@ export class DomainDetailsForm extends PureComponent {
 		};
 
 		this.inputRefs = {};
+		this.inputRefCallbacks = {};
 	}
 
 	componentWillMount() {
@@ -226,7 +227,7 @@ export class DomainDetailsForm extends PureComponent {
 
 	getFieldProps( name ) {
 		const ref = name === 'state'
-			? { inputRef: el => this.inputRefs[ name ] = el }
+			? { inputRef: this.getInputRefCallback( name ) }
 			: { ref: name };
 		return {
 			name,
@@ -500,6 +501,16 @@ export class DomainDetailsForm extends PureComponent {
 		} else {
 			removePrivacyFromAllDomains();
 		}
+	}
+
+	// We want to cache the functions to avoid triggering unecessary rerenders
+	getInputRefCallback( name ) {
+		if ( ! this.inputRefCallbacks[ name ] ) {
+			this.inputRefCallbacks[ name ] =
+				( el ) => this.inputRefs[ name ] = el;
+		}
+
+		return this.inputRefCallbacks[ name ];
 	}
 
 	renderCurrentForm() {

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -424,7 +424,8 @@ export class DomainDetailsForm extends PureComponent {
 
 	focusFirstError() {
 		const firstErrorName = kebabCase( head( formState.getInvalidFields( this.state.form ) ).name );
-		( this.inputRefs[ firstErrorName ] || this.refs[ firstErrorName ] ).focus();
+		const firstErrorRef = this.inputRefs[ firstErrorName ] || this.refs[ firstErrorName ];
+		firstErrorRef.focus();
 	}
 
 	handleSubmitButtonClick = ( event ) => {

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -88,7 +88,8 @@ export default React.createClass( {
 					maxLength={ this.props.maxLength }
 					onChange={ this.props.onChange }
 					onClick={ this.recordFieldClick }
-					isError={ this.props.isError } />
+					isError={ this.props.isError }
+					inputRef={ this.props.inputRef } />
 				{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
 			</div>
 		);

--- a/client/my-sites/upgrades/components/form/state-select.jsx
+++ b/client/my-sites/upgrades/components/form/state-select.jsx
@@ -63,7 +63,8 @@ class StateSelect extends Component {
 							disabled={ this.props.disabled }
 							onChange={ this.props.onChange }
 							onClick={ this.recordStateSelectClick }
-							isError={ this.props.isError } >
+							isError={ this.props.isError }
+							inputRef={ this.props.inputRef } >
 
 							<option key="--" value="--" disabled="disabled">{ this.props.translate( 'Select State' ) }</option>
 							{ this.props.countryStates.map( ( state ) =>
@@ -90,6 +91,7 @@ StateSelect.propTypes = {
 	name: PropTypes.string,
 	onChange: PropTypes.func,
 	value: PropTypes.string,
+	inputRef: PropTypes.func,
 };
 
 export default connect(


### PR DESCRIPTION
The string style of ref that we're using [is deprecated](https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs), and one of the
advantages of the callback ref style is that it can handle wrapped
components like this one.

Instead of implementing `focus()` functions on all our intermediate
components, we can pass the `inputRef` prop down however many intermediate classes to the terminal `input` components themselves and use their native focus(). (If we need special
handling we still have the freedom to consume the prop and handle any
required functions there).

However, our input components are very widely used across Calypso, and
changing their functionality would require auditing and updating all
that usage, so for now I'm just going to lay down the minimal new paths to fix the issue at hand alongside the deprecated string style.

Fixes #15027

https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs