### PR TITLE
Media library: add change source action

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -310,4 +310,12 @@ MediaActions.clearValidationErrorsByType = function( siteId, type ) {
 	} );
 };
 
+MediaActions.sourceChanged = function( siteId ) {
+	debug( 'Media data source changed' );
+	Dispatcher.handleViewAction( {
+		type: 'CHANGE_MEDIA_SOURCE',
+		siteId,
+	} );
+};
+
 module.exports = MediaActions;

--- a/client/lib/media/library-selected-store.js
+++ b/client/lib/media/library-selected-store.js
@@ -99,6 +99,11 @@ MediaLibrarySelectedStore.dispatchToken = Dispatcher.register( function( payload
 	Dispatcher.waitFor( [ MediaStore.dispatchToken ] );
 
 	switch ( action.type ) {
+		case 'CHANGE_MEDIA_SOURCE':
+			setSelectedItems( action.siteId, [] );
+			MediaLibrarySelectedStore.emit( 'change' );
+			break;
+
 		case 'SET_MEDIA_LIBRARY_SELECTED_ITEMS':
 			if ( action.error || ! action.siteId || ! action.data || ! Array.isArray( action.data ) ) {
 				break;

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -65,6 +65,11 @@ function receivePage( siteId, items ) {
 	} );
 }
 
+function clearPointers( siteId ) {
+	MediaStore._pointers[ siteId ] = {};
+	MediaStore._media[ siteId ] = {};
+}
+
 MediaStore.get = function( siteId, postId ) {
 	if ( ! ( siteId in MediaStore._media ) ) {
 		return;
@@ -91,6 +96,11 @@ MediaStore.dispatchToken = Dispatcher.register( function( payload ) {
 	Dispatcher.waitFor( [ MediaValidationStore.dispatchToken ] );
 
 	switch ( action.type ) {
+		case 'CHANGE_MEDIA_SOURCE':
+			clearPointers( action.siteId );
+			MediaStore.emit( 'change' );
+			break;
+
 		case 'CREATE_MEDIA_ITEM':
 		case 'RECEIVE_MEDIA_ITEM':
 		case 'RECEIVE_MEDIA_ITEMS':

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -15,7 +15,7 @@ import useMockery from 'test/helpers/use-mockery';
 /**
  * Module variables
  */
-var DUMMY_SITE_ID = 1,
+const DUMMY_SITE_ID = 1,
 	DUMMY_ITEM = { ID: 100, title: 'Sunset' },
 	DUMMY_UPLOAD = {
 		lastModified: '2015-06-19T09:36:09-04:00',
@@ -184,7 +184,7 @@ describe( 'MediaActions', function() {
 
 	describe( '#fetchNextPage()', function() {
 		it( 'should call to the internal WordPress.com REST API', function( done ) {
-			var query = MediaListStore.getNextPageQuery( DUMMY_SITE_ID );
+			const query = MediaListStore.getNextPageQuery( DUMMY_SITE_ID );
 
 			MediaActions.fetchNextPage( DUMMY_SITE_ID );
 
@@ -249,7 +249,7 @@ describe( 'MediaActions', function() {
 		} );
 
 		it( 'should accept a FileList of uploads', function() {
-			var uploads = [ DUMMY_UPLOAD, DUMMY_UPLOAD ];
+			const uploads = [ DUMMY_UPLOAD, DUMMY_UPLOAD ];
 			uploads.__proto__ = new window.FileList(); // eslint-disable-line no-proto
 			MediaActions.add( DUMMY_SITE_ID, uploads );
 			expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;
@@ -347,7 +347,7 @@ describe( 'MediaActions', function() {
 	} );
 
 	describe( '#edit()', function() {
-		var item = { ID: 100, description: 'Example' };
+		const item = { ID: 100, description: 'Example' };
 
 		it( 'should immediately edit the existing item', function() {
 			MediaActions.edit( DUMMY_SITE_ID, item );
@@ -361,7 +361,7 @@ describe( 'MediaActions', function() {
 	} );
 
 	describe( '#update()', function() {
-		var item = { ID: 100, description: 'Example' };
+		const item = { ID: 100, description: 'Example' };
 
 		it( 'should accept a single item', function() {
 			MediaActions.update( DUMMY_SITE_ID, item );
@@ -403,7 +403,7 @@ describe( 'MediaActions', function() {
 	} );
 
 	describe( '#delete()', function() {
-		var item = { ID: 100 };
+		const item = { ID: 100 };
 
 		it( 'should accept a single item', function() {
 			MediaActions.delete( DUMMY_SITE_ID, item );
@@ -460,6 +460,17 @@ describe( 'MediaActions', function() {
 				type: 'CLEAR_MEDIA_VALIDATION_ERRORS',
 				siteId: DUMMY_SITE_ID,
 				itemId: DUMMY_ITEM.ID
+			} );
+		} );
+	} );
+
+	describe( '#sourceChanged()', () => {
+		it( 'should dispatch the `CHANGE_MEDIA_SOURCE` action with the specified siteId', () => {
+			MediaActions.sourceChanged( DUMMY_SITE_ID );
+
+			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+				type: 'CHANGE_MEDIA_SOURCE',
+				siteId: DUMMY_SITE_ID,
 			} );
 		} );
 	} );

--- a/client/lib/media/test/library-selected-store.js
+++ b/client/lib/media/test/library-selected-store.js
@@ -144,5 +144,18 @@ describe( 'MediaLibrarySelectedStore', function() {
 
 			expect( MediaLibrarySelectedStore._media[ DUMMY_SITE_ID ] ).to.be.empty;
 		} );
+
+		it( 'should clear selected items when CHANGE_MEDIA_SOURCE is dispatched', function() {
+			dispatchSetLibrarySelectedItems();
+
+			handler( {
+				action: {
+					type: 'CHANGE_MEDIA_SOURCE',
+					siteId: DUMMY_SITE_ID,
+				}
+			} );
+
+			expect( MediaLibrarySelectedStore._media[ DUMMY_SITE_ID ] ).to.be.empty;
+		} );
 	} );
 } );

--- a/client/lib/media/test/store.js
+++ b/client/lib/media/test/store.js
@@ -11,7 +11,7 @@ import sinon from 'sinon';
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
 
-var DUMMY_SITE_ID = 1,
+const DUMMY_SITE_ID = 1,
 	DUMMY_MEDIA_ID = 10,
 	DUMMY_MEDIA_OBJECT = { ID: DUMMY_MEDIA_ID, title: 'Image' },
 	DUMMY_MEDIA_RESPONSE = {
@@ -148,7 +148,7 @@ describe( 'MediaStore', function() {
 		} );
 
 		it( 'should replace an item when RECEIVE_MEDIA_ITEM includes ID', function() {
-			var newItem = {
+			const newItem = {
 				ID: DUMMY_MEDIA_ID + 1,
 				ok: true
 			};
@@ -172,6 +172,23 @@ describe( 'MediaStore', function() {
 			expect( MediaStore.get( DUMMY_SITE_ID, DUMMY_MEDIA_ID ) ).to.eql( {
 				ID: DUMMY_MEDIA_ID
 			} );
+		} );
+
+		it( 'should clear all pointers when CHANGE_MEDIA_SOURCE called', () => {
+			MediaStore._pointers = {
+				[ DUMMY_SITE_ID ]: {
+					[ DUMMY_MEDIA_ID + 1 ]: DUMMY_MEDIA_ID
+				}
+			};
+
+			handler( {
+				action: {
+					type: 'CHANGE_MEDIA_SOURCE',
+					siteId: DUMMY_SITE_ID,
+				}
+			} );
+
+			expect( MediaStore._pointers[ DUMMY_SITE_ID ] ).to.eql( {} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Add a `changeSource` action to media actions. This allows other media stores to reset data when the media source is changed.

In this instance we:
- Reset pointers in `MediaStore` so nothing references existing data
- Clear all selected items in `MediaLibrarySelectedStore` so nothing is pre-selected

## To test

`npm run test-client client/lib/media/test/` to run included tests

Calypso itself won't be affected as the `changeSource` action is not currently called.