### PR TITLE
Show a cart abandonment nudge (notice) to users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -84,4 +84,22 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
+	postPublishPreview: {
+		datestamp: '20170627',
+		allowExistingUsers: true,
+		variations: {
+			showPostPublishPreview: 50,
+			noShowPostPublishPreview: 50,
+		},
+		defaultVariation: 'noShowPostPublishPreview',
+	},
+	showCartAbandonmentNotice: {
+		datestamp: '20170630',
+		variations: {
+			doNotShowNotice: 50,
+			showNotice: 50,
+		},
+		defaultVariation: 'doNotShowNotice',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -84,15 +84,6 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	postPublishPreview: {
-		datestamp: '20170627',
-		allowExistingUsers: true,
-		variations: {
-			showPostPublishPreview: 50,
-			noShowPostPublishPreview: 50,
-		},
-		defaultVariation: 'noShowPostPublishPreview',
-	},
 	showCartAbandonmentNotice: {
 		datestamp: '20170630',
 		variations: {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -809,6 +809,19 @@ function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestion ) {
 	return 'PRICE';
 }
 
+/**
+ * Determines whether any items in the cart were added more than X time ago (10 minutes)
+ *
+ * @param {Object} cart - cart as `CartValue` object
+ * @returns {boolean} true if there is at least one cart item added more than X time ago, false otherwise
+ */
+function hasStaleItem( cart ) {
+	return some( getAll( cart ), function( cartItem ) {
+		// time_added_to_cart is in seconds, Date.now() returns milliseconds
+		return ( cartItem.time_added_to_cart && cartItem.time_added_to_cart * 1000 < Date.now() - ( 10 * 60 * 1000 ) );
+	} );
+}
+
 module.exports = {
 	add,
 	addPrivacyToAllDomains,
@@ -867,5 +880,6 @@ module.exports = {
 	themeItem,
 	unlimitedSpaceItem,
 	unlimitedThemesItem,
-	videoPressItem
+	videoPressItem,
+	hasStaleItem
 };

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -87,7 +87,7 @@ class CurrentSite extends Component {
 			return null;
 		}
 
-		// Show a notice if there are stale itmes in the cart and it hasn't been shown in the last 10 (cart abandonment)
+		// Show a notice if there are stale items in the cart and it hasn't been shown in the last 10 minutes (cart abandonment)
 		if ( cartItems.hasStaleItem( CartStore.get() ) && this.props.staleCartItemNoticeLastTimeShown < Date.now() - ( 10 * 60 * 1000 ) ) {
 			if ( abtest( 'showCartAbandonmentNotice' ) === 'showNotice' ) {
 				this.props.infoNotice(

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -21,11 +21,16 @@ import DomainsStore from 'lib/domains/store';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import config from 'config';
 import SiteNotice from './notice';
+import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedOrAllSites } from 'state/selectors';
+import { infoNotice, removeNotice } from 'state/notices/actions';
+import { getNoticeLastTimeShown } from 'state/notices/selectors';
+import { getSectionName } from 'state/ui/selectors';
+import { abtest } from 'lib/abtest';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -50,10 +55,12 @@ class CurrentSite extends Component {
 		}
 
 		DomainsStore.on( 'change', this.handleStoreChange );
+		CartStore.on( 'change', this.showStaleCartItemsNotice );
 	}
 
 	componentWillUnmount() {
 		DomainsStore.off( 'change', this.handleStoreChange );
+		CartStore.off( 'change', this.showStaleCartItemsNotice );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -65,6 +72,36 @@ class CurrentSite extends Component {
 
 	handleStoreChange = () => {
 		this.setState( { domainsStore: DomainsStore } );
+	}
+
+	showStaleCartItemsNotice = () => {
+		const { selectedSite } = this.props,
+			cartItems = require( 'lib/cart-values' ).cartItems,
+			staleCartItemNoticeId = 'stale-cart-item-notice';
+
+		// Remove any existing stale cart notice
+		this.props.removeNotice( staleCartItemNoticeId );
+
+		// Don't show on the checkout page?
+		if ( this.props.sectionName === 'upgrades' ) {
+			return null;
+		}
+
+		// Show a notice if there are stale itmes in the cart and it hasn't been shown in the last 10 (cart abandonment)
+		if ( cartItems.hasStaleItem( CartStore.get() ) && this.props.staleCartItemNoticeLastTimeShown < Date.now() - ( 10 * 60 * 1000 ) ) {
+			if ( abtest( 'showCartAbandonmentNotice' ) === 'showNotice' ) {
+				this.props.infoNotice(
+					this.props.translate( 'Your site deserves a boost!' ),
+					{
+						id: staleCartItemNoticeId,
+						isPersistent: false,
+						duration: 10000,
+						button: this.props.translate( 'Complete your purchase' ),
+						href: '/checkout/' + selectedSite.slug,
+					}
+				);
+			}
+		}
 	}
 
 	switchSites = ( event ) => {
@@ -200,7 +237,9 @@ export default connect(
 			selectedSite: getSelectedSite( state ),
 			anySiteSelected: getSelectedOrAllSites( state ),
 			siteCount: get( user, 'visible_site_count', 0 ),
+			staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, 'stale-cart-item-notice' ),
+			sectionName: getSectionName( state ),
 		};
 	},
-	{ setLayoutFocus },
+	{ setLayoutFocus, infoNotice, removeNotice },
 )( localize( CurrentSite ) );

--- a/client/state/notices/reducer.js
+++ b/client/state/notices/reducer.js
@@ -50,6 +50,16 @@ export const items = createReducer( {}, {
 	}
 } );
 
+export const lastTimeShown = createReducer( {}, {
+	[ NOTICE_CREATE ]: ( state, action ) => {
+		const { notice } = action;
+		return {
+			...state,
+			[ notice.noticeId ]: Date.now()
+		};
+	}
+} );
+
 export default combineReducers( {
-	items
+	items, lastTimeShown
 } );

--- a/client/state/notices/selectors.js
+++ b/client/state/notices/selectors.js
@@ -18,3 +18,8 @@ export const getNotices = createSelector(
 	( state ) => values( state.notices.items ),
 	( state ) => state.notices.items
 );
+
+export const getNoticeLastTimeShown = createSelector(
+	( state, noticeId ) => state.notices.lastTimeShown[ noticeId ] || 0,
+	( state ) => state.notices.lastTimeShown
+);


### PR DESCRIPTION
As my first journey into Calypso development I'm trying to show a notice to a user who has an item in their cart older than a certain amount of time. A cart abandonment nudge.
This will be A/B tested on 50% of users.

What this PR does is:
* Start the cart polling which calls the me/shopping-cart/ endpoint to get the cart data (normally polled in other areas of Calypso).
* Check the timestamp (a recently added property) of each item in the cart to see if it is older than 10 minutes.
* If a stale item is found, and the user hasn't already seen the notice recently then show a notice. The notice should click through to the checkout page where they can complete their purchase.

This adds the `lastTimeShown` property to the state tree at `state.notices` which should keep track of the last time any global notice was shown (in milliseconds).

Any feedback is appreciated. :)

Do you see any issues with the shopping cart polling now happening everywhere under My Sites rather than only in a few sections?

**Test Plan**

* From the browser console add yourself to the test variation.
```
localStorage.setItem( 'ABTests', '{"showCartAbandonmentNotice_20170630":"showNotice"}' );
```
* With a test user and site, add any plan to your cart.
* Wait 10+ minutes.
* Click "My Site" to navigate to the stats page.
* As soon as the cart data is synced again (~30 sec.), you should see a notice in the top right of the page similar to this.<img width="515" alt="screen shot 2017-06-30 at 6 49 28 pm" src="https://user-images.githubusercontent.com/690843/27758286-91da891c-5dc5-11e7-83cb-08f416d3bd5f.png">
* Click the "Complete your purchase" button in the notice to make sure it takes you back to the checkout page.
* If you have Redux DevTools installed on your browser check to make sure the timestamp in `notices.lastTimeShown.stale-cart-item-notice` has updated.<img width="404" alt="screen shot 2017-07-05 at 4 24 15 pm" src="https://user-images.githubusercontent.com/690843/27889019-7082f236-619e-11e7-8832-2e563139818f.png">
