### PR TITLE
Auto-naming shipping zones

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -38,13 +38,17 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 		switch ( location.type ) {
 			case 'continent':
 				if ( location.selectedCountryCount && location.selectedCountryCount !== location.countryCount ) {
-					return translate( '%(selected)s out of %(count)s countries', {
-						count: location.countryCount,
-						args: {
-							selected: location.selectedCountryCount,
+					return translate(
+						'%(selected)s out of %(count)s country',
+						'%(selected)s out of %(count)s countries',
+						{
 							count: location.countryCount,
+							args: {
+								selected: location.selectedCountryCount,
+								count: location.countryCount,
+							}
 						}
-					} );
+					);
 				}
 
 				return translate( 'All countries' );

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
@@ -17,7 +17,7 @@ import { changeShippingZoneName } from 'woocommerce/state/ui/shipping/zones/acti
 import { bindActionCreatorsWithSiteId } from 'woocommerce/lib/redux-utils';
 
 export const getZoneName = ( zone, locations, translate, returnEmpty = false ) => {
-	if ( zone.name ) {
+	if ( zone && zone.name ) {
 		return zone.name;
 	}
 
@@ -30,7 +30,7 @@ export const getZoneName = ( zone, locations, translate, returnEmpty = false ) =
 	}
 
 	const locationNames = locations.map( ( { name, postcodeFilter } ) => (
-		postcodeFilter ? postcodeFilter : decodeEntities( name )
+		postcodeFilter ? `${ name } (${ postcodeFilter })` : decodeEntities( name )
 	) );
 
 	if ( locationNames.length > 10 ) {

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
@@ -12,9 +12,45 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import Card from 'components/card';
 import FormTextInput from 'components/forms/form-text-input';
-import { getCurrentlyEditingShippingZone } from 'woocommerce/state/ui/shipping/zones/selectors';
+import { decodeEntities } from 'lib/formatting';
 import { changeShippingZoneName } from 'woocommerce/state/ui/shipping/zones/actions';
 import { bindActionCreatorsWithSiteId } from 'woocommerce/lib/redux-utils';
+
+export const getZoneName = ( zone, locations, translate, returnEmpty = false ) => {
+	if ( zone.name ) {
+		return zone.name;
+	}
+
+	if ( returnEmpty ) {
+		return '';
+	}
+
+	if ( ! locations || ! locations.length ) {
+		return translate( 'Empty zone' );
+	}
+
+	const locationNames = locations.map( ( { name, postcodeFilter } ) => (
+		postcodeFilter ? postcodeFilter : decodeEntities( name )
+	) );
+
+	if ( locationNames.length > 10 ) {
+		const remaining = locationNames.length - 10;
+		const listed = locationNames.slice( 0, 10 );
+		return ( translate(
+			'%(locationList)s and %(count)s other region',
+			'%(locationList)s and %(count)s other regions',
+			{
+				count: remaining,
+				args: {
+					locationList: listed.join( ', ' ),
+					count: remaining,
+				}
+			}
+		) );
+	}
+
+	return locationNames.join( ', ' );
+};
 
 class ShippingZoneName extends Component {
 	constructor( props ) {
@@ -26,7 +62,7 @@ class ShippingZoneName extends Component {
 	}
 
 	render() {
-		const { loaded, isRestOfTheWorld, zone, actions, onChange } = this.props;
+		const { loaded, isRestOfTheWorld, zone, locations, actions, onChange, translate } = this.props;
 		const { editing } = this.state;
 
 		const startEditing = () => ( this.setState( { editing: true } ) );
@@ -51,7 +87,10 @@ class ShippingZoneName extends Component {
 			if ( editing ) {
 				return (
 					<div className="shipping-zone__name">
-						<FormTextInput value={ zone.name } onChange={ onNameChange } />
+						<FormTextInput
+							value={ getZoneName( zone, locations, translate, true ) }
+							onChange={ onNameChange }
+							placeholder={ translate( 'Enter a new zone name or leave empty to automatically list locations' ) } />
 						<Button borderless onClick={ stopEditing }>
 							<Gridicon icon="checkmark" size={ 24 } />
 						</Button>
@@ -61,7 +100,7 @@ class ShippingZoneName extends Component {
 
 			return (
 				<div className="shipping-zone__name">
-					<span>{ zone.name }</span>
+					<span>{ getZoneName( zone, locations, translate ) }</span>
 					{ isRestOfTheWorld
 						? null
 						: <Button borderless onClick={ startEditing }><Gridicon icon="pencil" size={ 24 } /></Button> }
@@ -82,12 +121,12 @@ ShippingZoneName.PropTypes = {
 	isRestOfTheWorld: PropTypes.bool.isRequired,
 	loaded: PropTypes.bool.isRequired,
 	onChange: PropTypes.func.isRequired,
+	zone: PropTypes.object,
+	locations: PropTypes.array,
 };
 
 export default connect(
-	( state ) => ( {
-		zone: getCurrentlyEditingShippingZone( state ),
-	} ),
+	null,
 	( dispatch, ownProps ) => ( {
 		actions: bindActionCreatorsWithSiteId( {
 			changeShippingZoneName,


### PR DESCRIPTION
Auto-names newly created shipping zones.

Works similar to core, i.e. once the zone has been saved, it's name is set and the zone won't be auto-named anymore. To reenable auto-naming, you can clear the zone name control.

Similar to core, limits the number of locations to 10, and afterwards appends "and X other regions" to the list.