### PR TITLE
Login: Clear notices when the route changes

### DIFF
--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -12,6 +12,7 @@ import {
 	LOGIN_REQUEST,
 	LOGIN_REQUEST_FAILURE,
 	LOGIN_REQUEST_SUCCESS,
+	ROUTE_SET,
 	SOCIAL_LOGIN_REQUEST,
 	SOCIAL_LOGIN_REQUEST_FAILURE,
 	SOCIAL_LOGIN_REQUEST_SUCCESS,
@@ -60,6 +61,7 @@ export const requestError = createReducer( null, {
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: () => null,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => error,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: () => null,
+	[ ROUTE_SET ]: () => null,
 } );
 
 export const requestSuccess = createReducer( null, {
@@ -75,6 +77,7 @@ export const requestNotice = createReducer( null, {
 	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS ]: ( state, { notice } ) => notice,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: ( state, { notice } ) => notice,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: () => null,
+	[ ROUTE_SET ]: () => null,
 } );
 
 const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) => Object.assign( {}, state, {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -114,7 +114,8 @@ export const isRequestingTwoFactorAuth = createReducer( false, {
 export const twoFactorAuthRequestError = createReducer( null, {
 	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST ]: () => null,
 	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS ]: () => null,
-	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE ]: ( state, { error } ) => error
+	[ TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE ]: ( state, { error } ) => error,
+	[ ROUTE_SET ]: () => null,
 } );
 
 export const twoFactorAuthPushPoll = createReducer( { inProgress: false, success: false }, {

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -19,6 +19,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_FAILURE,
 	TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
+	ROUTE_SET,
 } from 'state/action-types';
 import reducer, {
 	isRequesting,
@@ -173,6 +174,14 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( 'another error' );
+		} );
+
+		it( 'should reset the error to null when switching routes', () => {
+			const state = requestError( 'some error', {
+				type: ROUTE_SET
+			} );
+
+			expect( state ).to.be.null;
 		} );
 
 		it( 'should not persist state', () => {

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -233,6 +233,14 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( 'another error' );
 		} );
 
+		it( 'should reset the error to null when switching routes', () => {
+			const state = twoFactorAuthRequestError( 'some error', {
+				type: ROUTE_SET
+			} );
+
+			expect( state ).to.be.null;
+		} );
+
 		it( 'should not persist state', () => {
 			const state = twoFactorAuthRequestError( 'some error', {
 				type: SERIALIZE


### PR DESCRIPTION
This pull request fixes part of #15101 by hiding error and info notices when the route changes
  
#### Testing instructions
  
1. Run `git checkout update/login-notice-clear`
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Log into an account with 2FA enabled
4. Send an SMS to 2FA purposes and wait for the success notice to show
5. Switch back to the auth app screen
6. Check that the success notice about sending the SMS is hidden
7. Switch back to the SMS screen and wait for the error message to show
5. Switch back to the auth app screen
6. Check that the error notice is hidden

#### Reviews
  
- [x] Code
- [x] Product
