### PR TITLE
Editor: Pull global-styled EditorNotice outside of editor content.

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -226,10 +226,10 @@ export class EditorNotice extends Component {
 	}
 
 	render() {
-		const { siteId, message, status, onDismissClick, isPreviewable } = this.props;
+		const { siteId, message, status, onDismissClick } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
 		const classes = classNames( 'editor-notice', {
-			'is-global': config.isEnabled( 'post-editor/delta-post-publish-preview' ) && isPreviewable,
+			'is-global': config.isEnabled( 'post-editor/delta-post-publish-preview' ),
 		} );
 
 		return (

--- a/client/post-editor/editor-notice/style.scss
+++ b/client/post-editor/editor-notice/style.scss
@@ -39,8 +39,8 @@
 			@include breakpoint( ">660px" ) {
 				display: flex;
 				border-radius: 20px;
+				margin: 0;
 				overflow: hidden;
-				margin-bottom: 24px;
 			}
 		}
 

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -8,13 +8,13 @@
 	display: none;
 	opacity: 0;
 	position: fixed;
-		top: 46px;
+		top: 47px;
 		right: 0;
 		left: 0;
 		z-index: z-index( 'root', '.web-preview' );
 	transition: opacity 0.3s ease-in-out;
 	width: 100%;
-	height: calc( 100% - 46px );
+	height: calc( 100% - 47px );
 
 	&.is-visible {
 		display: flex;

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -275,10 +275,12 @@ export const PostEditor = React.createClass( {
 					/>
 					<div className="post-editor__content">
 						<div className="editor">
-							<EditorNotice
-								{ ...this.state.notice }
-								onDismissClick={ this.hideNotice }
-								onViewClick={ this.onPreview } />
+							{ ! config.isEnabled( 'post-editor/delta-post-publish-preview' )
+								? <EditorNotice
+									{ ...this.state.notice }
+									onDismissClick={ this.hideNotice }
+									onViewClick={ this.onPreview } />
+								: null }
 							<EditorActionBar
 								isNew={ this.state.isNew }
 								onPrivatePublish={ this.onPublish }
@@ -373,6 +375,12 @@ export const PostEditor = React.createClass( {
 							editUrl={ this.props.editPath }
 							defaultViewportDevice={ config.isEnabled( 'post-editor/delta-post-publish-preview' ) ? 'computer' : 'tablet' }
 						/>
+						: null }
+					{ config.isEnabled( 'post-editor/delta-post-publish-preview' )
+						? <EditorNotice
+								{ ...this.state.notice }
+								onDismissClick={ this.hideNotice }
+								onViewClick={ this.onPreview } />
 						: null }
 				</div>
 				{ isTrashed


### PR DESCRIPTION
This PR pulls the EditorNotice outside of `.post-editor__content` and adds global notification styles to all EditorNotices when the `post-editor/delta-post-publish-preview` feature flag is enabled.

This PR is part of a larger epic, see p8F9tW-3F-p2.

**To Test:**
* Check out branch
* `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
* From the editor, publish a new post or update an existing post.
* The full-screen preview should appear with a global-styles success notification (fixed to the bottom on mobile, fixed in a top-right bubble otherwise)
* Disable the feature flag.
* From the editor, publish a new post or update an existing post.
* No full-screen preview should appear, and the success notification should be full-width with an action link.
