### PR TITLE
Activity Log: Discretely display Activity IDs

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -213,12 +213,15 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div>
-				{ translate( 'An event "%(eventName)s" occurred at %(date)s', {
-					args: {
-						date: applySiteOffset( moment.utc( ts_utc ) ).format( 'LLL' ),
-						eventName: name,
-					}
-				} ) }
+				<div>
+					{ translate( 'An event "%(eventName)s" occurred at %(date)s', {
+						args: {
+							date: applySiteOffset( moment.utc( ts_utc ) ).format( 'LLL' ),
+							eventName: name,
+						}
+					} ) }
+				</div>
+				<div className="activity-log-item__id">ID { ts_utc }</div>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -121,3 +121,12 @@
 	flex-basis: 25%;
 	text-align:right;
 }
+
+.activity-log-item__id {
+	float: right;
+	font-size: 11px;
+	color: lighten( $gray, 20% );
+	font-style: italic;
+	margin-bottom: 4px;
+	margin-right: -7px;
+}


### PR DESCRIPTION
From discussion in #15444

<img width="945" alt="screen shot 2017-06-29 at 18 39 33" src="https://user-images.githubusercontent.com/7767559/27702009-89d87df8-5cfa-11e7-943f-6ed75dc51dfa.png">

<img width="122" alt="screen shot 2017-06-29 at 18 39 43" src="https://user-images.githubusercontent.com/7767559/27702013-8c6b5f18-5cfa-11e7-89b9-2ec5b41a413e.png">


We are displaying times and dates using the site offset/timezone, so showing the UTC timestamps, which double as activity IDs, can be useful for referring to specific activities when requesting support.