### PR TITLE
Google Apps: Properly format monthly price for G Suite

### DIFF
--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -21,6 +21,7 @@ import {
 	recordGoogleEvent,
 	composeAnalytics,
 } from 'state/analytics/actions';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 
 class GoogleAppsDialog extends React.Component {
 	static propTypes = {
@@ -51,9 +52,10 @@ class GoogleAppsDialog extends React.Component {
 
 	render() {
 		const gapps = this.props.productsList && this.props.productsList.get().gapps;
-		const price = gapps && gapps.cost_display;
-		const monthlyPrice = getMonthlyPrice( price );
-		const annualPrice = getAnnualPrice( price );
+		const prices = gapps && gapps.prices;
+		const { currencyCode } = this.props;
+		const annualPrice = getAnnualPrice( prices[ currencyCode ], currencyCode );
+		const monthlyPrice = getMonthlyPrice( prices[ currencyCode ], currencyCode );
 
 		return (
 			<form className="google-apps-dialog" onSubmit={ this.handleFormSubmit }>
@@ -301,7 +303,9 @@ const recordFormSubmit = ( section ) => composeAnalytics(
 );
 
 export default connect(
-	null,
+	( state ) => ( {
+		currencyCode: getCurrentUserCurrencyCode( state ),
+	} ),
 	{
 		recordAddEmailButtonClick,
 		recordCancelButtonClick,

--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -51,11 +52,11 @@ class GoogleAppsDialog extends React.Component {
 	}
 
 	render() {
-		const gapps = this.props.productsList && this.props.productsList.get().gapps;
-		const prices = gapps && gapps.prices;
+		const productsList = this.props.productsList && this.props.productsList.get();
 		const { currencyCode } = this.props;
-		const annualPrice = getAnnualPrice( prices[ currencyCode ], currencyCode );
-		const monthlyPrice = getMonthlyPrice( prices[ currencyCode ], currencyCode );
+		const price = get( productsList, [ 'gapps', 'prices', currencyCode ], 0 );
+		const annualPrice = getAnnualPrice( price, currencyCode );
+		const monthlyPrice = getMonthlyPrice( price, currencyCode );
 
 		return (
 			<form className="google-apps-dialog" onSubmit={ this.handleFormSubmit }>

--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -1,26 +1,19 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { numberFormat } from 'i18n-calypso';
+import formatCurrency from 'lib/format-currency';
 
 /**
  * Constants
  */
 const GOOGLE_APPS_LINK_PREFIX = 'https://mail.google.com/a/';
-const PRICE_FORMAT = /(\d+[.,]?\d+)/;
 
-function getAnnualPrice( price ) {
-	return price && price.replace( PRICE_FORMAT, ( value ) => {
-		const number = parseFloat( value );
-		return number % 1 === 0 ? number : numberFormat( number, 2 );
-	} );
+function getAnnualPrice( cost, currencyCode ) {
+	return formatCurrency( cost, currencyCode );
 }
 
-function getMonthlyPrice( price ) {
-	return price && price.replace( PRICE_FORMAT, ( value ) => {
-		const number = ( Math.round( parseFloat( value ) / 10 * 100 ) / 100 );
-		return number % 1 === 0 ? number : numberFormat( number, 2 );
-	} );
+function getMonthlyPrice( cost, currencyCode ) {
+	return formatCurrency( cost / 10, currencyCode );
 }
 
 function googleAppsSettingsUrl( domainName ) {

--- a/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
@@ -32,13 +32,13 @@ const AddGoogleAppsCard = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'email' ) ],
 
 	render() {
-		const prices = get( this.props, 'products.gapps.prices', [] ),
+		const { currencyCode, translate } = this.props,
+			price = get( this.props, [ 'products', 'gapps', 'prices', currencyCode ], 0 ),
 			googleAppsSupportUrl = support.ADDING_GOOGLE_APPS_TO_YOUR_SITE,
-			selectedDomainName = this.props.selectedSite.domain,
-			{ currencyCode, translate } = this.props;
+			selectedDomainName = this.props.selectedSite.domain;
 
-		const annualPrice = getAnnualPrice( prices[ currencyCode ], currencyCode );
-		const monthlyPrice = getMonthlyPrice( prices[ currencyCode ], currencyCode );
+		const annualPrice = getAnnualPrice( price, currencyCode );
+		const monthlyPrice = getMonthlyPrice( price, currencyCode );
 
 		return (
 			<div>

--- a/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import page from 'page';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +17,7 @@ import paths from 'my-sites/domains/paths';
 import support from 'lib/url/support';
 import analyticsMixin from 'lib/mixins/analytics';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 
 const AddGoogleAppsCard = React.createClass( {
 	propTypes: {
@@ -29,14 +32,13 @@ const AddGoogleAppsCard = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'email' ) ],
 
 	render() {
-		const gapps = this.props.products.gapps,
+		const prices = get( this.props, 'products.gapps.prices', [] ),
 			googleAppsSupportUrl = support.ADDING_GOOGLE_APPS_TO_YOUR_SITE,
-			price = gapps && gapps.cost_display,
 			selectedDomainName = this.props.selectedSite.domain,
-			{ translate } = this.props;
+			{ currencyCode, translate } = this.props;
 
-		const annualPrice = getAnnualPrice( price );
-		const monthlyPrice = getMonthlyPrice( price );
+		const annualPrice = getAnnualPrice( prices[ currencyCode ], currencyCode );
+		const monthlyPrice = getMonthlyPrice( prices[ currencyCode ], currencyCode );
 
 		return (
 			<div>
@@ -223,4 +225,8 @@ const AddGoogleAppsCard = React.createClass( {
 	}
 } );
 
-export default localize( AddGoogleAppsCard );
+export default connect(
+	( state ) => ( {
+		currencyCode: getCurrentUserCurrencyCode( state ),
+	} )
+)( localize( AddGoogleAppsCard ) );


### PR DESCRIPTION
The previous approach was hacky and brittle - for example, it failed and burned for Japanese Yen (formatted as `5,800`, with `,` as the thousands separator, not a decimal separator).

The new approach (hattip to @iamgabrielma for the idea) uses `format-currency` and the raw price we get from the backend. Less hacky code and should be future-proof.

### Testing
We show these monthly prices in two places:

1. Domains -> Add -> domain:
<img width="747" alt="screen shot 2017-06-28 at 15 31 47" src="https://user-images.githubusercontent.com/3392497/27639855-d89b2d0c-5c17-11e7-9fbd-c53c45e0e130.png">

2. Domains -> Email:
<img width="945" alt="screen shot 2017-06-28 at 15 33 05" src="https://user-images.githubusercontent.com/3392497/27639864-df4a128a-5c17-11e7-90f6-1e7cd83b4db4.png">

Fixes #15192