### PR TITLE
Use standalone publish button styles when calendar button is hidden.

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -289,7 +289,7 @@ export default React.createClass( {
 
 	renderGroundControlActionButtons: function() {
 		const publishComboClasses = classNames( 'editor-ground-control__publish-combo', {
-			'is-standalone': config.isEnabled( 'post-editor/delta-post-publish-flow' )
+			'is-standalone': ! this.canPublishPost() || config.isEnabled( 'post-editor/delta-post-publish-flow' )
 		} );
 
 		return ( <div className="editor-ground-control__action-buttons">


### PR DESCRIPTION
Fixes #15644

There is a publish button / calendar button combo which is two buttons next to each other, styled as if they were one. For that, the button on the left has `border-radius: 4px 0 0 4px;`

![combo](https://user-images.githubusercontent.com/1017839/27704376-c3cf489c-5d0a-11e7-8ada-d2d2ae1d03b7.png)

The culprit is that the button on the right is not always there, namely, when `this.canPublishPost()` evaluates to `false`. When the button on the right hand side is not displayed the publish button  should have `border-radius: 4px;` so that it has nice rounded corners.

The calendar button is going to be removed in future, and #14876 started preparing us for that scenario, and handles the styling for the standalone publish button. The fix in this PR merely activates that styling for when `this.canPublishPost()` evaluates to `false`.

Before:

![before](https://user-images.githubusercontent.com/1017839/27704391-cb81cdbc-5d0a-11e7-8418-c2364dc27f73.png)

After:

![after](https://user-images.githubusercontent.com/1017839/27704398-cf182eee-5d0a-11e7-90e2-49c94d183c4a.png)


To test:

Existing behavior:

- Checkout branch and run: `make run`
- Make sure you have a test blog, and a test user who is a contributor to that blog (this will make `this.canPublishPost()` evaluate to `false`.
- Load the editor and draft a post.
- Verify that the Publish button has rounded corners and otherwise looks as it should