### PR TITLE
Comments: update comment faker to show 20 comments

### DIFF
--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -23,8 +23,9 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! this.props.comments.length ) {
-			this.getCommentsFromProps( nextProps );
+		if ( this.props.comments.length !== nextProps.comments.length ||
+			this.props.siteId !== nextProps.siteId ) {
+				this.getCommentsFromProps( nextProps );
 		}
 	}
 

--- a/client/state/selectors/get-site-comments.js
+++ b/client/state/selectors/get-site-comments.js
@@ -4,18 +4,26 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+/**
  * Returns list of loaded comments for a given site
  *
  * @param {Object} state Redux state
  * @param {Number} siteId site for whose comments to find
  * @returns {Array<Object>} available comments for site
  */
-export const getSiteComments = ( state, siteId ) => {
-	const comments = get( state, 'comments.items', {} );
+export const getSiteComments = createSelector(
+	( state, siteId ) => {
+		const comments = get( state, 'comments.items', {} );
 
-	return Object.keys( comments )
-		.filter( key => parseInt( key.split( '-', 1 ), 10 ) === siteId )
-		.reduce( ( list, key ) => [ ...list, ...comments[ key ] ], [] );
-};
+		return Object.keys( comments )
+			.filter( key => parseInt( key.split( '-', 1 ), 10 ) === siteId )
+			.reduce( ( list, key ) => [ ...list, ...comments[ key ] ], [] );
+	},
+	state => [ state.comments.items ]
+);
 
 export default getSiteComments;


### PR DESCRIPTION
We currently copy over comments in comments management into component state, so we can mock out what some interactions look like do since the real actions aren't ready yet.

This PR updates comment faker to update comments in state on siteId changes and comment length changes. This should give us 20 comments to work with initially.

I also memoized `getSiteComments` since we are filtering through all site items.

### Testing Instructions
1. Navigate to http://calypso.localhost:3000/comments/all
2. Select a site with at least 20 comments
3. You should see 20 comments load
4. Perform an action like mark as spam
5. Clicking on the spam filter should show that comment
6. Refreshing the page resets all comments into their correct filters.

cc @Automattic/lannister 
