### PR TITLE
Redirect /jetpack/connect/plans to wp-admin for AT site - also on initial mount

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -60,7 +60,10 @@ class Plans extends Component {
 	};
 
 	componentDidMount() {
-		if ( this.hasPreSelectedPlan() ) {
+		if ( this.props.isAutomatedTransfer && ! this.redirecting && this.props.selectedSite ) {
+			this.redirecting = true;
+			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
+		} else if ( this.hasPreSelectedPlan() ) {
 			this.autoselectPlan();
 		} else {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_view', {


### PR DESCRIPTION
If the `/jetpack/connect/plans page` detects that the connected site is AT, it aborts the flow and redirects to `wp-admin` Jetpack page. However, this happens only in `componentDidUpdate`. When the plans page has a preselected plan, like when it was redirected to from `/jetpack/connect/personal`, the plan is autoselected in `componentDidMount` and we immediately navigate to checkout. The `componentDidUpdate` method is never called.

This patch adds the `isAutomatedTransfer` check also to `componentDidMount` as the first thing to do.