### PR TITLE
Reader: dynamic spacer for fixed area instead of padding-top

### DIFF
--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -9,23 +9,22 @@ import { debounce } from 'lodash';
  * withDimensions assumes that you care about the space at the dom location of the component, but you may also pass
  * in a domTarget in case you want to be tracking the dimensions of a different component
  *
- * @example:
- * 1. withDimensions( Component )
- * 2. withDimensions( Component, { domTarget: thingWhoseDimensionsToTrack } )
+ * @example: withDimensions( Component )
  *
  * @param {object} EnhancedComponent - react component to wrap and give the prop width/height to
  * @returns {object} the enhanced component
  */
-export default ( EnhancedComponent, { domTarget } = {} ) => class WithWidth extends React.Component {
+export default EnhancedComponent => class WithWidth extends React.Component {
 	static displayName = `WithDimensions( ${ EnhancedComponent.displayName || EnhancedComponent.name } )`;
+	static propTypes = { domTarget: React.PropTypes.object };
 
 	state = {
 		width: 0,
 		height: 0,
 	};
 
-	handleResize = () => {
-		const domElement = domTarget ? domTarget : this.divRef;
+	handleResize = ( props = this.props ) => {
+		const domElement = props.domTarget ? props.domTarget : this.divRef;
 
 		if ( domElement ) {
 			const dimensions = domElement.getClientRects()[ 0 ];
@@ -37,9 +36,12 @@ export default ( EnhancedComponent, { domTarget } = {} ) => class WithWidth exte
 	componentDidMount() {
 		this.resizeEventListener = window.addEventListener(
 			'resize',
-			debounce( this.handleResize, 50 )
+			debounce( this.handleResize, 50 ),
 		);
 		this.handleResize();
+	}
+	componentWillReceiveProps( nextProps ) {
+		this.handleResize( nextProps );
 	}
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.resizeEventListener );

--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -5,15 +5,15 @@ import React from 'react';
 import { debounce } from 'lodash';
 
 /**
- * withWidth is a Hoc that hands down a width prop of how much available width there is for it to consume.
- * withWidth assumes that you care about the space at the dom location of the component, but you may also pass
- * in a domTarget in case you want to be tracking the width of a different component
+ * withDimensions is a Hoc that hands down a width and height prop of how much available space there is for it to consume.
+ * withDimensions assumes that you care about the space at the dom location of the component, but you may also pass
+ * in a domTarget in case you want to be tracking the dimensions of a different component
  *
  * @example:
- * 1. widthWidth( Component )
- * 2. withWidth( Component, { domTarget: thingWhoseWidthToTrack } )
+ * 1. withDimensions( Component )
+ * 2. withDimensions( Component, { domTarget: thingWhoseDimensionsToTrack } )
  *
- * @param {object} EnhancedComponent - react component to wrap and give the prop width to
+ * @param {object} EnhancedComponent - react component to wrap and give the prop width/height to
  * @returns {object} the enhanced component
  */
 export default ( EnhancedComponent, { domTarget } = {} ) => class WithWidth extends React.Component {
@@ -27,8 +27,9 @@ export default ( EnhancedComponent, { domTarget } = {} ) => class WithWidth exte
 		const domElement = domTarget ? domTarget : this.divRef;
 
 		if ( domElement ) {
-			const width = domElement.getClientRects()[ 0 ].width;
-			this.setState( { width } );
+			const dimensions = domElement.getClientRects()[ 0 ];
+			const { width, height } = dimensions;
+			this.setState( { width, height } );
 		}
 	};
 
@@ -48,7 +49,11 @@ export default ( EnhancedComponent, { domTarget } = {} ) => class WithWidth exte
 	render() {
 		return (
 			<div ref={ this.handleMount }>
-				<EnhancedComponent { ...this.props } width={ this.state.width } />
+				<EnhancedComponent
+					{ ...this.props }
+					width={ this.state.width }
+					height={ this.state.height }
+				/>
 			</div>
 		);
 	}

--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -17,10 +17,11 @@ import { debounce } from 'lodash';
  * @returns {object} the enhanced component
  */
 export default ( EnhancedComponent, { domTarget } = {} ) => class WithWidth extends React.Component {
-	static displayName = `WithWidth( ${ EnhancedComponent.displayName } )`;
+	static displayName = `WithDimensions( ${ EnhancedComponent.displayName || EnhancedComponent.name } )`;
 
 	state = {
 		width: 0,
+		height: 0,
 	};
 
 	handleResize = () => {

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -31,7 +31,14 @@ const updateQueryArg = params =>
 
 const pickSort = sort => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
-const SpacerDiv = ( { width, height } ) => <div style={ { width, height } } />;
+const SpacerDiv = withDimensions( ( { width, height } ) => (
+	<div
+		style={ {
+			width: `${ width }px`,
+			height: `${ height }px`,
+		} }
+	/>
+) );
 
 class SearchStream extends React.Component {
 	static propTypes = {
@@ -131,8 +138,6 @@ class SearchStream extends React.Component {
 			'is-post-results': searchType === POSTS && query,
 		} );
 
-		const FixedAreaPadding = withDimensions( SpacerDiv, { domTarget: this.fixedAreaRef } );
-
 		return (
 			<div>
 				<DocumentHead title={ documentTitle } />
@@ -169,7 +174,7 @@ class SearchStream extends React.Component {
 							wideDisplay={ wideDisplay }
 						/> }
 				</div>
-				<FixedAreaPadding />
+				<SpacerDiv domTarget={ this.fixedAreaRef } />
 				{ wideDisplay &&
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -31,6 +31,8 @@ const updateQueryArg = params =>
 
 const pickSort = sort => ( sort === 'date' ? SORT_BY_LAST_UPDATED : SORT_BY_RELEVANCE );
 
+const SpacerDiv = ( { width, height } ) => <div style={ { width, height } } />;
+
 class SearchStream extends React.Component {
 	static propTypes = {
 		query: PropTypes.string,
@@ -95,6 +97,8 @@ class SearchStream extends React.Component {
 		updateQueryArg( { sort } );
 	};
 
+	handleFixedAreaMounted = ref => this.fixedAreaRef = ref;
+
 	handleSearchTypeSelection = searchType => updateQueryArg( { show: searchType } );
 
 	render() {
@@ -127,10 +131,16 @@ class SearchStream extends React.Component {
 			'is-post-results': searchType === POSTS && query,
 		} );
 
+		const FixedAreaPadding = withDimensions( SpacerDiv, { domTarget: this.fixedAreaRef } );
+
 		return (
 			<div>
 				<DocumentHead title={ documentTitle } />
-				<div className="search-stream__fixed-area" style={ { width: this.props.width } }>
+				<div
+					className="search-stream__fixed-area"
+					style={ { width: this.props.width } }
+					ref={ this.handleFixedAreaMounted }
+				>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput
 							onSearch={ this.updateQuery }
@@ -159,6 +169,7 @@ class SearchStream extends React.Component {
 							wideDisplay={ wideDisplay }
 						/> }
 				</div>
+				<FixedAreaPadding />
 				{ wideDisplay &&
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -21,8 +21,8 @@ import PostResults from './post-results';
 import ReaderMain from 'components/reader-main';
 import { addQueryArgs } from 'lib/url';
 import SearchStreamHeader, { POSTS } from './search-stream-header';
-import withWidth from 'lib/with-width';
 import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
+import withDimensions from 'lib/with-dimensions';
 
 const WIDE_DISPLAY_CUTOFF = 660;
 
@@ -196,4 +196,4 @@ const wrapWithMain = Component => props => (
 );
 /* eslint-enable */
 
-export default localize( wrapWithMain( withWidth( SearchStream ) ) );
+export default localize( wrapWithMain( withDimensions( SearchStream ) ) );

--- a/client/reader/search-stream/site-results.jsx
+++ b/client/reader/search-stream/site-results.jsx
@@ -16,7 +16,7 @@ import ReaderInfiniteStream from 'components/reader-infinite-stream';
 import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
 import { SEARCH_RESULTS_SITES } from 'reader/follow-button/follow-sources';
 import { siteRowRenderer } from 'components/reader-infinite-stream/row-renderers';
-import withWidth from 'lib/with-width';
+import withDimensions from 'lib/with-dimensions';
 
 class SiteResults extends React.Component {
 	static propTypes = {
@@ -72,4 +72,4 @@ export default connect(
 		),
 	} ),
 	{ requestFeedSearch },
-)( localize( withWidth( SiteResults ) ) );
+)( localize( withDimensions( SiteResults ) ) );

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -17,21 +17,14 @@
 	background-color: $white;
 	position: fixed;
 	top: 0;
-	padding-top: 47px;
+	margin-top: 50px;
+	padding-top: 30px;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
-
-	@include breakpoint( ">660px" ) {
-		padding-top: 77px;
-	}
 }
 
 .search-stream__fixed-area .section-nav-tabs.is-dropdown {
 	margin: 0;
-}
-
-.search-stream .reader__content .reader-post-card:first-child {
-	margin-top: 120px;
 }
 
 .search-stream .search-stream__input-card.card {
@@ -39,26 +32,10 @@
 	margin-bottom: 0;
 }
 
-// Fix for smaller breakpoint on the new site-search
-.is-reader-page .search-stream__with-sites .search-stream__fixed-area {
-	top: 20px;
-
-	@include breakpoint( ">660px" ) {
-		top: 0;
-	}
-}
-
 .search-stream__input-card.card {
 	margin-bottom: 16px;
 	padding: 0;
 	z-index: z-index( 'root', '.search-stream__input-card' );
-}
-
-// Top margins
-// Top margin for post recs and post results with suggested terms
-.search-stream .search-stream__recommendation-list-item:nth-child(2),
-.search-stream .search-stream__recommendation-list-item:nth-child(3) {
-	margin-top: 100px;
 }
 
 .search-stream .search-stream__recommendation-list-item:nth-child(3) {
@@ -69,24 +46,6 @@
 
 	@media #{$reader-related-card-v2-breakpoint-small} {
 		margin-top: 0;
-	}
-}
-
-// Top margin for post recs without suggested terms
-.search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(2),
-.search-stream.search-stream__with-sites .search-stream__recommendation-list-item:nth-child(3) {
-	margin-top: 70px;
-
-	@include breakpoint( ">660px" ) {
-		margin-top: 90px;
-	}
-}
-
-.search-stream.search-stream__with-sites .search-stream__single-column-results {
-	padding-top: 130px;
-
-	@include breakpoint( ">660px" ) {
-		padding-top: 150px;
 	}
 }
 
@@ -106,21 +65,12 @@
 	}
 }
 
-.search-stream.search-stream__with-sites .search-stream__post-results .reader__card:nth-child(2) {
-	margin-top: 120px;
-}
-
 // Top margin for site results
 .main.search-stream {
 
 	@include breakpoint( "<660px") {
 		perspective: none; // Fix search bar pushed up behind the masterbar in Safari
 	}
-}
-
-.search-stream.search-stream__with-sites .is-two-columns .search-stream__post-results .reader-post-card:nth-child(2),
-.search-stream.search-stream__with-sites .is-two-columns .search-stream__site-results {
-	margin-top: 135px;
 }
 
 // Search term suggestions

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -17,7 +17,7 @@
 	background-color: $white;
 	position: fixed;
 	top: 0;
-	margin-top: 50px;
+	margin-top: 47px; // masterbar is exactly 47px
 	padding-top: 30px;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
@@ -36,33 +36,6 @@
 	margin-bottom: 16px;
 	padding: 0;
 	z-index: z-index( 'root', '.search-stream__input-card' );
-}
-
-.search-stream .search-stream__recommendation-list-item:nth-child(3) {
-
-	@media #{$reader-related-card-v2-breakpoint-medium} {
-		margin-top: 0;
-	}
-
-	@media #{$reader-related-card-v2-breakpoint-small} {
-		margin-top: 0;
-	}
-}
-
-.search-stream.search-stream__with-sites .search-stream__single-column-results .search-stream__recommendation-list-item:nth-child(2) {
-	margin-top: -60px;
-}
-
-.search-stream.search-stream__with-sites .search-stream__single-column-results .search-stream__recommendation-list-item:nth-child(3) {
-	margin-top: -60px;
-
-	@media #{$reader-related-card-v2-breakpoint-medium} {
-		margin-top: 0;
-	}
-
-	@media #{$reader-related-card-v2-breakpoint-small} {
-		margin-top: 0;
-	}
 }
 
 // Top margin for site results


### PR DESCRIPTION
In the Reader we have a couple of places where we have fixed content and then scrollable content underneath.

An example is the search stream at: http://wordpress.com/read/search
<img width="1159" alt="screen shot 2017-06-29 at 11 47 55 am" src="https://user-images.githubusercontent.com/4656974/27696890-d111060c-5cc0-11e7-9e0c-c6de7864e39d.png">


The way we've built it, the fixed area is absolutely positioned. Absolutely positioning an item takes it completely out of the browsers usual layouting flow.  We naturally want the search results to flow _beneath_ the fixed searchbar, but actually making that happen is error prone.  Up until now we have been setting a precise pixel value `margin-top` for the results. 

The problem with this is:
1. what happens when someone resizes the browser and the fixed area changes its size? we need different margin-top for each breakpoint
2. what if we have different kinds of things we can show in the results that each have different expectations. aka. recs, sites, posts
3. what if we have a feature branch featuring differently sized headers..

While adding in the site to search, our css started exponentially growing to account for all these possibilities. It was very difficult to get right.

This PR solves the issue by creating a regular div that automatically adjusts itself to always be the size of the fixed area. This way we don't need to set any margin-tops and everything flows naturally.