### PR TITLE
WooCommerce - memoized shipping selectors

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -127,7 +127,6 @@ const ShippingZoneMethodList = ( {
 
 ShippingZoneMethodList.propTypes = {
 	siteId: PropTypes.number,
-	onChange: PropTypes.func.isRequired,
 	loaded: PropTypes.bool.isRequired,
 };
 

--- a/client/extensions/woocommerce/state/sites/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/selectors.js
@@ -51,7 +51,13 @@ export const getContinents = createSelector(
 		const continents = getRawLocations( state, siteId ).map( continent => omit( continent, 'countries' ) );
 		return sortBy( continents, 'name' );
 	},
-	[ areLocationsLoaded, getRawLocations ]
+	( state, siteId = getSelectedSiteId( state ) ) => {
+		const loaded = areLocationsLoaded( state, siteId );
+		return [
+			loaded,
+			loaded && getRawLocations( state, siteId ),
+		];
+	}
 );
 
 /**
@@ -72,7 +78,13 @@ export const getCountries = createSelector(
 		const countries = continent.countries.map( country => omit( country, 'states' ) );
 		return sortBy( countries, 'name' );
 	},
-	[ areLocationsLoaded, getRawLocations ]
+	( state, continentCode, siteId = getSelectedSiteId( state ) ) => {
+		const loaded = areLocationsLoaded( state, siteId );
+		return [
+			loaded,
+			loaded && getRawLocations( state, siteId ),
+		];
+	}
 );
 
 /**
@@ -92,7 +104,13 @@ export const getCountryName = createSelector(
 		}
 		return country.name;
 	},
-	[ areLocationsLoaded, getRawLocations ]
+	( state, countryCode, siteId = getSelectedSiteId( state ) ) => {
+		const loaded = areLocationsLoaded( state, siteId );
+		return [
+			loaded,
+			loaded && getRawLocations( state, siteId ),
+		];
+	}
 );
 
 /**
@@ -112,7 +130,13 @@ export const getStates = createSelector(
 		}
 		return sortBy( country.states, 'name' );
 	},
-	[ areLocationsLoaded, getRawLocations ]
+	( state, countryCode, siteId = getSelectedSiteId( state ) ) => {
+		const loaded = areLocationsLoaded( state, siteId );
+		return [
+			loaded,
+			loaded && getRawLocations( state, siteId ),
+		];
+	}
 );
 
 /**

--- a/client/extensions/woocommerce/state/sites/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/selectors.js
@@ -6,6 +6,7 @@ import { find, flatMap, get, isArray, isEmpty, omit, sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
+import createSelector from 'lib/create-selector';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -42,13 +43,16 @@ export const areLocationsLoading = ( state, siteId = getSelectedSiteId( state ) 
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} A list of continents, represented by { code, name } pairs. Sorted alphabetically by name.
  */
-export const getContinents = ( state, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areLocationsLoaded( state, siteId ) ) {
-		return [];
-	}
-	const continents = getRawLocations( state, siteId ).map( continent => omit( continent, 'countries' ) );
-	return sortBy( continents, 'name' );
-};
+export const getContinents = createSelector(
+	( state, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areLocationsLoaded( state, siteId ) ) {
+			return [];
+		}
+		const continents = getRawLocations( state, siteId ).map( continent => omit( continent, 'countries' ) );
+		return sortBy( continents, 'name' );
+	},
+	[ areLocationsLoaded, getRawLocations ]
+);
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -56,17 +60,20 @@ export const getContinents = ( state, siteId = getSelectedSiteId( state ) ) => {
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} A list of countries in the given country, represented by { code, name } pairs. Sorted alphabetically by name.
  */
-export const getCountries = ( state, continentCode, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areLocationsLoaded( state, siteId ) ) {
-		return [];
-	}
-	const continent = find( getRawLocations( state, siteId ), { code: continentCode } );
-	if ( ! continent ) {
-		return [];
-	}
-	const countries = continent.countries.map( country => omit( country, 'states' ) );
-	return sortBy( countries, 'name' );
-};
+export const getCountries = createSelector(
+	( state, continentCode, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areLocationsLoaded( state, siteId ) ) {
+			return [];
+		}
+		const continent = find( getRawLocations( state, siteId ), { code: continentCode } );
+		if ( ! continent ) {
+			return [];
+		}
+		const countries = continent.countries.map( country => omit( country, 'states' ) );
+		return sortBy( countries, 'name' );
+	},
+	[ areLocationsLoaded, getRawLocations ]
+);
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -74,16 +81,19 @@ export const getCountries = ( state, continentCode, siteId = getSelectedSiteId( 
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {String} The country name. If it can't be found, it will default to returning the country ISO code.
  */
-export const getCountryName = ( state, countryCode, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areLocationsLoaded( state, siteId ) ) {
-		return countryCode;
-	}
-	const country = find( flatMap( getRawLocations( state, siteId ), 'countries' ), { code: countryCode } );
-	if ( ! country ) {
-		return countryCode;
-	}
-	return country.name;
-};
+export const getCountryName = createSelector(
+	( state, countryCode, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areLocationsLoaded( state, siteId ) ) {
+			return countryCode;
+		}
+		const country = find( flatMap( getRawLocations( state, siteId ), 'countries' ), { code: countryCode } );
+		if ( ! country ) {
+			return countryCode;
+		}
+		return country.name;
+	},
+	[ areLocationsLoaded, getRawLocations ]
+);
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -91,16 +101,19 @@ export const getCountryName = ( state, countryCode, siteId = getSelectedSiteId( 
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} A list of states in the given country, represented by { code, name } pairs. Sorted alphabetically by name.
  */
-export const getStates = ( state, countryCode, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areLocationsLoaded( state, siteId ) ) {
-		return [];
-	}
-	const country = find( flatMap( getRawLocations( state, siteId ), 'countries' ), { code: countryCode } );
-	if ( ! country ) {
-		return [];
-	}
-	return sortBy( country.states, 'name' );
-};
+export const getStates = createSelector(
+	( state, countryCode, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areLocationsLoaded( state, siteId ) ) {
+			return [];
+		}
+		const country = find( flatMap( getRawLocations( state, siteId ), 'countries' ), { code: countryCode } );
+		if ( ! country ) {
+			return [];
+		}
+		return sortBy( country.states, 'name' );
+	},
+	[ areLocationsLoaded, getRawLocations ]
+);
 
 /**
  * @param {Object} state Whole Redux state tree

--- a/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-methods/selectors.js
@@ -6,6 +6,7 @@ import { find, get, isArray } from 'lodash';
 /**
  * Internal dependencies
  */
+import createSelector from 'lib/create-selector';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -58,15 +59,18 @@ export const getShippingMethod = ( state, id, siteId = getSelectedSiteId( state 
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {Function} utility function taking method type as an argument and returning a matched type
  */
-export const getShippingMethodNameMap = ( state, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areShippingMethodsLoaded( state, siteId ) ) {
-		return ( typeId ) => ( typeId );
-	}
+export const getShippingMethodNameMap = createSelector(
+	( state, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areShippingMethodsLoaded( state, siteId ) ) {
+			return ( typeId ) => ( typeId );
+		}
 
-	const map = getShippingMethods( state, siteId ).reduce( ( result, { id, title } ) => {
-		result[ id ] = title;
-		return result;
-	}, {} );
+		const map = getShippingMethods( state, siteId ).reduce( ( result, { id, title } ) => {
+			result[ id ] = title;
+			return result;
+		}, {} );
 
-	return ( typeId ) => ( map[ typeId ] || typeId );
-};
+		return ( typeId ) => ( map[ typeId ] || typeId );
+	},
+	[ areShippingMethodsLoaded, getShippingMethods ]
+);

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -37,10 +37,8 @@ const getContinentsOwnedByOtherZone = createSelector(
 		} );
 		return continents;
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId ) => {
 		return [
-			siteId,
 			getCurrentlyEditingShippingZone( state, siteId ),
 			getRawShippingZoneLocations( state, siteId ),
 		];
@@ -70,10 +68,8 @@ const getCountriesOwnedByOtherZone = createSelector(
 		} );
 		return countries;
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId ) => {
 		return [
-			siteId,
 			getCurrentlyEditingShippingZone( state, siteId ),
 			getRawShippingZoneLocations( state, siteId ),
 		];
@@ -106,10 +102,8 @@ const getStatesOwnedByOtherZone = createSelector(
 		} );
 		return states;
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId ) => {
 		return [
-			siteId,
 			getCurrentlyEditingShippingZone( state, siteId ),
 			getRawShippingZoneLocations( state, siteId ),
 		];
@@ -126,7 +120,6 @@ const getStatesOwnedByOtherZone = createSelector(
  */
 export const getShippingZoneLocationsWithEdits = createSelector(
 	( state, siteId = getSelectedSiteId( state ), overlayTemporalEdits = true ) => {
-		//console.log( 'yo' );
 		if ( ! areShippingZonesLoaded( state, siteId ) ) {
 			return null;
 		}
@@ -247,8 +240,7 @@ export const getShippingZoneLocationsWithEdits = createSelector(
 			postcode: null === edits.postcode ? [] : [ edits.postcode ],
 		};
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		const loaded = areShippingZonesLoaded( state, siteId );
 		const zone = loaded && getCurrentlyEditingShippingZone( state, siteId );
 		return [
@@ -340,8 +332,7 @@ export const areLocationsFilteredByPostcode = createSelector(
 		}
 		return ! canLocationsBeFilteredByState( state, siteId ) && Boolean( getCurrentSelectedCountryZoneOwner( state, siteId ) );
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		const canFilter = canLocationsBeFiltered( state, siteId );
 		return [
 			canFilter,
@@ -377,8 +368,7 @@ export const areLocationsFilteredByState = createSelector(
 		}
 		return ! areLocationsFilteredByPostcode( state, siteId ) && Boolean( getCurrentSelectedCountryZoneOwner( state, siteId ) );
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		const canFilter = canLocationsBeFiltered( state, siteId );
 		return [
 			canFilter,
@@ -496,8 +486,7 @@ export const getCurrentlyEditingShippingZoneLocationsList = createSelector(
 
 		return result;
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, maxCountries = 999, siteId = getSelectedSiteId( state ) ) => {
 		return [
 			getShippingZoneLocationsWithEdits( state, siteId, false ),
 		];
@@ -560,8 +549,7 @@ export const getCurrentlyEditingShippingZoneCountries = createSelector(
 		} );
 		return locationsList;
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		return [
 			getShippingZoneLocationsWithEdits( state, siteId ),
 			getContinentsOwnedByOtherZone( state, siteId ),
@@ -602,8 +590,7 @@ export const getCurrentlyEditingShippingZoneStates = createSelector(
 			ownerZoneId: forbiddenStates[ code ],
 		} ) );
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		return [
 			areLocationsFilteredByState( state, siteId ),
 			getShippingZoneLocationsWithEdits( state, siteId ),

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
@@ -25,8 +25,7 @@ const getShippingZone = createSelector(
 		}
 		return find( getAPIShippingZones( state, siteId ), { id: zoneId } );
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, zoneId, siteId ) => {
 		const loaded = areShippingZonesLoaded( state, siteId );
 		return [
 			loaded,
@@ -116,8 +115,7 @@ export const getShippingZoneMethods = createSelector(
 
 		return overlayShippingZoneMethods( state, zone, siteId );
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, zoneId, siteId = getSelectedSiteId( state ) ) => {
 		const loaded = areShippingZonesLoaded( state, siteId );
 		return [
 			loaded,
@@ -154,8 +152,7 @@ export const getCurrentlyEditingShippingZoneMethods = createSelector(
 		const currentMethodEdits = getShippingZonesEdits( state, siteId ).currentlyEditingChanges.methods;
 		return overlayShippingZoneMethods( state, zone, siteId, currentMethodEdits );
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		const loaded = areShippingZonesLoaded( state, siteId );
 		const zone = loaded && getCurrentlyEditingShippingZone( state, siteId );
 		return [

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/selectors.js
@@ -6,6 +6,7 @@ import { find, isEmpty, isNumber, isNil, map, pullAll } from 'lodash';
 /**
  * Internal dependencies
  */
+import createSelector from 'lib/create-selector';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getAPIShippingZones, areShippingZonesLoaded } from 'woocommerce/state/sites/shipping-zones/selectors';
 import { getShippingZoneMethod } from 'woocommerce/state/sites/shipping-zone-methods/selectors';
@@ -14,15 +15,33 @@ import { getBucket } from 'woocommerce/state/ui/helpers';
 import { builtInShippingMethods } from 'woocommerce/state/ui/shipping/zones/methods/reducer';
 import { mergeMethodEdits } from './helpers';
 
-const getShippingZone = ( state, zoneId, siteId ) => {
-	if ( ! areShippingZonesLoaded( state, siteId ) ) {
-		return null;
+const getShippingZone = createSelector(
+	( state, zoneId, siteId ) => {
+		if ( ! areShippingZonesLoaded( state, siteId ) ) {
+			return null;
+		}
+		if ( null === zoneId ) {
+			return getCurrentlyEditingShippingZone( state, siteId );
+		}
+		return find( getAPIShippingZones( state, siteId ), { id: zoneId } );
+	},
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const loaded = areShippingZonesLoaded( state, siteId );
+		return [
+			loaded,
+			loaded && getCurrentlyEditingShippingZone( state, siteId ),
+			loaded && getAPIShippingZones( state, siteId ),
+		];
+	},
+	( state, zoneId, siteId ) => {
+		if ( ! isNumber( zoneId ) ) {
+			return `i${ zoneId.index }${ siteId }`;
+		}
+
+		return `${ zoneId }${ siteId }`;
 	}
-	if ( null === zoneId ) {
-		return getCurrentlyEditingShippingZone( state, siteId );
-	}
-	return find( getAPIShippingZones( state, siteId ), { id: zoneId } );
-};
+);
 
 const getShippingZoneMethodsEdits = ( state, zoneId, siteId ) => {
 	const zonesEdits = getShippingZonesEdits( state, siteId );
@@ -88,14 +107,32 @@ const overlayShippingZoneMethods = ( state, zone, siteId, extraEdits ) => {
  * @return {Array} The list of shipping methods included in the given shipping zone. On any failure, it will return
  * an empty Array
  */
-export const getShippingZoneMethods = ( state, zoneId, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areShippingZonesLoaded( state, siteId ) ) {
-		return [];
-	}
-	const zone = getShippingZone( state, zoneId, siteId ) || { id: zoneId, methodIds: [] };
+export const getShippingZoneMethods = createSelector(
+	( state, zoneId, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areShippingZonesLoaded( state, siteId ) ) {
+			return [];
+		}
+		const zone = getShippingZone( state, zoneId, siteId ) || { id: zoneId, methodIds: [] };
 
-	return overlayShippingZoneMethods( state, zone, siteId );
-};
+		return overlayShippingZoneMethods( state, zone, siteId );
+	},
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const loaded = areShippingZonesLoaded( state, siteId );
+		return [
+			loaded,
+			loaded && getShippingZone( state, siteId ),
+			loaded && getShippingZonesEdits( state, siteId ),
+		];
+	},
+	( state, zoneId, siteId ) => {
+		if ( ! isNumber( zoneId ) ) {
+			return `i${ zoneId.index }${ siteId }`;
+		}
+
+		return `${ zoneId }${ siteId }`;
+	}
+);
 
 /**
  * @param {Object} state Whole Redux state tree
@@ -104,18 +141,30 @@ export const getShippingZoneMethods = ( state, zoneId, siteId = getSelectedSiteI
  * shipping methods that haven't yet been "committed" to the main state tree. On any failure, it will return
  * an empty Array
  */
-export const getCurrentlyEditingShippingZoneMethods = ( state, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! areShippingZonesLoaded( state, siteId ) ) {
-		return [];
-	}
-	const zone = getCurrentlyEditingShippingZone( state, siteId );
-	if ( ! zone ) {
-		return [];
-	}
+export const getCurrentlyEditingShippingZoneMethods = createSelector(
+	( state, siteId = getSelectedSiteId( state ) ) => {
+		if ( ! areShippingZonesLoaded( state, siteId ) ) {
+			return [];
+		}
+		const zone = getCurrentlyEditingShippingZone( state, siteId );
+		if ( ! zone ) {
+			return [];
+		}
 
-	const currentMethodEdits = getShippingZonesEdits( state, siteId ).currentlyEditingChanges.methods;
-	return overlayShippingZoneMethods( state, zone, siteId, currentMethodEdits );
-};
+		const currentMethodEdits = getShippingZonesEdits( state, siteId ).currentlyEditingChanges.methods;
+		return overlayShippingZoneMethods( state, zone, siteId, currentMethodEdits );
+	},
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const loaded = areShippingZonesLoaded( state, siteId );
+		const zone = loaded && getCurrentlyEditingShippingZone( state, siteId );
+		return [
+			loaded,
+			zone,
+			zone && getShippingZonesEdits( state, siteId ),
+		];
+	}
+);
 
 /**
  * @param {Object} state Whole Redux state tree

--- a/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
@@ -77,8 +77,7 @@ export const getShippingZones = createSelector(
 		} );
 		return orderShippingZones( [ ...zones, ...creates ] );
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		const loaded = areShippingZonesLoaded( state, siteId );
 		return [
 			siteId,
@@ -110,8 +109,7 @@ export const getCurrentlyEditingShippingZone = createSelector(
 		}
 		return { ...zone, ...edits.currentlyEditingChanges };
 	},
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
+	( state, siteId = getSelectedSiteId( state ) ) => {
 		const edits = getShippingZonesEdits( state, siteId );
 		return [
 			siteId,


### PR DESCRIPTION
Memoizes the selectors used on the shipping settings page.

The selector logic has not changed.

(also fixes a react warning on the zone page)