### PR TITLE
Adds a horizontal scroll prop which can be applied to make a table sc…

### DIFF
--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -172,7 +172,7 @@ class Orders extends Component {
 					</NavTabs>
 				</SectionNav>
 
-				<Table className="orders__table" header={ headers }>
+				<Table className="orders__table" header={ headers } horizontalScroll>
 					{ orders.map( this.renderOrderItems ) }
 				</Table>
 				{ this.renderPagination() }

--- a/client/extensions/woocommerce/app/products/products-list-table.js
+++ b/client/extensions/woocommerce/app/products/products-list-table.js
@@ -24,7 +24,7 @@ const ProductsListTable = ( { translate, products, site, isRequesting } ) => {
 
 	return (
 		<div>
-			<Table header={ headings } className={ classNames( { 'is-requesting': isRequesting } ) }>
+			<Table header={ headings } className={ classNames( { 'is-requesting': isRequesting } ) } horizontalScroll>
 				{ products && products.map( ( product, i ) => (
 					<ProductsListRow
 						key={ i }

--- a/client/extensions/woocommerce/components/table/index.js
+++ b/client/extensions/woocommerce/components/table/index.js
@@ -9,19 +9,24 @@ import classnames from 'classnames';
  */
 import Card from 'components/card';
 
-const Table = ( { className, compact = false, header, children, ...props } ) => {
+const Table = ( { className, compact = false, horizontalScroll = false, header, children, ...props } ) => {
 	const classes = classnames( {
 		table: true,
 		'is-compact-table': compact,
+		'is-horizontally-scrollable': horizontalScroll,
 	}, className );
 	return (
 		<Card className={ classes }>
-			<table { ...props }>
-				{ header && <thead>{ header }</thead> }
-				<tbody>
-					{ children }
-				</tbody>
-			</table>
+			<div className="table__wrapper-shadow">
+				<div className="table__wrapper">
+					<table { ...props }>
+						{ header && <thead>{ header }</thead> }
+						<tbody>
+							{ children }
+						</tbody>
+					</table>
+				</div>
+			</div>
 		</Card>
 	);
 };
@@ -30,6 +35,7 @@ Table.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node,
 	compact: PropTypes.bool,
+	horizontalScroll: PropTypes.bool,
 	header: PropTypes.node,
 };
 

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -94,14 +94,49 @@
 			}
 		}
 	}
+
+	&.is-horizontally-scrollable {
+		.table__wrapper-shadow {
+			position: relative;
+			overflow: hidden;
+
+			&:after {
+				content: "";
+				display: block;
+				width: 24px;
+				height: 100%;
+				position: absolute;
+				right: -12px;
+				top: 0;
+				background: radial-gradient( ellipse at center, rgba( $gray-dark,.125 ) 0%, rgba( $white,0 ) 75%, rgba( $white,0 ) 90% );
+			}
+
+			@include breakpoint( ">660px" ) {
+				&:after {
+					display: none;
+				}
+			}
+		}
+
+		.table__wrapper {
+			width: 1px;
+			max-width: 100%;
+			min-width: 100%;
+			overflow-x: auto;
+
+			table {
+				white-space: nowrap;
+			}
+		}
+	}
 }
 
 .table-row {
 	line-height: 36px;
-	
+
 	&:hover {
 		background: $gray-light;
-		
+
 		&.is-header {
 			background-color: initial;
 		}


### PR DESCRIPTION
…roll horizontally

This will be useful for https://github.com/Automattic/wp-calypso/pull/14871 and we can potentially update the variations table to use this in the future as well.

One thing I'm struggling with and wonder if a dev could assist - it would be nice if the `.table__wrapper-shadow` class was applied automatically once the table width is greater than the width of the container. 

At the moment the shadow appears when the component is flush against the browser window which is OK but not ideal.

To test:

* Add the `horizontalScroll` prop to an instance of the `<Table>` component (IE orders)
* Reduce browser width
* Notice the table begins to horizontally scroll