### PR TITLE
Editor: Don't show preview on publish when private is selected

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -700,7 +700,7 @@ export const PostEditor = React.createClass( {
 			return;
 		}
 
-		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) && 'open' === this.state.confirmationSidebar ) {
 			this.setConfirmationSidebar( { status: 'publishing' } );
 		}
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -749,10 +749,6 @@ export const PostEditor = React.createClass( {
 			message = 'published';
 		}
 
-		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
-			this.setConfirmationSidebar( { status: 'closed', context: 'publish_success' } );
-		}
-
 		this.onSaveSuccess( message, ( message === 'published' ? 'view' : 'preview' ), savedPost.URL );
 	},
 
@@ -820,6 +816,11 @@ export const PostEditor = React.createClass( {
 
 	onSaveSuccess: function( message, action, link ) {
 		const post = PostEditStore.get();
+		const isNotPrivateOrIsConfirmed = ( 'private' !== post.status ) || ( 'closed' !== this.state.confirmationSidebar );
+
+		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+			this.setConfirmationSidebar( { status: 'closed', context: 'publish_success' } );
+		}
 
 		if ( 'draft' === post.status ) {
 			this.props.setEditorLastDraft( post.site_ID, post.ID );
@@ -848,7 +849,11 @@ export const PostEditor = React.createClass( {
 
 			window.scrollTo( 0, 0 );
 
-			if ( config.isEnabled( 'post-editor/delta-post-publish-preview' ) && this.props.isSitePreviewable ) {
+			if (
+				config.isEnabled( 'post-editor/delta-post-publish-preview' ) &&
+				this.props.isSitePreviewable &&
+				isNotPrivateOrIsConfirmed
+			) {
 				this.setState( { isPostPublishPreview: true } );
 				this.iframePreview();
 			}


### PR DESCRIPTION
This PR modifies the behavior of the post-publish preview such that it is no longer shown when a post is published as a result of "private" being selected as post-visibility from the post-settings sidebar.

If, however, "private" is selected from the confirmation sidebar, the preview will continue to be shown.

This PR is part of a larger epic. See p8F9tW-3F-p2.

***To test:***
* Checkout branch
* Run the branch with previews enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
* Draft a post, and from post-settings change the post visibility to "private".
* From the ensuing confirmation dialog, select "yes". Your post should be saved as private and you **should not** be shown a preview.
* Draft another post. This time save it as "public" or "password protected". Upon publishing the post, you **should** be shown a preview.
* Stop the branch.
* Run the branch with previews **and** the confirmation flow enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-preview,post-editor/delta-post-publish-flow make run`
* Change visibility of a new post to private from post-settings as above. Again your post should be published as private and again you should _not_ see a preview.
* Create a new post. This time change it's visibility to private from the confirmation sidebar.
* After the post is published as private from the confirmation sidebar, you should see a preview of your post.
* Publishing posts as "public" or "password protected" should result in a preview regardless of whether the change was made from the confirmation sidebar or post-settings.