### PR TITLE
Login: update SMS to text message in copy

### DIFF
--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getRequestError,
+	getTwoFactorAuthRequestError,
+	getCreateSocialAccountError,
+	getRequestSocialAccountError,
+} from 'state/login/selectors';
+import Notice from 'components/notice';
+
+class ErrorNotice extends Component {
+	static propTypes = {
+		createAccountError: PropTypes.object,
+		requestAccountError: PropTypes.object,
+		requestError: PropTypes.object,
+		twoFactorAuthRequestError: PropTypes.object,
+	};
+
+	componentWillReceiveProps = ( nextProps ) => {
+		const receiveNewError = ( key ) => {
+			return this.props[ key ] !== nextProps[ key ];
+		};
+
+		if (
+			receiveNewError( 'createAccountError' ) ||
+			receiveNewError( 'requestAccountError' ) ||
+			receiveNewError( 'requestError' ) ||
+			receiveNewError( 'twoFactorAuthRequestError' )
+		) {
+			window.scrollTo( 0, 0 );
+		}
+	}
+
+	getCreateAccountError() {
+		const { createAccountError } = this.props;
+
+		if ( createAccountError && createAccountError.code !== 'unknown_user' ) {
+			return createAccountError;
+		}
+
+		return null;
+	}
+
+	getError() {
+		const { requestAccountError, requestError, twoFactorAuthRequestError } = this.props;
+
+		return requestError || twoFactorAuthRequestError || requestAccountError || this.getCreateAccountError();
+	}
+
+	render() {
+		const error = this.getError();
+
+		if ( ! error || ( error.field && error.field !== 'global' ) || ! error.message ) {
+			return null;
+		}
+
+		return (
+			<Notice status={ 'is-error' } showDismiss={ false }>
+				{ error.message }
+			</Notice>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		createAccountError: getCreateSocialAccountError( state ),
+		requestAccountError: getRequestSocialAccountError( state ),
+		requestError: getRequestError( state ),
+		twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),
+	} )
+)( ErrorNotice );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -10,15 +10,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
 import {
 	getRedirectTo,
-	getRequestError,
 	getRequestNotice,
-	getTwoFactorAuthRequestError,
 	getTwoFactorNotificationSent,
-	getCreateSocialAccountError,
-	getRequestSocialAccountError,
 	isTwoFactorEnabled,
 } from 'state/login/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -35,10 +32,8 @@ class Login extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectTo: PropTypes.string,
-		requestError: PropTypes.object,
 		requestNotice: PropTypes.object,
 		twoFactorAuthType: PropTypes.string,
-		twoFactorAuthRequestError: PropTypes.object,
 		twoFactorEnabled: PropTypes.bool,
 		twoFactorNotificationSent: PropTypes.string,
 	};
@@ -51,12 +46,10 @@ class Login extends Component {
 	};
 
 	componentWillReceiveProps = ( nextProps ) => {
-		const hasLoginError = this.props.requestError !== nextProps.requestError;
-		const hasTwoFactorAuthError = this.props.twoFactorAuthRequestError !== nextProps.twoFactorAuthRequestError;
 		const hasNotice = this.props.requestNotice !== nextProps.requestNotice;
 		const isNewPage = this.props.twoFactorAuthType !== nextProps.twoFactorAuthType;
 
-		if ( isNewPage || hasLoginError || hasTwoFactorAuthError || hasNotice ) {
+		if ( isNewPage || hasNotice ) {
 			window.scrollTo( 0, 0 );
 		}
 	};
@@ -91,23 +84,6 @@ class Login extends Component {
 		window.location.href = url;
 	};
 
-	renderError() {
-		const error = this.props.requestError ||
-			this.props.twoFactorAuthRequestError ||
-			this.props.requestAccountError ||
-			this.props.createAccountError && this.props.createAccountError.code !== 'unknown_user' ? this.props.createAccountError : null;
-
-		if ( ! error || ( error.field && error.field !== 'global' ) || ! error.message ) {
-			return null;
-		}
-
-		return (
-			<Notice status={ 'is-error' } showDismiss={ false }>
-				{ error.message }
-			</Notice>
-		);
-	}
-
 	renderNotice() {
 		const { requestNotice } = this.props;
 
@@ -140,8 +116,7 @@ class Login extends Component {
 					{ poller }
 					<VerificationCodeForm
 						onSuccess={ this.rebootAfterLogin }
-						twoFactorAuthType={ twoFactorAuthType }
-					/>
+						twoFactorAuthType={ twoFactorAuthType } />
 				</div>
 			);
 		}
@@ -169,7 +144,7 @@ class Login extends Component {
 					{ twoStepNonce ? translate( 'Two-Step Authentication' ) : translate( 'Log in to your account.' ) }
 				</div>
 
-				{ this.renderError() }
+				<ErrorNotice />
 
 				{ this.renderNotice() }
 
@@ -182,11 +157,7 @@ class Login extends Component {
 export default connect(
 	( state ) => ( {
 		redirectTo: getRedirectTo( state ),
-		createAccountError: getCreateSocialAccountError( state ),
-		requestAccountError: getRequestSocialAccountError( state ),
-		requestError: getRequestError( state ),
 		requestNotice: getRequestNotice( state ),
-		twoFactorAuthRequestError: getTwoFactorAuthRequestError( state ),
 		twoFactorEnabled: isTwoFactorEnabled( state ),
 		twoFactorNotificationSent: getTwoFactorNotificationSent( state ),
 	} ), {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -51,8 +51,8 @@ function getErrorMessageFromErrorCode( code ) {
 		invalid_username: translate( "We don't seem to have an account with that name. Double-check the spelling and try again!" ),
 		push_authentication_throttled: translate( 'You can only request a code via the WordPress mobile app once every ' +
 			'two minutes. Please wait and try again.' ),
-		sms_code_throttled: translate( 'You can only request a code via SMS once per minute. Please wait and try again.' ),
-		sms_recovery_code_throttled: translate( 'You can only request a recovery code via SMS once per minute. ' +
+		sms_code_throttled: translate( 'You can only request a code via text message once per minute. Please wait and try again.' ),
+		sms_recovery_code_throttled: translate( 'You can only request a recovery code via text message once per minute. ' +
 			'Please wait and try again.' ),
 		unknown: translate( "Hmm, we can't find a WordPress.com account with this username and password combo. " +
 			'Please double check your information and try again.' ),

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -138,7 +138,7 @@ export const socialAccount = createReducer( { isCreating: false }, {
 		requestError: error
 	} ),
 	[ USER_RECEIVE ]: state => ( { ...state, bearerToken: null, username: null } ),
-	[ LOGIN_REQUEST ]: state => ( { ...state, createError: false } ),
+	[ LOGIN_REQUEST ]: state => ( { ...state, createError: null } ),
 } );
 
 export default combineReducers( {


### PR DESCRIPTION
This pull request fixes #15473 by replacing occurrences of "SMS" in the login flow with "text message".
  
#### Testing instructions
  
1. Run `git checkout update/sms-to-text-message-copy` and start your server
2. Try to log in using an account that has 2FA enabled via an authenticator app
3. Click "Code via text message"
4. Do not enter the code you received, instead click "Your Authenticator app"
5. Click "Code via text message" again. 
6. You should see the following error: "You can only request a code via text message once per minute. Please wait and try again."
  
#### Additional notes
  
There are still occurrences of "SMS" under `https://wordpress.com/me/security/two-step` (cc @ebinnion) and under the new Account Recovery flow that is still under construction (@southp). These should be addressed at some point, considering the input from @ranh and @benhuberman in the original issue.

Additionally, all functions and variables still use "SMS", being inconsistent with the user-facing terminology.
  
#### Reviews
  
- [x] Code
- [x] Product