### PR TITLE
WooCommerce: Add product search UI

### DIFF
--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,15 +14,28 @@ import { localize } from 'i18n-calypso';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import EmptyContent from 'components/empty-content';
-import { fetchProducts } from 'woocommerce/state/sites/products/actions';
+import { fetchProducts, fetchProductSearchResults, clearProductSearch } from 'woocommerce/state/sites/products/actions';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import { getTotalProducts, areProductsLoaded } from 'woocommerce/state/sites/products/selectors';
-import { getProductListCurrentPage, getProductListProducts, getProductListRequestedPage } from 'woocommerce/state/ui/products/selectors';
+import {
+	getTotalProducts,
+	areProductsLoaded,
+	getTotalProductSearchResults,
+	areProductSearchResultsLoaded,
+} from 'woocommerce/state/sites/products/selectors';
+import {
+	getProductListCurrentPage,
+	getProductListProducts,
+	getProductListRequestedPage,
+	getProductSearchCurrentPage,
+	getProductSearchResults,
+	getProductSearchRequestedPage,
+} from 'woocommerce/state/ui/products/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import Pagination from 'my-sites/stats/pagination';
 import ProductsListTable from './products-list-table';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import Search from 'components/search';
 
 class Products extends Component {
 	static propTypes = {
@@ -43,6 +57,11 @@ class Products extends Component {
 	// Total number of results per page (the API returns 10)
 	perPage = 10;
 
+	state = {
+		isSearching: false,
+		query: '',
+	}
+
 	componentDidMount() {
 		const { site } = this.props;
 		if ( site && site.ID ) {
@@ -55,17 +74,42 @@ class Products extends Component {
 		const newSiteId = newProps.site && newProps.site.ID || null;
 		const oldSiteId = site && site.ID || null;
 		if ( oldSiteId !== newSiteId ) {
+			this.setState( { isSearching: false, query: '' } );
 			this.props.fetchProducts( newSiteId, 1 );
 		}
 	}
 
 	switchPage = ( page ) => {
 		const { site } = this.props;
-		this.props.fetchProducts( site.ID, page );
+		const { isSearching } = this.state;
+
+		if ( isSearching ) {
+			this.props.fetchProductSearchResults( site.ID, page );
+		} else {
+			this.props.fetchProducts( site.ID, page );
+		}
+	}
+
+	onSearch = ( query ) => {
+		const { site } = this.props;
+
+		if ( trim( query ) === '' ) {
+			this.setState( { isSearching: false, query: '' } );
+			this.props.clearProductSearch( site.ID );
+			return;
+		}
+
+		this.setState( { isSearching: true, query } );
+		this.props.fetchProductSearchResults( site.ID, 1, query );
 	}
 
 	pagination() {
-		const { site, currentPage, totalProducts, currentPageLoaded, requestedPage } = this.props;
+		const { isSearching } = this.state;
+		const { site } = this.props;
+		const totalProducts = isSearching ? this.props.totalSearchProducts : this.props.totalProducts;
+		const currentPage = isSearching ? this.props.currentSearchPage : this.props.currentPage;
+		const currentPageLoaded = isSearching ? this.props.currentSearchPageLoaded : this.props.currentPageLoaded;
+		const requestedPage = isSearching ? this.props.requestedSearchPage : this.props.requestedPage;
 
 		// If we know previously that all products fit on one page, don't show the placeholder
 		// since the Pagination component doesn't display anything for single page display.
@@ -101,11 +145,33 @@ class Products extends Component {
 		/>;
 	}
 
+	renderNoSearchResults() {
+		const { translate } = this.props;
+		return (
+			<div>
+				<p>
+					{ translate( 'No products match your search for {{searchTerm/}}.', {
+						components: {
+							searchTerm: <em>{ this.state.query }</em>
+						}
+					} )}
+				</p>
+			</div>
+		);
+	}
+
 	renderList() {
-		const { site, products, totalProducts, currentPageLoaded, requestedPageLoaded, requestedPage } = this.props;
+		const { site } = this.props;
+		const { isSearching } = this.state;
+
+		const products = isSearching ? this.props.searchResults : this.props.products;
+		const totalProducts = isSearching ? this.props.totalSearchProducts : this.props.totalProducts;
+		const currentPageLoaded = isSearching ? this.props.currentSearchPageLoaded : this.props.currentPageLoaded;
+		const requestedPage = isSearching ? this.props.requestedSearchPage : this.props.requestedPage;
+		const requestedPageLoaded = isSearching ? this.props.requestedSearchPageLoaded : this.props.requestedPageLoaded;
 
 		if ( currentPageLoaded === true && totalProducts === 0 ) {
-			return this.renderEmptyContent();
+			return isSearching ? this.renderNoSearchResults() : this.renderEmptyContent();
 		}
 
 		const isRequesting = ( requestedPage && ! requestedPageLoaded ) || ! products ? true : false;
@@ -132,6 +198,13 @@ class Products extends Component {
 						{ translate( 'Add a product' ) }
 					</Button>
 				</ActionHeader>
+				<Search
+					onSearch={ this.onSearch }
+					delaySearch
+					delayTimeout={ 400 }
+					disabled={ ! site }
+					placeholder={ translate( 'Search products…' ) }
+				/>
 				{ this.renderList() }
 			</Main>
 		);
@@ -140,12 +213,21 @@ class Products extends Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
+
 	const currentPage = site && getProductListCurrentPage( state, site.ID );
 	const currentPageLoaded = site && currentPage && areProductsLoaded( state, currentPage, site.ID );
 	const requestedPage = site && getProductListRequestedPage( state, site.ID );
 	const requestedPageLoaded = site && requestedPage && areProductsLoaded( state, requestedPage, site.ID );
 	const products = site && getProductListProducts( state, site.ID );
 	const totalProducts = site && getTotalProducts( state, site.ID );
+
+	const currentSearchPage = site && getProductSearchCurrentPage( state, site.ID );
+	const currentSearchPageLoaded = site && currentSearchPage && areProductSearchResultsLoaded( state, currentSearchPage, site.ID );
+	const requestedSearchPage = site && getProductSearchRequestedPage( state, site.ID );
+	const requestedSearchPageLoaded = site && requestedSearchPage && areProductSearchResultsLoaded( state, requestedSearchPage, site.ID );
+	const totalSearchProducts = site && getTotalProductSearchResults( state, site.ID );
+	const searchResults = site && getProductSearchResults( state, site.ID );
+
 	return {
 		site,
 		currentPage,
@@ -154,6 +236,12 @@ function mapStateToProps( state ) {
 		requestedPageLoaded,
 		products,
 		totalProducts,
+		currentSearchPage,
+		currentSearchPageLoaded,
+		requestedSearchPage,
+		requestedSearchPageLoaded,
+		totalSearchProducts,
+		searchResults,
 	};
 }
 
@@ -161,6 +249,8 @@ function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
 			fetchProducts,
+			fetchProductSearchResults,
+			clearProductSearch,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -13,27 +13,12 @@ import { trim } from 'lodash';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
-import EmptyContent from 'components/empty-content';
 import { fetchProducts, fetchProductSearchResults, clearProductSearch } from 'woocommerce/state/sites/products/actions';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import {
-	getTotalProducts,
-	areProductsLoaded,
-	getTotalProductSearchResults,
-	areProductSearchResultsLoaded,
-} from 'woocommerce/state/sites/products/selectors';
-import {
-	getProductListCurrentPage,
-	getProductListProducts,
-	getProductListRequestedPage,
-	getProductSearchCurrentPage,
-	getProductSearchResults,
-	getProductSearchRequestedPage,
-} from 'woocommerce/state/ui/products/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
-import Pagination from 'my-sites/stats/pagination';
-import ProductsListTable from './products-list-table';
+import ProductsList from './products-list';
+import ProductsListSearchResults from './products-list-search-results';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SearchCard from 'components/search-card';
 
@@ -42,23 +27,12 @@ class Products extends Component {
 		site: PropTypes.shape( {
 			slug: PropTypes.string,
 		} ),
-		products: PropTypes.oneOfType( [
-			PropTypes.array,
-			PropTypes.bool,
-		] ),
-		currentPage: PropTypes.number,
-		currentPageLoaded: PropTypes.bool,
-		requestedPage: PropTypes.number,
-		requestedPageLoaded: PropTypes.bool,
-		totalProducts: PropTypes.number,
-		fetchProducts: PropTypes.func,
+		fetchProducts: PropTypes.func.isRequired,
+		fetchProductSearchResults: PropTypes.func.isRequired,
+		clearProductSearch: PropTypes.func.isRequired,
 	};
 
-	// Total number of results per page (the API returns 10)
-	perPage = 10;
-
 	state = {
-		isSearching: false,
 		query: '',
 	}
 
@@ -74,16 +48,14 @@ class Products extends Component {
 		const newSiteId = newProps.site && newProps.site.ID || null;
 		const oldSiteId = site && site.ID || null;
 		if ( oldSiteId !== newSiteId ) {
-			this.setState( { isSearching: false, query: '' } );
+			this.setState( { query: '' } );
 			this.props.fetchProducts( newSiteId, 1 );
 		}
 	}
 
 	switchPage = ( page ) => {
 		const { site } = this.props;
-		const { isSearching } = this.state;
-
-		if ( isSearching ) {
+		if ( trim( this.state.query ) !== '' ) {
 			this.props.fetchProductSearchResults( site.ID, page );
 		} else {
 			this.props.fetchProducts( site.ID, page );
@@ -94,102 +66,26 @@ class Products extends Component {
 		const { site } = this.props;
 
 		if ( trim( query ) === '' ) {
-			this.setState( { isSearching: false, query: '' } );
+			this.setState( { query: '' } );
 			this.props.clearProductSearch( site.ID );
 			return;
 		}
 
-		this.setState( { isSearching: true, query } );
+		this.setState( { query } );
 		this.props.fetchProductSearchResults( site.ID, 1, query );
-	}
-
-	pagination() {
-		const { isSearching } = this.state;
-		const { site } = this.props;
-		const totalProducts = isSearching ? this.props.totalSearchProducts : this.props.totalProducts;
-		const currentPage = isSearching ? this.props.currentSearchPage : this.props.currentPage;
-		const currentPageLoaded = isSearching ? this.props.currentSearchPageLoaded : this.props.currentPageLoaded;
-		const requestedPage = isSearching ? this.props.requestedSearchPage : this.props.requestedPage;
-
-		// If we know previously that all products fit on one page, don't show the placeholder
-		// since the Pagination component doesn't display anything for single page display.
-		if ( totalProducts && totalProducts < ( this.perPage + 1 ) ) {
-			return null;
-		}
-
-		if ( ! site || ! currentPageLoaded ) {
-			return ( <div className="products__list-placeholder pagination"></div> );
-		}
-
-		const page = requestedPage || currentPage;
-		return (
-			<Pagination
-				page={ page }
-				perPage={ this.perPage }
-				total={ totalProducts }
-				pageClick={ this.switchPage }
-			/>
-		);
-	}
-
-	renderEmptyContent() {
-		const { translate, site } = this.props;
-		const emptyContentAction = (
-			<Button href={ getLink( '/store/product/:site/', site ) }>
-				{ translate( 'Add your first product' ) }
-			</Button>
-		);
-		return <EmptyContent
-				title={ translate( 'You don\'t have any products yet.' ) }
-				action={ emptyContentAction }
-		/>;
-	}
-
-	renderNoSearchResults() {
-		const { translate } = this.props;
-		return (
-			<div>
-				<p>
-					{ translate( 'No products match your search for {{searchTerm/}}.', {
-						components: {
-							searchTerm: <em>{ this.state.query }</em>
-						}
-					} )}
-				</p>
-			</div>
-		);
-	}
-
-	renderList() {
-		const { site } = this.props;
-		const { isSearching } = this.state;
-
-		const products = isSearching ? this.props.searchResults : this.props.products;
-		const totalProducts = isSearching ? this.props.totalSearchProducts : this.props.totalProducts;
-		const currentPageLoaded = isSearching ? this.props.currentSearchPageLoaded : this.props.currentPageLoaded;
-		const requestedPage = isSearching ? this.props.requestedSearchPage : this.props.requestedPage;
-		const requestedPageLoaded = isSearching ? this.props.requestedSearchPageLoaded : this.props.requestedPageLoaded;
-
-		if ( currentPageLoaded === true && totalProducts === 0 ) {
-			return isSearching ? this.renderNoSearchResults() : this.renderEmptyContent();
-		}
-
-		const isRequesting = ( requestedPage && ! requestedPageLoaded ) || ! products ? true : false;
-		return (
-			<div className="products__list-wrapper">
-				<ProductsListTable
-					site={ site }
-					products={ products }
-					isRequesting={ isRequesting }
-				/>
-				{ this.pagination() }
-			</div>
-		);
 	}
 
 	render() {
 		const { className, site, translate } = this.props;
 		const classes = classNames( 'products__list', className );
+
+		let productsDisplay;
+		if ( trim( this.state.query ) === '' ) {
+			productsDisplay = <ProductsList onSwitchPage={ this.switchPage } />;
+		} else {
+			productsDisplay = <ProductsListSearchResults onSwitchPage={ this.switchPage } />;
+		}
+
 		return (
 			<Main className={ classes }>
 				<SidebarNavigation />
@@ -205,7 +101,7 @@ class Products extends Component {
 					disabled={ ! site }
 					placeholder={ translate( 'Search products…' ) }
 				/>
-				{ this.renderList() }
+				{ productsDisplay }
 			</Main>
 		);
 	}
@@ -213,35 +109,8 @@ class Products extends Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
-
-	const currentPage = site && getProductListCurrentPage( state, site.ID );
-	const currentPageLoaded = site && currentPage && areProductsLoaded( state, currentPage, site.ID );
-	const requestedPage = site && getProductListRequestedPage( state, site.ID );
-	const requestedPageLoaded = site && requestedPage && areProductsLoaded( state, requestedPage, site.ID );
-	const products = site && getProductListProducts( state, site.ID );
-	const totalProducts = site && getTotalProducts( state, site.ID );
-
-	const currentSearchPage = site && getProductSearchCurrentPage( state, site.ID );
-	const currentSearchPageLoaded = site && currentSearchPage && areProductSearchResultsLoaded( state, currentSearchPage, site.ID );
-	const requestedSearchPage = site && getProductSearchRequestedPage( state, site.ID );
-	const requestedSearchPageLoaded = site && requestedSearchPage && areProductSearchResultsLoaded( state, requestedSearchPage, site.ID );
-	const totalSearchProducts = site && getTotalProductSearchResults( state, site.ID );
-	const searchResults = site && getProductSearchResults( state, site.ID );
-
 	return {
 		site,
-		currentPage,
-		currentPageLoaded,
-		requestedPage,
-		requestedPageLoaded,
-		products,
-		totalProducts,
-		currentSearchPage,
-		currentSearchPageLoaded,
-		requestedSearchPage,
-		requestedSearchPageLoaded,
-		totalSearchProducts,
-		searchResults,
 	};
 }
 

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -35,7 +35,7 @@ import Main from 'components/main';
 import Pagination from 'my-sites/stats/pagination';
 import ProductsListTable from './products-list-table';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import Search from 'components/search';
+import SearchCard from 'components/search-card';
 
 class Products extends Component {
 	static propTypes = {
@@ -198,7 +198,7 @@ class Products extends Component {
 						{ translate( 'Add a product' ) }
 					</Button>
 				</ActionHeader>
-				<Search
+				<SearchCard
 					onSearch={ this.onSearch }
 					delaySearch
 					delayTimeout={ 400 }

--- a/client/extensions/woocommerce/app/products/products-list-pagination.js
+++ b/client/extensions/woocommerce/app/products/products-list-pagination.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Pagination from 'my-sites/stats/pagination';
+
+const ProductsListPagination = ( { site, totalProducts, currentPage, currentPageLoaded, requestedPage, onSwitchPage } ) => {
+	const perPage = 10;
+
+	if ( totalProducts && totalProducts < ( perPage + 1 ) ) {
+		return null;
+	}
+
+	if ( ! site || ! currentPageLoaded ) {
+		return ( <div className="products__list-placeholder pagination"></div> );
+	}
+
+	const page = requestedPage || currentPage;
+	return (
+		<Pagination
+			page={ page }
+			perPage={ perPage }
+			total={ totalProducts }
+			pageClick={ onSwitchPage }
+		/>
+	);
+};
+
+ProductsListPagination.propTypes = {
+	site: PropTypes.object,
+	currentPage: PropTypes.number,
+	currentPageLoaded: PropTypes.bool,
+	requestedPage: PropTypes.number,
+	totalProducts: PropTypes.number,
+	onSwitchPage: PropTypes.func.isRequired,
+};
+
+export default ProductsListPagination;

--- a/client/extensions/woocommerce/app/products/products-list-search-results.js
+++ b/client/extensions/woocommerce/app/products/products-list-search-results.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import {
+	getTotalProductSearchResults,
+	areProductSearchResultsLoaded,
+	getProductSearchQuery,
+} from 'woocommerce/state/sites/products/selectors';
+import {
+	getProductSearchCurrentPage,
+	getProductSearchResults,
+	getProductSearchRequestedPage,
+ } from 'woocommerce/state/ui/products/selectors';
+import ProductsListPagination from './products-list-pagination';
+import ProductsListTable from './products-list-table';
+
+const ProductsListSearchResults = ( {
+	site,
+	translate,
+	products,
+	totalProducts,
+	currentPage,
+	currentPageLoaded,
+	requestedPage,
+	requestedPageLoaded,
+	query,
+	onSwitchPage,
+} ) => {
+	if ( currentPageLoaded === true && totalProducts === 0 ) {
+		return (
+			<div>
+				<p>
+					{ translate( 'No products match your search for {{searchTerm/}}.', {
+						components: {
+							searchTerm: <em>{ query }</em>
+						}
+					} )}
+				</p>
+			</div>
+		);
+	}
+
+	const isRequesting = ( requestedPage && ! requestedPageLoaded ) || ! products ? true : false;
+	return (
+		<div className="products__list-wrapper">
+			<ProductsListTable
+				site={ site }
+				products={ products }
+				isRequesting={ isRequesting }
+			/>
+			<ProductsListPagination
+				site={ site }
+				totalProducts={ totalProducts }
+				currentPage={ currentPage }
+				currentPageLoaded={ currentPageLoaded }
+				requestedPage={ requestedPage }
+				onSwitchPage={ onSwitchPage }
+			/>
+		</div>
+	);
+};
+
+ProductsListSearchResults.propTypes = {
+	site: PropTypes.object,
+	products: PropTypes.oneOfType( [
+		PropTypes.array,
+		PropTypes.bool,
+	] ),
+	currentPage: PropTypes.number,
+	currentPageLoaded: PropTypes.bool,
+	requestedPage: PropTypes.number,
+	requestedPageLoaded: PropTypes.bool,
+	totalProducts: PropTypes.number,
+	query: PropTypes.string,
+	onSwitchPage: PropTypes.func.isRequired,
+};
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const currentPage = site && getProductSearchCurrentPage( state, site.ID );
+	const currentPageLoaded = site && currentPage && areProductSearchResultsLoaded( state, currentPage, site.ID );
+	const requestedPage = site && getProductSearchRequestedPage( state, site.ID );
+	const requestedPageLoaded = site && requestedPage && areProductSearchResultsLoaded( state, requestedPage, site.ID );
+	const totalProducts = site && getTotalProductSearchResults( state, site.ID );
+	const products = site && getProductSearchResults( state, site.ID );
+	const query = site && getProductSearchQuery( state, site.ID );
+
+	return {
+		site,
+		currentPage,
+		currentPageLoaded,
+		requestedPage,
+		requestedPageLoaded,
+		products,
+		totalProducts,
+		query,
+	};
+}
+
+export default connect( mapStateToProps )( localize( ProductsListSearchResults ) );

--- a/client/extensions/woocommerce/app/products/products-list.js
+++ b/client/extensions/woocommerce/app/products/products-list.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import EmptyContent from 'components/empty-content';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import {
+	getTotalProducts,
+	areProductsLoaded,
+} from 'woocommerce/state/sites/products/selectors';
+import {
+	getProductListCurrentPage,
+	getProductListProducts,
+	getProductListRequestedPage,
+ } from 'woocommerce/state/ui/products/selectors';
+import ProductsListPagination from './products-list-pagination';
+import ProductsListTable from './products-list-table';
+
+const ProductsList = ( {
+	site,
+	translate,
+	products,
+	totalProducts,
+	currentPage,
+	currentPageLoaded,
+	requestedPage,
+	requestedPageLoaded,
+	onSwitchPage,
+} ) => {
+	const renderEmptyContent = () => {
+		const emptyContentAction = (
+			<Button href={ getLink( '/store/product/:site/', site ) }>
+				{ translate( 'Add your first product' ) }
+			</Button>
+		);
+		return <EmptyContent
+				title={ translate( 'You don\'t have any products yet.' ) }
+				action={ emptyContentAction }
+		/>;
+	};
+
+	if ( currentPageLoaded === true && totalProducts === 0 ) {
+		return renderEmptyContent;
+	}
+
+	const isRequesting = ( requestedPage && ! requestedPageLoaded ) || ! products ? true : false;
+	return (
+		<div className="products__list-wrapper">
+			<ProductsListTable
+				site={ site }
+				products={ products }
+				isRequesting={ isRequesting }
+			/>
+			<ProductsListPagination
+				site={ site }
+				totalProducts={ totalProducts }
+				currentPage={ currentPage }
+				currentPageLoaded={ currentPageLoaded }
+				requestedPage={ requestedPage }
+				onSwitchPage={ onSwitchPage }
+			/>
+		</div>
+	);
+};
+
+ProductsList.propTypes = {
+	site: PropTypes.object,
+	products: PropTypes.oneOfType( [
+		PropTypes.array,
+		PropTypes.bool,
+	] ),
+	currentPage: PropTypes.number,
+	currentPageLoaded: PropTypes.bool,
+	requestedPage: PropTypes.number,
+	requestedPageLoaded: PropTypes.bool,
+	totalProducts: PropTypes.number,
+	onSwitchPage: PropTypes.func.isRequired,
+};
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const currentPage = site && getProductListCurrentPage( state, site.ID );
+	const currentPageLoaded = site && currentPage && areProductsLoaded( state, currentPage, site.ID );
+	const requestedPage = site && getProductListRequestedPage( state, site.ID );
+	const requestedPageLoaded = site && requestedPage && areProductsLoaded( state, requestedPage, site.ID );
+	const products = site && getProductListProducts( state, site.ID );
+	const totalProducts = site && getTotalProducts( state, site.ID );
+
+	return {
+		site,
+		currentPage,
+		currentPageLoaded,
+		requestedPage,
+		requestedPageLoaded,
+		products,
+		totalProducts,
+	};
+}
+
+export default connect( mapStateToProps )( localize( ProductsList ) );

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -17,7 +17,7 @@
 		margin-top: 16px;
 	}
 
-	.products__list-wrapper {
+	.search {
 		@include breakpoint( ">660px" ) {
 			margin-top: 58px;
 		}
@@ -116,6 +116,10 @@
 
 	.products__list-name {
 		color: $blue-wordpress;
+	}
+
+	.search, .search .search__open-icon {
+		z-index: initial;
 	}
 
 }

--- a/client/extensions/woocommerce/state/ui/products/reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/reducer.js
@@ -5,10 +5,12 @@
 import { combineReducers, keyedReducer } from 'state/utils';
 import edits from './edits-reducer';
 import list from './list-reducer';
+import search from './search-reducer';
 import variations from './variations/reducer';
 
 export default keyedReducer( 'siteId', combineReducers( {
 	list,
 	edits,
+	search,
 	variations,
 } ) );

--- a/client/extensions/woocommerce/state/ui/products/search-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/search-reducer.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { createReducer } from 'state/utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST,
+	WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST_SUCCESS,
+	WOOCOMMERCE_PRODUCTS_SEARCH_CLEAR,
+} from 'woocommerce/state/action-types';
+
+export default createReducer( null, {
+	[ WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST ]: productsSearchRequest,
+	[ WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST_SUCCESS ]: productsSearchRequestSuccess,
+	[ WOOCOMMERCE_PRODUCTS_SEARCH_CLEAR ]: productsSearchClear,
+} );
+
+export function productsSearchRequestSuccess( state, action ) {
+	const prevState = state || {};
+	const { page, products } = action;
+	const productIds = products && products.map( ( p ) => {
+		return p.id;
+	} ) || [];
+	return { ...prevState,
+		currentPage: page,
+		productIds,
+		requestedPage: null,
+	};
+}
+
+export function productsSearchRequest( state, action ) {
+	const prevState = state || {};
+	const { page } = action;
+	return { ...prevState,
+		requestedPage: page,
+	};
+}
+
+export function productsSearchClear() {
+	return {};
+}

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -97,3 +97,41 @@ export function getProductListProducts( state, siteId = getSelectedSiteId( state
 export function getProductListRequestedPage( state, siteId = getSelectedSiteId( state ) ) {
 	return get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'list', 'requestedPage' ], null );
 }
+
+/**
+ * Gets the current product search page being viewed.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number} Current product search page (default: 1)
+ */
+export function getProductSearchCurrentPage( state, siteId = getSelectedSiteId( state ) ) {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'search', 'currentPage' ], 1 );
+}
+
+/**
+ * Gets an array of products for the current search page being viewed.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {array|false} Array of products or false if products are not available.
+ */
+export function getProductSearchResults( state, siteId = getSelectedSiteId( state ) ) {
+	const products = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], {} );
+	const productIds = get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'search', 'productIds' ], [] );
+	if ( productIds.length ) {
+		return productIds.map( id => find( products, ( p ) => id === p.id ) );
+	}
+	return false;
+}
+
+/**
+ * Gets the requested page for products search.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {number|null} Requested product search page
+ */
+export function getProductSearchRequestedPage( state, siteId = getSelectedSiteId( state ) ) {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'search', 'requestedPage' ], null );
+}

--- a/client/extensions/woocommerce/state/ui/products/test/search-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/search-reducer.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	productsSearchRequest,
+	productsSearchRequestSuccess,
+	productsSearchClear,
+} from '../search-reducer';
+
+import {
+	WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST,
+	WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST_SUCCESS,
+	WOOCOMMERCE_PRODUCTS_SEARCH_CLEAR,
+} from 'woocommerce/state/action-types';
+
+import products from 'woocommerce/state/sites/products/test/fixtures/products';
+
+describe( 'reducer', () => {
+	describe( 'productsRequest', () => {
+		it( 'should store the requested page', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST,
+				siteId: 123,
+				page: 3,
+				query: 'testing',
+			};
+			const newState = productsSearchRequest( undefined, action );
+			expect( newState.requestedPage ).to.eql( 3 );
+		} );
+	} );
+	describe( 'productsRequestSuccess', () => {
+		it( 'should store the current page', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST_SUCCESS,
+				siteId: 123,
+				page: 2,
+				totalProducts: 28,
+				query: 'testing',
+				products,
+			};
+			const newState = productsSearchRequestSuccess( undefined, action );
+			expect( newState.currentPage ).to.eql( 2 );
+		} );
+		it( 'should store product ids for the current page', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_SEARCH_REQUEST_SUCCESS,
+				siteId: 123,
+				page: 2,
+				totalProducts: 28,
+				query: 'testing',
+				products,
+			};
+			const newState = productsSearchRequestSuccess( undefined, action );
+			expect( newState.productIds ).to.eql( [ 15, 389 ] );
+		} );
+	} );
+	describe( 'productsSearchClear', () => {
+		it( 'should reset the search state', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCTS_SEARCH_CLEAR,
+				siteId: 123,
+			};
+			const newState = productsSearchClear( undefined, action );
+			expect( newState ).to.eql( {} );
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/test/selectors.js
@@ -14,6 +14,9 @@ import {
 	getProductListCurrentPage,
 	getProductListProducts,
 	getProductListRequestedPage,
+	getProductSearchCurrentPage,
+	getProductSearchResults,
+	getProductSearchRequestedPage,
 } from '../selectors';
 import products from 'woocommerce/state/sites/products/test/fixtures/products';
 
@@ -61,6 +64,42 @@ const loadedListState = {
 
 const loadedListStateWithUi = { ...loadedListState, ui: { selectedSiteId: 123 } };
 
+const loadedSearchState = {
+	extensions: {
+		woocommerce: {
+			ui: {
+				products: {
+					123: {
+						search: {
+							currentPage: 2,
+							requestedPage: 3,
+							productIds: [ 15, 389 ],
+						}
+					},
+					401: {
+						search: {
+						},
+					},
+				},
+			},
+			sites: {
+				123: {
+					products: {
+						products,
+					}
+				},
+				401: {
+					products: {
+						products: {},
+					},
+				},
+			}
+		},
+	},
+};
+
+const loadedSearchStateWithUi = { ...loadedSearchState, ui: { selectedSiteId: 123 } };
+
 describe( 'selectors', () => {
 	let state;
 
@@ -77,7 +116,9 @@ describe( 'selectors', () => {
 						products: {
 							123: {
 								list: {
-								}
+								},
+								search: {
+								},
 							}
 						}
 					},
@@ -215,6 +256,69 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getProductListProducts( loadedListStateWithUi ) ).to.eql( products );
+		} );
+	} );
+	describe( '#getProductSearchCurrentPage', () => {
+		it( 'should be 1 (default) when woocommerce state is not available.', () => {
+			expect( getProductSearchCurrentPage( preInitializedListState, 123 ) ).to.eql( 1 );
+		} );
+
+		it( 'should be 1 (default) when products are loading.', () => {
+			expect( getProductSearchCurrentPage( state, 123 ) ).to.eql( 1 );
+		} );
+
+		it( 'should be 2, the set page, if the products are loaded.', () => {
+			expect( getProductSearchCurrentPage( loadedSearchState, 123 ) ).to.eql( 2 );
+		} );
+
+		it( 'should be 1 (default) when products are loaded only for a different site.', () => {
+			expect( getProductSearchCurrentPage( loadedSearchState, 456 ) ).to.eql( 1 );
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getProductSearchCurrentPage( loadedSearchStateWithUi ) ).to.eql( 2 );
+		} );
+	} );
+	describe( '#getProductSearchRequestedPage', () => {
+		it( 'should be null (default) when woocommerce state is not available.', () => {
+			expect( getProductSearchRequestedPage( preInitializedListState, 123 ) ).to.be.null;
+		} );
+
+		it( 'should be null (default) when products are loading.', () => {
+			expect( getProductSearchRequestedPage( state, 123 ) ).to.be.null;
+		} );
+
+		it( 'should be 3, the set requested page, if the products are loaded.', () => {
+			expect( getProductSearchRequestedPage( loadedSearchState, 123 ) ).to.eql( 3 );
+		} );
+
+		it( 'should be null (default) when products are loaded only for a different site.', () => {
+			expect( getProductSearchRequestedPage( loadedSearchState, 456 ) ).to.be.null;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getProductSearchRequestedPage( loadedSearchStateWithUi ) ).to.eql( 3 );
+		} );
+	} );
+	describe( '#getProductSearchResults', () => {
+		it( 'should be false when woocommerce state is not available.', () => {
+			expect( getProductSearchResults( preInitializedListState, 123 ) ).to.be.false;
+		} );
+
+		it( 'should be false when products are loading.', () => {
+			expect( getProductSearchResults( state, 123 ) ).to.be.false;
+		} );
+
+		it( 'should be the list of products if they are loaded.', () => {
+			expect( getProductSearchResults( loadedSearchState, 123 ) ).to.eql( products );
+		} );
+
+		it( 'should be false when products are loaded only for a different site.', () => {
+			expect( getProductSearchResults( loadedSearchState, 456 ) ).to.be.false;
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getProductSearchResults( loadedSearchStateWithUi ) ).to.eql( products );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the UI for searching a site's products in the product list, including pagination, etc. It adds a search box above the list table.

<img width="714" alt="screen shot 2017-06-20 at 9 36 24 am" src="https://user-images.githubusercontent.com/689165/27344687-08e1a9be-559c-11e7-919e-9b2a30317fee.png">

To test:
* Run `npm test` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/products/:site`
* Type a search term in the box and watch the list table update with the new results.
* Paginate your results and make sure that works.
* Type a search term that will return no results and make sure you get a message saying so.
* Hit the "x" in the search box (or clear your query) and see the normal list results return.

cc @kellychoffman @jameskoster since this PR contains some UI.

Closes #13655.

