### PR TITLE
Activity Log: Fetch the maximum 1000 activities

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -19,6 +19,7 @@ const activityLogRequest = ( { dispatch }, action ) => {
 		apiVersion: '1',
 		method: 'GET',
 		path: `/sites/${ action.siteId }/activity`,
+		query: { number: 1000 },
 	}, action ) );
 };
 


### PR DESCRIPTION
Addresses #15256

Change the call to the /activity endpoint to specify `?number=1000` to give us the maximum number of activities that the endpoint will return in one go, instead of the default 20.

We can iterate on this to add paging later on.

<img width="462" alt="screen shot 2017-06-20 at 14 04 33" src="https://user-images.githubusercontent.com/7767559/27334638-d76730d6-55c1-11e7-9273-775697b100d4.png">

**To Test**
* Go to http://calypso.localhost:3000/stats/activity/{site}
* Check that activities are still visible
* If available, you should see more than 20 activities
