### PR TITLE
Post & Page Preview: Don't open the sidebar when closing the modal

### DIFF
--- a/client/state/ui/preview/actions.js
+++ b/client/state/ui/preview/actions.js
@@ -45,7 +45,7 @@ export function closePreview() {
 		dispatch( clearCustomizations( selectedSiteId ) );
 		dispatch( clearPreviewUrl( selectedSiteId ) );
 		dispatch( resetPreviewType() );
-		dispatch( setLayoutFocus( 'sidebar' ) );
+		dispatch( setLayoutFocus( 'content' ) );
 	};
 }
 


### PR DESCRIPTION
In the `ui/preview/actions/closePreview` action, instead of setting the layout focus to `sidebar`, set it to `content`.

Setting to sidebar was causing the (unclosable) sidebar to take over the screen on mobile-sized viewports.

## To Test:
1. Start at URL on a mobile device (or in an emulated mobile device à la Chrome's device toolbar): https://wordpress.com/posts/my/:slug?
2. Click view
3. Close the preview modal
4. Rejoice in being able to continue without clicking the `Posts` sidebar item or reloading the page

...repeat the same for `pages` & otherwise check for other regressions.


fixes #15231 