### PR TITLE
Post Editor: fix calendar bug

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -161,7 +161,7 @@ export default React.createClass( {
 				? this.moment( this.props.savedPost.date )
 				: null;
 
-			this.setPostDate( date );
+			this.props.setPostDate( date );
 		}
 
 		this.setState( { showSchedulePopover: false } );


### PR DESCRIPTION
This PR fixes a bug (in `prod`) that occurs when the Popover Calendar is canceled by pressing the `ESC` key: `this.setPostDate is not a function`

<img src="https://user-images.githubusercontent.com/77539/27335161-fbb8348c-55a1-11e7-95e5-37f9be44f74d.gif" width="600px" />

It seems to be there from the beginning.  :-o 
https://github.com/Automattic/wp-calypso/blame/master/client/post-editor/editor-ground-control/index.jsx#L164



