### PR TITLE
Reader: remove renderEventName from streams

### DIFF
--- a/client/components/reader-infinite-stream/index.js
+++ b/client/components/reader-infinite-stream/index.js
@@ -26,7 +26,6 @@ class ReaderInfiniteStream extends Component {
 		windowScrollerRef: PropTypes.func,
 		extraRenderItemProps: PropTypes.object,
 		minHeight: PropTypes.number,
-		renderEventName: PropTypes.string,
 		passthroughProp: PropTypes.any, // https://github.com/bvaughn/react-virtualized#pure-components. For use with things like sort etc.
 	};
 
@@ -49,12 +48,11 @@ class ReaderInfiniteStream extends Component {
 
 	rowRenderer = rowRendererProps => {
 		const railcar = get( this.props.items[ rowRendererProps.index ], 'railcar', undefined );
-		if ( railcar && this.props.renderEventName && ! this.recordedRender.has( rowRendererProps.index ) ) {
+		if ( railcar && ! this.recordedRender.has( rowRendererProps.index ) ) {
 			this.recordedRender.add( rowRendererProps.index );
 			this.recordTraintrackForRowRender( pickBy( {
 				index: rowRendererProps.index,
 				railcar,
-				eventName: this.props.renderEventName,
 			} ) );
 		}
 

--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -91,7 +91,6 @@ class FollowingManageSearchFeedsResults extends React.Component {
 					fetchNextPage={ this.fetchNextPage }
 					hasNextPage={ showMoreResults ? this.hasNextPage : undefined }
 					rowRenderer={ siteRowRenderer }
-					renderEventName={ 'following_manage_search' }
 				/>
 				{ ! showMoreResults &&
 					searchResultsCount > 10 &&

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -132,7 +132,6 @@ class FollowingManageSubscriptions extends Component {
 							totalCount={ sortedFollows.length }
 							windowScrollerRef={ this.props.windowScrollerRef }
 							rowRenderer={ siteRowRenderer }
-							renderEventName={ 'following_manage_subscription' }
 						/> }
 					{ noSitesMatchQuery &&
 						<span>

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -57,7 +57,6 @@ class SiteResults extends React.Component {
 					fetchNextPage={ this.fetchNextPage }
 					hasNextPage={ this.hasNextPage }
 					rowRenderer={ siteRowRenderer }
-					renderEventName={ 'search_stream_sites' }
 					passthroughProp={ this.props.sort }
 					extraRenderItemProps={ { showLastUpdatedDate } }
 				/>


### PR DESCRIPTION
As mentioned in https://github.com/Automattic/wp-calypso/issues/15060, this PR removes the `renderEventName` for render events in Reader streams. The event name is used to construct the `action` param in `recordTracksRailcar`:

https://github.com/Automattic/wp-calypso/blob/master/client/reader/stats.js#L140

@aaronyan advised that `action` should only be specified for interact events, not render events.