### PR TITLE
Me: Fix sidebar screen on /me so the styles only apply to Store

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -71,7 +71,7 @@
 	}
 }
 
-.focus-sidebar {
+.is-section-woocommerce.focus-sidebar {
 	@include breakpoint( "<660px" ) {
 		.sticky-panel,
 		.products__form,
@@ -81,7 +81,7 @@
 	}
 }
 
-.focus-content {
+.is-section-woocommerce.focus-content {
 	@include breakpoint( "<660px" ) {
 		.site-icon,
 		.current-section__site-title,


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/15088

This was caused by #14829. I had a style defined that wasn't specific to the Store section. 

**To test**

Visit http://calypso.localhost:3000/me with a mobile screen width and confirm that the top header is no longer broken (compared to the screenshot in https://github.com/Automattic/wp-calypso/issues/15088):
<img width="400" alt="screen shot 2017-06-14 at 9 56 00 pm" src="https://user-images.githubusercontent.com/5835847/27164708-5039ad06-514c-11e7-9620-7554b10e27b7.png">

Then go to http://calypso.localhost:3000/store/product/URL and confirm that the back arrow appears to the left of the breadcrumbs:
<img width="400" alt="screen shot 2017-06-14 at 9 55 54 pm" src="https://user-images.githubusercontent.com/5835847/27164724-6bcd6a76-514c-11e7-8b6e-5d359b03724f.png">


