### PR TITLE
PostSharing: update social preview labels

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -27,9 +27,9 @@ import NoticeAction from 'components/notice/notice-action';
 
 const serviceNames = {
 	facebook: 'Facebook',
+	twitter: 'Twitter',
 	google_plus: 'Google Plus',
 	linkedin: 'LinkedIn',
-	twitter: 'Twitter',
 	tumblr: 'Tumblr'
 };
 

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -11,12 +11,12 @@ import {
 import SocialLogo from 'social-logos';
 
 const services = translate => ( {
-	facebook: { icon: 'facebook', label: translate( 'Facebook feed' ) },
+	facebook: { icon: 'facebook', label: translate( 'Facebook' ) },
 	google: { icon: 'google', label: translate( 'Google search' ) },
 	google_plus: { icon: 'google-plus', label: translate( 'Google+ ' ) },
-	linkedin: { icon: 'linkedin', label: translate( 'LinkedIn share' ) },
-	tumblr: { icon: 'tumblr', label: translate( 'Tumblr post' ) },
-	twitter: { icon: 'twitter', label: translate( 'Twitter card' ) },
+	linkedin: { icon: 'linkedin', label: translate( 'LinkedIn' ) },
+	tumblr: { icon: 'tumblr', label: translate( 'Tumblr' ) },
+	twitter: { icon: 'twitter', label: translate( 'Twitter' ) },
 	wordpress: { icon: 'wordpress', label: translate( 'WordPress.com Reader' ) }
 } );
 


### PR DESCRIPTION
This updates the service labels for social previews.
I also updated the order of services in the republicize preview to show Facebook and Twitter in the 1 and 2 spots respectively.
 
fixes #15120

**Post Preview**
![screen shot 2017-06-15 at 11 13 50 pm](https://user-images.githubusercontent.com/744755/27214320-9bf1706a-5220-11e7-9bd1-6e5917d593bc.png)

**Site Preview**
![screen shot 2017-06-15 at 11 14 04 pm](https://user-images.githubusercontent.com/744755/27214329-a6236f98-5220-11e7-9215-a2011c31bb4a.png)

**Republicize Preview**
![screen shot 2017-06-15 at 11 14 25 pm](https://user-images.githubusercontent.com/744755/27214341-b8963138-5220-11e7-8369-4100790d29b3.png)

**Testing** 

- Open any social sharing preview
- Facebook, Twitter, Tumblr, Google+ and Linkedin should all be one word

