### PR TITLE
Session Restore: New section "root"

### DIFF
--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -29,18 +29,17 @@ function forceTeamA8C( context, next ) {
 
 export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
-		page( '/', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
-
-		// Old and incomplete paths that should be redirected to /
-		page( '/read/following', '/' );
-		page( '/read', '/' );
-		page( '/read/blogs', '/' );
-		page( '/read/feeds', '/' );
-		page( '/read/blog', '/' );
-		page( '/read/post', '/' );
-		page( '/read/feed', '/' );
+		// Old and incomplete paths that should be redirected to /read
+		page( '/read/following', '/read' );
+		page( '/read/blogs', '/read' );
+		page( '/read/feeds', '/read' );
+		page( '/read/blog', '/read' );
+		page( '/read/post', '/read' );
+		page( '/read/feed', '/read' );
 
 		// Feed stream
+		page( '/read', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
+
 		page( '/read/*', preloadReaderBundle, initAbTests );
 		page( '/read/blog/feed/:feed_id', legacyRedirects );
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );

--- a/client/root/controller.js
+++ b/client/root/controller.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import { get } from 'lodash';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { getSavedPath } from 'lib/restore-last-path';
+
+const debug = debugFactory( 'calypso:restore-last-location' );
+
+function sessionRestore( context, next ) {
+	const querystring = get( context, 'querystring', '' );
+	if ( querystring.length ) {
+		debug( 'cannot restore: has query string' );
+		return next();
+	}
+
+	// Attempt to restore the last path on the first run
+	getSavedPath()
+		.then( ( lastPath ) => {
+			debug( 'restoring: ' + lastPath );
+			page( lastPath );
+		} )
+		.catch( ( reason ) => {
+			debug( 'cannot restore', reason );
+			next();
+		} );
+}
+
+function readerFallback() {
+	page.redirect( '/read' );
+}
+
+export default {
+	readerFallback,
+	sessionRestore,
+};

--- a/client/root/index.js
+++ b/client/root/index.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import {
+	readerFallback,
+	sessionRestore,
+} from './controller';
+
+export default function() {
+	page( '/', sessionRestore, readerFallback );
+}

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -30,17 +30,8 @@ export const routingMiddleware = () => {
 		const isFirstRun = ! hasInitialized;
 		hasInitialized = true;
 
-		if ( isFirstRun && action.path === '/' ) {
-			// Attempt to restore the last path on the first run
-			return getSavedPath()
-					.then( ( lastPath ) => {
-						debug( 'restoring: ' + lastPath );
-						page( lastPath );
-					} )
-					.catch( ( reason ) => {
-						debug( 'cannot restore', reason );
-						next( action );
-					} );
+		if ( isFirstRun || action.path === '/' ) {
+			return next( action );
 		}
 
 		// Attempt to save the path so it might be restored in the future

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -3,6 +3,12 @@
  */
 const sections = [
 	{
+		name: 'root',
+		paths: [ '/' ],
+		module: 'root',
+		secondary: false,
+	},
+	{
 		name: 'sites',
 		paths: [ '/sites' ],
 		module: 'my-sites',
@@ -240,7 +246,7 @@ sections.push( {
 // this MUST be the first section for /read paths so subsequent sections under /read can override settings
 sections.push( {
 	name: 'reader',
-	paths: [ '/', '/read' ],
+	paths: [ '/read' ],
 	module: 'reader',
 	secondary: true,
 	group: 'reader',


### PR DESCRIPTION
**IN PROGRESS**

This aims to make session restores when browsing to the "root" (`/`) of Calypso WordPress.com (#11755) feasible to use in production.

Namely, this creates a new route handler for `/` & separates the Reader routes out to `/read` to avoid preloading the reader section code unless it will actually be used.

A side-effect is that `/` will not actually resolve to "Reader" content unless:
* we're restoring the user's last session to the Reader
* there is no last path to restore (this falls back to `/read`)

Previously:
* #14070
* #15051

