### PR TITLE
Framework: Make disabled input border match the prefix/suffix element

### DIFF
--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -24,6 +24,10 @@
 			// (fix found at http://stackoverflow.com/a/24728957)
 			transform: scale( 1 );
 		}
+
+		&:disabled {
+			border-color: lighten( $gray, 20% );
+		}
 	}
 }
 

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -26,7 +26,11 @@
 		}
 
 		&:disabled {
-			border-color: lighten( $gray, 20% );
+			border-right-width: 0;
+
+			& + .form-text-input-with-affixes__suffix {
+				border-left: 1px solid lighten( $gray, 20% );
+			}
 		}
 	}
 }
@@ -71,6 +75,17 @@
 
 	@include breakpoint( ">480px" ) {
 		@include no-prefix-wrap();
+	}
+
+	& + input[type="email"],
+	& + input[type="password"],
+	& + input[type="url"],
+	& + input[type="text"],
+	& + input[type="number"] {
+		&:disabled {
+			border-left-color: lighten( $gray, 20% );
+			border-right-width: 1px;
+		}
 	}
 }
 


### PR DESCRIPTION
In WooCommerce we have inputs with pre/suffixes that conditionally need to be disabled. Currently this looks a little funky;

![funky](https://cldup.com/9mPnCLtfsm-3000x3000.png)

This PR simply changes the input border to match the prefix/suffix like so;

![better](https://cldup.com/QOCyVJsp8i-3000x3000.png)

Tbh, I'd prefer that the prefix/suffix border and color matched the disabled input like this:

![even-better](https://cldup.com/XXGnirL_Zc-3000x3000.png)

But the lack of a previous sibling selector in css makes this impossible without additional logic which I'm not sure is worth it. We could update the template so the prefix/suffix always appear after the input in the markup. Then use the `+` selector to target it and use flex order to arrange prefixes before the input. That could have accessibility implications though, not to mention how it might impact current applications of this component.

What do we think?