### PR TITLE
WooCommerce: Add basic breadcrumbs for v1

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -40,10 +40,10 @@ class Order extends Component {
 			return null;
 		}
 
-		const breadcrumbs = ( <span>
-			<a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> &gt; { translate( 'Order Details' ) }
-		</span> );
-
+		const breadcrumbs = [
+			( <a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> ),
+			( <span>{ translate( 'Order Details' ) }</span> ),
+		];
 		return (
 			<Main className={ className }>
 				<OrderHeader siteSlug={ site.slug } breadcrumbs={ breadcrumbs } />

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -11,6 +11,7 @@ import React, { Component } from 'react';
  */
 import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
 import Main from 'components/main';
 import OrderActivityLog from './order-activity-log';
@@ -34,14 +35,18 @@ class Order extends Component {
 	}
 
 	render() {
-		const { className, order, site } = this.props;
+		const { className, order, site, translate } = this.props;
 		if ( ! order ) {
 			return null;
 		}
 
+		const breadcrumbs = ( <span>
+			<a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> &gt; { translate( 'Order Details' ) }
+		</span> );
+
 		return (
 			<Main className={ className }>
-				<OrderHeader siteSlug={ site.slug } />
+				<OrderHeader siteSlug={ site.slug } breadcrumbs={ breadcrumbs } />
 
 				<div className="order__container">
 					<OrderDetails order={ order } />

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -15,10 +15,10 @@ import OrdersList from './orders-list';
 
 class Orders extends Component {
 	render() {
-		const { className, site } = this.props;
+		const { className, site, translate } = this.props;
 		return (
 			<Main className={ className }>
-				<OrderHeader siteSlug={ site ? site.slug : false } />
+				<OrderHeader siteSlug={ site ? site.slug : false } breadcrumbs={ ( <span>{ translate( 'Orders' ) }</span> ) } />
 				<OrdersList />
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/orders/order-header.js
+++ b/client/extensions/woocommerce/app/orders/order-header.js
@@ -10,11 +10,11 @@ import React from 'react';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 
-const OrderHeader = ( { translate, siteSlug } ) => {
+const OrderHeader = ( { translate, siteSlug, breadcrumbs } ) => {
 	const addLink = `/store/order/${ siteSlug }`;
 
 	return (
-		<ActionHeader>
+		<ActionHeader breadcrumbs={ breadcrumbs }>
 			<Button primary href={ addLink }>{ translate( 'Add Order' ) }</Button>
 		</ActionHeader>
 	);

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -89,7 +89,7 @@ class Products extends Component {
 		return (
 			<Main className={ classes }>
 				<SidebarNavigation />
-				<ActionHeader>
+				<ActionHeader breadcrumbs={ ( <span>{ translate( 'Products' ) }</span> ) }>
 					<Button primary href={ getLink( '/store/product/:site/', site ) }>
 						{ translate( 'Add a product' ) }
 					</Button>

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -4,14 +4,16 @@
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
 
-const ProductHeader = ( { onTrash, onSave, isBusy, translate } ) => {
+const ProductHeader = ( { onTrash, onSave, isBusy, translate, site, product } ) => {
 	const trashButton = onTrash &&
 		<Button borderless onClick={ onTrash }><Gridicon icon="trash" /></Button>;
 
@@ -23,8 +25,18 @@ const ProductHeader = ( { onTrash, onSave, isBusy, translate } ) => {
 			{ translate( 'Save' ) }
 		</Button>;
 
+	const productsCrumbs = (
+		<a href={ getLink( '/store/products/:site/', site ) }>
+			{ translate( 'Products' ) }
+		</a>
+	);
+
+	const breadcrumbs = product && isNumber( product.id )
+		? ( <span>{ translate( 'Edit Product' ) }</span> )
+		: ( <span>{ translate( 'Add New Product' ) }</span> );
+
 	return (
-		<ActionHeader>
+		<ActionHeader breadcrumbs={ ( <span>{ productsCrumbs } &gt; { breadcrumbs }</span> ) }>
 			{ trashButton }
 			{ saveButton }
 		</ActionHeader>
@@ -32,6 +44,15 @@ const ProductHeader = ( { onTrash, onSave, isBusy, translate } ) => {
 };
 
 ProductHeader.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	product: PropTypes.shape( {
+		id: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.object,
+		] ),
+	} ),
 	onTrash: PropTypes.func,
 	onSave: PropTypes.oneOfType( [
 		React.PropTypes.func,

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -25,18 +25,17 @@ const ProductHeader = ( { onTrash, onSave, isBusy, translate, site, product } ) 
 			{ translate( 'Save' ) }
 		</Button>;
 
-	const productsCrumbs = (
-		<a href={ getLink( '/store/products/:site/', site ) }>
-			{ translate( 'Products' ) }
-		</a>
-	);
-
-	const breadcrumbs = product && isNumber( product.id )
+	const currentCrumb = product && isNumber( product.id )
 		? ( <span>{ translate( 'Edit Product' ) }</span> )
 		: ( <span>{ translate( 'Add New Product' ) }</span> );
 
+	const breadcrumbs = [
+		( <a href={ getLink( '/store/products/:site/', site ) }> { translate( 'Products' ) } </a> ),
+		currentCrumb,
+	];
+
 	return (
-		<ActionHeader breadcrumbs={ ( <span>{ productsCrumbs } &gt; { breadcrumbs }</span> ) }>
+		<ActionHeader breadcrumbs={ breadcrumbs }>
 			{ trashButton }
 			{ saveButton }
 		</ActionHeader>

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -30,9 +30,10 @@ class SettingsPayments extends Component {
 	render() {
 		const { site, translate, className } = this.props;
 
-		const breadcrumbs = ( <span>
-			<a href={ getLink( '/store/:site/', site ) }>{ translate( 'Settings' ) }</a> &gt; { translate( 'Payments' ) }
-		</span> );
+		const breadcrumbs = [
+			( <a href={ getLink( '/store/:site/', site ) }>{ translate( 'Settings' ) }</a> ),
+			( <span>{ translate( 'Payments' ) }</span> ),
+		];
 
 		return (
 			<Main

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -3,10 +3,15 @@
  */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import ActionHeader from 'woocommerce/components/action-header';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import SettingsPaymentsLocationCurrency from './payments-location-currency';
 import SettingsPaymentsOffline from './payments-offline';
@@ -16,13 +21,23 @@ import SettingsPaymentsOnSite from './payments-on-site';
 class SettingsPayments extends Component {
 
 	static propTypes = {
+		site: PropTypes.shape( {
+			slug: PropTypes.string,
+		} ),
 		className: PropTypes.string,
 	};
 
 	render() {
+		const { site, translate, className } = this.props;
+
+		const breadcrumbs = ( <span>
+			<a href={ getLink( '/store/:site/', site ) }>{ translate( 'Settings' ) }</a> &gt; { translate( 'Payments' ) }
+		</span> );
+
 		return (
 			<Main
-				className={ classNames( 'settingsPayments', this.props.className ) }>
+				className={ classNames( 'settingsPayments', className ) }>
+				<ActionHeader breadcrumbs={ breadcrumbs } />
 				<SettingsPaymentsLocationCurrency />
 				<SettingsPaymentsOnSite />
 				<SettingsPaymentsOffSite />
@@ -33,4 +48,11 @@ class SettingsPayments extends Component {
 
 }
 
-export default SettingsPayments;
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( SettingsPayments ) );

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -111,7 +111,7 @@ class SettingsPaymentsLocationCurrency extends Component {
 	render() {
 		const { currencies, currency, translate } = this.props;
 		return (
-			<div>
+			<div className="payments__location-currency">
 				<ExtendedHeader
 					label={ translate( 'Store location and currency' ) }
 					description={

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -3,9 +3,15 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	
+
 	@include breakpoint( "<660px" ) {
 		flex-direction: column;
+	}
+}
+
+.payments__location-currency {
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
 	}
 }
 
@@ -14,7 +20,7 @@
 	flex-direction: column;
 	max-width: 255px;
 	padding-top: 24px;
-	
+
 	@include breakpoint( ">960px" ) {
 		padding-left: 24px;
 		padding-top: 0;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -29,7 +29,6 @@ ShippingHeader.propTypes = {
 	site: PropTypes.shape( {
 		slug: PropTypes.string,
 	} ),
-	className: PropTypes.string,
 };
 
 function mapStateToProps( state ) {

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -9,13 +10,32 @@ import { localize } from 'i18n-calypso';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 
-const ShippingHeader = ( { translate } ) => {
+const ShippingHeader = ( { translate, site } ) => {
+	const breadcrumbs = ( <span>
+		<a href={ getLink( '/store/:site/', site ) }>{ translate( 'Settings' ) }</a> &gt; { translate( 'Shipping' ) }
+	</span> );
 	return (
-		<ActionHeader>
+		<ActionHeader breadcrumbs={ breadcrumbs }>
 			<Button primary>{ translate( 'Save' ) }</Button>
 		</ActionHeader>
 	);
 };
 
-export default localize( ShippingHeader );
+ShippingHeader.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	className: PropTypes.string,
+};
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( ShippingHeader ) );

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -14,9 +14,10 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 
 const ShippingHeader = ( { translate, site } ) => {
-	const breadcrumbs = ( <span>
-		<a href={ getLink( '/store/:site/', site ) }>{ translate( 'Settings' ) }</a> &gt; { translate( 'Shipping' ) }
-	</span> );
+	const breadcrumbs = [
+		( <a href={ getLink( '/store/:site/', site ) }>{ translate( 'Settings' ) }</a> ),
+		( <span>{ translate( 'Shipping' ) }</span> ),
+	];
 	return (
 		<ActionHeader breadcrumbs={ breadcrumbs }>
 			<Button primary>{ translate( 'Save' ) }</Button>

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -18,6 +18,12 @@
 	line-height: 18px;
 }
 
+.shipping__origin {
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
+	}
+}
+
 .shipping__address {
 	margin-bottom: 24px;
 

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies
@@ -9,19 +9,30 @@ import React from 'react';
 import Card from 'components/card';
 import StickyPanel from 'components/sticky-panel';
 
-const ActionHeader = ( { children } ) => {
-	// TODO: Implement breadcrumbs component.
-
+const ActionHeader = ( { children, breadcrumbs } ) => {
+	// TODO: Implement proper breadcrumbs component.
+	// For v1, we will just pass in a prop from each page.
 	return (
 		<StickyPanel>
 			<Card className="action-header__header">
-				<span className="action-header__breadcrumbs">Breadcrumbs / go / here</span>
+				<span className="action-header__breadcrumbs">{ breadcrumbs }</span>
 				<div className="action-header__actions">
 					{ children }
 				</div>
 			</Card>
 		</StickyPanel>
 	);
+};
+
+ActionHeader.propTypes = {
+	breadcrumbs: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.node
+	] ),
+	children: PropTypes.oneOfType( [
+		PropTypes.arrayOf( PropTypes.node ),
+		PropTypes.node
+	] ),
 };
 
 export default ActionHeader;

--- a/client/extensions/woocommerce/components/action-header/index.js
+++ b/client/extensions/woocommerce/components/action-header/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,10 +13,21 @@ import StickyPanel from 'components/sticky-panel';
 const ActionHeader = ( { children, breadcrumbs } ) => {
 	// TODO: Implement proper breadcrumbs component.
 	// For v1, we will just pass in a prop from each page.
+	let breadcrumbsOutput = breadcrumbs;
+	if ( isArray( breadcrumbs ) ) {
+		breadcrumbsOutput = breadcrumbs.map( function( crumb, i ) {
+			return (
+				<span key={ i }>
+					{crumb}
+					{ breadcrumbs.length - 1 === i ? '' : ( <span className="action-header__breadcrumbs-separator"> &gt; </span> ) }
+				</span>
+			);
+		} );
+	}
 	return (
 		<StickyPanel>
 			<Card className="action-header__header">
-				<span className="action-header__breadcrumbs">{ breadcrumbs }</span>
+				<span className="action-header__breadcrumbs">{ breadcrumbsOutput }</span>
 				<div className="action-header__actions">
 					{ children }
 				</div>
@@ -26,8 +38,8 @@ const ActionHeader = ( { children, breadcrumbs } ) => {
 
 ActionHeader.propTypes = {
 	breadcrumbs: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.node
+		PropTypes.arrayOf( PropTypes.node ),
+		PropTypes.node,
 	] ),
 	children: PropTypes.oneOfType( [
 		PropTypes.arrayOf( PropTypes.node ),

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -21,6 +21,11 @@
 	}
 }
 
+.action-header__breadcrumbs-separator {
+	color: $gray;
+	margin-left: 4px;
+}
+
 .action-header__actions {
 	width: 40%;
 	display: flex;

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -47,4 +47,7 @@
 		top: 47px;
 		left: 229px;
 	}
+	@include breakpoint( ">660px" ) {
+		margin-bottom: 58px;
+	}
 }


### PR DESCRIPTION
This PR adds breadcrumbs to all the pages except the dashboard view. In an ideal world we would have a smarter breadcrumbs component to help build these, but this branch at least gets us something other than placeholders for v1.

To Test:
* Go to `http://calypso.localhost:3000/store/products/:site` and make sure something shows in the breadcrumbs area.
* Start clicking through different screens. Products add, orders, orders view, payment settings, and shipping settings. Make sure breadcrumbs all show for these.

<img width="1008" alt="screen shot 2017-06-22 at 12 10 05 pm" src="https://user-images.githubusercontent.com/689165/27451579-50d6253e-5744-11e7-8f3d-ff872700f846.png">

cc @kellychoffman 