### PR TITLE
WooCommerce: Add `getOrder` selector

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/README.md
+++ b/client/extensions/woocommerce/state/sites/orders/README.md
@@ -75,6 +75,10 @@ Whether the given order is currently being retrieved from the server. Optional `
 
 Gets the list of orders for this page from the current state, or an empty array if not yet loaded.
 
+### `getOrder( state, orderId: number, siteId: number )`
+
+Gets a requested order object from the current state, or null if not yet loaded.
+
 ### `getTotalOrdersPages( state, siteId: number )`
 
 Gets the total number of pages of orders available on a site. Optional `siteId`, will default to currently selected site.

--- a/client/extensions/woocommerce/state/sites/orders/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/selectors.js
@@ -77,6 +77,16 @@ export const getOrders = ( state, page = 1, siteId = getSelectedSiteId( state ) 
 
 /**
  * @param {Object} state Whole Redux state tree
+ * @param {Number} orderId ID number of an order
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object|Null} The requested order object, or null if not available
+ */
+export const getOrder = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'orders', 'items', orderId ], null );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Number} Total number of pages of orders available on a site, or 1 if not loaded yet.
  */

--- a/client/extensions/woocommerce/state/sites/orders/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/selectors.js
@@ -10,10 +10,11 @@ import { keyBy } from 'lodash';
 import {
 	areOrdersLoaded,
 	areOrdersLoading,
-	isOrderLoaded,
-	isOrderLoading,
+	getOrder,
 	getOrders,
 	getTotalOrdersPages,
+	isOrderLoaded,
+	isOrderLoading,
 } from '../selectors';
 import orders from './fixtures/orders';
 
@@ -199,6 +200,28 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getTotalOrdersPages( loadedStateWithUi ) ).to.eql( 4 );
+		} );
+	} );
+
+	describe( '#getOrder', () => {
+		it( 'should be null when woocommerce state is not available.', () => {
+			expect( getOrder( preInitializedState, 35, 123 ) ).to.be.null;
+		} );
+
+		it( 'should be null when orders are loading.', () => {
+			expect( getOrder( loadingState, 35, 123 ) ).to.be.null;
+		} );
+
+		it( 'should be the order object if it is loaded.', () => {
+			expect( getOrder( loadedState, 35, 123 ) ).to.eql( orders[ 0 ] );
+		} );
+
+		it( 'should be null when orders are loaded only for a different site.', () => {
+			expect( getOrder( loadedState, 23, 456 ) ).to.be.null;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getOrder( loadedStateWithUi, 26 ) ).to.eql( orders[ 1 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a selector for getting a single order from the state. There are no UI changes here.

**To test:**

- Run `npm test`