### PR TITLE
Jetpack Plugins: Fix bulk editing header styling logic

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -21,8 +21,8 @@ import BulkSelect from 'components/bulk-select';
 import Tooltip from 'components/tooltip';
 import analytics from 'lib/analytics';
 
-// Constants help determin if the action bar should be a dropdown
-const MAX_ACTIONBAR_HEIGHT = 50;
+// Constants help determine if the action bar should be a dropdown
+const MAX_ACTIONBAR_HEIGHT = 57;
 const MIN_ACTIONBAR_WIDTH = 600;
 
 export class PluginsListHeader extends PureComponent {
@@ -74,7 +74,6 @@ export class PluginsListHeader extends PureComponent {
 		if ( actionBarDomElement.offsetWidth < MIN_ACTIONBAR_WIDTH ) {
 			return;
 		}
-		this.setState( { actionBarVisible: true } );
 		setTimeout( () => {
 			const actionBarVisible = actionBarDomElement.offsetHeight <= MAX_ACTIONBAR_HEIGHT;
 			this.setState( { actionBarVisible } );


### PR DESCRIPTION
Modify the logic to prevent falling back to a dropdown selector at "desktop" widths.

* Avoid flickering for fallback by not setting the the action bar to be visible before then maybe setting it invisible
* Increase the `MAX_ACTIONBAR_HEIGHT` constant by 7 pixels

This is a suboptimal solution as branching off an element height is pretty fragile (as witnessed by the breakage here).

This layout decision should be either tied to some global state or handled entirely by CSS breakpoints.

I'm happy to close this if either of the above is easily implemented.

However, this...
fixes #15309