### PR TITLE
WooCommerce: Add the ability to edit the store address on setting screens via modal

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -17,7 +17,6 @@ import {
 import { errorNotice } from 'state/notices/actions';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import { getSiteTitle } from 'state/sites/selectors';
 import { setSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/actions';
 import SetupFooter from './setup-footer';
 import SetupHeader from './setup-header';
@@ -133,15 +132,7 @@ class PreSetupView extends Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
-	let name = '';
-	if ( site ) {
-		name = getSiteTitle( state, site.ID );
-	}
-	const storeLocation = getStoreLocation( state );
-	const address = {
-		name,
-		...storeLocation,
-	};
+	const address = getStoreLocation( state );
 	const loading = areSettingsGeneralLoading( state );
 
 	return {

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -10,13 +10,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AddressView from 'woocommerce/components/address-view';
 import Card from 'components/card';
 import { decodeEntities } from 'lib/formatting';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
+import StoreAddress from 'woocommerce/components/store-address';
 import { changeCurrency } from 'woocommerce/state/ui/payments/currency/actions';
 import { fetchCurrencies } from 'woocommerce/state/sites/currencies/actions';
 import { fetchSettingsGeneral, saveCurrency } from 'woocommerce/state/sites/settings/general/actions';
@@ -55,20 +55,6 @@ class SettingsPaymentsLocationCurrency extends Component {
 			this.props.fetchCurrencies( newSiteId );
 			this.props.fetchSettingsGeneral( newSiteId );
 		}
-	}
-
-	constructor( props ) {
-		super( props );
-
-		//TODO: use redux state and real data
-		this.state = {
-			address: {
-				name: 'Octopus Outlet Emporium',
-				street: '27 Main Street',
-				city: 'Ellington, CT 06029',
-				country: 'United States'
-			},
-		};
 	}
 
 	renderOption = ( currency ) => {
@@ -124,8 +110,7 @@ class SettingsPaymentsLocationCurrency extends Component {
 						)
 					} />
 				<Card className="payments__address-currency-container">
-					<AddressView
-						address={ this.state.address } />
+					<StoreAddress />
 					<div className="payments__currency-container">
 						<FormLabel>
 							{ translate( 'Store Currency' ) }

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -7,6 +7,12 @@
 	@include breakpoint( "<660px" ) {
 		flex-direction: column;
 	}
+	
+	.store-address.card {
+		margin: 0;
+		padding: 0;
+		box-shadow: none;
+	}
 }
 
 .payments__location-currency {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -15,6 +15,10 @@
 	}
 }
 
+&.store-location__edit-dialog {
+	max-width: 600px;
+}
+
 .payments__location-currency {
 	@include breakpoint( ">660px" ) {
 		margin-top: 58px;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
@@ -1,46 +1,24 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import AddressView from 'woocommerce/components/address-view';
-import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
+import StoreAddress from 'woocommerce/components/store-address';
 
-class ShippingOrigin extends Component {
-	constructor( props ) {
-		super( props );
-
-		//TODO: use redux state and real data
-		this.state = {
-			address: {
-				name: 'Octopus Outlet Emporium',
-				street: '27 Main Street',
-				city: 'Ellington, CT 06029',
-				country: 'United States'
-			},
-		};
-	}
-
-	render() {
-		const { translate } = this.props;
-
-		return (
-			<div className="shipping__origin">
-				<ExtendedHeader
-					label={ translate( 'Shipping Origin' ) }
-					description={ translate( 'The address of where you will be shipping from.' ) } />
-				<Card>
-					<AddressView address={ this.state.address } />
-					<a>{ translate( 'Edit address' ) }</a>
-				</Card>
-			</div>
-		);
-	}
-}
+const ShippingOrigin = ( { translate } ) => {
+	return (
+		<div className="shipping__origin">
+			<ExtendedHeader
+				label={ translate( 'Shipping Origin' ) }
+				description={ translate( 'The address of where you will be shipping from.' ) } />
+			<StoreAddress />
+		</div>
+	);
+};
 
 export default localize( ShippingOrigin );

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -18,7 +18,6 @@ import FormTextInput from 'components/forms/form-text-input';
 class AddressView extends Component {
 	static propTypes = {
 		address: PropTypes.shape( {
-			name: PropTypes.string.isRequired,
 			street: PropTypes.string.isRequired,
 			street2: PropTypes.string,
 			city: PropTypes.string.isRequired,
@@ -27,13 +26,11 @@ class AddressView extends Component {
 			postcode: PropTypes.string,
 		} ),
 		isEditable: PropTypes.bool,
-		nameLabel: PropTypes.string,
 		onChange: PropTypes.func,
 	};
 
 	static defaultProps = {
 		address: {
-			name: '',
 			street: '',
 			street2: '',
 			city: '',
@@ -42,12 +39,11 @@ class AddressView extends Component {
 			postcode: '',
 		},
 		isEditable: false,
-		nameLabel: '',
 	}
 
 	renderEditable = () => {
-		const { nameLabel, onChange, translate } = this.props;
-		const { city, country, name, postcode, street, street2, state } = this.props.address;
+		const { onChange, translate } = this.props;
+		const { city, country, postcode, street, street2, state } = this.props.address;
 		const countryData = find( Countries, { code: country || 'US' } );
 		const foundCountry = Boolean( countryData );
 		const states = foundCountry ? countryData.states : [];
@@ -55,15 +51,6 @@ class AddressView extends Component {
 
 		return (
 			<div className="address-view__fields-editable">
-				<FormFieldSet>
-					<FormLabel>{ nameLabel || translate( 'Business Name' ) }</FormLabel>
-					<FormTextInput
-						disabled
-						name="name"
-						onChange={ onChange }
-						value={ name }
-					/>
-				</FormFieldSet>
 				<FormFieldSet>
 					<FormLabel>{ translate( 'Street address' ) }</FormLabel>
 					<FormTextInput
@@ -88,7 +75,7 @@ class AddressView extends Component {
 							value={ city }
 						/>
 					</FormFieldSet>
-					<FormFieldSet>
+					<FormFieldSet className="address-view__editable-state">
 						<FormLabel>{ statesLabel }</FormLabel>
 						<FormSelect
 							disabled={ ! foundCountry }
@@ -142,7 +129,9 @@ class AddressView extends Component {
 				</p>
 				{	street2 && <p>{ street2 }</p> }
 				<p>
-					{ city } { state && { state } } { postcode && { postcode } }
+					{ city && ( <span className="address-view__city">{ city }</span> ) }
+					{ state && ( <span className="address-view__state">{ state }</span> ) }
+					{ postcode && ( <span className="address-view__postcode">{ postcode }</span> ) }
 				</p>
 				<p>
 					{ country }

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -18,8 +18,16 @@
 	}
 }
 
+.form-label {
+	color: $gray-dark;
+}
+
 .address-view__editable-city-state-postcode {
 	display: flex;
+
+	@include breakpoint( ">960px" ) {
+		align-items: flex-end;
+	}
 
 	.form-fieldset {
 		flex: 1;
@@ -28,10 +36,6 @@
 		&:last-child {
 			margin-right: 0;
 		}
-	}
-
-	.address-view__editable-state {
-		max-width: 200px;
 	}
 
 	@include breakpoint( "<960px" ) {
@@ -43,6 +47,13 @@
 
 		.form-fieldset {
 			margin-right: 0;
+			width: 100%;
+		}
+	}
+
+	.form-select {
+		@include breakpoint( ">960px" ) {
+			max-width: 200px;
 		}
 	}
 }

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -1,6 +1,14 @@
 .address-view__address {
 	margin-bottom: 8px;
 
+ .address-view__city {
+		margin-right: 8px;
+	}
+
+	.address-view__state {
+		margin-right: 8px;
+	}
+
 	p {
 		margin-bottom: 0;
 
@@ -21,14 +29,18 @@
 			margin-right: 0;
 		}
 	}
-	
+
+	.address-view__editable-state {
+		max-width: 200px;
+	}
+
 	@include breakpoint( "<960px" ) {
 		flex-direction: column;
-		
+
 		label + select {
 			width: 100%;
 		}
-		
+
 		.form-fieldset {
 			margin-right: 0;
 		}
@@ -37,7 +49,7 @@
 
 .address-view__country {
 	margin-bottom: 32px;
-	
+
 	.form-select {
 		width: 100%;
 	}

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import AddressView from 'woocommerce/components/address-view';
+import Card from 'components/card';
+import Dialog from 'components/dialog';
+import { errorNotice } from 'state/notices/actions';
+import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getStoreLocation, areSettingsGeneralLoading } from 'woocommerce/state/sites/settings/general/selectors';
+import { setAddress } from 'woocommerce/state/sites/settings/actions';
+
+class StoreAddress extends Component {
+
+	componentDidMount = () => {
+		const { site } = this.props;
+
+		if ( site && site.ID ) {
+			this.props.fetchSettingsGeneral( site.ID );
+		}
+	}
+
+	componentWillReceiveProps = ( newProps ) => {
+		const { site } = this.props;
+
+		const newSiteId = newProps.site && newProps.site.ID || null;
+		const oldSiteId = site && site.ID || null;
+
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchSettingsGeneral( newSiteId );
+		}
+
+		this.setState( { address: newProps.address } );
+	}
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			showDialog: false,
+			address: props.address,
+		};
+	}
+
+	onChange = ( event ) => {
+		const addressEdits = { ...this.state.addressEdits };
+		addressEdits[ event.target.name ] = event.target.value;
+		this.setState( { addressEdits } );
+	}
+
+	onShowDialog = () => {
+		this.setState( {
+			showDialog: true,
+			addressEdits: { ...this.props.address },
+		} );
+	}
+
+	onCloseDialog = ( action ) => {
+		const { translate, site } = this.props;
+		if ( 'save' === action ) {
+			const onFailure = () => {
+				this.setState( { showDialog: false } );
+				return errorNotice( translate( 'There was a problem saving the store address. Please try again.' ) );
+			};
+			this.setState( {
+				showDialog: false,
+				address: { ...this.state.addressEdits },
+			} );
+			this.props.setAddress(
+				site.ID,
+				this.state.addressEdits.street,
+				this.state.addressEdits.street2,
+				this.state.addressEdits.city,
+				this.state.addressEdits.state,
+				this.state.addressEdits.postcode,
+				this.state.addressEdits.country,
+				onFailure
+			);
+		} else {
+			this.setState( {
+				showDialog: false,
+			} );
+		}
+	}
+
+	render() {
+		const { site, loading, translate } = this.props;
+
+		const buttons = [
+			{ action: 'close', label: translate( 'Close' ) },
+			{ action: 'save', label: translate( 'Save' ), isPrimary: true },
+		];
+
+		let display;
+		if ( ! site || loading ) {
+			display = (
+				<div>
+					<p></p>
+					<p></p>
+					<p></p>
+					<p></p>
+				</div>
+			);
+		} else {
+			display = (
+				<div>
+					<AddressView address={ this.state.address } />
+					<a onClick={ this.onShowDialog }>{ translate( 'Edit address' ) }</a>
+				</div>
+			);
+		}
+
+		const classes = classNames( 'store-address', { 'is-placeholder': ! site || loading } );
+		return (
+			<Card className={ classes }>
+				<Dialog
+					buttons={ buttons }
+					isVisible={ this.state.showDialog }
+					onClose={ this.onCloseDialog }
+					additionalClassNames="woocommerce"
+					><AddressView address={ this.state.addressEdits } isEditable onChange={ this.onChange } />
+				</Dialog>
+				{ display }
+			</Card>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const loading = areSettingsGeneralLoading( state );
+	const address = getStoreLocation( state );
+	return {
+		site,
+		address,
+		loading,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSettingsGeneral,
+			setAddress,
+		},
+		dispatch
+	);
+}
+
+export default localize( connect( mapStateToProps, mapDispatchToProps )( StoreAddress ) );

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -18,6 +18,7 @@ import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/a
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getStoreLocation, areSettingsGeneralLoading } from 'woocommerce/state/sites/settings/general/selectors';
 import { setAddress } from 'woocommerce/state/sites/settings/actions';
+import FormLabel from 'components/forms/form-label';
 
 class StoreAddress extends Component {
 
@@ -121,6 +122,7 @@ class StoreAddress extends Component {
 		const classes = classNames( 'store-address', { 'is-placeholder': ! site || loading } );
 		return (
 			<Card className={ classes }>
+				<FormLabel>{ translate( 'Store location' ) }</FormLabel>
 				<Dialog
 					buttons={ buttons }
 					isVisible={ this.state.showDialog }

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -127,7 +127,7 @@ class StoreAddress extends Component {
 					buttons={ buttons }
 					isVisible={ this.state.showDialog }
 					onClose={ this.onCloseDialog }
-					additionalClassNames="woocommerce"
+					additionalClassNames="woocommerce store-location__edit-dialog"
 					><AddressView address={ this.state.addressEdits } isEditable onChange={ this.onChange } />
 				</Dialog>
 				{ display }

--- a/client/extensions/woocommerce/components/store-address/style.scss
+++ b/client/extensions/woocommerce/components/store-address/style.scss
@@ -1,0 +1,22 @@
+.store-address {
+	&.is-placeholder {
+		@include placeholder();
+		pointer-events: none;
+		background: $white;
+
+		p {
+			width: 300px;
+			height: 14px;
+			animation: loading-fade 1.6s ease-in-out infinite;
+			background-color: lighten( $gray, 25% );
+		}
+	}
+
+	.address-view__address {
+		width: 300px;
+	}
+
+	a {
+		cursor: pointer;
+	}
+}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -30,6 +30,7 @@
 	@import 'components/reading-widget/style';
 	@import 'components/widget-group/style';
 	@import 'components/sparkline/style';
+	@import 'components/store-address/style';
 	@import 'app/store-stats/store-stats-chart/style';
 	@import 'app/store-stats/store-stats-navigation/style';
 	@import 'components/delta/style';


### PR DESCRIPTION
This PR makes the address editable on settings screens with a new `StoreAddress` component (that wraps `AddressView`) that allows editing of the address via modal. It also removes business name from address editing for v1.

This depends on #15537 because I am using the updated batch reducer.

<img width="771" alt="screen shot 2017-06-27 at 2 43 07 pm" src="https://user-images.githubusercontent.com/689165/27611589-a354c002-5b47-11e7-82d7-df998336b694.png">

<img width="1208" alt="screen shot 2017-06-27 at 2 43 14 pm" src="https://user-images.githubusercontent.com/689165/27611592-a6d6d4cc-5b47-11e7-890a-71e790d05fba.png">

To Test:
* You need to be running this branch of `wc-api-dev`: https://github.com/woocommerce/wc-api-dev/pull/14
* Go to `http://calypso.localhost:3000/store/settings/payments/:site`
* Click `edit address`
* Type in some values and make sure you can edit the inputs. Hit cancel.
* Make sure no values update/display.
* Click `edit address` again
* Type in some values. This time hit save, you should see the address update.
* Go to `http://calypso.localhost:3000/store/settings/shipping/:site` and repeat those steps.
* Verify that you can set the address in the initial store setup as well (since I removed business name).
* Run `npm run test-client client/extensions/woocommerce/state/` and make sure all tests pass.

cc @kellychoffman @jameskoster since this contains some UI.
