### PR TITLE
WooCommerce: Add-product - update copy, clean up spacing issues

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -125,7 +125,7 @@ class ProductFormAdditionalDetailsCard extends Component {
 		return (
 			<div key={ attribute.uid } className={ classes }>
 				<FormTextInput
-					placeholder={ translate( 'Material' ) }
+					placeholder={ translate( 'Fabric' ) }
 					value={ attributeName }
 					id={ attribute.uid }
 					name="type"
@@ -173,9 +173,9 @@ class ProductFormAdditionalDetailsCard extends Component {
 				clickableHeader
 			>
 				<FormSettingExplanation>
-					{ translate( 'Display additional details in a formatted list. Examples when selling ' +
-						'apparel include Cut, Type, and Material. This will also allow customers to filter ' +
-						'your store to find Women\'s cut Hoodies in Cotton.' ) }
+					{ translate( 'Include additional details about your products, like \‘fabric\’ or \‘type\’ ' +
+						'for apparel. This will help customers find the right products by' +
+						'filtering for their preferred options, like a cotton shirt in a women\’s cut.' ) }
 				</FormSettingExplanation>
 
 				<div className="products__additional-details-container">

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -13,7 +13,6 @@ import React, { PropTypes, Component } from 'react';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import TokenField from 'components/token-field';
 
@@ -172,11 +171,11 @@ class ProductFormAdditionalDetailsCard extends Component {
 				onClose={ this.cardClose }
 				clickableHeader
 			>
-				<FormSettingExplanation>
+				<p>
 					{ translate( 'Include additional details about your products, like \‘fabric\’ or \‘type\’ ' +
 						'for apparel. This will help customers find the right products by' +
 						'filtering for their preferred options, like a cotton shirt in a women\’s cut.' ) }
-				</FormSettingExplanation>
+				</p>
 
 				<div className="products__additional-details-container">
 					<div className="products__additional-details-form-group">

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -62,7 +62,7 @@ const ProductFormCategoriesCard = (
 					onChange={ handleChange }
 				/>
 				<FormSettingExplanation>
-					{ translate( 'Add a category so this product is easy to find.' ) }
+					{ translate( 'Categories let you group similar products so customers can find them more easily.' ) }
 				</FormSettingExplanation>
 			</FormFieldSet>
 			<div className="products__product-form-featured">
@@ -71,7 +71,7 @@ const ProductFormCategoriesCard = (
 						onChange={ toggleFeatured }
 						checked={ product.featured }
 					>
-					{ translate( 'Feature this product to promote it on your store' ) }
+					{ translate( 'Promote this product across the store' ) }
 				</CompactFormToggle>
 				</FormLabel>
 			</div>

--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -75,7 +75,10 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 				</FormFieldSet>
 			</div>
 			<FormSettingExplanation>{ translate(
-				'Shipping services will use this data to provide accurate rates.'
+				'Dimensions are used to calculate shipping. Enter the ' +
+				'size of the product as you’d put it in a package. For ' +
+				'a shirt, this would mean the size it is when folded. ' +
+				'For a vase, this would mean including bubble wrap.'
 			) }</FormSettingExplanation>
 		</Card>
 	);

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -100,7 +100,7 @@ class ProductFormVariationsCard extends Component {
 		const { siteId, product, variations, translate } = this.props;
 		const { editProductAttribute, editProductVariation } = this.props;
 		const variationToggleDescription = translate(
-			'%(productName)s has variations, for example size and color.', {
+			'%(productName)s has variations, like size and color.', {
 				args: {
 					productName: ( product && product.name ) || translate( 'This product' )
 				}

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -123,7 +123,7 @@ class ProductFormVariationsModal extends React.Component {
 						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
 						<Editor />
 						<FormSettingExplanation>{ translate(
-								'This will be displayed in addition to the main product description when this variation is selected.'
+								'This additional information will be displayed when a customer choses this variation.'
 						) }</FormSettingExplanation>
 					</FormFieldSet>
 
@@ -135,7 +135,7 @@ class ProductFormVariationsModal extends React.Component {
 						/>
 					</FormLabel>
 					<FormSettingExplanation>{ translate(
-						'Hidden variations cannot be selected for purchase by customers.'
+						'Hide variations you don’t want to offer to customers.'
 					) }</FormSettingExplanation>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -249,6 +249,10 @@
 	resize: vertical;
 }
 
+.products__product-form-details-basic-description.form-fieldset {
+	margin-bottom: 0;
+}
+
 .products__categories-card {
 	.form-fieldset {
 		&:last-child {
@@ -890,12 +894,10 @@
 	.products__product-stock-options-wrapper {
 		display: flex;
 		flex-direction: column;
-		margin-top: 12px;
 
 		.products__product-manage-stock {
 			width: 150px;
 			margin-right: 24px;
-			margin-bottom: 12px;
 		}
 
 		.products__product-backorders-wrapper {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -735,7 +735,7 @@
 .products__additional-details-preview {
 	border: 1px solid lighten( $gray, 20% );
 	padding: 16px 16px 4px 16px;
-	margin-top: 2px;
+	margin-top: 4px;
 	font-size: 13px;
 	color: darken( $gray, 10% );
 }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -864,8 +864,18 @@
 		width: 150px;
 	}
 
+	.products__product-manage-stock {
+		margin-bottom: 12px;
+
+		@include breakpoint( ">960px" ) {
+			margin-bottom: 0;
+		}
+	}
+
 	.products__product-form-stock-disabled {
-		height: 145px;
+		.products__product-manage-stock {
+			margin-bottom: 0;
+		}
 	}
 
 	.products__product-manage-stock-toggle,

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -106,11 +106,10 @@ export default class ProductVariationTypesForm extends Component {
 
 		return (
 			<div className="products__variation-types-form-wrapper">
-				<strong>{ i18n.translate( 'Okay, let\'s add some variations!' ) }</strong>
+				<strong>{ i18n.translate( 'Let\'s add some variations!' ) }</strong>
 				<p>
 					{ i18n.translate(
-						'A common variation type is color. ' +
-						'The values would be the colors the product is available in.',
+						'Variations let you sell one item in various different options.',
 						{ components: { em: <em /> } }
 					) }
 				</p>


### PR DESCRIPTION
Cleaning up the add-product page including new copy updates by Aviva.

Addresses the following items in https://github.com/Automattic/wp-calypso/issues/15432

>  - Inventory spacing on add product screen
> - Additional details preview box doesn't quite align with inputs
> - Padding below Product Description in add-product
> - Update all copy per Aviva's copy review (only on add-products)