### PR TITLE
View Site: Create main component, use proper URL

### DIFF
--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -18,6 +18,11 @@
 		max-width: 100%;
 	}
 
+	&.preview {
+		height: 100%;
+		max-width: none;
+	}
+
 	&.is-wide-layout {
 		max-width: 1040px;
 	}

--- a/client/my-sites/preview/controller.js
+++ b/client/my-sites/preview/controller.js
@@ -6,14 +6,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import WebPreviewContent from 'components/web-preview/content';
+import PreviewMain from './main';
 
 export default {
 	preview: function( context, next ) {
 		context.primary = (
-			<WebPreviewContent
-				previewUrl={ `https://${ context.params.site }/?iframe=true&preview=true` }
-				showClose={ false }
+			<PreviewMain
+				site={ context.params.site }
 			/>
 		);
 		next();

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -13,7 +13,6 @@ import {
 	getSelectedSite,
 	getSelectedSiteId,
 } from 'state/ui/selectors';
-import config from 'config';
 import addQueryArgs from 'lib/route/add-query-args';
 
 import DocumentHead from 'components/data/document-head';
@@ -31,13 +30,13 @@ class PreviewMain extends React.Component {
 	};
 
 	componentWillMount() {
-		console.log( this.props.site );
 		this.updateUrl();
 	}
 
 	updateUrl() {
 		if ( ! this.props.site ) {
 			if ( this.state.previewUrl !== null ) {
+				debug( 'unloaded page' );
 				this.setState( { previewUrl: null } );
 			}
 			return;
@@ -50,6 +49,7 @@ class PreviewMain extends React.Component {
 		}, this.getBasePreviewUrl() );
 
 		if ( this.iframeUrl !== newUrl ) {
+			debug( 'loading', previewUrl );
 			this.setState( { previewUrl: newUrl } );
 		}
 	}
@@ -58,12 +58,9 @@ class PreviewMain extends React.Component {
 		return this.props.site.options.unmapped_url;
 	}
 
-	componentDidMount() {
-		console.log(this.props);
-	}
-
 	componentDidUpdate( prevProps ) {
 		if ( this.props.siteId !== prevProps.siteId ) {
+			debug( 'site change detected' );
 			this.updateUrl();
 		}
 	}

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -49,7 +49,7 @@ class PreviewMain extends React.Component {
 		}, this.getBasePreviewUrl() );
 
 		if ( this.iframeUrl !== newUrl ) {
-			debug( 'loading', previewUrl );
+			debug( 'loading', newUrl );
 			this.setState( { previewUrl: newUrl } );
 		}
 	}

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -16,6 +16,8 @@ import {
 import config from 'config';
 import addQueryArgs from 'lib/route/add-query-args';
 
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
 import WebPreviewContent from 'components/web-preview/content';
 
 const debug = debugFactory( 'calypso:my-sites:preview' );
@@ -67,11 +69,16 @@ class PreviewMain extends React.Component {
 	}
 
 	render() {
+		const { translate } = this.props;
+
 		return (
-			<WebPreviewContent
-				showClose={ false }
-				previewUrl={ this.state.previewUrl }
-			/>
+			<Main className="preview">
+				<DocumentHead title={ translate( 'Site Preview' ) } />
+				<WebPreviewContent
+					showClose={ false }
+					previewUrl={ this.state.previewUrl }
+				/>
+			</Main>
 		);
 	}
 }

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+} from 'state/ui/selectors';
+import config from 'config';
+import addQueryArgs from 'lib/route/add-query-args';
+
+import WebPreviewContent from 'components/web-preview/content';
+
+const debug = debugFactory( 'calypso:my-sites:preview' );
+
+class PreviewMain extends React.Component {
+
+	static displayName = 'Preview';
+
+	state = {
+		previewUrl: null,
+	};
+
+	componentWillMount() {
+		console.log( this.props.site );
+		this.updateUrl();
+	}
+
+	updateUrl() {
+		if ( ! this.props.site ) {
+			if ( this.state.previewUrl !== null ) {
+				this.setState( { previewUrl: null } );
+			}
+			return;
+		}
+
+		const newUrl = addQueryArgs( {
+			preview: true,
+			iframe: true,
+			'frame-nonce': this.props.site.options.frame_nonce
+		}, this.getBasePreviewUrl() );
+
+		if ( this.iframeUrl !== newUrl ) {
+			this.setState( { previewUrl: newUrl } );
+		}
+	}
+
+	getBasePreviewUrl() {
+		return this.props.site.options.unmapped_url;
+	}
+
+	componentDidMount() {
+		console.log(this.props);
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.siteId !== prevProps.siteId ) {
+			this.updateUrl();
+		}
+	}
+
+	render() {
+		return (
+			<WebPreviewContent
+				showClose={ false }
+				previewUrl={ this.state.previewUrl }
+			/>
+		);
+	}
+}
+
+const mapState = ( state ) => ( {
+	site: getSelectedSite( state ),
+	siteId: getSelectedSiteId( state ),
+} );
+
+export default connect( mapState )( localize( PreviewMain ) );


### PR DESCRIPTION
This PR creates a proper main component for standalone site preview, gives the section its <title>, connects it to redux and uses proper URL building for iframe, based on site data from API.

To test:
- open /view/some-slug.com (use one of your sites)
- test if <title> of tab changed to "Site Preview"
- test if the site loaded in main content area
- try switching sites while at /view/:slug
    - current page should disappear as soon as possible and one should be loaded after that

Private sites should now load correctly, P2 previews should also work. There might still be some sites that don't load. We can address that separately (likely a backend change)