### PR TITLE
Editor Confirmation Sidebar: Remember display preference

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -14,6 +14,8 @@ import Gridicon from 'gridicons';
 import RootChild from 'components/root-child';
 import Button from 'components/button';
 import EditorVisibility from 'post-editor/editor-visibility';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -22,6 +24,7 @@ import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
+		handlePreferenceChange: React.PropTypes.func,
 		onPrivatePublish: React.PropTypes.func,
 		onPublish: React.PropTypes.func,
 		post: React.PropTypes.object,
@@ -121,6 +124,25 @@ class EditorConfirmationSidebar extends React.Component {
 		);
 	}
 
+	renderNoticeDisplayPreferenceCheckbox() {
+		return (
+			<div className="editor-confirmation-sidebar__display-preference">
+				<FormLabel>
+					<FormCheckbox
+						onChange={ this.props.handlePreferenceChange }
+						defaultChecked
+						className="editor-confirmation-sidebar__display-preference-checkbox"
+						id="confirmation_sidebar_display_preference"
+						name="confirmation_sidebar_display_preference" />
+					<span>{ this.props.translate( 'Show this every time I publish', {
+						comment: 'This string appears in the bottom of a publish confirmation sidebar.' +
+							'There is limited space. Longer strings will wrap.'
+					} ) }</span>
+				</FormLabel>
+			</div>
+		);
+	}
+
 	render() {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
@@ -160,6 +182,7 @@ class EditorConfirmationSidebar extends React.Component {
 								{ this.renderPrivacyControl() }
 							</div>
 						</div>
+						{ this.renderNoticeDisplayPreferenceCheckbox() }
 					</div>
 				</div>
 			</RootChild>

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -124,3 +124,19 @@
 .editor-confirmation-sidebar__content-wrap {
 	padding: 0 24px 24px 24px
 }
+
+.editor-confirmation-sidebar__sidebar .editor-confirmation-sidebar__display-preference {
+	@extend .sidebar__footer;
+	background-color: lighten( $gray, 25% );
+	padding: 4px 10px;
+
+	@include breakpoint( "<660px" ) {
+		background: none;
+		border-top: none;
+		padding: 0 24px 24px 24px;
+	}
+}
+
+input[type=checkbox].editor-confirmation-sidebar__display-preference-checkbox {
+	margin-top: 3px;
+}

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -23,7 +23,6 @@ import AsyncLoad from 'components/async-load';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
-import config from 'config';
 import classNames from 'classnames';
 
 export default React.createClass( {
@@ -31,6 +30,7 @@ export default React.createClass( {
 
 	propTypes: {
 		hasContent: React.PropTypes.bool,
+		isConfirmationSidebarEnabled: React.PropTypes.bool,
 		isDirty: React.PropTypes.bool,
 		isSaveBlocked: React.PropTypes.bool,
 		isPublishing: React.PropTypes.bool,
@@ -55,6 +55,7 @@ export default React.createClass( {
 	getDefaultProps: function() {
 		return {
 			hasContent: false,
+			isConfirmationSidebarEnabled: true,
 			isDirty: false,
 			isSaveBlocked: false,
 			isPublishing: false,
@@ -289,7 +290,7 @@ export default React.createClass( {
 
 	renderGroundControlActionButtons: function() {
 		const publishComboClasses = classNames( 'editor-ground-control__publish-combo', {
-			'is-standalone': ! this.canPublishPost() || config.isEnabled( 'post-editor/delta-post-publish-flow' )
+			'is-standalone': ! this.canPublishPost() || this.props.isConfirmationSidebarEnabled
 		} );
 
 		return ( <div className="editor-ground-control__action-buttons">
@@ -317,6 +318,7 @@ export default React.createClass( {
 					onSave={ this.props.onSave }
 					onPublish={ this.props.onPublish }
 					tabIndex={ 5 }
+					isConfirmationSidebarEnabled={ this.props.isConfirmationSidebarEnabled }
 					isPublishing={ this.props.isPublishing }
 					isSaveBlocked={ this.props.isSaveBlocked }
 					hasContent={ this.props.hasContent }
@@ -324,7 +326,7 @@ export default React.createClass( {
 					busy={ this.props.isPublishing || ( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving ) }
 				/>
 				{ this.canPublishPost() &&
-				! config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+				! this.props.isConfirmationSidebarEnabled &&
 				<Button
 					primary
 					compact
@@ -350,7 +352,7 @@ export default React.createClass( {
 				}
 			</div>
 			{ this.canPublishPost() &&
-			! config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+			! this.props.isConfirmationSidebarEnabled &&
 			this.schedulePostPopover()
 			}
 		</div> );

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -11,7 +11,6 @@ import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
 import Button from 'components/button';
 import { localize } from 'i18n-calypso';
-import config from 'config';
 
 export const getPublishButtonStatus = ( site, post, savedPost ) => {
 	if (
@@ -54,7 +53,8 @@ export class EditorPublishButton extends Component {
 		isSaveBlocked: PropTypes.bool,
 		hasContent: PropTypes.bool,
 		needsVerification: PropTypes.bool,
-		busy: PropTypes.bool
+		busy: PropTypes.bool,
+		isConfirmationSidebarEnabled: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -88,13 +88,13 @@ export class EditorPublishButton extends Component {
 			case 'update':
 				return this.props.translate( 'Update' );
 			case 'schedule':
-				if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+				if ( this.props.isConfirmationSidebarEnabled ) {
 					return this.props.translate( 'Schedule…',
 						{ comment: 'Button label on the editor sidebar - a confirmation step will follow' } );
 				}
 				return this.props.translate( 'Schedule' );
 			case 'publish':
-				if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+				if ( this.props.isConfirmationSidebarEnabled ) {
 					return this.props.translate( 'Publish…',
 						{ context: 'Button label on the editor sidebar - a confirmation step will follow' } );
 				}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -815,6 +815,13 @@ export const PostEditor = React.createClass( {
 			this.props.saveConfirmationSidebarPreference( this.props.siteId, false );
 		}
 
+		if (
+			config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+			this.props.isConfirmationSidebarEnabled
+		) {
+			this.setConfirmationSidebar( { status: 'closed', context: 'publish_success' } );
+		}
+
 		this.onSaveSuccess( message, ( message === 'published' ? 'view' : 'preview' ), savedPost.URL );
 	},
 
@@ -883,13 +890,6 @@ export const PostEditor = React.createClass( {
 	onSaveSuccess: function( message, action, link ) {
 		const post = PostEditStore.get();
 		const isNotPrivateOrIsConfirmed = ( 'private' !== post.status ) || ( 'closed' !== this.state.confirmationSidebar );
-
-		if (
-			config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
-			this.props.isConfirmationSidebarEnabled
-		) {
-			this.setConfirmationSidebar( { status: 'closed', context: 'publish_success' } );
-		}
 
 		if ( 'draft' === post.status ) {
 			this.props.setEditorLastDraft( post.site_ID, post.ID );

--- a/client/state/preferences/constants.js
+++ b/client/state/preferences/constants.js
@@ -8,5 +8,6 @@ export const DEFAULT_PREFERENCE_VALUES = {
 	'guided-tours-history': [],
 	recentSites: [],
 	mediaScale: 0.157,
-	editorAdvancedVisible: false
+	editorAdvancedVisible: false,
+	editorConfirmationDisabledSites: [],
 };

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -51,6 +51,10 @@ export const remoteValuesSchema = {
 		},
 		editorAdvancedVisible: {
 			type: 'boolean'
-		}
+		},
+		editorConfirmationDisabledSites: {
+			type: 'array',
+			items: { type: 'number' }
+		},
 	}
 };

--- a/client/state/ui/editor/actions.js
+++ b/client/state/ui/editor/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import {
@@ -9,6 +14,8 @@ import {
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { setMediaModalView } from 'state/ui/media-modal/actions';
 import { withAnalytics, bumpStat } from 'state/analytics/actions';
+import { savePreference } from 'state/preferences/actions';
+import { getPreference } from 'state/preferences/selectors';
 
 /**
  * Constants
@@ -85,4 +92,27 @@ export function setEditorMediaModalView( view ) {
 	}
 
 	return action;
+}
+
+/**
+ * Returns an action object used in signalling that the confirmation sidebar
+ * preference has changed.
+ *
+ * @param  {Number}  siteId    Site ID
+ * @param  {?Bool}   isEnabled Whether or not the sidebar should be shown
+ * @return {Object}            Action object
+ */
+export function saveConfirmationSidebarPreference( siteId, isEnabled = true ) {
+	return ( dispatch, getState ) => {
+		const disabledSites = getPreference( getState(), 'editorConfirmationDisabledSites' );
+
+		if ( isEnabled ) {
+			dispatch( savePreference( 'editorConfirmationDisabledSites', filter(
+				disabledSites,
+				_siteId => siteId !== _siteId
+			) ) );
+		} else {
+			dispatch( savePreference( 'editorConfirmationDisabledSites', [ ...disabledSites, siteId ] ) );
+		}
+	};
 }

--- a/client/state/ui/editor/actions.js
+++ b/client/state/ui/editor/actions.js
@@ -13,7 +13,7 @@ import {
 } from 'state/action-types';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { setMediaModalView } from 'state/ui/media-modal/actions';
-import { withAnalytics, bumpStat } from 'state/analytics/actions';
+import { withAnalytics, bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 
@@ -114,5 +114,13 @@ export function saveConfirmationSidebarPreference( siteId, isEnabled = true ) {
 		} else {
 			dispatch( savePreference( 'editorConfirmationDisabledSites', [ ...disabledSites, siteId ] ) );
 		}
+
+		dispatch(
+			recordTracksEvent( isEnabled
+				? 'calypso_publish_confirmation_preference_enable'
+				: 'calypso_publish_confirmation_preference_disable' )
+		);
+
+		dispatch( bumpStat( 'calypso_publish_confirmation', isEnabled ? 'enabled' : 'disabled' ) );
 	};
 }

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -8,6 +8,7 @@ import get from 'lodash/get';
  */
 import { getSiteSlug } from 'state/sites/selectors';
 import { getEditedPost } from 'state/posts/selectors';
+import { getPreference } from 'state/preferences/selectors';
 
 /**
  * Returns the current editor post ID, or `null` if a new post.
@@ -73,4 +74,15 @@ export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
 	}
 
 	return path;
+}
+
+/**
+ * Returns whether the confirmation sidebar is enabled for the given siteId
+ *
+ * @param  {Object}  state Global state tree
+ * @param  {Number}  siteId      Site ID
+ * @return {Boolean}             Whether or not the sidebar is enabled
+ */
+export function isConfirmationSidebarEnabled( state, siteId ) {
+	return getPreference( state, 'editorConfirmationDisabledSites' ).indexOf( siteId ) === -1;
 }


### PR DESCRIPTION
This PR adds an option to the bottom of the confirmation sidebar allowing you to skip confirmation for future posts.

![confirmation-preference](https://user-images.githubusercontent.com/363749/27744778-833e4afe-5d86-11e7-90cc-cd3b1e4345d0.gif)

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p8F9tW-3F-p2.

To test:

* `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`.
* Draft a post.
* Click on "Publish...".
* Do **not** change the preference at the bottom of the confirmation sidebar.
* Click on "Publish".
* Draft a new post. Verify that "Publish..." still appears and you're still taken to the sidebar.
* Uncheck the checkbox at the bottom of the sidebar.
* Click on "Publish".
* Draft another post. The sidebar should no longer appear for that site for that user.
* The sidebar should still appear for other users of the site.
* The sidebar should still appear for other sites.
