### PR TITLE
.ca form: Clarify the question about canadian presence

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -156,7 +156,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 				</p>
 				<FormFieldset>
 					<FormLabel htmlFor="legal-type">
-						{ translate( 'Choose the option that best describes you:' ) }
+						{ translate( 'Choose the option that best describes your Canadian presence:' ) }
 					</FormLabel>
 					<FormSelect
 						id="legal-type"


### PR DESCRIPTION
The current phrase doesn't clearly convey that registrants need to have a Canadian presence.