### PR TITLE
WooCommerce Orders: Switch to `request.getWithHeaders` function

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -27,9 +27,9 @@ export const fetchOrders = ( siteId, page ) => ( dispatch, getState ) => {
 	};
 	dispatch( fetchAction );
 
-	return request( siteId ).get( `orders?page=${ page }` ).then( ( data ) => {
-		// @todo Update request to get X-WP-TotalPages
-		const totalPages = 3;
+	return request( siteId ).getWithHeaders( `orders?page=${ page }&per_page=100` ).then( ( response ) => {
+		const { headers, data } = response;
+		const totalPages = headers[ 'X-WP-TotalPages' ];
 		dispatch( {
 			type: WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
 			siteId,


### PR DESCRIPTION
In #15065, a new function was introduced to get additional headers from a request, which includes the number of pages available. This PR switches the fetchOrder action to use this, so that we can also pass back the page count.

To test:

- Run `npm test`