### PR TITLE
Added PriceInput component

### DIFF
--- a/client/extensions/woocommerce/components/price-input/README.md
+++ b/client/extensions/woocommerce/components/price-input/README.md
@@ -1,0 +1,9 @@
+Price input component. Renders `<FormCurrencyInput/>` if possible, or falls back to a regular `<FormTextInput/>`
+ 
+Props:
+```
+value: optional, string or num, the value of the field
+currency: required, three-letter code of the currency (for example USD)
+```
+
+Will pass other props to the underlying component.

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormCurrencyInput from 'components/forms/form-currency-input';
+import FormTextInput from 'components/forms/form-text-input';
+import { getCurrencyObject } from 'lib/format-currency';
+
+const PriceInput = ( { value, currency, ...props } ) => {
+	const currencyObject = getCurrencyObject( value, currency );
+	if ( ! currencyObject ) {
+		return (
+			<FormTextInput
+				value={ value }
+				{ ...props } />
+		);
+	}
+
+	return (
+		<FormCurrencyInput
+			currencySymbolPrefix={ currencyObject.symbol }
+			value={ value }
+			{ ...props } />
+	);
+};
+
+PriceInput.propTypes = {
+	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
+	currency: PropTypes.string.isRequired,
+};
+
+export default PriceInput;


### PR DESCRIPTION
Adds a simple wrapper around `FormCurrencyInput` that takes a three-letter currency code to render a currency prefix.

If the currency code is not recognized, falls back to rendering `FormTextInput`.

@justinshreve 