### PR TITLE
WooCommerce: Add dashboard pre-setup store address prompt

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -11,11 +11,16 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
-import { areSetupChoicesLoading, getFinishedInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
+import {
+	areSetupChoicesLoading,
+	getFinishedInitialSetup,
+	getSetStoreAddressDuringInitialSetup
+} from 'woocommerce/state/sites/setup-choices/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import ManageNoOrdersView from './manage-no-orders-view';
 import ManageOrdersView from './manage-orders-view';
+import PreSetupView from './pre-setup-view';
 import SetupTasksView from './setup-tasks-view';
 
 class Dashboard extends Component {
@@ -48,17 +53,21 @@ class Dashboard extends Component {
 	}
 
 	renderDashboardContent = () => {
-		const { finishedInitialSetup, hasOrders, selectedSite } = this.props;
+		const { finishedInitialSetup, hasOrders, selectedSite, setStoreAddressDuringInitialSetup } = this.props;
 
-		if ( finishedInitialSetup && hasOrders ) {
-			return ( <ManageOrdersView site={ selectedSite } /> );
+		if ( ! setStoreAddressDuringInitialSetup ) {
+			return ( <PreSetupView site={ selectedSite } /> );
 		}
 
-		if ( finishedInitialSetup && ! hasOrders ) {
+		if ( ! finishedInitialSetup ) {
+			return ( <SetupTasksView onFinished={ this.onStoreSetupFinished } site={ selectedSite } /> );
+		}
+
+		if ( ! hasOrders ) {
 			return ( <ManageNoOrdersView site={ selectedSite } /> );
 		}
 
-		return ( <SetupTasksView onFinished={ this.onStoreSetupFinished } site={ selectedSite } /> );
+		return ( <ManageOrdersView site={ selectedSite } /> );
 	}
 
 	render = () => {
@@ -84,6 +93,7 @@ function mapStateToProps( state ) {
 		hasOrders: false, // TODO - connect to a selector when it becomes available
 		loading: areSetupChoicesLoading( state ),
 		selectedSite: getSelectedSiteWithFallback( state ),
+		setStoreAddressDuringInitialSetup: getSetStoreAddressDuringInitialSetup( state ),
 	};
 }
 

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -63,7 +63,6 @@ class PreSetupView extends Component {
 					address={ address }
 					className="dashboard__pre-setup-address"
 					isEditable
-					nameLabel={ translate( 'Business Name' ) }
 					onChange={ this.onChange }
 				/>
 				<SetupFooter

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import AddressView from 'woocommerce/components/address-view';
+import SetupFooter from './setup-footer';
+import SetupHeader from './setup-header';
+
+import {
+	setSetStoreAddressDuringInitialSetup,
+} from 'woocommerce/state/sites/setup-choices/actions';
+
+class PreSetupView extends Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+		} ),
+	};
+
+	onChange = ( /* event */ ) => {
+		// TODO - store changes in state
+	}
+
+	onNext = ( event ) => {
+		// TODO - save the address to the site
+		event.preventDefault();
+		// TODO - maybe make button disabled while saving
+		this.props.setSetStoreAddressDuringInitialSetup( this.props.site.ID, true );
+	}
+
+	render = () => {
+		const { translate } = this.props;
+
+		// TODO - use state, initialized from props passed in by redux
+		// to provide props to the address view and then remove this hardcoding
+
+		const address = {
+			name: 'Octopus Outlet Emporium',
+			street: '27 Main St',
+			street2: '',
+			city: 'Ellington',
+			state: 'CT',
+			postcode: '06029',
+			country: 'US',
+		};
+
+		return (
+			<div className="card dashboard__setup-wrapper dashboard__location">
+				<SetupHeader
+					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
+					imageWidth={ 160 }
+					title={ translate( 'Howdy! Let\'s set up your store & start selling' ) }
+					subtitle={ translate( 'First we need to know where you\'re located.' ) }
+				/>
+				<AddressView
+					address={ address }
+					className="dashboard__pre-setup-address"
+					isEditable
+					nameLabel={ translate( 'Business Name' ) }
+					onChange={ this.onChange }
+				/>
+				<SetupFooter
+					onClick={ this.onNext }
+					label={ translate( 'Next' ) }
+					primary
+				/>
+			</div>
+		);
+	}
+}
+
+function mapStateToProps( /* state */ ) {
+	return {
+		// TODO - get actual address from state
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			setSetStoreAddressDuringInitialSetup,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( PreSetupView ) );

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -118,6 +118,18 @@
 	}
 }
 
+.dashboard__location {
+	padding: 16px;
+	
+	@include breakpoint( ">960px" ) {
+		padding: 32px 32px 16px 32px;
+	}
+}
+
+.dashboard__location .dashboard__setup-footer {
+	padding: 16px 32px 0 32px;
+}
+
 .dashboard__setup-footer {
 	align-items: center;
 	border-top: none;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
@@ -43,6 +43,7 @@ class ShippingOrigin extends Component {
 				</Notice>
 				<Card>
 					<AddressView address={ this.state.address } />
+					<a>{ translate( 'Edit address' ) }</a>
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -1,51 +1,165 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
+import find from 'lodash/find';
+import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
-import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-class AddressView extends Component {
+import Countries from 'woocommerce/lib/countries';
+import FormFieldSet from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormTextInput from 'components/forms/form-text-input';
 
+class AddressView extends Component {
 	static propTypes = {
 		address: PropTypes.shape( {
 			name: PropTypes.string.isRequired,
 			street: PropTypes.string.isRequired,
+			street2: PropTypes.string,
 			city: PropTypes.string.isRequired,
+			state: PropTypes.string,
 			country: PropTypes.string.isRequired,
+			postcode: PropTypes.string,
 		} ),
+		isEditable: PropTypes.bool,
+		nameLabel: PropTypes.string,
+		onChange: PropTypes.func,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.edit = this.edit.bind( this );
+	static defaultProps = {
+		address: {
+			name: '',
+			street: '',
+			street2: '',
+			city: '',
+			state: '',
+			country: 'US',
+			postcode: '',
+		},
+		isEditable: false,
+		nameLabel: '',
 	}
 
-	edit() {
-		//TODO: Add edit functionality
-		return false;
-	}
-
-	render() {
-		const __ = i18n.translate;
+	renderEditable = () => {
+		const { nameLabel, onChange, translate } = this.props;
+		const { city, country, name, postcode, street, street2, state } = this.props.address;
+		const countryData = find( Countries, { code: country } );
+		const foundCountry = Boolean( countryData );
+		const states = foundCountry ? countryData.states : [];
+		const statesLabel = foundCountry ? countryData.statesLabel : '';
 
 		return (
-			<div>
-				<div className="address-view__address">
-					<p className="address-view__address-name">
-						{ this.props.address.name }
-					</p>
-					<p>{ this.props.address.street }</p>
-					<p>{ this.props.address.city }</p>
-					<p>{ this.props.address.country }</p>
+			<div className="address-view__fields-editable">
+				<FormFieldSet>
+					<FormLabel>{ nameLabel || translate( 'Business Name' ) }</FormLabel>
+					<FormTextInput
+						name="name"
+						onChange={ onChange }
+						value={ name }
+					/>
+				</FormFieldSet>
+				<FormFieldSet>
+					<FormLabel>{ translate( 'Street address' ) }</FormLabel>
+					<FormTextInput
+						name="street"
+						onChange={ onChange }
+						value={ street }
+					/>
+				</FormFieldSet>
+				<FormFieldSet>
+					<FormTextInput
+						name="street2"
+						onChange={ onChange }
+						value={ street2 }
+					/>
+				</FormFieldSet>
+				<div className="address-view__editable-city-state-postcode">
+					<FormFieldSet>
+						<FormLabel>{ translate( 'City' ) }</FormLabel>
+						<FormTextInput
+							name="city"
+							onChange={ onChange }
+							value={ city }
+						/>
+					</FormFieldSet>
+					<FormFieldSet>
+						<FormLabel>{ statesLabel }</FormLabel>
+						<FormSelect
+							disabled={ ! foundCountry }
+							name="state"
+							onChange={ onChange }
+							value={ state }
+						>
+							{ states.map( ( option ) => {
+								return (
+									<option key={ option.code } value={ option.code }>{ option.name }</option>
+								);
+							} ) }
+						</FormSelect>
+					</FormFieldSet>
+					<FormFieldSet>
+						<FormLabel>{ translate( 'Postal code' ) }</FormLabel>
+						<FormTextInput
+							name="postcode"
+							onChange={ onChange }
+							value={ postcode }
+						/>
+					</FormFieldSet>
 				</div>
-				<a>{ __( 'Edit address' ) }</a>
+				<FormFieldSet className="address-view__country">
+					<FormLabel>{ translate( 'Country' ) }</FormLabel>
+					<FormSelect
+						name="country"
+						onChange={ onChange }
+						value={ country }
+					>
+						{ Countries.map( ( option ) => {
+							return (
+								<option key={ option.code } value={ option.code }>{ option.name }</option>
+							);
+						} ) }
+					</FormSelect>
+				</FormFieldSet>
+			</div>
+		);
+	}
+
+	renderStatic = () => {
+		const { name, street, street2, city, state, postcode, country } = this.props.address;
+		return (
+			<div className="address-view__fields-static">
+				<p className="address-view__address-name">
+					{ name }
+				</p>
+				<p>
+					{ street }
+				</p>
+				{	street2 && <p>{ street2 }</p> }
+				<p>
+					{ city } { state && { state } } { postcode && { postcode } }
+				</p>
+				<p>
+					{ country }
+				</p>
+			</div>
+		);
+	}
+
+	render = () => {
+		const { className, isEditable } = this.props;
+		const classes = classNames( 'address-view__address', className );
+
+		return (
+			<div className={ classes }>
+				{ isEditable ? this.renderEditable() : this.renderStatic() }
 			</div>
 		);
 	}
 }
 
-export default AddressView;
+export default localize( AddressView );

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -9,3 +9,36 @@
 		}
 	}
 }
+
+.address-view__editable-city-state-postcode {
+	display: flex;
+
+	.form-fieldset {
+		flex: 1;
+		margin-right: 16px;
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+	
+	@include breakpoint( "<960px" ) {
+		flex-direction: column;
+		
+		label + select {
+			width: 100%;
+		}
+		
+		.form-fieldset {
+			margin-right: 0;
+		}
+	}
+}
+
+.address-view__country {
+	margin-bottom: 32px;
+	
+	.form-select {
+		width: 100%;
+	}
+}

--- a/client/extensions/woocommerce/lib/countries/CA.js
+++ b/client/extensions/woocommerce/lib/countries/CA.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+export default () => {
+	return (
+		{
+			code: 'CA',
+			name: translate( 'Canada' ),
+			states: [
+				{
+					code: 'AB',
+					name: translate( 'Alberta' ),
+				},
+				{
+					code: 'BC',
+					name: translate( 'British Columbia' ),
+				},
+				{
+					code: 'MB',
+					name: translate( 'Manitoba' ),
+				},
+				{
+					code: 'NB',
+					name: translate( 'New Brunswick' ),
+				},
+				{
+					code: 'NL',
+					name: translate( 'Newfoundland and Labrador' ),
+				},
+				{
+					code: 'NT',
+					name: translate( 'Northwest Territories' ),
+				},
+				{
+					code: 'NS',
+					name: translate( 'Nova Scotia' ),
+				},
+				{
+					code: 'NU',
+					name: translate( 'Nunavut' ),
+				},
+				{
+					code: 'ON',
+					name: translate( 'Ontario' ),
+				},
+				{
+					code: 'PE',
+					name: translate( 'Prince Edward Island' ),
+				},
+				{
+					code: 'QC',
+					name: translate( 'Quebec' ),
+				},
+				{
+					code: 'SK',
+					name: translate( 'Saskatchewan' ),
+				},
+				{
+					code: 'YT',
+					name: translate( 'Yukon Territory' ),
+				},
+			],
+			statesLabel: translate( 'Province' ),
+		}
+	);
+};

--- a/client/extensions/woocommerce/lib/countries/US.js
+++ b/client/extensions/woocommerce/lib/countries/US.js
@@ -1,0 +1,220 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+export default () => {
+	return (
+		{
+			code: 'US',
+			name: translate( 'United States of America' ),
+			states: [
+				{
+					code: 'AL',
+					name: translate( 'Alabama' ),
+				},
+				{
+					code: 'AK',
+					name: translate( 'Alaska' ),
+				},
+				{
+					code: 'AZ',
+					name: translate( 'Arizona' ),
+				},
+				{
+					code: 'AR',
+					name: translate( 'Arkansas' ),
+				},
+				{
+					code: 'CA',
+					name: translate( 'California' ),
+				},
+				{
+					code: 'CO',
+					name: translate( 'Colorado' ),
+				},
+				{
+					code: 'CT',
+					name: translate( 'Connecticut' ),
+				},
+				{
+					code: 'DE',
+					name: translate( 'Delaware' ),
+				},
+				{
+					code: 'DC',
+					name: translate( 'District Of Columbia' ),
+				},
+				{
+					code: 'FL',
+					name: translate( 'Florida' ),
+				},
+				{
+					code: 'GA',
+					name: translate( 'Georgia' ),
+				},
+				{
+					code: 'HI',
+					name: translate( 'Hawaii' ),
+				},
+				{
+					code: 'ID',
+					name: translate( 'Idaho' ),
+				},
+				{
+					code: 'IL',
+					name: translate( 'Illinois' ),
+				},
+				{
+					code: 'IN',
+					name: translate( 'Indiana' ),
+				},
+				{
+					code: 'IA',
+					name: translate( 'Iowa' ),
+				},
+				{
+					code: 'KS',
+					name: translate( 'Kansas' ),
+				},
+				{
+					code: 'KY',
+					name: translate( 'Kentucky' ),
+				},
+				{
+					code: 'LA',
+					name: translate( 'Louisiana' ),
+				},
+				{
+					code: 'ME',
+					name: translate( 'Maine' ),
+				},
+				{
+					code: 'MD',
+					name: translate( 'Maryland' ),
+				},
+				{
+					code: 'MA',
+					name: translate( 'Massachusetts' ),
+				},
+				{
+					code: 'MI',
+					name: translate( 'Michigan' ),
+				},
+				{
+					code: 'MN',
+					name: translate( 'Minnesota' ),
+				},
+				{
+					code: 'MS',
+					name: translate( 'Mississippi' ),
+				},
+				{
+					code: 'MO',
+					name: translate( 'Missouri' ),
+				},
+				{
+					code: 'MT',
+					name: translate( 'Montana' ),
+				},
+				{
+					code: 'NE',
+					name: translate( 'Nebraska' ),
+				},
+				{
+					code: 'NV',
+					name: translate( 'Nevada' ),
+				},
+				{
+					code: 'NH',
+					name: translate( 'New Hampshire' ),
+				},
+				{
+					code: 'NJ',
+					name: translate( 'New Jersey' ),
+				},
+				{
+					code: 'NM',
+					name: translate( 'New Mexico' ),
+				},
+				{
+					code: 'NY',
+					name: translate( 'New York' ),
+				},
+				{
+					code: 'NC',
+					name: translate( 'North Carolina' ),
+				},
+				{
+					code: 'ND',
+					name: translate( 'North Dakota' ),
+				},
+				{
+					code: 'OH',
+					name: translate( 'Ohio' ),
+				},
+				{
+					code: 'OK',
+					name: translate( 'Oklahoma' ),
+				},
+				{
+					code: 'OR',
+					name: translate( 'Oregon' ),
+				},
+				{
+					code: 'PA',
+					name: translate( 'Pennsylvania' ),
+				},
+				{
+					code: 'RI',
+					name: translate( 'Rhode Island' ),
+				},
+				{
+					code: 'SC',
+					name: translate( 'South Carolina' ),
+				},
+				{
+					code: 'SD',
+					name: translate( 'South Dakota' ),
+				},
+				{
+					code: 'TN',
+					name: translate( 'Tennessee' ),
+				},
+				{
+					code: 'TX',
+					name: translate( 'Texas' ),
+				},
+				{
+					code: 'UT',
+					name: translate( 'Utah' ),
+				},
+				{
+					code: 'VT',
+					name: translate( 'Vermont' ),
+				},
+				{
+					code: 'VA',
+					name: translate( 'Virginia' ),
+				},
+				{
+					code: 'WA',
+					name: translate( 'Washington' ),
+				},
+				{
+					code: 'WV',
+					name: translate( 'West Virginia' ),
+				},
+				{
+					code: 'WI',
+					name: translate( 'Wisconsin' ),
+				},
+				{
+					code: 'WY',
+					name: translate( 'Wyoming' ),
+				},
+			],
+			statesLabel: translate( 'State' ),
+		}
+	);
+};

--- a/client/extensions/woocommerce/lib/countries/index.js
+++ b/client/extensions/woocommerce/lib/countries/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import CA from './CA';
+import US from './US';
+
+// Note: We are not using the other state name resources in calypso
+// since 1) they do not include Canadian provinces and 2) we will
+// want to decorate these objects further in a subsequent PR
+// with things like origin vs destination based tax booleans
+
+export default [
+	CA(),
+	US(),
+];


### PR DESCRIPTION
Part 2 of 3 for #14775 

This part adds the pre-setup step where we ask the merchant for their store's address. This is a read-only version for now. The next PR will actually validate and save the name and address entered.

To test, go to
- http://calypso.localhost:3000/store/{site}
- Make sure the name, address, address2, city, state, postcode and country fields are displayed. All but address2 have hardcoded values for now
- Note that they are not yet editable
- Make sure the Next button works
- After you click the Next button, verify you are taken to the "egg" view (i.e. the list of tasks and checkboxes)
- Note that after you've done "Next" that the set_store_address_during_initial_setup flag will be set on WPCOM for that site.  If you want to get back to the address view, you can “reset” the site using the developer console at  https://developer.wordpress.com/docs/api/console/ -- you’ll need to POST to /sites/siteID/calypso-preferences/woocommerce setting set_store_address_during_initial_setup to 0
- The AddressView is also visible on the shipping settings page, in a static mode (not editable) - make sure it renders there. Note that the edit link on that page is not yet connected either.
- Lastly, run npm run test-client client/extensions/woocommerce/state and make sure everything passes
