### PR TITLE
Framework: Lazy load optional components referenced in Layout

### DIFF
--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -35,4 +35,4 @@ In general usage, this should be passed as a string of the module to be imported
 	<tr><td>Required</td><td>No</td></tr>
 </table>
 
-A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown.
+A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown. If `null` provided there is going to be no placeholder.

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -6,8 +6,12 @@ import { omit } from 'lodash';
 
 export default class AsyncLoad extends Component {
 	static propTypes = {
+		placeholder: PropTypes.node,
 		require: PropTypes.func.isRequired,
-		placeholder: PropTypes.node
+	};
+
+	static defaultProps = {
+		placeholder: <div className="async-load__placeholder async-load" />,
 	};
 
 	constructor() {
@@ -48,14 +52,10 @@ export default class AsyncLoad extends Component {
 
 	render() {
 		if ( this.state.component ) {
-			const props = omit( this.props, [ 'require', 'placeholder' ] );
+			const props = omit( this.props, [ 'placeholder', 'require' ] );
 			return <this.state.component { ...props } />;
 		}
 
-		if ( this.props.placeholder ) {
-			return this.props.placeholder;
-		}
-
-		return <div className="async-load" />;
+		return this.props.placeholder;
 	}
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -21,7 +21,6 @@ var AsyncLoad = require( 'components/async-load' ),
 	TranslatorLauncher = require( './community-translator/launcher' ),
 	Welcome = require( 'my-sites/welcome/welcome' ),
 	WelcomeMessage = require( 'layout/nux-welcome/welcome-message' ),
-	GuidedTours = require( 'layout/guided-tours' ),
 	analytics = require( 'lib/analytics' ),
 	config = require( 'config' ),
 	PulsingDot = require( 'components/pulsing-dot' ),
@@ -29,8 +28,7 @@ var AsyncLoad = require( 'components/async-load' ),
 	OfflineStatus = require( 'layout/offline-status' ),
 	QueryPreferences = require( 'components/data/query-preferences' ),
 	KeyboardShortcutsMenu,
-	Layout,
-	SupportUser;
+	Layout;
 
 import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
@@ -39,14 +37,9 @@ import { isHappychatOpen } from 'state/ui/happychat/selectors';
 import SitePreview from 'blocks/site-preview';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
-import NpsSurveyNotice from 'layout/nps-survey-notice';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
-}
-
-if ( config.isEnabled( 'support-user' ) ) {
-	SupportUser = require( 'support/support-user' );
 }
 
 Layout = React.createClass( {
@@ -145,11 +138,11 @@ Layout = React.createClass( {
 				<DocumentHead />
 				<QuerySites allSites />
 				<QueryPreferences />
-				{ <GuidedTours /> }
-				{ config.isEnabled( 'nps-survey/notice' ) && <NpsSurveyNotice /> }
-				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
+				{ <AsyncLoad require="layout/guided-tours" /> }
+				{ config.isEnabled( 'nps-survey/notice' ) && <AsyncLoad require="layout/nps-survey-notice" /> }
+				{ config.isEnabled( 'keyboard-shortcuts' ) && <KeyboardShortcutsMenu /> }
 				{ this.renderMasterbar() }
-				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
+				{ config.isEnabled( 'support-user' ) && <AsyncLoad require="support/support-user" /> }
 				<div className={ loadingClass } ><PulsingDot active={ this.props.isLoading } chunkName={ this.props.section.name } /></div>
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -138,11 +138,11 @@ Layout = React.createClass( {
 				<DocumentHead />
 				<QuerySites allSites />
 				<QueryPreferences />
-				{ <AsyncLoad require="layout/guided-tours" /> }
-				{ config.isEnabled( 'nps-survey/notice' ) && <AsyncLoad require="layout/nps-survey-notice" /> }
+				{ <AsyncLoad require="layout/guided-tours" placeholder={ null } /> }
+				{ config.isEnabled( 'nps-survey/notice' ) && <AsyncLoad require="layout/nps-survey-notice" placeholder={ null } /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) && <KeyboardShortcutsMenu /> }
 				{ this.renderMasterbar() }
-				{ config.isEnabled( 'support-user' ) && <AsyncLoad require="support/support-user" /> }
+				{ config.isEnabled( 'support-user' ) && <AsyncLoad require="support/support-user" placeholder={ null } /> }
 				<div className={ loadingClass } ><PulsingDot active={ this.props.isLoading } chunkName={ this.props.section.name } /></div>
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -10,8 +10,8 @@ import { partial } from 'lodash';
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'components/async-load';
 import MasterbarItem from './item';
-import Notifications from 'notifications';
 import store from 'store';
 import { recordTracksEvent } from 'state/analytics/actions';
 import {
@@ -138,7 +138,7 @@ class MasterbarItemNotifications extends Component {
 						key={ 'notification-indicator-animation-state-' + Math.abs( this.state.animationState ) }
 					/>
 				</MasterbarItem>
-				<Notifications
+				<AsyncLoad require="notifications"
 					isShowing={ this.props.isNotificationsOpen }
 					checkToggle={ this.checkToggleNotes }
 					setIndicator={ this.setNotesIndicator }

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -138,7 +138,7 @@ class MasterbarItemNotifications extends Component {
 						key={ 'notification-indicator-animation-state-' + Math.abs( this.state.animationState ) }
 					/>
 				</MasterbarItem>
-				<AsyncLoad require="notifications"
+				<AsyncLoad require="notifications" placeholder={ null }
 					isShowing={ this.props.isNotificationsOpen }
 					checkToggle={ this.checkToggleNotes }
 					setIndicator={ this.setNotesIndicator }


### PR DESCRIPTION
This PR is based on explorations done by @alexsanford in #14988. He extracted logged in layout to its own chunk. Seeing what gets bundles in this chunk I identified some code that can be lazy loaded:

![screen shot 2017-06-20 at 12 36 47](https://user-images.githubusercontent.com/699132/27329350-9794574c-55b5-11e7-8e9e-a5f9e22a1c74.png)


This PR updates logged in `<Layout />` component to lazy load components that are loaded conditionally:
* NPS survey notice
* Guided tours
* Support user

and notifications box, which isn't required during initial render of `<Masterbar />`.

It reduces code to be loaded by user on production by **50 kBs** on initial page load and should speed up processing of JS code. In case of logged out users, those chunks won't be sent to the user. 

It would be nice to remove also `immutable.js` library, but it is handled in other PRs.

### Before
![screen shot 2017-06-20 at 12 25 14](https://user-images.githubusercontent.com/699132/27328768-8af258e2-55b3-11e7-926f-93065b6b7552.png)

### After
![screen shot 2017-06-20 at 10 47 03](https://user-images.githubusercontent.com/699132/27328604-f4ca0112-55b2-11e7-8a60-45178397d92d.png)
![screen shot 2017-06-20 at 10 52 43](https://user-images.githubusercontent.com/699132/27328607-f4d0a378-55b2-11e7-9af1-692ce3db2a2c.png)
![screen shot 2017-06-20 at 10 49 47](https://user-images.githubusercontent.com/699132/27328605-f4ca4460-55b2-11e7-8aa8-27372bec43d6.png)
![screen shot 2017-06-20 at 10 54 10](https://user-images.githubusercontent.com/699132/27328606-f4cc4c06-55b2-11e7-96f6-d66ffe22e6b3.png)
![screen shot 2017-06-20 at 10 55 53](https://user-images.githubusercontent.com/699132/27328608-f4d225cc-55b2-11e7-8c08-1cfc69086e3f.png)

### Testing
1. Open http://calypso.localhost:3000.
2. Click notifications icon and make sure it loads like before.
3. Type SU and try to log in as support user.
4. Type http://calypso.localhost:3000/post/?tour=editorBasicsTour to start guided tour (you still will have to pick a site).

I'm not sure how to test NPS survey notice. I'm also fine with leaving the latter in the build as it is relatively small.

### Review

* [ ] Code
* [ ] Product
