### PR TITLE
Add an optional 'required' prop to form labels

### DIFF
--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -3,7 +3,8 @@
  */
 var React = require( 'react' ),
 	classnames = require( 'classnames' ),
-	omit = require( 'lodash/omit' );
+	omit = require( 'lodash/omit' ),
+	i18n = require( 'i18n-calypso' );
 
 module.exports = React.createClass( {
 
@@ -18,7 +19,7 @@ module.exports = React.createClass( {
 			<label { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-label' ) } >
 				{ this.props.children }
 				{ this.props.required && (
-					<span className="form-label__required"> *</span>
+					<small className="form-label__required">{ i18n.translate( 'Required' ) }</small>
 				) }
 			</label>
 		);

--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -9,10 +9,17 @@ module.exports = React.createClass( {
 
 	displayName: 'FormLabel',
 
+	propTypes: {
+		required: React.PropTypes.bool,
+	},
+
 	render: function() {
 		return (
 			<label { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-label' ) } >
 				{ this.props.children }
+				{ this.props.required && (
+					<span className="form-label__required"> *</span>
+				) }
 			</label>
 		);
 	}

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -3,6 +3,10 @@
 	font-size: 14px;
 	font-weight: 600;
 	margin-bottom: 5px;
+
+	.form-label__required {
+		color: $alert-red;
+	}
 }
 
 .form-label input[type="checkbox"] + span,

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -6,6 +6,8 @@
 
 	.form-label__required {
 		color: $alert-red;
+		font-weight: normal;
+		margin-left: 6px;
 	}
 }
 

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 5px;
 
 	.form-label__required {
-		color: $alert-red;
+		color: $orange-fire;
 		font-weight: normal;
 		margin-left: 6px;
 	}


### PR DESCRIPTION
This would be handy for some of the inputs in Store on WP.com.

To test:

Add a `required` flag to any instance of `FormLabel` e.g:

```
<FormLabel className="reset-password-confirm-form__text-input-label" htmlFor="password" required>
	{ translate( 'New password' ) }
</FormLabel>
```

See traditional red "required" asterisk:

![required](https://cldup.com/Ie6nwGdPJc-1200x1200.png)