### PR TITLE
Publicize Preview: wpcalypso enable

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -84,6 +84,7 @@
 		"post-editor/video-editor": true,
 		"press-this": true,
 		"preview-layout": true,
+		"publicize-preview": true,
 		"publicize-scheduling": true,
 		"reader": true,
 		"reader/following-intro": true,


### PR DESCRIPTION
This enable publicize previews on wpcalypso

## testing

Not really, you can see how it works in `development` environment, this will mirror that behaviour