### PR TITLE
Extensions: WPSC: Simplify Caching UI

### DIFF
--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { pick } from 'lodash';
+import { includes, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -96,7 +96,7 @@ const Caching = ( {
 					<FormFieldset className="wp-super-cache__cache-type-fieldset">
 						<FormLabel>
 							<FormRadio
-								checked={ 'PHP' === cache_type }
+								checked={ includes( [ 'PHP', 'wpcache' ], cache_type ) /* wpcache is legacy */ }
 								disabled={ isDisabled || ! is_cache_enabled }
 								name="cache_type"
 								onChange={ handleRadio }

--- a/client/extensions/wp-super-cache/caching.jsx
+++ b/client/extensions/wp-super-cache/caching.jsx
@@ -96,18 +96,6 @@ const Caching = ( {
 					<FormFieldset className="wp-super-cache__cache-type-fieldset">
 						<FormLabel>
 							<FormRadio
-								checked={ 'mod_rewrite' === cache_type }
-								disabled={ isDisabled || ! is_cache_enabled }
-								name="cache_type"
-								onChange={ handleRadio }
-								value="mod_rewrite" />
-							<span>
-								{ translate( 'Use mod_rewrite to serve cache files.' ) }
-							</span>
-						</FormLabel>
-
-						<FormLabel>
-							<FormRadio
 								checked={ 'PHP' === cache_type }
 								disabled={ isDisabled || ! is_cache_enabled }
 								name="cache_type"
@@ -115,7 +103,7 @@ const Caching = ( {
 								value="PHP" />
 							<span>
 								{ translate(
-									'Use PHP to serve cache files. {{em}}(Recommended){{/em}}',
+									'Simple {{em}}(Recommended){{/em}}',
 									{
 										components: { em: <em /> }
 									}
@@ -125,21 +113,20 @@ const Caching = ( {
 
 						<FormLabel>
 							<FormRadio
-								checked={ 'wpcache' === cache_type }
+								checked={ 'mod_rewrite' === cache_type }
 								disabled={ isDisabled || ! is_cache_enabled }
 								name="cache_type"
 								onChange={ handleRadio }
-								value="wpcache" />
+								value="mod_rewrite" />
 							<span>
-								{ translate( 'Legacy page caching.' ) }
+								{ translate( 'Expert' ) }
 							</span>
 						</FormLabel>
 						<FormSettingExplanation>
 							{
 								translate(
-									'Mod_rewrite is fastest, PHP is almost as fast and easier to get working, ' +
-									'while legacy caching is slower again, but more flexible and also easy to get ' +
-									'working. New users should use PHP caching.'
+									'Expert caching requires changes to important server files ' +
+									'and may require manual intervention if enabled.'
 								)
 							}
 						</FormSettingExplanation>


### PR DESCRIPTION
Rename PHP Caching option to "Simple" and mod_rewrite one to "Expert"; drop legacy caching option; update explanation string.
To align with https://github.com/Automattic/wp-super-cache/pull/255

Before:

![image](https://user-images.githubusercontent.com/96308/27535821-95553724-5a6c-11e7-8a0b-be01d90e253e.png)

After:

![image](https://user-images.githubusercontent.com/96308/27535767-5de5d582-5a6c-11e7-816f-783a51ef385f.png)

wp-admin:

![image](https://user-images.githubusercontent.com/96308/27535800-7febd6ae-5a6c-11e7-9473-0c8dbf946766.png)

To test: Find the above in the Advanced tab, try saving settings with both the 'Simple' and 'Expert' option.