### PR TITLE
Add support for additional currencies

### DIFF
--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -45,6 +45,36 @@ const CURRENCIES = {
 		grouping: ',',
 		decimal: '.',
 		precision: 2
+	},
+	ILS: {
+		symbol: '₪',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	HUF: {
+		symbol: 'Ft',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SEK: {
+		symbol: 'kr',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MXN: {
+		symbol: 'MX$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	RUB: {
+		symbol: '₽',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
 	}
 };
 

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -46,6 +46,12 @@ const CURRENCIES = {
 		decimal: '.',
 		precision: 2
 	},
+	NZD: {
+		symbol: 'NZ$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
 	ILS: {
 		symbol: '₪',
 		grouping: ',',

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -60,8 +60,8 @@ const CURRENCIES = {
 	},
 	HUF: {
 		symbol: 'Ft',
-		grouping: ',',
-		decimal: '.',
+		grouping: '.',
+		decimal: ',',
 		precision: 0
 	},
 	SEK: {

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -62,7 +62,7 @@ const CURRENCIES = {
 		symbol: 'Ft',
 		grouping: ',',
 		decimal: '.',
-		precision: 2
+		precision: 0
 	},
 	SEK: {
 		symbol: 'kr',

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -78,8 +78,8 @@ const CURRENCIES = {
 	},
 	RUB: {
 		symbol: '₽',
-		grouping: ',',
-		decimal: '.',
+		grouping: ' ',
+		decimal: ',',
 		precision: 2
 	}
 };

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -130,5 +130,12 @@ export function getCurrencyObject( number, code, options = {} ) {
  * @returns {?Object}          currency defaults
  */
 export function getCurrencyDefaults( code ) {
-	return CURRENCIES[ code ] || null;
+	const defaultCurrency = {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	};
+
+	return CURRENCIES[ code ] || defaultCurrency;
 }

--- a/client/lib/format-currency/test/index.js
+++ b/client/lib/format-currency/test/index.js
@@ -25,9 +25,9 @@ describe( 'formatCurrency', () => {
 		const money = formatCurrency( -1234.56789, 'USD' );
 		expect( money ).to.equal( '-$1,234.57' );
 	} );
-	it( 'unknown currency codes return null', () => {
+	it( 'unknown currency codes return default', () => {
 		const money = formatCurrency( 9800900.32, {} );
-		expect( money ).to.equal( null );
+		expect( money ).to.equal( '$9,800,900.32' );
 	} );
 
 	describe( 'supported currencies', () => {


### PR DESCRIPTION
This is required once the currencies have been enabled on the backend.
Require ~D6129-code~, D6130-code

Testing (internal):
- Apply server patches
- Set your account currency to one added here
- Test to see that the prices are displayed in that currency
(Or ping for details)
