### PR TITLE
Devdocs: fix WizardBar component name

### DIFF
--- a/client/components/wizard-bar/docs/example.jsx
+++ b/client/components/wizard-bar/docs/example.jsx
@@ -8,14 +8,16 @@ import React from 'react';
  */
 import WizardBar from 'components/wizard-bar';
 
-export default class WizardBarExample extends React.Component {
-	render() {
-		return (
-			<div>
-				<WizardBar value={ 0 } />
-				<WizardBar value={ 55 } total={ 100 } />
-				<WizardBar value={ 100 } color="#1BABDA" />
-			</div>
-		);
-	}
-}
+const WizardBarExample = () => {
+	return (
+		<div>
+			<WizardBar value={ 0 } />
+			<WizardBar value={ 55 } total={ 100 } />
+			<WizardBar value={ 100 } color="#1BABDA" />
+		</div>
+	);
+};
+
+WizardBarExample.displayName = 'WizardBar';
+
+export default WizardBarExample;


### PR DESCRIPTION
Before:

<img width="699" alt="screen shot 2017-06-28 at 12 26 59" src="https://user-images.githubusercontent.com/17325/27649692-834ef32c-5c00-11e7-874f-ee8738c01f7f.png">

After:

<img width="707" alt="screen shot 2017-06-28 at 12 48 27" src="https://user-images.githubusercontent.com/17325/27649697-864a4946-5c00-11e7-8b7a-edc63d6cb1f4.png">

### To test 

Visit http://calypso.localhost:3000/devdocs/design and check the title 'WizardBar' appears correctly.