### PR TITLE
Domain management: fix swapped domain/site in URLs

### DIFF
--- a/client/my-sites/upgrades/paths.js
+++ b/client/my-sites/upgrades/paths.js
@@ -22,7 +22,7 @@ function domainManagementEdit( siteName, domainName, slug ) {
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 	}
 
-	return domainManagementRoot() + '/' + domainName + '/' + slug + '/' + siteName;
+	return domainManagementRoot() + '/' + siteName + '/' + slug + '/' + domainName;
 }
 
 function domainManagementAddGoogleApps( siteName, domainName ) {


### PR DESCRIPTION
When a site has one or more mapped domains, there are many routes to edit the
domain properties, e.g.,
```
/domains/manage/:site/email-forwarding/:domain
```
However, when I navigate to an email forwarding page in the Calypso UI, its URL is:
```
/domains/manage/:domain/email-forwarding/:site
```
I.e., the `:domain` and `:site` slugs are swapped. If I construct a URL to directly open
email forwarding settings for a given domain, it doesn't work.

This patch fixes that.

We'll be soon redirecting to email-forwarding URLs after clicking a email verification link.
I discovered the bug while working on that feature.

Test plan:
Test the domain management routes as specifed in [docs](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/upgrades/domain-management/README.md) and check that they all work as expected.