### PR TITLE
Reader: Resolve cropping of tags on mobile

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -272,13 +272,19 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__tags {
-	flex: 1 0 0;
-	position: relative;
+	color: $gray;
+	display: flex;
+	flex-direction: row;
 	height: 20px;
-	overflow: hidden;
 	white-space: nowrap;
 	margin-left: 10px;
-	color: $gray;
+	overflow: hidden;
+	position: relative;
+	width: calc( 100% - 100px );
+
+	@include breakpoint( "<480px" ) {
+		max-width: 230px;
+	}
 
 	&::after {
 		@include long-content-fade( $size: 10% );
@@ -287,6 +293,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card__tag {
 	white-space: nowrap;
+	margin-right: 3px;
 
 	&::after {
 		content: ', '
@@ -299,11 +306,9 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 .reader-post-card__tags .gridicons-tag {
 	height: 18px;
-	margin: -4px 5px 0 0;
-	position: relative;
-		top: 5px;
-	width: 15px;
 	fill: $gray;
+	flex: 0 0 15px;
+	margin-right: 5px;
 }
 
 .reader-post-card__byline .reader-avatar {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/13192

**Before:**
![screenshot 2017-06-29 15 14 33](https://user-images.githubusercontent.com/4924246/27713099-d64890fe-5cde-11e7-8f38-36f8084ff94c.png)

**After:**
![screenshot 2017-06-29 15 14 44](https://user-images.githubusercontent.com/4924246/27713109-db34e95a-5cde-11e7-8ca9-63fa8c4d1512.png)
