### PR TITLE
Login: Fix error message in wrong locale after switching locale

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -36,25 +36,34 @@ import {
 } from 'state/login/selectors';
 import wpcom from 'lib/wp';
 
-const errorMessages = {
-	account_unactivated: translate( "This account hasn't been activated yet — check your email for a message from " +
-		"WordPress.com and click the activation link. You'll be able to log in after that." ),
-	empty_password: translate( "Don't forget to enter your password." ),
-	empty_two_step_code: translate( 'Please enter a verification code.' ),
-	empty_username: translate( 'Please enter a username or email address.' ),
-	forbidden_for_automattician: 'Cannot use social login with an Automattician account',
-	incorrect_password: translate( "Oops, that's not the right password. Please try again!" ),
-	invalid_email: translate( "Oops, looks like that's not the right address. Please try again!" ),
-	invalid_two_step_code: translate( "Hmm, that's not a valid verification code. Please double-check your app and try again." ),
-	invalid_two_step_nonce: translate( 'Your session has expired, please go back to the login screen.' ),
-	invalid_username: translate( "We don't seem to have an account with that name. Double-check the spelling and try again!" ),
-	push_authentication_throttled: translate( 'You can only request a code via the WordPress mobile app once every ' +
-		'two minutes. Please wait and try again.' ),
-	sms_code_throttled: translate( 'You can only request a code via SMS once per minute. Please wait and try again.' ),
-	sms_recovery_code_throttled: translate( 'You can only request a recovery code via SMS once per minute. Please wait and try again.' ),
-	unknown: translate( "Hmm, we can't find a WordPress.com account with this username and password combo. " +
-		'Please double check your information and try again.' ),
-};
+function getErrorMessageFromErrorCode( code ) {
+	const errorMessages = {
+		account_unactivated: translate( "This account hasn't been activated yet — check your email for a message from " +
+			"WordPress.com and click the activation link. You'll be able to log in after that." ),
+		empty_password: translate( "Don't forget to enter your password." ),
+		empty_two_step_code: translate( 'Please enter a verification code.' ),
+		empty_username: translate( 'Please enter a username or email address.' ),
+		forbidden_for_automattician: 'Cannot use social login with an Automattician account',
+		incorrect_password: translate( "Oops, that's not the right password. Please try again!" ),
+		invalid_email: translate( "Oops, looks like that's not the right address. Please try again!" ),
+		invalid_two_step_code: translate( "Hmm, that's not a valid verification code. Please double-check your app and try again." ),
+		invalid_two_step_nonce: translate( 'Your session has expired, please go back to the login screen.' ),
+		invalid_username: translate( "We don't seem to have an account with that name. Double-check the spelling and try again!" ),
+		push_authentication_throttled: translate( 'You can only request a code via the WordPress mobile app once every ' +
+			'two minutes. Please wait and try again.' ),
+		sms_code_throttled: translate( 'You can only request a code via SMS once per minute. Please wait and try again.' ),
+		sms_recovery_code_throttled: translate( 'You can only request a recovery code via SMS once per minute. ' +
+			'Please wait and try again.' ),
+		unknown: translate( "Hmm, we can't find a WordPress.com account with this username and password combo. " +
+			'Please double check your information and try again.' ),
+	};
+
+	if ( code in errorMessages ) {
+		return errorMessages[ code ];
+	}
+
+	return code;
+}
 
 const errorFields = {
 	empty_password: 'password',
@@ -79,14 +88,10 @@ function getErrorFromHTTPError( httpError ) {
 	const code = get( httpError, 'response.body.data.errors[0]' );
 
 	if ( code ) {
-		if ( code in errorMessages ) {
-			message = errorMessages[ code ];
+		message = getErrorMessageFromErrorCode( code );
 
-			if ( code in errorFields ) {
-				field = errorFields[ code ];
-			}
-		} else {
-			message = code;
+		if ( code in errorFields ) {
+			field = errorFields[ code ];
 		}
 	} else {
 		message = get( httpError, 'response.body.data', httpError.message );


### PR DESCRIPTION
This pull request fixes #15237 by moving the error messages to a function, so that they're translated with the current language, rather than the language at page load.

#### Testing instructions

1. Run `git checkout fix/15237-switch-login-message-language` and start your server, or open a [live branch](https://calypso.live/?branch=fix/15237-switch-login-message-language)
2. Ensure your browser has multiple languages enabled.
3. Ensure that you are logged out of WordPress.com.
4. Open the [`Log In` page](http://calypso.localhost:3000/log-in)
5. Switch to a different language by clicking on the locale switcher at the top of the page.
6. Without entering a username or password, click the Log In button.
7. Confirm that the error message is in the correct language.

#### Reviews

- [x] Code