### PR TITLE
PostShare: add preview button to RePublicize

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -241,9 +241,19 @@ class PostShare extends Component {
 			{ this.state.scheduledDate ? translate( 'Schedule post' ) : translate( 'Share post' ) }
 		</Button>;
 
+		const previewButton = isEnabled( 'publicize-preview' ) &&
+			<Button
+				disabled={ this.isDisabled() }
+				className="post-share__preview-button"
+				onClick={ this.toggleSharingPreview }
+			>
+				{ translate( 'Preview' ) }
+			</Button>;
+
 		if ( ! hasRepublicizeSchedulingFeature ) {
 			return (
 				<div className="post-share__button-actions">
+					{ previewButton }
 					{ shareButton }
 				</div>
 			);
@@ -251,15 +261,7 @@ class PostShare extends Component {
 
 		return (
 			<div className="post-share__button-actions">
-				{ ( isEnabled( 'publicize-preview' ) ) &&
-					<Button
-						disabled={ this.isDisabled() }
-						className="post-share__preview-button"
-						onClick={ this.toggleSharingPreview }
-					>
-						{ translate( 'Preview' ) }
-					</Button>
-				}
+				{ previewButton }
 
 				<ButtonGroup
 					className="post-share__share-combo"

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -233,7 +233,7 @@ class PostShare extends Component {
 		} = this.props;
 
 		const shareButton = <Button
-			className="post-share__button"
+			className="post-share__share-button"
 			primary
 			onClick={ this.sharePost }
 			disabled={ this.isDisabled() }

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -61,6 +61,15 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 	flex: 3 0 0;
 	padding-bottom: 16px;
 
+	.post-share__share-button {
+		margin-left: 8px;
+	}
+
+	.post-share__schedule-button {
+		padding-right: 8px;
+		padding-left: 8px;
+	}
+
 	@include breakpoint( ">480px" ) {
 		padding-bottom: 24px;
 	}
@@ -275,17 +284,6 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 
 .post-share__share-combo {
 	display: flex;
-	margin-left: 8px;
-}
-
-.post-share__schedule-button {
-	padding-right: 8px;
-	padding-left: 8px;
-}
-
-.post-share__share-combo .button:last-child {
-	border-top-left-radius: 0;
-	border-bottom-left-radius: 0;
 }
 
 .post-share .post-share__footer-nav {


### PR DESCRIPTION
This PR adds the _"new "_ `Preview` button to the RePubicize feature.
Although this button is being added with the new RePublicize/Scheduling feature we consider that we also could improve the current RePublicize.

**Before**
<img src="https://user-images.githubusercontent.com/77539/27244238-05b6529a-52bc-11e7-948c-542bef98bd65.png" width="500px" />
**After**

<img src="https://user-images.githubusercontent.com/77539/27244269-258f2196-52bc-11e7-9477-21e491108694.png" width="500px" />

Keep in mind that for now this whole feature is hidden under a flag but enabled in wpcalypso env.

### Testing

After to apply the patch select a site with a `Premium` plan. Take a look at the `Share` tab into posts page. Pay attention to the `Share` button.
