### PR TITLE
Reader X-Posts: handle the case where siteURL is null

### DIFF
--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -77,7 +77,7 @@ class CrossPost extends PureComponent {
 	};
 
 	getSiteNameFromURL = siteURL => {
-		return `+${ url.parse( siteURL ).hostname.split( '.' )[ 0 ] }`;
+		return siteURL && `+${ url.parse( siteURL ).hostname.split( '.' )[ 0 ] }`;
 	};
 
 	getDescription = authorFirstName => {


### PR DESCRIPTION
As reported by @richardmtl. One errant feed in his Following stream had a null `siteURL`, which caused `url.parse` to fail. 

This PR adds a check to see if siteURL exists before attempting to parse it.

### To test

Check that the Following stream loads correctly at http://calypso.localhost:3000/. OPML file with original feeds available on request.
