### PR TITLE
Count component: Add primary prop and style

### DIFF
--- a/client/components/count/README.md
+++ b/client/components/count/README.md
@@ -25,6 +25,10 @@ render: function() {
 
 The number to be displayed. Make sure it's a number, not a string containing a number.
 
+### `primary`
+
+Boolean. Applies `is-primary` class and related styles.
+
 ## Custom Styling
 
 In some cases, it may be necessary to increase the font size or remove the border. In your component's style file, specify rules for the `.count` within your component's selector. For an example, see the `select-dropdown` component's style file.

--- a/client/components/count/docs/example.jsx
+++ b/client/components/count/docs/example.jsx
@@ -8,7 +8,10 @@ import React from 'react';
 import Count from 'components/count';
 
 const count = () => (
-	<Count count={ 65365 } />
+	<div>
+		<Count count={ 65365 } />
+		<Count primary count={ 65366 } />
+	</div>
 )
 
 count.displayName = 'Count';

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -1,20 +1,29 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 
-export const Count = ( { count, numberFormat, ...inheritProps } ) => (
+export const Count = ( { count, numberFormat, primary, ...inheritProps } ) => (
 	// Omit props passed from the `localize` higher-order component that we don't need.
-	<span className="count" { ...omit( inheritProps, [ 'translate', 'moment' ] ) }>
+	<span
+		className={ classnames( 'count', { 'is-primary': primary } ) }
+		{ ...omit( inheritProps, [ 'translate', 'moment' ] ) }
+	>
 		{ numberFormat( count ) }
 	</span>
 );
 
 Count.propTypes = {
-	count: React.PropTypes.number.isRequired,
-	numberFormat: React.PropTypes.func
+	count: PropTypes.number.isRequired,
+	numberFormat: PropTypes.func,
+	primary: PropTypes.bool,
+};
+
+Count.defaultProps = {
+	primary: false,
 };
 
 export default localize( Count );

--- a/client/components/count/style.scss
+++ b/client/components/count/style.scss
@@ -8,4 +8,10 @@
 	line-height: 14px;
 	color: $gray-text-min;
 	text-align: center;
+
+	&.is-primary {
+		color: $white;
+		border-color: $blue-medium;
+		background-color: $blue-medium;
+	}
 }


### PR DESCRIPTION
Add prop `primary` to `Count` component.
Add `is-primary` styling.

**To test:**
* https://calypso.live/devdocs/design/count?branch=update/count-component-primary
* Ensure styling is appropriate.
* Ensure there are no console errors or warning.
* Check usage in #15488 

**Screenshot:**

Original left, with `primary` prop right.

<img width="165" alt="primary" src="https://user-images.githubusercontent.com/841763/27546283-ac21d680-5a92-11e7-9f2e-596ea104bd0a.png">

Included in #15488

via @rickybanister in https://github.com/Automattic/wp-calypso/pull/15427#issuecomment-310759356