### PR TITLE
State: Introduce isJetpackSiteConnected selector

### DIFF
--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -163,6 +163,7 @@ export isSchedulingPublicizeShareAction from './is-scheduling-publicize-share-ac
 export isJetpackModuleActive from './is-jetpack-module-active';
 export isJetpackModuleUnavailableInDevelopmentMode from './is-jetpack-module-unavailable-in-development-mode';
 export isJetpackSettingsSaveFailure from './is-jetpack-settings-save-failure';
+export isJetpackSiteConnected from './is-jetpack-site-connected';
 export isJetpackSiteInDevelopmentMode from './is-jetpack-site-in-development-mode';
 export isJetpackSiteInStagingMode from './is-jetpack-site-in-staging-mode';
 export isMappedDomainSite from './is-mapped-domain-site';

--- a/client/state/selectors/is-jetpack-site-connected.js
+++ b/client/state/selectors/is-jetpack-site-connected.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getJetpackConnectionStatus } from './';
+
+/**
+ * Returns true if we the Jetpack site is connected. False otherwise.
+ * Returns null if the site is unknown, or there is no information yet.
+ *
+ * @param  {Object}   state    Global state tree
+ * @param  {Number}   siteId   The ID of the site we're querying
+ * @return {?Boolean}          Whether the site is connected.
+ */
+export default function isJetpackSiteConnected( state, siteId ) {
+	return get( getJetpackConnectionStatus( state, siteId ), [ 'isActive' ], null );
+}

--- a/client/state/selectors/test/fixtures/jetpack-connection.js
+++ b/client/state/selectors/test/fixtures/jetpack-connection.js
@@ -1,6 +1,6 @@
 export const items = {
 	12345678: {
-		isActive: true,
+		isActive: false,
 		isStaging: false,
 		devMode: {
 			isActive: false,

--- a/client/state/selectors/test/is-jetpack-site-connected.js
+++ b/client/state/selectors/test/is-jetpack-site-connected.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackSiteConnected } from '../';
+import { items as ITEMS_FIXTURE } from './fixtures/jetpack-connection';
+
+describe( 'isJetpackSiteConnected()', () => {
+	it( 'should return true if the site is connected', () => {
+		const stateIn = {
+				jetpack: {
+					connection: {
+						items: ITEMS_FIXTURE
+					}
+				}
+			},
+			siteId = 87654321;
+		const output = isJetpackSiteConnected( stateIn, siteId );
+		expect( output ).to.be.true;
+	} );
+
+	it( 'should return false if the site is not connected', () => {
+		const stateIn = {
+				jetpack: {
+					connection: {
+						items: ITEMS_FIXTURE
+					}
+				}
+			},
+			siteId = 12345678;
+		const output = isJetpackSiteConnected( stateIn, siteId );
+		expect( output ).to.be.false;
+	} );
+
+	it( 'should return null if the site is not known yet', () => {
+		const stateIn = {
+				jetpack: {
+					connection: {
+						items: ITEMS_FIXTURE
+					}
+				}
+			},
+			siteId = 88888888;
+		const output = isJetpackSiteConnected( stateIn, siteId );
+		expect( output ).to.be.null;
+	} );
+} );


### PR DESCRIPTION
This PR introduces a `isJetpackSiteConnected` selector that we'll need in order to implement the connection management card in a consistent way to how it's currently integrated in Jetpack. This selector is a small part of the groundwork for #13232.

To test:
* Checkout this branch
* Verify all selector tests pass:

```
npm run test-client client/state/selectors/
```