### PR TITLE
Framework: Fix multiple notices with durations

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -75,10 +75,10 @@ const NoticesList = React.createClass( {
 		//This is an interim solution for displaying both notices from redux store
 		//and from the old component. When all notices are moved to redux store, this component
 		//needs to be updated.
-		noticesList = noticesList.concat( this.props.storeNotices.map( function( notice, index ) {
+		noticesList = noticesList.concat( this.props.storeNotices.map( function( notice ) {
 			return (
 				<Notice
-					key={ 'notice-' + index }
+					key={ 'notice-' + notice.noticeId }
 					status={ notice.status }
 					duration = { notice.duration || null }
 					showDismiss={ notice.showDismiss }


### PR DESCRIPTION
Multiple active notices with durations would break because of how we keyed the notice components in the list. When a second notice was created, it would take over the component instance of the formerly first notice. We would fail to set up a timer for the new notice, because componentWillMount would never fire. We would eventually auto-dismiss the first notice, but the second would hang around forever.

This changes how we key the components, using the `noticeId` instead of the index in the notice array. This prevents React from reusing the existing notice components, which allows our timer to act as expected.