### PR TITLE
Editor: hide global notice when preview is closed.

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -701,6 +701,7 @@ export const PostEditor = React.createClass( {
 			showPreview: false,
 			isPostPublishPreview: false,
 			previewAction: null,
+			notice: null,
 		} );
 
 		return false;


### PR DESCRIPTION
With #15213, a full-screen preview is shown after publishing a post, and with #15137 the success notifications were styled to float above the preview. This PR dismisses the notice when the preview is closed.

**Demo:**
![hide-notice](https://user-images.githubusercontent.com/942359/27244742-ef010578-52b5-11e7-9125-3a13aa1ddcf7.gif)

This is behind the `post-editor/delta-post-publish-preview` flag and part of a larger epic (See p3Ex-2ri-p2)

**To test:**
- Check out branch.
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Publish a new post.
- After publishing successfully, a full-screen preview will be shown with a global-styled success notification.
- Close the preview by clicking the "edit" button or left arrow.
- The notice should be dismissed.
