### PR TITLE
Media: copy external media

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -20,6 +20,13 @@ const DUMMY_FILE_BLOB = {
 	},
 	fileName: DUMMY_FILENAME,
 };
+const DUMMY_FILE_OBJECT = {
+	thumbnails: true,
+	URL: DUMMY_FILENAME,
+	name: DUMMY_FILENAME,
+	extension: 'jpg',
+	mime_type: 'image/jpeg',
+};
 const EXPECTED = {
 	'transient': true,
 	ID: UNIQUEID,
@@ -686,6 +693,12 @@ describe( 'MediaUtils', function() {
 
 		it( 'should return a transient for a filename', () => {
 			const actual = MediaUtils.createTransientMedia( DUMMY_FILENAME );
+
+			expect( actual ).to.eql( EXPECTED );
+		} );
+
+		it( 'should return a transient for a file object', () => {
+			const actual = MediaUtils.createTransientMedia( DUMMY_FILE_OBJECT );
 
 			expect( actual ).to.eql( EXPECTED );
 		} );

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -35,6 +35,16 @@ const EXPECTED = {
 	extension: 'jpg',
 	mime_type: 'image/jpeg',
 };
+const EXPECTED_FILE_OBJECT = {
+	'transient': true,
+	ID: UNIQUEID,
+	file: DUMMY_FILENAME,
+	title: 'test.jpg',
+	extension: 'jpg',
+	mime_type: 'image/jpeg',
+	guid: DUMMY_FILENAME,
+	URL: DUMMY_FILENAME,
+};
 
 describe( 'MediaUtils', function() {
 	let MediaUtils;
@@ -700,7 +710,7 @@ describe( 'MediaUtils', function() {
 		it( 'should return a transient for a file object', () => {
 			const actual = MediaUtils.createTransientMedia( DUMMY_FILE_OBJECT );
 
-			expect( actual ).to.eql( EXPECTED );
+			expect( actual ).to.eql( EXPECTED_FILE_OBJECT );
 		} );
 	} );
 } );

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -535,6 +535,16 @@ const MediaUtils = {
 				extension: MediaUtils.getFileExtension( file ),
 				mime_type: MediaUtils.getMimeType( file )
 			} );
+		} else if ( file.thumbnails ) {
+			// Generate from a file data object
+			Object.assign( transientMedia, {
+				file: file.URL,
+				title: file.name,
+				extension: file.extension,
+				mime_type: file.mime_type,
+				guid: file.URL,
+				URL: file.URL,
+			} );
 		} else {
 			// Handle the case where a an object has been passed that wraps a
 			// Blob and contains a fileName

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -36,7 +36,6 @@ module.exports = React.createClass( {
 		onSearch: React.PropTypes.func,
 		onScaleChange: React.PropTypes.func,
 		onEditItem: React.PropTypes.func,
-		onSourceChange: React.PropTypes.func,
 		fullScreenDropZone: React.PropTypes.bool,
 		containerWidth: React.PropTypes.number,
 		single: React.PropTypes.bool,
@@ -48,7 +47,6 @@ module.exports = React.createClass( {
 			fullScreenDropZone: true,
 			onAddMedia: () => {},
 			onScaleChange: () => {},
-			onSourceChange: () => {},
 			scrollable: false,
 			source: '',
 		};
@@ -171,7 +169,6 @@ module.exports = React.createClass( {
 					search={ this.props.search }
 					onFilterChange={ this.props.onFilterChange }
 					source={ this.props.source }
-					onSourceChange={ this.props.onSourceChange }
 					onSearch={ this.doSearch } />
 				{ content }
 			</div>

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -30,7 +30,7 @@ const EMPTY_COMPONENT = React.createClass( {
 } );
 
 describe( 'EditorMediaModal', function() {
-	let spy, translate, deleteMedia, accept, EditorMediaModal, setLibrarySelectedItems;
+	let spy, translate, deleteMedia, accept, EditorMediaModal, setLibrarySelectedItems, onClose;
 
 	translate = require( 'i18n-calypso' ).translate;
 
@@ -42,6 +42,7 @@ describe( 'EditorMediaModal', function() {
 		spy = sandbox.spy();
 		setLibrarySelectedItems = sandbox.stub();
 		deleteMedia = sandbox.stub();
+		onClose = sandbox.stub();
 		accept = sandbox.stub().callsArgWithAsync( 1, true );
 	} );
 
@@ -214,5 +215,49 @@ describe( 'EditorMediaModal', function() {
 		const buttons = tree.getModalButtons();
 
 		expect( buttons[ 1 ].label ).to.be.equals( 'Insert' );
+	} );
+
+	describe( '#confirmSelection()', () => {
+		it( 'should close modal if viewing local media and button is pressed', done => {
+			const tree = shallow(
+				<EditorMediaModal
+					site={ DUMMY_SITE }
+					mediaLibrarySelectedItems={ DUMMY_MEDIA }
+					onClose={ onClose }
+					view={ ModalViews.DETAIL }
+					setView={ spy } />
+			).instance();
+
+			tree.confirmSelection();
+
+			process.nextTick( () => {
+				expect( onClose ).to.have.been.calledWith( {
+					items: DUMMY_MEDIA,
+					settings: undefined,
+					type: 'media',
+				} );
+
+				done();
+			} );
+		} );
+
+		it( 'should copy external media if viewing external media and button is pressed', done => {
+			const tree = shallow(
+				<EditorMediaModal
+					site={ DUMMY_SITE }
+					mediaLibrarySelectedItems={ DUMMY_MEDIA }
+					view={ ModalViews.DETAIL }
+					setView={ spy } />
+			).instance();
+
+			tree.setState( { source: 'external' } );
+			tree.copyExternal = onClose;
+			tree.confirmSelection();
+
+			process.nextTick( () => {
+				expect( onClose ).to.have.been.calledWith( DUMMY_MEDIA, 'external' );
+				done();
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
Provides the functionality to copy external media to the WordPress media library instead of inserting a direct link.

When the copy button is clicked we:

- Trigger an action to clear selected items and media pointers
- Change the source back to WordPress - we want the uploading image to appear in our library
- Pass the selected items to the API endpoint, which handles the copying

We also modify how placeholder transients (the in-progress placeholders when uploading an image) are created. External media doesn't provide the same information, so we pass the raw file object through and use this to generate the transient.

Note: it would be better if the external image is directly copied-and-inserted, without the intermediate step. However, this would require more changes to the modal/post editor, and so we switch to the WordPress library, and will leave direct inserting for a future change.

### Testing

1. Open Google media modal in a post
<img width="212" alt="dropdown" src="https://user-images.githubusercontent.com/1277682/27481933-2fc8c5a8-5817-11e7-9ee0-a90f01dad1c3.png">

1. Select one or more pieces of media
1. Click the blue 'copy to library' button
<img width="303" alt="copy" src="https://user-images.githubusercontent.com/1277682/27482062-ba145498-5817-11e7-99e0-c6659f3c048a.png">

3. Verify the media modal switches back to the WordPress library and the media item(s) show a loading indicator
<img width="342" alt="loading" src="https://user-images.githubusercontent.com/1277682/27482093-e21352e6-5817-11e7-8696-e53902b97950.png">

4. Verify the image eventually appears. Insert this into the post
<img width="273" alt="appeared" src="https://user-images.githubusercontent.com/1277682/27482113-f7ce9f6e-5817-11e7-8d16-022edb961707.png">

5. Verify the inserted image is from the WP media library and not direct from Google

<img width="469" alt="yourblog" src="https://user-images.githubusercontent.com/1277682/27482129-0c7f13bc-5818-11e7-9e01-c14a9724a1d7.png">

6. Verify the above tests on a Jetpack site
7. Verify that local WordPress media can still be inserted into a Jetpack/WP.com post as before

Also run the included test:

`npm run test-client client/post-editor/media-modal/test/index.jsx`