### PR TITLE
Reader: Align Follow icons in Site results

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -198,7 +198,7 @@
 	fill: lighten( $gray, 10% );
 	height: 18px;
 	position: relative;
-		left: 0;
+		left: 1px;
 		top: 8px;
 
 	@include breakpoint( ">660px" ) {

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -198,7 +198,7 @@
 	fill: lighten( $gray, 10% );
 	height: 18px;
 	position: relative;
-		left: 1px;
+		left: 0;
 		top: 8px;
 
 	@include breakpoint( ">660px" ) {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -474,6 +474,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	top: 8px;
 }
 
+.search-stream .reader-subscription-list-item .gridicons-cog {
+	@include breakpoint( "<660px" ) {
+		left: 1px;
+	}
+}
+
 .card.reader-search-card.is-photo {
 
 	@include breakpoint( "<660px" ) {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -470,7 +470,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .search-stream__results.is-two-columns .search-stream__site-results .gridicons-cog {
-	left: -3px;
+	left: -2px;
 	top: 8px;
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15080

**Before:**
<img width="612" alt="screenshot 2017-06-22 20 43 21" src="https://user-images.githubusercontent.com/4924246/27465912-79435bee-578b-11e7-81ea-f84b2035e9f7.png">

**After:**
<img width="616" alt="screenshot 2017-06-22 20 43 59" src="https://user-images.githubusercontent.com/4924246/27465924-8bcc900a-578b-11e7-870a-8bfb35a6e961.png">
