### PR TITLE
Comments: Display "Untitled" for posts without a title

### DIFF
--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -81,7 +81,9 @@ export const CommentDetailHeader = ( {
 						</span>
 					</div>
 					<div className="comment-detail__author-info-element">
-						{ translate( 'on %(postTitle)s', { args: { postTitle } } ) }
+						{ translate( 'on %(postTitle)s', { args: {
+							postTitle: postTitle ? decodeEntities( postTitle ) : translate( 'Untitled' ),
+						} } ) }
 					</div>
 				</div>
 			</div>

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import SiteIcon from 'blocks/site-icon';
-import { decodeEntities } from 'lib/formatting';
 
 export const CommentDetailPost = ( {
 	parentCommentAuthorAvatarUrl,

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import SiteIcon from 'blocks/site-icon';
+import { decodeEntities } from 'lib/formatting';
 
 export const CommentDetailPost = ( {
 	parentCommentAuthorAvatarUrl,
@@ -51,7 +52,7 @@ export const CommentDetailPost = ( {
 					</span>
 				}
 				<a href={ postUrl }>
-					{ postTitle }
+					{ postTitle || translate( 'Untitled' ) }
 				</a>
 			</div>
 		</div>


### PR DESCRIPTION
Closes #15018

To be rebased with #15292 

Displays "Untitled" instead of empty post titles.

| Before | After |
| --- | --- |
| ![screen shot 2017-06-12 at 4 30 07 pm](https://user-images.githubusercontent.com/618551/27056156-9fcc402a-4f8c-11e7-934d-f6a5c9d9e75a.png) | <img width="733" alt="screen shot 2017-06-20 at 19 26 21" src="https://user-images.githubusercontent.com/2070010/27349194-653f8792-55ee-11e7-8009-f531f453a1c1.png"> |