### PR TITLE
Reader: Fix remaining Sites in Search nits from 14881

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -194,7 +194,7 @@
 	height: 18px;
 	position: relative;
 		left: 0;
-		top: 19px;
+		top: 8px;
 
 	@include breakpoint( ">660px" ) {
 		left: -4px;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -83,7 +83,11 @@
 }
 
 .search-stream.search-stream__with-sites .search-stream__single-column-results {
-	padding-top: 150px;
+	padding-top: 130px;
+
+	@include breakpoint( ">660px" ) {
+		padding-top: 150px;
+	}
 }
 
 .search-stream.search-stream__with-sites .search-stream__single-column-results .search-stream__recommendation-list-item:nth-child(2) {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -116,7 +116,7 @@
 
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__post-results .reader-post-card:nth-child(2),
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__site-results {
-	margin-top: 140px;
+	margin-top: 135px;
 }
 
 // Search term suggestions
@@ -294,7 +294,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	font-weight: 600;
 	list-style-type: none;
-	margin: 20px 0 0;
+	margin: 17px 0 0;
 	text-transform: uppercase;
 }
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -36,14 +36,15 @@
 
 .search-stream .search-stream__input-card.card {
 	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
+	margin-bottom: 0;
 }
 
 // Fix for smaller breakpoint on the new site-search
 .is-reader-page .search-stream__with-sites .search-stream__fixed-area {
-	padding-top: 20px;
+	top: 20px;
 
 	@include breakpoint( ">660px" ) {
-		padding-top: 77px;
+		top: 0;
 	}
 }
 
@@ -82,7 +83,7 @@
 }
 
 .search-stream.search-stream__with-sites .search-stream__single-column-results {
-	padding-top: 150px;
+	padding-top: 140px;
 }
 
 .search-stream.search-stream__with-sites .search-stream__single-column-results .search-stream__recommendation-list-item:nth-child(2) {
@@ -102,9 +103,16 @@
 }
 
 // Top margin for site results
+.main.search-stream {
+
+	@include breakpoint( "<660px") {
+		perspective: none; // Fix search bar pushed up behind the masterbar in Safari
+	}
+}
+
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__post-results .reader-post-card:nth-child(2),
 .search-stream.search-stream__with-sites .is-two-columns .search-stream__site-results {
-	margin-top: 150px;
+	margin-top: 140px;
 }
 
 // Search term suggestions
@@ -172,6 +180,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {
 			flex-basis: 100%;
+			margin-right: 0;
 		}
 
 		@include breakpoint( "<660px" ) {
@@ -281,8 +290,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	font-weight: 600;
 	list-style-type: none;
-	margin: 0;
-	padding-top: 20px;
+	margin: 20px 0 0;
 	text-transform: uppercase;
 }
 
@@ -294,8 +302,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .search-stream__post-header,
 .search-stream__site-header {
-	border-bottom: 1px solid lighten( $gray, 30% );
-	padding-bottom: 10px;
+	border-bottom: 1px solid lighten( $gray, 20% );
+	padding-bottom: 15px;
 	width: 100%;
 }
 
@@ -309,8 +317,13 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	background: inherit;
 	border-bottom: 2px solid lighten( $gray, 30% );
 	box-shadow: none;
+	height: 54px;
 	margin-bottom: 0;
 	padding-bottom: 0;
+
+	@include breakpoint( ">480px" ) {
+		height: 59px;
+	}
 }
 
 .search-stream__header .section-nav-group {
@@ -363,6 +376,17 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	.reader-subscription-list-item .follow-button__label,
 	.reader-subscription-list-item__settings-label {
 		display: none;
+	}
+}
+
+.search-stream__single-column-results .reader-subscription-list-item__options {
+	align-items: flex-end;
+	display: flex;
+	flex-direction: column;
+	min-width: 90px;
+
+	@include breakpoint( ">660px" ) {
+		align-items: flex-start;
 	}
 }
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -83,7 +83,7 @@
 }
 
 .search-stream.search-stream__with-sites .search-stream__single-column-results {
-	padding-top: 140px;
+	padding-top: 150px;
 }
 
 .search-stream.search-stream__with-sites .search-stream__single-column-results .search-stream__recommendation-list-item:nth-child(2) {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -457,7 +457,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .search-stream__results.is-two-columns .search-stream__site-results .gridicons-cog {
 	left: -3px;
-	top: 15px;
+	top: 8px;
 }
 
 .card.reader-search-card.is-photo {


### PR DESCRIPTION
This PR fixes the nits reported in: https://github.com/Automattic/wp-calypso/pull/14881#issuecomment-308256084

> Still need the top lines darker.

> Should be less space between search box and headers, more space between headers and lines, and less space between lines and first result. All three whitespace areas should be the same (~20px).

**Before:**
![screenshot 2017-06-14 19 36 36](https://user-images.githubusercontent.com/4924246/27162908-ce52f9b8-5138-11e7-8dd7-410221df6dfe.png)

**After:**
![screenshot 2017-06-14 19 36 40](https://user-images.githubusercontent.com/4924246/27162912-d1705082-5138-11e7-8377-f4399dc5a1cc.png)

> At middle widths, on Sites, the Follow buttons are misaligned.

**Before:**
![screenshot 2017-06-14 19 47 42](https://user-images.githubusercontent.com/4924246/27163158-5fa1801e-513a-11e7-9bb4-82b5c101c1ba.png)

**After:**
![screenshot 2017-06-14 19 47 55](https://user-images.githubusercontent.com/4924246/27163161-6272ba60-513a-11e7-93bf-87e615af7245.png)

> My two cents: We shouldn't have lines in between the site results.

@fraying I really think we should keep the dividers. Especially if there's a Settings icon (which was moved down a bit to increase mobile tap targets), there's not a clear distinction between each list item.

Example:
![screenshot 2017-06-14 19 41 53](https://user-images.githubusercontent.com/4924246/27163037-a5d606dc-5139-11e7-8132-38f2f703b3af.png)

> Spacing is broken at the smallest width.

This only happens in Safari. For some reason, `perspective: 1000;` was being rendered differently in Safari and Chrome. The Search bar also got pushed behind the masterbar in Safari.

**Before:**
![screenshot 2017-06-14 19 45 50](https://user-images.githubusercontent.com/4924246/27163129-350106f4-513a-11e7-9b89-e57d67a620a0.png)

**After:**
![screenshot 2017-06-14 19 46 14](https://user-images.githubusercontent.com/4924246/27163131-391bf35c-513a-11e7-9271-d4ffe941a868.png)
