### PR TITLE
Analytics: fix AB test assignment to correctly assign variation

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -251,7 +251,7 @@ ABTest.prototype.assignVariation = function() {
 
 	for ( variationName in this.variationDetails ) {
 		sum += this.variationDetails[ variationName ];
-		if ( randomAllocationAmount <= sum ) {
+		if ( randomAllocationAmount < sum ) {
 			return variationName;
 		}
 	}


### PR DESCRIPTION
Change to strictly less than because Math.random() is a random number in the range [0, 1).

# Example

Suppose we have the following test variations:
- original: 0
- modified: 100

and we set `randomAllocationAmount=Math.random() * allocationsTotal`, we have a chance that `randomAllocationAmount=0`. 

`sum += this.variationDetails[ variationName ]` and is therefore equal to 0.

and if we check if `randomAllocationAmount <= sum`, then we would assign the variation "original".

There should be a 0% chance of assigning the "original" AB test variation. Changing the `randomAllocationAmount <= sum` comparison to `randomAllocationAmount < sum`.