### PR TITLE
WooCommerce Get rid of doc links on dashboard

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -10,8 +10,6 @@ import React, { Component, PropTypes } from 'react';
  */
 import Button from 'components/button';
 
-// TODO add doc url and documentation link
-
 class SetupTask extends Component {
 	static propTypes = {
 		actions: PropTypes.arrayOf( PropTypes.shape( {
@@ -21,7 +19,6 @@ class SetupTask extends Component {
 			path: PropTypes.string,
 		} ) ),
 		checked: PropTypes.bool.isRequired,
-		docURL: PropTypes.string,
 		explanation: PropTypes.string,
 		label: PropTypes.string.isRequired,
 	};
@@ -70,8 +67,7 @@ class SetupTask extends Component {
 	};
 
 	render = () => {
-		const { actions, checked, docURL, explanation, label, translate } = this.props;
-		const docLink = docURL ? <a href={ docURL }>{ translate( 'Documentation' ) }</a> : null;
+		const { actions, checked, explanation, label } = this.props;
 
 		return (
 			<div className="dashboard__setup-task">
@@ -84,7 +80,7 @@ class SetupTask extends Component {
 							{ label }
 						</h2>
 						<p>
-							{ explanation } { docLink }
+							{ explanation }
 						</p>
 					</div>
 					<div className="dashboard__setup-task-actions">

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -96,7 +96,6 @@ class SetupTasks extends Component {
 		return [
 			{
 				checked: hasProducts,
-				docURL: 'https://support.wordpress.com/',
 				explanation: translate( 'Start by adding the first product to your store.' ),
 				label: translate( 'Add a product' ),
 				show: true,
@@ -109,7 +108,6 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: shippingIsSetUp,
-				docURL: 'https://support.wordpress.com/',
 				explanation: translate( 'Be ready to ship by the time your first order comes in.' ),
 				label: translate( 'Set up shipping' ),
 				show: this.state.showShippingTask,
@@ -127,7 +125,6 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: paymentsAreSetUp,
-				docURL: 'https://support.wordpress.com/',
 				explanation: translate( 'Choose how you would like your customers to pay you.' ),
 				label: translate( 'Set up payments' ),
 				show: true,
@@ -140,7 +137,6 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: taxesAreSetUp,
-				docURL: 'https://support.wordpress.com/',
 				explanation: translate( 'Taxes. Everyone\'s favorite. We made it simple.' ),
 				label: translate( 'Set up taxes' ),
 				show: this.state.showTaxesTask,
@@ -158,7 +154,6 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: triedCustomizer,
-				docURL: 'https://support.wordpress.com/',
 				explanation: translate( 'View your store and make any final tweaks before opening for business.' ),
 				label: translate( 'View and customize' ),
 				show: true,
@@ -182,7 +177,6 @@ class SetupTasks extends Component {
 			<SetupTask
 				actions={ setupTask.actions }
 				checked={ setupTask.checked }
-				docURL= { setupTask.docURL }
 				explanation={ setupTask.explanation }
 				key={ index }
 				label={ setupTask.label }

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -97,7 +97,7 @@ class SetupTasks extends Component {
 			{
 				checked: hasProducts,
 				docURL: 'https://support.wordpress.com/',
-				explanation: translate( 'Add your products to your store.' ),
+				explanation: translate( 'Start by adding the first product to your store.' ),
 				label: translate( 'Add a product' ),
 				show: true,
 				actions: [
@@ -110,7 +110,7 @@ class SetupTasks extends Component {
 			{
 				checked: shippingIsSetUp,
 				docURL: 'https://support.wordpress.com/',
-				explanation: translate( 'Configure the locations to which you ship your products.' ),
+				explanation: translate( 'Be ready to ship by the time your first order comes in.' ),
 				label: translate( 'Set up shipping' ),
 				show: this.state.showShippingTask,
 				actions: [
@@ -128,7 +128,7 @@ class SetupTasks extends Component {
 			{
 				checked: paymentsAreSetUp,
 				docURL: 'https://support.wordpress.com/',
-				explanation: translate( 'Choose which payment methods to offer your customers.' ),
+				explanation: translate( 'Choose how you would like your customers to pay you.' ),
 				label: translate( 'Set up payments' ),
 				show: true,
 				actions: [
@@ -141,7 +141,7 @@ class SetupTasks extends Component {
 			{
 				checked: taxesAreSetUp,
 				docURL: 'https://support.wordpress.com/',
-				explanation: translate( 'Configure how tax rates are calculated at your store.' ),
+				explanation: translate( 'Taxes. Everyone\'s favorite. We made it simple.' ),
 				label: translate( 'Set up taxes' ),
 				show: this.state.showTaxesTask,
 				actions: [
@@ -150,7 +150,7 @@ class SetupTasks extends Component {
 						path: getLink( '/store/settings/taxes/:site', site ),
 					},
 					{
-						label: translate( 'I\'m not charging sales tax' ),
+						label: translate( 'I won\'t be charging sales tax' ),
 						isSecondary: true,
 						onClick: this.onClickNoTaxes
 					}
@@ -159,7 +159,7 @@ class SetupTasks extends Component {
 			{
 				checked: triedCustomizer,
 				docURL: 'https://support.wordpress.com/',
-				explanation: translate( 'View your store, test your settings and customize the design.' ),
+				explanation: translate( 'View your store and make any final tweaks before opening for business.' ),
 				label: translate( 'View and customize' ),
 				show: true,
 				actions: [

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -35,7 +35,7 @@
 	@include breakpoint( ">960px" ) {
 		margin-left: -32px;
 		margin-right: -32px;
-		padding: 32px;
+		padding: 24px 32px;
 		align-items: center;
 	}
 
@@ -46,13 +46,14 @@
 		text-align: center;
 		width: 24px;
 		flex-shrink: 0;
-		border-radius: 100%;
+		border-radius: 4px;
 		margin-right: 24px;
-		margin-top: 4px;
+		margin-top: 2px;
 
 		@include breakpoint( ">960px" ) {
 			height: 48px;
 			width: 48px;
+			margin-top: -8px;
 		}
 
 		.gridicon {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/15359 

To test, go to http://calypso.localhost:3000/store/SITEURL and conform that there is no longer links to documentation on the egg dashboard.

I also had to restyle this and while I was in there I updated the copy as well. _If you give a mouse a cookie..._