### PR TITLE
Ignore bin/pre-{commit,push}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ env-config.sh
 /calypso-strings.pot
 cover.html
 .test.log
+
+/bin/pre-commit
+/bin/pre-push


### PR DESCRIPTION
Ignores a few pesky files that aren't intended to be versioned but aren't reliably cleaned up.

I'm not sure how to reliably create these files without them being cleaned up, but you can manually create `bin/pre-commit` and `bin/pre-push` to ensure they are ignored.