### PR TITLE
Publicize: Minor style fixes for social preview modal

### DIFF
--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -426,25 +426,23 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share__sharing-preview-modal {
-	padding: 0px;
-	@include breakpoint( ">960px" ) {
-		&.dialog.card {
-			position: absolute;
-		}
+	border-radius: 4px;
+	overflow: hidden;
+	width: 100%;
+}
 
-		left: 25%;
-		right: 25%;
-		top: 25%;
-		width: 50%;
-		min-width: 500px;
-	}
+.card.post-share__sharing-preview-modal {
+	padding: 0px;
+}
+
+.dialog.card.post-share__sharing-preview-modal {
+	max-width: 865px;
 }
 
 .post-share__sharing-preview-modal-header {
 	height: 48px;
 	background: $white;
 	border-bottom: 1px solid lighten( $gray, 20% );
-	border-radius: 4px 4px 0;
 	display: flex;
 }
 


### PR DESCRIPTION
Minor style bug fixes for social preview modal.

**Unnecessary padding around the modal**
<img width="711" alt="screen shot 2017-06-15 at 15 26 56" src="https://user-images.githubusercontent.com/908665/27188935-b174d49c-51e7-11e7-9550-566824ebc8ef.png">

**The width is too narrow when viewports is wide**
<img width="1021" alt="screen shot 2017-06-15 at 15 27 14" src="https://user-images.githubusercontent.com/908665/27188968-cc30bf1c-51e7-11e7-9d06-e8438b67c653.png">
