### PR TITLE
PostShare: add `busy` state to Share button in RePublicize feature

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -234,6 +234,7 @@ class PostShare extends Component {
 
 		const shareButton = <Button
 			className="post-share__share-button"
+			busy={ this.props.requesting && ! hasRepublicizeSchedulingFeature }
 			primary
 			onClick={ this.sharePost }
 			disabled={ this.isDisabled() }


### PR DESCRIPTION
This PR adds the `busy` state to `Share` button when a post is shared.

<img src="https://user-images.githubusercontent.com/77539/27306330-9616299e-551b-11e7-9fb8-b0cbcc45a809.gif" width="500px" />

After to apply the patch select a site with `Personal` plan in order to enable the `RePublicize` feature. Share a post paying attention to the Share button. You should be able to see the `busy` state there.