### PR TITLE
Reader: Fix grav/site info overlap

### DIFF
--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -175,10 +175,6 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-right: 0;
 	}
 
-	.reader-subscription-list-item__avatar {
-		min-width: 0;
-	}
-
 	.reader-subscription-list-item__byline {
 		margin-right: 0;
 		padding-right: 0;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15068

**Before:**
![screenshot 2017-06-21 10 22 11](https://user-images.githubusercontent.com/4924246/27397561-9e0a3e28-566b-11e7-905f-0ef6c7821997.png)

**After:**
![screenshot 2017-06-21 10 22 44](https://user-images.githubusercontent.com/4924246/27397563-a0a2dd70-566b-11e7-9293-b6c15844478e.png)
