### PR TITLE
PostShare: show Premium nudge once plan is loaded

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -46,6 +46,7 @@ import PublicizeMessage from 'post-editor/editor-sharing/publicize-message';
 import Notice from 'components/notice';
 import {
 	hasFeature,
+	isRequestingSitePlans,
 	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
 } from 'state/sites/plans/selectors';
@@ -499,22 +500,22 @@ class PostShare extends Component {
 			return null;
 		}
 
-		if ( ! this.props.hasRepublicizeFeature ) {
+		const { postId, siteId } = this.props;
+
+		if ( ! siteId || ! postId ) {
+			return null;
+		}
+
+		if ( ! this.props.hasRepublicizeFeature && ! this.props.isRequestingPlans ) {
 			return this.renderUpgradeToGetPublicizeNudge();
 		}
 
 		const {
 			hasRepublicizeFeature,
 			hasRepublicizeSchedulingFeature,
-			postId,
-			siteId,
 			siteSlug,
 			translate,
 		} = this.props;
-
-		if ( ! siteId || ! postId ) {
-			return null;
-		}
 
 		const classes = classNames(
 			'post-share__wrapper',
@@ -577,6 +578,7 @@ export default connect(
 			hasRepublicizeSchedulingFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE_SCHEDULING ),
 			siteSlug: getSiteSlug( state, siteId ),
 			isPublicizeEnabled: isPublicizeEnabled( state, siteId, props.post.type ),
+			isRequestingPlans: isRequestingSitePlans( state, siteId ),
 			scheduling: isSchedulingPublicizeShareAction( state, siteId, postId ),
 			connections: getSiteUserConnections( state, siteId, userId ),
 			requesting: isRequestingSharePost( state, siteId, postId ),


### PR DESCRIPTION
This PR shows the `Premium` nudge only if the current plan of the site has been loaded. It avoids showing the nudge when the data is still loading.

**before**
<img src="https://user-images.githubusercontent.com/77539/27163010-045b923c-515b-11e7-8ce8-ff15a4e83cde.gif" width="500px" />

**after**
<img src="https://user-images.githubusercontent.com/77539/27163011-0461df52-515b-11e7-96a5-8001a6620a07.gif" width="500px" />

### Testing

Go to Share Tab into posts page of use the devdocs testing page: http://calypso.localhost:3000/devdocs/blocks/post-share

Pay attention trying to confirm that the nudge never is shown. If you have a relly nice connection (it isn't my case :'() use the network tab of Chrome dev tool to simulate a slower connection.

<img src="https://user-images.githubusercontent.com/77539/27163135-ca193c22-515b-11e7-8084-43186ff5f62c.png" width="500px" />

<img src="https://user-images.githubusercontent.com/77539/27163138-cfa248c8-515b-11e7-8332-91e7eca5dbd5.png" width="500px" />

