### PR TITLE
Added context to domain upgrade renewal and expiration strings

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
@@ -25,7 +25,7 @@ const MappedDomain = React.createClass( {
 
 		if ( domain.isAutoRenewing ) {
 			return (
-				<Property label={ translate( 'Mapping renews on' ) }>
+				<Property label={ translate( 'Mapping renews on', { comment: 'The corresponding date is in a different cell in the UI, the date is not included within the translated string' } ) }>
 					{ domain.autoRenewalMoment.format( 'LL' ) }
 				</Property>
 			);
@@ -35,7 +35,7 @@ const MappedDomain = React.createClass( {
 			<em>{ translate( 'Never Expires', { context: 'Expiration detail for a mapped domain' } ) }</em>;
 
 		return (
-			<Property label={ translate( 'Mapping expires on' ) }>
+			<Property label={ translate( 'Mapping expires on', { comment: 'The corresponding date is in a different cell in the UI, the date is not included within the translated string' } ) }>
 				{ expirationMessage }
 			</Property>
 		);

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -27,14 +27,14 @@ const RegisteredDomain = React.createClass( {
 
 		if ( domain.isAutoRenewing ) {
 			return (
-				<Property label={ translate( 'Renews on' ) }>
+				<Property label={ translate( 'Renews on', { comment: 'The corresponding date is in a different cell in the UI, the date is not included within the translated string' } ) }>
 					{ domain.autoRenewalMoment.format( 'LL' ) }
 				</Property>
 			);
 		}
 
 		return (
-			<Property label={ translate( 'Expires on' ) }>
+			<Property label={ translate( 'Expires on', { comment: 'The corresponding date is in a different cell in the UI, the date is not included within the translated string' } ) }>
 				{ domain.expirationMoment.format( 'LL' ) }
 			</Property>
 		);
@@ -212,7 +212,7 @@ const RegisteredDomain = React.createClass( {
 							{ translate( 'Registered Domain' ) }
 						</Property>
 
-						<Property label={ translate( 'Registered on' ) }>
+						<Property label={ translate( 'Registered on', { comment: 'The corresponding date is in a different cell in the UI, the date is not included within the translated string' } ) }>
 							{ domain.registrationMoment.format( 'LL' ) }
 						</Property>
 

--- a/client/my-sites/upgrades/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/wpcom-domain.jsx
@@ -51,7 +51,7 @@ const WpcomDomain = React.createClass( {
 							{ this.translate( 'Included with Site' ) }
 						</Property>
 
-						<Property label={ this.translate( 'Renews on' ) }>
+						<Property label={ this.translate( 'Renews on', { comment: 'The corresponding date is in a different cell in the UI, the date is not included within the translated string' } ) }>
 							<em>{ this.translate( 'Never Expires' ) }</em>
 						</Property>
 					</Card>


### PR DESCRIPTION
Fixes #248  adding context for the translators when translating some strings. Followed the examples here: https://github.com/Automattic/i18n-calypso#more-translate-examples . With these 3 files we should cover all the cases on domain upgrade renewal / expiration.

I'm not quite sure how to test this locally, as the context will show up on http://translate.wordpress.com/ once is live. Any feedback is appreciated. 