### PR TITLE
Ensure Emojify saves props set by AutoDirection

### DIFF
--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -164,7 +164,7 @@ const setChildDirection = ( child ) => {
 	const childDirection = getChildDirection( child );
 
 	if ( childDirection ) {
-		return React.cloneElement( child, getDirectionProps( childDirection ) );
+		return React.cloneElement( child, getDirectionProps( child, childDirection ) );
 	}
 
 	if ( child && child.props.children ) {

--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -10,6 +10,7 @@ import get from 'lodash/get';
 import userModule from 'lib/user';
 import { stripHTML } from 'lib/formatting';
 import { isRTLCharacter, isLTRCharacter } from './direction';
+import Emojify from 'components/emojify';
 
 const user = userModule();
 
@@ -150,7 +151,7 @@ const getChildDirection = child => {
 	return null;
 };
 
-const inlineClasses = [ 'emojify' ];
+const inlineComponents = [ Emojify ];
 /***
  * Sets a react component child directionality according to it's text content
  * That function intended to be used recursively with React.Children.map
@@ -178,7 +179,7 @@ const setChildDirection = ( child ) => {
 				return innerChild;
 			}
 
-			if ( inlineClasses.some( inlineClass => innerChild.props.className.indexOf( inlineClass ) > -1 ) ) {
+			if ( inlineComponents.some( inlineComponent => innerChild.type === inlineComponent ) ) {
 				innerChildDirection = getChildDirection( innerChild );
 				return innerChild;
 			}

--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -174,6 +174,10 @@ const setChildDirection = ( child ) => {
 				return innerChild;
 			}
 
+			if ( typeof innerChild === 'string' ) {
+				return innerChild;
+			}
+
 			if ( inlineClasses.some( inlineClass => innerChild.props.className.indexOf( inlineClass ) > -1 ) ) {
 				innerChildDirection = getChildDirection( innerChild );
 				return innerChild;

--- a/client/components/auto-direction/test/auto-direction.jsx
+++ b/client/components/auto-direction/test/auto-direction.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import Emojify from 'components/emojify';
+
+describe( 'AutoDirection', function() {
+	useFakeDom();
+	let AutoDirection;
+
+	context( 'component rendering', () => {
+		before( () => {
+			AutoDirection = require( '..' );
+		} );
+
+		it( 'adds a direction to RTL text', () => {
+			const wrapper = shallow(
+				<AutoDirection><div>השנה היא 2017.</div></AutoDirection>
+			);
+
+			expect( wrapper.node.props.direction ).to.equal( 'rtl' );
+		} );
+
+		it( "doesn't add a direction to LTR text", () => {
+			const wrapper = shallow(
+				<AutoDirection><div>The year is 2017.</div></AutoDirection>
+			);
+
+			expect( wrapper.node.props ).to.not.have.property( 'direction' );
+		} );
+
+		it( "doesn't add a direction to RTL text without a container", () => {
+			const wrapper = shallow(
+				<AutoDirection>השנה היא 2017.</AutoDirection>
+			);
+
+			expect( wrapper.html() ).to.be( 'השנה היא 2017.' );
+		} );
+
+		it( 'adds a direction to the parent of an inline component', () => {
+			const wrapper = shallow(
+				<AutoDirection><div><Emojify>השנה היא 2017.</Emojify></div></AutoDirection>
+			);
+
+			expect( wrapper.node.props.direction ).to.equal( 'rtl' );
+
+			// Things get weird when mounting a stateless component, so just check for the HTML, instead.
+			expect( wrapper.html() ).to.include( '<div class="emojify">השנה היא 2017.</div>' );
+		} );
+	} );
+} );

--- a/client/components/auto-direction/test/auto-direction.jsx
+++ b/client/components/auto-direction/test/auto-direction.jsx
@@ -36,14 +36,6 @@ describe( 'AutoDirection', function() {
 			expect( wrapper.node.props ).to.not.have.property( 'direction' );
 		} );
 
-		it( "doesn't add a direction to RTL text without a container", () => {
-			const wrapper = shallow(
-				<AutoDirection>השנה היא 2017.</AutoDirection>
-			);
-
-			expect( wrapper.html() ).to.be( 'השנה היא 2017.' );
-		} );
-
 		it( 'adds a direction to the parent of an inline component', () => {
 			const wrapper = shallow(
 				<AutoDirection><div><Emojify>השנה היא 2017.</Emojify></div></AutoDirection>

--- a/client/components/emojify/README.md
+++ b/client/components/emojify/README.md
@@ -13,7 +13,7 @@ var Emojify = require( 'components/emojify' ),
 
 	// more component stuff
 	// ...
-	render( <div><p>This text will be unaffected</p><Emojify size="72">{ textToEmojify }</Emojify></div> );
+	render( <div><p>This text will be unaffected</p><Emojify>{ textToEmojify }</Emojify></div> );
 
 ```
 
@@ -29,7 +29,7 @@ var Emojify = require( 'components/emojify' ),
 
 Typically a string that you want to search for UTF emoji
 
-### `className`
+### `imgClassName`
 
 <table>
 	<tr><th>Type</th><td>String</td></tr>

--- a/client/components/emojify/docs/example.jsx
+++ b/client/components/emojify/docs/example.jsx
@@ -12,7 +12,7 @@ const EmojifyExample = () => {
 	const textToEmojify = 'This 🙈 will be converted 🙉🙊🙂';
 
 	return (
-		<div className="design-assets__group">
+		<div imgClassName="design-assets__group">
 			<Emojify>{ textToEmojify }</Emojify>
 		</div>
 	);

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -47,8 +47,14 @@ export default class Emojify extends PureComponent {
 	}
 
 	render() {
+		const {
+			children,
+			className, // eslint-disable-line no-unused-vars
+			...other
+		} = this.props;
+
 		return (
-			<div className="emojify" ref="emojified">{ this.props.children }</div>
+			<div className="emojify" ref="emojified" { ...other }>{ children }</div>
 		);
 	}
 }

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PureComponent, PropTypes } from 'react';
-import classNames from 'classNames';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -2,6 +2,11 @@
  * External dependencies
  */
 import React, { PureComponent, PropTypes } from 'react';
+import classNames from 'classNames';
+
+/**
+ * Internal dependencies
+ */
 import twemoji from 'twemoji';
 import config from 'config';
 
@@ -12,11 +17,11 @@ export default class Emojify extends PureComponent {
 			PropTypes.object.isRequired,
 			PropTypes.string.isRequired,
 		] ),
-		className: PropTypes.string
+		imgClassName: PropTypes.string
 	}
 
 	static defaultProps = {
-		className: 'emojify__emoji'
+		imgClassName: 'emojify__emoji'
 	}
 
 	componentDidMount() {
@@ -28,12 +33,12 @@ export default class Emojify extends PureComponent {
 	}
 
 	parseEmoji = () => {
-		const { className } = this.props;
+		const { imgClassName } = this.props;
 
 		twemoji.parse( this.refs.emojified, {
 			base: config( 'twemoji_cdn_url' ),
 			size: '72x72',
-			className: className,
+			className: imgClassName,
 			callback: function( icon, options ) {
 				const ignored = [ 'a9', 'ae', '2122', '2194', '2660', '2663', '2665', '2666' ];
 
@@ -49,12 +54,15 @@ export default class Emojify extends PureComponent {
 	render() {
 		const {
 			children,
-			className, // eslint-disable-line no-unused-vars
+			className,
+			imgClassName, // eslint-disable-line no-unused-vars
 			...other
 		} = this.props;
 
+		const classes = classNames( className, 'emojify' );
+
 		return (
-			<div className="emojify" ref="emojified" { ...other }>{ children }</div>
+			<div className={ classes } ref="emojified" { ...other }>{ children }</div>
 		);
 	}
 }

--- a/client/components/emojify/test/emojify.jsx
+++ b/client/components/emojify/test/emojify.jsx
@@ -58,5 +58,14 @@ describe( 'Emojify', function() {
 				'src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/72x72/1f9d4-1f3fb.png"></p></div>'
 			);
 		} );
+
+		it( 'maintains AutoDirection properties', () => {
+			const AutoDirection = require( 'components/auto-direction' );
+
+			const wrapper = shallow(
+				<AutoDirection><Emojify>השנה היא 2017.</Emojify></AutoDirection>
+			);
+			expect( wrapper.node.props.direction ).to.equal( 'rtl' );
+		} );
 	} );
 } );

--- a/client/components/emojify/test/emojify.jsx
+++ b/client/components/emojify/test/emojify.jsx
@@ -59,13 +59,11 @@ describe( 'Emojify', function() {
 			);
 		} );
 
-		it( 'maintains AutoDirection properties', () => {
-			const AutoDirection = require( 'components/auto-direction' );
-
+		it( 'maintains custom props', () => {
 			const wrapper = shallow(
-				<AutoDirection><Emojify>השנה היא 2017.</Emojify></AutoDirection>
+				<Emojify alt="bar">השנה היא 2017.</Emojify>
 			);
-			expect( wrapper.node.props.direction ).to.equal( 'rtl' );
+			expect( wrapper.node.props.alt ).to.equal( 'bar' );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request fixes #15336 by saving the props that `AutoDirection` sets on `Emojify`, when `Emojify` re-renders.

#### Testing instructions

1. Run `git checkout fix/15336-emojify-autodirection` and start your server, or open a [live branch](https://calypso.live/?branch=fix/15336-emojify-autodirection).
2. Log in as an LTR user.
3. Create a post with RTL characters in to the title in a blog that you follow.
4. Open the [`Home` page](http://calypso.localhost:3000/)
5. Check that the title is correctly aligned.

#### Reviews

- [ ] Code
- [ ] Tests