### PR TITLE
Remove the "protectForm" functionality from the Shipping Zones page.

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -24,7 +24,6 @@ import { changeShippingZoneName } from 'woocommerce/state/ui/shipping/zones/acti
 import { getCurrentlyEditingShippingZone } from 'woocommerce/state/ui/shipping/zones/selectors';
 import { getCurrentlyEditingShippingZoneLocationsList } from 'woocommerce/state/ui/shipping/zones/locations/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { protectForm } from 'lib/protect-form';
 
 class Shipping extends Component {
 	componentWillMount() {
@@ -53,15 +52,13 @@ class Shipping extends Component {
 	}
 
 	render() {
-		const { siteId, className, loaded, markSaved, markChanged, params, zone, locations, actions, translate } = this.props;
+		const { siteId, className, loaded, params, zone, locations, actions, translate } = this.props;
 		const isRestOfTheWorld = 0 === Number( params.zone );
 
 		const onSave = () => {
 			actions.changeShippingZoneName( siteId, getZoneName( zone, locations, translate ) );
 
 			//TODO: saving
-
-			markSaved();
 		};
 
 		return (
@@ -73,15 +70,13 @@ class Shipping extends Component {
 					loaded={ loaded }
 					zone={ zone }
 					locations={ locations }
-					isRestOfTheWorld={ isRestOfTheWorld }
-					onChange={ markChanged } />
+					isRestOfTheWorld={ isRestOfTheWorld } />
 				{ isRestOfTheWorld
 					? null
-					: <ShippingZoneLocationList siteId={ siteId } loaded={ loaded } onChange={ markChanged } /> }
+					: <ShippingZoneLocationList siteId={ siteId } loaded={ loaded } /> }
 				<ShippingZoneMethodList
 					siteId={ siteId }
-					loaded={ loaded }
-					onChange={ markChanged } />
+					loaded={ loaded } />
 			</Main>
 		);
 	}
@@ -111,4 +106,4 @@ export default connect(
 				changeShippingZoneName,
 			}, dispatch
 		)
-	} ) )( localize( protectForm( Shipping ) ) );
+	} ) )( localize( Shipping ) );

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
@@ -21,7 +21,7 @@ import {
 	areCurrentlyEditingShippingZoneLocationsValid,
 } from 'woocommerce/state/ui/shipping/zones/locations/selectors';
 
-const ShippingZoneLocationDialog = ( { siteId, isVisible, translate, actions, canSave, onChange } ) => {
+const ShippingZoneLocationDialog = ( { siteId, isVisible, translate, actions, canSave } ) => {
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -32,7 +32,6 @@ const ShippingZoneLocationDialog = ( { siteId, isVisible, translate, actions, ca
 			return;
 		}
 
-		onChange();
 		actions.closeEditLocations();
 	};
 
@@ -58,7 +57,6 @@ const ShippingZoneLocationDialog = ( { siteId, isVisible, translate, actions, ca
 
 ShippingZoneLocationDialog.propTypes = {
 	siteId: PropTypes.number,
-	onChange: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -21,7 +21,7 @@ import { bindActionCreatorsWithSiteId } from 'woocommerce/lib/redux-utils';
 import { getCurrentlyEditingShippingZoneLocationsList } from 'woocommerce/state/ui/shipping/zones/locations/selectors';
 import { openEditLocations } from 'woocommerce/state/ui/shipping/zones/locations/actions';
 
-const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actions, onChange } ) => {
+const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actions } ) => {
 	const getLocationFlag = ( location ) => {
 		if ( 'continent' === location.type ) {
 			return null;
@@ -96,7 +96,6 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 		if ( ! loaded ) {
 			return;
 		}
-		onChange();
 		actions.openEditLocations();
 	};
 
@@ -120,7 +119,7 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 				</ListHeader>
 				{ locationsToRender.map( renderLocation ) }
 			</List>
-			<ShippingZoneLocationDialog siteId={ siteId } onChange={ onChange } />
+			<ShippingZoneLocationDialog siteId={ siteId } />
 		</div>
 	);
 };
@@ -128,7 +127,6 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 ShippingZoneLocationList.PropTypes = {
 	siteId: PropTypes.number,
 	loaded: PropTypes.bool.isRequired,
-	onChange: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -46,7 +46,6 @@ const ShippingZoneMethodDialog = ( {
 		isVisible,
 		isNew,
 		currency,
-		onChange,
 		actions
 	} ) => {
 	if ( ! isVisible ) {
@@ -58,11 +57,9 @@ const ShippingZoneMethodDialog = ( {
 		actions.cancelShippingZoneMethod();
 	};
 	const onClose = () => {
-		onChange();
 		actions.closeShippingZoneMethod();
 	};
 	const onDelete = () => {
-		onChange();
 		actions.removeMethodFromShippingZone( method.id );
 	};
 	const onMethodTitleChange = ( event ) => ( actions.changeShippingZoneMethodTitle( event.target.value ) );
@@ -148,7 +145,6 @@ const ShippingZoneMethodDialog = ( {
 
 ShippingZoneMethodDialog.propTypes = {
 	siteId: PropTypes.number,
-	onChange: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -40,7 +40,6 @@ const ShippingZoneMethodList = ( {
 		newMethodTypeOptions,
 		currency,
 		translate,
-		onChange,
 		actions,
 	} ) => {
 	const renderMethod = ( method, index ) => {
@@ -95,7 +94,6 @@ const ShippingZoneMethodList = ( {
 		if ( ! loaded ) {
 			return;
 		}
-		onChange();
 
 		const newType = newMethodTypeOptions[ 0 ];
 		actions.addMethodToShippingZone( newType, methodNamesMap( newType ) );
@@ -122,7 +120,7 @@ const ShippingZoneMethodList = ( {
 				</ListHeader>
 				{ methodsToRender.map( renderMethod ) }
 			</List>
-			<ShippingZoneMethodDialog siteId={ siteId } onChange={ onChange } />
+			<ShippingZoneMethodDialog siteId={ siteId } />
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
@@ -62,13 +62,12 @@ class ShippingZoneName extends Component {
 	}
 
 	render() {
-		const { loaded, isRestOfTheWorld, zone, locations, actions, onChange, translate } = this.props;
+		const { loaded, isRestOfTheWorld, zone, locations, actions, translate } = this.props;
 		const { editing } = this.state;
 
 		const startEditing = () => ( this.setState( { editing: true } ) );
 		const stopEditing = () => ( this.setState( { editing: false } ) );
 		const onNameChange = ( event ) => {
-			onChange();
 			actions.changeShippingZoneName( event.target.value );
 		};
 
@@ -120,7 +119,6 @@ ShippingZoneName.PropTypes = {
 	siteId: PropTypes.number,
 	isRestOfTheWorld: PropTypes.bool.isRequired,
 	loaded: PropTypes.bool.isRequired,
-	onChange: PropTypes.func.isRequired,
 	zone: PropTypes.object,
 	locations: PropTypes.array,
 };


### PR DESCRIPTION
The `protectForm` HoC doesn't play well with our Redux-based approach to
data handling, because it maintains local state and needs local functions to
be called to mark the form as `saved` or `dirty`. Until we figure out a non-hacky
way to make it work with the `action-list` business, the better solution is to remove it.
Additionally, no other part of WooCommerce uses it, and altough I believe it's
useful, it's better to be consistent within ourselves.

To test:
* Go edit a shipping zone.
* Change its name.
* Navigate away (using the breadcrumbs or any other way.
* You shouldn't get a pop-up to confirm you want to navigate away.

cc/ @marcinbot