### PR TITLE
Plugins: add tracking for plugin clicks coming from WP.com Masterbar

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -6,6 +6,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import controller from 'my-sites/controller';
 import config from 'config';
 import pluginsController from './controller';
@@ -35,6 +36,16 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
+		page( '/plugins/wpcom-masterbar-redirect/:site', context => {
+			analytics.tracks.recordEvent( 'calypso_wpcom_masterbar_plugins_view_redirect' );
+			page.redirect( '/plugins/' + context.params.site );
+		} );
+
+		page( '/plugins/browse/wpcom-masterbar-redirect/:site', context => {
+			analytics.tracks.recordEvent( 'calypso_wpcom_masterbar_plugins_add_redirect' );
+			page.redirect( '/plugins/browse/' + context.params.site );
+		} );
+
 		page( '/plugins/browse/:category/:site',
 			controller.siteSelection,
 			controller.navigation,

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -6,10 +6,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import controller from 'my-sites/controller';
 import config from 'config';
 import pluginsController from './controller';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const nonJetpackRedirectTo = path => ( context, next ) => {
@@ -37,12 +37,12 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
 		page( '/plugins/wpcom-masterbar-redirect/:site', context => {
-			analytics.tracks.recordEvent( 'calypso_wpcom_masterbar_plugins_view_redirect' );
+			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_view_click' ) );
 			page.redirect( '/plugins/' + context.params.site );
 		} );
 
 		page( '/plugins/browse/wpcom-masterbar-redirect/:site', context => {
-			analytics.tracks.recordEvent( 'calypso_wpcom_masterbar_plugins_add_redirect' );
+			context.store.dispatch( recordTracksEvent( 'calypso_wpcom_masterbar_plugins_add_click' ) );
 			page.redirect( '/plugins/browse/' + context.params.site );
 		} );
 


### PR DESCRIPTION
Depends on: D5792-code

With the release of AT to all users, we'll be showing Add Plugin option in front end Masterbar too. The purpose of this change is to enable tracking for users that end up in Calypso's plugin section via that route.  This will help us gauge how many Business plan conversions and AT initializations we get, with front-end Masterbar's Add button as the starting point.

### Testing instructions
1. Apply D5792-code.
2. Open up `My Sites` menu of you WP.com test site.
3. Click on `Plugins` menu item, or `Add` button in plugins section.
4. Verify that corresponding events have been recorded in tracks, and that you are redirected to appropriate plugin pages in Calypso.