### PR TITLE
Reader: hide the last updated date on site search results

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -400,6 +400,11 @@
 	}
 }
 
+// Hide the last updated date for the moment - see https://github.com/Automattic/wp-calypso/issues/15121
+.search-stream__single-column-results .reader-subscription-list-item__timestamp {
+	display: none;
+}
+
 .search-stream__results.is-two-columns .gridicon__follow {
 	left: 2px;
 }
@@ -481,7 +486,6 @@
 }
 
 .card.reader-search-card.is-photo {
-
 	@include breakpoint( "<660px" ) {
 		z-index: z-index( 'root', '.reader-search-card' );
 	}


### PR DESCRIPTION
Whilst we do some Elasticsearch wrangling, hide the last updated date on site search results. You usually only see this on the smaller breakpoint:

<img width="482" alt="screenshot 2017-06-26 16 40 14" src="https://user-images.githubusercontent.com/17325/27559924-59e4d0cc-5a90-11e7-8219-8ca9510a016c.png">

The last updated date should no longer appear.

See https://github.com/Automattic/wp-calypso/issues/15121.