### PR TITLE
Hid the WooCommerce Services-specific controls

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/index.js
@@ -9,9 +9,7 @@ import classNames from 'classnames';
  */
 import Main from 'components/main';
 import ShippingHeader from './shipping-header';
-import ShippingLabels from './shipping-labels';
 import ShippingOrigin from './shipping-origin';
-import ShippingPackageList from './shipping-package-list';
 import ShippingZoneList from './shipping-zone-list';
 
 const Shipping = ( { className } ) => {
@@ -20,8 +18,6 @@ const Shipping = ( { className } ) => {
 			<ShippingHeader />
 			<ShippingOrigin />
 			<ShippingZoneList />
-			<ShippingLabels />
-			<ShippingPackageList />
 		</Main>
 	);
 };


### PR DESCRIPTION
Removes the WCS-specific sections (Labels and Packages) from the shipping page. We are not going to include these in the initial launch.

I haven't removed the actual component files yet, as we haven't fully decided how we're going to integrate WCS UI into Calypso (or vice versa).

CC @DanReyLop @jeffstieler @kellychoffman @jameskoster 