### PR TITLE
Publicize: fix nudges and tiers

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -53,7 +53,8 @@ import {
 import {
 	FEATURE_REPUBLICIZE,
 	FEATURE_REPUBLICIZE_SCHEDULING,
-	PLAN_BUSINESS,
+	PLAN_PREMIUM,
+	PLAN_JETPACK_PREMIUM
 } from 'lib/plans/constants';
 import { UpgradeToPersonalNudge } from 'blocks/post-share/nudges';
 
@@ -76,8 +77,6 @@ class PostShare extends Component {
 		disabled: PropTypes.bool,
 
 		// connect prps
-		businessDiscountedRawPrice: PropTypes.number,
-		businessRawPrice: PropTypes.number,
 		connections: PropTypes.array,
 		failed: PropTypes.bool,
 		hasFetchedConnections: PropTypes.bool,
@@ -540,6 +539,12 @@ class PostShare extends Component {
 		);
 	}
 }
+
+const getDiscountedOrRegularPrice = ( state, siteId, plan ) => (
+	getPlanDiscountedRawPrice( state, siteId, plan, { isMonthly: true } ) ||
+	getSitePlanRawPrice( state, siteId, plan, { isMonthly: true } )
+);
+
 export default connect(
 	( state, props ) => {
 		const { siteId } = props;
@@ -565,8 +570,8 @@ export default connect(
 			failed: sharePostFailure( state, siteId, postId ),
 			success: sharePostSuccessMessage( state, siteId, postId ),
 			scheduledAt: getScheduledPublicizeShareActionTime( state, siteId, postId ),
-			businessRawPrice: getSitePlanRawPrice( state, siteId, PLAN_BUSINESS, { isMonthly: true } ),
-			businessDiscountedRawPrice: getPlanDiscountedRawPrice( state, siteId, PLAN_BUSINESS, { isMonthly: true } ),
+			premiumPrice: getDiscountedOrRegularPrice( state, siteId, PLAN_PREMIUM ),
+			jetpackPremiumPrice: getDiscountedOrRegularPrice( state, siteId, PLAN_JETPACK_PREMIUM ),
 			userCurrency: getCurrentUserCurrencyCode( state ),
 		};
 	},

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -15,7 +15,6 @@ import Gridicon from 'gridicons';
 import QueryPostTypes from 'components/data/query-post-types';
 import QueryPosts from 'components/data/query-posts';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
-import { UpgradeToPersonalNudge } from 'blocks/post-share/nudges';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import NoticeAction from 'components/notice/notice-action';
@@ -28,6 +27,7 @@ import {
 import {
 	getSiteSlug,
 	getSitePlanSlug,
+	isJetpackSite,
 } from 'state/sites/selectors';
 import { getCurrentUserId, getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import {
@@ -55,6 +55,7 @@ import {
 	FEATURE_REPUBLICIZE_SCHEDULING,
 	PLAN_BUSINESS,
 } from 'lib/plans/constants';
+import Banner from 'components/banner';
 
 import SharingPreviewModal from './sharing-preview-modal';
 import ConnectionsList, { NoConnectionsNotice } from './connections-list';
@@ -452,9 +453,21 @@ class PostShare extends Component {
 			! hasRepublicizeSchedulingFeature &&
 			isEnabled( 'publicize-scheduling' )
 		) {
+			let description;
+			if ( this.props.isJetpack ) {
+				description = translate( 'Get spam protection, unlimited backup storage and more.' );
+			} else {
+				description = translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' );
+			}
 			return (
 				<div>
-					<UpgradeToPersonalNudge { ...this.props } />
+					<Banner
+						className="post-share__upgrade-nudge"
+						feature="republicize"
+						title={ translate( 'Unlock the ability to re-share posts to social media' ) }
+						callToAction={ translate( 'Upgrade to Personal' ) }
+						description={ description }
+					/>
 					<ActionsList { ...this.props } />
 				</div>
 			);
@@ -551,6 +564,7 @@ export default connect(
 			siteId,
 			postId,
 			planSlug,
+			isJetpack: isJetpackSite( state, siteId ),
 			hasFetchedConnections: siteHasFetchedConnections( state, siteId ),
 			hasRepublicizeFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE ),
 			hasRepublicizeSchedulingFeature: hasFeature( state, siteId, FEATURE_REPUBLICIZE_SCHEDULING ),

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -55,7 +55,7 @@ import {
 	FEATURE_REPUBLICIZE_SCHEDULING,
 	PLAN_BUSINESS,
 } from 'lib/plans/constants';
-import Banner from 'components/banner';
+import { UpgradeToPersonalNudge } from 'blocks/post-share/nudges';
 
 import SharingPreviewModal from './sharing-preview-modal';
 import ConnectionsList, { NoConnectionsNotice } from './connections-list';
@@ -437,7 +437,7 @@ class PostShare extends Component {
 			return null;
 		}
 
-		const { siteSlug, translate } = this.props;
+		const { siteSlug, translate, isJetpack } = this.props;
 
 		if ( ! this.hasConnections() ) {
 			return (
@@ -453,21 +453,9 @@ class PostShare extends Component {
 			! hasRepublicizeSchedulingFeature &&
 			isEnabled( 'publicize-scheduling' )
 		) {
-			let description;
-			if ( this.props.isJetpack ) {
-				description = translate( 'Get spam protection, unlimited backup storage and more.' );
-			} else {
-				description = translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' );
-			}
 			return (
 				<div>
-					<Banner
-						className="post-share__upgrade-nudge"
-						feature="republicize"
-						title={ translate( 'Unlock the ability to re-share posts to social media' ) }
-						callToAction={ translate( 'Upgrade to Personal' ) }
-						description={ description }
-					/>
+					<UpgradeToPersonalNudge { ...{ translate, isJetpack } } />
 					<ActionsList { ...this.props } />
 				</div>
 			);

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -38,18 +38,3 @@ export const UpgradeToPremiumNudge = props => {
 			title={ translate( 'Upgrade to a Business Plan!' ) } />
 	);
 };
-
-export const UpgradeToPersonalNudge = props => {
-	const { translate } = props;
-
-	return (
-		<Banner
-			className="post-share__upgrade-nudge"
-			feature="republicize"
-			title={ translate( 'Unlock the ability to re-share posts to social media' ) }
-			callToAction={ translate( 'Upgrade to Personal' ) }
-			description={ translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' ) }
-		/>
-	);
-};
-

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -38,3 +38,24 @@ export const UpgradeToPremiumNudge = props => {
 			title={ translate( 'Upgrade to a Business Plan!' ) } />
 	);
 };
+
+export const UpgradeToPersonalNudge = props => {
+	const { translate, isJetpack } = props;
+
+	let description;
+	if ( isJetpack ) {
+		description = translate( 'Get spam protection, unlimited backup storage and more.' );
+	} else {
+		description = translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' );
+	}
+	return (
+		<Banner
+			className="post-share__upgrade-nudge"
+			feature="republicize"
+			title={ translate( 'Unlock the ability to re-share posts to social media' ) }
+			callToAction={ translate( 'Upgrade to Personal' ) }
+			description={ description }
+		/>
+	);
+};
+

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -7,35 +7,52 @@ import React from 'react';
  * Internal dependencies
  */
 import Banner from 'components/banner';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 import formatCurrency from 'lib/format-currency';
 
 export const UpgradeToPremiumNudge = props => {
 	const {
-		businessDiscountedRawPrice,
-		businessRawPrice,
+		premiumPrice,
+		jetpackPremiumPrice,
 		translate,
 		userCurrency,
+		isJetpack,
 	} = props;
+
+	let price, featureList, proposedPlan;
+	if ( isJetpack ) {
+		price = jetpackPremiumPrice;
+		featureList = [
+			translate( 'Schedule your social messages in advance.' ),
+			translate( 'Easy monetization options' ),
+			translate( 'VideoPress support' ),
+			translate( 'Daily Malware Scanning' ),
+		];
+		proposedPlan = PLAN_JETPACK_PREMIUM;
+	} else {
+		price = premiumPrice;
+		featureList = [
+			translate( 'Schedule your social messages in advance.' ),
+			translate( 'Remove all advertising from your site.' ),
+			translate( 'Enjoy live chat support.' ),
+			translate( 'Easy monetization options' ),
+			translate( 'Unlimited premium themes.' ),
+		];
+		proposedPlan = PLAN_PREMIUM;
+	}
 
 	return (
 		<Banner
 			className="post-share__actions-list-upgrade-nudge"
 			callToAction={
 				translate( 'Upgrade for %s', {
-					args: formatCurrency( businessDiscountedRawPrice || businessRawPrice, userCurrency ),
+					args: formatCurrency( price, userCurrency ),
 					comment: '%s will be replaced by a formatted price, i.e $9.99'
 				} )
 			}
-			list={ [
-				translate( 'Schedule your social messages in advance.' ),
-				translate( 'Remove all advertising from your site.' ),
-				translate( 'Enjoy live chat support.' ),
-				translate( 'Ability to add features through external plugins.' ),
-				translate( 'Access to thousands of themes.' ),
-			] }
-			plan={ PLAN_BUSINESS }
-			title={ translate( 'Upgrade to a Business Plan!' ) } />
+			list={ featureList }
+			plan={ proposedPlan }
+			title={ translate( 'Upgrade to a Premium Plan!' ) } />
 	);
 };
 

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -13,7 +13,6 @@ import {
 	getPostShareScheduledActions,
 	getPostSharePublishedActions,
 } from 'state/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import QuerySharePostActions from 'components/data/query-share-post-actions/index.jsx';
 import CompactCard from 'components/card/compact';
 import SocialLogo from 'social-logos';

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -13,6 +13,7 @@ import {
 	getPostShareScheduledActions,
 	getPostSharePublishedActions,
 } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import QuerySharePostActions from 'components/data/query-share-post-actions/index.jsx';
 import CompactCard from 'components/card/compact';
 import SocialLogo from 'social-logos';

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -285,6 +285,7 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' )
 	},
@@ -311,6 +312,7 @@ export const PLANS_LIST = {
 			FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 			FEATURE_MALWARE_SCANNING_DAILY,
 			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
+			isEnabled( 'publicize-scheduling' ) && FEATURE_REPUBLICIZE_SCHEDULING,
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -332,7 +332,8 @@ export const PLANS_LIST = {
 			FEATURE_AUTOMATED_RESTORES,
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_PREMIUM_SUPPORT
+			FEATURE_PREMIUM_SUPPORT,
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per year' )
 	},
@@ -354,7 +355,8 @@ export const PLANS_LIST = {
 			FEATURE_AUTOMATED_RESTORES,
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
-			FEATURE_PREMIUM_SUPPORT
+			FEATURE_PREMIUM_SUPPORT,
+			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},


### PR DESCRIPTION
This PR is matching publicize tiers support to the support on wpcom plans.
It implements our strategy from p5uIfZ-6le-p2

- makes republicize tier available to personal plan on JP
- makes publicize scheduling available to premium and business plans on JP.

It also:
- fixes the bug where republicize is open to jetpack free plan in calypso right now.
- makes nudges make sense, desplays proper nudges.

## Screenshots

### wpcom free

<img width="746" alt="zrzut ekranu 2017-06-19 o 17 30 41" src="https://user-images.githubusercontent.com/3775068/27293049-963f570c-5515-11e7-93df-60b8c08f8769.png">

### Jetpack free

<img width="750" alt="zrzut ekranu 2017-06-19 o 17 30 56" src="https://user-images.githubusercontent.com/3775068/27293065-a0b7bd32-5515-11e7-8f2d-5634fbbc30d7.png">

### wpcom personal

<img width="824" alt="zrzut ekranu 2017-06-19 o 17 29 55" src="https://user-images.githubusercontent.com/3775068/27293109-c2ccb3be-5515-11e7-8ce1-690049b79237.png">

### Jetpack personal

<img width="782" alt="zrzut ekranu 2017-06-19 o 17 31 28" src="https://user-images.githubusercontent.com/3775068/27293122-c9ec48e4-5515-11e7-96a0-f169f105e83b.png">

### wpcom Premium, Business, Jetpack premium, Business

<img width="758" alt="zrzut ekranu 2017-06-19 o 17 30 12" src="https://user-images.githubusercontent.com/3775068/27293145-da335062-5515-11e7-9332-a93531969ad0.png">




## Testing

get a JP sites:
- free
- personal
- premium
- business

1. Connect at least 1 social media account
2. Go to posts list
3. Click share under a post
- for a free site you should get a nudge to upgrade to personal
- for personal there should be a form and a nudge in scheduled tab
- for premium and business there should be no nudge, but there should be a calendar button next to "share" button