### PR TITLE
Removed sites-list from daily-post-button.

### DIFF
--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -59,7 +59,7 @@ export class DailyPostButton extends React.Component {
 		position: React.PropTypes.string,
 		tagName: React.PropTypes.string,
 		canParticipate: React.PropTypes.bool.isRequired,
-		primarySiteSlug: React.PropTypes.string.isRequired,
+		primarySiteSlug: React.PropTypes.string,
 		onlyOneSite: React.PropTypes.bool.isRequired
 	};
 

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -7,6 +7,7 @@ import page from 'page';
 import qs from 'qs';
 import { get, defer } from 'lodash';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -17,11 +18,11 @@ import SitesPopover from 'components/sites-popover';
 import Button from 'components/button';
 import { markSeen as markPostSeen } from 'lib/feed-post-store/actions';
 
-import getSitesList from 'lib/sites-list';
 import { recordGaEvent, recordAction, recordTrackForPost } from 'reader/stats';
 import { getDailyPostType } from './helper';
-
-const sitesList = getSitesList();
+import { getPrimarySiteId } from 'state/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 function getPingbackAttributes( post ) {
 	const typeTitles = {
@@ -41,11 +42,7 @@ function preloadEditor() {
 	preload( 'post-editor' );
 }
 
-function onlyOneSite() {
-	return sitesList.data.length === 1;
-}
-
-class DailyPostButton extends React.Component {
+export class DailyPostButton extends React.Component {
 	constructor() {
 		super();
 		this.state = {
@@ -61,6 +58,9 @@ class DailyPostButton extends React.Component {
 		site: React.PropTypes.object.isRequired,
 		position: React.PropTypes.string,
 		tagName: React.PropTypes.string,
+		canParticipate: React.PropTypes.bool.isRequired,
+		primarySiteSlug: React.PropTypes.string.isRequired,
+		onlyOneSite: React.PropTypes.bool.isRequired
 	};
 
 	static defaultProps = {
@@ -110,9 +110,8 @@ class DailyPostButton extends React.Component {
 			recordGaEvent( 'Opened Daily Post Challenge' );
 			recordTrackForPost( 'calypso_reader_daily_post_challenge_opened', this.props.post );
 
-			if ( onlyOneSite() ) {
-				const primarySlug = get( sitesList.getPrimary(), 'slug' );
-				return this.openEditorWithSite( primarySlug );
+			if ( this.props.onlyOneSite ) {
+				return this.openEditorWithSite( this.props.primarySiteSlug );
 			}
 		}
 		this.deferMenuChange( ! this.state.showingMenu );
@@ -132,7 +131,6 @@ class DailyPostButton extends React.Component {
 			<SitesPopover
 				key="menu"
 				header={ <div> { translate( 'Post on' ) } </div> }
-				sites={ sitesList }
 				context={ this.refs && this.refs.dailyPostButton }
 				visible={ this.state.showingMenu }
 				groups={ true }
@@ -145,7 +143,6 @@ class DailyPostButton extends React.Component {
 	};
 
 	render() {
-		const canParticipate = !! sitesList.getPrimary();
 		const title = get( this.props, 'post.title' );
 		const buttonClasses = classnames( {
 			'daily-post-button__button': true,
@@ -153,7 +150,7 @@ class DailyPostButton extends React.Component {
 			'is-active': this.state.showingMenu,
 		} );
 
-		if ( ! canParticipate ) {
+		if ( ! this.props.canParticipate ) {
 			return null;
 		}
 
@@ -176,4 +173,14 @@ class DailyPostButton extends React.Component {
 	}
 }
 
-export default DailyPostButton;
+export default connect(
+	state => {
+		const primarySiteId = getPrimarySiteId( state );
+		const user = getCurrentUser( state );
+		const visibleSiteCount = get( user, 'visible_site_count', 0 );
+		return {
+			canParticipate: !! primarySiteId,
+			primarySiteSlug: getSiteSlug( state, primarySiteId ),
+			onlyOneSite: visibleSiteCount === 1
+		};
+	} )( DailyPostButton );

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -17,11 +17,6 @@ import { sites, dailyPromptPost } from './fixtures';
 describe( 'DailyPostButton', () => {
 	const SitesPopover = props => <span { ...props } />;
 	const pageSpy = spy();
-	const sitesListMock = {
-		fetched: true,
-		data: sites,
-		getPrimary: stub(),
-	};
 	let DailyPostButton;
 
 	useMockery( mockery => {
@@ -32,67 +27,84 @@ describe( 'DailyPostButton', () => {
 		};
 		mockery.registerMock( 'reader/stats', statsMocks );
 		mockery.registerMock( 'lib/analytics', stub() );
-		mockery.registerMock( 'lib/sites-list', () => sitesListMock );
 		mockery.registerMock( 'page', pageSpy );
 		mockery.registerMock( 'components/sites-popover', SitesPopover );
 	} );
 
+	const [ sampleUserSite, sampleReadingSite ] = sites;
+
 	before( () => {
-		DailyPostButton = require( '../index' );
-		sitesListMock.getPrimary.returns( sitesListMock.data[ 0 ] );
+		DailyPostButton = require( '../index' ).DailyPostButton;
 	} );
 
 	describe( 'rendering', () => {
-		before( () => {
-			sitesListMock.getPrimary.onFirstCall().returns();
-		} );
-
-		it( 'does not render if the user does not have any sites', () => {
-			const dailyPostPrompt = shallow( <DailyPostButton post={ dailyPromptPost } /> );
+		it( 'does not render if the user can not participate (does not have any sites)', () => {
+			const dailyPostPrompt = shallow(
+				<DailyPostButton
+					post={ dailyPromptPost }
+					site={ sampleReadingSite }
+					canParticipate={ false }
+					primarySiteSlug= { sampleUserSite.slug }
+					onlyOneSite={ false }
+				/>
+			);
 			assert.isNull( dailyPostPrompt.type() );
 		} );
 
 		it( 'renders as an li tag by default', () => {
-			const renderAsLi = shallow( <DailyPostButton post={ dailyPromptPost } /> );
+			const renderAsLi = shallow(
+				<DailyPostButton
+					post={ dailyPromptPost }
+					site={ sampleReadingSite }
+					canParticipate={ true }
+					primarySiteSlug= { sampleUserSite.slug }
+					onlyOneSite={ true }
+				/>
+			);
 			assert.equal( 'li', renderAsLi.type() );
 		} );
 
 		it( 'renders as the tag specified in props tagName', () => {
-			const renderAsSpan = shallow( <DailyPostButton tagName="span" post={ dailyPromptPost } /> );
+			const renderAsSpan = shallow(
+				<DailyPostButton
+					tagName="span"
+					post={ dailyPromptPost }
+					site={ sampleReadingSite }
+					canParticipate={ true }
+					primarySiteSlug= { sampleUserSite.slug }
+					onlyOneSite={ true }
+				/>
+			);
 			assert.equal( 'span', renderAsSpan.type() );
-		} );
-
-		it( 'hides the sites list by default', () => {
-			const inactive = shallow( <DailyPostButton post={ dailyPromptPost } /> );
-			assert.isFalse( inactive.containsMatchingElement( <SitesPopover /> ) );
-		} );
-
-		it( 'shows the sites list if showingMenu is true', () => {
-			const active = shallow( <DailyPostButton post={ dailyPromptPost } /> ).setState( {
-				showingMenu: true,
-			} );
-			assert.isTrue( active.containsMatchingElement( <SitesPopover /> ) );
 		} );
 	} );
 
 	describe( 'clicking daily post button', () => {
-		let dailyPostButton;
-
-		before( () => {
-			dailyPostButton = shallow( <DailyPostButton post={ dailyPromptPost } /> );
-		} );
-
-		afterEach( () => {
-			sitesListMock.data = sites;
-		} );
-
-		it( 'rediects to primary site if the user only has one site', () => {
-			sitesListMock.data = sitesListMock.data.slice( 0, 1 );
+		it( 'redirects to primary site if the user only has one site', () => {
+			const dailyPostButton = shallow(
+				<DailyPostButton
+					post={ dailyPromptPost }
+					site={ sampleReadingSite }
+					canParticipate={ true }
+					primarySiteSlug= { sampleUserSite.slug }
+					onlyOneSite={ true }
+				/>
+			);
 			dailyPostButton.simulate( 'click', { preventDefault: noop } );
 			assert.isTrue( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) );
 		} );
 
 		it( 'shows the site selector if the user has more than one site', done => {
+			const dailyPostButton = shallow(
+				<DailyPostButton
+					tagName="span"
+					post={ dailyPromptPost }
+					site={ sampleReadingSite }
+					canParticipate={ true }
+					primarySiteSlug= { sampleUserSite.slug }
+					onlyOneSite={ false }
+				/>
+			);
 			dailyPostButton.instance().renderSitesPopover = done;
 			dailyPostButton.simulate( 'click', { preventDefault: noop } );
 		} );
@@ -100,7 +112,16 @@ describe( 'DailyPostButton', () => {
 
 	describe( 'starting a post', () => {
 		it( 'adds the daily post prompt attributes to the redirect url', () => {
-			const prompt = shallow( <DailyPostButton post={ dailyPromptPost } /> );
+			const prompt = shallow(
+				<DailyPostButton
+					tagName="span"
+					post={ dailyPromptPost }
+					site={ sampleReadingSite }
+					canParticipate={ true }
+					primarySiteSlug= { sampleUserSite.slug }
+					onlyOneSite={ true }
+				/>
+			);
 			prompt.instance().openEditorWithSite( 'apps.wordpress.com' );
 			const pageArgs = pageSpy.lastCall.args[ 0 ];
 			const query = qs.parse( pageArgs.split( '?' )[ 1 ] );


### PR DESCRIPTION
To test:
1-	Go to the reader and open daily post blog http://calypso.localhost:3000/read/feeds/27030
2-	Press the daily post button
3-	If the user contains just one visible site, the editor opens to post on that site. If the user has more than one visible site, a site selector appears, choose a site and the editor opens to post on that site.

After being in the editor going back works fine if you press daily post button outside a post (in the post list) but crashes if you press the button inside a post. I discovered this bug while testing and checked it has an already existing problem, so I created an issue for that problem: https://github.com/Automattic/wp-calypso/issues/15371

Please be aware that the button receives a site prop but that site it receives is not the currently selected site of the user. The site that it receives, is the site of the post the user is seeing in the reader. The component just uses site prop to mark the post as read when the user presses the button.


Some notes to reviewers:
In the tests, in order to import the component, I used a required I thought about changing it to an import but I checked other tests for blocks and most of them used a require so for consistency I did the same.

The tests, test the component used by connect and don’t test the connect functions (mapStateToProps), as in the other test case we have. I think that’s not a problem because the code there uses mostly selectors (that are/should already be tested).

In my refactoring, I tried to keep the old test logic to the maximum, in order to focus on the main objective, remove sites-list. So maybe the tests are not totally well fitted to the new interface as if they were created with the new interface in mind. 
