### PR TITLE
Add 'never expires' to the cart when purchasing a theme

### DIFF
--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -136,6 +136,8 @@ const CartItem = React.createClass( {
 		if ( this.props.cartItem.bill_period && this.props.cartItem.bill_period !== -1 ) {
 			if ( isMonthly( this.props.cartItem ) ) {
 				name += ' - ' + this.props.translate( 'monthly subscription' );
+			} else if ( isTheme( this.props.cartItem ) ) {
+				name += ' - ' + this.props.translate( 'never expires' );
 			} else {
 				name += ' - ' + this.props.translate( 'annual subscription' );
 			}


### PR DESCRIPTION
Fixes  #15514

cart-item.jsx just validated is the product was a monthly subscription or an annual one, added another statement to check if the product is a theme, and in this case display the "never expires" message.

How it looks:
<img width="1229" alt="screen shot 2017-06-26 at 22 25 32" src="https://user-images.githubusercontent.com/3812076/27558984-3457909a-5abf-11e7-8304-5daaa8107ebd.png">
