### PR TITLE
Introduce TypeScript Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@types/react": "15.0.29",
+    "@types/react-dom": "15.5.0",
     "async": "0.9.0",
     "autoprefixer": "6.3.5",
     "autosize": "3.0.15",
@@ -219,6 +221,7 @@
   },
   "devDependencies": {
     "5to6-codemod": "5to6/5to6-codemod#v1.7.0",
+    "awesome-typescript-loader": "3.1.3",
     "babel-eslint": "6.1.2",
     "cash-touch": "0.2.0",
     "chai": "3.5.0",
@@ -257,8 +260,10 @@
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "socket.io": "1.4.5",
+    "source-map-loader": "0.1.5",
     "stylelint": "6.9.0",
     "supertest": "2.0.0",
+    "typescript": "2.3.4",
     "webpack-bundle-analyzer": "2.2.1",
     "webpack-dashboard": "0.2.0",
     "webpack-dev-server": "1.11.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "es2015",
+    "jsx": "preserve",
+    "sourceMap": true,
+    "outDir": "build-ts",
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "baseUrl": "client",
+    "allowSyntheticDefaultImports": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,11 +65,16 @@ const webpackConfig = {
 			{
 				include: /node_modules[\/\\]tinymce/,
 				loader: 'imports?this=>window',
+			},
+			{
+				test: /\.tsx?$/,
+				exclude: /node_mdoules/,
+				loaders: [ 'babel-loader', 'awesome-typescript-loader' ]
 			}
 		]
 	},
 	resolve: {
-		extensions: [ '', '.json', '.js', '.jsx' ],
+		extensions: [ '', '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		root: [ path.join( __dirname, 'client' ), path.join( __dirname, 'client', 'extensions' ) ],
 		modulesDirectories: [ 'node_modules' ],
 		alias: {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -75,6 +75,11 @@ const webpackConfig = {
 				loader: path.join( __dirname, 'server', 'isomorphic-routing', 'loader' )
 			},
 			{
+				test: /\.tsx?$/,
+				exclude: /node_modules/,
+				loaders: [ 'babel-loader', 'awesome-typescript-laoder' ]
+			},
+			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs[\/\\]search-index)/,
 				loader: 'babel',


### PR DESCRIPTION
This change introduces the `awesome-typescript-loader` and dependencies
needed to write code for Calypso in TypeScript.

It does not introduce any actual TypeScript code.

It's a for-realz PR and the motivation is dealing with data models in Calypso though the benefits extend far beyond here.

## Why?

Because JavaScript cannot give us the guarantees we want with things (like what properties of the site object are being used) nor does it have a good was of providing a declarative data model (see my exploration in #14595).

TypeScript can give us this and all the benefits of static typing as well as the benefits of compiling our code.

## Why TypeScript and not Flow?

TypeScript is a compile-to-JS language while Flow is a type checker. There are strong advantages to both but my preference has been TypeScript since it's compiled and since it seems to be more conservative in its failures, as in it is more likely to fail a valid type than pass an invalid one.

TypeScript also may have the best IDE integration. Microsoft has put good effort into supporting useful autocomplete, error messages, and refactoring support. I could not find as much added benefit from Flow.

## Why TypeScript and now Elm/ReasonML?

You tell me!

## What negatives does this bring?

I'm not sure how this will impact compile time yet and it will be hard to measure since it's a gradual introduction. It's very possible that TypeScript compiles faster than our JS code merely on account of the static typing. It _is_ making type inference though so some additional delay could be expected.

TypeScript is also not JavaScript. It's very close and preserves most of the JS semantics (as a superset it kind of must) but there are new bits of syntax and style it presents that will be unfamiliar to people.

## Open Questions

TypeScript can compile to ES3, ES5, ES2015, ESNext, etc… Right now I'm having it generate ES2015 modules and preserve JSX then piping the results through Babel. The goal here is to preserve existing transforms we play out in Babel. We could just as easily skip the entire Babel chain and generate ES5 code. In my opinion this would be advantageous because it would certainly be much faster than going through Babel.

What should be written in TypeScript? Anything. Many teams have echoed a smooth transition from JS to TS. Many popular libraries already publish their type signatures and we can depend on them with a straightforward command, e.g. `npm install @types/redux`.

Is it worth it? As I've expressed quite a bit lately I think we have no choice but to start looking for a compile-to-JS language. It's my opinion that we will always be chasing browser compatibility and build performance and runtime performance with JS. TypeScript here provides marginal complexity but offers most of the desired goals. I would like to start using this in the new comments management section where we will be working with lots of data from comments and I'd like to pave the way to make that easy to optimize and hard to mess up.