### PR TITLE
Exclude VIP sites from being eligible for sidebar nudges.

### DIFF
--- a/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -5,6 +5,7 @@ import {
 	canCurrentUser,
 	isMappedDomainSite,
 	isSiteOnFreePlan,
+	isVipSite,
 } from 'state/selectors';
 
 /**
@@ -18,8 +19,9 @@ const isEligibleForDomainToPaidPlanUpsell = ( state, siteId ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
+	const siteIsVipSite = isVipSite( state, siteId );
 
-	return userCanManageOptions && siteHasMappedDomain && siteIsOnFreePlan;
+	return userCanManageOptions && siteHasMappedDomain && ! siteIsVipSite && siteIsOnFreePlan;
 };
 
 export default isEligibleForDomainToPaidPlanUpsell;

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -6,6 +6,7 @@ import {
 	isMappedDomainSite,
 	isSiteOnFreePlan,
 	isUserRegistrationDaysWithinRange,
+	isVipSite,
 } from 'state/selectors';
 
 /**
@@ -21,8 +22,9 @@ const isEligibleForFreeToPaidUpsell = ( state, siteId, moment ) => {
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const registrationDaysIsWithinRange = isUserRegistrationDaysWithinRange( state, moment, 0, 180 );
+	const siteIsVipSite = isVipSite( state, siteId );
 
-	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && registrationDaysIsWithinRange;
+	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && ! siteIsVipSite && registrationDaysIsWithinRange;
 };
 
 export default isEligibleForFreeToPaidUpsell;

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -16,16 +16,19 @@ describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 	let canCurrentUser;
 	let isMappedDomainSite;
 	let isSiteOnFreePlan;
+	let isVipSite;
 	let isEligibleForDomainToPaidPlanUpsell;
 
 	useMockery( mockery => {
 		canCurrentUser = stub();
 		isMappedDomainSite = stub();
 		isSiteOnFreePlan = stub();
+		isVipSite = stub();
 
 		mockery.registerMock( 'state/selectors/can-current-user', canCurrentUser );
 		mockery.registerMock( 'state/selectors/is-mapped-domain-site', isMappedDomainSite );
 		mockery.registerMock( 'state/selectors/is-site-on-free-plan', isSiteOnFreePlan );
+		mockery.registerMock( 'state/selectors/is-vip-site', isVipSite );
 	} );
 
 	before( () => {
@@ -36,6 +39,7 @@ describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( true );
 		isMappedDomainSite.withArgs( state, siteId ).returns( true );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
+		isVipSite.withArgs( state, siteId ).returns( false );
 	};
 
 	it( 'should return false when user can not manage options', () => {
@@ -53,6 +57,12 @@ describe( 'isEligibleForDomainToPaidPlanUpsell', () => {
 	it( 'should return false when site is not on a free plan', () => {
 		meetAllConditions();
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( false );
+		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).to.be.false;
+	} );
+
+	it( 'should return false when site is a vip site', () => {
+		meetAllConditions();
+		isVipSite.withArgs( state, siteId ).returns( true );
 		expect( isEligibleForDomainToPaidPlanUpsell( state, siteId ) ).to.be.false;
 	} );
 

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -18,6 +18,7 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 	let isMappedDomainSite;
 	let isSiteOnFreePlan;
 	let isUserRegistrationDaysWithinRange;
+	let isVipSite;
 	let isEligibleForFreeToPaidUpsell;
 
 	useMockery( mockery => {
@@ -25,11 +26,13 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		isMappedDomainSite = stub();
 		isSiteOnFreePlan = stub();
 		isUserRegistrationDaysWithinRange = stub();
+		isVipSite = stub();
 
 		mockery.registerMock( 'state/selectors/can-current-user', canCurrentUser );
 		mockery.registerMock( 'state/selectors/is-mapped-domain-site', isMappedDomainSite );
 		mockery.registerMock( 'state/selectors/is-site-on-free-plan', isSiteOnFreePlan );
 		mockery.registerMock( 'state/selectors/is-user-registration-days-within-range', isUserRegistrationDaysWithinRange );
+		mockery.registerMock( 'state/selectors/is-vip-site', isVipSite );
 	} );
 
 	before( () => {
@@ -41,6 +44,7 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
 		isUserRegistrationDaysWithinRange.withArgs( state, moment, 0, 180 ).returns( true );
+		isVipSite.withArgs( state, siteId ).returns( false );
 	};
 
 	it( 'should return false when user can not manage options', () => {
@@ -64,6 +68,12 @@ describe( 'isEligibleForFreeToPaidUpsell', () => {
 	it( 'should return false when user registration days is not within range', () => {
 		meetAllConditions();
 		isUserRegistrationDaysWithinRange.withArgs( state, moment, 0, 180 ).returns( false );
+		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
+	} );
+
+	it( 'should return false when site is a vip site', () => {
+		meetAllConditions();
+		isVipSite.withArgs( state, siteId ).returns( true );
 		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
 	} );
 


### PR DESCRIPTION
VIP sites should never have been eligible for the recently added sidebar upsell nudges.

This changes ensure that they will not be displayed.

To test, view a VIP site as an admin and verify that you do *not* see the following green sidebar 'Upgrade your site and save' upsell:

<img width="1003" alt="screen shot 2017-06-21 at 4 55 36 pm" src="https://user-images.githubusercontent.com/1926/27371066-8adae078-56a2-11e7-8e77-f0eb2f277cb3.png">
