### PR TITLE
Comments: show correct notices when we have no comments

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -220,16 +220,19 @@ export class CommentList extends Component {
 	render() {
 		const {
 			comments,
+			isLoading,
 			siteId,
 			siteSlug,
 			status,
-			showPlaceholder,
-			showEmptyContent,
 		} = this.props;
 		const {
 			isBulkEdit,
 			selectedComments,
 		} = this.state;
+
+		const zeroComments = size( comments ) <= 0;
+		const showPlaceholder = ( ! siteId || isLoading ) && zeroComments;
+		const showEmptyContent = zeroComments && ! showPlaceholder;
 
 		const [ emptyMessageTitle, emptyMessageLine ] = this.getEmptyMessage();
 
@@ -290,13 +293,9 @@ export class CommentList extends Component {
 const mapStateToProps = ( state, { siteId } ) => {
 	const comments = getSiteComments( state, siteId );
 	const isLoading = ! hasSiteComments( state, siteId );
-	const zeroComments = size( comments ) <= 0;
-	const showPlaceholder = ( ! siteId || isLoading ) && zeroComments;
-	const showEmptyContent = zeroComments && ! showPlaceholder;
 	return {
 		comments,
-		showPlaceholder,
-		showEmptyContent,
+		isLoading,
 		notices: getNotices( state ),
 		siteId,
 	};


### PR DESCRIPTION
In #15181 I forgot that our comments in mapStateToProps is different from what's returned in CommentFaker

This PR fixes the case where our empty notices never load.

<img width="712" alt="screen shot 2017-06-27 at 3 41 51 pm" src="https://user-images.githubusercontent.com/1270189/27613254-68c00926-5b4f-11e7-8d20-1b85b89c642a.png">

### Testing Instructions
- Navigate to http://calypso.localhost:3000/comments/all
- Select a site with comments
- Loading placeholder should display
- Click on another filter with 0 expected comments
- We should see an empty notice.