### PR TITLE
WooCommerce: Add the total number of products on a site to the products state.

### DIFF
--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -77,11 +77,13 @@ export const fetchProducts = ( siteId, page ) => ( dispatch, getState ) => {
 	return request( siteId ).getWithHeaders( `products?page=${ page }&per_page=10` ).then( ( response ) => {
 		const { headers, data } = response;
 		const totalPages = headers[ 'X-WP-TotalPages' ];
+		const totalProducts = headers[ 'X-WP-Total' ];
 		dispatch( {
 			type: WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
 			siteId,
 			page,
 			totalPages,
+			totalProducts,
 			products: data,
 		} );
 	} ).catch( error => {

--- a/client/extensions/woocommerce/state/sites/products/reducer.js
+++ b/client/extensions/woocommerce/state/sites/products/reducer.js
@@ -53,6 +53,7 @@ export function productsRequestSuccess( state, action ) {
 		products,
 		isLoading,
 		totalPages: action.totalPages,
+		totalProducts: action.totalProducts,
 	};
 }
 

--- a/client/extensions/woocommerce/state/sites/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/selectors.js
@@ -40,3 +40,12 @@ export const areProductsLoading = ( state, page = 1, siteId = getSelectedSiteId(
 export const getTotalProductsPages = ( state, siteId = getSelectedSiteId( state ) ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'totalPages' ], 0 );
 };
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number} Total number of products available on a site, or 0 if not loaded yet.
+ */
+export const getTotalProducts = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'totalProducts' ], 0 );
+};

--- a/client/extensions/woocommerce/state/sites/products/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/test/actions.js
@@ -30,7 +30,7 @@ describe( 'actions', () => {
 				.reply( 200, {
 					data: {
 						body: products,
-						headers: { 'X-WP-TotalPages': 3 },
+						headers: { 'X-WP-TotalPages': 3, 'X-WP-Total': 30 },
 						status: 200,
 					}
 				} )
@@ -63,6 +63,7 @@ describe( 'actions', () => {
 					siteId,
 					page: 1,
 					totalPages: 3,
+					totalProducts: 30,
 					products
 				} );
 			} );

--- a/client/extensions/woocommerce/state/sites/products/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/products/test/reducer.js
@@ -84,6 +84,18 @@ describe( 'reducer', () => {
 			const newState = productsRequestSuccess( undefined, action );
 			expect( newState.totalPages ).to.eql( 3 );
 		} );
+		it( 'should store the total number of products', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+				siteId: 123,
+				page: 1,
+				totalPages: 3,
+				totalProducts: 30,
+				products,
+			};
+			const newState = productsRequestSuccess( undefined, action );
+			expect( newState.totalProducts ).to.eql( 30 );
+		} );
 	} );
 	describe( 'productsRequestFailure', () => {
 		it( 'should should show that request has loaded on failure', () => {

--- a/client/extensions/woocommerce/state/sites/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/test/selectors.js
@@ -9,6 +9,7 @@ import {
 	areProductsLoaded,
 	areProductsLoading,
 	getTotalProductsPages,
+	getTotalProducts,
 } from '../selectors';
 import products from './fixtures/products';
 
@@ -43,7 +44,8 @@ const loadedState = {
 							1: false,
 						},
 						products,
-						totalPages: 3
+						totalPages: 3,
+						totalProducts: 30,
 					}
 				},
 				401: {
@@ -52,7 +54,7 @@ const loadedState = {
 							1: true,
 						},
 						products: {},
-						totalPages: 1
+						totalPages: 1,
 					},
 				},
 			},
@@ -126,6 +128,28 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getTotalProductsPages( loadedStateWithUi ) ).to.eql( 3 );
+		} );
+	} );
+
+	describe( '#getTotalProducts', () => {
+		it( 'should be 0 (default) when woocommerce state is not available.', () => {
+			expect( getTotalProducts( preInitializedState, 123 ) ).to.eql( 0 );
+		} );
+
+		it( 'should be 0 (default) when products are loading.', () => {
+			expect( getTotalProducts( loadingState, 123 ) ).to.eql( 0 );
+		} );
+
+		it( 'should be 30, the set products total, if the products are loaded.', () => {
+			expect( getTotalProducts( loadedState, 123 ) ).to.eql( 30 );
+		} );
+
+		it( 'should be 0 (default) when products are loaded only for a different site.', () => {
+			expect( getTotalProducts( loadedState, 456 ) ).to.eql( 0 );
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getTotalProducts( loadedStateWithUi ) ).to.eql( 30 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This adds the total number of products on a site to the products state tree.  It is a requirement for the pagination component I am going to use.

To test:
* Run `npm test` and make sure all tests pass.