### PR TITLE
WooCommerce: Updates to table & order list view

### DIFF
--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -19,6 +19,7 @@ import {
 	getOrders,
 	getTotalOrdersPages
 } from 'woocommerce/state/sites/orders/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
 import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getSiteAdminUrl } from 'state/sites/selectors';
@@ -89,9 +90,9 @@ class Orders extends Component {
 	renderOrderItems = ( order, i ) => {
 		const { moment, site } = this.props;
 		return (
-			<TableRow key={ i }>
+			<TableRow key={ i } href={ getLink( `/store/order/:site/${ order.number }`, site ) }>
 				<TableItem className="orders__table-name" isRowHeader>
-					<a className="orders__item-link" href={ `/store/order/${ site.slug }/${ order.number }` }>#{ order.number }</a>
+					<span className="orders__item-link">#{ order.number }</span>
 					<span className="orders__item-name">
 						{ `${ order.billing.first_name } ${ order.billing.last_name }` }
 					</span>

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -23,6 +23,7 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getSiteAdminUrl } from 'state/sites/selectors';
+import humanDate from 'lib/human-date';
 import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
@@ -88,7 +89,7 @@ class Orders extends Component {
 	}
 
 	renderOrderItems = ( order, i ) => {
-		const { moment, site } = this.props;
+		const { site } = this.props;
 		return (
 			<TableRow key={ i } href={ getLink( `/store/order/:site/${ order.number }`, site ) }>
 				<TableItem className="orders__table-name" isRowHeader>
@@ -98,7 +99,7 @@ class Orders extends Component {
 					</span>
 				</TableItem>
 				<TableItem className="orders__table-date">
-					{ moment( order.date_modified ).format( 'LLL' ) }
+					{ humanDate( order.date_created ) }
 				</TableItem>
 				<TableItem className="orders__table-status">
 					{ this.getOrderStatus( order.status ) }

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -13,6 +13,7 @@ import { times } from 'lodash';
 import Button from 'components/button';
 import EmptyContent from 'components/empty-content';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
+import formatCurrency from 'lib/format-currency';
 import {
 	areOrdersLoading,
 	areOrdersLoaded,
@@ -105,7 +106,7 @@ class Orders extends Component {
 					{ this.getOrderStatus( order.status ) }
 				</TableItem>
 				<TableItem className="orders__table-total">
-					{ 'USD' === order.currency ? `$${ order.total }` : order.total }
+					{ formatCurrency( order.total, order.currency ) || order.total }
 				</TableItem>
 			</TableRow>
 		);

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -158,10 +158,10 @@ class Orders extends Component {
 
 		const headers = (
 			<TableRow>
-				<TableItem isHeader>{ translate( 'Order' ) }</TableItem>
-				<TableItem isHeader>{ translate( 'Date' ) }</TableItem>
-				<TableItem isHeader>{ translate( 'Status' ) }</TableItem>
-				<TableItem isHeader>{ translate( 'Total' ) }</TableItem>
+				<TableItem className="orders__table-name" isHeader>{ translate( 'Order' ) }</TableItem>
+				<TableItem className="orders__table-date" isHeader>{ translate( 'Date' ) }</TableItem>
+				<TableItem className="orders__table-status" isHeader>{ translate( 'Status' ) }</TableItem>
+				<TableItem className="orders__table-total" isHeader>{ translate( 'Total' ) }</TableItem>
 			</TableRow>
 		);
 

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -82,7 +82,6 @@
 	}
 }
 
-.orders__table-total,
-.table-heading:last-child {
+.orders__table-total {
 	text-align: right;
 }

--- a/client/extensions/woocommerce/app/products/products-list-row.js
+++ b/client/extensions/woocommerce/app/products/products-list-row.js
@@ -3,7 +3,6 @@
  */
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -45,13 +44,8 @@ const ProductsListRow = ( { site, product } ) => {
 		</div>
 	);
 
-	const goToProduct = () => {
-		const link = getLink( '/store/product/:site/' + product.id, site );
-		page( link );
-	};
-
 	return (
-		<TableRow onClick={ goToProduct }>
+		<TableRow href={ getLink( '/store/product/:site/' + product.id, site ) }>
 			<TableItem isTitle className="products__list-product">
 				{ renderImage() }
 				<span className="products__list-name">{ product.name }</span>

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -98,10 +98,10 @@
 
 .table-row {
 	line-height: 36px;
-	
+
 	&:hover {
 		background: $gray-light;
-		
+
 		&.is-header {
 			background-color: initial;
 		}
@@ -109,6 +109,15 @@
 
 	&.is-header {
 		color: $gray-text-min;
+	}
+
+	&.has-action {
+		cursor: pointer;
+
+		&:focus,
+		&:active {
+			box-shadow: inset 2px 0 0 $blue-medium;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -3,14 +3,38 @@
  */
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
+import page from 'page';
 
-const TableRow = ( { className, isHeader, children, ...props } ) => {
+/**
+ * Internal dependencies
+ */
+import onKeyDownCallback from 'woocommerce/lib/keydown-callback';
+
+const TableRow = ( { className, isHeader, href, children, ...props } ) => {
 	const rowClasses = classnames( 'table-row', className, {
 		'is-header': isHeader,
 	} );
 
+	if ( ! href ) {
+		return (
+			<tr className={ rowClasses } { ...props }>
+				{ children }
+			</tr>
+		);
+	}
+
+	const goToHref = () => {
+		page( href );
+	};
+
 	return (
-		<tr className={ rowClasses } { ...props }>
+		<tr
+			className={ rowClasses + ' has-action' }
+			role="button"
+			tabIndex="0"
+			onClick={ goToHref }
+			onKeyDown={ onKeyDownCallback( goToHref ) }
+			{ ...props }>
 			{ children }
 		</tr>
 	);
@@ -19,6 +43,7 @@ const TableRow = ( { className, isHeader, children, ...props } ) => {
 TableRow.propTypes = {
 	children: PropTypes.node,
 	className: PropTypes.string,
+	href: PropTypes.string,
 	isHeader: PropTypes.bool,
 };
 

--- a/client/extensions/woocommerce/lib/keydown-callback/index.js
+++ b/client/extensions/woocommerce/lib/keydown-callback/index.js
@@ -1,0 +1,16 @@
+// Helper function for keyboard-equivalents of onClick events
+
+/**
+ * Helper function which triggers a callback on a keydown event, only
+ * if the key pressed is space or enter - to mirror button functionality.
+ *
+ * @param {Function} callback A callback function
+ * @return {Function} the callback to fire on a keydown event
+ */
+export default function( callback ) {
+	return ( event ) => {
+		if ( event.which === 13 || event.which === 32 ) {
+			callback( event );
+		}
+	};
+}

--- a/client/extensions/woocommerce/lib/keydown-callback/index.js
+++ b/client/extensions/woocommerce/lib/keydown-callback/index.js
@@ -9,7 +9,7 @@
  */
 export default function( callback ) {
 	return ( event ) => {
-		if ( event.which === 13 || event.which === 32 ) {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
 			callback( event );
 		}
 	};


### PR DESCRIPTION
This PR updates the `TableRow` component to now accept a `href` prop, which lets us link a row to a different page (ex: the view order page, the edit product page). When an href is supplied, the row becomes focusable, and the new page is loaded on click or on enter or space press.

This also updates the class names on the order list table headers, and switches the date format to use `humanDate`, relative timestamps for orders less than a week old.

To test:

- Visit the orders list screen, the products list screen, and anywhere else using the `Table` component
- Make sure your tables work right, and clicking into the row works.