### PR TITLE
Comments: Fix whitespaces and reduces nesting

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -57,9 +57,7 @@ export class CommentDetailAuthor extends Component {
 			<div className="comment-detail__author-more-info">
 				<div className="comment-detail__author-more-actions">
 					<div className="comment-detail__author-more-element comment-detail__author-more-element-author">
-						<div className="comment-detail__author-avatar">
-							<img className="comment-detail__author-avatar-image" src={ authorAvatarUrl } />
-						</div>
+						<img className="comment-detail__author-avatar" src={ authorAvatarUrl } />
 						<div className="comment-detail__author-info">
 							<div className="comment-detail__author-name">
 								<strong>
@@ -73,37 +71,36 @@ export class CommentDetailAuthor extends Component {
 					</div>
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="mail" />
-								<span>
-									{ authorEmail }
-								</span>
+						<span>
+							{ authorEmail }
+						</span>
 					</div>
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="link" />
-								<span>
-									{ authorUrl }
-								</span>
+						<span>
+							{ authorUrl }
+						</span>
 					</div>
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="globe" />
-								<span>
-									{ authorIp }
-								</span>
+						<span>
+							{ authorIp }
+						</span>
 					</div>
 				</div>
 				<div className="comment-detail__author-more-actions">
 					<a
 						className={ classNames(
-									'comment-detail__author-more-element comment-detail__author-more-element-block-user',
-									{ 'is-blocked': authorIsBlocked }
-								) }
+							'comment-detail__author-more-element comment-detail__author-more-element-block-user',
+							{ 'is-blocked': authorIsBlocked }
+						) }
 						onClick={ blockUser }
 					>
 						<Gridicon icon="block" />
-								<span>{
-									authorIsBlocked
-										? translate( 'Unblock user' )
-										: translate( 'Block user' )
-								}</span>
+						<span>{ authorIsBlocked
+							? translate( 'Unblock user' )
+							: translate( 'Block user' )
+						} </span>
 					</a>
 				</div>
 			</div>
@@ -128,12 +125,7 @@ export class CommentDetailAuthor extends Component {
 		return (
 			<div className={ classes }>
 				<div className="comment-detail__author-preview">
-					<div className="comment-detail__author-avatar">
-						<img
-							className="comment-detail__author-avatar-image"
-							src={ authorAvatarUrl }
-						/>
-					</div>
+					<img className="comment-detail__author-avatar" src={ authorAvatarUrl } />
 					<div className="comment-detail__author-info">
 						<div className="comment-detail__author-info-element comment-detail__author-name">
 							<strong>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -70,9 +70,7 @@ export const CommentDetailHeader = ( {
 				</label>
 			}
 			<div className="comment-detail__author-preview">
-				<div className="comment-detail__author-avatar">
-					<img className="comment-detail__author-avatar-image" src={ authorAvatarUrl } />
-				</div>
+				<img className="comment-detail__author-avatar" src={ authorAvatarUrl } />
 				<div className="comment-detail__author-info">
 					<div className="comment-detail__author-info-element">
 						<strong>

--- a/client/blocks/comment-detail/comment-detail-placeholder.jsx
+++ b/client/blocks/comment-detail/comment-detail-placeholder.jsx
@@ -12,9 +12,7 @@ export const CommentDetailPlaceholder = () =>
 	<Card className="comment-detail comment-detail__placeholder is-expanded">
 		<div className="comment-detail__header">
 			<div className="comment-detail__author-info">
-				<div className="comment-detail__author-avatar">
-					<span className="comment-detail__author-avatar-image" />
-				</div>
+				<div className="comment-detail__author-avatar" />
 			</div>
 			<div className="comment-detail__comment-preview" />
 		</div>

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -50,11 +50,9 @@
 }
 
 .comment-detail__author-avatar {
-	flex-shrink: 0;
-}
-
-.comment-detail__author-avatar-image {
 	border-radius: 50%;
+	display: block;
+	flex-shrink: 0;
 }
 
 .comment-detail__author-info {
@@ -131,11 +129,11 @@
 
 	&:after {
 		background: linear-gradient(to right, rgba( $white, 0 ), rgba( $white, 1 ) 50%);
-		bottom: 0;
 		content: '';
 		height: 19px;
 		position: absolute;
-		right: 0;
+			bottom: 0;
+			right: 0;
 		width: 30%;
 	}
 	@supports( -webkit-line-clamp: 2 ) {
@@ -396,21 +394,21 @@ a.comment-detail__author-more-element {
 .comment-detail__placeholder {
 	@include placeholder();
 
-	.comment-detail__author-avatar-image,
+	.comment-detail__author-avatar,
 	.comment-detail__comment-preview {
-		color: transparent;
-		background-color: lighten( $gray, 30% );
 		animation: loading-fade 1.6s ease-in-out infinite;
+		background-color: lighten( $gray, 30% );
+		color: transparent;
+		height: 32px;
+		margin: 0 8px;
 	}
 
 	&.is-expanded .comment-detail__header {
 		border: none;
 	}
 
-	.comment-detail__author-avatar-image {
-		display: inline-block;
-		height: 100%;
-		width: 100%;
+	.comment-detail__author-avatar {
+		width: 32px;
 	}
 
 	.comment-detail__author-info {
@@ -418,7 +416,6 @@ a.comment-detail__author-more-element {
 	}
 
 	.comment-detail__comment-preview {
-		margin: 0 8px;
 		width: 100%;
 	}
 }


### PR DESCRIPTION
Fixes the whitespaces in `comment-detail-author.jsx` that went awry after a copy-paste amid editorconfig changes.

Replaces the unnecessary nested author avatar block with a simple image, and adapt the CSS accordingly.

Fixes the comment detail placeholder not showing the blank parts inside.