### PR TITLE
WooCommerce Orders: Detect & enable manual refunds

### DIFF
--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -143,7 +143,7 @@ class OrderRefundCard extends Component {
 			return (
 				<div className="order__refund-method">
 					<h3>{ translate( 'Manual Refund' ) }</h3>
-					<p>{ translate( 'This payment method doesn\'t support automated refunds' ) }</p>
+					<p>{ translate( 'This payment method doesn\'t support automated refunds and must be submitted manually.' ) }</p>
 				</div>
 			);
 		}

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -115,7 +115,7 @@ class OrderRefundCard extends Component {
 	}
 
 	sendRefund = () => {
-		const { order, site, translate } = this.props;
+		const { order, paymentMethod, site, translate } = this.props;
 		const maxRefund = parseFloat( order.total ) + this.getRefundedTotal( order );
 		if ( this.state.refundTotal > maxRefund ) {
 			this.setState( { errorMessage: translate( 'Refund must be less than order total.' ) } );
@@ -128,7 +128,7 @@ class OrderRefundCard extends Component {
 		const refundObj = {
 			amount: this.state.refundTotal + '', // API expects a string
 			reason: this.state.refundNote,
-			// api_refund
+			api_refund: ( -1 !== paymentMethod.method_supports.indexOf( 'refunds' ) ),
 		};
 		this.props.sendRefund( site.ID, order.id, refundObj );
 	}
@@ -162,7 +162,7 @@ class OrderRefundCard extends Component {
 	}
 
 	render() {
-		const { order, site, translate } = this.props;
+		const { isPaymentLoading, order, site, translate } = this.props;
 		const { errorMessage, refundNote, showDialog } = this.state;
 		const dialogClass = 'woocommerce'; // eslint/css specificity hack
 		let refundTotal = formatCurrency( 0, order.currency );
@@ -211,7 +211,7 @@ class OrderRefundCard extends Component {
 						<div className="order__refund-actions">
 							{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
 							<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>
-							<Button primary onClick={ this.sendRefund }>{ translate( 'Refund' ) }</Button>
+							<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>{ translate( 'Refund' ) }</Button>
 						</div>
 					</form>
 				</Dialog>

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -184,7 +184,11 @@ class OrderRefundCard extends Component {
 					}
 				</div>
 
-				<Dialog isVisible={ showDialog } onClose={ this.toggleDialog } className={ dialogClass }>
+				<Dialog
+					isVisible={ showDialog }
+					onClose={ this.toggleDialog }
+					className={ dialogClass }
+					additionalClassNames="order__refund-dialog woocommerce">
 					<h1>{ translate( 'Refund order' ) }</h1>
 					<OrderDetailsTable order={ order } isEditable onChange={ this.recalculateRefund } site={ site } />
 					<form className="order__refund-container">

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -134,11 +134,16 @@
 
 .order__details-refund,
 .order__details-fulfillment {
-	margin: 0 -24px;
-	padding: 24px;
+	margin: 0 -16px;
+	padding: 16px;
 	border-top: 1px solid lighten( $gray, 30% );
 	display: flex;
 	align-items: center;
+
+	@include breakpoint( ">960px" ) {
+		margin: 0 -24px;
+		padding: 24px;
+	}
 
 	.order__details-refund-label,
 	.order__details-fulfillment-label {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -74,9 +74,21 @@
 	}
 }
 
-&.dialog__content {
-	@include breakpoint( ">960px" ) {
-		width: 720px;
+&.order__refund-dialog {
+	max-width: 720px;
+	max-height: 85%;
+	display: flex;
+	flex-direction: column;
+	padding: 0;
+
+	.dialog__content {
+		height: 100%;
+		overflow-y: scroll;
+		padding: 16px;
+
+		@include breakpoint( ">960px" ) {
+			padding: 24px;
+		}
 	}
 
 	.form-text-input,

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -101,6 +101,12 @@
 	.form-text-input-with-affixes input {
 		text-align: right;
 	}
+
+	.form-label {
+		.form-text-input-with-affixes {
+			font-weight: normal;
+		}
+	}
 }
 
 .order__details-totals {
@@ -134,7 +140,7 @@
 
 	.order__details-total .order__details-totals-label,
 	.order__details-total .order__details-totals-value {
-		font-weight: bold;
+		font-weight: 600;
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -85,10 +85,16 @@
 		height: 100%;
 		overflow-y: scroll;
 		padding: 16px;
+		color: $gray-text-min;
 
 		@include breakpoint( ">960px" ) {
 			padding: 24px;
 		}
+	}
+
+	.order__detail-header,
+	.order__details-total {
+		color: $gray-dark;
 	}
 
 	.form-text-input,

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -229,7 +229,7 @@
 		}
 	}
 
-	.order__refund-credit-card h3 {
+	.order__refund-method h3 {
 		font-size: 11px;
 		text-transform: uppercase;
 		margin-bottom: 8px;

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -112,6 +112,7 @@
 .order__details-totals {
 	padding: 24px 0;
 	text-align: right;
+	font-size: 14px;
 
 	.order__details-total-discount,
 	.order__details-total-shipping,

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -230,8 +230,12 @@
 		flex: 1;
 	}
 
-	.order__refund-note .form-textarea {
-		margin-top: 8px;
+	.order__refund-note {
+		margin-bottom: 16px;
+
+		.form-textarea {
+			margin-top: 8px;
+		}
 	}
 
 	.order__refund-details {

--- a/client/extensions/woocommerce/state/sites/payment-methods/README.md
+++ b/client/extensions/woocommerce/state/sites/payment-methods/README.md
@@ -42,3 +42,7 @@ Whether the payment methods list is currently being retrieved from the server. O
 ### `getPaymentMethodsGroup( state, type, [siteId] )`
 
 Gets group of payment methods by type (offline, off-site, on-site). Optional `siteId`, will default to currently selected site.
+
+### `getPaymentMethod( state, methodId, [siteId] )`
+
+Get a single payment method by method name (bacs, cheque, etc). Returns false if no method found. Optional `siteId`, will default to currently selected site.

--- a/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isArray } from 'lodash';
+import { find, get, isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,17 @@ import { LOADING } from 'woocommerce/state/constants';
  */
 export const getPaymentMethods = ( state, siteId = getSelectedSiteId( state ) ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'paymentMethods' ] );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {string} methodId Method to fetch (if exists)
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} Object with payment method data, false if no method found
+ */
+export const getPaymentMethod = ( state, methodId, siteId = getSelectedSiteId( state ) ) => {
+	const methods = getPaymentMethods( state, siteId );
+	return find( methods, { id: methodId } ) || false;
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/payment-methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/selectors.js
@@ -9,7 +9,8 @@ import { expect } from 'chai';
 import {
 	arePaymentMethodsLoaded,
 	arePaymentMethodsLoading,
-	getPaymentMethods
+	getPaymentMethods,
+	getPaymentMethod,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -110,6 +111,28 @@ describe( 'selectors', () => {
 
 		it( 'should return undefined when given a pre-initialized state tree.', () => {
 			expect( getPaymentMethods( preInitializedState, 123 ) ).to.be.undefined;
+		} );
+	} );
+
+	describe( '#getPaymentMethod', () => {
+		it( 'should return the requested paymentMethod when given populated state tree.', () => {
+			expect( getPaymentMethod( loadedState, 'bacs', 123 ) ).to.eql( {
+				id: 'bacs',
+				title: 'Direct bank transfer',
+				description: 'Make your payment directly into our bank account.',
+				enabled: false,
+				method_title: 'BACS',
+				methodType: 'offline',
+				method_description: 'Allows payments by BACS, more commonly known as direct bank/wire transfer.',
+			} );
+		} );
+
+		it( 'should be false when given a loading state tree.', () => {
+			expect( getPaymentMethod( loadingState, 'bacs', 123 ) ).to.be.false;
+		} );
+
+		it( 'should be false when given a pre-initialized state tree.', () => {
+			expect( getPaymentMethod( preInitializedState, 'bacs', 123 ) ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
See #15672; and #15589, which this PR builds on. This PR detects whether the payment method used for an order supports automated refunds, or if it needs to be manually refunded. In both cases it will create a refund on the remote site, but if the payment method supports it (PayPal, for example), it will also automatically refund the customer.

This changes the design a bit, since we don't actually have data to show in the credit card section of the mockup. What it shows now, for a automatic refund:

![screen shot 2017-06-29 at 10 22 10 pm](https://user-images.githubusercontent.com/541093/27718766-08d90a2a-5d1c-11e7-8d13-80d86171ccbd.png)

And for manual refunds (totally happy to change this text 🙂  ):

![screen shot 2017-06-29 at 10 21 16 pm](https://user-images.githubusercontent.com/541093/27718767-08e7fe90-5d1c-11e7-848c-751de3c7290f.png)

**To test:**

- Visit the orders page
- Click into an order
- Click Refund, and see the new section above the "Cancel/Refund" buttons
- For orders placed with a check payment, you should see the manual text. Clicking refund should work.
- For orders placed with a credit card service, you should see that listed. Clicking refund should work.

_(Note: in testing, I noticed that I would hit the 5s timeout and the refund would appear to fail, but had succeeded on the remote site)_