### PR TITLE
Reader: Hide site results behind Search box

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -373,7 +373,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .search-stream__results.is-two-columns .search-stream__post-results {
 	max-width: 660px;
-	width: 100%;
+	width: calc( 100% - 300px );
 
 	.reader-post-card__post {
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15066

This happens in all browsers at ~1060px.

**Before:**
![screenshot 2017-06-14 12 04 06](https://user-images.githubusercontent.com/4924246/27150303-902a16cc-50fb-11e7-8936-7e357ef5ef87.png)

**After:**
![screenshot 2017-06-14 12 20 48](https://user-images.githubusercontent.com/4924246/27150387-e90c6aba-50fb-11e7-9068-de301e7a02cf.png)

