### PR TITLE
Woo: Handle remove product category creates

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -14,13 +14,14 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { successNotice, errorNotice } from 'state/notices/actions';
 
 import { editProduct, editProductAttribute, createProductActionList } from 'woocommerce/state/ui/products/actions';
+import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
 import { actionListStepNext } from 'woocommerce/state/action-list/actions';
 import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
 import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
-import { getProductCategories } from 'woocommerce/state/sites/product-categories/selectors';
+import { getProductCategoriesWithLocalEdits } from 'woocommerce/state/ui/product-categories/selectors';
 import { createProduct } from 'woocommerce/state/sites/products/actions';
 import ProductForm from './product-form';
 import ProductHeader from './product-header';
@@ -35,7 +36,9 @@ class ProductCreate extends React.Component {
 		} ),
 		fetchProductCategories: PropTypes.func.isRequired,
 		editProduct: PropTypes.func.isRequired,
+		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
+		editProductVariation: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {
@@ -115,6 +118,7 @@ class ProductCreate extends React.Component {
 					variations={ variations }
 					productCategories={ productCategories }
 					editProduct={ this.props.editProduct }
+					editProductCategory={ this.props.editProductCategory }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
 				/>
@@ -127,7 +131,7 @@ function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const product = getCurrentlyEditingProduct( state, siteId );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id, siteId );
-	const productCategories = getProductCategories( state, siteId );
+	const productCategories = getProductCategoriesWithLocalEdits( state, siteId );
 	const actionList = getActionList( state );
 
 	return {
@@ -146,6 +150,7 @@ function mapDispatchToProps( dispatch ) {
 			createProduct,
 			createProductActionList,
 			editProduct,
+			editProductCategory,
 			editProductAttribute,
 			editProductVariation,
 			fetchProductCategories,

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -14,24 +14,27 @@ import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import TokenField from 'components/token-field';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { generateProductCategoryId } from 'woocommerce/state/ui/product-categories/actions';
 
 // TODO Rename this card since it contains other controls, and may contain more in the future (like tax)
 const ProductFormCategoriesCard = (
-	{ siteId, product, productCategories, editProduct, translate }
+	{ siteId, product, productCategories, editProduct, editProductCategory, translate }
 ) => {
 	const handleChange = ( categoryNames ) => {
 		const newCategories = compact( categoryNames.map( ( name ) => {
 			const category = find( productCategories, { name: escape( name ) } );
 
 			if ( ! category ) {
-				// TODO: Add new product category to edit state.
-				// TODO: Remove 'compact' calls afterwards as they will no longer be needed.
-				return undefined;
+				// Add a new product category to the creates list.
+				const newCategoryId = generateProductCategoryId();
+				editProductCategory( siteId, { id: newCategoryId }, { name } );
+				return { id: newCategoryId };
 			}
 
 			return pick( category, 'id' );
 		} ) );
 
+		// Update the categories list.
 		const data = { id: product.id, categories: newCategories };
 		editProduct( siteId, product, data );
 	};

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -25,6 +25,7 @@ export default class ProductForm extends Component {
 		variations: PropTypes.array,
 		productCategories: PropTypes.array.isRequired,
 		editProduct: PropTypes.func.isRequired,
+		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
 	};
@@ -42,7 +43,7 @@ export default class ProductForm extends Component {
 
 	render() {
 		const { siteId, product, productCategories, variations } = this.props;
-		const { editProduct, editProductVariation, editProductAttribute } = this.props;
+		const { editProduct, editProductCategory, editProductVariation, editProductAttribute } = this.props;
 
 		if ( ! siteId ) {
 			return this.renderPlaceholder();
@@ -66,12 +67,14 @@ export default class ProductForm extends Component {
 					product={ product }
 					productCategories={ productCategories }
 					editProduct={ editProduct }
+					editProductCategory={ editProductCategory }
 				/>
 				<ProductFormVariationsCard
 					siteId={ siteId }
 					product={ product }
 					variations={ variations }
 					editProduct={ editProduct }
+					editProductCategory={ editProductCategory }
 					editProductAttribute={ editProductAttribute }
 					editProductVariation={ editProductVariation }
 				/>

--- a/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
@@ -10,128 +10,130 @@ import { makeProductActionList, } from '../';
 import { actionListStepSuccess, actionListStepFailure } from 'woocommerce/state/action-list/actions';
 import { createProduct } from 'woocommerce/state/sites/products/actions';
 
-describe( 'makeProductActionList', () => {
-	it( 'should return null when there are no edits', () => {
-		expect( makeProductActionList( null, 123, null ) ).to.equal.null;
-	} );
+describe( 'handlers', () => {
+	describe( '#makeProductActionList', () => {
+		it( 'should return null when there are no edits', () => {
+			expect( makeProductActionList( null, 123, null ) ).to.equal.null;
+		} );
 
-	it( 'should return a single product create request', () => {
-		const rootState = {
-			extensions: {
-				woocommerce: {
+		it( 'should return a single product create request', () => {
+			const rootState = {
+				extensions: {
+					woocommerce: {
+					}
 				}
-			}
-		};
+			};
 
-		const product1 = { id: { index: 0 }, name: 'Product #1' };
+			const product1 = { id: { index: 0 }, name: 'Product #1' };
 
-		const edits = {
-			creates: [
+			const edits = {
+				creates: [
+					product1,
+				]
+			};
+
+			const action1 = createProduct(
+				123,
 				product1,
-			]
-		};
+				actionListStepSuccess( 0 ),
+				actionListStepFailure( 0, 'UNKNOWN' )
+			);
 
-		const action1 = createProduct(
-			123,
-			product1,
-			actionListStepSuccess( 0 ),
-			actionListStepFailure( 0, 'UNKNOWN' )
-		);
+			const expectedActionList = {
+				steps: [
+					{ description: 'Creating product: Product #1', action: action1 },
+				],
+				successAction: undefined,
+				failureAction: undefined,
+				clearUponComplete: true,
+			};
 
-		const expectedActionList = {
-			steps: [
-				{ description: 'Creating product: Product #1', action: action1 },
-			],
-			successAction: undefined,
-			failureAction: undefined,
-			clearUponComplete: true,
-		};
+			expect( makeProductActionList( rootState, 123, edits ) ).to.eql( expectedActionList );
+		} );
 
-		expect( makeProductActionList( rootState, 123, edits ) ).to.eql( expectedActionList );
-	} );
-
-	it( 'should return multiple product create requests', () => {
-		const rootState = {
-			extensions: {
-				woocommerce: {
+		it( 'should return multiple product create requests', () => {
+			const rootState = {
+				extensions: {
+					woocommerce: {
+					}
 				}
-			}
-		};
+			};
 
-		const product1 = { id: { index: 0 }, name: 'Product #1' };
-		const product2 = { id: { index: 1 }, name: 'Product #2' };
+			const product1 = { id: { index: 0 }, name: 'Product #1' };
+			const product2 = { id: { index: 1 }, name: 'Product #2' };
 
-		const edits = {
-			creates: [
+			const edits = {
+				creates: [
+					product1,
+					product2,
+				]
+			};
+
+			const action1 = createProduct(
+				123,
 				product1,
+				actionListStepSuccess( 0 ),
+				actionListStepFailure( 0, 'UNKNOWN' )
+			);
+
+			const action2 = createProduct(
+				123,
 				product2,
-			]
-		};
+				actionListStepSuccess( 1 ),
+				actionListStepFailure( 1, 'UNKNOWN' )
+			);
 
-		const action1 = createProduct(
-			123,
-			product1,
-			actionListStepSuccess( 0 ),
-			actionListStepFailure( 0, 'UNKNOWN' )
-		);
+			const expectedActionList = {
+				steps: [
+					{ description: 'Creating product: Product #1', action: action1 },
+					{ description: 'Creating product: Product #2', action: action2 },
+				],
+				successAction: undefined,
+				failureAction: undefined,
+				clearUponComplete: true,
+			};
 
-		const action2 = createProduct(
-			123,
-			product2,
-			actionListStepSuccess( 1 ),
-			actionListStepFailure( 1, 'UNKNOWN' )
-		);
+			expect( makeProductActionList( rootState, 123, edits ) ).to.eql( expectedActionList );
+		} );
 
-		const expectedActionList = {
-			steps: [
-				{ description: 'Creating product: Product #1', action: action1 },
-				{ description: 'Creating product: Product #2', action: action2 },
-			],
-			successAction: undefined,
-			failureAction: undefined,
-			clearUponComplete: true,
-		};
-
-		expect( makeProductActionList( rootState, 123, edits ) ).to.eql( expectedActionList );
-	} );
-
-	it( 'should create an action list with success/failure actions', () => {
-		const rootState = {
-			extensions: {
-				woocommerce: {
+		it( 'should create an action list with success/failure actions', () => {
+			const rootState = {
+				extensions: {
+					woocommerce: {
+					}
 				}
-			}
-		};
+			};
 
-		const product1 = { id: { index: 0 }, name: 'Product #1' };
+			const product1 = { id: { index: 0 }, name: 'Product #1' };
 
-		const edits = {
-			creates: [
+			const edits = {
+				creates: [
+					product1,
+				]
+			};
+
+			const action1 = createProduct(
+				123,
 				product1,
-			]
-		};
+				actionListStepSuccess( 0 ),
+				actionListStepFailure( 0, 'UNKNOWN' )
+			);
 
-		const action1 = createProduct(
-			123,
-			product1,
-			actionListStepSuccess( 0 ),
-			actionListStepFailure( 0, 'UNKNOWN' )
-		);
+			const successAction = { type: '%%SUCCESS%%' };
+			const failureAction = { type: '%%FAILURE%%' };
 
-		const successAction = { type: '%%SUCCESS%%' };
-		const failureAction = { type: '%%FAILURE%%' };
+			const expectedActionList = {
+				steps: [
+					{ description: 'Creating product: Product #1', action: action1 },
+				],
+				successAction,
+				failureAction,
+				clearUponComplete: true,
+			};
 
-		const expectedActionList = {
-			steps: [
-				{ description: 'Creating product: Product #1', action: action1 },
-			],
-			successAction,
-			failureAction,
-			clearUponComplete: true,
-		};
-
-		const actionList = makeProductActionList( rootState, 123, edits, successAction, failureAction );
-		expect( actionList ).to.eql( expectedActionList );
+			const actionList = makeProductActionList( rootState, 123, edits, successAction, failureAction );
+			expect( actionList ).to.eql( expectedActionList );
+		} );
 	} );
 } );
 

--- a/client/extensions/woocommerce/state/ui/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/actions.js
@@ -24,7 +24,7 @@ export function generateProductCategoryId() {
  *
  * @param {Number} siteId The id of the site to which the category belongs.
  * @param {Object} [category] The most recent version of the category object, or null if new.
- * @param {Object} data An object containing the properties to be edited for the object.
+ * @param {Object} data An object containing the properties to be edited for the object, if null, the category will be removed.
  * @return {Object} The action object.
  */
 export function editProductCategory( siteId, category, data ) {

--- a/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { compact } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
@@ -30,13 +35,15 @@ function editProductCategory( array, category, data ) {
 	let found = false;
 
 	// Look for this object in the appropriate create or edit array first.
-	const newArray = prevArray.map( ( c ) => {
+	const newArray = compact( prevArray.map( ( c ) => {
 		if ( category.id === c.id ) {
 			found = true;
-			return { ...c, ...data };
+
+			// If data is null, remove this edit, otherwise update the edit data.
+			return ( data ? { ...c, ...data } : undefined );
 		}
 		return c;
-	} );
+	} ) );
 
 	if ( ! found ) {
 		// update or create not already in edit state, so add it now.

--- a/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
@@ -100,6 +100,28 @@ describe( 'edits-reducer', () => {
 		expect( edits2.creates[ 1 ].slug ).to.eql( 'second-category' );
 	} );
 
+	it( 'should remove a "create"', () => {
+		const newCategory = {
+			name: 'New Category',
+			slug: 'first-category',
+		};
+		const edits1 = reducer( undefined, editProductCategory( siteId, null, newCategory ) );
+		const edits2 = reducer( edits1, editProductCategory( siteId, edits1.creates[ 0 ], null ) );
+
+		expect( edits1.creates[ 0 ].name ).to.eql( 'New Category' );
+		expect( edits2.creates[ 0 ] ).to.not.exist;
+	} );
+
+	it( 'should remove an "update"', () => {
+		const category = { id: 101 };
+		const categoryUpdate = { name: 'After first edit' };
+		const edits1 = reducer( undefined, editProductCategory( siteId, category, categoryUpdate ) );
+		const edits2 = reducer( edits1, editProductCategory( siteId, edits1.updates[ 0 ], null ) );
+
+		expect( edits1.updates[ 0 ].name ).to.eql( 'After first edit' );
+		expect( edits2.updates[ 0 ] ).to.not.exist;
+	} );
+
 	it( 'should set currentlyEditingId when editing a new category', () => {
 		const edits1 = reducer( undefined, editProductCategory( siteId, null, {
 			name: 'First Category',

--- a/client/extensions/woocommerce/state/ui/products/actions.js
+++ b/client/extensions/woocommerce/state/ui/products/actions.js
@@ -26,6 +26,18 @@ export function editProductAttribute( siteId, product, attribute, data ) {
 	};
 }
 
+export function editProductAddCategory( siteId, product, categoryId ) {
+	const categories = [ ...product.categories, { id: categoryId } ];
+
+	return editProduct( siteId, product, { categories } );
+}
+
+export function editProductRemoveCategory( siteId, product, categoryId ) {
+	const categories = product.categories.filter( ( c ) => categoryId !== c.id );
+
+	return editProduct( siteId, product, { categories } );
+}
+
 /**
  * Creates an action list to save product-related edits.
  *


### PR DESCRIPTION
*Note: the first commit of this PR is just formatting, to see the changes without formatting, visit the [second commit](https://github.com/Automattic/wp-calypso/commit/2d33ce67f9efa3cddf33b84d5af52035ff13668d) which is only 160 lines*

This adds a data-layer handler which removes not-yet-created categories
from product edits when creates are removed.

To test: `npm test`