### PR TITLE
Removed call to setTitle in domainManagementTransferToOtherSite.

### DIFF
--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -249,11 +249,6 @@ export default {
 			return;
 		}
 
-		setTitle(
-			i18n.translate( 'Transfer Domain' ),
-			pageContext
-		);
-
 		renderWithReduxStore(
 			<TransferData
 				component={ DomainManagement.TransferToOtherSite }


### PR DESCRIPTION
#15025 removed `setTitle` from `client/my-sites/upgrades/domain-management/controller.jsx` which broke #14810 as noted here: https://github.com/Automattic/wp-calypso/pull/14810#issuecomment-309529805.

This PR removes the call to `setTitle` in the `domainManagementTransferToOtherSite`.