### PR TITLE
Magic Login: Fix footer link

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -16,6 +16,7 @@ import {
 	CHECK_YOUR_EMAIL_PAGE,
 	INTERSTITIAL_PAGE,
 	LINK_EXPIRED_PAGE,
+	REQUEST_FORM,
 } from 'state/login/magic-login/constants';
 import {
 	getMagicLoginEmailAddressFormInput,
@@ -91,7 +92,7 @@ class MagicLogin extends React.Component {
 		return (
 			<Main className={ {
 				'magic-login': true,
-				'magic-login__request_link': ! magicLoginView,
+				'magic-login__request_link': ! magicLoginView || magicLoginView === REQUEST_FORM,
 			} }>
 				<PageViewTracker path="/login" title="Login" />
 


### PR DESCRIPTION
## This fixes:

Start at http://calypso.localhost:3000/log-in & clicking `Email me a login link`, the footer link on the next screen extends past the card.

If you refresh the page or just go directly to http://calypso.localhost:3000/log-in/link it looks fine.

## How
This applies the required narrow wrapper class when the view in state is not set _or_ is set to the appropriate value.

| Before | After |
| ------- | ------|
| <img width="736" alt="screen shot 2017-06-14 at 14 28 48" src="https://user-images.githubusercontent.com/1587282/27196355-1f8c4e20-51d8-11e7-9e93-2ed3e058f3e1.png"> | <img width="750" alt="screen shot 2017-06-14 at 14 28 59" src="https://user-images.githubusercontent.com/1587282/27196366-2615d450-51d8-11e7-9f7e-5d479a3a2345.png"> |

## To Test

Start at http://calypso.localhost:3000/log-in & click `Email me a login link`, the footer link on the next screen should be aligned below the card.