### PR TITLE
Reader: Only set the action if present

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -136,9 +136,9 @@ export function recordTracksRailcar( action, eventName, railcar, overrides = {} 
 	recordTrack(
 		action,
 		Object.assign(
-			{
-				action: eventName.replace( 'calypso_reader_', '' ),
-			},
+			eventName
+				? { action: eventName.replace( 'calypso_reader_', '' ) }
+				: {},
 			railcar,
 			overrides,
 		),


### PR DESCRIPTION
Fixes sites in search on wpcalypso. Only set the action on a tracks event if an eventName is present.