### PR TITLE
Woo: Product Categories: Generate placeholder IDs

### DIFF
--- a/client/extensions/woocommerce/state/ui/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { uniqueId } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import {
@@ -6,10 +11,19 @@ import {
 } from 'woocommerce/state/action-types';
 
 /**
+ * Generates a new product category placeholder ID
+ * This is used for new creates.
+ * @return {String} A new unique ID.
+ */
+export function generateProductCategoryId() {
+	return uniqueId( 'productCategory_' );
+}
+
+/**
  * Action creator: Edit a product category
  *
  * @param {Number} siteId The id of the site to which the category belongs.
- * @param {Object} category The unedited version of the category object.
+ * @param {Object} [category] The most recent version of the category object, or null if new.
  * @param {Object} data An object containing the properties to be edited for the object.
  * @return {Object} The action object.
  */
@@ -17,7 +31,7 @@ export function editProductCategory( siteId, category, data ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_CATEGORY_EDIT,
 		siteId,
-		category,
+		category: category || { id: { placeholder: generateProductCategoryId() } },
 		data,
 	};
 }

--- a/client/extensions/woocommerce/state/ui/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/actions.js
@@ -13,10 +13,10 @@ import {
 /**
  * Generates a new product category placeholder ID
  * This is used for new creates.
- * @return {String} A new unique ID.
+ * @return {Object} A new unique placeholder ID.
  */
 export function generateProductCategoryId() {
-	return uniqueId( 'productCategory_' );
+	return { placeholder: uniqueId( 'productCategory_' ) };
 }
 
 /**
@@ -31,7 +31,7 @@ export function editProductCategory( siteId, category, data ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_CATEGORY_EDIT,
 		siteId,
-		category: category || { id: { placeholder: generateProductCategoryId() } },
+		category: category || { id: generateProductCategoryId() },
 		data,
 	};
 }

--- a/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
@@ -5,7 +5,7 @@ import { createReducer } from 'state/utils';
 import {
 	WOOCOMMERCE_PRODUCT_CATEGORY_EDIT,
 } from 'woocommerce/state/action-types';
-import { getBucket, nextBucketIndex } from '../helpers';
+import { getBucket } from '../helpers';
 
 export default createReducer( null, {
 	[ WOOCOMMERCE_PRODUCT_CATEGORY_EDIT ]: editProductCategoryAction,
@@ -15,13 +15,12 @@ function editProductCategoryAction( edits, action ) {
 	const { category, data } = action;
 	const prevEdits = edits || {};
 	const bucket = getBucket( category );
-	const categoryWithId = category || { id: nextBucketIndex( prevEdits[ bucket ] ) };
-	const newArray = editProductCategory( prevEdits[ bucket ], categoryWithId, data );
+	const newArray = editProductCategory( prevEdits[ bucket ], category, data );
 
 	return {
 		...prevEdits,
 		[ bucket ]: newArray,
-		currentlyEditingId: categoryWithId.id,
+		currentlyEditingId: category.id,
 	};
 }
 

--- a/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { isObject, isString } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,7 +21,7 @@ describe( 'actions', () => {
 			const id2 = generateProductCategoryId();
 			const id3 = generateProductCategoryId();
 
-			expect( typeof id1 ).to.equal( 'string' );
+			expect( isObject( id1 ) ).to.be.true;
 			expect( id1 ).to.not.equal( id2 );
 			expect( id1 ).to.not.equal( id3 );
 			expect( id2 ).to.not.equal( id3 );
@@ -32,8 +33,8 @@ describe( 'actions', () => {
 			const action = editProductCategory( siteId, null, { name: 'Cat 1' } );
 
 			expect( action.category ).to.exist;
-			expect( typeof action.category.id ).to.equal( 'object' );
-			expect( typeof action.category.id.placeholder ).to.equal( 'string' );
+			expect( isObject( action.category.id ) ).to.be.true;
+			expect( isString( action.category.id.placeholder ) ).to.be.true;
 		} );
 
 		it( 'should not create a placeholder if category is passed in', () => {

--- a/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/actions.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	generateProductCategoryId,
+	editProductCategory,
+} from '../actions';
+
+const siteId = 123;
+
+describe( 'actions', () => {
+	describe( '#generateProductCategoryId', () => {
+		it( 'should generate a unique string id each time.', () => {
+			const id1 = generateProductCategoryId();
+			const id2 = generateProductCategoryId();
+			const id3 = generateProductCategoryId();
+
+			expect( typeof id1 ).to.equal( 'string' );
+			expect( id1 ).to.not.equal( id2 );
+			expect( id1 ).to.not.equal( id3 );
+			expect( id2 ).to.not.equal( id3 );
+		} );
+	} );
+
+	describe( '#editProductCategory', () => {
+		it( 'should create a placeholder id if category is not passed in', () => {
+			const action = editProductCategory( siteId, null, { name: 'Cat 1' } );
+
+			expect( action.category ).to.exist;
+			expect( typeof action.category.id ).to.equal( 'object' );
+			expect( typeof action.category.id.placeholder ).to.equal( 'string' );
+		} );
+
+		it( 'should not create a placeholder if category is passed in', () => {
+			const category = { id: 101, name: 'Cat 1' };
+			const action = editProductCategory( siteId, category, { name: 'Updated Cat 1' } );
+
+			expect( action.category ).to.equal( category );
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
@@ -65,7 +65,8 @@ describe( 'edits-reducer', () => {
 	} );
 
 	it( 'should create "creates" on first edit', () => {
-		const edits = reducer( undefined, editProductCategory( siteId, null, {
+		const id1 = { placeholder: 'productCategory_1' };
+		const edits = reducer( undefined, editProductCategory( siteId, { id: id1 }, {
 			name: 'New Category',
 			slug: 'new-category',
 		} ) );
@@ -73,26 +74,28 @@ describe( 'edits-reducer', () => {
 		expect( edits ).to.not.equal( null );
 		expect( edits.creates ).to.exist;
 		expect( edits.creates[ 0 ] ).to.exist;
-		expect( edits.creates[ 0 ].id ).to.eql( { index: 0 } );
+		expect( edits.creates[ 0 ].id ).to.eql( id1 );
 		expect( edits.creates[ 0 ].name ).to.eql( 'New Category' );
 		expect( edits.creates[ 0 ].slug ).to.eql( 'new-category' );
 	} );
 
 	it( 'should create more than one category', () => {
-		const edits1 = reducer( undefined, editProductCategory( siteId, null, {
+		const id1 = { placeholder: 'productCategory_1' };
+		const edits1 = reducer( undefined, editProductCategory( siteId, { id: id1 }, {
 			name: 'First Category',
 			slug: 'first-category',
 		} ) );
 
-		const edits2 = reducer( edits1, editProductCategory( siteId, null, {
+		const id2 = { placeholder: 'productCategory_2' };
+		const edits2 = reducer( edits1, editProductCategory( siteId, { id: id2 }, {
 			name: 'Second Category',
 			slug: 'second-category',
 		} ) );
 
-		expect( edits2.creates[ 0 ].id ).to.eql( { index: 0 } );
+		expect( edits2.creates[ 0 ].id ).to.eql( id1 );
 		expect( edits2.creates[ 0 ].name ).to.eql( 'First Category' );
 		expect( edits2.creates[ 0 ].slug ).to.eql( 'first-category' );
-		expect( edits2.creates[ 1 ].id ).to.eql( { index: 1 } );
+		expect( edits2.creates[ 1 ].id ).to.eql( id2 );
 		expect( edits2.creates[ 1 ].name ).to.eql( 'Second Category' );
 		expect( edits2.creates[ 1 ].slug ).to.eql( 'second-category' );
 	} );


### PR DESCRIPTION
This changes the placeholder ids from the `{ index: 0 }` format to a
generated format: `{ placeholder: 'productCategory_1' }`

This is to allow for the removal of creates from the edit state and also
to facilitate more complex operations of adding a new category while
editing a product. See #15333

To Test: `npm test`