### PR TITLE
AT: adds event attribute to fire tracks event

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -64,6 +64,10 @@ export const EligibilityWarnings = ( {
 						? FEATURE_UPLOAD_PLUGINS
 						: FEATURE_UPLOAD_THEMES
 					}
+					event={ 'plugins' === context
+						? 'calypso-plugin-eligibility-upgrade-nudge'
+						: 'calypso-theme-eligibility-upgrade-nudge'
+					}
 					plan={ PLAN_BUSINESS }
 					title={ translate( 'Business plan required' ) }
 				/>


### PR DESCRIPTION
The `banner` component requires an `event` attribute to fire the tracks events we use to track the effectiveness of an upgrade banner.

### Testing
You need to watch the `calypso:analytics*` events via the `debug` module. I do this with this javascript bookmarklet:
```js
javascript:(function(){var originalString=localStorage.getItem( 'debug' ),defaultString=(originalString)?originalString:'',debugString=prompt('enter debug string', defaultString);localStorage.setItem('debug',debugString );})();
```
Add that ^^ as a favorite bookmark, then click it and you can set the string to listen to for debug. Then go to the themes upload page on a non-business site. You should see a tracks event like this in your javascript console:
![console impression event](http://cld.wthms.co/GjdxEe+)

Now click the theme upgrade nudge and you should see an event like this.
![console click event](http://cld.wthms.co/5io6uq+)

I'm 95% sure this code is only ever shown for the themes plugin, even though other code here allows for the possibility of display in the "plugins" context. I added the string for plugins, but in practice I don't think that will ever get fired.