### PR TITLE
Fix centering of the Masterbar items on small screens.

### DIFF
--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -123,7 +123,7 @@ class MasterbarItemNotifications extends Component {
 		} );
 
 		return (
-			<div ref="notificationLink">
+			<div className="masterbar__notifications" ref="notificationLink">
 				<MasterbarItem
 					url="/notifications"
 					icon="bell"

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -392,3 +392,11 @@ $autobar-height: 20px;
 		display: none;
 	}
 }
+
+.masterbar__notifications {
+	flex: 1 1 auto;
+
+	@include breakpoint( '>480px' ) {
+		flex-grow: 0;
+	}
+}


### PR DESCRIPTION
This PR fixes the centering of items in the Masterbar on small screens (<480px). The imbalance is caused by a wrapping div around the notifications Masterbar item, which [cannot be easily removed](https://github.com/Automattic/wp-calypso/issues/15689#issuecomment-312093793).

Fixes #15689.

![screen shot 2017-06-29 at 1 43 20 pm](https://user-images.githubusercontent.com/349751/27709683-de674490-5cd1-11e7-83c9-236c34ed1401.png)

![screen shot 2017-06-29 at 1 44 01 pm](https://user-images.githubusercontent.com/349751/27709687-e261a2ac-5cd1-11e7-917e-35fd91674a0a.png)
