### PR TITLE
WooCommerce: Fix the customizer link and redirect

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -50,7 +50,11 @@ class SetupTask extends Component {
 						const target = '/' === action.path.substring( 0, 1 ) ? '_self' : '_blank';
 						const trackClick = () => {
 							this.track( action.analyticsProp );
-							page.redirect( action.path );
+							if ( target === '_self' ) {
+								page.redirect( action.path );
+							} else {
+								window.open( action.path );
+							}
 						};
 						return (
 							<Button

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -171,7 +171,7 @@ class SetupTasks extends Component {
 				actions: [
 					{
 						label: translate( 'Customize' ),
-						path: getLink( 'https://:site/wp-admin/customize.php?return=%2Fwp-admin%2F', site ),
+						path: getLink( 'https://:site/wp-admin/customize.php?return=' + encodeURIComponent( '//' + site.slug ), site ),
 						// TODO use onClick here instead in order to hit setTriedCustomizerDuringInitialSetup,
 						analyticsProp: 'view-and-customize',
 					}


### PR DESCRIPTION
I broke the customizer link in master with my stats changes. This PR fixes that. It also takes care of Kelly's request from #15321.

> When I click on 'Customize', the customizer opens. I click the x there to close the customizer out and am redirected to wp-admin. Anyway we can be brought back to calypso instead? I'm adding it to this PR as it doesn't happen in master, but can also open a separate issue.

I clarified with Kelly over DM that this was supposed to be a separate window and the dashboard would still be opened -- but we agreed redirecting to the frontend instead of `wp-admin` makes sense.

cc @allendav @kellychoffman 

To Test:
* Go to `http://calypso.localhost:3000/store/:site`
* Click `Customizer`. The customizer should open in a new tab.
* Hit the "x" on the customizer. Instead of being redirected to `wp-admin`, you should be taken to the front end of your site.