### PR TITLE
Publicize: drop personal ASAP

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -61,7 +61,7 @@ export const UpgradeToPersonalNudge = props => {
 
 	let description;
 	if ( isJetpack ) {
-		description = translate( 'Get spam protection, unlimited backup storage and more.' );
+		description = translate( 'Get easy monetization options, Videopress support and more.' );
 	} else {
 		description = translate( 'Get unlimited premium themes, video uploads, monetize your site and more.' );
 	}
@@ -69,8 +69,8 @@ export const UpgradeToPersonalNudge = props => {
 		<Banner
 			className="post-share__upgrade-nudge"
 			feature="republicize"
-			title={ translate( 'Unlock the ability to re-share posts to social media' ) }
-			callToAction={ translate( 'Upgrade to Personal' ) }
+			title={ translate( 'Schedule your social messages in advance.' ) }
+			callToAction={ translate( 'Upgrade to Premium' ) }
 			description={ description }
 		/>
 	);

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -148,7 +148,6 @@ export const PLANS_LIST = {
 			FEATURE_BASIC_DESIGN,
 			FEATURE_6GB_STORAGE,
 			FEATURE_NO_ADS,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' )
 	},
@@ -335,7 +334,6 @@ export const PLANS_LIST = {
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
 			FEATURE_PREMIUM_SUPPORT,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per year' )
 	},
@@ -358,7 +356,6 @@ export const PLANS_LIST = {
 			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_EASY_SITE_MIGRATION,
 			FEATURE_PREMIUM_SUPPORT,
-			isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' )
 	},


### PR DESCRIPTION
We decided to drop republicize support for personal plans.

This is quick lock until https://github.com/Automattic/wp-calypso/pull/15356 is merged
<img width="1025" alt="zrzut ekranu 2017-06-23 o 16 38 59" src="https://user-images.githubusercontent.com/3775068/27486947-813be8d2-5832-11e7-9595-1c8e857b50ef.png">

## testing

Advanced social media should work ONLY for Business and Premium. You should not be able to see any form in share tab for free and personal