### PR TITLE
Reader: Fix Combined Cards in Site Results

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -142,10 +142,14 @@
 }
 
 // Post recommendations in Search
-.is-reader-page .search-stream .reader__content,
-.is-reader-page .search-stream.search-stream__with-sites .reader__content {
+.is-reader-page .search-stream .reader__content {
 	display: flex;
-	flex-flow: row wrap;
+	flex-flow: row wrap; // So post recs are side by side
+}
+
+.is-reader-page .search-stream.search-stream__with-sites .search-stream__results.is-two-columns .reader__content,
+.is-reader-page .search-stream.search-stream__with-sites .search-stream__single-column-results .reader__content {
+	flex-direction: column; // So post results are stacked
 }
 
 .is-reader-page .search-stream__recommendation-list-item {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -148,7 +148,8 @@
 }
 
 .is-reader-page .search-stream.search-stream__with-sites .search-stream__results.is-two-columns .reader__content,
-.is-reader-page .search-stream.search-stream__with-sites .search-stream__single-column-results .reader__content {
+.is-reader-page .search-stream.search-stream__with-sites .search-stream__single-column-results.is-post-results .reader__content {
+	flex-flow: inherit;
 	flex-direction: column; // So post results are stacked
 }
 

--- a/client/reader/search-stream/with-sites.jsx
+++ b/client/reader/search-stream/with-sites.jsx
@@ -123,7 +123,7 @@ class SearchStream extends React.Component {
 		} );
 
 		const singleColumnResultsClasses = cx( 'search-stream__single-column-results', {
-			'is-posts': ( searchType === POSTS || ! query )
+			'is-recs': ! query,
 		} );
 
 		return (

--- a/client/reader/search-stream/with-sites.jsx
+++ b/client/reader/search-stream/with-sites.jsx
@@ -122,6 +122,10 @@ class SearchStream extends React.Component {
 			'is-two-columns': !! query,
 		} );
 
+		const singleColumnResultsClasses = cx( 'search-stream__single-column-results', {
+			'is-posts': ( searchType === POSTS || ! query )
+		} );
+
 		return (
 			<div>
 				<DocumentHead title={ documentTitle } />
@@ -165,7 +169,7 @@ class SearchStream extends React.Component {
 							</div> }
 					</div> }
 				{ ! wideDisplay &&
-					<div className="search-stream__single-column-results">
+					<div className={ singleColumnResultsClasses }>
 						{ ( ( searchType === POSTS || ! query ) && <PostResults { ...this.props } /> ) ||
 							<SiteResults query={ query } sort={ sortOrder } showLastUpdatedDate={ true } /> }
 					</div> }

--- a/client/reader/search-stream/with-sites.jsx
+++ b/client/reader/search-stream/with-sites.jsx
@@ -123,7 +123,7 @@ class SearchStream extends React.Component {
 		} );
 
 		const singleColumnResultsClasses = cx( 'search-stream__single-column-results', {
-			'is-recs': ! query,
+			'is-post-results': searchType === POSTS && query,
 		} );
 
 		return (


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15184

Examples:
https://wpcalypso.wordpress.com/read/search?q=Lance&focus=1&sort=date
![screenshot 2017-06-27 15 35 44](https://user-images.githubusercontent.com/4924246/27613059-58862096-5b4e-11e7-8ad1-f5454775bd4a.png)

https://wpcalypso.wordpress.com/read/search?q=techcrunch&focus=1&sort=date
![screenshot 2017-06-27 15 35 59](https://user-images.githubusercontent.com/4924246/27613062-5bf98010-5b4e-11e7-9049-8298cd6f2792.png) 