### PR TITLE
Performance: Lazy-load SitePreview

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -36,7 +36,6 @@ import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
 import { hasSidebar } from 'state/ui/selectors';
 import { isHappychatOpen } from 'state/ui/happychat/selectors';
-import SitePreview from 'blocks/site-preview';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
@@ -119,7 +118,7 @@ Layout = React.createClass( {
 	renderPreview() {
 		if ( config.isEnabled( 'preview-layout' ) && this.props.section.group === 'sites' ) {
 			return (
-				<SitePreview />
+				<AsyncLoad require='blocks/site-preview' />
 			);
 		}
 	},


### PR DESCRIPTION
The `SitePreview` component is loaded in the Layout, but is only rendered in some sections. Loading it async reduces the amount of code in `build`.

## Reports

- [Before](https://alexsanford.gitlab.io/calypso-performance/report-before-extract-preview-a713d92f.html)

- [After](https://alexsanford.gitlab.io/calypso-performance/report-after-extract-preview-ef4b087c.html)

## Discussion

This is a pretty simple change, and it reduces the size of `build` by about **88KB** gzipped.

Before:

<img width="208" alt="2017-06-24_1740" src="https://user-images.githubusercontent.com/842193/27511830-4d9ec4ea-5904-11e7-9f0a-fe9a0350fc71.png">

After:

<img width="211" alt="2017-06-24_1741" src="https://user-images.githubusercontent.com/842193/27511833-6725d494-5904-11e7-9759-bb315c553a20.png">

<img width="356" alt="2017-06-24_1743" src="https://user-images.githubusercontent.com/842193/27511839-a3802534-5904-11e7-86d7-dc3cdac1c5a6.png">

However, when comparing the two reports linked above, several other chunks have grown by almost as much as I pulled out of `build` (e.g. see `post-editor`).

So although this PR will move unnecessary code out of `build` and get the initial render happening a little quicker, it will cause several other chunks to be loaded more slowly.

I believe that this is a general issue with the way our chunks are split up. By pulling dependencies out of `build.js`, Webpack is forced to duplicate those dependencies in other chunks that need them. I've been thinking about this, and I [proposed a possible solution](https://github.com/Automattic/wp-calypso/issues/14922#issuecomment-310861021) that I think we should explore after the upgrade to Webpack 2.

In the meantime, I guess it's a question of whether breaking this chunk out of `build` is worth the cost.