### PR TITLE
WooCommerce: Load the correct currency on the product form

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -9,7 +9,6 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
-import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -17,6 +16,7 @@ import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormWeightInput from 'woocommerce/components/form-weight-input';
+import PriceInput from 'woocommerce/components/price-input';
 
 const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) => {
 	const setDimension = ( e ) => {
@@ -43,16 +43,15 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 		editProduct( siteId, product, { backorders: e.target.value } );
 	};
 
-	// TODO Pull in currency and currency position.
 	const renderPrice = () => (
 		<Card className="products__product-form-price">
 			<FormLabel>{ translate( 'Price' ) }</FormLabel>
-			<FormCurrencyInput noWrap
-				currencySymbolPrefix="$"
-				name="price"
+			<PriceInput noWrap
 				value={ product.regular_price || '' }
+				name="price"
 				onChange={ setPrice }
 				size="4"
+				placeholder="0.00"
 			/>
 		</Card>
 	);

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -12,11 +12,11 @@ import { head } from 'lodash';
  */
 import formattedVariationName from 'woocommerce/lib/formatted-variation-name';
 import Button from 'components/button';
-import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
 import FormWeightInput from 'woocommerce/components/form-weight-input';
 import ImagePreloader from 'components/image-preloader';
+import PriceInput from 'woocommerce/components/price-input';
 import ProductImageUploader from 'woocommerce/components/product-image-uploader';
 import Spinner from 'components/spinner';
 
@@ -194,10 +194,9 @@ class ProductFormVariationsRow extends Component {
 					</div>
 				</td>
 				<td>
-					<FormCurrencyInput noWrap
-						currencySymbolPrefix="$"
-						name="price"
+					<PriceInput noWrap
 						value={ variation.regular_price || '' }
+						name="price"
 						placeholder="0.00"
 						onChange={ this.setPrice }
 						size="4"

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -9,10 +9,10 @@ import { find, isNumber } from 'lodash';
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
 import FormWeightInput from 'woocommerce/components/form-weight-input';
+import PriceInput from 'woocommerce/components/price-input';
 import ProductFormVariationsModal from './product-form-variations-modal';
 import ProductFormVariationsRow from './product-form-variations-row';
 
@@ -153,10 +153,9 @@ class ProductFormVariationsTable extends React.Component {
 					</div>
 				</td>
 				<td>
-					<FormCurrencyInput noWrap
-						currencySymbolPrefix="$"
-						name="price"
+					<PriceInput noWrap
 						value={ regular_price }
+						name="price"
 						placeholder="0.00"
 						onChange={ this.setPrice }
 						size="4"

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -433,7 +433,7 @@
 .products__product-form-variation-table-wrapper .form-text-input-with-affixes .form-text-input,
 .form-dimensions-input__length,
 .form-dimensions-input__width {
-	min-width: 75px;
+	min-width: 80px;
 }
 
 .products__product-form-variation-image {

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -1,36 +1,85 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import { omit } from 'lodash';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormTextInput from 'components/forms/form-text-input';
 import { getCurrencyObject } from 'lib/format-currency';
+import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-const PriceInput = ( { value, currency, ...props } ) => {
-	const currencyObject = getCurrencyObject( value, currency );
-	if ( ! currencyObject ) {
+class PriceInput extends Component {
+
+	static propTypes = {
+		value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
+		currency: PropTypes.string,
+		currencySetting: PropTypes.shape( {
+			value: PropTypes.string,
+		} ),
+	};
+
+	componentDidMount() {
+		const { siteId, currency } = this.props;
+
+		if ( siteId && ! currency ) {
+			this.props.fetchSettingsGeneral( siteId );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { siteId, currency } = this.props;
+
+		if ( siteId !== newProps.siteId && ! currency ) {
+			this.props.fetchSettingsGeneral( newProps.siteId );
+		}
+	}
+
+	render() {
+		const { value, currency, currencySetting } = this.props;
+		const props = { ...omit( this.props, [ 'value', 'currency', 'currencySetting', 'siteId', 'fetchSettingsGeneral' ] ) };
+		const displayCurrency = ! currency && currencySetting ? currencySetting.value : currency;
+		const currencyObject = getCurrencyObject( value, displayCurrency );
+		if ( ! currencyObject ) {
+			return (
+				<FormTextInput
+					value={ value }
+					{ ...omit( props, [ 'noWrap' ] ) } />
+			);
+		}
+
 		return (
-			<FormTextInput
+			<FormCurrencyInput
+				currencySymbolPrefix={ currencyObject.symbol }
 				value={ value }
 				{ ...props } />
 		);
 	}
+}
 
-	return (
-		<FormCurrencyInput
-			currencySymbolPrefix={ currencyObject.symbol }
-			value={ value }
-			{ ...props } />
+function mapStateToProps( state ) {
+	const siteId = getSelectedSiteId( state );
+	const currencySetting = getPaymentCurrencySettings( state );
+	return {
+		siteId,
+		currencySetting,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSettingsGeneral,
+		},
+		dispatch
 	);
-};
+}
 
-PriceInput.propTypes = {
-	value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
-	currency: PropTypes.string.isRequired,
-};
-
-export default PriceInput;
+export default connect( mapStateToProps, mapDispatchToProps )( PriceInput );


### PR DESCRIPTION
This PR hooks the `PriceInput` component to the currency settings to load in the correct site currency, if no currency is supplied. It implements the `PriceInput` component on the product form and variations table.

cc @marcinbot -- You can omit the `currency` prop now and it'll load the correct one, though you can still pass one manually.

To Test:
* Change your currency to something other than USD.
* Go to `http://calypso.localhost:3000/store/product/:site`.
* Make sure the correct currency is visible on both the simple card and variations table.
* Change your currency again / back to USD and refresh and make sure the correct currency is pulled in.