### PR TITLE
Reader: Align Follow icons Site Results

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -400,6 +400,10 @@
 	}
 }
 
+.search-stream__results.is-two-columns .gridicon__follow {
+	left: 2px;
+}
+
 // Custom styling for cards in post results
 .search-stream__results.is-two-columns {
 	display: flex;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15507

**After:** (2-cols)
<img width="294" alt="screenshot 2017-06-26 10 41 33" src="https://user-images.githubusercontent.com/4924246/27553902-97d344ba-5a61-11e7-92d6-b3a62dd1e6fd.png">

Single-col:
<img width="583" alt="screenshot 2017-06-26 10 44 45" src="https://user-images.githubusercontent.com/4924246/27553935-ae0d3eb6-5a61-11e7-98a6-7d6f5217e923.png">

Single-col mobile:
<img width="447" alt="screenshot 2017-06-26 10 47 25" src="https://user-images.githubusercontent.com/4924246/27553945-b5173ffe-5a61-11e7-8c31-8ee8462423f2.png">



