### PR TITLE
Comments: disable post link when not expanded

### DIFF
--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -11,18 +11,9 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import CommentDetailActions from './comment-detail-actions';
-import ExternalLink from 'components/external-link';
 import FormCheckbox from 'components/forms/form-checkbox';
 import AutoDirection from 'components/auto-direction';
 import { stripHTML, decodeEntities } from 'lib/formatting';
-
-const controlExternalLink = isBulkEdit => event => {
-	if ( isBulkEdit ) {
-		event.preventDefault();
-	} else {
-		event.stopPropagation();
-	}
-};
 
 export const CommentDetailHeader = ( {
 	authorAvatarUrl,
@@ -37,7 +28,6 @@ export const CommentDetailHeader = ( {
 	isBulkEdit,
 	isExpanded,
 	postTitle,
-	postUrl,
 	toggleApprove,
 	toggleExpanded,
 	toggleLike,
@@ -92,14 +82,7 @@ export const CommentDetailHeader = ( {
 						</span>
 					</div>
 					<div className="comment-detail__author-info-element">
-						{ translate( 'on {{postLink/}}', {
-							components: {
-								postLink:
-									<ExternalLink href={ postUrl } onClick={ controlExternalLink( isBulkEdit ) }>
-										{ postTitle }
-									</ExternalLink>,
-							},
-						} ) }
+						{ translate( 'on %(postTitle)s', { args: { postTitle } } ) }
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This PR prevents accidental mis-clicks on unexpanded comments. If a post title was very long, we could accidentally be redirected to that post instead of expanding the comment.

<img width="536" alt="screen shot 2017-06-14 at 3 50 37 pm" src="https://user-images.githubusercontent.com/1270189/27157986-52f3c424-5119-11e7-8f88-746fc506b8a8.png">

### Testing Instructions
- Navigate to http://calypso.localhost:3000/comments/all
- Select a site with comments
- Click on the post title, when the comment is unexpanded
- Comment should expand
- With the expanded title, click on the post link
- We should be redirected to the post

cc @Automattic/lannister 
