### PR TITLE
WooCommerce: Add the products list UI.

### DIFF
--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -92,11 +92,11 @@ class Products extends Component {
 		const { translate, site } = this.props;
 		const emptyContentAction = (
 			<Button href={ getLink( '/store/product/:site/', site ) }>
-				{ translate( 'Add a product' ) }
+				{ translate( 'Add your first product' ) }
 			</Button>
 		);
 		return <EmptyContent
-				title={ translate( 'You don\'t have any products.' ) }
+				title={ translate( 'You don\'t have any products yet.' ) }
 				action={ emptyContentAction }
 		/>;
 	}
@@ -135,7 +135,7 @@ class Products extends Component {
 				<SidebarNavigation />
 				<ActionHeader>
 					<Button primary href={ getLink( '/store/product/:site/', site ) }>
-						{ translate( 'Add product' ) }
+						{ translate( 'Add a product' ) }
 					</Button>
 				</ActionHeader>
 				{ this.renderList() }

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -1,0 +1,178 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import EmptyContent from 'components/empty-content';
+import { fetchProducts } from 'woocommerce/state/sites/products/actions';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getTotalProducts, areProductsLoaded } from 'woocommerce/state/sites/products/selectors';
+import { getProductListCurrentPage, getProductListProducts, getProductListRequestedPage } from 'woocommerce/state/ui/products/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import Main from 'components/main';
+import Pagination from 'my-sites/stats/pagination';
+import ProductsListTable from './products-list-table';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+
+class Products extends Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			slug: PropTypes.string,
+		} ),
+		products: PropTypes.oneOfType( [
+			PropTypes.array,
+			PropTypes.bool,
+		] ),
+		currentPage: PropTypes.number,
+		currentPageLoaded: PropTypes.bool,
+		requestedPage: PropTypes.number,
+		requestedPageLoaded: PropTypes.bool,
+		totalProducts: PropTypes.number,
+		fetchProducts: PropTypes.func,
+	};
+
+	// Total number of results per page (the API returns 10)
+	perPage = 10;
+
+	componentDidMount() {
+		const { site } = this.props;
+		if ( site && site.ID ) {
+			this.props.fetchProducts( site.ID, 1 );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { site } = this.props;
+		const newSiteId = newProps.site && newProps.site.ID || null;
+		const oldSiteId = site && site.ID || null;
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchProducts( newSiteId, 1 );
+		}
+	}
+
+	switchPage = ( page ) => {
+		const { site } = this.props;
+		this.props.fetchProducts( site.ID, page );
+	}
+
+	pagination() {
+		const { site, currentPage, totalProducts, currentPageLoaded, requestedPage } = this.props;
+
+		// If we know previously that all products fit on one page, don't show the placeholder
+		// since the Pagination component doesn't display anything for single page display.
+		if ( totalProducts && totalProducts < ( this.perPage + 1 ) ) {
+			return null;
+		}
+
+		if ( ! site || ! currentPageLoaded ) {
+			return ( <div className="products__list-placeholder pagination"></div> );
+		}
+
+		const page = requestedPage || currentPage;
+		return (
+			<Pagination
+				page={ page }
+				perPage={ this.perPage }
+				total={ totalProducts }
+				pageClick={ this.switchPage }
+			/>
+		);
+	}
+
+	renderEmptyContent() {
+		const { translate, site } = this.props;
+		const emptyContentAction = (
+			<Button href={ getLink( '/store/product/:site/', site ) }>
+				{ translate( 'Add a product' ) }
+			</Button>
+		);
+		return <EmptyContent
+				title={ translate( 'You don\'t have any products.' ) }
+				action={ emptyContentAction }
+		/>;
+	}
+
+	renderList() {
+		const { site, products, totalProducts, currentPageLoaded, requestedPageLoaded, requestedPage } = this.props;
+
+		if ( currentPageLoaded === true && totalProducts === 0 ) {
+			return this.renderEmptyContent();
+		}
+
+		let isRequesting = false;
+		if ( requestedPage && ! requestedPageLoaded ) {
+			isRequesting = true;
+		} else if ( ! products ) {
+			isRequesting = true;
+		}
+
+		return (
+			<div className="products__list-wrapper">
+				{ this.pagination() }
+
+				<ProductsListTable
+					site={ site }
+					products={ products }
+					isRequesting={ isRequesting }
+				/>
+
+				{ this.pagination() }
+			</div>
+		);
+	}
+
+	render() {
+		const { className, site, translate } = this.props;
+		const classes = classNames( 'products__list', className );
+		return (
+			<Main className={ classes }>
+				<SidebarNavigation />
+				<ActionHeader>
+					<Button href={ getLink( '/store/product/:site/', site ) }>
+						{ translate( 'Add new product' ) }
+					</Button>
+				</ActionHeader>
+				{ this.renderList() }
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const currentPage = site && getProductListCurrentPage( state, site.ID );
+	const currentPageLoaded = site && currentPage && areProductsLoaded( state, currentPage, site.ID );
+	const requestedPage = site && getProductListRequestedPage( state, site.ID );
+	const requestedPageLoaded = site && requestedPage && areProductsLoaded( state, requestedPage, site.ID );
+	const products = site && getProductListProducts( state, site.ID );
+	const totalProducts = site && getTotalProducts( state, site.ID );
+	return {
+		site,
+		currentPage,
+		currentPageLoaded,
+		requestedPage,
+		requestedPageLoaded,
+		products,
+		totalProducts,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchProducts,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( Products ) );

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -117,8 +117,7 @@ class Products extends Component {
 
 		return (
 			<div className="products__list-wrapper">
-				{ this.pagination() }
-
+				
 				<ProductsListTable
 					site={ site }
 					products={ products }
@@ -137,8 +136,8 @@ class Products extends Component {
 			<Main className={ classes }>
 				<SidebarNavigation />
 				<ActionHeader>
-					<Button href={ getLink( '/store/product/:site/', site ) }>
-						{ translate( 'Add new product' ) }
+					<Button primary href={ getLink( '/store/product/:site/', site ) }>
+						{ translate( 'Add product' ) }
 					</Button>
 				</ActionHeader>
 				{ this.renderList() }

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -108,13 +108,7 @@ class Products extends Component {
 			return this.renderEmptyContent();
 		}
 
-		let isRequesting = false;
-		if ( requestedPage && ! requestedPageLoaded ) {
-			isRequesting = true;
-		} else if ( ! products ) {
-			isRequesting = true;
-		}
-
+		const isRequesting = ( requestedPage && ! requestedPageLoaded ) || ! products ? true : false;
 		return (
 			<div className="products__list-wrapper">
 				<ProductsListTable

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -117,13 +117,11 @@ class Products extends Component {
 
 		return (
 			<div className="products__list-wrapper">
-				
 				<ProductsListTable
 					site={ site }
 					products={ products }
 					isRequesting={ isRequesting }
 				/>
-
 				{ this.pagination() }
 			</div>
 		);

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -90,7 +90,7 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 			<div className="products__product-stock-options-wrapper">
 
 				<div className="products__product-manage-stock">
-					<FormLabel>{ translate( 'Stock' ) }</FormLabel>
+					<FormLabel>{ translate( 'Inventory' ) }</FormLabel>
 					<FormTextInput
 						name="stock_quantity"
 						value={ product.stock_quantity || '' }

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -197,7 +197,7 @@ class ProductFormVariationsTable extends React.Component {
 						<thead>
 							<tr>
 								<th></th>
-								<th>{ translate( 'Stock' ) }</th>
+								<th>{ translate( 'Inventory' ) }</th>
 								<th className="products__product-price">{ translate( 'Price' ) }</th>
 								<th>{ translate( 'Dimensions & weight' ) }</th>
 							</tr>

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -27,7 +27,10 @@ const ProductsListRow = ( { site, product, translate } ) => {
 	} );
 	const renderCategories = () => (
 		<div className="products__list-categories">
-			{ categoryNames && categoryNames.join( ', ' ) }
+			{ categoryNames &&
+				( categoryNames.join( ', ' ) ) ||
+				( <span>{ translate( '-' ) }</span> )
+			}
 		</div>
 	);
 
@@ -35,7 +38,7 @@ const ProductsListRow = ( { site, product, translate } ) => {
 		<div>
 			{ product.manage_stock && 'simple' === product.type &&
 				( <span>{ product.stock_quantity }</span> ) ||
-				( <span>{ translate( 'N/A' ) }</span> )
+				( <span>{ translate( '-' ) }</span> )
 			}
 		</div>
 	);

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -3,7 +3,6 @@
  */
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
 import page from 'page';
 
 /**
@@ -13,10 +12,11 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
 
-const ProductsListRow = ( { site, product, translate } ) => {
+const ProductsListRow = ( { site, product } ) => {
 	// The first returned image from the API is the featured image.
 	const featuredImage = product.images && product.images[ 0 ];
 	const imageClasses = classNames( 'products__list-image', { 'is-thumb-placeholder': ! featuredImage } );
+
 	const renderImage = () => (
 		<div className={ imageClasses }>
 			{ featuredImage && ( <img src={ featuredImage.src } /> ) }
@@ -26,11 +26,12 @@ const ProductsListRow = ( { site, product, translate } ) => {
 	const categoryNames = product.categories && product.categories.map( function( category ) {
 		return category.name;
 	} );
+
 	const renderCategories = () => (
 		<div className="products__list-categories">
 			{ categoryNames &&
 				( categoryNames.join( ', ' ) ) ||
-				( <span>{ translate( '-' ) }</span> )
+				( <span>-</span> )
 			}
 		</div>
 	);
@@ -39,7 +40,7 @@ const ProductsListRow = ( { site, product, translate } ) => {
 		<div>
 			{ product.manage_stock && 'simple' === product.type &&
 				( <span>{ product.stock_quantity }</span> ) ||
-				( <span>{ translate( '-' ) }</span> )
+				( <span>-</span> )
 			}
 		</div>
 	);
@@ -75,4 +76,4 @@ ProductsListRow.propTypes = {
 	} ),
 };
 
-export default localize( ProductsListRow );
+export default ProductsListRow;

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getLink } from 'woocommerce/lib/nav-utils';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+
+const ProductsListRow = ( { site, product, translate } ) => {
+	// The first returned image from the API is the featured image.
+	const featuredImage = product.images && product.images[ 0 ];
+	const imageClasses = classNames( 'products__list-image', { 'is-thumb-placeholder': ! featuredImage } );
+	const renderImage = () => (
+		<div className={ imageClasses }>
+			{ featuredImage && ( <img src={ featuredImage.src } /> ) }
+		</div>
+	);
+
+	const categoryNames = product.categories && product.categories.map( function( category ) {
+		return category.name;
+	} );
+	const renderCategories = () => (
+		<div className="products__list-categories">
+			{ categoryNames && categoryNames.join( ', ' ) }
+		</div>
+	);
+
+	const renderStock = () => (
+		<div>
+			{ product.manage_stock && 'simple' === product.type &&
+				( <span>{ product.stock_quantity }</span> ) ||
+				( <span>{ translate( 'N/A' ) }</span> )
+			}
+		</div>
+	);
+
+	return (
+		<TableRow>
+			<TableItem isTitle className="products__list-product">
+				{ renderImage() }
+				<a href={ getLink( '/store/product/:site/' + product.id, site ) }>
+					{ product.name }
+				</a>
+			</TableItem>
+			<TableItem>{ renderStock() }</TableItem>
+			<TableItem>{ renderCategories() }</TableItem>
+		</TableRow>
+	);
+};
+
+ProductsListRow.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	product: PropTypes.shape( {
+		id: PropTypes.number,
+		name: PropTypes.string,
+		manage_stock: PropTypes.bool,
+		stock_quantity: PropTypes.number,
+		images: PropTypes.array,
+		categories: PropTypes.array,
+	} ),
+};
+
+export default localize( ProductsListRow );

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -43,13 +44,16 @@ const ProductsListRow = ( { site, product, translate } ) => {
 		</div>
 	);
 
+	const goToProduct = () => {
+		const link = getLink( '/store/product/:site/' + product.id, site );
+		page( link );
+	};
+
 	return (
-		<TableRow>
+		<TableRow onClick={ goToProduct }>
 			<TableItem isTitle className="products__list-product">
 				{ renderImage() }
-				<a href={ getLink( '/store/product/:site/' + product.id, site ) }>
-					{ product.name }
-				</a>
+				<span className="products__list-name">{ product.name }</span>
 			</TableItem>
 			<TableItem>{ renderStock() }</TableItem>
 			<TableItem>{ renderCategories() }</TableItem>

--- a/client/extensions/woocommerce/app/products/products-list-table.js
+++ b/client/extensions/woocommerce/app/products/products-list-table.js
@@ -16,7 +16,7 @@ import TableItem from 'woocommerce/components/table/table-item';
 const ProductsListTable = ( { translate, products, site, isRequesting } ) => {
 	const headings = (
 		<TableRow isHeader className={ classNames( { 'products__list-placeholder': ! products } ) }>
-			{ [ translate( 'Product' ), translate( 'Stock' ), translate( 'Category' ) ].map( ( item, i ) =>
+			{ [ translate( 'Product' ), translate( 'Inventory' ), translate( 'Category' ) ].map( ( item, i ) =>
 				<TableItem isHeader key={ i } isTitle={ 0 === i }>{ item }</TableItem>
 			) }
 		</TableRow>

--- a/client/extensions/woocommerce/app/products/products-list-table.js
+++ b/client/extensions/woocommerce/app/products/products-list-table.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ProductsListRow from './products-list-row';
+import Table from 'woocommerce/components/table';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+
+const ProductsListTable = ( { translate, products, site, isRequesting } ) => {
+	const headings = (
+		<TableRow isHeader className={ classNames( { 'products__list-placeholder': ! products } ) }>
+			{ [ translate( 'Product' ), translate( 'Stock' ), translate( 'Category' ) ].map( ( item, i ) =>
+				<TableItem isHeader key={ i } isTitle={ 0 === i }>{ item }</TableItem>
+			) }
+		</TableRow>
+	);
+
+	return (
+		<div>
+			<Table header={ headings } className={ classNames( { 'is-requesting': isRequesting } ) }>
+				{ products && products.map( ( product, i ) => (
+					<ProductsListRow
+						key={ i }
+						site={ site }
+						product={ product }
+					/>
+				) ) }
+			</Table>
+			{ ! products && ( <div className="products__list-placeholder"></div> ) }
+		</div>
+	);
+};
+
+ProductsListRow.propTypes = {
+	isRequesting: PropTypes.bool,
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	products: PropTypes.oneOfType( [
+		PropTypes.array,
+		PropTypes.bool,
+	] ),
+};
+
+export default localize( ProductsListTable );

--- a/client/extensions/woocommerce/app/products/products-list-table.js
+++ b/client/extensions/woocommerce/app/products/products-list-table.js
@@ -38,7 +38,7 @@ const ProductsListTable = ( { translate, products, site, isRequesting } ) => {
 	);
 };
 
-ProductsListRow.propTypes = {
+ProductsListTable.propTypes = {
 	isRequesting: PropTypes.bool,
 	site: PropTypes.shape( {
 		slug: PropTypes.string,

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -106,7 +106,7 @@
 		}
 	}
 
-	.table-row {
+	.table-row:not(.is-header) {
 		cursor: pointer;
 	}
 

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -1,4 +1,12 @@
 &.products__list {
+	
+	.empty-content.has-title-only {
+		margin-top: 42px;
+	}
+
+	.empty-content.has-title-only .empty-content__title {
+		margin-bottom: 24px;
+	}
 
 	.action-header__actions {
 		padding-bottom: 3px;

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -111,7 +111,7 @@
 	}
 
 	.table-row:hover {
-		background: lighten( $gray, 30% );
+		background: lighten( $gray, 35% );
 	}
 
 	.products__list-name {

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -10,7 +10,24 @@
 	}
 
 	.products__list-wrapper {
-		margin-top: 48px;
+		@include breakpoint( ">660px" ) {
+			margin-top: 58px;
+		}
+	}
+	
+	.stats-pagination__list {
+		background: $white;
+		border: 1px solid lighten( $gray, 25% );
+		padding: 8px;
+	}
+	
+	.stats-pagination__list-item {
+		padding: 0 8px;
+		line-height: 34px;
+	}
+	
+	.stats-pagination__list-item.is-selected {
+		border: 1px solid lighten( $gray, 20% );
 	}
 
 	.products__list-placeholder {

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -1,0 +1,84 @@
+&.products__list {
+
+	.action-header__actions {
+		padding-bottom: 3px;
+	}
+
+	.table {
+		margin-bottom: 16px;
+		margin-top: 16px;
+	}
+
+	.products__list-wrapper {
+		margin-top: 48px;
+	}
+
+	.products__list-placeholder {
+		@include placeholder();
+		background: $white;
+		height: 525px;
+		margin-bottom: 16px;
+		margin-top: -15px;
+
+		&.is-header {
+			height: 50px;
+			width: 100%;
+		}
+
+		.table-heading {
+			border-bottom: 0;
+		}
+
+		&.pagination {
+			height: 44px;
+			margin-top: 16px;
+		}
+
+	}
+
+	.is-requesting td div {
+		@include placeholder();
+		background: transparent;
+	}
+
+	.products__list-product .table-item__cell-title {
+		display: flex;
+	}
+
+	.products__list-image {
+		height: 40px;
+		width: 40px;
+		overflow: hidden;
+		position: relative;
+		margin-right: 16px;
+
+		&.is-thumb-placeholder {
+			background: $gray-light;
+		}
+
+		img {
+			position: absolute;
+			left: 50%;
+			top: 50%;
+			height: 100%;
+			width: auto;
+			-webkit-transform: translate( -50%, -50% );
+			transform: translate( -50%, -50% );
+		}
+	}
+
+	.is-header th {
+		&:first-child {
+			width: 50%;
+		}
+
+		&:nth-child( 2 ) {
+			width: 20%;
+		}
+
+		&:last-child {
+			width: 30%;
+		}
+	}
+
+}

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -1,5 +1,5 @@
 &.products__list {
-	
+
 	.empty-content.has-title-only {
 		margin-top: 42px;
 	}
@@ -22,18 +22,18 @@
 			margin-top: 58px;
 		}
 	}
-	
+
 	.stats-pagination__list {
 		background: $white;
 		border: 1px solid lighten( $gray, 25% );
 		padding: 8px;
 	}
-	
+
 	.stats-pagination__list-item {
 		padding: 0 8px;
 		line-height: 34px;
 	}
-	
+
 	.stats-pagination__list-item.is-selected {
 		border: 1px solid lighten( $gray, 20% );
 	}
@@ -104,6 +104,18 @@
 		&:last-child {
 			width: 30%;
 		}
+	}
+
+	.table-row {
+		cursor: pointer;
+	}
+
+	.table-row:hover {
+		background: lighten( $gray, 30% );
+	}
+
+	.products__list-name {
+		color: $blue-wordpress;
 	}
 
 }

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -107,15 +107,15 @@
 .table-heading,
 .table-item {
 	font-size: 14px;
-	padding: 6px 12px;
+	padding: 12px;
 	vertical-align: middle;
 
 	&:first-child {
-		padding: 6px 12px 6px 24px;
+		padding-left: 24px;
 	}
 
 	&:last-child {
-		padding: 6px 24px 6px 12px;
+		padding-right: 24px;
 	}
 
 	&.is-row-heading {

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -42,7 +42,7 @@
 			}
 
 			&:hover {
-				background-color: $gray-light;
+				background: $gray-light;
 
 				.table-item__cell-title:after {
 					background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, $gray-light 90%);
@@ -98,6 +98,14 @@
 
 .table-row {
 	line-height: 36px;
+	
+	&:hover {
+		background: $gray-light;
+		
+		&.is-header {
+			background-color: initial;
+		}
+	}
 
 	&.is-header {
 		color: $gray-text-min;

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,6 +12,7 @@ import { translate } from 'i18n-calypso';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
+import Products from './app/products';
 import ProductCreate from './app/products/product-create';
 import Dashboard from './app/dashboard';
 import SettingsPayments from './app/settings/payments';
@@ -37,7 +38,7 @@ const getStorePages = () => {
 			},
 		},
 		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			container: Products,
 			configKey: 'woocommerce/extension-products',
 			path: '/store/products/:site',
 			sidebarItem: {
@@ -183,4 +184,3 @@ export default function() {
 // TODO: This could probably be done in a better way through the same mechanisms
 // that bring in the rest of the extension code. Maybe extension-loader?
 initExtension();
-

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -8,6 +8,7 @@
 .woocommerce {
 	flex-grow: 1;
 
+	@import 'app/products/products-list';
 	@import 'app/products/product-form';
 	@import 'app/settings/payments/style';
 	@import 'components/action-header/style';


### PR DESCRIPTION
This PR implements the UI for the products list for v1, which is a list table with pagination.
This PR does not implement searching per the mockup, which still needs to be worked on.

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site`
* See your products load.
* Page through your products.

cc @kellychoffman @jameskoster Since this PR contains UI.

<img width="1335" alt="screen shot 2017-06-16 at 11 32 12 am" src="https://user-images.githubusercontent.com/689165/27240022-1247c856-5288-11e7-8d74-f3955ade8eb0.png">


