### PR TITLE
WooCommerce: Only show the store link if a site is an AT site

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -345,7 +345,7 @@ export class MySitesSidebar extends Component {
 		const { canUserManageOptions, isJetpack, site, siteSuffix, translate } = this.props;
 		const storeLink = '/store' + siteSuffix;
 		const showStoreLink = config.isEnabled( 'woocommerce/extension-dashboard' ) &&
-			site && isJetpack && canUserManageOptions;
+			site && isJetpack && canUserManageOptions && this.props.isSiteAutomatedTransfer;
 
 		return (
 			showStoreLink &&
@@ -353,11 +353,8 @@ export class MySitesSidebar extends Component {
 				label={ translate( 'Store (BETA)' ) }
 				link={ storeLink }
 				onNavigate={ this.trackStoreClick }
-				icon="cart" >
-				<SidebarButton href={ storeLink }>
-					{ translate( 'Set up' ) }
-				</SidebarButton>
-			</SidebarItem>
+				icon="cart"
+			/>
 		);
 	}
 


### PR DESCRIPTION
This PR only shows the `Store` link if a site is an Automated Transfer site, the behavior we want for v1. See #15508 for post-v1. It also removes the `Set up` link.

To Test:
* Go to `http://calypso.localhost:3000/stats/day/:site` for a non-AT site, with Jetpack installed. You should not see a store link anymore.
* Go to `http://calypso.localhost:3000/stats/day/:site` for an AT site and you should see the store link. There should be no set up button.

