### PR TITLE
PostShare: disable past days

### DIFF
--- a/client/blocks/calendar-button/docs/example.jsx
+++ b/client/blocks/calendar-button/docs/example.jsx
@@ -12,7 +12,11 @@ import CalendarButton from 'blocks/calendar-button';
 const CalendarButtonExample = () => {
 	const tomorrow = new Date( new Date().getTime() + 24 * 60 * 60 * 1000 );
 	return (
-		<CalendarButton primary selectedDay={ tomorrow } />
+		<CalendarButton
+			primary
+			enableOutsideDays={ false }
+			disabledDays={ [ { before: new Date() } ] }
+			selectedDay={ tomorrow } />
 	);
 };
 

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -21,6 +21,7 @@ class CalendarButton extends Component {
 		// calendar-popover properties
 		autoPosition: PropTypes.bool,
 		closeOnEsc: PropTypes.bool,
+		disabledDays: PropTypes.array,
 		events: PropTypes.array,
 		ignoreContext: PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
 		isVisible: PropTypes.bool,
@@ -71,9 +72,12 @@ class CalendarButton extends Component {
 		const calendarProperties = Object.assign( {}, pick( this.props, [
 			'autoPosition',
 			'closeOnEsc',
+			'disabledDays',
 			'events',
+			'enableOutsideDays',
 			'ignoreContext',
 			'isVisible',
+			'modifiers',
 			'rootClassName',
 			'selectedDay',
 			'showDelay',

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -65,6 +65,9 @@ class CalendarPopover extends Component {
 			'events',
 			'posts',
 			'site',
+			'disabledDays',
+			'enableOutsideDays',
+			'modifiers',
 			'onDateChange',
 			'onMonthChange',
 		] ) );

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -291,6 +291,8 @@ class PostShare extends Component {
 						events={ actionsEvents }
 						className="post-share__schedule-button"
 						disabled={ this.isDisabled() }
+						disabledDays={ [ { before: new Date() } ] }
+						enableOutsideDays={ false }
 						title={ translate( 'Set date and time' ) }
 						selectedDay={ this.state.scheduledDate }
 						tabIndex={ 3 }

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -52,13 +52,7 @@ class DatePickerDay extends Component {
 	}
 
 	renderTooltip() {
-		if ( ! this.state.showTooltip ) {
-			return null;
-		}
-
-		if ( ! this.props.events.length ) {
-			return null;
-		}
+		const isVisible = !! this.props.events.length && this.state.showTooltip;
 
 		const label = this.props.translate(
 			'%d post',
@@ -74,7 +68,7 @@ class DatePickerDay extends Component {
 			<Tooltip
 				className="date-picker__events-tooltip"
 				context={ this.refs.dayTarget }
-				isVisible={ this.state.showTooltip }
+				isVisible={ isVisible }
 				onClose={ noop }
 			>
 				<span>{ label }</span>

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -3,7 +3,6 @@
  */
 import React, { PropTypes, Component } from 'react';
 import { noop, map } from 'lodash';
-import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -110,42 +109,14 @@ class DatePickerDay extends Component {
 	}
 
 	render() {
-		const classes = { 'date-picker__day': true };
-		let i = 0;
-		let dayEvent;
-
-		classes[ 'is-selected' ] = this.props.selected === true;
-		classes[ 'past-day' ] = this.isPastDay() === true;
-
-		if ( this.props.events.length ) {
-			classes[ 'date-picker__day_event' ] = true;
-
-			for ( i; i < this.props.events.length; i++ ) {
-				dayEvent = this.props.events[ i ];
-
-				if (
-					dayEvent.type &&
-					( ! classes[ 'date-picker__day_event_' + dayEvent.type ] )
-				) {
-					classes[ 'date-picker__day_event_' + dayEvent.type ] = true;
-				}
-			}
-		}
-
 		return (
 			<div
 				ref="dayTarget"
-				className={ classNames( classes ) }
+				className="date-picker__day"
 				onMouseEnter={ this.showTooltip }
 				onMouseLeave={ this.hideTooltip }
 			>
-				<span
-					key={ 'selected-' + ( this.props.date.getTime() / 1000 | 0 ) }
-					className="date-picker__day-selected">
-				</span>
-				<span className="date-picker__day-text">
-					{ this.props.date.getDate() }
-				</span>
+				{ this.props.date.getDate() }
 
 				{ this.renderTooltip() }
 			</div>

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -23,7 +23,7 @@ class DatePickerExample extends Component {
 
 			{
 				title: 'Social Media - Facebook',
-				date: new Date(),
+				date: new Date( Date.now() + 60 * 60 * 24 * 1000 ),
 				socialIcon: 'facebook',
 			},
 
@@ -48,7 +48,7 @@ class DatePickerExample extends Component {
 
 			{
 				title: 'Social Media - Tumblr',
-				date: new Date(),
+				date: new Date( Date.now() + 60 * 60 * 24 * 1000 ),
 				socialIcon: 'tumblr',
 			},
 
@@ -86,22 +86,28 @@ class DatePickerExample extends Component {
 
 			{
 				title: 'Tomorrow is tomorrow',
-				date: new Date( +new Date() + 60 * 60 * 24 * 1000 ),
-				type: 'future-event',
+				date: new Date( Date.now() + 60 * 60 * 24 * 1000 ),
+				type: 'future',
 			},
 			{
 				title: 'Yesterday',
-				date: new Date( +new Date() - 60 * 60 * 24 * 1000 ),
-				type: 'past-event',
+				date: new Date( Date.now() - 60 * 60 * 24 * 1000 ),
+				type: 'past',
+			},
+			{
+				title: 'Retro birthday',
+				date: new Date( '1977-07-18' ),
+				type: 'birthday',
+				icon: 'offline',
 			}
 		]
 	};
 
 	selectDay = ( date, modifiers ) => {
-		this.setState( { selectedDay: date } );
+		this.setState( { selectedDay: date.toDate() } );
 
 		if ( date ) {
-			console.log( date.toDate(), modifiers );
+			console.log( date.toDate(), modifiers ); // eslint-disable-line no-console
 		}
 	};
 
@@ -109,6 +115,7 @@ class DatePickerExample extends Component {
 		return (
 			<Card style={ { width: '300px', margin: 0 } }>
 				<DatePicker
+					disabledDays={ [ { before: new Date() } ] }
 					events={ this.state.events }
 					onSelectDay={ this.selectDay }
 					selectedDay={ this.state.selectedDay } />

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -104,7 +104,7 @@ class DatePickerExample extends Component {
 	};
 
 	selectDay = ( date, modifiers ) => {
-		this.setState( { selectedDay: date.toDate() } );
+		this.setState( { selectedDay: date } );
 
 		if ( date ) {
 			console.log( date.toDate(), modifiers ); // eslint-disable-line no-console

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -129,6 +129,7 @@ class DatePicker extends PureComponent {
 			<DayPicker
 				ref="daypicker"
 				className="date-picker"
+				disabledDays={ this.props.disabledDays }
 				initialMonth={ this.props.calendarViewDate }
 				renderDay={ this.renderDay }
 				localeUtils={ this.locale() }

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -133,8 +133,11 @@ class DatePicker extends PureComponent {
 	}
 
 	renderDay = day => {
+		const isSelected = this.props.selectedDay && this.isSameDay( this.props.selectedDay, day );
+
 		return (
 			<DayItem
+				selected= { isSelected }
 				events={ this.filterEventsByDay( day ) }
 				date={ day } />
 		);

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -39,6 +39,7 @@ class DatePicker extends PureComponent {
 	isSameDay( d0, d1 ) {
 		d0 = this.props.moment( d0 );
 		d1 = this.props.moment( d1 );
+
 		return d0.isSame( d1, 'day' );
 	}
 
@@ -94,18 +95,22 @@ class DatePicker extends PureComponent {
 		return merge( locale, this.props.locale );
 	}
 
-	setCalendarDay = ( event, clickedDay ) => {
-		clickedDay = this.props.moment( clickedDay );
+	setCalendarDay = ( day, modifiers ) => {
+		const momentDay = this.props.moment( day );
 
-		const modifiers = {
-			year: clickedDay.year(),
-			month: clickedDay.month(),
-			date: clickedDay.date()
+		if ( modifiers.disabled ) {
+			return null;
+		}
+
+		const dateMods = {
+			year: momentDay.year(),
+			month: momentDay.month(),
+			date: momentDay.date()
 		};
 
-		const date = ( this.props.timeReference || clickedDay ).set( modifiers );
+		const date = ( this.props.timeReference || momentDay ).set( dateMods );
 
-		this.props.onSelectDay( date, modifiers );
+		this.props.onSelectDay( date, dateMods, modifiers );
 	};
 
 	setCalendarMonth = () => {
@@ -114,11 +119,8 @@ class DatePicker extends PureComponent {
 	};
 
 	renderDay = day => {
-		const isSelected = this.props.selectedDay && this.isSameDay( this.props.selectedDay, day );
-
 		return (
 			<DayItem
-				selected={ isSelected }
 				events={ this.filterEventsByDay( day ) }
 				date={ day } />
 		);
@@ -127,13 +129,17 @@ class DatePicker extends PureComponent {
 	render() {
 		return (
 			<DayPicker
+				modifiers= { {
+					'is-selected': this.props.selectedDay,
+					'past-days': { before: new Date() }
+				} }
 				ref="daypicker"
 				className="date-picker"
 				disabledDays={ this.props.disabledDays }
-				initialMonth={ this.props.calendarViewDate }
+				month={ this.props.calendarViewDate }
+				onDayClick={ this.setCalendarDay }
 				renderDay={ this.renderDay }
 				localeUtils={ this.locale() }
-				onDayClick={ this.setCalendarDay }
 				onMonthChange={ this.props.onMonthChange }
 				enableOutsideDays={ this.props.enableOutsideDays }
 				onCaptionClick={ this.setCalendarMonth } />

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -2,9 +2,6 @@ $date-picker_caption_height: 50px;
 $date-picker_nav_button_size: 20px;
 
 .date-picker {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
 	position: relative;
 	padding: 0;
 	user-select: none;
@@ -98,7 +95,7 @@ $date-picker_nav_button_size: 20px;
 	position: relative;
 	width: 100%;
 
-	&::after {
+	&:after {
 		@include long-content-fade( $color: darken( $gray, 30% ) );
 	}
 }
@@ -227,6 +224,17 @@ $date-picker_nav_button_size: 20px;
 	display: table-row;
 }
 
+
+// - days cell -
+// modifiers - clean inherit styles from daypicker component
+.date-picker .DayPicker-Day,
+.date-picker .DayPicker-Day.DayPicker-Day--selected,
+.date-picker .DayPicker-Day.DayPicker-Day--today,
+.date-picker .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+	background-color: transparent;
+}
+
+// default day styles
 .DayPicker-Day {
 	display: table-cell;
 	position: relative;
@@ -234,7 +242,6 @@ $date-picker_nav_button_size: 20px;
 	line-height: 34px;
 	vertical-align: middle;
 	text-align: center;
-	cursor: pointer;
 	font-size: 11px;
 	font-weight: 600;
 }
@@ -243,43 +250,64 @@ $date-picker_nav_button_size: 20px;
 	cursor: default;
 }
 
-// Modifiers
+// base styles of the cell child element
+.DayPicker-Day .date-picker__day {
+	content: " ";
+	display: block;
+	height: 24px;
+	width: 24px;
+	border-radius: 50%;
+	cursor: pointer;
+}
 
-.DayPicker-Day--today .date-picker__day:not(.is-selected) {
+// `today` day
+.DayPicker-Day--today .date-picker__day {
 	color: $white;
+	background-color: $gray-dark;
 
-	.date-picker__day-selected {
-		background-color: $gray-dark;
-		opacity: 1;
-		transform: scale( 1 );
-	}
-
-	&:hover .date-picker__day-selected {
+	&:hover {
 		background-color: darken( $gray, 20% );
 	}
 }
 
-.DayPicker-Day--disabled {
+// `outside` day
+.DayPicker-Day--outside .date-picker__day {
+	font-weight: normal;
+}
+
+// `disabled` day
+.DayPicker-Day--disabled .date-picker__day {
 	color: lighten( $gray, 20% );
 	cursor: default;
 }
 
+// `is-selected` day (not today -> adds animation)
+.DayPicker-Day.DayPicker-Day--is-selected:not(.DayPicker-Day--today) .date-picker__day {
+	color: $white;
+	animation: isSelectedDay 125ms ease-out;
+	background-color: $blue-medium;
+}
+
+// `is-selected` day (today -> no animation)
+.DayPicker-Day.DayPicker-Day--is-selected.DayPicker-Day--today .date-picker__day {
+	color: $white;
+	background-color: $blue-medium;
+}
+
+// `Sunday` day
 .DayPicker-Day--sunday {
 	color: $gray-light;
 }
 
-.DayPicker-Day--outside {
-	cursor: pointer;
-	font-weight: normal;
-
-	.date-picker__day:not(.is-selected) {
-		color: $gray;
-	}
-}
-
-.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-	color: $white;
-	background-color: $gray-light;
+@keyframes isSelectedDay {
+  0% {
+    transform: scale( 0 );
+	opacity: 0;
+  }
+  100% {
+    transform: scale( 1 );
+	opacity: 1;
+  }
 }
 
 .DayPicker--ar {

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -223,14 +223,15 @@ $date-picker_nav_button_size: 20px;
 }
 
 // `is-selected` day (not today -> adds animation)
-.DayPicker-Day.DayPicker-Day--is-selected:not(.DayPicker-Day--today) .date-picker__day {
+.DayPicker-Day.DayPicker-Day--is-selected:not(.DayPicker-Day--today):not(.DayPicker-Day--events) .date-picker__day {
 	color: $white;
 	animation: isSelectedDay 125ms ease-out;
 	background-color: $blue-medium;
 }
 
 // `is-selected` day (today -> no animation)
-.DayPicker-Day.DayPicker-Day--is-selected.DayPicker-Day--today .date-picker__day {
+.DayPicker-Day.DayPicker-Day--is-selected.DayPicker-Day--today .date-picker__day,
+.DayPicker-Day.DayPicker-Day--is-selected.DayPicker-Day--events .date-picker__day {
 	color: $white;
 	background-color: $blue-medium;
 }
@@ -244,6 +245,11 @@ $date-picker_nav_button_size: 20px;
 .DayPicker-Day--events:not(.DayPicker-Day--is-selected) .date-picker__day {
 	border-color: $gray;
 }
+
+.DayPicker-Day--events.DayPicker-Day--disabled:not(.DayPicker-Day--is-selected) .date-picker__day {
+	border-color: lighten( $gray, 20% );
+}
+
 
 @keyframes isSelectedDay {
   0% {

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -8,66 +8,6 @@ $date-picker_nav_button_size: 20px;
 	width: 100%;
 }
 
-.date-picker__day {
-	position: relative;
-	border-radius: 50%;
-	border: 1px solid $transparent;
-	width: 24px;
-	height: 24px;
-	color: inherit;
-	font-weight: inherit;
-	text-decoration: inherit;
-	line-height: 24px;
-	text-align: center;
-	margin: 0 auto;
-
-	&.is-selected {
-		color: $white;
-		&:hover {
-			color: $white;
-		}
-	}
-
-	&:hover {
-		color: darken( $gray, 10% );
-	}
-}
-
-.date-picker__day_event:not(.is-selected) {
-	border-color: lighten( $gray, 10% );
-}
-
-.date-picker__day-text {
-	position: absolute;
-		left: 0;
-		right: 0;
-		top: 0;
-		bottom: 0;
-	color: inherit;
-	font-weight: inherit;
-	text-decoration: inherit;
-	transition: color 90ms ease;
-}
-
-.date-picker__day-selected {
-	position: absolute;
-		left: 0;
-		right: 0;
-		top: 0;
-		bottom: 0;
-	transition: transform 125ms cubic-bezier( 0.215, 0.610, 0.355, 1.000 ), opacity 125ms ease-out;
-	transform: scale( 0 );
-	opacity: 0;
-	border-radius: 50%;
-	background-color: $blue-medium;
-}
-
-.date-picker__day.is-selected .date-picker__day-selected {
-	transition: transform 125ms cubic-bezier( 0.105, 1.075, 0.940, 1.080 ) , opacity 125ms ease-out;
-	transform: scale( 1 );
-	opacity: 1;
-}
-
 .date-picker__division {
 	margin: 8px 0;
 	background: $gray;
@@ -115,11 +55,6 @@ $date-picker_nav_button_size: 20px;
 	height: 18px;
 	line-height: 18px;
 }
-
-/**
- * The follow class names are coming from react-day-picker component
- * and they aren't possible change them without change its code base.
- */
 
 .DayPicker-Month {
 	display: table;
@@ -256,8 +191,13 @@ $date-picker_nav_button_size: 20px;
 	display: block;
 	height: 24px;
 	width: 24px;
+	line-height: 24px;
 	border-radius: 50%;
 	cursor: pointer;
+	border: 1px solid $transparent;
+	color: $gray-dark;
+	text-align: center;
+	margin: 0 auto;
 }
 
 // `today` day
@@ -273,10 +213,11 @@ $date-picker_nav_button_size: 20px;
 // `outside` day
 .DayPicker-Day--outside .date-picker__day {
 	font-weight: normal;
+	color: $gray;
 }
 
 // `disabled` day
-.DayPicker-Day--disabled .date-picker__day {
+.DayPicker-Day--disabled:not(.DayPicker-Day--outside) .date-picker__day {
 	color: lighten( $gray, 20% );
 	cursor: default;
 }
@@ -295,8 +236,13 @@ $date-picker_nav_button_size: 20px;
 }
 
 // `Sunday` day
-.DayPicker-Day--sunday {
-	color: $gray-light;
+.DayPicker-Day--sunday .date-picker__day {
+	color: $gray;
+}
+
+// `event` day
+.DayPicker-Day--events:not(.DayPicker-Day--is-selected) .date-picker__day {
+	border-color: $gray;
 }
 
 @keyframes isSelectedDay {

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -193,6 +193,9 @@ class PostSchedule extends Component {
 				<DatePicker
 					events={ this.events() }
 					locale={ this.locale() }
+					disabledDays={ this.props.disabledDays }
+					enableOutsideDays={ this.props.enableOutsideDays }
+					modifiers={ this.props.modifiers }
 					selectedDay={
 						this.state.localizedDate
 							? this.state.localizedDate.toDate()

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1828,11 +1828,11 @@
       "version": "3.1.3"
     },
     "esrecurse": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "dev": true,
       "dependencies": {
         "estraverse": {
-          "version": "4.1.1",
+          "version": "4.2.0",
           "dev": true
         }
       }
@@ -2142,6 +2142,460 @@
     },
     "fs.realpath": {
       "version": "1.0.0"
+    },
+    "fsevents": {
+      "version": "1.1.1",
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1"
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2",
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9"
+        },
+        "boom": {
+          "version": "2.10.1"
+        },
+        "brace-expansion": {
+          "version": "1.1.6"
+        },
+        "buffer-shims": {
+          "version": "1.0.0"
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0"
+        },
+        "combined-stream": {
+          "version": "1.0.5"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1"
+        },
+        "console-control-strings": {
+          "version": "1.1.0"
+        },
+        "core-util-is": {
+          "version": "1.0.2"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "optional": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.1",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0"
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "optional": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.2",
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0"
+        },
+        "fstream": {
+          "version": "1.0.10"
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.3",
+          "optional": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1"
+        },
+        "graceful-fs": {
+          "version": "4.1.11"
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "optional": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "optional": true
+        },
+        "hoek": {
+          "version": "2.16.3"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6"
+        },
+        "inherits": {
+          "version": "2.0.3"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0"
+        },
+        "is-my-json-valid": {
+          "version": "2.15.0",
+          "optional": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.3.1",
+          "optional": true
+        },
+        "mime-db": {
+          "version": "1.26.0"
+        },
+        "mime-types": {
+          "version": "2.1.14"
+        },
+        "minimatch": {
+          "version": "3.0.3"
+        },
+        "minimist": {
+          "version": "0.0.8"
+        },
+        "mkdirp": {
+          "version": "0.5.1"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.33",
+          "optional": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.0.2",
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0"
+        },
+        "path-is-absolute": {
+          "version": "1.0.1"
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.3.1",
+          "optional": true
+        },
+        "rc": {
+          "version": "1.1.7",
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "optional": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.5.4"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.10.2",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31"
+        },
+        "string-width": {
+          "version": "1.0.2"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1"
+        },
+        "tar-pack": {
+          "version": "3.3.0",
+          "optional": true,
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "optional": true
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2"
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2"
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "optional": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11"
@@ -4332,7 +4786,10 @@
       "version": "1.0.0"
     },
     "promise": {
-      "version": "7.3.0"
+      "version": "7.3.1"
+    },
+    "prop-types": {
+      "version": "15.5.10"
     },
     "propagate": {
       "version": "0.4.0",
@@ -4482,7 +4939,7 @@
       }
     },
     "react-day-picker": {
-      "version": "2.4.1"
+      "version": "6.0.2"
     },
     "react-docgen": {
       "version": "2.13.0",
@@ -4518,9 +4975,6 @@
           "dev": true
         }
       }
-    },
-    "react-is-deprecated": {
-      "version": "0.1.2"
     },
     "react-modal": {
       "version": "1.6.5"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "react-addons-shallow-compare": "15.4.0",
     "react-addons-update": "15.4.0",
     "react-click-outside": "2.1.0",
-    "react-day-picker": "2.4.1",
+    "react-day-picker": "6.0.2",
     "react-docgen": "2.13.0",
     "react-dom": "15.4.0",
     "react-modal": "1.6.5",


### PR DESCRIPTION
The final purpose of this PR is to be able to disable past days into the calendar in the `Share` section.

<img src="https://user-images.githubusercontent.com/77539/27480871-601716f0-57f0-11e7-8575-4f80a1b9e7fc.png" width="400px" />

For this, we've had to do extra tasks _aparentelly_ not related to the primary issue, however, sooner or later we have to do it.

### Actions list:

* bump calendar dependency from `2.4.1` to `6.0.2`.
A lot of changes when the `<DayPicker />` is updated. Some of them are breaking changes.

* update `<DatePicker />` according to the changes of `<DayPicker />`

* Re-implement events, selected-day, Sunday days, etc. using [modifiers](http://react-day-picker.js.org/docs/api-daypicker.html#modifiers).

* Propagate properties between calendar components: PostSchedule, CalendarButton.

After these changes, the implementation of `<DatePicker />` is better and lighter.

### Testing

Take a look to the `<datePicker />`, `<PostSchedule />` and `<CalendarButton />` components

http://calypso.localhost:3000/devdocs/design/date-picker
* http://calypso.localhost:3000/devdocs/blocks/post-schedule
* http://calypso.localhost:3000/devdocs/blocks/calendar-popover

Everything should be ok. I've disabled past days on the `<DatePicker />` and `<CalendarButton />` examples. Confirm that you aren't able to select a past date.

<img src="https://user-images.githubusercontent.com/77539/27484583-29d47096-5800-11e7-861e-8e09fb0cbbf9.png" width="400px" />

Now test the Advanced Social Media section

1) Go to posts list page of a site with ASM section enabled: `http://calypso.localhost:3000/posts/my/my-business-or-premium-testing-site`
2) Click on the `Share` tab
3) Confirm that you aren't able to select a past day from there. 

<img src="https://user-images.githubusercontent.com/77539/27490155-960fb988-5813-11e7-9bce-d5ff1f46ef2e.png" width="400px" />




