### PR TITLE
Framework: created new selector canCurrentUserManagePlugins.

### DIFF
--- a/client/state/selectors/can-current-user-manage-plugins.js
+++ b/client/state/selectors/can-current-user-manage-plugins.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { canCurrentUser } from 'state/selectors';
+
+/**
+ * Returns true if user can manage plugins for at least one site and returns false otherwise
+ *
+ * @param {Object} state  Global state tree
+ * @return {Boolean} Whether the user can manage plugins or not
+ */
+export default createSelector(
+	state => {
+		const siteIds = Object.keys( get( state, 'currentUser.capabilities', {} ) );
+		return siteIds.some( ( siteId ) => canCurrentUser( state, siteId, 'manage_options' ) );
+	},
+	state => state.currentUser.capabilities
+);

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -16,6 +16,7 @@
 export areAllSitesSingleUser from './are-all-sites-single-user';
 export areSitePermalinksEditable from './are-site-permalinks-editable';
 export canCurrentUser from './can-current-user';
+export canCurrentUserManagePlugins from './can-current-user-manage-plugins';
 export countPostLikes from './count-post-likes';
 export editedPostHasContent from './edited-post-has-content';
 export getAccountRecoveryResetOptions from './get-account-recovery-reset-options';

--- a/client/state/selectors/test/can-current-user-manage-plugins.js
+++ b/client/state/selectors/test/can-current-user-manage-plugins.js
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { canCurrentUserManagePlugins } from '../';
+
+describe( 'canCurrentUserManagePlugins()', () => {
+	it( 'should return false if no capabilities information exist in state', () => {
+		const state = {
+			currentUser: {
+				capabilities: {}
+			}
+		};
+		expect( canCurrentUserManagePlugins( state ) ).be.false;
+	} );
+
+	it( 'should return false if one site capability exists without referring if the user can manage it or not', () => {
+		const state = {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						edit_pages: true
+					}
+				}
+			}
+		};
+		expect( canCurrentUserManagePlugins( state ) ).be.false;
+	} );
+
+	it( 'should return false if several sites capabilities exists without referring if the user can manage it or not', () => {
+		const state = {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						edit_pages: true,
+					},
+					2916285: {
+						edit_posts: false,
+					},
+					2916286: {}
+				}
+			}
+		};
+		expect( canCurrentUserManagePlugins( state ) ).be.false;
+	} );
+
+	it( 'should return false if sites capabilities explicitly tell the user can not manage', () => {
+		const state = {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						edit_pages: true,
+						manage_options: false,
+					},
+					2916285: {
+						edit_posts: false,
+						manage_options: false,
+					},
+					2916286: {
+						manage_options: false,
+					}
+				}
+			}
+		};
+		expect( canCurrentUserManagePlugins( state ) ).be.false;
+	} );
+
+	it( 'should return true if just one site capability exists and the user can manage it', () => {
+		const state = {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						manage_options: true,
+					}
+				}
+			}
+		};
+		expect( canCurrentUserManagePlugins( state ) ).be.true;
+	} );
+
+	it( 'should return true if many sites capabilities exist and the user can manage in all of them', () => {
+		const state = {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						edit_pages: true,
+						manage_options: true,
+					},
+					2916285: {
+						edit_posts: false,
+						manage_options: true,
+					},
+					2916286: {
+						manage_options: true,
+					}
+				}
+			}
+		};
+		expect( canCurrentUserManagePlugins( state ) ).be.true;
+	} );
+
+	it( 'should return true if many sites capabilities exist and the user can manage in just one', () => {
+		const state = {
+			currentUser: {
+				capabilities: {
+					2916284: {
+						edit_pages: true,
+						manage_options: false,
+					},
+					2916285: {
+						edit_posts: true,
+						manage_options: true,
+					},
+					2916286: {
+						manage_options: false,
+					}
+				}
+			}
+		};
+		expect( canCurrentUserManagePlugins( state ) ).be.true;
+	} );
+} );


### PR DESCRIPTION
This pull request creates a new selector canCurrentUserManagePlugins (with corresponding tests) in accordance with the feedback received in pull request https://github.com/Automattic/wp-calypso/pull/15325.

The selector is not yet in use but will be used in sidebar and in many components, inside /my-sites/plugins.

To test it:
npm run test-client client/state/selectors
or 
npm run test-client client/state/selectors/test/can-current-user-manage-plugins.js (to test just this selector).
