### PR TITLE
Drop sites-list from plugins/access-control

### DIFF
--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -6,32 +6,23 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import sitesList from 'lib/sites-list';
 import config from 'config';
 import notices from 'notices';
 
-const sites = sitesList();
-
-const hasErrorCondition = ( site, type ) => {
-	const errorConditions = {
-		notMinimumJetpackVersion: site && ! site.hasMinimumJetpackVersion && site.jetpack,
-		notRightsToManagePlugins: sites.initialized && ! sites.canManageSelectedOrAll()
-	};
-	return errorConditions[ type ];
+const getHasRightsToManagePlutins = ( selectedOrAll ) => {
+	return selectedOrAll.some( ( site ) => site.capabilities && site.capabilities.manage_options );
 };
 
-const hasRestrictedAccess = ( site ) => {
-	site = site || sites.getSelectedSite();
-
+const hasRestrictedAccess = ( site, hasRightsToManagePlutins, isMinJetpackVersionValidationFailed ) => {
 	// Display a 404 to users that don't have the rights to manage plugins
-	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) ) {
+	if ( ! hasRightsToManagePlutins ) {
 		return {
 			title: i18n.translate( 'Not Available' ),
 			line: i18n.translate( 'The page you requested could not be found' ),
 			illustration: '/calypso/images/illustrations/illustration-404.svg',
 			fullWidth: true
 		};
-	} else if ( hasErrorCondition( site, 'notMinimumJetpackVersion' ) ) {
+	} else if ( isMinJetpackVersionValidationFailed ) {
 		notices.warning(
 			i18n.translate( 'Jetpack %(version)s is required to take full advantage of plugin management in %(site)s.', {
 				args: {
@@ -48,4 +39,4 @@ const hasRestrictedAccess = ( site ) => {
 	}
 };
 
-export default { hasRestrictedAccess };
+export default { getHasRightsToManagePlutins, hasRestrictedAccess };

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -28,7 +28,8 @@ import FeatureExample from 'components/feature-example';
 import { hasTouch } from 'lib/touch-detect';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
-import { isJetpackSite, canJetpackSiteManage } from 'state/sites/selectors';
+import { getSelectedOrAllSites } from 'state/selectors';
+import { isJetpackSite, canJetpackSiteManage, siteHasMinimumJetpackVersion } from 'state/sites/selectors';
 
 const PluginsBrowser = React.createClass( {
 	_SHORT_LIST_LENGTH: 6,
@@ -92,7 +93,9 @@ const PluginsBrowser = React.createClass( {
 		} );
 		fullLists.search = PluginsListStore.getSearchList( search );
 		return {
-			accessError: pluginsAccessControl.hasRestrictedAccess(),
+			accessError: pluginsAccessControl.hasRestrictedAccess( this.props.selectedSite,
+				this.props.hasRightsToManagePlutins,
+				this.props.isMinJetpackVersionValidationFailed ),
 			shortLists: shortLists,
 			fullLists: fullLists
 		};
@@ -335,10 +338,16 @@ const PluginsBrowser = React.createClass( {
 export default connect(
 	state => {
 		const selectedSite = getSelectedSite( state );
+		const selectedOrAll = getSelectedOrAllSites( state );
+		const hasRightsToManagePlutins = pluginsAccessControl.getHasRightsToManagePlutins( selectedOrAll );
+		const selectedSiteIsJetpack = selectedSite && isJetpackSite( state, selectedSite.ID );
+		const isMinJetpackVersionValidationFailed = selectedSiteIsJetpack && ! siteHasMinimumJetpackVersion( state, selectedSite.ID );
 		return {
 			selectedSite,
 			isJetpackSite: siteId => isJetpackSite( state, siteId ),
 			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+			hasRightsToManagePlutins,
+			isMinJetpackVersionValidationFailed
 		};
 	},
 	{


### PR DESCRIPTION
This is my first pull request, so odds are high I may be being doing something different from what site-list killers normally do (although I tried my best to avoid that), if so please provide feedback and I will correct it asap.

This pull request drop sites-list from client/my-sites/plugins/access-control.js. This a crucial step to get rid of sites-list from all modules in client/my-sites/plugins. 
In order to remove sites-list from access-control I had to change the interface it exposes and change all the places that use access-control (so this pull request is error prone):

- client/my-sites/plugins/plugins-browser 
- client/my-sites/plugins/plugin.jsx
- client/my-sites/plugins/main.jsx

 Some of the new selectors being called in this module, right now are just being used to compute access-control info but they will be required when we get rid of sites-list there, so this will make that work easier.
To test:
Make sure all tests in plugins continue to execute with success “npm run test-client client/my-sites/plugins”.
Test the following url combinations

- http://calypso.localhost:3000/plugins/{site/no-site/jetpack-site}, --
- http://calypso.localhost:3000/plugins/hello-dolly/{site/no-site/jetpack-site}, 
- http://calypso.localhost:3000/plugins/browse/{site/no-site/jetpack-site}

On users with permission to manage plugins and on users without permission to manage plugins (make sure in the later case not found pages appear):
Use the plugins section and make sure everything is behaving as it should.

Thank you for your attention!
