### PR TITLE
Analytics: add method to assign AB test variations by userid

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -35,6 +35,7 @@ There are also several optional configuration settings available:
 * `localeTargets` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `localeTargets` to 'any', or to an array of a specific locale or locales  `localeTargets: ['de']`
 Don't forget: any test that runs for locales other than English means strings will need to be translated.
 * `countryCodeTarget` - Only run tests for users from a specific country. You'll need to pass the current user country to the abtest method when calling it.
+* `assignmentMethod` - By default, test variations are assigned using a random number generator. You can also assign test variations using the 'userId'. Using the userId to assign test variations will still assign a random assignment; however, it ensures the user is assigned the same assignment in the event their local storage gets cleared or is compromised. This includes cases where they manually clear their local storage, use multiple devices, or use an incognito window (storageless browser). This assignment method should not be used if a user does not have a userId by the time the AB test starts.
 
 Next, in your code, import the `abtest` method from the `abtest` module:
 
@@ -63,7 +64,7 @@ You should keep the translation comment to make it clear to people reading the c
 
 When this code runs the first time, we'll fire a `calypso_abtest_start` Tracks event with two properties: `abtest_name` and `abtest_variation`. This information is used by Tracks to help you analyze the impact of your test. For logged-in users, this event is fired via POST request to the `/me/abtest` endpoint and can be seen in a browser's network tab. For logged-out users, this event is fired via the [analytics.tracks.recordEvent method](https://github.com/Automattic/wp-calypso/tree/master/client/lib/analytics#tracks-api) and can be seen by watching the `calypso:analytics` string via [the debug module](https://github.com/Automattic/wp-calypso/blob/master/.github/CONTRIBUTING.md#debugging). The event is fired when there is no variant stored for a given test in localStorage. So you can trigger the event again by removing the record from localStorage.
 
-Also, the user's variation is saved in local storage. You can see this in Chrome's dev tools by going to Resources > Local Storage > Calypso URL and viewing the `ABTests` key. If you'd like to force a specific variation while testing, you can simply change the value for your particular test then reload the page. In the example above, you'd change the value for `freeTrialButtonWording_20150216` to either `startFreeTrial` or `beginYourFreeTrial`.
+Also, the user's variation is saved in local storage. You can see this in Chrome's dev tools by going to Application > Local Storage > Calypso URL and viewing the `ABTests` key. If you'd like to force a specific variation while testing, you can simply change the value for your particular test then reload the page. In the example above, you'd change the value for `freeTrialButtonWording_20150216` to either `startFreeTrial` or `beginYourFreeTrial`.
 
 Here's another example with country targeting:
 ```jsx

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -5,6 +5,7 @@ import debugFactory from 'debug';
 import { includes, keys, reduce, some, map, every, isArray } from 'lodash';
 import store from 'store';
 import i18n from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -80,6 +81,7 @@ ABTest.prototype.init = function( name, geoLocation ) {
 	}
 
 	const variationDetails = testConfig.variations;
+	const assignmentMethod = ( typeof testConfig.assignmentMethod !== 'undefined' ) ? testConfig.assignmentMethod : 'default';
 	const variationNames = keys( variationDetails );
 	if ( ! variationDetails || variationNames.length === 0 ) {
 		throw new Error( 'No A/B test variations found for ' + name );
@@ -115,6 +117,7 @@ ABTest.prototype.init = function( name, geoLocation ) {
 	this.variationDetails = variationDetails;
 	this.defaultVariation = testConfig.defaultVariation;
 	this.variationNames = variationNames;
+	this.assignmentMethod = assignmentMethod;
 	this.experimentId = name + '_' + variationDatestamp;
 
 	if ( testConfig.countryCodeTarget ) {
@@ -232,14 +235,19 @@ ABTest.prototype.getSavedVariation = function() {
 };
 
 ABTest.prototype.assignVariation = function() {
-	let variationName;
+	let variationName, randomAllocationAmount;
 	let sum = 0;
 
+	const userId = get( user, 'data.ID' );
 	const allocationsTotal = reduce( this.variationDetails, ( allocations, allocation ) => {
 		return allocations + allocation;
 	}, 0 );
 
-	const randomAllocationAmount = Math.random() * allocationsTotal;
+	if ( this.assignmentMethod === 'userId' && ! isNaN( +userId ) ) {
+		randomAllocationAmount = Number( user.data.ID ) % allocationsTotal;
+	} else {
+		randomAllocationAmount = Math.random() * allocationsTotal;
+	}
 
 	for ( variationName in this.variationDetails ) {
 		sum += this.variationDetails[ variationName ];


### PR DESCRIPTION
# The problem

By default, AB test variations are assigned using a random number generator. This works when we don't expect any problems with the user's local storage. If the saved test variation cannot be retrieved, we reassign the user a test variation, but **the user may be given a different test variation**. We have observed some AB tests experiencing up to 30% of the users being assigned different test variations.

# Assigning test variation with userid

Using the userid to assign test variations will still assign a random assignment; however, it ensures the user is assigned the same assignment in the event their local storage gets cleared or is compromised. This includes:

- manually clearing local storage
- using multiple devices
- using an incognito window (storageless browser)

This assignment method should not be used if a user does not have a userid by the time the AB test starts.