### PR TITLE
Me: Allow Gravatar uploads

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import path from 'path';
 import Gridicon from 'gridicons';
@@ -17,7 +16,6 @@ import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 import Dialog from 'components/dialog';
 import FilePicker from 'components/file-picker';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { getToken as getOauthToken } from 'lib/oauth-token';
 import Gravatar from 'components/gravatar';
 import {
 	isCurrentUserUploadingGravatar,
@@ -40,11 +38,6 @@ import {
 	recordGoogleEvent,
 	composeAnalytics,
 } from 'state/analytics/actions';
-
-/**
- * Module dependencies
- */
-const debug = debugFactory( 'calypso:edit-gravatar' );
 
 export class EditGravatar extends Component {
 	state = {
@@ -124,24 +117,8 @@ export class EditGravatar extends Component {
 			return;
 		}
 
-		// check for bearerToken from desktop app
-		let bearerToken = getOauthToken();
-
-		// check for bearer token from local storage - for testing purposes
-		if ( ! bearerToken ) {
-			bearerToken = localStorage.getItem( 'bearerToken' );
-		}
-
 		// send gravatar request
-		if ( bearerToken ) {
-			debug( 'Got the bearerToken, sending request' );
-			uploadGravatarAction( imageBlob, bearerToken, user.email );
-		} else {
-			receiveGravatarImageFailedAction( {
-				errorMessage: translate( "Hmm, we can't save a new Gravatar now. Please try again later." ),
-				statName: 'no_bearer_token',
-			} );
-		}
+		uploadGravatarAction( imageBlob, user.email );
 	};
 
 	hideImageEditor = () => {

--- a/client/state/current-user/gravatar-status/actions.js
+++ b/client/state/current-user/gravatar-status/actions.js
@@ -22,7 +22,7 @@ export function uploadGravatar( file, email ) {
 export const receiveGravatarImageFailed = ( { errorMessage, statName } ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( 'calypso_edit_gravatar_file_recieve_failure' ),
+			recordTracksEvent( 'calypso_edit_gravatar_file_receive_failure' ),
 			bumpStat( 'calypso_gravatar_update_error', statName )
 		),
 		{

--- a/client/state/current-user/gravatar-status/actions.js
+++ b/client/state/current-user/gravatar-status/actions.js
@@ -1,17 +1,9 @@
 /**
- * External dependencies
- */
-import request from 'superagent';
-
-/**
  * Internal dependencies
  */
 import {
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
-	GRAVATAR_UPLOAD_RECEIVE,
 	GRAVATAR_UPLOAD_REQUEST,
-	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
-	GRAVATAR_UPLOAD_REQUEST_FAILURE
 } from 'state/action-types';
 import {
 	bumpStat,
@@ -20,44 +12,11 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 
-export function uploadGravatar( file, bearerToken, email ) {
-	return dispatch => {
-		dispatch( withAnalytics(
-			recordTracksEvent( 'calypso_edit_gravatar_upload_start' ),
-			{ type: GRAVATAR_UPLOAD_REQUEST }
-		) );
-
-		const data = new FormData();
-		data.append( 'filedata', file );
-		data.append( 'account', email );
-		return request
-			.post( 'https://api.gravatar.com/v1/upload-image' )
-			.send( data )
-			.set( 'Authorization', 'Bearer ' + bearerToken )
-			.then( () => {
-				const fileReader = new FileReader();
-				fileReader.addEventListener( 'load', function() {
-					dispatch( {
-						type: GRAVATAR_UPLOAD_RECEIVE,
-						src: fileReader.result,
-					} );
-					dispatch( withAnalytics(
-						recordTracksEvent( 'calypso_edit_gravatar_upload_success' ),
-						{ type: GRAVATAR_UPLOAD_REQUEST_SUCCESS }
-					) );
-				} );
-				fileReader.readAsDataURL( file );
-			} )
-			.catch( () => {
-				dispatch( withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( 'calypso_edit_gravatar_upload_failure' ),
-						bumpStat( 'calypso_gravatar_update_error', 'unsuccessful_http_response' )
-					),
-					{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
-				) );
-			} );
-	};
+export function uploadGravatar( file, email ) {
+	return withAnalytics(
+		recordTracksEvent( 'calypso_edit_gravatar_upload_start' ),
+		{ type: GRAVATAR_UPLOAD_REQUEST, file, email }
+	);
 }
 
 export const receiveGravatarImageFailed = ( { errorMessage, statName } ) =>

--- a/client/state/current-user/gravatar-status/test/actions.js
+++ b/client/state/current-user/gravatar-status/test/actions.js
@@ -2,95 +2,26 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { noop } from 'lodash';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
 import {
 	GRAVATAR_RECEIVE_IMAGE_FAILURE,
-	GRAVATAR_UPLOAD_RECEIVE,
 	GRAVATAR_UPLOAD_REQUEST,
-	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
-	GRAVATAR_UPLOAD_REQUEST_FAILURE
- } from 'state/action-types';
+} from 'state/action-types';
 import {
 	receiveGravatarImageFailed,
 	uploadGravatar
 } from '../actions';
-import useNock from 'test/helpers/use-nock';
-import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'actions', () => {
-	let sandbox, spy;
-	const tempImageSrc = 'tempImageSrc';
-	useSandbox( newSandbox => {
-		sandbox = newSandbox;
-		spy = sandbox.spy();
-		global.FormData = sandbox.stub().returns( {
-			append: noop
-		} );
-		global.FileReader = sandbox.stub().returns( {
-			readAsDataURL: noop,
-			addEventListener: function( event, callback ) {
-				this.result = tempImageSrc;
-				callback();
-			}
-		} );
-	} );
-
 	describe( '#uploadGravatar', () => {
-		it( 'dispatches request action when thunk triggered', () => {
-			uploadGravatar( 'file', 'bearerToken', 'email' )( spy );
-			expect( spy ).to.have.been.calledWith( sinon.match( {
-				type: GRAVATAR_UPLOAD_REQUEST
-			} ) );
-		} );
-
-		describe( 'successful request', () => {
-			useNock( ( nock ) => {
-				nock( 'https://api.gravatar.com' )
-					.persist()
-					.post( '/v1/upload-image' )
-					.reply( 200, 'Successful request' );
-			} );
-
-			it( 'dispatches receive action', () => {
-				return uploadGravatar( 'file', 'bearerToken', 'email' )( spy )
-					.then( () => {
-						expect( spy ).to.have.been.calledWith( {
-							type: GRAVATAR_UPLOAD_RECEIVE,
-							src: tempImageSrc
-						} );
-					} );
-			} );
-
-			it( 'dispatches success action', () => {
-				return uploadGravatar( 'file', 'bearerToken', 'email' )( spy )
-					.then( () => {
-						expect( spy ).to.have.been.calledWith( sinon.match( {
-							type: GRAVATAR_UPLOAD_REQUEST_SUCCESS
-						} ) );
-					} );
-			} );
-		} );
-
-		describe( 'failed request', () => {
-			useNock( ( nock ) => {
-				nock( 'https://api.gravatar.com' )
-					.post( '/v1/upload-image' )
-					.reply( 400, 'Failed request' );
-			} );
-
-			it( 'dispatches failure action', () => {
-				return uploadGravatar( 'file', 'bearerToken', 'email' )( spy )
-					.then( () => {
-						expect( spy ).to.have.been.calledWith( sinon.match( {
-							type: GRAVATAR_UPLOAD_REQUEST_FAILURE
-						} ) );
-					} );
-			} );
+		it( 'dispatches request action with the file and email', () => {
+			const action = uploadGravatar( 'file', 'email' );
+			expect( action.type ).to.equal( GRAVATAR_UPLOAD_REQUEST );
+			expect( action.file ).to.equal( 'file' );
+			expect( action.email ).to.equal( 'email' );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/gravatar-upload/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/index.js
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import {
+	GRAVATAR_UPLOAD_RECEIVE,
+	GRAVATAR_UPLOAD_REQUEST,
+	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
+	GRAVATAR_UPLOAD_REQUEST_FAILURE,
+} from 'state/action-types';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+
+export function uploadGravatar( { dispatch }, action ) {
+	const { email, file } = action;
+	dispatch( http( {
+		method: 'POST',
+		path: '/gravatar-upload',
+		body: {},
+		apiNamespace: 'wpcom/v2',
+		formData: [
+			[ 'account', email ],
+			[ 'filedata', file ],
+		],
+	}, action ) );
+}
+
+export function announceSuccess( { dispatch }, { file } ) {
+	const fileReader = new FileReader();
+	fileReader.addEventListener( 'load', () => {
+		dispatch( {
+			type: GRAVATAR_UPLOAD_RECEIVE,
+			src: fileReader.result,
+		} );
+		dispatch( withAnalytics(
+			recordTracksEvent( 'calypso_edit_gravatar_upload_success' ),
+			{ type: GRAVATAR_UPLOAD_REQUEST_SUCCESS }
+		) );
+	} );
+	fileReader.readAsDataURL( file );
+}
+
+export function announceFailure( { dispatch } ) {
+	dispatch( withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_edit_gravatar_upload_failure' ),
+			bumpStat( 'calypso_gravatar_update_error', 'unsuccessful_http_response' )
+		),
+		{ type: GRAVATAR_UPLOAD_REQUEST_FAILURE }
+	) );
+}
+
+export default {
+	[ GRAVATAR_UPLOAD_REQUEST ]: [ dispatchRequest( uploadGravatar, announceSuccess, announceFailure ) ],
+};

--- a/client/state/data-layer/wpcom/gravatar-upload/test/index.js
+++ b/client/state/data-layer/wpcom/gravatar-upload/test/index.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon, { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { useSandbox } from 'test/helpers/use-sinon';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	GRAVATAR_UPLOAD_RECEIVE,
+	GRAVATAR_UPLOAD_REQUEST_SUCCESS,
+	GRAVATAR_UPLOAD_REQUEST_FAILURE,
+} from 'state/action-types';
+import {
+	uploadGravatar,
+	announceSuccess,
+	announceFailure,
+} from '../';
+
+describe( '#uploadGravatar()', () => {
+	it( 'dispatches an HTTP request to the gravatar upload endpoint', () => {
+		const action = {
+			type: 'DUMMY_ACTION',
+			file: 'file',
+			email: 'email',
+		};
+		const dispatch = spy();
+
+		uploadGravatar( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWith( http( {
+			apiNamespace: 'wpcom/v2',
+			method: 'POST',
+			body: {},
+			path: '/gravatar-upload',
+			formData: [
+				[ 'account', 'email' ],
+				[ 'filedata', 'file' ],
+			],
+		}, action ) );
+	} );
+} );
+
+describe( '#announceSuccess()', () => {
+	let sandbox;
+	const noop = () => {};
+
+	const tempImageSrc = 'tempImageSrc';
+	useSandbox( newSandbox => {
+		sandbox = newSandbox;
+		global.FormData = sandbox.stub().returns( {
+			append: noop
+		} );
+		global.FileReader = sandbox.stub().returns( {
+			readAsDataURL: noop,
+			addEventListener: function( event, callback ) {
+				this.result = tempImageSrc;
+				callback();
+			}
+		} );
+	} );
+
+	it( 'dispatches a success action when the file is read', () => {
+		const action = {
+			type: 'DUMMY_ACTION',
+			file: 'file',
+			email: 'email',
+		};
+		const dispatch = spy();
+
+		announceSuccess( { dispatch }, action, noop, { success: true } );
+		expect( dispatch ).to.have.been.calledWith( sinon.match( { type: GRAVATAR_UPLOAD_REQUEST_SUCCESS } ) );
+	} );
+
+	it( 'dispatches a upload received action with the image data when the file is read', () => {
+		const action = {
+			type: 'DUMMY_ACTION',
+			file: 'file',
+			email: 'email',
+		};
+		const dispatch = spy();
+
+		announceSuccess( { dispatch }, action, noop, { success: true } );
+		expect( dispatch ).to.have.been.calledWith( sinon.match( { type: GRAVATAR_UPLOAD_RECEIVE, src: 'tempImageSrc' } ) );
+	} );
+} );
+
+describe( '#announceFailure()', () => {
+	it( 'should dispatch an error notice', () => {
+		const dispatch = spy();
+
+		announceFailure( { dispatch } );
+
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWith( sinon.match( { type: GRAVATAR_UPLOAD_REQUEST_FAILURE } ) );
+	} );
+} );

--- a/client/state/data-layer/wpcom/index.js
+++ b/client/state/data-layer/wpcom/index.js
@@ -5,6 +5,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import accountRecovery from './account-recovery';
 import activityLog from './activity-log';
 import comments from './comments';
+import gravatarUpload from './gravatar-upload';
 import me from './me';
 import plans from './plans';
 import posts from './posts';
@@ -20,6 +21,7 @@ export const handlers = mergeHandlers(
 	accountRecovery,
 	activityLog,
 	comments,
+	gravatarUpload,
 	me,
 	plans,
 	posts,

--- a/config/development.json
+++ b/config/development.json
@@ -95,7 +95,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
-		"me/edit-gravatar": false,
+		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,


### PR DESCRIPTION
There is already a Gravatar REST API endpoint to upload images, but it requires authentication with an OAuth token. Clients like Calypso use the WPCOM REST API with a Cookie instead of a token, and therefore they cannot use the Gravatar API directly.

In D6120, we added a WPCOM endpoint that effectively proxies the request to the Gravatar API by providing the OAuth token itself.

This PR changes the `EditGravatar` component to use this new endpoint and enables the component in development.

## Testing

Visit http://calypso.localhost:3000/me and you should see Gravatar section in the Profile box:

<img width="184" alt="screen shot 2017-06-28 at 4 58 42 pm" src="https://user-images.githubusercontent.com/2036909/27659914-24792c6e-5c23-11e7-9ff5-549142850302.png">

Clicking on the image there, you should be able to follow the flow to upload a new image. When the upload is complete you should see a completion message:

<img width="561" alt="screen shot 2017-06-28 at 5 09 25 pm" src="https://user-images.githubusercontent.com/2036909/27660261-9372cf52-5c24-11e7-8ee7-026aa662fa0d.png">

Also view the Gravatar page at https://gravatar.com and be sure that the uploaded image is there:

<img width="448" alt="screen shot 2017-06-28 at 5 12 47 pm" src="https://user-images.githubusercontent.com/2036909/27660407-0cde9d12-5c25-11e7-864a-c925ed307283.png">
