### PR TITLE
Reader: Fix post recs to display 2-columns

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -137,13 +137,9 @@
 	}
 }
 
-// Custom breakpoints
-$reader-post-card-breakpoint-large: "( min-width: 961px ) and ( max-width: 1040px )";
-$reader-post-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 940px )";
-$reader-post-card-breakpoint-small: "( max-width: 550px )";
-
 // Post recommendations in Search
-.is-reader-page .search-stream .reader__content {
+.is-reader-page .search-stream .reader__content,
+.is-reader-page .search-stream.search-stream__with-sites .reader__content {
 	display: flex;
 	flex-flow: row wrap;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -400,11 +400,6 @@
 	display: flex;
 }
 
-.search-stream__results.is-two-columns .reader__content,
-.search-stream .search-stream__single-column-results .reader__content {
-	display: inline;
-}
-
 .is-reader-page .search-stream .reader-post-card.card {
 	flex-basis: 100%; // Override the 50% flex-basis for post recommendations
 }


### PR DESCRIPTION
**Before:** (Happens at ~1011px)
![screenshot 2017-06-22 14 32 06](https://user-images.githubusercontent.com/4924246/27457038-01c46168-5758-11e7-96b5-79d0bdfe3fab.png)

**After:**
![screenshot 2017-06-22 14 32 11](https://user-images.githubusercontent.com/4924246/27457057-1282f53c-5758-11e7-8881-747e75f5b434.png)

Current post recs in Search:
![screenshot 2017-06-22 14 32 20](https://user-images.githubusercontent.com/4924246/27457072-27079b20-5758-11e7-9cdf-18d09db9dc58.png)
