### PR TITLE
Add external media uploader to media actions

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -91,6 +91,10 @@ MediaActions.fetchNextPage = function( siteId ) {
 	}
 };
 
+const getExternalUploader = service => ( file, siteId ) => {
+	return wpcom.undocumented().site( siteId ).uploadExternalMedia( service, [ file.guid ] );
+};
+
 const getFileUploader = () => ( file, siteId ) => {
 	// Determine upload mechanism by object type
 	const isUrl = 'string' === typeof file;
@@ -174,6 +178,10 @@ function uploadFiles( uploader, files, siteId ) {
 		} );
 	}, Promise.resolve() );
 }
+
+MediaActions.addExternal = function( siteId, files, service ) {
+	return uploadFiles( getExternalUploader( service ), files, siteId );
+};
 
 MediaActions.add = function( siteId, files ) {
 	if ( files instanceof window.FileList ) {


### PR DESCRIPTION
Adds an external media service uploader to the file uploader.

This allows the same base code to be used, but sends the data to the external media service endpoint instead of the normal media endpoint.

## How to test

Run the included unit tests. Manually verify that media uploads and 'add url' continue to work.