### PR TITLE
Publicize: new notification setting

### DIFF
--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -69,7 +69,15 @@ class BlogSettings extends Component {
 								onSave,
 								onSaveToAll
 							} }
-							settingKeys={ [ 'new_comment', 'comment_like', 'post_like', 'follow', 'achievement', 'mentions' ] } />;
+							settingKeys={ [
+								'new_comment',
+								'comment_like',
+								'post_like',
+								'follow',
+								'achievement',
+								'mentions',
+								'scheduled_publicize'
+							] } />;
 					}
 				} )() }
 			</Card>

--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -76,7 +76,7 @@ class BlogSettings extends Component {
 								'follow',
 								'achievement',
 								'mentions',
-								'scheduled_publicize'
+								'scheduled_publicize',
 							] } />;
 					}
 				} )() }

--- a/client/me/notification-settings/settings-form/constants.js
+++ b/client/me/notification-settings/settings-form/constants.js
@@ -1,3 +1,3 @@
 export const NOTIFICATIONS_EXCEPTIONS = {
-	email: [ 'achievement' ]
+	email: [ 'achievement', 'scheduled_publicize' ]
 };

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -13,7 +13,8 @@ export const settingLabels = {
 	post_like: () => i18n.translate( 'Likes on my posts' ),
 	follow: () => i18n.translate( 'Site follows' ),
 	achievement: () => i18n.translate( 'Site achievements' ),
-	mentions: () => i18n.translate( 'Username mentions' )
+	mentions: () => i18n.translate( 'Username mentions' ),
+	scheduled_publicize: () => i18n.translate( 'Post Publicized' )
 };
 
 export const getLabelForStream = stream => stream in streamLabels

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -14,7 +14,7 @@ export const settingLabels = {
 	follow: () => i18n.translate( 'Site follows' ),
 	achievement: () => i18n.translate( 'Site achievements' ),
 	mentions: () => i18n.translate( 'Username mentions' ),
-	scheduled_publicize: () => i18n.translate( 'Post Publicized' )
+	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),
 };
 
 export const getLabelForStream = stream => stream in streamLabels


### PR DESCRIPTION
New notification setting for publicize scheduled action.

D6090-code introduces notifications for advanced social media functionality.
Some users can have loads of activity, so this setting 

Backend work for this has been done in D6090-code .

<img width="799" alt="zrzut ekranu 2017-06-23 o 15 23 48" src="https://user-images.githubusercontent.com/3775068/27484388-52fde58c-5829-11e7-8354-ca74f4d1620e.png">


## How to test?

1. Apply D6090-code
2. go to http://calypso.localhost:3000/me/notifications , find your sites, disable notifications for publicize.
3. Go to wpsh, follow instructions for D6090-code (replace user id and blog id with yours)
4. See that notification did not come, even after a reload
5. Exit out of wpsh. That is importand because caching
6. Reenable notifiactions for publicize on your site with http://calypso.localhost:3000/me/notifications
6. Repeat step 3
7. You should see notification (after a while or after a reload)