### PR TITLE
Checkout: Add code to checkout to apply coupons directly

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -81,9 +81,6 @@ const Checkout = React.createClass( {
 
 		if ( this.props.cart.hasLoadedFromServer && this.props.product ) {
 			this.addProductToCart();
-			if ( this.props.couponCode ) {
-				upgradesActions.applyCoupon( this.props.couponCode );
-			}
 		}
 
 		window.scrollTo( 0, 0 );
@@ -133,6 +130,9 @@ const Checkout = React.createClass( {
 			this.addRenewItemToCart();
 		} else {
 			this.addNewItemToCart();
+		}
+		if ( this.props.couponCode ) {
+			upgradesActions.applyCoupon( this.props.couponCode );
 		}
 	},
 

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -57,6 +57,7 @@ const Checkout = React.createClass( {
 
 	propTypes: {
 		cards: React.PropTypes.array.isRequired,
+		couponCode: React.PropTypes.string,
 		selectedFeature: React.PropTypes.string
 	},
 
@@ -80,6 +81,9 @@ const Checkout = React.createClass( {
 
 		if ( this.props.cart.hasLoadedFromServer && this.props.product ) {
 			this.addProductToCart();
+			if ( this.props.couponCode ) {
+				upgradesActions.applyCoupon( this.props.couponCode );
+			}
 		}
 
 		window.scrollTo( 0, 0 );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -198,6 +198,7 @@ module.exports = {
 						productsList={ productsList }
 						purchaseId={ context.params.purchaseId }
 						selectedFeature={ selectedFeature }
+						couponCode={ context.query.code }
 					/>
 				</CheckoutData>
 			),


### PR DESCRIPTION
Adds a url parameter `code` to checkout urls to immediately apply a coupon code when cart is accessed directly.

**Observations:**
* I'm unable to _clear_ a coupon code once it has been applied. I'm not sure how this is persisted or how it should be cleared. The changes seem to apply a coupon code correctly.
* I'm mostly unfamiliar with cart and checkout, so I'd appreciate thorough review 🙂 

**To test:**
* Ensure invalid/absent codes have no effect:
  * Invalid: `https://calypso.live/checkout/SITE/professional?branch=add/checkout-coupon-url&code=this-is-not-a-code`
  * Empty: `https://calypso.live/checkout/SITE/professional?branch=add/checkout-coupon-url&code`
  * Absent: `https://calypso.live/checkout/SITE/professional?branch=add/checkout-coupon-url`
* Visit checkout url for a site with a free plan: `https://calypso.live/checkout/SITE/professional?branch=add/checkout-coupon-url&code=VALID_COUPON_CODE`
* You should see the code applied immediately (see screenshot).
* Ensure results are the same as manually entering `SOME_VALID_CODE`

![code](https://user-images.githubusercontent.com/841763/27491336-49a1b0ae-5842-11e7-948f-d43dc8e28cd7.png)