### PR TITLE
Editor: add Google Photos to post editor media dropdown

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -347,6 +347,17 @@
 	}
 }
 
+.section-nav-tab__title {
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+	padding: 15px;
+	width: 100%;
+	font-size: 14px;
+	line-height: 18px;
+	color: $gray-dark;
+}
+
 // -------- Nav Tabs - dropdowns --------
 .section-nav-tabs__dropdown {
 	position: relative;

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -1,24 +1,42 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
-
 import Gridicon from 'gridicons';
 import i18n from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 const GridiconButton = ( { icon, label } ) => (
 	<div>
 		<Gridicon className="wpcom-insert-menu__menu-icon" icon={ icon } />
 		<span className="wpcom-insert-menu__menu-label">{ label }</span>
 	</div>
 );
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
-export default [
-	{
-		name: 'insert_media_item',
-		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } />,
-		cmd: 'wpcomAddMedia'
-	},
-	{
-		name: 'insert_contact_form',
-		item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } />,
-		cmd: 'wpcomContactForm'
-	}
-];
+const menuItems = [	{
+	name: 'insert_media_item',
+	item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } />,
+	cmd: 'wpcomAddMedia'
+} ];
+
+if ( config.isEnabled( 'external-media' ) ) {
+	menuItems.push( {
+		name: 'insert_from_google',
+		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add from Google' ) } />,
+		cmd: 'googleAddMedia'
+	} );
+}
+
+menuItems.push( {
+	name: 'insert_contact_form',
+	item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } />,
+	cmd: 'wpcomContactForm'
+} );
+
+export default menuItems;

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -423,14 +423,27 @@ function mediaButton( editor ) {
 		renderDropZone( { visible: event.type === 'dragend' } );
 	}
 
-	editor.addCommand( 'wpcomAddMedia', () => {
+	function initMediaModal() {
 		const selectedSite = getSelectedSiteFromState();
 		if ( selectedSite ) {
 			MediaActions.clearValidationErrors( selectedSite.ID );
 		}
+	}
+
+	editor.addCommand( 'wpcomAddMedia', () => {
+		initMediaModal();
 
 		renderModal( {
 			visible: true
+		} );
+	} );
+
+	editor.addCommand( 'googleAddMedia', () => {
+		initMediaModal();
+
+		renderModal( {
+			visible: true,
+			source: 'google_photos',
 		} );
 	} );
 

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -24,6 +24,7 @@ import {
 	ValidationErrors as MediaValidationErrors,
 	MEDIA_IMAGE_PHOTON,
 	MEDIA_IMAGE_RESIZER,
+	MEDIA_IMAGE_THUMBNAIL,
 } from 'lib/media/constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import MediaLibraryHeader from './header';
@@ -168,6 +169,10 @@ const MediaLibraryContent = React.createClass( {
 	},
 
 	getThumbnailType() {
+		if ( this.props.source !== '' ) {
+			return MEDIA_IMAGE_THUMBNAIL;
+		}
+
 		if ( this.props.site.is_private ) {
 			return MEDIA_IMAGE_RESIZER;
 		}

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -6,7 +6,6 @@ import { localize } from 'i18n-calypso';
 import {
 	includes,
 	noop,
-	map,
 	identity
 } from 'lodash';
 
@@ -19,6 +18,7 @@ import Search from 'components/search';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlanStorage from 'blocks/plan-storage';
 import FilterItem from './filter-item';
+import TitleItem from './title-item';
 
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {
@@ -85,19 +85,39 @@ export class MediaLibraryFilterBar extends Component {
 		this.props.onFilterChange( filter );
 	};
 
-	renderTabItems() {
-		const tabs = this.props.source === '' ? [ '', 'images', 'documents', 'videos', 'audio' ] : [];
+	renderSectionTitle() {
+		const { translate } = this.props;
 
-		return map( tabs, filter =>
-			<FilterItem
-				key={ 'filter-tab-' + filter }
-				value={ filter }
-				selected={ this.props.filter === filter }
-				onChange={ this.changeFilter }
-				disabled={ this.isFilterDisabled( filter ) }
-			>
-				{ this.getFilterLabel( filter ) }
-			</FilterItem>
+		if ( this.props.source === 'google_photos' ) {
+			return <TitleItem>{ translate( 'Photos from Google' ) }</TitleItem>;
+		}
+
+		return null;
+	}
+
+	renderTabItems() {
+		if ( this.props.source !== '' ) {
+			return null;
+		}
+
+		const tabs = [ '', 'images', 'documents', 'videos', 'audio' ];
+
+		return (
+			<SectionNavTabs>
+				{
+					tabs.map( filter =>
+						<FilterItem
+							key={ 'filter-tab-' + filter }
+							value={ filter }
+							selected={ this.props.filter === filter }
+							onChange={ this.changeFilter }
+							disabled={ this.isFilterDisabled( filter ) }
+						>
+							{ this.getFilterLabel( filter ) }
+						</FilterItem>
+					)
+				}
+			</SectionNavTabs>
 		);
 	}
 
@@ -132,11 +152,11 @@ export class MediaLibraryFilterBar extends Component {
 		return (
 			<div className="media-library__filter-bar">
 				<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
-					<SectionNavTabs>
-						{ this.renderTabItems() }
-					</SectionNavTabs>
+					{ this.renderSectionTitle() }
+					{ this.renderTabItems() }
 					{ this.renderSearchSection() }
 				</SectionNav>
+
 				{ this.renderPlanStorage() }
 			</div>
 		);

--- a/client/my-sites/media-library/title-item.jsx
+++ b/client/my-sites/media-library/title-item.jsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const TitleItem = props => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<h6 className="section-nav-tab__title">{ props.children }</h6>
+	);
+};
+
+export default TitleItem;

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -38,6 +38,7 @@ import Button from 'components/button';
 import ContactFormDialog from 'components/tinymce/plugins/contact-form/dialog';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
+import config from 'config';
 
 /**
  * Module constant
@@ -70,6 +71,7 @@ export class EditorHtmlToolbar extends Component {
 		showInsertContentMenu: false,
 		showLinkDialog: false,
 		showMediaModal: false,
+		source: '',
 	};
 
 	componentDidMount() {
@@ -414,6 +416,15 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( {
 			showInsertContentMenu: false,
 			showMediaModal: true,
+			source: '',
+		} );
+	}
+
+	openGoogleModal = () => {
+		this.setState( {
+			showInsertContentMenu: false,
+			showMediaModal: true,
+			source: 'google_photos',
 		} );
 	}
 
@@ -444,6 +455,24 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );
+
+	renderExternal() {
+		const { translate } = this.props;
+
+		if ( ! config.isEnabled( 'external-media' ) ) {
+			return null;
+		}
+
+		return (
+			<div
+				className="editor-html-toolbar__insert-content-dropdown-item"
+				onClick={ this.openGoogleModal }
+			>
+				<Gridicon icon="add-image" />
+				<span>{ translate( 'Add from Google' ) }</span>
+			</div>
+		);
+	}
 
 	render() {
 		const {
@@ -556,6 +585,9 @@ export class EditorHtmlToolbar extends Component {
 								<Gridicon icon="add-image" />
 								<span>{ translate( 'Add Media' ) }</span>
 							</div>
+
+							{ this.renderExternal() }
+
 							<div
 								className="editor-html-toolbar__insert-content-dropdown-item"
 								onClick={ this.openContactFormDialog }
@@ -597,6 +629,7 @@ export class EditorHtmlToolbar extends Component {
 					onClose={ this.closeMediaModal }
 					onInsertMedia={ this.onInsertMedia }
 					visible={ this.state.showMediaModal }
+					source={ this.state.source }
 				/>
 
 				<MediaLibraryDropZone

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -127,7 +127,7 @@ export class EditorMediaModal extends Component {
 		return {
 			filter: '',
 			detailSelectedIndex: 0,
-			source: '',
+			source: props.source ? props.source : '',
 			gallerySettings: props.initialGallerySettings
 		};
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -49,6 +49,7 @@
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
+		"external-media": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,


### PR DESCRIPTION
Enables Google Photos in the media library for _development only._

This will:
- Add a 'Add from Google' option to the post editor media dropdown
- Connect the 'Add from Google' option to the media library modal to show Google Photos
- Enables MEDIA_IMAGE_THUMBNAIL thumbnails for Google Photos
- Show a static title in the media modal instead of media filters

### Testing

1. Ensure you are connected to Google Photos first from the Sharing menu (a check for this will be added in #15107) - you'll need some photos in your Google Photos account!
1. Run the branch and verify the post editor media dropdown has the 'Add from Google' option in both HTML and Visual edit mode
<img width="212" alt="dropdown" src="https://user-images.githubusercontent.com/1277682/27481799-72bab5fc-5816-11e7-902c-73975d3f57b8.png">

3. Select 'Add from Google'
3. Verify that you can view your Google Photos media and perform searches
3. Verify that the modal title is:
<img width="304" alt="title" src="https://user-images.githubusercontent.com/1277682/27482810-d111819a-581a-11e7-8d41-ec0d175a21c9.png">

5. Verify that thumbnails are loaded directly from Google and not through Photon
5. Click a media item and verify the blue 'Copy to your library' button is enabled (copy functionality to be added in #15435)
5. Verify that the media actions ('add new', edit, and delete buttons - just below the modal title) do not appear
5. Verify you have access to your Google library from a Jetpack site
5. Verify that normal WordPress media library functions continue to operate

Then edit `config/development.json`, set `external-media` to false, and check that Google Photos cannot be accessed and the media modal behaves as normal.
