### PR TITLE
Adds segmented to control to test mode stripe toggle

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -119,21 +119,21 @@ class PaymentMethodStripe extends Component {
 				<FormFieldset className="payments__method-edit-field-container">
 					<FormLabel>{ translate( 'Payment Mode' ) }</FormLabel>
 					<SegmentedControl
-						primary={ true }
-						compact={ true }
+						primary
+						compact
 					>
 						<ControlItem
 							selected={ method.settings.testmode.value === 'yes' }
 							onClick={ this.onToggleTestMode( 'test' ) }
 						>
-							translate( 'Test Mode' )
+							{ translate( 'Test Mode' ) }
 						</ControlItem>
 
 						<ControlItem
 							selected={ method.settings.testmode.value === 'no' }
 							onClick={ this.onToggleTestMode( 'live' ) }
 						>
-							translate( 'Live Mode' )
+							{ translate( 'Live Mode' ) }
 						</ControlItem>
 					</SegmentedControl>
 				</FormFieldset>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -126,14 +126,14 @@ class PaymentMethodStripe extends Component {
 							selected={ method.settings.testmode.value === 'yes' }
 							onClick={ this.onToggleTestMode( 'test' ) }
 						>
-							Test Mode
+							translate( 'Test Mode' )
 						</ControlItem>
 
 						<ControlItem
 							selected={ method.settings.testmode.value === 'no' }
 							onClick={ this.onToggleTestMode( 'live' ) }
 						>
-							Live Mode
+							translate( 'Live Mode' )
 						</ControlItem>
 					</SegmentedControl>
 				</FormFieldset>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -8,12 +8,14 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import ControlItem from 'components/segmented-control/item';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
+import SegmentedControl from 'components/segmented-control';
 
 class PaymentMethodStripe extends Component {
 
@@ -34,6 +36,14 @@ class PaymentMethodStripe extends Component {
 
 	onEditFieldHandler = ( e ) => {
 		this.props.onEditField( e.target.name, e.target.value );
+	}
+
+	onToggleTestMode = ( mode ) => {
+		const testmode = mode === 'test' ? 'yes' : 'no';
+		// return curried function
+		return () => {
+			this.props.onEditField( 'testmode', testmode );
+		};
 	}
 
 	onSaveHandler = () => {
@@ -107,11 +117,25 @@ class PaymentMethodStripe extends Component {
 					{ this.renderEnabledField( method.settings.enabled.value ) }
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>{ translate( 'Enable Test Mode' ) }</FormLabel>
-					<PaymentMethodEditFormToggle
-						checked={ method.settings.testmode.value === 'yes' ? true : false }
-						name="testmode"
-						onChange={ this.onEditFieldHandler } />
+					<FormLabel>{ translate( 'Payment Mode' ) }</FormLabel>
+					<SegmentedControl
+						primary={ true }
+						compact={ true }
+					>
+						<ControlItem
+							selected={ method.settings.testmode.value === 'yes' }
+							onClick={ this.onToggleTestMode( 'test' ) }
+						>
+							Test Mode
+						</ControlItem>
+
+						<ControlItem
+							selected={ method.settings.testmode.value === 'no' }
+							onClick={ this.onToggleTestMode( 'live' ) }
+						>
+							Live Mode
+						</ControlItem>
+					</SegmentedControl>
 				</FormFieldset>
 				{ method.settings.testmode.value === 'yes' && this.renderKeyFields( false ) }
 				{ method.settings.testmode.value === 'no' && this.renderKeyFields( true ) }


### PR DESCRIPTION
Adds:  https://github.com/Automattic/wp-calypso/issues/15133

To test go to:  http://calypso.localhost:3000/store/settings/payments/belcher.mystagingwebsite.com

- Open stripe method settings
- Observe test mode toggle
- Toggle the test mode segmented control
- Click save
- refresh
- Ensure changes saved to server