### PR TITLE
Added UI selectors for the Shipping Zone locations edit

### DIFF
--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
@@ -112,8 +112,8 @@ export const areShippingZonesLocationsValid = ( reduxState, siteId = getSelected
 				}
 				statesSet.add( s );
 			}
-		} else {
-			// A zone must have *any* location. If it doesn't, it's incorrect.
+		} else if ( ! isEmpty( postcode ) ) {
+			// A postcode without a country is not valid
 			return false;
 		}
 	}

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
@@ -9,7 +9,7 @@ import { get, isEmpty, isObject } from 'lodash';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
-const getRawShippingZoneLocations = ( state, siteId = getSelectedSiteId( state ) ) => {
+export const getRawShippingZoneLocations = ( state, siteId = getSelectedSiteId( state ) ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'shippingZoneLocations' ] );
 };
 

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
@@ -149,7 +149,7 @@ describe( 'selectors', () => {
 			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
 		} );
 
-		it( 'should return false for a zone without locations.', () => {
+		it( 'should return true for a zone without locations.', () => {
 			const state = createState( {
 				site: {
 					shippingZoneLocations: {
@@ -163,7 +163,7 @@ describe( 'selectors', () => {
 				},
 				ui: {},
 			} );
-			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
 		} );
 
 		it( 'should return true for a zone with a single continent.', () => {

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -1,0 +1,463 @@
+/**
+ * External dependencies
+ */
+import { forIn, isEmpty, sortBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { areShippingZonesLoaded } from 'woocommerce/state/sites/shipping-zones/selectors';
+import { getRawShippingZoneLocations } from 'woocommerce/state/sites/shipping-zone-locations/selectors';
+import { getShippingZonesEdits, getCurrentlyEditingShippingZone } from '../selectors';
+import { getContinents, getCountries, getCountryName, getStates, hasStates } from 'woocommerce/state/sites/locations/selectors';
+import { JOURNAL_ACTIONS } from './reducer';
+import { mergeLocationEdits } from './helpers';
+
+/**
+ * Computes a map of the continents that belong to a zone different than the one that's currently being edited.
+ * That information will be used to mark them as "disabled" in the UI.
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} siteId Site ID
+ * @return {Object} A map with the form { continentCode => zoneId }. If a continent doesn't appear in the map, it means that
+ * it doesn't belong to a zone.
+ */
+const getContinentsOwnedByOtherZone = ( state, siteId ) => {
+	const continents = {};
+	const currentZone = getCurrentlyEditingShippingZone( state, siteId );
+	forIn( getRawShippingZoneLocations( state, siteId ), ( { continent }, zoneId ) => {
+		if ( currentZone.id === Number( zoneId ) ) {
+			return;
+		}
+		for ( const c of continent ) {
+			continents[ c ] = Number( zoneId );
+		}
+	} );
+	return continents;
+};
+
+/**
+ * Computes a map of the countries that belong to a zone different than the one that's currently being edited.
+ * That information will be used to mark them as "disabled" in the UI.
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} siteId Site ID
+ * @return {Object} A map with the form { countryCode => zoneId }. If a country doesn't appear in the map, it means that
+ * it doesn't belong to a zone.
+ */
+const getCountriesOwnedByOtherZone = ( state, siteId ) => {
+	const countries = {};
+	const currentZone = getCurrentlyEditingShippingZone( state, siteId );
+	forIn( getRawShippingZoneLocations( state, siteId ), ( { country, postcode }, zoneId ) => {
+		if ( currentZone.id === Number( zoneId ) || ! isEmpty( postcode ) ) {
+			return;
+		}
+		for ( const c of country ) {
+			countries[ c ] = Number( zoneId );
+		}
+	} );
+	return countries;
+};
+
+/**
+ * Computes a map of the states that belong to a zone different than the one that's currently being edited.
+ * That information will be used to mark them as "disabled" in the UI.
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} siteId Site ID
+ * @param {String} countryCode 2-letter ISO country code
+ * @return {Object} A map with the form { stateCode: zoneId }. If a state doesn't appear in the map, it means that
+ * it doesn't belong to a zone.
+ */
+const getStatesOwnedByOtherZone = ( state, siteId, countryCode ) => {
+	const states = {};
+	const currentZone = getCurrentlyEditingShippingZone( state, siteId );
+	forIn( getRawShippingZoneLocations( state, siteId ), ( locations, zoneId ) => {
+		if ( currentZone.id === Number( zoneId ) ) {
+			return;
+		}
+		for ( const s of locations.state ) {
+			const [ stateCountry, stateCode ] = s.split( ':' );
+			if ( stateCountry === countryCode ) {
+				states[ stateCode ] = Number( zoneId );
+			}
+		}
+	} );
+	return states;
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @param {Boolean} [overlayTemporalEdits] Whether to overlay the temporal location edits that are being made inside the modal (true),
+ * or just use the committed edits.
+ * @return {Object} The list of locations for the shipping zone, including any edits made, in the form
+ * { continent: [ ... ], country: [ ... ], state: [ ... ], postcode: [ ... ] }. On any failure, it will return null.
+ */
+export const getShippingZoneLocationsWithEdits = ( state, siteId = getSelectedSiteId( state ), overlayTemporalEdits = true ) => {
+	if ( ! areShippingZonesLoaded( state, siteId ) ) {
+		return null;
+	}
+	const zone = getCurrentlyEditingShippingZone( state, siteId );
+	if ( ! zone ) {
+		return null;
+	}
+
+	const locations = getRawShippingZoneLocations( state, siteId )[ zone.id ] || {
+		continent: [],
+		country: [],
+		state: [],
+		postcode: [],
+	};
+
+	const continents = new Set( locations.continent );
+	const countries = new Set( locations.country );
+	// Extract the country/state pair from the raw states (they are in the format "Country:State")
+	const states = new Set();
+	locations.state.forEach( ( fullCode ) => {
+		const [ countryCode, stateCode ] = fullCode.split( ':' );
+		countries.add( countryCode );
+		states.add( stateCode );
+	} );
+
+	const { temporaryChanges, ...committedEdits } = getShippingZonesEdits( state, siteId ).currentlyEditingChanges.locations;
+	const edits = overlayTemporalEdits ? mergeLocationEdits( committedEdits, temporaryChanges ) : committedEdits;
+	if ( edits.pristine ) {
+		return {
+			continent: Array.from( continents ),
+			country: Array.from( countries ),
+			state: Array.from( states ),
+			postcode: locations.postcode,
+		};
+	}
+
+	const forbiddenCountries = new Set( Object.keys( getCountriesOwnedByOtherZone( state, siteId ) ) );
+	// Play the journal entries in order, from oldest to newest
+	edits.journal.forEach( ( { action, code } ) => {
+		switch ( action ) {
+			case JOURNAL_ACTIONS.ADD_CONTINENT:
+				// When selecting a whole continent, remove all its countries from the selection
+				getCountries( state, code, siteId ).forEach( country => countries.delete( country.code ) );
+				if ( countries.size ) {
+					// If the zone has countries selected, then instead of selecting the continent we select all its countries
+					getCountries( state, code, siteId ).forEach( ( country ) => {
+						if ( ! forbiddenCountries.has( country.code ) ) {
+							countries.add( country.code );
+						}
+					} );
+				} else {
+					continents.add( code );
+				}
+				break;
+			case JOURNAL_ACTIONS.REMOVE_CONTINENT:
+				continents.delete( code );
+				getCountries( state, code, siteId ).forEach( country => countries.delete( country.code ) );
+				break;
+			case JOURNAL_ACTIONS.ADD_COUNTRY:
+				forbiddenCountries.forEach( countryCode => {
+					countries.delete( countryCode );
+				} );
+				countries.add( code );
+				// If the zone has continents selected, then we need to replace them with their respective countries
+				continents.forEach( ( continentCode ) => {
+					getCountries( state, continentCode, siteId ).forEach( ( country ) => {
+						if ( ! forbiddenCountries.has( country.code ) ) {
+							countries.add( country.code );
+						}
+					} );
+				} );
+				// This is a "countries" zone now, remove all the continents
+				continents.clear();
+				break;
+			case JOURNAL_ACTIONS.REMOVE_COUNTRY:
+				let insideSelectedContinent = false;
+				for ( const continentCode of continents ) {
+					if ( insideSelectedContinent ) {
+						break;
+					}
+					for ( const country of getCountries( state, continentCode, siteId ) ) {
+						if ( country.code === code ) {
+							insideSelectedContinent = true;
+							break;
+						}
+					}
+				}
+				// If the user unselected a country that was inside a selected continent, replace the continent for its countries
+				if ( insideSelectedContinent ) {
+					continents.forEach( ( continentCode ) => {
+						getCountries( state, continentCode, siteId ).forEach( ( country ) => {
+							if ( ! forbiddenCountries.has( country.code ) ) {
+								countries.add( country.code );
+							}
+						} );
+					} );
+					// This is a "countries" zone now, remove all the continents
+					continents.clear();
+				}
+				countries.delete( code );
+				break;
+		}
+	} );
+
+	// If there are journal entries, then the user selected/unselected countries&continents, so the original states must be purged
+	if ( ! edits.states || edits.states.removeAll || ! isEmpty( edits.journal ) ) {
+		states.clear();
+	}
+	if ( edits.states ) {
+		edits.states.add.forEach( ( code ) => states.add( code ) );
+		edits.states.remove.forEach( ( code ) => states.delete( code ) );
+	}
+
+	return {
+		continent: Array.from( continents ),
+		country: Array.from( countries ),
+		state: Array.from( states ),
+		postcode: null === edits.postcode ? [] : [ edits.postcode ],
+	};
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the "Edit Locations" modal is opened or not.
+ */
+export const isEditLocationsModalOpen = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! areShippingZonesLoaded( state, siteId ) || ! getCurrentlyEditingShippingZone( state, siteId ) ) {
+		return false;
+	}
+	return Boolean( getShippingZonesEdits( state, siteId ).currentlyEditingChanges.locations.temporaryChanges );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the locations can be filtered (by state or postcode) or not. They can be filtered if there
+ * is only one country selected (and no continents).
+ */
+export const canLocationsBeFiltered = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! isEditLocationsModalOpen( state, siteId ) ) {
+		return false;
+	}
+	const locations = getShippingZoneLocationsWithEdits( state, siteId );
+	return locations && isEmpty( locations.continent ) && 1 === locations.country.length;
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number|undefined} The Zone ID that is the "owner" of the currently selected country, or "false-y" if the
+ * currently selected country isn't owned by any other zone. If this returns a Zone ID, then the user shouldn't be able
+ * to filter by "whole country", only by states / postcode.
+ */
+export const getCurrentSelectedCountryZoneOwner = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! canLocationsBeFiltered( state, siteId ) ) {
+		return null;
+	}
+	const locations = getShippingZoneLocationsWithEdits( state, siteId );
+	return getCountriesOwnedByOtherZone( state, siteId )[ locations.country[ 0 ] ];
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the locations currently being edited can be filtered by state. This will happen when there
+ * is only one country selected and it has a list of available states.
+ */
+export const canLocationsBeFilteredByState = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! canLocationsBeFiltered( state, siteId ) ) {
+		return false;
+	}
+
+	const locations = getShippingZoneLocationsWithEdits( state, siteId );
+	return locations && hasStates( state, locations.country[ 0 ], siteId );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the "Filter by postcode range" option is selected.
+ */
+export const areLocationsFilteredByPostcode = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! canLocationsBeFiltered( state, siteId ) ) {
+		return false;
+	}
+	const zone = getCurrentlyEditingShippingZone( state, siteId );
+	const locations = getRawShippingZoneLocations( state, siteId )[ zone.id ];
+	const { temporaryChanges, ...committedEdits } = getShippingZonesEdits( state, siteId ).currentlyEditingChanges.locations;
+	const edits = mergeLocationEdits( committedEdits, temporaryChanges );
+
+	if ( edits.pristine ) {
+		return ! isEmpty( locations.postcode );
+	}
+	if ( null !== edits.postcode ) {
+		return true;
+	}
+	return ! canLocationsBeFilteredByState( state, siteId ) && Boolean( getCurrentSelectedCountryZoneOwner( state, siteId ) );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the "Filter by state" option is selected.
+ */
+export const areLocationsFilteredByState = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! canLocationsBeFiltered( state, siteId ) || ! canLocationsBeFilteredByState( state, siteId ) ) {
+		return false;
+	}
+	const zone = getCurrentlyEditingShippingZone( state, siteId );
+	const locations = getRawShippingZoneLocations( state, siteId )[ zone.id ];
+	const { temporaryChanges, ...committedEdits } = getShippingZonesEdits( state, siteId ).currentlyEditingChanges.locations;
+	const edits = mergeLocationEdits( committedEdits, temporaryChanges );
+
+	if ( edits.pristine ) {
+		return ! isEmpty( locations.state );
+	}
+	if ( null !== edits.states ) {
+		return true;
+	}
+	return ! areLocationsFilteredByPostcode( state, siteId ) && Boolean( getCurrentSelectedCountryZoneOwner( state, siteId ) );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the "Ship to the whole country" option is selected.
+ */
+export const areLocationsUnfiltered = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return canLocationsBeFiltered( state, siteId ) &&
+		! getCurrentSelectedCountryZoneOwner( state, siteId ) &&
+		! areLocationsFilteredByState( state, siteId ) &&
+		! areLocationsFilteredByPostcode( state, siteId );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Array} The list of locations currently configured for the zone. This doesn't include temporary edits,
+ * since it's made to be used for the UI outside of the modal. Each element of the list will have these properties:
+ * - type: 'continent|country|state'
+ * - code: Continent code, country code or state code, depending on the type
+ * - name: Name of the location to be displayed
+ * Additionally, if the "type" is "country", it will have an optional field:
+ * - postcodeFilter: String, postcode range applied, if any.
+ * And if the "type" is "state":
+ * - countryName: Name of the country that this state is part of.
+ * - countryCode: Code of the ecountry that this state is part of.
+ */
+export const getCurrentlyEditingShippingZoneLocationsList = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const locations = getShippingZoneLocationsWithEdits( state, siteId, false );
+	if ( ! locations ) {
+		return [];
+	}
+
+	const selectedContinents = new Set( locations.continent );
+	if ( selectedContinents.size ) {
+		return getContinents( state, siteId )
+			.filter( ( { code } ) => selectedContinents.has( code ) )
+			.map( ( { code, name } ) => ( {
+				type: 'continent',
+				code,
+				name,
+			} ) );
+	}
+
+	const selectedStates = new Set( locations.state );
+	if ( selectedStates.size ) {
+		const countryCode = locations.country[ 0 ];
+		const countryName = getCountryName( state, countryCode, siteId );
+		return getStates( state, countryCode, siteId )
+			.filter( ( { code } ) => selectedStates.has( code ) )
+			.map( ( { code, name } ) => ( {
+				type: 'state',
+				code,
+				name,
+				countryName,
+				countryCode
+			} ) );
+	}
+
+	return sortBy( locations.country.map( code => ( {
+		type: 'country',
+		code,
+		name: getCountryName( state, code, siteId ),
+		postcodeFilter: locations.postcode[ 0 ],
+	} ) ), 'name' );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Array} The list of continents and countries for this zone, ready to be rendered in the UI. This includes
+ * temporary edits, as it's made to be used inside the modal UI. Each element will have these properties:
+ * - type: 'continent|country'
+ * - code: Continent code or country code
+ * - name: Name of the location to be displayed
+ * - selected: Boolean, whether this location should be markef as "selected"
+ * - disabled: Boolean, whether this location should be marked as "disabled". The user shouldn't be able to toggle a disabled element.
+ * - ownerZoneId: The Zone ID that is the "owner" of this location, or undefined if no other zone includes this location.
+ */
+export const getCurrentlyEditingShippingZoneCountries = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const locations = getShippingZoneLocationsWithEdits( state, siteId );
+	if ( ! locations ) {
+		return [];
+	}
+	const selectedContinents = new Set( locations.continent );
+	const selectedCountries = new Set( locations.country );
+	const forbiddenContinents = getContinentsOwnedByOtherZone( state, siteId );
+	const forbiddenCountries = getCountriesOwnedByOtherZone( state, siteId );
+	const locationsList = [];
+	const allowSelectingForbiddenCountries = 0 === selectedContinents.size && 0 === selectedCountries.size;
+
+	getContinents( state, siteId ).forEach( ( { code: continentCode, name: continentName } ) => {
+		const continentSelected = selectedContinents.has( continentCode );
+		locationsList.push( {
+			code: continentCode,
+			name: continentName,
+			selected: continentSelected,
+			disabled: Boolean( forbiddenContinents[ continentCode ] ),
+			ownerZoneId: forbiddenContinents[ continentCode ],
+			type: 'continent',
+		} );
+		getCountries( state, continentCode, siteId ).forEach( ( { code: countryCode, name: countryName } ) => {
+			locationsList.push( {
+				code: countryCode,
+				name: countryName,
+				selected: continentSelected || selectedCountries.has( countryCode ),
+				disabled: ! allowSelectingForbiddenCountries && Boolean( forbiddenCountries[ countryCode ] ),
+				ownerZoneId: forbiddenCountries[ countryCode ],
+				type: 'country',
+			} );
+		} );
+	} );
+	return locationsList;
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Array} The list of states for this zone, ready to be rendered in the UI. This includes
+ * temporary edits, as it's made to be used inside the modal UI. Each element will have these properties:
+ * - code: State code
+ * - name: State name
+ * - selected: Boolean, whether this location should be markef as "selected"
+ * - disabled: Boolean, whether this location should be marked as "disabled". The user shouldn't be able to toggle a disabled element.
+ * - ownerZoneId: The Zone ID that is the "owner" of this state, or undefined if no other zone includes this state.
+ */
+export const getCurrentlyEditingShippingZoneStates = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! areLocationsFilteredByState( state, siteId ) ) {
+		return [];
+	}
+	const locations = getShippingZoneLocationsWithEdits( state, siteId );
+	if ( ! locations ) {
+		return [];
+	}
+	const countryCode = locations.country[ 0 ];
+	const selectedStates = new Set( locations.state );
+	const forbiddenStates = getStatesOwnedByOtherZone( state, siteId, countryCode );
+
+	return getStates( state, countryCode, siteId ).map( ( { code, name } ) => ( {
+		code,
+		name,
+		selected: selectedStates.has( code ),
+		disabled: Boolean( forbiddenStates[ code ] ),
+		ownerZoneId: forbiddenStates[ code ],
+	} ) );
+};

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forIn, isEmpty, sortBy } from 'lodash';
+import { every, forIn, isEmpty, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -460,4 +460,27 @@ export const getCurrentlyEditingShippingZoneStates = ( state, siteId = getSelect
 		disabled: Boolean( forbiddenStates[ code ] ),
 		ownerZoneId: forbiddenStates[ code ],
 	} ) );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the locations for the shipping zone currently being edited are valid. This includes
+ * temporary edits, as it's designed to be used for enabling / disabling the "Save Changes" button.
+ */
+export const areCurrentlyEditingShippingZoneLocationsValid = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const locations = getShippingZoneLocationsWithEdits( state, siteId );
+	if ( ! locations ) {
+		return false;
+	}
+	if ( every( locations, isEmpty ) ) {
+		return false;
+	}
+	if ( areLocationsFilteredByPostcode( state, siteId ) && ! locations.postcode[ 0 ] ) {
+		return false;
+	}
+	if ( areLocationsFilteredByState( state, siteId ) && isEmpty( locations.state ) ) {
+		return false;
+	}
+	return true;
 };

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
@@ -18,6 +18,7 @@ import {
 	getCurrentlyEditingShippingZoneLocationsList,
 	getCurrentlyEditingShippingZoneCountries,
 	getCurrentlyEditingShippingZoneStates,
+	areCurrentlyEditingShippingZoneLocationsValid,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 import { createState } from 'woocommerce/state/test/helpers';
@@ -2295,6 +2296,203 @@ describe( 'selectors', () => {
 					ownerZoneId: 7,
 				},
 			] );
+		} );
+	} );
+
+	describe( 'areCurrentlyEditingShippingZoneLocationsValid', () => {
+		it( 'should return false when the locations are empty', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when the locations are filtered by postcode but it is empty', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: '',
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when the locations are filtered by state but there are no states selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [],
+						remove: [],
+						removeAll: false,
+					},
+					postcode: null,
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when the locations are several countries', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US', 'UK' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: null,
+					pristine: true,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when the locations are several continents', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA', 'EU' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: null,
+					pristine: true,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when the locations are a country with a postcode', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: '12345',
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when the locations are a country with states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [ 'CA', 'NY' ],
+						remove: [],
+						removeAll: false,
+					},
+					postcode: null,
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should overlay the temporary changes', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
@@ -1,0 +1,2300 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getShippingZoneLocationsWithEdits,
+	isEditLocationsModalOpen,
+	canLocationsBeFiltered,
+	getCurrentSelectedCountryZoneOwner,
+	canLocationsBeFilteredByState,
+	areLocationsFilteredByPostcode,
+	areLocationsFilteredByState,
+	areLocationsUnfiltered,
+	getCurrentlyEditingShippingZoneLocationsList,
+	getCurrentlyEditingShippingZoneCountries,
+	getCurrentlyEditingShippingZoneStates,
+} from '../selectors';
+import { LOADING } from 'woocommerce/state/constants';
+import { createState } from 'woocommerce/state/test/helpers';
+import { initialState, JOURNAL_ACTIONS } from '../reducer';
+
+const initialStateWithEmptyTempEdits = {
+	...initialState,
+	temporaryChanges: {
+		journal: [],
+		states: null,
+		postcode: null,
+		pristine: true,
+	},
+};
+
+const locations = [
+	{
+		code: 'EU',
+		name: 'Europe',
+		countries: [
+			{
+				code: 'UK',
+				name: 'United Kingdom',
+				states: [],
+			},
+			{
+				code: 'FR',
+				name: 'France',
+				states: [],
+			},
+			{
+				code: 'ES',
+				name: 'Spain',
+				states: [],
+			},
+		],
+	},
+	{
+		code: 'NA',
+		name: 'North America',
+		countries: [
+			{
+				code: 'US',
+				name: 'United States',
+				states: [
+					{
+						code: 'AL',
+						name: 'Alabama',
+					},
+					{
+						code: 'CA',
+						name: 'California',
+					},
+					{
+						code: 'NY',
+						name: 'New York',
+					},
+					{
+						code: 'UT',
+						name: 'Utah',
+					},
+				],
+			},
+			{
+				code: 'CA',
+				name: 'Canada',
+				states: [],
+			},
+		],
+	},
+];
+
+const createEditState = ( { zoneLocations, locationEdits } ) => createState( {
+	site: {
+		shippingZones: Object.keys( zoneLocations ).map( zoneId => ( { id: zoneId, methodIds: [] } ) ),
+		shippingZoneLocations: zoneLocations,
+		locations,
+	},
+	ui: {
+		shipping: {
+			zones: {
+				creates: [], updates: [], deletes: [],
+				currentlyEditingId: 1,
+				currentlyEditingChanges: {
+					locations: locationEdits,
+				},
+			},
+		},
+	},
+} );
+
+describe( 'selectors', () => {
+	describe( 'getShippingZoneLocationsWithEdits', () => {
+		it( 'should return null when the shipping zones are not fully loaded', () => {
+			const state = createState( {
+				site: {
+					shippingZones: [
+						{ id: 1, methodIds: [] },
+					],
+					shippingZoneLocations: { 1: LOADING },
+				},
+				ui: {},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.be.null;
+		} );
+
+		it( 'should return null when there is no zone currently being edited', () => {
+			const state = createState( {
+				site: {
+					shippingZones: [
+						{ id: 1, methodIds: [] },
+					],
+					shippingZoneLocations: { 1: { continent: [], country: [], state: [], postcode: [] } },
+				},
+				ui: {
+					shipping: {
+						zones: {
+							creates: [], updates: [], deletes: [],
+							currentlyEditingId: null,
+						},
+					},
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.be.null;
+		} );
+
+		it( 'should return null when there is no zone currently being edited', () => {
+			const state = createState( {
+				site: {
+					shippingZones: [],
+					shippingZoneLocations: {},
+				},
+				ui: {
+					shipping: {
+						zones: {
+							creates: [], updates: [], deletes: [],
+							currentlyEditingId: { index: 0 },
+							currentlyEditingChanges: { locations: initialState }
+						},
+					},
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [],
+				state: [],
+				postcode: []
+			} );
+		} );
+
+		it( 'should return the original locations if there are no changes', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					pristine: true,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should add the continents logged in the journal', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_CONTINENT, code: 'EU' },
+						{ action: JOURNAL_ACTIONS.ADD_CONTINENT, code: 'NA' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [ 'EU', 'NA' ],
+				country: [],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should remove the continents logged in the journal', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'EU', 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_CONTINENT, code: 'EU' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [ 'NA' ],
+				country: [],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should add all the continent\'s countries instead of the continent if the locations already include countries', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_CONTINENT, code: 'NA' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'UK', 'CA', 'US' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should not add the countries that already belong to another zone', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'FR' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_CONTINENT, code: 'EU' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US', 'ES', 'UK' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should add remove all the continent\'s countries when adding the whole continent', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_CONTINENT, code: 'EU' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [ 'EU' ],
+				country: [],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should add the countries logged in the journal', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'UK', 'US' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should remove the countries logged in the journal', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'CA', 'US', 'UK' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'CA' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should replace all the continents with their respective countries when adding a country', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'UK', 'CA', 'US' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should not add the countries to the list of they already belong to another zone', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'CA' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'UK', 'US' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should allow selecting a single country even if it belongs to another zone', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should allow selecting a second country even if the first belongs to another zone, but the first will be removed', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'CA' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'CA' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should remove the continent and add in its place all its countries when removing a country inside it', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA', 'EU' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'CA', 'US', 'FR', 'ES' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should not add the countries to the list if they already belong to another zone', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA', 'EU' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'CA', 'FR' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US', 'ES' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should process all the entries in the journal in order', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						// this should add all the American countries and remove "NA"
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+						// Can't add EU because there are selected NA countries, add all EU countries instead
+						{ action: JOURNAL_ACTIONS.ADD_CONTINENT, code: 'EU' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'CA', 'FR', 'ES', 'UK' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should remove all the states when there were country or continent additions or removals', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US', 'UK' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should remove the postcode when there were country or continent additions or removals', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US', 'UK' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should add states to the locations', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [ 'NY', 'UT' ],
+						remove: [],
+						removeAll: false,
+					},
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [ 'CA', 'NY', 'UT' ],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should remove states from the locations', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA', 'US:NY', 'US:UT' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [],
+						remove: [ 'UT', 'NY' ],
+						removeAll: false,
+					},
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [ 'CA' ],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should both add and remove states on the locations', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA', 'US:UT' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [ 'NY' ],
+						remove: [ 'UT' ],
+						removeAll: false,
+					},
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [ 'CA', 'NY' ],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should clear the states list if the removeAll flag is set', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA', 'US:UT' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [ 'NY' ],
+						remove: [],
+						removeAll: true,
+					},
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [ 'NY' ],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should clear the states list if the locations are not filtered by state anymore', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA', 'US:UT' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: '12345',
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [],
+				postcode: [ '12345' ],
+			} );
+		} );
+
+		it( 'should clear the postcode if the locations are not filtered by postcode anymore', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: null,
+					pristine: false,
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should overlay temporary edits by default', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'FR' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					}
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US', 'UK', 'FR' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+
+		it( 'should NOT overlay temporary edits if specified', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'FR' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					}
+				},
+			} );
+
+			expect( getShippingZoneLocationsWithEdits( state, undefined, false ) ).to.deep.equal( {
+				continent: [],
+				country: [ 'US', 'UK' ],
+				state: [],
+				postcode: [],
+			} );
+		} );
+	} );
+
+	describe( 'isEditLocationsModalOpen', () => {
+		it( 'should return false when there is no shipping zone being edited', () => {
+			const state = createState( {
+				site: {
+					shippingZones: [
+						{ id: 1, methodIds: [] },
+					],
+					shippingZoneLocations: { 1: { continent: [], country: [], state: [], postcode: [] } },
+				},
+				ui: {
+					shipping: {
+						zones: {
+							creates: [], updates: [], deletes: [],
+							currentlyEditingId: null,
+						},
+					},
+				},
+			} );
+
+			expect( isEditLocationsModalOpen( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there are no temporary changes', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialState,
+			} );
+
+			expect( isEditLocationsModalOpen( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there are temporary changes (even empty changes)', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( isEditLocationsModalOpen( state ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'canLocationsBeFiltered', () => {
+		it( 'should return false when there are continents selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there are multiple countries selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US', 'CA' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is no country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( canLocationsBeFiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there is a single country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFiltered( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when there is a single country selected with states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA', 'US:NY' ],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFiltered( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when there is a single country selected with postcode filter', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFiltered( state ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'getCurrentSelectedCountryZoneOwner', () => {
+		it( 'should return null when the zone locations can\'t be filtered', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: null,
+					pristine: true,
+				},
+			} );
+
+			expect( getCurrentSelectedCountryZoneOwner( state ) ).to.be.nil;
+		} );
+
+		it( 'should return null when there are no other zones that have the current country', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'CA' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: null,
+						postcode: null,
+						pristine: true,
+					}
+				},
+			} );
+
+			expect( getCurrentSelectedCountryZoneOwner( state ) ).to.be.nil;
+		} );
+
+		it( 'should return null when there are no other zones that own the *whole* country', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( getCurrentSelectedCountryZoneOwner( state ) ).to.be.nil;
+		} );
+
+		it( 'should return the zone ID that owns the current country', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( getCurrentSelectedCountryZoneOwner( state ) ).to.equal( 7 );
+		} );
+	} );
+
+	describe( 'canLocationsBeFilteredByState', () => {
+		it( 'should return false when there are continents selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there are multiple countries selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US', 'CA' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is no country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there is a single country selected, and it has states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when there is a single country selected with states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA', 'US:NY' ],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when there is a single country selected with postcode filter, and it has states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when there is a single country selected, and it does not have states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a single country selected with postcode filter, and it does not have states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( canLocationsBeFilteredByState( state ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'areLocationsFilteredByPostcode', () => {
+		it( 'should return false when there are continents selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there are multiple countries selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US', 'CA' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is no country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a whole single country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a whole country selected but the it belongs to other zone', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there is a whole country selected but the it belongs to other zone and does not allow states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					}
+				},
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.true;
+		} );
+
+		it( 'should return false when there is a single country selected, filtered by states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: {
+							add: [ 'NY' ],
+							remove: [],
+							removeAll: true,
+						},
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a single country with postcode selected, but the postcode filter was removed', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there is a single country with postcode selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when there is a single country with postcode selected, and the postcode was edited', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: null,
+						postcode: '12345',
+						pristine: false,
+					}
+				},
+			} );
+
+			expect( areLocationsFilteredByPostcode( state ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'areLocationsFilteredByState', () => {
+		it( 'should return false when there are continents selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there are multiple countries selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US', 'CA' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is no country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a whole single country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there is a whole single country selected but it belongs to another zone', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.true;
+		} );
+
+		it( 'should return false when there is a single country selected, filtered by postcode', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: null,
+						postcode: '12345',
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a single country with states selected, but the states filter was removed', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:NY', 'US:CA' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there is a single country with states selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:NY', 'US:CA' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: {
+							add: [],
+							remove: [],
+							removeAll: false,
+						},
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when there is a single country with states selected, and the states filter was edited', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: {
+							add: [ 'CA', 'NY' ],
+							remove: [],
+							removeAll: true,
+						},
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsFilteredByState( state ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'areLocationsUnfiltered', () => {
+		it( 'should return false when there are continents selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsUnfiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there are multiple countries selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US', 'CA' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialStateWithEmptyTempEdits,
+			} );
+
+			expect( areLocationsUnfiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is no country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsUnfiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there is a whole single country selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsUnfiltered( state ) ).to.be.true;
+		} );
+
+		it( 'should return false when there is a whole single country selected but it belongs to another zone', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'UK' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'UK' },
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsUnfiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a single country selected, filtered by postcode', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: null,
+						postcode: '12345',
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsUnfiltered( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when there is a single country with states selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:NY', 'US:CA' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					...initialState,
+					temporaryChanges: {
+						journal: [],
+						states: {
+							add: [],
+							remove: [],
+							removeAll: false,
+						},
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areLocationsUnfiltered( state ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingShippingZoneLocationsList', () => {
+		it( 'should return an empty list if the locations are not available', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: LOADING,
+				},
+				locationEdits: {},
+			} );
+
+			expect( getCurrentlyEditingShippingZoneLocationsList( state ) ).to.deep.equal( [] );
+		} );
+
+		it( 'should return a list of continents if the locations are only continents, sorted by name', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA', 'EU' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialState,
+			} );
+
+			expect( getCurrentlyEditingShippingZoneLocationsList( state ) ).to.deep.equal( [
+				{
+					type: 'continent',
+					code: 'EU',
+					name: 'Europe',
+				},
+				{
+					type: 'continent',
+					code: 'NA',
+					name: 'North America',
+				},
+			] );
+		} );
+
+		it( 'should return a list of countries if the locations are only countries, sorted by name', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'FR', 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: initialState,
+			} );
+
+			expect( getCurrentlyEditingShippingZoneLocationsList( state ) ).to.deep.equal( [
+				{
+					type: 'country',
+					code: 'FR',
+					name: 'France',
+					postcodeFilter: undefined,
+				},
+				{
+					type: 'country',
+					code: 'US',
+					name: 'United States',
+					postcodeFilter: undefined,
+				},
+			] );
+		} );
+
+		it( 'should return a list of states if the locations are only states, sorted by name', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [],
+						state: [ 'US:CA', 'US:NY' ],
+						postcode: [],
+					},
+				},
+				locationEdits: initialState,
+			} );
+
+			expect( getCurrentlyEditingShippingZoneLocationsList( state ) ).to.deep.equal( [
+				{
+					type: 'state',
+					code: 'CA',
+					name: 'California',
+					countryCode: 'US',
+					countryName: 'United States',
+				},
+				{
+					type: 'state',
+					code: 'NY',
+					name: 'New York',
+					countryCode: 'US',
+					countryName: 'United States',
+				},
+			] );
+		} );
+
+		it( 'should return the country info and the postcode filter info if the locations are a country plus a postcode', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [ '12345' ],
+					},
+				},
+				locationEdits: initialState,
+			} );
+
+			expect( getCurrentlyEditingShippingZoneLocationsList( state ) ).to.deep.equal( [
+				{
+					type: 'country',
+					code: 'US',
+					name: 'United States',
+					postcodeFilter: '12345',
+				},
+			] );
+		} );
+
+		it( 'should apply the commited edits, but not the temporal edits', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'FR' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'US' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( getCurrentlyEditingShippingZoneLocationsList( state ) ).to.deep.equal( [
+				{
+					type: 'country',
+					code: 'FR',
+					name: 'France',
+					postcodeFilter: undefined,
+				},
+				{
+					type: 'country',
+					code: 'UK',
+					name: 'United Kingdom',
+					postcodeFilter: undefined,
+				},
+			] );
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingShippingZoneCountries', () => {
+		it( 'should return all the continents and countries, sorted hierarchically and by name', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'EU' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [ 'FR', 'US' ],
+						state: [],
+						postcode: [],
+					},
+					8: {
+						continent: [ 'NA' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: null,
+					pristine: true,
+				},
+			} );
+
+			expect( getCurrentlyEditingShippingZoneCountries( state ) ).to.deep.equal( [
+				{
+					code: 'EU',
+					name: 'Europe',
+					type: 'continent',
+					selected: true,
+					disabled: false,
+					ownerZoneId: undefined,
+				},
+				{
+					code: 'FR',
+					name: 'France',
+					type: 'country',
+					selected: true,
+					disabled: true,
+					ownerZoneId: 7,
+				},
+				{
+					code: 'ES',
+					name: 'Spain',
+					type: 'country',
+					selected: true,
+					disabled: false,
+					ownerZoneId: undefined,
+				},
+				{
+					code: 'UK',
+					name: 'United Kingdom',
+					type: 'country',
+					selected: true,
+					disabled: false,
+					ownerZoneId: undefined,
+				},
+				{
+					code: 'NA',
+					name: 'North America',
+					type: 'continent',
+					selected: false,
+					disabled: true,
+					ownerZoneId: 8,
+				},
+				{
+					code: 'CA',
+					name: 'Canada',
+					type: 'country',
+					selected: false,
+					disabled: false,
+					ownerZoneId: undefined,
+				},
+				{
+					code: 'US',
+					name: 'United States',
+					type: 'country',
+					selected: false,
+					disabled: true,
+					ownerZoneId: 7,
+				},
+			] );
+		} );
+	} );
+
+	describe( 'getCurrentlyEditingShippingZoneStates', () => {
+		it( 'should return an empty list when the locations are not filtered by state', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: '12345',
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( getCurrentlyEditingShippingZoneStates( state ) ).to.deep.equal( [] );
+		} );
+
+		it( 'should return all the country states, sorted by name', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+					7: {
+						continent: [],
+						country: [],
+						state: [ 'US:UT' ],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [ 'NY', 'CA' ],
+						remove: [],
+						removeAll: true,
+					},
+					postcode: null,
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( getCurrentlyEditingShippingZoneStates( state ) ).to.deep.equal( [
+				{
+					code: 'AL',
+					name: 'Alabama',
+					selected: false,
+					disabled: false,
+					ownerZoneId: undefined,
+				},
+				{
+					code: 'CA',
+					name: 'California',
+					selected: true,
+					disabled: false,
+					ownerZoneId: undefined,
+				},
+				{
+					code: 'NY',
+					name: 'New York',
+					selected: true,
+					disabled: false,
+					ownerZoneId: undefined,
+				},
+				{
+					code: 'UT',
+					name: 'Utah',
+					selected: false,
+					disabled: true,
+					ownerZoneId: 7,
+				},
+			] );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds UI selectors for editing locations on a shipping zone.

The PR looks big but like 80% of it are tests.

The UI is not yet wired, so just check that tests pass.