### PR TITLE
WooCommerce: Add single order view

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getOrder } from 'woocommerce/state/sites/orders/selectors';
+import Main from 'components/main';
+import OrderActivityLog from './order-activity-log';
+import OrderCustomerInfo from './order-customer-info';
+import OrderDetails from './order-details';
+import OrderHeader from '../orders/order-header';
+
+class Order extends Component {
+	componentDidMount() {
+		const { siteId, orderId } = this.props;
+
+		if ( siteId ) {
+			this.props.fetchOrder( siteId, orderId );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
+			this.props.fetchOrder( newProps.siteId, newProps.orderId );
+		}
+	}
+
+	render() {
+		const { className, order, site } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<Main className={ className }>
+				<OrderHeader siteSlug={ site.slug } />
+
+				<div className="order__container">
+					<OrderDetails order={ order } />
+					<OrderActivityLog order={ order } />
+					<OrderCustomerInfo order={ order } />
+				</div>
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	( state, props ) => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+		const orderId = props.params.order;
+		const order = getOrder( state, orderId );
+
+		return {
+			siteId,
+			site,
+			orderId,
+			order
+		};
+	},
+	dispatch => bindActionCreators( { fetchOrder }, dispatch )
+)( localize( Order ) );

--- a/client/extensions/woocommerce/app/order/order-activity-log.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+
+class OrderActivityLog extends Component {
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<div className="order__activity-log">
+				<SectionHeader label={ translate( 'Activity Log' ) } />
+				<Card></Card>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderActivityLog );

--- a/client/extensions/woocommerce/app/order/order-activity-log.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -11,6 +11,10 @@ import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
 class OrderActivityLog extends Component {
+	static propTypes = {
+		order: PropTypes.object,
+	}
+
 	render() {
 		const { order, translate } = this.props;
 		if ( ! order ) {

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -23,7 +23,7 @@ class OrderCustomerInfo extends Component {
 			<div className="order__customer-info">
 				<SectionHeader label={ translate( 'Customer Information' ) } />
 				<Card>
-					<h3>{ translate( 'Billing Details' ) }</h3>
+					<h3 className="order__billing-details">{ translate( 'Billing Details' ) }</h3>
 					<div className="order__customer-billing">
 						<h4>{ translate( 'Address' ) }</h4>
 						<div className="order__billing-address">
@@ -41,7 +41,7 @@ class OrderCustomerInfo extends Component {
 						<p>{ billing.phone }</p>
 					</div>
 
-					<h3>{ translate( 'Shipping Details' ) }</h3>
+					<h3 className="order__shipping-details">{ translate( 'Shipping Details' ) }</h3>
 					<div className="order__customer-shipping">
 						<h4>{ translate( 'Address' ) }</h4>
 						<div className="order__shipping-address">

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -18,7 +18,6 @@ class OrderCustomerInfo extends Component {
 		}
 
 		const { billing, shipping } = order;
-		console.log( billing, shipping );
 
 		return (
 			<div className="order__customer-info">

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+
+class OrderCustomerInfo extends Component {
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<div className="order__customer-info">
+				<SectionHeader label={ translate( 'Customer Information' ) } />
+				<Card></Card>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderCustomerInfo );

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -17,10 +17,43 @@ class OrderCustomerInfo extends Component {
 			return null;
 		}
 
+		const { billing, shipping } = order;
+		console.log( billing, shipping );
+
 		return (
 			<div className="order__customer-info">
 				<SectionHeader label={ translate( 'Customer Information' ) } />
-				<Card></Card>
+				<Card>
+					<h3>{ translate( 'Billing Details' ) }</h3>
+					<div className="order__customer-billing">
+						<h4>{ translate( 'Address' ) }</h4>
+						<div className="order__billing-address">
+							<p>{ `${ billing.first_name } ${ billing.last_name }` }</p>
+							<p>{ billing.address_1 }</p>
+							<p>{ billing.address_2 }</p>
+							<p>{ `${ billing.city }, ${ billing.state } ${ billing.postcode }` }</p>
+							<p>{ billing.country }</p>
+						</div>
+
+						<h4>{ translate( 'Email' ) }</h4>
+						<p>{ billing.email }</p>
+
+						<h4>{ translate( 'Phone' ) }</h4>
+						<p>{ billing.phone }</p>
+					</div>
+
+					<h3>{ translate( 'Shipping Details' ) }</h3>
+					<div className="order__customer-shipping">
+						<h4>{ translate( 'Address' ) }</h4>
+						<div className="order__shipping-address">
+							<p>{ `${ shipping.first_name } ${ shipping.last_name }` }</p>
+							<p>{ shipping.address_1 }</p>
+							<p>{ shipping.address_2 }</p>
+							<p>{ `${ shipping.city }, ${ shipping.state } ${ shipping.postcode }` }</p>
+							<p>{ shipping.country }</p>
+						</div>
+					</div>
+				</Card>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -11,6 +11,13 @@ import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
 class OrderCustomerInfo extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			billing: PropTypes.object.isRequired,
+			shipping: PropTypes.object.isRequired,
+		} ),
+	}
+
 	render() {
 		const { order, translate } = this.props;
 		if ( ! order ) {

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import Table from 'woocommerce/components/table';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+
+class OrderDetails extends Component {
+	renderTableHeader = () => {
+		const { translate } = this.props;
+		return (
+			<TableRow className="order__detail-header">
+				<TableItem isHeader className="order__detail-item-product">{ translate( 'Product' ) }</TableItem>
+				<TableItem isHeader className="order__detail-item-cost">{ translate( 'Cost' ) }</TableItem>
+				<TableItem isHeader className="order__detail-item-quantity">{ translate( 'Quantity' ) }</TableItem>
+				<TableItem isHeader className="order__detail-item-total">{ translate( 'Total' ) }</TableItem>
+			</TableRow>
+		);
+	}
+
+	renderOrderItems = ( item, i ) => {
+		return (
+			<TableRow key={ i } className="order__detail-items">
+				<TableItem isRowHeader className="order__detail-item-product">{ item.name }</TableItem>
+				<TableItem className="order__detail-item-cost">{ item.price }</TableItem>
+				<TableItem className="order__detail-item-quantity">{ item.quantity }</TableItem>
+				<TableItem className="order__detail-item-total">{ item.total }</TableItem>
+			</TableRow>
+		);
+	}
+
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<div className="order__details">
+				<SectionHeader label={ translate( 'Order Details' ) } />
+				<Card className="order__details-card">
+					<Table className="order__details-table" header={ this.renderTableHeader() }>
+						{ order.line_items.map( this.renderOrderItems ) }
+					</Table>
+
+					<div className="order__details-totals">
+						<div className="order__details-total-discount">
+							<div className="order__details-totals-label">{ translate( 'Discount' ) }</div>
+							<div className="order__details-totals-value">{ order.discount_total }</div>
+						</div>
+						<div className="order__details-total-shipping">
+							<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
+							<div className="order__details-totals-value">{ order.shipping_total }</div>
+						</div>
+						<div className="order__details-total">
+							<div className="order__details-totals-label">{ translate( 'Total' ) }</div>
+							<div className="order__details-totals-value">{ order.total }</div>
+						</div>
+					</div>
+
+					<div className="order__details-refund">
+						<div className="order__details-refund-label">
+							<Gridicon icon="checkmark" />
+							{ translate( 'Payment of %(total)s received via %(method)s', {
+								args: {
+									total: order.total,
+									method: order.payment_method_title
+								}
+							} ) }
+						</div>
+						<div className="order__details-refund-action">
+							<Button>{ translate( 'Submit Refund' ) }</Button>
+						</div>
+					</div>
+
+					<div className="order__details-fulfillment">
+						<div className="order__details-fulfillment-label">
+							<Gridicon icon="shipping" />
+							{ translate( 'Order needs to be fulfilled' ) }
+						</div>
+						<div className="order__details-fulfillment-action">
+							<Button primary>{ translate( 'Print label' ) }</Button>
+						</div>
+					</div>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderDetails );

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import Gridicon from 'gridicons';
 
 /**
@@ -16,6 +16,16 @@ import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
 
 class OrderDetails extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			discount_total: PropTypes.string.isRequired,
+			line_items: PropTypes.array.isRequired,
+			payment_method_title: PropTypes.string.isRequired,
+			shipping_total: PropTypes.string.isRequired,
+			total: PropTypes.string.isRequired,
+		} ),
+	}
+
 	renderTableHeader = () => {
 		const { translate } = this.props;
 		return (

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -110,3 +110,22 @@
 		margin-right: 8px;
 	}
 }
+
+.order__customer-info {
+	h3 {
+		margin-bottom: 16px;
+	}
+
+	h4 {
+		font-weight: bold;
+	}
+}
+
+.order__billing-address,
+.order__shipping-address {
+	margin-bottom: 1.5em;
+
+	p {
+		margin-bottom: 0;
+	}
+}

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -82,6 +82,10 @@
 		}
 	}
 
+	.order__details-total {
+		margin-bottom: 0;
+	}
+
 	.order__details-total .order__details-totals-label,
 	.order__details-total .order__details-totals-value {
 		font-weight: bold;
@@ -141,6 +145,12 @@
 
 	h4 {
 		font-weight: bold;
+	}
+
+	.order__customer-shipping {
+		.order__shipping-address {
+			margin-bottom: 0;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -118,6 +118,8 @@
 		.button {
 			float: left;
 			margin-right: 8px;
+			white-space: nowrap;
+			margin-left: 12px;
 		}
 
 		& > .button:last-child {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -54,6 +54,12 @@
 	thead .table-heading {
 		border-bottom: 1px solid lighten( $gray, 30% );
 	}
+
+	.table-row {
+		&:hover {
+			background: transparent;
+		}
+	}
 }
 
 .order__details-totals {
@@ -75,7 +81,7 @@
 			width: 16%;
 		}
 	}
-	
+
 	.order__details-total .order__details-totals-label,
 	.order__details-total .order__details-totals-value {
 		font-weight: bold;
@@ -96,7 +102,7 @@
 		align-items: center;
 		flex-grow: 1;
 	}
-	
+
 	.order__details-refund-label .gridicon {
 		color: $alert-green;
 	}

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -75,6 +75,11 @@
 			width: 16%;
 		}
 	}
+	
+	.order__details-total .order__details-totals-label,
+	.order__details-total .order__details-totals-value {
+		font-weight: bold;
+	}
 }
 
 .order__details-refund,
@@ -90,6 +95,10 @@
 		display: flex;
 		align-items: center;
 		flex-grow: 1;
+	}
+	
+	.order__details-refund-label .gridicon {
+		color: $alert-green;
 	}
 
 	.order__details-refund-action,
@@ -111,9 +120,17 @@
 	}
 }
 
+.order__details-fulfillment {
+	background: lighten( $blue-light, 25% );
+}
+
 .order__customer-info {
-	h3 {
+	.order__billing-details,
+	.order__shipping-details {
 		margin-bottom: 16px;
+		color: $gray-text-min;
+		font-size: 12px;
+		text-transform: uppercase;
 	}
 
 	h4 {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -1,0 +1,112 @@
+.order__container {
+	padding-bottom: 0;
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
+	}
+
+	@include breakpoint( ">960px" ) {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+
+		.order__details {
+			flex: 1 1 100%;
+		}
+
+		.order__activity-log {
+			flex: 2;
+			margin-right: 16px;
+		}
+
+		.order__customer-info {
+			flex: 1;
+		}
+	}
+
+	.section-header__label {
+		font-size: 16px;
+	}
+
+	thead {
+		.table-row:hover {
+			background: transparent;
+		}
+	}
+}
+
+.order__details-card {
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
+.order__details-table {
+	margin: 0 -24px;
+	box-shadow: none;
+	border-bottom: 1px solid lighten( $gray, 30% );
+
+	.order__detail-item-cost,
+	.order__detail-item-quantity,
+	.order__detail-item-total {
+		text-align: right;
+	}
+
+	thead .table-heading {
+		border-bottom: 1px solid lighten( $gray, 30% );
+	}
+}
+
+.order__details-totals {
+	padding: 24px 0;
+	text-align: right;
+
+	.order__details-total-discount,
+	.order__details-total-shipping,
+	.order__details-total {
+		margin-bottom: 8px;
+
+		.order__details-totals-label {
+			display: inline-block;
+			width: 84%;
+		}
+
+		.order__details-totals-value {
+			display: inline-block;
+			width: 16%;
+		}
+	}
+}
+
+.order__details-refund,
+.order__details-fulfillment {
+	margin: 0 -24px;
+	padding: 24px;
+	border-top: 1px solid lighten( $gray, 30% );
+	display: flex;
+	align-items: center;
+
+	.order__details-refund-label,
+	.order__details-fulfillment-label {
+		display: flex;
+		align-items: center;
+		flex-grow: 1;
+	}
+
+	.order__details-refund-action,
+	.order__details-fulfillment-action {
+		flex-grow: 0;
+
+		.button {
+			float: left;
+			margin-right: 8px;
+		}
+
+		& > .button:last-child {
+			margin-right: 0;
+		}
+	}
+
+	.gridicon {
+		margin-right: 8px;
+	}
+}

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -87,11 +87,11 @@ class Orders extends Component {
 	}
 
 	renderOrderItems = ( order, i ) => {
-		const { moment, siteId } = this.props;
+		const { moment, site } = this.props;
 		return (
 			<TableRow key={ i }>
 				<TableItem className="orders__table-name" isRowHeader>
-					<a className="orders__item-link" href={ `/store/order/${ siteId }/${ order.number }` }>#{ order.number }</a>
+					<a className="orders__item-link" href={ `/store/order/${ site.slug }/${ order.number }` }>#{ order.number }</a>
 					<span className="orders__item-name">
 						{ `${ order.billing.first_name } ${ order.billing.last_name }` }
 					</span>
@@ -198,6 +198,7 @@ export default connect(
 			orders,
 			ordersLoading,
 			ordersLoaded,
+			site,
 			siteId,
 			totalPages,
 		};

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -30,13 +30,21 @@
 	background: lighten( $gray, 20% );
 	border-radius: 4px;
 
-	&.is-cancelled,
 	&.is-failed {
 		background: lighten( $alert-red, 20% );
 		color: darken( $alert-red, 30% );
 
 		span + span {
 			border-color: $alert-red;
+		}
+	}
+
+	&.is-cancelled {
+		background: $gray-light;
+		color: $gray-dark;
+
+		span + span {
+			border-color: $gray-text-min;
 		}
 	}
 

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,6 +12,7 @@ import { translate } from 'i18n-calypso';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
+import Order from './app/order';
 import Orders from './app/orders';
 import Products from './app/products';
 import ProductCreate from './app/products/product-create';
@@ -74,6 +75,11 @@ const getStorePages = () => {
 				label: translate( 'Orders' ),
 				slug: 'orders',
 			},
+		},
+		{
+			container: Order,
+			configKey: 'woocommerce/extension-orders',
+			path: '/store/order/:site/:order',
 		},
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
@@ -147,7 +153,7 @@ function getStoreSidebarItemButtons() {
 function addStorePage( storePage, storeNavigation ) {
 	page( storePage.path, siteSelection, storeNavigation, function( context ) {
 		renderWithReduxStore(
-			React.createElement( storePage.container, { className: 'woocommerce' } ),
+			React.createElement( storePage.container, { className: 'woocommerce', params: context.params } ),
 			document.getElementById( 'primary' ),
 			context.store
 		);

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -22,6 +22,7 @@
 	@import 'components/list/style';
 	@import 'components/table/style';
 	@import 'app/dashboard/style';
+	@import 'app/order/style';
 	@import 'app/orders/style';
 	@import 'components/basic-widget/style';
 	@import 'components/share-widget/style';
@@ -45,7 +46,7 @@
 }
 
 .is-section-woocommerce {
-	// overwrite notice styles due to sticky bar 
+	// overwrite notice styles due to sticky bar
 	.global-notices {
 		@include breakpoint( ">660px" ) {
 			top: 115px;


### PR DESCRIPTION
This PR adds the single order view, only the content for basic styling, no functionality yet. I'm pushing this up for review now in the interest of speedy review & collaboration 😁 

Current screenshot:

![screen shot 2017-06-21 at 6 23 11 pm](https://user-images.githubusercontent.com/541093/27409303-c14bf1c2-56ae-11e7-9033-2de5fe90be9b.png)

Known issues on my to-do list:

- [ ] Update the refund/fulfillment actions based on the current order
- [ ] Implement print label button
- [ ] Add activity log
- [ ] Format currency
- [ ] Add product SKU to item list
- [ ] Check on address formatting (for other countries)
- [ ] Make the entire order row clickable in orders list
- [ ] Highlight the Orders item in the sidebar nav
- [ ] Make product name in order link to product
- [ ] Include product thumb in product list

@kellychoffman Are we allowing refunds in v1? Does the rest of ^ make sense?

To test:

- Go to your orders: `http://calypso.localhost:3000/store/orders/$site`
- Click into a order (by clicking the ID), and see the order data populated.