### PR TITLE
Add link rel=canonical tag for `/log-in` to tell search engine it is the same page as `/wp-login.php`

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -3,12 +3,16 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
+import { forEach, isEqual, map } from 'lodash';
 
 /**
  * Internal dependencies.
  */
-import { getDocumentHeadFormattedTitle } from 'state/document-head/selectors';
+import {
+	getDocumentHeadFormattedTitle,
+	getDocumentHeadLink,
+	getDocumentHeadMeta
+} from 'state/document-head/selectors';
 import {
 	setDocumentHeadTitle as setTitle,
 	setDocumentHeadLink as setLink,
@@ -43,6 +47,8 @@ class DocumentHead extends Component {
 	componentDidMount() {
 		const { formattedTitle } = this.props;
 		document.title = formattedTitle;
+
+		this.refreshHeadTags();
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -65,6 +71,31 @@ class DocumentHead extends Component {
 		if ( nextProps.formattedTitle !== this.props.formattedTitle ) {
 			document.title = nextProps.formattedTitle;
 		}
+
+		this.refreshHeadTags( nextProps );
+	}
+
+	refreshHeadTags( props = this.props ) {
+		const { allLinks, allMeta } = props;
+
+		allLinks.forEach( tagProperties => this.ensureTag( 'link', tagProperties ) );
+		allMeta.forEach( tagProperties => this.ensureTag( 'meta', tagProperties ) );
+	}
+
+	ensureTag( tagName, properties ) {
+		const propertiesSelector = map( properties, ( value, key ) => {
+			const escapedValueInSelector = value.replace( /([ #;?%&,.+*~\':"!^$[\]()=>|\/@])/g, '\\$1' );
+			return `[${ key }="${ escapedValueInSelector }"]`;
+		} ).join( '' );
+		const element = document.querySelector( `${ tagName }${ propertiesSelector }` );
+		if ( ! element ) {
+			const newTag = document.createElement( tagName );
+			forEach( properties, ( value, key ) => {
+				newTag[ key ] = value;
+			} );
+			const head = document.getElementsByTagName( 'head' )[ 0 ];
+			head.appendChild( newTag );
+		}
 	}
 
 	render() {
@@ -85,7 +116,9 @@ DocumentHead.propTypes = {
 
 export default connect(
 	state => ( {
-		formattedTitle: getDocumentHeadFormattedTitle( state )
+		formattedTitle: getDocumentHeadFormattedTitle( state ),
+		allLinks: getDocumentHeadLink( state ),
+		allMeta: getDocumentHeadMeta( state ),
 	} ),
 	{
 		setTitle,

--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -84,8 +84,11 @@ class DocumentHead extends Component {
 
 	ensureTag( tagName, properties ) {
 		const propertiesSelector = map( properties, ( value, key ) => {
-			const escapedValueInSelector = value.replace( /([ #;?%&,.+*~\':"!^$[\]()=>|\/@])/g, '\\$1' );
-			return `[${ key }="${ escapedValueInSelector }"]`;
+			if ( value !== undefined && typeof value === 'string' ) {
+				const escapedValueInSelector = value.toString().replace( /([ #;?%&,.+*~\':"!^$[\]()=>|\/@])/g, '\\$1' );
+				return `[${ key }="${ escapedValueInSelector }"]`;
+			}
+			return `[${ key }]`;
 		} ).join( '' );
 		const element = document.querySelector( `${ tagName }${ propertiesSelector }` );
 		if ( ! element ) {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -77,7 +77,9 @@ export class Login extends React.Component {
 				<Main className="wp-login__main">
 					{ this.renderLocaleSuggestions() }
 
-					<DocumentHead title={ translate( 'Log In', { textOnly: true } ) } />
+					<DocumentHead
+						title={ translate( 'Log In', { textOnly: true } ) }
+						link={ [ { rel: 'canonical', href: 'https://wordpress.com/login' } ] } />
 
 					<GlobalNotices id="notices" notices={ notices.list } />
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -70,7 +70,9 @@ export class Login extends React.Component {
 	}
 
 	render() {
-		const { translate, twoFactorAuthType } = this.props;
+		const { locale, translate, twoFactorAuthType } = this.props;
+
+		const canonicalUrl = `https://${ locale !== 'en' ? locale + '.' : '' }wordpress.com/login`;
 
 		return (
 			<div>
@@ -79,7 +81,7 @@ export class Login extends React.Component {
 
 					<DocumentHead
 						title={ translate( 'Log In', { textOnly: true } ) }
-						link={ [ { rel: 'canonical', href: 'https://wordpress.com/login' } ] } />
+						link={ [ { rel: 'canonical', href: canonicalUrl } ] } />
 
 					<GlobalNotices id="notices" notices={ notices.list } />
 

--- a/client/state/document-head/schema.js
+++ b/client/state/document-head/schema.js
@@ -23,7 +23,7 @@ export const linkSchema = {
 	items: {
 		type: 'object',
 		properties: {
-			name: { type: 'string' },
+			href: { type: 'string' },
 			rel: { type: 'string' },
 		}
 	}


### PR DESCRIPTION
Redirecting `/wp-login.php` to `/log-in` resulted in some internal checks raising errors regarding our meta and link tags.
This fix will tell search engine that our new `/log-in` page is essentially the same as the legacy  one (`/wp-login.php`).

### Testing instructions
- Load this branch locally and boot your server (`npm start`)
- Run `curl "http://calypso.localhost:3000/log-in" | grep '<link rel="canonical"'` and check that the tag is indeed in the returned html
- Note that `curl "http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F" | grep '<link rel="canonical"'` will not work
- Visit http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F (logged out), inspect the html once the js has loaded and check that the tag is present.
- Note that `curl "http://calypso.localhost:3000/log-in/fr" | grep '<link rel="canonical"'` will not work
- Visit http://calypso.localhost:3000/log-in/fr (logged out), inspect the html once the js has loaded and check that the tag is present.

### Reviews
- [x] Code
- [x] Product
