### PR TITLE
PostShare: Improve terminology in calendar tooltip

### DIFF
--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -32,6 +32,8 @@ class CalendarButton extends Component {
 
 		onClose: PropTypes.func,
 		onDateChange: PropTypes.func,
+		onDayMouseEnter: PropTypes.func,
+		onDayMouseLeave: PropTypes.func,
 		onMonthChange: PropTypes.func,
 		onShow: PropTypes.func,
 	};
@@ -41,6 +43,9 @@ class CalendarButton extends Component {
 		type: 'button',
 		popoverPosition: 'bottom',
 		onDateChange: noop,
+		onDayMouseEnter: noop,
+		onDayMouseLeave: noop,
+		onClose: noop,
 	};
 
 	state = { showPopover: false };
@@ -50,7 +55,10 @@ class CalendarButton extends Component {
 		this.props.onDateChange( date );
 	};
 
-	closePopover = () => this.setState( { showPopover: false } );
+	closePopover = () => {
+		this.setState( { showPopover: false } );
+		this.props.onClose();
+	};
 
 	togglePopover = () => {
 		if ( this.props.disabled ) {
@@ -84,7 +92,10 @@ class CalendarButton extends Component {
 			'siteId',
 			'onDateChange',
 			'onMonthChange',
+			'onDayMouseEnter',
+			'onDayMouseLeave',
 			'onShow',
+			'onClose',
 		] ) );
 
 		return (

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -40,11 +40,15 @@ class CalendarPopover extends Component {
 		siteId: PropTypes.number,
 		onDateChange: PropTypes.func,
 		onMonthChange: PropTypes.func,
+		onDayMouseEnter: PropTypes.func,
+		onDayMouseLeave: PropTypes.func,
 	};
 
 	static defaultProps = {
 		timezoneValue: '',
 		onDateChange: noop,
+		onDayMouseEnter: noop,
+		onDayMouseLeave: noop,
 	};
 
 	state = { date: null };
@@ -70,6 +74,8 @@ class CalendarPopover extends Component {
 			'modifiers',
 			'onDateChange',
 			'onMonthChange',
+			'onDayMouseEnter',
+			'onDayMouseLeave',
 		] ) );
 
 		return (

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -66,6 +66,7 @@ import ConnectionsList, { NoConnectionsNotice } from './connections-list';
 
 import ActionsList from './publicize-actions-list';
 import CalendarButton from 'blocks/calendar-button';
+import EventsTooltip from 'components/date-picker/events-tooltip';
 
 import SectionHeader from 'components/section-header';
 import Tooltip from 'components/tooltip';
@@ -106,6 +107,9 @@ class PostShare extends Component {
 		showSharingPreview: false,
 		showAccountTooltip: false,
 		scheduledDate: null,
+		showTooltip: false,
+		tooltipContext: null,
+		eventsByDay: [],
 	};
 
 	hasConnections() {
@@ -227,6 +231,22 @@ class PostShare extends Component {
 		);
 	}
 
+	showCalendarTooltip = ( date, modifiers, event, eventsByDay ) => {
+		this.setState( {
+			eventsByDay,
+			context: event.target,
+			showTooltip: true,
+		} );
+	};
+
+	hideEventsTooltip = () => {
+		this.setState( {
+			eventsByDay: [],
+			context: null,
+			showTooltip: false,
+		} );
+	};
+
 	renderSharingButtons() {
 		const {
 			siteId,
@@ -262,6 +282,28 @@ class PostShare extends Component {
 			socialIcon: service === 'google_plus' ? 'google-plus' : service,
 		} ) );
 
+		// custom tooltip title
+		const { eventsByDay } = this.state;
+
+		const tooltipTitle = this.props.translate(
+			'%d share',
+			'%d shares', {
+				count: eventsByDay.length,
+				args: eventsByDay.length,
+			}
+		);
+
+		const maxEvents = 8;
+		const moreShares = eventsByDay.length - maxEvents;
+
+		const tooltipMoreEventsLabel = this.props.translate(
+			'… and %d more share',
+			'… and %d more shares', {
+				count: moreShares,
+				args: moreShares
+			}
+		);
+
 		return (
 			<div className="post-share__button-actions">
 				{ previewButton }
@@ -286,8 +328,21 @@ class PostShare extends Component {
 						tabIndex={ 3 }
 						siteId={ siteId }
 						onDateChange={ this.scheduleDate }
-						popoverPosition="bottom left" />
+						onDayMouseEnter={ this.showCalendarTooltip }
+						onDayMouseLeave={ this.hideEventsTooltip }
+						onClose={ this.hideEventsTooltip }
+						popoverPosition="bottom left"
+					/>
 				</ButtonGroup>
+
+				<EventsTooltip
+					events={ eventsByDay }
+					context={ this.state.context }
+					isVisible={ this.state.showTooltip }
+					title={ tooltipTitle }
+					moreEventsLabel={ tooltipMoreEventsLabel }
+					maxEvents={ maxEvents }
+				/>
 			</div>
 		);
 	}

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -1,122 +1,26 @@
 /**
  * External Dependencies
  */
-import React, { PropTypes, Component } from 'react';
-import { noop, map } from 'lodash';
-import { localize } from 'i18n-calypso';
+import React from 'react';
 
-/**
- * Internal dependencies
- */
-import Tooltip from 'components/tooltip';
-import { CalendarEvent } from './event';
+const handleDayMouseEnter = ( date, modifiers, onMouseEnter ) => event => {
+	onMouseEnter( date, modifiers, event );
+};
 
-class DatePickerDay extends Component {
-	static propTypes = {
-		date: PropTypes.object.isRequired,
-		events: PropTypes.array,
-		moment: PropTypes.func.isRequired,
-		maxEventsPerTooltip: PropTypes.number,
-	};
+const handleDayMouseLeave = ( date, modifiers, onMouseLeave ) => event => {
+	onMouseLeave( date, modifiers, event );
+};
 
-	static defaultProps = {
-		maxEventsPerTooltip: 8,
-	};
+const DatePickerDay = ( { date, modifiers, onMouseEnter, onMouseLeave } ) => {
+	return (
+		<div
+			className="date-picker__day"
+			onMouseEnter={ handleDayMouseEnter( date, modifiers, onMouseEnter ) }
+			onMouseLeave={ handleDayMouseLeave( date, modifiers, onMouseLeave ) }
+		>
+			{ date.getDate() }
+		</div>
+	);
+};
 
-	state = {
-		showTooltip: false,
-	};
-
-	isPastDay( date ) {
-		const today = this.props.moment().set( {
-			hour: 0,
-			minute: 0,
-			second: 0,
-			millisecond: 0
-		} );
-
-		date = date || this.props.date;
-		return ( +today - 1 ) >= +date;
-	}
-
-	showTooltip = () => {
-		if ( ! this.props.events.length ) {
-			return;
-		}
-
-		this.setState( { showTooltip: true } );
-	}
-
-	hideTooltip = () => {
-		this.setState( { showTooltip: false } );
-	}
-
-	renderTooltip() {
-		const isVisible = !! this.props.events.length && this.state.showTooltip;
-
-		const label = this.props.translate(
-			'%d post',
-			'%d posts', {
-				count: this.props.events.length,
-				args: this.props.events.length,
-			}
-		);
-
-		const moreEvents = this.props.events.length - this.props.maxEventsPerTooltip;
-
-		return (
-			<Tooltip
-				className="date-picker__events-tooltip"
-				context={ this.refs.dayTarget }
-				isVisible={ isVisible }
-				onClose={ noop }
-			>
-				<span>{ label }</span>
-				<hr className="date-picker__division" />
-				<ul>
-					{ map( this.props.events, ( event, i ) => ( i < this.props.maxEventsPerTooltip ) &&
-						<li key={ event.id }>
-							<CalendarEvent
-								icon={ event.icon }
-								socialIcon={ event.socialIcon }
-								socialIconColor={ event.socialIconColor }
-								title={ event.title } />
-						</li>
-					) }
-
-					{ ( moreEvents > 0 ) &&
-						<li>
-							{ this.props.translate(
-								'… and %(moreEvents)d more post',
-								'… and %(moreEvents)d more posts', {
-									count: moreEvents,
-									args: {
-										moreEvents
-									}
-								}
-							) }
-						</li>
-					}
-				</ul>
-			</Tooltip>
-		);
-	}
-
-	render() {
-		return (
-			<div
-				ref="dayTarget"
-				className="date-picker__day"
-				onMouseEnter={ this.showTooltip }
-				onMouseLeave={ this.hideTooltip }
-			>
-				{ this.props.date.getDate() }
-
-				{ this.renderTooltip() }
-			</div>
-		);
-	}
-}
-
-export default localize( DatePickerDay );
-
+export default DatePickerDay;

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -2,12 +2,13 @@
  * External Dependencies
  */
 import React from 'react';
+import { noop } from 'lodash';
 
-const handleDayMouseEnter = ( date, modifiers, onMouseEnter ) => event => {
+const handleDayMouseEnter = ( date, modifiers, onMouseEnter = noop ) => event => {
 	onMouseEnter( date, modifiers, event );
 };
 
-const handleDayMouseLeave = ( date, modifiers, onMouseLeave ) => event => {
+const handleDayMouseLeave = ( date, modifiers, onMouseLeave = noop ) => event => {
 	onMouseLeave( date, modifiers, event );
 };
 

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -103,8 +104,10 @@ const events = [
  */
 class DatePickerExample extends Component {
 	state = {
-		dayEvents: [],
+		eventsByDay: [],
+		selectedDay: null,
 		showTooltip: false,
+		tooltipContext: null,
 	};
 
 	selectDay = ( date, modifiers ) => {
@@ -115,23 +118,32 @@ class DatePickerExample extends Component {
 		}
 	};
 
-	handleDayMouseEnter = ( date, modifiers, event, dayEvents ) => {
+	handleDayMouseEnter = ( date, modifiers, event, eventsByDay ) => {
 		this.setState( {
-			dayEvents,
-			context: event.target,
+			eventsByDay,
+			tooltipContext: event.target,
 			showTooltip: true,
 		} );
 	};
 
 	handleDayMouseLeave = () => {
 		this.setState( {
-			dayEvents: [],
-			context: null,
+			eventsByDay: [],
+			tooltipContext: null,
 			showTooltip: false,
 		} );
 	};
 
 	render() {
+		// custom tooltip title
+		const tooltipTitle = this.props.translate(
+			'%d Event',
+			'%d Events', {
+				count: this.state.eventsByDay.length,
+				args: this.state.eventsByDay.length,
+			}
+		);
+
 		return (
 			<Card style={ { width: '300px', margin: 0 } }>
 				<DatePicker
@@ -143,16 +155,20 @@ class DatePickerExample extends Component {
 					selectedDay={ this.state.selectedDay } />
 
 				<EventsTooltip
-					events={ this.state.dayEvents }
-					context={ this.state.context }
+					events={ this.state.eventsByDay }
+					context={ this.state.tooltipContext }
 					isVisible={ this.state.showTooltip }
+					title={ tooltipTitle }
+					maxEvents={ 5 }
 				/>
 			</Card>
 		);
 	}
 }
 
-DatePickerExample.displayName = 'DatePicker';
+const localizedDatePickerExample = localize( DatePickerExample );
 
-export default DatePickerExample;
+localizedDatePickerExample.displayName = 'DatePicker';
+
+export default localizedDatePickerExample;
 

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -8,99 +8,103 @@ import React, { Component } from 'react';
  */
 import Card from 'components/card';
 import DatePicker from 'components/date-picker';
+import EventsTooltip from 'components/date-picker/events-tooltip';
+
+const events = [
+	{
+		title: 'Today',
+		date: new Date(),
+		type: 'scheduled'
+	},
+
+	{
+		title: 'Social Media - Facebook',
+		date: new Date( +new Date() + 60 * 60 * 24 * 1000 ),
+		socialIcon: 'facebook',
+	},
+
+	{
+		title: 'Social Media - Twitter',
+		date: new Date(),
+		socialIcon: 'twitter',
+		socialIconColor: false,
+	},
+
+	{
+		title: 'Social Media - Google Plus',
+		date: new Date(),
+		socialIcon: 'google-plus',
+	},
+
+	{
+		title: 'Social Media - LinkedIn',
+		date: new Date(),
+		socialIcon: 'linkedin',
+	},
+
+	{
+		title: 'Social Media - Tumblr',
+		date: new Date( +new Date() + 60 * 60 * 24 * 1000 ),
+		socialIcon: 'tumblr',
+	},
+
+	{
+		title: 'Social Media - Path',
+		date: new Date(),
+		socialIcon: 'path',
+		socialIconColor: false,
+	},
+
+	{
+		title: 'Social Media - Eventbrite',
+		date: new Date(),
+		socialIcon: 'eventbrite',
+		socialIconColor: false,
+	},
+
+	{
+		title: 'Gridicon - Time',
+		date: new Date(),
+		icon: 'time',
+	},
+
+	{
+		title: 'Gridicon - Offline',
+		date: new Date(),
+		icon: 'offline',
+	},
+
+	{
+		title: 'Gridicon - Shipping',
+		date: new Date(),
+		icon: 'shipping',
+	},
+
+	{
+		title: 'Tomorrow is tomorrow',
+		date: new Date( +new Date() + 60 * 60 * 24 * 1000 ),
+		type: 'future',
+	},
+	{
+		title: 'Yesterday',
+		date: new Date( +new Date() - 60 * 60 * 24 * 1000 ),
+		type: 'past',
+	},
+	{
+		title: 'Retro birthday',
+		date: new Date( '1977-07-18' ),
+		type: 'birthday',
+		icon: 'offline',
+	}
+];
 
 /*
  * Date Picker Demo
  */
 class DatePickerExample extends Component {
 	state = {
-		events: [
-			{
-				title: 'Today',
-				date: new Date(),
-				type: 'scheduled'
-			},
-
-			{
-				title: 'Social Media - Facebook',
-				date: new Date( Date.now() + 60 * 60 * 24 * 1000 ),
-				socialIcon: 'facebook',
-			},
-
-			{
-				title: 'Social Media - Twitter',
-				date: new Date(),
-				socialIcon: 'twitter',
-				socialIconColor: false,
-			},
-
-			{
-				title: 'Social Media - Google Plus',
-				date: new Date(),
-				socialIcon: 'google-plus',
-			},
-
-			{
-				title: 'Social Media - LinkedIn',
-				date: new Date(),
-				socialIcon: 'linkedin',
-			},
-
-			{
-				title: 'Social Media - Tumblr',
-				date: new Date( Date.now() + 60 * 60 * 24 * 1000 ),
-				socialIcon: 'tumblr',
-			},
-
-			{
-				title: 'Social Media - Path',
-				date: new Date(),
-				socialIcon: 'path',
-				socialIconColor: false,
-			},
-
-			{
-				title: 'Social Media - Eventbrite',
-				date: new Date(),
-				socialIcon: 'eventbrite',
-				socialIconColor: false,
-			},
-
-			{
-				title: 'Gridicon - Time',
-				date: new Date(),
-				icon: 'time',
-			},
-
-			{
-				title: 'Gridicon - Offline',
-				date: new Date(),
-				icon: 'offline',
-			},
-
-			{
-				title: 'Gridicon - Shipping',
-				date: new Date(),
-				icon: 'shipping',
-			},
-
-			{
-				title: 'Tomorrow is tomorrow',
-				date: new Date( Date.now() + 60 * 60 * 24 * 1000 ),
-				type: 'future',
-			},
-			{
-				title: 'Yesterday',
-				date: new Date( Date.now() - 60 * 60 * 24 * 1000 ),
-				type: 'past',
-			},
-			{
-				title: 'Retro birthday',
-				date: new Date( '1977-07-18' ),
-				type: 'birthday',
-				icon: 'offline',
-			}
-		]
+		dayEvents: [],
+		showTooltip: false,
 	};
 
 	selectDay = ( date, modifiers ) => {
@@ -111,14 +115,38 @@ class DatePickerExample extends Component {
 		}
 	};
 
+	handleDayMouseEnter = ( date, modifiers, event, dayEvents ) => {
+		this.setState( {
+			dayEvents,
+			context: event.target,
+			showTooltip: true,
+		} );
+	};
+
+	handleDayMouseLeave = () => {
+		this.setState( {
+			dayEvents: [],
+			context: null,
+			showTooltip: false,
+		} );
+	};
+
 	render() {
 		return (
 			<Card style={ { width: '300px', margin: 0 } }>
 				<DatePicker
 					disabledDays={ [ { before: new Date() } ] }
-					events={ this.state.events }
+					events={ events }
 					onSelectDay={ this.selectDay }
+					onDayMouseEnter={ this.handleDayMouseEnter }
+					onDayMouseLeave={ this.handleDayMouseLeave }
 					selectedDay={ this.state.selectedDay } />
+
+				<EventsTooltip
+					events={ this.state.dayEvents }
+					context={ this.state.context }
+					isVisible={ this.state.showTooltip }
+				/>
 			</Card>
 		);
 	}

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -1,0 +1,80 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes, Component } from 'react';
+import { noop, map } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Tooltip from 'components/tooltip';
+import { CalendarEvent } from './event';
+
+class EventsTooltip extends Component {
+	static propTypes = {
+		title: PropTypes.string,
+		events: PropTypes.array,
+		moment: PropTypes.func.isRequired,
+		maxEventsPerTooltip: PropTypes.number,
+	};
+
+	static defaultProps = {
+		maxEventsPerTooltip: 8,
+	};
+
+	render() {
+		const { events, maxEventsPerTooltip, isVisible } = this.props;
+
+		const label = this.props.translate(
+			'%d post',
+			'%d posts', {
+				count: events.length,
+				args: events.length,
+			}
+		);
+
+		const show = !! ( events && events.length && isVisible );
+		const moreEvents = events.length - maxEventsPerTooltip;
+
+		return (
+			<Tooltip
+				className="date-picker__events-tooltip"
+				context={ this.props.context }
+				isVisible={ show }
+				onClose={ noop }
+			>
+				<span>{ label }</span>
+				<hr className="date-picker__division" />
+				<ul>
+					{ map( events, ( event, i ) => ( i < maxEventsPerTooltip ) &&
+						<li key={ event.id }>
+							<CalendarEvent
+								icon={ event.icon }
+								socialIcon={ event.socialIcon }
+								socialIconColor={ event.socialIconColor }
+								title={ event.title } />
+						</li>
+					) }
+
+					{ ( moreEvents > 0 ) &&
+						<li>
+							{ this.props.translate(
+								'… and %(moreEvents)d more post',
+								'… and %(moreEvents)d more posts', {
+									count: moreEvents,
+									args: {
+										moreEvents
+									}
+								}
+							) }
+						</li>
+					}
+				</ul>
+			</Tooltip>
+		);
+	}
+}
+
+export default localize( EventsTooltip );
+

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -16,26 +16,49 @@ class EventsTooltip extends Component {
 		title: PropTypes.string,
 		events: PropTypes.array,
 		moment: PropTypes.func.isRequired,
-		maxEventsPerTooltip: PropTypes.number,
+		maxEvents: PropTypes.number,
+		moreEvents: PropTypes.string,
 	};
 
 	static defaultProps = {
-		maxEventsPerTooltip: 8,
+		events: [],
+		maxEvents: 8,
 	};
 
 	render() {
-		const { events, maxEventsPerTooltip, isVisible } = this.props;
+		const {
+			events,
+			isVisible,
+			maxEvents,
+		} = this.props;
 
-		const label = this.props.translate(
-			'%d post',
-			'%d posts', {
-				count: events.length,
-				args: events.length,
-			}
-		);
+		let title = this.props.title;
+		if ( ! title ) {
+			title = this.props.translate(
+				'%d post',
+				'%d posts', {
+					count: events.length,
+					args: events.length,
+				}
+			);
+		}
 
 		const show = !! ( events && events.length && isVisible );
-		const moreEvents = events.length - maxEventsPerTooltip;
+		const moreEvents = events.length - maxEvents;
+
+		let moreEventsLabel = this.props.moreEventsLabel;
+
+		if ( ! moreEventsLabel ) {
+			moreEventsLabel = this.props.translate(
+				'… and %(moreEvents)d more post',
+				'… and %(moreEvents)d more posts', {
+					count: moreEvents,
+					args: {
+						moreEvents
+					}
+				}
+			);
+		}
 
 		return (
 			<Tooltip
@@ -44,10 +67,10 @@ class EventsTooltip extends Component {
 				isVisible={ show }
 				onClose={ noop }
 			>
-				<span>{ label }</span>
+				<span>{ title }</span>
 				<hr className="date-picker__division" />
 				<ul>
-					{ map( events, ( event, i ) => ( i < maxEventsPerTooltip ) &&
+					{ map( events, ( event, i ) => ( i < maxEvents ) &&
 						<li key={ event.id }>
 							<CalendarEvent
 								icon={ event.icon }
@@ -57,19 +80,7 @@ class EventsTooltip extends Component {
 						</li>
 					) }
 
-					{ ( moreEvents > 0 ) &&
-						<li>
-							{ this.props.translate(
-								'… and %(moreEvents)d more post',
-								'… and %(moreEvents)d more posts', {
-									count: moreEvents,
-									args: {
-										moreEvents
-									}
-								}
-							) }
-						</li>
-					}
+					{ ( moreEvents > 0 ) && <li>{ moreEventsLabel }</li> }
 				</ul>
 			</Tooltip>
 		);

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -132,15 +132,22 @@ class DatePicker extends PureComponent {
 		return v;
 	}
 
-	renderDay = day => {
-		const isSelected = this.props.selectedDay && this.isSameDay( this.props.selectedDay, day );
+	renderDay = ( date, modifiers ) =>
+		<DayItem
+			date={ date }
+			modifiers={ modifiers }
+			onMouseEnter={ this.handleDayMouseEnter }
+			onMouseLeave={ this.handleDayMouseLeave }
+		/>;
 
-		return (
-			<DayItem
-				selected= { isSelected }
-				events={ this.filterEventsByDay( day ) }
-				date={ day } />
-		);
+	handleDayMouseEnter = ( date, modifiers, event ) => {
+		const events = this.filterEventsByDay( date );
+		this.props.onDayMouseEnter( date, modifiers, event, events );
+	};
+
+	handleDayMouseLeave = ( date, modifiers, event ) => {
+		const events = this.filterEventsByDay( date );
+		this.props.onDayMouseLeave( date, modifiers, event, events );
 	};
 
 	render() {

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -27,6 +27,8 @@ class DatePicker extends PureComponent {
 
 		onMonthChange: PropTypes.func,
 		onSelectDay: PropTypes.func,
+		onDayMouseEnter: PropTypes.func,
+		onDayMouseLeave: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -36,6 +38,8 @@ class DatePicker extends PureComponent {
 		selectedDay: null,
 		onMonthChange: noop,
 		onSelectDay: noop,
+		onDayMouseEnter: noop,
+		onDayMouseLeave: noop,
 	};
 
 	isSameDay( d0, d1 ) {

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -141,13 +141,13 @@ class DatePicker extends PureComponent {
 		/>;
 
 	handleDayMouseEnter = ( date, modifiers, event ) => {
-		const events = this.filterEventsByDay( date );
-		this.props.onDayMouseEnter( date, modifiers, event, events );
+		const eventsByDay = this.filterEventsByDay( date );
+		this.props.onDayMouseEnter( date, modifiers, event, eventsByDay );
 	};
 
 	handleDayMouseLeave = ( date, modifiers, event ) => {
-		const events = this.filterEventsByDay( date );
-		this.props.onDayMouseLeave( date, modifiers, event, events );
+		const eventsByDay = this.filterEventsByDay( date );
+		this.props.onDayMouseLeave( date, modifiers, event, eventsByDay );
 	};
 
 	render() {

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -250,7 +250,6 @@ $date-picker_nav_button_size: 20px;
 	border-color: lighten( $gray, 20% );
 }
 
-
 @keyframes isSelectedDay {
   0% {
     transform: scale( 0 );

--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'gridicons';
 import PostSchedule from 'components/post-schedule';
 import Timezone from 'components/timezone';
 import Card from 'components/card';
+import EventsTooltip from 'components/date-picker/events-tooltip';
 
 /**
  * Date Picker Demo
@@ -54,7 +55,11 @@ export default React.createClass( {
 			],
 			gmtOffset: 1,
 			timezone: tz,
-			date: date
+			date: date,
+
+			eventsByDay: [],
+			showTooltip: false,
+			tooltipContext: null,
 		};
 	},
 
@@ -65,7 +70,7 @@ export default React.createClass( {
 	},
 
 	setDate( date ) {
-		console.log( `date: %s`, date.format() );
+		console.log( 'date: ', date.format() ); // eslint-disable-line no-console
 
 		this.setState( {
 			isFuture: +new Date() < +new Date( date ),
@@ -74,7 +79,7 @@ export default React.createClass( {
 	},
 
 	setMonth( date ) {
-		console.log( `month: %s`, date.format() );
+		console.log( 'month: %s', date.format() ); // eslint-disable-line no-console
 		this.setState( { month: date } );
 	},
 
@@ -95,6 +100,22 @@ export default React.createClass( {
 		this.setState( { [ state ]: null } );
 	},
 
+	handleDayMouseEnter( date, modifiers, event, eventsByDay ) {
+		this.setState( {
+			eventsByDay,
+			tooltipContext: event.target,
+			showTooltip: true,
+		} );
+	},
+
+	handleDayMouseLeave() {
+		this.setState( {
+			eventsByDay: [],
+			tooltipContext: null,
+			showTooltip: false,
+		} );
+	},
+
 	render() {
 		return (
 			<div>
@@ -110,7 +131,15 @@ export default React.createClass( {
 						onMonthChange={ this.setMonth }
 						gmtOffset={ this.state.gmtOffset }
 						timezone={ this.state.timezone }
+						onDayMouseEnter={ this.handleDayMouseEnter }
+						onDayMouseLeave={ this.handleDayMouseLeave }
 						selectedDay={ this.state.date } />
+
+					<EventsTooltip
+						events={ this.state.eventsByDay }
+						context={ this.state.tooltipContext }
+						isVisible={ this.state.showTooltip }
+					/>
 				</Card>
 
 				<div style={ {

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -201,11 +201,14 @@ class PostSchedule extends Component {
 							? this.state.localizedDate.toDate()
 							: null
 					}
+
 					timeReference={ this.getCurrentDate() }
 					calendarViewDate={ this.state.calendarViewDate.toDate() }
 
 					onMonthChange={ this.setCurrentMonth }
 					onSelectDay={ this.updateDate }
+					onDayMouseEnter={ this.props.onDayMouseEnter }
+					onDayMouseLeave={ this.props.onDayMouseLeave }
 				/>
 
 				{ this.renderClock() }

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -11,6 +11,7 @@ import InputChrono from 'components/input-chrono';
 import DatePicker from 'components/date-picker';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import User from 'lib/user';
+import EventsTooltip from 'components/date-picker/events-tooltip';
 
 /**
  * Local dependencies
@@ -30,18 +31,24 @@ class PostSchedule extends Component {
 		gmtOffset: PropTypes.number,
 		site: PropTypes.object,
 		onDateChange: PropTypes.func,
-		onMonthChange: PropTypes.func
+		onMonthChange: PropTypes.func,
+		onDayMouseEnter: PropTypes.func,
+		onDayMouseLeave: PropTypes.func,
 	};
 
 	static defaultProps = {
 		posts: [],
 		events: [],
 		onDateChange: noop,
-		onMonthChange: noop
+		onMonthChange: noop,
+		onDayMouseEnter: noop,
+		onDayMouseLeave: noop,
 	};
 
 	state = {
-		calendarViewDate: moment( this.props.selectedDay ? this.props.selectedDay : new Date() )
+		calendarViewDate: moment( this.props.selectedDay ? this.props.selectedDay : new Date() ),
+		tooltipContext: null,
+		showTooltip: false,
 	}
 
 	componentWillMount() {
@@ -124,7 +131,35 @@ class PostSchedule extends Component {
 			this.props.timezone,
 			this.props.gmtOffset
 		) );
-	}
+	};
+
+	handleOnDayMouseEnter = ( date, modifiers, event, eventsByDay ) => {
+		const postEvents = this.getEventsFromPosts( this.props.posts );
+
+		if ( ! postEvents || ! postEvents.length ) {
+			return this.props.onDayMouseEnter( date, modifiers, event, eventsByDay );
+		}
+
+		this.setState( {
+			eventsByDay,
+			tooltipContext: event.target,
+			showTooltip: true,
+		} );
+	};
+
+	handleOnDayMouseLeave = ( date, modifiers, event, eventsByDay ) => {
+		const postEvents = this.getEventsFromPosts( this.props.posts );
+
+		if ( ! postEvents || ! postEvents.length ) {
+			return this.props.onDayMouseLeave( date, modifiers, event, eventsByDay );
+		}
+
+		this.setState( {
+			eventsByDay: [],
+			tooltipContext: null,
+			showTooltip: false,
+		} );
+	};
 
 	renderInputChrono() {
 		const lang = user.getLanguage();
@@ -177,6 +212,8 @@ class PostSchedule extends Component {
 	}
 
 	render() {
+		const handleEventsTooltip = ! this.props.events || ! this.props.events.length;
+
 		return (
 			<div className="post-schedule">
 				{
@@ -207,11 +244,20 @@ class PostSchedule extends Component {
 
 					onMonthChange={ this.setCurrentMonth }
 					onSelectDay={ this.updateDate }
-					onDayMouseEnter={ this.props.onDayMouseEnter }
-					onDayMouseLeave={ this.props.onDayMouseLeave }
+					onDayMouseEnter={ this.handleOnDayMouseEnter }
+					onDayMouseLeave={ this.handleOnDayMouseLeave }
 				/>
 
 				{ this.renderClock() }
+
+				{
+					handleEventsTooltip &&
+					<EventsTooltip
+						events={ this.state.eventsByDay }
+						context={ this.state.tooltipContext }
+						isVisible={ this.state.showTooltip }
+					/>
+				}
 			</div>
 		);
 	}


### PR DESCRIPTION
~This PR depends on #15437~

This PR changes the shares-tooltip title and the bottom description when it appears. 

<img src="https://user-images.githubusercontent.com/77539/27603312-2ae0812e-5b4c-11e7-8948-39755622db7b.png"  width="500px" />


This apparently simple task takes more effort than we initially could thought.

In order to change the title of the tooltip I've created a <EventsTooltip /> component and now it's handled outside of the <DatePicker /> component. It gives us the ability to customize the tooltip with total liberty.

### Testing

1. Test the calendar in the post editor section. It should work as usual.

<img src="https://user-images.githubusercontent.com/77539/27605062-cef9e11a-5b51-11e7-9465-44bf31b70f65.png" width="300px" />

2. a. Go to the posts list section: `http://calypso.localhost:3000/posts/my/<business-or-premium-site/>`

2. b. Ensure you already have published/scheduled actions on this month.

2. c. Open the calendar clicking on the calendar button

2. d. Mouse over a day with events (gray circle)

you should see the events tooltip component there. Pay attention to the tootltip title.

<img src="https://user-images.githubusercontent.com/77539/27605264-86cf0ec8-5b52-11e7-8a8b-62480743c58a.png" width="400px" />
