### PR TITLE
WooCommerce - Added required prop to the locations dialog labels

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
@@ -133,7 +133,7 @@ const ShippingZoneLocationDialogSettings = ( {
 
 			return (
 				<FormFieldSet>
-					<FormLabel>{ translate( 'Post codes' ) }<span className="shipping-zone__location-dialog-required">*</span></FormLabel>
+					<FormLabel required>{ translate( 'Post codes' ) }</FormLabel>
 					<FormTextInput
 						value={ postcode }
 						onChange={ onPostcodeChange } />
@@ -148,7 +148,7 @@ const ShippingZoneLocationDialogSettings = ( {
 		if ( filteredByState ) {
 			return (
 				<FormFieldSet>
-					<FormLabel>{ translate( 'States' ) }<span className="shipping-zone__location-dialog-required">*</span></FormLabel>
+					<FormLabel required>{ translate( 'States' ) }</FormLabel>
 					<FilteredList
 						items={ states }
 						filterBy="name"

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -333,10 +333,6 @@
 	&.is-disabled {
 		color: $gray-text-min;
 
-		span {
-			text-decoration: line-through;
-		}
-
 		img {
 			filter: grayscale(1);
 			opacity: .5;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -369,8 +369,3 @@
 		margin-left: 24px;
 	}
 }
-
-.shipping-zone__location-dialog-required {
-	font-weight: normal;
-	color: $alert-red;
-}


### PR DESCRIPTION
Removes the existing implementation of the required field mark (red asterisk) and replaces it with the newly added `required` prop on `FormLabel`.

CC @jameskoster 