### PR TITLE
WooCommerce: Make improvements to the stats copy and remove the reading widget.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -11,7 +11,6 @@ import page from 'page';
 import analytics from 'lib/analytics';
 import BasicWidget from 'woocommerce/components/basic-widget';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import ReadingWidget from 'woocommerce/components/reading-widget';
 import ShareWidget from 'woocommerce/components/share-widget';
 import WidgetGroup from 'woocommerce/components/widget-group';
 
@@ -36,38 +35,25 @@ class ManageNoOrdersView extends Component {
 		);
 	}
 
-	renderReadingWidget = () => {
-		const { translate } = this.props;
-		return (
-			<ReadingWidget
-				className="dashboard__reading-widget"
-				text={ translate( 'You’re not alone! Get tips from seasoned merchants,' +
-					' learn best practices to keep your store ship-shape,' +
-					' and find how to boost your sales and drive traffic.' ) }
-				title={ translate( 'Recommended reading' ) }
-			/>
-		);
-	}
-
-	renderExampleOrderWidget = () => {
+	renderStatsWidget = () => {
 		const { site, translate } = this.props;
 		const trackClick = () => {
 			analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
-				action: 'view-example-order',
+				action: 'view-stats',
 			} );
-			page.redirect( getLink( '/store/orders/:site/example', site ) );
+			page.redirect( getLink( '/store/stats/orders/day/:site', site ) );
 		};
 		return (
 			<BasicWidget
-				buttonLabel={ translate( 'View an example order' ) }
+				buttonLabel={ translate( 'View stats' ) }
 				onButtonClick={ trackClick }
-				className="dashboard__example-order-widget"
-				title={ translate( 'Looking for orders and reports?' ) }
+				className="dashboard__stats-widget"
+				title={ translate( 'Looking for stats?' ) }
 			>
 				<p>
 					{ translate( 'This dashboard will evolve as your store grows.' +
-						' Statistics will form and order overviews will display when your' +
-						' first orders start arriving.' ) }
+						' Statistics will form and order overviews will display as soon as' +
+						' your orders start arriving.' ) }
 				</p>
 			</BasicWidget>
 		);
@@ -108,9 +94,8 @@ class ManageNoOrdersView extends Component {
 		return (
 			<div className="dashboard__manage-no-orders">
 				{ this.renderShareWidget() }
-				{ this.renderReadingWidget() }
 				<WidgetGroup>
-					{ this.renderExampleOrderWidget() }
+					{ this.renderStatsWidget() }
 					{ this.renderViewAndTestWidget() }
 				</WidgetGroup>
 			</div>

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -23,7 +23,6 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
 import ProcessOrdersWidget from 'woocommerce/components/process-orders-widget';
-import ReadingWidget from 'woocommerce/components/reading-widget';
 import ShareWidget from 'woocommerce/components/share-widget';
 import Card from 'components/card';
 
@@ -97,19 +96,6 @@ class ManageOrdersView extends Component {
 		);
 	}
 
-	possiblyRenderReadingWidget = () => {
-		// TODO - connect to display preferences in a follow-on PR
-		const { translate } = this.props;
-		return (
-			<ReadingWidget
-				text={ translate( 'You’re not alone! Get tips from seasoned merchants,' +
-					' learn best practices to keep your store ship-shape,' +
-					' and find how to boost your sales and drive traffic.' ) }
-				title={ translate( 'Recommended reading' ) }
-			/>
-		);
-	}
-
 	render = () => {
 		const { site, translate, orders, user } = this.props;
 		return (
@@ -148,7 +134,6 @@ class ManageOrdersView extends Component {
 					</div>
 				</Card>
 				{ this.possiblyRenderShareWidget() }
-				{ this.possiblyRenderReadingWidget() }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -147,7 +147,7 @@
 	}
 }
 
-.dashboard__example-order-widget {
+.dashboard__stats-widget {
 	background-image: url( '/calypso/images/extensions/woocommerce/woocommerce-sample-graph.svg' );
 	background-position: center bottom;
 	background-repeat: no-repeat;


### PR DESCRIPTION
This is a follow up to #15402 that does the following (after discussing with Kelly):

* Removes the example order widget
* Removes the reading widget -- we don't have anything to populate this with that is relevant for v1.
* Updates stats copy

To Test:
* Go to `http://calypso.localhost:3000/store/:site`
* Look at the widgets & copy
* To view fledging, you will have to temporarily trash any orders you might have in wp-admin. Restoring them will show you the final/momma view.