### PR TITLE
Editor: show full-screen preview only on publish

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -65,6 +65,7 @@ class PreviewToolbar extends Component {
 			device: currentDevice,
 			editUrl,
 			externalUrl,
+			isModalWindow,
 			onClose,
 			onEdit,
 			previewUrl,
@@ -90,7 +91,7 @@ class PreviewToolbar extends Component {
 						data-tip-target="web-preview__close"
 						onClick={ onClose }
 					>
-						<Gridicon icon="cross" />
+						<Gridicon icon={ isModalWindow ? 'cross' : 'arrow-left' } />
 					</Button>
 				}
 				{ showDeviceSwitcher &&

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import WebPreview from 'components/web-preview';
 import WebPreviewContent from 'components/web-preview/content';
 
@@ -22,6 +21,7 @@ const EditorPreview = React.createClass( {
 		showPreview: React.PropTypes.bool,
 		isSaving: React.PropTypes.bool,
 		isLoading: React.PropTypes.bool,
+		isFullScreen: React.PropTypes.bool,
 		previewUrl: React.PropTypes.string,
 		editUrl: React.PropTypes.string,
 		onClose: React.PropTypes.func,
@@ -96,14 +96,14 @@ const EditorPreview = React.createClass( {
 	},
 
 	render() {
-		const previewFlow = config.isEnabled( 'post-editor/delta-post-publish-preview' );
+		const isFullScreen = this.props.isFullScreen;
 		const className = classNames( 'editor-preview', {
-			'is-fullscreen': previewFlow,
+			'is-fullscreen': isFullScreen,
 		} );
 
 		return (
 			<div className={ className }>
-				{ previewFlow
+				{ isFullScreen
 					? <WebPreviewContent
 							showPreview={ this.props.showPreview }
 							showEdit={ true }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -363,17 +363,18 @@ export const PostEditor = React.createClass( {
 						onSave={ this.onSave }
 						isPostPrivate={ utils.isPrivate( this.state.post ) }
 						/>
-					{ this.props.isSitePreviewable ?
-						<EditorPreview
+					{ this.props.isSitePreviewable
+						? <EditorPreview
 							showPreview={ this.state.showPreview }
 							onClose={ this.onPreviewClose }
 							onEdit={ this.onPreviewEdit }
 							isSaving={ this.state.isSaving || this.state.isAutosaving }
 							isLoading={ this.state.isLoading }
+							isFullScreen={ this.state.isPostPublishPreview }
 							previewUrl={ this.state.previewUrl }
 							externalUrl={ this.state.previewUrl }
 							editUrl={ this.props.editPath }
-							defaultViewportDevice={ config.isEnabled( 'post-editor/delta-post-publish-preview' ) ? 'computer' : 'tablet' }
+							defaultViewportDevice={ this.state.isPostPublishPreview ? 'computer' : 'tablet' }
 						/>
 						: null }
 					{ config.isEnabled( 'post-editor/delta-post-publish-preview' )


### PR DESCRIPTION
In #15004, a full-screen preview was introduced for the post editor. This PR only shows the full-screen view on publishing (or updating), keeping the modal view when a user clicks the "preview" button all other times.

**Mock:**
![previewing](https://user-images.githubusercontent.com/942359/27240089-744ec810-52a1-11e7-9351-a314eb081c93.gif)

This is part of a larger epic (See p3Ex-2ri-p2)

**To Test:**
- Check out branch.
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Create a new post.
- Click the "Preview" button and see the modal preview.
- Publish the post and see the full-screen preview.
- Return to edit the post and click the "Preview" button - modal again.
- Update the post - full-screen again.
- Rinse.
- Repeat.