### PR TITLE
Reader: Align Search results headers with content in IE

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -290,6 +290,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // Post and Sites static headers
 .search-stream__headers {
 	color: $gray;
+	display: flex;
 	font-size: 14px;
 	display: flex;
 	font-weight: 600;
@@ -298,17 +299,23 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	text-transform: uppercase;
 }
 
-.search-stream .search-stream__site-header {
-	margin-left: 40px;
-	max-width: 265px;
-	width: 100%;
-}
-
 .search-stream__post-header,
 .search-stream__site-header {
 	border-bottom: 1px solid lighten( $gray, 20% );
 	padding-bottom: 15px;
-	width: 100%;
+}
+
+.search-stream .search-stream__post-header,
+.search-stream .search-stream__site-header {
+	flex: 1 1 auto;
+}
+
+.search-stream .search-stream__post-header {
+	margin-right: 40px;
+}
+
+.search-stream .search-stream__site-header {
+	max-width: 265px;
 }
 
 // Posts and Sites tabbed headers


### PR DESCRIPTION
In Site Results in IE, Posts and Sites headers don't align with their content.

**Before:**
![screenshot 2017-06-19 17 03 14](https://user-images.githubusercontent.com/4924246/27310768-7d41379c-5511-11e7-8cd2-6c5fc826088f.png)

**After:**
![screenshot 2017-06-19 17 05 53](https://user-images.githubusercontent.com/4924246/27310782-8fdb1fb2-5511-11e7-86f6-cb5cf0ae2228.png)

Double-checked in Chrome, Safari, and FF:

Chrome:
![screenshot 2017-06-19 17 06 33](https://user-images.githubusercontent.com/4924246/27310811-bff58084-5511-11e7-8d63-c3ee0f547d70.png)

Safari:
![screenshot 2017-06-19 17 06 45](https://user-images.githubusercontent.com/4924246/27310815-c2c479b4-5511-11e7-9d8a-f3553ed3cb0d.png)

FF:
![screenshot 2017-06-19 17 08 39](https://user-images.githubusercontent.com/4924246/27310855-f271acb8-5511-11e7-9eaf-272353b23733.png)

