### PR TITLE
Woo payment method placeholder

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item-placeholder.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item-placeholder.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ListItem from 'woocommerce/components/list/list-item';
+import ListItemField from 'woocommerce/components/list/list-item-field';
+
+class PaymentMethodItemPlaceHolder extends Component {
+
+	render() {
+		return (
+			<ListItem>
+				<ListItemField>
+					<span className="payments__method-loading-suggested"></span>
+					<span className="payments__method-loading-title"></span>
+				</ListItemField>
+				<ListItemField className="payments__method-loading">
+					<span className="payments__method-loading-fee"></span>
+					<span className="payments__method-loading-feelink"></span>
+				</ListItemField>
+				<ListItemField className="payments__method-loading">
+					<span className="payments__method-loading-settings"></span>
+				</ListItemField>
+			</ListItem>
+		);
+	}
+}
+
+export default PaymentMethodItemPlaceHolder;

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item-placeholder.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item-placeholder.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -9,25 +9,22 @@ import React, { Component } from 'react';
 import ListItem from 'woocommerce/components/list/list-item';
 import ListItemField from 'woocommerce/components/list/list-item-field';
 
-class PaymentMethodItemPlaceHolder extends Component {
-
-	render() {
-		return (
-			<ListItem>
-				<ListItemField>
-					<span className="payments__method-loading-suggested"></span>
-					<span className="payments__method-loading-title"></span>
-				</ListItemField>
-				<ListItemField className="payments__method-loading">
-					<span className="payments__method-loading-fee"></span>
-					<span className="payments__method-loading-feelink"></span>
-				</ListItemField>
-				<ListItemField className="payments__method-loading">
-					<span className="payments__method-loading-settings"></span>
-				</ListItemField>
-			</ListItem>
-		);
-	}
-}
+const PaymentMethodItemPlaceHolder = () => {
+	return (
+		<ListItem>
+			<ListItemField>
+				<span className="payments__method-loading-suggested"></span>
+				<span className="payments__method-loading-title"></span>
+			</ListItemField>
+			<ListItemField className="payments__method-loading">
+				<span className="payments__method-loading-fee"></span>
+				<span className="payments__method-loading-feelink"></span>
+			</ListItemField>
+			<ListItemField className="payments__method-loading">
+				<span className="payments__method-loading-settings"></span>
+			</ListItemField>
+		</ListItem>
+	);
+};
 
 export default PaymentMethodItemPlaceHolder;

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item-placeholder.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item-placeholder.js
@@ -16,11 +16,11 @@ const PaymentMethodItemPlaceHolder = () => {
 				<span className="payments__method-loading-suggested"></span>
 				<span className="payments__method-loading-title"></span>
 			</ListItemField>
-			<ListItemField className="payments__method-loading">
+			<ListItemField>
 				<span className="payments__method-loading-fee"></span>
 				<span className="payments__method-loading-feelink"></span>
 			</ListItemField>
-			<ListItemField className="payments__method-loading">
+			<ListItemField>
 				<span className="payments__method-loading-settings"></span>
 			</ListItemField>
 		</ListItem>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { arePaymentMethodsLoaded } from 'woocommerce/state/sites/payment-methods/selectors';
 import { fetchPaymentMethods } from 'woocommerce/state/sites/payment-methods/actions';
 import { getPaymentMethodsGroup } from 'woocommerce/state/ui/payments/methods/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
@@ -16,9 +17,11 @@ import List from 'woocommerce/components/list/list';
 import ListHeader from 'woocommerce/components/list/list-header';
 import ListItemField from 'woocommerce/components/list/list-item-field';
 import PaymentMethodItem from './payment-method-item';
+import PaymentMethodItemPlaceholder from './payment-method-item-placeholder';
 
 class SettingsPaymentsMethodList extends Component {
 	static propTypes = {
+		isLoading: PropTypes.bool,
 		fetchPaymentMethods: PropTypes.func.isRequired,
 		methodType: PropTypes.string.isRequired,
 		paymentMethods: PropTypes.array.isRequired,
@@ -50,8 +53,14 @@ class SettingsPaymentsMethodList extends Component {
 		);
 	}
 
+	showPlaceholder = () => {
+		return (
+			<PaymentMethodItemPlaceholder />
+		);
+	}
+
 	render() {
-		const { translate, methodType, paymentMethods } = this.props;
+		const { isLoading, methodType, paymentMethods, translate } = this.props;
 
 		return (
 			<List>
@@ -67,6 +76,7 @@ class SettingsPaymentsMethodList extends Component {
 					<ListItemField className="payments__methods-column-settings">
 					</ListItemField>
 				</ListHeader>
+				{ isLoading && this.showPlaceholder() }
 				{ paymentMethods && paymentMethods.map( this.renderMethodItem ) }
 			</List>
 		);
@@ -76,7 +86,9 @@ class SettingsPaymentsMethodList extends Component {
 function mapStateToProps( state, ownProps ) {
 	const paymentMethods = getPaymentMethodsGroup( state, ownProps.methodType );
 	const site = getSelectedSiteWithFallback( state );
+	const isLoading = ! arePaymentMethodsLoaded( state );
 	return {
+		isLoading,
 		paymentMethods,
 		site,
 	};

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -76,3 +76,40 @@
 		padding: 24px;
 	}
 }
+
+.payments__method-loading-suggested,
+.payments__method-loading-title,
+.payments__method-loading-fee,
+.payments__method-loading-feelink,
+.payments__method-loading-settings {
+	background-color: lighten( $gray, 30% );
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
+.payments__method-loading-suggested {
+	height: 15px;
+	margin-bottom: 5px;
+	width: 100%;
+}
+
+.payments__method-loading-title {
+	height: 12px;
+	width: 90%;
+}
+
+.payments__method-loading-fee {
+	height: 15px;
+	margin-bottom: 5px;
+	width: 100%;
+}
+
+.payments__method-loading-feelink {
+	height: 12px;
+	width: 90%;
+}
+
+.payments__method-loading-settings {
+	align-self: flex-end;
+	height: 26px;
+	width: 54px;
+}


### PR DESCRIPTION
Adds: #15175

To test: http://calypso.localhost:3000/store/settings/payments/{site}

Verify that there are loading placeholders for each payment method type.

Not sure what happened but this replaces:  https://github.com/Automattic/wp-calypso/pull/15209