### PR TITLE
Reader: Move down first post results placeholder

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -102,6 +102,10 @@
 	}
 }
 
+.search-stream.search-stream__with-sites .search-stream__post-results .reader__card:nth-child(2) {
+	margin-top: 120px;
+}
+
 // Top margin for site results
 .main.search-stream {
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15500

This happens in all browsers.

**Before:**
<img width="913" alt="screen shot 2017-06-26 at 11 26 58" src="https://user-images.githubusercontent.com/17325/27547827-2833da1c-5a65-11e7-95ab-40d6197664d3.png">

**After:**
![screenshot 2017-06-26 13 39 20](https://user-images.githubusercontent.com/4924246/27560085-b595da06-5a77-11e7-8f0b-306140971a06.png)
