### PR TITLE
Activate .ca domains 

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -73,8 +73,8 @@ class DomainRegistrationSuggestion extends React.Component {
 		let buttonClasses, buttonContent;
 
 		if ( domain ) {
-			const newTLDs = [ '.rocks', '.site', '.cloud', '.club', '.today', '.tube' ];
-			const testTLDs = [ '.ca', '.de', '.fr' ];
+			const newTLDs = [ '.rocks', '.site', '.cloud', '.club', '.today', '.tube', '.ca' ];
+			const testTLDs = [ '.de', '.fr' ];
 			// Grab everything after the first dot, so 'example.co.uk' will
 			// match '.co.uk' but not '.uk'
 			// This won't work if we add subdomains.

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -19,6 +19,8 @@
 		"community-translator": true,
 		"desktop": true,
 		"desktop-promo": false,
+		"domains/cctlds": true,
+		"domains/cctlds/ca": true,
 		"fluid-width": true,
 		"help": true,
 		"help/courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -20,6 +20,8 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,
+		"domains/cctlds": true,
+		"domains/cctlds/ca": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -19,6 +19,8 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,
+		"domains/cctlds": true,
+		"domains/cctlds/ca": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,6 +21,8 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,
+		"domains/cctlds": true,
+		"domains/cctlds/ca": true,
 		"external-media": true,
 		"happychat": true,
 		"help": true,


### PR DESCRIPTION
This will activate domains for public consumption.
Requires D6156-code 

Testing: .ca domains should show up in the search results for non Automattic accounts, and have a "new" label next to them.
