### PR TITLE
Make the media delete message scarier

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -196,8 +196,8 @@ class Media extends Component {
 		const selected = MediaLibrarySelectedStore.getAll( site.ID );
 		const selectedCount = selected.length;
 		const confirmMessage = this.props.translate(
-			'Are you sure you want to permanently delete this item?',
-			'Are you sure you want to permanently delete these items?',
+			'All deleted media will stop functioning on your website. Are you sure you want to delete this item? This cannot be undone.',
+			'All deleted media will stop functioning on your website. Are you sure you want to delete these items? This cannot be undone.',
 			{ count: selectedCount }
 		);
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -193,8 +193,8 @@ export class EditorMediaModal extends Component {
 		}
 
 		const confirmMessage = this.props.translate(
-			'Are you sure you want to permanently delete this item?',
-			'Are you sure you want to permanently delete these items?',
+			'All deleted media will stop functioning on your website. Are you sure you want to delete this item? This cannot be undone.',
+			'All deleted media will stop functioning on your website. Are you sure you want to delete these items? This cannot be undone.',
 			{ count: selectedCount }
 		);
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -76,7 +76,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
+		expect( accept ).to.have.been.calledWith( 'All deleted media will stop functioning on your website. Are you sure you want to delete this item? This cannot be undone.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -89,7 +89,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete these items?' );
+		expect( accept ).to.have.been.calledWith( 'All deleted media will stop functioning on your website. Are you sure you want to delete these items? This cannot be undone.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA );
 			done();
@@ -105,7 +105,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
+		expect( accept ).to.have.been.calledWith( 'All deleted media will stop functioning on your website. Are you sure you want to delete this item? This cannot be undone.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
 			done();
@@ -118,7 +118,7 @@ describe( 'EditorMediaModal', function() {
 		).instance();
 		tree.deleteMedia();
 
-		expect( accept ).to.have.been.calledWith( 'Are you sure you want to permanently delete this item?' );
+		expect( accept ).to.have.been.calledWith( 'All deleted media will stop functioning on your website. Are you sure you want to delete this item? This cannot be undone.' );
 		process.nextTick( function() {
 			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA[ 0 ] );
 			done();


### PR DESCRIPTION
Improves #10982 message by clarifying that deleted media items cannot be recovered.

Got some errors when pre-commiting: 

`/Users/gma992/Dropbox/wp-calypso/client/my-sites/media/main.jsx
  199:1  error  Line 199 exceeds the maximum line length of 140  max-len
  200:1  error  Line 200 exceeds the maximum line length of 140  max-len

/Users/gma992/Dropbox/wp-calypso/client/post-editor/media-modal/index.jsx
  196:1  error  Line 196 exceeds the maximum line length of 140  max-len
  197:1  error  Line 197 exceeds the maximum line length of 140  max-len

/Users/gma992/Dropbox/wp-calypso/client/post-editor/media-modal/test/index.jsx
   79:1  error  Line 79 exceeds the maximum line length of 140   max-len
   92:1  error  Line 92 exceeds the maximum line length of 140   max-len
  108:1  error  Line 108 exceeds the maximum line length of 140  max-len
  121:1  error  Line 121 exceeds the maximum line length of 140  max-len`

But do not exceed 140 chars. any advice is welcome, as is my first PR :)