### PR TITLE
Woo: Allow new product categories in product form.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -14,13 +14,14 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { successNotice, errorNotice } from 'state/notices/actions';
 
 import { editProduct, editProductAttribute, createProductActionList } from 'woocommerce/state/ui/products/actions';
+import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
 import { actionListStepNext } from 'woocommerce/state/action-list/actions';
 import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
 import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
-import { getProductCategories } from 'woocommerce/state/sites/product-categories/selectors';
+import { getProductCategoriesWithLocalEdits } from 'woocommerce/state/ui/product-categories/selectors';
 import { createProduct } from 'woocommerce/state/sites/products/actions';
 import ProductForm from './product-form';
 import ProductHeader from './product-header';
@@ -35,7 +36,9 @@ class ProductCreate extends React.Component {
 		} ),
 		fetchProductCategories: PropTypes.func.isRequired,
 		editProduct: PropTypes.func.isRequired,
+		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
+		editProductVariation: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {
@@ -115,6 +118,7 @@ class ProductCreate extends React.Component {
 					variations={ variations }
 					productCategories={ productCategories }
 					editProduct={ this.props.editProduct }
+					editProductCategory={ this.props.editProductCategory }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
 				/>
@@ -127,7 +131,7 @@ function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const product = getCurrentlyEditingProduct( state, siteId );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id, siteId );
-	const productCategories = getProductCategories( state, siteId );
+	const productCategories = getProductCategoriesWithLocalEdits( state, siteId );
 	const actionList = getActionList( state );
 
 	return {
@@ -146,6 +150,7 @@ function mapDispatchToProps( dispatch ) {
 			createProduct,
 			createProductActionList,
 			editProduct,
+			editProductCategory,
 			editProductAttribute,
 			editProductVariation,
 			fetchProductCategories,

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -14,24 +14,27 @@ import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import TokenField from 'components/token-field';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { generateProductCategoryId } from 'woocommerce/state/ui/product-categories/actions';
 
 // TODO Rename this card since it contains other controls, and may contain more in the future (like tax)
 const ProductFormCategoriesCard = (
-	{ siteId, product, productCategories, editProduct, translate }
+	{ siteId, product, productCategories, editProduct, editProductCategory, translate }
 ) => {
 	const handleChange = ( categoryNames ) => {
 		const newCategories = compact( categoryNames.map( ( name ) => {
 			const category = find( productCategories, { name: escape( name ) } );
 
 			if ( ! category ) {
-				// TODO: Add new product category to edit state.
-				// TODO: Remove 'compact' calls afterwards as they will no longer be needed.
-				return undefined;
+				// Add a new product category to the creates list.
+				const newCategoryId = generateProductCategoryId();
+				editProductCategory( siteId, { id: newCategoryId }, { name } );
+				return { id: newCategoryId };
 			}
 
 			return pick( category, 'id' );
 		} ) );
 
+		// Update the categories list.
 		const data = { id: product.id, categories: newCategories };
 		editProduct( siteId, product, data );
 	};

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -25,6 +25,7 @@ export default class ProductForm extends Component {
 		variations: PropTypes.array,
 		productCategories: PropTypes.array.isRequired,
 		editProduct: PropTypes.func.isRequired,
+		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
 	};
@@ -42,7 +43,7 @@ export default class ProductForm extends Component {
 
 	render() {
 		const { siteId, product, productCategories, variations } = this.props;
-		const { editProduct, editProductVariation, editProductAttribute } = this.props;
+		const { editProduct, editProductCategory, editProductVariation, editProductAttribute } = this.props;
 
 		if ( ! siteId ) {
 			return this.renderPlaceholder();
@@ -66,12 +67,14 @@ export default class ProductForm extends Component {
 					product={ product }
 					productCategories={ productCategories }
 					editProduct={ editProduct }
+					editProductCategory={ editProductCategory }
 				/>
 				<ProductFormVariationsCard
 					siteId={ siteId }
 					product={ product }
 					variations={ variations }
 					editProduct={ editProduct }
+					editProductCategory={ editProductCategory }
 					editProductAttribute={ editProductAttribute }
 					editProductVariation={ editProductVariation }
 				/>


### PR DESCRIPTION
This ties together the support needed to allow new product categories to
be created on the product form.

To test:

1. Run `npm test`
2. Run `npm start`
3. Visit `http://calypso.localhost:3000/store/product/<site url>`
4. Try adding a new product category that doesn't yet exist, hit comma, enter, etc.
5. New product category should be created in the list and selected for this product.
6. Click the "X" next to the new product category.
7. new product category should disappear from the selected line and the list below.
