### PR TITLE
Enable button to open post preview in a new tab.

### DIFF
--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -106,7 +106,7 @@ const EditorPreview = React.createClass( {
 					? <WebPreviewContent
 							showPreview={ this.props.showPreview }
 							showEdit={ true }
-							showExternal={ false }
+							showExternal={ true }
 							defaultViewportDevice={ this.props.defaultViewportDevice }
 							onClose={ this.props.onClose }
 							onEdit={ this.props.onEdit }


### PR DESCRIPTION
This PR enables a button on the preview toolbar in the post-publish preview flow to open the post preview in a new browser tab.

![open-in-tab](https://user-images.githubusercontent.com/1017839/27194089-99531c10-5201-11e7-841c-c289c2ecf0bd.png)

This PR is part of a larger epic, see p8F9tW-3F-p2.

To Test:

- Checkout this branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Draft a new post
- Publish the post
- Verify that a button to open the post preview in an external browser tab is present, and it behaves as expected