### PR TITLE
Comments: Add comment status labels on non-approved comments

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -22,6 +22,7 @@ export class CommentDetailAuthor extends Component {
 		authorUsername: PropTypes.string,
 		blockUser: PropTypes.func,
 		commentDate: PropTypes.string,
+		commentStatus: PropTypes.string,
 		showAuthorInfo: PropTypes.bool,
 	};
 
@@ -36,6 +37,25 @@ export class CommentDetailAuthor extends Component {
 	toggleExpanded = () => {
 		this.setState( { isExpanded: ! this.state.isExpanded } );
 	};
+
+	commentStatusLabel = () => {
+		const { commentStatus, translate } = this.props;
+		if ( 'approved' === commentStatus ) {
+			return null;
+		}
+
+		const statusLabels = {
+			unapproved: translate( 'Pending' ),
+			spam: translate( 'Spam' ),
+			trash: translate( 'Trash' ),
+		};
+
+		return (
+			<div className={ `comment-detail__status-label is-${ commentStatus }` }>
+				{ statusLabels[ commentStatus ] }
+			</div>
+		);
+	}
 
 	authorMoreInfo() {
 		if ( ! this.props.showAuthorInfo ) {
@@ -139,6 +159,7 @@ export class CommentDetailAuthor extends Component {
 							{ moment( commentDate ).format( 'MMMM D, YYYY H:mma' ) }
 						</div>
 					</div>
+					{ this.commentStatusLabel() }
 					{
 						showAuthorInfo &&
 						<a className="comment-detail__author-more-info-toggle" onClick={ this.toggleExpanded }>

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -38,25 +38,6 @@ export class CommentDetailAuthor extends Component {
 		this.setState( { isExpanded: ! this.state.isExpanded } );
 	};
 
-	commentStatusLabel = () => {
-		const { commentStatus, translate } = this.props;
-		if ( 'approved' === commentStatus ) {
-			return null;
-		}
-
-		const statusLabels = {
-			unapproved: translate( 'Pending' ),
-			spam: translate( 'Spam' ),
-			trash: translate( 'Trash' ),
-		};
-
-		return (
-			<div className={ `comment-detail__status-label is-${ commentStatus }` }>
-				{ statusLabels[ commentStatus ] }
-			</div>
-		);
-	}
-
 	authorMoreInfo() {
 		if ( ! this.props.showAuthorInfo ) {
 			return null;
@@ -133,8 +114,10 @@ export class CommentDetailAuthor extends Component {
 			authorDisplayName,
 			authorUrl,
 			commentDate,
+			commentStatus,
 			moment,
 			showAuthorInfo,
+			translate,
 		} = this.props;
 		const { isExpanded } = this.state;
 
@@ -159,7 +142,11 @@ export class CommentDetailAuthor extends Component {
 							{ moment( commentDate ).format( 'MMMM D, YYYY H:mma' ) }
 						</div>
 					</div>
-					{ this.commentStatusLabel() }
+					{ 'unapproved' === commentStatus &&
+						<div className="comment-detail__status-label is-unapproved">
+							{ translate( 'Pending' ) }
+						</div>
+					}
 					{
 						showAuthorInfo &&
 						<a className="comment-detail__author-more-info-toggle" onClick={ this.toggleExpanded }>

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -101,7 +101,7 @@ export class CommentDetailAuthor extends Component {
 						<span>{ authorIsBlocked
 							? translate( 'Unblock user' )
 							: translate( 'Block user' )
-						} </span>
+						}</span>
 					</a>
 				</div>
 			</div>

--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -24,6 +24,7 @@ export class CommentDetailComment extends Component {
 		blockUser: PropTypes.func,
 		commentContent: PropTypes.string,
 		commentDate: PropTypes.string,
+		commentStatus: PropTypes.string,
 	};
 
 	render() {
@@ -38,6 +39,7 @@ export class CommentDetailComment extends Component {
 			blockUser,
 			commentContent,
 			commentDate,
+			commentStatus,
 			repliedToComment,
 			translate,
 		} = this.props;
@@ -55,6 +57,7 @@ export class CommentDetailComment extends Component {
 						authorUsername={ authorUsername }
 						blockUser={ blockUser }
 						commentDate={ commentDate }
+						commentStatus={ commentStatus }
 					/>
 					<AutoDirection>
 						<div className="comment-detail__comment-body"

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -186,6 +186,7 @@ export class CommentDetail extends Component {
 							blockUser={ this.blockUser }
 							commentContent={ commentContent }
 							commentDate={ commentDate }
+							commentStatus={ commentStatus }
 							repliedToComment={ repliedToComment }
 						/>
 						<CommentDetailReply />

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -301,6 +301,23 @@
 	padding-bottom: 16px;
 }
 
+.comment-detail__status-label {
+	align-self: flex-start;
+	border-radius: 9px;
+	font-size: 12px;
+	margin-left: auto;
+	padding: 0 10px;
+
+	&.is-unapproved {
+		background-color: $alert-yellow;
+	}
+	&.is-spam,
+	&.is-trash {
+		background: $alert-red;
+		color: $white;
+	}
+}
+
 .comment-detail__author-more-info-toggle {
 	color: $gray;
 	cursor: pointer;


### PR DESCRIPTION
Adds status labels to expanded (non-approved) comment details, as proposed in https://github.com/Automattic/wp-calypso/pull/15075#issuecomment-308836766.

<img width="506" alt="screen shot 2017-06-21 at 15 08 45" src="https://user-images.githubusercontent.com/2070010/27388499-925376bc-5693-11e7-8fa0-db5c2a94a911.png">

<img width="507" alt="screen shot 2017-06-21 at 15 08 33" src="https://user-images.githubusercontent.com/2070010/27388500-92575b1a-5693-11e7-9cda-45ae91bd02c6.png">

<img width="508" alt="screen shot 2017-06-21 at 15 08 23" src="https://user-images.githubusercontent.com/2070010/27388498-924db380-5693-11e7-9ea2-bf0dc483bf39.png">
