### PR TITLE
WebPreview: Update toolbar styles to match EditorGroundControl

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -116,8 +116,6 @@ a.web-preview__external.button {
 }
 
 a.web-preview__external.button {
-	border-left: 1px solid lighten( $gray, 25% );
-
 	.gridicon {
 		top: 6px;
 	}

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -60,7 +60,7 @@
 		@include breakpoint( ">960px" ) {
 			left: 24px;
 			right: 24px;
-			width: calc( 100% - 48px ); /* IE11 fix */
+			width: calc( 100% - 46px ); /* IE11 fix */
 		}
 	}
 
@@ -88,38 +88,45 @@
 }
 
 .web-preview__toolbar {
-	height: 48px;
+	height: 46px;
 	background: $white;
 	border-bottom: 1px solid lighten( $gray, 20% );
 	border-radius: 4px 4px 0 0;
 	display: flex;
 }
 
-.web-preview__close,
-a.web-preview__external {
+.web-preview__close.button,
+a.web-preview__external.button {
 	color: $gray;
-	padding: 12px 16px;
+	padding: 6px 10px;
 
 	cursor: pointer;
 
 	&:hover {
 		color: $gray-dark;
 	}
+}
+
+.web-preview__close.button {
+	border-right: 1px solid lighten( $gray, 25% );
 
 	.gridicon {
-		vertical-align: middle;
+		top: 4px;
 	}
 }
 
-.web-preview__close {
-	height: 49px;
-	cursor: pointer;
+a.web-preview__external.button {
+	border-left: 1px solid lighten( $gray, 25% );
+
+	.gridicon {
+		top: 6px;
+	}
 }
 
-.web-preview__edit {
+.web-preview__edit.button {
 	color: $gray;
 	border: none;
-	padding: 15px 12px;
+	padding: 6px 12px;
 
 	&:visited {
 		color: $gray;
@@ -140,7 +147,7 @@ a.web-preview__external {
 
 .web-preview__device-switcher {
 	display: flex;
-	margin: 6px 0 0 8px;
+	margin: 6px 0 0 12px;
 	width: 200px;
 }
 

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -83,14 +83,15 @@ class PreviewToolbar extends Component {
 		return (
 			<div className="web-preview__toolbar">
 				{ showClose &&
-					<button
+					<Button
+						borderless
 						aria-label={ translate( 'Close preview' ) }
 						className="web-preview__close"
 						data-tip-target="web-preview__close"
 						onClick={ onClose }
 					>
 						<Gridicon icon="cross" />
-					</button>
+					</Button>
 				}
 				{ showDeviceSwitcher &&
 					<SelectDropdown
@@ -114,6 +115,7 @@ class PreviewToolbar extends Component {
 				<div className="web-preview__toolbar-actions">
 					{ showEdit &&
 						<Button
+							borderless
 							className="web-preview__edit"
 							href={ editUrl }
 							onClick={ onEdit }
@@ -122,14 +124,15 @@ class PreviewToolbar extends Component {
 						</Button>
 					}
 					{ showExternal &&
-						<a
+						<Button
+							borderless
 							className="web-preview__external"
 							href={ externalUrl || previewUrl }
 							target="_blank"
 							rel="noopener noreferrer"
 						>
 							<Gridicon icon="external" />
-						</a>
+						</Button>
 					}
 					<div className="web-preview__toolbar-tray">
 						{ this.props.children }

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -43,3 +43,13 @@
 		margin-bottom: 5px;
 	}
 }
+
+.editor-preview .web-preview__close.button,
+.editor-preview a.web-preview__external.button,
+.editor-preview .web-preview__edit.button {
+	color: $gray-text-min;
+
+	&:hover {
+		color: $gray-dark;
+	}
+}

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -25,7 +25,6 @@
 
 .editor-preview .web-preview__loading-message-wrapper {
 	display: flex;
-	align-items: center;
 	justify-content: center;
 	height: 100%;
 }
@@ -34,6 +33,7 @@
 	font-size: 16px;
 	height: initial;
 	position: relative;
+		top: 30%;
 		z-index: z-index( 'root', '.web-preview' );
 
 	strong {


### PR DESCRIPTION
In #14330 and #15004, WebPreviewContent is now being used to show full-screen previews in different contexts. This PR updates the preview toolbar height, button usage, and button alignment to more closely match that of `EditorGroundControl`, another full-screen toolbar implementation in Calypso.

**Before:**
<img width="1366" alt="before" src="https://user-images.githubusercontent.com/942359/27238352-87c9f326-529a-11e7-9f38-292a22eaf291.png">

**After:**
<img width="1364" alt="after" src="https://user-images.githubusercontent.com/942359/27238359-90f4bb0c-529a-11e7-86b7-3494dfa7f805.png">

Big changes, right?

This is part of a larger epic (See p3Ex-2ri-p2)

**To Test:**

- Check out branch.
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Open `WebPreview` in different contexts to see if anything looks broken. (i.e. site preview, theme preview, post preview)