### PR TITLE
Reader Sites in Search: fix alignment of sites when no post results

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -373,6 +373,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .search-stream__results.is-two-columns .search-stream__post-results {
 	max-width: 660px;
+	width: 100%;
 
 	.reader-post-card__post {
 


### PR DESCRIPTION
To test:
- Do a search for something that only has site results and no post results.
- verify alignment looks good for site results

Fixes: https://github.com/Automattic/wp-calypso/issues/15086