### PR TITLE
Plans: Don't try to render undefined features

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -189,7 +189,7 @@ class PlanFeatures extends Component {
 
 	renderMobileFeatures( features ) {
 		return map( features, ( currentFeature, index ) => {
-			return this.renderFeatureItem( currentFeature, index );
+			return currentFeature ? this.renderFeatureItem( currentFeature, index ) : null;
 		} );
 	}
 


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-desktop/issues/307 by not trying to render undefined features.

This needs testing in both the desktop app, and in regular calypso.