### PR TITLE
View Site: Handle unpreviewable sites

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -49,6 +49,7 @@ export default React.createClass( {
 					onClick={ this.props.onNavigate }
 					href={ this.props.link }
 					target={ isExternalLink ? '_blank' : null }
+					rel={ isExternalLink ? 'noopener noreferrer' : null }
 					onMouseEnter={ this.preload }
 				>
 					<Gridicon icon={ this.props.icon } size={ 24 } />

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -80,15 +80,15 @@ class PreviewMain extends React.Component {
 		if ( ! isPreviewable ) {
 			const action = (
 				<Button primary icon href={ site.URL } target="_blank">
-					Open Externally
+					{ translate( 'Open' ) }
 					<Gridicon icon="external" />
 				</Button>
 			);
 
 			return (
 				<EmptyContent
-					title={ 'Site cannot be previewed here' }
-					line={ 'You can open it in a new tab' }
+					title={ translate( 'Unable to show your site here' ) }
+					line={ translate( 'To view your site, click the button below' ) }
 					action={ action }
 					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					illustrationWidth={ 350 }

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -16,7 +16,10 @@ import {
 import { isSitePreviewable } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 
+import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
+import EmptyContent from 'components/empty-content';
+import Gridicon from 'gridicons';
 import Main from 'components/main';
 import WebPreviewContent from 'components/web-preview/content';
 
@@ -67,10 +70,30 @@ class PreviewMain extends React.Component {
 	}
 
 	render() {
-		const { translate, isPreviewable } = this.props;
+		const { translate, isPreviewable, site } = this.props;
+
+		if ( ! site ) {
+			// todo: some loading state?
+			return <span></span>;
+		}
 
 		if ( ! isPreviewable ) {
-			return <span>only external preview available :(</span>;
+			const action = (
+				<Button primary icon href={ site.URL } target="_blank">
+					Open Externally
+					<Gridicon icon="external" />
+				</Button>
+			);
+
+			return (
+				<EmptyContent
+					title={ 'Site cannot be previewed here' }
+					line={ 'Here we should say why…' }
+					action={ action }
+					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					illustrationWidth={ 350 }
+				/>
+			);
 		}
 
 		return (
@@ -88,7 +111,7 @@ class PreviewMain extends React.Component {
 const mapState = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		isPreviewable: isSitePreviewable( state, selectedSiteId ),
+		isPreviewable: false,// isSitePreviewable( state, selectedSiteId ),
 		site: getSelectedSite( state ),
 		siteId: selectedSiteId,
 	}

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -88,7 +88,7 @@ class PreviewMain extends React.Component {
 			return (
 				<EmptyContent
 					title={ 'Site cannot be previewed here' }
-					line={ 'Here we should say why…' }
+					line={ 'You can open it in a new tab' }
 					action={ action }
 					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					illustrationWidth={ 350 }

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -102,6 +102,7 @@ class PreviewMain extends React.Component {
 				<WebPreviewContent
 					showClose={ false }
 					previewUrl={ this.state.previewUrl }
+					externalUrl={ site.URL }
 				/>
 			</Main>
 		);
@@ -114,7 +115,7 @@ const mapState = ( state ) => {
 		isPreviewable: isSitePreviewable( state, selectedSiteId ),
 		site: getSelectedSite( state ),
 		siteId: selectedSiteId,
-	}
+	};
 };
 
 export default connect( mapState )( localize( PreviewMain ) );

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -111,7 +111,7 @@ class PreviewMain extends React.Component {
 const mapState = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
-		isPreviewable: false,// isSitePreviewable( state, selectedSiteId ),
+		isPreviewable: isSitePreviewable( state, selectedSiteId ),
 		site: getSelectedSite( state ),
 		siteId: selectedSiteId,
 	}

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -13,6 +13,7 @@ import {
 	getSelectedSite,
 	getSelectedSiteId,
 } from 'state/ui/selectors';
+import { isSitePreviewable } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 
 import DocumentHead from 'components/data/document-head';
@@ -66,7 +67,11 @@ class PreviewMain extends React.Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, isPreviewable } = this.props;
+
+		if ( ! isPreviewable ) {
+			return <span>only external preview available :(</span>;
+		}
 
 		return (
 			<Main className="preview">
@@ -80,9 +85,13 @@ class PreviewMain extends React.Component {
 	}
 }
 
-const mapState = ( state ) => ( {
-	site: getSelectedSite( state ),
-	siteId: getSelectedSiteId( state ),
-} );
+const mapState = ( state ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	return {
+		isPreviewable: isSitePreviewable( state, selectedSiteId ),
+		site: getSelectedSite( state ),
+		siteId: selectedSiteId,
+	}
+};
 
 export default connect( mapState )( localize( PreviewMain ) );

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -74,7 +74,7 @@ class PreviewMain extends React.Component {
 
 		if ( ! site ) {
 			// todo: some loading state?
-			return <span></span>;
+			return null;
 		}
 
 		if ( ! isPreviewable ) {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -159,7 +159,7 @@ export class MySitesSidebar extends Component {
 				tipTarget="sitePreview"
 				label={ this.props.translate( 'View Site' ) }
 				className={ this.itemLinkClass( [ '/view' ], 'preview' ) }
-				link={ isSitePreviewable && false ? '/view' + this.props.siteSuffix : site.URL }
+				link={ isSitePreviewable ? '/view' + this.props.siteSuffix : site.URL }
 				onNavigate={ this.onNavigate }
 				icon="computer"
 				preloadSectionName="preview"

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -152,14 +152,14 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const { site, isSitePreviewable } = this.props;
+		const { site, isPreviewable } = this.props;
 
 		return (
 			<SidebarItem
 				tipTarget="sitePreview"
 				label={ this.props.translate( 'View Site' ) }
 				className={ this.itemLinkClass( [ '/view' ], 'preview' ) }
-				link={ isSitePreviewable ? '/view' + this.props.siteSuffix : site.URL }
+				link={ isPreviewable ? '/view' + this.props.siteSuffix : site.URL }
 				onNavigate={ this.onNavigate }
 				icon="computer"
 				preloadSectionName="preview"
@@ -652,10 +652,10 @@ function mapStateToProps( state ) {
 		hasJetpackSites,
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
+		isPreviewable: isSitePreviewable( state, selectedSiteId ),
 		isPreviewShowing,
 		isSharingEnabledOnJetpackSite,
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
-		isSitePreviewable: isSitePreviewable( state, selectedSiteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -43,7 +43,8 @@ import {
 	getSite,
 	isJetpackMinimumVersion,
 	isJetpackModuleActive,
-	isJetpackSite
+	isJetpackSite,
+	isSitePreviewable
 } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
 import { abtest } from 'lib/abtest';
@@ -151,12 +152,14 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		const { site, isSitePreviewable } = this.props;
+
 		return (
 			<SidebarItem
 				tipTarget="sitePreview"
 				label={ this.props.translate( 'View Site' ) }
 				className={ this.itemLinkClass( [ '/view' ], 'preview' ) }
-				link={ '/view' + this.props.siteSuffix }
+				link={ isSitePreviewable && false ? '/view' + this.props.siteSuffix : site.URL }
 				onNavigate={ this.onNavigate }
 				icon="computer"
 				preloadSectionName="preview"
@@ -652,6 +655,7 @@ function mapStateToProps( state ) {
 		isPreviewShowing,
 		isSharingEnabledOnJetpackSite,
 		isSiteAutomatedTransfer: !! isSiteAutomatedTransfer( state, selectedSiteId ),
+		isSitePreviewable: isSitePreviewable( state, selectedSiteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',


### PR DESCRIPTION
This PR changes the link in the sidebar from the `/view/:slug` to `site.URL` which opens in a new tab/window. Link also gets the "external" icon:

<img width="274" alt="screen shot 2017-06-26 at 15 30 38" src="https://user-images.githubusercontent.com/156676/27541551-99e653f0-5a84-11e7-8325-e5e040316732.png">

While developing this I noticed that user can still end up on `/view/:slug` even for unpreviewabe sites. Easiest way to click "View Site" on previewable site and then click "Switch Site" and select unpreviewable one. For this case I used the `EmptyContent` component. Illustration and content WIP.

<img width="964" alt="screen shot 2017-06-26 at 15 28 00" src="https://user-images.githubusercontent.com/156676/27541630-e0c4e44e-5a84-11e7-8ad7-1f36d0ae5087.png">
