### PR TITLE
Jetpack Plans: Add HappyChat button to thank you page after Jetpack plan was acquired

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -300,6 +300,10 @@
 	}
 }
 
+.checkout-thank-you__jetpack .button.thank-you-card__button {
+	font-weight: inherit;
+}
+
 .checkout-thank-you__jetpack-error-card {
 	text-align: left;
 }


### PR DESCRIPTION
* Adds a HappyChat Buttonin to the Jetpack ThankYou Card before the "Visit your site" button.
* Introduces an event `calypso_plans_autoconfig_chat_initiated' that' recorded when the button is clicked.

#### Testing instructions

1. Clone this branch and test it locally.
1. Log in into HappyChat staging as an operator (this is just to ensure there's at least one operator and the HappyChatButton shows. Otherwise you won't see it).
1. Connect a Jetpack site and acquire a paid plan.
1. Wait until you see the Thank you card, and until the "Ask a question" button is shown.

#### Screenshot

![image](https://user-images.githubusercontent.com/746152/27657700-f5843998-5c23-11e7-8bec-ce30e85177a0.png)


