### PR TITLE
Login: Update copy for login limit exceeded error

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -49,6 +49,7 @@ function getErrorMessageFromErrorCode( code ) {
 		invalid_two_step_code: translate( "Hmm, that's not a valid verification code. Please double-check your app and try again." ),
 		invalid_two_step_nonce: translate( 'Your session has expired, please go back to the login screen.' ),
 		invalid_username: translate( "We don't seem to have an account with that name. Double-check the spelling and try again!" ),
+		login_limit_exceeded: translate( "Slow down, you're trying to log in too fast." ),
 		push_authentication_throttled: translate( 'You can only request a code via the WordPress mobile app once every ' +
 			'two minutes. Please wait and try again.' ),
 		sms_code_throttled: translate( 'You can only request a code via SMS once per minute. Please wait and try again.' ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/14779 by updating the copy of the error displayed when a user tries to log in multiple in a short period of time.

#### Testing instructions
 
I was unable to reproduce this error, but @martinremy says he gets it consistently on the 3rd login attempt within a minute or so.

#### Notes

I added the error to `errorMessages` but I see we also have `wpcomErrorMessages`. I'm not entirely sure what's the difference between those, as both contain client and API errors.
  
#### Reviews
  
- [x] Code
- [x] Product