### PR TITLE
Components: update ClipboardButtonInput style

### DIFF
--- a/client/components/clipboard-button-input/style.scss
+++ b/client/components/clipboard-button-input/style.scss
@@ -11,10 +11,12 @@
 
 	&:not( :disabled )::before {
 		@include long-content-fade( $size: 16px );
-		right: calc( 100% + 1px );
+		right: auto;
+		left: -17px;
 	}
 
 	&:focus::before {
-		right: calc( 100% + 3px );
+		right: auto;
+		left: -19px;
 	}
 }


### PR DESCRIPTION
If CSS `calc` results in a decimal, the pseudo element blur can cover the left border in Safari. This PR switches the positioning of the pseudo element to use a negative pixel number from the left.

**Issue:**
![safari_-_copy_button_left_edge](https://user-images.githubusercontent.com/942359/27655714-4b78e8f4-5c14-11e7-88ef-2911e3f757b0.png)

**To test:**
- Check out branch.
- In Safari, create a new post.
- Set your AB variant for the `postPublishPreview` test to `showPostPublishPreview`.
- Publish the post.
- Make sure that the button border is fully visible.
- Repeat in other browsers.