### PR TITLE
Site Settings: Don't attempt to save portfolio/testimonial posts per page using the REST API

### DIFF
--- a/client/state/jetpack/settings/test/utils.js
+++ b/client/state/jetpack/settings/test/utils.js
@@ -128,7 +128,9 @@ describe( 'utils', () => {
 			const settings = {
 				some_other_setting: 123,
 				jetpack_testimonial: true,
+				jetpack_testimonial_posts_per_page: true,
 				jetpack_portfolio: true,
+				jetpack_portfolio_posts_per_page: true,
 				'custom-content-types': true,
 			};
 
@@ -221,7 +223,9 @@ describe( 'utils', () => {
 			const settings = {
 				some_other_setting: 123,
 				jetpack_testimonial: true,
+				jetpack_testimonial_posts_per_page: true,
 				jetpack_portfolio: true,
+				jetpack_portfolio_posts_per_page: true,
 				'custom-content-types': true,
 			};
 

--- a/client/state/jetpack/settings/utils.js
+++ b/client/state/jetpack/settings/utils.js
@@ -18,6 +18,8 @@ export const normalizeSettings = ( settings ) => {
 			case 'custom-content-types':
 			case 'jetpack_testimonial':
 			case 'jetpack_portfolio':
+			case 'jetpack_testimonial_posts_per_page':
+			case 'jetpack_portfolio_posts_per_page':
 				break;
 			case 'jetpack_protect_global_whitelist':
 				const whitelist = get( settings[ key ], [ 'local' ], [] );
@@ -58,6 +60,8 @@ export const sanitizeSettings = ( settings ) => {
 			case 'infinite-scroll':
 			case 'jetpack_portfolio':
 			case 'jetpack_testimonial':
+			case 'jetpack_testimonial_posts_per_page':
+			case 'jetpack_portfolio_posts_per_page':
 			case 'post_by_email_address':
 				break;
 			case 'infinite_scroll':


### PR DESCRIPTION
The settings for Testimonial and Portfolio posts per page are named `jetpack_testimonial_posts_per_page` and `jetpack_testimonial_posts_per_page`. This setting name is the same both in settings coming from the shadow site and from the sites REST API. This causes an undesired state when deciding whether to save settings using .com's settings endpoint or using the Jetpack site's REST API.

The problem is that if we send these settings directly to the REST API it may be the case that the custom-content-types modules is disabled and thus, the settings won't have effect. 

As we need these settings to be able to work for .com sites too, I'm removing them from the settings response coming from the original site. 

Related to #13862 and #14718.

#### Testing instructions

1. Run the unit tests: `npm run test-client client/state/jetpack/settings/test/utils.js`

#### Why

Same reasons behind #13862