### PR TITLE
View Site: Add close button on mobile

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -16,7 +16,7 @@ import addQueryArgs from 'lib/route/add-query-args';
  */
 import Toolbar from './toolbar';
 import touchDetect from 'lib/touch-detect';
-import { isMobile } from 'lib/viewport';
+import { isWithinBreakpoint } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import Spinner from 'components/spinner';
 import SpinnerLine from 'components/spinner-line';
@@ -28,7 +28,6 @@ const debug = debugModule( 'calypso:web-preview' );
 export class WebPreviewContent extends Component {
 	previewId = uuid();
 	_hasTouch = false;
-	_isMobile = false;
 
 	state = {
 		iframeUrl: null,
@@ -44,7 +43,6 @@ export class WebPreviewContent extends Component {
 	componentWillMount() {
 		// Cache touch and mobile detection for the entire lifecycle of the component
 		this._hasTouch = touchDetect.hasTouch();
-		this._isMobile = isMobile();
 	}
 
 	componentDidMount() {
@@ -241,7 +239,7 @@ export class WebPreviewContent extends Component {
 					device={ this.state.device }
 					{ ...this.props }
 					showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
-					showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
+					showDeviceSwitcher={ this.props.showDeviceSwitcher && isWithinBreakpoint( '>660px' ) }
 					selectSeoPreview={ this.selectSEO }
 					isLoading={ this.state.isLoadingSubpage }
 				/>

--- a/client/lib/viewport/index.js
+++ b/client/lib/viewport/index.js
@@ -61,7 +61,6 @@ function isDesktop() {
 // FIXME: We can't detect window size on the server, so until we have more intelligent detection,
 // use 769, which is just above the general maximum mobile screen width.
 function getWindowInnerWidth() {
-	console.log('innerWidth called');
 	return global.window ? global.window.innerWidth : 769;
 }
 

--- a/client/lib/viewport/index.js
+++ b/client/lib/viewport/index.js
@@ -61,6 +61,7 @@ function isDesktop() {
 // FIXME: We can't detect window size on the server, so until we have more intelligent detection,
 // use 769, which is just above the general maximum mobile screen width.
 function getWindowInnerWidth() {
+	console.log('innerWidth called');
 	return global.window ? global.window.innerWidth : 769;
 }
 

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -17,6 +17,7 @@ import {
 import { isSitePreviewable } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { isWithinBreakpoint } from 'lib/viewport';
 
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
@@ -34,10 +35,28 @@ class PreviewMain extends React.Component {
 	state = {
 		previewUrl: null,
 		externalUrl: null,
+		showingClose: false,
 	};
 
 	componentWillMount() {
 		this.updateUrl();
+		this.updateLayout();
+	}
+
+	updateLayout = () => {
+		this.setState( {
+			showingClose: isWithinBreakpoint( '<660px' ),
+		} );
+	}
+
+	throttledUpdateLayout = throttle( this.updateLayout, 100 );
+
+	componentDidMount() {
+		global.window && global.window.addEventListener( 'resize', this.throttledUpdateLayout );
+	}
+
+	componentWillUnmount() {
+		global.window && global.window.removeEventListener( 'resize', this.throttledUpdateLayout );
 	}
 
 	updateUrl() {
@@ -122,7 +141,7 @@ class PreviewMain extends React.Component {
 				<WebPreviewContent
 					onLocationUpdate={ this.updateSiteLocation }
 					showUrl={ !! this.state.externalUrl }
-					showClose={ this._isMobile }
+					showClose={ this.state.showingClose }
 					onClose={ this.focusSidebar }
 					previewUrl={ this.state.previewUrl }
 					externalUrl={ this.state.externalUrl }

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -3,6 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { throttle } from 'lodash';
 import React from 'react';
 import debugFactory from 'debug';
 
@@ -16,7 +17,6 @@ import {
 import { isSitePreviewable } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { isMobile } from 'lib/viewport';
 
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
@@ -38,7 +38,6 @@ class PreviewMain extends React.Component {
 
 	componentWillMount() {
 		this.updateUrl();
-		this._isMobile = isMobile();
 	}
 
 	updateUrl() {

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { throttle } from 'lodash';
+import { debounce } from 'lodash';
 import React from 'react';
 import debugFactory from 'debug';
 
@@ -49,14 +49,14 @@ class PreviewMain extends React.Component {
 		} );
 	}
 
-	throttledUpdateLayout = throttle( this.updateLayout, 100 );
+	debouncedUpdateLayout = debounce( this.updateLayout, 50 );
 
 	componentDidMount() {
-		global.window && global.window.addEventListener( 'resize', this.throttledUpdateLayout );
+		global.window && global.window.addEventListener( 'resize', this.debouncedUpdateLayout );
 	}
 
 	componentWillUnmount() {
-		global.window && global.window.removeEventListener( 'resize', this.throttledUpdateLayout );
+		global.window && global.window.removeEventListener( 'resize', this.debouncedUpdateLayout );
 	}
 
 	updateUrl() {

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -15,6 +15,8 @@ import {
 } from 'state/ui/selectors';
 import { isSitePreviewable } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { isMobile } from 'lib/viewport';
 
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
@@ -36,6 +38,7 @@ class PreviewMain extends React.Component {
 
 	componentWillMount() {
 		this.updateUrl();
+		this._isMobile = isMobile();
 	}
 
 	updateUrl() {
@@ -83,6 +86,10 @@ class PreviewMain extends React.Component {
 		} );
 	}
 
+	focusSidebar = () => {
+		this.props.setLayoutFocus( 'sidebar' );
+	}
+
 	render() {
 		const { translate, isPreviewable, site } = this.props;
 
@@ -116,7 +123,8 @@ class PreviewMain extends React.Component {
 				<WebPreviewContent
 					onLocationUpdate={ this.updateSiteLocation }
 					showUrl={ !! this.state.externalUrl }
-					showClose={ false }
+					showClose={ this._isMobile }
+					onClose={ this.focusSidebar }
 					previewUrl={ this.state.previewUrl }
 					externalUrl={ this.state.externalUrl }
 				/>
@@ -134,4 +142,4 @@ const mapState = ( state ) => {
 	};
 };
 
-export default connect( mapState )( localize( PreviewMain ) );
+export default connect( mapState, { setLayoutFocus } )( localize( PreviewMain ) );


### PR DESCRIPTION
In our new site view, users are not able to go back to the sidebar to navigate somewhere else. This PR adds a close button for mobile

![mobile-preview](https://user-images.githubusercontent.com/156676/27641757-18e8a57e-5c1d-11e7-871f-e70129e14d0e.gif)
