### PR TITLE
WooCommerce: Add a nav bar to the settings screen

### DIFF
--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -8,77 +8,64 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getSiteSlug } from 'state/sites/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
 
-export const StoreSettings = ( {
-	siteId,
-	siteSlug,
+export const SettingsNavigation = ( {
+	site,
+	activeSection,
 	translate,
 } ) => {
-	const pathSuffix = siteSlug ? '/' + siteSlug : '';
-	const filters = [];
-
-	filters.push( {
-		id: 'payments',
-		route: '/store/settings/payments' + pathSuffix,
-		title: translate( 'Payments' ),
-	} );
-
-	filters.push( {
-		id: 'shipping',
-		route: '/store/settings/shipping' + pathSuffix,
-		title: translate( 'Shipping' ),
-	} );
-
-	filters.push( {
-		id: 'tax',
-		route: '/store/settings/tax' + pathSuffix,
-		title: translate( 'Tax' ),
-	} );
-
-	filters.push( {
-		id: 'display',
-		route: '/store/settings/display' + pathSuffix,
-		title: translate( 'Display' ),
-	} );
-
-	filters.push( {
-		id: 'emails',
-		route: '/store/settings/emails' + pathSuffix,
-		title: translate( 'Emails' ),
-	} );
-
+	const items = [
+		{
+			id: 'payments',
+			path: '/store/settings/payments/:site',
+			title: translate( 'Payments' ),
+		},
+		{
+			id: 'shipping',
+			path: '/store/settings/shipping/:site',
+			title: translate( 'Shipping' ),
+		},
+		{
+			id: 'tax',
+			path: '/store/settings/tax/:site',
+			title: translate( 'Tax' ),
+		},
+	];
 
 	return (
 		<SectionNav>
 			<NavTabs>
-				{ filters.map( ( { id, route, title } ) => (
-					<NavItem className={ route } key={ id } path={ route }>
-						{ title }
-					</NavItem>
-				) ) }
+				{ items.map( ( { id, path, title } ) => {
+					const link = getLink( path, site );
+					return (
+						<NavItem selected={ activeSection === id } key={ id } path={ link }>
+							{ title }
+						</NavItem>
+					);
+				} ) }
 			</NavTabs>
 		</SectionNav>
 	);
 };
 
-StoreSettings.propTypes = {
-	siteId: PropTypes.number,
-	siteSlug: PropTypes.string,
+SettingsNavigation.propTypes = {
+	site: PropTypes.shape( {
+		ID: PropTypes.number,
+		slug: PropTypes.string,
+	} ),
+	activeSection: PropTypes.string,
 	translate: PropTypes.func,
 };
 
 export default connect(
 	( state ) => {
-		const siteId = getSelectedSiteId( state );
-
 		return {
-			siteId,
-			siteSlug: getSiteSlug( state, siteId ),
+			site: getSelectedSiteWithFallback( state ),
 		};
 	},
-)( localize( StoreSettings ) );
+)( localize( SettingsNavigation ) );

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import SectionNav from 'components/section-nav';
+
+export const StoreSettings = ( {
+	siteId,
+	siteSlug,
+	translate,
+} ) => {
+	const pathSuffix = siteSlug ? '/' + siteSlug : '';
+	const filters = [];
+
+	filters.push( {
+		id: 'payments',
+		route: '/store/settings/payments' + pathSuffix,
+		title: translate( 'Payments' ),
+	} );
+
+	filters.push( {
+		id: 'shipping',
+		route: '/store/settings/shipping' + pathSuffix,
+		title: translate( 'Shipping' ),
+	} );
+
+	filters.push( {
+		id: 'tax',
+		route: '/store/settings/tax' + pathSuffix,
+		title: translate( 'Tax' ),
+	} );
+
+	filters.push( {
+		id: 'display',
+		route: '/store/settings/display' + pathSuffix,
+		title: translate( 'Display' ),
+	} );
+
+	filters.push( {
+		id: 'emails',
+		route: '/store/settings/emails' + pathSuffix,
+		title: translate( 'Emails' ),
+	} );
+
+
+	return (
+		<SectionNav>
+			<NavTabs>
+				{ filters.map( ( { id, route, title } ) => (
+					<NavItem className={ route } key={ id } path={ route }>
+						{ title }
+					</NavItem>
+				) ) }
+			</NavTabs>
+		</SectionNav>
+	);
+};
+
+StoreSettings.propTypes = {
+	siteId: PropTypes.number,
+	siteSlug: PropTypes.string,
+	translate: PropTypes.func,
+};
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			siteId,
+			siteSlug: getSiteSlug( state, siteId ),
+		};
+	},
+)( localize( StoreSettings ) );

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -37,8 +38,9 @@ export const SettingsNavigation = ( {
 		},
 	];
 
+	const section = find( items, { id: activeSection } );
 	return (
-		<SectionNav>
+		<SectionNav selectedText={ section && section.title }>
 			<NavTabs>
 				{ items.map( ( { id, path, title } ) => {
 					const link = getLink( path, site );

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -32,9 +32,9 @@ export const SettingsNavigation = ( {
 			title: translate( 'Shipping' ),
 		},
 		{
-			id: 'tax',
-			path: '/store/settings/tax/:site',
-			title: translate( 'Tax' ),
+			id: 'taxes',
+			path: '/store/settings/taxes/:site',
+			title: translate( 'Taxes' ),
 		},
 	];
 

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -14,6 +14,7 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import SettingsPaymentsLocationCurrency from './payments-location-currency';
+import SettingsNavigation from '../navigation';
 import SettingsPaymentsOffline from './payments-offline';
 import SettingsPaymentsOffSite from './payments-off-site';
 import SettingsPaymentsOnSite from './payments-on-site';
@@ -39,6 +40,7 @@ class SettingsPayments extends Component {
 			<Main
 				className={ classNames( 'settingsPayments', className ) }>
 				<ActionHeader breadcrumbs={ breadcrumbs } />
+				<SettingsNavigation />
 				<SettingsPaymentsLocationCurrency />
 				<SettingsPaymentsOnSite />
 				<SettingsPaymentsOffSite />

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -40,7 +40,7 @@ class SettingsPayments extends Component {
 			<Main
 				className={ classNames( 'settingsPayments', className ) }>
 				<ActionHeader breadcrumbs={ breadcrumbs } />
-				<SettingsNavigation />
+				<SettingsNavigation activeSection="payments" />
 				<SettingsPaymentsLocationCurrency />
 				<SettingsPaymentsOnSite />
 				<SettingsPaymentsOffSite />

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -19,12 +19,6 @@
 	max-width: 600px;
 }
 
-.payments__location-currency {
-	@include breakpoint( ">660px" ) {
-		margin-top: 58px;
-	}
-}
-
 .payments__currency-container {
 	display: flex;
 	flex-direction: column;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import ActionHeader from 'woocommerce/components/action-header';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import SettingsNavigation from '../navigation';
 
 const ShippingHeader = ( { translate, site } ) => {
 	const breadcrumbs = [
@@ -18,7 +19,10 @@ const ShippingHeader = ( { translate, site } ) => {
 		( <span>{ translate( 'Shipping' ) }</span> ),
 	];
 	return (
-		<ActionHeader breadcrumbs={ breadcrumbs } />
+		<div>
+			<ActionHeader breadcrumbs={ breadcrumbs } />
+			<SettingsNavigation activeSection="shipping" />
+		</div>
 	);
 };
 

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -1,10 +1,6 @@
 @import 'shipping-zone/style';
 @import 'shipping-zone/style';
 
-.shipping__origin {
-	margin-top: 58px;
-}
-
 .shipping__zones-header,
 .shipping__packages-header {
 	font-weight: 600;
@@ -16,12 +12,6 @@
 	padding-bottom: 8px;
 	font-size: 14px;
 	line-height: 18px;
-}
-
-.shipping__origin {
-	@include breakpoint( ">660px" ) {
-		margin-top: 58px;
-	}
 }
 
 .shipping__address {

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -34,6 +34,7 @@ import {
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
+import SettingsNavigation from '../navigation';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import StoreAddress from 'woocommerce/components/store-address';
 import TaxesOptions from './taxes-options';
@@ -158,6 +159,7 @@ class SettingsTaxes extends Component {
 						{ translate( 'Save' ) }
 					</Button>
 				</ActionHeader>
+				<SettingsNavigation activeSection="taxes" />
 				<div className="taxes__nexus">
 					<ExtendedHeader
 						label={ translate( 'Store Address / Tax Nexus' ) }

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -1,7 +1,3 @@
-.taxes__nexus {
-	margin-top: 58px;
-}
-
 .taxes__taxes-rates {
 	.form-toggle__label-content {
 		float: left;

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -59,6 +59,7 @@ const getStorePages = () => {
 			container: ProductCreate,
 			configKey: 'woocommerce/extension-products',
 			path: '/store/product/:site',
+			parentPath: '/store/products/:site',
 			sidebarItemButton: {
 				label: translate( 'Add' ),
 				parentSlug: 'products',
@@ -70,6 +71,7 @@ const getStorePages = () => {
 			container: ProductUpdate,
 			configKey: 'woocommerce/extension-products',
 			path: '/store/product/:site/:product',
+			parentPath: '/store/products/:site',
 		},
 		{
 			container: Orders,
@@ -87,6 +89,7 @@ const getStorePages = () => {
 			container: Order,
 			configKey: 'woocommerce/extension-orders',
 			path: '/store/order/:site/:order',
+			parentPath: '/store/orders/:site',
 		},
 		{
 			container: SettingsPayments,
@@ -104,21 +107,25 @@ const getStorePages = () => {
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings-payments',
 			path: '/store/settings/payments/:site',
+			parentPath: '/store/settings/:site',
 		},
 		{
 			container: Shipping,
 			configKey: 'woocommerce/extension-settings-shipping',
 			path: '/store/settings/shipping/:site',
+			parentPath: '/store/settings/:site',
 		},
 		{
 			container: ShippingZone,
 			configKey: 'woocommerce/extension-settings-shipping',
 			path: '/store/settings/shipping/:site/zone/:zone',
+			parentPath: '/store/settings/:site',
 		},
 		{
 			container: SettingsTaxes,
 			configKey: 'woocommerce/extension-settings-tax',
 			path: '/store/settings/taxes/:site',
+			parentPath: '/store/settings/:site',
 		},
 	];
 };
@@ -145,10 +152,11 @@ function addStorePage( storePage, storeNavigation ) {
 	} );
 }
 
-function createStoreNavigation( context, next ) {
+function createStoreNavigation( context, next, storePage ) {
 	renderWithReduxStore(
 		React.createElement( StoreSidebar, {
 			path: context.path,
+			page: storePage,
 			sidebarItems: getStoreSidebarItems(),
 			sidebarItemButtons: getStoreSidebarItemButtons(),
 		} ),
@@ -163,7 +171,7 @@ export default function() {
 	// Add pages that use the store navigation
 	getStorePages().forEach( function( storePage ) {
 		if ( config.isEnabled( storePage.configKey ) ) {
-			addStorePage( storePage, createStoreNavigation );
+			addStorePage( storePage, ( context, next ) => createStoreNavigation( context, next, storePage ) );
 		}
 	} );
 

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -89,7 +89,7 @@ const getStorePages = () => {
 			path: '/store/order/:site/:order',
 		},
 		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
+			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings',
 			path: '/store/settings/:site',
 			sidebarItem: {
@@ -104,25 +104,11 @@ const getStorePages = () => {
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings-payments',
 			path: '/store/settings/payments/:site',
-			sidebarItem: {
-				isPrimary: false,
-				label: translate( 'Payments' ),
-				parentSlug: 'settings',
-				slug: 'settings-payments',
-				showDuringSetup: false,
-			},
 		},
 		{
 			container: Shipping,
 			configKey: 'woocommerce/extension-settings-shipping',
 			path: '/store/settings/shipping/:site',
-			sidebarItem: {
-				isPrimary: false,
-				label: translate( 'Shipping' ),
-				parentSlug: 'settings',
-				slug: 'settings-shipping',
-				showDuringSetup: false,
-			},
 		},
 		{
 			container: ShippingZone,
@@ -133,13 +119,6 @@ const getStorePages = () => {
 			container: SettingsTaxes,
 			configKey: 'woocommerce/extension-settings-tax',
 			path: '/store/settings/taxes/:site',
-			sidebarItem: {
-				isPrimary: false,
-				label: translate( 'Taxes' ),
-				parentSlug: 'settings',
-				slug: 'settings-tax',
-				showDuringSetup: false,
-			},
 		},
 	];
 };

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -75,7 +75,7 @@ class StoreSidebar extends Component {
 	}
 
 	renderSidebarMenuItems = ( items, buttons, isDisabled ) => {
-		const { site, finishedInitialSetup } = this.props;
+		const { site, finishedInitialSetup, page } = this.props;
 
 		return items.map( function( item, index ) {
 			if ( ! item.showDuringSetup && ! finishedInitialSetup ) {
@@ -119,13 +119,14 @@ class StoreSidebar extends Component {
 				childLinks.push( getLink( child.path, site ) );
 			} );
 
+			const selected = this.isItemLinkSelected( itemLink ) || page.parentPath === item.path;
 			// Build the classnames for the item
 			const itemClasses = classNames( item.slug,
 				{
 					'has-selected-child': this.isItemLinkSelected( childLinks ),
 					'is-child-item': isChild,
 					'is-placeholder': isDisabled,
-					selected: this.isItemLinkSelected( itemLink ),
+					selected,
 				}
 			);
 

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -46,6 +46,12 @@
 			margin-left: 8px;
 		}
 	}
+
+	.section-nav {
+		@include breakpoint( ">660px" ) {
+			margin-top: 58px;
+		}
+	}
 }
 
 .is-section-woocommerce {


### PR DESCRIPTION
This PR moves the settings navigation items from the sidebar, to a nav bar on the settings screen.

It also makes sure that the correct active item is highlighted on the sidebar when you are on subsections. For example, 'Products' is still highlighted if you are on 'Product Add' or 'Product Edit', or the list. 'Settings' is highlighted when you are on 'Payments', etc.

Desktop:

<img width="679" alt="screen shot 2017-06-30 at 6 22 50 am" src="https://user-images.githubusercontent.com/689165/27737327-975aa41c-5d5c-11e7-91bf-254d9b71f474.png">

Mobile:

<img width="420" alt="screen shot 2017-06-30 at 6 22 36 am" src="https://user-images.githubusercontent.com/689165/27737334-9e22da76-5d5c-11e7-9bb4-d85612bf16ba.png">

To Test:
* Go to `http://calypso.localhost:3000/store/settings/payments/:site`
* Make sure the nav bar shows up, and you can switch between the sections 
* Make sure that 'settings' on the sidebar is highlighted
* Go to mobile widths, and make sure the nav bar shows the correct page title, and you can select navigation options from the dropdown.
* Finally, go to product add (or another sub page) and make sure the correct section is highlighted.
