### PR TITLE
Roll out pulsing cart badge for all users.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -84,16 +84,6 @@ module.exports = {
 		},
 		defaultVariation: 'show',
 	},
-	pulsingCartTestingAB: {
-		datestamp: '20170601',
-		variations: {
-			original: 50,
-			modified: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	signupProgressIndicator: {
 		datestamp: '20170612',
 		variations: {

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -10,7 +10,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import CartBody from './cart-body';
 import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
 import CartMessagesMixin from './cart-messages-mixin';
@@ -54,11 +53,8 @@ const PopoverCart = React.createClass( {
 		} );
 
 		if ( this.itemCount() ) {
-			const className = abtest( 'pulsingCartTestingAB' ) === 'modified'
-					? 'popover-cart__count-badge count-badge-pulsing'
-					: 'popover-cart__count-badge';
 			countBadge = (
-				<div className={ className }>
+				<div className="cart__count-badge count-badge-pulsing">
 					{ this.itemCount() }
 					<TrackComponentView eventName="calypso_popover_cart_badge_impression" />
 				</div>

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -211,7 +211,7 @@
 	@include hide-content-accessibly;
 }
 
-.popover-cart__count-badge {
+.cart__count-badge {
 	background: $blue-medium;
 	border-radius: 16px;
 	color: $white;
@@ -222,17 +222,14 @@
 	height: 16px;
 	padding: 0 5px;
 	position: absolute;
-		top: 5px;
-		right: 5px;
+	top: 5px;
+	right: 5px;
 	text-align: center;
-}
-
-.count-badge-pulsing {
 	box-shadow: 0 0 0 rgba(0,170,220, 0.4);
 	animation: pulsing-badge 2s infinite;
 }
 
-.count-badge-pulsing:hover {
+.cart__count-badge:hover {
 	animation: none;
 }
 


### PR DESCRIPTION
a/b test results suggest that the pulsing cart badge animation has higher conversion than the original.

Refer to #14652 for screenshots and testing instructions.

This change just removes the test and rolls the test out to all users.