### PR TITLE
Publicize: scheduled feature discovery notice

### DIFF
--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -31,6 +31,7 @@ import { deletePostShareAction } from 'state/sharing/publicize/publicize-actions
 import analytics from 'lib/analytics';
 import SharingPreviewModal from './sharing-preview-modal';
 import { UpgradeToPremiumNudge } from 'blocks/post-share/nudges';
+import Notice from 'components/notice';
 
 class PublicizeActionsList extends PureComponent {
 	static propTypes = {
@@ -180,6 +181,7 @@ class PublicizeActionsList extends PureComponent {
 			hasRepublicizeSchedulingFeature,
 			publishedActions,
 			scheduledActions,
+			translate,
 		} = this.props;
 
 		if ( this.state.selectedShareTab === PUBLISHED ) {
@@ -192,6 +194,13 @@ class PublicizeActionsList extends PureComponent {
 
 		if ( hasRepublicizeFeature && ! hasRepublicizeSchedulingFeature ) {
 			return <UpgradeToPremiumNudge { ...this.props } />;
+		}
+		if ( scheduledActions.length === 0 ) {
+			return <Notice
+				status="is-info"
+				showDismiss={ false }
+				text={ translate( 'You can schedule social media actions with the calendar above.' ) }
+			/>;
 		}
 
 		return (

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -199,7 +199,8 @@ class PublicizeActionsList extends PureComponent {
 			return <Notice
 				status="is-info"
 				showDismiss={ false }
-				text={ translate( 'You can schedule social media actions with the calendar above.' ) }
+				text={ translate( 'Did you know you can decide exactly when Publicize shares your post? You can!' +
+					'Click the calendar icon next to "Share post" to schedule your social shares.' ) }
 			/>;
 		}
 


### PR DESCRIPTION
Makes a small notice if scheduled tab is empty

<img width="774" alt="zrzut ekranu 2017-06-20 o 12 14 21" src="https://user-images.githubusercontent.com/3775068/27328375-3ccf1228-55b2-11e7-89fc-f1a5d244b190.png">

## testing

Go to scheduled tab, if its empty, you should have this notice