### PR TITLE
Remove a/b test around domain only to paid plan upsell to all users.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -50,15 +50,6 @@ module.exports = {
 		defaultVariation: 'show',
 		allowExistingUsers: true,
 	},
-	domainToPaidPlanUpsellNudge: {
-		datestamp: '20170607',
-		variations: {
-			skip: 50,
-			show: 50,
-		},
-		defaultVariation: 'skip',
-		allowExistingUsers: true,
-	},
 	ATPromptOnCancel: {
 		datestamp: '20170515',
 		variations: {

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -11,7 +11,6 @@ import {
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isEligibleForDomainToPaidPlanUpsell } from 'state/selectors';
 import Notice from 'components/notice';
@@ -39,7 +38,7 @@ export class DomainToPaidPlanNotice extends Component {
 	render() {
 		const { eligible, site, translate } = this.props;
 
-		if ( ! site || ! eligible || abtest( 'domainToPaidPlanUpsellNudge' ) === 'skip' ) {
+		if ( ! site || ! eligible ) {
 			return null;
 		}
 

--- a/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
@@ -9,24 +9,13 @@ import { stub } from 'sinon';
 /**
  * Internal dependencies
  */
-import useMockery from 'test/helpers/use-mockery';
+import { DomainToPaidPlanNotice } from '../domain-to-paid-plan-notice';
 
 describe( 'DomainToPaidPlanNotice', function() {
 	const translate = stub();
 	const site = { ID: 12345, slug: 'site_slug' };
-	const abtests = [];
-	let DomainToPaidPlanNotice;
-
-	useMockery( ( mockery ) => {
-		mockery.registerMock( 'lib/abtest', { abtest: ( test ) => abtests[ test ] } );
-	} );
-
-	before( () => {
-		DomainToPaidPlanNotice = require( '../domain-to-paid-plan-notice' ).DomainToPaidPlanNotice;
-	} );
 
 	beforeEach( () => {
-		abtests.domainToPaidPlanUpsellNudge = 'show';
 		translate.returns( 'translated content' );
 	} );
 
@@ -42,14 +31,7 @@ describe( 'DomainToPaidPlanNotice', function() {
 		expect( wrapper.type() ).to.equal( null );
 	} );
 
-	it( 'should render null when a/b test variant is skip', function() {
-		abtests.domainToPaidPlanUpsellNudge = 'skip';
-		const wrapper = shallow( <DomainToPaidPlanNotice site={ site } eligible /> );
-
-		expect( wrapper.type() ).to.equal( null );
-	} );
-
-	it( 'should render component when a/b test variant is show', function() {
+	it( 'should render component when ', function() {
 		const wrapper = shallow( <DomainToPaidPlanNotice site={ site } eligible /> );
 		expect( wrapper.type().displayName ).to.equal( 'Localized(Notice)' );
 	} );

--- a/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
@@ -31,7 +31,7 @@ describe( 'DomainToPaidPlanNotice', function() {
 		expect( wrapper.type() ).to.equal( null );
 	} );
 
-	it( 'should render component when ', function() {
+	it( 'should render component when site information is available and the site is eligible', function() {
 		const wrapper = shallow( <DomainToPaidPlanNotice site={ site } eligible /> );
 		expect( wrapper.type().displayName ).to.equal( 'Localized(Notice)' );
 	} );


### PR DESCRIPTION
This nudge has been demonstrated to result in a significant improvement on domain only to paid plan conversion so will now be released to all users.

# Test Plan

You will need a site on a free plan with a domain registration or domain mapping.

Verify that the following nudge is visible:

![screen-shot-2017-06-15-at-10-36-45-am](https://user-images.githubusercontent.com/1926/27164537-51b9eda0-51d1-11e7-993d-98629d22a1b2.png)
