### PR TITLE
CSS rework

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -102,6 +102,7 @@ class StoreStatsChart extends Component {
 						if ( ! isLoading ) {
 							const itemChartData = this.buildChartData( orderData[ selectedIndex ], tabs[ tabIndex ] );
 							const delta = this.getDeltaByStat( tab.attr );
+							const deltaValue = Math.abs( Math.round( delta.percentage_change * 100 ) );
 							return (
 								<Tab
 									key={ tab.attr }
@@ -112,7 +113,7 @@ class StoreStatsChart extends Component {
 								>
 									<span className="store-stats-chart__value value">{ itemChartData.value }</span>
 									<Delta
-										value={ `${ Math.abs( Math.round( delta.percentage_change * 100 ) ) }%` }
+										value={ `${ deltaValue }%` }
 										className={ `${ delta.favorable } ${ delta.direction }` }
 										suffix={ `since ${ moment( delta.reference_period ).format( 'MMM D' ) }` }
 									/>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -113,7 +113,7 @@ class StoreStatsChart extends Component {
 									<span className="store-stats-chart__value value">{ itemChartData.value }</span>
 									<Delta
 										value={ `${ Math.abs( Math.round( delta.percentage_change * 100 ) ) }%` }
-										classNames={ `${ delta.favorable } ${ delta.direction }` }
+										className={ `${ delta.favorable } ${ delta.direction }` }
 										suffix={ `since ${ moment( delta.reference_period ).format( 'MMM D' ) }` }
 									/>
 								</Tab>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/style.scss
@@ -17,16 +17,12 @@
 	a {
 		align-items: center;
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
+		justify-content: space-between;
 		box-sizing: border-box;
 		padding: 10px 5px;
 		width: 100%;
-		justify-content: flex-end;
 		height: 100%;
-
-		.label {
-			margin-right: auto;
-		}
 
 		.value {
 			display: none;
@@ -39,21 +35,19 @@
 		}
 
 		.delta {
-			width: 35%;
+			margin-top: 10px;
+			width: initial;
+		}
+
+		.delta__icon {
+			width: 16px;
+			height: 16px;
 		}
 
 		@include breakpoint( '>480px' ) {
-			flex-direction: column;
-			justify-content: space-between;
-
-			.label {
-				margin-bottom: 10px;
-				margin-right: 0;
-			}
-
-			.delta {
-				margin-top: 10px;
+			.delta__icon {
 				width: initial;
+				height: initial;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/style.scss
@@ -1,13 +1,31 @@
+.stats-tabs {
+	display: flex;
+	flex-direction: column;
+
+	.stats-tab a::after {
+		content: none;
+	}
+
+	@include breakpoint( '>480px' ) {
+		flex-direction: row;
+	}
+}
+
 .stats-tab {
+	float: none;
+
 	a {
 		align-items: center;
 		display: flex;
 		flex-direction: row;
-		padding-bottom: 10px;
+		box-sizing: border-box;
+		padding: 10px 5px;
 		width: 100%;
+		justify-content: flex-end;
+		height: 100%;
 
 		.label {
-			width: 40%;
+			margin-right: auto;
 		}
 
 		.value {
@@ -15,13 +33,9 @@
 			float: none;
 		}
 
-		.store-stats-chart__value {
-			&.value {
-				display: inline-block;
-				padding-right: 10px;
-				text-align: right;
-				width: 25%;
-			}
+		.store-stats-chart__value.value {
+			display: inline-block;
+			margin-top: auto;
 		}
 
 		.delta {
@@ -30,40 +44,16 @@
 
 		@include breakpoint( '>480px' ) {
 			flex-direction: column;
-			min-height: 102px;
-			justify-content: center;
+			justify-content: space-between;
 
 			.label {
-				width: 100%;
-			}
-
-			.store-stats-chart__value {
-				&.value {
-					width: 100%;
-					text-align: center;
-					padding: 0;
-				}
+				margin-bottom: 10px;
+				margin-right: 0;
 			}
 
 			.delta {
-				width: 100%;
-				justify-content: center;
-				margin: 8px auto 0;
-			}
-		}
-
-		@include breakpoint( '<960px' ) {
-			.delta {
-				margin-left: 8px;
-
-				.delta__icon {
-					&.gridicon {
-						margin: 0 4px 0 0;
-					}
-				}
-				.delta__label {
-					padding-right: 4px;
-				}
+				margin-top: 10px;
+				width: initial;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/style.scss
@@ -31,11 +31,13 @@
 
 		.store-stats-chart__value.value {
 			display: inline-block;
-			margin-top: auto;
+			font-size: 20px;
+			font-weight: 300;
+			margin-top: 4px;
 		}
 
 		.delta {
-			margin-top: 10px;
+			margin-top: 8px;
 			width: initial;
 		}
 

--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -15,12 +15,17 @@ export default class Delta extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		icon: PropTypes.string,
+		iconSize: PropTypes.number,
 		suffix: PropTypes.string,
 		value: PropTypes.string.isRequired,
 	};
 
+	static defaultProps = {
+		iconSize: 18,
+	};
+
 	render() {
-		const { className, icon, suffix, value } = this.props;
+		const { className, icon, iconSize, suffix, value } = this.props;
 		const deltaClasses = classnames( 'delta', className );
 		let deltaIcon;
 		if ( icon ) {
@@ -31,7 +36,7 @@ export default class Delta extends Component {
 		}
 		return (
 			<div className={ deltaClasses }>
-				<Gridicon className="delta__icon" icon={ deltaIcon } />
+				<Gridicon className="delta__icon" icon={ deltaIcon } size={ iconSize } />
 				<span className="delta__labels">
 					<span className="delta__value">{ value }</span>
 					{ suffix &&

--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -13,21 +13,21 @@ import { includes } from 'lodash';
 export default class Delta extends Component {
 
 	static propTypes = {
-		classNames: PropTypes.string,
+		className: PropTypes.string,
 		icon: PropTypes.string,
 		suffix: PropTypes.string,
 		value: PropTypes.string.isRequired,
 	};
 
 	render() {
-		const { classNames, icon, suffix, value } = this.props;
-		const deltaClasses = classnames( 'delta', classNames );
+		const { className, icon, suffix, value } = this.props;
+		const deltaClasses = classnames( 'delta', className );
 		let deltaIcon;
 		if ( icon ) {
 			deltaIcon = icon;
 		} else {
-			deltaIcon = ( includes( classNames, 'is-increase' ) ) ? 'arrow-up' : 'arrow-down';
-			deltaIcon = ( includes( classNames, 'is-neutral' ) ) ? 'minus-small' : deltaIcon;
+			deltaIcon = ( includes( className, 'is-increase' ) ) ? 'arrow-up' : 'arrow-down';
+			deltaIcon = ( includes( className, 'is-neutral' ) ) ? 'minus-small' : deltaIcon;
 		}
 		return (
 			<div className={ deltaClasses }>

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -28,7 +28,7 @@
 		&.gridicon {
 			fill: white;
 			padding: 3px 1px;
-			margin: 0 12px 0 0;
+			margin: 0 6px 0 0;
 		}
 	}
 
@@ -45,6 +45,7 @@
 			font-size: 13px;
 			font-weight: 300;
 			line-height: 13px;
+			text-align: left;
 		}
 		.delta__value {
 			margin-right: 6px;

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -5,30 +5,51 @@
 
 	&.is-favorable {
 		.delta__icon {
-			background-color: #4ab866;
+			&.gridicon {
+				fill: $alert-green;
+			}
+		}
+		.delta__labels {
+			.delta__value {
+				color: $alert-green;
+			}
 		}
 	}
 	&.is-unfavorable {
 		.delta__icon {
-			background-color: #d54e21;
+			&.gridicon {
+				fill: $alert-red;
+			}
+		}
+		.delta__labels {
+			.delta__value {
+				color: $alert-red;
+			}
 		}
 	}
 	&.is-neutral {
 		.delta__icon {
-			background-color: #e9eff3;
+			&.gridicon {
+				fill: $gray-light;
+			}
+		}
+		.delta__labels {
+			.delta__value {
+				color: $gray-light;
+			}
 		}
 	}
 
 	.delta__icon {
-		width: 20px;
-		height: 20px;
+		width: 15px;
+		height: 15px;
 		border-radius: 5px;
 		min-width: 15px;
 
 		&.gridicon {
 			fill: white;
 			padding: 3px 1px;
-			margin: 0 6px 0 0;
+			margin: 0;
 		}
 	}
 
@@ -40,7 +61,7 @@
 
 		.delta__suffix,
 		.delta__value {
-			color: #87a6bc;
+			color: $gray;
 			display: inline-block;
 			font-size: 13px;
 			font-weight: 300;


### PR DESCRIPTION
@greenafrican The CSS wasn't quite working in https://github.com/Automattic/wp-calypso/pull/14911, so I took a stab at it. The issue was around variable heights in the label and deltas. Items weren't lined up across all tabs and `stats-tabs` floats were causing problems. 

### Result
<img width="434" alt="screen shot 2017-06-17 at 12 52 18 pm" src="https://user-images.githubusercontent.com/1922453/27254936-36fd5362-5361-11e7-825a-854b400cf35b.png">

I also changed the `classNames` prop to `className` on `Delta` to match the React API uniformity.
