### PR TITLE
Cart: Use Count for cart item badge

### DIFF
--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -14,6 +14,7 @@ import CartBody from './cart-body';
 import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
 import CartMessagesMixin from './cart-messages-mixin';
 import CartButtons from './cart-buttons';
+import Count from 'components/count';
 import Popover from 'components/popover';
 import CartEmpty from './cart-empty';
 import CartPlanAd from './cart-plan-ad';
@@ -55,7 +56,7 @@ const PopoverCart = React.createClass( {
 		if ( this.itemCount() ) {
 			countBadge = (
 				<div className="cart__count-badge count-badge-pulsing">
-					{ this.itemCount() }
+					<Count primary count={ this.itemCount() } />
 					<TrackComponentView eventName="calypso_popover_cart_badge_impression" />
 				</div>
 			);

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -211,26 +211,14 @@
 	@include hide-content-accessibly;
 }
 
-.cart__count-badge {
-	background: $blue-medium;
-	border-radius: 16px;
-	color: $white;
-	cursor: pointer;
-	display: inline-block;
-	float: right;
-	font-size: 11px;
-	height: 16px;
-	line-height: 16px;
-	padding: 0 5px;
+.cart__count-badge .count {
 	position: absolute;
 	top: 5px;
 	right: 5px;
-	text-align: center;
-	box-shadow: 0 0 0 rgba(0,170,220, 0.4);
 	animation: pulsing-badge 2s infinite;
 }
 
-.cart__count-badge:hover {
+.cart__count-badge:hover .count {
 	animation: none;
 }
 


### PR DESCRIPTION
Use the `Count` component in cart item count. This ensures more uniform structure and styling.

To test:
* Visit plans page for a site on the free plan
* Select a paid plan
* Without purchasing, navigate back to the plan page for the site
* You will see the icon
* Ensure component view tracks event is still fired. Run the following in the console and ensure you see `calypso:analytics:tracks Recording event "calypso_popover_cart_badge_impression" [...]` on mount:
  `localStorage.setItem('debug', 'calypso:analytics:*' )`

Before (from #15427):

![after](https://user-images.githubusercontent.com/841763/27533000-5d3cfd90-5a62-11e7-8117-5ca14717d81e.png)

After:

![after](https://user-images.githubusercontent.com/841763/27533062-894eccba-5a62-11e7-8db1-bba850d2670b.png)
![after](https://user-images.githubusercontent.com/841763/27533061-894a0e46-5a62-11e7-8be6-acecbe436dec.gif)

Contains #15487 

via @rickybanister in https://github.com/Automattic/wp-calypso/pull/15427#issuecomment-310759356