### PR TITLE
Add fr link for CIRA agreement

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -25,7 +25,8 @@ import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormInputValidation from 'components/forms/form-input-validation';
 
-const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
+const ciraAgreementUrlEn = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
+const ciraAgreementUrlFr = 'https://services.cira.ca/agree/agreement_fr/agreementVersion2.0.jsp';
 const defaultValues = {
 	lang: 'EN',
 	legalType: 'CCT',
@@ -97,7 +98,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		}
 
 		// Set the lang to FR if user languages is French, otherwise leave EN
-		if ( this.props.userWpcomLang.match( /^fr-?/i ) ) {
+		if ( this.props.userWpcomLangIsFr ) {
 			defaultValues.lang = 'FR';
 		}
 
@@ -122,7 +123,9 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 			legalType,
 			ciraAgreementAccepted,
 		} = { ...defaultValues, ...this.props.contactDetailsExtra };
-
+		const ciraAgreementUrl = this.props.userWpcomLangIsFr
+			? ciraAgreementUrlFr
+			: ciraAgreementUrlEn;
 
 		const submitButton = React.cloneElement( this.props.children, {
 			disabled: ! ciraAgreementAccepted
@@ -179,7 +182,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 export default connect(
 	state => ( {
 		contactDetailsExtra: getContactDetailsExtraCache( state ),
-		userWpcomLang: getCurrentUserLocale( state )
+		userWpcomLangIsFr: getCurrentUserLocale( state ).match( /^fr-?/i )
 	} ),
 	{ updateContactDetailsCache }
 )( localize( RegistrantExtraInfoCaForm ) );


### PR DESCRIPTION
CIRA provides the agreement in French, so we might as well offer that to our French speaking users.

This PR is based on #15412, just split out into a separate PR to make sure I don't slow that PR landing.
![convention_d_enregistrement_-_titulaire__version_2_0_and_checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/27538487-90a09486-5abb-11e7-9e6e-71e175ddbe2a.jpg)
