### PR TITLE
QueryJetpackConnection: Make the siteId prop be optional

### DIFF
--- a/client/components/data/query-jetpack-connection/index.jsx
+++ b/client/components/data/query-jetpack-connection/index.jsx
@@ -12,7 +12,7 @@ import { requestJetpackConnectionStatus } from 'state/jetpack/connection/actions
 
 class QueryJetpackConnection extends Component {
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
+		siteId: PropTypes.number,
 		requestingJetpackConnectionStatus: PropTypes.bool,
 		requestJetpackConnectionStatus: PropTypes.func
 	};
@@ -28,11 +28,9 @@ class QueryJetpackConnection extends Component {
 	}
 
 	request( props ) {
-		if ( props.requestingJetpackConnectionStatus ) {
-			return;
+		if ( props.siteId !== null && ! props.requestingJetpackConnectionStatus ) {
+			props.requestJetpackConnectionStatus( props.siteId );
 		}
-
-		props.requestJetpackConnectionStatus( props.siteId );
 	}
 
 	render() {

--- a/client/my-sites/site-settings/sitemaps.jsx
+++ b/client/my-sites/site-settings/sitemaps.jsx
@@ -209,7 +209,7 @@ class Sitemaps extends Component {
 
 		return (
 			<div>
-				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }
+				<QueryJetpackConnection siteId={ siteId } />
 
 				<SectionHeader label={ translate( 'Sitemaps' ) } />
 


### PR DESCRIPTION
* Updates the `QueryJetpackConnection` component to not declare its `siteId` prop as required.
* Updates the component to only request data if the `siteId` prop is not `null`.