### PR TITLE
Make are payments setup check mark work

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -22,11 +22,17 @@ import {
 	fetchProducts
 } from 'woocommerce/state/sites/products/actions';
 import {
+	fetchPaymentMethods,
+} from 'woocommerce/state/sites/payment-methods/actions';
+import {
 	fetchSetupChoices,
 	setOptedOutOfShippingSetup,
 	setOptedOutOfTaxesSetup,
 	setTriedCustomizerDuringInitialSetup,
 } from 'woocommerce/state/sites/setup-choices/actions';
+import {
+	arePaymentsSetup
+} from 'woocommerce/state/ui/payments/methods/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import SetupTask from './setup-task';
 
@@ -51,6 +57,7 @@ class SetupTasks extends Component {
 
 		if ( site && site.ID ) {
 			this.props.fetchSetupChoices( site.ID );
+			this.props.fetchPaymentMethods( site.ID );
 			this.props.fetchProducts( site.ID, 1 );
 		}
 	}
@@ -208,7 +215,7 @@ function mapStateToProps( state ) {
 		triedCustomizer: getTriedCustomizerDuringInitialSetup( state ),
 		hasProducts: getTotalProducts( state ) > 0,
 		// TODO - connect the following to selectors when they become available
-		paymentsAreSetUp: false,
+		paymentsAreSetUp: arePaymentsSetup( state ),
 		shippingIsSetUp: false,
 		taxesAreSetUp: false,
 	};
@@ -217,6 +224,7 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
+			fetchPaymentMethods,
 			fetchProducts,
 			fetchSetupChoices,
 			setOptedOutOfShippingSetup,

--- a/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
@@ -61,6 +61,17 @@ export const getPaymentMethodsWithEdits = ( state, siteId = getSelectedSiteId( s
 };
 
 /**
+ * Are payment settings setup?
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId wpcom site id
+ * @return {Boolean} Bool indicating if payments are setup
+ */
+export const arePaymentsSetup = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return !! filter( getPaymentMethodsWithEdits( state, siteId ), { enabled: true } ).length;
+};
+
+/**
  * Gets group of payment methods. (offline, off-site, on-site)
  *
  * @param {Object} state Global state tree

--- a/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	arePaymentsSetup,
 	getPaymentMethodEdits,
 	getPaymentMethodsWithEdits,
 	getCurrentlyEditingPaymentMethod,
@@ -118,6 +119,24 @@ describe( 'selectors', () => {
 				currentlyEditingChanges: { name: 'This name has not been saved yet' },
 			};
 			expect( getPaymentMethodsWithEdits( state ) ).to.deep.equal( [ { id: 1, name: 'Method1' } ] );
+		} );
+	} );
+
+	describe( 'arePaymentsSetup', () => {
+		it( 'should return false when there are no enabled payemnt methods', () => {
+			siteState.paymentMethods = [
+				{ id: 1, enabled: false },
+			];
+
+			expect( arePaymentsSetup( state ) ).to.be.false;
+		} );
+
+		it( 'should return true when there are is an enabled payemnt method', () => {
+			siteState.paymentMethods = [
+				{ id: 1, enabled: true },
+			];
+
+			expect( arePaymentsSetup( state ) ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
This will show the payments setup as complete when there is one enabled payment method.

- Set set_store_address_during_initial_setup to 1 and finished_initial_setup to 0 here: https://developer.wordpress.com/docs/api/console/
- Load http://calypso.localhost:3000/store/{site}
- Click payment setup, enable a payment method, go back
- Check mark should be there next to payments.