### PR TITLE
Magic Login: Enable in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -32,6 +32,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack_core_inline_update": true,
+		"login/magic-login": true,
 		"login/wp-login": true,
 		"keyboard-shortcuts": true,
 		"manage/customize": true,


### PR DESCRIPTION
Two factor support & was added & flows generally improved in #14949.

This enables Magic Login routes and UI in the wpcalypso environment so we can further test.