### PR TITLE
Woo: Add success/failure actions for overall action list

### DIFF
--- a/client/extensions/woocommerce/state/action-list/README.md
+++ b/client/extensions/woocommerce/state/action-list/README.md
@@ -26,14 +26,18 @@ which are objects that describe each sequential step in the list. Using the abov
 example, this could look like:
 
 ```
-[
-  { description: "Creating product: super-awesome thing", action: { ... } },
-  { description: "Creating super-awesome thing variation: small", action: { ... } },
-  { description: "Creating super-awesome thing variation: large", action: { ... } }
-]
+{
+  steps: [
+    { description: "Creating product: super-awesome thing", action: { ... } },
+    { description: "Creating super-awesome thing variation: small", action: { ... } },
+    { description: "Creating super-awesome thing variation: large", action: { ... } }
+  ]
+  successAction: { type: 'MY_SUCCESS_ACTION' },
+  failureAction: { type: 'MY_FAILURE_ACTION' },
+}
 ```
 
-Note: Actions in the state list should not contain functions or anything not serializable,
+Note: Actions in the action list should not contain functions or anything else not serializable,
 due to the fact that the action list is stored in state.
 
 
@@ -90,7 +94,9 @@ step is started. If this is the last step, then no further action is taken.
 #### Action List Complete
 
 The entire list is considered done either when all steps have been ended
-successfully, or when an error is logged on a step.
+successfully, or when an error is logged on a step. When this occurs, if the
+`successAction` or `failureAction` is designated, the appropriate one will be
+dispatched at the end of action list processing.
 
 #### Action List Clear
 

--- a/client/extensions/woocommerce/state/action-list/README.md
+++ b/client/extensions/woocommerce/state/action-list/README.md
@@ -34,6 +34,7 @@ example, this could look like:
   ]
   successAction: { type: 'MY_SUCCESS_ACTION' },
   failureAction: { type: 'MY_FAILURE_ACTION' },
+  clearUponComplete: true,
 }
 ```
 
@@ -101,6 +102,7 @@ dispatched at the end of action list processing.
 #### Action List Clear
 
 This action will clear the current action list from the application state.
+This happens automatically if `clearUponComplete` is set to true.
 
 
 ## Questions

--- a/client/extensions/woocommerce/state/action-list/reducer.js
+++ b/client/extensions/woocommerce/state/action-list/reducer.js
@@ -30,7 +30,7 @@ function handleActionListAnnotate( actionList, action ) {
 
 	if ( undefined !== typeof stepIndex ) {
 		const { startTime, endTime, error } = annotations;
-		const step = actionList[ stepIndex ];
+		const step = actionList.steps[ stepIndex ];
 
 		const newStep = { ...step };
 
@@ -44,9 +44,9 @@ function handleActionListAnnotate( actionList, action ) {
 			newStep.error = error;
 		}
 
-		const newActionList = { ...actionList };
-		newActionList[ stepIndex ] = newStep;
-		return newActionList;
+		const newSteps = { ...actionList.steps };
+		newSteps[ stepIndex ] = newStep;
+		return { ...actionList, steps: newSteps };
 	}
 
 	return actionList;

--- a/client/extensions/woocommerce/state/action-list/selectors.js
+++ b/client/extensions/woocommerce/state/action-list/selectors.js
@@ -24,15 +24,17 @@ export function getActionList( rootState ) {
  * @return {Number|null} The index of the current step, or actionList.length if all steps are complete,
  */
 export function getCurrentStepIndex( actionList ) {
-	for ( let i = 0; i < actionList.length; i++ ) {
-		const step = actionList[ i ];
+	const { steps } = actionList;
+
+	for ( let i = 0; i < steps.length; i++ ) {
+		const step = steps[ i ];
 		if ( ! step.endTime ) {
 			return i;
 		}
 	}
 
 	// All steps complete
-	return actionList.length;
+	return steps.length;
 }
 
 /**
@@ -43,6 +45,6 @@ export function getCurrentStepIndex( actionList ) {
  */
 export function getStepCountRemaining( actionList ) {
 	const currentIndex = getCurrentStepIndex( actionList );
-	return actionList.length - currentIndex;
+	return actionList.steps.length - currentIndex;
 }
 

--- a/client/extensions/woocommerce/state/action-list/test/reducer.js
+++ b/client/extensions/woocommerce/state/action-list/test/reducer.js
@@ -20,11 +20,15 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should create an action list', () => {
-		const actionList = [
-			{ description: 'Do Step 1', action: { type: '%%1%%', id: 1 } },
-			{ description: 'Do Step 2', action: { type: '%%2%%', id: 2 } },
-			{ description: 'Do Step 3', action: { type: '%%3%%', id: 3 } },
-		];
+		const actionList = {
+			steps: [
+				{ description: 'Do Step 1', action: { type: '%%1%%', id: 1 } },
+				{ description: 'Do Step 2', action: { type: '%%2%%', id: 2 } },
+				{ description: 'Do Step 3', action: { type: '%%3%%', id: 3 } },
+			],
+			successAction: { type: '%%SUCCESS%%' },
+			failureAction: { type: '%%FAILURE%%' },
+		};
 
 		expect( reducer( undefined, actionListCreate( actionList ) ) ).to.equal( actionList );
 	} );
@@ -34,30 +38,36 @@ describe( 'reducer', () => {
 		const step0End = Date.now();
 		const step0Error = 'This is an error';
 
-		const actionList = [
-			{ description: 'Do Step 1', action: { type: '%%1%%', id: 1 } },
-			{ description: 'Do Step 2', action: { type: '%%2%%', id: 2 } },
-			{ description: 'Do Step 3', action: { type: '%%3%%', id: 3 } },
-		];
+		const actionList = {
+			steps: [
+				{ description: 'Do Step 1', action: { type: '%%1%%', id: 1 } },
+				{ description: 'Do Step 2', action: { type: '%%2%%', id: 2 } },
+				{ description: 'Do Step 3', action: { type: '%%3%%', id: 3 } },
+			],
+		};
 
 		const state1 = reducer( undefined, actionListCreate( actionList ) );
 		const state2 = reducer( state1, actionListStepAnnotate( 0, { startTime: step0Start } ) );
 		const state3 = reducer( state2, actionListStepAnnotate( 0, { endTime: step0End, error: step0Error } ) );
 
 		expect( state1 ).to.equal( actionList );
-		expect( state2[ 0 ].startTime ).to.equal( step0Start );
-		expect( state2[ 0 ].endTime ).to.not.exist;
-		expect( state3[ 0 ].startTime ).to.equal( step0Start );
-		expect( state3[ 0 ].endTime ).to.equal( step0End );
-		expect( state3[ 0 ].error ).to.equal( step0Error );
+		expect( state2.steps[ 0 ].startTime ).to.equal( step0Start );
+		expect( state2.steps[ 0 ].endTime ).to.not.exist;
+		expect( state3.steps[ 0 ].startTime ).to.equal( step0Start );
+		expect( state3.steps[ 0 ].endTime ).to.equal( step0End );
+		expect( state3.steps[ 0 ].error ).to.equal( step0Error );
 	} );
 
 	it( 'should clear the actionList', () => {
-		const actionList = [
-			{ description: 'Do Step 1', operation: { name: 'doStepOne', id: 1 } },
-			{ description: 'Do Step 2', operation: { name: 'doStepTwo', id: 2 } },
-			{ description: 'Do Step 3', operation: { name: 'doStepThree', id: 3 } },
-		];
+		const actionList = {
+			steps: [
+				{ description: 'Do Step 1', operation: { name: 'doStepOne', id: 1 } },
+				{ description: 'Do Step 2', operation: { name: 'doStepTwo', id: 2 } },
+				{ description: 'Do Step 3', operation: { name: 'doStepThree', id: 3 } },
+			],
+			successAction: { type: '%%SUCCESS%%' },
+			failureAction: { type: '%%FAILURE%%' },
+		};
 
 		const state1 = reducer( undefined, actionListCreate( actionList ) );
 		const state2 = reducer( state1, actionListClear() );

--- a/client/extensions/woocommerce/state/action-list/test/selectors.js
+++ b/client/extensions/woocommerce/state/action-list/test/selectors.js
@@ -16,11 +16,13 @@ import {
 describe( 'selectors', () => {
 	describe( 'getActionList', () => {
 		it( 'should access an existing action list', () => {
-			const actionList = [
-				{ description: 'Action Step 1', action: { type: 'ACTION1' } },
-				{ description: 'Action Step 2', action: { type: 'ACTION2' } },
-				{ description: 'Action Step 3', action: { type: 'ACTION3' } },
-			];
+			const actionList = {
+				steps: [
+					{ description: 'Action Step 1', action: { type: 'ACTION1' } },
+					{ description: 'Action Step 2', action: { type: 'ACTION2' } },
+					{ description: 'Action Step 3', action: { type: 'ACTION3' } },
+				],
+			};
 
 			const rootState = {};
 			set( rootState, 'extensions.woocommerce.actionList', actionList );
@@ -41,13 +43,17 @@ describe( 'selectors', () => {
 			const threeSecondsAgo = Date.now() - 3000;
 			const twoSecondsAgo = Date.now() - 2000;
 
-			const actionList = [
-				{ description: 'Action Step 1', action: { type: 'ACTION1' },
-					startTime: fiveSecondsAgo, endTime: threeSecondsAgo },
-				{ description: 'Action Step 2', action: { type: 'ACTION2' },
-					startTime: twoSecondsAgo },
-				{ description: 'Action Step 3', action: { type: 'ACTION3' } },
-			];
+			const actionList = {
+				steps: [
+					{ description: 'Action Step 1', action: { type: 'ACTION1' },
+						startTime: fiveSecondsAgo, endTime: threeSecondsAgo },
+					{ description: 'Action Step 2', action: { type: 'ACTION2' },
+						startTime: twoSecondsAgo },
+					{ description: 'Action Step 3', action: { type: 'ACTION3' } },
+				],
+				successAction: { type: '%%SUCCESS%%' },
+				failureAction: { type: '%%FAILURE%%' },
+			};
 
 			expect( getCurrentStepIndex( actionList ) ).to.equal( 1 );
 		} );
@@ -58,21 +64,27 @@ describe( 'selectors', () => {
 			const twoSecondsAgo = Date.now() - 2000;
 			const oneSecondAgo = Date.now() - 1000;
 
-			const actionList = [
-				{ description: 'Action Step 1', action: { type: 'ACTION1' },
-					startTime: fiveSecondsAgo, endTime: threeSecondsAgo },
-				{ description: 'Action Step 2', action: { type: 'ACTION2' },
-					startTime: twoSecondsAgo, endTime: oneSecondAgo },
-			];
+			const actionList = {
+				steps: [
+					{ description: 'Action Step 1', action: { type: 'ACTION1' },
+						startTime: fiveSecondsAgo, endTime: threeSecondsAgo },
+					{ description: 'Action Step 2', action: { type: 'ACTION2' },
+						startTime: twoSecondsAgo, endTime: oneSecondAgo },
+				],
+				successAction: { type: '%%SUCCESS%%' },
+				failureAction: { type: '%%FAILURE%%' },
+			};
 
-			expect( getCurrentStepIndex( actionList ) ).to.equal( actionList.length );
+			expect( getCurrentStepIndex( actionList ) ).to.equal( actionList.steps.length );
 		} );
 
 		it( 'should return first step if no steps have been started', () => {
-			const actionList = [
-				{ description: 'Action Step 1', action: { type: 'ACTION1' } },
-				{ description: 'Action Step 2', action: { type: 'ACTION2' } },
-			];
+			const actionList = {
+				steps: [
+					{ description: 'Action Step 1', action: { type: 'ACTION1' } },
+					{ description: 'Action Step 2', action: { type: 'ACTION2' } },
+				],
+			};
 
 			expect( getCurrentStepIndex( actionList ) ).to.equal( 0 );
 		} );
@@ -80,24 +92,28 @@ describe( 'selectors', () => {
 
 	describe( 'getStepCountRemaining', () => {
 		it( 'should return array length if no steps have been started', () => {
-			const actionList = [
-				{ description: 'Action Step 1', action: { type: 'ACTION1' } },
-				{ description: 'Action Step 2', action: { type: 'ACTION2' } },
-			];
+			const actionList = {
+				steps: [
+					{ description: 'Action Step 1', action: { type: 'ACTION1' } },
+					{ description: 'Action Step 2', action: { type: 'ACTION2' } },
+				],
+			};
 
-			expect( getStepCountRemaining( actionList ) ).to.equal( actionList.length );
+			expect( getStepCountRemaining( actionList ) ).to.equal( actionList.steps.length );
 		} );
 
 		it( 'should return array length if no steps have been yet completed', () => {
 			const fiveSecondsAgo = Date.now() - 5000;
 
-			const actionList = [
-				{ description: 'Action Step 1', action: { type: 'ACTION1' },
-					startTime: fiveSecondsAgo },
-				{ description: 'Action Step 2', action: { type: 'ACTION2' } },
-			];
+			const actionList = {
+				steps: [
+					{ description: 'Action Step 1', action: { type: 'ACTION1' },
+						startTime: fiveSecondsAgo },
+					{ description: 'Action Step 2', action: { type: 'ACTION2' } },
+				],
+			};
 
-			expect( getStepCountRemaining( actionList ) ).to.equal( actionList.length );
+			expect( getStepCountRemaining( actionList ) ).to.equal( actionList.steps.length );
 		} );
 
 		it( 'should return zero if all steps are completed', () => {
@@ -106,12 +122,16 @@ describe( 'selectors', () => {
 			const twoSecondsAgo = Date.now() - 2000;
 			const oneSecondAgo = Date.now() - 1000;
 
-			const actionList = [
-				{ description: 'Action Step 1', action: { type: 'ACTION1' },
-					startTime: fiveSecondsAgo, endTime: threeSecondsAgo },
-				{ description: 'Action Step 2', action: { type: 'ACTION2' },
-					startTime: twoSecondsAgo, endTime: oneSecondAgo },
-			];
+			const actionList = {
+				steps: [
+					{ description: 'Action Step 1', action: { type: 'ACTION1' },
+						startTime: fiveSecondsAgo, endTime: threeSecondsAgo },
+					{ description: 'Action Step 2', action: { type: 'ACTION2' },
+						startTime: twoSecondsAgo, endTime: oneSecondAgo },
+				],
+				successAction: { type: '%%SUCCESS%%' },
+				failureAction: { type: '%%FAILURE%%' },
+			};
 
 			expect( getStepCountRemaining( actionList ) ).to.equal( 0 );
 		} );

--- a/client/extensions/woocommerce/state/data-layer/action-list/index.js
+++ b/client/extensions/woocommerce/state/data-layer/action-list/index.js
@@ -9,7 +9,11 @@ const debug = debugFactor( 'woocommerce:action-list' );
  * Internal dependencies
  */
 import { getActionList, getCurrentStepIndex } from 'woocommerce/state/action-list/selectors';
-import { actionListStepAnnotate, actionListStepNext } from 'woocommerce/state/action-list/actions';
+import {
+	actionListClear,
+	actionListStepAnnotate,
+	actionListStepNext,
+} from 'woocommerce/state/action-list/actions';
 import {
 	WOOCOMMERCE_ACTION_LIST_STEP_NEXT,
 	WOOCOMMERCE_ACTION_LIST_STEP_SUCCESS,
@@ -49,6 +53,9 @@ export function handleStepSuccess( { dispatch, getState }, action ) {
 		if ( actionList.successAction ) {
 			dispatch( actionList.successAction );
 		}
+		if ( actionList.clearUponComplete ) {
+			dispatch( actionListClear() );
+		}
 	}
 }
 
@@ -62,6 +69,9 @@ export function handleStepFailure( { dispatch, getState }, action ) {
 	dispatch( actionListStepAnnotate( stepIndex, { endTime, error } ) );
 	if ( actionList.failureAction ) {
 		dispatch( actionList.failureAction );
+	}
+	if ( actionList.clearUponComplete ) {
+		dispatch( actionListClear() );
 	}
 }
 

--- a/client/extensions/woocommerce/state/data-layer/action-list/index.js
+++ b/client/extensions/woocommerce/state/data-layer/action-list/index.js
@@ -20,7 +20,7 @@ export function handleStepNext( { dispatch, getState }, action ) {
 	const startTime = action.time || Date.now();
 	const actionList = getActionList( getState() );
 	const stepIndex = getCurrentStepIndex( actionList );
-	const step = actionList[ stepIndex ];
+	const step = actionList.steps[ stepIndex ];
 
 	if ( step.startTime ) {
 		debug( `WOOCOMMERCE_ACTION_LIST_STEP_NEXT dispatched twice for step ${ stepIndex }` );
@@ -40,17 +40,29 @@ export function handleStepSuccess( { dispatch, getState }, action ) {
 
 	dispatch( actionListStepAnnotate( stepIndex, { endTime } ) );
 
-	if ( nextStepIndex < actionList.length ) {
+	if ( nextStepIndex < actionList.steps.length ) {
 		// Still more work to do.
 		dispatch( actionListStepNext( action.time ) );
+	} else {
+		// All done!
+		debug( `Action List Success. ${ actionList.steps.length } steps completed.` );
+		if ( actionList.successAction ) {
+			dispatch( actionList.successAction );
+		}
 	}
 }
 
 export function handleStepFailure( { dispatch, getState }, action ) {
 	const { stepIndex, time, error } = action;
+	const actionList = getActionList( getState() );
 	const endTime = time || Date.now();
 
+	debug( `Action List Failed on step ${ stepIndex } with error: ${ error }` );
+
 	dispatch( actionListStepAnnotate( stepIndex, { endTime, error } ) );
+	if ( actionList.failureAction ) {
+		dispatch( actionList.failureAction );
+	}
 }
 
 export default {

--- a/client/extensions/woocommerce/state/data-layer/action-list/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/action-list/test/index.js
@@ -27,9 +27,11 @@ describe( 'handlers', () => {
 			const rootState = {
 				extensions: {
 					woocommerce: {
-						actionList: [
-							{ description: 'Step 1', action: step1Action },
-						],
+						actionList: {
+							steps: [
+								{ description: 'Step 1', action: step1Action },
+							],
+						}
 					}
 				}
 			};
@@ -54,10 +56,12 @@ describe( 'handlers', () => {
 			const rootState = {
 				extensions: {
 					woocommerce: {
-						actionList: [
-							{ description: 'Step 1', action: { type: '%%1%%' } },
-							{ description: 'Step 2', action: { type: '%%2%%' } },
-						],
+						actionList: {
+							steps: [
+								{ description: 'Step 1', action: { type: '%%1%%' } },
+								{ description: 'Step 2', action: { type: '%%2%%' } },
+							],
+						}
 					}
 				}
 			};
@@ -83,15 +87,22 @@ describe( 'handlers', () => {
 			const step2Start = Date.now() - 100;
 			const step2End = Date.now();
 
+			const successAction = { type: '%%SUCCESS%%' };
+			const failureAction = { type: '%%FAILURE%%' };
+
 			const rootState = {
 				extensions: {
 					woocommerce: {
-						actionList: [
-							{ description: 'Step 1', action: { type: '%%1%%' },
-								startTime: step1Start, endTime: step1End },
-							{ description: 'Step 2', action: { type: '%%2%%' },
-								startTime: step2Start },
-						],
+						actionList: {
+							steps: [
+								{ description: 'Step 1', action: { type: '%%1%%' },
+									startTime: step1Start, endTime: step1End },
+								{ description: 'Step 2', action: { type: '%%2%%' },
+									startTime: step2Start },
+							],
+							successAction,
+							failureAction,
+						}
 					}
 				}
 			};
@@ -110,18 +121,26 @@ describe( 'handlers', () => {
 			expect( store.dispatch ).to.have.been.called.once;
 			expect( store.dispatch ).to.have.been.calledWith( annotationAction );
 			expect( store.dispatch ).to.not.have.been.calledWith( stepNextAction );
+			expect( store.dispatch ).to.have.been.calledWith( successAction );
 		} );
 	} );
 
 	describe( '#handleStepFailure', () => {
 		it( 'should annotate endTime and error', () => {
+			const successAction = { type: '%%SUCCESS%%' };
+			const failureAction = { type: '%%FAILURE%%' };
+
 			const rootState = {
 				extensions: {
 					woocommerce: {
-						actionList: [
-							{ description: 'Step 1', action: { type: '%%1%%' } },
-							{ description: 'Step 2', action: { type: '%%2%%' } },
-						],
+						actionList: {
+							steps: [
+								{ description: 'Step 1', action: { type: '%%1%%' } },
+								{ description: 'Step 2', action: { type: '%%2%%' } },
+							],
+							successAction,
+							failureAction,
+						}
 					}
 				}
 			};
@@ -138,6 +157,7 @@ describe( 'handlers', () => {
 			handleStepFailure( store, action );
 
 			expect( store.dispatch ).to.have.been.calledWith( annotationAction );
+			expect( store.dispatch ).to.have.been.calledWith( failureAction );
 		} );
 	} );
 } );


### PR DESCRIPTION
This adds success/failure actions for the overall action list.
They are fired at the conclusion of the action list execution.

To test: `npm test`