### PR TITLE
Publicize: Enable scheduled action preview

### DIFF
--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -55,14 +55,14 @@ class PublicizeActionsList extends PureComponent {
 
 	togglePreviewModal = ( message = '', service = '' ) => () => {
 		if ( this.state.showPreviewModal ) {
-			this.setState( { showPreviewModal: false } );
-		} else {
-			this.setState( {
-				showPreviewModal: true,
-				previewMessage: message,
-				previewService: service,
-			} );
+			return this.setState( { showPreviewModal: false } );
 		}
+
+		this.setState( {
+			showPreviewModal: true,
+			previewMessage: message,
+			previewService: service,
+		} );
 	}
 
 	renderFooterSectionItem( {
@@ -103,9 +103,10 @@ class PublicizeActionsList extends PureComponent {
 		if ( isEnabled( 'publicize-preview' ) ) {
 			actions.push(
 				<PopoverMenuItem
-					onClick = { this.togglePreviewModal( message, service ) }
+					onClick={ this.togglePreviewModal( message, service ) }
 					key="1"
-					icon="visible">
+					icon="visible"
+				>
 					{ translate( 'Preview' ) }
 				</PopoverMenuItem>
 			);

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -29,6 +29,7 @@ import { isEnabled } from 'config';
 import Dialog from 'components/dialog';
 import { deletePostShareAction } from 'state/sharing/publicize/publicize-actions/actions';
 import analytics from 'lib/analytics';
+import SharingPreviewModal from './sharing-preview-modal';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {
@@ -41,13 +42,25 @@ class PublicizeActionsList extends PureComponent {
 	state = {
 		selectedShareTab: SCHEDULED,
 		showDeleteDialog: false,
-		selectedScheduledShareId: null
+		selectedScheduledShareId: null,
+		showPreviewModal: false,
+		previewMessage: '',
+		previewService: '',
 	};
 
 	setFooterSection = selectedShareTab => () => {
 		analytics.tracks.recordEvent( 'calypso_publicize_action_tab_click', { tab: selectedShareTab } );
 		this.setState( { selectedShareTab } );
 	};
+
+	togglePreviewModal = ( message = '', service = '' ) => () => {
+		const showPreviewModal = ! this.state.showPreviewModal;
+		this.setState( {
+			showPreviewModal,
+			previewMessage: message,
+			previewService: service,
+		} );
+	}
 
 	renderFooterSectionItem( {
 		ID: actionId,
@@ -75,18 +88,21 @@ class PublicizeActionsList extends PureComponent {
 						{ message }
 					</div>
 				</div>
-				{ this.renderElipsisMenu( actionId ) }
+				{ this.renderElipsisMenu( actionId, message, service ) }
 			</CompactCard>
 		);
 	}
 
-	renderElipsisMenu( publicizeActionId ) {
+	renderElipsisMenu( publicizeActionId, message, service ) {
 		const actions = [];
 		const { translate } = this.props;
 
 		if ( isEnabled( 'publicize-preview' ) ) {
 			actions.push(
-				<PopoverMenuItem key="1" icon="visible">
+				<PopoverMenuItem
+					onClick = { this.togglePreviewModal( message, service ) }
+					key="1"
+					icon="visible">
 					{ translate( 'Preview' ) }
 				</PopoverMenuItem>
 			);
@@ -204,6 +220,15 @@ class PublicizeActionsList extends PureComponent {
 				</div>
 
 				{ this.renderDeleteDialog() }
+
+				<SharingPreviewModal
+					siteId={ siteId }
+					postId={ postId }
+					message={ this.state.previewMessage }
+					selectedService= { this.state.previewService }
+					isVisible={ this.state.showPreviewModal }
+					onClose={ this.togglePreviewModal() }
+				/>
 			</div>
 		);
 	}

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -54,12 +54,15 @@ class PublicizeActionsList extends PureComponent {
 	};
 
 	togglePreviewModal = ( message = '', service = '' ) => () => {
-		const showPreviewModal = ! this.state.showPreviewModal;
-		this.setState( {
-			showPreviewModal,
-			previewMessage: message,
-			previewService: service,
-		} );
+		if ( this.state.showPreviewModal ) {
+			this.setState( { showPreviewModal: false } );
+		} else {
+			this.setState( {
+				showPreviewModal: true,
+				previewMessage: message,
+				previewService: service,
+			} );
+		}
 	}
 
 	renderFooterSectionItem( {

--- a/client/blocks/post-share/sharing-preview-modal.jsx
+++ b/client/blocks/post-share/sharing-preview-modal.jsx
@@ -3,7 +3,6 @@
  */
 import React, { PropTypes } from 'react';
 import Gridicon from 'gridicons';
-import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,10 +11,10 @@ import Dialog from 'components/dialog';
 import SharingPreviewPane from 'blocks/sharing-preview-pane';
 
 const SharingPreviewModal = ( props ) => {
-	const previewProps = pick( props, [ 'message', 'siteId', 'postId' ] );
 	const {
 		isVisible,
 		onClose,
+		...previewProps,
 	} = props;
 
 	return (
@@ -38,6 +37,7 @@ SharingPreviewModal.propTypes = {
 	siteId: PropTypes.number,
 	postId: PropTypes.number,
 	message: PropTypes.string,
+	selectedService: PropTypes.string,
 };
 
 export default SharingPreviewModal;

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -44,15 +44,19 @@ class SharingPreviewPane extends PureComponent {
 		site: PropTypes.object,
 		post: PropTypes.object,
 		seoTitle: PropTypes.string,
+		selectedService: PropTypes.string,
 	};
 
 	static defaultProps = {
 		services: Object.keys( serviceNames )
 	};
 
-	state = {
-		selectedService: 'facebook'
-	};
+	constructor( props ) {
+		super( props );
+		this.state = {
+			selectedService: props.selectedService || props.services[ 0 ]
+		};
+	}
 
 	selectPreview = ( selectedService ) => {
 		this.setState( { selectedService } );
@@ -117,6 +121,7 @@ class SharingPreviewPane extends PureComponent {
 
 	render() {
 		const { translate, services } = this.props;
+		const initialMenuItemIndex = services.indexOf( this.state.selectedService );
 
 		return (
 			<div className="sharing-preview-pane">
@@ -132,7 +137,7 @@ class SharingPreviewPane extends PureComponent {
 								'the networks below' ) }
 						</p>
 					</div>
-					<VerticalMenu onClick={ this.selectPreview }>
+					<VerticalMenu onClick={ this.selectPreview } initialItemIndex={ initialMenuItemIndex } >
 						{ services.map( service => <SocialItem { ...{ key: service, service } } /> ) }
 					</VerticalMenu>
 				</div>

--- a/client/components/vertical-menu/README.md
+++ b/client/components/vertical-menu/README.md
@@ -27,6 +27,7 @@ const announceIt = service =>
 ## Props
 
  - **onClick** - Function - click handler. Transparently passes data from list items into handler.
+ - **initalItemIndex** - Number - The index of the item to initially activate. defaults to 0
 
 ### SocialItem
 

--- a/client/components/vertical-menu/index.jsx
+++ b/client/components/vertical-menu/index.jsx
@@ -8,19 +8,30 @@ import {
 } from 'lodash';
 
 export class VerticalMenu extends PureComponent {
+
+	static propTypes = {
+		onClick: PropTypes.func,
+		initalItemIndex: PropTypes.number,
+		children: PropTypes.arrayOf(
+			PropTypes.element
+		)
+	}
+
+	static defaultProps = {
+		initialItemIndex: 0,
+		onClick: identity
+	}
+
 	constructor( props ) {
 		super( props );
 
 		this.state = {
-			selectedIndex: 0
+			selectedIndex: props.initialItemIndex
 		};
-
-		this.select = this.select.bind( this );
 	}
 
-	select( selectedIndex, ...args ) {
+	select = ( selectedIndex, ...args ) => {
 		const { onClick } = this.props;
-
 		this.setState( { selectedIndex }, partial( onClick, ...args ) );
 	}
 
@@ -40,16 +51,5 @@ export class VerticalMenu extends PureComponent {
 		);
 	}
 }
-
-VerticalMenu.propTypes = {
-	onClick: PropTypes.func,
-	children: PropTypes.arrayOf(
-		PropTypes.element
-	)
-};
-
-VerticalMenu.defaultProps = {
-	onClick: identity
-};
 
 export default VerticalMenu;


### PR DESCRIPTION
This enables the sharing preview in the scheduled action ellipsis menu. It will shows the message for the scheduled action and initializes the preview with the targeted service.

**Screencast**
![scheduled-preview](https://user-images.githubusercontent.com/744755/27164551-ecd5c73a-5142-11e7-8c95-951daad37862.gif)


**Testing**
1. Create 2 or more scheduled actions with different message and targeting different services
2. Open the ellipsis menu for the scheduled action
3. Clicking "Preview" should open the social preview modal
4. The previewed message should be the same as the scheduled action
5. The modal should display the preview for the targeted service when opened.