### PR TITLE
Editor: Update privately published success message.

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -134,6 +134,15 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'publishedPrivately':
+				if ( config.isEnabled( 'post-editor/delta-post-publish-preview' ) ) {
+					return translate( '{{strong}}Privately published.{{/strong}} Only admins and editors can view.', {
+						components: {
+							strong: <strong />,
+						},
+						comment: 'Editor: Message displayed when a post is published privately.',
+					} );
+				}
+
 				if ( ! site ) {
 					if ( 'page' === type ) {
 						return translate( 'Page privately published!' );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -135,7 +135,7 @@ export class EditorNotice extends Component {
 
 			case 'publishedPrivately':
 				if ( config.isEnabled( 'post-editor/delta-post-publish-preview' ) ) {
-					return translate( '{{strong}}Privately published.{{/strong}} Only admins and editors can view.', {
+					return translate( '{{strong}}Published privately.{{/strong}} Only admins and editors can view.', {
 						components: {
 							strong: <strong />,
 						},


### PR DESCRIPTION
This PR updates the success message for privately published posts and pages to be more descriptive of who can view the content. Behind `post-editor/delta-post-publish-preview` flag.

**Mock:**
<img width="1022" alt="screencapture_at_tue_jun_13_09_52_27_edt_2017" src="https://user-images.githubusercontent.com/942359/27200276-32d1b3c6-51e7-11e7-87f1-8e2dc15902b5.png">

This is part of a larger epic (See p3Ex-2ri-p2).

**To Test:**
- Check out branch
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Privately publish a post.
- After the post is published, a full-screen view of the post should be displayed with a success message: "**Published privately.** Only admins and editors can view."