### PR TITLE
Webpack build performance improvements: babel-cache

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,7 +163,7 @@ const jsLoader = {
 	exclude: /node_modules[\/\\](?!notifications-panel)/,
 	loader: 'babel',
 	query: {
-		cacheDirectory: './.babel-cache',
+		cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
 		cacheIdentifier: cacheIdentifier,
 		plugins: [ [
 			path.join( __dirname, 'server', 'bundler', 'babel', 'babel-plugin-transform-wpcalypso-async' ),

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -83,7 +83,7 @@ const webpackConfig = {
 						path.join( __dirname, 'server', 'bundler', 'babel', 'babel-plugin-transform-wpcalypso-async' ),
 						{ async: false }
 					] ],
-					cacheDirectory: path.join( __dirname, './build/.babel-cache' ),
+					cacheDirectory: path.join( __dirname, 'build', '.babel-server-cache' ),
 					cacheIdentifier: cacheIdentifier,
 				}
 			},

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -12,6 +12,7 @@ const webpack = require( 'webpack' ),
  * Internal dependencies
  */
 const config = require( 'config' );
+const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 
 /**
  * This lists modules that must use commonJS `require()`s
@@ -81,7 +82,9 @@ const webpackConfig = {
 					plugins: [ [
 						path.join( __dirname, 'server', 'bundler', 'babel', 'babel-plugin-transform-wpcalypso-async' ),
 						{ async: false }
-					] ]
+					] ],
+					cacheDirectory: './build/.babel-cache',
+					cacheIdentifier: cacheIdentifier,
 				}
 			},
 			{

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -83,7 +83,7 @@ const webpackConfig = {
 						path.join( __dirname, 'server', 'bundler', 'babel', 'babel-plugin-transform-wpcalypso-async' ),
 						{ async: false }
 					] ],
-					cacheDirectory: './build/.babel-cache',
+					cacheDirectory: path.join( __dirname, './build/.babel-cache' ),
 					cacheIdentifier: cacheIdentifier,
 				}
 			},


### PR DESCRIPTION
While working on https://github.com/Automattic/wp-calypso/pull/14786 , I found 3 performance improvements that I plan on porting to our webpack1 setup (because 2 won't be ready for a good bit).

This PR implements the first of the three: use babel-cache for the server build. SERVER BUILD.

Before: ~40s each run
After: 40s first run, 11s after that.  That means ~4x as fast 🎉 .

Note: this affects the server build _not_ the client build.