### PR TITLE
Reader: Fix site results header lines

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -319,14 +319,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .search-stream__header .section-nav {
 	background: inherit;
-	border-bottom: 2px solid lighten( $gray, 30% );
+	border-bottom: 1px solid lighten( $gray, 20% );
 	box-shadow: none;
-	height: 54px;
+	height: 53px;
 	margin-bottom: 0;
 	padding-bottom: 0;
 
 	@include breakpoint( ">480px" ) {
-		height: 59px;
+		height: 58px;
 	}
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15264

**Before:**
![screenshot 2017-06-19 11 52 23](https://user-images.githubusercontent.com/4924246/27300804-dcba49ba-54e5-11e7-9b0a-67b98808faf2.png)

**After:**
![screenshot 2017-06-19 11 52 33](https://user-images.githubusercontent.com/4924246/27300805-df7e20cc-54e5-11e7-8461-64b1e545be0c.png)
