### PR TITLE
WooCommerce - Fixed saved general settings not loading

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/general/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/reducer.js
@@ -15,7 +15,7 @@ import {
 
 // TODO: Handle error
 
-export default createReducer( [], {
+export default createReducer( null, {
 	[ WOOCOMMERCE_CURRENCY_UPDATE ]: ( state ) => {
 		// TODO: Return some sort of saving indicator
 		return state;
@@ -44,6 +44,6 @@ export default createReducer( [], {
 	},
 
 	[ WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return updateSettings( 'general', state, data );
+		return updateSettings( 'general', state || [], data );
 	},
 } );

--- a/client/extensions/woocommerce/state/sites/settings/general/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/selectors.js
@@ -15,7 +15,15 @@ import { LOADING } from 'woocommerce/state/constants';
 
 const preInitializedState = {
 	extensions: {
-		woocommerce: {},
+		woocommerce: {
+			sites: {
+				123: {
+					settings: {
+						general: null,
+					}
+				},
+			},
+		},
 	},
 };
 const loadingState = {

--- a/client/extensions/woocommerce/state/sites/settings/products/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/reducer.js
@@ -10,7 +10,7 @@ import {
 	WOOCOMMERCE_SETTINGS_PRODUCTS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-export default createReducer( [], {
+export default createReducer( null, {
 	[ WOOCOMMERCE_SETTINGS_PRODUCTS_REQUEST ]: () => {
 		return LOADING;
 	},
@@ -20,6 +20,6 @@ export default createReducer( [], {
 	},
 
 	[ WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return updateSettings( 'products', state, data );
+		return updateSettings( 'products', state || [], data );
 	},
 } );

--- a/client/extensions/woocommerce/state/sites/settings/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/test/selectors.js
@@ -16,7 +16,15 @@ import { LOADING } from 'woocommerce/state/constants';
 
 const preInitializedState = {
 	extensions: {
-		woocommerce: {},
+		woocommerce: {
+			sites: {
+				123: {
+					settings: {
+						products: null,
+					}
+				},
+			},
+		},
 	},
 };
 const loadingState = {


### PR DESCRIPTION
Fixes #15651 

To test:
1. Update the general settings (currency or address)
2. Refresh the page
3. Verify that the new settings are still shown
4. Also test on a brand new site with no preexisting settings
