### PR TITLE
Editor: Enable post-publish preview in dev

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -113,7 +113,7 @@
 		"plans/personal-plan": true,
 		"plans/jetpack-config-v2": true,
 		"post-editor/delta-post-publish-flow": false,
-		"post-editor/delta-post-publish-preview": false,
+		"post-editor/delta-post-publish-preview": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
**In progress, do not merge**

This PR enables post-publish preview in dev to simplify testing by enabling the feature to be used with calypso.live.

![post-publish-preview](https://user-images.githubusercontent.com/363749/27232231-e061b75a-527a-11e7-9113-851372d89922.gif)

Part of a larger epic. See p8F9tW-3F-p2.