### PR TITLE
Woo: Add clearUponComplete flag to action-list

### DIFF
--- a/client/extensions/woocommerce/state/action-list/README.md
+++ b/client/extensions/woocommerce/state/action-list/README.md
@@ -34,6 +34,7 @@ example, this could look like:
   ]
   successAction: { type: 'MY_SUCCESS_ACTION' },
   failureAction: { type: 'MY_FAILURE_ACTION' },
+  clearUponComplete: true,
 }
 ```
 
@@ -101,6 +102,7 @@ dispatched at the end of action list processing.
 #### Action List Clear
 
 This action will clear the current action list from the application state.
+This happens automatically if `clearUponComplete` is set to true.
 
 
 ## Questions

--- a/client/extensions/woocommerce/state/data-layer/action-list/index.js
+++ b/client/extensions/woocommerce/state/data-layer/action-list/index.js
@@ -9,7 +9,11 @@ const debug = debugFactor( 'woocommerce:action-list' );
  * Internal dependencies
  */
 import { getActionList, getCurrentStepIndex } from 'woocommerce/state/action-list/selectors';
-import { actionListStepAnnotate, actionListStepNext } from 'woocommerce/state/action-list/actions';
+import {
+	actionListClear,
+	actionListStepAnnotate,
+	actionListStepNext,
+} from 'woocommerce/state/action-list/actions';
 import {
 	WOOCOMMERCE_ACTION_LIST_STEP_NEXT,
 	WOOCOMMERCE_ACTION_LIST_STEP_SUCCESS,
@@ -49,6 +53,9 @@ export function handleStepSuccess( { dispatch, getState }, action ) {
 		if ( actionList.successAction ) {
 			dispatch( actionList.successAction );
 		}
+		if ( actionList.clearUponComplete ) {
+			dispatch( actionListClear() );
+		}
 	}
 }
 
@@ -62,6 +69,9 @@ export function handleStepFailure( { dispatch, getState }, action ) {
 	dispatch( actionListStepAnnotate( stepIndex, { endTime, error } ) );
 	if ( actionList.failureAction ) {
 		dispatch( actionList.failureAction );
+	}
+	if ( actionList.clearUponComplete ) {
+		dispatch( actionListClear() );
 	}
 }
 


### PR DESCRIPTION
This adds an optional `clearUponComplete` flag to the action list that
will automatically clear the action list after it's reached completion
either successfully or from failing on a step.

To Test: Run `npm test`