### PR TITLE
WooCommerce: Display placeholder for product form when siteId is not available

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -95,7 +95,7 @@ class ProductCreate extends React.Component {
 					onTrash={ this.onTrash }
 					onSave={ siteId && this.onSave || false }
 				/>
-				{ siteId && ( <ProductForm
+				<ProductForm
 					siteId={ siteId }
 					product={ product || { type: 'simple' } }
 					variations={ variations }
@@ -103,7 +103,7 @@ class ProductCreate extends React.Component {
 					editProduct={ this.props.editProduct }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
-				/> ) }
+				/>
 			</Main>
 		);
 	}

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -29,9 +29,24 @@ export default class ProductForm extends Component {
 		editProductVariation: PropTypes.func.isRequired,
 	};
 
+	renderPlaceholder() {
+		const { className } = this.props;
+		return (
+			<div className={ classNames( 'products__form', 'is-placeholder', className ) }>
+				<div></div>
+				<div></div>
+				<div></div>
+			</div>
+		);
+	}
+
 	render() {
 		const { siteId, product, productCategories, variations } = this.props;
 		const { editProduct, editProductVariation, editProductAttribute } = this.props;
+
+		if ( ! siteId ) {
+			return this.renderPlaceholder();
+		}
 
 		return (
 			<div className={ classNames( 'products__form', this.props.className ) }>

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -6,6 +6,33 @@
 	@include breakpoint( ">660px" ) {
 		margin-top: 58px;
 	}
+
+	&.is-placeholder div {
+		@include placeholder();
+		background: $white;
+		width: 720px;
+		margin-bottom: 8px;
+
+		@include breakpoint( "<480px" ) {
+			width: 100%;
+		}
+
+		@include breakpoint( "660px-960px" ) {
+			width: 620px;
+		}
+
+		&:first-child {
+			height: 575px;
+		}
+
+		&:nth-child( 2 ) {
+			height: 200px;
+		}
+
+		&:last-child {
+			height: 400px;
+		}
+	}
 }
 
 .form-label {


### PR DESCRIPTION
This PR is a follow-up to #15127 and implements a placeholder to show for the product form for when the `siteId` isn't available yet.

Per Kelly's suggestion, we show 3 pulsating boxes in the shape of the underlying cards.

<img width="683" alt="screen shot 2017-06-14 at 3 38 29 pm" src="https://user-images.githubusercontent.com/689165/27158231-ddfc4a5e-511a-11e7-8b86-28dad2899764.png">

To Test:
* Go to `http://calypso.localhost:3000/store/product/:site`
* Open the developer console and enter `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` to clear out existing state. Alternatively, just refresh a few times because Calypso clears state every few page loads.
* Refresh the product form.
* See placeholders.
