### PR TITLE
Reader: turn off autocorrect for search inputs on Manage Following

### DIFF
--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -11,7 +11,6 @@ import Card from 'components/card';
 import Search from 'components/search';
 
 class SearchCard extends React.Component {
-
 	static propTypes = {
 		additionalClasses: React.PropTypes.string,
 		initialValue: React.PropTypes.string,
@@ -25,7 +24,8 @@ class SearchCard extends React.Component {
 		dir: React.PropTypes.string,
 		maxLength: React.PropTypes.number,
 		hideOpenIcon: React.PropTypes.bool,
-	}
+		disableAutocorrect: React.PropTypes.bool,
+	};
 
 	render() {
 		const cardClasses = classnames( 'search-card', this.props.className );
@@ -39,11 +39,11 @@ class SearchCard extends React.Component {
 
 	focus = () => {
 		this.refs.search.focus();
-	}
+	};
 
 	clear = () => {
 		this.refs.search.clear();
-	}
+	};
 }
 
 export default SearchCard;

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -220,6 +220,7 @@ class FollowingManage extends Component {
 							initialValue={ sitesQuery }
 							value={ sitesQuery }
 							maxLength={ 500 }
+							disableAutocorrect={ true }
 						/>
 					</CompactCard>
 

--- a/client/reader/following-manage/search-followed.jsx
+++ b/client/reader/following-manage/search-followed.jsx
@@ -34,6 +34,7 @@ class FollowingManageSearchFollowed extends Component {
 				delaySearch={ true }
 				delayTimeout={ 100 }
 				hideOpenIcon={ true }
+				disableAutocorrect={ true }
 			/>
 		);
 	}


### PR DESCRIPTION
Having browser autocorrect enabled on search inputs that accept URLs can have interesting results. For example, typing "futonbleu." will get corrected to "futon bleu" in ~Firefox~ Safari.

<img width="260" alt="screen shot 2017-06-27 at 12 44 13" src="https://user-images.githubusercontent.com/17325/27599560-24c0013a-5b37-11e7-96aa-b909815eb598.png">

For this reason we had autocorrection turned off in the previous Manage Following. This PR applies the same settings to the new version.

### To test

Visit http://calypso.localhost:3000/following/manage and check that autocorrect is not enabled on either search input.