### PR TITLE
Improve/post share disabled mode

### DIFF
--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -56,7 +56,7 @@ class CalendarButton extends Component {
 			return null;
 		}
 
-		return this.setState( { showPopover: ! this.state.showPopover } )
+		return this.setState( { showPopover: ! this.state.showPopover } );
 	};
 
 	setPopoverReference = calendarButtonRef => ( this.reference = calendarButtonRef );

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -51,7 +51,13 @@ class CalendarButton extends Component {
 
 	closePopover = () => this.setState( { showPopover: false } );
 
-	togglePopover = () => this.setState( { showPopover: ! this.state.showPopover } );
+	togglePopover = () => {
+		if ( this.props.disabled ) {
+			return null;
+		}
+
+		return this.setState( { showPopover: ! this.state.showPopover } )
+	};
 
 	setPopoverReference = calendarButtonRef => ( this.reference = calendarButtonRef );
 

--- a/client/blocks/post-share/README.md
+++ b/client/blocks/post-share/README.md
@@ -1,0 +1,27 @@
+# Post Share
+
+Component/Block to share posts to social-media accounts
+
+## Example
+
+```es6
+import PostShare from 'blocks/post-share';
+
+<PostShare
+	post={ post }
+	siteId={ siteId } />
+```
+
+## Props
+
+### `post`
+
+A post object.
+
+### `siteId`
+
+The id of the site
+
+### `disabled`
+
+If it's true, the form elements of the component will be disabled such as buttons, input fields, etc.

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -35,11 +35,17 @@
 		border-left-width: 1px;
 		border-top-left-radius: 4px;
 		border-bottom-left-radius: 4px;
+		&:active {
+			border-right-width: 0;
+		}
 	}
 
 	.button:last-child {
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
+		&:active {
+			border-left-width: 0;
+		}
 	}
 
 	.section-header & .button {

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -83,11 +83,11 @@ export default React.createClass( {
 		} else {
 			return (
 				<FormTextarea
-					disabled={ this.props.disabled }				
+					disabled={ this.props.disabled }
 					value={ this.props.message }
 					placeholder={ this.props.preview }
 					onChange={ this.onChange }
-					className="editor-sharing__message-input"/>
+					className="editor-sharing__message-input" />
 			);
 		}
 	},

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -17,6 +17,7 @@ export default React.createClass( {
 	displayName: 'PublicizeMessage',
 
 	propTypes: {
+		message: React.PropTypes.bool,
 		message: React.PropTypes.string,
 		preview: React.PropTypes.string,
 		acceptableLength: React.PropTypes.number,
@@ -26,6 +27,7 @@ export default React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			disabled: false,
 			message: '',
 			acceptableLength: 140,
 			requireCount: false,
@@ -66,6 +68,7 @@ export default React.createClass( {
 		if ( this.props.requireCount ) {
 			return (
 				<CountedTextarea
+					disabled={ this.props.disabled }
 					value={ this.props.message }
 					placeholder={ this.props.preview }
 					countPlaceholderLength={ true }
@@ -80,6 +83,7 @@ export default React.createClass( {
 		} else {
 			return (
 				<FormTextarea
+					disabled={ this.props.disabled }				
 					value={ this.props.message }
 					placeholder={ this.props.preview }
 					onChange={ this.onChange }


### PR DESCRIPTION
Issues: #15037.


This PR blocks some input elements of the `<PostShare />` when it's needed, for instance, when it's disabled or when a post is being published.
<img src="https://user-images.githubusercontent.com/77539/27138839-d338a8f6-50f7-11e7-9063-146403376e72.gif" width="500px" />

--------------
Testing:

Test the disabled mode in the devdocs section page: http://calypso.localhost:3000/devdocs/blocks/post-share.

Either on this page or going to posts page -> Share tab, you could testing publishing a post. When the post is being published you shouldn't be able to edit the content, date via the calendar or click again the `Share post` button.
Also, the component should be disabled when there aren't activated connections.
Take a look at the gif above.



