### PR TITLE
Publicize: Minor style fix for Google Plus

### DIFF
--- a/client/components/share/google-plus-share-preview/style.scss
+++ b/client/components/share/google-plus-share-preview/style.scss
@@ -7,7 +7,7 @@
 	margin: 0 auto;
 	max-width: 530px;
 	width: 100%;
-	
+
 	// Nesting to win main.scss
 	.google-plus-share-preview__profile-name {
 		color: rgba(0, 0, 0, 0.87);
@@ -64,10 +64,9 @@
 	font-size: 20px;
 	font-weight: 300;
 	line-height: 1.4;
-	margin: 16px;
 	max-height: 56px;
 	overflow: hidden;
-	padding-top: 16px;
+	padding: 16px;
 	text-overflow: ellipsis;
 	-webkit-box-orient: vertical;
 	-webkit-line-clamp: 2;

--- a/client/components/share/google-plus-share-preview/style.scss
+++ b/client/components/share/google-plus-share-preview/style.scss
@@ -26,7 +26,6 @@
 	}
 }
 
-
 .google-plus-share-preview__header {
 	align-items: center;
 	display: flex;
@@ -36,6 +35,7 @@
 .google-plus-share-preview__profile-picture-part {
 	flex: 0 0 36px;
 }
+
 .google-plus-share-preview__profile-picture {
 	border-radius: 50%;
 	display: block;


### PR DESCRIPTION
It's minor, but this PR intends to fix a collapsed margin when a shared post doesn't have a featured image.

**Before**
<img width="902" alt="screen shot 2017-06-19 at 17 34 59" src="https://user-images.githubusercontent.com/908665/27295809-1d9f0c06-5516-11e7-9907-0b739a02dee7.png">

**After**
<img width="915" alt="screen shot 2017-06-19 at 17 36 33" src="https://user-images.githubusercontent.com/908665/27295819-26d794c8-5516-11e7-9c79-138e758508e2.png">
