### PR TITLE
My Sites: Async load parts of sidebar

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -200,7 +200,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		} );
 	}
 
-	require( 'my-sites' )();
+	require( 'my-sites/controller' );
 
 	if ( config.isEnabled( 'olark' ) ) {
 		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -200,7 +200,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		} );
 	}
 
-	require( 'my-sites/controller' );
+	require( 'my-sites' )();
 
 	if ( config.isEnabled( 'olark' ) ) {
 		asyncRequire( 'lib/olark', olark => olark.initialize( reduxStore.dispatch ) );

--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -36,3 +36,12 @@ In general usage, this should be passed as a string of the module to be imported
 </table>
 
 A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown.
+
+### `noPlaceholder`
+
+<table>
+	<tr><td>Type</td><td>PropTypes.bool</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+A flag indicating if a placeholder should be hidden while the module is being asynchronously required. If omitted, the placeholder will be shown.

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -6,8 +6,13 @@ import { omit } from 'lodash';
 
 export default class AsyncLoad extends Component {
 	static propTypes = {
+		noPlaceholder: PropTypes.bool,
+		placeholder: PropTypes.node,
 		require: PropTypes.func.isRequired,
-		placeholder: PropTypes.node
+	};
+
+	static defaultProps = {
+		noPlaceholder: false,
 	};
 
 	constructor() {
@@ -48,8 +53,12 @@ export default class AsyncLoad extends Component {
 
 	render() {
 		if ( this.state.component ) {
-			const props = omit( this.props, [ 'require', 'placeholder' ] );
+			const props = omit( this.props, [ 'noPlaceholder', 'placeholder', 'require' ] );
 			return <this.state.component { ...props } />;
+		}
+
+		if ( this.props.noPlaceholder ) {
+			return null;
 		}
 
 		if ( this.props.placeholder ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -15,11 +15,9 @@ import userFactory from 'lib/user';
 import { receiveSite, requestSites } from 'state/sites/actions';
 import {
 	getSite,
-	isJetpackModuleActive,
-	isJetpackSite,
 	isRequestingSites,
 } from 'state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import {
 	setSelectedSiteId,
 	setSection,
@@ -58,7 +56,6 @@ import {
 	domainManagementTransferToAnotherUser
 } from 'my-sites/upgrades/paths';
 import SitesComponent from 'my-sites/sites';
-import { isATEnabled } from 'lib/automated-transfer';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -369,28 +366,6 @@ module.exports = {
 		next();
 	},
 
-	jetpackModuleActive( moduleId, redirect ) {
-		return function( context, next ) {
-			const { getState } = getStore( context );
-			const siteId = getSelectedSiteId( getState() );
-			const isJetpack = isJetpackSite( getState(), siteId );
-			const isModuleActive = isJetpackModuleActive(
-					getState(),
-					siteId,
-					moduleId );
-
-			if ( ! isJetpack ) {
-				return next();
-			}
-
-			if ( isModuleActive || false === redirect ) {
-				next();
-			} else {
-				page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
-			}
-		};
-	},
-
 	makeNavigation: function( context, next ) {
 		context.secondary = createNavigation( context );
 		next();
@@ -404,29 +379,6 @@ module.exports = {
 			context.store
 		);
 		next();
-	},
-
-	jetPackWarning( context, next ) {
-		const { getState } = getStore( context );
-		const Main = require( 'components/main' );
-		const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
-		const basePath = route.sectionify( context.path );
-		const selectedSite = getSelectedSite( getState() );
-
-		if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
-			renderWithReduxStore( (
-				<Main>
-					<JetpackManageErrorPage
-						template="noDomainsOnJetpack"
-						siteId={ selectedSite.ID }
-					/>
-				</Main>
-			), document.getElementById( 'primary' ), context.store );
-
-			analytics.pageView.record( basePath, '> No Domains On Jetpack' );
-		} else {
-			next();
-		}
 	},
 
 	sites( context ) {

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
+import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import QuerySiteDomains from 'components/data/query-site-domains';
+
+const CurrentSiteDomainWarnings = ( { domains, isJetpack, selectedSiteId, selectedSite } ) => {
+	if ( ! selectedSiteId || isJetpack ) {
+		return null;
+	}
+
+	if ( ! domains.length ) {
+		return <QuerySiteDomains siteId={ selectedSiteId } />;
+	}
+
+	return (
+		<DomainWarnings
+			isCompact
+			selectedSite={ selectedSite }
+			domains={ domains }
+			ruleWhiteList={ [
+				'unverifiedDomainsCanManage',
+				'unverifiedDomainsCannotManage',
+				'expiredDomainsCanManage',
+				'expiringDomainsCanManage',
+				'expiredDomainsCannotManage',
+				'expiringDomainsCannotManage',
+				'wrongNSMappedDomains',
+				'pendingGappsTosAcceptanceDomains',
+			] }
+		/>
+	);
+};
+
+CurrentSiteDomainWarnings.propTypes = {
+	domains: PropTypes.array,
+	isJetpack: PropTypes.bool,
+	selectedSite: PropTypes.object,
+	selectedSiteId: PropTypes.number,
+};
+
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			domains: getDecoratedSiteDomains( state, selectedSiteId ),
+			isJetpack: isJetpackSite( state, selectedSiteId ),
+			selectedSite: getSelectedSite( state ),
+			selectedSiteId,
+		};
+	}
+)( CurrentSiteDomainWarnings );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -10,63 +10,29 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-const AllSites = require( 'my-sites/all-sites' ),
-	analytics = require( 'lib/analytics' ),
-	Button = require( 'components/button' ),
-	Card = require( 'components/card' ),
-	Site = require( 'blocks/site' ),
-	Gridicon = require( 'gridicons' ),
-	UpgradesActions = require( 'lib/upgrades/actions' ),
-	DomainsStore = require( 'lib/domains/store' ),
-	DomainWarnings = require( 'my-sites/upgrades/components/domain-warnings' );
-
+import AllSites from 'my-sites/all-sites';
+import analytics from 'lib/analytics';
+import AsyncLoad from 'components/async-load';
+import Button from 'components/button';
+import Card from 'components/card';
 import config from 'config';
-import SiteNotice from './notice';
-import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedOrAllSites } from 'state/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+import Gridicon from 'gridicons';
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import Site from 'blocks/site';
+import SiteNotice from './notice';
 
 class CurrentSite extends Component {
 	static propTypes = {
-		isJetpack: React.PropTypes.bool,
 		isPreviewShowing: React.PropTypes.bool,
 		siteCount: React.PropTypes.number.isRequired,
 		setLayoutFocus: React.PropTypes.func.isRequired,
-		selectedSiteId: React.PropTypes.number,
 		selectedSite: React.PropTypes.object,
 		translate: React.PropTypes.func.isRequired,
 		anySiteSelected: React.PropTypes.array
 	};
-
-	state = {
-		domainsStore: DomainsStore
-	};
-
-	componentWillMount() {
-		const { selectedSiteId, isJetpack } = this.props;
-		if ( selectedSiteId && ! isJetpack ) {
-			UpgradesActions.fetchDomains( selectedSiteId );
-		}
-
-		DomainsStore.on( 'change', this.handleStoreChange );
-	}
-
-	componentWillUnmount() {
-		DomainsStore.off( 'change', this.handleStoreChange );
-	}
-
-	componentDidUpdate( prevProps ) {
-		const { selectedSiteId, isJetpack } = this.props;
-		if ( selectedSiteId && ! isJetpack && selectedSiteId !== prevProps.selectedSiteId ) {
-			UpgradesActions.fetchDomains( selectedSiteId );
-		}
-	}
-
-	handleStoreChange = () => {
-		this.setState( { domainsStore: DomainsStore } );
-	}
 
 	switchSites = ( event ) => {
 		event.preventDefault();
@@ -74,36 +40,7 @@ class CurrentSite extends Component {
 		this.props.setLayoutFocus( 'sites' );
 
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
-	}
-
-	getDomainWarnings() {
-		const { selectedSiteId, selectedSite: site } = this.props;
-
-		if ( ! selectedSiteId ) {
-			return null;
-		}
-
-		const domainStore = this.state.domainsStore.getBySite( selectedSiteId );
-		const domains = domainStore && domainStore.list || [];
-
-		return (
-			<DomainWarnings
-				isCompact
-				selectedSite={ site }
-				domains={ domains }
-				ruleWhiteList={ [
-					'unverifiedDomainsCanManage',
-					'unverifiedDomainsCannotManage',
-					'expiredDomainsCanManage',
-					'expiringDomainsCanManage',
-					'expiredDomainsCannotManage',
-					'expiringDomainsCannotManage',
-					'wrongNSMappedDomains',
-					'pendingGappsTosAcceptanceDomains'
-				] }
-			/>
-		);
-	}
+	};
 
 	previewSite = ( event ) => this.props.onClick && this.props.onClick( event );
 
@@ -145,7 +82,7 @@ class CurrentSite extends Component {
 	}
 
 	render() {
-		const { isJetpack, selectedSite, translate, anySiteSelected } = this.props;
+		const { selectedSite, translate, anySiteSelected } = this.props;
 
 		if ( ! anySiteSelected.length ) {
 			return (
@@ -182,7 +119,8 @@ class CurrentSite extends Component {
 					</div>
 					: <AllSites />
 				}
-				{ ! isJetpack && this.getDomainWarnings() }
+				<AsyncLoad require="my-sites/current-site/domain-warnings"
+					noPlaceholder={ true } />
 				<SiteNotice site={ selectedSite } allSitesPath={ this.props.allSitesPath } />
 			</Card>
 		);
@@ -191,12 +129,9 @@ class CurrentSite extends Component {
 
 export default connect(
 	( state ) => {
-		const selectedSiteId = getSelectedSiteId( state );
 		const user = getCurrentUser( state );
 
 		return {
-			isJetpack: isJetpackSite( state, selectedSiteId ),
-			selectedSiteId,
 			selectedSite: getSelectedSite( state ),
 			anySiteSelected: getSelectedOrAllSites( state ),
 			siteCount: get( user, 'visible_site_count', 0 ),

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -8,6 +8,11 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import {
+	isJetpackModuleActive,
+	isJetpackSite,
+} from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import notices from 'notices';
 import { pageView } from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
@@ -74,4 +79,26 @@ export const buttons = ( context, next ) => {
 	context.contentComponent = createElement( SharingButtons );
 
 	next();
+};
+
+export const jetpackModuleActive = ( moduleId, redirect ) => {
+	return function( context, next ) {
+		const state = context.store.getState();
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isModuleActive = isJetpackModuleActive(
+			state,
+			siteId,
+			moduleId );
+
+		if ( ! isJetpack ) {
+			return next();
+		}
+
+		if ( isModuleActive || false === redirect ) {
+			next();
+		} else {
+			page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
+		}
+	};
 };

--- a/client/my-sites/sharing/index.js
+++ b/client/my-sites/sharing/index.js
@@ -6,8 +6,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { jetpackModuleActive, navigation, sites, siteSelection } from 'my-sites/controller';
-import { buttons, connections, layout } from './controller';
+import { navigation, sites, siteSelection } from 'my-sites/controller';
+import { jetpackModuleActive, buttons, connections, layout } from './controller';
 
 export default function() {
 	page( /^\/sharing(\/buttons)?$/, siteSelection, sites );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -26,6 +26,7 @@ import {
 	getSelectedSiteSlug
 } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { isATEnabled } from 'lib/automated-transfer';
 
 /**
  * Module variables
@@ -279,6 +280,27 @@ module.exports = {
 		);
 
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	},
+
+	jetPackWarning( context, next ) {
+		const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
+		const basePath = route.sectionify( context.path );
+		const selectedSite = getSelectedSite( context.store.getState() );
+
+		if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
+			renderWithReduxStore( (
+				<Main>
+					<JetpackManageErrorPage
+						template="noDomainsOnJetpack"
+						siteId={ selectedSite.ID }
+					/>
+				</Main>
+			), document.getElementById( 'primary' ), context.store );
+
+			analytics.pageView.record( basePath, '> No Domains On Jetpack' );
+		} else {
+			next();
+		}
 	},
 
 	redirectIfNoSite: function( redirectTo ) {

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -28,7 +28,7 @@ function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJ
 	}
 
 	if ( warnIfJetpack ) {
-		handlers.push( controller.jetPackWarning );
+		handlers.push( upgradesController.jetPackWarning );
 	}
 
 	return handlers;
@@ -161,7 +161,7 @@ module.exports = function() {
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
 			upgradesController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			controller.sites
 		);
 
@@ -169,7 +169,7 @@ module.exports = function() {
 			'/domains/add/mapping',
 			controller.siteSelection,
 			upgradesController.domainsAddHeader,
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			controller.sites
 		);
 
@@ -177,7 +177,7 @@ module.exports = function() {
 			'/domains/add/site-redirect',
 			controller.siteSelection,
 			upgradesController.domainsAddRedirectHeader,
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			controller.sites
 		);
 
@@ -186,7 +186,7 @@ module.exports = function() {
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
 			upgradesController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.domainSearch
 		);
 
@@ -195,7 +195,7 @@ module.exports = function() {
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
 			upgradesController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.domainSearch
 		);
 
@@ -203,7 +203,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add' ),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.googleAppsWithRegistration
 		);
 
@@ -211,7 +211,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/mapping' ),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.mapDomain
 		);
 
@@ -219,7 +219,7 @@ module.exports = function() {
 			controller.siteSelection,
 			controller.navigation,
 			upgradesController.redirectIfNoSite( '/domains/add/site-redirect' ),
-			controller.jetPackWarning,
+			upgradesController.jetPackWarning,
 			upgradesController.siteRedirect
 		);
 	}
@@ -234,7 +234,7 @@ module.exports = function() {
 		'/domains/:site',
 		controller.siteSelection,
 		controller.navigation,
-		controller.jetPackWarning,
+		upgradesController.jetPackWarning,
 		domainManagementController.domainManagementIndex
 	);
 


### PR DESCRIPTION
It's another take on #14249. I picked only part of changes from that PR that don't have any influence on the Webpack memory consumption.

This PR changes the way we load `<DomainWarnings />` component. It is now loaded asynchronously.

I also added 2 more refactoring where I moved two Jetpack related middlewares to put them next to the code that consumes them.

Those 2 changes directly impact the size of the main build file. See over 30 kb differences in the size with those changes applied.

### Before
![screen shot 2017-06-21 at 09 43 43](https://user-images.githubusercontent.com/699132/27372826-24a188b6-5666-11e7-9da6-e09c830a3b9c.png)

### After
![screen shot 2017-06-21 at 09 38 04](https://user-images.githubusercontent.com/699132/27372666-a00d3d3e-5665-11e7-90f9-a29ac22d1b10.png)
![screen shot 2017-06-21 at 09 38 43](https://user-images.githubusercontent.com/699132/27372665-a00ca8c4-5665-11e7-8d54-d5234531f828.png)

### Testing
1. Open Calypso using calypso.live branch or http://calypso.localhost:3000/.
2. Click My Sites button in the masterbar.
3. Make sure it works as before.
4. Navigate to a few subpages and make sure they still work.
5. Navigate to http://calypso.localhost:3000/sharing.
6. Pick a site and make sure it still works.
7. Navigate to http://calypso.localhost:3000/domains/add.
8. Pick a site and make sure it loads properly.
9. Pick a Jetpack site and make sure you see the feature gate.
10. Run `npm build-docker` and make sure it succeeds.

This is how current site should look like with domain warnings enabled:

![screen shot 2017-05-16 at 14 20 53](https://cloud.githubusercontent.com/assets/699132/26105621/f4f93d8c-3a42-11e7-82ab-5fe265da9bf2.png)

Jetpack feature gate:
![screen shot 2017-06-21 at 09 19 36](https://user-images.githubusercontent.com/699132/27371888-d0a0fa6a-5662-11e7-9f6a-1b0186eb362f.png)


### Review

* [ ] Code
* [x] Product