### PR TITLE
Change payments settings edit button text based on enabled

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -90,7 +90,7 @@ class PaymentMethodItem extends Component {
 		const { method, translate } = this.props;
 		let editButtonText = translate( 'Set up' );
 		if ( method.settings.enabled.value === 'yes' ) {
-			editButtonText = translate( 'Settings' );
+			editButtonText = translate( 'Manage' );
 		}
 		if ( currentlyEditingId === method.id ) {
 			editButtonText = translate( 'Cancel' );

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -89,6 +89,9 @@ class PaymentMethodItem extends Component {
 			this.props.currentlyEditingMethod.id;
 		const { method, translate } = this.props;
 		let editButtonText = translate( 'Set up' );
+		if ( method.settings.enabled.value === 'yes' ) {
+			editButtonText = translate( 'Settings' );
+		}
 		if ( currentlyEditingId === method.id ) {
 			editButtonText = translate( 'Cancel' );
 		}


### PR DESCRIPTION
To test:  http://calypso.localhost:3000/store/settings/payments/{site}

Observe button text on a enabled and a not enabled payment method.

There is a bug on enabling/disabling payment methods that is fix in another PR.