### PR TITLE
Editor: add loading messsage to fullscreen EditorPreview

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -213,7 +213,7 @@ export class WebPreviewContent extends Component {
 				/>
 				<div className="web-preview__placeholder">
 					{ this.props.showPreview && ! this.state.loaded && 'seo' !== this.state.device &&
-						<div>
+						<div className="web-preview__loading-message-wrapper">
 							<Spinner />
 							{ this.props.loadingMessage &&
 								<span className="web-preview__loading-message">
@@ -278,7 +278,7 @@ WebPreviewContent.propTypes = {
 	// Called when the edit button is clicked
 	onEdit: PropTypes.func,
 	// Optional loading message to display during loading
-	loadingMessage: PropTypes.string,
+	loadingMessage: PropTypes.oneOfType( [ PropTypes.array, PropTypes.string ] ),
 	// The iframe's title element, used for accessibility purposes
 	iframeTitle: PropTypes.string,
 	// Makes room for a sidebar if desired

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import url from 'url';
 import omit from 'lodash/omit';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -112,6 +113,12 @@ const EditorPreview = React.createClass( {
 							onEdit={ this.props.onEdit }
 							previewUrl={ this.state.iframeUrl }
 							editUrl={ this.props.editUrl }
+							externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }
+							loadingMessage={
+								this.props.translate( '{{strong}}One moment please…{{/strong}} loading your new post.',
+									{ components: { strong: <strong /> } }
+								)
+							}
 						/>
 					: <WebPreview
 							showPreview={ this.props.showPreview }
@@ -126,4 +133,4 @@ const EditorPreview = React.createClass( {
 	}
 } );
 
-module.exports = EditorPreview;
+module.exports = localize( EditorPreview );

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -23,8 +23,16 @@
     }
 }
 
+.editor-preview .web-preview__loading-message-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+}
+
 .editor-preview .web-preview__loading-message {
 	font-size: 16px;
+	height: initial;
 	position: relative;
 		z-index: z-index( 'root', '.web-preview' );
 

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -22,3 +22,16 @@
 		visibility: visible;
     }
 }
+
+.editor-preview .web-preview__loading-message {
+	font-size: 16px;
+	position: relative;
+		z-index: z-index( 'root', '.web-preview' );
+
+	strong {
+		color: $gray-text-min;
+		display: block;
+		font-size: 24px;
+		margin-bottom: 5px;
+	}
+}


### PR DESCRIPTION
This PR adds a loadingMessage to the full-screen EditorPreview when viewed behind the `post-editor/delta-post-publish-preview` flag.

**Mock:**
![loading_preview](https://user-images.githubusercontent.com/942359/27142238-7279e8a8-50f8-11e7-998f-d550cc7d1669.png)

This is part of a larger epic (See p3Ex-2ri-p2).

**To Test:**
- Check out the branch.
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Preview a post from the editor - the full-screen preview should be shown.
- Use the React dev tools to set the `WebPreviewContent` component's `isLoaded` state to `false`:
![screen shot 2017-06-15 at 10 16 14 am](https://user-images.githubusercontent.com/942359/27185615-e3e977c2-51b3-11e7-9eca-94c7a48ae085.png)
- Verify the loadingMessage is displayed.