### PR TITLE
Activity log: Restore items

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -16,8 +16,8 @@ class ActivityLogConfirmDialog extends Component {
 		isVisible: PropTypes.bool.isRequired,
 		onClose: PropTypes.func.isRequired,
 		onConfirm: PropTypes.func.isRequired,
-		siteName: PropTypes.string.isRequired,
-		timestamp: PropTypes.string.isRequired,
+		siteName: PropTypes.string,
+		timestamp: PropTypes.number,
 
 		// Localize
 		translate: PropTypes.func.isRequired,
@@ -75,7 +75,7 @@ class ActivityLogConfirmDialog extends Component {
 					{
 						translate( 'Restoring to {{b}}%(time)s{{/b}}', {
 							args: {
-								time: moment( timestamp, 'x' ).format( 'LLL' ),
+								time: moment( timestamp ).format( 'LLL' ),
 							},
 							components: { b: <b /> },
 						} )

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -16,7 +16,7 @@ class ActivityLogConfirmDialog extends Component {
 		isVisible: PropTypes.bool.isRequired,
 		onClose: PropTypes.func.isRequired,
 		onConfirm: PropTypes.func.isRequired,
-		siteName: PropTypes.string,
+		siteTitle: PropTypes.string,
 		timestamp: PropTypes.number,
 
 		// Localize
@@ -50,7 +50,7 @@ class ActivityLogConfirmDialog extends Component {
 		const {
 			isVisible,
 			moment,
-			siteName,
+			siteTitle,
 			timestamp,
 			translate,
 		} = this.props;
@@ -64,8 +64,8 @@ class ActivityLogConfirmDialog extends Component {
 				<p className="activity-log-confirm-dialog__highlight">
 					{
 						translate(
-							'To proceed please confirm this restore on your site %(siteName)s',
-							{ args: { siteName } }
+							'To proceed please confirm this restore on your site %(siteTitle)s',
+							{ args: { siteTitle } }
 						)
 					}
 				</p>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -4,49 +4,33 @@
 import React, { Component, PropTypes } from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 import ActivityLogItem from '../activity-log-item';
-import { rewindRestore as rewindRestoreAction } from 'state/activity-log/actions';
 
 class ActivityLogDay extends Component {
 	static propTypes = {
 		isRewindEnabled: PropTypes.bool,
 		logs: PropTypes.array.isRequired,
+		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
-		timestamp: PropTypes.string.isRequired,
+		timestamp: PropTypes.number.isRequired,
 	};
 
 	static defaultProps = {
 		isRewindEnabled: true,
 	};
 
-	state = {
-		isRestoreConfirmDialogOpen: false,
-	};
-
-	handleRestoreClick = () => this.setState( { isRestoreConfirmDialogOpen: true } );
-
-	handleRestoreDialogClose = () => this.setState( { isRestoreConfirmDialogOpen: false } );
-
-	handleRestoreDialogConfirm = () => {
+	handleClickRestore = () => {
 		const {
-			rewindRestore,
-			siteId,
-			// FIXME: update to timestamp
-			dateIsoString,
+			requestRestore,
+			timestamp,
 		} = this.props;
-
-		const timestamp = this.props.moment( dateIsoString ).format( 'x' );
-
-		this.setState( { isRestoreConfirmDialogOpen: false } );
-		rewindRestore( siteId, timestamp );
+		requestRestore( timestamp );
 	};
 
 	/**
@@ -58,12 +42,13 @@ class ActivityLogDay extends Component {
 	getRewindButton( type = '' ) {
 		return (
 			<Button
-				primary={ 'primary' === type }
-				disabled={ ! this.props.isRewindEnabled }
-				onClick={ this.handleRestoreClick }
 				compact
+				disabled={ ! this.props.isRewindEnabled }
+				onClick={ this.handleClickRestore }
+				primary={ 'primary' === type }
 			>
 				<Gridicon icon="history" size={ 18 } />
+				{ ' ' }
 				{ this.props.translate( 'Rewind to this day' ) }
 			</Button>
 		);
@@ -84,7 +69,7 @@ class ActivityLogDay extends Component {
 
 		return (
 			<div>
-				<div className="activity-log-day__day">{ moment( Number( timestamp ) ).format( 'LL' ) }</div>
+				<div className="activity-log-day__day">{ moment( timestamp ).format( 'LL' ) }</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,
@@ -98,11 +83,8 @@ class ActivityLogDay extends Component {
 	render() {
 		const {
 			logs,
-			timestamp,
+			requestRestore,
 		} = this.props;
-
-		// FIXME get real props
-		const siteName = 'Placeholder site name';
 
 		return (
 			<div className="activity-log-day">
@@ -114,6 +96,8 @@ class ActivityLogDay extends Component {
 					{ logs.map( ( log, index ) => (
 						<ActivityLogItem
 							key={ index }
+							requestRestore={ requestRestore }
+
 							title={ log.name }
 							subTitle={ log.subTitle }
 							description={ log.description }
@@ -127,18 +111,9 @@ class ActivityLogDay extends Component {
 						/>
 					) ) }
 				</FoldableCard>
-				<ActivityLogConfirmDialog
-					isVisible={ this.state.isRestoreConfirmDialogOpen }
-					siteName={ siteName }
-					timestamp={ timestamp }
-					onClose={ this.handleRestoreDialogClose }
-					onConfirm={ this.handleRestoreDialogConfirm }
-				/>
 			</div>
 		);
 	}
 }
 
-export default connect( null, {
-	rewindRestore: rewindRestoreAction
-} )( localize( ActivityLogDay ) );
+export default localize( ActivityLogDay );

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +12,7 @@ import Gridicon from 'gridicons';
 import FoldableCard from 'components/foldable-card';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
-import PopoverMenuSeparator from 'components/popover/menu-separator';
+// import PopoverMenuSeparator from 'components/popover/menu-separator';
 import Gravatar from 'components/gravatar';
 
 class ActivityLogItem extends Component {
@@ -21,22 +20,28 @@ class ActivityLogItem extends Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		timestamp: PropTypes.number.isRequired,
-		requestRestore: PropTypes.func,
+		requestRestore: PropTypes.func.isRequired,
 		title: PropTypes.string,
 		subTitle: PropTypes.string,
 		className: PropTypes.string,
 		icon: PropTypes.string,
 		status: PropTypes.oneOf( [ 'is-success', 'is-warning', 'is-error', 'is-info' ] ),
 		user: PropTypes.object,
-		onClick: PropTypes.func,
 		actionText: PropTypes.string,
 		description: PropTypes.string
 	};
 
 	static defaultProps = {
-		onClick: noop,
 		status: 'is-info',
 		icon: 'info-outline'
+	};
+
+	handleClickRestore = () => {
+		const {
+			requestRestore,
+			timestamp,
+		} = this.props;
+		requestRestore( timestamp );
 	};
 
 	getTime() {
@@ -105,18 +110,14 @@ class ActivityLogItem extends Component {
 	}
 
 	getSummary() {
-		const {
-			translate,
-			actionText
-		} = this.props;
+		const { translate } = this.props;
 
-		return ( actionText &&
+		return (
 			<div className="activity-log-item__action">
 				<EllipsisMenu position="bottom right">
-					<PopoverMenuItem onClick={ noop } icon="undo">{ actionText }</PopoverMenuItem>
-					<PopoverMenuItem icon="pencil">Option B</PopoverMenuItem>
-					<PopoverMenuSeparator />
-					<PopoverMenuItem icon="help">{ translate( 'More Info' ) }</PopoverMenuItem>
+					<PopoverMenuItem onClick={ this.handleClickRestore } icon="undo">
+						{ translate( 'Rewind to this point' ) }
+					</PopoverMenuItem>
 				</EllipsisMenu>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -12,7 +12,6 @@ import Gridicon from 'gridicons';
 import FoldableCard from 'components/foldable-card';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
-// import PopoverMenuSeparator from 'components/popover/menu-separator';
 import Gravatar from 'components/gravatar';
 
 class ActivityLogItem extends Component {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -298,7 +298,7 @@ class ActivityLog extends Component {
 				{ this.renderErrorMessage() || this.renderContent() }
 				<ActivityLogConfirmDialog
 					isVisible={ showRestoreConfirmDialog }
-					siteName={ siteTitle }
+					siteTitle={ siteTitle }
 					timestamp={ requestedRestoreTimestamp }
 					onClose={ this.handleRestoreDialogClose }
 					onConfirm={ this.handleRestoreDialogConfirm }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { groupBy, map, get, filter } from 'lodash';
@@ -11,12 +12,17 @@ import { groupBy, map, get, filter } from 'lodash';
  */
 import Main from 'components/main';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import {
+	getSiteSlug,
+	getSiteTitle,
+	isJetpackSite,
+} from 'state/sites/selectors';
 import { getRewindStatusError } from 'state/selectors';
 import { getActivityLogs } from 'state/selectors';
 import StatsFirstView from '../stats-first-view';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from '../stats-navigation';
+import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import ActivityLogDay from '../activity-log-day';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import ProgressBanner from '../activity-log-banner/progress-banner';
@@ -28,6 +34,9 @@ import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
 import { isRewindActive as isRewindActiveSelector } from 'state/selectors';
+import { rewindRestore as rewindRestoreAction } from 'state/activity-log/actions';
+
+const debug = debugFactory( 'calypso:activity-log' );
 
 class ActivityLog extends Component {
 	static propTypes = {
@@ -47,9 +56,36 @@ class ActivityLog extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	state = {
+		requestedRestoreTimestamp: null,
+		showRestoreConfirmDialog: false,
+	};
+
 	componentDidMount() {
 		window.scrollTo( 0, 0 );
 	}
+
+	handleRequestRestore = ( requestedRestoreTimestamp ) => {
+		this.setState( {
+			requestedRestoreTimestamp,
+			showRestoreConfirmDialog: true,
+		} );
+	};
+
+	handleRestoreDialogClose = () => this.setState( { showRestoreConfirmDialog: false } );
+
+	handleRestoreDialogConfirm = () => {
+		const {
+			rewindRestore,
+			siteId,
+		} = this.props;
+
+		const { requestedRestoreTimestamp } = this.state;
+
+		debug( 'Restore requested for site %d to time %d', this.props.siteId, requestedRestoreTimestamp );
+		this.setState( { showRestoreConfirmDialog: false } );
+		rewindRestore( siteId, requestedRestoreTimestamp );
+	};
 
 	tryFetchLogs( siteId ) {
 		const {
@@ -198,11 +234,12 @@ class ActivityLog extends Component {
 			),
 			( daily_logs, timestamp ) => (
 				<ActivityLogDay
-					key={ timestamp }
-					timestamp={ timestamp }
-					logs={ daily_logs }
-					siteId={ siteId }
 					isRewindEnabled={ isRewindActive }
+					key={ timestamp }
+					logs={ daily_logs }
+					requestRestore={ this.handleRequestRestore }
+					siteId={ siteId }
+					timestamp={ +timestamp }
 				/>
 			)
 		);
@@ -239,8 +276,13 @@ class ActivityLog extends Component {
 		const {
 			isJetpack,
 			siteId,
+			siteTitle,
 			slug,
 		} = this.props;
+		const {
+			requestedRestoreTimestamp,
+			showRestoreConfirmDialog,
+		} = this.state;
 
 		return (
 			<Main wideLayout={ true }>
@@ -254,6 +296,13 @@ class ActivityLog extends Component {
 					section="activity"
 				/>
 				{ this.renderErrorMessage() || this.renderContent() }
+				<ActivityLogConfirmDialog
+					isVisible={ showRestoreConfirmDialog }
+					siteName={ siteTitle }
+					timestamp={ requestedRestoreTimestamp }
+					onClose={ this.handleRestoreDialogClose }
+					onConfirm={ this.handleRestoreDialogConfirm }
+				/>
 			</Main>
 		);
 	}
@@ -266,6 +315,7 @@ export default connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			logs: getActivityLogs( state, siteId ),
 			siteId,
+			siteTitle: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			rewindStatusError: getRewindStatusError( state, siteId ),
 			isRewindActive: isRewindActiveSelector( state, siteId ),
@@ -273,6 +323,8 @@ export default connect(
 			// FIXME: Testing only
 			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], false ),
 		};
-	},
-	{ recordGoogleEvent }
+	}, {
+		recordGoogleEvent,
+		rewindRestore: rewindRestoreAction,
+	}
 )( localize( ActivityLog ) );


### PR DESCRIPTION
Add restoring to individual items.
Move all restore confirmation dialogs into single dialog component 🎉 
Ensure all timestamps are numbers.

To test:
1. Visit https://calypso.live/stats/activity?branch=update/activitylog-restore-item
1. Try restoring days or activity items
   * Ensure the correct dates and times are displayed.
   * Ensure no warnings/errors are displayed in the console during the process.
1. Check network activity and ensure the requests are correct.