### PR TITLE
Enable .CA TLD extra info form on wpcalypso

### DIFF
--- a/client/components/domains/registrant-extra-info/index.jsx
+++ b/client/components/domains/registrant-extra-info/index.jsx
@@ -2,11 +2,12 @@
  * Extrenal dependencies
  */
 import React, { PureComponent } from 'react';
-import { keys } from 'lodash';
+import { keys, filter } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import config from 'config';
 import fr from './fr-form';
 import ca from './ca-form';
 
@@ -15,7 +16,12 @@ const tldSpecificForms = {
 	fr,
 };
 
-export const tldsWithAdditionalDetailsForms = keys( tldSpecificForms );
+const enabledTldForms = filter(
+	keys( tldSpecificForms ),
+	tld => config.isEnabled( `domains/cctlds/${ tld }` )
+);
+
+export const tldsWithAdditionalDetailsForms = enabledTldForms;
 
 export default class DomainDetailsForm extends PureComponent {
 	render() {

--- a/config/development.json
+++ b/config/development.json
@@ -47,6 +47,8 @@
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
 		"domains/cctlds": true,
+		"domains/cctlds/ca": true,
+		"domains/cctlds/fr": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -25,6 +25,8 @@
 		"devdocs/redirect-loggedout-homepage": false,
 		"devdocs/components-usage-stats": false,
 		"dev/test-helper": true,
+		"domains/cctlds": true,
+		"domains/cctlds/ca": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,


### PR DESCRIPTION
This PR enables the .ca TLD extra info form on the wpcalypso environment, to enable easier testing as we prepare for release.

The desired behaviour is that adding a .CA domain will show the the .CA extra info dialog on dev & wpcalypso (but not staging or release), while the .FR dialog is available only on dev.