### PR TITLE
Remove sites-list from site-selector/add-site

### DIFF
--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -15,10 +15,8 @@ import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
-import sitesFactory from 'lib/sites-list';
 import { abtest } from 'lib/abtest';
-
-const sites = sitesFactory();
+import { hasJetpackSites } from 'state/selectors';
 
 class SiteSelectorAddSite extends Component {
 	constructor() {
@@ -38,7 +36,7 @@ class SiteSelectorAddSite extends Component {
 	}
 
 	getAddNewSiteUrl() {
-		if ( sites.getJetpack().length ||
+		if ( this.props.hasJetpackSites ||
 			abtest( 'newSiteWithJetpack' ) === 'showNewJetpackSite' ) {
 			return '/jetpack/new/?ref=calypso-selector';
 		}
@@ -117,7 +115,9 @@ class SiteSelectorAddSite extends Component {
 }
 
 export default connect(
-	null,
+	state => ( {
+		hasJetpackSites: hasJetpackSites( state )
+	} ),
 	dispatch => bindActionCreators( {
 		recordTracksEvent
 	}, dispatch )

--- a/client/state/selectors/has-jetpack-sites.js
+++ b/client/state/selectors/has-jetpack-sites.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { isJetpackSite } from 'state/sites/selectors';
+
+/**
+ * Returns true if the user has one or more Jetpack sites, and false otherwise.
+ *
+ * @param {Object} state  Global state tree
+ * @return {Boolean} Whether Jetpack sites exist or not
+ */
+export default createSelector(
+	( state ) => {
+		const siteIds = Object.keys( state.sites.items );
+		return siteIds.some( ( siteId ) => isJetpackSite( state, siteId ) );
+	},
+	( state ) => state.sites.items
+);

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -130,6 +130,7 @@ export getUserSettings from './get-user-settings';
 export getVisibleSites from './get-visible-sites';
 export hasBrokenSiteUserConnection from './has-broken-site-user-connection';
 export hasInitializedSites from './has-initialized-sites';
+export hasJetpackSites from './has-jetpack-sites';
 export hasSiteComments from './has-site-comments';
 export hasUnsavedUserSettings from './has-unsaved-user-settings';
 export hasUserSettings from './has-user-settings';

--- a/client/state/selectors/test/has-jetpack-sites.js
+++ b/client/state/selectors/test/has-jetpack-sites.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { hasJetpackSites } from '../';
+
+describe( 'hasJetpackSites()', () => {
+	it( 'it should return false if sites are empty', () => {
+		expect(
+			hasJetpackSites( {
+				sites: {
+					items: {}
+				}
+			} )
+		).to.be.false;
+	} );
+
+	it( 'it should return false if one site exists and the site is not a Jetpack site', () => {
+		expect(
+			hasJetpackSites( {
+				sites: {
+					items: {
+						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', jetpack: false }
+					}
+				}
+			} )
+		).to.be.false;
+	} );
+
+	it( 'it should return false if several sites exist and none of them is a Jetpack site', () => {
+		expect(
+			hasJetpackSites( {
+				sites: {
+					items: {
+						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', jetpack: false },
+						12203074: { ID: 12203074, URL: 'https://example2.wordpress.com', jetpack: false },
+						32203074: { ID: 32203074, URL: 'https://test.wordpress.com', jetpack: false }
+					}
+				}
+			} )
+		).to.be.false;
+	} );
+
+	it( 'it should return true if one site is a Jetpack site and the others are not', () => {
+		expect(
+			hasJetpackSites( {
+				sites: {
+					items: {
+						77203074: { ID: 77203074, URL: 'https://example.wordpress.com', jetpack: false },
+						12203074: { ID: 12203074, URL: 'https://example2.jetpack.com', jetpack: true },
+						32203074: { ID: 32203074, URL: 'https://test.wordpress.com', jetpack: false }
+					}
+				}
+			} )
+		).to.be.true;
+	} );
+
+	it( 'it should return true if several sites exist and all of them are Jetpack sites', () => {
+		expect(
+			hasJetpackSites( {
+				sites: {
+					items: {
+						77203074: { ID: 77203074, URL: 'https://example.jetpack.com', jetpack: true },
+						12203074: { ID: 12203074, URL: 'https://example2.jetpack.com', jetpack: true },
+						32203074: { ID: 32203074, URL: 'https://test.jetpack.com', jetpack: true }
+					}
+				}
+			} )
+		).to.be.true;
+	} );
+} );


### PR DESCRIPTION
This pull-requests removes sites-list from components/site-selector/add-site.jsx! One more :) 
In order to remove sites-list from there a new selector hasJetpackSites with corresponding tests was created it will also be used in my-sites/plugins. 

**To run the tests just on the new selector please execute:**
-npm run test-client client/state/selectors/test/has-jetpack-sites.js

**To test the change to the component:**
Have 2 test accounts ready UserA, UserB, both with more than one site. Account UserA has at least one jetpack site, account UserB has no jetpack sites.

- Go to http://calypso.localhost:3000/stats/day.
- Press Switch site button
- Press Add New Site button 

Check that on account UserA it should always go to http://calypso.localhost:3000/jetpack/new?ref=calypso-selector.

On account UserB if the abtest “newSiteWithJetpack” is “onlyDotComSites” the button should point to http://calypso.localhost:3000/start?ref=calypso-selector that then redirects to http://calypso.localhost:3000/start/survey?ref=calypso-selector if abtest “newSiteWithJetpack” is “showNewJetpackSite” the button should point to http://calypso.localhost:3000/jetpack/new?ref=calypso-selector
