### PR TITLE
Reader: Make sure content stays within Sites column

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -148,7 +148,7 @@
 	word-break: break-all;
 	width: initial;
 	max-height: 16px * 1.3;
-	max-width: calc( 100% - 10px ); // Need to set max width for IE so URLs don't overlow
+	max-width: calc( 100% - 10px ); // Need to set max-width for IE so URLs don't overflow
 
 	@include breakpoint( "<960px" ) {
 		height: 20px;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -88,7 +88,9 @@
 	overflow-wrap: break-word;
 	position: relative;
 	width: 100%;
+	overflow-wrap: break-word;
 	word-wrap: break-word;
+	word-break: break-word;
 
 	&:not( .is-placeholder )::after {
 		@include long-content-fade( $size: 20% );
@@ -146,6 +148,7 @@
 	word-break: break-all;
 	width: initial;
 	max-height: 16px * 1.3;
+	max-width: calc( 100% - 10px ); // Need to set max width for IE so URLs don't overlow
 
 	@include breakpoint( "<960px" ) {
 		height: 20px;


### PR DESCRIPTION
In 2-col Search results, the Follow button gets cropped if there are URLs in the excerpt.

Example: http://calypso.dev:3000/read/search?q=popco&show=Sites

**Before:**
![screenshot 2017-06-19 19 59 17](https://user-images.githubusercontent.com/4924246/27314743-7cb524b4-552a-11e7-8a68-e2a7025f0391.png)

**After:**
![screenshot 2017-06-19 19 59 35](https://user-images.githubusercontent.com/4924246/27314763-979bfafa-552a-11e7-80c5-56abfb4bfb7e.png)

If the URLs are long, they also get cropped along with the excerpt in IE:

**Before:**
![screenshot 2017-06-19 20 00 28](https://user-images.githubusercontent.com/4924246/27314774-af334862-552a-11e7-8d0f-f3257143e287.png)

![screenshot 2017-06-19 20 00 32](https://user-images.githubusercontent.com/4924246/27314775-af354766-552a-11e7-960e-b970dd0f3069.png)

**After:**
![screenshot 2017-06-19 20 08 55](https://user-images.githubusercontent.com/4924246/27314852-23d28d40-552b-11e7-9fdc-e60febab8cbf.png)

![screenshot 2017-06-19 20 08 23](https://user-images.githubusercontent.com/4924246/27314866-2a78b9a8-552b-11e7-9d3e-f808a59331da.png)
