### PR TITLE
Plans: Pass isInSignup properly to PlanFeaturesHeader

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -157,6 +157,7 @@ class PlanFeatures extends Component {
 						site={ site }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
+						isInSignup={ isInSignup }
 					/>
 					<p className="plan-features__description">
 						{ planConstantObj.getDescription( abtest ) }
@@ -193,7 +194,7 @@ class PlanFeatures extends Component {
 	}
 
 	renderPlanHeaders() {
-		const { planProperties, intervalType, site, basePlansPath } = this.props;
+		const { planProperties, intervalType, site, basePlansPath, isInSignup } = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -228,6 +229,7 @@ class PlanFeatures extends Component {
 						hideMonthly={ hideMonthly }
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
+						isInSignup={ isInSignup }
 					/>
 				</td>
 			);


### PR DESCRIPTION
This PR fixes a bug with plans, where the `isInSignup` was not being passed properly to the `PlanFeaturesHeader`, which was causing the plans page to wrongly display the current plan of the selected site as the current plan while creating a new .com site:

![](https://cldup.com/Xux15CbJqZ.png)

Originally found by @rickybanister.

To test:
* Checkout this branch or get it going on calypso.live
* Click "My Sites" and make sure you've selected one of your sites with a paid plan.
* Go to "Add New Site" and create a new WordPress.com site.
* Go through the site creation flow.
* At the last step (plans), verify you're not seeing the "Your Plan" ribbon on any of the plans, and specifically on the type of plan that your selected site has.