### PR TITLE
Publicize: Minor adjustment for external icons for published items

### DIFF
--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -291,6 +291,7 @@ $section-border: solid 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 .post-share .post-share__footer-items {
+	align-items: center;
 	display: flex;
 	flex-wrap: nowrap;
 	justify-content: space-between;


### PR DESCRIPTION
This PR fixes the external icon to be vertically centre all the time.

**Before**
<img width="601" alt="screen shot 2017-06-19 at 22 27 18" src="https://user-images.githubusercontent.com/908665/27307318-0f259dcc-5541-11e7-87f6-6f8087e77e7d.png">

**After**
<img width="605" alt="screen shot 2017-06-19 at 22 27 32" src="https://user-images.githubusercontent.com/908665/27307327-18d124ae-5541-11e7-87f6-98ef7ac3346f.png">

