### PR TITLE
Reader: Fix padding around Search suggestions

### DIFF
--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -4,7 +4,6 @@
 
 .following__search.card.is-compact {
 	padding: 0;
-	margin-bottom: 16px;
 	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
 	z-index: z-index( 'root', '.reader-following-search' );
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -124,7 +124,7 @@
 	border-bottom: 1px solid lighten( $gray, 20% );
 	font-size: 13px;
 	color: $gray;
-	padding: 15px 0;
+	padding: 16px 0;
 	text-align:left;
 
 	a,
@@ -137,7 +137,7 @@
 	}
 
 	@include breakpoint( "<660px" ) {
-		padding-left: 16px;
+		padding: 16px 16px;
 	}
 }
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -124,7 +124,7 @@
 	border-bottom: 1px solid lighten( $gray, 20% );
 	font-size: 13px;
 	color: $gray;
-	padding-bottom: 15px;
+	padding: 15px 0;
 	text-align:left;
 
 	a,


### PR DESCRIPTION
## Current Search stream

**Recs:**
![screenshot 2017-06-16 15 46 39](https://user-images.githubusercontent.com/4924246/27247203-6a07ea62-52ab-11e7-936e-9d93fe4d2785.png)

**Post results:**
![screenshot 2017-06-16 15 46 54](https://user-images.githubusercontent.com/4924246/27247207-7442be8a-52ab-11e7-9d97-fc812c9d6740.png)

## Wanted to make sure this didn't affect the new Search stream with Site Results:

![screenshot 2017-06-16 15 50 46](https://user-images.githubusercontent.com/4924246/27247231-9d71210c-52ab-11e7-93a6-51c599c2e725.png)

![screenshot 2017-06-16 15 51 03](https://user-images.githubusercontent.com/4924246/27247233-9f6ba270-52ab-11e7-9e14-dcf51f2f86e6.png)

