### PR TITLE
Reader: Fix Timestamp and URL in subscription lists

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -82,7 +82,7 @@
 .reader-subscription-list-item__site-excerpt,
 .reader-subscription-list-item__site-url-timestamp {
 	display: block;
-	max-height: 16px * 1.3;
+	max-height: 16px * 2.5;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	overflow-wrap: break-word;
@@ -92,7 +92,7 @@
 
 	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
-		height: 16px * 1.4;
+		height: 16px * 1.3;
 		top: auto;
 	}
 }
@@ -113,6 +113,9 @@
 .reader-subscription-list-item__site-url-timestamp {
 	display: flex;
 	flex-direction: row;
+	flex-wrap: wrap;
+	max-height: 16px * 3.2;
+	min-width: 100%;
 
 	@include breakpoint( "<960px" ) {
 		height: auto;
@@ -121,24 +124,29 @@
 
 	@include breakpoint( "<660px" ) {
 		flex-direction: row;
+		max-height: none;
 	}
 
 	@include breakpoint( "<480px" ) {
 		flex-direction: column;
 	}
+
+	&:not( .is-placeholder )::after {
+		@include long-content-fade( $size: 20% );
+		height: 100%;
+		top: auto;
+	}
 }
 
 .reader-subscription-list-item__site-url {
-	margin-right: 8px;
-}
-
-.following-manage__subscriptions .reader-subscription-list-item__site-url {
 	display: inline;
-	max-width: 70%;
+	margin-right: 8px;
 	overflow: hidden;
+	position: relative;
 	text-overflow: ellipsis;
 	word-break: break-all;
 	width: initial;
+	max-height: 16px * 1.3;
 
 	@include breakpoint( "<960px" ) {
 		height: 20px;
@@ -152,14 +160,6 @@
 
 	@include breakpoint( "<480px" ) {
 		flex: 1 1 auto;
-		max-width: none;
-	}
-}
-
-.following-manage__subscriptions .reader-subscription-list-item__timestamp {
-	max-width: 30%;
-
-	@include breakpoint( "<960px" ) {
 		max-width: none;
 	}
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -124,7 +124,6 @@
 
 	@include breakpoint( "<660px" ) {
 		flex-direction: row;
-		max-height: none;
 	}
 
 	@include breakpoint( "<480px" ) {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -387,17 +387,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	align-items: flex-end;
 	display: flex;
 	flex-direction: column;
-	min-width: 90px;
+	min-width: 0;
+	max-width: 25px;
 
 	@include breakpoint( ">660px" ) {
 		align-items: flex-start;
-	}
-}
-
-.search-stream .search-stream__single-column-results .reader-subscription-list-item .reader-subscription-list-item__site-url-timestamp {
-
-	@include breakpoint( "<960px" ) {
-		max-height: none;
+		min-width: 90px;
 	}
 }
 


### PR DESCRIPTION
This happens where the the `ReaderSubscriptionListItem` is being used:
- Site Results
- Following list in Manage

## Site Results
At ~660px, if URLs are long, this (including the timestamp), would wrap:
![screenshot 2017-06-16 14 31 49](https://user-images.githubusercontent.com/4924246/27245556-2c6d7d98-52a1-11e7-9bf3-e1166a68be7c.png)

At ~480px:
![screenshot 2017-06-16 14 32 17](https://user-images.githubusercontent.com/4924246/27245607-7638716c-52a1-11e7-9e3b-896ce590f4c5.png)

This is fixed:
![screenshot 2017-06-16 14 31 59](https://user-images.githubusercontent.com/4924246/27245592-6524c6e6-52a1-11e7-9d7d-cc9c2586765a.png)

![screenshot 2017-06-16 14 32 29](https://user-images.githubusercontent.com/4924246/27245616-7ccf1490-52a1-11e7-92dc-0ecc7a5a79cd.png)

## Following list in Manage:

In some breakpoints, the URLs sometimes disappear:
![screenshot 2017-06-16 14 33 46](https://user-images.githubusercontent.com/4924246/27245666-c60c3232-52a1-11e7-996f-3f4e767e9616.png)

Fixed:
![screenshot 2017-06-16 14 33 51](https://user-images.githubusercontent.com/4924246/27245681-cfb289da-52a1-11e7-9c1c-09d52f29fda5.png)


