### PR TITLE
WooCommerce: Track events for dashboard buttons, payment methods, and store link.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -60,7 +60,7 @@ class ManageNoOrdersView extends Component {
 		return (
 			<BasicWidget
 				buttonLabel={ translate( 'View an example order' ) }
-				buttonClick={ trackClick }
+				onButtonClick={ trackClick }
 				className="dashboard__example-order-widget"
 				title={ translate( 'Looking for orders and reports?' ) }
 			>
@@ -84,7 +84,7 @@ class ManageNoOrdersView extends Component {
 			<BasicWidget
 				buttonLabel={ translate( 'View & test your store' ) }
 				buttonLink={ site.URL }
-				buttonClick={ trackClick }
+				onButtonClick={ trackClick }
 				className="dashboard__view-and-test-widget"
 				title={ translate( 'Test all the things' ) }
 			>

--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -3,10 +3,12 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import BasicWidget from 'woocommerce/components/basic-widget';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import ReadingWidget from 'woocommerce/components/reading-widget';
@@ -49,10 +51,16 @@ class ManageNoOrdersView extends Component {
 
 	renderExampleOrderWidget = () => {
 		const { site, translate } = this.props;
+		const trackClick = () => {
+			analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+				action: 'view-example-order',
+			} );
+			page.redirect( getLink( '/store/orders/:site/example', site ) );
+		};
 		return (
 			<BasicWidget
 				buttonLabel={ translate( 'View an example order' ) }
-				buttonLink={ getLink( '/store/orders/:site/example', site ) }
+				buttonClick={ trackClick }
 				className="dashboard__example-order-widget"
 				title={ translate( 'Looking for orders and reports?' ) }
 			>
@@ -67,10 +75,16 @@ class ManageNoOrdersView extends Component {
 
 	renderViewAndTestWidget = () => {
 		const { site, translate } = this.props;
+		const trackClick = () => {
+			analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+				action: 'view-and-test',
+			} );
+		};
 		return (
 			<BasicWidget
 				buttonLabel={ translate( 'View & test your store' ) }
 				buttonLink={ site.URL }
+				buttonClick={ trackClick }
 				className="dashboard__view-and-test-widget"
 				title={ translate( 'Test all the things' ) }
 			>

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -3,11 +3,13 @@
  */
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 
 // TODO add doc url and documentation link
@@ -17,6 +19,7 @@ class SetupTask extends Component {
 		actions: PropTypes.arrayOf( PropTypes.shape( {
 			isSecondary: PropTypes.bool,
 			label: PropTypes.string.isRequired,
+			analyticsProp: PropTypes.string.isRequired,
 			onClick: PropTypes.func,
 			path: PropTypes.string,
 		} ) ),
@@ -30,6 +33,12 @@ class SetupTask extends Component {
 		isSecondary: false,
 	}
 
+	track( analyticsProp ) {
+		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+			action: analyticsProp,
+		} );
+	}
+
 	renderTaskPrimaryActions = ( actions, taskCompleted ) => {
 		const primaryActions = actions.filter( action => ! action.isSecondary );
 		return (
@@ -39,9 +48,13 @@ class SetupTask extends Component {
 						// Only the last primary action gets to be a primary button
 						const primary = ( index === primaryActions.length - 1 ) && ! taskCompleted;
 						const target = '/' === action.path.substring( 0, 1 ) ? '_self' : '_blank';
+						const trackClick = () => {
+							this.track( action.analyticsProp );
+							page.redirect( action.path );
+						};
 						return (
 							<Button
-								href={ action.path }
+								onClick={ trackClick }
 								key={ index }
 								primary={ primary }
 								target={ target }>
@@ -60,8 +73,12 @@ class SetupTask extends Component {
 			<div className="dashboard__setup-task-secondary-actions">
 				{
 					secondaryActions.map( ( action, index ) => {
+						const trackClick = ( e ) => {
+							this.track( action.analyticsProp );
+							action.onClick( e );
+						};
 						return (
-							<a key={ index } onClick={ action.onClick }>{ action.label }</a>
+							<a key={ index } onClick={ trackClick }>{ action.label }</a>
 						);
 					} )
 				}

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
@@ -9,6 +9,7 @@ import React, { Component, PropTypes } from 'react';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import {
 	getOptedOutOfShippingSetup,
 	getOptedOutofTaxesSetup,
@@ -31,6 +32,9 @@ class SetupTasksView extends Component {
 
 	onFinished = ( event ) => {
 		event.preventDefault();
+		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+			action: 'finished',
+		} );
 		this.props.setFinishedInitialSetup( this.props.site.ID, true );
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -104,6 +104,7 @@ class SetupTasks extends Component {
 					{
 						label: 'Add a product',
 						path: getLink( '/store/product/:site', site ),
+						analyticsProp: 'add-product',
 					}
 				]
 			},
@@ -117,11 +118,13 @@ class SetupTasks extends Component {
 					{
 						label: translate( 'Set up shipping' ),
 						path: getLink( '/store/settings/shipping/:site', site ),
+						analyticsProp: 'set-up-shipping',
 					},
 					{
 						label: translate( 'I won\'t be shipping' ),
 						isSecondary: true,
-						onClick: this.onClickNoShip
+						onClick: this.onClickNoShip,
+						analyticsProp: 'not-shipping',
 					}
 				]
 			},
@@ -135,6 +138,7 @@ class SetupTasks extends Component {
 					{
 						label: translate( 'Set up payments' ),
 						path: getLink( '/store/settings/payments/:site', site ),
+						analyticsProp: 'set-up-payments',
 					}
 				]
 			},
@@ -148,11 +152,13 @@ class SetupTasks extends Component {
 					{
 						label: translate( 'Set up taxes' ),
 						path: getLink( '/store/settings/taxes/:site', site ),
+						analyticsProp: 'set-up-taxes',
 					},
 					{
 						label: translate( 'I\'m not charging sales tax' ),
 						isSecondary: true,
-						onClick: this.onClickNoTaxes
+						onClick: this.onClickNoTaxes,
+						analyticsProp: 'no-taxes',
 					}
 				]
 			},
@@ -166,7 +172,8 @@ class SetupTasks extends Component {
 					{
 						label: translate( 'Customize' ),
 						path: getLink( 'https://:site/wp-admin/customize.php?return=%2Fwp-admin%2F', site ),
-						// TODO use onClick here instead in order to hit setTriedCustomizerDuringInitialSetup
+						// TODO use onClick here instead in order to hit setTriedCustomizerDuringInitialSetup,
+						analyticsProp: 'view-and-customize',
 					}
 				]
 			}

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 import {
 	cancelEditingPaymentMethod,
@@ -80,6 +81,16 @@ class PaymentMethodItem extends Component {
 			method.id,
 			enabled
 		);
+
+		if ( enabled ) {
+			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_enabled', {
+				paymentMethod: method.id,
+			} );
+		} else {
+			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_disabled', {
+				paymentMethod: method.id,
+			} );
+		}
 
 		const successAction = () => {
 			return successNotice(

--- a/client/extensions/woocommerce/components/basic-widget/index.js
+++ b/client/extensions/woocommerce/components/basic-widget/index.js
@@ -3,15 +3,16 @@
  */
 import classNames from 'classnames';
 import React, { PropTypes } from 'react';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 
-const BasicWidget = ( { buttonLabel, buttonLink, children, className, title } ) => {
+const BasicWidget = ( { buttonLabel, buttonLink, buttonClick, children, className, title } ) => {
 	const classes = classNames( { 'basic-widget__container': true }, className );
-	const target = '/' === buttonLink.substring( 0, 1 ) ? '_self' : '_blank';
+	const target = buttonLink && '/' !== buttonLink.substring( 0, 1 ) ? '_blank' : '_self';
 	return (
 		<div className={ classes } >
 			<h2>{ title }</h2>
@@ -19,6 +20,7 @@ const BasicWidget = ( { buttonLabel, buttonLink, children, className, title } ) 
 				{ children }
 			</div>
 			<Button
+				onClick={ buttonClick }
 				href={ buttonLink }
 				target={ target }>
 				{ buttonLabel }
@@ -30,12 +32,17 @@ const BasicWidget = ( { buttonLabel, buttonLink, children, className, title } ) 
 BasicWidget.propTypes = {
 	buttonLabel: PropTypes.string,
 	buttonLink: PropTypes.string,
+	buttonClick: PropTypes.func,
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),
 		PropTypes.node
 	] ),
 	className: PropTypes.string,
 	title: PropTypes.string,
+};
+
+BasicWidget.defaultProps = {
+	buttonClick: noop,
 };
 
 export default BasicWidget;

--- a/client/extensions/woocommerce/components/basic-widget/index.js
+++ b/client/extensions/woocommerce/components/basic-widget/index.js
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
  */
 import Button from 'components/button';
 
-const BasicWidget = ( { buttonLabel, buttonLink, buttonClick, children, className, title } ) => {
+const BasicWidget = ( { buttonLabel, buttonLink, onButtonClick, children, className, title } ) => {
 	const classes = classNames( { 'basic-widget__container': true }, className );
 	const target = buttonLink && '/' !== buttonLink.substring( 0, 1 ) ? '_blank' : '_self';
 	return (
@@ -20,7 +20,7 @@ const BasicWidget = ( { buttonLabel, buttonLink, buttonClick, children, classNam
 				{ children }
 			</div>
 			<Button
-				onClick={ buttonClick }
+				onClick={ onButtonClick }
 				href={ buttonLink }
 				target={ target }>
 				{ buttonLabel }
@@ -32,7 +32,7 @@ const BasicWidget = ( { buttonLabel, buttonLink, buttonClick, children, classNam
 BasicWidget.propTypes = {
 	buttonLabel: PropTypes.string,
 	buttonLink: PropTypes.string,
-	buttonClick: PropTypes.func,
+	onButtonClick: PropTypes.func,
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),
 		PropTypes.node
@@ -42,7 +42,7 @@ BasicWidget.propTypes = {
 };
 
 BasicWidget.defaultProps = {
-	buttonClick: noop,
+	onButtonClick: noop,
 };
 
 export default BasicWidget;

--- a/client/extensions/woocommerce/components/reading-widget/index.js
+++ b/client/extensions/woocommerce/components/reading-widget/index.js
@@ -9,6 +9,7 @@ import React, { Component, PropTypes } from 'react';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 import config from 'config';
 import ExternalLink from 'components/external-link';
@@ -137,6 +138,9 @@ class ReadingWidget extends Component {
 
 	onSubmit = () => {
 		// TODO
+		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+			action: 'subscribe',
+		} );
 	}
 
 	renderSubscriptionFormFields = ( expanded ) => {
@@ -157,7 +161,7 @@ class ReadingWidget extends Component {
 					/>
 				) }
 				{ expanded && (
-					<Button disabled={ ! this.isFormSubmittable() } >
+					<Button disabled={ ! this.isFormSubmittable() } onClick={ this.onSubmit }>
 						{ translate( 'Subscribe' ) }
 					</Button>
 				) }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -336,6 +336,11 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	trackStoreClick = () => {
+		analytics.tracks.recordEvent( 'calypso_woocommerce_store_nav_item_click' );
+		this.onNavigate();
+	};
+
 	store() {
 		const { canUserManageOptions, isJetpack, site, siteSuffix, translate } = this.props;
 		const storeLink = '/store' + siteSuffix;
@@ -347,7 +352,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label={ translate( 'Store (BETA)' ) }
 				link={ storeLink }
-				onNavigate={ this.onNavigate }
+				onNavigate={ this.trackStoreClick }
 				icon="cart" >
 				<SidebarButton href={ storeLink }>
 					{ translate( 'Set up' ) }


### PR DESCRIPTION
See #15316. This PR adds tracking for the following events mentioned in the issue:

* Number of clicks on 'store' nav item
* Each button click on dashboard
* Payment Methods Used (Enabled & Disabled Counts)

This does not do any sort of tracking for orders or products yet.

I did not implement the following:
* `number who fill out the pre-egg store location` cc @allendav can you add this as you complete that section?
* `shipping methods used` cc @marcinbot  can you add that as you complete this section?

To Test:

* Go to `https://developer.wordpress.com/docs/api/console/` and make a post request to `/sites/:site/calypso-preferences/woocommerce`, setting each field to 0. See p6q8Tx-Cn-p2 for more information.
* Go to http://calypso.localhost:3000/store/:site
* Open your dev console and enter `localStorage.setItem('debug', 'calypso:analytics:*');` [See Analytics Docs](https://github.com/Automattic/wp-calypso/tree/master/client/lib/analytics#tracks-api).
* You should see the `Howdy! Let's set up your store & start selling` page.
* Click the various action buttons, and confirm that you see messages in the console for the action. Example: `calypso:analytics:tracks Record event`.
* Click "I'm finished setting up". This should also record an event.
* Test the buttons on this version of the dashboard to make sure these record events too.
* Go to `Settings > Payments`.
* Enable and disable payment methods and see that events are recorded for these actions.
* Click the site selector arrow so that you go to the stats / normal my sites view for your site.
* Click the `Store (BETA)` link, and verify an event is recorded for that link.

@kellychoffman 