### PR TITLE
Editor: add postPublishPreview AB test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,6 +94,7 @@ module.exports = {
 	},
 	postPublishPreview: {
 		datestamp: '20170627',
+		allowExistingUsers: true,
 		variations: {
 			showPostPublishPreview: 50,
 			noShowPostPublishPreview: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,6 +98,6 @@ module.exports = {
 			showPostPublishPreview: 50,
 			noShowPostPublishPreview: 50,
 		},
-		defaultVariation: 'showPostPublishPreview',
+		defaultVariation: 'noShowPostPublishPreview',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,4 +92,12 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
+	postPublishPreview: {
+		datestamp: '20170627',
+		variations: {
+			showPostPublishPreview: 50,
+			noShowPostPublishPreview: 50,
+		},
+		defaultVariation: 'showPostPublishPreview',
+	},
 };

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { abtest } from 'lib/abtest';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
@@ -134,7 +134,7 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'publishedPrivately':
-				if ( config.isEnabled( 'post-editor/delta-post-publish-preview' ) ) {
+				if ( abtest( 'postPublishPreview' ) === 'showPostPublishPreview' ) {
 					return translate( '{{strong}}Published privately.{{/strong}} Only admins and editors can view.', {
 						components: {
 							strong: <strong />,
@@ -238,7 +238,7 @@ export class EditorNotice extends Component {
 		const { siteId, message, status, onDismissClick } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
 		const classes = classNames( 'editor-notice', {
-			'is-global': config.isEnabled( 'post-editor/delta-post-publish-preview' ),
+			'is-global': abtest( 'postPublishPreview' ) === 'showPostPublishPreview',
 		} );
 
 		return (

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -38,6 +38,12 @@ export class EditorNotice extends Component {
 		error: PropTypes.object
 	}
 
+	constructor( props ) {
+		super( props );
+
+		this.isPostPublishPreviewABTest = abtest( 'postPublishPreview' ) === 'showPostPublishPreview';
+	}
+
 	componentWillReceiveProps( nextProps ) {
 		if ( isMobile() &&
 			( ( ! this.props.message && nextProps.message ) || ( ! this.props.error && nextProps.error ) ) ) {
@@ -134,7 +140,7 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'publishedPrivately':
-				if ( abtest( 'postPublishPreview' ) === 'showPostPublishPreview' ) {
+				if ( this.isPostPublishPreviewABTest ) {
 					return translate( '{{strong}}Published privately.{{/strong}} Only admins and editors can view.', {
 						components: {
 							strong: <strong />,
@@ -238,7 +244,7 @@ export class EditorNotice extends Component {
 		const { siteId, message, status, onDismissClick } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
 		const classes = classNames( 'editor-notice', {
-			'is-global': abtest( 'postPublishPreview' ) === 'showPostPublishPreview',
+			'is-global': this.isPostPublishPreviewABTest,
 		} );
 
 		return (

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -9,7 +9,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
@@ -34,14 +33,9 @@ export class EditorNotice extends Component {
 		link: PropTypes.string,
 		onViewClick: PropTypes.func,
 		isPreviewable: PropTypes.bool,
+		isFullScreenPreview: PropTypes.bool,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object
-	}
-
-	constructor( props ) {
-		super( props );
-
-		this.isPostPublishPreviewABTest = abtest( 'postPublishPreview' ) === 'showPostPublishPreview';
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -140,7 +134,7 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'publishedPrivately':
-				if ( this.isPostPublishPreviewABTest ) {
+				if ( this.props.isFullScreenPreview ) {
 					return translate( '{{strong}}Published privately.{{/strong}} Only admins and editors can view.', {
 						components: {
 							strong: <strong />,
@@ -244,7 +238,7 @@ export class EditorNotice extends Component {
 		const { siteId, message, status, onDismissClick } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
 		const classes = classNames( 'editor-notice', {
-			'is-global': this.isPostPublishPreviewABTest,
+			'is-global': this.props.isFullScreenPreview,
 		} );
 
 		return (

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -33,6 +33,7 @@ const actions = require( 'lib/posts/actions' ),
 	analytics = require( 'lib/analytics' );
 
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
 import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
@@ -279,7 +280,7 @@ export const PostEditor = React.createClass( {
 					/>
 					<div className="post-editor__content">
 						<div className="post-editor__content-editor">
-							{ ! config.isEnabled( 'post-editor/delta-post-publish-preview' )
+							{ ! abtest( 'postPublishPreview' ) === 'showPostPublishPreview'
 								? <EditorNotice
 									{ ...this.state.notice }
 									onDismissClick={ this.hideNotice }
@@ -382,7 +383,7 @@ export const PostEditor = React.createClass( {
 							revision={ get( this.state, 'post.revisions.length', 0 ) }
 						/>
 						: null }
-					{ config.isEnabled( 'post-editor/delta-post-publish-preview' )
+					{ abtest( 'postPublishPreview' ) === 'showPostPublishPreview'
 						? <EditorNotice
 								{ ...this.state.notice }
 								onDismissClick={ this.hideNotice }
@@ -876,13 +877,13 @@ export const PostEditor = React.createClass( {
 				status: 'is-success',
 				message,
 				action,
-				link: config.isEnabled( 'post-editor/delta-post-publish-preview' ) ? null : link,
+				link: abtest( 'postPublishPreview' ) === 'showPostPublishPreview' ? null : link,
 			};
 
 			window.scrollTo( 0, 0 );
 
 			if (
-				config.isEnabled( 'post-editor/delta-post-publish-preview' ) &&
+				abtest( 'postPublishPreview' ) === 'showPostPublishPreview' &&
 				this.props.isSitePreviewable &&
 				isNotPrivateOrIsConfirmed
 			) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -80,6 +80,8 @@ export const PostEditor = React.createClass( {
 
 	_previewWindow: null,
 
+	isPostPublishPreviewABTest: abtest( 'postPublishPreview' ) === 'showPostPublishPreview',
+
 	getInitialState() {
 		return {
 			...this.getPostEditState(),
@@ -280,7 +282,7 @@ export const PostEditor = React.createClass( {
 					/>
 					<div className="post-editor__content">
 						<div className="post-editor__content-editor">
-							{ ! abtest( 'postPublishPreview' ) === 'showPostPublishPreview'
+							{ ! this.isPostPublishPreviewABTest
 								? <EditorNotice
 									{ ...this.state.notice }
 									onDismissClick={ this.hideNotice }
@@ -383,7 +385,7 @@ export const PostEditor = React.createClass( {
 							revision={ get( this.state, 'post.revisions.length', 0 ) }
 						/>
 						: null }
-					{ abtest( 'postPublishPreview' ) === 'showPostPublishPreview'
+					{ this.isPostPublishPreviewABTest
 						? <EditorNotice
 								{ ...this.state.notice }
 								onDismissClick={ this.hideNotice }
@@ -877,13 +879,13 @@ export const PostEditor = React.createClass( {
 				status: 'is-success',
 				message,
 				action,
-				link: abtest( 'postPublishPreview' ) === 'showPostPublishPreview' ? null : link,
+				link: this.isPostPublishPreviewABTest ? null : link,
 			};
 
 			window.scrollTo( 0, 0 );
 
 			if (
-				abtest( 'postPublishPreview' ) === 'showPostPublishPreview' &&
+				this.isPostPublishPreviewABTest &&
 				this.props.isSitePreviewable &&
 				isNotPrivateOrIsConfirmed
 			) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -389,7 +389,8 @@ export const PostEditor = React.createClass( {
 						? <EditorNotice
 								{ ...this.state.notice }
 								onDismissClick={ this.hideNotice }
-								onViewClick={ this.onPreview } />
+								onViewClick={ this.onPreview }
+								isFullScreenPreview={ true } />
 						: null }
 				</div>
 				{ isTrashed

--- a/config/development.json
+++ b/config/development.json
@@ -112,7 +112,6 @@
 		"plans/personal-plan": true,
 		"plans/jetpack-config-v2": true,
 		"post-editor/delta-post-publish-flow": false,
-		"post-editor/delta-post-publish-preview": false,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
This PR adds the `postPublishPreview` AB test, removes the `post-editor/delta-post-publish-preview` development flag, and replaces the latter with the former.

**Mock:**
![27043122-2092f7ce-4f67-11e7-9b5e-081e5bb76557](https://user-images.githubusercontent.com/942359/27606400-17b0acf8-5b4e-11e7-9271-5abab4be9940.png)

Milestone: https://github.com/Automattic/wp-calypso/milestone/199
This is part of a larger epic (See p3Ex-2ri-p2).

**Test details:**
- Name: `postPublishPreview`
- Date: 2017-06-27
- Variations:
  - `showPostPublishPreview`: (50) A full-screen preview of the post should be shown onPublish, with a global-styled success notice.
  - `noShowPostPublishPreview`: (Default | 50) No preview is show onPublish. The success notice will be inside the editor with a "view post" action link.

**To test:**
- Check out branch.
- Create a new post.
- Once the editor is loaded, a variation for the `postPublishPreview` should be set (`localStorage.setItem('debug', 'calypso:abtests');`).
- Publish the new post.
  - `showPostPublishPreview`: A full-screen preview of the post should be shown onPublish, with a global-styled success notice.
  - `noShowPostPublishPreview`: No preview is show onPublish. The success notice will be inside the editor with a "view post" action link.
- Create a new post.
- Use the dev ABTest tool to set the other variation (or `localStorage.setItem('ABTests','{"postPublishPreview_20170627":"showPostPublishPreview"}')`). 
- Verify that it works correctly.