### PR TITLE
Editor: Only propose posts of public post types for links

### DIFF
--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -454,7 +454,7 @@ const PostSelectorPosts = React.createClass( {
 export default connect( ( state, ownProps ) => {
 	const { siteId, query } = ownProps;
 
-	const apiVersion = ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '99' )
+	const apiVersion = ! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.0' )
 		? '1.2'
 		: undefined;
 	const queryWithVersion = { ...query, apiVersion };


### PR DESCRIPTION
This PR is extending the original one #11887 and enables Jetpack support for the feature. My work on API side is now shipped in Jetpack 5.0 so I'm adding this version as a requirement for calling the new endpoint.

This will completely fix #4940 for everyone