### PR TITLE
Turn on post publish preview in development

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -114,7 +114,7 @@
 		"plans/personal-plan": true,
 		"plans/jetpack-config-v2": true,
 		"post-editor/delta-post-publish-flow": false,
-		"post-editor/delta-post-publish-preview": false,
+		"post-editor/delta-post-publish-preview": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
This PR is to enable easier testing on mobile using calypso.live. It is NOT meant to be merged.