### PR TITLE
Editor: adjust confirmation sidebar busy button styling

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -36,9 +36,10 @@
 }
 
 .editor-confirmation-sidebar__publishing-button {
+	padding: 7px 22px;
 	position: absolute;
-		top: 53px;
-		right: 16px;
+		top: 51px;
+		right: 24px;
 		min-width: 142px;
 }
 


### PR DESCRIPTION
This PR adjusts the positioning and padding of the EditorCofirmationSidebar busy button that displays after a user has confirmed publishing of their post to match the height and top-right alignment of the publish buttons seen before and after.

**Before:** | **After:**
------------ | -------------
<img width="300" alt="before" src="https://user-images.githubusercontent.com/942359/27246052-123074b4-52bd-11e7-874e-8d1cc25a7389.png"> | <img width="301" alt="after" src="https://user-images.githubusercontent.com/942359/27246063-20893afa-52bd-11e7-8474-dbc3bf1c1d13.png">

**To Test:**
- Check out branch.
- `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Create a new post. 
- Click "Publish…"
- Click "Publish!"
- The right positioning and height of the busy button should match the button just clicked (and the button shown after the overlay closes).



