### PR TITLE
Comments: Fix transitions

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -31,24 +31,6 @@
 	}
 }
 
-.comment-detail__transition-enter {
-	opacity: 0.01;
-
-	&.comment-detail__transition-enter-active {
-		opacity: 1;
-		transition: opacity .15s linear;
-		transition-delay: .15s;
-	}
-}
-.comment-detail__transition-leave {
-	opacity: 1;
-
-	&.comment-detail__transition-leave-active {
-		opacity: 0.01;
-		transition: opacity .15s linear;
-	}
-}
-
 .comment-detail__author-avatar {
 	border-radius: 50%;
 	display: block;

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -249,11 +249,11 @@ export class CommentList extends Component {
 					toggleBulkEdit={ this.toggleBulkEdit }
 					toggleSelectAll={ this.toggleSelectAll }
 				/>
-
 				<ReactCSSTransitionGroup
-					transitionEnterTimeout={ 300 }
+					className="comment-list__transition-wrapper"
+					transitionEnterTimeout={ 150 }
 					transitionLeaveTimeout={ 150 }
-					transitionName="comment-detail__transition"
+					transitionName="comment-list__transition"
 				>
 					{ map( comments, comment =>
 						<CommentDetail
@@ -269,14 +269,9 @@ export class CommentList extends Component {
 							toggleCommentSelected={ this.toggleCommentSelected }
 						/>
 					) }
-				</ReactCSSTransitionGroup>
-				<ReactCSSTransitionGroup
-					className="comment-list__transition-wrapper"
-					component="div"
-					transitionEnterTimeout={ 300 }
-					transitionLeaveTimeout={ 150 }
-					transitionName="comment-list__transition" >
+
 					{ showPlaceholder && <CommentDetailPlaceholder key="comment-detail-placeholder" /> }
+
 					{ showEmptyContent && <EmptyContent
 						illustration="/calypso/images/comments/illustration_comments_gray.svg"
 						illustrationWidth={ 150 }

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -60,27 +60,37 @@
 	}
 }
 
-.comment-list__transition-wrapper {
-	position: relative;
-}
-
 .comment-list__transition-enter {
-	opacity: 0.01;
-	position: absolute;
+	display: none;
 
 	&.comment-list__transition-enter-active {
-		opacity: 1;
-		transition: opacity .15s linear;
-		transition-delay: .15s;
+		animation: comment-list__transition-enter .15s linear;
 	}
 }
 
 .comment-list__transition-leave {
 	opacity: 1;
-	position: absolute;
 
 	&.comment-list__transition-leave-active {
 		opacity: 0.01;
-		transition: opacity 0.15s linear;
+		transition: opacity .15s linear;
+	}
+}
+
+@keyframes comment-list__transition-enter {
+	0% {
+		display: none;
+		opacity: 0;
+	}
+	50% {
+		display: none;
+		opacity: 0;
+	}
+	51% {
+		display: block;
+		opacity: 0.01;
+	}
+	100% {
+		opacity: 1;
 	}
 }


### PR DESCRIPTION
This PR fixes the transitions when changing comment management list.
The involved components are: `CommentDetail`, `CommentDetailPlaceholder`, `EmptyContent`.
These elements are not displaced and don't lose their correct size when transitioned out anymore.

Here's a gif, but the transitions are just too fast (and there are compression artifacts).
It'd be best to actually try it out and see if it feels right.

![jun-28-2017 13-01-28](https://user-images.githubusercontent.com/2070010/27636146-fa98c6c8-5c01-11e7-9f72-5b3c9c9732f0.gif)
