### PR TITLE
Remove sites-list from reader-share.

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -25,8 +25,6 @@ import User from 'lib/user';
 /**
  * Local variables
  */
-// Remove me
-const sitesList = require( 'lib/sites-list' )(); // eslint-disable-line no-restricted-modules
 
 const user = User();
 const actionMap = {
@@ -202,7 +200,6 @@ class ReaderShare extends React.Component {
 						? <SitesPopover
 								key="menu"
 								header={ <div>{ this.props.translate( 'Share on:' ) }</div> }
-								sites={ sitesList }
 								context={ this.refs && this.refs.shareButton }
 								visible={ this.state.showingMenu }
 								groups={ true }


### PR DESCRIPTION

In reader-share block, sites-list was just used to pass the sites property to the SitesPopover component. Now SitesPopover component does not use sites property, it reads the list of sites directly from the redux store. So, removing sites list dependency from reader-share was trivial.
To test:
Open reader press share button, see that a site picker appears with the user list of sites (if the user has just one site a list with just one site appears).
Select one of the sites by clicking it, the editor open to post on the selected site a share of the original post. 
Test the share button also inside a post in the reader and in the devdocs (http://calypso.localhost:3000/devdocs/blocks).
Pressing back button and save button on the editor should work in all the cases.
