### PR TITLE
Media library: unconnected & empty message for external services

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -12,6 +12,7 @@ import groupBy from 'lodash/groupBy';
 import toArray from 'lodash/toArray';
 import some from 'lodash/some';
 import { translate } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -185,16 +186,24 @@ const MediaLibraryContent = React.createClass( {
 		analytics.tracks.recordEvent( tracksEvent, tracksData );
 	},
 
+	goToSharing( ev ) {
+		ev.preventDefault();
+		page( `/sharing/${ this.props.site.slug }` );
+	},
+
 	renderExternalMedia() {
-		if ( this.props.isRequesting ) {
-			return (
-				<MediaLibraryList key="list-loading" filterRequiresUpgrade={ this.props.filterRequiresUpgrade } />
-			);
-		}
+		const connectMessage = translate(
+			'To show Photos from Google, you need to connect your Google account. Do that from {{link}}your Sharing settings{{/link}}.', {
+				components: {
+					link: <a href={ `/sharing/${ this.props.site.slug }` } onClick={ this.goToSharing } />
+				}
+			}
+		);
 
 		return (
-			<div>
-				<p>{ translate( 'You will need to connect your account to view your media. Go to the Sharing tab.' ) }</p>
+			<div className="media-library__connect-message">
+				<p><img src="/calypso/images/sharing/google-photos-logo.svg" width="96" height="96" /></p>
+				<p>{ connectMessage }</p>
 			</div>
 		);
 	},

--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -22,3 +22,10 @@
 .media-library__scale-range .range__content.is-max {
 	right: -28px;
 }
+
+.media-library__connect-message {
+	max-width: 480px;
+	padding: 36px;
+	margin: 0 auto;
+	text-align: center;
+}

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -15,7 +15,8 @@ export default React.createClass( {
 
 	propTypes: {
 		site: React.PropTypes.object,
-		filter: React.PropTypes.string
+		filter: React.PropTypes.string,
+		source: React.PropTypes.string,
 	},
 
 	getLabel() {
@@ -53,8 +54,9 @@ export default React.createClass( {
 	},
 
 	render() {
-		let line, action;
-		if ( userCan( 'upload_files', this.props.site ) ) {
+		let line = '', action = '';
+
+		if ( userCan( 'upload_files', this.props.site ) && ! this.props.source ) {
 			line = this.translate( 'Would you like to upload something?' );
 			action = (
 				<UploadButton className="button is-primary" site={ this.props.site }>

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -209,7 +209,8 @@ export const MediaLibraryList = React.createClass( {
 			return React.createElement( this.props.search ? ListNoResults : ListNoContent, {
 				site: this.props.site,
 				filter: this.props.filter,
-				search: this.props.search
+				search: this.props.search,
+				source: this.props.source,
 			} );
 		}
 


### PR DESCRIPTION
Adds some messaging for external media.

1) Shows an unconnected message if external media is shown and the user hasn’t authorised a connection to that service.

<img width="760" alt="connect" src="https://user-images.githubusercontent.com/1277682/27471884-3d39598a-57f1-11e7-88e2-01ea267ec892.png">

Note that we just link the user to the sharing page for simplicity. A future version should provide the ability to do this directly.

2) Shows a 'you have no media' message without upload button if the user is connected to Google Photos, but doesn't have any media

<img width="826" alt="no_media" src="https://user-images.githubusercontent.com/1277682/27627672-862c5470-5be4-11e7-949c-5a36862ef480.png">

### Testing

1. On the Sharing menu, ensure you are not connected to Google Photos
1. Edit a post, click the media dropdown, and select 'Add from Google'
1. Verify that the above message is shown
1. Go back to Sharing menu and connect to Google Photos
1. Repeat the media dropdown and verify that your Google photos are shown
1. Remove all photos from your Google account (or connect to an account without photos!)
1. Open media modal and verify that the above 'you have no media' message is shown and that no upload button or dropzone is active
1. Open media modal on a site without media and verify that the same message is shown but with an active upload button
