### PR TITLE
ES6: Upgrade blocks to es6 import / export.

### DIFF
--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -230,7 +230,7 @@ const SwitcherShell = React.createClass( {
 	}
 } );
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'AuthorSelector',
 	propTypes: {
 		siteId: React.PropTypes.number.isRequired,

--- a/client/blocks/reader-full-post/docs/header-example.jsx
+++ b/client/blocks/reader-full-post/docs/header-example.jsx
@@ -10,7 +10,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import ReaderFullPostHeader from 'blocks/reader-full-post/header';
 import Card from 'components/card';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'ReaderFullPostHeader',
 
 	mixins: [ PureRenderMixin ],

--- a/client/blocks/site/placeholder.jsx
+++ b/client/blocks/site/placeholder.jsx
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:site' );
+import React from 'react';
 
-module.exports = React.createClass( {
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:my-sites:site' );
+
+export default React.createClass( {
 	displayName: 'SitePlaceholder',
 
 	componentDidMount: function() {


### PR DESCRIPTION
No functional changes.

Tests will fail because this doesn't _also_ fix the eslint errors on the same lines.