### PR TITLE
Reader: Fix post results extending too far

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -13,10 +13,6 @@
 	margin-bottom: 0;
 }
 
-.is-reader-page .search-stream .reader-post-card.card {
-	width: 100%;
-}
-
 .is-reader-page .search-stream__fixed-area {
 	background-color: $white;
 	position: fixed;
@@ -149,7 +145,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // Post recommendations in Search
 .is-reader-page .search-stream .reader__content {
 	display: flex;
-	flex-flow: wrap;
+	flex-flow: row wrap;
 }
 
 .is-reader-page .search-stream__recommendation-list-item {
@@ -411,6 +407,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .search-stream__results.is-two-columns .reader__content,
 .search-stream .search-stream__single-column-results .reader__content {
 	display: inline;
+}
+
+.is-reader-page .search-stream .reader-post-card.card {
+	flex-basis: 100%; // Override the 50% flex-basis for post recommendations
 }
 
 .search-stream__results.is-two-columns .search-stream__post-results {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15318

**After:**

Chrome:
![screenshot 2017-06-20 20 22 35](https://user-images.githubusercontent.com/4924246/27365755-a378c41c-55f6-11e7-885c-194fe4c56056.png)

Safari:
![screenshot 2017-06-20 20 22 41](https://user-images.githubusercontent.com/4924246/27365760-a8de3810-55f6-11e7-9259-baf57abadd93.png)

FF:
![screenshot 2017-06-20 21 23 43](https://user-images.githubusercontent.com/4924246/27366999-c12500d6-55fe-11e7-82f1-b713b26e14b8.png)

IE:
![screenshot 2017-06-20 20 25 24](https://user-images.githubusercontent.com/4924246/27365764-b0ed06da-55f6-11e7-851c-3c8b3b376b7b.png)
