### PR TITLE
Activity log: Add documentation links

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -36,7 +36,7 @@ class ErrorBanner extends PureComponent {
 					{ translate( 'Try again' ) }
 				</Button>
 				{ '  ' }
-				<Button>
+				<Button href="https://help.vaultpress.com/restore-tips-troubleshooting-steps/">
 					{ translate( 'Get help' ) }
 				</Button>
 			</ActivityLogBanner>

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -92,7 +92,7 @@ class ActivityLogConfirmDialog extends Component {
 
 				<a
 					className="activity-log-confirm-dialog__more-info-link"
-					href="#" // FIXME: real link
+					href="https://help.vaultpress.com/one-click-restore/"
 				>
 					{ translate( 'Read More about Site Restores' ) }
 				</a>


### PR DESCRIPTION
Add links to documentation in error banner and restore dialog. Currently, these links are to VaultPress documentation as I don't think we have any Activity Log specific documentation at this point.

To test:
* Go to https://calypso.live/stats/activity/?branch=add/activitylog-banner-documentation-links
* Check the Error banner "Get help" link:
   ```js
   dispatch({ siteId: SITE_ID, type: 'REWIND_RESTORE_UPDATE_PROGRESS', timestamp: 1498168800000, restoreId: 123, errorCode: "restore-broke", failureReason: "Something went wrong", message: "A message", percent: 100, status: "finished" })
   ```
* Check the restore dialog help link. Click any rewind button to see the dialog.
  ~_api changes have broken display, needs rebase after #15524 lands_~ ✅ 

Work on #15260 