### PR TITLE
Comments: Enable Comment Management in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 		"apple-pay": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
+		"comments/management": true,
 		"community-translator": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
Enable the Comment Management section in `wpcalypso` in order to allow for user testing.