### PR TITLE
Show happychat step to all premium and personal plans (remove a/b test)

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
@@ -15,7 +15,7 @@ export default function stepsForProductAndSurvey( survey, product, canChat ) {
 			return [ steps.INITIAL_STEP, steps.CONCIERGE_STEP, steps.FINAL_STEP ];
 		}
 
-		if ( canChat && includesProduct( PERSONAL_PREMIUM_PLANS, product ) && abtest( 'chatOfferOnCancel' ) === 'show' ) {
+		if ( canChat && includesProduct( PERSONAL_PREMIUM_PLANS, product ) ) {
 			return [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
 		}
 	}

--- a/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/stepsForProductAndSurvey.js
@@ -37,9 +37,8 @@ describe( 'stepsForProductAndSurvey', function() {
 	describe( 'question one answer is "too hard"', function() {
 		const survey = { questionOneRadio: 'tooHard' };
 
-		it( 'should include happychat step if product is personal plan, abtest variant is show and happychat is available', function() {
+		it( 'should include happychat step if product is personal plan and happychat is available', function() {
 			const product = { product_slug: plans.PLAN_PERSONAL };
-			abtests.chatOfferOnCancel = 'show';
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
@@ -48,27 +47,14 @@ describe( 'stepsForProductAndSurvey', function() {
 			expect( stepsForProductAndSurvey( survey, product, false ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 
-		it( 'should not include happychat step if product is personal plan, happychat is available but abtest variant is hide', function() {
-			const product = { product_slug: plans.PLAN_PERSONAL };
-			abtests.chatOfferOnCancel = 'hide';
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
-		} );
-
-		it( 'should include happychat step if product is premium plan, abtest is show and happychat is available', function() {
+		it( 'should include happychat step if product is premium plan and happychat is available', function() {
 			const product = { product_slug: plans.PLAN_PREMIUM };
-			abtests.chatOfferOnCancel = 'show';
 			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		it( 'should not include happychat step if product is premium plan but happychat is not available', function() {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			expect( stepsForProductAndSurvey( survey, product, false ) ).to.deep.equal( DEFAULT_STEPS );
-		} );
-
-		it( 'should not include happychat step if product is premium plan, happychat is available but abtest is hide', function() {
-			const product = { product_slug: plans.PLAN_PREMIUM };
-			abtests.chatOfferOnCancel = 'hide';
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
 		} );
 
 		it( 'should include concierge step if product is business plan', function() {


### PR DESCRIPTION
This PR removes the a/b test around an extra step in the cancellation survey for personal and premium plans.

The testing instructions are the same as for #13165 except that the happychat step will now always be displayed when meeting the other criteria:

* cancellation of a personal or premium plan
* choosing 'too hard' as the reason
* happychat being connected and an operator available).

You can simulate happychat becoming connected and an operator becoming available by dispatching actions from a console:

```
dispatch( { type: 'HAPPYCHAT_CONNECTED' } );
dispatch( { type: 'HAPPYCHAT_SET_AVAILABLE', isAvailable: true } );
```