### PR TITLE
Editor: post-publish-preview update close action

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -275,6 +275,8 @@ WebPreviewContent.propTypes = {
 	onLoad: PropTypes.func,
 	// Called when the preview is closed, either via the 'X' button or the escape key
 	onClose: PropTypes.func,
+	// Called when the edit button is clicked
+	onEdit: PropTypes.func,
 	// Optional loading message to display during loading
 	loadingMessage: PropTypes.string,
 	// The iframe's title element, used for accessibility purposes
@@ -298,6 +300,7 @@ WebPreviewContent.defaultProps = {
 	previewMarkup: null,
 	onLoad: noop,
 	onClose: noop,
+	onEdit: noop,
 	onDeviceUpdate: noop,
 	hasSidebar: false,
 	isModalWindow: false,

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -142,6 +142,8 @@ WebPreview.propTypes = {
 	onLoad: PropTypes.func,
 	// Called when the preview is closed, either via the 'X' button or the escape key
 	onClose: PropTypes.func,
+	// Called when the edit button is clicked
+	onEdit: PropTypes.func,
 	// Optional loading message to display during loading
 	loadingMessage: PropTypes.string,
 	// The iframe's title element, used for accessibility purposes
@@ -161,6 +163,7 @@ WebPreview.defaultProps = {
 	previewMarkup: null,
 	onLoad: noop,
 	onClose: noop,
+	onEdit: noop,
 	hasSidebar: false,
 };
 

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -41,6 +41,8 @@ class PreviewToolbar extends Component {
 		setDeviceViewport: PropTypes.func,
 		// Called when the close button is pressed
 		onClose: PropTypes.func.isRequired,
+		// Called when the edit button is clicked
+		onEdit: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -64,6 +66,7 @@ class PreviewToolbar extends Component {
 			editUrl,
 			externalUrl,
 			onClose,
+			onEdit,
 			previewUrl,
 			setDeviceViewport,
 			showClose,
@@ -113,7 +116,7 @@ class PreviewToolbar extends Component {
 						<Button
 							className="web-preview__edit"
 							href={ editUrl }
-							onClick={ onClose }
+							onClick={ onEdit }
 						>
 							<Gridicon icon="pencil" /> { translate( 'Edit' ) }
 						</Button>

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -109,6 +109,7 @@ const EditorPreview = React.createClass( {
 							showExternal={ false }
 							defaultViewportDevice={ this.props.defaultViewportDevice }
 							onClose={ this.props.onClose }
+							onEdit={ this.props.onEdit }
 							previewUrl={ this.state.iframeUrl }
 							editUrl={ this.props.editUrl }
 						/>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -90,7 +90,8 @@ export const PostEditor = React.createClass( {
 			showAutosaveDialog: true,
 			isLoadingAutosave: false,
 			isTitleFocused: false,
-			showPreview: false
+			showPreview: false,
+			isPostPublishPreview: false,
 		};
 	},
 
@@ -364,6 +365,7 @@ export const PostEditor = React.createClass( {
 						<EditorPreview
 							showPreview={ this.state.showPreview }
 							onClose={ this.onPreviewClose }
+							onEdit={ this.onPreviewEdit }
 							isSaving={ this.state.isSaving || this.state.isAutosaving }
 							isLoading={ this.state.isLoading }
 							previewUrl={ this.state.previewUrl }
@@ -653,7 +655,16 @@ export const PostEditor = React.createClass( {
 	},
 
 	onPreviewClose: function() {
-		this.setState( { showPreview: false } );
+		if ( this.state.isPostPublishPreview ) {
+			page.back( this.getAllPostsUrl() );
+		} else {
+			this.setState( { showPreview: false, isPostPublishPreview: false } );
+		}
+	},
+
+	onPreviewEdit: function() {
+		this.setState( { showPreview: false, isPostPublishPreview: false } );
+		return false;
 	},
 
 	onSaveDraftFailure: function( error ) {
@@ -830,6 +841,7 @@ export const PostEditor = React.createClass( {
 			window.scrollTo( 0, 0 );
 
 			if ( config.isEnabled( 'post-editor/delta-post-publish-preview' ) && this.props.isSitePreviewable ) {
+				this.setState( { isPostPublishPreview: true } );
 				this.iframePreview();
 			}
 		} else {


### PR DESCRIPTION
This PR updates the post-publish preview such that clicking on "X" to close the preview returns you to the page from which you began triggered the editor.

This PR is part of a larger epic, see p8F9tW-3F-p2.

To accomplish this, selecting "Edit" in the full screen preview now is separately handled via `onEdit`. Clicking "Edit" now closes the preview returning you to the editor.

***To Test:***
* Checkout branch
* `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
* Draft a new post
* Click on "Preview" in the editor ground control: 
![image](https://user-images.githubusercontent.com/363749/27154026-312ea73c-5119-11e7-818a-4801b932d1e7.png)
* When the preview appears, click on "X" to ensure the dialog closes as normal and returns you to the editor.
* Click "Preview" again. Click on "Edit" and make sure you are too returned to the editor.
* Start from another page (such as Stats). Click on "Add" next to "Blog Posts" in the sidebar. Draft and publish a post. In the ensuing preview, click "X", you should be returned to the Stats page.
* Start from another page (again, such as Stats) and click on "Add" again. Draft and publish a post. In the ensuing preview, click "Edit", you should be returned to the editor with the ability to edit your post.
