### PR TITLE
Store Stats in Calypso: support period request formats and responses for weeks, months & years

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -41,20 +41,24 @@ export const UNITS = {
 		quantity: 30,
 		label: 'days',
 		durationFn: 'asDays',
+		format: 'YYYY-MM-DD',
 	},
 	week: {
 		quantity: 30,
 		label: 'weeks',
 		durationFn: 'asWeeks',
+		format: 'YYYY',
 	},
 	month: {
 		quantity: 30,
 		label: 'months',
 		durationFn: 'asMonths',
+		format: 'YYYY-MM'
 	},
 	year: {
 		quantity: 10,
 		label: 'years',
 		durationFn: 'asYears',
+		format: 'YYYY',
 	},
 };

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -55,7 +55,12 @@ class StoreStats extends Component {
 				>
 					<DatePicker
 						period={ unit }
-						date={ selectedDate }
+						// this is needed to counter the +1d adjustment made in DatePicker for weeks
+						date={
+							( unit === 'week' )
+								? moment( selectedDate, 'YYYY-MM-DD' ).subtract( 1, 'days' ).format( 'YYYY-MM-DD' )
+								: selectedDate
+						}
 						query={ ordersQuery }
 						statsType="statsOrders"
 						showQueryDate

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -26,6 +27,12 @@ class StoreStats extends Component {
 
 	render() {
 		const { path, queryDate, selectedDate, siteId, slug, unit } = this.props;
+		const unitQueryDate = ( unit === 'week' )
+			? `${ moment( queryDate ).format( UNITS[ unit ].format ) }-W${ moment( queryDate ).isoWeek() }`
+			: moment( queryDate ).format( UNITS[ unit ].format );
+		const unitSelectedDate = ( unit === 'week' )
+			? moment( selectedDate ).endOf( 'isoWeek' ).format( 'YYYY-MM-DD' )
+			: moment( selectedDate ).endOf( unit ).format( 'YYYY-MM-DD' );
 		const ordersQuery = {
 			unit,
 			date: queryDate,
@@ -36,8 +43,8 @@ class StoreStats extends Component {
 				<Navigation unit={ unit } type="orders" slug={ slug } />
 				<Chart
 					path={ path }
-					query={ ordersQuery }
-					selectedDate={ selectedDate }
+					query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
+					selectedDate={ unitSelectedDate }
 					siteId={ siteId }
 					unit={ unit }
 				/>
@@ -60,10 +67,8 @@ class StoreStats extends Component {
 }
 
 export default connect(
-	state => {
-		return {
-			slug: getSelectedSiteSlug( state ),
-			siteId: getSelectedSiteId( state ),
-		};
-	}
+	state => ( {
+		slug: getSelectedSiteSlug( state ),
+		siteId: getSelectedSiteId( state ),
+	} )
 )( StoreStats );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -128,10 +128,8 @@ class StoreStatsChart extends Component {
 }
 
 export default connect(
-	( state, { query, siteId } ) => {
-		return {
-			data: getSiteStatsNormalizedData( state, siteId, 'statsOrders', query ),
-			isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsOrders', query ),
-		};
-	}
+	( state, { query, siteId } ) => ( {
+		data: getSiteStatsNormalizedData( state, siteId, 'statsOrders', query ),
+		isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsOrders', query ),
+	} )
 )( StoreStatsChart );


### PR DESCRIPTION
- week: given date 27th June 2017, request date = `2017-W26`, week start = `2017-06-26` (Monday), week end = `2017-07-02` (Sunday)
- month: given date 27th June 2017, request date = `2017-06`, month start = `2017-06-01`, month end = `2017-06-30`
- year: given date 27th June 2017, request date = `2017`, year start = `2017-01-01`, year end = `2017-12-31`
- day = `2017-06-27` as before

cc @westi @psealock 

Fixes #15104 