### PR TITLE
People: Open Jetpack Invites for all Jetpack Sites

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -19,10 +19,7 @@ import InvitePeople from './invite-people';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import config from 'config';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 
 export default {
 	redirectToTeam,

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -76,18 +76,7 @@ function renderPeopleList( filter, context ) {
 
 function renderInvitePeople( context ) {
 	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
-	const siteSlug = getSelectedSiteSlug( state );
-	const isJetpack = isJetpackSite( state, siteId );
-	const isAutomatedTransfer = isSiteAutomatedTransfer( state, siteId );
-
-	if ( isJetpack && ! config.isEnabled( 'jetpack/invites' ) && ! isAutomatedTransfer ) {
-		const currentLayoutFocus = getCurrentLayoutFocus( state );
-		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
-		page.redirect( '/people/team/' + siteSlug );
-		analytics.tracks.recordEvent( 'calypso_invite_people_controller_redirect_to_team' );
-	}
 
 	context.store.dispatch( setTitle( i18n.translate( 'Invite People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -15,7 +15,6 @@ import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import Tooltip from 'components/tooltip';
-import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -72,7 +72,6 @@ class PeopleListSectionHeader extends Component {
 						<Button
 							compact
 							href={ siteLink }
-							target={ this.shouldUseWPAdmin() ? '_new' : null }
 							className="people-list-section-header__add-button"
 							onMouseEnter={ this.showAddTooltip }
 							onMouseLeave={ this.hideAddTooltip }

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -43,21 +43,12 @@ class PeopleListSectionHeader extends Component {
 
 	hideAddTooltip = () => this.setState( { addPeopleTooltip: false } );
 
-	shouldUseWPAdmin() {
-		return ! config.isEnabled( 'jetpack/invites' ) && get( this.props, 'site.jetpack' ) && ! this.props.isSiteAutomatedTransfer;
-	}
-
 	getAddLink() {
 		const siteSlug = get( this.props, 'site.slug' );
 		const isJetpack = get( this.props, 'site.jetpack' );
-		const wpAdminUrl = get( this.props, 'site.options.admin_url' );
 
 		if ( ! siteSlug || ( isJetpack && this.props.isFollower ) ) {
 			return false;
-		}
-
-		if ( this.shouldUseWPAdmin() ) {
-			return wpAdminUrl + 'user-new.php';
 		}
 
 		return '/people/new/' + siteSlug;

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -393,7 +393,7 @@ export class MySitesSidebar extends Component {
 	users() {
 		const { site, canUserListUsers } = this.props;
 		let usersLink = '/people/team' + this.props.siteSuffix;
-		let addPeopleLink = '/people/new' + this.props.siteSuffix;
+		const addPeopleLink = '/people/new' + this.props.siteSuffix;
 
 		if ( ! site ) {
 			return null;
@@ -405,11 +405,6 @@ export class MySitesSidebar extends Component {
 
 		if ( ! config.isEnabled( 'manage/people' ) && site.options ) {
 			usersLink = site.options.admin_url + 'users.php';
-		}
-
-		if ( ! config.isEnabled( 'jetpack/invites' ) &&
-			! this.props.isSiteAutomatedTransfer && site && site.options && this.props.isJetpack ) {
-			addPeopleLink = site.options.admin_url + 'user-new.php';
 		}
 
 		return (

--- a/config/development.json
+++ b/config/development.json
@@ -52,7 +52,6 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"help": true,
 		"help/courses": true,
-		"jetpack/invites": true,
 		"jetpack_core_inline_update": true,
 		"jetpack/api-cache": true,
 		"jetpack/activity-log": true,


### PR DESCRIPTION
**This PR completely removes `'jetpack/invites'` feature flag.**

Since Jetpack 5.0, Jetpack has the required endpoints to make invites work on JP sites. 

Jetpack Invites has been open and tested on AT sites since 4.9

If a site is running an old JP version, users will be prompted to upgrade when trying to Add new users:
<img width="745" alt="screen shot 2017-06-21 at 11 47 37" src="https://user-images.githubusercontent.com/104869/27390544-ea32d4c0-5677-11e7-940d-183d8396c3d4.png">

## Testing instructions

For Jetpack running 5.0 
- make sure "People - Add" button works
- try inviting a user

4.9 and below
- make sure you are prompted to upgrade when trying to use "People - Add"
