### PR TITLE
Added a selector to check if the shipping zones returned by the server are valid for editing in Calypso

### DIFF
--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isObject } from 'lodash';
+import { get, isEmpty, isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,4 +33,90 @@ export const areShippingZoneLocationsLoaded = ( state, zoneId, siteId = getSelec
 export const areShippingZoneLocationsLoading = ( state, zoneId, siteId = getSelectedSiteId( state ) ) => {
 	const rawLocations = getRawShippingZoneLocations( state, siteId );
 	return rawLocations && LOADING === getRawShippingZoneLocations( state, siteId )[ zoneId ];
+};
+
+/**
+ * Checks if the shipping zones configuration is valid for being edited in Calypso. If the user only has ever
+ * used the Calypso interface, this method will always return true. If he has done some configuration
+ * in WP-Admin (which doesn't have as many restrictions), then it could be that he configured the zones in a way
+ * that can't be reliably represented in Calypso, and as such the UI must forbid him to add new zones or edit
+ * existing zones locations.
+ * @param {Object} reduxState Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean} Whether the shipping zones have valid locations to be edited in Calypso
+ */
+export const areShippingZonesLocationsValid = ( reduxState, siteId = getSelectedSiteId( reduxState ) ) => {
+	const continentsSet = new Set();
+	const countriesSet = new Set();
+	const statesSet = new Set();
+	const allLocations = getRawShippingZoneLocations( reduxState, siteId );
+	for ( const zoneId of Object.keys( allLocations ) ) {
+		if ( ! areShippingZoneLocationsLoaded( reduxState, zoneId, siteId ) ) {
+			continue;
+		}
+		if ( 0 === Number( zoneId ) ) { // The "Rest of the world" zone is always valid, it doesn't have any locations
+			continue;
+		}
+
+		const { continent, country, state, postcode } = allLocations[ zoneId ];
+		if ( ! isEmpty( continent ) ) {
+			// If the zone has one or more continents, then it must *not* have any other type of location
+			if ( ! isEmpty( country ) || ! isEmpty( state ) || ! isEmpty( postcode ) ) {
+				return false;
+			}
+			for ( const c of continent ) {
+				// 2 zones can't have the same continent
+				if ( continentsSet.has( c ) ) {
+					return false;
+				}
+				continentsSet.add( c );
+			}
+		} else if ( ! isEmpty( country ) ) {
+			// If the zone has one or more countries, then it must *not* have any states too
+			if ( ! isEmpty( state ) ) {
+				return false;
+			}
+			if ( ! isEmpty( postcode ) ) { // Single country + postcode is allowed
+				// Only 1 postcode range is allowed in a zone
+				if ( 1 < country.length || 1 < postcode.length ) {
+					return false;
+				}
+			} else { // Whole country, or multiple countries
+				for ( const c of country ) {
+					// 2 zones can't have the same country
+					if ( countriesSet.has( c ) ) {
+						return false;
+					}
+					countriesSet.add( c );
+				}
+			}
+		} else if ( ! isEmpty( state ) ) {
+			// If the zone has one or more states, then it must *not* have any other type of location
+			if ( ! isEmpty( postcode ) ) {
+				return false;
+			}
+			let countryCode;
+			for ( const s of state ) {
+				if ( countryCode ) {
+					// States are represented like "CountryCode:StateCode".
+					// Check that the zone doesn't have states from multiple countries.
+					if ( s.split( ':' )[ 0 ] !== countryCode ) {
+						return false;
+					}
+				} else {
+					countryCode = s.split( ':' )[ 0 ];
+				}
+				// 2 zones can't have the same state
+				if ( statesSet.has( s ) ) {
+					return false;
+				}
+				statesSet.add( s );
+			}
+		} else {
+			// A zone must have *any* location. If it doesn't, it's incorrect.
+			return false;
+		}
+	}
+
+	return true;
 };

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
@@ -9,8 +9,10 @@ import { expect } from 'chai';
 import {
 	areShippingZoneLocationsLoaded,
 	areShippingZoneLocationsLoading,
+	areShippingZonesLocationsValid,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
+import { createState } from 'woocommerce/state/test/helpers';
 
 const zoneId = 7;
 
@@ -112,6 +114,426 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( areShippingZoneLocationsLoading( loadingState, zoneId ) ).to.be.true;
+		} );
+	} );
+
+	describe( '#areShippingZonesLocationsValid', () => {
+		it( 'should return true if the zones locations are still loading.', () => {
+			expect( areShippingZonesLocationsValid( loadingState ) ).to.be.true;
+		} );
+
+		it( 'should return true for an empty zone list.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true for the "Rest of the world" zone.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						0: {
+							continent: [],
+							country: [],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return false for a zone without locations.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return true for a zone with a single continent.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [ 'NA' ],
+							country: [],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true for a zone with multiple continents.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [ 'NA', 'EU' ],
+							country: [],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return false for zones that have repeated continents.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [ 'NA', 'EU' ],
+							country: [],
+							state: [],
+							postcode: [],
+						},
+						2: {
+							continent: [ 'EU' ],
+							country: [],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for a zone that mixes continents and countries.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [ 'NA' ],
+							country: [ 'UK' ],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for a zone that mixes continents and states.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [ 'NA' ],
+							country: [],
+							state: [ 'US:CA' ],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for a zone that mixes continents and postcodes.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [ 'NA' ],
+							country: [],
+							state: [],
+							postcode: [ '12345' ],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return true for a zone with a single country.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US' ],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true for a zone with multiple countries.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US', 'CA' ],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return false for zones that have repeated countries.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US', 'UK' ],
+							state: [],
+							postcode: [],
+						},
+						2: {
+							continent: [],
+							country: [ 'US', 'CA' ],
+							state: [],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for a zone that mixes countries and states.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US' ],
+							state: [ 'US:CA' ],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return true for a zone with a single state.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [],
+							state: [ 'US:CA' ],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true for a zone with multiple states from the same country.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [],
+							state: [ 'US:UT', 'US:CA', 'US:NY' ],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return false for a zone with multiple states from different countries.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [],
+							state: [ 'US:UT', 'US:CA', 'CA:BC' ],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for zones that have repeated states.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [],
+							state: [ 'US:UT', 'US:CA' ],
+							postcode: [],
+						},
+						2: {
+							continent: [],
+							country: [],
+							state: [ 'US:CA', 'US:NY' ],
+							postcode: [],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for a zone that mixes states and postcodes.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [],
+							state: [ 'US:CA' ],
+							postcode: [ '80123' ],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for a zone that has only a postcode, without country.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [],
+							state: [],
+							postcode: [ '80123' ],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false for a zone that has a postcode with several countries.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US', 'CA' ],
+							state: [],
+							postcode: [ '80100...80199' ],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return true for a zone that has a postcode with a country.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US' ],
+							state: [],
+							postcode: [ '80100...80199' ],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return false for a zone that has multiple postcodes.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US' ],
+							state: [],
+							postcode: [ '80123', '12345' ],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false even if only a single zone is incorrect.', () => {
+			const state = createState( {
+				site: {
+					shippingZoneLocations: {
+						1: {
+							continent: [],
+							country: [ 'US' ],
+							state: [],
+							postcode: [ '80123' ],
+						},
+						2: {
+							continent: [ 'NA' ],
+							country: [],
+							state: [],
+							postcode: [],
+						},
+						3: { // wrong!
+							continent: [],
+							country: [ 'US' ],
+							state: [ 'US:CA' ],
+							postcode: [ '80123' ],
+						},
+					},
+				},
+				ui: {},
+			} );
+			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a selector to check if the shipping zones returned by the server are valid for editing in Calypso, or they are "tainted" by editing them in WP-Admin. Right now it only checks that the locations are valid following the rules we have defined for the UX.

No code is using this selector, so just make sure the tests pass.