### PR TITLE
Woo: Update local state upon product create

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -3,8 +3,10 @@
  */
 import { post } from 'woocommerce/state/data-layer/request/actions';
 import { setError } from 'woocommerce/state/sites/status/wc-api/actions';
+import { productUpdated } from 'woocommerce/state/sites/products/actions';
 import {
 	WOOCOMMERCE_PRODUCT_CREATE,
+	WOOCOMMERCE_PRODUCT_UPDATED,
 } from 'woocommerce/state/action-types';
 
 export function handleProductCreate( { dispatch }, action ) {
@@ -21,10 +23,18 @@ export function handleProductCreate( { dispatch }, action ) {
 		return;
 	}
 
-	dispatch( post( siteId, 'products', productData, successAction, failureAction ) );
+	const updatedAction = productUpdated( siteId, null, successAction ); // data field will be filled in by request.
+	dispatch( post( siteId, 'products', productData, updatedAction, failureAction ) );
+}
+
+export function handleProductUpdated( { dispatch }, action ) {
+	const { completionAction } = action;
+
+	completionAction && dispatch( completionAction );
 }
 
 export default {
 	[ WOOCOMMERCE_PRODUCT_CREATE ]: [ handleProductCreate ],
+	[ WOOCOMMERCE_PRODUCT_UPDATED ]: [ handleProductUpdated ],
 };
 

--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -7,8 +7,11 @@ import { spy, match } from 'sinon';
 /**
  * Internal dependencies
  */
-import { createProduct } from 'woocommerce/state/sites/products/actions';
-import { handleProductCreate } from '../';
+import { createProduct, productUpdated } from 'woocommerce/state/sites/products/actions';
+import {
+	handleProductCreate,
+	handleProductUpdated,
+} from '../';
 import {
 	WOOCOMMERCE_API_REQUEST,
 } from 'woocommerce/state/action-types';
@@ -32,11 +35,27 @@ describe( 'handlers', () => {
 					type: WOOCOMMERCE_API_REQUEST,
 					method: 'post',
 					siteId: 123,
-					onSuccessAction: successAction,
+					onSuccessAction: productUpdated( 123, null, successAction ),
 					onFailureAction: failureAction,
 					body: { name: 'Product #1', type: 'simple' },
 				} )
 			);
+		} );
+	} );
+
+	describe( '#handleProductUpdated', () => {
+		it( 'should dispatch a completion action', () => {
+			const store = {
+				dispatch: spy(),
+			};
+
+			const product1 = { id: 101, name: 'Newly Created Product', type: 'simple' };
+			const completionAction = { type: '%%complete%%' };
+			const action = productUpdated( 123, product1, completionAction );
+
+			handleProductUpdated( store, action );
+
+			expect( store.dispatch ).to.have.been.calledWith( completionAction );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -52,14 +52,16 @@ export function createProduct( siteId, product, successAction, failureAction ) {
  * This action prompts the state to update itself after a product has been updated.
  *
  * @param {Number} siteId The id of the site to which the product belongs.
- * @param {Object} product The complete product object with which to update the state.
+ * @param {Object} data The complete product object with which to update the state.
+ * @param {Object} [completionAction] An action that is dispatched after the update is complete.
  * @return {Object} Action object
  */
-export function productUpdated( siteId, product ) {
+export function productUpdated( siteId, data, completionAction ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_UPDATED,
 		siteId,
-		product,
+		data,
+		completionAction,
 	};
 }
 

--- a/client/extensions/woocommerce/state/sites/products/reducer.js
+++ b/client/extensions/woocommerce/state/sites/products/reducer.js
@@ -32,10 +32,10 @@ export default createReducer( {}, {
 } );
 
 function productUpdated( state, action ) {
-	const { product } = action;
+	const { data } = action;
 	const products = state.products || [];
 	return { ...state,
-		products: updateCachedProduct( products, product ),
+		products: updateCachedProduct( products, data ),
 	};
 }
 


### PR DESCRIPTION
This adds code that is compatible with action-list, etc, by extending
the product updated action with a completion action that can carry on a
success action that was given to the request. This ensures that every
time a product is successfully created, that it will be updated in the
local state.

To Test:
1. Run `npm test`
2. Run `npm start`
3. Visit `http://calypso.localhost:3000/store/product/<site_url>`
4. Type in a name for a product.
5. Click "Save".
6. Open Redux dev tools to inspect the state.
7. Look under `extensions.woocommerce.sites.<site_number>.products` to verify that the product has been added to state upon successful API call.
