### PR TITLE
CCTLDs: open CIRA agreement link in new window

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -144,7 +144,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 							translate( 'I have read and agree to the {{a}}CIRA Registrant Agreement{{/a}}',
 								{
 									components: {
-										a: <a href={ ciraAgreementUrl } />,
+										a: <a target="_blank" rel="noopener noreferrer" href={ ciraAgreementUrl } />,
 									},
 								}
 							)


### PR DESCRIPTION
There's no easy back - if we open in the same window and come back, we lose the whois form data.

