### PR TITLE
DatePicker: set `moment` property as required

### DIFF
--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -16,7 +16,7 @@ class DatePickerDay extends Component {
 	static propTypes = {
 		date: PropTypes.object.isRequired,
 		events: PropTypes.array,
-		moment: PropTypes.func,
+		moment: PropTypes.func.isRequired,
 		maxEventsPerTooltip: PropTypes.number,
 	};
 

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -19,7 +19,7 @@ class DatePicker extends PureComponent {
 		enableOutsideDays: PropTypes.bool,
 		events: PropTypes.array,
 		locale: PropTypes.object,
-		moment: PropTypes.func,
+		moment: PropTypes.func.isRequired,
 
 		selectedDay: PropTypes.object,
 		timeReference: PropTypes.object,


### PR DESCRIPTION
This PR simply sets the `moment` property as required either to the code of the component as the DatePickerDay subcomponent. 