### PR TITLE
WooCommerce: Remove EUR and JPY currency codes from list of allowed currencies.

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -113,7 +113,7 @@ class SettingsPaymentsLocationCurrency extends Component {
 
 	render() {
 		const { currencies, currency, translate } = this.props;
-		const validCurrencies = [ 'USD', 'AUD', 'CAD', 'EUR', 'GBP', 'JPY', 'BRL' ];
+		const validCurrencies = [ 'USD', 'AUD', 'CAD', 'GBP', 'BRL' ];
 		return (
 			<div className="payments__location-currency">
 				<ExtendedHeader


### PR DESCRIPTION
Per Slack, for v1, we are only supporting currencies that all have the same extra currency settings (position on the left, 2 decimal places, `,` for thousands separator, etc).

To Test:
* Go to `http://calypso.localhost:3000/store/settings/payments/:site`
* Make sure the correct currencies show up