### PR TITLE
WooCommerce: Update single order view

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -44,7 +44,7 @@ class Order extends Component {
 				<OrderHeader siteSlug={ site.slug } />
 
 				<div className="order__container">
-					<OrderDetails order={ order } />
+					<OrderDetails order={ order } siteSlug={ site.slug } />
 					<OrderActivityLog order={ order } />
 					<OrderCustomerInfo order={ order } />
 				</div>

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -10,6 +10,7 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import formatCurrency from 'lib/format-currency';
 import SectionHeader from 'components/section-header';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
@@ -39,12 +40,18 @@ class OrderDetails extends Component {
 	}
 
 	renderOrderItems = ( item, i ) => {
+		const { order, siteSlug } = this.props;
 		return (
 			<TableRow key={ i } className="order__detail-items">
-				<TableItem isRowHeader className="order__detail-item-product">{ item.name }</TableItem>
-				<TableItem className="order__detail-item-cost">{ item.price }</TableItem>
+				<TableItem isRowHeader className="order__detail-item-product">
+					<a href={ `/store/product/${ siteSlug }/${ item.product_id }` } className="order__detail-item-link">
+						{ item.name }
+					</a>
+					<span className="order__detail-item-sku">{ item.sku }</span>
+				</TableItem>
+				<TableItem className="order__detail-item-cost">{ formatCurrency( item.price, order.currency ) || item.price }</TableItem>
 				<TableItem className="order__detail-item-quantity">{ item.quantity }</TableItem>
-				<TableItem className="order__detail-item-total">{ item.total }</TableItem>
+				<TableItem className="order__detail-item-total">{ formatCurrency( item.total, order.currency ) || item.total }</TableItem>
 			</TableRow>
 		);
 	}
@@ -66,15 +73,21 @@ class OrderDetails extends Component {
 					<div className="order__details-totals">
 						<div className="order__details-total-discount">
 							<div className="order__details-totals-label">{ translate( 'Discount' ) }</div>
-							<div className="order__details-totals-value">{ order.discount_total }</div>
+							<div className="order__details-totals-value">
+								{ formatCurrency( order.discount_total, order.currency ) || order.discount_total }
+							</div>
 						</div>
 						<div className="order__details-total-shipping">
 							<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
-							<div className="order__details-totals-value">{ order.shipping_total }</div>
+							<div className="order__details-totals-value">
+								{ formatCurrency( order.shipping_total, order.currency ) || order.shipping_total }
+							</div>
 						</div>
 						<div className="order__details-total">
 							<div className="order__details-totals-label">{ translate( 'Total' ) }</div>
-							<div className="order__details-totals-value">{ order.total }</div>
+							<div className="order__details-totals-value">
+								{ formatCurrency( order.total, order.currency ) || order.total }
+							</div>
 						</div>
 					</div>
 
@@ -83,7 +96,7 @@ class OrderDetails extends Component {
 							<Gridicon icon="checkmark" />
 							{ translate( 'Payment of %(total)s received via %(method)s', {
 								args: {
-									total: order.total,
+									total: formatCurrency( order.total, order.currency ) || order.total,
 									method: order.payment_method_title
 								}
 							} ) }

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -60,6 +60,23 @@ class OrderDetails extends Component {
 		);
 	}
 
+	renderRefundValue = () => {
+		const { order, translate } = this.props;
+		const refundValue = order.refunds.length ? this.getRefundedTotal( order ) : false;
+		if ( ! refundValue ) {
+			return null;
+		}
+
+		return (
+			<div className="order__details-total-refund">
+				<div className="order__details-totals-label">{ translate( 'Refunded' ) }</div>
+				<div className="order__details-totals-value">
+					{ formatCurrency( refundValue, order.currency ) || refundValue }
+				</div>
+			</div>
+		);
+	}
+
 	renderRefundCard = () => {
 		const { order, translate } = this.props;
 		let refundStatus = translate( 'Payment of %(total)s received via %(method)s', {
@@ -106,7 +123,6 @@ class OrderDetails extends Component {
 		if ( ! order ) {
 			return null;
 		}
-		const refundValue = order.refunds.length ? this.getRefundedTotal( order ) : false;
 
 		return (
 			<div className="order__details">
@@ -135,15 +151,7 @@ class OrderDetails extends Component {
 								{ formatCurrency( order.total, order.currency ) || order.total }
 							</div>
 						</div>
-						{ refundValue
-							? <div className="order__details-total-refund">
-								<div className="order__details-totals-label">{ translate( 'Refunded' ) }</div>
-								<div className="order__details-totals-value">
-									{ formatCurrency( refundValue, order.currency ) || refundValue }
-								</div>
-							</div>
-							: null
-						}
+						{ this.renderRefundValue() }
 					</div>
 
 					{ this.renderRefundCard() }

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -77,6 +77,7 @@
 
 	.order__details-total-discount,
 	.order__details-total-shipping,
+	.order__details-total-refund,
 	.order__details-total {
 		margin-bottom: 8px;
 
@@ -91,7 +92,7 @@
 		}
 	}
 
-	.order__details-total {
+	& > div:last-child {
 		margin-bottom: 0;
 	}
 

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -51,6 +51,15 @@
 		text-align: right;
 	}
 
+	.order__detail-item-sku {
+		display: block;
+		margin-bottom: 8px;
+		color: $gray-text-min;
+		font-size: 12px;
+		line-height: 1;
+		text-transform: uppercase;
+	}
+
 	thead .table-heading {
 		border-bottom: 1px solid lighten( $gray, 30% );
 	}


### PR DESCRIPTION
This PR fixes the visual issues raised in #15381 on the single order view

- Adds the SKU to each order line item
- Does not add the product thumbnail, we don't have that data in the order response (happy to revisit post v1)
- Links the product to the product screen
- Formats the price using the order's currency
- Adds the refund data, and updates the action card based on order status (refunded or partially refunded)

Screenshot:

Fully refunded order:
![screen shot 2017-06-22 at 6 04 12 pm](https://user-images.githubusercontent.com/541093/27484714-3ebd4544-57f8-11e7-9490-024102b1c21c.png)

Partially refunded order:
![screen shot 2017-06-22 at 6 05 36 pm](https://user-images.githubusercontent.com/541093/27484721-4886c3d4-57f8-11e7-937b-88e4c82b997b.png)

To test:

- View an order which has been refunded or partially refunded, make sure everything looks as it should.