### PR TITLE
PostShare: Improve upgrade information in function of the current plan

### DIFF
--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import PostShare from 'blocks/post-share';
 import QueryPosts from 'components/data/query-posts';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { getSite } from 'state/sites/selectors';
+import { getSite, getSitePlanSlug } from 'state/sites/selectors';
 import { getSitePosts } from 'state/posts/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import Card from 'components/card';
@@ -27,7 +27,7 @@ class PostShareExample extends Component {
 	toggleEnable = () => this.setState( { isEnabled: ! this.state.isEnabled } );
 
 	render() {
-		const { post, site, siteId } = this.props;
+		const { planSlug, post, site, siteId } = this.props;
 
 		return (
 			<div>
@@ -39,8 +39,13 @@ class PostShareExample extends Component {
 						query={ { number: 1, type: 'post' } } />
 				) }
 
-				{ site && <p>Site: <strong>{ site.name }</strong> ({ siteId })</p> }
-				{ post && <p>Post: <em>{ post.title }</em></p> }
+				{ site &&
+					<p>
+						Site: <strong>{ site.name }</strong> ({ siteId })<br />
+						Plan: <strong>{ planSlug }</strong><br />
+						Post: <em>{ post.title }</em><br />
+					</p>
+				}
 
 				<p onClick={ this.toggleEnable }>
 					<label>Enabled: <FormToggle checked={ this.state.isEnabled } /></label>
@@ -71,9 +76,11 @@ const ConnectedPostShareExample = connect( ( state ) => {
 	const site = getSite( state, siteId );
 	const posts = getSitePosts( state, siteId );
 	const post = posts && posts[ posts.length - 1 ];
+	const planSlug = getSitePlanSlug( state, siteId );
 
 	return {
 		siteId,
+		planSlug,
 		post,
 		site,
 	};

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -25,8 +25,9 @@ class PostShareExample extends Component {
 	};
 
 	toggleEnable = () => this.setState( { isEnabled: ! this.state.isEnabled } );
+
 	render() {
-		const { post = {}, site, siteId } = this.props;
+		const { post, site, siteId } = this.props;
 
 		return (
 			<div>
@@ -47,6 +48,7 @@ class PostShareExample extends Component {
 
 				{ this.state.isEnabled && <Notice
 					status="is-warning"
+					showDismiss={ false }
 					text={ `Keep in mind that you are able to share the '${ post.title }' post now. Be careful!` } />
 				}
 

--- a/client/blocks/post-share/docs/example.jsx
+++ b/client/blocks/post-share/docs/example.jsx
@@ -39,7 +39,7 @@ class PostShareExample extends Component {
 						query={ { number: 1, type: 'post' } } />
 				) }
 
-				{ site &&
+				{ site && post &&
 					<p>
 						Site: <strong>{ site.name }</strong> ({ siteId })<br />
 						Plan: <strong>{ planSlug }</strong><br />

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
 import QueryPostTypes from 'components/data/query-post-types';
 import QueryPosts from 'components/data/query-posts';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
+import { UpgradeToPersonalNudge } from 'blocks/post-share/nudges';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import NoticeAction from 'components/notice/notice-action';
@@ -423,7 +424,11 @@ class PostShare extends Component {
 	}
 
 	renderPrimarySection() {
-		const { hasFetchedConnections } = this.props;
+		const {
+			hasFetchedConnections,
+			hasRepublicizeFeature,
+			hasRepublicizeSchedulingFeature,
+		} = this.props;
 
 		if ( ! hasFetchedConnections ) {
 			return null;
@@ -437,6 +442,19 @@ class PostShare extends Component {
 					siteSlug,
 					translate,
 				} } />
+			);
+		}
+
+		if (
+			! hasRepublicizeFeature &&
+			! hasRepublicizeSchedulingFeature &&
+			isEnabled( 'publicize-scheduling' )
+		) {
+			return (
+				<div>
+					<UpgradeToPersonalNudge { ...this.props } />
+					<ActionsList { ...this.props } />
+				</div>
 			);
 		}
 

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -298,7 +298,7 @@ class PostShare extends Component {
 		);
 	}
 
-	renderUpgradeToGetSchedulingNudge() {
+	renderUpgradeToBusinessPlanNudge() {
 		if (
 			this.props.hasRepublicizeSchedulingFeature ||
 			! isEnabled( 'publicize-scheduling' )
@@ -498,7 +498,7 @@ class PostShare extends Component {
 					{ this.renderConnectionsSection() }
 				</div>
 
-				{ this.renderUpgradeToGetSchedulingNudge() }
+				{ this.renderUpgradeToBusinessPlanNudge() }
 				{ this.props.hasRepublicizeSchedulingFeature &&
 					<ActionsList
 						siteId={ siteId }

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -465,7 +465,7 @@ class PostShare extends Component {
 					{ this.renderConnectionsSection() }
 				</div>
 
-				<ActionsList { ...this.props } />
+				{ isEnabled( 'publicize-scheduling' ) && <ActionsList { ...this.props } /> }
 			</div>
 		);
 	}

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -55,7 +55,6 @@ import {
 	PLAN_BUSINESS,
 } from 'lib/plans/constants';
 
-import Banner from 'components/banner';
 import SharingPreviewModal from './sharing-preview-modal';
 import ConnectionsList, { NoConnectionsNotice } from './connections-list';
 
@@ -284,19 +283,6 @@ class PostShare extends Component {
 		);
 	}
 
-	renderUpgradeToGetPublicizeNudge() {
-		const { translate } = this.props;
-		return (
-			<Banner
-				className="post-share__upgrade-nudge"
-				feature="republicize"
-				title={ translate( 'Unlock the ability to re-share posts to social media' ) }
-				callToAction={ translate( 'Upgrade to Premium' ) }
-				description={ translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' ) }
-			/>
-		);
-	}
-
 	renderConnectionsWarning() {
 		const {
 			connections,
@@ -473,10 +459,6 @@ class PostShare extends Component {
 	render() {
 		if ( ! this.props.isPublicizeEnabled ) {
 			return null;
-		}
-
-		if ( ! this.props.hasRepublicizeFeature ) {
-			return this.renderUpgradeToGetPublicizeNudge();
 		}
 
 		const {

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -61,7 +61,6 @@ import ConnectionsList, { NoConnectionsNotice } from './connections-list';
 
 import ActionsList from './publicize-actions-list';
 import CalendarButton from 'blocks/calendar-button';
-import formatCurrency from 'lib/format-currency';
 
 import SectionHeader from 'components/section-header';
 import Tooltip from 'components/tooltip';
@@ -298,40 +297,6 @@ class PostShare extends Component {
 		);
 	}
 
-	renderUpgradeToBusinessPlanNudge() {
-		if (
-			this.props.hasRepublicizeSchedulingFeature ||
-			! isEnabled( 'publicize-scheduling' )
-		) {
-			return null;
-		}
-
-		const {
-			businessDiscountedRawPrice,
-			businessRawPrice,
-			translate,
-			userCurrency,
-		} = this.props;
-
-		return (
-			<Banner
-				className="post-share__footer-banner"
-				callToAction={
-					translate( 'Upgrade for %s', {
-						args: formatCurrency( businessDiscountedRawPrice || businessRawPrice, userCurrency ),
-						comment: '%s will be replaced by a formatted price, i.e $9.99'
-					} )
-				}
-				list={ [
-					translate( 'Schedule your social messages in advance.' ),
-					translate( 'Remove all advertising from your site.' ),
-					translate( 'Enjoy live chat support.' ),
-				] }
-				plan={ PLAN_BUSINESS }
-				title={ translate( 'Upgrade to a Business Plan!' ) } />
-		);
-	}
-
 	renderConnectionsWarning() {
 		const {
 			connections,
@@ -472,11 +437,13 @@ class PostShare extends Component {
 	}
 
 	renderPrimarySection() {
-		const { hasFetchedConnections, siteSlug, translate, siteId, postId } = this.props;
+		const { hasFetchedConnections } = this.props;
 
 		if ( ! hasFetchedConnections ) {
 			return null;
 		}
+
+		const { siteSlug, translate } = this.props;
 
 		if ( ! this.hasConnections() ) {
 			return (
@@ -498,12 +465,7 @@ class PostShare extends Component {
 					{ this.renderConnectionsSection() }
 				</div>
 
-				{ this.renderUpgradeToBusinessPlanNudge() }
-
-				<ActionsList
-					siteId={ siteId }
-					postId={ postId }
-				/>
+				<ActionsList { ...this.props } />
 			</div>
 		);
 	}

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -499,12 +499,11 @@ class PostShare extends Component {
 				</div>
 
 				{ this.renderUpgradeToBusinessPlanNudge() }
-				{ this.props.hasRepublicizeSchedulingFeature &&
-					<ActionsList
-						siteId={ siteId }
-						postId={ postId }
-					/>
-				}
+
+				<ActionsList
+					siteId={ siteId }
+					postId={ postId }
+				/>
 			</div>
 		);
 	}

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -96,6 +96,7 @@ class PostShare extends Component {
 	static defaultProps = {
 		connections: [],
 		disabled: false,
+		post: {},
 	};
 
 	state = {
@@ -579,6 +580,7 @@ export default connect(
 	( state, props ) => {
 		const { siteId } = props;
 		const postId = get( props, 'post.ID' );
+		const postType = get( props, 'post.type' );
 		const userId = getCurrentUserId( state );
 		const planSlug = getSitePlanSlug( state, siteId );
 
@@ -590,7 +592,7 @@ export default connect(
 			hasRepublicizeFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE ),
 			hasRepublicizeSchedulingFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE_SCHEDULING ),
 			siteSlug: getSiteSlug( state, siteId ),
-			isPublicizeEnabled: isPublicizeEnabled( state, siteId, props.post.type ),
+			isPublicizeEnabled: isPublicizeEnabled( state, siteId, postType ),
 			scheduling: isSchedulingPublicizeShareAction( state, siteId, postId ),
 			connections: getSiteUserConnections( state, siteId, userId ),
 			requesting: isRequestingSharePost( state, siteId, postId ),

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Banner from 'components/banner';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+import formatCurrency from 'lib/format-currency';
+
+export const UpgradeToPremiumNudge = props => {
+	const {
+		businessDiscountedRawPrice,
+		businessRawPrice,
+		translate,
+		userCurrency,
+	} = props;
+
+	return (
+		<Banner
+			className="post-share__actions-list-upgrade-nudge"
+			callToAction={
+				translate( 'Upgrade for %s', {
+					args: formatCurrency( businessDiscountedRawPrice || businessRawPrice, userCurrency ),
+					comment: '%s will be replaced by a formatted price, i.e $9.99'
+				} )
+			}
+			list={ [
+				translate( 'Schedule your social messages in advance.' ),
+				translate( 'Remove all advertising from your site.' ),
+				translate( 'Enjoy live chat support.' ),
+				translate( 'Ability to add features through external plugins.' ),
+				translate( 'Access to thousands of themes.' ),
+			] }
+			plan={ PLAN_BUSINESS }
+			title={ translate( 'Upgrade to a Business Plan!' ) } />
+	);
+};
+
+export const UpgradeToPersonalNudge = props => {
+	const { translate } = props;
+
+	return (
+		<Banner
+			className="post-share__upgrade-nudge"
+			feature="republicize"
+			title={ translate( 'Unlock the ability to re-share posts to social media' ) }
+			callToAction={ translate( 'Upgrade to Personal' ) }
+			description={ translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' ) }
+		/>
+	);
+};
+

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -102,7 +102,7 @@ class PublicizeActionsList extends PureComponent {
 		);
 	}
 
-	renderFooterSectionItem( item, index ) {
+	renderActionItem( item, index ) {
 		const {
 			service,
 			connectionName,
@@ -212,7 +212,7 @@ class PublicizeActionsList extends PureComponent {
 
 	renderActionsList = ( actions ) => (
 			<div>
-				{ actions.map( ( item, index ) => this.renderFooterSectionItem( item, index ) ) }
+				{ actions.map( ( item, index ) => this.renderActionItem( item, index ) ) }
 			</div>
 		);
 

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -68,7 +68,21 @@ class PublicizeActionsList extends PureComponent {
 		} );
 	};
 
-	renderUpgradeToBusinessPlanNudge() {
+	renderUpgradeToPremiumNudge() {
+		const { translate } = this.props;
+
+		return (
+			<Banner
+				className="post-share__upgrade-nudge"
+				feature="republicize"
+				title={ translate( 'Unlock the ability to re-share posts to social media' ) }
+				callToAction={ translate( 'Upgrade to Premium' ) }
+				description={ translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' ) }
+			/>
+		);
+	}
+
+	renderUpgradeToBusinessNudge() {
 		const {
 			businessDiscountedRawPrice,
 			businessRawPrice,
@@ -196,7 +210,7 @@ class PublicizeActionsList extends PureComponent {
 		if ( dialogAction === 'delete' ) {
 			const {
 				siteId,
-				postId
+				postId,
 			} = this.props;
 			analytics.tracks.recordEvent( 'calypso_publicize_scheduled_delete' );
 			this.props.deletePostShareAction( siteId, postId, this.state.selectedScheduledShareId );
@@ -205,10 +219,33 @@ class PublicizeActionsList extends PureComponent {
 		this.setState( { showDeleteDialog: false } );
 	};
 
-	renderActionsList = actions => {
+	renderActionsList = () => {
+		const {
+			hasRepublicizeFeature,
+			hasRepublicizeSchedulingFeature,
+			publishedActions,
+			scheduledActions,
+		} = this.props;
+
+		if ( this.state.selectedShareTab === PUBLISHED ) {
+			return (
+				<div className="post-share__published-list">
+					{ publishedActions.map( ( item, index ) => this.renderActionItem( item, index ) ) }
+				</div>
+			);
+		}
+
+		if ( ! hasRepublicizeFeature && ! hasRepublicizeSchedulingFeature ) {
+			return this.renderUpgradeToPremiumNudge();
+		}
+
+		if ( ! hasRepublicizeSchedulingFeature ) {
+			return this.renderUpgradeToBusinessNudge();
+		}
+
 		return (
-			<div>
-				{ actions.map( ( item, index ) => this.renderActionItem( item, index ) ) }
+			<div className="post-share__scheduled-list">
+				{ scheduledActions.map( ( item, index ) => this.renderActionItem( item, index ) ) }
 			</div>
 		);
 	};
@@ -234,15 +271,7 @@ class PublicizeActionsList extends PureComponent {
 	}
 
 	render() {
-		const {
-			hasRepublicizeSchedulingFeature,
-			postId,
-			siteId,
-			scheduledActions,
-			publishedActions,
-		} = this.props;
-
-		const showUpgradeToBusinessNudger = ! hasRepublicizeSchedulingFeature && this.state.selectedShareTab === SCHEDULED;
+		const { postId, siteId } = this.props;
 
 		return (
 			<div>
@@ -268,23 +297,7 @@ class PublicizeActionsList extends PureComponent {
 					<QuerySharePostActions siteId={ siteId } postId={ postId } status={ SCHEDULED } />
 					<QuerySharePostActions siteId={ siteId } postId={ postId } status={ PUBLISHED } />
 
-					{
-						this.state.selectedShareTab === SCHEDULED &&
-						showUpgradeToBusinessNudger &&
-						this.renderUpgradeToBusinessPlanNudge()
-					}
-
-					{ this.state.selectedShareTab === SCHEDULED && ! showUpgradeToBusinessNudger &&
-						<div className="post-share__scheduled-list">
-							{ this.renderActionsList( scheduledActions ) }
-						</div>
-					}
-
-					{ this.state.selectedShareTab === PUBLISHED &&
-						<div className="post-share__published-list">
-							{ this.renderActionsList( publishedActions ) }
-						</div>
-					}
+					{ this.renderActionsList() }
 				</div>
 
 				{ this.renderDeleteDialog() }

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -22,8 +22,6 @@ import {
 	SCHEDULED,
 	PUBLISHED,
 } from './constants';
-import Banner from 'components/banner';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -32,7 +30,7 @@ import Dialog from 'components/dialog';
 import { deletePostShareAction } from 'state/sharing/publicize/publicize-actions/actions';
 import analytics from 'lib/analytics';
 import SharingPreviewModal from './sharing-preview-modal';
-import formatCurrency from 'lib/format-currency';
+import { UpgradeToPremiumNudge } from 'blocks/post-share/nudges';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {
@@ -43,7 +41,7 @@ class PublicizeActionsList extends PureComponent {
 	};
 
 	state = {
-		selectedShareTab: SCHEDULED,
+		selectedShareTab: PUBLISHED,
 		showDeleteDialog: false,
 		selectedScheduledShareId: null,
 		showPreviewModal: false,
@@ -67,49 +65,6 @@ class PublicizeActionsList extends PureComponent {
 			previewService: service,
 		} );
 	};
-
-	renderUpgradeToPremiumNudge() {
-		const { translate } = this.props;
-
-		return (
-			<Banner
-				className="post-share__upgrade-nudge"
-				feature="republicize"
-				title={ translate( 'Unlock the ability to re-share posts to social media' ) }
-				callToAction={ translate( 'Upgrade to Premium' ) }
-				description={ translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' ) }
-			/>
-		);
-	}
-
-	renderUpgradeToBusinessNudge() {
-		const {
-			businessDiscountedRawPrice,
-			businessRawPrice,
-			translate,
-			userCurrency,
-		} = this.props;
-
-		return (
-			<Banner
-				className="post-share__actions-list-upgrade-nudge"
-				callToAction={
-					translate( 'Upgrade for %s', {
-						args: formatCurrency( businessDiscountedRawPrice || businessRawPrice, userCurrency ),
-						comment: '%s will be replaced by a formatted price, i.e $9.99'
-					} )
-				}
-				list={ [
-					translate( 'Schedule your social messages in advance.' ),
-					translate( 'Remove all advertising from your site.' ),
-					translate( 'Enjoy live chat support.' ),
-					translate( 'Ability to add features through external plugins.' ),
-					translate( 'Access to thousands of themes.' ),
-				] }
-				plan={ PLAN_BUSINESS }
-				title={ translate( 'Upgrade to a Business Plan!' ) } />
-		);
-	}
 
 	renderActionItem( item, index ) {
 		const {
@@ -235,12 +190,8 @@ class PublicizeActionsList extends PureComponent {
 			);
 		}
 
-		if ( ! hasRepublicizeFeature && ! hasRepublicizeSchedulingFeature ) {
-			return this.renderUpgradeToPremiumNudge();
-		}
-
-		if ( ! hasRepublicizeSchedulingFeature ) {
-			return this.renderUpgradeToBusinessNudge();
+		if ( hasRepublicizeFeature && ! hasRepublicizeSchedulingFeature ) {
+			return <UpgradeToPremiumNudge { ...this.props } />;
 		}
 
 		return (
@@ -271,19 +222,26 @@ class PublicizeActionsList extends PureComponent {
 	}
 
 	render() {
-		const { postId, siteId } = this.props;
+		const {
+			hasRepublicizeFeature,
+			hasRepublicizeSchedulingFeature,
+			postId,
+			siteId,
+		} = this.props;
 
 		return (
 			<div>
 				<SectionNav className="post-share__footer-nav" selectedText={ 'some text' }>
 					<NavTabs label="Status" selectedText="Published">
-						<NavItem
-							selected={ this.state.selectedShareTab === SCHEDULED }
-							count={ this.props.scheduledActions.length }
-							onClick={ this.setFooterSection( SCHEDULED ) }
-						>
-							Scheduled
-						</NavItem>
+						{ ( hasRepublicizeFeature || hasRepublicizeSchedulingFeature ) &&
+							<NavItem
+								selected={ this.state.selectedShareTab === SCHEDULED }
+								count={ this.props.scheduledActions.length }
+								onClick={ this.setFooterSection( SCHEDULED ) }
+							>
+								Scheduled
+							</NavItem>
+						}
 						<NavItem
 							selected={ this.state.selectedShareTab === PUBLISHED }
 							count={ this.props.publishedActions.length }

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -69,13 +69,6 @@ class PublicizeActionsList extends PureComponent {
 	};
 
 	renderUpgradeToBusinessPlanNudge() {
-		if (
-			this.props.hasRepublicizeSchedulingFeature ||
-			! isEnabled( 'publicize-scheduling' )
-		) {
-			return null;
-		}
-
 		const {
 			businessDiscountedRawPrice,
 			businessRawPrice,
@@ -85,7 +78,7 @@ class PublicizeActionsList extends PureComponent {
 
 		return (
 			<Banner
-				className="post-share__footer-banner"
+				className="post-share__actions-list-upgrade-nudge"
 				callToAction={
 					translate( 'Upgrade for %s', {
 						args: formatCurrency( businessDiscountedRawPrice || businessRawPrice, userCurrency ),
@@ -96,6 +89,8 @@ class PublicizeActionsList extends PureComponent {
 					translate( 'Schedule your social messages in advance.' ),
 					translate( 'Remove all advertising from your site.' ),
 					translate( 'Enjoy live chat support.' ),
+					translate( 'Ability to add features through external plugins.' ),
+					translate( 'Access to thousands of themes.' ),
 				] }
 				plan={ PLAN_BUSINESS }
 				title={ translate( 'Upgrade to a Business Plan!' ) } />
@@ -210,11 +205,13 @@ class PublicizeActionsList extends PureComponent {
 		this.setState( { showDeleteDialog: false } );
 	};
 
-	renderActionsList = ( actions ) => (
+	renderActionsList = actions => {
+		return (
 			<div>
 				{ actions.map( ( item, index ) => this.renderActionItem( item, index ) ) }
 			</div>
 		);
+	};
 
 	renderDeleteDialog() {
 		const { translate } = this.props;
@@ -238,11 +235,14 @@ class PublicizeActionsList extends PureComponent {
 
 	render() {
 		const {
+			hasRepublicizeSchedulingFeature,
 			postId,
 			siteId,
 			scheduledActions,
 			publishedActions,
 		} = this.props;
+
+		const showUpgradeToBusinessNudger = ! hasRepublicizeSchedulingFeature && this.state.selectedShareTab === SCHEDULED;
 
 		return (
 			<div>
@@ -267,11 +267,19 @@ class PublicizeActionsList extends PureComponent {
 				<div className="post-share__actions-list">
 					<QuerySharePostActions siteId={ siteId } postId={ postId } status={ SCHEDULED } />
 					<QuerySharePostActions siteId={ siteId } postId={ postId } status={ PUBLISHED } />
-					{ this.state.selectedShareTab === SCHEDULED &&
+
+					{
+						this.state.selectedShareTab === SCHEDULED &&
+						showUpgradeToBusinessNudger &&
+						this.renderUpgradeToBusinessPlanNudge()
+					}
+
+					{ this.state.selectedShareTab === SCHEDULED && ! showUpgradeToBusinessNudger &&
 						<div className="post-share__scheduled-list">
 							{ this.renderActionsList( scheduledActions ) }
 						</div>
 					}
+
 					{ this.state.selectedShareTab === PUBLISHED &&
 						<div className="post-share__published-list">
 							{ this.renderActionsList( publishedActions ) }

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -22,6 +22,8 @@ import {
 	SCHEDULED,
 	PUBLISHED,
 } from './constants';
+import Banner from 'components/banner';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -30,6 +32,7 @@ import Dialog from 'components/dialog';
 import { deletePostShareAction } from 'state/sharing/publicize/publicize-actions/actions';
 import analytics from 'lib/analytics';
 import SharingPreviewModal from './sharing-preview-modal';
+import formatCurrency from 'lib/format-currency';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {
@@ -63,6 +66,40 @@ class PublicizeActionsList extends PureComponent {
 			previewMessage: message,
 			previewService: service,
 		} );
+	};
+
+	renderUpgradeToBusinessPlanNudge() {
+		if (
+			this.props.hasRepublicizeSchedulingFeature ||
+			! isEnabled( 'publicize-scheduling' )
+		) {
+			return null;
+		}
+
+		const {
+			businessDiscountedRawPrice,
+			businessRawPrice,
+			translate,
+			userCurrency,
+		} = this.props;
+
+		return (
+			<Banner
+				className="post-share__footer-banner"
+				callToAction={
+					translate( 'Upgrade for %s', {
+						args: formatCurrency( businessDiscountedRawPrice || businessRawPrice, userCurrency ),
+						comment: '%s will be replaced by a formatted price, i.e $9.99'
+					} )
+				}
+				list={ [
+					translate( 'Schedule your social messages in advance.' ),
+					translate( 'Remove all advertising from your site.' ),
+					translate( 'Enjoy live chat support.' ),
+				] }
+				plan={ PLAN_BUSINESS }
+				title={ translate( 'Upgrade to a Business Plan!' ) } />
+		);
 	}
 
 	renderFooterSectionItem( item, index ) {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -4,6 +4,9 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 .card.post-share__upgrade-nudge {
 	margin: 0;
 }
+.post-share__actions-list .card.post-share__actions-list-upgrade-nudge {
+	margin: 10px;
+}
 
 .post-share__wrapper {
 	animation: appear .3s ease-in-out;

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -4,9 +4,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 .card.post-share__upgrade-nudge {
 	margin: 0;
 }
-.post-share__actions-list .card.post-share__actions-list-upgrade-nudge {
-	margin: 10px;
-}
 
 .post-share__wrapper {
 	animation: appear .3s ease-in-out;

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -175,7 +175,7 @@ export const PLANS_LIST = {
 			FEATURE_ADVANCED_DESIGN,
 			FEATURE_13GB_STORAGE,
 			FEATURE_NO_ADS,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_VIDEO_UPLOADS,
 		] ),


### PR DESCRIPTION
This PR tries to improve the upgrade plan information according to the current plan of the site.

Primary changes: 

* Always shows the actions list for any paid plan
* Move the `Business` nudge into the scheduled actions list when the paid plan isn't `Business`

### How it looks depending on the site plan

#### Free

<img src="https://user-images.githubusercontent.com/77539/27241845-cd917bde-52b0-11e7-9a6f-2a596e08225c.png" width="600px" />


#### Personal
<img src="https://user-images.githubusercontent.com/77539/27223332-4aa9bfdc-5266-11e7-886a-2752b269a5cb.png" width="600px" />

#### Premium and Business
<img src="https://user-images.githubusercontent.com/77539/27223367-6f0a3622-5266-11e7-9ff0-78a056be7ae6.png" width="600px" />

### Testing

Walk to sites with different plans and check the how the nudges are shown.