### PR TITLE
Comments: Add parent comment data to the post block

### DIFF
--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ export const CommentDetailPost = ( {
 	postTitle,
 	postUrl,
 	siteId,
+	translate,
 } ) => {
 	if ( parentCommentContent ) {
 		return (
@@ -27,7 +29,7 @@ export const CommentDetailPost = ( {
 				</div>
 				<div className="comment-detail__post-info">
 					<span>
-						{ parentCommentAuthorDisplayName }
+						{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
 					</span>
 					<a href={ parentCommentUrl }>
 						{ parentCommentContent }
@@ -42,7 +44,7 @@ export const CommentDetailPost = ( {
 			<SiteIcon siteId={ siteId } size={ 24 } />
 			<div className="comment-detail__post-info">
 				<span>
-					{ postAuthorDisplayName }
+					{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
 				</span>
 				<a href={ postUrl }>
 					{ postTitle }
@@ -52,4 +54,4 @@ export const CommentDetailPost = ( {
 	);
 };
 
-export default CommentDetailPost;
+export default localize( CommentDetailPost );

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -7,28 +7,30 @@ import React from 'react';
  * Internal dependencies
  */
 import SiteIcon from 'blocks/site-icon';
-import { decodeEntities, stripHTML } from 'lib/formatting';
 
 export const CommentDetailPost = ( {
-	parentComment,
+	parentCommentAuthorAvatarUrl,
+	parentCommentAuthorDisplayName,
+	parentCommentContent,
+	parentCommentUrl,
 	postAuthorDisplayName,
 	postTitle,
 	postUrl,
 	siteId,
 } ) => {
-	if ( parentComment ) {
+	if ( parentCommentContent ) {
 		return (
 			<div className="comment-detail__post">
 				<div className="comment-detail__site-icon-author-avatar">
 					<SiteIcon siteId={ siteId } size={ 24 } />
-					<img className="comment-detail__author-avatar-image" src={ parentComment.author.avatar_URL } />
+					<img className="comment-detail__author-avatar-image" src={ parentCommentAuthorAvatarUrl } />
 				</div>
 				<div className="comment-detail__post-info">
 					<span>
-						{ parentComment.author.name }
+						{ parentCommentAuthorDisplayName }
 					</span>
-					<a href={ parentComment.URL }>
-						{ decodeEntities( stripHTML( parentComment.content ) ) }
+					<a href={ parentCommentUrl }>
+						{ parentCommentContent }
 					</a>
 				</div>
 			</div>

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -7,23 +7,47 @@ import React from 'react';
  * Internal dependencies
  */
 import SiteIcon from 'blocks/site-icon';
+import { decodeEntities, stripHTML } from 'lib/formatting';
 
 export const CommentDetailPost = ( {
+	parentComment,
 	postAuthorDisplayName,
 	postTitle,
 	postUrl,
 	siteId,
-} ) =>
-	<div className="comment-detail__post">
-		<SiteIcon siteId={ siteId } size={ 24 } />
-		<div className="comment-detail__post-info">
-			<span>
-				{ postAuthorDisplayName }
-			</span>
-			<a href={ postUrl }>
-				{ postTitle }
-			</a>
+} ) => {
+	if ( parentComment ) {
+		return (
+			<div className="comment-detail__post">
+				<div className="comment-detail__site-icon-author-avatar">
+					<SiteIcon siteId={ siteId } size={ 24 } />
+					<img className="comment-detail__author-avatar-image" src={ parentComment.author.avatar_URL } />
+				</div>
+				<div className="comment-detail__post-info">
+					<span>
+						{ parentComment.author.name }
+					</span>
+					<a href={ parentComment.URL }>
+						{ decodeEntities( stripHTML( parentComment.content ) ) }
+					</a>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="comment-detail__post">
+			<SiteIcon siteId={ siteId } size={ 24 } />
+			<div className="comment-detail__post-info">
+				<span>
+					{ postAuthorDisplayName }
+				</span>
+				<a href={ postUrl }>
+					{ postTitle }
+				</a>
+			</div>
 		</div>
-	</div>;
+	);
+};
 
 export default CommentDetailPost;

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -28,9 +28,11 @@ export const CommentDetailPost = ( {
 					<img className="comment-detail__author-avatar-image" src={ parentCommentAuthorAvatarUrl } />
 				</div>
 				<div className="comment-detail__post-info">
-					<span>
-						{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
-					</span>
+					{ parentCommentAuthorDisplayName &&
+						<span>
+							{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
+						</span>
+					}
 					<a href={ parentCommentUrl }>
 						{ parentCommentContent }
 					</a>
@@ -43,9 +45,11 @@ export const CommentDetailPost = ( {
 		<div className="comment-detail__post">
 			<SiteIcon siteId={ siteId } size={ 24 } />
 			<div className="comment-detail__post-info">
-				<span>
-					{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
-				</span>
+				{ postAuthorDisplayName &&
+					<span>
+						{ translate( '%(authorName)s:', { args: { authorName: postAuthorDisplayName } } ) }
+					</span>
+				}
 				<a href={ postUrl }>
 					{ postTitle }
 				</a>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -223,6 +223,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const parentCommentId = get( commentsTree, `[${ comment.ID }].data.parent.ID`, 0 );
 	const parentComment = get( commentsTree, `[${ parentCommentId }].data`, {} );
 
+	// TODO: eventually it will be returned already decoded from the data layer.
 	const parentCommentContent = decodeEntities( stripHTML( get( parentComment, 'content' ) ) );
 
 	return ( {

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -15,7 +15,7 @@ import CommentDetailComment from './comment-detail-comment';
 import CommentDetailHeader from './comment-detail-header';
 import CommentDetailPost from './comment-detail-post';
 import CommentDetailReply from './comment-detail-reply';
-import { decodeEntities } from 'lib/formatting';
+import { decodeEntities, stripHTML } from 'lib/formatting';
 import { getPostCommentsTree } from 'state/comments/selectors';
 
 export class CommentDetail extends Component {
@@ -122,7 +122,10 @@ export class CommentDetail extends Component {
 			commentIsSelected,
 			commentStatus,
 			isBulkEdit,
-			parentComment,
+			parentCommentAuthorAvatarUrl,
+			parentCommentAuthorDisplayName,
+			parentCommentContent,
+			parentCommentUrl,
 			postAuthorDisplayName,
 			postTitle,
 			postUrl,
@@ -172,7 +175,10 @@ export class CommentDetail extends Component {
 				{ isExpanded &&
 					<div className="comment-detail__content">
 						<CommentDetailPost
-							parentComment={ parentComment }
+							parentCommentAuthorAvatarUrl={ parentCommentAuthorAvatarUrl }
+							parentCommentAuthorDisplayName={ parentCommentAuthorDisplayName }
+							parentCommentContent={ parentCommentContent }
+							parentCommentUrl={ parentCommentUrl }
 							postAuthorDisplayName={ postAuthorDisplayName }
 							postTitle={ postTitle }
 							postUrl={ postUrl }
@@ -215,7 +221,9 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
 	const parentCommentId = get( commentsTree, `[${ comment.ID }].data.parent.ID`, 0 );
-	const parentComment = get( commentsTree, `[${ parentCommentId }].data`, false );
+	const parentComment = get( commentsTree, `[${ parentCommentId }].data`, {} );
+
+	const parentCommentContent = decodeEntities( stripHTML( get( parentComment, 'content' ) ) );
 
 	return ( {
 		authorAvatarUrl: get( comment, 'author.avatar_URL' ),
@@ -231,7 +239,10 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentId: comment.ID,
 		commentIsLiked: comment.i_like,
 		commentStatus: comment.status,
-		parentComment,
+		parentCommentAuthorAvatarUrl: get( parentComment, 'author.avatar_URL' ),
+		parentCommentAuthorDisplayName: get( parentComment, 'author.name' ),
+		parentCommentContent,
+		parentCommentUrl: get( parentComment, 'URL' ),
 		postAuthorDisplayName: get( comment, 'post.author.name' ), // TODO: not available in the current data structure
 		postId,
 		postTitle,

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -16,6 +16,7 @@ import CommentDetailHeader from './comment-detail-header';
 import CommentDetailPost from './comment-detail-post';
 import CommentDetailReply from './comment-detail-reply';
 import { decodeEntities } from 'lib/formatting';
+import { getPostCommentsTree } from 'state/comments/selectors';
 
 export class CommentDetail extends Component {
 	static propTypes = {
@@ -121,6 +122,7 @@ export class CommentDetail extends Component {
 			commentIsSelected,
 			commentStatus,
 			isBulkEdit,
+			parentComment,
 			postAuthorDisplayName,
 			postTitle,
 			postUrl,
@@ -170,6 +172,7 @@ export class CommentDetail extends Component {
 				{ isExpanded &&
 					<div className="comment-detail__content">
 						<CommentDetailPost
+							parentComment={ parentComment }
 							postAuthorDisplayName={ postAuthorDisplayName }
 							postTitle={ postTitle }
 							postUrl={ postUrl }
@@ -205,8 +208,14 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteId,
 	} = ownProps;
 
+	const postId = get( comment, 'post.ID' );
+
 	// TODO: eventually it will be returned already decoded from the data layer.
 	const postTitle = decodeEntities( get( comment, 'post.title' ) );
+
+	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
+	const parentCommentId = get( commentsTree, `[${ comment.ID }].data.parent.ID`, 0 );
+	const parentComment = get( commentsTree, `[${ parentCommentId }].data`, false );
 
 	return ( {
 		authorAvatarUrl: get( comment, 'author.avatar_URL' ),
@@ -222,7 +231,9 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentId: comment.ID,
 		commentIsLiked: comment.i_like,
 		commentStatus: comment.status,
-		postAuthorDisplayName: get( comment, 'post.author.name' ),
+		parentComment,
+		postAuthorDisplayName: get( comment, 'post.author.name' ), // TODO: not available in the current data structure
+		postId,
 		postTitle,
 		postUrl: get( comment, 'URL' ),
 		repliedToComment: comment.replied, // TODO: not available in the current data structure

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -197,10 +197,13 @@ export class CommentDetail extends Component {
 }
 
 const mapStateToProps = ( state, ownProps ) => {
-	// TODO: replace with
+	// TODO: replace `const comment = ownProps.comment;` with
 	// `const comment = ownProps.comment || getComment( ownProps.commentId );`
 	// when the selector is ready.
-	const comment = ownProps.comment;
+	const {
+		comment,
+		siteId,
+	} = ownProps;
 
 	// TODO: eventually it will be returned already decoded from the data layer.
 	const postTitle = decodeEntities( get( comment, 'post.title' ) );
@@ -223,7 +226,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		postTitle,
 		postUrl: get( comment, 'URL' ),
 		repliedToComment: comment.replied, // TODO: not available in the current data structure
-		siteId: comment.siteId,
+		siteId: comment.siteId || siteId,
 	} );
 };
 

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -220,8 +220,8 @@ const mapStateToProps = ( state, ownProps ) => {
 	const postTitle = decodeEntities( get( comment, 'post.title' ) );
 
 	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
-	const parentCommentId = get( commentsTree, `[${ comment.ID }].data.parent.ID`, 0 );
-	const parentComment = get( commentsTree, `[${ parentCommentId }].data`, {} );
+	const parentCommentId = get( commentsTree, [ comment.ID, 'data', 'parent', 'ID' ], 0 );
+	const parentComment = get( commentsTree, [ parentCommentId, 'data' ], {} );
 
 	// TODO: eventually it will be returned already decoded from the data layer.
 	const parentCommentContent = decodeEntities( stripHTML( get( parentComment, 'content' ) ) );

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -230,9 +230,9 @@
 
 	.comment-detail__author-avatar-image {
 		border: 2px solid $white;
-		bottom: -7px;
 		position: absolute;
-		right: -7px;
+			bottom: -7px;
+			right: -7px;
 		width: 18px;
 	}
 }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -225,6 +225,18 @@
 	}
 }
 
+.comment-detail__site-icon-author-avatar {
+	position: relative;
+
+	.comment-detail__author-avatar-image {
+		border: 2px solid $white;
+		bottom: -7px;
+		position: absolute;
+		right: -7px;
+		width: 18px;
+	}
+}
+
 .comment-detail__post-info {
 	overflow: hidden;
 	padding-left: 8px;
@@ -233,7 +245,7 @@
 
 	span {
 		color: $gray-text;
-		margin-right: 8px;
+		margin: 0 8px;
 	}
 
 	a {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -230,6 +230,7 @@
 
 	.comment-detail__author-avatar-image {
 		border: 2px solid $white;
+		border-radius: 50%;
 		position: absolute;
 			bottom: -7px;
 			right: -7px;


### PR DESCRIPTION
Closes #15204

If a comment is a reply, displays parent comment data (author name and avatar; comment content and URL) in the `CommentDetailPost` component.

The "blavatar+avatar" element does not use the `ReaderAvatar` block, because of the completely different usage, that would require workarounds for both the required props and the style.

### Note 1 (cc @drw158)

The "blavatar+avatar" is smaller than `ReaderAvatar` to be consistent with the 24px `SiteIcon`.
When compact, `ReaderAvatar` has a 32px `SiteIcon` and a 24px author avatar (see: https://wpcalypso.wordpress.com/devdocs/blocks/reader-avatar).
Here instead, we have a 24px `SiteIcon` and a 18px avatar.
Is it too small?

### Note 2 (cc @gwwar)

If a comment is _not_ a reply, we currently don't have the post author available. That's why in the first comment of the following screenshot there's a "dangling" colon.
I didn't want to introduce a query component to fish up posts only for one single property.
I guess it'd make sense to add it to the whole comment structure; the same goes for the parent comment data, which I currently retrieve via `getPostCommentsTree`, which might not be the best approach ever.

<img width="614" alt="screen shot 2017-06-22 at 15 27 04" src="https://user-images.githubusercontent.com/2070010/27439266-7d2e78f0-575f-11e7-8e03-cf3c58925c6c.png">
