### PR TITLE
Checkout: G Suite: the email field is required for G Suite

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -392,7 +392,7 @@ export class DomainDetailsForm extends PureComponent {
 			<form>
 				{ this.renderNameFields() }
 				{ ! needsOnlyGoogleAppsDetails && this.renderOrganizationField() }
-				{ ! needsOnlyGoogleAppsDetails && this.renderEmailField() }
+				{ this.renderEmailField() }
 				{ ! needsOnlyGoogleAppsDetails && this.renderPhoneField() }
 				{ this.renderCountryField() }
 				{ ! needsOnlyGoogleAppsDetails && this.needsFax() && this.renderFaxField() }


### PR DESCRIPTION
When upgrading an existing domain with G Suite, we require for an alternate email. We reuse the domain contact information feature for domains for that purpose and on that form, the email field may be skipped for G Suite users leading to the numerous instances of invalid alternate email we observe.

To test:
1. With an existing domain, add G Suite to cart with the Network tab open.
2. On the final step, right before paying, confirm that POST to the shopping cart contains the email

Note: there are two emails. One is the G Suite email, let's say veselin@mydomain.blog, and the other is the alternate email, coming from the domain contact information form. It needs to be different and it was missing in the form.

You might want to try `localStorage.clear()` as well.