### PR TITLE
Posts List: do not load PostShare asynchronously

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -28,7 +28,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 
 import Comments from 'blocks/comments';
-import AsyncLoad from 'components/async-load';
+import PostShare from 'blocks/post-share';
 import PostActions from 'blocks/post-actions';
 
 function recordEvent( eventAction ) {
@@ -342,8 +342,7 @@ const Post = React.createClass( {
 				{
 					this.state.showShare &&
 					config.isEnabled( 'republicize' ) &&
-					<AsyncLoad
-						require="blocks/post-share"
+					<PostShare
 						post={ this.props.post }
 						siteId={ this.props.post.site_ID } />
 				}


### PR DESCRIPTION
This PR tries do a quick fix a bug (in prod) because the wrong chunk loaded.
See [this PR](https://github.com/Automattic/wp-calypso/pull/12005) to know more about this issue.

```
manifest.981760b….min.js:1 TypeError: Cannot read property 'call' of undefined
    at e (manifest.981760b….min.js:1)
    at posts-pages.f68d46d….min.js:3
    at <anonymous>
```

### Testing

In this case I suggest use the testing branch to check if the bug is fixed:

`https://calypso.live/posts/my/<your-testing-site>?branch=fix/post-share-async-loading`

Confirme that you are able to open the `Share` tab.

<img src="https://user-images.githubusercontent.com/77539/27642271-a31127cc-5bf4-11e7-8e96-13a9aee57e55.png" width="400px" />