### PR TITLE
Woo product create: busy state for save button.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -88,12 +88,18 @@ class ProductCreate extends React.Component {
 		this.props.actionListStepNext();
 	}
 
+	isProductValid( product = this.props.product ) {
+		return product &&
+			product.type &&
+			product.name && product.name.length > 0;
+	}
+
 	render() {
 		const { siteId, product, className, variations, productCategories, actionList } = this.props;
 
-		const isReady = 'undefined' !== siteId;
+		const isValid = 'undefined' !== siteId && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
-		const saveEnabled = isReady && ! isBusy;
+		const saveEnabled = isValid && ! isBusy;
 
 		return (
 			<Main className={ className }>

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -14,6 +14,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { successNotice, errorNotice } from 'state/notices/actions';
 
 import { editProduct, editProductAttribute, createProductActionList } from 'woocommerce/state/ui/products/actions';
+import { getActionList } from 'woocommerce/state/action-list/selectors';
 import { actionListStepNext } from 'woocommerce/state/action-list/actions';
 import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
@@ -88,14 +89,19 @@ class ProductCreate extends React.Component {
 	}
 
 	render() {
-		const { siteId, product, className, variations, productCategories } = this.props;
+		const { siteId, product, className, variations, productCategories, actionList } = this.props;
+
+		const isReady = 'undefined' !== siteId;
+		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
+		const saveEnabled = isReady && ! isBusy;
 
 		return (
 			<Main className={ className }>
 				<SidebarNavigation />
 				<ProductHeader
 					onTrash={ this.onTrash }
-					onSave={ siteId && this.onSave || false }
+					onSave={ saveEnabled ? this.onSave : false }
+					isBusy={ isBusy }
 				/>
 				<ProductForm
 					siteId={ siteId }
@@ -116,12 +122,14 @@ function mapStateToProps( state ) {
 	const product = getCurrentlyEditingProduct( state, siteId );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id, siteId );
 	const productCategories = getProductCategories( state, siteId );
+	const actionList = getActionList( state );
 
 	return {
 		siteId,
 		product,
 		variations,
 		productCategories,
+		actionList,
 	};
 }
 

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -11,12 +11,17 @@ import Gridicon from 'gridicons';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 
-const ProductHeader = ( { onTrash, onSave, translate } ) => {
+const ProductHeader = ( { onTrash, onSave, isBusy, translate } ) => {
 	const trashButton = onTrash &&
 		<Button borderless onClick={ onTrash }><Gridicon icon="trash" /></Button>;
 
-	const saveButton = 'undefined' !== typeof onSave &&
-		<Button primary onClick={ onSave } disabled={ onSave === false }>{ translate( 'Save' ) }</Button>;
+	const saveExists = 'undefined' !== typeof onSave;
+	const saveDisabled = false === onSave;
+
+	const saveButton = saveExists &&
+		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }>
+			{ translate( 'Save' ) }
+		</Button>;
 
 	return (
 		<ActionHeader>

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -42,6 +42,15 @@
 	}
 }
 
+.is-section-woocommerce {
+	// overwrite notice styles due to sticky bar 
+	.global-notices {
+		@include breakpoint( ">660px" ) {
+			top: 115px;
+		}
+	}
+}
+
 .store-sidebar__sidebar {
 	display: block;
 


### PR DESCRIPTION
This adds an "busy" state to the save button while the action-list is
present.

To Test:

1. Visit http://calypso.localhost:3000/store/product/<site url>
2. Edit some product information.
3. Click the Save button.
4. Save button should be "busy" and disabled while save operation occurs.
5. After success notification pops up, Save button should return to normal.
