### PR TITLE
Login: Fix error code

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -59,7 +59,7 @@ class SocialLoginForm extends Component {
 				} ).catch( wpcomError => {
 					this.props.recordTracksEvent( 'calypso_login_social_signup_failure', {
 						social_account_type: 'google',
-						error_code: wpcomError.code,
+						error_code: wpcomError.error,
 						error_message: wpcomError.message
 					} );
 				} );


### PR DESCRIPTION
The wpcomError object has an `error` property, not `code`. 

To test, try logging in to a Google email address that already has a wordpress.com account associated with it, and then look in Tracks at the `calypso_login_social_signup_failure` event and make sure you see a value on the `error_code` property.