### PR TITLE
Site Settings: Remove unnecessary evaluation from Spam Filtering settings card

### DIFF
--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -126,8 +126,7 @@ export default connect( state => {
 	const hasAkismetKeyError =
 		jetpackSettingsSaveStatus &&
 		jetpackSettingsSaveStatus === 'error' &&
-		( includes( jetpackSettingsSaveError, 'wordpress_api_key' ) ||
-			includes( jetpackSettingsSaveError, 'wordpress_api_key' ) );
+		includes( jetpackSettingsSaveError, 'wordpress_api_key' );
 	return {
 		hasAkismetKeyError,
 	};


### PR DESCRIPTION
Removes a duplicate evaluation in the component's connect() statement


#### Testing instructions 

1. Verify that the evaluation was 100% redundant just by looking at the code.
