### PR TITLE
Framework: Removed sites-list use from media validation store.

### DIFF
--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -23,8 +23,9 @@ import {
 	ERROR_UPLOADING_IMAGE,
 } from './constants';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import { getMediaItem } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
 import Dialog from 'components/dialog';
 import FilePicker from 'components/file-picker';
 import { resetAllImageEditorState } from 'state/ui/editor/image-editor/actions';
@@ -151,7 +152,7 @@ class UploadImage extends Component {
 	};
 
 	uploadImage( imageBlob, imageEditorProps ) {
-		const { siteId } = this.props;
+		const { site } = this.props;
 
 		const { fileName, mimeType } = imageEditorProps;
 
@@ -171,7 +172,7 @@ class UploadImage extends Component {
 		MediaStore.on( 'change', this.handleMediaStoreChange );
 
 		// Upload the image.
-		MediaActions.add( siteId, item );
+		MediaActions.add( site, item );
 
 		this.setState( { isUploading: true } );
 	}
@@ -440,6 +441,7 @@ export default connect(
 
 		return {
 			siteId,
+			site: getSite( state, siteId ),
 			defaultImage,
 		};
 	},

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -186,7 +186,7 @@ class ProductImageUploader extends Component {
 
 		MediaValidationStore.on( 'change', this.storeValidationErrors );
 		MediaStore.on( 'change', handleUpload );
-		MediaActions.add( site.ID, filesToUpload );
+		MediaActions.add( site, filesToUpload );
 	};
 
 	renderCompactUploader() {

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -138,12 +138,13 @@ const getFileUploader = () => ( file, siteId ) => {
 	return wpcom.site( siteId ).addMediaFiles( {}, file );
 };
 
-function uploadFiles( uploader, files, siteId ) {
+function uploadFiles( uploader, files, site ) {
 	// We offset the current time when generating a fake date for the transient
 	// media so that the first uploaded media doesn't suddenly become newest in
 	// the set once it finishes uploading. This duration is pretty arbitrary,
 	// but one would hope that it would never take this long to upload an item.
 	const baseTime = Date.now() + ONE_YEAR_IN_MILLISECONDS;
+	const siteId = site.ID;
 
 	return files.reduce( ( lastUpload, file, i ) => {
 		// Assign a date such that the first item will be the oldest at the
@@ -161,6 +162,7 @@ function uploadFiles( uploader, files, siteId ) {
 			type: 'CREATE_MEDIA_ITEM',
 			siteId: siteId,
 			data: transientMedia,
+			site,
 		} );
 
 		// Abort upload if file fails to pass validation.
@@ -193,11 +195,11 @@ function uploadFiles( uploader, files, siteId ) {
 	}, Promise.resolve() );
 }
 
-MediaActions.addExternal = function( siteId, files, service ) {
-	return uploadFiles( getExternalUploader( service ), files, siteId );
+MediaActions.addExternal = function( site, files, service ) {
+	return uploadFiles( getExternalUploader( service ), files, site );
 };
 
-MediaActions.add = function( siteId, files ) {
+MediaActions.add = function( site, files ) {
 	if ( files instanceof window.FileList ) {
 		files = [ ...files ];
 	}
@@ -206,7 +208,7 @@ MediaActions.add = function( siteId, files ) {
 		files = [ files ];
 	}
 
-	return uploadFiles( getFileUploader(), files, siteId );
+	return uploadFiles( getFileUploader(), files, site );
 };
 
 MediaActions.edit = function( siteId, item ) {

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -23,6 +23,7 @@ import {
 	DUMMY_URL,
 } from './fixtures';
 import { stubs } from './mocks/lib/wp';
+import { site } from './fixtures/site';
 
 jest.mock( 'lib/media/library-selected-store', () => ( {
 	getAll: () => [ require( './fixtures' ).DUMMY_ITEM ],
@@ -177,7 +178,7 @@ describe( 'MediaActions', () => {
 
 	describe( '#add()', () => {
 		test( 'should accept a single upload', () => {
-			return MediaActions.add( DUMMY_SITE_ID, DUMMY_UPLOAD ).then( () => {
+			return MediaActions.add( site, DUMMY_UPLOAD ).then( () => {
 				expect( Dispatcher.handleViewAction ).to.have.been.calledOnce;
 				expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
 					type: 'CREATE_MEDIA_ITEM',
@@ -186,7 +187,7 @@ describe( 'MediaActions', () => {
 		} );
 
 		test( 'should accept an array of uploads', () => {
-			return MediaActions.add( DUMMY_SITE_ID, [ DUMMY_UPLOAD, DUMMY_UPLOAD ] ).then( () => {
+			return MediaActions.add( site, [ DUMMY_UPLOAD, DUMMY_UPLOAD ] ).then( () => {
 				expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;
 				expect( Dispatcher.handleViewAction ).to.have.always.been.calledWithMatch( {
 					type: 'CREATE_MEDIA_ITEM',
@@ -195,7 +196,7 @@ describe( 'MediaActions', () => {
 		} );
 
 		test( 'should accept a file URL', () => {
-			return MediaActions.add( DUMMY_SITE_ID, DUMMY_URL ).then( () => {
+			return MediaActions.add( site, DUMMY_URL ).then( () => {
 				expect( stubs.mediaAddUrls ).to.have.been.calledWithMatch( {}, DUMMY_URL );
 			} );
 		} );
@@ -203,7 +204,7 @@ describe( 'MediaActions', () => {
 		test( 'should accept a FileList of uploads', () => {
 			const uploads = [ DUMMY_UPLOAD, DUMMY_UPLOAD ];
 			uploads.__proto__ = new window.FileList(); // eslint-disable-line no-proto
-			return MediaActions.add( DUMMY_SITE_ID, uploads ).then( () => {
+			return MediaActions.add( site, uploads ).then( () => {
 				expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;
 				expect( Dispatcher.handleViewAction ).to.have.always.been.calledWithMatch( {
 					type: 'CREATE_MEDIA_ITEM',
@@ -212,7 +213,7 @@ describe( 'MediaActions', () => {
 		} );
 
 		test( 'should accept a Blob object wrapper and pass it as "file" parameter', () => {
-			return MediaActions.add( DUMMY_SITE_ID, DUMMY_BLOB_UPLOAD ).then( () => {
+			return MediaActions.add( site, DUMMY_BLOB_UPLOAD ).then( () => {
 				expect( stubs.mediaAdd ).to.have.been.calledWithMatch( {}, { file: DUMMY_BLOB_UPLOAD } );
 				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
 					type: 'RECEIVE_MEDIA_ITEM',
@@ -224,7 +225,7 @@ describe( 'MediaActions', () => {
 		} );
 
 		test( 'should call to the WordPress.com REST API', () => {
-			return MediaActions.add( DUMMY_SITE_ID, DUMMY_UPLOAD ).then( () => {
+			return MediaActions.add( site, DUMMY_UPLOAD ).then( () => {
 				expect( stubs.mediaAdd ).to.have.been.calledWithMatch( {}, DUMMY_UPLOAD );
 				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
 					type: 'RECEIVE_MEDIA_ITEM',
@@ -236,7 +237,7 @@ describe( 'MediaActions', () => {
 		} );
 
 		test( 'should immediately receive a transient object', () => {
-			return MediaActions.add( DUMMY_SITE_ID, DUMMY_UPLOAD ).then( () => {
+			return MediaActions.add( site, DUMMY_UPLOAD ).then( () => {
 				expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
 					type: 'CREATE_MEDIA_ITEM',
 					data: {
@@ -251,7 +252,7 @@ describe( 'MediaActions', () => {
 		test( 'should attach file upload to a post if one is being edited', () => {
 			sandbox.stub( PostEditStore, 'get' ).returns( { ID: 200 } );
 
-			return MediaActions.add( DUMMY_SITE_ID, DUMMY_UPLOAD ).then( () => {
+			return MediaActions.add( site, DUMMY_UPLOAD ).then( () => {
 				expect( stubs.mediaAdd ).to.have.been.calledWithMatch(
 					{},
 					{
@@ -265,7 +266,7 @@ describe( 'MediaActions', () => {
 		test( 'should attach URL upload to a post if one is being edited', () => {
 			sandbox.stub( PostEditStore, 'get' ).returns( { ID: 200 } );
 
-			return MediaActions.add( DUMMY_SITE_ID, DUMMY_URL ).then( () => {
+			return MediaActions.add( site, DUMMY_URL ).then( () => {
 				expect( stubs.mediaAddUrls ).to.have.been.calledWithMatch(
 					{},
 					{
@@ -283,7 +284,7 @@ describe( 'MediaActions', () => {
 			Dispatcher.handleServerAction.restore();
 			sandbox.stub( Dispatcher, 'handleServerAction' ).throws();
 
-			return MediaActions.add( DUMMY_SITE_ID, [ DUMMY_UPLOAD, DUMMY_UPLOAD ] )
+			return MediaActions.add( site, [ DUMMY_UPLOAD, DUMMY_UPLOAD ] )
 				.then( () => {
 					expect( Dispatcher.handleServerAction ).to.have.thrown;
 				} )
@@ -295,7 +296,7 @@ describe( 'MediaActions', () => {
 
 	describe( '#addExternal()', () => {
 		test( 'should accept an upload', () => {
-			return MediaActions.addExternal( DUMMY_SITE_ID, [ DUMMY_UPLOAD ], 'external' ).then( () => {
+			return MediaActions.addExternal( site, [ DUMMY_UPLOAD ], 'external' ).then( () => {
 				expect( stubs.mediaAddExternal ).to.have.been.calledWithMatch( 'external', [
 					DUMMY_UPLOAD.guid,
 				] );

--- a/client/lib/media/test/fixtures/site.js
+++ b/client/lib/media/test/fixtures/site.js
@@ -1,0 +1,7 @@
+export const site = {
+	ID: 1,
+	options: {
+		allowed_file_types: [ 'gif', 'pdf', 'avi' ],
+		max_upload_size: 1024,
+	},
+};

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -13,7 +13,6 @@ import { map } from 'lodash';
  * Internal dependencies
  */
 import MediaUtils from '../utils';
-import JetpackSite from 'lib/site/jetpack';
 
 jest.mock( 'lib/impure-lodash', () => ( {
 	uniqueId: () => 'media-13',
@@ -359,14 +358,14 @@ describe( 'MediaUtils', () => {
 		} );
 
 		test( 'should return true for versions of Jetpack where option is not synced', () => {
-			var isSupported = MediaUtils.isSupportedFileTypeForSite(
+			const isSupported = MediaUtils.isSupportedFileTypeForSite(
 				{ extension: 'exe' },
-				new JetpackSite( {
+				{
 					jetpack: true,
 					options: {
 						jetpack_version: '3.8.0',
 					},
-				} )
+				}
 			);
 
 			expect( isSupported ).to.be.true;
@@ -394,14 +393,14 @@ describe( 'MediaUtils', () => {
 				max_upload_size: 1024,
 			},
 		};
-		const jetpackSite = new JetpackSite( {
+		const jetpackSite = {
 			jetpack: true,
-			modules: [ 'videopress' ],
 			options: {
 				jetpack_version: '4.5',
 				max_upload_size: 1024,
+				active_modules: [ 'videopress' ],
 			},
-		} );
+		};
 
 		test( 'should return null if the provided `bytes` are not numeric', () => {
 			expect( MediaUtils.isExceedingSiteMaxUploadSize( {}, site ) ).to.be.null;
@@ -436,14 +435,14 @@ describe( 'MediaUtils', () => {
 		test( 'should not return null if a video is being uploaded for a pre-4.5 Jetpack site with VideoPress enabled', () => {
 			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize(
 				{ size: 1024, mime_type: 'video/mp4' },
-				new JetpackSite( {
+				{
 					jetpack: true,
-					modules: [ 'videopress' ],
 					options: {
 						jetpack_version: '3.8.1',
 						max_upload_size: 1024,
+						active_modules: [ 'videopress' ],
 					},
-				} )
+				}
 			);
 
 			expect( isAcceptableSize ).to.not.be.null;
@@ -461,13 +460,13 @@ describe( 'MediaUtils', () => {
 		test( 'should not return null if a video is being uploaded for a Jetpack site with VideoPress disabled', () => {
 			const isAcceptableSize = MediaUtils.isExceedingSiteMaxUploadSize(
 				{ size: 1024, mime_type: 'video/mp4' },
-				new JetpackSite( {
+				{
 					jetpack: true,
 					options: {
 						jetpack_version: '4.5',
 						max_upload_size: 1024,
 					},
-				} )
+				}
 			);
 
 			expect( isAcceptableSize ).to.not.be.null;

--- a/client/lib/media/test/validation-store.js
+++ b/client/lib/media/test/validation-store.js
@@ -14,6 +14,7 @@ jest.mock( 'lib/sites-list', () => () => ( {
 		},
 	} ),
 } ) );
+import { site } from './fixtures/site';
 
 /**
  * Module variables
@@ -66,6 +67,7 @@ describe( 'MediaValidationStore', () => {
 					type: 'CREATE_MEDIA_ITEM',
 					siteId: DUMMY_SITE_ID,
 					data: DUMMY_MEDIA_OBJECT,
+					site,
 				},
 				action
 			),
@@ -104,13 +106,13 @@ describe( 'MediaValidationStore', () => {
 		} );
 
 		test( 'should have no effect for a valid file', () => {
-			validateItem( DUMMY_SITE_ID, Object.assign( {}, DUMMY_MEDIA_OBJECT, { extension: 'gif' } ) );
+			validateItem( site, Object.assign( {}, DUMMY_MEDIA_OBJECT, { extension: 'gif' } ) );
 
 			expect( MediaValidationStore._errors ).to.eql( {} );
 		} );
 
 		test( 'should set an error array for an invalid file', () => {
-			validateItem( DUMMY_SITE_ID, DUMMY_MEDIA_OBJECT );
+			validateItem( site, DUMMY_MEDIA_OBJECT );
 
 			expect( MediaValidationStore._errors ).to.eql( {
 				[ DUMMY_SITE_ID ]: {
@@ -121,7 +123,7 @@ describe( 'MediaValidationStore', () => {
 
 		test( 'should set an error array for a file exceeding acceptable size', () => {
 			validateItem(
-				DUMMY_SITE_ID,
+				site,
 				Object.assign( {}, DUMMY_MEDIA_OBJECT, { size: 2048, extension: 'gif' } )
 			);
 
@@ -133,7 +135,7 @@ describe( 'MediaValidationStore', () => {
 		} );
 
 		test( 'should accumulate multiple validation errors', () => {
-			validateItem( DUMMY_SITE_ID, Object.assign( {}, DUMMY_MEDIA_OBJECT, { size: 2048 } ) );
+			validateItem( site, Object.assign( {}, DUMMY_MEDIA_OBJECT, { size: 2048 } ) );
 
 			expect( MediaValidationStore._errors ).to.eql( {
 				[ DUMMY_SITE_ID ]: {
@@ -327,6 +329,7 @@ describe( 'MediaValidationStore', () => {
 				type: 'CREATE_MEDIA_ITEM',
 				siteId: DUMMY_SITE_ID,
 				data: DUMMY_MEDIA_OBJECT,
+				site,
 			};
 
 			handler( { action } );
@@ -340,7 +343,9 @@ describe( 'MediaValidationStore', () => {
 			var action = {
 				type: 'CREATE_MEDIA_ITEM',
 				siteId: DUMMY_SITE_ID,
+
 				data: DUMMY_MEDIA_OBJECT,
+				site,
 			};
 
 			handler( {
@@ -348,6 +353,7 @@ describe( 'MediaValidationStore', () => {
 					type: 'CREATE_MEDIA_ITEM',
 					siteId: DUMMY_SITE_ID,
 					data: assign( {}, DUMMY_MEDIA_OBJECT, { ID: 101 } ),
+					site,
 				},
 			} );
 

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -7,7 +7,7 @@
 import url from 'url';
 import path from 'path';
 import photon from 'photon';
-import { includes, omitBy, startsWith } from 'lodash';
+import { includes, omitBy, startsWith, get } from 'lodash';
 import { isUri } from 'valid-url';
 
 /**
@@ -24,6 +24,7 @@ import {
 } from './constants';
 import Shortcode from 'lib/shortcode';
 import { uniqueId } from 'lib/impure-lodash';
+import versionCompare from 'lib/version-compare';
 
 /**
  * Module variables
@@ -323,8 +324,8 @@ const MediaUtils = {
 
 		if (
 			site.jetpack &&
-			site.isModuleActive( 'videopress' ) &&
-			site.versionCompare( '4.5', '>=' ) &&
+			includes( get( site, 'options.active_modules' ), 'videopress' ) &&
+			versionCompare( get( site, 'options.jetpack_version' ), '4.5', '>=' ) &&
 			startsWith( MediaUtils.getMimeType( item ), 'video/' )
 		) {
 			return null;

--- a/client/lib/media/validation-store.js
+++ b/client/lib/media/validation-store.js
@@ -11,7 +11,6 @@ import { isEmpty, mapValues, pickBy, without } from 'lodash';
  */
 import Dispatcher from 'dispatcher';
 import emitter from 'lib/mixins/emitter';
-import Sites from 'lib/sites-list';
 import MediaUtils from './utils';
 import { ValidationErrors as MediaValidationErrors } from './constants';
 
@@ -21,7 +20,6 @@ import { ValidationErrors as MediaValidationErrors } from './constants';
 const MediaValidationStore = {
 	_errors: {},
 };
-const sites = Sites();
 const ERROR_GLOBAL_ITEM_ID = 0;
 
 /**
@@ -55,9 +53,8 @@ function ensureErrorsObjectForSite( siteId ) {
 const isExternalError = message => message.error && message.error === 'servicefail';
 const isMediaError = action => action.error && ( action.id || isExternalError( action.error ) );
 
-MediaValidationStore.validateItem = function( siteId, item ) {
-	var site = sites.getSite( siteId ),
-		itemErrors = [];
+MediaValidationStore.validateItem = function( site, item ) {
+	const itemErrors = [];
 
 	if ( ! site ) {
 		return;
@@ -76,8 +73,8 @@ MediaValidationStore.validateItem = function( siteId, item ) {
 	}
 
 	if ( itemErrors.length ) {
-		ensureErrorsObjectForSite( siteId );
-		MediaValidationStore._errors[ siteId ][ item.ID ] = itemErrors;
+		ensureErrorsObjectForSite( site.ID );
+		MediaValidationStore._errors[ site.ID ][ item.ID ] = itemErrors;
 	}
 };
 
@@ -169,7 +166,7 @@ MediaValidationStore.dispatchToken = Dispatcher.register( function( payload ) {
 			errors = items.reduce( function( memo, item ) {
 				var itemErrors;
 
-				MediaValidationStore.validateItem( action.siteId, item );
+				MediaValidationStore.validateItem( action.site, item );
 
 				itemErrors = MediaValidationStore.getErrors( action.siteId, item.ID );
 				if ( itemErrors.length ) {

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -38,7 +38,7 @@ export default class extends React.Component {
 		}
 
 		MediaActions.clearValidationErrors( this.props.site.ID );
-		MediaActions.add( this.props.site.ID, files );
+		MediaActions.add( this.props.site, files );
 		this.props.onAddMedia();
 
 		if ( this.props.trackStats ) {

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -97,7 +97,7 @@ class MediaLibraryExternalHeader extends React.Component {
 		const { site, selectedItems, source, onSourceChange } = this.props;
 
 		onSourceChange( '', () => {
-			MediaActions.addExternal( site.ID, selectedItems, source );
+			MediaActions.addExternal( site, selectedItems, source );
 		} );
 	};
 

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -43,7 +43,7 @@ export default class extends React.Component {
 	uploadFiles = event => {
 		if ( event.target.files && this.props.site ) {
 			MediaActions.clearValidationErrors( this.props.site.ID );
-			MediaActions.add( this.props.site.ID, event.target.files );
+			MediaActions.add( this.props.site, event.target.files );
 		}
 
 		ReactDom.findDOMNode( this.refs.form ).reset();

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -47,7 +47,7 @@ class MediaLibraryUploadUrl extends Component {
 		}
 
 		MediaActions.clearValidationErrors( this.props.site.ID );
-		MediaActions.add( this.props.site.ID, this.state.value );
+		MediaActions.add( this.props.site, this.state.value );
 
 		this.setState( { value: '', isError: false } );
 		this.props.onAddMedia();

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -25,10 +25,10 @@ import { isSavingSiteSettings } from 'state/site-settings/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
 import { resetAllImageEditorState } from 'state/ui/editor/image-editor/actions';
 import { receiveMedia, deleteMedia } from 'state/media/actions';
-import { isJetpackSite, getCustomizerUrl, getSiteAdminUrl } from 'state/sites/selectors';
+import { getCustomizerUrl, getSiteAdminUrl, isJetpackSite } from 'state/sites/selectors';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import InfoPopover from 'components/info-popover';
@@ -101,7 +101,7 @@ class SiteIconSetting extends Component {
 	}
 
 	uploadSiteIcon( blob, fileName ) {
-		const { siteId, translate, siteIconId } = this.props;
+		const { siteId, translate, siteIconId, site } = this.props;
 
 		// Upload media using a manually generated ID so that we can continue
 		// to reference it within this function
@@ -154,7 +154,7 @@ class SiteIconSetting extends Component {
 
 		MediaStore.on( 'change', checkUploadComplete );
 
-		MediaActions.add( siteId, {
+		MediaActions.add( site, {
 			ID: transientMediaId,
 			fileContents: blob,
 			fileName,
@@ -358,6 +358,7 @@ export default connect(
 			generalOptionsUrl: getSiteAdminUrl( state, siteId, 'options-general.php' ),
 			crop: getImageEditorCrop( state ),
 			transform: getImageEditorTransform( state ),
+			site: getSelectedSite( state ),
 		};
 	},
 	{

--- a/client/post-editor/editor-featured-image/dropzone.jsx
+++ b/client/post-editor/editor-featured-image/dropzone.jsx
@@ -21,7 +21,7 @@ import FeaturedImageDropZoneIcon from './dropzone-icon';
 
 import { receiveMedia, deleteMedia } from 'state/media/actions';
 import { editPost } from 'state/posts/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -39,7 +39,7 @@ class FeaturedImageDropZone extends Component {
 		}
 
 		const transientMediaId = uniqueId( 'featured-image' );
-		const { siteId } = this.props;
+		const { siteId, site } = this.props;
 
 		const handleFeaturedImageUpload = () => {
 			const media = MediaStore.get( siteId, transientMediaId );
@@ -86,7 +86,7 @@ class FeaturedImageDropZone extends Component {
 
 		MediaStore.on( 'change', handleFeaturedImageUpload );
 
-		MediaActions.add( siteId, {
+		MediaActions.add( site, {
 			ID: transientMediaId,
 			fileContents: droppedImage,
 			fileName: droppedImage.name,
@@ -110,6 +110,7 @@ export default connect(
 	state => ( {
 		siteId: getSelectedSiteId( state ),
 		postId: getEditorPostId( state ),
+		site: getSelectedSite( state ),
 	} ),
 	{
 		editPost,

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -163,14 +163,14 @@ export class EditorMediaModal extends Component {
 				// Copy the selected item from the external source. Note we pass the actual media data as we need this to generate
 				// transient placeholders. This is done after the state changes so our transients and external items appear
 				// in the WordPress library that we've just switched to
-				MediaActions.addExternal( site.ID, selectedMedia, originalSource );
+				MediaActions.addExternal( site, selectedMedia, originalSource );
 			}
 		);
 	}
 
 	copyExternal( selectedMedia, originalSource ) {
 		const { site } = this.props;
-		MediaActions.addExternal( site.ID, selectedMedia, originalSource );
+		MediaActions.addExternal( site, selectedMedia, originalSource );
 	}
 
 	confirmSelection = () => {


### PR DESCRIPTION
In order to remove sites list, the media validation store interface had to be changed so the "add" action, now receives the site object and not the siteId. 

**All the places that use MediaAction add (upload files) had to be changed including a file in the WooCommerce  extension**. (client/extensions/woocommerce/components/product-image-uploader/index.js).
Having to change lots of different parts of the project makes this pull request risky.

Besides that media utils had to be changed to not depend on JetpackSite prototype functions. Some verifications done in media utils could make use of a selector, but media utils has no access to the state. And as the verifications were simple I did them there. To use a selectors we would need to add the selector values to all the places that use MediaAction.add and if doing that probably would be even better to convert media/utils to selectors.

This pull request involves lots of changes but I was not seeing a way to isolate them in sepated PR's. If they were not done together things would fail.

**To test:**
Test updating a file in all the places where it is possible (gallery with dropzone, add button, add external, post feature image, editor drop, site-icon upload and crop etc...).

Execute the automated tests:  npm run test-client client/lib/media/

**Test Live:**
https://calypso.live/?branch=update/remove-sites-list-media-validation-store