### PR TITLE
Woo: Add updates to product action-list

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -70,10 +70,6 @@ class ProductCreate extends React.Component {
 		// TODO: Remove the product we added here from the edit state.
 	}
 
-	onTrash = () => {
-		// TODO: Add action dispatch to trash this product.
-	}
-
 	onSave = () => {
 		const { product, translate } = this.props;
 
@@ -111,7 +107,6 @@ class ProductCreate extends React.Component {
 				<ProductHeader
 					site={ site }
 					product={ product }
-					onTrash={ this.onTrash }
 					onSave={ saveEnabled ? this.onSave : false }
 					isBusy={ isBusy }
 				/>

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -83,7 +83,7 @@ ProductFormCategoriesCard.propTypes = {
 	siteId: PropTypes.number,
 	product: PropTypes.shape( {
 		id: PropTypes.isRequired,
-		type: PropTypes.string.isRequired,
+		type: PropTypes.string,
 	} ),
 	productCategories: PropTypes.array.isRequired,
 	editProduct: PropTypes.func.isRequired,

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -22,7 +22,7 @@ export default class ProductFormDetailsCard extends Component {
 		siteId: PropTypes.number,
 		product: PropTypes.shape( {
 			id: PropTypes.isRequired,
-			type: PropTypes.string.isRequired,
+			type: PropTypes.string,
 			name: PropTypes.string,
 		} ),
 		editProduct: PropTypes.func.isRequired,

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -22,7 +22,7 @@ class ProductFormVariationsCard extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		product: PropTypes.shape( {
-			type: PropTypes.string.isRequired,
+			type: PropTypes.string,
 			name: PropTypes.string,
 			attributes: PropTypes.array,
 		} ),
@@ -44,7 +44,9 @@ class ProductFormVariationsCard extends Component {
 	 * A user shouldn't lose work just because they locally toggled a card.
 	 */
 	handleToggle = () => {
-		if ( 'variable' !== this.props.product.type ) {
+		const type = this.props.product.type || 'simple';
+
+		if ( 'variable' !== type ) {
 			this.setProductTypeVariable();
 		} else {
 			this.setProductTypeSimple();
@@ -99,6 +101,7 @@ class ProductFormVariationsCard extends Component {
 	render() {
 		const { siteId, product, variations, translate } = this.props;
 		const { editProductAttribute, editProductVariation } = this.props;
+		const type = product.type || 'simple';
 		const variationToggleDescription = translate(
 			'%(productName)s has variations, like size and color.', {
 				args: {
@@ -112,12 +115,12 @@ class ProductFormVariationsCard extends Component {
 				icon=""
 				expanded
 				className="products__variation-card"
-				header={ ( <FormToggle onChange={ this.handleToggle } checked={ 'variable' === product.type }>
+				header={ ( <FormToggle onChange={ this.handleToggle } checked={ 'variable' === type }>
 					{ variationToggleDescription }
 				</FormToggle>
 				) }
 			>
-				{ 'variable' === product.type && (
+				{ 'variable' === type && (
 					<div>
 						<ProductVariationTypesForm
 							siteId={ siteId }

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -19,7 +19,7 @@ export default class ProductForm extends Component {
 		siteId: PropTypes.number,
 		product: PropTypes.shape( {
 			id: PropTypes.isRequired,
-			type: PropTypes.string.isRequired,
+			type: PropTypes.string,
 			name: PropTypes.string,
 		} ),
 		variations: PropTypes.array,
@@ -44,6 +44,7 @@ export default class ProductForm extends Component {
 	render() {
 		const { siteId, product, productCategories, variations } = this.props;
 		const { editProduct, editProductCategory, editProductVariation, editProductAttribute } = this.props;
+		const type = product.type || 'simple';
 
 		if ( ! siteId ) {
 			return this.renderPlaceholder();
@@ -79,7 +80,7 @@ export default class ProductForm extends Component {
 					editProductVariation={ editProductVariation }
 				/>
 
-				{ 'simple' === product.type && (
+				{ 'simple' === type && (
 					<div className="products__product-simple-cards">
 						<ProductFormSimpleCard
 							siteId={ siteId }

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -13,22 +13,47 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { getLink } from 'woocommerce/lib/nav-utils';
 
-const ProductHeader = ( { onView, onTrash, onSave, isBusy, translate, site, product } ) => {
-	const existing = product && ! isObject( product.id );
+function renderViewButton( product, translate ) {
+	const url = product && product.permalink;
+	return (
+		// TODO: Do more to validate this URL?
+		<a href={ url } className="products__header-view-link" target="_blank" rel="noopener noreferrer">
+			<Button borderless><Gridicon icon="visible" /><span> { translate( 'View' ) } </span></Button>
+		</a>
+	);
+}
 
-	const viewButton = onView &&
-		<Button borderless onClick={ onView }><Gridicon icon="visible" /><span> { translate( 'View' ) } </span></Button>;
+function renderTrashButton( onTrash, product, isBusy, translate ) {
+	return onTrash && (
+		<Button borderless scary onClick={ onTrash }>
+			<Gridicon icon="trash" />
+			<span>{ translate( 'Trash' ) } </span>
+		</Button>
+	);
+}
 
-	const trashButton = onTrash &&
-		<Button borderless scary onClick={ onTrash }><Gridicon icon="trash" /><span>{ translate( 'Trash' ) } </span></Button>;
-
+function renderSaveButton( onSave, product, isBusy, translate ) {
 	const saveExists = 'undefined' !== typeof onSave;
 	const saveDisabled = false === onSave;
 
-	const saveLabel = ( product && existing ? translate( 'Update' ) : translate( 'Save & Publish' ) );
+	const saveLabel = ( product && ! isObject( product.id )
+		? translate( 'Update' )
+		: translate( 'Save & Publish' )
+	);
 
-	const saveButton = saveExists &&
-		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }> { saveLabel } </Button>;
+	return saveExists && (
+		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }>
+			{ saveLabel }
+		</Button>
+	);
+}
+
+const ProductHeader = ( { viewEnabled, onTrash, onSave, isBusy, translate, site, product } ) => {
+	const existing = product && ! isObject( product.id );
+
+	const viewButton = viewEnabled && renderViewButton( product, translate );
+	const trashButton = renderTrashButton( onTrash, product, isBusy, translate );
+	const saveButton = renderSaveButton( onSave, product, isBusy, translate );
 
 	const currentCrumb = product && existing
 		? ( <span>{ translate( 'Edit Product' ) }</span> )
@@ -58,7 +83,7 @@ ProductHeader.propTypes = {
 			PropTypes.object,
 		] ),
 	} ),
-	onView: PropTypes.func,
+	viewEnabled: PropTypes.bool,
 	onTrash: PropTypes.func,
 	onSave: PropTypes.oneOfType( [
 		React.PropTypes.func,

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -17,10 +17,10 @@ const ProductHeader = ( { onView, onTrash, onSave, isBusy, translate, site, prod
 	const existing = product && ! isObject( product.id );
 
 	const viewButton = onView &&
-		<Button borderless onClick={ onView }><Gridicon icon="visible" /> { translate( 'View' ) } </Button>;
+		<Button borderless onClick={ onView }><Gridicon icon="visible" /><span> { translate( 'View' ) } </span></Button>;
 
 	const trashButton = onTrash &&
-		<Button borderless scary onClick={ onTrash }><Gridicon icon="trash" /> { translate( 'Trash' ) } </Button>;
+		<Button borderless scary onClick={ onTrash }><Gridicon icon="trash" /><span>{ translate( 'Trash' ) } </span></Button>;
 
 	const saveExists = 'undefined' !== typeof onSave;
 	const saveDisabled = false === onSave;

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { isNumber } from 'lodash';
+import { isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,21 +13,26 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { getLink } from 'woocommerce/lib/nav-utils';
 
-const ProductHeader = ( { onTrash, onSave, isBusy, translate, site, product } ) => {
+const ProductHeader = ( { onView, onTrash, onSave, isBusy, translate, site, product } ) => {
+	const existing = product && ! isObject( product.id );
+
+	const viewButton = onView &&
+		<Button borderless onClick={ onView }><Gridicon icon="visible" /> { translate( 'View' ) } </Button>;
+
 	const trashButton = onTrash &&
-		<Button borderless onClick={ onTrash }><Gridicon icon="trash" /></Button>;
+		<Button borderless scary onClick={ onTrash }><Gridicon icon="trash" /> { translate( 'Trash' ) } </Button>;
 
 	const saveExists = 'undefined' !== typeof onSave;
 	const saveDisabled = false === onSave;
 
-	const saveButton = saveExists &&
-		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }>
-			{ translate( 'Save' ) }
-		</Button>;
+	const saveLabel = ( product && existing ? translate( 'Update' ) : translate( 'Save & Publish' ) );
 
-	const currentCrumb = product && isNumber( product.id )
+	const saveButton = saveExists &&
+		<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }> { saveLabel } </Button>;
+
+	const currentCrumb = product && existing
 		? ( <span>{ translate( 'Edit Product' ) }</span> )
-		: ( <span>{ translate( 'Add New Product' ) }</span> );
+		: ( <span>{ translate( 'Add New' ) }</span> );
 
 	const breadcrumbs = [
 		( <a href={ getLink( '/store/products/:site/', site ) }> { translate( 'Products' ) } </a> ),
@@ -37,6 +42,7 @@ const ProductHeader = ( { onTrash, onSave, isBusy, translate, site, product } ) 
 	return (
 		<ActionHeader breadcrumbs={ breadcrumbs }>
 			{ trashButton }
+			{ viewButton }
 			{ saveButton }
 		</ActionHeader>
 	);
@@ -52,6 +58,7 @@ ProductHeader.propTypes = {
 			PropTypes.object,
 		] ),
 	} ),
+	onView: PropTypes.func,
 	onTrash: PropTypes.func,
 	onSave: PropTypes.oneOfType( [
 		React.PropTypes.func,

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -77,10 +77,6 @@ class ProductUpdate extends React.Component {
 		// TODO: Remove the product we added here from the edit state.
 	}
 
-	onView = () => {
-		// TODO: Add action dispatch to view this product.
-	}
-
 	onTrash = () => {
 		// TODO: Add action dispatch to trash this product.
 	}
@@ -123,7 +119,7 @@ class ProductUpdate extends React.Component {
 				<ProductHeader
 					site={ site }
 					product={ product }
-					onView={ this.onView }
+					viewEnabled={ true }
 					onTrash={ this.onTrash }
 					onSave={ saveEnabled ? this.onSave : false }
 					isBusy={ isBusy }

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -1,0 +1,174 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import { getActionList } from 'woocommerce/state/action-list/selectors';
+import { createProduct, fetchProduct } from 'woocommerce/state/sites/products/actions';
+import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
+import { fetchProductVariations } from 'woocommerce/state/sites/product-variations/actions';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import {
+	editProduct,
+	editProductAttribute,
+	createProductActionList
+} from 'woocommerce/state/ui/products/actions';
+import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
+import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
+import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
+import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
+import { getProductCategoriesWithLocalEdits } from 'woocommerce/state/ui/product-categories/selectors';
+import ProductForm from './product-form';
+import ProductHeader from './product-header';
+
+class ProductUpdate extends React.Component {
+	static propTypes = {
+		params: PropTypes.object,
+		className: PropTypes.string,
+		product: PropTypes.shape( {
+			id: PropTypes.isRequired,
+		} ),
+		fetchProduct: PropTypes.func.isRequired,
+		fetchProductVariations: PropTypes.func.isRequired,
+		fetchProductCategories: PropTypes.func.isRequired,
+		editProduct: PropTypes.func.isRequired,
+		editProductCategory: PropTypes.func.isRequired,
+		editProductAttribute: PropTypes.func.isRequired,
+		editProductVariation: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		const { params, product, site } = this.props;
+		const productId = Number( params.product );
+
+		if ( site && site.ID ) {
+			if ( ! product ) {
+				this.props.fetchProduct( site.ID, productId );
+				this.props.fetchProductVariations( site.ID, productId );
+				this.props.editProduct( site.ID, { id: productId }, {} );
+			}
+			this.props.fetchProductCategories( site.ID );
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { params, site } = this.props;
+		const productId = Number( params.product );
+		const newSiteId = newProps.site && newProps.site.ID || null;
+		const oldSiteId = site && site.ID || null;
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchProduct( newSiteId, productId );
+			this.props.fetchProductVariations( newSiteId, productId );
+			this.props.editProduct( newSiteId, { id: productId }, {} );
+			this.props.fetchProductCategories( newSiteId );
+		}
+	}
+
+	componentWillUnmount() {
+		// TODO: Remove the product we added here from the edit state.
+	}
+
+	onTrash = () => {
+		// TODO: Add action dispatch to trash this product.
+	}
+
+	onSave = () => {
+		const { product, translate } = this.props;
+
+		const successAction = successNotice(
+			translate( '%(product)s successfully updated.', {
+				args: { product: product.name },
+			} ),
+			{ duration: 4000 }
+		);
+
+		const failureAction = errorNotice(
+			translate( 'There was a problem saving %(product)s. Please try again.', {
+				args: { product: product.name },
+			} )
+		);
+
+		this.props.createProductActionList( successAction, failureAction );
+	}
+
+	isProductValid( product = this.props.product ) {
+		return product &&
+			product.type &&
+			product.name && product.name.length > 0;
+	}
+
+	render() {
+		const { site, product, className, variations, productCategories, actionList } = this.props;
+
+		const isValid = 'undefined' !== site && this.isProductValid();
+		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
+		const saveEnabled = isValid && ! isBusy;
+
+		return (
+			<Main className={ className }>
+				<SidebarNavigation />
+				<ProductHeader
+					site={ site }
+					product={ product }
+					onTrash={ this.onTrash }
+					onSave={ saveEnabled ? this.onSave : false }
+					isBusy={ isBusy }
+				/>
+				<ProductForm
+					siteId={ site && site.ID }
+					product={ product || { type: 'simple' } }
+					variations={ variations }
+					productCategories={ productCategories }
+					editProduct={ this.props.editProduct }
+					editProductCategory={ this.props.editProductCategory }
+					editProductAttribute={ this.props.editProductAttribute }
+					editProductVariation={ this.props.editProductVariation }
+				/>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const product = getCurrentlyEditingProduct( state );
+	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
+	const productCategories = getProductCategoriesWithLocalEdits( state );
+	const actionList = getActionList( state );
+
+	return {
+		site,
+		product,
+		variations,
+		productCategories,
+		actionList,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			createProduct,
+			createProductActionList,
+			editProduct,
+			editProductCategory,
+			editProductAttribute,
+			editProductVariation,
+			fetchProduct,
+			fetchProductVariations,
+			fetchProductCategories,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ProductUpdate ) );

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -77,6 +77,10 @@ class ProductUpdate extends React.Component {
 		// TODO: Remove the product we added here from the edit state.
 	}
 
+	onView = () => {
+		// TODO: Add action dispatch to view this product.
+	}
+
 	onTrash = () => {
 		// TODO: Add action dispatch to trash this product.
 	}
@@ -119,6 +123,7 @@ class ProductUpdate extends React.Component {
 				<ProductHeader
 					site={ site }
 					product={ product }
+					onView={ this.onView }
 					onTrash={ this.onTrash }
 					onSave={ saveEnabled ? this.onSave : false }
 					isBusy={ isBusy }

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -27,14 +27,23 @@
 }
 
 .action-header__actions {
-	width: 40%;
+	width: 52%;
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
 
+	.button.is-borderless span {
+		@include breakpoint( "<660px" ) {
+			display: none;
+		}
+	}
+
 	.button {
-		margin-left: 12px;
 		white-space: nowrap;
+		margin-left: 24px;
+		@include breakpoint( "<660px" ) {
+			margin-left: 18px;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -16,6 +16,7 @@ import Order from './app/order';
 import Orders from './app/orders';
 import Products from './app/products';
 import ProductCreate from './app/products/product-create';
+import ProductUpdate from './app/products/product-update';
 import Dashboard from './app/dashboard';
 import SettingsPayments from './app/settings/payments';
 import SettingsTaxes from './app/settings/taxes';
@@ -64,6 +65,11 @@ const getStorePages = () => {
 				slug: 'product-add',
 				showDuringSetup: false,
 			},
+		},
+		{
+			container: ProductUpdate,
+			configKey: 'woocommerce/extension-products',
+			path: '/store/product/:site/:product',
 		},
 		{
 			container: Orders,

--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -9,9 +9,13 @@ import { get, find, isNumber, isEqual } from 'lodash';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getVariationsForProduct } from 'woocommerce/state/sites/product-variations/selectors';
 
-export function getVariationEditsStateForProduct( state, productId, siteId = getSelectedSiteId( state ) ) {
+export function getAllVariationEdits( state, siteId = getSelectedSiteId( state ) ) {
 	const woocommerce = state.extensions.woocommerce;
-	const variations = get( woocommerce, [ 'ui', 'products', siteId, 'variations', 'edits' ], [] );
+	return get( woocommerce, [ 'ui', 'products', siteId, 'variations', 'edits' ], [] );
+}
+
+export function getVariationEditsStateForProduct( state, productId, siteId = getSelectedSiteId( state ) ) {
+	const variations = getAllVariationEdits( state, siteId );
 	return find( variations, ( v ) => isEqual( productId, v.productId ) );
 }
 


### PR DESCRIPTION
This adds updates for both Products and Variations to the action list,
making it suitable for editing existing products/variations and updating
them via the API.

To test: `npm test`