### PR TITLE
Add tracks events for domain warnings

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -91,6 +91,7 @@ class CurrentSite extends Component {
 				isCompact
 				selectedSite={ site }
 				domains={ domains }
+				position="site-sidebar"
 				ruleWhiteList={ [
 					'unverifiedDomainsCanManage',
 					'unverifiedDomainsCannotManage',

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -112,6 +112,7 @@ class CurrentPlan extends Component {
 
 				{ showDomainWarnings && <DomainWarnings
 						domains={ domains }
+						position="current-plan"
 						selectedSite={ selectedSite }
 						ruleWhiteList={ [
 							'newDomainsWithPrimary',

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -19,6 +19,7 @@ import { isSubdomain } from 'lib/domains';
 import support from 'lib/url/support';
 import paths from 'my-sites/upgrades/paths';
 import { hasPendingGoogleAppsUsers } from 'lib/domains';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 const domainTypes = domainConstants.type;
 const debug = _debug( 'calypso:domain-warnings' );
@@ -93,6 +94,17 @@ export default React.createClass( {
 
 	getDomains() {
 		return ( this.props.domains || [ this.props.domain ] );
+	},
+
+	trackImpression( warning, count ) {
+		const { position } = this.props;
+
+		return (
+			<TrackComponentView
+				eventName="calypso_domain_warning_impression"
+				eventProperties={ { position, warning, count } }
+			/>
+		);
 	},
 
 	wrongNSMappedDomains() {
@@ -192,14 +204,17 @@ export default React.createClass( {
 			} );
 		}
 
+		const key = 'expired-domains-can-manage';
+
 		return (
 			<Notice
 				isCompact={ this.props.isCompact }
 				status="is-error"
 				showDismiss={ false }
-				key="expired-domains-can-manage"
+				key={ key }
 				text={ text }>
 				{ renewLink }
+				{ this.trackImpression( key, expiredDomains.length ) }
 			</Notice>
 		);
 	},
@@ -231,12 +246,16 @@ export default React.createClass( {
 			} );
 		}
 
+		const key = 'expired-domains-cannot-manage';
+
 		return (
 			<Notice
-				isCompact={ this.props.isCompact }
-				showDismiss={ false }
-				key="expired-domains-cannot-manage"
-				text={ text } />
+			isCompact={ this.props.isCompact }
+			showDismiss={ false }
+			key={ key }
+			text={ text }>
+			{ this.trackImpression( key, expiredDomains.length ) }
+			</Notice>
 		);
 	},
 

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -285,14 +285,17 @@ export default React.createClass( {
 			} );
 		}
 
+		const key = 'expiring-domains-can-manage';
+
 		return (
 			<Notice
 				isCompact={ this.props.isCompact }
 				status="is-error"
 				showDismiss={ false }
-				key="expiring-domains-can-manage"
+				key={ key }
 				text={ text }>
 				{ renewLink }
+				{ this.trackImpression( key, expiringDomains.length ) }
 			</Notice>
 		);
 	},
@@ -324,12 +327,16 @@ export default React.createClass( {
 			} );
 		}
 
+		const key = 'expiring-domains-cannot-manage';
+
 		return (
 			<Notice
 				isCompact={ this.props.isCompact }
 				showDismiss={ false }
-				key="expiring-domains-cannot-manage"
-				text={ text } />
+				key={ key }
+				text={ text }>
+				{ this.trackImpression( key, expiringDomains.length ) }
+			</Notice>
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
@@ -48,6 +48,7 @@ const MappedDomain = React.createClass( {
 	domainWarnings() {
 		return <DomainWarnings
 			domain={ this.props.domain }
+			position="mapped-domain"
 			selectedSite={ this.props.selectedSite }
 			ruleWhiteList={ [ 'wrongNSMappedDomains' ] } />;
 	},

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -117,6 +117,7 @@ const RegisteredDomain = React.createClass( {
 	domainWarnings() {
 		return <DomainWarnings
 			domain={ this.props.domain }
+			position="registered-domain"
 			selectedSite={ this.props.selectedSite }
 			ruleWhiteList={ [
 				'expiredDomainsCanManage',

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -56,6 +56,7 @@ export const List = React.createClass( {
 		if ( this.props.domains.hasLoadedFromServer ) {
 			return <DomainWarnings
 				domains={ this.props.domains.list }
+				position="domain-list"
 				selectedSite={ this.props.selectedSite }
 				ruleWhiteList={ [
 					'newDomainsWithPrimary',


### PR DESCRIPTION
This is the first in a series of PRs related to tracking interaction with notifications for domain and subscription issues with the intention of measuring impact of changes in some future a/b testing.

Currently there is no tracking of impression and clicks for warnings of domain related issues.

This PR adds tracks events for impressions of the following events:

* expiring domains (where user can manage domain)
* expiring domains (where user can't manage the domain)
* expired domains (where user can manage domain)
* expired domains (where user can't manage the domain)

Subsequent PRs will add the CTA click tracking.

# Testing

You can enable debug logging of tracks events in the console by running `localStorage.setItem('debug', 'calypso:analytics:tracks');` and then reloading.

It isn't especially convenient to wait for domains to expire to test this functionality so these conditions can be simulated by manipulating server responses with local edits to `client/lib/domains/assembler.js:23`:

```
		if ( domain.domain === 'testdomain.com' ) {
			const now = ( new Date() ).getTime();
			domain.current_user_can_manage = true;
			domain.expiry = ( new Date( now - 60 * 1000 ) ).toISOString();
			domain.expired = true;
			domain.expiry_soon = false;
		}
```

Change `expiry_soon` and `expiry` to simulate a domain expiring and `expired` and `expiry` to simulate a domain having expired.  `current_user_can_manage` can be used to control which notification message is displayed (and `testdomain.com` is an actual domain associated with the site you are using to test).