### PR TITLE
Comments: Remove overflow hidden from CommentDetail reply box

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -13,11 +13,27 @@ import { get } from 'lodash';
 import AutoDirection from 'components/auto-direction';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+const TEXTAREA_MAX_HEIGHT = 236; // 10 lines
+const TEXTAREA_MIN_HEIGHT_COLLAPSED = 47;
+const TEXTAREA_MIN_HEIGHT_FOCUSED = 68; // 2 lines
+const TEXTAREA_VERTICAL_BORDER = 2;
+
 export class CommentDetailReply extends Component {
 	state = {
 		commentText: '',
 		hasFocus: false,
+		textareaMinHeight: TEXTAREA_MIN_HEIGHT_COLLAPSED,
 	};
+
+	bindTextareaRef = textarea => {
+		this.textarea = textarea;
+	}
+
+	calculateTextareaMinHeight = () => {
+		const textareaScrollHeight = this.textarea.scrollHeight;
+		const textareaMinHeight = Math.min( TEXTAREA_MAX_HEIGHT, textareaScrollHeight + TEXTAREA_VERTICAL_BORDER );
+		return Math.max( TEXTAREA_MIN_HEIGHT_FOCUSED, textareaMinHeight );
+	}
 
 	getTextareaPlaceholder = () => this.props.authorDisplayName
 		? this.props.translate( 'Reply to %(commentAuthor)s…', {
@@ -25,9 +41,20 @@ export class CommentDetailReply extends Component {
 		} )
 		: 'Reply to comment…';
 
-	handleTextChange = event => this.setState( { commentText: event.target.value } );
+	handleTextChange = event => {
+		const { value } = event.target;
+		const textareaMinHeight = this.calculateTextareaMinHeight();
 
-	setFocus = () => this.setState( { hasFocus: true } );
+		this.setState( {
+			commentText: value,
+			textareaMinHeight,
+		} );
+	}
+
+	setFocus = () => this.setState( {
+		hasFocus: true,
+		textareaMinHeight: this.calculateTextareaMinHeight(),
+	} );
 
 	submit = () => {
 		const {
@@ -67,11 +94,18 @@ export class CommentDetailReply extends Component {
 		}
 	}
 
-	unsetFocus = () => this.setState( { hasFocus: false } );
+	unsetFocus = () => this.setState( {
+		hasFocus: false,
+		textareaMinHeight: TEXTAREA_MIN_HEIGHT_COLLAPSED,
+	} );
 
 	render() {
 		const { translate } = this.props;
-		const { commentText, hasFocus } = this.state;
+		const {
+			commentText,
+			hasFocus,
+			textareaMinHeight,
+		} = this.state;
 
 		const hasCommentText = commentText.trim().length > 0;
 
@@ -80,32 +114,44 @@ export class CommentDetailReply extends Component {
 			'is-visible': hasFocus || hasCommentText,
 		} );
 
-		const expandingAreaClasses = classNames( 'is-expanding-area', {
+		const textareaClasses = classNames( {
 			'is-focused': hasFocus,
 		} );
 
+		const textareaStyle = {
+			minHeight: textareaMinHeight,
+		};
+		if ( ! hasFocus ) {
+			// Force the textarea to collapse even if it was manually resized
+			textareaStyle.height = TEXTAREA_MIN_HEIGHT_COLLAPSED;
+		}
+		if ( textareaMinHeight === TEXTAREA_MAX_HEIGHT ) {
+			// Only show the scrollbar if the textarea content exceeds the max height
+			textareaStyle.overflow = 'auto';
+		}
+
 		return (
 			<form className="comment-detail__reply">
-				<div className={ expandingAreaClasses }>
-					<pre><span>{ commentText }</span><br /></pre>
-					<AutoDirection>
-						<textarea
-							onBlur={ this.unsetFocus }
-							onChange={ this.handleTextChange }
-							onFocus={ this.setFocus }
-							onKeyDown={ this.submitCommentOnCtrlEnter }
-							placeholder={ this.getTextareaPlaceholder() }
-							value={ commentText }
-						/>
-					</AutoDirection>
-					<button
-						className={ buttonClasses }
-						disabled={ ! hasCommentText }
-						onClick={ this.submitComment }
-					>
-						{ translate( 'Send' ) }
-					</button>
-				</div>
+				<AutoDirection>
+					<textarea
+						className={ textareaClasses }
+						onBlur={ this.unsetFocus }
+						onChange={ this.handleTextChange }
+						onFocus={ this.setFocus }
+						onKeyDown={ this.submitCommentOnCtrlEnter }
+						placeholder={ this.getTextareaPlaceholder() }
+						ref={ this.bindTextareaRef }
+						style={ textareaStyle }
+						value={ commentText }
+					/>
+				</AutoDirection>
+				<button
+					className={ buttonClasses }
+					disabled={ ! hasCommentText }
+					onClick={ this.submitComment }
+				>
+					{ translate( 'Send' ) }
+				</button>
 			</form>
 		);
 	}

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -13,26 +13,26 @@ import { get } from 'lodash';
 import AutoDirection from 'components/auto-direction';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+const TEXTAREA_HEIGHT_COLLAPSED = 47; // 1 line
+const TEXTAREA_HEIGHT_FOCUSED = 68; // 2 lines
 const TEXTAREA_MAX_HEIGHT = 236; // 10 lines
-const TEXTAREA_MIN_HEIGHT_COLLAPSED = 47;
-const TEXTAREA_MIN_HEIGHT_FOCUSED = 68; // 2 lines
 const TEXTAREA_VERTICAL_BORDER = 2;
 
 export class CommentDetailReply extends Component {
 	state = {
 		commentText: '',
 		hasFocus: false,
-		textareaMinHeight: TEXTAREA_MIN_HEIGHT_COLLAPSED,
+		textareaHeight: TEXTAREA_HEIGHT_COLLAPSED,
 	};
 
 	bindTextareaRef = textarea => {
 		this.textarea = textarea;
 	}
 
-	calculateTextareaMinHeight = () => {
+	calculateTextareaHeight = () => {
 		const textareaScrollHeight = this.textarea.scrollHeight;
-		const textareaMinHeight = Math.min( TEXTAREA_MAX_HEIGHT, textareaScrollHeight + TEXTAREA_VERTICAL_BORDER );
-		return Math.max( TEXTAREA_MIN_HEIGHT_FOCUSED, textareaMinHeight );
+		const textareaHeight = Math.min( TEXTAREA_MAX_HEIGHT, textareaScrollHeight + TEXTAREA_VERTICAL_BORDER );
+		return Math.max( TEXTAREA_HEIGHT_FOCUSED, textareaHeight );
 	}
 
 	getTextareaPlaceholder = () => this.props.authorDisplayName
@@ -43,17 +43,17 @@ export class CommentDetailReply extends Component {
 
 	handleTextChange = event => {
 		const { value } = event.target;
-		const textareaMinHeight = this.calculateTextareaMinHeight();
+		const textareaHeight = this.calculateTextareaHeight();
 
 		this.setState( {
 			commentText: value,
-			textareaMinHeight,
+			textareaHeight,
 		} );
 	}
 
 	setFocus = () => this.setState( {
 		hasFocus: true,
-		textareaMinHeight: this.calculateTextareaMinHeight(),
+		textareaHeight: this.calculateTextareaHeight(),
 	} );
 
 	submit = () => {
@@ -96,7 +96,7 @@ export class CommentDetailReply extends Component {
 
 	unsetFocus = () => this.setState( {
 		hasFocus: false,
-		textareaMinHeight: TEXTAREA_MIN_HEIGHT_COLLAPSED,
+		textareaHeight: TEXTAREA_HEIGHT_COLLAPSED,
 	} );
 
 	render() {
@@ -104,13 +104,13 @@ export class CommentDetailReply extends Component {
 		const {
 			commentText,
 			hasFocus,
-			textareaMinHeight,
+			textareaHeight,
 		} = this.state;
 
 		const hasCommentText = commentText.trim().length > 0;
 
 		// Only show the scrollbar if the textarea content exceeds the max height
-		const hasScrollbar = textareaMinHeight === TEXTAREA_MAX_HEIGHT;
+		const hasScrollbar = textareaHeight === TEXTAREA_MAX_HEIGHT;
 
 		const buttonClasses = classNames( 'comment-detail__reply-submit', {
 			'has-scrollbar': hasScrollbar,
@@ -122,13 +122,10 @@ export class CommentDetailReply extends Component {
 			'has-scrollbar': hasScrollbar,
 		} );
 
+		// Without focus, force the textarea to collapse even if it was manually resized
 		const textareaStyle = {
-			minHeight: textareaMinHeight,
+			height: hasFocus ? textareaHeight : TEXTAREA_HEIGHT_COLLAPSED,
 		};
-		if ( ! hasFocus ) {
-			// Force the textarea to collapse even if it was manually resized
-			textareaStyle.height = TEXTAREA_MIN_HEIGHT_COLLAPSED;
-		}
 
 		return (
 			<form className="comment-detail__reply">

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -142,7 +142,7 @@ export class CommentDetailReply extends Component {
 						value={ commentText }
 					/>
 				</AutoDirection>
-				{ hasFocus &&
+				{ ( hasFocus || hasCommentText ) &&
 					<button
 						className={ buttonClasses }
 						disabled={ ! hasCommentText }

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -109,13 +109,17 @@ export class CommentDetailReply extends Component {
 
 		const hasCommentText = commentText.trim().length > 0;
 
+		// Only show the scrollbar if the textarea content exceeds the max height
+		const hasScrollbar = textareaMinHeight === TEXTAREA_MAX_HEIGHT;
+
 		const buttonClasses = classNames( 'comment-detail__reply-submit', {
+			'has-scrollbar': hasScrollbar,
 			'is-active': hasCommentText,
-			'is-visible': hasFocus || hasCommentText,
 		} );
 
 		const textareaClasses = classNames( {
-			'is-focused': hasFocus,
+			'has-focus': hasFocus,
+			'has-scrollbar': hasScrollbar,
 		} );
 
 		const textareaStyle = {
@@ -124,10 +128,6 @@ export class CommentDetailReply extends Component {
 		if ( ! hasFocus ) {
 			// Force the textarea to collapse even if it was manually resized
 			textareaStyle.height = TEXTAREA_MIN_HEIGHT_COLLAPSED;
-		}
-		if ( textareaMinHeight === TEXTAREA_MAX_HEIGHT ) {
-			// Only show the scrollbar if the textarea content exceeds the max height
-			textareaStyle.overflow = 'auto';
 		}
 
 		return (
@@ -145,13 +145,15 @@ export class CommentDetailReply extends Component {
 						value={ commentText }
 					/>
 				</AutoDirection>
-				<button
-					className={ buttonClasses }
-					disabled={ ! hasCommentText }
-					onClick={ this.submitComment }
-				>
-					{ translate( 'Send' ) }
-				</button>
+				{ hasFocus &&
+					<button
+						className={ buttonClasses }
+						disabled={ ! hasCommentText }
+						onClick={ this.submitComment }
+					>
+						{ translate( 'Send' ) }
+					</button>
+				}
 			</form>
 		);
 	}

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -424,6 +424,7 @@ a.comment-detail__author-more-element {
 		padding: 12px 70px 12px 16px;
 		position: relative;
 		resize: vertical;
+		transition: min-height .15s linear;
 		white-space: pre-wrap;
 		word-wrap: break-word;
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -411,43 +411,30 @@ a.comment-detail__author-more-element {
 }
 
 .comment-detail__reply {
-	// The inner working of these styles is covered here:
-	// http://alistapart.com/article/expanding-text-areas-made-elegant
-	.is-expanding-area {
-		min-height: 33px;
+	line-height: 0;
+	position: relative;
+
+	textarea {
+		font-family: $serif;
+		font-size: 14px;
+		height: 47px;
+		line-height: 21px;
+		min-height: 47px;
+		overflow: hidden;
+		padding: 12px 70px 12px 16px;
 		position: relative;
-		transition: min-height 0.2s ease-in-out;
+		resize: vertical;
+		white-space: pre-wrap;
+		word-wrap: break-word;
 
-		&.is-focused {
-			min-height: 70px;
-		}
-
-		pre,
-		textarea {
-			font-family: $serif;
-			font-size: 14px;
-			line-height: 21px;
-			margin: 0;
-			max-height: 400px;
-			min-height: 33px;
-			padding: 12px 70px 12px 16px;
-			white-space: pre-wrap;
-			word-wrap: break-word;
-		}
-
-		pre {
-			box-sizing: border-box;
-			display: block;
-			visibility: hidden;
-		}
-
-		textarea {
-			border: none;
-			height: 100%;
-			position: absolute;
-				left: 0;
-				top: 0;
+		&:not( :focus ) {
+			border-color: $white;
 			resize: none;
+		}
+
+		&:focus,
+		&.is-focused {
+			min-height: 68px; // 2 lines
 		}
 	}
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -430,7 +430,6 @@ a.comment-detail__author-more-element {
 			margin: 0;
 			max-height: 400px;
 			min-height: 33px;
-			overflow: hidden;
 			padding: 12px 70px 12px 16px;
 			white-space: pre-wrap;
 			word-wrap: break-word;

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -433,8 +433,12 @@ a.comment-detail__author-more-element {
 		}
 
 		&:focus,
-		&.is-focused {
+		&.has-focus {
 			min-height: 68px; // 2 lines
+		}
+
+		&.has-scrollbar {
+			overflow-y: auto;
 		}
 	}
 
@@ -442,21 +446,20 @@ a.comment-detail__author-more-element {
 		color: lighten( $gray, 10% );
 		font-size: 12px;
 		font-weight: 600;
-		opacity: 0;
 		padding: 4px;
 		position: absolute;
-			right: 24px;
-			top: 10px;
+			right: 18px;
+			top: 11px;
 		text-transform: uppercase;
 		transition: opacity 0.2s ease-in-out;
+
+		&.has-scrollbar {
+			right: 24px;
+		}
 
 		&.is-active {
 			color: $blue-medium;
 			cursor: pointer;
-		}
-
-		&.is-visible {
-			opacity: 1;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #15576

Refactor of the textarea expansion logic to take care of:
- The resize handle.
- The scrollbar.
- The blue border.
- The correct Send button position.

![jun-30-2017 13-25-23](https://user-images.githubusercontent.com/2070010/27735555-1d040820-5d98-11e7-9d16-2e2fc0013caf.gif)
![jun-30-2017 13-26-19](https://user-images.githubusercontent.com/2070010/27735554-1d039fca-5d98-11e7-95a8-f10980bdb718.gif)

### Glitches

There are extremely minor glitches that I believe do not really worsen the UX.
Still, here they are:

- The `textarea` max height is set at 10 lines. This means that the scrollbar shows up on line 10.
Somehow, a scrollbar appears briefly during the transition between line 9 and 10. I believe it's caused by the fact that the `overflow: auto` is applied immediately, but the actual height transitions for a little bit.
Note: there's no transition on the `textarea`; I'm assuming it's the one that handles the `CommentDetail` expand/collapse.

- When the scrollbar appears, the Send button is "displaced" a little bit (from `right: 18px` to `right: 24px`). Once displaced, though, it remains at `24px` even if the scrollbar disappears.
This is caused by the fact that the `textarea` internal height (`scrollHeight`) only increases but never decreases (i.e. it increases when you add a line, but when you remove the line it remains at its maximum value).
This is why previously we employed a workaround consisting in mirroring the `textarea` with an invisible `<pre>` that, instead, updates its `scrollHeight` "downwards" as well.
I've removed this mirror because it doesn't work well with the resize handle, so we don't have any easy way to know when the height decreases.

- The `textarea` cannot be resized below its `min-height`.
For the reasons explained before, the `min-height` is only updated "upwards" (and until a max value of 10 lines).
So, for example, once the `textarea` is filled with X lines of content, it can only be extended, but not shrank below X lines.