### PR TITLE
Woo: Add Product Category selector

### DIFF
--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -1,19 +1,40 @@
 /**
  * External dependencies
  */
-import { get, isArray } from 'lodash';
+import { get, find, isArray } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Gets product categories from API data.
  *
- * @param {Object} state Global state tree
- * @param {Number} siteId wpcom site id
+ * @param {Object} rootState Global state tree
+ * @param {Number} [ siteId ] wpcom site id, if not provided, uses the selected site id.
  * @return {Array} List of product categories
  */
-export function getProductCategories( state, siteId ) {
-	const categories = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories' ], [] );
+export function getProductCategories( rootState, siteId = getSelectedSiteId( rootState ) ) {
+	const categories = get( rootState, [ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories' ], [] );
 	if ( ! isArray( categories ) ) {
 		return [];
 	}
 	return categories;
+}
+
+/**
+ * Gets product category fetched from API data.
+ *
+ * @param {Object} rootState Global state tree
+ * @param {Number} categoryId The id of the category sought
+ * @param {Number} siteId wpcom site id
+ * @return {Object|null} Product category if found, otherwise null.
+ */
+export function getProductCategory( rootState, categoryId, siteId = getSelectedSiteId( rootState ) ) {
+	const categories = get( rootState, [ 'extensions', 'woocommerce', 'sites', siteId, 'productCategories' ], [] );
+	if ( ! isArray( categories ) ) {
+		return;
+	}
+	return find( categories, { id: categoryId } ) || null;
 }

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getProductCategories } from '../selectors';
+import { getProductCategories, getProductCategory } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
 describe( 'selectors', () => {
@@ -65,6 +65,85 @@ describe( 'selectors', () => {
 
 			expect( getProductCategories( state, 123 ) ).to.equal( categories123 );
 			expect( getProductCategories( state, 345 ) ).to.equal( categories345 );
+		} );
+	} );
+
+	describe( '#getProductCategory', () => {
+		it( 'should return undefined if data is not available.', () => {
+			const state = {
+				extensions: {
+					woocommerce: {}
+				}
+			};
+
+			expect( getProductCategory( state, 1, 123 ) ).to.not.exist;
+		} );
+
+		it( 'should return undefined if data is still loading.', () => {
+			const state = {
+				extensions: {
+					woocommerce: {
+						sites: {
+							123: {
+								productCategories: LOADING,
+							}
+						}
+					}
+				}
+			};
+
+			expect( getProductCategory( state, 1, 123 ) ).to.not.exist;
+		} );
+
+		it( 'should return null if category is not found', () => {
+			const state = {
+				extensions: {
+					woocommerce: {
+						sites: {
+							123: {
+								productCategories: [
+									{ id: 1, name: 'Cat 1', slug: 'cat-1' },
+								]
+							}
+						}
+					}
+				}
+			};
+
+			expect( getProductCategory( state, 2, 123 ) ).to.equal( null );
+			expect( getProductCategory( state, { index: 0 }, 123 ) ).to.equal( null );
+		} );
+
+		it( 'should return categories that exist in fetched state', () => {
+			const categories123 = [
+				{ id: 1, name: 'Cat 1', slug: 'cat-1' },
+				{ id: 2, name: 'Cat 2', slug: 'cat-2' },
+			];
+
+			const categories345 = [
+				{ id: 3, name: 'Cat 3', slug: 'cat-3' },
+				{ id: 4, name: 'Cat 4', slug: 'cat-4' },
+			];
+
+			const state = {
+				extensions: {
+					woocommerce: {
+						sites: {
+							123: {
+								productCategories: categories123,
+							},
+							345: {
+								productCategories: categories345,
+							},
+						}
+					}
+				}
+			};
+
+			expect( getProductCategory( state, 1, 123 ) ).to.equal( categories123[ 0 ] );
+			expect( getProductCategory( state, 2, 123 ) ).to.equal( categories123[ 1 ] );
+			expect( getProductCategory( state, 3, 345 ) ).to.equal( categories345[ 0 ] );
+			expect( getProductCategory( state, 4, 345 ) ).to.equal( categories345[ 1 ] );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/ui/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { uniqueId } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import {
@@ -6,10 +11,19 @@ import {
 } from 'woocommerce/state/action-types';
 
 /**
+ * Generates a new product category placeholder ID
+ * This is used for new creates.
+ * @return {String} A new unique ID.
+ */
+export function generateProductCategoryId() {
+	return uniqueId( 'productCategory_' );
+}
+
+/**
  * Action creator: Edit a product category
  *
  * @param {Number} siteId The id of the site to which the category belongs.
- * @param {Object} category The unedited version of the category object.
+ * @param {Object} [category] The most recent version of the category object, or null if new.
  * @param {Object} data An object containing the properties to be edited for the object.
  * @return {Object} The action object.
  */
@@ -17,7 +31,7 @@ export function editProductCategory( siteId, category, data ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_CATEGORY_EDIT,
 		siteId,
-		category,
+		category: category || { id: { placeholder: generateProductCategoryId() } },
 		data,
 	};
 }

--- a/client/extensions/woocommerce/state/ui/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/actions.js
@@ -13,10 +13,10 @@ import {
 /**
  * Generates a new product category placeholder ID
  * This is used for new creates.
- * @return {String} A new unique ID.
+ * @return {Object} A new unique placeholder ID.
  */
 export function generateProductCategoryId() {
-	return uniqueId( 'productCategory_' );
+	return { placeholder: uniqueId( 'productCategory_' ) };
 }
 
 /**
@@ -31,7 +31,7 @@ export function editProductCategory( siteId, category, data ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_CATEGORY_EDIT,
 		siteId,
-		category: category || { id: { placeholder: generateProductCategoryId() } },
+		category: category || { id: generateProductCategoryId() },
 		data,
 	};
 }

--- a/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
@@ -5,7 +5,7 @@ import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_PRODUCT_CATEGORY_EDIT,
 } from 'woocommerce/state/action-types';
-import { getBucket, nextBucketIndex } from '../helpers';
+import { getBucket } from '../helpers';
 
 export default createReducer( null, {
 	[ WOOCOMMERCE_PRODUCT_CATEGORY_EDIT ]: editProductCategoryAction,
@@ -15,13 +15,12 @@ function editProductCategoryAction( edits, action ) {
 	const { category, data } = action;
 	const prevEdits = edits || {};
 	const bucket = getBucket( category );
-	const categoryWithId = category || { id: nextBucketIndex( prevEdits[ bucket ] ) };
-	const newArray = editProductCategory( prevEdits[ bucket ], categoryWithId, data );
+	const newArray = editProductCategory( prevEdits[ bucket ], category, data );
 
 	return {
 		...prevEdits,
 		[ bucket ]: newArray,
-		currentlyEditingId: categoryWithId.id,
+		currentlyEditingId: category.id,
 	};
 }
 

--- a/client/extensions/woocommerce/state/ui/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/selectors.js
@@ -7,7 +7,7 @@ import { get, find, isNumber } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getProductCategory } from 'woocommerce/state/sites/product-categories/selectors';
+import { getProductCategory, getProductCategories } from 'woocommerce/state/sites/product-categories/selectors';
 
 /**
  * Gets all edits for product categories.
@@ -51,6 +51,25 @@ export function getProductCategoryWithLocalEdits( rootState, categoryId, siteId 
 	const categoryEdits = getProductCategoryEdits( rootState, categoryId, siteId );
 
 	return ( category || categoryEdits ) && { ...category, ...categoryEdits } || undefined;
+}
+
+/**
+ * Gets all categories, either fetched, edited, or both.
+ *
+ * This returns a list of all fetched categories overlaid with updates (if any) and
+ * all categories in the creates list as well.
+ *
+ * @param {Object} rootState Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, will use selected Site ID
+ * @return {Object} The category list merged between the fetched data, edits, and creates
+ */
+export function getProductCategoriesWithLocalEdits( rootState, siteId ) {
+	const categoryCreates = getAllProductCategoryEdits( rootState, siteId ).creates || [];
+	const fetchedCategoriesWithUpdates = getProductCategories( rootState, siteId ).map(
+		( c ) => getProductCategoryWithLocalEdits( rootState, c.id, siteId )
+	);
+
+	return [ ...categoryCreates, ...fetchedCategoriesWithUpdates ];
 }
 
 /**

--- a/client/extensions/woocommerce/state/ui/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/selectors.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { get, find, isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getProductCategory } from 'woocommerce/state/sites/product-categories/selectors';
+
+/**
+ * Gets all edits for product categories.
+ *
+ * @param {Object} rootState Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, will use selected Site ID
+ * @return {Object} All product category edits in the form of { creates: [], updates: [] }
+ */
+export function getAllProductCategoryEdits( rootState, siteId = getSelectedSiteId( rootState ) ) {
+	return get( rootState, [ 'extensions', 'woocommerce', 'ui', 'productCategories', siteId, 'edits' ], {} );
+}
+
+/**
+ * Gets the accumulated edits for a category, if any.
+ *
+ * @param {Object} rootState Global state tree
+ * @param {Number|Object} categoryId The id of the product category (or { index: # } if pending create)
+ * @param {Number} [siteId] Site ID to check. If not provided, will use selected Site ID
+ * @return {Object} The current accumulated edits
+ */
+export function getProductCategoryEdits( rootState, categoryId, siteId ) {
+	const edits = getAllProductCategoryEdits( rootState, siteId );
+	const bucket = isNumber( categoryId ) && 'updates' || 'creates';
+	const array = get( edits, bucket, [] );
+
+	return find( array, ( c ) => categoryId === c.id );
+}
+
+/**
+ * Gets a category with local edits overlayed on top of fetched data.
+ *
+ * @param {Object} rootState Global state tree
+ * @param {Number|Object} categoryId The id of the product category (or { index: # } if pending create)
+ * @param {Number} [siteId] Site ID to check. If not provided, will use selected Site ID
+ * @return {Object} The category data merged between the fetched data and edits
+ */
+export function getProductCategoryWithLocalEdits( rootState, categoryId, siteId ) {
+	const existing = isNumber( categoryId );
+
+	const category = existing && getProductCategory( rootState, categoryId, siteId );
+	const categoryEdits = getProductCategoryEdits( rootState, categoryId, siteId );
+
+	return ( category || categoryEdits ) && { ...category, ...categoryEdits } || undefined;
+}
+
+/**
+ * Gets the product category last edited in the UI.
+ *
+ * @param {Object} rootState Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, will use selected Site ID
+ * @return {Object} The category data merged between the fetched data and edits
+ */
+export function getCurrentlyEditingProductCategory( rootState, siteId ) {
+	const edits = getAllProductCategoryEdits( rootState, siteId );
+	const { currentlyEditingId } = edits;
+
+	return getProductCategoryWithLocalEdits( rootState, currentlyEditingId, siteId );
+}
+

--- a/client/extensions/woocommerce/state/ui/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/selectors.js
@@ -8,6 +8,7 @@ import { get, find, isNumber } from 'lodash';
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getProductCategory, getProductCategories } from 'woocommerce/state/sites/product-categories/selectors';
+import { getBucket } from '../helpers';
 
 /**
  * Gets all edits for product categories.
@@ -30,10 +31,10 @@ export function getAllProductCategoryEdits( rootState, siteId = getSelectedSiteI
  */
 export function getProductCategoryEdits( rootState, categoryId, siteId ) {
 	const edits = getAllProductCategoryEdits( rootState, siteId );
-	const bucket = isNumber( categoryId ) && 'updates' || 'creates';
+	const bucket = getBucket( { id: categoryId } );
 	const array = get( edits, bucket, [] );
 
-	return find( array, ( c ) => categoryId === c.id );
+	return find( array, { id: categoryId } );
 }
 
 /**
@@ -50,7 +51,7 @@ export function getProductCategoryWithLocalEdits( rootState, categoryId, siteId 
 	const category = existing && getProductCategory( rootState, categoryId, siteId );
 	const categoryEdits = getProductCategoryEdits( rootState, categoryId, siteId );
 
-	return ( category || categoryEdits ) && { ...category, ...categoryEdits } || undefined;
+	return ( ( category || categoryEdits ) ? { ...category, ...categoryEdits } : undefined );
 }
 
 /**
@@ -80,8 +81,7 @@ export function getProductCategoriesWithLocalEdits( rootState, siteId ) {
  * @return {Object} The category data merged between the fetched data and edits
  */
 export function getCurrentlyEditingProductCategory( rootState, siteId ) {
-	const edits = getAllProductCategoryEdits( rootState, siteId );
-	const { currentlyEditingId } = edits;
+	const { currentlyEditingId } = getAllProductCategoryEdits( rootState, siteId );
 
 	return getProductCategoryWithLocalEdits( rootState, currentlyEditingId, siteId );
 }

--- a/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { isObject, isString } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +21,7 @@ describe( 'actions', () => {
 			const id2 = generateProductCategoryId();
 			const id3 = generateProductCategoryId();
 
-			expect( typeof id1 ).to.equal( 'string' );
+			expect( isObject( id1 ) ).to.be.true;
 			expect( id1 ).to.not.equal( id2 );
 			expect( id1 ).to.not.equal( id3 );
 			expect( id2 ).to.not.equal( id3 );
@@ -32,8 +33,8 @@ describe( 'actions', () => {
 			const action = editProductCategory( siteId, null, { name: 'Cat 1' } );
 
 			expect( action.category ).to.exist;
-			expect( typeof action.category.id ).to.equal( 'object' );
-			expect( typeof action.category.id.placeholder ).to.equal( 'string' );
+			expect( isObject( action.category.id ) ).to.be.true;
+			expect( isString( action.category.id.placeholder ) ).to.be.true;
 		} );
 
 		it( 'should not create a placeholder if category is passed in', () => {

--- a/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	generateProductCategoryId,
+	editProductCategory,
+} from '../actions';
+
+const siteId = 123;
+
+describe( 'actions', () => {
+	describe( '#generateProductCategoryId', () => {
+		it( 'should generate a unique string id each time.', () => {
+			const id1 = generateProductCategoryId();
+			const id2 = generateProductCategoryId();
+			const id3 = generateProductCategoryId();
+
+			expect( typeof id1 ).to.equal( 'string' );
+			expect( id1 ).to.not.equal( id2 );
+			expect( id1 ).to.not.equal( id3 );
+			expect( id2 ).to.not.equal( id3 );
+		} );
+	} );
+
+	describe( '#editProductCategory', () => {
+		it( 'should create a placeholder id if category is not passed in', () => {
+			const action = editProductCategory( siteId, null, { name: 'Cat 1' } );
+
+			expect( action.category ).to.exist;
+			expect( typeof action.category.id ).to.equal( 'object' );
+			expect( typeof action.category.id.placeholder ).to.equal( 'string' );
+		} );
+
+		it( 'should not create a placeholder if category is passed in', () => {
+			const category = { id: 101, name: 'Cat 1' };
+			const action = editProductCategory( siteId, category, { name: 'Updated Cat 1' } );
+
+			expect( action.category ).to.equal( category );
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
@@ -65,7 +65,8 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should create "creates" on first edit', () => {
-		const edits = reducer( undefined, editProductCategory( siteId, null, {
+		const id1 = { placeholder: 'productCategory_1' };
+		const edits = reducer( undefined, editProductCategory( siteId, { id: id1 }, {
 			name: 'New Category',
 			slug: 'new-category',
 		} ) );
@@ -73,26 +74,28 @@ describe( 'edits-reducer', () => {
 		expect( edits ).to.not.equal( null );
 		expect( edits.creates ).to.exist;
 		expect( edits.creates[ 0 ] ).to.exist;
-		expect( edits.creates[ 0 ].id ).to.eql( { index: 0 } );
+		expect( edits.creates[ 0 ].id ).to.eql( id1 );
 		expect( edits.creates[ 0 ].name ).to.eql( 'New Category' );
 		expect( edits.creates[ 0 ].slug ).to.eql( 'new-category' );
 	} );
 
 	it( 'should create more than one category', () => {
-		const edits1 = reducer( undefined, editProductCategory( siteId, null, {
+		const id1 = { placeholder: 'productCategory_1' };
+		const edits1 = reducer( undefined, editProductCategory( siteId, { id: id1 }, {
 			name: 'First Category',
 			slug: 'first-category',
 		} ) );
 
-		const edits2 = reducer( edits1, editProductCategory( siteId, null, {
+		const id2 = { placeholder: 'productCategory_2' };
+		const edits2 = reducer( edits1, editProductCategory( siteId, { id: id2 }, {
 			name: 'Second Category',
 			slug: 'second-category',
 		} ) );
 
-		expect( edits2.creates[ 0 ].id ).to.eql( { index: 0 } );
+		expect( edits2.creates[ 0 ].id ).to.eql( id1 );
 		expect( edits2.creates[ 0 ].name ).to.eql( 'First Category' );
 		expect( edits2.creates[ 0 ].slug ).to.eql( 'first-category' );
-		expect( edits2.creates[ 1 ].id ).to.eql( { index: 1 } );
+		expect( edits2.creates[ 1 ].id ).to.eql( id2 );
 		expect( edits2.creates[ 1 ].name ).to.eql( 'Second Category' );
 		expect( edits2.creates[ 1 ].slug ).to.eql( 'second-category' );
 	} );

--- a/client/extensions/woocommerce/state/ui/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { set } from 'lodash';
+import { set, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,9 +10,13 @@ import { set } from 'lodash';
 import {
 	getProductCategoryEdits,
 	getProductCategoryWithLocalEdits,
+	getProductCategoriesWithLocalEdits,
 	getCurrentlyEditingProductCategory,
 } from '../selectors';
-import { getProductCategory } from 'woocommerce/state/sites/product-categories/selectors';
+import {
+	getProductCategory,
+	getProductCategories
+} from 'woocommerce/state/sites/product-categories/selectors';
 
 const siteId = 123;
 
@@ -94,6 +98,39 @@ describe( 'selectors', () => {
 		it( 'should return undefined if no category is found for category id', () => {
 			expect( getProductCategoryWithLocalEdits( state, 42 ) ).to.not.exist;
 			expect( getProductCategoryWithLocalEdits( state, { index: 42 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( '#getProductCategoriesWithLocalEdits', () => {
+		it( 'should match fetched data when there have been no edits', () => {
+			const fetchedCategories = getProductCategories( state );
+			expect( getProductCategoriesWithLocalEdits( state ) ).to.eql( fetchedCategories );
+		} );
+
+		it( 'should contain categories in "creates"', () => {
+			const newCategory1 = { id: { index: 0 }, name: 'New Category 1' };
+			const newCategory2 = { id: { index: 1 }, name: 'New Category 2' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'creates' ], [ newCategory1, newCategory2 ] );
+
+			const combinedCategories = getProductCategoriesWithLocalEdits( state );
+			expect( find( combinedCategories, c => newCategory1.id === c.id ) ).to.equal( newCategory1 );
+			expect( find( combinedCategories, c => newCategory2.id === c.id ) ).to.equal( newCategory2 );
+		} );
+
+		it( 'should contain combined categories from fetched data with "updates" overlaid', () => {
+			const fetchedCategory1 = getProductCategory( state, 1 );
+			const fetchedCategory2 = getProductCategory( state, 2 );
+			const categoryUpdate1 = { id: 1, name: 'Updated Category 1' };
+			const categoryUpdate2 = { id: 2, name: 'Updated Category 2' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'updates' ], [ categoryUpdate1, categoryUpdate2 ] );
+
+			const combinedCategories = getProductCategoriesWithLocalEdits( state );
+			const combinedCategory1 = find( combinedCategories, c => categoryUpdate1.id === c.id );
+			const combinedCategory2 = find( combinedCategories, c => categoryUpdate2.id === c.id );
+			expect( combinedCategory1 ).to.eql( { ...fetchedCategory1, ...categoryUpdate1 } );
+			expect( combinedCategory2 ).to.eql( { ...fetchedCategory2, ...categoryUpdate2 } );
 		} );
 	} );
 

--- a/client/extensions/woocommerce/state/ui/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/selectors.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { set } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getProductCategoryEdits,
+	getProductCategoryWithLocalEdits,
+	getCurrentlyEditingProductCategory,
+} from '../selectors';
+import { getProductCategory } from 'woocommerce/state/sites/product-categories/selectors';
+
+const siteId = 123;
+
+describe( 'selectors', () => {
+	let state;
+
+	beforeEach( () => {
+		state = {
+			ui: { selectedSiteId: siteId },
+			extensions: {
+				woocommerce: {
+					sites: {
+						[ siteId ]: {
+							productCategories: [
+								{ id: 1, name: 'cat 1', slug: 'cat-1' },
+								{ id: 2, name: 'cat 2', slug: 'cat-2' },
+								{ id: 3, name: 'cat 3', slug: 'cat-3' },
+							],
+						},
+					},
+					ui: {
+						productCategories: {
+							[ siteId ]: {
+							}
+						}
+					},
+				}
+			}
+		};
+	} );
+
+	describe( '#getProductCategoryEdits', () => {
+		it( 'should get a category from "creates"', () => {
+			const newCategory = { id: { index: 0 }, name: 'New Category' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'creates' ], [ newCategory ] );
+
+			expect( getProductCategoryEdits( state, newCategory.id ) ).to.equal( newCategory );
+		} );
+
+		it( 'should get a category from "updates"', () => {
+			const categoryUpdate = { id: 1, name: 'Existing Category' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'updates' ], [ categoryUpdate ] );
+
+			expect( getProductCategoryEdits( state, categoryUpdate.id ) ).to.equal( categoryUpdate );
+		} );
+
+		it( 'should return undefined if no edits are found for category id', () => {
+			expect( getProductCategoryEdits( state, 1 ) ).to.not.exist;
+			expect( getProductCategoryEdits( state, { index: 9 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( '#getProductCategoryWithLocalEdits', () => {
+		it( 'should get just edits for a category in "creates"', () => {
+			const newCategory = { id: { index: 0 }, name: 'New Category' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'creates' ], [ newCategory ] );
+
+			expect( getProductCategoryWithLocalEdits( state, newCategory.id ) ).to.eql( newCategory );
+		} );
+
+		it( 'should get just fetched data for a category that has no edits', () => {
+			const fetchedCategory2 = getProductCategory( state, 2 );
+			expect( getProductCategoryWithLocalEdits( state, 2 ) ).to.eql( fetchedCategory2 );
+		} );
+
+		it( 'should get both fetched data and edits for a category in "updates"', () => {
+			const fetchedCategory2 = getProductCategory( state, 2 );
+			const categoryUpdate = { id: 2, name: 'Existing Category' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'updates' ], [ categoryUpdate ] );
+
+			const combinedCategory = { ...fetchedCategory2, ...categoryUpdate };
+			expect( getProductCategoryWithLocalEdits( state, 2 ) ).to.eql( combinedCategory );
+		} );
+
+		it( 'should return undefined if no category is found for category id', () => {
+			expect( getProductCategoryWithLocalEdits( state, 42 ) ).to.not.exist;
+			expect( getProductCategoryWithLocalEdits( state, { index: 42 } ) ).to.not.exist;
+		} );
+	} );
+
+	describe( '#getCurrentlyEditingProductCategory', () => {
+		it( 'should return undefined if there are no edits', () => {
+			expect( getCurrentlyEditingProductCategory( state ) ).to.not.exist;
+		} );
+
+		it( 'should get the last edited category', () => {
+			const newCategory = { id: { index: 0 }, name: 'New Category' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'creates' ], [ newCategory ] );
+			set( uiProductCategories, [ siteId, 'edits', 'currentlyEditingId' ], newCategory.id );
+
+			expect( getCurrentlyEditingProductCategory( state ) ).to.eql( newCategory );
+		} );
+	} );
+} );
+


### PR DESCRIPTION
This adds a "getProductCategory" selector to find a category by its id
from the fetched API state.

To Test: `npm test`