### PR TITLE
Comments: Add `fromApi()` to map into native Calypso data structure

### DIFF
--- a/client/state/comments/from-api.js
+++ b/client/state/comments/from-api.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { pickBy } from 'lodash';
+
+export const toAuthor = ( { avatar_URL, email, ID, name } ) => {
+	if ( ID > 0 ) {
+		return {
+			kind: 'known',
+			userId: parseInt( ID, 10 ),
+		};
+	}
+
+	return Object.assign(
+		{ kind: 'anonymous' },
+		avatar_URL && { avatar: avatar_URL },
+		email && { email },
+		name && { displayName: name },
+	);
+};
+
+export const toWpcomUser = author => pickBy( {
+	ID: author.ID,
+	avatar_URL: author.avatarURL,
+	display_name: author.name,
+	email: author.email,
+	primary_blog: author.site_ID,
+	primary_blog_url: author.URL,
+	username: author.login,
+}, a => !! a );
+
+export const validStatusValues = {
+	approved: 'approved',
+	spam: 'spam',
+	trash: 'trash',
+	unapproved: 'pending',
+};
+
+/**
+ * Attempts to parse a response from the comment endpoint
+ * and return the mapped comment object with its author
+ *
+ * @param {Number} siteId site id is not included in the response items
+ * @param {Object} data raw comment data from API
+ * @returns {Object} comment and WordPress.com user if available
+ */
+export const fromApi = ( siteId, data ) => {
+	try {
+		return Object.assign(
+			{
+				comment: Object.assign(
+					{
+						state: 'loaded',
+						author: toAuthor( data.author ),
+						commentId: parseInt( data.ID, 10 ),
+						content: data.content,
+						createdAt: Date.parse( data.date ),
+						isLiked: Boolean( data.i_like ),
+					},
+					data.parent && data.parent.type === 'comment' && { parentId: parseInt( data.parent.ID, 10 ) },
+					{
+						postId: parseInt( data.post.ID, 10 ),
+						siteId,
+						status: validStatusValues[ data.status ],
+					}
+				)
+			},
+			data.author.ID > 0 && { user: toWpcomUser( data.author ) },
+		);
+	} catch ( e ) {
+		return {
+			state: 'error',
+			error: 'invalid data structure',
+		};
+	}
+};


### PR DESCRIPTION
One final attempt at adding an explicit comment data model.
See #14595 and #15397 

This function takes the response from an API call and attempts to parse it into Calypso-native data structures. There may also be a user object produced due to the way that the API reports comment authors.

If a comment was left by a logged in user we get their user id. If anonymously left we only get a few fields. I have organized this structure so that only the minimal amount of information needs to be stored for the author. That is, if it's a WordPress.com user we should be pulling our data from Redux state by user id or risk getting out of sync and duplicating memory.

If WordPress.com user information is available we return the fields which we are able to use and that can be used to feed directly into `state.users` to provide missing or out-of-date info there.

If we use the data structure produced here in comments management we will be able to get rid of the big list of comment properties and use the properties directly off of `comment` because we will _know_ they are supposed to be there. We would also want to make a distinction when showing the author between anonymous and known users (but this is a small matter).

There is nothing to test because this code is not used. Unit tests will follow feedback here because I don't want to waste time if nobody likes this proposal.

If we need to eventually add more fields (such as if the logged-in user has replied to the comment) then we will have to explicitly add them here since nothing else gets into app state.