### PR TITLE
Activity Log: Use site timezone/offset for time/date display

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -19,8 +19,7 @@ class ActivityLogDay extends Component {
 		logs: PropTypes.array.isRequired,
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
-		timestamp: PropTypes.number.isRequired,
-		siteOffset: PropTypes.func.isRequired,
+		day: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -72,15 +71,13 @@ class ActivityLogDay extends Component {
 	getEventsHeading() {
 		const {
 			logs,
-			moment,
-			timestamp,
 			translate,
-			siteOffset,
+			day,
 		} = this.props;
 
 		return (
 			<div>
-				<div className="activity-log-day__day">{ siteOffset( moment( timestamp ) ).format( 'LL' ) }</div>
+				<div className="activity-log-day__day">{ day }</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -20,6 +20,7 @@ class ActivityLogDay extends Component {
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		timestamp: PropTypes.number.isRequired,
+		siteOffset: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -74,11 +75,12 @@ class ActivityLogDay extends Component {
 			moment,
 			timestamp,
 			translate,
+			siteOffset,
 		} = this.props;
 
 		return (
 			<div>
-				<div className="activity-log-day__day">{ moment( timestamp ).format( 'LL' ) }</div>
+				<div className="activity-log-day__day">{ siteOffset( moment( timestamp ) ).format( 'LL' ) }</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,
@@ -95,6 +97,7 @@ class ActivityLogDay extends Component {
 			logs,
 			requestRestore,
 			siteId,
+			siteOffset,
 		} = this.props;
 
 		return (
@@ -111,6 +114,7 @@ class ActivityLogDay extends Component {
 							siteId={ siteId }
 							requestRestore={ requestRestore }
 							log={ log }
+							siteOffset={ siteOffset }
 						/>
 					) ) }
 				</FoldableCard>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -20,7 +20,7 @@ class ActivityLogDay extends Component {
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		day: PropTypes.string.isRequired,
-		applySiteOffset: PropTypes.function.isRequired,
+		applySiteOffset: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -20,6 +20,7 @@ class ActivityLogDay extends Component {
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		day: PropTypes.string.isRequired,
+		applySiteOffset: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -94,7 +95,7 @@ class ActivityLogDay extends Component {
 			logs,
 			requestRestore,
 			siteId,
-			siteOffset,
+			applySiteOffset,
 		} = this.props;
 
 		return (
@@ -111,7 +112,7 @@ class ActivityLogDay extends Component {
 							siteId={ siteId }
 							requestRestore={ requestRestore }
 							log={ log }
-							siteOffset={ siteOffset }
+							applySiteOffset={ applySiteOffset }
 						/>
 					) ) }
 				</FoldableCard>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -20,7 +20,7 @@ class ActivityLogDay extends Component {
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		day: PropTypes.string.isRequired,
-		applySiteOffset: PropTypes.string.isRequired,
+		applySiteOffset: PropTypes.function.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -213,7 +213,7 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div>
-				{ translate( 'An event "%(eventName)s" occurred at %(date)s.', {
+				{ translate( 'An event "%(eventName)s" occurred at %(date)s', {
 					args: {
 						date: applySiteOffset( moment.utc( ts_utc ) ).format( 'LLL' ),
 						eventName: name,

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -213,9 +213,9 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div>
-				{ translate( 'An event "%(eventName)s" occurred at %(date)s', {
+				{ translate( 'An event "%(eventName)s" occurred at %(date)s.', {
 					args: {
-						date: siteOffset( moment( ts_utc ) ).format( 'LLL' ),
+						date: siteOffset( moment.utc( ts_utc ) ).format( 'LLL' ),
 						eventName: name,
 					}
 				} ) }
@@ -276,7 +276,7 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div className="activity-log-item__time">
-				{ siteOffset( moment( log.ts_utc ) ).format( 'LT' ) }
+				{ siteOffset( moment.utc( log.ts_utc ) ).format( 'LT' ) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -21,7 +21,7 @@ class ActivityLogItem extends Component {
 		allowRestore: PropTypes.bool.isRequired,
 		siteId: PropTypes.number.isRequired,
 		requestRestore: PropTypes.func.isRequired,
-		siteOffset: PropTypes.func.isRequired,
+		applySiteOffset: PropTypes.func.isRequired,
 		log: PropTypes.shape( {
 			group: PropTypes.oneOf( [
 				'attachment',
@@ -204,7 +204,7 @@ class ActivityLogItem extends Component {
 			log,
 			moment,
 			translate,
-			siteOffset,
+			applySiteOffset,
 		} = this.props;
 		const {
 			name,
@@ -215,7 +215,7 @@ class ActivityLogItem extends Component {
 			<div>
 				{ translate( 'An event "%(eventName)s" occurred at %(date)s.', {
 					args: {
-						date: siteOffset( moment.utc( ts_utc ) ).format( 'LLL' ),
+						date: applySiteOffset( moment.utc( ts_utc ) ).format( 'LLL' ),
 						eventName: name,
 					}
 				} ) }
@@ -271,12 +271,12 @@ class ActivityLogItem extends Component {
 		const {
 			moment,
 			log,
-			siteOffset,
+			applySiteOffset,
 		} = this.props;
 
 		return (
 			<div className="activity-log-item__time">
-				{ siteOffset( moment.utc( log.ts_utc ) ).format( 'LT' ) }
+				{ applySiteOffset( moment.utc( log.ts_utc ) ).format( 'LT' ) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -21,7 +21,7 @@ class ActivityLogItem extends Component {
 		allowRestore: PropTypes.bool.isRequired,
 		siteId: PropTypes.number.isRequired,
 		requestRestore: PropTypes.func.isRequired,
-
+		siteOffset: PropTypes.func.isRequired,
 		log: PropTypes.shape( {
 			group: PropTypes.oneOf( [
 				'attachment',
@@ -270,11 +270,12 @@ class ActivityLogItem extends Component {
 		const {
 			moment,
 			log,
+			siteOffset,
 		} = this.props;
 
 		return (
 			<div className="activity-log-item__time">
-				{ moment( log.ts_site ).format( 'LT' ) }
+				{ siteOffset( moment( log.ts_site ) ).format( 'LT' ) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -204,17 +204,18 @@ class ActivityLogItem extends Component {
 			log,
 			moment,
 			translate,
+			siteOffset,
 		} = this.props;
 		const {
 			name,
-			ts_site,
+			ts_utc,
 		} = log;
 
 		return (
 			<div>
 				{ translate( 'An event "%(eventName)s" occurred at %(date)s', {
 					args: {
-						date: moment( ts_site ).format( 'LLL' ),
+						date: siteOffset( moment( ts_utc ) ).format( 'LLL' ),
 						eventName: name,
 					}
 				} ) }
@@ -275,7 +276,7 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div className="activity-log-item__time">
-				{ siteOffset( moment( log.ts_site ) ).format( 'LT' ) }
+				{ siteOffset( moment( log.ts_utc ) ).format( 'LT' ) }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -116,6 +116,14 @@ class ActivityLog extends Component {
 		rewindRestore( siteId, requestedRestoreTimestamp );
 	};
 
+	/**
+	 * Creates a function that will offset a moment by the site
+	 * timezone or gmt offset. Use the resulting function wherever
+	 * log times need to be formatted for display to ensure all times
+	 * are displayed as site times.
+	 *
+	 * @returns {function} func that takes a moment and returns moment offset by site timezone or offset
+	 */
 	getSiteOffsetFunc() {
 		const { timezone, gmtOffset } = this.props;
 		return ( moment ) => {
@@ -218,13 +226,8 @@ class ActivityLog extends Component {
 		const filteredLogs = filter( logs, obj => startOfMonthMs <= obj.ts_utc && obj.ts_utc <= endOfMonthMs );
 		const logsGroupedByDay = map(
 			groupBy(
-<<<<<<< HEAD
 				filteredLogs,
-				log => moment( log.ts_site ).startOf( 'day' ).format( 'x' )
-=======
-				filteredLogs.map( this.update_logs, this ),
 				log => siteOffset( moment( log.ts_utc ) ).startOf( 'day' ).format( 'x' )
->>>>>>> Activity Log: Use site timezone/offset for time/date display
 			),
 			( daily_logs, timestamp ) => (
 				<ActivityLogDay

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -220,30 +220,30 @@ class ActivityLog extends Component {
 
 		const siteOffset = this.getSiteOffsetFunc();
 
-		const startOfMonthMs = siteOffset( moment( startDate ).startOf( 'month' ) ).valueOf();
-		const endOfMonthMs = siteOffset( moment( startDate ).endOf( 'month' ) ).valueOf();
+		const startOfMonthMs = moment.utc( startDate ).startOf( 'month' ).valueOf();
+		const endOfMonthMs = moment.utc( startDate ).endOf( 'month' ).valueOf();
+		const logsForMonth = filter( logs, obj => startOfMonthMs <= obj.ts_utc && obj.ts_utc <= endOfMonthMs );
 
-		const filteredLogs = filter( logs, obj => startOfMonthMs <= obj.ts_utc && obj.ts_utc <= endOfMonthMs );
 		const logsGroupedByDay = map(
 			groupBy(
-				filteredLogs,
-				log => siteOffset( moment( log.ts_utc ) ).startOf( 'day' ).format( 'x' )
+				logsForMonth,
+				log => siteOffset( moment.utc( log.ts_utc ) ).format( 'LL' )
 			),
-			( daily_logs, timestamp ) => (
+			( daily_logs, day ) => (
 				<ActivityLogDay
 					allowRestore={ !! isPressable }
 					isRewindActive={ isRewindActive }
-					key={ timestamp }
+					key={ day }
 					logs={ daily_logs }
 					requestRestore={ this.handleRequestRestore }
 					siteId={ siteId }
-					timestamp={ +timestamp }
+					day={ day }
 					siteOffset={ siteOffset }
 				/>
 			)
 		);
 
-		const startOfMonth = moment( startDate ).startOf( 'month' );
+		const startOfMonth = moment.utc( startDate ).startOf( 'month' );
 		const query = {
 			period: 'month',
 			date: startOfMonth.format( 'YYYY-MM-DD' )

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -323,7 +323,7 @@ export default connect(
 			isRewindActive: isRewindActiveSelector( state, siteId ),
 
 			// FIXME: Testing only
-			isPressable: true || get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], null ),
+			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], null ),
 			timezone: getSiteTimezoneValue( state, siteId ),
 			gmtOffset: getSiteGmtOffset( state, siteId ) || 0,
 		};

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -222,8 +222,8 @@ class ActivityLog extends Component {
 
 		// example: "2019 3"
 		const selectedMonthAndYear = moment( startDate ).format( 'YYYY M' );
-		const logsForMonth = filter( logs, ( item ) => {
-			return applySiteOffset( moment.utc( item.ts_utc ) ).format( 'YYYY M' ) === selectedMonthAndYear;
+		const logsForMonth = filter( logs, ( { ts_utc } ) => {
+			return applySiteOffset( moment.utc( ts_utc ) ).format( 'YYYY M' ) === selectedMonthAndYear;
 		} );
 
 		const logsGroupedByDay = map(

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -218,7 +218,7 @@ class ActivityLog extends Component {
 			startDate,
 		} = this.props;
 
-		const siteOffset = this.getSiteOffsetFunc();
+		const applySiteOffset = this.getSiteOffsetFunc();
 
 		const startOfMonthMs = moment.utc( startDate ).startOf( 'month' ).valueOf();
 		const endOfMonthMs = moment.utc( startDate ).endOf( 'month' ).valueOf();
@@ -227,7 +227,7 @@ class ActivityLog extends Component {
 		const logsGroupedByDay = map(
 			groupBy(
 				logsForMonth,
-				log => siteOffset( moment.utc( log.ts_utc ) ).format( 'LL' )
+				log => applySiteOffset( moment.utc( log.ts_utc ) ).format( 'LL' )
 			),
 			( daily_logs, day ) => (
 				<ActivityLogDay
@@ -238,7 +238,7 @@ class ActivityLog extends Component {
 					requestRestore={ this.handleRequestRestore }
 					siteId={ siteId }
 					day={ day }
-					siteOffset={ siteOffset }
+					applySiteOffset={ applySiteOffset }
 				/>
 			)
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -220,9 +220,11 @@ class ActivityLog extends Component {
 
 		const applySiteOffset = this.getSiteOffsetFunc();
 
-		const startOfMonthMs = moment.utc( startDate ).startOf( 'month' ).valueOf();
-		const endOfMonthMs = moment.utc( startDate ).endOf( 'month' ).valueOf();
-		const logsForMonth = filter( logs, obj => startOfMonthMs <= obj.ts_utc && obj.ts_utc <= endOfMonthMs );
+		// example: "2019 3"
+		const selectedMonthAndYear = moment( startDate ).format( 'YYYY M' );
+		const logsForMonth = filter( logs, ( item ) => {
+			return applySiteOffset( moment.utc( item.ts_utc ) ).format( 'YYYY M' ) === selectedMonthAndYear;
+		} );
 
 		const logsGroupedByDay = map(
 			groupBy(

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -220,10 +220,10 @@ class ActivityLog extends Component {
 
 		const applySiteOffset = this.getSiteOffsetFunc();
 
-		// example: "2019 3"
-		const selectedMonthAndYear = moment( startDate ).format( 'YYYY M' );
+		const YEAR_MONTH = 'YYYY-MM';
+		const selectedMonthAndYear = moment( startDate ).format( YEAR_MONTH );
 		const logsForMonth = filter( logs, ( { ts_utc } ) => {
-			return applySiteOffset( moment.utc( ts_utc ) ).format( 'YYYY M' ) === selectedMonthAndYear;
+			return applySiteOffset( moment.utc( ts_utc ) ).format( YEAR_MONTH ) === selectedMonthAndYear;
 		} );
 
 		const logsGroupedByDay = map(

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -328,7 +328,7 @@ export default connect(
 			// FIXME: Testing only
 			isPressable: get( state.activityLog.rewindStatus, [ siteId, 'isPressable' ], null ),
 			timezone: getSiteTimezoneValue( state, siteId ),
-			gmtOffset: getSiteGmtOffset( state, siteId ) || 0,
+			gmtOffset: getSiteGmtOffset( state, siteId ),
 		};
 	}, {
 		recordGoogleEvent,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -131,7 +131,7 @@ class ActivityLog extends Component {
 				return moment.tz( timezone );
 			}
 			if ( gmtOffset ) {
-				return moment.offset( timezone );
+				return moment.utcOffset( gmtOffset );
 			}
 			return moment;
 		};


### PR DESCRIPTION
Addresses #15444

* Remove all uses of `ts_site` and use only `ts_utc`
* Format any times for display using the site timezone or offset
* Perform day groupings based on days in site timezone or offset


**To Test**
* Use various values of offset/timezone in wp-admin->settings->general->timezone
* Check that all displayed times in http://calypso.localhost:3000/stats/activity/{site} are relative to the above setting
* Check that day groupings are correct

