### PR TITLE
Comments: Add confirm dialog when deleting a comment permanently

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { get, noop } from 'lodash';
+import { get, isUndefined, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,7 +70,7 @@ export class CommentDetail extends Component {
 
 	deleteCommentPermanently = () => {
 		const { commentId, deleteCommentPermanently, translate } = this.props;
-		if ( window.confirm( translate( 'Delete this comment permanently?' ) ) ) {
+		if ( isUndefined( window ) || window.confirm( translate( 'Delete this comment permanently?' ) ) ) {
 			deleteCommentPermanently( commentId );
 		}
 	}

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, noop } from 'lodash';
 
@@ -68,8 +69,10 @@ export class CommentDetail extends Component {
 	}
 
 	deleteCommentPermanently = () => {
-		const { commentId, deleteCommentPermanently } = this.props;
-		deleteCommentPermanently( commentId );
+		const { commentId, deleteCommentPermanently, translate } = this.props;
+		if ( window.confirm( translate( 'Delete this comment permanently?' ) ) ) {
+			deleteCommentPermanently( commentId );
+		}
 	}
 
 	edit = () => noop;
@@ -220,4 +223,4 @@ const mapStateToProps = ( state, ownProps ) => {
 	} );
 };
 
-export default connect( mapStateToProps )( CommentDetail );
+export default connect( mapStateToProps )( localize( CommentDetail ) );


### PR DESCRIPTION
Closes #15067

Add a simple confirm dialog when deleting a comment permanently.

<img width="451" alt="screen shot 2017-06-20 at 18 49 40" src="https://user-images.githubusercontent.com/2070010/27347710-702819f8-55e9-11e7-8be8-9845398f4229.png">

cc @drw158 