### PR TITLE
Woo: Update product create action-list

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -15,7 +15,6 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { editProduct, editProductAttribute, createProductActionList } from 'woocommerce/state/ui/products/actions';
 import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
-import { actionListStepNext } from 'woocommerce/state/action-list/actions';
 import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
@@ -93,7 +92,6 @@ class ProductCreate extends React.Component {
 		);
 
 		this.props.createProductActionList( successAction, failureAction );
-		this.props.actionListStepNext();
 	}
 
 	isProductValid( product = this.props.product ) {
@@ -153,7 +151,6 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			actionListStepNext,
 			createProduct,
 			createProductActionList,
 			editProduct,

--- a/client/extensions/woocommerce/state/helpers.js
+++ b/client/extensions/woocommerce/state/helpers.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { isFunction, isObject } from 'lodash';
+
+/**
+ * Dispatch an action or function with additional properties.
+ *
+ * If the action is an object, it adds props as properties to the action.
+ * If the action is a function, it passes them to the function in the form
+ * of func( dispatch, getState, props )
+ * Additionally, if the function returns either an action object or another
+ * function, it is recursively dispatched in the same manner.
+ *
+ * @param {Function} dispatch The dispatch function (same as in an action thunk)
+ * @param {Function} getState Gets the current state (same as in an action thunk)
+ * @param {Object|Function} action The action to be dispatched
+ * @param {Object} props The props to be sent to the function or assigned to the object.
+ */
+export function dispatchWithProps( dispatch, getState, action, props ) {
+	if ( isFunction( action ) ) {
+		const returnValue = action( dispatch, getState, props );
+		dispatchWithProps( dispatch, getState, returnValue, props );
+	} else if ( isObject( action ) ) {
+		dispatch( { ...action, ...props } );
+	}
+}
+

--- a/client/extensions/woocommerce/state/sites/product-categories/actions.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/actions.js
@@ -55,8 +55,8 @@ export function fetchProductCategoriesSuccess( siteId, data ) {
  *
  * @param {Number} siteId The id of the site upon which to create.
  * @param {Object} category The product category object (may include a placeholder id).
- * @param {String} [successAction=undefined] Optional action object to be dispatched upon success.
- * @param {String} [failureAction=undefined] Optional action object to be dispatched upon error.
+ * @param {Object|Function} [successAction] action with extra props { sentData, receivedData }
+ * @param {Object|Function} [failureAction] action with extra props { error }
  * @return {Object} Action object
  */
 export function createProductCategory( siteId, category, successAction, failureAction ) {
@@ -78,15 +78,15 @@ export function createProductCategory( siteId, category, successAction, failureA
  *
  * @param {Number} siteId The id of the site to which the category belongs.
  * @param {Object} data The complete product category object with which to update the state.
- * @param {Object} [completionAction] An action that is dispatched after the update is complete.
+ * @param {Object} originatingAction The action that precipitated this update.
  * @return {Object} Action object
  */
-export function productCategoryUpdated( siteId, data, completionAction ) {
+export function productCategoryUpdated( siteId, data, originatingAction ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_CATEGORY_UPDATED,
 		siteId,
 		data,
-		completionAction,
+		originatingAction,
 	};
 }
 

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -53,15 +53,14 @@ export function createProduct( siteId, product, successAction, failureAction ) {
  *
  * @param {Number} siteId The id of the site to which the product belongs.
  * @param {Object} data The complete product object with which to update the state.
- * @param {Object} [completionAction] An action that is dispatched after the update is complete.
  * @return {Object} Action object
  */
-export function productUpdated( siteId, data, completionAction ) {
+export function productUpdated( siteId, data, originatingAction ) {
 	return {
 		type: WOOCOMMERCE_PRODUCT_UPDATED,
 		siteId,
 		data,
-		completionAction,
+		originatingAction,
 	};
 }
 


### PR DESCRIPTION
_This PR depends on the work in #15424._

This updates the product create action-list for use with the refactored
action-list code.

To Test:

1. Run `npm test`
2. Run `npm start`
3. Visit `http://calypso.localhost:3000/store/product/<site url>`
4. Fill out name
5. Add old and new categories
6. Click Save
7. Visit wp-admin to verify that the category and product have been created correctly.
