### PR TITLE
Reader: Remove min-height for subscriptionlistitem with email settings

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -1,12 +1,6 @@
 .reader-subscription-list-item {
 	display: flex;
 	flex-direction: row;
-
-	&.has-email-settings {
-		@include breakpoint( "<660px" ) {
-			min-height: 56px;
-		}
-	}
 }
 
 .reader-subscription-list-item__byline {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/15531

Question: Did we need this css rule for anything?