### PR TITLE
PostShare: make stronger css rules in actions list

### DIFF
--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -290,75 +290,77 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	margin: 0;
 }
 
-.post-share__footer-items {
-	display: flex;
-	flex-wrap: nowrap;
-	justify-content: space-between;
-
-	&::after {
-		content: '';
-		display: none;
-	}
-}
-
-.post-share__footer-items .ellipsis-menu {
-	display: flex;
-}
-
-.post-share__footer-items .ellipsis-menu__toggle {
-	padding-top: 0;
-	padding-bottom: 0;
-}
-
-.post-share__footer-items .ellipsis-menu__toggle .gridicon {
-	top: 4px;
-}
-
-.post-share__footer-item {
-	display: flex;
-	flex: 1 1 auto;
-	flex-direction: column;
-	overflow: hidden;
-	position: relative;
-
-	@include breakpoint( ">480px" ) {
-		align-items: center;
-		flex-direction: row;
+.post-share__scheduled-list {
+	.post-share__footer-items {
+		display: flex;
+		flex-wrap: nowrap;
+		justify-content: space-between;
 
 		&::after {
-			@include long-content-fade( $color: $white );
+			content: '';
+			display: none;
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
-		align-items: flex-start;
+	.post-share__footer-items .ellipsis-menu {
+		display: flex;
+	}
+
+	.post-share__footer-items .ellipsis-menu__toggle {
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	.post-share__footer-items .ellipsis-menu__toggle .gridicon {
+		top: 4px;
+	}
+
+	.post-share__footer-item {
+		display: flex;
+		flex: 1 1 auto;
 		flex-direction: column;
-	}
-
-	@include breakpoint( ">960px" ) {
-		align-items: center;
-		flex-direction: row;
-	}
-}
-
-.post-share__footer-item .social-logo {
-	flex: 0 0 24px;
-
-	@include breakpoint( ">660px" ) {
+		overflow: hidden;
 		position: relative;
-		top: 1px;
+
+		@include breakpoint( ">480px" ) {
+			align-items: center;
+			flex-direction: row;
+
+			&::after {
+				@include long-content-fade( $color: $white );
+			}
+		}
+
+		@include breakpoint( ">660px" ) {
+			align-items: flex-start;
+			flex-direction: column;
+		}
+
+		@include breakpoint( ">960px" ) {
+			align-items: center;
+			flex-direction: row;
+		}
 	}
-}
 
-.post-share__footer-item .gridicons-time {
-	flex: 0 0 18px;
-	padding: 3px;
-	position: relative;
-		top: -1px;
-		left: -1px;
+	.post-share__footer-item .social-logo {
+		flex: 0 0 24px;
 
-	@include breakpoint( ">660px" ) {
-		top: 0;
+		@include breakpoint( ">660px" ) {
+			position: relative;
+			top: 1px;
+		}
+	}
+
+	.post-share__footer-item .gridicons-time {
+		flex: 0 0 18px;
+		padding: 3px;
+		position: relative;
+			top: -1px;
+			left: -1px;
+
+		@include breakpoint( ">660px" ) {
+			top: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
When we moved the `<PostShare />` component into the `blocks/` folder we also changed the order of the sass files into the `_components.scss.

<img src="https://user-images.githubusercontent.com/77539/27165086-2203583a-5168-11e7-8a86-3b4369ae1544.png" width="600px" />

it changed stronger order between `card` and `post-share__footer-items` classes. Now (before to this patch) `card` is stronger than `post-share__footer-items` which means that the `display` value is `block` instead of `flex`. Both of them belong to the action element.


![image](https://user-images.githubusercontent.com/77539/27164947-231369e6-5167-11e7-9746-5994ccfd3dc2.png)


This PR makes stronger the `post-share__footer-items` classes in order to apply the right css properties.

**before to this patch**
<img src="https://user-images.githubusercontent.com/77539/27164915-e59c74cc-5166-11e7-9ae4-d6b9cb857eb0.png" width="500px" />

**after this patch**
<img src="https://user-images.githubusercontent.com/77539/27164927-fccaa9e8-5166-11e7-95dc-300f73c012e8.png" width="500px" />

### Testing
Apply the patch and confirm that the actions list is ok.
