### PR TITLE
DatePicker: Janitorial - Styles Improvements

### DIFF
--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -18,7 +18,7 @@ import PostSchedule from 'components/post-schedule';
 class CalendarPopover extends Component {
 	static propTypes = {
 		children: PropTypes.element,
-		
+
 		// connect props
 		gmtOffset: PropTypes.number,
 		timezoneValue: PropTypes.string,

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -23,11 +23,13 @@ module.exports = React.createClass( {
 			{
 				title: '1 other post scheduled',
 				date: new Date( '2015-10-15 10:30' ),
-				type: 'schedulled'
+				type: 'schedulled',
+				icon: 'time',
 			},
 			{
 				title: 'Happy birthday Damian!',
-				date: new Date( '2015-07-18 15:00' )
+				date: new Date( '2015-07-18 15:00' ),
+				socialIcon: 'path',
 			}
 		];
 
@@ -36,8 +38,7 @@ module.exports = React.createClass( {
 				initialMonth = { new Date( '2015-07-01' ) }
 				events= { events }
 				onSelectDay= { this.onSelectDay }
-				selectedDay= { this.state.date } >
-			</DatePicker>
+				selectedDay= { this.state.date } />
 		);
 	}
 

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -23,7 +23,7 @@ module.exports = React.createClass( {
 			{
 				title: '1 other post scheduled',
 				date: new Date( '2015-10-15 10:30' ),
-				type: 'schedulled',
+				type: 'scheduled',
 				icon: 'time',
 			},
 			{

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -53,7 +53,11 @@ class DatePickerDay extends Component {
 
 	renderTooltip() {
 		if ( ! this.state.showTooltip ) {
-			return;
+			return null;
+		}
+
+		if ( ! this.props.events.length ) {
+			return null;
 		}
 
 		const label = this.props.translate(

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -5,13 +5,12 @@ import React, { PropTypes, Component } from 'react';
 import { noop, map } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
-import SocialLogo from 'social-logos';
 
 /**
  * Internal dependencies
  */
 import Tooltip from 'components/tooltip';
+import { CalendarEvent } from './event';
 
 class DatePickerDay extends Component {
 	static propTypes = {
@@ -77,17 +76,11 @@ class DatePickerDay extends Component {
 				<hr className="date-picker__division" />
 				<ul>{ map( this.props.events, event =>
 					<li key={ event.id }>
-						{ event.icon &&
-							<span className={ `date-picker__social-icon-wrapper date-picker__social-icon-wrapper-${ event.icon }` }>
-								<Gridicon icon={ event.icon } size={ 18 } />
-							</span>
-						}
-						{ event.socialIcon &&
-							<span className={ `date-picker__social-icon-wrapper date-picker__social-icon-wrapper-${ event.socialIcon }` }>
-								<SocialLogo icon={ event.socialIcon } size={ 18 } />
-							</span>
-						}
-						<span className="date-picker__event-title">{ event.title }</span>
+						<CalendarEvent
+							icon={ event.icon }
+							socialIcon={ event.socialIcon }
+							socialIconColor={ event.socialIconColor }
+							title={ event.title } />
 					</li>
 				) }</ul>
 			</Tooltip>

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -2,9 +2,11 @@
  * External Dependencies
  */
 import React, { PropTypes, Component } from 'react';
-import { noop } from 'lodash';
+import { noop, map } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import SocialLogo from 'social-logos';
 
 /**
  * Internal dependencies
@@ -66,19 +68,28 @@ class DatePickerDay extends Component {
 
 		return (
 			<Tooltip
+				className="date-picker__events-tooltip"
 				context={ this.refs.dayTarget }
 				isVisible={ this.state.showTooltip }
 				onClose={ noop }
 			>
 				<span>{ label }</span>
 				<hr className="date-picker__division" />
-				<ul>
-					{
-						this.props.events.map( function( event ) {
-							return <li key={ event.id }>{ event.title }</li>;
-						} )
-					}
-				</ul>
+				<ul>{ map( this.props.events, event =>
+					<li key={ event.id }>
+						{ event.icon &&
+							<span className={ `date-picker__social-icon-wrapper date-picker__social-icon-wrapper-${ event.icon }` }>
+								<Gridicon icon={ event.icon } size={ 18 } />
+							</span>
+						}
+						{ event.socialIcon &&
+							<span className={ `date-picker__social-icon-wrapper date-picker__social-icon-wrapper-${ event.socialIcon }` }>
+								<SocialLogo icon={ event.socialIcon } size={ 18 } />
+							</span>
+						}
+						<span className="date-picker__event-title">{ event.title }</span>
+					</li>
+				) }</ul>
 			</Tooltip>
 		);
 	}
@@ -97,8 +108,10 @@ class DatePickerDay extends Component {
 			for ( i; i < this.props.events.length; i++ ) {
 				dayEvent = this.props.events[ i ];
 
-				if ( dayEvent.type &&
-					( ! classes[ 'date-picker__day_event_' + dayEvent.type ] ) ) {
+				if (
+					dayEvent.type &&
+					( ! classes[ 'date-picker__day_event_' + dayEvent.type ] )
+				) {
 					classes[ 'date-picker__day_event_' + dayEvent.type ] = true;
 				}
 			}

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -1,31 +1,32 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	noop = require( 'lodash/noop' ),
-	classNames = require( 'classnames' );
+import React, { PropTypes, Component } from 'react';
+import { noop } from 'lodash';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var Tooltip = require( 'components/tooltip' );
+import Tooltip from 'components/tooltip';
 
-module.exports = React.createClass( {
-	displayName: 'DatePickerDay',
+class DatePickerDay extends Component {
+	static propTypes = {
+		date: PropTypes.object.isRequired,
+		events: PropTypes.array
+	};
 
-	propTypes: {
-		date: React.PropTypes.object.isRequired,
-		events: React.PropTypes.array
-	},
+	static defaultProps = {
+		showTooltip: false
+	};
 
-	getInitialState: function() {
-		return {
-			showTooltip: false
-		};
-	},
+	state = {
+		showTooltip: false,
+	}
 
-	isPastDay: function( date ) {
-		var today = this.moment().set( {
+	isPastDay( date ) {
+		const today = this.props.moment().set( {
 			hour: 0,
 			minute: 0,
 			second: 0,
@@ -33,23 +34,27 @@ module.exports = React.createClass( {
 		} );
 
 		date = date || this.props.date;
-
 		return ( +today - 1 ) >= +date;
-	},
+	}
 
-	handleTooltip: function( show ) {
-		var showTooltip = ! ! this.props.events.length && show;
-		this.setState( { showTooltip: showTooltip } );
-	},
+	showTooltip = () => {
+		if ( ! this.props.events.length ) {
+			return;
+		}
 
-	renderTooltip: function() {
-		var label;
+		this.setState( { showTooltip: true } );
+	}
 
+	hideTooltip = () => {
+		this.setState( { showTooltip: false } );
+	}
+
+	renderTooltip() {
 		if ( ! this.state.showTooltip ) {
 			return;
 		}
 
-		label = this.translate(
+		const label = this.props.translate(
 				'%(posts)d post',
 				'%(posts)d posts', {
 					count: this.props.events.length,
@@ -66,7 +71,7 @@ module.exports = React.createClass( {
 				onClose={ noop }
 			>
 				<span>{ label }</span>
-				<hr className="tooltip__hr" />
+				<hr className="date-picker__division" />
 				<ul>
 					{
 						this.props.events.map( function( event ) {
@@ -76,12 +81,12 @@ module.exports = React.createClass( {
 				</ul>
 			</Tooltip>
 		);
-	},
+	}
 
-	render: function() {
-		var classes = { 'date-picker__day': true },
-			i = 0,
-			dayEvent;
+	render() {
+		const classes = { 'date-picker__day': true };
+		let i = 0;
+		let dayEvent;
 
 		classes[ 'is-selected' ] = this.props.selected === true;
 		classes[ 'past-day' ] = this.isPastDay() === true;
@@ -103,8 +108,8 @@ module.exports = React.createClass( {
 			<div
 				ref="dayTarget"
 				className={ classNames( classes ) }
-				onMouseEnter={ this.handleTooltip.bind( this, true ) }
-				onMouseLeave={ this.handleTooltip.bind( this, false ) }
+				onMouseEnter={ this.showTooltip }
+				onMouseLeave={ this.hideTooltip }
 			>
 				<span
 					key={ 'selected-' + ( this.props.date.getTime() / 1000 | 0 ) }
@@ -118,4 +123,7 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default localize( DatePickerDay );
+

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -15,16 +15,17 @@ import { CalendarEvent } from './event';
 class DatePickerDay extends Component {
 	static propTypes = {
 		date: PropTypes.object.isRequired,
-		events: PropTypes.array
+		events: PropTypes.array,
+		maxEventsPerTooltip: PropTypes.number,
 	};
 
 	static defaultProps = {
-		showTooltip: false
+		maxEventsPerTooltip: 8,
 	};
 
 	state = {
 		showTooltip: false,
-	}
+	};
 
 	isPastDay( date ) {
 		const today = this.props.moment().set( {
@@ -56,14 +57,14 @@ class DatePickerDay extends Component {
 		}
 
 		const label = this.props.translate(
-				'%(posts)d post',
-				'%(posts)d posts', {
-					count: this.props.events.length,
-					args: {
-						posts: this.props.events.length
-					}
-				}
-			);
+			'%d post',
+			'%d posts', {
+				count: this.props.events.length,
+				args: this.props.events.length,
+			}
+		);
+
+		const moreEvents = this.props.events.length - this.props.maxEventsPerTooltip;
 
 		return (
 			<Tooltip
@@ -74,15 +75,31 @@ class DatePickerDay extends Component {
 			>
 				<span>{ label }</span>
 				<hr className="date-picker__division" />
-				<ul>{ map( this.props.events, event =>
-					<li key={ event.id }>
-						<CalendarEvent
-							icon={ event.icon }
-							socialIcon={ event.socialIcon }
-							socialIconColor={ event.socialIconColor }
-							title={ event.title } />
-					</li>
-				) }</ul>
+				<ul>
+					{ map( this.props.events, ( event, i ) => ( i < this.props.maxEventsPerTooltip ) &&
+						<li key={ event.id }>
+							<CalendarEvent
+								icon={ event.icon }
+								socialIcon={ event.socialIcon }
+								socialIconColor={ event.socialIconColor }
+								title={ event.title } />
+						</li>
+					) }
+
+					{ ( moreEvents > 0 ) &&
+						<li>
+							{ this.props.translate(
+								'… and %(moreEvents)d more post',
+								'… and %(moreEvents)d more posts', {
+									count: moreEvents,
+									args: {
+										moreEvents
+									}
+								}
+							) }
+						</li>
+					}
+				</ul>
 			</Tooltip>
 		);
 	}

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -16,6 +16,7 @@ class DatePickerDay extends Component {
 	static propTypes = {
 		date: PropTypes.object.isRequired,
 		events: PropTypes.array,
+		moment: PropTypes.func,
 		maxEventsPerTooltip: PropTypes.number,
 	};
 

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -22,15 +22,66 @@ class DatePickerExample extends Component {
 			},
 
 			{
-				title: 'Social media event',
+				title: 'Social Media - Facebook',
 				date: new Date(),
-				socialIcon: 'twitter',
+				socialIcon: 'facebook',
 			},
 
 			{
-				title: 'Gridicon event',
+				title: 'Social Media - Twitter',
+				date: new Date(),
+				socialIcon: 'twitter',
+				socialIconColor: false,
+			},
+
+			{
+				title: 'Social Media - Google Plus',
+				date: new Date(),
+				socialIcon: 'google-plus',
+			},
+
+			{
+				title: 'Social Media - LinkedIn',
+				date: new Date(),
+				socialIcon: 'linkedin',
+			},
+
+			{
+				title: 'Social Media - Tumblr',
+				date: new Date(),
+				socialIcon: 'tumblr',
+			},
+
+			{
+				title: 'Social Media - Path',
+				date: new Date(),
+				socialIcon: 'path',
+				socialIconColor: false,
+			},
+
+			{
+				title: 'Social Media - Eventbrite',
+				date: new Date(),
+				socialIcon: 'eventbrite',
+				socialIconColor: false,
+			},
+
+			{
+				title: 'Gridicon - Time',
 				date: new Date(),
 				icon: 'time',
+			},
+
+			{
+				title: 'Gridicon - Offline',
+				date: new Date(),
+				icon: 'offline',
+			},
+
+			{
+				title: 'Gridicon - Shipping',
+				date: new Date(),
+				icon: 'shipping',
 			},
 
 			{

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -1,60 +1,60 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	DatePicker = require( 'components/date-picker' );
+import Card from 'components/card';
+import DatePicker from 'components/date-picker';
 
 /**
  * Date Picker Demo
  */
-var datePicker = React.createClass( {
-	mixins: [ PureRenderMixin ],
-	displayName: 'DatePicker',
+class DatePickerExample extends Component {
+	state = {
+		events: [
+			{
+				title: 'Today',
+				date: new Date(),
+				type: 'scheduled'
+			},
 
-	getInitialState: function() {
-		var date = new Date();
-		date.setDate( date.getDate() + 3 );
-		date.setMilliseconds( 0 );
-		date.setSeconds( 0 );
-		date.setMinutes( 0 );
-		date.setHours( 0 );
+			{
+				title: 'Social media event',
+				date: new Date(),
+				socialIcon: 'twitter',
+			},
 
-		return {
-			events: [
-				{
-					title: '1 other post scheduled',
-					date: new Date( '2015-07-15 10:30' ),
-					type: 'scheduled'
-				},
-				{
-					title: 'Happy birthday Damian',
-					date: new Date( '2015-07-18 15:00' ),
-					type: 'birthday'
-				},
-				{
-					title: 'Do not rest',
-					date: new Date( '2015-07-18 8:00' )
-				}
-			],
-			selectedDay: this.moment( date )
-		};
-	},
+			{
+				title: 'Gridicon event',
+				date: new Date(),
+				icon: 'time',
+			},
 
-	selectDay: function( date, modifiers ) {
+			{
+				title: 'Tomorrow is tomorrow',
+				date: new Date( +new Date() + 60 * 60 * 24 * 1000 ),
+				type: 'future-event',
+			},
+			{
+				title: 'Yesterday',
+				date: new Date( +new Date() - 60 * 60 * 24 * 1000 ),
+				type: 'past-event',
+			}
+		]
+	};
+
+	selectDay( date, modifiers ) {
 		this.setState( { selectedDay: date } );
 
 		if ( date ) {
 			console.log( date.toDate(), modifiers );
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<Card style={ { width: '300px', margin: 0 } }>
 				<DatePicker
@@ -65,6 +65,9 @@ var datePicker = React.createClass( {
 			</Card>
 		);
 	}
-} );
+}
 
-module.exports = datePicker;
+DatePickerExample.displayName = 'DatePicker';
+
+export default DatePickerExample;
+

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 import Card from 'components/card';
 import DatePicker from 'components/date-picker';
 
-/**
+/*
  * Date Picker Demo
  */
 class DatePickerExample extends Component {
@@ -97,13 +97,13 @@ class DatePickerExample extends Component {
 		]
 	};
 
-	selectDay( date, modifiers ) {
+	selectDay = ( date, modifiers ) => {
 		this.setState( { selectedDay: date } );
 
 		if ( date ) {
 			console.log( date.toDate(), modifiers );
 		}
-	}
+	};
 
 	render() {
 		return (
@@ -111,8 +111,7 @@ class DatePickerExample extends Component {
 				<DatePicker
 					events={ this.state.events }
 					onSelectDay={ this.selectDay }
-					selectedDay={ this.state.selectedDay }>
-				</DatePicker>
+					selectedDay={ this.state.selectedDay } />
 			</Card>
 		);
 	}

--- a/client/components/date-picker/event.jsx
+++ b/client/components/date-picker/event.jsx
@@ -1,0 +1,46 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+import SocialLogo from 'social-logos';
+import classNames from 'classnames';
+
+const renderIcon = icon => icon &&
+	<span className={ `date-picker__icon-wrapper date-picker__icon-wrapper-${ icon }` }>
+		<Gridicon icon={ icon } size={ 18 } />
+	</span>;
+
+const renderSocialIcon = ( icon, color ) => {
+	if ( ! icon ) {
+		return null;
+	}
+
+	const socialIconClasses = classNames(
+		'date-picker__social-icon-wrapper',
+		`date-picker__social-icon-wrapper-${ icon }`,
+		{ 'date-picker__social-icon-wrapper-color': color }
+	);
+
+	return (
+		<span className={ socialIconClasses }>
+			<SocialLogo icon={ icon } size={ 18 } />
+		</span>
+	);
+};
+
+export const CalendarEvent = ( {
+	icon,
+	socialIcon,
+	socialIconColor = true,
+	title,
+} ) => {
+	return (
+		<div className="date-picker__calendar-event">
+			{ renderIcon( icon ) }
+			{ renderSocialIcon( socialIcon, socialIconColor ) }
+
+			<span className="date-picker__event-title">{ title }</span>
+		</div>
+	);
+};

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 import DayPicker from 'react-day-picker';
-import merge from 'lodash/merge';
-import noop from 'lodash/noop';
+import { noop, merge } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,40 +13,37 @@ import DayItem from 'components/date-picker/day';
 
 /* Internal dependencies
  */
-module.exports = React.createClass( {
-	displayName: 'DatePicker',
+class DatePicker extends PureComponent {
+	static propTypes = {
+		calendarViewDate: PropTypes.object,
+		enableOutsideDays: PropTypes.bool,
+		events: PropTypes.array,
+		locale: PropTypes.object,
 
-	propTypes: {
-		calendarViewDate: React.PropTypes.object,
-		enableOutsideDays: React.PropTypes.bool,
-		events: React.PropTypes.array,
-		locale: React.PropTypes.object,
+		selectedDay: PropTypes.object,
+		timeReference: PropTypes.object,
 
-		selectedDay: React.PropTypes.object,
-		timeReference: React.PropTypes.object,
+		onMonthChange: PropTypes.func,
+		onSelectDay: PropTypes.func,
+	};
 
-		onMonthChange: React.PropTypes.func,
-		onSelectDay: React.PropTypes.func
-	},
+	static defaultProps = {
+		enableOutsideDays: true,
+		calendarViewDate: new Date(),
+		selectedDay: null,
+		onMonthChange: noop,
+		onSelectDay: noop,
+	};
 
-	getDefaultProps: function() {
-		return {
-			enableOutsideDays: true,
-			calendarViewDate: new Date(),
-			selectedDay: null,
-			onMonthChange: noop,
-			onSelectDay: noop
-		};
-	},
-
-	isSameDay: function( d0, d1 ) {
-		d0 = this.moment( d0 );
-		d1 = this.moment( d1 );
+	isSameDay( d0, d1 ) {
+		d0 = this.props.moment( d0 );
+		d1 = this.props.moment( d1 );
 		return d0.isSame( d1, 'day' );
-	},
+	}
 
-	filterEventsByDay: function( day ) {
-		var i, event, eventsInDay = [];
+	filterEventsByDay( day ) {
+		let i, event;
+		const eventsInDay = [];
 
 		if ( ! this.props.events ) {
 			return [];
@@ -61,83 +58,82 @@ module.exports = React.createClass( {
 		}
 
 		return eventsInDay;
-	},
+	}
 
-	locale: function() {
-		var moment = this.moment,
-			localeData = moment().localeData(),
-			locale = {
-				formatDay: function( date ) {
-					return moment( date ).format( 'llll' );
-				},
+	locale() {
+		const { moment } = this.props;
+		const localeData = moment().localeData();
 
-				formatMonthTitle: function( date ) {
-					return moment( date ).format( 'MMMM YYYY' );
-				},
+		const locale = {
+			formatDay: function( date ) {
+				return moment( date ).format( 'llll' );
+			},
 
-				formatWeekdayShort: function( day ) {
-					return moment().weekday( day ).format( 'dd' )[ 0 ];
-				},
+			formatMonthTitle: function( date ) {
+				return moment( date ).format( 'MMMM YYYY' );
+			},
 
-				formatWeekdayLong: function( day ) {
-					return moment().weekday( day ).format( 'dddd' );
-				},
+			formatWeekdayShort: function( day ) {
+				return moment().weekday( day ).format( 'dd' )[ 0 ];
+			},
 
-				getFirstDayOfWeek: function() {
-					return Number( localeData.firstDayOfWeek() );
-				}
-			};
+			formatWeekdayLong: function( day ) {
+				return moment().weekday( day ).format( 'dddd' );
+			},
+
+			getFirstDayOfWeek: function() {
+				return Number( localeData.firstDayOfWeek() );
+			}
+		};
 
 		return merge( locale, this.props.locale );
-	},
+	}
 
-	setCalendarDay: function( event, clickedDay ) {
-		clickedDay = this.moment( clickedDay );
+	setCalendarDay = ( event, clickedDay ) => {
+		clickedDay = this.props.moment( clickedDay );
 
-		let modifiers = {
+		const modifiers = {
 			year: clickedDay.year(),
 			month: clickedDay.month(),
 			date: clickedDay.date()
 		};
 
-		let date = ( this.props.timeReference || clickedDay ).set( modifiers );
+		const date = ( this.props.timeReference || clickedDay ).set( modifiers );
 
 		this.props.onSelectDay( date, modifiers );
-	},
+	};
 
-	handleCaptionClick: function() {
-		var daypicker = this.refs.daypicker;
+	setCalendarMonth = () => {
+		const { daypicker } = this.refs;
 		daypicker.showMonth( new Date() );
-	},
+	};
 
-	renderDay: function( day ) {
-		var isSelected = this.props.selectedDay &&
-			this.isSameDay( this.props.selectedDay, day );
+	renderDay = day => {
+		const isSelected = this.props.selectedDay && this.isSameDay( this.props.selectedDay, day );
 
 		return (
 			<DayItem
 				selected={ isSelected }
 				events={ this.filterEventsByDay( day ) }
-				date={ day }
-			/>
+				date={ day } />
 		);
-	},
+	};
 
-	render: function() {
+	render() {
 		return (
-			<div className="date-picker_container">
-				<DayPicker
-					ref="daypicker"
-					className="date-picker"
-					initialMonth={ this.props.calendarViewDate }
-					renderDay={ this.renderDay }
-					localeUtils={ this.locale() }
-					onDayClick={ this.setCalendarDay }
-					onMonthChange={ this.props.onMonthChange }
-					enableOutsideDays={ this.props.enableOutsideDays }
-					onCaptionClick={ this.handleCaptionClick }>
-				</DayPicker>
-			</div>
+			<DayPicker
+				ref="daypicker"
+				className="date-picker"
+				initialMonth={ this.props.calendarViewDate }
+				renderDay={ this.renderDay }
+				localeUtils={ this.locale() }
+				onDayClick={ this.setCalendarDay }
+				onMonthChange={ this.props.onMonthChange }
+				enableOutsideDays={ this.props.enableOutsideDays }
+				onCaptionClick={ this.setCalendarMonth } />
 		);
 	}
-} );
+}
+
+export default localize( DatePicker );
+

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -42,17 +42,21 @@ class DatePicker extends PureComponent {
 	}
 
 	filterEventsByDay( day ) {
-		let i, event;
-		const eventsInDay = [];
-
 		if ( ! this.props.events ) {
 			return [];
 		}
+
+		let i, event;
+		const eventsInDay = [];
 
 		for ( i = 0; i < this.props.events.length; i++ ) {
 			event = this.props.events[ i ];
 
 			if ( this.isSameDay( event.date, day ) ) {
+				if ( typeof event.id === 'undefined' ) {
+					event.id = `event-${ i }`;
+				}
+
 				eventsInDay.push( event );
 			}
 		}

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -19,6 +19,7 @@ class DatePicker extends PureComponent {
 		enableOutsideDays: PropTypes.bool,
 		events: PropTypes.array,
 		locale: PropTypes.object,
+		moment: PropTypes.func,
 
 		selectedDay: PropTypes.object,
 		timeReference: PropTypes.object,

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -71,6 +71,11 @@ $date-picker_nav_button_size: 20px;
 	opacity: 1;
 }
 
+.date-picker__division {
+	margin: 8px 0;
+	background: $gray;
+}
+
 /**
  * The follow class names are coming from react-day-picker component
  * and they aren't possible change them without change its code base.

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -94,7 +94,7 @@ $date-picker_nav_button_size: 20px;
 .date-picker__calendar-event .social-logo {
 	flex: 0 0 18px;
 	position: relative;
-	top: 2px;
+	top: -1px;
 	left: -1px;
 }
 

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -79,72 +79,28 @@ $date-picker_nav_button_size: 20px;
 /*
  * Events Tooltip
  */
-.date-picker__events-tooltip {
-	.date-picker__icon-wrapper,
-	.date-picker__social-icon-wrapper {
-		display: inline-block;
-		height: 14px;
-		width: 14px;
-		margin-top: 4px;
-		margin-right: 4px;
-		border-radius: 2px;
+.date-picker__icon-wrapper,
+.date-picker__social-icon-wrapper {
+	height: 18px;
+	margin-right: 2px;
+	width: 18px;
+}
 
-		&.date-picker__social-icon-wrapper-google-plus {
-			border-radius: 7px;
-		}
-	}
+.date-picker__calendar-event {
+	display: flex;
+}
 
-	.date-picker__social-icon-wrapper {		
-		&.date-picker__social-icon-wrapper-google-plus {
-			border-radius: 7px;
-		}
-	}
+.date-picker__calendar-event .gridicon,
+.date-picker__calendar-event .social-logo {
+	flex: 0 0 18px;
+	position: relative;
+	top: 2px;
+	left: -1px;
+}
 
-	.date-picker__event-title {
-	    height: 22px;
-	    line-height: 22px;
-	    vertical-align: top;
-	}
-
-	.gridicon,
-	.social-logo {
-		margin-top: -2px;
-		margin-left: -2px;
-	}
-
-	.date-picker__social-icon-wrapper-color {
-		background-color: white;
-
-		.social-logo {
-			&.twitter{
-				color: $color-twitter;
-			}
-
-			&.facebook{
-				color: $color-facebook;
-			}
-
-			&.google-plus {
-				color: $color-gplus;
-			}
-
-			&.linkedin {
-				color: $color-linkedin;
-			}
-
-			&.tumblr {
-				color: $color-tumblr;
-			}
-
-			&.path {
-				color: $color-path;
-			}
-
-			&.eventbrite {
-				color: $color-eventbrite;
-			}
-		}
-	}
+.date-picker__event-title {
+	flex: 0 1 auto;
+	vertical-align: top;
 }
 
 /**

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -76,6 +76,77 @@ $date-picker_nav_button_size: 20px;
 	background: $gray;
 }
 
+/*
+ * Events Tooltip
+ */
+.date-picker__events-tooltip {
+	.date-picker__icon-wrapper,
+	.date-picker__social-icon-wrapper {
+		display: inline-block;
+		height: 14px;
+		width: 14px;
+		margin-top: 4px;
+		margin-right: 4px;
+		border-radius: 2px;
+
+		&.date-picker__social-icon-wrapper-google-plus {
+			border-radius: 7px;
+		}
+	}
+
+	.date-picker__social-icon-wrapper {		
+		&.date-picker__social-icon-wrapper-google-plus {
+			border-radius: 7px;
+		}
+	}
+
+	.date-picker__event-title {
+	    height: 22px;
+	    line-height: 22px;
+	    vertical-align: top;
+	}
+
+	.gridicon,
+	.social-logo {
+		margin-top: -2px;
+		margin-left: -2px;
+	}
+
+	.date-picker__social-icon-wrapper-color {
+		background-color: white;
+
+		.social-logo {
+			&.twitter{
+				color: $color-twitter;
+			}
+
+			&.facebook{
+				color: $color-facebook;
+			}
+
+			&.google-plus {
+				color: $color-gplus;
+			}
+
+			&.linkedin {
+				color: $color-linkedin;
+			}
+
+			&.tumblr {
+				color: $color-tumblr;
+			}
+
+			&.path {
+				color: $color-path;
+			}
+
+			&.eventbrite {
+				color: $color-eventbrite;
+			}
+		}
+	}
+}
+
 /**
  * The follow class names are coming from react-day-picker component
  * and they aren't possible change them without change its code base.

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -86,8 +86,21 @@ $date-picker_nav_button_size: 20px;
 	width: 18px;
 }
 
+.tooltip.date-picker__events-tooltip .popover__inner {
+	max-width: 250px;
+	min-width: 100px;
+}
+
 .date-picker__calendar-event {
 	display: flex;
+	max-width: 200px;
+	overflow: hidden;
+	position: relative;
+	width: 100%;
+
+	&::after {
+		@include long-content-fade( $color: darken( $gray, 30% ) );
+	}
 }
 
 .date-picker__calendar-event .gridicon,
@@ -101,6 +114,9 @@ $date-picker_nav_button_size: 20px;
 .date-picker__event-title {
 	flex: 0 1 auto;
 	vertical-align: top;
+	white-space: nowrap;
+	height: 18px;
+	line-height: 18px;
 }
 
 /**

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -156,8 +156,7 @@
 			font-size: 11px;
 			font-weight: 100;
 			border: 0;
-			height: 22px;
-			line-height: 22px;
+			padding: 2px 0;
 		}
 	}
 }

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -156,6 +156,8 @@
 			font-size: 11px;
 			font-weight: 100;
 			border: 0;
+			height: 22px;
+			line-height: 22px;
 		}
 	}
 }


### PR DESCRIPTION
This PR implements a janitorial process to the `<DatePicker />` component and adds some styles improvements such as the ability to add an icon into the event item.

<img src="https://user-images.githubusercontent.com/77539/27303535-7eb104b8-5511-11e7-9616-4fbb52aaaef6.png" width="400px" />

### Limit the number of events per day.
<img src="https://user-images.githubusercontent.com/77539/27303571-a21874e0-5511-11e7-82f1-b466cfa32710.png" width="250px" />

### Limit the width of the tooltip

<img src="https://user-images.githubusercontent.com/77539/27303578-a77d095a-5511-11e7-895a-cbe60bde7b9b.png" width="250px" />

It fixes some issues that live already in production. For instance when the post title is long:

**before**
<img src="https://user-images.githubusercontent.com/77539/27303838-73e5f632-5512-11e7-9933-bb0d52d3e2fd.png" width="600px" />

**afte**
<img src="https://user-images.githubusercontent.com/77539/27303877-932f8a08-5512-11e7-9b32-9b33860d48a7.png" width="350px" />

### Testing

Go to the devdocs testing page http://calypso.localhost:3000/devdocs/design/date-picker and take a look at the whole implementation paying attention to the events tooltip. Everything should be ok.
