### PR TITLE
View Site: Add feature flag for showing preview in sidebar

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -20,6 +20,7 @@ const AllSites = require( 'my-sites/all-sites' ),
 	DomainsStore = require( 'lib/domains/store' ),
 	DomainWarnings = require( 'my-sites/upgrades/components/domain-warnings' );
 
+import config from 'config';
 import SiteNotice from './notice';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -107,6 +108,10 @@ class CurrentSite extends Component {
 	previewSite = ( event ) => this.props.onClick && this.props.onClick( event );
 
 	renderSiteViewLink() {
+		if ( config.isEnabled( 'standalone-site-preview' ) ) {
+			return;
+		}
+
 		const {
 			isPreviewShowing,
 			selectedSite,

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -559,8 +559,7 @@ export class MySitesSidebar extends Component {
 			<div>
 				<SidebarMenu>
 					<ul>
-						{/* TODO: enable once we have the new view ready */}
-						{/* this.preview() */}
+						{ config.isEnabled( 'standalone-site-preview' ) && this.preview() }
 						{ this.stats() }
 						{ this.plan() }
 						{ this.store() }

--- a/config/development.json
+++ b/config/development.json
@@ -143,6 +143,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"standalone-site-preview": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
This will allow us to better collaborate on the feature before we release it for testing or for public audience. 

This branch shouldn't look any different in all environments unless you run Calypso like this: `ENABLE_FEATURES=standalone-site-preview npm start`


| Feature flag OFF | Feature Flag ON |
| --- | --- |
| <img width="271" alt="screen shot 2017-06-19 at 15 39 00" src="https://user-images.githubusercontent.com/156676/27287948-92de1112-5505-11e7-8fe0-eee6f10fdb86.png"> | <img width="272" alt="screen shot 2017-06-19 at 15 40 32" src="https://user-images.githubusercontent.com/156676/27287976-ab0b4aac-5505-11e7-87ec-e02d490e9bb9.png"> |
