### PR TITLE
Makes the FoldableCard component react to a change in its "expanded" prop

### DIFF
--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -36,7 +36,7 @@ render: function() {
 * `compact`: a boolean indicating if the foldable card is compact
 * `disabled`: boolean indicating if the component it's not interactive
 * `expandedSummary`: string or component to show next to the action button when expanded
-* `expanded`: boolean indicating if the component is expanded on initial render
+* `expanded`: boolean indicating if the component is expanded
 * `onClick`: function to be executed in addition to the expand action when the header is clicked
 * `onClose`: function to be executed in addition to the expand action when the card is closed
 * `onOpen`: function to be executed in addition to the expand action when the card is opened

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -42,9 +42,15 @@ var FoldableCard = React.createClass( {
 			onClose: noop,
 			cardKey: '',
 			icon: 'chevron-down',
-			isExpanded: false,
+			expanded: false,
 			screenReaderText: false,
 		};
+	},
+
+	componentWillReceiveProps: function( nextProps ) {
+		if ( nextProps.expanded !== this.props.expanded ) {
+			this.setState( { expanded: nextProps.expanded } );
+		}
 	},
 
 	onClick: function() {


### PR DESCRIPTION
In `woocommerce-services`, we use the `<FoldableCard>` component extensively, and sometimes we expand / collapse them in response to an API response or a form submission (not a direct click on the header). As such, we need that the component reacts properly when its `expanded` property is changed, instead of just using it on initial render and after that just relying in its internal `state`. This PR fixed that.

It also fixes a typo (`isExpanded` isn't present anywhere else in the code, so it *must* have been a typo of `expanded`).

To test: The only usage of `<FoldableCard>` with a dynamic `expanded={ ... }` declaration is when adding a Contact Form to a post. So check out that it still works as expected (expand / collapse the field cards etc).