### PR TITLE
Update Jetpack test

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -71,7 +71,7 @@ export const FEATURE_BUSINESS_ONBOARDING = 'business-onboarding';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 export const FEATURE_REPUBLICIZE = 'republicize';
-export const FEATURE_ALL_FREE_FEATURES = 'all-free-features';
+export const FEATURE_ALL_FREE_FEATURES = 'all-free-features'; //PLANS COPY TEST START
 export const FEATURE_ALL_PERSONAL_FEATURES = 'all-personal-features';
 export const FEATURE_ALL_PREMIUM_FEATURES = 'all-premium-features';
 export const FEATURE_ADVANCED_CUSTOMIZATION = 'advanced-customization';
@@ -119,6 +119,10 @@ export const FEATURE_SECURITY_ESSENTIALS_JETPACK = 'security-essentials-jetpack'
 export const FEATURE_PRIORITY_SUPPORT_JETPACK = 'priority-support-jetpack';
 export const FEATURE_TRAFFIC_TOOLS_JETPACK = 'seo-tools-jetpack';
 export const FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK = 'seo-tools-jetpack';
+export const FEATURE_FREE_WORDPRESS_THEMES = 'free-wordpress-themes'; //PLANS COPY TEST START
+export const FEATURE_VIDEO_CDN_LIMITIED = 'video-cdn-limited';
+export const FEATURE_VIDEO_CDN_UNLIMITIED = 'video-cdn-unlimited';
+export const FEATURE_SEO_PREVIEW_TOOLS = 'seo-preview-tools';
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
 export const PLANS_LIST = {
@@ -346,11 +350,13 @@ export const PLANS_LIST = {
 			FEATURE_MANAGE
 		],
 		getSignupFeatures: () => [
-			FEATURE_STANDARD_SECURITY_TOOLS,
+			FEATURE_FREE_WORDPRESS_THEMES,
 			FEATURE_SITE_STATS,
+			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_TRAFFIC_TOOLS
 		],
 		getBillingTimeFrame: () => i18n.translate( 'for life' ),
+		getSignupBillingTimeFrame: () => 'for life', //PLANS A/B TEST: Translate if test passes
 	},
 	[ PLAN_JETPACK_PREMIUM ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
@@ -378,11 +384,13 @@ export const PLANS_LIST = {
 			FEATURE_MALWARE_SCANNING_DAILY,
 		] ),
 		getSignupFeatures: () => compact( [
-			FEATURE_WORDADS_INSTANT,
 			FEATURE_MALWARE_SCANNING_DAILY,
+			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_WORDADS_INSTANT,
 			FEATURE_ALL_PERSONAL_FEATURES,
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getSignupBillingTimeFrame: () => 'per year', //PLANS A/B TEST: Translate if test passes
 	},
 
 	[ PLAN_JETPACK_PREMIUM_MONTHLY ]: {
@@ -410,11 +418,13 @@ export const PLANS_LIST = {
 			FEATURE_MALWARE_SCANNING_DAILY,
 		] ),
 		getSignupFeatures: () => compact( [
-			FEATURE_WORDADS_INSTANT,
 			FEATURE_MALWARE_SCANNING_DAILY,
+			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_WORDADS_INSTANT,
 			FEATURE_ALL_PERSONAL_FEATURES,
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		getSignupBillingTimeFrame: () => 'per month', //PLANS A/B TEST: Translate if test passes
 	},
 
 	[ PLAN_JETPACK_PERSONAL ]: {
@@ -438,11 +448,13 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_SUPPORT,
 		],
 		getSignupFeatures: () => [
+			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_PREMIUM_SUPPORT,
-			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP,
+			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_ALL_FREE_FEATURES,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getSignupBillingTimeFrame: () => 'per year', //PLANS A/B TEST: Translate if test passes
 	},
 
 	[ PLAN_JETPACK_PERSONAL_MONTHLY ]: {
@@ -466,11 +478,13 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_SUPPORT,
 		],
 		getSignupFeatures: () => [
+			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_PREMIUM_SUPPORT,
-			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP,
+			FEATURE_SPAM_AKISMET_PLUS,
 			FEATURE_ALL_FREE_FEATURES,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		getSignupBillingTimeFrame: () => 'per month', //PLANS A/B TEST: Translate if test passes
 	},
 
 	[ PLAN_JETPACK_BUSINESS ]: {
@@ -508,10 +522,12 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
+			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_SEO_PREVIEW_TOOLS,
 			FEATURE_ALL_PREMIUM_FEATURES
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
+		getSignupBillingTimeFrame: () => 'per year', //PLANS A/B TEST: Translate if test passes
 	},
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
 		getTitle: () => i18n.translate( 'Professional' ),
@@ -548,10 +564,12 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_ONE_CLICK_THREAT_RESOLUTION,
+			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_SEO_PREVIEW_TOOLS,
 			FEATURE_ALL_PREMIUM_FEATURES
 		] ),
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		getSignupBillingTimeFrame: () => 'per month', //PLANS A/B TEST: Translate if test passes
 	}
 };
 
@@ -629,6 +647,26 @@ export const FEATURES_LIST = {
 	[ FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP ]: {
 		getSlug: () => FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP,
 		getTitle: () => 'Unlimited Backup Space', //PLANS A/B TEST: Translate if test passes
+	},
+
+	[ FEATURE_FREE_WORDPRESS_THEMES ]: {
+		getSlug: () => FEATURE_FREE_WORDPRESS_THEMES,
+		getTitle: () => 'Free WordPress Themes', //PLANS A/B TEST: Translate if test passes
+	},
+
+	[ FEATURE_VIDEO_CDN_LIMITIED ]: {
+		getSlug: () => FEATURE_VIDEO_CDN_LIMITIED,
+		getTitle: () => 'Video CDN (13GB)', //PLANS A/B TEST: Translate if test passes
+	},
+
+	[ FEATURE_VIDEO_CDN_UNLIMITIED ]: {
+		getSlug: () => FEATURE_VIDEO_CDN_UNLIMITIED,
+		getTitle: () => 'Video CDN (Unlimited)', //PLANS A/B TEST: Translate if test passes
+	},
+
+	[ FEATURE_SEO_PREVIEW_TOOLS ]: {
+		getSlug: () => FEATURE_SEO_PREVIEW_TOOLS,
+		getTitle: () => 'SEO Preview Tools', //PLANS A/B TEST: Translate if test passes
 	},
 
 	[ FEATURE_GOOGLE_ANALYTICS ]: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -522,7 +522,7 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_VIDEO_CDN_UNLIMITIED,
 			FEATURE_SEO_PREVIEW_TOOLS,
 			FEATURE_ALL_PREMIUM_FEATURES
 		] ),
@@ -564,7 +564,7 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_VIDEO_CDN_UNLIMITIED,
 			FEATURE_SEO_PREVIEW_TOOLS,
 			FEATURE_ALL_PREMIUM_FEATURES
 		] ),
@@ -656,12 +656,12 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_VIDEO_CDN_LIMITIED ]: {
 		getSlug: () => FEATURE_VIDEO_CDN_LIMITIED,
-		getTitle: () => 'Video CDN (13GB)', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => '13GB Video Storage', //PLANS A/B TEST: Translate if test passes
 	},
 
 	[ FEATURE_VIDEO_CDN_UNLIMITIED ]: {
 		getSlug: () => FEATURE_VIDEO_CDN_UNLIMITIED,
-		getTitle: () => 'Video CDN (Unlimited)', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => 'Unlimited Video Storage', //PLANS A/B TEST: Translate if test passes
 	},
 
 	[ FEATURE_SEO_PREVIEW_TOOLS ]: {

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -71,7 +71,7 @@ export const FEATURE_BUSINESS_ONBOARDING = 'business-onboarding';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 export const FEATURE_REPUBLICIZE = 'republicize';
-export const FEATURE_ALL_FREE_FEATURES = 'all-free-features'; //PLANS COPY TEST START
+export const FEATURE_ALL_FREE_FEATURES = 'all-free-features';
 export const FEATURE_ALL_PERSONAL_FEATURES = 'all-personal-features';
 export const FEATURE_ALL_PREMIUM_FEATURES = 'all-premium-features';
 export const FEATURE_ADVANCED_CUSTOMIZATION = 'advanced-customization';
@@ -119,9 +119,9 @@ export const FEATURE_SECURITY_ESSENTIALS_JETPACK = 'security-essentials-jetpack'
 export const FEATURE_PRIORITY_SUPPORT_JETPACK = 'priority-support-jetpack';
 export const FEATURE_TRAFFIC_TOOLS_JETPACK = 'seo-tools-jetpack';
 export const FEATURE_ADVANCED_TRAFFIC_TOOLS_JETPACK = 'seo-tools-jetpack';
-export const FEATURE_FREE_WORDPRESS_THEMES = 'free-wordpress-themes'; //PLANS COPY TEST START
-export const FEATURE_VIDEO_CDN_LIMITIED = 'video-cdn-limited';
-export const FEATURE_VIDEO_CDN_UNLIMITIED = 'video-cdn-unlimited';
+export const FEATURE_FREE_WORDPRESS_THEMES = 'free-wordpress-themes';
+export const FEATURE_VIDEO_CDN_LIMITED = 'video-cdn-limited';
+export const FEATURE_VIDEO_CDN_UNLIMITED = 'video-cdn-unlimited';
 export const FEATURE_SEO_PREVIEW_TOOLS = 'seo-preview-tools';
 
 // DO NOT import. Use `getPlan` from `lib/plans` instead.
@@ -356,7 +356,7 @@ export const PLANS_LIST = {
 			FEATURE_TRAFFIC_TOOLS
 		],
 		getBillingTimeFrame: () => i18n.translate( 'for life' ),
-		getSignupBillingTimeFrame: () => 'for life', //PLANS A/B TEST: Translate if test passes
+		getSignupBillingTimeFrame: () => i18n.translate( 'for life' ),
 	},
 	[ PLAN_JETPACK_PREMIUM ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
@@ -385,12 +385,12 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_MALWARE_SCANNING_DAILY,
-			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_VIDEO_CDN_LIMITED,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_ALL_PERSONAL_FEATURES,
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getSignupBillingTimeFrame: () => 'per year', //PLANS A/B TEST: Translate if test passes
+		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
 	},
 
 	[ PLAN_JETPACK_PREMIUM_MONTHLY ]: {
@@ -419,7 +419,7 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_MALWARE_SCANNING_DAILY,
-			FEATURE_VIDEO_CDN_LIMITIED,
+			FEATURE_VIDEO_CDN_LIMITED,
 			FEATURE_WORDADS_INSTANT,
 			FEATURE_ALL_PERSONAL_FEATURES,
 		] ),
@@ -454,7 +454,7 @@ export const PLANS_LIST = {
 			FEATURE_ALL_FREE_FEATURES,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getSignupBillingTimeFrame: () => 'per year', //PLANS A/B TEST: Translate if test passes
+		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
 	},
 
 	[ PLAN_JETPACK_PERSONAL_MONTHLY ]: {
@@ -522,12 +522,12 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_VIDEO_CDN_UNLIMITIED,
+			FEATURE_VIDEO_CDN_UNLIMITED,
 			FEATURE_SEO_PREVIEW_TOOLS,
 			FEATURE_ALL_PREMIUM_FEATURES
 		] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
-		getSignupBillingTimeFrame: () => 'per year', //PLANS A/B TEST: Translate if test passes
+		getSignupBillingTimeFrame: () => i18n.translate( 'per year' ),
 	},
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
 		getTitle: () => i18n.translate( 'Professional' ),
@@ -564,7 +564,7 @@ export const PLANS_LIST = {
 		] ),
 		getSignupFeatures: () => compact( [
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-			FEATURE_VIDEO_CDN_UNLIMITIED,
+			FEATURE_VIDEO_CDN_UNLIMITED,
 			FEATURE_SEO_PREVIEW_TOOLS,
 			FEATURE_ALL_PREMIUM_FEATURES
 		] ),
@@ -654,13 +654,13 @@ export const FEATURES_LIST = {
 		getTitle: () => 'Free WordPress Themes', //PLANS A/B TEST: Translate if test passes
 	},
 
-	[ FEATURE_VIDEO_CDN_LIMITIED ]: {
-		getSlug: () => FEATURE_VIDEO_CDN_LIMITIED,
+	[ FEATURE_VIDEO_CDN_LIMITED ]: {
+		getSlug: () => FEATURE_VIDEO_CDN_LIMITED,
 		getTitle: () => '13GB Video Storage', //PLANS A/B TEST: Translate if test passes
 	},
 
-	[ FEATURE_VIDEO_CDN_UNLIMITIED ]: {
-		getSlug: () => FEATURE_VIDEO_CDN_UNLIMITIED,
+	[ FEATURE_VIDEO_CDN_UNLIMITED ]: {
+		getSlug: () => FEATURE_VIDEO_CDN_UNLIMITED,
 		getTitle: () => 'Unlimited Video Storage', //PLANS A/B TEST: Translate if test passes
 	},
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -122,7 +122,7 @@ class PlanFeatures extends Component {
 		// center plans
 		if ( isInSignupTest && plansWrapper ) {
 			displayJetpackPlans
-				? plansWrapper.scrollLeft = 150
+				? plansWrapper.scrollLeft = 190
 				: plansWrapper.scrollLeft = 495;
 		}
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -235,7 +235,16 @@ class PlanFeatures extends Component {
 	}
 
 	renderPlanHeaders() {
-		const { planProperties, intervalType, site, basePlansPath, isInSignup, isInSignupTest, siteType } = this.props;
+		const {
+			planProperties,
+			intervalType,
+			site,
+			basePlansPath,
+			isInSignup,
+			isInSignupTest,
+			siteType,
+			displayJetpackPlans
+		} = this.props;
 
 		return map( planProperties, ( properties ) => {
 			const {
@@ -252,6 +261,7 @@ class PlanFeatures extends Component {
 			const { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
 			let audience = planConstantObj.getAudience();
+			let billingTimeFrame = planConstantObj.getBillingTimeFrame();
 
 			if ( isInSignupTest ) {
 				switch ( siteType ) {
@@ -266,6 +276,10 @@ class PlanFeatures extends Component {
 				}
 			}
 
+			if ( isInSignupTest && displayJetpackPlans ) {
+				billingTimeFrame = planConstantObj.getSignupBillingTimeFrame();
+			}
+
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesHeader
@@ -278,7 +292,7 @@ class PlanFeatures extends Component {
 						planType={ planName }
 						rawPrice={ rawPrice }
 						discountPrice={ discountPrice }
-						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
+						billingTimeFrame={ billingTimeFrame }
 						isPlaceholder={ isPlaceholder }
 						intervalType={ intervalType }
 						site={ site }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -37,11 +37,10 @@ import { abtest } from 'lib/abtest';
 class PlansFeaturesMain extends Component {
 	isInSignupTest() {
 		const {
-			isInSignup,
-			displayJetpackPlans
+			isInSignup
 		} = this.props;
 
-		return ( ( isInSignup && ! displayJetpackPlans ) && ( abtest( 'signupPlansCopyChanges' ) === 'modified' ) );
+		return ( ( isInSignup ) && ( abtest( 'signupPlansCopyChanges' ) === 'modified' ) );
 	}
 
 	getPlanFeatures() {
@@ -375,8 +374,7 @@ class PlansFeaturesMain extends Component {
 		const {
 			site,
 			displayJetpackPlans,
-			isInSignup,
-			isInSignupTest
+			isInSignup
 		} = this.props;
 
 		const renderFAQ = () =>
@@ -391,7 +389,7 @@ class PlansFeaturesMain extends Component {
 
 		return (
 			<div className="plans-features-main">
-				{ ( displayJetpackPlans && isInSignupTest ) ? this.getIntervalTypeToggle() : null }
+				{ ( displayJetpackPlans && this.isInSignupTest() ) ? this.getIntervalTypeToggle() : null }
 				<QueryPlans />
 				<QuerySitePlans siteId={ get( site, 'ID' ) } />
 				{ this.getPlanFeatures() }


### PR DESCRIPTION
This PR adds exposes a test on the Jetpack plans connect page. It's similar to the signup plans test we just launched for WP.com but for Jetpack.

**Hypothesis**
Variation `modified` will increase purchase rate for Jetpack plans by a minimum of 2%

**Variations**
`original`
![image](https://user-images.githubusercontent.com/6981253/27639056-296081cc-5be3-11e7-91ce-f0b937a57e82.png)

`modified`
![image](https://user-images.githubusercontent.com/6981253/27688127-74cebb50-5ca7-11e7-8703-fe3494f27454.png)


**Testing**
- Make sure you have an instance of WP.org installed somewhere.
- Visit calypso.localhost:3000/jetpack/connect/plans/[URL] — where URL is your hosted site's url.
- Enable the test with: `localStorage.setItem( 'ABTests', '{"signupPlansCopyChanges_20170623":"modified"}' );`

@markryall @taggon can you take a look when you have a chance. 
