### PR TITLE
Webpack: don't overwrite process.env, only process.env.NODE_ENV

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,9 +91,7 @@ const webpackConfig = {
 	},
 	plugins: [
 		new webpack.DefinePlugin( {
-			'process.env': {
-				NODE_ENV: JSON.stringify( bundleEnv )
-			},
+			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 			'PROJECT_NAME': JSON.stringify( config( 'project' ) )
 		} ),
 		new WebpackStableBuildPlugin( {


### PR DESCRIPTION
This follows the best practice pointed by Webpack docs here https://webpack.js.org/plugins/define-plugin/#feature-flags by not overwriting the `process.env` object, only the `process.env.NODE_ENV` property.