### PR TITLE
Woo: Update product create with finishing touches for product categories

### DIFF
--- a/client/extensions/woocommerce/state/action-list/reducer.js
+++ b/client/extensions/woocommerce/state/action-list/reducer.js
@@ -28,7 +28,7 @@ function handleActionListClear() {
 function handleActionListAnnotate( actionList, action ) {
 	const { stepIndex, annotations } = action;
 
-	if ( undefined !== typeof stepIndex ) {
+	if ( actionList && undefined !== typeof stepIndex ) {
 		const { startTime, endTime, error } = annotations;
 		const step = actionList.steps[ stepIndex ];
 

--- a/client/extensions/woocommerce/state/action-list/reducer.js
+++ b/client/extensions/woocommerce/state/action-list/reducer.js
@@ -44,7 +44,7 @@ function handleActionListAnnotate( actionList, action ) {
 			newStep.error = error;
 		}
 
-		const newSteps = { ...actionList.steps };
+		const newSteps = [ ...actionList.steps ];
 		newSteps[ stepIndex ] = newStep;
 		return { ...actionList, steps: newSteps };
 	}

--- a/client/extensions/woocommerce/state/data-layer/action-list/index.js
+++ b/client/extensions/woocommerce/state/data-layer/action-list/index.js
@@ -23,6 +23,12 @@ import {
 export function handleStepNext( { dispatch, getState }, action ) {
 	const startTime = action.time || Date.now();
 	const actionList = getActionList( getState() );
+
+	if ( ! actionList ) {
+		// Action list has been cancelled, we're too late to participate.
+		return;
+	}
+
 	const stepIndex = getCurrentStepIndex( actionList );
 	const step = actionList.steps[ stepIndex ];
 
@@ -39,6 +45,12 @@ export function handleStepSuccess( { dispatch, getState }, action ) {
 	const { stepIndex, time } = action;
 	const endTime = time || Date.now();
 	const actionList = getActionList( getState() );
+
+	if ( ! actionList ) {
+		// Action list has been cancelled, we're too late to participate.
+		return;
+	}
+
 	const currentStepIndex = getCurrentStepIndex( actionList );
 	const nextStepIndex = currentStepIndex + 1;
 
@@ -65,6 +77,11 @@ export function handleStepFailure( { dispatch, getState }, action ) {
 	const endTime = time || Date.now();
 
 	debug( `Action List Failed on step ${ stepIndex } with error: ${ error }` );
+
+	if ( ! actionList ) {
+		// Action list has been cancelled, we're too late to participate.
+		return;
+	}
 
 	dispatch( actionListStepAnnotate( stepIndex, { endTime, error } ) );
 	if ( actionList.failureAction ) {

--- a/client/extensions/woocommerce/state/data-layer/product-categories/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/index.js
@@ -23,7 +23,7 @@ export function handleProductCategoryCreate( { dispatch }, action ) {
 		return;
 	}
 
-	const updatedAction = productCategoryUpdated( siteId, null, successAction ); // data field will be filled in by request.
+	const updatedAction = productCategoryUpdated( siteId, null, action, successAction ); // data field will be filled in by request.
 	dispatch( post( siteId, 'products/categories', categoryData, updatedAction, failureAction ) );
 }
 

--- a/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
@@ -32,7 +32,7 @@ describe( 'handlers', () => {
 					type: WOOCOMMERCE_API_REQUEST,
 					method: 'post',
 					siteId: 123,
-					onSuccessAction: productCategoryUpdated( 123, null, successAction ),
+					onSuccessAction: productCategoryUpdated( 123, null, action, successAction ),
 					onFailureAction: failureAction,
 					body: { name: 'Category 1', slug: 'category-1' },
 				} )
@@ -47,8 +47,9 @@ describe( 'handlers', () => {
 			};
 
 			const category1 = { id: 101, name: 'Newly Created Category' };
+			const originatingAction = { type: '%%originating%%' };
 			const completionAction = { type: '%%complete%%' };
-			const action = productCategoryUpdated( 123, category1, completionAction );
+			const action = productCategoryUpdated( 123, category1, originatingAction, completionAction );
 
 			handleProductCategoryUpdated( store, action );
 

--- a/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
@@ -7,7 +7,7 @@ import { spy } from 'sinon';
 /**
  * Internal dependencies
  */
-import { handleProductCategoryEdit, makeProductActionList, } from '../';
+import { handleProductCategoryEdit, updateActionListCategoryId, makeProductActionList, } from '../';
 import { actionListStepSuccess, actionListStepFailure } from 'woocommerce/state/action-list/actions';
 import { createProduct } from 'woocommerce/state/sites/products/actions';
 import { createProductCategory } from 'woocommerce/state/sites/product-categories/actions';
@@ -93,6 +93,66 @@ describe( 'handlers', () => {
 			expect( store.dispatch ).to.have.been.calledWith(
 				editProductRemoveCategory( 123, newProduct, newCategory1.id )
 			);
+		} );
+	} );
+
+	describe( '#updateActionListCategoryId', () => {
+		it( 'should convert placeholder ids to real ones', () => {
+			const category1 = { id: { placeholder: 'productCategory_1' }, name: 'Category 1', slug: 'category-1' };
+			const category2 = { id: { placeholder: 'productCategory_2' }, name: 'Category 2', slug: 'category-2' };
+
+			const product1Before = {
+				id: { index: 0 },
+				name: 'Product #1',
+				categories: [ { id: category1.id }, { id: category2.id } ]
+			};
+
+			const product1After = {
+				id: { index: 0 },
+				name: 'Product #1',
+				categories: [ { id: 101 }, { id: category2.id } ]
+			};
+
+			const createCategory1Action = createProductCategory(
+				123, category1, actionListStepSuccess( 0 ), actionListStepFailure( 0, 'UNKNOWN' ),
+			);
+
+			const createCategory2Action = createProductCategory(
+				123, category2, actionListStepSuccess( 1 ), actionListStepFailure( 1, 'UNKNOWN' ),
+			);
+
+			const createProduct1ActionBefore = createProduct(
+				123, product1Before, actionListStepSuccess( 2 ), actionListStepFailure( 2, 'UNKNOWN' ),
+			);
+
+			const createProduct1ActionAfter = createProduct(
+				123, product1After, actionListStepSuccess( 2 ), actionListStepFailure( 2, 'UNKNOWN' ),
+			);
+
+			const actionListBefore = {
+				steps: [
+					{ description: 'Creating product category: Category 1', action: createCategory1Action },
+					{ description: 'Creating product category: Category 2', action: createCategory2Action },
+					{ description: 'Creating product: Product #1', action: createProduct1ActionBefore },
+				],
+				successAction: undefined,
+				failureAction: undefined,
+				clearUponComplete: true,
+			};
+
+			const actionListAfter = {
+				steps: [
+					{ description: 'Creating product category: Category 1', action: createCategory1Action },
+					{ description: 'Creating product category: Category 2', action: createCategory2Action },
+					{ description: 'Creating product: Product #1', action: createProduct1ActionAfter },
+				],
+				successAction: undefined,
+				failureAction: undefined,
+				clearUponComplete: true,
+			};
+
+			const newActionList = updateActionListCategoryId( actionListBefore, category1.id, 101 );
+			expect( newActionList ).to.eql( actionListAfter );
 		} );
 	} );
 

--- a/client/extensions/woocommerce/state/sites/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/actions.js
@@ -78,14 +78,16 @@ export function createProductCategory( siteId, category, successAction, failureA
  *
  * @param {Number} siteId The id of the site to which the category belongs.
  * @param {Object} data The complete product category object with which to update the state.
+ * @param {Object} originatingAction The action that precipitated this update.
  * @param {Object} [completionAction] An action that is dispatched after the update is complete.
  * @return {Object} Action object
  */
-export function productCategoryUpdated( siteId, data, completionAction ) {
+export function productCategoryUpdated( siteId, data, originatingAction, completionAction ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_CATEGORY_UPDATED,
 		siteId,
 		data,
+		originatingAction,
 		completionAction,
 	};
 }


### PR DESCRIPTION
This adds a few small things to make the code more robust in places (like if the action-list is somehow cleared in the middle of an HTTP request)

To Test:

1. Run npm test
2. Run npm start
3. Visit `http://calypso.localhost:3000/store/product/<site url>`
4. Fill out name
5. Add a new category
6. Click Save
7. Visit wp-admin to verify that the category and product have been created correctly.
