### PR TITLE
Fixes cancel editing payment method by calling correct function

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import {
+	cancelEditingPaymentMethod,
 	changePaymentMethodField,
 	closeEditingPaymentMethod,
 	openPaymentMethodForEdit,
@@ -25,6 +26,7 @@ import { savePaymentMethod } from 'woocommerce/state/sites/payment-methods/actio
 
 class PaymentMethodItem extends Component {
 	static propTypes = {
+		cancelEditingPaymentMethod: PropTypes.func.isRequired,
 		closeEditingPaymentMethod: PropTypes.func.isRequired,
 		currentlyEditingId: PropTypes.string,
 		currentlyEditingMethod: PropTypes.shape( {
@@ -53,7 +55,7 @@ class PaymentMethodItem extends Component {
 	};
 
 	onCancel = () => {
-		this.props.closeEditingPaymentMethod( this.props.site.ID, this.props.method.id );
+		this.props.cancelEditingPaymentMethod( this.props.site.ID, this.props.method.id );
 	}
 
 	onEdit = () => {
@@ -147,6 +149,7 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
+			cancelEditingPaymentMethod,
 			changePaymentMethodField,
 			closeEditingPaymentMethod,
 			openPaymentMethodForEdit,


### PR DESCRIPTION
To test: http://calypso.localhost:3000/store/settings/payments/{site}

- Open a payment method edit
- Make changes to title
- Click cancel button
- Observe that title did not change