### PR TITLE
Fix: Fixes of alerts from lgtm.com

### DIFF
--- a/client/components/data/query-site-stats/index.jsx
+++ b/client/components/data/query-site-stats/index.jsx
@@ -38,7 +38,7 @@ class QuerySiteStats extends Component {
 
 		this.props.requestSiteStats( siteId, statType, query );
 		this.clearInterval();
-		if ( heartbeat, isAutoRefreshAllowedForQuery( query ) ) {
+		if ( heartbeat && isAutoRefreshAllowedForQuery( query ) ) {
 			this.interval = setInterval( () => {
 				if ( ! this.props.requesting ) {
 					this.props.requestSiteStats( siteId, statType, query );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -417,7 +417,7 @@ const navigateToSite = ( siteId, {
 	allSitesSingleUser,
 	siteBasePath,
 } ) => ( dispatch, getState ) => {
-	const pathname = getPathnameForSite( siteId );
+	const pathname = getPathnameForSite();
 	if ( pathname ) {
 		page( pathname );
 	}

--- a/client/components/tinymce/plugins/after-the-deadline/core.js
+++ b/client/components/tinymce/plugins/after-the-deadline/core.js
@@ -174,7 +174,6 @@ AtDCore.prototype.processXML = function( responseXML ) {
 			errorString = errors[ i ].getElementsByTagName( 'string' ).item( 0 ).firstChild.data;
 			errorType = errors[ i ].getElementsByTagName( 'type' ).item( 0 ).firstChild.data;
 			errorDescription = errors[ i ].getElementsByTagName( 'description' ).item( 0 ).firstChild.data;
-			errorContext;
 
 			if ( errors[ i ].getElementsByTagName( 'precontext' ).item( 0 ).firstChild !== null ) {
 				errorContext = errors[ i ].getElementsByTagName( 'precontext' ).item( 0 ).firstChild.data;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -137,7 +137,7 @@ const ShippingZoneMethodDialog = ( {
 						value={ title || '' }
 						onChange={ onMethodTitleChange } />
 				</FormFieldSet>
-				{ renderMethodSettingsView( method, siteId ) }
+				{ renderMethodSettingsView() }
 			</FormFieldSet>
 		</Dialog>
 	);

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -41,7 +41,7 @@ export const MainTour = makeTour(
 		<Step name="init" placement="right">
 			<p>
 				{
-					translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place," +
+					translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, " +
 											'and give you some ideas for what to do next.',
 						{
 							components: {

--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -21,7 +21,7 @@ function validateField( { name, value, type, domainName } ) {
 		case 'name':
 			return isValidName( value, type, domainName );
 		case 'target':
-			return isValidDomain( value, type );
+			return isValidDomain( value );
 		case 'data':
 			return isValidData( value, type );
 		case 'protocol':

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -102,7 +102,7 @@ FeedPostStore.dispatchToken = Dispatcher.register( function( payload ) {
 			break;
 
 		case FeedPostActionType.MARK_FEED_POST_SEEN:
-			markPostSeen( action.data.post, action.data.site, action.data.source );
+			markPostSeen( action.data.post, action.data.site );
 			break;
 	}
 } );

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -161,7 +161,10 @@ function receivePending( action ) {
 			site_ID: action.blogId,
 			ID: action.postId
 		};
-		const currentPost = _postsForBlogs[ blogKey( action.blogId, action.postId ) ];
+		const currentPost = _postsForBlogs[ blogKey( {
+			blogId: action.blogId,
+			postId: action.postId
+		} ) ];
 		post = assign( post, currentPost, { _state: 'pending' } );
 		setPost( null, post );
 	} else {

--- a/client/lib/text-utils/index.js
+++ b/client/lib/text-utils/index.js
@@ -20,7 +20,7 @@ export function countWords( content ) {
 		content = content.replace( /&.+?;/g, ' ' ); // turn all other entities into spaces
 
 		// remove numbers and punctuation
-		content = content.replace( /[0-9.(),;:!?%#$?\x27\x22_+=\\\/\-]*/g, '' );
+		content = content.replace( /[0-9.(),;:!?%#$\x27\x22_+=\\\/\-]*/g, '' );
 
 		const words = content.match( /[\w\u2019\x27\-\u00C0-\u1FFF]+/g );
 		if ( words ) {

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -284,9 +284,9 @@ const Post = React.createClass( {
 		const { isPreviewable, previewUrl, selectedSiteId } = this.props;
 
 		if ( this.props.post.status && this.props.post.status === 'future' ) {
-			this.analyticsEvents.previewPost;
+			this.analyticsEvents.previewPost();
 		} else {
-			this.analyticsEvents.viewPost;
+			this.analyticsEvents.viewPost();
 		}
 
 		if ( ! isPreviewable || ! selectedSiteId ) {

--- a/client/state/current-user/gravatar-status/actions.js
+++ b/client/state/current-user/gravatar-status/actions.js
@@ -35,7 +35,7 @@ export function uploadGravatar( file, bearerToken, email ) {
 			.send( data )
 			.set( 'Authorization', 'Bearer ' + bearerToken )
 			.then( () => {
-				const fileReader = new FileReader( file );
+				const fileReader = new FileReader();
 				fileReader.addEventListener( 'load', function() {
 					dispatch( {
 						type: GRAVATAR_UPLOAD_RECEIVE,

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -130,8 +130,8 @@ export const applyDuplicatesHandlers = inboundData => {
 
 	if ( ! queued ) {
 		debug(
-			'applyDuplicatesHandler has entered an impossible state!' +
-			'A HTTP request is exiting the http pipeline without having entered it.' +
+			'applyDuplicatesHandler has entered an impossible state! ' +
+			'A HTTP request is exiting the http pipeline without having entered it. ' +
 			'There must be a bug somewhere'
 		);
 		return inboundData;

--- a/client/state/data-layer/wpcom/read/following/mine/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/index.js
@@ -65,8 +65,8 @@ export function requestPage( store, action ) {
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
 
 export function receivePage( store, action, next, apiResponse ) {
-	if ( ! isValidApiResponse( apiResponse, action ) ) {
-		receiveError( store, action, next, apiResponse );
+	if ( ! isValidApiResponse( apiResponse ) ) {
+		receiveError( store );
 		return;
 	}
 

--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -298,7 +298,7 @@ export function checkPermissionsState() {
 					} )
 					.catch( err => {
 						debug( 'Error checking permission state', err );
-						dispatch( receivePermissionState( 'denied', err ) );
+						dispatch( receivePermissionState( 'denied' ) );
 					} )
 				;
 			} )

--- a/client/state/ui/preview/actions.js
+++ b/client/state/ui/preview/actions.js
@@ -43,7 +43,7 @@ export function closePreview() {
 	return ( dispatch, getState ) => {
 		const selectedSiteId = getSelectedSiteId( getState() );
 		dispatch( clearCustomizations( selectedSiteId ) );
-		dispatch( clearPreviewUrl( selectedSiteId ) );
+		dispatch( clearPreviewUrl() );
 		dispatch( resetPreviewType() );
 		dispatch( setLayoutFocus( 'content' ) );
 	};


### PR DESCRIPTION
Various small fixes and code cleanup. Most of these changes should be semantics preserving, with the exceptions of:

- Replacing a `undefined !== typeof stepIndex` (always true) test with `'undefined' !== typeof stepIndex` (true iff `stepIndex` is undefined)
- `QuerySiteStats` will only auto-refresh if the `heartbeat` prop is defined and non-zero. I think that this was the original intent behind the relevant `if` guard.
- Fix up a couple of message strings that appear to be missing spaces between `+` concatenated parts
- Replace a call to a function that expects an object containing its parameters, but was instead passed the bare parameters (i.e. `f(x, y)` rather than `f({a: x, b: y})`)

I've separated this into several commits to make this easier to review in small chunks, but let me know if you want me to squash them together.

These results were found on https://lgtm.com/projects/g/Automattic/wp-calypso/alerts/ - there are further results there, most of which would probably be best handled by people more familiar with the codebase. If you are interested in this kind of analysis, then [Pull Request Integration](https://lgtm.com/projects/g/Automattic/wp-calypso/ci/) is available. (Full disclosure - I work on lgtm.com).