### PR TITLE
WooCommerce: Update products UI state to be keyed by siteId.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -39,19 +39,21 @@ class ProductCreate extends React.Component {
 	componentDidMount() {
 		const { product, siteId } = this.props;
 
-		if ( ! product ) {
-			this.props.editProduct( null, {
-				type: 'simple'
-			} );
-		}
-
 		if ( siteId ) {
+			if ( ! product ) {
+				this.props.editProduct( siteId, null, {
+					type: 'simple'
+				} );
+			}
 			this.props.fetchProductCategories( siteId );
 		}
 	}
 
 	componentWillReceiveProps( newProps ) {
 		if ( newProps.siteId !== this.props.siteId ) {
+			this.props.editProduct( newProps.siteId, null, {
+				type: 'simple'
+			} );
 			this.props.fetchProductCategories( newProps.siteId );
 		}
 	}
@@ -84,7 +86,7 @@ class ProductCreate extends React.Component {
 	}
 
 	render() {
-		const { product, className, variations, productCategories } = this.props;
+		const { siteId, product, className, variations, productCategories } = this.props;
 
 		return (
 			<Main className={ className }>
@@ -92,15 +94,17 @@ class ProductCreate extends React.Component {
 				<ProductHeader
 					onTrash={ this.onTrash }
 					onSave={ this.onSave }
+					saveDisabled={ ! siteId }
 				/>
-				<ProductForm
+				{ siteId && ( <ProductForm
+					siteId={ siteId }
 					product={ product || { type: 'simple' } }
 					variations={ variations }
 					productCategories={ productCategories }
 					editProduct={ this.props.editProduct }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
-				/>
+				/> ) }
 			</Main>
 		);
 	}
@@ -108,8 +112,8 @@ class ProductCreate extends React.Component {
 
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
-	const product = getCurrentlyEditingProduct( state );
-	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
+	const product = getCurrentlyEditingProduct( state, siteId );
+	const variations = product && getProductVariationsWithLocalEdits( state, product.id, siteId );
 	const productCategories = getProductCategories( state, siteId );
 
 	return {

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -93,8 +93,7 @@ class ProductCreate extends React.Component {
 				<SidebarNavigation />
 				<ProductHeader
 					onTrash={ this.onTrash }
-					onSave={ this.onSave }
-					saveDisabled={ ! siteId }
+					onSave={ siteId && this.onSave || false }
 				/>
 				{ siteId && ( <ProductForm
 					siteId={ siteId }

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -24,6 +24,7 @@ class ProductFormAdditionalDetailsCard extends Component {
 	};
 
 	static propTypes = {
+		siteId: PropTypes.number,
 		product: PropTypes.shape( {
 			attributes: PropTypes.array,
 		} ),
@@ -48,8 +49,8 @@ class ProductFormAdditionalDetailsCard extends Component {
 	}
 
 	addAttribute = () => {
-		const { product, editProductAttribute } = this.props;
-		editProductAttribute( product, null, { name: '', options: [] } );
+		const { siteId, product, editProductAttribute } = this.props;
+		editProductAttribute( siteId, product, null, { name: '', options: [] } );
 	}
 
 	cardOpen = () => {
@@ -71,16 +72,16 @@ class ProductFormAdditionalDetailsCard extends Component {
 	}
 
 	removeAttribute( uid ) {
-		const { product, editProduct } = this.props;
+		const { siteId, product, editProduct } = this.props;
 		const attributes = [ ...product.attributes ];
 		const attribute = this.getAttribute( product, uid );
 		attributes.splice( attributes.indexOf( attribute ), 1 );
-		editProduct( product, { attributes } );
+		editProduct( siteId, product, { attributes } );
 	}
 
 	updateValues = ( values, attribute ) => {
-		const { product, editProductAttribute } = this.props;
-		editProductAttribute( product, attribute, { options: values } );
+		const { siteId, product, editProductAttribute } = this.props;
+		editProductAttribute( siteId, product, attribute, { options: values } );
 	}
 
 	updateNameHandler = ( e ) => {
@@ -91,9 +92,9 @@ class ProductFormAdditionalDetailsCard extends Component {
 	}
 
 	updateName( attributeId, name ) {
-		const { product, editProductAttribute } = this.props;
+		const { siteId, product, editProductAttribute } = this.props;
 		const attribute = this.getAttribute( product, attributeId );
-		editProductAttribute( product, attribute, { name } );
+		editProductAttribute( siteId, product, attribute, { name } );
 	}
 
 	renderInput( attribute ) {

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -17,7 +17,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 // TODO Rename this card since it contains other controls, and may contain more in the future (like tax)
 const ProductFormCategoriesCard = (
-	{ product, productCategories, editProduct, translate }
+	{ siteId, product, productCategories, editProduct, translate }
 ) => {
 	const handleChange = ( categoryNames ) => {
 		const newCategories = compact( categoryNames.map( ( name ) => {
@@ -33,11 +33,11 @@ const ProductFormCategoriesCard = (
 		} ) );
 
 		const data = { id: product.id, categories: newCategories };
-		editProduct( product, data );
+		editProduct( siteId, product, data );
 	};
 
 	const toggleFeatured = () => {
-		editProduct( product, { featured: ! product.featured } );
+		editProduct( siteId, product, { featured: ! product.featured } );
 	};
 
 	const selectedCategories = product.categories || [];
@@ -77,6 +77,7 @@ const ProductFormCategoriesCard = (
 };
 
 ProductFormCategoriesCard.propTypes = {
+	siteId: PropTypes.number,
 	product: PropTypes.shape( {
 		id: PropTypes.isRequired,
 		type: PropTypes.string.isRequired,

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -19,6 +19,7 @@ import ProductFormImages from './product-form-images';
 export default class ProductFormDetailsCard extends Component {
 
 	static propTypes = {
+		siteId: PropTypes.number,
 		product: PropTypes.shape( {
 			id: PropTypes.isRequired,
 			type: PropTypes.string.isRequired,
@@ -43,19 +44,19 @@ export default class ProductFormDetailsCard extends Component {
 	// TODO: Consider consolidating the following set functions
 	// into a general purpose Higher Order Component
 	setName( e ) {
-		const { product, editProduct } = this.props;
+		const { siteId, product, editProduct } = this.props;
 		const name = e.target.value;
-		editProduct( product, { name } );
+		editProduct( siteId, product, { name } );
 
 		if ( this.state.updateSkuOnNameChange ) {
 			const sku = trim( name ).toLowerCase().replace( /\s+/g, '-' );
-			editProduct( product, { sku } );
+			editProduct( siteId, product, { sku } );
 		}
 	}
 
 	setSku = ( sku ) => {
-		const { product, editProduct } = this.props;
-		editProduct( product, { sku } );
+		const { siteId, product, editProduct } = this.props;
+		editProduct( siteId, product, { sku } );
 
 		if ( this.state.updateSkuOnNameChange ) {
 			this.setState( {
@@ -65,24 +66,24 @@ export default class ProductFormDetailsCard extends Component {
 	}
 
 	setDescription( description ) {
-		const { product, editProduct } = this.props;
-		editProduct( product, { description } );
+		const { siteId, product, editProduct } = this.props;
+		editProduct( siteId, product, { description } );
 	}
 
 	onImageUpload = ( image ) => {
-		const { product, editProduct } = this.props;
+		const { siteId, product, editProduct } = this.props;
 		const images = product.images && [ ...product.images ] || [];
 		images.push( {
 			id: image.ID,
 			src: image.URL,
 		} );
-		editProduct( product, { images } );
+		editProduct( siteId, product, { images } );
 	}
 
 	onImageRemove = ( id ) => {
-		const { product, editProduct } = this.props;
+		const { siteId, product, editProduct } = this.props;
 		const images = product.images && [ ...product.images ].filter( i => i.id !== id ) || [];
-		editProduct( product, { images } );
+		editProduct( siteId, product, { images } );
 	}
 
 	render() {

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -19,31 +19,31 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormWeightInput from 'woocommerce/components/form-weight-input';
 
-const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
+const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) => {
 	const setDimension = ( e ) => {
 		const dimensions = { ...product.dimensions, [ e.target.name ]: e.target.value };
-		editProduct( product, { dimensions } );
+		editProduct( siteId, product, { dimensions } );
 	};
 
 	const setWeight = ( e ) => {
 		const weight = e.target.value;
-		Number( weight ) >= 0 && editProduct( product, { weight } );
+		Number( weight ) >= 0 && editProduct( siteId, product, { weight } );
 	};
 
 	const setPrice = ( e ) => {
-		editProduct( product, { regular_price: e.target.value } );
+		editProduct( siteId, product, { regular_price: e.target.value } );
 	};
 
 	const toggleStock = () => {
-		editProduct( product, { manage_stock: ! product.manage_stock } );
+		editProduct( siteId, product, { manage_stock: ! product.manage_stock } );
 	};
 
 	const setStockQuantity = ( e ) => {
-		editProduct( product, { stock_quantity: e.target.value } );
+		editProduct( siteId, product, { stock_quantity: e.target.value } );
 	};
 
 	const setBackorders = ( e ) => {
-		editProduct( product, { backorders: e.target.value } );
+		editProduct( siteId, product, { backorders: e.target.value } );
 	};
 
 	// TODO Pull in currency and currency position.
@@ -138,6 +138,7 @@ const ProductFormSimpleCard = ( { product, editProduct, translate } ) => {
 };
 
 ProductFormSimpleCard.propTypes = {
+	siteId: PropTypes.number,
 	product: PropTypes.shape( {
 		dimensions: PropTypes.object,
 		weight: PropTypes.string,

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -20,6 +20,7 @@ class ProductFormVariationsCard extends Component {
 	};
 
 	static propTypes = {
+		siteId: PropTypes.number,
 		product: PropTypes.shape( {
 			type: PropTypes.string.isRequired,
 			name: PropTypes.string,
@@ -51,7 +52,7 @@ class ProductFormVariationsCard extends Component {
 	}
 
 	setProductTypeVariable() {
-		const { product, editProduct } = this.props;
+		const { siteId, product, editProduct } = this.props;
 		const attributes = product.attributes && [ ...product.attributes ] || [];
 		const productData = { ...product };
 		const simpleProduct = [ ...this.state.simpleProduct ];
@@ -67,7 +68,7 @@ class ProductFormVariationsCard extends Component {
 		} );
 
 		this.setState( { simpleProduct, variationAttributes: [] } );
-		editProduct( product, {
+		editProduct( siteId, product, {
 			...productData,
 			type: 'variable',
 			attributes,
@@ -75,7 +76,7 @@ class ProductFormVariationsCard extends Component {
 	}
 
 	setProductTypeSimple() {
-		const { product, editProduct } = this.props;
+		const { siteId, product, editProduct } = this.props;
 		const productData = { ...product };
 		const simpleProduct = this.state.simpleProduct;
 
@@ -88,7 +89,7 @@ class ProductFormVariationsCard extends Component {
 		const attributes = ( product.attributes && product.attributes.filter( attribute => ! attribute.variation ) ) || null;
 
 		this.setState( { variationAttributes, simpleProduct: [] } );
-		editProduct( product, {
+		editProduct( siteId, product, {
 			...productData,
 			type: 'simple',
 			attributes,
@@ -96,7 +97,8 @@ class ProductFormVariationsCard extends Component {
 	}
 
 	render() {
-		const { product, variations, translate, editProductAttribute, editProductVariation } = this.props;
+		const { siteId, product, variations, translate } = this.props;
+		const { editProductAttribute, editProductVariation } = this.props;
 		const variationToggleDescription = translate(
 			'%(productName)s has variations, for example size and color.', {
 				args: {
@@ -118,10 +120,12 @@ class ProductFormVariationsCard extends Component {
 				{ 'variable' === product.type && (
 					<div>
 						<ProductVariationTypesForm
+							siteId={ siteId }
 							product={ product }
 							editProductAttribute={ editProductAttribute }
 						/>
 						<ProductFormVariationsTable
+							siteId={ siteId }
 							product={ product }
 							variations={ variations }
 							editProductVariation={ editProductVariation }

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -21,6 +21,7 @@ import VerticalMenu from 'components/vertical-menu';
 class ProductFormVariationsModal extends React.Component {
 
 	static propTypes = {
+		siteId: PropTypes.number,
 		product: PropTypes.object.isRequired,
 		variations: PropTypes.array.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
@@ -46,10 +47,10 @@ class ProductFormVariationsModal extends React.Component {
 	 * same TinyMCE instance for different descriptions.
 	 */
 	editorComponent = ( variationId ) => {
-		const { product, variations, editProductVariation } = this.props;
+		const { siteId, product, variations, editProductVariation } = this.props;
 		const variation = find( variations, ( v ) => variationId === v.id );
 		const setDescription = debounce( ( description ) => {
-			editProductVariation( product, variation, { description } );
+			editProductVariation( siteId, product, variation, { description } );
 		}, 200 );
 		return <CompactTinyMCE
 				value={ variation.description || '' }
@@ -64,16 +65,16 @@ class ProductFormVariationsModal extends React.Component {
 	}
 
 	setSku = ( sku ) => {
-		const { product, editProductVariation } = this.props;
+		const { siteId, product, editProductVariation } = this.props;
 		const variation = this.selectedVariation();
-		editProductVariation( product, variation, { sku } );
+		editProductVariation( siteId, product, variation, { sku } );
 	}
 
 	toggleVisible() {
-		const { product, editProductVariation } = this.props;
+		const { siteId, product, editProductVariation } = this.props;
 		const variation = this.selectedVariation();
 		const status = 'publish' === variation.status ? 'private' : 'publish';
-		editProductVariation( product, variation, { status } );
+		editProductVariation( siteId, product, variation, { status } );
 	}
 
 	switchVariation( selectedVariation ) {

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -22,6 +22,7 @@ import Spinner from 'components/spinner';
 
 class ProductFormVariationsRow extends Component {
 	static propTypes = {
+		siteId: PropTypes.number,
 		product: PropTypes.object.isRequired,
 		variation: PropTypes.object.isRequired,
 		manageStock: PropTypes.bool,
@@ -45,25 +46,25 @@ class ProductFormVariationsRow extends Component {
 
 	// TODO: Consildate the following set/toggle functions with a helper (along with the form-details functions).
 	setPrice = ( e ) => {
-		const { editProductVariation, product, variation } = this.props;
-		editProductVariation( product, variation, { regular_price: e.target.value } );
+		const { siteId, editProductVariation, product, variation } = this.props;
+		editProductVariation( siteId, product, variation, { regular_price: e.target.value } );
 	}
 
 	setWeight = ( e ) => {
-		const { editProductVariation, product, variation } = this.props;
-		editProductVariation( product, variation, { weight: e.target.value } );
+		const { siteId, editProductVariation, product, variation } = this.props;
+		editProductVariation( siteId, product, variation, { weight: e.target.value } );
 	}
 
 	setDimension = ( e ) => {
-		const { editProductVariation, product, variation } = this.props;
+		const { siteId, editProductVariation, product, variation } = this.props;
 		const dimensions = { ...variation.dimensions, [ e.target.name ]: e.target.value };
-		editProductVariation( product, variation, { dimensions } );
+		editProductVariation( siteId, product, variation, { dimensions } );
 	}
 
 	setStockQuantity = ( e ) => {
-		const { editProductVariation, product, variation } = this.props;
+		const { siteId, editProductVariation, product, variation } = this.props;
 		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
-		editProductVariation( product, variation, { stock_quantity } );
+		editProductVariation( siteId, product, variation, { stock_quantity } );
 	}
 
 	showDialog = () => {
@@ -81,7 +82,7 @@ class ProductFormVariationsRow extends Component {
 	}
 
 	onUpload = ( file ) => {
-		const { editProductVariation, product, variation } = this.props;
+		const { siteId, editProductVariation, product, variation } = this.props;
 		const image = {
 			src: file.URL,
 			id: file.ID,
@@ -90,7 +91,7 @@ class ProductFormVariationsRow extends Component {
 			transientId: null,
 			isUploading: false,
 		} );
-		editProductVariation( product, variation, { image } );
+		editProductVariation( siteId, product, variation, { image } );
 	}
 
 	onError = () => {
@@ -102,7 +103,7 @@ class ProductFormVariationsRow extends Component {
 	}
 
 	removeImage = () => {
-		const { editProductVariation, product, variation } = this.props;
+		const { siteId, editProductVariation, product, variation } = this.props;
 		this.setState( {
 			placeholder: null,
 			transientId: null,
@@ -110,7 +111,7 @@ class ProductFormVariationsRow extends Component {
 			src: null,
 			id: null,
 		} );
-		editProductVariation( product, variation, { image: {} } );
+		editProductVariation( siteId, product, variation, { image: {} } );
 	}
 
 	renderImage = () => {

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -20,6 +20,7 @@ import ProductFormVariationsRow from './product-form-variations-row';
 class ProductFormVariationsTable extends React.Component {
 
 	static propTypes = {
+		siteId: PropTypes.number,
 		variations: PropTypes.array,
 		product: PropTypes.object,
 		editProductVariation: PropTypes.func.isRequired,
@@ -43,10 +44,10 @@ class ProductFormVariationsTable extends React.Component {
 	}
 
 	editAllVariations( field, value ) {
-		const { product, variations, editProductVariation } = this.props;
+		const { siteId, product, variations, editProductVariation } = this.props;
 		this.setState( { [ field ]: value } );
 		variations.map( function( variation ) {
-			editProductVariation( product, variation, { [ field ]: value } );
+			editProductVariation( siteId, product, variation, { [ field ]: value } );
 		} );
 	}
 
@@ -91,7 +92,7 @@ class ProductFormVariationsTable extends React.Component {
 	}
 
 	renderModal() {
-		const { variations, product, editProductVariation, translate } = this.props;
+		const { siteId, variations, product, editProductVariation, translate } = this.props;
 		const { showDialog, selectedVariation } = this.state;
 
 		const buttons = [
@@ -107,6 +108,7 @@ class ProductFormVariationsTable extends React.Component {
 				additionalClassNames="woocommerce products__product-form-variation-dialog"
 			>
 				<ProductFormVariationsModal
+					siteId={ siteId }
 					product={ product }
 					variations={ variations }
 					selectedVariation={ selectedVariation }
@@ -118,12 +120,13 @@ class ProductFormVariationsTable extends React.Component {
 	}
 
 	renderVariationRow( variation ) {
-		const { product, variations, editProductVariation } = this.props;
+		const { siteId, product, variations, editProductVariation } = this.props;
 		const id = isNumber( variation.id ) && variation.id || 'index_' + variation.id.index;
 		const manageStock = ( find( variations, ( v ) => v.manage_stock ) ) ? true : false;
 
 		return (
 			<ProductFormVariationsRow
+				siteId={ siteId }
 				key={ id }
 				product={ product }
 				variation={ variation }

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -16,6 +16,7 @@ import ProductFormVariationsCard from './product-form-variations-card';
 export default class ProductForm extends Component {
 	static propTypes = {
 		className: PropTypes.string,
+		siteId: PropTypes.number,
 		product: PropTypes.shape( {
 			id: PropTypes.isRequired,
 			type: PropTypes.string.isRequired,
@@ -29,26 +30,30 @@ export default class ProductForm extends Component {
 	};
 
 	render() {
-		const { product, productCategories, variations } = this.props;
+		const { siteId, product, productCategories, variations } = this.props;
 		const { editProduct, editProductVariation, editProductAttribute } = this.props;
 
 		return (
 			<div className={ classNames( 'products__form', this.props.className ) }>
 				<ProductFormDetailsCard
+					siteId={ siteId }
 					product={ product }
 					editProduct={ editProduct }
 				/>
 				<ProductFormAdditionalDetailsCard
+					siteId={ siteId }
 					product={ product }
 					editProduct={ this.props.editProduct }
 					editProductAttribute={ this.props.editProductAttribute }
 				/>
 				<ProductFormCategoriesCard
+					siteId={ siteId }
 					product={ product }
 					productCategories={ productCategories }
 					editProduct={ editProduct }
 				/>
 				<ProductFormVariationsCard
+					siteId={ siteId }
 					product={ product }
 					variations={ variations }
 					editProduct={ editProduct }
@@ -59,6 +64,7 @@ export default class ProductForm extends Component {
 				{ 'simple' === product.type && (
 					<div className="products__product-simple-cards">
 						<ProductFormSimpleCard
+							siteId={ siteId }
 							product={ product }
 							editProduct={ this.props.editProduct }
 						/>

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -11,12 +11,12 @@ import Gridicon from 'gridicons';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 
-const ProductHeader = ( { onTrash, onSave, translate, saveDisabled } ) => {
+const ProductHeader = ( { onTrash, onSave, translate } ) => {
 	const trashButton = onTrash &&
 		<Button borderless onClick={ onTrash }><Gridicon icon="trash" /></Button>;
 
-	const saveButton = onSave &&
-		<Button primary onClick={ onSave } disabled={ saveDisabled }>{ translate( 'Save' ) }</Button>;
+	const saveButton = 'undefined' !== typeof onSave &&
+		<Button primary onClick={ onSave } disabled={ onSave === false }>{ translate( 'Save' ) }</Button>;
 
 	return (
 		<ActionHeader>
@@ -28,12 +28,10 @@ const ProductHeader = ( { onTrash, onSave, translate, saveDisabled } ) => {
 
 ProductHeader.propTypes = {
 	onTrash: PropTypes.func,
-	onSave: PropTypes.func,
-	saveDisabled: PropTypes.bool,
-};
-
-ProductHeader.defaultProps = {
-	saveDisabled: false,
+	onSave: PropTypes.oneOfType( [
+		React.PropTypes.func,
+		React.PropTypes.bool,
+	] ),
 };
 
 export default localize( ProductHeader );

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -11,12 +11,12 @@ import Gridicon from 'gridicons';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 
-const ProductHeader = ( { onTrash, onSave, translate } ) => {
+const ProductHeader = ( { onTrash, onSave, translate, saveDisabled } ) => {
 	const trashButton = onTrash &&
 		<Button borderless onClick={ onTrash }><Gridicon icon="trash" /></Button>;
 
 	const saveButton = onSave &&
-		<Button primary onClick={ onSave }>{ translate( 'Save' ) }</Button>;
+		<Button primary onClick={ onSave } disabled={ saveDisabled }>{ translate( 'Save' ) }</Button>;
 
 	return (
 		<ActionHeader>
@@ -29,6 +29,11 @@ const ProductHeader = ( { onTrash, onSave, translate } ) => {
 ProductHeader.propTypes = {
 	onTrash: PropTypes.func,
 	onSave: PropTypes.func,
+	saveDisabled: PropTypes.bool,
+};
+
+ProductHeader.defaultProps = {
+	saveDisabled: false,
 };
 
 export default localize( ProductHeader );

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -20,6 +20,7 @@ export default class ProductVariationTypesForm extends Component {
 	};
 
 	static propTypes = {
+		siteId: PropTypes.number,
 		product: PropTypes.shape( {
 			id: PropTypes.isRequired,
 			type: PropTypes.string.isRequired,
@@ -49,8 +50,8 @@ export default class ProductVariationTypesForm extends Component {
 	}
 
 	addType = () => {
-		const { product, editProductAttribute } = this.props;
-		editProductAttribute( product, null, this.getNewFields() );
+		const { siteId, product, editProductAttribute } = this.props;
+		editProductAttribute( siteId, product, null, this.getNewFields() );
 	}
 
 	updateNameHandler = ( e ) => {
@@ -61,16 +62,16 @@ export default class ProductVariationTypesForm extends Component {
 	}
 
 	updateName( attributeId, name ) {
-		const { product, editProductAttribute } = this.props;
+		const { siteId, product, editProductAttribute } = this.props;
 		const attribute = product.attributes && find( product.attributes, function( a ) {
 			return a.uid === attributeId;
 		} );
-		editProductAttribute( product, attribute, { name } );
+		editProductAttribute( siteId, product, attribute, { name } );
 	}
 
 	updateValues = ( values, attribute ) => {
-		const { product, editProductAttribute } = this.props;
-		editProductAttribute( product, attribute, { options: values } );
+		const { siteId, product, editProductAttribute } = this.props;
+		editProductAttribute( siteId, product, attribute, { options: values } );
 	}
 
 	renderInputs( attribute ) {

--- a/client/extensions/woocommerce/state/ui/products/actions.js
+++ b/client/extensions/woocommerce/state/ui/products/actions.js
@@ -6,16 +6,21 @@ import {
 	WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT,
 } from 'woocommerce/state/action-types';
 
-export function editProduct( product, data ) {
+export function editProduct( siteId, product, data ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_EDIT,
-		payload: { product, data },
+		siteId,
+		product,
+		data,
 	};
 }
 
-export function editProductAttribute( product, attribute, data ) {
+export function editProductAttribute( siteId, product, attribute, data ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT,
-		payload: { product, attribute, data },
+		siteId,
+		product,
+		attribute,
+		data,
 	};
 }

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -19,8 +19,7 @@ export default createReducer( null, {
 } );
 
 function editProductAction( edits, action ) {
-	const { product, data } = action.payload;
-
+	const { product, data } = action;
 	const prevEdits = edits || {};
 	const bucket = getBucket( product );
 	const _product = product || { id: nextBucketIndex( prevEdits[ bucket ] ) };
@@ -34,7 +33,7 @@ function editProductAction( edits, action ) {
 }
 
 function editProductAttributeAction( edits, action ) {
-	const { product, attribute, data } = action.payload;
+	const { product, attribute, data } = action;
 	const attributes = product && product.attributes;
 
 	const prevEdits = edits || {};

--- a/client/extensions/woocommerce/state/ui/products/reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/reducer.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import edits from './edits-reducer';
-import { combineReducers } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import variations from './variations/reducer';
 import apiPlan from './api-plan/reducer';
 
-export default combineReducers( {
+export default keyedReducer( 'siteId', combineReducers( {
 	edits,
 	variations,
 	apiPlan,
-} );
+} ) );

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -6,11 +6,11 @@ import { get, find, isNumber } from 'lodash';
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getProduct } from '../../products/selectors';
 
-export function getAllProductEdits( state ) {
-	const woocommerce = state.extensions.woocommerce;
-	return get( woocommerce, 'ui.products.edits', {} );
+export function getAllProductEdits( state, siteId ) {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'edits' ], {} );
 }
 
 /**
@@ -18,10 +18,11 @@ export function getAllProductEdits( state ) {
  *
  * @param {Object} state Global state tree
  * @param {any} productId The id of the product (or { index: # } )
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The current accumulated edits
  */
-export function getProductEdits( state, productId ) {
-	const edits = getAllProductEdits( state );
+export function getProductEdits( state, productId, siteId = getSelectedSiteId( state ) ) {
+	const edits = getAllProductEdits( state, siteId );
 	const bucket = isNumber( productId ) && 'updates' || 'creates';
 	const array = get( edits, bucket, [] );
 
@@ -33,13 +34,14 @@ export function getProductEdits( state, productId ) {
  *
  * @param {Object} state Global state tree
  * @param {any} productId The id of the product (or { index: # } )
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The product data merged between the fetched data and edits
  */
-export function getProductWithLocalEdits( state, productId ) {
+export function getProductWithLocalEdits( state, productId, siteId = getSelectedSiteId( state ) ) {
 	const existing = isNumber( productId );
 
 	const product = existing && getProduct( state, productId );
-	const productEdits = getProductEdits( state, productId );
+	const productEdits = getProductEdits( state, productId, siteId );
 
 	return ( product || productEdits ) && { ...product, ...productEdits } || undefined;
 }
@@ -48,11 +50,12 @@ export function getProductWithLocalEdits( state, productId ) {
  * Gets the product being currently edited in the UI.
  *
  * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} Product object that is merged between fetched data and edits
  */
-export function getCurrentlyEditingProduct( state ) {
-	const edits = getAllProductEdits( state ) || {};
+export function getCurrentlyEditingProduct( state, siteId = getSelectedSiteId( state ) ) {
+	const edits = getAllProductEdits( state, siteId ) || {};
 	const { currentlyEditingId } = edits;
 
-	return getProductWithLocalEdits( state, currentlyEditingId );
+	return getProductWithLocalEdits( state, currentlyEditingId, siteId );
 }

--- a/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
@@ -13,6 +13,8 @@ import {
 	editProductAttribute,
 } from '../actions';
 
+const siteId = 123;
+
 describe( 'edits-reducer', () => {
 	it( 'should initialize to null', () => {
 		expect( reducer( undefined, { type: '@@test/INIT' } ) ).to.equal( null );
@@ -20,7 +22,7 @@ describe( 'edits-reducer', () => {
 
 	it( 'should create "updates" upon first edit', () => {
 		const product = { id: 1 };
-		const edits = reducer( undefined, editProduct( product, { name: 'A Product' } ) );
+		const edits = reducer( undefined, editProduct( siteId, product, { name: 'A Product' } ) );
 
 		expect( edits ).to.not.equal( null );
 		expect( edits.updates ).to.exist;
@@ -29,11 +31,11 @@ describe( 'edits-reducer', () => {
 
 	it( 'should modify "updates" on second edit', () => {
 		const product = { id: 1 };
-		const edits1 = reducer( undefined, editProduct( product, {
+		const edits1 = reducer( undefined, editProduct( siteId, product, {
 			name: 'After first edit',
 		} ) );
 
-		const edits2 = reducer( undefined, editProduct( product, {
+		const edits2 = reducer( undefined, editProduct( siteId, product, {
 			name: 'After second edit',
 			description: 'Description',
 		} ) );
@@ -46,12 +48,12 @@ describe( 'edits-reducer', () => {
 
 	it( 'should create updates for more than one existing product', () => {
 		const product1 = { id: 1 };
-		const edits1 = reducer( undefined, editProduct( product1, {
+		const edits1 = reducer( undefined, editProduct( siteId, product1, {
 			name: 'First product',
 		} ) );
 
 		const product2 = { id: 2 };
-		const edits2 = reducer( edits1, editProduct( product2, {
+		const edits2 = reducer( edits1, editProduct( siteId, product2, {
 			name: 'Second product',
 		} ) );
 
@@ -62,7 +64,7 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should create "creates" on first edit', () => {
-		const edits = reducer( undefined, editProduct( null, {
+		const edits = reducer( undefined, editProduct( siteId, null, {
 			name: 'A new product',
 		} ) );
 
@@ -74,14 +76,14 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should modify "creates" on second edit', () => {
-		const edits1 = reducer( undefined, editProduct( null, {
+		const edits1 = reducer( undefined, editProduct( siteId, null, {
 			name: 'After first edit',
 		} ) );
 
 		expect( edits1.creates[ 0 ].name ).to.eql( 'After first edit' );
 		expect( edits1.creates[ 0 ].description ).to.not.exist;
 
-		const edits2 = reducer( edits1, editProduct( edits1.creates[ 0 ], {
+		const edits2 = reducer( edits1, editProduct( siteId, edits1.creates[ 0 ], {
 			name: 'After second edit',
 			description: 'Description',
 		} ) );
@@ -91,11 +93,11 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should create more than one new product', () => {
-		const edits1 = reducer( undefined, editProduct( null, {
+		const edits1 = reducer( undefined, editProduct( siteId, null, {
 			name: 'First product',
 		} ) );
 
-		const edits2 = reducer( edits1, editProduct( null, {
+		const edits2 = reducer( edits1, editProduct( siteId, null, {
 			name: 'Second product',
 		} ) );
 
@@ -106,7 +108,7 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should create new product in "creates" when editing attribute the first time', () => {
-		const edits = reducer( undefined, editProductAttribute( null, null, {
+		const edits = reducer( undefined, editProductAttribute( siteId, null, null, {
 			name: 'New Attribute',
 		} ) );
 
@@ -117,14 +119,14 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should modify product in "creates" when editing attribute a second time', () => {
-		const edits1 = reducer( undefined, editProductAttribute( null, null, {
+		const edits1 = reducer( undefined, editProductAttribute( siteId, null, null, {
 			name: 'Edited once',
 		} ) );
 
 		let product = edits1.creates[ 0 ];
 		let attribute = product.attributes[ 0 ];
 
-		const edits2 = reducer( edits1, editProductAttribute( product, attribute, {
+		const edits2 = reducer( edits1, editProductAttribute( siteId, product, attribute, {
 			name: 'Edited twice',
 		} ) );
 
@@ -135,14 +137,14 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should create more than one attribute for a newly created product', () => {
-		const edits1 = reducer( undefined, editProductAttribute( null, null, {
+		const edits1 = reducer( undefined, editProductAttribute( siteId, null, null, {
 			name: 'Attribute One',
 		} ) );
 
 		let product = edits1.creates[ 0 ];
 		let attribute1 = product.attributes[ 0 ];
 
-		const edits2 = reducer( edits1, editProductAttribute( product, null, {
+		const edits2 = reducer( edits1, editProductAttribute( siteId, product, null, {
 			name: 'Attribute Two',
 		} ) );
 
@@ -158,7 +160,7 @@ describe( 'edits-reducer', () => {
 		let product = {
 			id: 1,
 		};
-		const edits = reducer( undefined, editProductAttribute( product, null, {
+		const edits = reducer( undefined, editProductAttribute( siteId, product, null, {
 			name: 'New Attribute',
 		} ) );
 
@@ -176,14 +178,14 @@ describe( 'edits-reducer', () => {
 		let product = {
 			id: 1,
 		};
-		const edits1 = reducer( undefined, editProductAttribute( product, null, {
+		const edits1 = reducer( undefined, editProductAttribute( siteId, product, null, {
 			name: 'Edited once',
 		} ) );
 
 		product = edits1.updates[ 0 ];
 		let attribute = product.attributes[ 0 ];
 
-		const edits2 = reducer( edits1, editProductAttribute( product, attribute, {
+		const edits2 = reducer( edits1, editProductAttribute( siteId, product, attribute, {
 			name: 'Edited twice',
 		} ) );
 
@@ -197,14 +199,14 @@ describe( 'edits-reducer', () => {
 		let product = {
 			id: 1,
 		};
-		const edits1 = reducer( undefined, editProductAttribute( product, null, {
+		const edits1 = reducer( undefined, editProductAttribute( siteId, product, null, {
 			name: 'Attribute One',
 		} ) );
 
 		product = edits1.updates[ 0 ];
 		let attribute1 = product.attributes[ 0 ];
 
-		const edits2 = reducer( edits1, editProductAttribute( product, null, {
+		const edits2 = reducer( edits1, editProductAttribute( siteId, product, null, {
 			name: 'Attribute Two',
 		} ) );
 
@@ -217,13 +219,13 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should set currentlyEditingId when editing a new product', () => {
-		const edits1 = reducer( undefined, editProduct( null, {
+		const edits1 = reducer( undefined, editProduct( siteId, null, {
 			name: 'A new product',
 		} ) );
 
 		expect( edits1.currentlyEditingId ).to.eql( edits1.creates[ 0 ].id );
 
-		const edits2 = reducer( edits1, editProduct( null, {
+		const edits2 = reducer( edits1, editProduct( siteId, null, {
 			name: 'Second product',
 		} ) );
 
@@ -232,7 +234,7 @@ describe( 'edits-reducer', () => {
 
 	it( 'should set currentlyEditingId when editing an existing product', () => {
 		const product1 = { id: 1 };
-		const edits1 = reducer( undefined, editProduct( product1, {
+		const edits1 = reducer( undefined, editProduct( siteId, product1, {
 			name: 'First product',
 		} ) );
 		expect( edits1.currentlyEditingId ).to.eql( edits1.updates[ 0 ].id );

--- a/client/extensions/woocommerce/state/ui/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/test/selectors.js
@@ -13,11 +13,14 @@ import {
 	getCurrentlyEditingProduct,
 } from '../selectors';
 
+const siteId = 123;
+
 describe( 'selectors', () => {
 	let state;
 
 	beforeEach( () => {
 		state = {
+			ui: { selectedSiteId: 123 },
 			extensions: {
 				woocommerce: {
 					products: [
@@ -26,6 +29,8 @@ describe( 'selectors', () => {
 					],
 					ui: {
 						products: {
+							123: {
+							}
 						}
 					},
 				},
@@ -37,7 +42,7 @@ describe( 'selectors', () => {
 		it( 'should get a product from "creates"', () => {
 			const newProduct = { id: { index: 0 }, name: 'New Product' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
-			set( uiProducts, 'edits.creates', [ newProduct ] );
+			set( uiProducts, [ siteId, 'edits', 'creates' ], [ newProduct ] );
 
 			expect( getProductEdits( state, newProduct.id ) ).to.equal( newProduct );
 		} );
@@ -45,7 +50,7 @@ describe( 'selectors', () => {
 		it( 'should get a product from "updates"', () => {
 			const updateProduct = { id: 1, name: 'Existing Product' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
-			set( uiProducts, 'edits.updates', [ updateProduct ] );
+			set( uiProducts, [ siteId, 'edits', 'updates' ], [ updateProduct ] );
 
 			expect( getProductEdits( state, updateProduct.id ) ).to.equal( updateProduct );
 		} );
@@ -60,7 +65,7 @@ describe( 'selectors', () => {
 		it( 'should get just edits for a product in "creates"', () => {
 			const newProduct = { id: { index: 0 }, name: 'New Product' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
-			set( uiProducts, 'edits.creates', [ newProduct ] );
+			set( uiProducts, [ siteId, 'edits', 'creates' ], [ newProduct ] );
 
 			expect( getProductWithLocalEdits( state, newProduct.id ) ).to.eql( newProduct );
 		} );
@@ -76,7 +81,7 @@ describe( 'selectors', () => {
 			const products = state.extensions.woocommerce.products;
 
 			const existingProduct = { id: 1, name: 'Existing Product' };
-			set( uiProducts, 'edits.updates', [ existingProduct ] );
+			set( uiProducts, [ siteId, 'edits', 'updates' ], [ existingProduct ] );
 
 			const combinedProduct = { ...products[ 0 ], ...existingProduct };
 			expect( getProductWithLocalEdits( state, 1 ) ).to.eql( combinedProduct );
@@ -96,8 +101,8 @@ describe( 'selectors', () => {
 		it( 'should get the last edited product', () => {
 			const newProduct = { id: { index: 0 }, name: 'New Product' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
-			set( uiProducts, 'edits.creates', [ newProduct ] );
-			set( uiProducts, 'edits.currentlyEditingId', newProduct.id );
+			set( uiProducts, [ siteId, 'edits', 'creates' ], [ newProduct ] );
+			set( uiProducts, [ siteId, 'edits', 'currentlyEditingId' ], newProduct.id );
 
 			expect( getCurrentlyEditingProduct( state ) ).to.eql( newProduct );
 		} );

--- a/client/extensions/woocommerce/state/ui/products/variations/actions.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/actions.js
@@ -9,14 +9,18 @@ import {
  * Edits a product variation.
  * This adds the variation to the edit state.
  *
+ * @param {Number} siteId Site ID.
  * @param {object} product The product to which the variation should belong.
  * @param {object} variation The variation to be edited, or null if new.
  * @param {object} data The fields to be edited and values for them.
  * @return {object} the action to be dispatched.
  */
-export function editProductVariation( product, variation, data ) {
+export function editProductVariation( siteId, product, variation, data ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_VARIATION_EDIT,
-		payload: { product, variation, data },
+		siteId,
+		product,
+		variation,
+		data,
 	};
 }

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -21,7 +21,7 @@ export default createReducer( null, {
 } );
 
 function editProductVariationAction( edits, action ) {
-	const { product, variation, data } = action.payload;
+	const { product, variation, data } = action;
 	const prevEdits = edits || [];
 	const productId = product.id;
 	const bucket = getBucket( variation );
@@ -86,7 +86,7 @@ function editProductVariation( array, variation, data ) {
 
 function editProductAttributeAction( edits, action ) {
 	const prevEdits = edits || [];
-	const { product, attribute, data } = action.payload;
+	const { product, attribute, data } = action;
 	const attributes = editProductAttribute( product.attributes, attribute, data );
 	const variations = generateVariations( { ...product, attributes } );
 	let productEdits = null;

--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -6,11 +6,12 @@ import { get, find, isNumber } from 'lodash';
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getVariation } from '../../../variations/selectors';
 
-function getVariationEditsStateForProduct( state, productId ) {
+function getVariationEditsStateForProduct( state, productId, siteId = getSelectedSiteId( state ) ) {
 	const woocommerce = state.extensions.woocommerce;
-	const variations = get( woocommerce, 'ui.products.variations.edits', [] );
+	const variations = get( woocommerce, [ 'ui', 'products', siteId, 'variations', 'edits' ], [] );
 	return find( variations, ( v ) => productId === v.productId );
 }
 
@@ -20,10 +21,11 @@ function getVariationEditsStateForProduct( state, productId ) {
  * @param {Object} state Global state tree
  * @param {any} productId The id of the product (or { index: # } )
  * @param {any} variationId The id of the variation (or { index: # } )
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The current accumulated edits
  */
-export function getVariationEdits( state, productId, variationId ) {
-	const edits = getVariationEditsStateForProduct( state, productId );
+export function getVariationEdits( state, productId, variationId, siteId = getSelectedSiteId( state ) ) {
+	const edits = getVariationEditsStateForProduct( state, productId, siteId );
 	const bucket = isNumber( variationId ) && 'updates' || 'creates';
 	const array = get( edits, bucket, [] );
 	return find( array, ( v ) => variationId === v.id );
@@ -35,12 +37,13 @@ export function getVariationEdits( state, productId, variationId ) {
  * @param {Object} state Global state tree
  * @param {any} productId The id of the product (or { index: # } )
  * @param {any} variationId The id of the variation (or { index: # } )
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The product data merged between the fetched data and edits
  */
-export function getVariationWithLocalEdits( state, productId, variationId ) {
+export function getVariationWithLocalEdits( state, productId, variationId, siteId = getSelectedSiteId( state ) ) {
 	const existing = isNumber( variationId );
 	const variation = existing && getVariation( state, productId, variationId );
-	const variationEdits = getVariationEdits( state, productId, variationId );
+	const variationEdits = getVariationEdits( state, productId, variationId, siteId );
 
 	return ( variation || variationEdits ) && { ...variation, ...variationEdits } || undefined;
 }
@@ -50,13 +53,14 @@ export function getVariationWithLocalEdits( state, productId, variationId ) {
  *
  * @param {Object} state Global state tree
  * @param {any} productId The id of the product (or { index: # } )
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} Variation object that is merged between fetched data and edits
  */
-export function getCurrentlyEditingVariation( state, productId ) {
-	const edits = getVariationEditsStateForProduct( state, productId ) || {};
+export function getCurrentlyEditingVariation( state, productId, siteId = getSelectedSiteId( state ) ) {
+	const edits = getVariationEditsStateForProduct( state, productId, siteId ) || {};
 	const { currentlyEditingId } = edits;
 
-	return getVariationWithLocalEdits( state, productId, currentlyEditingId );
+	return getVariationWithLocalEdits( state, productId, currentlyEditingId, siteId );
 }
 
 /**
@@ -64,10 +68,11 @@ export function getCurrentlyEditingVariation( state, productId ) {
  *
  * @param {Object} state Global state tree
  * @param {any} productId The id of the product (or { index: # } )
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} Array of variation objects.
  */
-export function getProductVariationsWithLocalEdits( state, productId ) {
-	const edits = getVariationEditsStateForProduct( state, productId );
+export function getProductVariationsWithLocalEdits( state, productId, siteId = getSelectedSiteId( state ) ) {
+	const edits = getVariationEditsStateForProduct( state, productId, siteId );
 	const creates = get( edits, 'creates', undefined );
 	// TODO Merge in existing variations loaded by the API for existing products.
 	return creates;

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -16,6 +16,8 @@ import {
 	editProductAttribute
 } from '../../actions';
 
+const siteId = 123;
+
 describe( 'edits-reducer', () => {
 	it( 'should initialize to null', () => {
 		expect( reducer( undefined, { type: '@@test/INIT' } ) ).to.equal( null );
@@ -24,7 +26,7 @@ describe( 'edits-reducer', () => {
 	it( 'should create "updates" on first edit', () => {
 		const product = { id: 48 };
 		const variation = { id: 23, regular_price: '0.99' };
-		const edits = reducer( undefined, editProductVariation( product, variation, { regular_price: '1.99' } ) );
+		const edits = reducer( undefined, editProductVariation( siteId, product, variation, { regular_price: '1.99' } ) );
 
 		expect( edits ).to.not.equal( null );
 		expect( edits[ 0 ] ).to.exist;
@@ -36,10 +38,10 @@ describe( 'edits-reducer', () => {
 	it( 'should modify "updates" on second edit', () => {
 		const product = { id: 48 };
 		let variation = { id: 23, regular_price: '0.99' };
-		const edits1 = reducer( undefined, editProductVariation( product, variation, { regular_price: '1.99' } ) );
+		const edits1 = reducer( undefined, editProductVariation( siteId, product, variation, { regular_price: '1.99' } ) );
 
 		variation = edits1[ 0 ].updates[ 0 ];
-		const edits2 = reducer( edits1, editProductVariation( product, variation, { regular_price: '3.99' } ) );
+		const edits2 = reducer( edits1, editProductVariation( siteId, product, variation, { regular_price: '3.99' } ) );
 
 		expect( edits2[ 0 ].updates[ 0 ] ).to.eql( { id: 23, regular_price: '3.99' } );
 	} );
@@ -49,9 +51,9 @@ describe( 'edits-reducer', () => {
 		const variation1 = { id: 23, regular_price: '0.99', attributes: [ { name: 'Color', option: 'Red' } ] };
 		const variation2 = { id: 24, regular_price: '0.99', attributes: [ { name: 'Color', option: 'Blue' } ] };
 
-		const edits1 = reducer( undefined, editProductVariation( product, variation1, { regular_price: '1.99' } ) );
+		const edits1 = reducer( undefined, editProductVariation( siteId, product, variation1, { regular_price: '1.99' } ) );
 
-		const edits2 = reducer( edits1, editProductVariation( product, variation2, { regular_price: '2.99' } ) );
+		const edits2 = reducer( edits1, editProductVariation( siteId, product, variation2, { regular_price: '2.99' } ) );
 
 		expect( edits2[ 0 ].updates[ 0 ] ).to.eql( { id: 23, regular_price: '1.99' } );
 		expect( edits2[ 0 ].updates[ 1 ] ).to.eql( { id: 24, regular_price: '2.99' } );
@@ -60,7 +62,7 @@ describe( 'edits-reducer', () => {
 	it( 'should create "creates" on first edit', () => {
 		const product = { id: 48 };
 
-		const edits = reducer( undefined, editProductVariation( product, null, { regular_price: '1.99' } ) );
+		const edits = reducer( undefined, editProductVariation( siteId, product, null, { regular_price: '1.99' } ) );
 
 		expect( edits ).to.not.equal( null );
 		expect( edits[ 0 ] ).to.exist;
@@ -72,10 +74,10 @@ describe( 'edits-reducer', () => {
 	it( 'should modify "creates" on second edit', () => {
 		const product = { id: 48 };
 
-		const edits1 = reducer( undefined, editProductVariation( product, null, { regular_price: '1.99' } ) );
+		const edits1 = reducer( undefined, editProductVariation( siteId, product, null, { regular_price: '1.99' } ) );
 
 		const variation = edits1[ 0 ].creates[ 0 ];
-		const edits2 = reducer( edits1, editProductVariation( product, variation, { regular_price: '2.99' } ) );
+		const edits2 = reducer( edits1, editProductVariation( siteId, product, variation, { regular_price: '2.99' } ) );
 
 		expect( edits2[ 0 ].creates[ 0 ].regular_price ).to.eql( '2.99' );
 	} );
@@ -83,8 +85,8 @@ describe( 'edits-reducer', () => {
 	it( 'should create more than one new variation', () => {
 		const product = { id: 48 };
 
-		const edits1 = reducer( undefined, editProductVariation( product, null, { regular_price: '1.99' } ) );
-		const edits2 = reducer( edits1, editProductVariation( product, null, { regular_price: '2.99' } ) );
+		const edits1 = reducer( undefined, editProductVariation( siteId, product, null, { regular_price: '1.99' } ) );
+		const edits2 = reducer( edits1, editProductVariation( siteId, product, null, { regular_price: '2.99' } ) );
 
 		expect( edits2[ 0 ].creates[ 0 ].regular_price ).to.eql( '1.99' );
 		expect( edits2[ 0 ].creates[ 0 ].id ).to.not.eql( edits2[ 0 ].creates[ 1 ].id );
@@ -95,8 +97,8 @@ describe( 'edits-reducer', () => {
 		const product1 = { id: 48 };
 		const product2 = { id: 49 };
 
-		const edits1 = reducer( undefined, editProductVariation( product1, null, { regular_price: '1.99' } ) );
-		const edits2 = reducer( edits1, editProductVariation( product2, null, { regular_price: '2.99' } ) );
+		const edits1 = reducer( undefined, editProductVariation( siteId, product1, null, { regular_price: '1.99' } ) );
+		const edits2 = reducer( edits1, editProductVariation( siteId, product2, null, { regular_price: '2.99' } ) );
 
 		expect( edits2[ 0 ].productId ).to.eql( 48 );
 		expect( edits2[ 0 ].creates[ 0 ].regular_price ).to.eql( '1.99' );
@@ -107,7 +109,7 @@ describe( 'edits-reducer', () => {
 	it( 'should set currentlyEditingId when editing a new variation', () => {
 		const product = { id: 48 };
 
-		const edits1 = reducer( undefined, editProductVariation( product, null, { regular_price: '1.99' } ) );
+		const edits1 = reducer( undefined, editProductVariation( siteId, product, null, { regular_price: '1.99' } ) );
 		const productEdits1 = edits1.find( function( p ) {
 			if ( product.id === p.productId ) {
 				return p;
@@ -116,7 +118,7 @@ describe( 'edits-reducer', () => {
 
 		expect( productEdits1.currentlyEditingId ).to.eql( productEdits1.creates[ 0 ].id );
 
-		const edits2 = reducer( edits1, editProductVariation( product, null, { regular_price: '2.99' } ) );
+		const edits2 = reducer( edits1, editProductVariation( siteId, product, null, { regular_price: '2.99' } ) );
 		const productEdits2 = edits2.find( function( p ) {
 			if ( product.id === p.productId ) {
 				return p;
@@ -130,7 +132,7 @@ describe( 'edits-reducer', () => {
 		const product = { id: 48 };
 		const variation1 = { id: 23, regular_price: '0.99', attributes: [ { name: 'Color', option: 'Red' } ] };
 
-		const edits1 = reducer( undefined, editProductVariation( product, variation1, { regular_price: '1.99' } ) );
+		const edits1 = reducer( undefined, editProductVariation( siteId, product, variation1, { regular_price: '1.99' } ) );
 		const _edits1 = edits1.find( function( p ) {
 			if ( product.id === p.productId ) {
 				return p;
@@ -145,7 +147,7 @@ describe( 'edits-reducer', () => {
 			const product = { id: 48 };
 			const attributes = [ { name: 'Color', option: 'Blue' } ];
 
-			const edits1 = reducer( undefined, editProductAttribute( product, null, {
+			const edits1 = reducer( undefined, editProductAttribute( siteId, product, null, {
 				name: 'Color',
 				options: [ 'Blue' ],
 				variation: true
@@ -158,7 +160,7 @@ describe( 'edits-reducer', () => {
 			const product = { id: 48, attributes: [] };
 			const attributes = [ { name: 'Color', option: 'Blue' } ];
 
-			const edits1 = reducer( undefined, editProductAttribute( product, null, {
+			const edits1 = reducer( undefined, editProductAttribute( siteId, product, null, {
 				name: 'Color',
 				options: [ 'Blue' ],
 				variation: true
@@ -176,7 +178,7 @@ describe( 'edits-reducer', () => {
 				uid: 'edit_0'
 			} );
 
-			const edits2 = reducer( edits1, editProductAttribute( product, null, {
+			const edits2 = reducer( edits1, editProductAttribute( siteId, product, null, {
 				name: 'Size',
 				options: [ 'Small', 'Medium' ],
 				variation: true
@@ -190,7 +192,7 @@ describe( 'edits-reducer', () => {
 		it( 'should preserve variations that are still valid', () => {
 			const product = { id: { index: 0 }, attributes: [] };
 
-			const edits1 = reducer( undefined, editProductAttribute( product, null, {
+			const edits1 = reducer( undefined, editProductAttribute( siteId, product, null, {
 				name: 'Color',
 				options: [ 'Blue' ],
 				variation: true
@@ -203,7 +205,7 @@ describe( 'edits-reducer', () => {
 				uid: 'edit_0'
 			} );
 
-			const edits2 = reducer( edits1, editProductAttribute( product, null, {
+			const edits2 = reducer( edits1, editProductAttribute( siteId, product, null, {
 				name: 'Size',
 				options: [ 'Small', 'Medium' ],
 				variation: true
@@ -217,11 +219,14 @@ describe( 'edits-reducer', () => {
 			} );
 
 			const blueMediumVariation = edits2[ 0 ].creates[ 1 ];
-			const edits3 = reducer( edits2, editProductVariation( product, blueMediumVariation, { regular_price: '2.99' } ) );
+			const edits3 = reducer( edits2, editProductVariation( siteId, product, blueMediumVariation, { regular_price: '2.99' } ) );
 
 			const blueMediumAttributes = [ { name: 'Color', option: 'Blue' }, { name: 'Size', option: 'Medium' } ];
 
-			const edits4 = reducer( edits3, editProductAttribute( product, product.attributes[ 0 ], { options: [ 'Blue', 'Red' ] } ) );
+			const edits4 = reducer(
+				edits3,
+				editProductAttribute( siteId, product, product.attributes[ 0 ], { options: [ 'Blue', 'Red' ] } )
+			);
 			expect( edits4[ 0 ].creates.length ).to.eql( 4 );
 			expect( edits4[ 0 ].creates[ 1 ].attributes ).to.eql( blueMediumAttributes );
 			expect( edits4[ 0 ].creates[ 1 ].regular_price ).to.equal( '2.99' );

--- a/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
@@ -14,11 +14,14 @@ import {
 	getProductVariationsWithLocalEdits,
 } from '../selectors';
 
+const siteId = 123;
+
 describe( 'selectors', () => {
 	let state;
 
 	beforeEach( () => {
 		state = {
+			ui: { selectedSiteId: 123 },
 			extensions: {
 				woocommerce: {
 					products: [
@@ -31,7 +34,9 @@ describe( 'selectors', () => {
 					],
 					ui: {
 						products: {
-							variations: {
+							123: {
+								variations: {
+								}
 							}
 						}
 					},
@@ -44,18 +49,18 @@ describe( 'selectors', () => {
 		it( 'should get a variation from "creates"', () => {
 			const newVariation = { id: { index: 1 }, name: 'New Variation' };
 			const productId = { index: 0 };
-			const uiVariations = state.extensions.woocommerce.ui.products.variations;
-			set( uiVariations, 'edits[0].productId', productId );
-			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], productId );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );
 
 			expect( getVariationEdits( state, productId, newVariation.id ) ).to.equal( newVariation );
 		} );
 
 		it( 'should get a variation from "updates"', () => {
 			const updateVariation = { id: 3, name: 'Existing Variation' };
-			const uiVariations = state.extensions.woocommerce.ui.products.variations;
-			set( uiVariations, 'edits[0].productId', 2 );
-			set( uiVariations, 'edits[0].updates', [ updateVariation ] );
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 2 );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'updates' ], [ updateVariation ] );
 
 			expect( getVariationEdits( state, 2, updateVariation.id ) ).to.equal( updateVariation );
 		} );
@@ -76,9 +81,9 @@ describe( 'selectors', () => {
 	describe( 'getVariationWithLocalEdits', () => {
 		it( 'should get just edits for a variation in "creates"', () => {
 			const newVariation = { id: { index: 0 }, name: 'New Variation' };
-			const uiVariations = state.extensions.woocommerce.ui.products.variations;
-			set( uiVariations, 'edits[0].productId', 2 );
-			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 2 );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );
 
 			expect( getVariationWithLocalEdits( state, 2, newVariation.id ) ).to.eql( newVariation );
 		} );
@@ -90,12 +95,12 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should get both fetched data and edits for a variation in "updates"', () => {
-			const uiVariations = state.extensions.woocommerce.ui.products.variations;
+			const uiProducts = state.extensions.woocommerce.ui.products;
 			const variations = state.extensions.woocommerce.variations;
 
 			const existingVariation = { id: 3, name: 'Existing Variation' };
-			set( uiVariations, 'edits[0].productId', 2 );
-			set( uiVariations, 'edits[0].updates', [ existingVariation ] );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 2 );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'updates' ], [ existingVariation ] );
 
 			const combinedVariation = { ...variations[ 0 ], ...existingVariation };
 			expect( getVariationWithLocalEdits( state, 2, 3 ) ).to.eql( combinedVariation );
@@ -121,10 +126,10 @@ describe( 'selectors', () => {
 
 		it( 'should get the last edited variation', () => {
 			const newVariation = { id: { index: 0 }, name: 'New Variation' };
-			const uiVariations = state.extensions.woocommerce.ui.products.variations;
-			set( uiVariations, 'edits[0].productId', 2 );
-			set( uiVariations, 'edits[0].creates', [ newVariation ] );
-			set( uiVariations, 'edits[0].currentlyEditingId', newVariation.id );
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 2 );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'currentlyEditingId' ], newVariation.id );
 
 			expect( getCurrentlyEditingVariation( state, 2 ) ).to.eql( newVariation );
 		} );
@@ -136,9 +141,9 @@ describe( 'selectors', () => {
 		} );
 		it( 'should get variations from "creates"', () => {
 			const newVariation = { id: { index: 0 }, name: 'New Variation' };
-			const uiVariations = state.extensions.woocommerce.ui.products.variations;
-			set( uiVariations, 'edits[0].productId', 2 );
-			set( uiVariations, 'edits[0].creates', [ newVariation ] );
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 2 );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );
 
 			expect( getProductVariationsWithLocalEdits( state, 2 ) ).to.eql( [ newVariation ] );
 		} );


### PR DESCRIPTION
This PR updates the products (and variations, since they are located under products) UI state to be keyed by siteId. It also drops `payload` from the actions like we have done elsewhere. 

I wanted to do this before adding anything new to the state tree here (like tracking the current page of products for product listing, like #15042) so that we are storing the correct product information under the correct site. I also wanted to bring this code closer to what we are doing elsewhere (all of other state branches under `state.extensions.woocommerce.ui` are keyed by siteId). 

To test:
* Run `npm test` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/product/:site`
* Test various parts of the form to make sure you can type inside input boxes, create variations, etc.

cc @kellychoffman Any recommendations on what to show if someone goes directly to the product form and we don't have a siteId loaded in yet? Right now I am just disabling the save button and hiding the form -- the sidebar already shows placeholders. I looked at what Calypso does for posting and they show the form -- but anything you type gets lost once the siteId loads in, which isn't great. Whatever we want to do, I will do in a smaller follow-up PR.