### PR TITLE
Comments: Remove HTTP from site links

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { withoutHttp } from 'lib/url';
+import { urlToDomainAndPath } from 'lib/url';
 
 export class CommentDetailAuthor extends Component {
 	static propTypes = {
@@ -140,7 +140,7 @@ export class CommentDetailAuthor extends Component {
 								{ authorDisplayName }
 							</strong>
 							<span>
-								{ withoutHttp( authorUrl ).replace( /\/$/, '' ) }
+								{ urlToDomainAndPath( authorUrl ) }
 							</span>
 						</div>
 						<div className="comment-detail__author-info-element comment-detail__comment-date">

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -6,6 +6,11 @@ import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import { withoutHttp } from 'lib/url';
+
 export class CommentDetailAuthor extends Component {
 	static propTypes = {
 		authorAvatarUrl: PropTypes.string,
@@ -135,7 +140,7 @@ export class CommentDetailAuthor extends Component {
 								{ authorDisplayName }
 							</strong>
 							<span>
-								{ authorUrl }
+								{ withoutHttp( authorUrl ).replace( /\/$/, '' ) }
 							</span>
 						</div>
 						<div className="comment-detail__author-info-element comment-detail__comment-date">

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -14,6 +14,7 @@ import CommentDetailActions from './comment-detail-actions';
 import FormCheckbox from 'components/forms/form-checkbox';
 import AutoDirection from 'components/auto-direction';
 import { stripHTML, decodeEntities } from 'lib/formatting';
+import { withoutHttp } from 'lib/url';
 
 export const CommentDetailHeader = ( {
 	authorAvatarUrl,
@@ -78,7 +79,7 @@ export const CommentDetailHeader = ( {
 							{ authorDisplayName }
 						</strong>
 						<span>
-							{ authorUrl }
+							{ withoutHttp( authorUrl ).replace( /\/$/, '' ) }
 						</span>
 					</div>
 					<div className="comment-detail__author-info-element">

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -14,7 +14,7 @@ import CommentDetailActions from './comment-detail-actions';
 import FormCheckbox from 'components/forms/form-checkbox';
 import AutoDirection from 'components/auto-direction';
 import { stripHTML, decodeEntities } from 'lib/formatting';
-import { withoutHttp } from 'lib/url';
+import { urlToDomainAndPath } from 'lib/url';
 
 export const CommentDetailHeader = ( {
 	authorAvatarUrl,
@@ -79,7 +79,7 @@ export const CommentDetailHeader = ( {
 							{ authorDisplayName }
 						</strong>
 						<span>
-							{ withoutHttp( authorUrl ).replace( /\/$/, '' ) }
+							{ urlToDomainAndPath( authorUrl ) }
 						</span>
 					</div>
 					<div className="comment-detail__author-info-element">

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -109,6 +109,18 @@ function urlToSlug( url ) {
 }
 
 /**
+ * Removes the `http(s)://` part and the trailing slash from an URL.
+ * "http://blog.wordpress.com" will be converted into "blog.wordpress.com".
+ * "https://www.wordpress.com/blog/" will be converted into "www.wordpress.com/blog".
+ *
+ * @param  {String} urlToConvert The URL to convert
+ * @return {String} The URL's domain and path
+ */
+function urlToDomainAndPath( urlToConvert ) {
+	return withoutHttp( urlToConvert ).replace( /\/$/, '' );
+}
+
+/**
  * Checks if the supplied string appears to be a URL.
  * Looks only for the absolute basics:
  *  - does it have a .suffix?
@@ -151,6 +163,7 @@ export default {
 	addSchemeIfMissing,
 	setUrlScheme,
 	urlToSlug,
+	urlToDomainAndPath,
 	// [TODO]: Move lib/route/add-query-args contents here
 	addQueryArgs,
 	resemblesUrl,


### PR DESCRIPTION
Closes #15019

Removes `http://`, `https://`, and the last `/` from site links in comment details.

| Before | After |
| --- | --- |
| ![screen shot 2017-06-12 at 4 32 43 pm](https://user-images.githubusercontent.com/618551/27056259-fc5c4506-4f8c-11e7-8b92-2146cb939fb2.png) | <img width="633" alt="screen shot 2017-06-20 at 12 54 55" src="https://user-images.githubusercontent.com/2070010/27331941-b21c9ce4-55b7-11e7-9a02-8e1865862fb1.png"> |

cc @drw158  