### PR TITLE
Web Preview: Add clipboard url to toolbar

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -248,8 +248,10 @@ export class WebPreviewContent extends Component {
 WebPreviewContent.propTypes = {
 	// Display the preview
 	showPreview: PropTypes.bool,
-	// Show external link button (only if there is a previewUrl)
+	// Show external link button
 	showExternal: PropTypes.bool,
+	// Show external link with clipboard input
+	showUrl: PropTypes.bool,
 	// Show close button
 	showClose: PropTypes.bool,
 	// Show SEO button

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -115,8 +115,10 @@ export class WebPreview extends Component {
 WebPreview.propTypes = {
 	// Display the preview
 	showPreview: PropTypes.bool,
-	// Show external link button (only if there is a previewUrl)
+	// Show external link button
 	showExternal: PropTypes.bool,
+	// Show external link with clipboard input
+	showUrl: PropTypes.bool,
 	// Show close button
 	showClose: PropTypes.bool,
 	// Show SEO button

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -149,6 +149,17 @@ a.web-preview__external.button {
 	width: 200px;
 }
 
+.web-preview__url-clipboard-input {
+	margin: 6px auto;
+	width: 35%;
+
+	input {
+		color: $gray;
+		font-size: 14px;
+		height: 35px;
+	}
+}
+
 .web-preview__device-button {
 	border-right: none;
 	padding-left: 8px;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -153,10 +153,24 @@ a.web-preview__external.button {
 	margin: 6px auto;
 	width: 35%;
 
-	input {
+	.form-text-input {
 		color: $gray;
 		font-size: 14px;
 		height: 35px;
+		border-color: transparent;
+		text-overflow: ellipsis;
+	}
+
+	&:hover .form-text-input {
+		border-color: lighten( $gray, 20% );
+	}
+
+	.clipboard-button {
+		display: none;
+	}
+
+	&:hover .clipboard-button {
+		display: block;
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -150,8 +150,9 @@ a.web-preview__external.button {
 }
 
 .web-preview__url-clipboard-input {
-	margin: 6px auto;
-	width: 35%;
+	flex-grow: 1;
+	margin: 6px 10px;
+	width: auto;
 
 	.form-text-input {
 		color: $gray;
@@ -171,6 +172,16 @@ a.web-preview__external.button {
 
 	&:hover .clipboard-button {
 		display: block;
+	}
+
+	@include breakpoint( ">660px" ) {
+		max-width: 50%;
+	}
+
+	@include breakpoint( ">960px" ) {
+		margin: 6px auto;
+		width: 35%;
+		flex-grow: inherit;
 	}
 }
 

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
+import ClipboardButtonInput from 'components/clipboard-button-input';
 
 const possibleDevices = [
 	'computer',
@@ -23,6 +24,8 @@ class PreviewToolbar extends Component {
 	static propTypes = {
 		// Show device viewport switcher
 		showDeviceSwitcher: PropTypes.bool,
+		// Show external link in clipboard input
+		showUrl: PropTypes.bool,
 		// Show external link button
 		showExternal: PropTypes.bool,
 		// Show close button
@@ -72,6 +75,7 @@ class PreviewToolbar extends Component {
 			setDeviceViewport,
 			showClose,
 			showDeviceSwitcher,
+			showUrl,
 			showEdit,
 			showExternal,
 			showSEO,
@@ -112,6 +116,12 @@ class PreviewToolbar extends Component {
 							</DropdownItem>
 						) ) }
 					</SelectDropdown>
+				}
+				{ showUrl &&
+					<ClipboardButtonInput
+						className="web-preview__url-clipboard-input"
+						value={ externalUrl || previewUrl }
+					/>
 				}
 				<div className="web-preview__toolbar-actions">
 					{ showEdit &&

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -24,7 +24,7 @@ class PreviewToolbar extends Component {
 	static propTypes = {
 		// Show device viewport switcher
 		showDeviceSwitcher: PropTypes.bool,
-		// Show external link in clipboard input
+		// Show external link with clipboard input
 		showUrl: PropTypes.bool,
 		// Show external link button
 		showExternal: PropTypes.bool,

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -110,6 +110,7 @@ const EditorPreview = React.createClass( {
 							showPreview={ this.props.showPreview }
 							showEdit={ true }
 							showExternal={ true }
+							showUrl={ true }
 							defaultViewportDevice={ this.props.defaultViewportDevice }
 							onClose={ this.props.onClose }
 							onEdit={ this.props.onEdit }


### PR DESCRIPTION
This PR adds a `ClipboardButtonInputer` component to the `WebPreview` toolbar with the current external or preview URL when the `showUrl` prop is set.

**Mock:**
![showurl](https://user-images.githubusercontent.com/942359/27257775-71af2058-53b1-11e7-8cbd-6e05591d2bcc.png)

**To Test:**
- Check out branch.
- `ENABLE_FEATURES=post-editor/delta-post-publish-preview make run`
- Publish a new post.
- The full-screen preview will be shown with the post's url in the toolbar
- Copy the URL to the clipboard.