### PR TITLE
Happychat: Direct AT sites to WP.com operators instead of jetpack

### DIFF
--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -17,7 +17,8 @@ import {
 	HAPPYCHAT_GROUP_JPOP,
 	HAPPYCHAT_CONNECTION_ERROR_PING_TIMEOUT
 } from './constants';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite, getSite } from 'state/sites/selectors';
+import { isATEnabled } from 'lib/automated-transfer';
 
 // How much time needs to pass before we consider the session inactive:
 const HAPPYCHAT_INACTIVE_TIMEOUT_MS = 1000 * 60 * 10;
@@ -40,8 +41,12 @@ export const HAPPYCHAT_CHAT_STATUS_PENDING = 'pending';
  */
 export const getGroups = ( state, siteId ) => {
 	const groups = [];
+	const siteDetails = getSite( state, siteId );
 
-	if ( isJetpackSite( state, siteId ) ) {
+	if ( isATEnabled( siteDetails ) ) {
+		// AT sites should go to WP.com even though they are jetpack also
+		groups.push( HAPPYCHAT_GROUP_WPCOM );
+	} else if ( isJetpackSite( state, siteId ) ) {
 		groups.push( HAPPYCHAT_GROUP_JPOP );
 	} else {
 		groups.push( HAPPYCHAT_GROUP_WPCOM );

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -31,6 +31,7 @@ import {
 	HAPPYCHAT_GROUP_WPCOM,
 	HAPPYCHAT_GROUP_JPOP
 } from '../constants';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 const TIME_SECOND = 1000;
 const TIME_MINUTE = TIME_SECOND * 60;
@@ -276,6 +277,8 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getGroups()', () => {
+		global.window = {};
+
 		it( 'should return default group for no sites', () => {
 			const siteId = 1;
 			const state = {
@@ -303,6 +306,14 @@ describe( 'selectors', () => {
 		it( 'should return JPOP group for jetpack site', () => {
 			const siteId = 1;
 			const state = {
+				currentUser: {
+					id: 1,
+					capabilities: {
+						[ siteId ]: {
+							manage_options: true
+						}
+					}
+				},
 				sites: {
 					items: {
 						[ siteId ]: { jetpack: true }
@@ -311,6 +322,31 @@ describe( 'selectors', () => {
 			};
 
 			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_JPOP ] );
+		} );
+
+		it( 'should return WPCOM for AT sites group for jetpack site', () => {
+			const siteId = 1;
+			const state = {
+				currentUser: {
+					id: 1,
+					capabilities: {
+						[ siteId ]: {
+							manage_options: true
+						}
+					}
+				},
+				sites: {
+					items: {
+						[ siteId ]: {
+							jetpack: true,
+							options: { is_automated_transfer: true },
+							plan: { product_slug: PLAN_BUSINESS }
+						}
+					}
+				}
+			};
+
+			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_WPCOM ] );
 		} );
 	} );
 } );

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -277,7 +277,16 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getGroups()', () => {
-		global.window = {};
+		let _window; // Keep a copy of the original window if any
+
+		beforeEach( () => {
+			_window = global.window;
+			global.window = {};
+		} );
+
+		afterEach( () => {
+			global.window = _window;
+		} );
 
 		it( 'should return default group for no sites', () => {
 			const siteId = 1;


### PR DESCRIPTION
This PR updates the happychat groups routing rules. Because an `AT` site is considered `jetpack` we were basically sending all `AT` users to email support because we have no `JPOP` operators yet. I updated the group selection so if the selected site is an `AT` it will be directed to `WPCOM` operators and only if its `jetpack` but not `AT` it will direct users to `JPOP` operators.

### Testing scenarios
Tests should run successfully.

#### AT site to WPCOM operator
1. Go to contact form
2. Open HUD and select only WPCOM group
3. Select from the dropdown a site that is `AT`
4. Happychat button should be active (the AT customer should be routed to WPCOM operator)

#### WPCOM site to WPCOM operator
1. Go to contact form
2. Open HUD and select only WPCOM group
3. Select from the dropdown a site that is regular WPCOM
4. Happychat button should be active (the WPCOM customer should be routed to WPCOM operator)

#### Jetpack site to WPCOM operator
1. Go to contact form
2. Open HUD and select only WPCOM group
3. Select from the dropdown a site that is Jetpack
4. Happychat button should not be active (the Jetpack customer should not be routed to WPCOM operator)

#### Jetpack site to JPOP operator
1. Go to contact form
2. Open HUD and select JPOP group also
3. Select from the dropdown a site that is Jetpack
4. Happychat button should be active (the Jetpack customer should be routed to JPOP operator)

### Implementation description
- When selecting a group of operators we check if the site is AT first and only afterwards jetpack. Because AT sites are marked as jetpack also.

