### PR TITLE
Reader Recommendations: break long words in WebKit browsers

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -727,6 +727,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		-webkit-box-orient: vertical;
 		-webkit-line-clamp: initial;
 		word-wrap: break-word;
+		word-break: break-word; // Wrap long words in WebKit
 	}
 }
 


### PR DESCRIPTION
As reported by @sirino, long words (namely URLs) were not breaking lines in Chrome and Safari, leading to this spectacular layout:

<img width="876" alt="screen shot 2017-06-27 at 11 23 29" src="https://user-images.githubusercontent.com/17325/27595668-56be62d2-5b2b-11e7-9cb5-e762e530dcbf.png">

I've added the WebKit-only `word-break: break-word` to fix it:

https://css-tricks.com/almanac/properties/w/word-break/

After it looks like this:

<img width="772" alt="screen shot 2017-06-27 at 11 23 37" src="https://user-images.githubusercontent.com/17325/27595709-721fad60-5b2b-11e7-95dd-ef311ed25a7d.png">

Other browsers were not affected by the bug (verified in IE11 and Firefox).

### To test

Compare before:

https://wpcalypso.wordpress.com/read/feeds/40474296/posts/1390283223

and after:

http://calypso.localhost:3000/read/feeds/40474296/posts/1390283223