### PR TITLE
Add Q&A search on contact message

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2021,7 +2021,7 @@ Undocumented.prototype.getHelpLinks = function( searchQuery, fn ) {
 };
 
 Undocumented.prototype.getQandA = function( query, site, fn ) {
-	debug( 'help-contact-qanda/ searchQuery {searchQuery}' );
+	debug( 'help-contact-qanda/ searchQuery {query}' );
 
 	return this.wpcom.req.get( '/help/qanda', {
 		query,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2020,6 +2020,15 @@ Undocumented.prototype.getHelpLinks = function( searchQuery, fn ) {
 	}, fn );
 };
 
+Undocumented.prototype.getQandA = function( searchQuery, fn ) {
+	debug( 'help-contact-qanda/ searchQuery {searchQuery}' );
+
+	return this.wpcom.req.get( '/help/qanda', {
+		query: searchQuery,
+		site: config( 'happychat_support_blog' ),
+	}, fn );
+};
+
 Undocumented.prototype.cancelPurchase = function( purchaseId, fn ) {
 	debug( 'upgrades/{purchaseId}/disable-auto-renew' );
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2020,12 +2020,12 @@ Undocumented.prototype.getHelpLinks = function( searchQuery, fn ) {
 	}, fn );
 };
 
-Undocumented.prototype.getQandA = function( searchQuery, fn ) {
+Undocumented.prototype.getQandA = function( query, site, fn ) {
 	debug( 'help-contact-qanda/ searchQuery {searchQuery}' );
 
 	return this.wpcom.req.get( '/help/qanda', {
-		query: searchQuery,
-		site: config( 'happychat_support_blog' ),
+		query,
+		site,
 	}, fn );
 };
 

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import config from 'config';
 import FormLabel from 'components/forms/form-label';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
@@ -116,7 +117,7 @@ export const HelpContactForm = React.createClass( {
 
 	doQandASearch() {
 		const query = this.state.subject + ' ' + this.state.message;
-		wpcom.getQandA( query )
+		wpcom.getQandA( query, config( 'happychat_support_blog' ) )
 			.then( qanda => this.setState( { qanda } ) )
 			.catch( () => this.setState( { qanda: [] } ) );
 	},

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -29,6 +29,7 @@
 	"olark": {},
 	"port": false,
 	"happychat_url": "https://happychat.io/customer",
+	"happychat_support_blog": "en.support.wordpress.com",
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",
 	"facebook_app_id": "611241942420191",
 	"support_locales": [ "en", "es", "pt-br" ],

--- a/config/client.json
+++ b/config/client.json
@@ -16,6 +16,7 @@
   "google_analytics_enabled",
   "google_analytics_key",
   "happychat_url",
+  "happychat_support_blog",
   "hostname",
   "i18n_default_locale_slug",
   "jetpack_min_version",


### PR DESCRIPTION
The Q&A endpoint on wpcom matches user's initial messages to support against a database of frequently asked questions, as a final automated search in an attempt to help them before they start chats or open tickets.

This PR adds as-you-type searching using the Q&A API, on the contact form.