### PR TITLE
Activity log: Add restore selectors

### DIFF
--- a/client/state/selectors/get-restore-error.js
+++ b/client/state/selectors/get-restore-error.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the error for a restore request
+ *
+ * @param {Object} state Global state tree
+ * @param {Number|String} siteId the site ID
+ * @return {?Object} Error object, null if no data
+ */
+export default function getRestoreError( state, siteId ) {
+	return get( state, [
+		'activityLog',
+		'restoreError',
+		siteId,
+	], null );
+}

--- a/client/state/selectors/get-restore-progress.js
+++ b/client/state/selectors/get-restore-progress.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the progress of a restore request
+ *
+ * @param {Object} state Global state tree
+ * @param {Number|String} siteId the site ID
+ * @return {?Object} Progress object, null if no data
+ */
+export default function getRestoreProgress( state, siteId ) {
+	return get( state, [
+		'activityLog',
+		'restoreProgress',
+		siteId,
+	], null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -44,6 +44,8 @@ export getJetpackSettings from './get-jetpack-settings';
 export getJetpackSettingsSaveError from './get-jetpack-settings-save-error';
 export getJetpackSettingsSaveRequestStatus from './get-jetpack-settings-save-request-status';
 export getReaderFollowsLastSyncTime from './get-reader-follows-last-sync-time';
+export getRestoreProgress from './get-restore-progress';
+export getRestoreError from './get-restore-error';
 export getRewindStatusError from './get-rewind-status-error';
 export getRewindStartDate from './get-rewind-start-date';
 export getMagicLoginCurrentView from './get-magic-login-current-view';

--- a/client/state/selectors/test/get-restore-error.js
+++ b/client/state/selectors/test/get-restore-error.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getRestoreError } from 'state/selectors';
+
+const SITE_ID = 1234;
+
+describe( 'getRestoreError()', () => {
+	it( 'should return null if no error exists for a site', () => {
+		const result = getRestoreError( {
+			activityLog: {
+				restoreError: {},
+			},
+		}, SITE_ID );
+		expect( result ).to.be.null;
+	} );
+
+	it( 'should return an existing error for a site', () => {
+		const error = {
+			error: 'error',
+			message: 'Error.',
+			status: 400,
+		};
+		const result = getRestoreError( {
+			activityLog: {
+				restoreError: {
+					[ SITE_ID ]: error,
+				},
+			},
+		}, SITE_ID );
+		expect( result ).to.deep.equal( error );
+	} );
+} );

--- a/client/state/selectors/test/get-restore-progress.js
+++ b/client/state/selectors/test/get-restore-progress.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getRestoreProgress } from 'state/selectors';
+
+const SITE_ID = 1234;
+
+describe( 'getRestoreProgress()', () => {
+	it( 'should return null if no progress exists for a site', () => {
+		const result = getRestoreProgress( {
+			activityLog: {
+				restoreProgress: {},
+			},
+		}, SITE_ID );
+		expect( result ).to.be.null;
+	} );
+
+	it( 'should return existing progress for a site', () => {
+		const progress = {
+			complete: false,
+			percent: 20,
+			status: 'in-progress',
+		};
+		const result = getRestoreProgress( {
+			activityLog: {
+				restoreProgress: {
+					[ SITE_ID ]: progress,
+				},
+			},
+		}, SITE_ID );
+		expect( result ).to.deep.equal( progress );
+	} );
+} );


### PR DESCRIPTION
Add getRestoreProgress and getRestoreError selectors.
Will be required for displaying activity log banners.

To test:
- Ensure tests pass `npm run test-client client/state/selectors/`