### PR TITLE
Media: add Google Photos

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -347,6 +347,17 @@
 	}
 }
 
+.section-nav-tab__title {
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+	padding: 15px;
+	width: 100%;
+	font-size: 14px;
+	line-height: 18px;
+	color: $gray-dark;
+}
+
 // -------- Nav Tabs - dropdowns --------
 .section-nav-tabs__dropdown {
 	position: relative;

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -24,6 +24,7 @@ import {
 	ValidationErrors as MediaValidationErrors,
 	MEDIA_IMAGE_PHOTON,
 	MEDIA_IMAGE_RESIZER,
+	MEDIA_IMAGE_THUMBNAIL,
 } from 'lib/media/constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import MediaLibraryHeader from './header';
@@ -168,6 +169,10 @@ const MediaLibraryContent = React.createClass( {
 	},
 
 	getThumbnailType() {
+		if ( this.props.source !== '' ) {
+			return MEDIA_IMAGE_THUMBNAIL;
+		}
+
 		if ( this.props.site.is_private ) {
 			return MEDIA_IMAGE_RESIZER;
 		}

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -6,7 +6,6 @@ import { localize } from 'i18n-calypso';
 import {
 	includes,
 	noop,
-	map,
 	identity
 } from 'lodash';
 
@@ -19,6 +18,7 @@ import Search from 'components/search';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlanStorage from 'blocks/plan-storage';
 import FilterItem from './filter-item';
+import TitleItem from './title-item';
 
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {
@@ -85,19 +85,39 @@ export class MediaLibraryFilterBar extends Component {
 		this.props.onFilterChange( filter );
 	};
 
-	renderTabItems() {
-		const tabs = this.props.source === '' ? [ '', 'images', 'documents', 'videos', 'audio' ] : [];
+	renderSectionTitle() {
+		const { translate } = this.props;
 
-		return map( tabs, filter =>
-			<FilterItem
-				key={ 'filter-tab-' + filter }
-				value={ filter }
-				selected={ this.props.filter === filter }
-				onChange={ this.changeFilter }
-				disabled={ this.isFilterDisabled( filter ) }
-			>
-				{ this.getFilterLabel( filter ) }
-			</FilterItem>
+		if ( this.props.source === 'google_photos' ) {
+			return <TitleItem>{ translate( 'Photos from Google' ) }</TitleItem>;
+		}
+
+		return null;
+	}
+
+	renderTabItems() {
+		if ( this.props.source !== '' ) {
+			return null;
+		}
+
+		const tabs = [ '', 'images', 'documents', 'videos', 'audio' ];
+
+		return (
+			<SectionNavTabs>
+				{
+					tabs.map( filter =>
+						<FilterItem
+							key={ 'filter-tab-' + filter }
+							value={ filter }
+							selected={ this.props.filter === filter }
+							onChange={ this.changeFilter }
+							disabled={ this.isFilterDisabled( filter ) }
+						>
+							{ this.getFilterLabel( filter ) }
+						</FilterItem>
+					)
+				}
+			</SectionNavTabs>
 		);
 	}
 
@@ -132,11 +152,11 @@ export class MediaLibraryFilterBar extends Component {
 		return (
 			<div className="media-library__filter-bar">
 				<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
-					<SectionNavTabs>
-						{ this.renderTabItems() }
-					</SectionNavTabs>
+					{ this.renderSectionTitle() }
+					{ this.renderTabItems() }
 					{ this.renderSearchSection() }
 				</SectionNav>
+
 				{ this.renderPlanStorage() }
 			</div>
 		);

--- a/client/my-sites/media-library/title-item.jsx
+++ b/client/my-sites/media-library/title-item.jsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const TitleItem = props => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<h6 className="section-nav-tab__title">{ props.children }</h6>
+	);
+};
+
+export default TitleItem;


### PR DESCRIPTION
Finishes off the media modal UI for Google photos by:

- Enabling the MEDIA_IMAGE_THUMBNAIL mode when the media modal source is showing Google Photos.
- Hide the media modal filter bar and shows a plain text header:
<img width="304" alt="title" src="https://user-images.githubusercontent.com/1277682/27482810-d111819a-581a-11e7-8d41-ec0d175a21c9.png">

## Testing


### Testing

1. Ensure you are connected to Google Photos first from the Sharing menu - a check for this will be added in #15107
1. Edit a post and click the 'add from Google' media dropdown option:
<img width="212" alt="dropdown" src="https://user-images.githubusercontent.com/1277682/27481799-72bab5fc-5816-11e7-902c-73975d3f57b8.png">

3. Verify that the media modal title is as shown in the above description
1. Verify that thumbnails are loaded directly from Google and not through Photon
1. Click a media item and verify the blue 'Copy to your library' button is enabled (copy functionality to be added in #15435)
1. Verify that the media actions ('add new', edit, and delete buttons - just below the modal title) do not appear
1. Search for something in your Google library and verify that results are returned. Note that Google analyzes your images and can do a deep search that doesn't depend on filename. i.e. you have a picture of cat you can search for 'cat'
1. Verify you have access to your Google library from a Jetpack site
1. Verify that normal WordPress media library functions continue to operate