### PR TITLE
Framework: Move set route logic to it's own middleware

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -111,8 +111,8 @@ const oauthTokenMiddleware = () => {
 	}
 };
 
-const clearNoticesMiddleware = () => {
-	page( '*', function( context, next ) {
+const setRouteMiddleware = () => {
+	page( '*', ( context, next ) => {
 		context.store.dispatch( setRouteAction(
 			context.pathname,
 			context.query
@@ -120,7 +120,9 @@ const clearNoticesMiddleware = () => {
 
 		next();
 	} );
+};
 
+const clearNoticesMiddleware = () => {
 	//TODO: remove this one when notices are reduxified - it is for old notices
 	page( '*', require( 'notices' ).clearNoticesOnNavigation );
 };
@@ -196,6 +198,7 @@ export const setupMiddlewares = ( currentUser, reduxStore ) => {
 	oauthTokenMiddleware();
 	loadSectionsMiddleware();
 	loggedOutMiddleware( currentUser );
+	setRouteMiddleware();
 	clearNoticesMiddleware();
 	unsavedFormsMiddleware();
 };


### PR DESCRIPTION
This is only refactoring. There are no changes in the logic. When working on #12404 we refactored boot folder and distribute code into the several files. I found out today that we put code that stores data for a current route in notices middleware. This PR fixes it.

### Testing

1. Open http://calypso.localhost:3000/log-in?redirect_to=/me when logged out (incognito mode can help).
2. Log in and make sure you are redirected to http://calypso.localhost:3000/me page.

We use Redux state set by setRouteMiddleware to discover where to redirect user based on `redirect_to` url param.

### Review
* [ ] Code
* [ ] Product