### PR TITLE
Media library: fetch external media

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -54,7 +54,7 @@ module.exports = React.createClass( {
 	},
 
 	getQuery: function( props ) {
-		var query = {};
+		const query = {};
 
 		props = props || this.props;
 
@@ -64,6 +64,11 @@ module.exports = React.createClass( {
 
 		if ( props.filter ) {
 			query.mime_type = utils.getMimeBaseTypeFromFilter( props.filter );
+		}
+
+		if ( props.source ) {
+			query.source = props.source;
+			query.path = 'recent';
 		}
 
 		return query;

--- a/client/components/data/media-list-data/test/index.jsx
+++ b/client/components/data/media-list-data/test/index.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import mockery from 'mockery';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+
+/**
+ * Module variables
+ */
+
+const DUMMY_SITE_ID = 1;
+
+const EMPTY_COMPONENT = () => {
+	return <div />;
+};
+
+describe( 'EditorMediaModal', function() {
+	let MediaListData;
+
+	useMockery();
+	useFakeDom();
+
+	before( () => {
+		mockery.registerMock( 'lib/media/actions', { setQuery: noop, fetchNextPage: noop } );
+		mockery.registerMock( 'lib/media/list-store', { getAll: noop, hasNextPage: noop, isFetchingNextPage: noop, on: noop } );
+
+		MediaListData = require( 'components/data/media-list-data' );
+	} );
+
+	it( 'should pass search parameter to media query', () => {
+		const tree = shallow( <MediaListData siteId={ DUMMY_SITE_ID }><EMPTY_COMPONENT /></MediaListData> ).instance();
+		const query = { search: true };
+		const result = tree.getQuery( query );
+
+		expect( result ).to.eql( query );
+	} );
+
+	it( 'should pass and process filter parameter to media query', () => {
+		const tree = shallow( <MediaListData siteId={ DUMMY_SITE_ID }><EMPTY_COMPONENT /></MediaListData> ).instance();
+		const query = { filter: 'images' };
+		const result = tree.getQuery( query );
+
+		expect( result ).to.eql( { mime_type: 'image/' } );
+	} );
+
+	it( 'should pass source parameter and set recent path to media query', () => {
+		const tree = shallow( <MediaListData siteId={ DUMMY_SITE_ID }><EMPTY_COMPONENT /></MediaListData> ).instance();
+		const query = { source: 'anything' };
+		const result = tree.getQuery( query );
+
+		expect( result ).to.eql( { path: 'recent', source: 'anything' } );
+	} );
+} );

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -62,8 +62,6 @@ MediaActions.fetch = function( siteId, itemId ) {
 };
 
 MediaActions.fetchNextPage = function( siteId ) {
-	var query;
-
 	if ( MediaListStore.isFetchingNextPage( siteId ) ) {
 		return;
 	}
@@ -73,10 +71,8 @@ MediaActions.fetchNextPage = function( siteId ) {
 		siteId: siteId
 	} );
 
-	query = MediaListStore.getNextPageQuery( siteId );
-
-	debug( 'Fetching media for %d using query %o', siteId, query );
-	wpcom.site( siteId ).mediaList( query, function( error, data ) {
+	const query = MediaListStore.getNextPageQuery( siteId );
+	const mediaReceived = ( error, data ) => {
 		Dispatcher.handleServerAction( {
 			type: 'RECEIVE_MEDIA_ITEMS',
 			error: error,
@@ -84,7 +80,15 @@ MediaActions.fetchNextPage = function( siteId ) {
 			data: data,
 			query: query
 		} );
-	} );
+	};
+
+	debug( 'Fetching media for %d using query %o', siteId, query );
+
+	if ( ! query.source ) {
+		wpcom.site( siteId ).mediaList( query, mediaReceived );
+	} else {
+		wpcom.undocumented().externalMediaList( query, mediaReceived );
+	}
 };
 
 MediaActions.add = function( siteId, files ) {


### PR DESCRIPTION
Modifies the `MediaListData` component's `getQuery` so it passes along the `source` parameter, if provided. This ensures media library data source is passed down to `MediaActions.fetchNextPage`, which uses the source parameter to decide whether to use the standard WordPress media endpoint, or the external media endpoint.

It should be noted that both the internal and external media list endpoints return data in the same format.

This PR does not enable any external media requests, and it should not affect how the media library currently works.

## Testing

Run the included unit tests which checks the switch between internal/external, and that the `source` parameter is only passed down when present.

Manually verify that the media library continues to work as expected - there should be no changes.