### PR TITLE
First-View: Fix a bug that caused the first-view overlay to remain

### DIFF
--- a/client/components/first-view/index.jsx
+++ b/client/components/first-view/index.jsx
@@ -43,7 +43,9 @@ const FirstView = React.createClass( {
 	},
 
 	componentWillUnmount() {
-		this.updateDocumentStylesForHiddenFirstView();
+		process.nextTick( () => {
+			this.updateDocumentStylesForHiddenFirstView();
+		} );
 	},
 
 	render() {


### PR DESCRIPTION
This PR fixes a bug that caused the first-view overlay to remain visible after navigating to another section.

Before the fix:
![first-view-before](https://user-images.githubusercontent.com/363749/27649243-cb450086-5bf6-11e7-9b9b-e61b45862b31.gif)

After the fix:
![first-view-after](https://user-images.githubusercontent.com/363749/27649336-13624162-5bf7-11e7-8dfd-51811db9d4ec.gif)


To test:
* Before checking out branch, confirm existing behavior.
* With a new user, visit the Stats section of My Site.
* Without dismissing the First-View overlay, click on another section, like "Plans".
* Notice that the overlay remains and you cannot interact with the page.
* Checkout branch.
* Repeat process of clicking on Stats, leaving First-View alone, and then navigating to another section.
* Confirm fixed.