### PR TITLE
Comments: show loading placeholder

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -22,6 +22,7 @@ import CommentFaker from 'blocks/comment-detail/docs/comment-faker';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
 import QuerySiteComments from 'components/data/query-site-comments';
+import { hasSiteComments } from 'state/selectors';
 
 export class CommentList extends Component {
 	static propTypes = {
@@ -212,6 +213,8 @@ export class CommentList extends Component {
 			siteId,
 			siteSlug,
 			status,
+			showPlaceholder,
+			showEmptyContent,
 		} = this.props;
 		const {
 			isBulkEdit,
@@ -253,29 +256,20 @@ export class CommentList extends Component {
 						/>
 					) }
 				</ReactCSSTransitionGroup>
-
 				<ReactCSSTransitionGroup
 					className="comment-list__transition-wrapper"
 					component="div"
 					transitionEnterTimeout={ 300 }
 					transitionLeaveTimeout={ 150 }
-					transitionName="comment-list__transition"
-				>
-					{ null === comments &&
-						<CommentDetailPlaceholder
-							key="comment-detail-placeholder"
-						/>
-					}
-
-					{ 0 === size( comments ) &&
-						<EmptyContent
-							illustration="/calypso/images/comments/illustration_comments_gray.svg"
-							illustrationWidth={ 150 }
-							key="comment-list-empty"
-							line={ emptyMessageLine }
-							title={ emptyMessageTitle }
-						/>
-					}
+					transitionName="comment-list__transition" >
+					{ showPlaceholder && <CommentDetailPlaceholder key="comment-detail-placeholder" /> }
+					{ showEmptyContent && <EmptyContent
+						illustration="/calypso/images/comments/illustration_comments_gray.svg"
+						illustrationWidth={ 150 }
+						key="comment-list-empty"
+						line={ emptyMessageLine }
+						title={ emptyMessageTitle }
+					/> }
 				</ReactCSSTransitionGroup>
 			</div>
 		);
@@ -284,8 +278,14 @@ export class CommentList extends Component {
 
 const mapStateToProps = ( state, { siteId } ) => {
 	const comments = getSiteComments( state, siteId );
+	const isLoading = ! hasSiteComments( state, siteId );
+	const zeroComments = size( comments ) <= 0;
+	const showPlaceholder = ( ! siteId || isLoading ) && zeroComments;
+	const showEmptyContent = zeroComments && ! showPlaceholder;
 	return {
 		comments,
+		showPlaceholder,
+		showEmptyContent,
 		notices: getNotices( state ),
 		siteId,
 	};

--- a/client/state/selectors/has-site-comments.js
+++ b/client/state/selectors/has-site-comments.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { get, some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+/**
+ * Returns true if we have site comments
+ *
+ * @param  {Object}  state       Global state tree
+ * @param  {Number}  siteId      The ID of the site we're querying
+ */
+export const hasSiteComments = createSelector(
+	( state, siteId ) => {
+		const comments = get( state, 'comments.items', {} );
+		return some( Object.keys( comments ), key => parseInt( key.split( '-', 1 ), 10 ) === siteId );
+	},
+	state => [ state.comments.items ]
+);
+
+export default hasSiteComments;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -130,6 +130,7 @@ export getUserSettings from './get-user-settings';
 export getVisibleSites from './get-visible-sites';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
 export hasInitializedSites from './has-initialized-sites';
+export hasSiteComments from './has-site-comments';
 export hasUnsavedUserSettings from './has-unsaved-user-settings';
 export hasUserSettings from './has-user-settings';
 export isAccountRecoveryResetOptionsReady from './is-account-recovery-reset-options-ready';

--- a/client/state/selectors/test/has-site-comments.js
+++ b/client/state/selectors/test/has-site-comments.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { hasSiteComments } from '../';
+
+const state = deepFreeze( { comments: { items: { '2916284-1': [ {} ], '2916284-44': [ {} ] } } } );
+
+describe( 'hasSiteComments()', () => {
+	it( 'should return true if we have site comments', () => {
+		expect( hasSiteComments( state, 2916284 ) ).to.equal( true );
+	} );
+	it( 'should return false if we do not have site comments', () => {
+		expect( hasSiteComments( state, 77203074 ) ).to.equal( false );
+	} );
+} );


### PR DESCRIPTION
This PR adds a new selector so we can track when we have any site comments. This allows us to know when to show a placeholder for comments management.

### Testing Instructions
- Navigate to http://calypso.localhost:3000/comments/all
- We should see a placeholder
- The placeholder should be removed to show empty content or a list of comments.

cc @Automattic/lannister 