### PR TITLE
Reader: Follow by URL/Drake overlap

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -53,6 +53,7 @@ $z-layers: (
 		'.reader-feed-header': 0,
 		'.reader-feed-header__back-and-follow': 0,
 		'.reader-related-card-v2.card': 0,
+		'.following-manage__url-follow': 1,
 		'.list-stream__header-follow': 0,
 		'.following__intro-close-icon-bg' : 0,
 		'.following__intro-close-icon': 1,

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -249,10 +249,12 @@
 
 .following-manage__url-follow {
 	border-bottom: 1px solid lighten( $gray, 30% );
-	padding: 13px 0 10px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	padding: 13px 0 10px;
+	position: relative;
+	z-index: z-index( 'root', '.following-manage__url-follow' );
 
 	.follow-button {
 		.gridicon {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15563

Before:
<img width="983" alt="screen shot 2017-06-27 at 11 55 16" src="https://user-images.githubusercontent.com/17325/27597204-b3e37b88-5b2f-11e7-9660-a45232829f2f.png">

After:
<img width="773" alt="screenshot 2017-06-27 12 15 47" src="https://user-images.githubusercontent.com/4924246/27605849-c19da462-5b32-11e7-8ff8-7c799faa8ace.png">
