### PR TITLE
Reader: Make sure site results content stays within Sites column in IE

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -12,7 +12,7 @@
 .reader-subscription-list-item__byline {
 	color: darken( $gray, 30% );
 	margin-right: 16px;
-	flex: 1 1 auto;
+	flex: 1 1 0px;
 }
 
 .following-manage__subscriptions-list {
@@ -85,7 +85,6 @@
 	max-height: 16px * 2.5;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	overflow-wrap: break-word;
 	position: relative;
 	width: 100%;
 	overflow-wrap: break-word;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -148,7 +148,6 @@
 	word-break: break-all;
 	width: initial;
 	max-height: 16px * 1.3;
-	max-width: calc( 100% - 10px ); // Need to set max-width for IE so URLs don't overflow
 
 	@include breakpoint( "<960px" ) {
 		height: 20px;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -390,6 +390,11 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	}
 }
 
+.search-stream__results.is-two-columns .reader-subscription-list-item__byline {
+	min-width: 180px;
+	max-width: 180px;
+}
+
 .search-stream__single-column-results .reader-subscription-list-item__options {
 	align-items: flex-end;
 	display: flex;


### PR DESCRIPTION
I thought I had fixed this issue in this PR: https://github.com/Automattic/wp-calypso/pull/15282, but apparently, it only fixed it for the excerpts (they were no longer cropped), but Follow buttons still were.

So instead of adding a max-width to `.reader-subscription-list-item__site-url`, I'm adding it to `.reader-subscription-list-item__byline` instead to make sure everything (site title, excerpt, and URL) doesn't overflow.

This only happens in IE.

**Before:** (Some Follow buttons were missing)
![screenshot 2017-06-20 10 44 46](https://user-images.githubusercontent.com/4924246/27347732-788f6ee0-55a6-11e7-8bdf-1d77898305a8.png)

**After:** (Follow buttons exist for all sites in the list)
![screenshot 2017-06-20 10 51 45](https://user-images.githubusercontent.com/4924246/27347751-856e1756-55a6-11e7-9ad5-4c048f86e540.png)

Still looks good in other browsers.

Safari:
![screenshot 2017-06-20 10 54 23](https://user-images.githubusercontent.com/4924246/27347858-eff36fa4-55a6-11e7-8e3f-28a8e776a9f5.png)

Chrome:
![screenshot 2017-06-20 10 54 31](https://user-images.githubusercontent.com/4924246/27347863-f2b32afe-55a6-11e7-82cf-d57e09ed9898.png)

FF:
![screenshot 2017-06-20 10 54 34](https://user-images.githubusercontent.com/4924246/27347867-f53fe80c-55a6-11e7-8292-7afa5a8485b8.png)
