### PR TITLE
Activate installed plugins when already installed

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -95,16 +95,16 @@ class RequiredPluginsInstallView extends Component {
 			if ( ! plugin ) {
 				const wporgPlugin = getPlugin( wporg, slug );
 				const progress = this.state.progress + ( 100 / requiredPlugins.length );
-				this.setState( {
+				this.setState( () => ( {
 					installingPlugin: slug,
 					progress
-				} );
+				} ) );
 				this.props.installPlugin( site.ID, wporgPlugin );
 				return;
 			}
 			if ( ! plugin.active ) {
 				const wporgPlugin = getPlugin( wporg, slug );
-				this.setState( { activatingPlugin: slug } );
+				this.setState( () => ( { activatingPlugin: slug } ) );
 				this.props.activatePlugin( site.ID, { ...wporgPlugin, id: plugin.id } );
 				return;
 			}

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -42,7 +42,7 @@ class RequiredPluginsInstallView extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			activatingPlugins: [],
+			activatingPlugin: null,
 			installingPlugin: null,
 			progress: 0,
 		};
@@ -60,9 +60,16 @@ class RequiredPluginsInstallView extends Component {
 
 	componentDidUpdate = ( prevProps ) => {
 		const { plugins, site } = this.props;
+		if ( ! plugins || ! site ) {
+			return;
+		}
+		const isReady = plugins.length && ! this.state.installingPlugin && ! this.state.activatingPlugin;
+		const isDoneInstalling = prevProps.plugins && plugins.length > prevProps.plugins.length;
+		const activatingPlugin = find( plugins, { slug: this.state.activatingPlugin } );
+		const isDoneActivating = activatingPlugin && activatingPlugin.active;
 		if (
-			( site && plugins && plugins.length && ! this.state.installingPlugin ) ||
-			( plugins && prevProps.plugins && plugins.length > prevProps.plugins.length )
+			isReady ||
+			( isDoneInstalling || isDoneActivating )
 		) {
 			this.installPlugins( this.props.plugins );
 		}
@@ -96,12 +103,10 @@ class RequiredPluginsInstallView extends Component {
 				return;
 			}
 			if ( ! plugin.active ) {
-				if ( -1 < this.state.activatingPlugins.indexOf( slug ) ) {
-					return;
-				}
 				const wporgPlugin = getPlugin( wporg, slug );
-				this.setState( { activatingPlugins: [ ...this.state.activatingPlugins, slug ] } );
+				this.setState( { activatingPlugin: slug } );
 				this.props.activatePlugin( site.ID, { ...wporgPlugin, id: plugin.id } );
+				return;
 			}
 		}
 		this.props.setFinishedInstallOfRequiredPlugins(


### PR DESCRIPTION
This will activate plugins that are installed but not activated.

- To test, go to your wp-admin and deactivate the woo plugins
- Wait a couple minutes
- Set `finished_initial_install_of_required_plugins` to 0 here:  https://developer.wordpress.com/docs/api/console/
- Load http://calypso.localhost:3000/store/{site}
- Once it runs, go look at your wp-admin to see if the plugins activated