### PR TITLE
Social signup: Update designs to match /log-in

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -264,7 +264,6 @@ class SignupForm extends Component {
 	globalNotice( notice ) {
 		return <Notice
 			className="signup-form__notice"
-			isCompact={ true }
 			showDismiss={ false }
 			status={ notices.getStatusHelper( notice ) }
 			text={ notice.message } />;
@@ -460,14 +459,15 @@ class SignupForm extends Component {
 	render() {
 		return (
 			<div className={ classNames( 'signup-form', this.props.className ) }>
+
+				{ this.getNotice() }
+
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>
 					{ this.props.formHeader && (
 						<header className="signup-form__header">
 							{ this.props.formHeader }
 						</header>
 					) }
-
-					{ this.getNotice() }
 
 					{ this.formFields() }
 

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -473,10 +473,11 @@ class SignupForm extends Component {
 
 					{ this.props.formFooter || this.formFooter() }
 
-					{ this.props.isSocialSignupEnabled && (
-						<SocialSignupForm handleResponse={ this.props.handleSocialResponse } />
-					) }
 				</LoggedOutForm>
+
+				{ this.props.isSocialSignupEnabled && (
+					<SocialSignupForm handleResponse={ this.props.handleSocialResponse } />
+				) }
 
 				{ this.props.footerLink || this.footerLink() }
 			</div>

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -7,8 +7,9 @@ import FacebookLoginButton from 'components/social-buttons/facebook';
 import { localize } from 'i18n-calypso';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
+import Card from 'components/card';
 import config from 'config';
 
 class SocialSignupForm extends Component {
@@ -41,7 +42,7 @@ class SocialSignupForm extends Component {
 
 	render() {
 		return (
-			<div className="signup-form__social">
+			<Card className="signup-form__social">
 				<p>
 					{ this.props.translate( 'Or create an account using your existing social profile:' ) }
 				</p>
@@ -56,12 +57,12 @@ class SocialSignupForm extends Component {
 						responseHandler={ this.handleFacebookResponse } />
 				</div>
 
-        <p>
+				<p>
 					{ this.props.translate(
-            "Connect to your existing social profile to get started faster. We'll never post without your permission."
-          ) }
+						"Connect to your existing social profile to get started faster. We'll never post without your permission."
+					) }
 				</p>
-			</div>
+			</Card>
 		);
 	}
 }

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import config from 'config';
+import { preventWidows } from 'lib/formatting';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -44,7 +45,7 @@ class SocialSignupForm extends Component {
 		return (
 			<Card className="signup-form__social">
 				<p>
-					{ this.props.translate( 'Or create an account using your existing social profile:' ) }
+					{ preventWidows( this.props.translate( "Or create an account using your existing social profile to get started faster. We'll never post without your permission." ) ) }
 				</p>
 
 				<div className="signup-form__social-buttons">
@@ -56,12 +57,6 @@ class SocialSignupForm extends Component {
 						appId={ config( 'facebook_app_id' ) }
 						responseHandler={ this.handleFacebookResponse } />
 				</div>
-
-				<p>
-					{ this.props.translate(
-						"Connect to your existing social profile to get started faster. We'll never post without your permission."
-					) }
-				</p>
 			</Card>
 		);
 	}

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -20,8 +20,7 @@
 }
 
 .signup-form__social {
-	p {
-		font-size: 11px;
+	p {;
 		margin: 0 0 20px 0;
 		text-align: center;
 

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -20,7 +20,6 @@
 }
 
 .signup-form__social {
-	max-width: 400px;
 	p {
 		font-size: 11px;
 		margin: 0 0 20px 0;
@@ -39,6 +38,9 @@
 	}
 }
 
+.signup-form__social,
 .signup-form__notice.notice {
-	margin-bottom: 10px;
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 400px;
 }

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -20,11 +20,7 @@
 }
 
 .signup-form__social {
-	background-color: #f6f9fa;
-	border-top: 1px solid #e9eff3;
-	margin: 24px -24px -24px -24px;
-	padding: 24px;
-
+	max-width: 400px;
 	p {
 		font-size: 11px;
 		margin: 0 0 20px 0;


### PR DESCRIPTION
This pull request updates the designs of /start/social to be inline with /log-in:
  
<img width="579" alt="screen shot 2017-06-20 at 11 44 55" src="https://user-images.githubusercontent.com/275961/27329554-ed057c5e-55ad-11e7-8c37-47e4c68ab1c3.png">
<img width="564" alt="screen shot 2017-06-20 at 11 44 51" src="https://user-images.githubusercontent.com/275961/27329553-ed02f858-55ad-11e7-8d56-5265b3e4a1b7.png">

  
#### Testing instructions
  
1. Run `git checkout update/social-signup` and start your server
2. Open the [`Social signup` page](http://calypso.localhost:3000/start/social)
3. Check that the footer area matches the screenshot above
4. Try doing a social signup with an email that is already associated to a wordpress.com account
5. Check that you see the error as in the screenshot above
  
#### Reviews
  
- [ ] Code
- [ ] Product

cc @danhauk, since you suggested these changes :)