### PR TITLE
Publicize: switch to using the v2 publicize endpoint

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -921,7 +921,7 @@ Undocumented.prototype.publicizePost = function( siteId, postId, message, skippe
 		body.skipped_connections = skippedConnections;
 	}
 
-	return this.wpcom.req.post( { path: `/sites/${ siteId }/post/${ postId }/publicize`, body, apiVersion: '1.1' }, fn );
+	return this.wpcom.req.post( { path: `/sites/${ siteId }/posts/${ postId }/publicize`, body, apiNamespace: 'wpcom/v2' }, fn );
 };
 
 /**

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -43,7 +43,9 @@ export function sharePost( siteId, postId, skippedConnections, message ) {
 
 		return new Promise( ( resolve ) => {
 			wpcom.undocumented().publicizePost( siteId, postId, message, skippedConnections, ( error, data ) => {
-				if ( error || ! data.success ) {
+				// Note: successes are recorded in data.results, errors are recorded in data.errors. There could be
+				// several errors and several successes.
+				if ( error || ! data.results ) {
 					dispatch( { type: PUBLICIZE_SHARE_FAILURE, siteId, postId, error } );
 				} else {
 					dispatch( { type: PUBLICIZE_SHARE_SUCCESS, siteId, postId } );


### PR DESCRIPTION
The v1 publicize endpoint just returned "success" or "failure", but "failure" just meant that the WP post was non-existent or was not published, which is likely never to happen in Calypso. There was no report if the publicize attempt actually failed.

The v2 endpoint returns two arrays, `results` and `errors`.

`results` is an array of successful publicize connections, including the URL of each and `errors` is an array of failed connections.

## To do

These could be addressed in separate PRs.

- Any given request to the new endpoint could return several successful connections and several failures, but right now we don't have a UX to display that kind of information. We don't even have a way to display an error. For this PR (or one following) I think we should come up with these.
- Secondly, it's possible, although unlikely, for both of the arrays to be empty. This would occur if the endpoint for some reason did not have any connections available or if they were all marked to skip. We should probably have some UI for that result as well.
- Lastly, currently a successful publicize operation does not update the local (redux) list of published actions until the page is reloaded to query the published-actions endpoint again. Since this PR provides that data, we could update the local state immediately.

## Testing

1. On a site that has a Premium plan, run this branch.
2. Under "Sharing" in Calypso, set up a publicize connection or connections (eg: to twitter and facebook). It's fine if these connections already exist.
1. Visit the "Blog Posts" page in Calypso.
2. Click "Share" below a post to bring up the sharing panel.
3. Click the "Share post" button to publicize the post.
4. Verify that a green "Post shared..." banner appears.
4. Verify that the post was successfully shared to the connection(s).