### PR TITLE
Fix typo in PropTypes of the PublicizeMessage component

### DIFF
--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -17,7 +17,7 @@ export default React.createClass( {
 	displayName: 'PublicizeMessage',
 
 	propTypes: {
-		message: React.PropTypes.bool,
+		disabled: React.PropTypes.bool,
 		message: React.PropTypes.string,
 		preview: React.PropTypes.string,
 		acceptableLength: React.PropTypes.number,


### PR DESCRIPTION
The proptype is `message`, but should be `disabled`. Fixes a typo introduced in #15109.