### PR TITLE
Cart icon: Improve items count vertical alignment

### DIFF
--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -220,6 +220,7 @@
 	float: right;
 	font-size: 11px;
 	height: 16px;
+	line-height: 16px;
 	padding: 0 5px;
 	position: absolute;
 		top: 5px;


### PR DESCRIPTION
Add `line-height` to improve cart item count vertically positioning.

While reviewing #15421, I noticed the cart count is not vertically well positioned.

Before (safari / chrome / firefox):

![before](https://user-images.githubusercontent.com/841763/27471527-470bf0f6-57f8-11e7-8cca-099bbec459fb.png)

After (safari / chrome / firefox):

![after](https://user-images.githubusercontent.com/841763/27471534-4bf0ea0e-57f8-11e7-8350-bd62e8ef95bb.png)

To test:
1. Visit plans page for a site on the free plan
1. Select a paid plan
1. Without purchasing, navigate back to the plan page for the site
1. You should see the icon with improved positioning