### PR TITLE
Add HoC replacement of update-post-status mixin; use in Pages

### DIFF
--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -1,0 +1,188 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import UpdateTemplate from './update-template';
+import PostActions from 'lib/posts/actions';
+import analytics from 'lib/analytics';
+
+// TODO(mcsf): use i18n#localize?
+const strings = {
+	page: {
+		deleteWarning: translate( 'Delete this page permanently?' ),
+		deleted: translate( 'Page Deleted' ),
+		deleting: translate( 'Deleting Page' ),
+		error: translate( 'Error' ),
+		restored: translate( 'Page Restored' ),
+		restoring: translate( 'Restoring Page' ),
+		trashed: translate( 'Moved to Trash' ),
+		trashing: translate( 'Trashing Page' ),
+		undo: translate( 'undo?' ),
+		updated: translate( 'Updated' ),
+		updating: translate( 'Updating Page' ),
+	},
+	post: {
+		deleteWarning: translate( 'Delete this post permanently?' ),
+		deleted: translate( 'Post Deleted' ),
+		deleting: translate( 'Deleting Post' ),
+		error: translate( 'Error' ),
+		restored: translate( 'Restored' ),
+		restoring: translate( 'Restoring' ),
+		trashed: translate( 'Moved to Trash' ),
+		trashing: translate( 'Trashing Post' ),
+		undo: translate( 'undo?' ),
+		updated: translate( 'Updated' ),
+		updating: translate( 'Updating Post' ),
+	},
+};
+
+const updatePostStatus = ( WrappedComponent ) =>
+	class UpdatePostStatus extends Component {
+		static displayName = `UpdatePostStatus(${
+			WrappedComponent.displayName || WrappedComponent.name || ''
+		})`;
+
+		state = {
+			updated: false,
+			updatedStatus: null,
+			previousStatus: null,
+			showMoreOptions: false,
+			showPageActions: false,
+		};
+
+		getType() {
+			return this.props.page ? 'page' : 'post';
+		}
+
+		buildUpdateTemplate = () => {
+			if ( ! this.state.updated ) {
+				return;
+			}
+
+			return <UpdateTemplate
+				post={ this.props.post || this.props.page }
+				previousStatus={ this.state.previousStatus }
+				resetToPreviousState={ this.resetToPreviousState }
+				status={ this.state.updatedStatus }
+				strings={ strings[ this.getType() ] }
+			/>;
+		}
+
+		updatePostStatus = ( status ) => {
+			const post = this.props.post || this.props.page;
+			let previousStatus = null;
+
+			const setNewStatus = ( error, resultPost ) => {
+				if ( error ) {
+					this.setErrorState();
+					return false;
+				}
+
+				this.setState( {
+					previousStatus,
+					updatedStatus: resultPost.status,
+					showMoreOptions: false,
+				} );
+				return true;
+			};
+
+			if ( status === 'delete' ) {
+				this.setState( {
+					showPageActions: false,
+					updatedStatus: 'deleting',
+					updated: true,
+				} );
+
+				const type = this.props.post ? 'post' : 'page';
+				if ( window.confirm( strings[ type ].deleteWarning ) ) { // eslint-disable-line no-alert
+					PostActions.trash( post, setNewStatus );
+				} else {
+					this.resetState();
+				}
+
+				return;
+			}
+
+			if ( status === 'trash' ) {
+				this.setState( {
+					showPageActions: false,
+					updatedStatus: 'trashing',
+					updated: true,
+				} );
+				previousStatus = post.status;
+				PostActions.trash( post, setNewStatus );
+				return;
+			}
+
+			if ( status === 'restore' ) {
+				this.setState( {
+					showPageActions: false,
+					updatedStatus: 'restoring',
+					updated: true,
+				} );
+				previousStatus = 'trash';
+				PostActions.restore( post, setNewStatus );
+				return;
+			}
+
+			this.setState( {
+				showPageActions: false,
+				updatedStatus: 'updating',
+				updated: true,
+			} );
+			PostActions.update( post, { status }, ( error, resultPost ) => {
+				if ( ! setNewStatus( error, resultPost ) ) {
+					return;
+				}
+				setTimeout( this.resetState, 1200 );
+			} );
+		}
+
+		resetState = () => {
+			this.setState( {
+				updatedStatus: null,
+				updated: false,
+				showMoreOptions: false,
+				showPageActions: false
+			} );
+		}
+
+		resetToPreviousState = () => {
+			const { group, eventName } = this.getType() === 'page'
+				? { group: 'Pages', eventName: 'Clicked Undo Trashed Page' }
+				: { group: 'Posts', eventName: 'Clicked Undo Trashed Post' };
+
+			analytics.ga.recordEvent( group, eventName );
+			if ( this.state.previousStatus ) {
+				this.updatePostStatus( this.state.previousStatus );
+			}
+		}
+
+		togglePageActions = () => {
+			this.setState( { showPageActions: ! this.state.showPageActions } );
+		}
+
+		setErrorState() {
+			this.setState( {
+				updated: true,
+				updatedStatus: 'error',
+			} );
+			setTimeout( this.resetState, 1200 );
+		}
+
+		render() {
+			return <WrappedComponent { ...this.props }
+				buildUpdateTemplate={ this.buildUpdateTemplate }
+				togglePageActions={ this.togglePageActions }
+				updatePostStatus={ this.updatePostStatus }
+				{ ...this.state } />;
+		}
+	};
+
+export default updatePostStatus;
+

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -13,6 +13,8 @@ import UpdateTemplate from './update-template';
 import PostActions from 'lib/posts/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+const RESET_TIMEOUT_MS = 1200;
+
 const getStrings = once( ( translate ) => ( {
 	page: {
 		deleteWarning: translate( 'Delete this page permanently?' ),
@@ -155,7 +157,7 @@ const updatePostStatus = ( WrappedComponent ) => enhance(
 						if ( ! setNewStatus( error, resultPost ) ) {
 							return;
 						}
-						setTimeout( this.resetState, 1200 );
+						setTimeout( this.resetState, RESET_TIMEOUT_MS );
 					} );
 			}
 		}
@@ -189,7 +191,7 @@ const updatePostStatus = ( WrappedComponent ) => enhance(
 				updated: true,
 				updatedStatus: 'error',
 			} );
-			setTimeout( this.resetState, 1200 );
+			setTimeout( this.resetState, RESET_TIMEOUT_MS );
 		}
 
 		render() {

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -106,59 +106,58 @@ const updatePostStatus = ( WrappedComponent ) => enhance(
 				return true;
 			};
 
-			if ( status === 'delete' ) {
-				this.setState( {
-					showPageActions: false,
-					updatedStatus: 'deleting',
-					updated: true,
-				} );
+			switch ( status ) {
+				case 'delete':
+					this.setState( {
+						showPageActions: false,
+						updatedStatus: 'deleting',
+						updated: true,
+					} );
 
-				const strings = getStrings( this.props.translate );
-				const type = this.props.post ? 'post' : 'page';
+					const strings = getStrings( this.props.translate );
+					const type = this.props.post ? 'post' : 'page';
 
-				if ( typeof window === 'object' &&
-						window.confirm( strings[ type ].deleteWarning ) ) { // eslint-disable-line no-alert
-					PostActions.trash( post, setNewStatus );
-				} else {
-					this.resetState();
-				}
-
-				return;
-			}
-
-			if ( status === 'trash' ) {
-				this.setState( {
-					showPageActions: false,
-					updatedStatus: 'trashing',
-					updated: true,
-				} );
-				previousStatus = post.status;
-				PostActions.trash( post, setNewStatus );
-				return;
-			}
-
-			if ( status === 'restore' ) {
-				this.setState( {
-					showPageActions: false,
-					updatedStatus: 'restoring',
-					updated: true,
-				} );
-				previousStatus = 'trash';
-				PostActions.restore( post, setNewStatus );
-				return;
-			}
-
-			this.setState( {
-				showPageActions: false,
-				updatedStatus: 'updating',
-				updated: true,
-			} );
-			PostActions.update( post, { status }, ( error, resultPost ) => {
-				if ( ! setNewStatus( error, resultPost ) ) {
+					if ( typeof window === 'object' &&
+							window.confirm( strings[ type ].deleteWarning ) ) { // eslint-disable-line no-alert
+						PostActions.trash( post, setNewStatus );
+					} else {
+						this.resetState();
+					}
 					return;
-				}
-				setTimeout( this.resetState, 1200 );
-			} );
+
+				case 'trash':
+					this.setState( {
+						showPageActions: false,
+						updatedStatus: 'trashing',
+						updated: true,
+					} );
+					previousStatus = post.status;
+					PostActions.trash( post, setNewStatus );
+					return;
+
+				case 'restore':
+					this.setState( {
+						showPageActions: false,
+						updatedStatus: 'restoring',
+						updated: true,
+					} );
+					previousStatus = 'trash';
+					PostActions.restore( post, setNewStatus );
+					return;
+
+				default:
+					this.setState( {
+						showPageActions: false,
+						updatedStatus: 'updating',
+						updated: true,
+					} );
+					PostActions.update( post, { status }, ( error, resultPost ) => {
+						if ( ! setNewStatus( error, resultPost ) ) {
+							return;
+						}
+						setTimeout( this.resetState, 1200 );
+					} );
+			}
 		}
 
 		resetState = () => {

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -116,7 +116,8 @@ const updatePostStatus = ( WrappedComponent ) => enhance(
 				const strings = getStrings( this.props.translate );
 				const type = this.props.post ? 'post' : 'page';
 
-				if ( window.confirm( strings[ type ].deleteWarning ) ) { // eslint-disable-line no-alert
+				if ( typeof window === 'object' &&
+						window.confirm( strings[ type ].deleteWarning ) ) { // eslint-disable-line no-alert
 					PostActions.trash( post, setNewStatus );
 				} else {
 					this.resetState();

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { once } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,8 +12,7 @@ import UpdateTemplate from './update-template';
 import PostActions from 'lib/posts/actions';
 import analytics from 'lib/analytics';
 
-// TODO(mcsf): use i18n#localize?
-const strings = {
+const getStrings = once( ( translate ) => ( {
 	page: {
 		deleteWarning: translate( 'Delete this page permanently?' ),
 		deleted: translate( 'Page Deleted' ),
@@ -39,13 +39,19 @@ const strings = {
 		updated: translate( 'Updated' ),
 		updating: translate( 'Updating Post' ),
 	},
-};
+} ) );
 
-const updatePostStatus = ( WrappedComponent ) =>
+const updatePostStatus = ( WrappedComponent ) => localize(
 	class UpdatePostStatus extends Component {
 		static displayName = `UpdatePostStatus(${
 			WrappedComponent.displayName || WrappedComponent.name || ''
 		})`;
+
+		static propTypes = {
+			translate: PropTypes.func.isRequired,
+			post: PropTypes.object,
+			page: PropTypes.object,
+		};
 
 		state = {
 			updated: false,
@@ -63,6 +69,8 @@ const updatePostStatus = ( WrappedComponent ) =>
 			if ( ! this.state.updated ) {
 				return;
 			}
+
+			const strings = getStrings( this.props.translate );
 
 			return <UpdateTemplate
 				post={ this.props.post || this.props.page }
@@ -98,7 +106,9 @@ const updatePostStatus = ( WrappedComponent ) =>
 					updated: true,
 				} );
 
+				const strings = getStrings( this.props.translate );
 				const type = this.props.post ? 'post' : 'page';
+
 				if ( window.confirm( strings[ type ].deleteWarning ) ) { // eslint-disable-line no-alert
 					PostActions.trash( post, setNewStatus );
 				} else {
@@ -182,7 +192,8 @@ const updatePostStatus = ( WrappedComponent ) =>
 				updatePostStatus={ this.updatePostStatus }
 				{ ...this.state } />;
 		}
-	};
+	}
+);
 
 export default updatePostStatus;
 

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -45,13 +45,13 @@ const updatePostStatus = ( WrappedComponent ) => localize(
 	class UpdatePostStatus extends Component {
 		static displayName = `UpdatePostStatus(${
 			WrappedComponent.displayName || WrappedComponent.name || ''
-		})`;
+		})`
 
 		static propTypes = {
 			translate: PropTypes.func.isRequired,
 			post: PropTypes.object,
 			page: PropTypes.object,
-		};
+		}
 
 		state = {
 			updated: false,
@@ -59,7 +59,7 @@ const updatePostStatus = ( WrappedComponent ) => localize(
 			previousStatus: null,
 			showMoreOptions: false,
 			showPageActions: false,
-		};
+		}
 
 		getType() {
 			return this.props.page ? 'page' : 'post';
@@ -196,4 +196,3 @@ const updatePostStatus = ( WrappedComponent ) => localize(
 );
 
 export default updatePostStatus;
-

--- a/client/components/update-post-status/update-template.js
+++ b/client/components/update-post-status/update-template.js
@@ -3,6 +3,14 @@
  */
 import React from 'react';
 
+const Ellipsis = () => (
+	<span>
+		<span className="loading-dot">.</span>
+		<span className="loading-dot">.</span>
+		<span className="loading-dot">.</span>
+	</span>
+);
+
 export default function UpdateTemplate( {
 	post,
 	previousStatus,
@@ -18,7 +26,7 @@ export default function UpdateTemplate( {
 		case 'deleting':
 			trashText = ( status === 'deleting' ) ? s.deleting : s.trashing;
 			updateText = (
-				<span>{ trashText } <span className="loading-dot">.</span><span className="loading-dot">.</span><span className="loading-dot">.</span></span>
+				<span>{ trashText } <Ellipsis /></span>
 			);
 			updateClass += ' conf-alert--trashing';
 			break;
@@ -39,7 +47,7 @@ export default function UpdateTemplate( {
 
 		case 'updating':
 			updateText = (
-				<span>{ s.updating } <span className="loading-dot">.</span><span className="loading-dot">.</span><span className="loading-dot">.</span></span>
+				<span>{ s.updating } <Ellipsis /></span>
 			);
 			updateClass += ' conf-alert--updating';
 			break;
@@ -50,7 +58,7 @@ export default function UpdateTemplate( {
 			break;
 
 		case 'restoring':
-			updateText = ( <span>{ s.restoring } <span className="loading-dot">.</span><span className="loading-dot">.</span><span className="loading-dot">.</span></span> );
+			updateText = ( <span>{ s.restoring } <Ellipsis /></span> );
 			updateClass += ' conf-alert--updating';
 			break;
 

--- a/client/components/update-post-status/update-template.js
+++ b/client/components/update-post-status/update-template.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function UpdateTemplate( {
+	post,
+	previousStatus,
+	resetToPreviousState,
+	status,
+	strings: s,
+} ) {
+	let updateClass = 'conf-alert';
+	let updateText, undoTemplate, undoClick, trashText;
+
+	switch ( status ) {
+		case 'trashing':
+		case 'deleting':
+			trashText = ( status === 'deleting' ) ? s.deleting : s.trashing;
+			updateText = (
+				<span>{ trashText } <span className="loading-dot">.</span><span className="loading-dot">.</span><span className="loading-dot">.</span></span>
+			);
+			updateClass += ' conf-alert--trashing';
+			break;
+
+		case 'trash':
+			undoClick = resetToPreviousState;
+			undoTemplate = (
+				<a className="undo" onClick={ undoClick }><span>{ s.undo }</span></a>
+			);
+			updateText = s.trashed;
+			updateClass += ' conf-alert--trashed';
+			break;
+
+		case 'deleted':
+			updateText = s.deleted;
+			updateClass += ' conf-alert--deleted';
+			break;
+
+		case 'updating':
+			updateText = (
+				<span>{ s.updating } <span className="loading-dot">.</span><span className="loading-dot">.</span><span className="loading-dot">.</span></span>
+			);
+			updateClass += ' conf-alert--updating';
+			break;
+
+		case 'error':
+			updateText = s.error;
+			updateClass += ' conf-alert--error';
+			break;
+
+		case 'restoring':
+			updateText = ( <span>{ s.restoring } <span className="loading-dot">.</span><span className="loading-dot">.</span><span className="loading-dot">.</span></span> );
+			updateClass += ' conf-alert--updating';
+			break;
+
+		default:
+			updateText = previousStatus === 'trash'
+				? s.restored
+				: s.updated;
+	}
+
+	return (
+		<div key={ post.global_ID + '-update' } className="updated-confirmation">
+			<div className={ updateClass }>
+				<div className="conf-alert_con">
+					<span className="conf-alert_title">{ updateText }</span>{ undoTemplate }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -46,8 +46,7 @@ function recordEvent( eventAction ) {
 	analytics.ga.recordEvent( 'Pages', eventAction );
 }
 
-// FIXME(mcsf): I vow to follow-up on this and port to Component
-const Page = React.createClass( { // eslint-disable-line react/prefer-es6-class
+const Page = React.createClass( {
 	propTypes: {
 		// connected via updatePostStatus
 		buildUpdateTemplate: PropTypes.func.isRequired,


### PR DESCRIPTION
~Branch based on [`fix/pages-popover-highlight`](https://github.com/Automattic/wp-calypso/pull/15152). [See direct diff](https://github.com/Automattic/wp-calypso/compare/fix/pages-popover-highlight...remove/update-post-status-mixin?expand=1).~ [merged]

# Why

- We'd like Calypso to be free of mixins soon-ish, and a few of these can be replaced with analogous higher-order components (HoC).
- Pages is crumbling under tech debt; mixin usage is just a sliver, but entangling it from `mixins/update-post-status` is a step in the right direction.

# Reviewing

Right now, CI is *not* happy about the non-namespaced usage of `className`. This PR is large as it is; I'm not sure that that work, which would include making sure no CSS rule is affected throughout our assets, should be covered by it.

# Testing

In `/pages`, across its different tabs (published, draft, scheduled, trash), make sure that page actions (via the ellipsis button) work the same way as before. Example:
- Trashing a page successfully
- Undoing that action
- Trashing it again, without undoing
- Navigating to Trash
- Restoring it
- Trashing again + actually deleting
- etc.