### PR TITLE
Publicize: preview pane default service

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -145,7 +145,7 @@ class SharingPreviewPane extends PureComponent {
 							) }
 						</p>
 					</div>
-					<VerticalMenu onClick={ this.selectPreview } initialItemIndex={ initialMenuItemIndex }>
+					<VerticalMenu onClick={ this.selectPreview } initialItemIndex={ initialMenuItemIndex } >
 						{ services.map( service => <SocialItem { ...{ key: service, service } } /> ) }
 					</VerticalMenu>
 				</div>

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, find } from 'lodash';
+import { get, find, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,9 +56,13 @@ class SharingPreviewPane extends PureComponent {
 
 	constructor( props ) {
 		super( props );
-		this.state = {
-			selectedService: props.selectedService || props.services[ 0 ],
-		};
+
+		const connectedServices = map( props.connections, 'service' );
+		const firstConnectedService = find( props.services, service => {
+			return find( connectedServices, connectedService => service === connectedService );
+		} );
+		const selectedService = props.selectedService || firstConnectedService;
+		this.state = { selectedService };
 	}
 
 	selectPreview = selectedService => {

--- a/client/components/vertical-menu/index.jsx
+++ b/client/components/vertical-menu/index.jsx
@@ -9,19 +9,16 @@ import PropTypes from 'prop-types';
 import { identity, partial } from 'lodash';
 
 export class VerticalMenu extends PureComponent {
-
 	static propTypes = {
 		onClick: PropTypes.func,
 		initalItemIndex: PropTypes.number,
-		children: PropTypes.arrayOf(
-			PropTypes.element
-		)
-	}
+		children: PropTypes.arrayOf( PropTypes.element ),
+	};
 
 	static defaultProps = {
 		initialItemIndex: 0,
-		onClick: identity
-	}
+		onClick: identity,
+	};
 
 	constructor( props ) {
 		super( props );

--- a/client/components/vertical-menu/index.jsx
+++ b/client/components/vertical-menu/index.jsx
@@ -9,16 +9,19 @@ import PropTypes from 'prop-types';
 import { identity, partial } from 'lodash';
 
 export class VerticalMenu extends PureComponent {
+
 	static propTypes = {
 		onClick: PropTypes.func,
 		initalItemIndex: PropTypes.number,
-		children: PropTypes.arrayOf( PropTypes.element ),
-	};
+		children: PropTypes.arrayOf(
+			PropTypes.element
+		)
+	}
 
 	static defaultProps = {
 		initialItemIndex: 0,
-		onClick: identity,
-	};
+		onClick: identity
+	}
 
 	constructor( props ) {
 		super( props );


### PR DESCRIPTION
This updates the publicize preview modal to show the first connected service when opening. It also updates the vertical nav component to specify the initial selected item.

Before :  
![preview-default-a](https://user-images.githubusercontent.com/744755/27157393-221b692c-5116-11e7-988d-838e0c11c2a0.gif)


After:
![preview-default-b](https://user-images.githubusercontent.com/744755/27157390-1f1b26f4-5116-11e7-8cc6-f89eb39420ba.gif)


**Testing**
- Disconnect from facebook
- Open the publicize preview
- The modal should not display the first connected service in the nav list


 