### PR TITLE
PostShare: add shares (actions) into the calendar

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get, includes, map } from 'lodash';
+import { get, includes, map, concat } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { isEnabled } from 'config';
 import Gridicon from 'gridicons';
@@ -18,6 +18,10 @@ import QueryPublicizeConnections from 'components/data/query-publicize-connectio
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import NoticeAction from 'components/notice/notice-action';
+import {
+	getPostShareScheduledActions,
+	getPostSharePublishedActions,
+} from 'state/selectors';
 import {
 	isPublicizeEnabled,
 	isSchedulingPublicizeShareAction,
@@ -230,6 +234,8 @@ class PostShare extends Component {
 			hasRepublicizeSchedulingFeature,
 			siteId,
 			translate,
+			publishedActions,
+			scheduledActions,
 		} = this.props;
 
 		const shareButton = <Button
@@ -259,6 +265,14 @@ class PostShare extends Component {
 			);
 		}
 
+		const actionsEvents = map( concat( publishedActions, scheduledActions ), ( { ID, message, date, service } ) => ( {
+			id: ID,
+			type: 'published-action',
+			title: message,
+			date,
+			socialIcon: service === 'google_plus' ? 'google-plus' : service,
+		} ) );
+
 		return (
 			<div className="post-share__button-actions">
 				{ previewButton }
@@ -273,6 +287,7 @@ class PostShare extends Component {
 
 					<CalendarButton
 						primary
+						events={ actionsEvents }
 						className="post-share__schedule-button"
 						disabled={ this.isDisabled() }
 						title={ translate( 'Set date and time' ) }
@@ -430,13 +445,15 @@ class PostShare extends Component {
 			hasFetchedConnections,
 			hasRepublicizeFeature,
 			hasRepublicizeSchedulingFeature,
+			siteSlug,
+			translate,
 		} = this.props;
 
 		if ( ! hasFetchedConnections ) {
 			return null;
 		}
 
-		const { siteSlug, translate, isJetpack } = this.props;
+		const { isJetpack } = this.props;
 
 		if ( ! this.hasConnections() ) {
 			return (
@@ -573,6 +590,8 @@ export default connect(
 			premiumPrice: getDiscountedOrRegularPrice( state, siteId, PLAN_PREMIUM ),
 			jetpackPremiumPrice: getDiscountedOrRegularPrice( state, siteId, PLAN_JETPACK_PREMIUM ),
 			userCurrency: getCurrentUserCurrencyCode( state ),
+			scheduledActions: getPostShareScheduledActions( state, siteId, postId ),
+			publishedActions: getPostSharePublishedActions( state, siteId, postId ),
 		};
 	},
 	{ requestConnections, sharePost, dismissShareConfirmation, schedulePostShareAction }

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -23,16 +23,25 @@ const user = new User();
 const noop = () => {};
 
 class PostSchedule extends Component {
-	constructor() {
-		super( ...arguments );
+	static propTypes = {
+		events: PropTypes.array,
+		posts: PropTypes.array,
+		timezone: PropTypes.string,
+		gmtOffset: PropTypes.number,
+		site: PropTypes.object,
+		onDateChange: PropTypes.func,
+		onMonthChange: PropTypes.func
+	};
 
-		this.state = {
-			calendarViewDate: moment(
-				this.props.selectedDay
-					? this.props.selectedDay
-					: new Date()
-			)
-		};
+	static defaultProps = {
+		posts: [],
+		events: [],
+		onDateChange: noop,
+		onMonthChange: noop
+	};
+
+	state = {
+		calendarViewDate: moment( this.props.selectedDay ? this.props.selectedDay : new Date() )
 	}
 
 	componentWillMount() {
@@ -201,27 +210,5 @@ class PostSchedule extends Component {
 		);
 	}
 }
-
-/**
- * Statics
- */
-PostSchedule.displayName = 'PostSchedule';
-
-PostSchedule.propTypes = {
-	events: PropTypes.array,
-	posts: PropTypes.array,
-	timezone: PropTypes.string,
-	gmtOffset: PropTypes.number,
-	site: PropTypes.object,
-	onDateChange: PropTypes.func,
-	onMonthChange: PropTypes.func
-};
-
-PostSchedule.defaultProps = {
-	posts: [],
-	events: [],
-	onDateChange: noop,
-	onMonthChange: noop
-};
 
 export default PostSchedule;

--- a/client/state/selectors/utils/index.js
+++ b/client/state/selectors/utils/index.js
@@ -29,6 +29,7 @@ export function enrichPublicizeActionsWithConnections( state, postShareActions )
 		external_url: url,
 	} ) => {
 		const connection = getPublicizeConnection( state, connection_id );
+		const actionDate = moment( share_date );
 
 		return {
 			ID,
@@ -38,7 +39,8 @@ export function enrichPublicizeActionsWithConnections( state, postShareActions )
 			message,
 			result,
 			service: get( connection, 'service', 'twitter' ),
-			shareDate: moment( share_date ).format( 'llll' ),
+			shareDate: actionDate.format( 'llll' ),
+			date: actionDate,
 			status,
 			url,
 		};


### PR DESCRIPTION
This PR adds the shares (actions) into the PostShare calendar.

<img src="https://user-images.githubusercontent.com/77539/27334110-972eac38-559e-11e7-8304-e2c0c1142f0b.png" width="600px" />

### Testing

1) Select a site with a `Premium` or `Business` plan
2) Go to posts list page: `http://calypso.localhost:3000/posts/<your-testing-site>`
3) Click on the `Share` tab
4) Start to test adding new scheduled posts paying attention how the new posts are added to the calendar. If you have already have scheduled events then better!

<img src="https://user-images.githubusercontent.com/77539/27334058-68aead2c-559e-11e7-8f25-dd6419d1a209.gif" width="600px" />



