### PR TITLE
Fix test failure caused by trailing / characters in import.

### DIFF
--- a/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -1,9 +1,11 @@
 /**
  * Internal dependencies
  */
-import canCurrentUser from './can-current-user';
-import isMappedDomainSite from './is-mapped-domain-site';
-import isSiteOnFreePlan from './is-site-on-free-plan';
+import {
+	canCurrentUser,
+	isMappedDomainSite,
+	isSiteOnFreePlan,
+} from 'state/selectors';
 
 /**
  * Returns true if the current user is eligible for a domain to paid plan upsell for the site

--- a/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -5,7 +5,7 @@ import {
 	canCurrentUser,
 	isMappedDomainSite,
 	isSiteOnFreePlan,
-} from 'state/selectors/';
+} from 'state/selectors';
 
 /**
  * Returns true if the current user is eligible for a domain to paid plan upsell for the site

--- a/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -1,11 +1,9 @@
 /**
  * Internal dependencies
  */
-import {
-	canCurrentUser,
-	isMappedDomainSite,
-	isSiteOnFreePlan,
-} from 'state/selectors';
+import canCurrentUser from './can-current-user';
+import isMappedDomainSite from './is-mapped-domain-site';
+import isSiteOnFreePlan from './is-site-on-free-plan';
 
 /**
  * Returns true if the current user is eligible for a domain to paid plan upsell for the site

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -1,10 +1,12 @@
 /**
  * Internal dependencies
  */
-import canCurrentUser from './can-current-user';
-import isMappedDomainSite from './is-mapped-domain-site';
-import isSiteOnFreePlan from './is-site-on-free-plan';
-import isUserRegistrationDaysWithinRange from './is-user-registration-days-within-range';
+import {
+	canCurrentUser,
+	isMappedDomainSite,
+	isSiteOnFreePlan,
+	isUserRegistrationDaysWithinRange
+} from 'state/selectors';
 
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -6,7 +6,7 @@ import {
 	isMappedDomainSite,
 	isSiteOnFreePlan,
 	isUserRegistrationDaysWithinRange,
-} from 'state/selectors/';
+} from 'state/selectors';
 
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -5,7 +5,7 @@ import {
 	canCurrentUser,
 	isMappedDomainSite,
 	isSiteOnFreePlan,
-	isUserRegistrationDaysWithinRange
+	isUserRegistrationDaysWithinRange,
 } from 'state/selectors';
 
 /**

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import {
-	canCurrentUser,
-	isMappedDomainSite,
-	isSiteOnFreePlan,
-	isUserRegistrationDaysWithinRange,
-} from 'state/selectors';
+import canCurrentUser from './can-current-user';
+import isMappedDomainSite from './is-mapped-domain-site';
+import isSiteOnFreePlan from './is-site-on-free-plan';
+import isUserRegistrationDaysWithinRange from './is-user-registration-days-within-range';
 
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -23,11 +23,9 @@ describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 		isMappedDomainSite = stub();
 		isSiteOnFreePlan = stub();
 
-		mockery.registerMock( 'state/selectors/', {
-			canCurrentUser,
-			isMappedDomainSite,
-			isSiteOnFreePlan
-		} );
+		mockery.registerMock( './can-current-user', canCurrentUser );
+		mockery.registerMock( './is-mapped-domain-site', isMappedDomainSite );
+		mockery.registerMock( './is-site-on-free-plan', isSiteOnFreePlan );
 	} );
 
 	before( () => {

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -23,9 +23,9 @@ describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 		isMappedDomainSite = stub();
 		isSiteOnFreePlan = stub();
 
-		mockery.registerMock( './can-current-user', canCurrentUser );
-		mockery.registerMock( './is-mapped-domain-site', isMappedDomainSite );
-		mockery.registerMock( './is-site-on-free-plan', isSiteOnFreePlan );
+		mockery.registerMock( 'state/selectors/can-current-user', canCurrentUser );
+		mockery.registerMock( 'state/selectors/is-mapped-domain-site', isMappedDomainSite );
+		mockery.registerMock( 'state/selectors/is-site-on-free-plan', isSiteOnFreePlan );
 	} );
 
 	before( () => {

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -26,12 +26,10 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		isSiteOnFreePlan = stub();
 		isUserRegistrationDaysWithinRange = stub();
 
-		mockery.registerMock( 'state/selectors/', {
-			canCurrentUser,
-			isMappedDomainSite,
-			isSiteOnFreePlan,
-			isUserRegistrationDaysWithinRange
-		} );
+		mockery.registerMock( './can-current-user', canCurrentUser );
+		mockery.registerMock( './is-mapped-domain-site', isMappedDomainSite );
+		mockery.registerMock( './is-site-on-free-plan', isSiteOnFreePlan );
+		mockery.registerMock( './is-user-registration-days-within-range', isUserRegistrationDaysWithinRange );
 	} );
 
 	before( () => {

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -26,10 +26,10 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		isSiteOnFreePlan = stub();
 		isUserRegistrationDaysWithinRange = stub();
 
-		mockery.registerMock( './can-current-user', canCurrentUser );
-		mockery.registerMock( './is-mapped-domain-site', isMappedDomainSite );
-		mockery.registerMock( './is-site-on-free-plan', isSiteOnFreePlan );
-		mockery.registerMock( './is-user-registration-days-within-range', isUserRegistrationDaysWithinRange );
+		mockery.registerMock( 'state/selectors/can-current-user', canCurrentUser );
+		mockery.registerMock( 'state/selectors/is-mapped-domain-site', isMappedDomainSite );
+		mockery.registerMock( 'state/selectors/is-site-on-free-plan', isSiteOnFreePlan );
+		mockery.registerMock( 'state/selectors/is-user-registration-days-within-range', isUserRegistrationDaysWithinRange );
 	} );
 
 	before( () => {


### PR DESCRIPTION
`npm test` is currently broken on master.

`npm run test-client` and `npm run test-server` are both fine however (which is why circle ci is passing).

@coderkevin and I were able to narrow this down to reproduce the problem on master with the following sequence of tests:

`npm run test-client client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx client/state/selectors/test/index.js`