### PR TITLE
Reader: add blog stickers block to feed header

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -22,6 +22,7 @@
 @import 'blocks/app-promo/style';
 @import 'blocks/author-compact-profile/style';
 @import 'blocks/author-selector/style';
+@import 'blocks/blog-stickers/style';
 @import 'blocks/calendar-button/style';
 @import 'blocks/calendar-popover/style';
 @import 'blocks/comment-button/style';

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -1,0 +1,42 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { find } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { connect } from 'react-redux';
+import QueryReaderTeams from 'components/data/query-reader-teams';
+import QueryBlogStickers from 'components/data/query-blog-stickers';
+import { getReaderTeams, getBlogStickers } from 'state/selectors';
+import BlogStickersList from 'blocks/blog-stickers/list';
+
+const BlogStickers = ( { blogId, teams, stickers } ) => {
+	// If the user isn't in the a8c team, don't show the feature
+	const isTeamMember = !! find( teams, [ 'slug', 'a8c' ] );
+
+	if ( teams && ! isTeamMember ) {
+		return null;
+	}
+
+	return (
+		<div className="blog-stickers">
+			{ isTeamMember && stickers && <BlogStickersList stickers={ stickers } /> }
+			{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
+			{ ! teams && <QueryReaderTeams /> }
+		</div>
+	);
+};
+
+BlogStickers.propTypes = {
+	blogId: React.PropTypes.number.isRequired,
+};
+
+export default connect( ( state, ownProps ) => {
+	return {
+		teams: getReaderTeams( state ),
+		stickers: getBlogStickers( state, ownProps.blogId ),
+	};
+} )( BlogStickers );

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -12,6 +12,7 @@ import QueryReaderTeams from 'components/data/query-reader-teams';
 import QueryBlogStickers from 'components/data/query-blog-stickers';
 import { getReaderTeams, getBlogStickers } from 'state/selectors';
 import BlogStickersList from 'blocks/blog-stickers/list';
+import InfoPopover from 'components/info-popover';
 
 const BlogStickers = ( { blogId, teams, stickers } ) => {
 	// If the user isn't in the a8c team, don't show the feature
@@ -23,7 +24,9 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 
 	return (
 		<div className="blog-stickers">
-			{ isTeamMember && stickers && <BlogStickersList stickers={ stickers } /> }
+			{ isTeamMember &&
+				stickers &&
+				<InfoPopover><BlogStickersList stickers={ stickers } /></InfoPopover> }
 			{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			{ ! teams && <QueryReaderTeams /> }
 		</div>

--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -26,6 +26,7 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 		<div className="blog-stickers">
 			{ isTeamMember &&
 				stickers &&
+				stickers.length > 0 &&
 				<InfoPopover><BlogStickersList stickers={ stickers } /></InfoPopover> }
 			{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			{ ! teams && <QueryReaderTeams /> }

--- a/client/blocks/blog-stickers/list.jsx
+++ b/client/blocks/blog-stickers/list.jsx
@@ -3,16 +3,20 @@
  */
 import React from 'react';
 import { map } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 const BlogStickersList = ( { stickers } ) => {
 	return (
-		<ul className="blog-stickers__list">
-			{ map( stickers, sticker => {
-				const key = `blog-sticker-${ sticker }`;
-				return <li key={ key }>{ sticker }</li>;
-			} ) }
-		</ul>
+		<div className="blog-stickers__list">
+			<h3 className="blog-stickers__list-title">Blog stickers</h3>
+			<ul className="blog-stickers__list-ul">
+				{ map( stickers, sticker => {
+					const key = `blog-sticker-${ sticker }`;
+					return <li className="blog-stickers__list-item" key={ key }>{ sticker }</li>;
+				} ) }
+			</ul>
+		</div>
 	);
 };
 
-export default BlogStickersList;
+export default localize( BlogStickersList );

--- a/client/blocks/blog-stickers/list.jsx
+++ b/client/blocks/blog-stickers/list.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 const BlogStickersList = ( { stickers, translate } ) => {
 	return (
 		<div className="blog-stickers__list">
-			<h3 className="blog-stickers__list-title">{ translate( 'Blog stickers' ) }</h3>
+			<h3 className="blog-stickers__list-title">{ translate( 'Blog Stickers' ) }</h3>
 			<ul className="blog-stickers__list-ul">
 				{ map( stickers, sticker => {
 					return <li className="blog-stickers__list-item" key={ sticker }>{ sticker }</li>;

--- a/client/blocks/blog-stickers/list.jsx
+++ b/client/blocks/blog-stickers/list.jsx
@@ -1,0 +1,18 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { map } from 'lodash';
+
+const BlogStickersList = ( { stickers } ) => {
+	return (
+		<ul className="blog-stickers__list">
+			{ map( stickers, sticker => {
+				const key = `blog-sticker-${ sticker }`;
+				return <li key={ key }>{ sticker }</li>;
+			} ) }
+		</ul>
+	);
+};
+
+export default BlogStickersList;

--- a/client/blocks/blog-stickers/list.jsx
+++ b/client/blocks/blog-stickers/list.jsx
@@ -5,14 +5,13 @@ import React from 'react';
 import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
-const BlogStickersList = ( { stickers } ) => {
+const BlogStickersList = ( { stickers, translate } ) => {
 	return (
 		<div className="blog-stickers__list">
-			<h3 className="blog-stickers__list-title">Blog stickers</h3>
+			<h3 className="blog-stickers__list-title">{ translate( 'Blog stickers' ) }</h3>
 			<ul className="blog-stickers__list-ul">
 				{ map( stickers, sticker => {
-					const key = `blog-sticker-${ sticker }`;
-					return <li className="blog-stickers__list-item" key={ key }>{ sticker }</li>;
+					return <li className="blog-stickers__list-item" key={ sticker }>{ sticker }</li>;
 				} ) }
 			</ul>
 		</div>

--- a/client/blocks/blog-stickers/style.scss
+++ b/client/blocks/blog-stickers/style.scss
@@ -4,15 +4,14 @@
 
 .blog-stickers__list-title {
 	font-weight: bold;
-	margin-bottom: 0.5em;
+	margin-bottom: 3px;
 }
 
 .blog-stickers__list-ul {
-	margin-left: 0;
-	margin-bottom: 0;
+	margin: 0;
 	list-style-type: square;
 }
 
 .blog-stickers__list-item {
-	margin-left: 1.3em;
+	margin-left: 16px;
 }

--- a/client/blocks/blog-stickers/style.scss
+++ b/client/blocks/blog-stickers/style.scss
@@ -1,0 +1,18 @@
+.blog-stickers {
+	display: inline;
+}
+
+.blog-stickers__list-title {
+	font-weight: bold;
+	margin-bottom: 0.5em;
+}
+
+.blog-stickers__list-ul {
+	margin-left: 0;
+	margin-bottom: 0;
+	list-style-type: square;
+}
+
+.blog-stickers__list-item {
+	margin-left: 1.3em;
+}

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -88,9 +88,10 @@ class FeedHeader extends Component {
 					</a>
 					<div className="reader-feed-header__site-title">
 						<a className="reader-feed-header__site-title-link" href={ siteUrl }>
-							{ siteBadge &&
+							{ site &&
 								<span className="reader-feed-header__site-badge">
 									{ siteBadge }
+									<BlogStickers blogId={ site.ID } />
 								</span> }
 							{ siteTitle }
 						</a>
@@ -106,7 +107,6 @@ class FeedHeader extends Component {
 									},
 								} ) }
 							</span> }
-						{ site && <BlogStickers blogId={ site.ID } /> }
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -15,6 +15,7 @@ import HeaderBack from 'reader/header-back';
 import { getSiteDescription, getSiteName, getSiteUrl } from 'reader/get-helpers';
 import Gridicon from 'gridicons';
 import SiteIcon from 'blocks/site-icon';
+import BlogStickers from 'blocks/blog-stickers';
 
 const getBadgeForSite = site => {
 	/* eslint-disable wpcalypso/jsx-gridicon-size */
@@ -105,6 +106,7 @@ class FeedHeader extends Component {
 									},
 								} ) }
 							</span> }
+						{ site && <BlogStickers blogId={ site.ID } /> }
 					</div>
 				</Card>
 			</div>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -87,12 +87,12 @@ class FeedHeader extends Component {
 						<SiteIcon site={ site } size={ 96 } />
 					</a>
 					<div className="reader-feed-header__site-title">
+						{ site &&
+							<span className="reader-feed-header__site-badge">
+								{ siteBadge }
+								<BlogStickers blogId={ site.ID } />
+							</span> }
 						<a className="reader-feed-header__site-title-link" href={ siteUrl }>
-							{ site &&
-								<span className="reader-feed-header__site-badge">
-									{ siteBadge }
-									<BlogStickers blogId={ site.ID } />
-								</span> }
 							{ siteTitle }
 						</a>
 					</div>


### PR DESCRIPTION
For Automattic team members only, this PR shows the current blog's stickers in the feed header. 

If you're eligible to see the blog stickers, and info icon will appear to the left of the site title:

<img width="453" alt="screen shot 2017-06-28 at 17 24 14" src="https://user-images.githubusercontent.com/17325/27661202-6e846450-5c27-11e7-9527-a698abc1417c.png">

By opening the popover, you can see a list of blog stickers.

For private sites, the info icon appears next to the padlock icon:

<img width="378" alt="screen shot 2017-06-28 at 17 28 42" src="https://user-images.githubusercontent.com/17325/27661227-82f9de38-5c27-11e7-974a-9f557a177d30.png">

### To test

Check http://calypso.localhost:3000/read/blogs/122463145 and make sure you can see the 'headstart' blog sticker.

The info icon won't appear on feeds with no blog ID, or if we don't have any stickers set at all.