### PR TITLE
Revisions #7: Instead of defaulting to no change, compute the first revision's diff as if everything was added from a blank page

### DIFF
--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, forEach, map, mapKeys, mapValues, omit, pick } from 'lodash';
+import { flow, forEach, get, map, mapKeys, mapValues, omit, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -69,9 +69,10 @@ export const receiveSuccess = ( { dispatch }, { siteId, postId }, revisions ) =>
 	const normalizedRevisions = map( revisions, normalizeRevision );
 
 	forEach( normalizedRevisions, ( revision, index ) => {
-		revision.changes = index === normalizedRevisions.length - 1
-			? { added: 0, removed: 0 }
-			: countDiffWords( diffWords( normalizedRevisions[ index + 1 ].content, revision.content ) );
+		revision.changes = countDiffWords( diffWords(
+			get( normalizedRevisions, [ index + 1, 'content' ], '' ),
+			revision.content
+		) );
 	} );
 
 	dispatch( receivePostRevisionsSuccess( siteId, postId ) );

--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -135,7 +135,7 @@ describe( '#receiveSuccess', () => {
 
 		const expectedRevisions = cloneDeep( normalizedPostRevisions );
 		forEach( expectedRevisions, revision => {
-			revision.changes = { added: 0, removed: 0 };
+			revision.changes = { added: 2, removed: 0 };
 		} );
 
 		expect( dispatch ).to.have.callCount( 2 );


### PR DESCRIPTION
~**Note: This builds on top of #14927, so it's not merge-able yet**~

This is to fix a small UX issue raised during #14927's review: the first revision's changes summary defaulted to no change ( `{ added: 0, removed: 0 }` ), instead we compute it as if everything was added from a blank page, it also makes it more consistent with what the diff viewer was displaying (everything was highlighted as if it was added content):

<img width="668" alt="screen shot 2017-06-21 at 15 32 43" src="https://user-images.githubusercontent.com/1145270/27386715-ebc60d4c-5696-11e7-8ef4-791bd5fcbe8a.png">
