### PR TITLE
Activity log: Banner dismissal

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes, PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -9,11 +10,16 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityLogBanner from './index';
 import Button from 'components/button';
+import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
 
 class ErrorBanner extends PureComponent {
 	static propTypes = {
 		requestRestore: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
 		timestamp: PropTypes.number.isRequired,
+
+		// connect
+		dismissRewindRestoreProgress: PropTypes.func.isRequired,
 
 		// localize
 		translate: PropTypes.func.isRequired,
@@ -21,13 +27,15 @@ class ErrorBanner extends PureComponent {
 
 	handleClickRestore = () => this.props.requestRestore( this.props.timestamp );
 
+	handleDismiss = () => this.props.dismissRewindRestoreProgress( this.props.siteId );
+
 	render() {
 		const { translate } = this.props;
 
 		return (
 			<ActivityLogBanner
 				isDismissable
-				onDismissClick={ /* FIXME */ function() {} }
+				onDismissClick={ this.handleDismiss }
 				status="error"
 				title={ translate( 'Problem restoring your site' ) }
 			>
@@ -44,4 +52,6 @@ class ErrorBanner extends PureComponent {
 	}
 }
 
-export default localize( ErrorBanner );
+export default connect( null, {
+	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
+} )( localize( ErrorBanner ) );

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes, PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -9,35 +10,53 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityLogBanner from './index';
 import Button from 'components/button';
+import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
 
-function SuccessBanner( {
-	moment,
-	timestamp,
-	translate,
-} ) {
-	// FIXME: real dismiss
-	const handleDismiss = () => {};
+class SuccessBanner extends PureComponent {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		timestamp: PropTypes.number.isRequired,
 
-	return (
-		<ActivityLogBanner
-			isDismissable
-			onDismissClick={ handleDismiss }
-			status="success"
-			title={ translate( 'Your site has been successfully restored' ) }
-		>
-			<p>{ translate(
-				'We successfully restored your site back to %s!',
-				{ args: moment( timestamp ).format( 'LLLL' ) }
-			) }</p>
-			<Button primary>
-				{ translate( 'View site' ) }
-			</Button>
-			{ '  ' }
-			<Button onClick={ handleDismiss }>
-				{ translate( 'Thanks, got it!' ) }
-			</Button>
-		</ActivityLogBanner>
-	);
+		// connect
+		dismissRewindRestoreProgress: PropTypes.func.isRequired,
+
+		// localize
+		moment: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	handleDismiss = () => this.props.dismissRewindRestoreProgress( this.props.siteId );
+
+	render() {
+		const {
+			moment,
+			timestamp,
+			translate,
+		} = this.props;
+
+		return (
+			<ActivityLogBanner
+				isDismissable
+				onDismissClick={ this.handleDismiss }
+				status="success"
+				title={ translate( 'Your site has been successfully restored' ) }
+			>
+				<p>{ translate(
+					'We successfully restored your site back to %s!',
+					{ args: moment( timestamp ).format( 'LLLL' ) }
+				) }</p>
+				<Button primary>
+					{ /* FIXME: Link to site */ translate( 'View site' ) }
+				</Button>
+				{ '  ' }
+				<Button onClick={ this.handleDismiss }>
+					{ translate( 'Thanks, got it!' ) }
+				</Button>
+			</ActivityLogBanner>
+		);
+	}
 }
 
-export default localize( SuccessBanner );
+export default connect( null, {
+	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
+} )( localize( SuccessBanner ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -138,7 +138,10 @@ class ActivityLog extends Component {
 	}
 
 	renderBanner() {
-		const { restoreProgress } = this.props;
+		const {
+			restoreProgress,
+			siteId,
+		} = this.props;
 
 		if ( ! restoreProgress ) {
 			return null;
@@ -160,11 +163,13 @@ class ActivityLog extends Component {
 						errorCode={ errorCode }
 						failureReason={ failureReason }
 						requestRestore={ this.handleRequestRestore }
+						siteId={ siteId }
 						siteTitle={ siteTitle }
 						timestamp={ timestamp }
 					/>
 				) : (
 					<SuccessBanner
+						siteId={ siteId }
 						timestamp={ timestamp }
 					/>
 				)


### PR DESCRIPTION
Add dismissal to success and error banners

To test:
1. Visit http://calypso.localhost:3000/stats/activity
1. Do a restore
1. You should see a progress banner.
1. When complete, try dismissing the banner from the button or the `X` in the corner.
1. Ensure you try both success and error banners. Dispatch the following to test:
1. Test different banners: (`const SITE_ID = ...` first to copy/paste 😀 )
   * error
     ```js
     dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: SITE_ID, timestamp: 1498168800000, restoreId: 123, errorCode: "restore-broke", failureReason: "Something went wrong", message: "A message", percent: 100, status: "finished" })
     ```
   * success
     ```js
     dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: SITE_ID, timestamp: 1498168800000, restoreId: 123, errorCode: "", failureReason: "", message: "", percent: 100, status: "finished" })
     ```
1. Ensure there are no errors/warnings in the console.

Work on #15260