### PR TITLE
Jetpack disconnect: Fix missing feature list

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -19,6 +19,7 @@ import { setAllSitesSelected } from 'state/ui/actions';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanClass } from 'lib/plans/constants';
 import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
+import QuerySitePlans from 'components/data/query-site-plans';
 
 class DisconnectJetpackButton extends Component {
 	constructor( props ) {
@@ -111,6 +112,7 @@ class DisconnectJetpackButton extends Component {
 
 		return <Button { ...buttonProps }>
 			{ text }
+			<QuerySitePlans siteId={ site.ID } />
 			<DisconnectJetpackDialog
 				isVisible={ this.state.dialogVisible }
 				onDisconnect={ this.disconnectJetpack }
@@ -141,8 +143,7 @@ export default connect(
 		const plan = getCurrentPlan( state, ownProps.site.ID );
 		const planClass = plan && plan.productSlug
 			? getPlanClass( plan.productSlug )
-			: 'free';
-
+			: 'is-free-plan';
 		return {
 			planClass
 		};


### PR DESCRIPTION
**Before**
<img width="408" alt="screen shot 2017-06-23 at 12 39 16" src="https://user-images.githubusercontent.com/7767559/27480727-1868d43a-5811-11e7-834c-58ecc087fb64.png">

**After**
<img width="408" alt="screen shot 2017-06-23 at 12 38 45" src="https://user-images.githubusercontent.com/7767559/27480731-1de9d65c-5811-11e7-905b-ccc7b587b363.png">


Add query component for site plans so we can properly list the plan features that will be lost when disconnecting a site.

**To Test**
* Break/delete a jetpack site so that the warning and disconnect button shows up in the Calypso sidebar:
<img width="273" alt="screen shot 2017-06-23 at 12 41 17" src="https://user-images.githubusercontent.com/7767559/27480757-4ad41862-5811-11e7-8036-64202338667c.png">
* For example, rename `jetpack` plugin folder on the site
* Click the warning icon in the Calypso sidebar, then click _disconnect site_
Expected:
* Plan features should be properly listed in the dialog as in the screenshot above
