### PR TITLE
Activity log: Banner state 

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -10,26 +10,38 @@ import { localize } from 'i18n-calypso';
 import ActivityLogBanner from './index';
 import Button from 'components/button';
 
-function ErrorBanner( {
-	translate,
-} ) {
-	return (
-		<ActivityLogBanner
-			isDismissable
-			onDismissClick={ /* FIXME */ function() {} }
-			status="error"
-			title={ translate( 'Problem restoring your site' ) }
-		>
-			<p>{ translate( 'We came across a problem while trying to restore your site.' ) }</p>
-			<Button primary >
-				{ translate( 'Try again' ) }
-			</Button>
-			{ '  ' }
-			<Button>
-				{ translate( 'Get help' ) }
-			</Button>
-		</ActivityLogBanner>
-	);
+class ErrorBanner extends PureComponent {
+	static propTypes = {
+		requestRestore: PropTypes.func.isRequired,
+		timestamp: PropTypes.number.isRequired,
+
+		// localize
+		translate: PropTypes.func.isRequired,
+	};
+
+	handleClickRestore = () => this.props.requestRestore( this.props.timestamp );
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<ActivityLogBanner
+				isDismissable
+				onDismissClick={ /* FIXME */ function() {} }
+				status="error"
+				title={ translate( 'Problem restoring your site' ) }
+			>
+				<p>{ translate( 'We came across a problem while trying to restore your site.' ) }</p>
+				<Button primary onClick={ this.handleClickRestore }>
+					{ translate( 'Try again' ) }
+				</Button>
+				{ '  ' }
+				<Button>
+					{ translate( 'Get help' ) }
+				</Button>
+			</ActivityLogBanner>
+		);
+	}
 }
 
 export default localize( ErrorBanner );

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -11,13 +11,12 @@ import ActivityLogBanner from './index';
 import ProgressBar from 'components/progress-bar';
 
 function SuccessBanner( {
-	translate,
 	moment,
+	percent,
+	translate,
 } ) {
 	// FIXME: real dates
 	const date = 1496400468285;
-	// FIXME: real progress
-	const progress = 25;
 
 	return (
 		<ActivityLogBanner
@@ -32,7 +31,7 @@ function SuccessBanner( {
 
 			<div>
 				<em>{ translate( 'Currently restoring posts…' ) }</em>
-				<ProgressBar value={ progress } isPulsing />
+				<ProgressBar value={ percent } isPulsing />
 			</div>
 		</ActivityLogBanner>
 	);

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,28 +13,42 @@ import ProgressBar from 'components/progress-bar';
 function SuccessBanner( {
 	moment,
 	percent,
+	status,
+	timestamp,
 	translate,
 } ) {
-	// FIXME: real dates
-	const date = 1496400468285;
-
 	return (
 		<ActivityLogBanner
 			status="info"
 			title={ translate( 'Currently restoring your site' ) }
 		>
 			<p>{ translate(
-				'We\'re in the process of restoring your site back to %s.' +
-				'You\'ll be notified once it\'s complete.',
-				{ args: moment( date ).format( 'LLLL' ) }
+				"We're in the process of restoring your site back to %s." +
+				"You'll be notified once it's complete.",
+				{ args: moment( timestamp ).format( 'LLLL' ) }
 			) }</p>
 
 			<div>
-				<em>{ translate( 'Currently restoring posts…' ) }</em>
-				<ProgressBar value={ percent } isPulsing />
+				<em>{
+					/*
+					* FIXME: Do we have a detailed message or should this be removed?
+					* FIXME: Show a message for `queued` status before progress?
+					* */
+					translate( 'Currently restoring posts…' )
+				}</em>
+				<ProgressBar value={ percent } isPulsing={ status === 'running' } />
 			</div>
 		</ActivityLogBanner>
 	);
 }
+
+SuccessBanner.propTypes = {
+	percent: PropTypes.number.isRequired,
+	status: PropTypes.oneOf( [
+		'queued',
+		'running',
+	] ).isRequired,
+	timestamp: PropTypes.number.isRequired,
+};
 
 export default localize( SuccessBanner );

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -23,7 +23,7 @@ function SuccessBanner( {
 			title={ translate( 'Currently restoring your site' ) }
 		>
 			<p>{ translate(
-				"We're in the process of restoring your site back to %s." +
+				"We're in the process of restoring your site back to %s. " +
 				"You'll be notified once it's complete.",
 				{ args: moment( timestamp ).format( 'LLLL' ) }
 			) }</p>

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -11,11 +11,10 @@ import ActivityLogBanner from './index';
 import Button from 'components/button';
 
 function SuccessBanner( {
-	translate,
 	moment,
+	timestamp,
+	translate,
 } ) {
-	// FIXME: real dates
-	const date = 1496400468285;
 	// FIXME: real dismiss
 	const handleDismiss = () => {};
 
@@ -28,9 +27,9 @@ function SuccessBanner( {
 		>
 			<p>{ translate(
 				'We successfully restored your site back to %s!',
-				{ args: moment( date ).format( 'LLLL' ) }
+				{ args: moment( timestamp ).format( 'LLLL' ) }
 			) }</p>
-			<Button primary >
+			<Button primary>
 				{ translate( 'View site' ) }
 			</Button>
 			{ '  ' }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -53,9 +53,13 @@ class ActivityLog extends Component {
 		restoreProgress: PropTypes.shape( {
 			percent: PropTypes.number.isRequired,
 			status: PropTypes.oneOf( [
+				'aborted',
+				'fail',
+				'finished',
 				'queued',
 				'running',
 				'success',
+				'success-with-errors',
 			] ).isRequired,
 		} ),
 		rewindStatusError: PropTypes.shape( {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -50,7 +50,7 @@ class ActivityLog extends Component {
 			failureReason: PropTypes.string.isRequired,
 			message: PropTypes.string.isRequired,
 			percent: PropTypes.number.isRequired,
-			restoreId: PropTypes.number.isRequired,
+			restoreId: PropTypes.number,
 			status: PropTypes.oneOf( [
 				'finished',
 				'queued',

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -203,6 +203,7 @@ class ActivityLog extends Component {
 			restoreProgress,
 		} = this.props;
 
+		// FIXME: We should account for status === 'fail' or status === 'aborted'
 		if ( restoreError ) {
 			return (
 				<ErrorBanner />
@@ -213,7 +214,8 @@ class ActivityLog extends Component {
 				percent,
 			} = restoreProgress;
 			return (
-				status === 'success'
+				'success' === status ||
+				'success-with-errors' === status
 					? <SuccessBanner />
 					: <ProgressBanner percent={ percent } />
 			);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -32,7 +32,7 @@ import QueryRewindStatus from 'components/data/query-rewind-status';
 import QueryActivityLog from 'components/data/query-activity-log';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
 import { isRewindActive as isRewindActiveSelector } from 'state/selectors';
 import { rewindRestore as rewindRestoreAction } from 'state/activity-log/actions';

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -4,14 +4,13 @@
 import { combineReducers } from 'state/utils';
 import { activationRequesting } from './activation/reducer';
 import { logItems, logError } from './log/reducer';
-import { restoreProgress, restoreError } from './restore/reducer';
+import { restoreProgress } from './restore/reducer';
 import { rewindStatus, rewindStatusError } from './rewind-status/reducer';
 
 export default combineReducers( {
 	activationRequesting,
 	logError,
 	logItems,
-	restoreError,
 	restoreProgress,
 	rewindStatus,
 	rewindStatusError,

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -4,14 +4,11 @@
 import {
 	REWIND_RESTORE,
 	REWIND_RESTORE_UPDATE_PROGRESS,
-	REWIND_RESTORE_UPDATE_ERROR,
 } from 'state/action-types';
 import {
 	createReducer,
 	keyedReducer,
 } from 'state/utils';
-
-const stubNull = () => null;
 
 const startProgress = ( state, { timestamp } ) => ( {
 	errorCode: '',
@@ -40,14 +37,7 @@ const updateProgress = ( state, {
 	timestamp,
 } );
 
-export const restoreError = keyedReducer( 'siteId', createReducer( {}, {
-	[ REWIND_RESTORE ]: stubNull,
-	[ REWIND_RESTORE_UPDATE_ERROR ]: ( state, { error } ) => error,
-	[ REWIND_RESTORE_UPDATE_PROGRESS ]: stubNull,
-} ) );
-
 export const restoreProgress = keyedReducer( 'siteId', createReducer( {}, {
 	[ REWIND_RESTORE ]: startProgress,
-	[ REWIND_RESTORE_UPDATE_ERROR ]: stubNull,
 	[ REWIND_RESTORE_UPDATE_PROGRESS ]: updateProgress,
 } ) );

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -14,16 +14,30 @@ import {
 const stubNull = () => null;
 
 const startProgress = ( state, { timestamp } ) => ( {
+	errorCode: '',
+	failureReason: '',
+	message: '',
 	percent: 0,
 	status: 'queued',
 	timestamp,
 } );
 
-const updateProgress = ( state, { percent, restoreId, status, timestamp } ) => ( {
+const updateProgress = ( state, {
+	errorCode,
+	failureReason,
+	message,
 	percent,
+	restoreId,
 	status,
 	timestamp,
+} ) => ( {
+	errorCode,
+	failureReason,
+	message,
+	percent,
 	restoreId,
+	status,
+	timestamp,
 } );
 
 export const restoreError = keyedReducer( 'siteId', createReducer( {}, {

--- a/client/state/activity-log/restore/test/reducer.js
+++ b/client/state/activity-log/restore/test/reducer.js
@@ -7,10 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import {
-	restoreError,
-	restoreProgress,
-} from '../reducer';
+import { restoreProgress } from '../reducer';
 import {
     rewindRestore,
     rewindRestoreUpdateError,
@@ -30,24 +27,13 @@ describe( '#restoreProgress()', () => {
 	it( 'should start at 0% queued', () => {
 		const state = restoreProgress( undefined, rewindRestore( SITE_ID, TIMESTAMP ) );
 		expect( state[ SITE_ID ] ).to.deep.equal( {
+			errorCode: '',
+			failureReason: '',
+			message: '',
 			percent: 0,
 			status: 'queued',
 			timestamp: TIMESTAMP,
 		} );
-	} );
-
-	it( 'should null on errors', () => {
-		const prevState = deepFreeze( {
-			[ SITE_ID ]: {
-				active: false,
-				firstBackupDate: '',
-				isPressable: false,
-				plan: 'jetpack-free',
-			},
-		} );
-
-		const state = restoreProgress( prevState, rewindRestoreUpdateError( SITE_ID, TIMESTAMP, ERROR ) );
-		expect( state[ SITE_ID ] ).to.be.null;
 	} );
 
 	it( 'should preserve other sites', () => {
@@ -69,34 +55,3 @@ describe( '#restoreProgress()', () => {
 		);
 	} );
 } );
-
-describe( '#restoreError()', () => {
-	it( 'should insert errors', () => {
-		const state = restoreError( undefined, rewindRestoreUpdateError( SITE_ID, TIMESTAMP, ERROR ) );
-		expect( state[ SITE_ID ] ).to.deep.equal( ERROR );
-	} );
-
-	it( 'should null on progress', () => {
-		const prevState = deepFreeze( {
-			[ SITE_ID ]: ERROR,
-		} );
-		const state = restoreError( prevState, rewindRestore( SITE_ID, TIMESTAMP ) );
-		expect( state[ SITE_ID ] ).to.be.null;
-	} );
-
-	it( 'should preserve other sites', () => {
-		const otherSiteId = 123456;
-		const prevState = deepFreeze( {
-			[ otherSiteId ]: {
-				active: false,
-				firstBackupDate: '',
-				isPressable: false,
-				plan: 'jetpack-free',
-			},
-		} );
-
-		const state = restoreError( prevState, rewindRestoreUpdateError( SITE_ID, TIMESTAMP, ERROR ) );
-		expect( state[ otherSiteId ] ).to.deep.equal( prevState[ otherSiteId ] );
-	} );
-} );
-


### PR DESCRIPTION
Links up the banners to real state. Also fixes #15449 which was getting in the way.

To test:
1. Visit http://calypso.localhost:3000/stats/activity
1. Do a restore
1. You should see a progress banner. Restores do not seem to be fully working, so it will likely stay at progress 0.
1. Test different banners: (`const SITE_ID = ...` first to copy/paste 😀 )
   * error
     ```js
     dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: SITE_ID, timestamp: 1498168800000, restoreId: 123, errorCode: "restore-broke", failureReason: "Something went wrong", message: "A message", percent: 100, status: "finished" })
     ```
   * progress
     ```js
     dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: SITE_ID, timestamp: 1498168800000, restoreId: 123, errorCode: "", failureReason: "", message: "", percent: 33, status: "running" })
     ```
   * success
     ```js
     dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: SITE_ID, timestamp: 1498168800000, restoreId: 123, errorCode: "", failureReason: "", message: "", percent: 100, status: "finished" })
     ```
1. Ensure there are no errors/warnings in the console.

Here's an example of manually dispatching these actions:

![banners](https://user-images.githubusercontent.com/841763/27490210-a79baf3e-583d-11e7-8b4b-68ea0905661e.gif)
 
Follow up:
* Connect help/visit/dismiss banner buttons

Missing pieces:
* ~Handle `success-with-errors` messages~
* ~Fix timestamps, will be returned from API (not currently, #15293)~
* ~Polling progress will allow us to report real progress.~


Contains #15259
First pass of #15260 