### PR TITLE
Activity log: Show data for non-pressable sites

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -44,21 +44,21 @@ class ActivityLogDay extends Component {
 	getRewindButton( type = '' ) {
 		const { allowRestore } = this.props;
 
-		return ( allowRestore
-			? (
-				<Button
-					compact
-					disabled={ ! this.props.isRewindActive }
-					onClick={ this.handleClickRestore }
-					primary={ 'primary' === type }
-				>
-					<Gridicon icon="history" size={ 18 } />
-					{ ' ' }
-					{ this.props.translate( 'Rewind to this day' ) }
-				</Button>
-			) : (
-				null
-			)
+		if ( ! allowRestore ) {
+			return null;
+		}
+
+		return (
+			<Button
+				compact
+				disabled={ ! this.props.isRewindActive }
+				onClick={ this.handleClickRestore }
+				primary={ 'primary' === type }
+			>
+				<Gridicon icon="history" size={ 18 } />
+				{ ' ' }
+				{ this.props.translate( 'Rewind to this day' ) }
+			</Button>
 		);
 	}
 

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -14,6 +14,7 @@ import ActivityLogItem from '../activity-log-item';
 
 class ActivityLogDay extends Component {
 	static propTypes = {
+		allowRestore: PropTypes.bool.isRequired,
 		isRewindActive: PropTypes.bool,
 		logs: PropTypes.array.isRequired,
 		requestRestore: PropTypes.func.isRequired,
@@ -22,6 +23,7 @@ class ActivityLogDay extends Component {
 	};
 
 	static defaultProps = {
+		allowRestore: true,
 		isRewindActive: true,
 	};
 
@@ -40,17 +42,23 @@ class ActivityLogDay extends Component {
 	 * @returns { object } Button to display.
 	 */
 	getRewindButton( type = '' ) {
-		return (
-			<Button
-				compact
-				disabled={ ! this.props.isRewindActive }
-				onClick={ this.handleClickRestore }
-				primary={ 'primary' === type }
-			>
-				<Gridicon icon="history" size={ 18 } />
-				{ ' ' }
-				{ this.props.translate( 'Rewind to this day' ) }
-			</Button>
+		const { allowRestore } = this.props;
+
+		return ( allowRestore
+			? (
+				<Button
+					compact
+					disabled={ ! this.props.isRewindActive }
+					onClick={ this.handleClickRestore }
+					primary={ 'primary' === type }
+				>
+					<Gridicon icon="history" size={ 18 } />
+					{ ' ' }
+					{ this.props.translate( 'Rewind to this day' ) }
+				</Button>
+			) : (
+				null
+			)
 		);
 	}
 
@@ -82,6 +90,7 @@ class ActivityLogDay extends Component {
 
 	render() {
 		const {
+			allowRestore,
 			logs,
 			requestRestore,
 		} = this.props;
@@ -96,6 +105,7 @@ class ActivityLogDay extends Component {
 					{ logs.map( ( log, index ) => (
 						<ActivityLogItem
 							key={ index }
+							allowRestore={ allowRestore }
 							requestRestore={ requestRestore }
 
 							title={ log.name }

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -14,7 +14,7 @@ import ActivityLogItem from '../activity-log-item';
 
 class ActivityLogDay extends Component {
 	static propTypes = {
-		isRewindEnabled: PropTypes.bool,
+		isRewindActive: PropTypes.bool,
 		logs: PropTypes.array.isRequired,
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
@@ -22,7 +22,7 @@ class ActivityLogDay extends Component {
 	};
 
 	static defaultProps = {
-		isRewindEnabled: true,
+		isRewindActive: true,
 	};
 
 	handleClickRestore = () => {
@@ -43,7 +43,7 @@ class ActivityLogDay extends Component {
 		return (
 			<Button
 				compact
-				disabled={ ! this.props.isRewindEnabled }
+				disabled={ ! this.props.isRewindActive }
 				onClick={ this.handleClickRestore }
 				primary={ 'primary' === type }
 			>

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -17,6 +17,7 @@ import Gravatar from 'components/gravatar';
 class ActivityLogItem extends Component {
 
 	static propTypes = {
+		allowRestore: PropTypes.bool.isRequired,
 		siteId: PropTypes.number.isRequired,
 		timestamp: PropTypes.number.isRequired,
 		requestRestore: PropTypes.func.isRequired,
@@ -31,6 +32,7 @@ class ActivityLogItem extends Component {
 	};
 
 	static defaultProps = {
+		allowRestore: true,
 		status: 'is-info',
 		icon: 'info-outline'
 	};
@@ -109,16 +111,23 @@ class ActivityLogItem extends Component {
 	}
 
 	getSummary() {
-		const { translate } = this.props;
+		const {
+			allowRestore,
+			translate,
+		} = this.props;
 
-		return (
-			<div className="activity-log-item__action">
-				<EllipsisMenu position="bottom right">
-					<PopoverMenuItem onClick={ this.handleClickRestore } icon="undo">
-						{ translate( 'Rewind to this point' ) }
-					</PopoverMenuItem>
-				</EllipsisMenu>
-			</div>
+		return ( allowRestore
+			? (
+				<div className="activity-log-item__action">
+					<EllipsisMenu position="bottom right">
+						<PopoverMenuItem onClick={ this.handleClickRestore } icon="undo">
+							{ translate( 'Rewind to this point' ) }
+						</PopoverMenuItem>
+					</EllipsisMenu>
+				</div>
+			) : (
+				null
+			)
 		);
 	}
 

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -116,18 +116,18 @@ class ActivityLogItem extends Component {
 			translate,
 		} = this.props;
 
-		return ( allowRestore
-			? (
-				<div className="activity-log-item__action">
-					<EllipsisMenu position="bottom right">
-						<PopoverMenuItem onClick={ this.handleClickRestore } icon="undo">
-							{ translate( 'Rewind to this point' ) }
-						</PopoverMenuItem>
-					</EllipsisMenu>
-				</div>
-			) : (
-				null
-			)
+		if ( ! allowRestore ) {
+			return null;
+		}
+
+		return (
+			<div className="activity-log-item__action">
+				<EllipsisMenu position="bottom right">
+					<PopoverMenuItem onClick={ this.handleClickRestore } icon="undo">
+						{ translate( 'Rewind to this point' ) }
+					</PopoverMenuItem>
+				</EllipsisMenu>
+			</div>
 		);
 	}
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -227,7 +227,7 @@ class ActivityLog extends Component {
 			),
 			( daily_logs, timestamp ) => (
 				<ActivityLogDay
-					isRewindEnabled={ isRewindActive }
+					isRewindActive={ isRewindActive }
 					key={ timestamp }
 					logs={ daily_logs }
 					requestRestore={ this.handleRequestRestore }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -210,6 +210,7 @@ class ActivityLog extends Component {
 
 	renderContent() {
 		const {
+			isPressable,
 			siteId,
 			slug,
 			moment,
@@ -227,6 +228,7 @@ class ActivityLog extends Component {
 			),
 			( daily_logs, timestamp ) => (
 				<ActivityLogDay
+					allowRestore={ !! isPressable }
 					isRewindActive={ isRewindActive }
 					key={ timestamp }
 					logs={ daily_logs }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -24,6 +24,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from '../stats-navigation';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import ActivityLogDay from '../activity-log-day';
+import ActivityLogBanner from '../activity-log-banner';
 import ErrorBanner from '../activity-log-banner/error-banner';
 import ProgressBanner from '../activity-log-banner/progress-banner';
 import SuccessBanner from '../activity-log-banner/success-banner';
@@ -185,7 +186,6 @@ class ActivityLog extends Component {
 		</div>;
 	}
 
-	// FIXME: This is for internal testing
 	renderErrorMessage() {
 		const {
 			isPressable,
@@ -193,37 +193,45 @@ class ActivityLog extends Component {
 			translate,
 		} = this.props;
 
-		// FIXME: Do something nicer with the error
+		// Do not match null
+		// FIXME: This is for internal testing
+		if ( false === isPressable ) {
+			return (
+				<ActivityLogBanner status="info" icon={ null } >
+					{ translate( 'Rewind is currently only available for Pressable sites' ) }
+				</ActivityLogBanner>
+			);
+		}
+
 		if ( rewindStatusError ) {
 			return (
-				<div>
+				<ActivityLogBanner status="error" icon={ null } >
 					{ translate( 'Rewind error: %s', { args: rewindStatusError.message } ) }
 					<br />
 					{ translate( 'Do you have an appropriate plan?' ) }
-				</div>
+				</ActivityLogBanner>
 			);
-		}
-		if ( ! isPressable ) {
-			return translate( 'Currently only available for Pressable sites' );
 		}
 	}
 
 	renderContent() {
 		const {
 			isPressable,
+			isRewindActive,
+			logs,
+			moment,
 			siteId,
 			slug,
-			moment,
 			startDate,
-			isRewindActive,
 		} = this.props;
+
 		const startOfMonth = moment( startDate ).startOf( 'month' ),
 			startOfMonthMs = startOfMonth.valueOf(),
 			endOfMonthMs = moment( startDate ).endOf( 'month' ).valueOf();
-		const logs = filter( this.props.logs, obj => startOfMonthMs <= obj.ts_site && obj.ts_site <= endOfMonthMs );
+		const filteredLogs = filter( logs, obj => startOfMonthMs <= obj.ts_site && obj.ts_site <= endOfMonthMs );
 		const logsGroupedByDate = map(
 			groupBy(
-				logs.map( this.update_logs, this ),
+				filteredLogs.map( this.update_logs, this ),
 				log => moment( log.ts_site ).startOf( 'day' ).format( 'x' )
 			),
 			( daily_logs, timestamp ) => (
@@ -259,7 +267,7 @@ class ActivityLog extends Component {
 					/>
 				</StatsPeriodNavigation>
 				{ this.renderBanner() }
-				{ ! isRewindActive && <ActivityLogRewindToggle siteId={ siteId } /> }
+				{ ! isRewindActive && !! isPressable && <ActivityLogRewindToggle siteId={ siteId } /> }
 				<section className="activity-log__wrapper">
 					{ logsGroupedByDate }
 				</section>
@@ -280,7 +288,7 @@ class ActivityLog extends Component {
 		} = this.state;
 
 		return (
-			<Main wideLayout={ true }>
+			<Main wideLayout>
 				<QueryRewindStatus siteId={ siteId } />
 				<QueryActivityLog siteId={ siteId } />
 				<StatsFirstView />
@@ -290,7 +298,8 @@ class ActivityLog extends Component {
 					slug={ slug }
 					section="activity"
 				/>
-				{ this.renderErrorMessage() || this.renderContent() }
+				{ this.renderErrorMessage() }
+				{ this.renderContent() }
 				<ActivityLogConfirmDialog
 					isVisible={ showRestoreConfirmDialog }
 					siteTitle={ siteTitle }
@@ -316,7 +325,7 @@ export default connect(
 			isRewindActive: isRewindActiveSelector( state, siteId ),
 
 			// FIXME: Testing only
-			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], false ),
+			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], null ),
 		};
 	}, {
 		recordGoogleEvent,


### PR DESCRIPTION
This PR changes some logic which hid the Activity Log for non-Pressable sites.
With this change, data will be shown but restore buttons are hidden.

It also adds some improved banners to indicate Pressable is required for restors and whether there was an error checking Rewind enabled status.

To test:
1. http://calypso.localhost:3000/stats/activity
1. Check pressable and non pressable sites. Ensure display is coherent.