### PR TITLE
Plugins: Fix wporg query plugins request

### DIFF
--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -86,7 +86,7 @@ module.exports = {
 			'&request[fields][requires]=0&request[fields][sections]=0';
 
 		if ( options.search ) {
-			payload += '&request[search]=' + options.search + '*';
+			payload += '&request[search]=' + options.search;
 		} else {
 			payload += '&request[browse]=' + options.category;
 		}


### PR DESCRIPTION

GET requests to https://api.wordpress.org/plugins/info/1.1/?action=query_plugins
no longer require a `*` wildcard.

To test:
- checkout this branch and go to calypso.localhost:3000/plugins/browse/$site
- where $site is a jetpack site
- trying searching for terms like 'calendar', 'mailchimp', or 'woo'
- ensure that relevant plugins come back

