### PR TITLE
WooCommerce: Add product UI state for the products list.

### DIFF
--- a/client/extensions/woocommerce/state/ui/products/list-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/list-reducer.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { createReducer } from 'state/utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	WOOCOMMERCE_PRODUCTS_REQUEST,
+	WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+} from 'woocommerce/state/action-types';
+
+export default createReducer( null, {
+	[ WOOCOMMERCE_PRODUCTS_REQUEST ]: productsRequest,
+	[ WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS ]: productsRequestSuccess,
+} );
+
+export function productsRequestSuccess( state, action ) {
+	const prevState = state || {};
+	const { page, products } = action;
+	const productIds = products.map( ( p ) => {
+		return p.id;
+	} );
+	return { ...prevState,
+		currentPage: page,
+		productIds,
+		requestedPage: null,
+	};
+}
+
+export function productsRequest( state, action ) {
+	const prevState = state || {};
+	const { page } = action;
+	return { ...prevState,
+		requestedPage: page,
+	};
+}

--- a/client/extensions/woocommerce/state/ui/products/reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/reducer.js
@@ -1,12 +1,15 @@
 /**
  * Internal dependencies
  */
-import edits from './edits-reducer';
+
 import { combineReducers, keyedReducer } from 'state/utils';
+import edits from './edits-reducer';
+import list from './list-reducer';
 import variations from './variations/reducer';
 import apiPlan from './api-plan/reducer';
 
 export default keyedReducer( 'siteId', combineReducers( {
+	list,
 	edits,
 	variations,
 	apiPlan,

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -59,3 +59,41 @@ export function getCurrentlyEditingProduct( state, siteId = getSelectedSiteId( s
 
 	return getProductWithLocalEdits( state, currentlyEditingId, siteId );
 }
+
+/**
+ * Gets the current products list page being viewed.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number} Current product list page (defaul: 1)
+ */
+export function getProductListCurrentPage( state, siteId = getSelectedSiteId( state ) ) {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'list', 'currentPage' ], 1 );
+}
+
+/**
+ * Gets an array of products for the current page being viewed.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {array|false} Array of products or false if products are not available.
+ */
+export function getProductListProducts( state, siteId = getSelectedSiteId( state ) ) {
+	const products = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], {} );
+	const productIds = get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'list', 'productIds' ], [] );
+	if ( productIds.length ) {
+		return productIds.map( id => find( products, ( p ) => id === p.id ) );
+	}
+	return false;
+}
+
+/**
+ * Gets the requested/loading page for the products list.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {number|null} Requested product list page
+ */
+export function getProductListRequestedPage( state, siteId = getSelectedSiteId( state ) ) {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'list', 'requestedPage' ], null );
+}

--- a/client/extensions/woocommerce/state/ui/products/test/list-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/list-reducer.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	productsRequest,
+	productsRequestSuccess,
+} from '../list-reducer';
+
+import {
+	WOOCOMMERCE_PRODUCTS_REQUEST,
+	WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+} from 'woocommerce/state/action-types';
+
+import products from 'woocommerce/state/sites/products/test/fixtures/products';
+
+describe( 'reducer', () => {
+	describe( 'productsRequest', () => {
+		it( 'should store the requested page', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_REQUEST,
+				siteId: 123,
+				page: 3,
+			};
+			const newState = productsRequest( undefined, action );
+			expect( newState.requestedPage ).to.eql( 3 );
+		} );
+	} );
+	describe( 'productsRequestSuccess', () => {
+		it( 'should store the current page', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+				siteId: 123,
+				page: 2,
+				totalPages: 3,
+				totalProducts: 30,
+				products,
+			};
+			const newState = productsRequestSuccess( undefined, action );
+			expect( newState.currentPage ).to.eql( 2 );
+		} );
+		it( 'should store product ids for the current page', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
+				siteId: 123,
+				page: 2,
+				totalPages: 3,
+				totalProducts: 30,
+				products,
+			};
+			const newState = productsRequestSuccess( undefined, action );
+			expect( newState.productIds ).to.eql( [ 15, 389 ] );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds a `list` state branch to the Products **UI** state that includes the current page being viewed (last fetch), the current page requested by a user (for when a fetch is kicked off), and the product IDs that are to be displayed on the current listing page, so that we can pull the proper products out of our fetched products list. It includes selectors for these items.

This is used for the product list UI which I'll have a PR up for shortly.

To Test:
* Run `npm test` and make sure all tests pass.