### PR TITLE
Display an error message when there's already a user with the same email

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -53,7 +53,19 @@ class SocialLoginForm extends Component {
 							error: wpcomError.message
 						} );
 
-						this.props.errorNotice( wpcomError.message );
+						if ( wpcomError.error === 'user_exists' ) {
+							this.props.errorNotice(
+								this.props.translate(
+									'Whoops! Your email on Google is already in use on WordPress.com. ' +
+									'To use your existing WordPress.com account, log in with your email address ' +
+									'and password. To create a new WordPress.com account, ' +
+									"you'll have to switch to a different Google account."
+								)
+							);
+						} else {
+							this.props.errorNotice( wpcomError.message );
+						}
+
 					} else {
 						this.props.recordTracksEvent( 'calypso_social_login_form_signup_success', {
 							social_account_type: 'google',


### PR DESCRIPTION
This pull request fixes #13954 by changing the error message text

![screen shot 2017-06-14 at 9 55 41](https://user-images.githubusercontent.com/326402/27119295-f8147b06-50e7-11e7-9877-11aac0ee252e.png)


#### Testing instructions
  
1. Run `git checkout update/social-user-exists-message` and start your server, or open a [live branch](https://calypso.live/?branch=update/social-user-exists-message)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Try to log-in with Google account that has an email that already has a WordPress.com account
4. Assert you see a correct error message
5. Repeat with a fresh email and assert the account is indeed created.
 
#### Reviews
  
- [x] Code
- [x] Product
- [ ] Design