### PR TITLE
Add ActionHeader to dashboard

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -85,7 +85,7 @@ class Dashboard extends Component {
 			return translate( 'Store Setup' );
 		}
 
-		return translate( 'Orders' );
+		return translate( 'Dashboard' );
 	}
 
 	renderDashboardContent = () => {

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ActionHeader from 'woocommerce/components/action-header';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import {
 	areSetupChoicesLoading,
@@ -64,6 +65,29 @@ class Dashboard extends Component {
 		}
 	}
 
+	getBreadcrumb = () => {
+		const {
+			finishedInstallOfRequiredPlugins,
+			finishedInitialSetup,
+			setStoreAddressDuringInitialSetup,
+			translate
+		} = this.props;
+
+		if ( ! finishedInstallOfRequiredPlugins ) {
+			return translate( 'Installing Plugins' );
+		}
+
+		if ( ! setStoreAddressDuringInitialSetup ) {
+			return translate( 'Store Location' );
+		}
+
+		if ( ! finishedInitialSetup ) {
+			return translate( 'Store Setup' );
+		}
+
+		return translate( 'Orders' );
+	}
+
 	renderDashboardContent = () => {
 		const {
 			finishedInstallOfRequiredPlugins,
@@ -102,6 +126,7 @@ class Dashboard extends Component {
 
 		return (
 			<Main className={ classNames( 'dashboard', className ) }>
+				<ActionHeader breadcrumbs={ this.getBreadcrumb() } />
 				{ this.renderDashboardContent() }
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -1,6 +1,13 @@
 .dashboard__setup-wrapper {
 	@include breakpoint( ">960px" ) {
 		padding: 32px;
+		margin-top: 58px;
+	}
+}
+
+.dashboard__manage-no-orders {
+	@include breakpoint( ">960px" ) {
+		margin-top: 58px;
 	}
 }
 


### PR DESCRIPTION
This adds the ActionHeader to the dashboard flow pages.

To test:

- Clear flags:  https://developer.wordpress.com/docs/api/console/ POST: /sites/{siteid}/calypso-preferences/woocommerce
- Look at heading for each page
