### PR TITLE
Activity log: Include progress data in restoreProgress reducer

### DIFF
--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -14,16 +14,30 @@ import {
 const stubNull = () => null;
 
 const startProgress = ( state, { timestamp } ) => ( {
+	errorCode: '',
+	failureReason: '',
+	message: '',
 	percent: 0,
 	status: 'queued',
 	timestamp,
 } );
 
-const updateProgress = ( state, { percent, restoreId, status, timestamp } ) => ( {
+const updateProgress = ( state, {
+	errorCode,
+	failureReason,
+	message,
 	percent,
+	restoreId,
 	status,
 	timestamp,
+} ) => ( {
+	errorCode,
+	failureReason,
+	message,
+	percent,
 	restoreId,
+	status,
+	timestamp,
 } );
 
 export const restoreError = keyedReducer( 'siteId', createReducer( {}, {


### PR DESCRIPTION
Add relevant missing data.
`restoreProgress` reducer did not include all relevant data from endpoint.

Included in #15284