### PR TITLE
Pages: Page: Refactor to ES6 class component

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -84,9 +84,9 @@ class Page extends Component {
 
 	viewPage = ( event ) => {
 		event.preventDefault();
-		const { isPreviewable, previewURL } = this.props;
+		const { isPreviewable, page, previewURL } = this.props;
 
-		if ( this.props.page.status && this.props.page.status === 'publish' ) {
+		if ( page.status && page.status === 'publish' ) {
 			this.props.recordViewPage();
 		}
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -444,17 +444,18 @@ class Page extends Component {
 }
 
 const mapState = ( state, props ) => {
-	const site = getSite( state, props.page.site_ID );
+	const pageSiteId = get( props, 'page.site_ID' );
+	const site = getSite( state, pageSiteId );
 	const siteSlugOrId = get( site, 'slug' ) || get( site, 'ID', null );
 	const selectedSiteId = getSelectedSiteId( state );
 	const isPreviewable =
-		false !== isSitePreviewable( state, props.page.site_ID ) &&
+		false !== isSitePreviewable( state, pageSiteId ) &&
 		site && site.ID === selectedSiteId;
 
 	return {
-		hasStaticFrontPage: hasStaticFrontPage( state, props.page.site_ID ),
-		isFrontPage: isFrontPage( state, props.page.site_ID, props.page.ID ),
-		isPostsPage: isPostsPage( state, props.page.site_ID, props.page.ID ),
+		hasStaticFrontPage: hasStaticFrontPage( state, pageSiteId ),
+		isFrontPage: isFrontPage( state, pageSiteId, props.page.ID ),
+		isPostsPage: isPostsPage( state, pageSiteId, props.page.ID ),
 		isPreviewable,
 		previewURL: getPreviewURL( props.page ),
 		site,


### PR DESCRIPTION
~Depends on [`remove/update-post-status-mixin`](https://github.com/Automattic/wp-calypso/pull/15160)~ [merged]

Also gets rid of direct `lib/analytics` usage.