### PR TITLE
Reader: Increase height of image recs in fullpost

### DIFF
--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -657,7 +657,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__featured-image {
 	border: 1px solid lighten( $gray, 30% );
-	min-height: 100px;
+	min-height: 150px;
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex: 1 1 0;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -663,12 +663,14 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		flex: 1 1 0;
 		height: auto;
 		margin: 0 15px 0 0;
+		min-height: 78px;
 	}
 
 	@media #{$reader-related-card-v2-breakpoint-medium} {
 		height: auto;
 		flex: 1 1 0;
 		margin: 0 15px 0 0;
+		min-height: 78px;
 	}
 }
 

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -657,7 +657,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__featured-image {
 	border: 1px solid lighten( $gray, 30% );
-	min-height: 78px;
+	min-height: 100px;
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex: 1 1 0;

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -404,7 +404,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 	// Wrapper for site title, thumbnail, excerpt
 	.reader-related-card-v2__post {
-		max-height: 206px;
+		max-height: 282px;
 
 		&::after {
 			@include long-content-fade( $size: 30% );
@@ -461,7 +461,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		margin-top: 40px;
 
 		.reader-related-card-v2__post {
-			max-height: 206px;
+			max-height: 282px;
 
 			@media #{$reader-related-card-v2-breakpoint-medium} {
 				max-height: 108px;
@@ -657,7 +657,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-related-card-v2__featured-image {
 	border: 1px solid lighten( $gray, 30% );
-	min-height: 150px;
+	min-height: 153px;
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		flex: 1 1 0;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -148,6 +148,10 @@
 	flex-flow: row wrap;
 }
 
+.search-stream .reader-related-card-v2__featured-image {
+	min-height: 78px;
+}
+
 .is-reader-page .search-stream__recommendation-list-item {
 	box-sizing: border-box;
 	border-bottom: 1px solid lighten( $gray, 20% );


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/15585

**Before:**
![screenshot 2017-06-27 19 59 11](https://user-images.githubusercontent.com/4924246/27618777-1df50904-5b73-11e7-9576-f3c964843bee.png)

**After:**

At 128px:
![screenshot 2017-06-27 20 00 21](https://user-images.githubusercontent.com/4924246/27618801-42a29df2-5b73-11e7-8bb1-d1cb1e5eac08.png)

At 100px:
![screenshot 2017-06-27 20 00 34](https://user-images.githubusercontent.com/4924246/27618807-4e02bf4c-5b73-11e7-94c3-6899d62c7831.png)

@fraying I think adding ~50px more (which is 128px) is a bit too tall, but I think 100px is just right. What do you think?