### PR TITLE
Components: Guard against null children in ButtonGroup

### DIFF
--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -10,7 +10,7 @@ class ButtonGroup extends PureComponent {
 		children( props ) {
 			let error = null;
 			React.Children.forEach( props.children, ( child ) => {
-				if ( ! child.props || child.props.type !== 'button' ) {
+				if ( child && ( ! child.props || child.props.type !== 'button' ) ) {
 					error = new Error( 'All children elements should be a Button.' );
 				}
 			} );


### PR DESCRIPTION
Add an additional check to allow for `null` children in `ButtonGroup`.

This prevent a console warning showing up in `CommentNavigation` that makes heavy use of conditionally rendering buttons inside `ButtonGroup` (see: https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/comments/comment-navigation/index.jsx#L94-L145).