### PR TITLE
Login: Back link broken

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -87,12 +87,6 @@ const loggedOutMiddleware = currentUser => {
 				page.redirect( '/devdocs/start' );
 			}
 		} );
-	} else {
-		// Break routing if the user is logged out, and tries to visit /
-		page( '/', () => {
-			window.location.href = '/';
-			return;
-		} );
 	}
 
 	const sections = require( 'sections' );

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -87,6 +87,12 @@ const loggedOutMiddleware = currentUser => {
 				page.redirect( '/devdocs/start' );
 			}
 		} );
+	} else {
+		// Break routing if the user is logged out, and tries to visit /
+		page( '/', () => {
+			window.location.href = '/';
+			return;
+		} );
 	}
 
 	const sections = require( 'sections' );

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -123,6 +123,7 @@ export class LoginLinks extends React.Component {
 					href="https://wordpress.com"
 					key="return-to-wpcom-link"
 					onClick={ this.recordBackToWpcomLinkClick }
+					rel="external"
 				>
 					<Gridicon icon="arrow-left" size={ 18 } />
 					{ this.props.translate( 'Back to WordPress.com' ) }


### PR DESCRIPTION
This pull request fixes #15349 by breaking routing if a logged out user tries to visit /.

#### Testing instructions

I haven't found a good way of testing this in dev, this is the least hacky way. 🙃

1. Run `git checkout fix/15349-reboot-logged-out-home-visit`
2. In `login-links.jsx`, change the "Back to WordPress.com" `href` to `http://calypso.localhost:3000/`
3. Start your server in the `production` environment: `CALYPSO_ENV=production npm start`
2. Open the [`Log In` page](http://calypso.localhost:3000/log-in)
3. Click the "Back to WordPress.com" link.

The result is that you'll be redirected to https://wordpress.com/wp-login.php, but if you check your network activity, you should see that you went to http://calypso.localhost:3000/, first.

#### Reviews

- [x] Code
