### PR TITLE
Fix CSS margin of the PublicizeMessage textarea

### DIFF
--- a/client/post-editor/editor-sharing/publicize-message.scss
+++ b/client/post-editor/editor-sharing/publicize-message.scss
@@ -13,7 +13,7 @@
 	}
 
 	.editor-sharing__message-input {
-		margin: 13px 20px 8px 20px;
+		margin: 8px 0;
 	}
 
 	.info-popover {


### PR DESCRIPTION
Fixes broken `PublicizeMessage` display in the "Post Settings" sidebar when editing a post.

Here's a picture before and after the fix:
<img width="580" alt="publicize-message-editor-margin" src="https://user-images.githubusercontent.com/664258/27435289-ff2509ae-575b-11e7-9f78-baff2fec1a01.png">

The patch reverts a CSS change that was introduced in #12471, most likely to style the `PublicizeMessage` component for the `PostShare` block:
<img width="631" alt="publicize-message-post-share" src="https://user-images.githubusercontent.com/664258/27435371-5303f8aa-575c-11e7-8abf-f1a48461d6c3.png">

But these margins are already taken care of in `PostShare` styles [here](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/post-share/style.scss#L92-L107).