### PR TITLE
WooCommerce: Hide products, orders, & settings sidebar items until setup has been completed

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -38,6 +38,7 @@ const getStorePages = () => {
 				isPrimary: true,
 				label: translate( 'Dashboard' ),
 				slug: 'dashboard',
+				showDuringSetup: true,
 			},
 		},
 		{
@@ -49,6 +50,7 @@ const getStorePages = () => {
 				isPrimary: true,
 				label: translate( 'Products' ),
 				slug: 'products',
+				showDuringSetup: false,
 			},
 		},
 		{
@@ -59,12 +61,8 @@ const getStorePages = () => {
 				label: translate( 'Add' ),
 				parentSlug: 'products',
 				slug: 'product-add',
+				showDuringSetup: false,
 			},
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-products-import',
-			path: '/store/products/import/:site',
 		},
 		{
 			container: Orders,
@@ -75,22 +73,13 @@ const getStorePages = () => {
 				isPrimary: true,
 				label: translate( 'Orders' ),
 				slug: 'orders',
+				showDuringSetup: false,
 			},
 		},
 		{
 			container: Order,
 			configKey: 'woocommerce/extension-orders',
 			path: '/store/order/:site/:order',
-		},
-		{
-			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
-			configKey: 'woocommerce/extension-orders',
-			path: '/store/order/:site',
-			sidebarItemButton: {
-				label: translate( 'Add' ),
-				parentSlug: 'orders',
-				slug: 'order-add',
-			},
 		},
 		{
 			container: Dashboard, // TODO use Dashboard as a placeholder until this page becomes available
@@ -101,6 +90,7 @@ const getStorePages = () => {
 				isPrimary: false,
 				label: translate( 'Settings' ),
 				slug: 'settings',
+				showDuringSetup: false,
 			},
 		},
 		{
@@ -112,6 +102,7 @@ const getStorePages = () => {
 				label: translate( 'Payments' ),
 				parentSlug: 'settings',
 				slug: 'settings-payments',
+				showDuringSetup: false,
 			},
 		},
 		{
@@ -123,6 +114,7 @@ const getStorePages = () => {
 				label: translate( 'Shipping' ),
 				parentSlug: 'settings',
 				slug: 'settings-shipping',
+				showDuringSetup: false,
 			},
 		},
 		{
@@ -139,6 +131,7 @@ const getStorePages = () => {
 				label: translate( 'Taxes' ),
 				parentSlug: 'settings',
 				slug: 'settings-tax',
+				showDuringSetup: false,
 			},
 		},
 	];

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { find, filter } from 'lodash';
@@ -9,6 +10,8 @@ import React, { Component, PropTypes } from 'react';
 /**
  * Internal dependencies
  */
+import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
+import { getFinishedInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import Sidebar from 'layout/sidebar';
@@ -38,6 +41,25 @@ class StoreSidebar extends Component {
 		site: PropTypes.object,
 	}
 
+	componentDidMount = () => {
+		const { site } = this.props;
+
+		if ( site && site.ID ) {
+			this.props.fetchSetupChoices( site.ID );
+		}
+	}
+
+	componentWillReceiveProps = ( newProps ) => {
+		const { site } = this.props;
+
+		const newSiteId = newProps.site ? newProps.site.ID : null;
+		const oldSiteId = site ? site.ID : null;
+
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchSetupChoices( newSiteId );
+		}
+	}
+
 	onNavigate = () => {
 		window.scrollTo( 0, 0 );
 	}
@@ -53,9 +75,12 @@ class StoreSidebar extends Component {
 	}
 
 	renderSidebarMenuItems = ( items, buttons, isDisabled ) => {
-		const { site } = this.props;
+		const { site, finishedInitialSetup } = this.props;
 
 		return items.map( function( item, index ) {
+			if ( ! item.showDuringSetup && ! finishedInitialSetup ) {
+				return null;
+			}
 			const isChild = ( 'undefined' !== typeof item.parentSlug );
 			const itemLink = getLink( item.path, site );
 			const itemButton = buttons.filter( button => button.parentSlug === item.slug ).map( button => {
@@ -140,9 +165,20 @@ class StoreSidebar extends Component {
 }
 
 function mapStateToProps( state ) {
+	const finishedInitialSetup = getFinishedInitialSetup( state );
 	return {
+		finishedInitialSetup,
 		site: getSelectedSiteWithFallback( state )
 	};
 }
 
-export default connect( mapStateToProps )( StoreSidebar );
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSetupChoices,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( StoreSidebar );


### PR DESCRIPTION
This PR updates the sidebar links and hides products, orders, and settings from the sidebar until the initial setup has been completed.

To Test:
* Set finished initial setup to 0 at https://developer.wordpress.com/docs/api/console/
* Go to `http://calypso.localhost:3000/store/:site`
* Links for products, orders, etc should not be visible.
* Walk through the steps until you get to the checklist screen.
* Click the finished setting up button.
* Links for products, orders, etc should appear in the sidebar.