### PR TITLE
WooCommerce: Update stock management UI

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -97,6 +97,7 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 						type="number"
 						min="0"
 						onChange={ setStockQuantity }
+						placeholder={ translate( 'Quantity' ) }
 					/>
 				</div>
 

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -9,7 +9,6 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
-import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormFieldSet from 'components/forms/form-fieldset';
@@ -34,12 +33,10 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 		editProduct( siteId, product, { regular_price: e.target.value } );
 	};
 
-	const toggleStock = () => {
-		editProduct( siteId, product, { manage_stock: ! product.manage_stock } );
-	};
-
 	const setStockQuantity = ( e ) => {
-		editProduct( siteId, product, { stock_quantity: e.target.value } );
+		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
+		const manage_stock = ( stock_quantity !== '' );
+		editProduct( siteId, product, { manage_stock, stock_quantity } );
 	};
 
 	const setBackorders = ( e ) => {
@@ -90,26 +87,19 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 
 	const renderStock = () => (
 		<Card className={ stockClasses }>
-			<div className="products__product-manage-stock-toggle">
-				<CompactFormToggle
-					checked={ Boolean( product.manage_stock ) }
-					name="manage_stock"
-					onChange={ toggleStock } />
-				<FormLabel onClick={ toggleStock }>{ translate( 'Manage stock' ) }</FormLabel>
-			</div>
 			<div className="products__product-stock-options-wrapper">
-				{ product.manage_stock && (
-					<div className="products__product-manage-stock">
-						<FormLabel>{ translate( 'Quantity' ) }</FormLabel>
-						<FormTextInput
-							name="stock_quantity"
-							value={ product.stock_quantity || '' }
-							type="number"
-							min="0"
-							onChange={ setStockQuantity }
-							placeholder={ translate( 'Quantity' ) } />
-					</div>
-				) }
+
+				<div className="products__product-manage-stock">
+					<FormLabel>{ translate( 'Stock' ) }</FormLabel>
+					<FormTextInput
+						name="stock_quantity"
+						value={ product.stock_quantity || '' }
+						type="number"
+						min="0"
+						onChange={ setStockQuantity }
+					/>
+				</div>
+
 				{ product.manage_stock && (
 					<div className="products__product-backorders-wrapper">
 						<FormLabel>{ translate( 'Backorders' ) }</FormLabel>

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -35,7 +35,7 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 
 	const setStockQuantity = ( e ) => {
 		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
-		const manage_stock = ( stock_quantity !== '' );
+		const manage_stock = stock_quantity !== '';
 		editProduct( siteId, product, { manage_stock, stock_quantity } );
 	};
 

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -64,7 +64,7 @@ class ProductFormVariationsRow extends Component {
 	setStockQuantity = ( e ) => {
 		const { siteId, editProductVariation, product, variation } = this.props;
 		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
-		const manage_stock = ( stock_quantity !== '' );
+		const manage_stock = stock_quantity !== '';
 		editProductVariation( siteId, product, variation, { stock_quantity, manage_stock } );
 	}
 
@@ -171,7 +171,7 @@ class ProductFormVariationsRow extends Component {
 	}
 
 	render() {
-		const { variation } = this.props;
+		const { variation, translate } = this.props;
 		return (
 			<tr className="products__product-form-variation-row">
 				<td className="products__product-id">

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -64,7 +64,8 @@ class ProductFormVariationsRow extends Component {
 	setStockQuantity = ( e ) => {
 		const { siteId, editProductVariation, product, variation } = this.props;
 		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
-		editProductVariation( siteId, product, variation, { stock_quantity } );
+		const manage_stock = ( stock_quantity !== '' );
+		editProductVariation( siteId, product, variation, { stock_quantity, manage_stock } );
 	}
 
 	showDialog = () => {
@@ -170,7 +171,7 @@ class ProductFormVariationsRow extends Component {
 	}
 
 	render() {
-		const { variation, manageStock, translate } = this.props;
+		const { variation } = this.props;
 		return (
 			<tr className="products__product-form-variation-row">
 				<td className="products__product-id">
@@ -179,6 +180,16 @@ class ProductFormVariationsRow extends Component {
 						<span className="products__product-name products__variation-settings-link" onClick={ this.showDialog }>
 							{ formattedVariationName( variation ) }
 						</span>
+					</div>
+				</td>
+				<td>
+					<div className="products__product-manage-stock">
+						<FormTextInput
+							name="stock_quantity"
+							value={ variation.stock_quantity || '' }
+							type="number"
+							onChange={ this.setStockQuantity }
+						/>
 					</div>
 				</td>
 				<td>
@@ -206,17 +217,6 @@ class ProductFormVariationsRow extends Component {
 								noWrap
 							/>
 						</div>
-					</div>
-				</td>
-				<td>
-					<div className="products__product-manage-stock">
-						{ manageStock && ( <FormTextInput
-							name="stock_quantity"
-							value={ variation.stock_quantity || '' }
-							type="number"
-							onChange={ this.setStockQuantity }
-							placeholder={ translate( 'Quantity' ) }
-						/> ) }
 					</div>
 				</td>
 			</tr>

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -189,6 +189,7 @@ class ProductFormVariationsRow extends Component {
 							value={ variation.stock_quantity || '' }
 							type="number"
 							onChange={ this.setStockQuantity }
+							placeholder={ translate( 'Quantity' ) }
 						/>
 					</div>
 				</td>

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -60,7 +60,7 @@ class ProductFormVariationsTable extends React.Component {
 
 	setStockQuantity = ( e ) => {
 		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
-		const manage_stock = ( stock_quantity !== '' );
+		const manage_stock = stock_quantity !== '';
 		this.editAllVariations( 'stock_quantity', stock_quantity );
 		this.editAllVariations( 'manage_stock', manage_stock );
 	}

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -148,6 +148,7 @@ class ProductFormVariationsTable extends React.Component {
 							value={ stock_quantity }
 							type="number"
 							onChange={ this.setStockQuantity }
+							placeholder={ translate( 'Quantity' ) }
 						/>
 					</div>
 				</td>

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -8,7 +8,6 @@ import { find, isNumber } from 'lodash';
 /**
  * Internal dependencies
  */
-import CompactFormToggle from 'components/forms/form-toggle/compact';
 import Dialog from 'components/dialog';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
@@ -61,21 +60,15 @@ class ProductFormVariationsTable extends React.Component {
 
 	setStockQuantity = ( e ) => {
 		const stock_quantity = Number( e.target.value ) >= 0 ? e.target.value : '';
+		const manage_stock = ( stock_quantity !== '' );
 		this.editAllVariations( 'stock_quantity', stock_quantity );
+		this.editAllVariations( 'manage_stock', manage_stock );
 	}
 
 	setDimension = ( e ) => {
 		const dimensions = { ...this.state.dimensions, [ e.target.name ]: e.target.value };
 		this.editAllVariations( 'dimensions', dimensions );
 	}
-
-	toggleStock = () => {
-		const manage_stock = ! this.state.manage_stock;
-		if ( this.state.manage_stock ) {
-			this.editAllVariations( 'stock_quantity', '' );
-		}
-		this.editAllVariations( 'manage_stock', manage_stock );
-	};
 
 	onShowDialog( selectedVariation ) {
 		this.setState( {
@@ -138,15 +131,24 @@ class ProductFormVariationsTable extends React.Component {
 	}
 
 	renderBulkRow() {
-		const { translate, variations } = this.props;
+		const { translate } = this.props;
 		const { regular_price, dimensions, weight, stock_quantity } = this.state;
-		const manageStock = ( find( variations, ( v ) => v.manage_stock ) ) ? true : false;
 
 		return (
 			<tr className="products__product-form-variation-all-row">
 				<td className="products__product-id">
 					<div className="products__product-name">
 						{ translate( 'All variations' ) }
+					</div>
+				</td>
+				<td>
+					<div className="products__product-manage-stock">
+						<FormTextInput
+							name="stock_quantity"
+							value={ stock_quantity }
+							type="number"
+							onChange={ this.setStockQuantity }
+						/>
 					</div>
 				</td>
 				<td>
@@ -176,23 +178,6 @@ class ProductFormVariationsTable extends React.Component {
 						</div>
 					</div>
 				</td>
-				<td>
-					<div className="products__product-manage-stock">
-						<div className="products__product-manage-stock-toggle">
-							<CompactFormToggle
-								checked={ manageStock }
-								onChange={ this.toggleStock }
-							/>
-						</div>
-						{ manageStock && ( <FormTextInput
-							name="stock_quantity"
-							value={ stock_quantity }
-							type="number"
-							placeholder={ translate( 'Quantity' ) }
-							onChange={ this.setStockQuantity }
-						/> ) }
-					</div>
-				</td>
 			</tr>
 		);
 	}
@@ -211,9 +196,9 @@ class ProductFormVariationsTable extends React.Component {
 						<thead>
 							<tr>
 								<th></th>
+								<th>{ translate( 'Stock' ) }</th>
 								<th className="products__product-price">{ translate( 'Price' ) }</th>
 								<th>{ translate( 'Dimensions & weight' ) }</th>
-								<th>{ translate( 'Manage stock' ) }</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -781,12 +781,8 @@
 		}
 	}
 
-	.products__product-manage-stock {
-		width: 200px;
-
-		.form-text-input {
+	.products__product-manage-stock .form-text-input {
 			width: 110px;
-		}
 	}
 }
 
@@ -846,7 +842,7 @@
 	}
 
 	.products__product-form-stock-disabled {
-		height: 70px;
+		height: 145px;
 	}
 
 	.products__product-manage-stock-toggle,


### PR DESCRIPTION
This PR updates the stock management UI as described in #15165.

It removes the stock toggle and just always displays the stock input (if you a value is entered, you are managing stock).

It also moves the stock column to the first column in the variations table.

Fixes  #15165.

cc @kellychoffman 

To test:
* Go to `http://calypso.localhost:3000/store/product/:site`
* Verify that the stock quantity input always shows on both the variations editor and the simple card.
* Type a value in the simple card stock input and see backorder appear (since you are now managing stock).
* You can verify that `manage_stock` correctly gets set for variations using Redux dev tools. For the simple card, backorders displaying proves this.