### PR TITLE
Mobile Theme: update verbiage

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -132,7 +132,7 @@ class ThemeEnhancements extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="minileven"
-					label={ translate( 'Optimize your site with a mobile-friendly theme for tablets and phones' ) }
+					label={ translate( 'Enable the Jetpack Mobile theme' ) }
 					disabled={ formPending }
 					/>
 


### PR DESCRIPTION
The existing feature verbiage `Optimize your site with a mobile-friendly theme for tablets and phones` was too confusing to users, leading them to activate it without understanding what was going on.  

see https://github.com/Automattic/jetpack/issues/7036

Updates it to: 
![screen shot 2017-06-28 at 9 32 31 am](https://user-images.githubusercontent.com/7129409/27639703-078b615a-5be5-11e7-8224-e6173e555ce2.png)

You can see this in the themes settings card for your Jetpack site at `/settings/writing/%SITEID%`