### PR TITLE
Comments: Add expandable reply texarea

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -28,6 +28,7 @@ export class CommentDetailReply extends Component {
 			authorName: this.props.currentUser.display_name,
 			authorUrl: this.props.currentUser.primary_blog_url,
 			parentId: this.props.commentId,
+			postId: this.props.postId,
 			postTitle: this.props.postTitle,
 			content: this.state.commentText,
 			URL: this.props.postUrl,

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,17 +24,27 @@ export class CommentDetailReply extends Component {
 	setFocus = () => this.setState( { hasFocus: true } );
 
 	submit = () => {
+		const {
+			commentId,
+			currentUser,
+			postId,
+			postTitle,
+			postUrl,
+			submitComment,
+		} = this.props;
+		const { commentText } = this.state;
+
 		const comment = {
-			authorAvatarUrl: this.props.currentUser.avatar_URL,
-			authorName: this.props.currentUser.display_name,
-			authorUrl: this.props.currentUser.primary_blog_url,
-			parentId: this.props.commentId,
-			postId: this.props.postId,
-			postTitle: this.props.postTitle,
-			content: this.state.commentText,
-			URL: this.props.postUrl,
+			authorAvatarUrl: get( currentUser, 'avatar_URL', '' ),
+			authorName: get( currentUser, 'display_name', '' ),
+			authorUrl: get( currentUser, 'primary_blog_url', '' ),
+			parentId: commentId,
+			postId: postId,
+			postTitle: postTitle,
+			content: commentText,
+			URL: postUrl,
 		};
-		this.props.submitComment( comment );
+		submitComment( comment );
 		this.setState( { commentText: '' } );
 	}
 

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -3,15 +3,80 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import AutoDirection from 'components/auto-direction';
 
 export class CommentDetailReply extends Component {
+	state = {
+		commentText: '',
+		haveFocus: false,
+	};
+
+	handleBlur = () => this.setState( { haveFocus: false } );
+
+	handleFocus = () => this.setState( { haveFocus: true } );
+
+	handleKeyDown = event => {
+		// Use Ctrl+Enter to submit comment
+		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
+			event.preventDefault();
+			this.submit();
+		}
+	}
+
+	handleSubmit = event => {
+		event.preventDefault();
+		this.submit();
+	}
+
+	handleTextChange = event => this.setState( { commentText: event.target.value } );
+
+	submit = () => {
+		this.setState( { commentText: '' } );
+	}
+
 	render() {
 		const { translate } = this.props;
+		const { commentText, haveFocus } = this.state;
+
+		const hasCommentText = commentText.trim().length > 0;
+
+		const buttonClasses = classNames( 'comment-detail__reply-submit', {
+			'is-active': hasCommentText,
+			'is-visible': haveFocus || hasCommentText,
+		} );
+
+		const expandingAreaClasses = classNames( 'expanding-area', {
+			focused: haveFocus,
+		} );
 
 		return (
-			<div className="comment-detail__reply">
-				<textarea placeholder={ translate( 'Reply' ) }></textarea>
-			</div>
+			<form className="comment-detail__reply">
+				<div className={ expandingAreaClasses }>
+					<pre><span>{ commentText }</span><br /></pre>
+					<AutoDirection>
+						<textarea
+							onBlur={ this.handleBlur }
+							onChange={ this.handleTextChange }
+							onFocus={ this.handleFocus }
+							onKeyDown={ this.handleKeyDown }
+							placeholder={ translate( 'Enter your comment here…' ) }
+							value={ commentText }
+						/>
+					</AutoDirection>
+					<button
+						className={ buttonClasses }
+						disabled={ ! hasCommentText }
+						onClick={ this.handleSubmit }
+					>
+						{ translate( 'Send' ) }
+					</button>
+				</div>
+			</form>
 		);
 	}
 }

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -15,12 +15,12 @@ import { getCurrentUser } from 'state/current-user/selectors';
 export class CommentDetailReply extends Component {
 	state = {
 		commentText: '',
-		haveFocus: false,
+		hasFocus: false,
 	};
 
-	handleBlur = () => this.setState( { haveFocus: false } );
+	handleBlur = () => this.setState( { hasFocus: false } );
 
-	handleFocus = () => this.setState( { haveFocus: true } );
+	handleFocus = () => this.setState( { hasFocus: true } );
 
 	handleKeyDown = event => {
 		// Use Ctrl+Enter to submit comment
@@ -53,17 +53,17 @@ export class CommentDetailReply extends Component {
 
 	render() {
 		const { translate } = this.props;
-		const { commentText, haveFocus } = this.state;
+		const { commentText, hasFocus } = this.state;
 
 		const hasCommentText = commentText.trim().length > 0;
 
 		const buttonClasses = classNames( 'comment-detail__reply-submit', {
 			'is-active': hasCommentText,
-			'is-visible': haveFocus || hasCommentText,
+			'is-visible': hasFocus || hasCommentText,
 		} );
 
-		const expandingAreaClasses = classNames( 'expanding-area', {
-			focused: haveFocus,
+		const expandingAreaClasses = classNames( 'is-expanding-area', {
+			'is-focused': hasFocus,
 		} );
 
 		return (

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -9,6 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 export class CommentDetailReply extends Component {
 	state = {
@@ -36,6 +38,16 @@ export class CommentDetailReply extends Component {
 	handleTextChange = event => this.setState( { commentText: event.target.value } );
 
 	submit = () => {
+		const comment = {
+			authorAvatarUrl: this.props.currentUser.avatar_URL,
+			authorName: this.props.currentUser.display_name,
+			authorUrl: this.props.currentUser.primary_blog_url,
+			parentId: this.props.commentId,
+			postTitle: this.props.postTitle,
+			content: this.state.commentText,
+			URL: this.props.postUrl,
+		};
+		this.props.submitComment( comment );
 		this.setState( { commentText: '' } );
 	}
 
@@ -81,4 +93,8 @@ export class CommentDetailReply extends Component {
 	}
 }
 
-export default localize( CommentDetailReply );
+const mapStateToProps = state => ( {
+	currentUser: getCurrentUser( state )
+} );
+
+export default connect( mapStateToProps )( localize( CommentDetailReply ) );

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -18,24 +18,9 @@ export class CommentDetailReply extends Component {
 		hasFocus: false,
 	};
 
-	handleBlur = () => this.setState( { hasFocus: false } );
-
-	handleFocus = () => this.setState( { hasFocus: true } );
-
-	handleKeyDown = event => {
-		// Use Ctrl+Enter to submit comment
-		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
-			event.preventDefault();
-			this.submit();
-		}
-	}
-
-	handleSubmit = event => {
-		event.preventDefault();
-		this.submit();
-	}
-
 	handleTextChange = event => this.setState( { commentText: event.target.value } );
+
+	setFocus = () => this.setState( { hasFocus: true } );
 
 	submit = () => {
 		const comment = {
@@ -50,6 +35,21 @@ export class CommentDetailReply extends Component {
 		this.props.submitComment( comment );
 		this.setState( { commentText: '' } );
 	}
+
+	submitComment = event => {
+		event.preventDefault();
+		this.submit();
+	}
+
+	submitCommentOnCtrlEnter = event => {
+		// Use Ctrl+Enter to submit comment
+		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
+			event.preventDefault();
+			this.submit();
+		}
+	}
+
+	unsetFocus = () => this.setState( { hasFocus: false } );
 
 	render() {
 		const { translate } = this.props;
@@ -72,10 +72,10 @@ export class CommentDetailReply extends Component {
 					<pre><span>{ commentText }</span><br /></pre>
 					<AutoDirection>
 						<textarea
-							onBlur={ this.handleBlur }
+							onBlur={ this.unsetFocus }
 							onChange={ this.handleTextChange }
-							onFocus={ this.handleFocus }
-							onKeyDown={ this.handleKeyDown }
+							onFocus={ this.setFocus }
+							onKeyDown={ this.submitCommentOnCtrlEnter }
 							placeholder={ translate( 'Enter your comment here…' ) }
 							value={ commentText }
 						/>
@@ -83,7 +83,7 @@ export class CommentDetailReply extends Component {
 					<button
 						className={ buttonClasses }
 						disabled={ ! hasCommentText }
-						onClick={ this.handleSubmit }
+						onClick={ this.submitComment }
 					>
 						{ translate( 'Send' ) }
 					</button>

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { filter, get, isNil, keyBy, keys, map, omit } from 'lodash';
+import { filter, get, isNil, keyBy, keys, map, maxBy, omit } from 'lodash';
 
 /**
  * `CommentFaker` is a HOC to easily test the Comments Management without the necessity of real data or actions.
@@ -89,6 +89,41 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 		} } );
 	}
 
+	submitComment = comment => {
+		const { comments } = this.state;
+		const newCommentId = parseInt( maxBy( keys( this.state.comments ) ) + 1, 10 );
+		const now = new Date();
+
+		const newComment = {
+			author: {
+				avatar_URL: comment.authorAvatarUrl,
+				name: comment.authorName,
+				URL: comment.authorUrl,
+			},
+			content: comment.content,
+			date: now.toISOString(),
+			i_like: false,
+			ID: newCommentId,
+			like_count: 0,
+			parent: {
+				ID: comment.parentId,
+			},
+			post: {
+				title: comment.postTitle,
+			},
+			status: 'approved',
+			type: 'comment',
+			URL: comment.URL,
+		};
+
+		this.setState( {
+			comments: {
+				...comments,
+				newCommentId: newComment,
+			}
+		} );
+	}
+
 	/**
 	 * Resets the status and the like value of a list of comments to their previous values.
 	 *
@@ -123,6 +158,7 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 			setBulkStatus={ this.setBulkStatus }
 			setCommentLike={ this.setCommentLike }
 			setCommentStatus={ this.setCommentStatus }
+			submitComment={ this.submitComment }
 			undoBulkStatus={ this.undoBulkStatus }
 		/>;
 };

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -4,6 +4,8 @@
 import React, { Component } from 'react';
 import { filter, get, isNil, keyBy, keys, map, maxBy, omit } from 'lodash';
 
+import { createPlaceholderComment } from 'state/data-layer/wpcom/comments';
+
 /**
  * `CommentFaker` is a HOC to easily test the Comments Management without the necessity of real data or actions.
  *
@@ -91,35 +93,27 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 
 	submitComment = comment => {
 		const { comments } = this.state;
-		const newCommentId = parseInt( maxBy( keys( this.state.comments ) ) + 1, 10 );
-		const now = new Date();
 
 		const newComment = {
+			...createPlaceholderComment( comment.content, comment.postId, comment.parentId ),
 			author: {
 				avatar_URL: comment.authorAvatarUrl,
 				name: comment.authorName,
 				URL: comment.authorUrl,
 			},
-			content: comment.content,
-			date: now.toISOString(),
 			i_like: false,
-			ID: newCommentId,
 			like_count: 0,
-			parent: {
-				ID: comment.parentId,
-			},
 			post: {
 				title: comment.postTitle,
 			},
 			status: 'approved',
-			type: 'comment',
 			URL: comment.URL,
 		};
 
 		this.setState( {
 			comments: {
 				...comments,
-				newCommentId: newComment,
+				[ newComment.ID ]: newComment,
 			}
 		} );
 	}

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -30,7 +30,7 @@ export class CommentDetail extends Component {
 		authorUsername: PropTypes.string,
 		commentContent: PropTypes.string,
 		commentDate: PropTypes.string,
-		commentId: PropTypes.number,
+		commentId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
 		commentIsLiked: PropTypes.bool,
 		commentIsSelected: PropTypes.bool,
 		commentStatus: PropTypes.string,
@@ -129,6 +129,7 @@ export class CommentDetail extends Component {
 			parentCommentContent,
 			parentCommentUrl,
 			postAuthorDisplayName,
+			postId,
 			postTitle,
 			postUrl,
 			repliedToComment,
@@ -203,6 +204,7 @@ export class CommentDetail extends Component {
 						/>
 						<CommentDetailReply
 							commentId={ commentId }
+							postId={ postId }
 							postTitle={ postTitle }
 							submitComment={ submitComment }
 						/>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -42,6 +42,7 @@ export class CommentDetail extends Component {
 		repliedToComment: PropTypes.bool,
 		setCommentStatus: PropTypes.func,
 		siteId: PropTypes.number,
+		submitComment: PropTypes.func,
 		toggleCommentLike: PropTypes.func,
 		toggleCommentSelected: PropTypes.func,
 	};
@@ -118,6 +119,7 @@ export class CommentDetail extends Component {
 			authorUsername,
 			commentContent,
 			commentDate,
+			commentId,
 			commentIsLiked,
 			commentIsSelected,
 			commentStatus,
@@ -131,6 +133,7 @@ export class CommentDetail extends Component {
 			postUrl,
 			repliedToComment,
 			siteId,
+			submitComment,
 		} = this.props;
 
 		const {
@@ -198,7 +201,11 @@ export class CommentDetail extends Component {
 							commentStatus={ commentStatus }
 							repliedToComment={ repliedToComment }
 						/>
-						<CommentDetailReply />
+						<CommentDetailReply
+							commentId={ commentId }
+							postTitle={ postTitle }
+							submitComment={ submitComment }
+						/>
 					</div>
 				}
 			</Card>

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -433,7 +433,7 @@ a.comment-detail__author-more-element {
 			max-height: 400px;
 			min-height: 33px;
 			overflow: hidden;
-			padding: 5px 60px 5px 5px;
+			padding: 12px 70px 12px 16px;
 			white-space: pre-wrap;
 			word-wrap: break-word;
 		}
@@ -461,8 +461,8 @@ a.comment-detail__author-more-element {
 		opacity: 0;
 		padding: 4px;
 		position: absolute;
-			right: 16px;
-			top: 4px;
+			right: 24px;
+			top: 10px;
 		text-transform: uppercase;
 		transition: opacity 0.2s ease-in-out;
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -415,12 +415,12 @@ a.comment-detail__author-more-element {
 .comment-detail__reply {
 	// The inner working of these styles is covered here:
 	// http://alistapart.com/article/expanding-text-areas-made-elegant
-	.expanding-area {
+	.is-expanding-area {
 		min-height: 33px;
 		position: relative;
 		transition: min-height 0.2s ease-in-out;
 
-		&.focused {
+		&.is-focused {
 			min-height: 70px;
 		}
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -413,11 +413,67 @@ a.comment-detail__author-more-element {
 }
 
 .comment-detail__reply {
-	line-height: 0;
+	// The inner working of these styles is covered here:
+	// http://alistapart.com/article/expanding-text-areas-made-elegant
+	.expanding-area {
+		min-height: 33px;
+		position: relative;
+		transition: min-height 0.2s ease-in-out;
 
-	textarea {
-		border: none;
-		resize: vertical;
+		&.focused {
+			min-height: 70px;
+		}
+
+		pre,
+		textarea {
+			font-family: $serif;
+			font-size: 14px;
+			line-height: 21px;
+			margin: 0;
+			max-height: 400px;
+			min-height: 33px;
+			overflow: hidden;
+			padding: 5px 60px 5px 5px;
+			white-space: pre-wrap;
+			word-wrap: break-word;
+		}
+
+		pre {
+			box-sizing: border-box;
+			display: block;
+			visibility: hidden;
+		}
+
+		textarea {
+			border: none;
+			height: 100%;
+			position: absolute;
+				left: 0;
+				top: 0;
+			resize: none;
+		}
+	}
+
+	.comment-detail__reply-submit {
+		color: lighten( $gray, 10% );
+		font-size: 12px;
+		font-weight: 600;
+		opacity: 0;
+		padding: 4px;
+		position: absolute;
+			right: 16px;
+			top: 4px;
+		text-transform: uppercase;
+		transition: opacity 0.2s ease-in-out;
+
+		&.is-active {
+			color: $blue-medium;
+			cursor: pointer;
+		}
+
+		&.is-visible {
+			opacity: 1;
+		}
 	}
 }
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -165,6 +165,16 @@ export class CommentList extends Component {
 		this.props.createNotice( type, message, options );
 	}
 
+	submitComment = comment => {
+		this.props.removeNotice( 'comment-submitted' );
+		this.props.createNotice( 'is-success', this.props.translate( 'Comment submitted.' ), {
+			duration: 5000,
+			id: 'comment-submitted',
+			isPersistent: true,
+		} );
+		this.props.submitComment( comment );
+	}
+
 	toggleBulkEdit = () => this.setState( { isBulkEdit: ! this.state.isBulkEdit } );
 
 	toggleCommentLike = commentId => {
@@ -215,7 +225,6 @@ export class CommentList extends Component {
 			status,
 			showPlaceholder,
 			showEmptyContent,
-			submitComment,
 		} = this.props;
 		const {
 			isBulkEdit,
@@ -252,7 +261,7 @@ export class CommentList extends Component {
 							key={ `comment-${ siteId }-${ comment.ID }` }
 							setCommentStatus={ this.setCommentStatus }
 							siteId={ siteId }
-							submitComment={ submitComment }
+							submitComment={ this.submitComment }
 							toggleCommentLike={ this.toggleCommentLike }
 							toggleCommentSelected={ this.toggleCommentSelected }
 						/>

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -215,6 +215,7 @@ export class CommentList extends Component {
 			status,
 			showPlaceholder,
 			showEmptyContent,
+			submitComment,
 		} = this.props;
 		const {
 			isBulkEdit,
@@ -251,6 +252,7 @@ export class CommentList extends Component {
 							key={ `comment-${ siteId }-${ comment.ID }` }
 							setCommentStatus={ this.setCommentStatus }
 							siteId={ siteId }
+							submitComment={ submitComment }
 							toggleCommentLike={ this.toggleCommentLike }
 							toggleCommentSelected={ this.toggleCommentSelected }
 						/>

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -27,7 +27,7 @@ import { getPostOldestCommentDate } from 'state/comments/selectors';
  * @param {Number|undefined} parentCommentId parent comment identifier
  * @returns {Object} comment placeholder
  */
-function createPlaceholderComment( commentText, postId, parentCommentId ) {
+export function createPlaceholderComment( commentText, postId, parentCommentId ) {
 	// We need placehodler id to be unique in the context of siteId, postId for that specific user,
 	// date milliseconds will do for that purpose.
 	return {


### PR DESCRIPTION
This PR introduces the expandable textarea in the same fashion of the Reader and Notifications reply boxes.

Additionally, extends the `CommentFaker` to also support a basic comment writing function to help with the upcoming test runs.

![jun-23-2017 16-10-04](https://user-images.githubusercontent.com/2070010/27488312-89739b66-582e-11e7-94bf-84386b7ee98b.gif)
