### PR TITLE
Publicize: add external link to published actions

### DIFF
--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -108,7 +108,12 @@ class PublicizeActionsList extends PureComponent {
 			return this.renderScheduledMenu( actionId, message, service );
 		}
 
-		return null;
+		// PUBLISHED tab
+		return (
+			<a className="post-share__external-url" href={ item.url } target="_blank" rel="noopener noreferrer" >
+				<Gridicon icon="external" size={ 24 } />
+			</a>
+		);
 	}
 
 	renderScheduledMenu( publicizeActionId, message, service ) {

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -65,13 +65,14 @@ class PublicizeActionsList extends PureComponent {
 		} );
 	}
 
-	renderFooterSectionItem( {
-		ID: actionId,
-		connectionName,
-		message,
-		shareDate,
-		service,
-	}, index ) {
+	renderFooterSectionItem( item, index ) {
+		const {
+			service,
+			connectionName,
+			shareDate,
+			message,
+		} = item;
+
 		return (
 			<CompactCard className="post-share__footer-items" key={ index }>
 				<div className="post-share__footer-item">
@@ -91,12 +92,26 @@ class PublicizeActionsList extends PureComponent {
 						{ message }
 					</div>
 				</div>
-				{ this.renderElipsisMenu( actionId, message, service ) }
+				{ this.renderFooterSectionItemActions( item ) }
 			</CompactCard>
 		);
 	}
 
-	renderElipsisMenu( publicizeActionId, message, service ) {
+	renderFooterSectionItemActions( item ) {
+		const {
+			ID: actionId,
+			message,
+			service,
+		} = item;
+
+		if ( this.state.selectedShareTab === SCHEDULED ) {
+			return this.renderScheduledMenu( actionId, message, service );
+		}
+
+		return null;
+	}
+
+	renderScheduledMenu( publicizeActionId, message, service ) {
 		const actions = [];
 		const { translate } = this.props;
 
@@ -112,17 +127,15 @@ class PublicizeActionsList extends PureComponent {
 			);
 		}
 
-		if ( this.state.selectedShareTab === SCHEDULED ) {
-			actions.push(
-				<PopoverMenuItem
-					onClick={ this.deleteScheduledAction( publicizeActionId ) }
-					key="2"
-					icon="trash"
-				>
-					{ translate( 'Trash' ) }
-				</PopoverMenuItem>
-			);
-		}
+		actions.push(
+			<PopoverMenuItem
+				onClick={ this.deleteScheduledAction( publicizeActionId ) }
+				key="2"
+				icon="trash"
+			>
+				{ translate( 'Trash' ) }
+			</PopoverMenuItem>
+		);
 
 		if ( actions.length === 0 ) {
 			return <div />;

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -102,6 +102,7 @@ class PublicizeActionsList extends PureComponent {
 			ID: actionId,
 			message,
 			service,
+			url,
 		} = item;
 
 		if ( this.state.selectedShareTab === SCHEDULED ) {
@@ -110,7 +111,7 @@ class PublicizeActionsList extends PureComponent {
 
 		// PUBLISHED tab
 		return (
-			<a className="post-share__external-url" href={ item.url } target="_blank" rel="noopener noreferrer" >
+			url && <a className="post-share__external-url" href={ url } target="_blank" rel="noopener noreferrer" >
 				<Gridicon icon="external" size={ 24 } />
 			</a>
 		);

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -456,3 +456,20 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 		color: $gray-dark;
 	}
 }
+
+.post-share__external-url {
+	color: lighten( $gray, 20% );
+	cursor: pointer;
+
+	&:visited {
+		color: lighten( $gray, 20% );
+	}
+
+	&:hover {
+		color: $gray-dark;
+	}
+	.gridicon {
+		vertical-align: middle;
+	}
+
+}

--- a/client/state/selectors/utils/index.js
+++ b/client/state/selectors/utils/index.js
@@ -26,7 +26,7 @@ export function enrichPublicizeActionsWithConnections( state, postShareActions )
 		result,
 		share_date,
 		status,
-		url,
+		external_url: url,
 	} ) => {
 		const connection = getPublicizeConnection( state, connection_id );
 


### PR DESCRIPTION
This adds the external url to published actions in the post sharing tab

![screen shot 2017-06-15 at 10 52 15 pm](https://user-images.githubusercontent.com/744755/27213704-725ff6de-521d-11e7-9d58-3d2bada7d521.png)

The external icon is rendered only if an external link is available.  ( Note the missing link for the Google+ scheduled action. This is a known issue with Google+ ) 

** Testing **
- Share a post with Google+ and any other service
- The external link for the non Google+ share should open the share in a new window 
- The Google+ share should not display an external link  
