### PR TITLE
WithWidth: update displayName for debugging

### DIFF
--- a/client/lib/with-width/index.jsx
+++ b/client/lib/with-width/index.jsx
@@ -17,7 +17,7 @@ import { debounce } from 'lodash';
  * @returns {object} the enhanced component
  */
 export default ( EnhancedComponent, { domTarget } = {} ) => class WithWidth extends React.Component {
-	static displayName = `WithWidth( ${ EnhancedComponent.displayName } )`;
+	static displayName = `WithWidth( ${ EnhancedComponent.displayName || EnhancedComponent.name } )`;
 
 	state = {
 		width: 0,


### PR DESCRIPTION
Recently I created a new HoC `withWidth` that hands down the width of a available to a component as a prop.  Its helpful to see it in devtools as `WithWidth( componentName )` as opposed to `WithWidth( undefined )` which we had been seeing.

The fix was to also look for Component.name instead of just Component.displayName