### PR TITLE
Publicize: prevent document scrolling when previewing publicize

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -141,6 +141,13 @@ class PostShare extends Component {
 
 	toggleSharingPreview = () => {
 		const showSharingPreview = ! this.state.showSharingPreview;
+
+		if ( showSharingPreview ) {
+			document.documentElement.classList.add( 'no-scroll', 'is-previewing' );
+		} else {
+			document.documentElement.classList.remove( 'no-scroll', 'is-previewing' );
+		}
+
 		analytics.tracks.recordEvent( 'calypso_publicize_share_preview_toggle', { show: showSharingPreview } );
 		this.setState( { showSharingPreview } );
 	}


### PR DESCRIPTION
This prevents document scrolling when the republicize preview modal is active.
fixes #15157

**Testing**
- Open up the preview from the posts list page
- Scrolling the page should be prevented
- Close the preview
- Scrolling should be re enabled. 