### PR TITLE
Activity log: Item data and generic design

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -93,6 +93,7 @@ class ActivityLogDay extends Component {
 			allowRestore,
 			logs,
 			requestRestore,
+			siteId,
 		} = this.props;
 
 		return (
@@ -106,18 +107,9 @@ class ActivityLogDay extends Component {
 						<ActivityLogItem
 							key={ index }
 							allowRestore={ allowRestore }
+							siteId={ siteId }
 							requestRestore={ requestRestore }
-
-							title={ log.name }
-							subTitle={ log.subTitle }
-							description={ log.description }
-							icon={ log.icon }
-							siteId={ this.props.siteId }
-							timestamp={ log.ts_site }
-							user={ log.user }
-							actionText={ log.actionText }
-							status={ log.status }
-							className={ log.className }
+							log={ log }
 						/>
 					) ) }
 				</FoldableCard>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -50,6 +50,7 @@ class ActivityLogDay extends Component {
 
 		return (
 			<Button
+				className="activity-log-day__rewind-button"
 				compact
 				disabled={ ! this.props.isRewindActive }
 				onClick={ this.handleClickRestore }

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -35,3 +35,7 @@
 	font-size: 12px;
 	color: $gray;
 }
+
+.activity-log-day__rewind-button {
+	text-transform: uppercase;
+}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -167,7 +167,7 @@ class ActivityLogItem extends Component {
 					FIXME: actor does not correspond to a Gravatar user
 					We need to receive `avatar_URL` from the endpoint or query users.
 				*/ }
-				<Gravatar user={ {} } size={ 48 } />
+				<Gravatar user={ {} } size={ 40 } />
 				<div className="activity-log-item__actor-info">
 					<div className="activity-log-item__actor-name">{ actor.display_name }</div>
 					<div className="activity-log-item__actor-role">{ actor.translated_role }</div>

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -2,17 +2,17 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Gridicon from 'gridicons';
-import FoldableCard from 'components/foldable-card';
 import EllipsisMenu from 'components/ellipsis-menu';
-import PopoverMenuItem from 'components/popover/menu-item';
+import FoldableCard from 'components/foldable-card';
 import Gravatar from 'components/gravatar';
+import Gridicon from 'gridicons';
+import PopoverMenuItem from 'components/popover/menu-item';
 import { addQueryArgs } from 'lib/route';
 
 class ActivityLogItem extends Component {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -13,6 +13,7 @@ import FoldableCard from 'components/foldable-card';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gravatar from 'components/gravatar';
+import { addQueryArgs } from 'lib/route';
 
 class ActivityLogItem extends Component {
 
@@ -40,6 +41,7 @@ class ActivityLogItem extends Component {
 				user_email: PropTypes.string,
 				user_roles: PropTypes.string,
 				wpcom_user_id: PropTypes.number,
+				avatar_url: PropTypes.string,
 			} ),
 
 			object: PropTypes.shape( {
@@ -161,13 +163,17 @@ class ActivityLogItem extends Component {
 			return null;
 		}
 
+		const avatar_URL = actor.avatar_url
+			? addQueryArgs( { s: 40 }, actor.avatar_url )
+			: null;
+
 		return (
 			<div className="activity-log-item__actor">
 				{ /*
 					FIXME: actor does not correspond to a Gravatar user
 					We need to receive `avatar_URL` from the endpoint or query users.
 				*/ }
-				<Gravatar user={ {} } size={ 40 } />
+				<Gravatar user={ { avatar_URL } } size={ 40 } />
 				<div className="activity-log-item__actor-info">
 					<div className="activity-log-item__actor-name">{ actor.display_name }</div>
 					<div className="activity-log-item__actor-role">{ actor.translated_role }</div>

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -19,98 +19,227 @@ class ActivityLogItem extends Component {
 	static propTypes = {
 		allowRestore: PropTypes.bool.isRequired,
 		siteId: PropTypes.number.isRequired,
-		timestamp: PropTypes.number.isRequired,
 		requestRestore: PropTypes.func.isRequired,
-		title: PropTypes.string,
-		subTitle: PropTypes.string,
-		className: PropTypes.string,
-		icon: PropTypes.string,
-		status: PropTypes.oneOf( [ 'is-success', 'is-warning', 'is-error', 'is-info' ] ),
-		user: PropTypes.object,
-		actionText: PropTypes.string,
-		description: PropTypes.string
+
+		log: PropTypes.shape( {
+			group: PropTypes.oneOf( [
+				'attachment',
+				'comment',
+				'post',
+				'term',
+				'user',
+			] ).isRequired,
+			name: PropTypes.string.isRequired,
+			ts_site: PropTypes.number.isRequired,
+			ts_utc: PropTypes.number.isRequired,
+
+			actor: PropTypes.shape( {
+				display_name: PropTypes.string,
+				login: PropTypes.string,
+				translated_role: PropTypes.string,
+				user_email: PropTypes.string,
+				user_roles: PropTypes.string,
+				wpcom_user_id: PropTypes.number,
+			} ),
+
+			object: PropTypes.shape( {
+				attachment: PropTypes.shape( {
+					mime_type: PropTypes.string,
+					id: PropTypes.number.isRequired,
+					title: PropTypes.string.isRequired,
+					url: PropTypes.shape( {
+						host: PropTypes.string.isRequired,
+						url: PropTypes.string.isRequired,
+						host_reversed: PropTypes.string.isRequired,
+					} ).isRequired,
+				} ),
+
+				comment: PropTypes.shape( {
+					approved: PropTypes.bool.isRequired,
+					id: PropTypes.number.isRequired,
+				} ),
+
+				post: PropTypes.shape( {
+					id: PropTypes.number.isRequired,
+					status: PropTypes.string.isRequired,
+					type: PropTypes.string.isRequired,
+					title: PropTypes.string.isRequired,
+				} ),
+
+				term: PropTypes.shape( {
+					id: PropTypes.number.isRequired,
+					title: PropTypes.string.isRequired,
+					type: PropTypes.string.isRequired,
+				} ),
+
+				user: PropTypes.shape( {
+					display_name: PropTypes.string,
+					login: PropTypes.string.isRequired,
+					external_user_id: PropTypes.number,
+					wpcom_user_id: PropTypes.number,
+				} ),
+			} ),
+		} ).isRequired,
+
+		// localize
+		moment: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
 	};
 
-	static defaultProps = {
-		allowRestore: true,
-		status: 'is-info',
-		icon: 'info-outline'
-	};
+	static defaultProps = { allowRestore: true };
 
+	// TODO: Add analytics
 	handleClickRestore = () => {
 		const {
 			requestRestore,
-			timestamp,
+			log,
 		} = this.props;
-		requestRestore( timestamp );
+		requestRestore( log.ts_utc );
 	};
 
-	getTime() {
+	getIcon() {
+		const { log } = this.props;
 		const {
-			moment,
-			timestamp
-		} = this.props;
+			group,
+			name,
+		} = log;
+
+		switch ( name ) {
+			// Inline return makes alphabetizing and searching easier :)
+			case 'post__published': return 'create';
+			case 'post__trashed': return 'trash';
+			case 'user__registered': return 'user-add';
+		}
+
+		switch ( group ) {
+			case 'attachment':
+				return 'image';
+
+			case 'comment':
+				return 'comment';
+
+			case 'post':
+				return 'posts';
+
+			case 'term':
+				return 'folder';
+
+			case 'user':
+				return 'user';
+		}
+
+		return 'info-outline';
+	}
+
+	getStatus() {
+		const { log } = this.props;
+		const { name } = log;
+
+		switch ( name ) {
+			case 'comment__trashed':
+			case 'post__trashed':
+				return 'is-error';
+
+			case 'attachment__uploaded':
+			case 'comment__published':
+			case 'post__published':
+			case 'term__created':
+			case 'user__registered':
+				return 'is-success';
+
+			case 'comment__published_awaiting_approval':
+			case 'comment__unapproved':
+				return 'is-warning';
+		}
+	}
+
+	renderActor() {
+		const { log } = this.props;
+		const { actor } = log;
+
+		if ( ! actor ) {
+			return null;
+		}
 
 		return (
-			<div className="activity-log-item__time">
-				{ moment( timestamp ).format( 'LT' ) }
+			<div className="activity-log-item__actor">
+				{ /*
+					FIXME: actor does not correspond to a Gravatar user
+					We need to receive `avatar_URL` from the endpoint or query users.
+				*/ }
+				<Gravatar user={ {} } size={ 48 } />
+				<div className="activity-log-item__actor-info">
+					<div className="activity-log-item__actor-name">{ actor.display_name }</div>
+					<div className="activity-log-item__actor-role">{ actor.translated_role }</div>
+				</div>
 			</div>
 		);
 	}
 
-	getIcon() {
+	renderContent() {
+		const { log } = this.props;
 		const {
-			icon,
-			status
-		} = this.props;
+			name,
+		} = log;
 
-		const classes = classNames(
-			'activity-log-item__icon',
-			status
-		);
+		const subTitle = null;
 
 		return (
+			<div className="activity-log-item__content">
+				<div className="activity-log-item__content-title">{ name }</div>
+				{ subTitle && <div className="activity-log-item__content-sub-title">{ subTitle }</div> }
+			</div>
+		);
+	}
+
+	// FIXME: Just for demonstration purposes
+	renderDescription() {
+		const {
+			log,
+			moment,
+			translate,
+		} = this.props;
+		const {
+			name,
+			ts_site,
+		} = log;
+
+		return (
+			<div>
+				{ translate( 'An event "%(eventName)s" occurred at %(date)s', {
+					args: {
+						date: moment( ts_site ).format( 'LLL' ),
+						eventName: name,
+					}
+				} ) }
+			</div>
+		);
+	}
+
+	renderHeader() {
+		return (
+			<div className="activity-log-item__card-header">
+				{ this.renderActor() }
+				{ this.renderContent() }
+			</div>
+		);
+	}
+
+	renderIcon() {
+		const classes = classNames(
+			'activity-log-item__icon',
+			this.getStatus(),
+		);
+		const icon = this.getIcon();
+
+		return ( icon &&
 			<div className={ classes }>
 				<Gridicon icon={ icon } size={ 24 } />
 			</div>
 		);
 	}
 
-	getActor() {
-		const {
-			user
-		} = this.props;
-
-		if ( ! user ) {
-			return null;
-		}
-
-		return (
-			<div className="activity-log-item__actor">
-				<Gravatar user={ user } size={ 48 } />
-				<div className="activity-log-item__actor-info">
-					<div className="activity-log-item__actor-name">{ user.name }</div>
-					<div className="activity-log-item__actor-role">{ user.role }</div>
-				</div>
-			</div>
-		);
-	}
-
-	getContent() {
-		const {
-			title,
-			subTitle
-		} = this.props;
-
-		return (
-			<div className="activity-log-item__content">
-				<div className="activity-log-item__content-title">{ title }</div>
-				{ subTitle && <div className="activity-log-item__content-sub-title">{ subTitle }</div> }
-			</div>
-		);
-	}
-
-	getSummary() {
+	renderSummary() {
 		const {
 			allowRestore,
 			translate,
@@ -131,39 +260,39 @@ class ActivityLogItem extends Component {
 		);
 	}
 
-	getHeader() {
+	renderTime() {
+		const {
+			moment,
+			log,
+		} = this.props;
+
 		return (
-			<div className="activity-log-item__card-header">
-				{ this.getActor() }
-				{ this.getContent() }
+			<div className="activity-log-item__time">
+				{ moment( log.ts_site ).format( 'LT' ) }
 			</div>
 		);
 	}
 
 	render() {
-		const {
-			className,
-			description
-		} = this.props;
-
+		const { className } = this.props;
 		const classes = classNames(
 			'activity-log-item',
 			className
 		);
+
 		return (
 			<div className={ classes } >
 				<div className="activity-log-item__type">
-					{ this.getTime() }
-					{ this.getIcon() }
+					{ this.renderTime() }
+					{ this.renderIcon() }
 				</div>
 				<FoldableCard
 					className="activity-log-item__card"
-					header={ this.getHeader() }
-					summary={ this.getSummary() }
-					expandedSummary={ this.getSummary() }
-					clickableHeader={ true }
+					header={ this.renderHeader() }
+					summary={ this.renderSummary() }
+					expandedSummary={ this.renderSummary() }
 				>
-					{ description }
+					{ this.renderDescription() }
 				</FoldableCard>
 			</div>
 		);

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -6,9 +6,7 @@
 	align-content: flex-start;
 	align-items: center;
 	position: relative;
-	z-index: 2;
-	margin-left: 8px;
-	margin-bottom: 8px;
+	margin-top: 24px;
 
 	.card {
 		width: 300px;
@@ -17,16 +15,6 @@
 		flex-basis: 200px;
 		align-items: center;
 		background: $white;
-	}
-
-	&:first-child {
-		margin-top: 24px;
-	}
-
-	&.is-disabled {
-		.card {
-			opacity: .55;
-		}
 	}
 
 	.activity-log-item__card .foldable-card__content {
@@ -49,24 +37,18 @@
 }
 
 .activity-log-item__type {
-	flex-grow: 0;
-	flex-shrink: 0;
-	flex-basis: 0;
 	align-self: flex-start;
-	text-align:center;
-	margin-top: -5px;
-	margin-right: 24px;
+	background: $gray-light;
+	text-align: center;
+	margin: -2px 22px 0 10px;
+	padding: 4px 0 6px;
 }
 
 .activity-log-item__time {
-	width: 106%;
-	margin-left: -3%;
-	padding-top: 2px;
 	font-size: 11px;
 	color: $gray;
-	text-align:center;
 	text-transform: uppercase;
-	background: $gray-light;
+	white-space: nowrap;
 }
 
 .activity-log-item__icon {
@@ -75,10 +57,8 @@
 	color: $white;
 	display: flex;
 	border-radius: 50%;
-	height:32px;
-	width: 32px;
-	padding: 8px;
-	margin: 4px 0;
+	padding: 12px;
+	margin-top: 2px;
 
 	// Success
 	&.is-success {
@@ -93,10 +73,6 @@
 	// Error! OHNO!
 	&.is-error {
 		background: $alert-red;
-	}
-
-	.gridicon {
-		margin: auto;
 	}
 }
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -112,95 +112,6 @@ class ActivityLog extends Component {
 		rewindRestore( siteId, requestedRestoreTimestamp );
 	};
 
-	update_logs( log ) {
-		const { translate } = this.props;
-		switch ( log.type ) {
-			// Scans
-			case 'security_threat_found':
-				log.subTitle = translate( 'Security Threat Found!' );
-				log.icon = 'notice';
-				log.actionText = translate( 'Fix it' );
-				break;
-			// Backups
-			case 'site_backed_up':
-				log.subTitle = translate( 'Site Backed up' );
-				log.icon = 'checkmark';
-				log.status = 'is-success';
-				log.actionText = 'Restore';
-				break;
-			// Backups
-			case 'site_backed_up_failed':
-				log.subTitle = translate( 'Site Backed up' );
-				log.icon = 'notice';
-				log.actionText = 'Fix';
-				log.status = 'is-error';
-				break;
-			// Plugins
-			case 'plugin_activated':
-				log.subTitle = translate( 'Plugin Activated' );
-				log.icon = 'plugins';
-				log.actionText = 'Deactivate';
-				break;
-			case 'plugin_deactivated':
-				log.subTitle = translate( 'Plugin Deactivated' );
-				log.icon = 'plugins';
-				log.actionText = 'Activate';
-				break;
-			case 'plugin_needs_update':
-				log.subTitle = translate( 'Plugin Update Available' );
-				log.icon = 'plugins';
-				log.status = 'is-warning';
-				log.actionText = 'Update';
-				break;
-			case 'suspicious_code':
-				log.subTitle = translate( 'Security Scan' );
-				log.icon = 'notice';
-				log.status = 'is-error';
-				log.actionText = 'Fix';
-				break;
-			case 'plugin_updated':
-				log.subTitle = translate( 'Plugin Updated' );
-				log.icon = 'plugins';
-				log.actionText = 'Revert';
-				break;
-
-			// Themes
-			case 'theme_switched':
-				log.subTitle = translate( 'Theme Activated' );
-				log.icon = 'themes';
-				log.actionText = 'Revert';
-				break;
-			case 'theme_updated':
-				log.subTitle = translate( 'Theme Updated' );
-				log.icon = 'themes';
-				log.actionText = 'Revert';
-				break;
-			// Plans
-			case 'plan_updated':
-				log.subTitle = translate( 'Plan' );
-				log.icon = 'clipboard';
-				log.actionText = 'Cancel';
-				break;
-			case 'plan_renewed':
-				log.subTitle = translate( 'Plan Renewed' );
-				log.icon = 'clipboard';
-				break;
-			// Jetpack Modules
-			case 'activate_jetpack_feature':
-				log.subTitle = translate( 'Jetpack' );
-				log.icon = 'cog';
-				log.actionText = 'Deactivate';
-				break;
-			case 'deactivate_jetpack_feature':
-				log.subTitle = translate( 'Jetpack' );
-				log.icon = 'cog';
-				log.actionText = 'Activate';
-				break;
-		}
-
-		return log;
-	}
-
 	renderBanner() {
 		const { restoreProgress } = this.props;
 
@@ -288,7 +199,7 @@ class ActivityLog extends Component {
 		const filteredLogs = filter( logs, obj => startOfMonthMs <= obj.ts_site && obj.ts_site <= endOfMonthMs );
 		const logsGroupedByDate = map(
 			groupBy(
-				filteredLogs.map( this.update_logs, this ),
+				filteredLogs,
 				log => moment( log.ts_site ).startOf( 'day' ).format( 'x' )
 			),
 			( daily_logs, timestamp ) => (

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -3,7 +3,7 @@
 .activity-log__wrapper {
 	position: relative;
 
-	&:after {
+	&:before {
 		content: "";
 		position: absolute;
 		top: 0;
@@ -11,7 +11,6 @@
 		left: 33px;
 		width: 2px;
 		background-color: lighten( $gray, 20% );
-		z-index: 1;
 	}
 }
 

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -7,9 +7,9 @@
 		content: "";
 		position: absolute;
 		top: 0;
-		left: 31px;
+		bottom: 0;
+		left: 33px;
 		width: 2px;
-		height: calc( 100% - 64px );
 		background-color: lighten( $gray, 20% );
 		z-index: 1;
 	}


### PR DESCRIPTION
This is not complete as some cleanup is required, but the concept is ready for some feedback.

I largely refactored `ActivityLogItem` and removed an unused chunk of logic from `ActivityLog` that was used mostly for mocking activity in _the big PR_.

I tried to capture `log` in `propTypes`, largely just to document what sorts of data are present.

I added some specific `icon` and `status` just to see what that would look like in code and on the screen.

### To test:
* https://calypso.live/stats/activity?branch=update/activity-log-item-genericstyles
* This is just a generic UI. Try to have a look at how different activity behave.
* Keep an eye on the console for warnings/errors.

### Screenshot:

<!-- old: ![activity](https://user-images.githubusercontent.com/841763/27478655-cf116b80-5810-11e7-9f29-ee8635a75306.png) -->

![al](https://user-images.githubusercontent.com/841763/27582628-dde81b9e-5b31-11e7-8f14-f8d0b9540594.png)


### Discussion points:

1. Raw `log` prop is passed as an object. How do we feel about that?
   * Easy for now as data may change
   * More difficult to work with props
   * More difficult to diff props (performance/render)
1. Should something like `fromApi` be normalizing all of the activity data?
1. Sub-components: ActivityLogItem is pretty big and a few subcomponents would work nicely. It would also allow flattening and passing a few selected props from `log`.
1. Actor Gravatar  - the actor does not include avatar_URL which is what the `Gravatar` component requires. Some possible solutions:
   * API includes URL
   * Fetch wpcom user if wpcom_user_id is included
1. Using some `switch`es in a few places. It feels good so far, allows for nice cascading. Another option to consider is using a big object that maps `name`s to `{ status, icon, ... }`.
1. We've essentially punted on `description` and the translation parts of this component after conversation in #15344 and p1498130501662286-slack-activity-log. The question remains of how to best deal with it.

### To do:
- [x] cleanup dev output
- [x] actor Gravatar solution

### Follow up work
* Restore and other action analytics
* Link activity to content? (post, comment...)
* Ellipsis menu actions - there's a lot of interesting actions that could happen here, like approving a comment right from the list. OTOH
* Add/update `status` and `icon` for different activity.
* break down into logical sub-components. Proposed sub-components (please discuss):
   * icon
   * actor
   * description
   * menu
