### PR TITLE
Plugins: Swap out XML Sitemaps for MailChimp in the featured plugins list.

### DIFF
--- a/client/lib/plugins/wporg-data/curated.json
+++ b/client/lib/plugins/wporg-data/curated.json
@@ -20,14 +20,14 @@
 		"slug": "wordpress-seo"
 	},
 	{
-		"name": "Google XML Sitemaps",
-		"author": "<a href=\"http://www.arnebrachhold.de/\">Arne Brachhold</a>",
+		"name": "MailChimp for WordPress",
+		"author": "<a href=\"https://ibericode.com/\">ibericode</a>",
 		"rating": 98,
 		"icons": {
-			"1x": "https://ps.w.org/google-sitemap-generator/assets/icon-128x128.png?rev=976338",
-			"2x": "https://ps.w.org/google-sitemap-generator/assets/icon-256x256.png?rev=976338"
+			"1x": "https://ps.w.org/mailchimp-for-wp/assets/icon-128x128.png?rev=1224577",
+			"2x": "https://ps.w.org/mailchimp-for-wp/assets/icon-256x256.png?rev=1224577"
 		},
-		"slug": "google-sitemap-generator"
+		"slug": "mailchimp-for-wp"
 	},
 	{
 		"name": "TinyMCE Advanced",

--- a/client/lib/plugins/wporg-data/curated.json
+++ b/client/lib/plugins/wporg-data/curated.json
@@ -20,14 +20,14 @@
 		"slug": "wordpress-seo"
 	},
 	{
-		"name": "MailChimp for WordPress",
-		"author": "<a href=\"https://ibericode.com/\">ibericode</a>",
-		"rating": 98,
+		"name": "BuddyPress",
+		"author": "<a href=\"https://buddypress.org/\">The BuddyPress Community</a>",
+		"rating": 88,
 		"icons": {
-			"1x": "https://ps.w.org/mailchimp-for-wp/assets/icon-128x128.png?rev=1224577",
-			"2x": "https://ps.w.org/mailchimp-for-wp/assets/icon-256x256.png?rev=1224577"
+			"1x": "https://ps.w.org/buddypress/assets/icon-128x128.png?rev=1309232",
+			"2x": "https://ps.w.org/buddypress/assets/icon-256x256.png?rev=1309232"
 		},
-		"slug": "mailchimp-for-wp"
+		"slug": "buddypress"
 	},
 	{
 		"name": "TinyMCE Advanced",


### PR DESCRIPTION
Swap out Google XML Sitemaps for MailChimp for WordPress in /plugins/browse.

![screen shot 2017-06-21 at 3 19 20 pm](https://user-images.githubusercontent.com/349751/27409196-22da7950-5695-11e7-8f2c-cdc95f4ddb11.png)
