### PR TITLE
CA extra info form: add final polish before launch

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -113,7 +113,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 		if ( target.type === 'checkbox' ) {
 			value = target.checked;
-			this.setState( { uncheckedCiraAgreementFlag: false } );
+			this.registerClick();
 		}
 
 		this.props.updateContactDetailsCache( {
@@ -121,29 +121,30 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		} );
 	}
 
-	shimSubmit( event, originalOnClick ) {
+	handleInvalidSubmit = ( event ) => {
 		event.preventDefault();
+		this.registerClick();
+	}
 
-		if ( ! this.props.contactDetailsExtra.ciraAgreementAccepted ) {
-			this.setState( { uncheckedCiraAgreementFlag: true } );
-			return;
-		}
-
-		originalOnClick( event );
+	registerClick = () => {
+		this.setState( { hasBeenClicked: true } );
 	}
 
 	render() {
 		const { translate } = this.props;
-		const { legalTypeOptions, uncheckedCiraAgreementFlag } = this.state;
+		const { legalTypeOptions, hasBeenClicked } = this.state;
 		const {
 			legalType,
 			ciraAgreementAccepted,
 		} = { ...defaultValues, ...this.props.contactDetailsExtra };
 
-		const unvalidatedSubmitButton = this.props.children;
-		const submitButton = React.cloneElement( unvalidatedSubmitButton, {
-			onClick: ( e ) => this.shimSubmit( e, unvalidatedSubmitButton.props.onClick ),
-		} );
+		const validatingSubmitButton = ciraAgreementAccepted
+			? this.props.children
+			: React.cloneElement(
+				this.props.children,
+				{ onClick: this.handleInvalidSubmit } );
+
+		const showValidationError = hasBeenClicked && ! ciraAgreementAccepted;
 
 		return (
 			<form className="registrant-extra-info__form">
@@ -183,11 +184,11 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 								}
 							)
 						}</span>
-						{ uncheckedCiraAgreementFlag ? <FormInputValidation text={ translate( 'Required' ) } isError={ true } /> : null }
+						{ showValidationError ? <FormInputValidation text={ translate( 'Required' ) } isError={ true } /> : null }
 					</FormLabel>
 				</FormFieldset>
 
-				{ submitButton }
+				{ validatingSubmitButton }
 			</form>
 		);
 	}

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -23,7 +23,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
-import FormInputValidation from 'components/forms/form-input-validation';
 
 const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 const defaultValues = {
@@ -166,7 +165,6 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 								}
 							)
 						}</span>
-						{ ! ciraAgreementAccepted ? <FormInputValidation text={ translate( 'Required' ) } isError={ true } /> : null }
 					</FormLabel>
 				</FormFieldset>
 

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -23,6 +23,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
+import FormInputValidation from 'components/forms/form-input-validation';
 
 const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 const defaultValues = {
@@ -108,6 +109,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 	handleChangeEvent = ( event ) => {
 		const { target } = event;
 		const value = target.type === 'checkbox' ? target.checked : target.value;
+
 		this.props.updateContactDetailsCache( {
 			extra: { [ camelCase( event.target.id ) ]: value },
 		} );
@@ -120,6 +122,11 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 			legalType,
 			ciraAgreementAccepted,
 		} = { ...defaultValues, ...this.props.contactDetailsExtra };
+
+
+		const submitButton = React.cloneElement( this.props.children, {
+			disabled: ! ciraAgreementAccepted
+		} );
 
 		return (
 			<form className="registrant-extra-info__form">
@@ -148,7 +155,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 					<FormLabel>
 						<FormCheckbox
 							id="cira-agreement-accepted"
-							value={ ciraAgreementAccepted }
+							defaultChecked={ true }
 							onChange={ this.handleChangeEvent } />
 						<span>{
 							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',
@@ -159,10 +166,11 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 								}
 							)
 						}</span>
+						{ ! ciraAgreementAccepted ? <FormInputValidation text={ translate( 'Required' ) } isError={ true } /> : null }
 					</FormLabel>
 				</FormFieldset>
 
-				{ this.props.children }
+				{ submitButton }
 			</form>
 		);
 	}

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -161,7 +161,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',
 								{
 									components: {
-										a: <a href={ ciraAgreementUrl } />,
+										a: <a target="_blank" rel="noopener noreferrer" href={ ciraAgreementUrl } />,
 									},
 								}
 							)

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -11,7 +11,6 @@ import {
 	keys,
 	map,
 	pick,
-	upperCase,
 } from 'lodash';
 
 /**
@@ -96,8 +95,8 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 			return;
 		}
 
-		// Set the lang to FR if user is FR, otherwise leave EN
-		if ( upperCase( this.props.userWpcomLang ) === 'FR' ) {
+		// Set the lang to FR if user languages is French, otherwise leave EN
+		if ( this.props.userWpcomLang.match( /^fr-?/i ) ) {
 			defaultValues.lang = 'FR';
 		}
 

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -155,7 +155,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 					<FormLabel>
 						<FormCheckbox
 							id="cira-agreement-accepted"
-							defaultChecked={ true }
+							checked={ ciraAgreementAccepted }
 							onChange={ this.handleChangeEvent } />
 						<span>{
 							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',


### PR DESCRIPTION
CIRA, the ca registrar, requires a `lang` attribute when registering indicating the user’s language preference of either EN or FR. We derive the appropriate choice here from the user’s WP.com lang setting.

Also:
- Open CIRA agreement link in new window
- Check checkbox by default
- Don't allow form submission if checkbox is unchecked