### PR TITLE
QueryJetpackModules: Make the siteId prop be optional

### DIFF
--- a/client/components/data/query-jetpack-modules/index.jsx
+++ b/client/components/data/query-jetpack-modules/index.jsx
@@ -12,7 +12,7 @@ import { fetchModuleList } from 'state/jetpack/modules/actions';
 
 class QueryJetpackModules extends Component {
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
+		siteId: PropTypes.number,
 		requestingModules: PropTypes.bool,
 		fetchModuleList: PropTypes.func
 	};
@@ -28,11 +28,9 @@ class QueryJetpackModules extends Component {
 	}
 
 	request( props ) {
-		if ( props.requestingModules ) {
-			return;
+		if ( props.siteId !== null && ! props.requestingModules ) {
+			props.fetchModuleList( props.siteId );
 		}
-
-		props.fetchModuleList( props.siteId );
 	}
 
 	render() {

--- a/client/my-sites/sharing/main.jsx
+++ b/client/my-sites/sharing/main.jsx
@@ -62,7 +62,7 @@ export const Sharing = ( {
 	return (
 		<Main className="sharing">
 			<DocumentHead title={ translate( 'Sharing' ) } />
-			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
+			<QueryJetpackModules siteId={ siteId } />
 			<SidebarNavigation />
 			{ filters.length > 0 &&
 				<SectionNav selectedText={ get( selected, 'title', '' ) }>


### PR DESCRIPTION
* This PR updates the `QueryJetpackModules` component to declare its `siteId` prop as optional to only request data if the `siteId` prop is not `null` when mounting.