### PR TITLE
Comments: Fix comment detail preview line-clamp fallback gradient

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -20,7 +20,6 @@
 	// If the comment is unapproved and collapsed, color it yellow.
 	&.is-unapproved.is-collapsed {
 		.comment-detail__header {
-			//background: rgba( $alert-yellow, 0.085 );
 			background: mix( $alert-yellow, $white, 8.5% );
 			box-shadow: inset 4px 0 0 0 $alert-yellow;
 		}

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -20,7 +20,8 @@
 	// If the comment is unapproved and collapsed, color it yellow.
 	&.is-unapproved.is-collapsed {
 		.comment-detail__header {
-			background: rgba( $alert-yellow, 0.085 );
+			//background: rgba( $alert-yellow, 0.085 );
+			background: mix( $alert-yellow, $white, 8.5% );
 			box-shadow: inset 4px 0 0 0 $alert-yellow;
 		}
 	}
@@ -128,7 +129,11 @@
 	width: 60%;
 
 	&:after {
-		background: linear-gradient(to right, rgba( $white, 0 ), rgba( $white, 1 ) 50%);
+		background: linear-gradient(
+			to right,
+			rgba( $white, 0 ),
+			rgba( $white, 1 ) 50%
+		);
 		content: '';
 		height: 19px;
 		position: absolute;
@@ -144,6 +149,13 @@
 			background: transparent;
 		}
 	}
+}
+.comment-detail.is-unapproved .comment-detail__comment-preview:after {
+	background: linear-gradient(
+		to right,
+		rgba( mix( $alert-yellow, $white, 8.5% ), 0 ),
+		rgba( mix( $alert-yellow, $white, 8.5% ), 1 ) 50%
+	);
 }
 
 .comment-detail__actions {
@@ -487,6 +499,9 @@ a.comment-detail__author-more-element {
 		color: transparent;
 		height: 32px;
 		margin: 0 8px;
+		&:after {
+			background: transparent;
+		}
 	}
 
 	&.is-expanded .comment-detail__header {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/15590

In browsers not supporting `line-clamp` and using the gradient workaround:
- Add a yellow gradient for pending comments, to match the yellow background.
- Remove the gradient on placeholders.

<img width="645" alt="screen shot 2017-06-28 at 14 02 34" src="https://user-images.githubusercontent.com/2070010/27641131-e9e1ff0a-5c12-11e7-95ec-b3342b860c69.png">
