### PR TITLE
Added a selector to check if the zone currently being edited has a valid set of locations.

### DIFF
--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
@@ -9,7 +9,7 @@ import { get, isEmpty, isObject } from 'lodash';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
-const getRawShippingZoneLocations = ( state, siteId = getSelectedSiteId( state ) ) => {
+export const getRawShippingZoneLocations = ( state, siteId = getSelectedSiteId( state ) ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'shippingZoneLocations' ] );
 };
 
@@ -112,8 +112,8 @@ export const areShippingZonesLocationsValid = ( reduxState, siteId = getSelected
 				}
 				statesSet.add( s );
 			}
-		} else {
-			// A zone must have *any* location. If it doesn't, it's incorrect.
+		} else if ( ! isEmpty( postcode ) ) {
+			// A postcode without a country is not valid
 			return false;
 		}
 	}

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
@@ -149,7 +149,7 @@ describe( 'selectors', () => {
 			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
 		} );
 
-		it( 'should return false for a zone without locations.', () => {
+		it( 'should return true for a zone without locations.', () => {
 			const state = createState( {
 				site: {
 					shippingZoneLocations: {
@@ -163,7 +163,7 @@ describe( 'selectors', () => {
 				},
 				ui: {},
 			} );
-			expect( areShippingZonesLocationsValid( state ) ).to.be.false;
+			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
 		} );
 
 		it( 'should return true for a zone with a single continent.', () => {

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forIn, isEmpty, sortBy } from 'lodash';
+import { every, forIn, isEmpty, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -460,4 +460,27 @@ export const getCurrentlyEditingShippingZoneStates = ( state, siteId = getSelect
 		disabled: Boolean( forbiddenStates[ code ] ),
 		ownerZoneId: forbiddenStates[ code ],
 	} ) );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Boolean} Whether the locations for the shipping zone currently being edited are valid. This includes
+ * temporary edits, as it's designed to be used for enabling / disabling the "Save Changes" button.
+ */
+export const areCurrentlyEditingShippingZoneLocationsValid = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const locations = getShippingZoneLocationsWithEdits( state, siteId );
+	if ( ! locations ) {
+		return false;
+	}
+	if ( every( locations, isEmpty ) ) {
+		return false;
+	}
+	if ( areLocationsFilteredByPostcode( state, siteId ) && ! locations.postcode[ 0 ] ) {
+		return false;
+	}
+	if ( areLocationsFilteredByState( state, siteId ) && isEmpty( locations.state ) ) {
+		return false;
+	}
+	return true;
 };

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/test/selectors.js
@@ -18,6 +18,7 @@ import {
 	getCurrentlyEditingShippingZoneLocationsList,
 	getCurrentlyEditingShippingZoneCountries,
 	getCurrentlyEditingShippingZoneStates,
+	areCurrentlyEditingShippingZoneLocationsValid,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 import { createState } from 'woocommerce/state/test/helpers';
@@ -2295,6 +2296,203 @@ describe( 'selectors', () => {
 					ownerZoneId: 7,
 				},
 			] );
+		} );
+	} );
+
+	describe( 'areCurrentlyEditingShippingZoneLocationsValid', () => {
+		it( 'should return false when the locations are empty', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when the locations are filtered by postcode but it is empty', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: '',
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return false when the locations are filtered by state but there are no states selected', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [],
+						remove: [],
+						removeAll: false,
+					},
+					postcode: null,
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when the locations are several countries', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US', 'UK' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: null,
+					pristine: true,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when the locations are several continents', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [ 'NA', 'EU' ],
+						country: [],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: null,
+					pristine: true,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when the locations are a country with a postcode', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: null,
+					postcode: '12345',
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should return true when the locations are a country with states', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [],
+					states: {
+						add: [ 'CA', 'NY' ],
+						remove: [],
+						removeAll: false,
+					},
+					postcode: null,
+					pristine: false,
+					temporaryChanges: initialState,
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
+		} );
+
+		it( 'should overlay the temporary changes', () => {
+			const state = createEditState( {
+				zoneLocations: {
+					1: {
+						continent: [],
+						country: [ 'US' ],
+						state: [],
+						postcode: [],
+					},
+				},
+				locationEdits: {
+					journal: [
+						{ action: JOURNAL_ACTIONS.REMOVE_COUNTRY, code: 'US' },
+					],
+					states: null,
+					postcode: null,
+					pristine: false,
+					temporaryChanges: {
+						journal: [
+							{ action: JOURNAL_ACTIONS.ADD_COUNTRY, code: 'UK' },
+						],
+						states: null,
+						postcode: null,
+						pristine: false,
+					},
+				},
+			} );
+
+			expect( areCurrentlyEditingShippingZoneLocationsValid( state ) ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a UI selector to check if the current zone locations are valid. This will be used to enable / disable the "Close" button on the "Edit Locations" modal, and the "Save" button on the "Edit Zone" page.

The UI is not yet wired, so just check that tests pass.