### PR TITLE
Store Stats in Calypso: sparkline widgets added

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -3,6 +3,42 @@
  */
 import { translate } from 'i18n-calypso';
 
+export const sparkWidgetList1 = [
+	{
+		key: 'products',
+		title: translate( 'Products Purchased' ),
+		type: 'number'
+	},
+	{
+		key: 'avg_products_per_order',
+		title: translate( 'Products Per Order' ),
+		type: 'number'
+	},
+	{
+		key: 'coupons',
+		title: translate( 'Coupons Used' ),
+		type: 'number'
+	}
+];
+
+export const sparkWidgetList2 = [
+	{
+		key: 'total_refund',
+		title: translate( 'Refunds' ),
+		type: 'currency'
+	},
+	{
+		key: 'total_shipping',
+		title: translate( 'Shipping' ),
+		type: 'currency'
+	},
+	{
+		key: 'total_tax',
+		title: translate( 'Tax' ),
+		type: 'currency'
+	}
+];
+
 export const topProducts = {
 	basePath: '/store/stats/products',
 	title: translate( 'Products' ),

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { moment } from 'i18n-calypso';
+import { moment, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,8 +16,9 @@ import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import Module from './store-stats-module';
 import List from './store-stats-list';
+import WidgetList from './store-stats-widget-list';
 import SectionHeader from 'components/section-header';
-import { topProducts, topCategories, topCoupons, UNITS } from 'woocommerce/app/store-stats/constants';
+import { sparkWidgetList1, sparkWidgetList2, topProducts, topCategories, topCoupons, UNITS } from 'woocommerce/app/store-stats/constants';
 
 class StoreStats extends Component {
 	static propTypes = {
@@ -58,8 +59,35 @@ class StoreStats extends Component {
 			date: unitSelectedDate,
 			limit: 10,
 		};
-		const widgets = [ topProducts, topCategories, topCoupons ];
+		const topWidgets = [ topProducts, topCategories, topCoupons ];
 		const widgetPath = `/${ unit }/${ slug }${ querystring ? '?' : '' }${ querystring || '' }`;
+
+		const widgetList1 = (
+			<div className="store-stats__widgets-column spark-widgets" key="sparkwidgets1">
+				<WidgetList
+					siteId={ siteId }
+					header={ null }
+					emptyMessage={ translate( 'No data found.' ) }
+					query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
+					selectedDate={ endSelectedDate }
+					statType="statsOrders"
+					widgets={ sparkWidgetList1 }
+				/>
+			</div>
+			);
+		const widgetList2 = (
+			<div className="store-stats__widgets-column spark-widgets" key="sparkwidgets2">
+				<WidgetList
+					siteId={ siteId }
+					header={ null }
+					emptyMessage={ translate( 'No data found.' ) }
+					query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
+					selectedDate={ endSelectedDate }
+					statType="statsOrders"
+					widgets={ sparkWidgetList2 }
+				/>
+			</div>
+		);
 
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
@@ -90,31 +118,33 @@ class StoreStats extends Component {
 					/>
 				</StatsPeriodNavigation>
 				<div className="store-stats__widgets">
-				{ widgets.map( widget => {
-					const header = (
-						<SectionHeader href={ widget.basePath + widgetPath }>
-							{ widget.title }
-						</SectionHeader>
-					);
-					return (
-						<div className="store-stats__widgets-column" key={ widget.basePath }>
-							<Module
-								siteId={ siteId }
-								header={ header }
-								emptyMessage={ widget.empty }
-								query={ topQuery }
-								statType={ widget.statType }
-							>
-								<List
+					{ widgetList1 }
+					{ widgetList2 }
+					{ topWidgets.map( widget => {
+						const header = (
+							<SectionHeader href={ widget.basePath + widgetPath }>
+								{ widget.title }
+							</SectionHeader>
+						);
+						return (
+							<div className="store-stats__widgets-column" key={ widget.basePath }>
+								<Module
 									siteId={ siteId }
-									values={ widget.values }
+									header={ header }
+									emptyMessage={ widget.empty }
 									query={ topQuery }
 									statType={ widget.statType }
-								/>
-							</Module>
-						</div>
-					);
-				} ) }
+								>
+									<List
+										siteId={ siteId }
+										values={ widget.values }
+										query={ topQuery }
+										statType={ widget.statType }
+									/>
+								</Module>
+							</div>
+						);
+					} ) }
 				</div>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -19,6 +19,7 @@ import Legend from 'components/chart/legend';
 import Tabs from 'my-sites/stats/stats-tabs';
 import Tab from 'my-sites/stats/stats-tabs/tab';
 import Delta from 'woocommerce/components/delta';
+import formatCurrency from 'lib/format-currency';
 
 class StoreStatsChart extends Component {
 	static propTypes = {
@@ -68,7 +69,7 @@ class StoreStatsChart extends Component {
 		return this.getDeltasBySelectedPeriod()[ stat ];
 	};
 
-	getSelectedIndex = data => {
+	getSelectedIndex = ( data ) => {
 		return findIndex( data, d => d.period === this.props.selectedDate );
 	};
 
@@ -77,10 +78,10 @@ class StoreStatsChart extends Component {
 		const { selectedTabIndex } = this.state;
 		const orderData = data.data;
 		const tabs = [
-			{ label: 'Gross Sales', attr: 'gross_sales' },
-			{ label: 'Net Sales', attr: 'net_sales' },
-			{ label: 'Orders', attr: 'orders' },
-			{ label: 'Average Order Value', attr: 'avg_order_value' },
+			{ label: 'Gross Sales', attr: 'gross_sales', type: 'currency' },
+			{ label: 'Net Sales', attr: 'net_sales', type: 'currency' },
+			{ label: 'Orders', attr: 'orders', type: 'number' },
+			{ label: 'Average Order Value', attr: 'avg_order_value', type: 'currency' },
 		];
 		const selectedTab = tabs[ selectedTabIndex ];
 		const isLoading = ! orderData.length;
@@ -111,7 +112,11 @@ class StoreStatsChart extends Component {
 									selected={ tabIndex === selectedTabIndex }
 									tabClick={ this.tabClick }
 								>
-									<span className="store-stats-chart__value value">{ itemChartData.value }</span>
+									<span className="store-stats-chart__value value">
+										{ ( tab.type === 'currency' )
+											? formatCurrency( itemChartData.value )
+											:	Math.round( itemChartData.value * 100 ) / 100 }
+									</span>
 									<Delta
 										value={ `${ deltaValue }%` }
 										className={ `${ delta.favorable } ${ delta.direction }` }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
@@ -25,7 +25,9 @@ const StoreStatsList = ( { data, values } ) => {
 			{ data.map( ( row, i ) => (
 				<TableRow key={ i }>
 					{ values.map( ( value, j ) => (
-						<TableItem key={ value.key } isTitle={ 0 === j }>{ row[ value.key ] }</TableItem>
+						<TableItem key={ value.key } isTitle={ 0 === j }>
+							{ row[ value.key ] }
+						</TableItem>
 					) ) }
 				</TableRow>
 			) ) }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
+import { isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ class StoreStatsModule extends Component {
 			this.setState( { loaded: true } );
 		}
 
-		if ( nextProps.query !== this.props.query && this.state.loaded ) {
+		if ( ! isEqual( nextProps.query, this.props.query ) && this.state.loaded ) {
 			this.setState( { loaded: false } );
 		}
 	}

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -1,0 +1,181 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes, Component } from 'react';
+import classnames from 'classnames';
+import { connect } from 'react-redux';
+import { find, findIndex, isEqual } from 'lodash';
+import { moment, translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Delta from 'woocommerce/components/delta';
+import ErrorPanel from 'my-sites/stats/stats-error';
+import formatCurrency from 'lib/format-currency';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData
+} from 'state/stats/lists/selectors';
+import QuerySiteStats from 'components/data/query-site-stats';
+import Sparkline from 'woocommerce/components/sparkline';
+import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
+import Table from 'woocommerce/components/table';
+import TableItem from 'woocommerce/components/table/table-item';
+import TableRow from 'woocommerce/components/table/table-row';
+
+class StoreStatsWidgetList extends Component {
+
+	static propTypes = {
+		data: PropTypes.object.isRequired, // TODO refactor to array :(
+		emptyMessage: PropTypes.string,
+		selectedDate: PropTypes.string.isRequired,
+		siteId: PropTypes.number,
+		statType: PropTypes.string,
+		query: PropTypes.object.isRequired,
+		widgets: PropTypes.array.isRequired,
+	};
+
+	state = {
+		loaded: false
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.requesting && this.props.requesting ) {
+			this.setState( { loaded: true } );
+		}
+		if ( ! isEqual( nextProps.query, this.props.query ) && this.state.loaded ) {
+			this.setState( { loaded: false } );
+		}
+	}
+
+	getEndPeriod = ( date ) => {
+		const { unit } = this.props.query;
+		return ( unit === 'week' )
+			? moment( date ).endOf( 'isoWeek' ).format( 'YYYY-MM-DD' )
+			: moment( date ).endOf( unit ).format( 'YYYY-MM-DD' );
+	};
+
+	getDeltasBySelectedPeriod = () => {
+		return find( this.props.data.deltas, ( item ) =>
+			item.period === this.props.selectedDate
+		);
+	};
+
+	getDeltaByStat = ( stat ) => {
+		return this.getDeltasBySelectedPeriod()[ stat ];
+	};
+
+	getSelectedIndex = ( data ) => {
+		return findIndex( data, d => d.period === this.props.selectedDate );
+	};
+
+	render() {
+		const { siteId, statType, query, data, emptyMessage, widgets } = this.props;
+		const selectedIndex = this.getSelectedIndex( data.data );
+		const { loaded } = this.state;
+		const isLoading = ! loaded && ! ( data && data.data.length );
+		const hasEmptyData = loaded && data && data.data.length === 0;
+		let values = [];
+		let titles = null;
+		let widgetData = null;
+		let widgetList = null;
+
+		if ( ! isLoading && ! hasEmptyData ) {
+			const firstRealKey = Object.keys( data.deltas[ selectedIndex ] ).filter( key => key !== 'period' )[ 0 ];
+			const sincePeriod = this.getDeltaByStat( firstRealKey );
+			values = [
+				{
+					key: 'title',
+					label: translate( 'Stat' )
+				},
+				{
+					key: 'value',
+					label: translate( 'Value' )
+				},
+				{
+					key: 'sparkline',
+					label: translate( 'Trend' )
+				},
+				{
+					key: 'delta',
+					label: `${ translate( 'Since' ) } ${ moment( sincePeriod.reference_period ).format( 'MMM D' ) }`
+				}
+			];
+
+			titles = (
+				<TableRow isHeader>
+					{ values.map( ( value, i ) => {
+						return (
+							<TableItem
+								className={ classnames( 'store-stats-widget-list__table-item', value.key ) }
+								isHeader
+								key={ i }
+								isTitle={ 0 === i }
+							>
+								{ value.label }
+							</TableItem>
+						);
+					} ) }
+				</TableRow>
+			);
+
+			widgetData = widgets.map( widget => {
+				const timeSeries = data.data.map( row => +row[ widget.key ] );
+				const delta = this.getDeltaByStat( widget.key );
+				return {
+					title: widget.title,
+					value: ( widget.type === 'currency' )
+						? formatCurrency( timeSeries[ selectedIndex ] )
+						:	Math.round( timeSeries[ selectedIndex ] * 100 ) / 100,
+					sparkline: <Sparkline
+						aspectRatio={ 3 }
+						data={ timeSeries }
+						highlightIndex={ selectedIndex }
+						maxHeight={ 50 }
+					/>,
+					delta: <Delta
+						value={ `${ Math.abs( Math.round( delta.percentage_change * 100 ) ) }%` }
+						className={ `${ delta.favorable } ${ delta.direction }` }
+					/>
+				};
+			} );
+			widgetList = (
+				<Table header={ titles }>
+					{ widgetData.map( ( row, i ) => (
+						<TableRow className="store-stats-widget-list__table-row" key={ i }>
+							{ values.map( ( value, j ) => (
+								<TableItem
+									className={ classnames( 'store-stats-widget-list__table-item', value.key ) }
+									key={ value.key }
+									isTitle={ 0 === j }
+								>
+									{ row[ value.key ] }
+								</TableItem>
+							) ) }
+						</TableRow>
+					) ) }
+				</Table>
+			);
+		}
+
+		return (
+			<div>
+				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+				{ isLoading && <Card><StatsModulePlaceholder isLoading={ isLoading } /></Card> }
+				{ ! isLoading && hasEmptyData && <Card><ErrorPanel message={ emptyMessage } /></Card> }
+				{ ! isLoading && ! hasEmptyData && widgetList }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state, { siteId, statType, query } ) => {
+		return {
+			data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+			requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
+		};
+	}
+)( StoreStatsWidgetList );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/style.scss
@@ -1,0 +1,17 @@
+.store-stats-widget-list__table-row {
+	height: 100%;
+}
+.store-stats-widget-list__table-item {
+	height: 50px;
+	padding: 12px 8px;
+	&.title {
+		width: 40%;
+	}
+	&.sparkline {
+		padding: 8px 4px;
+		width: 25%;
+	}
+	&.value {
+		width: 20%;
+	}
+}

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -17,13 +17,14 @@
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
-	.store-stats__widgets-column {
-		width: calc(50% - 4px);
-	}
 }
 
 @include breakpoint( ">1280px" ) {
 	.store-stats__widgets-column {
-		width: calc(33% - 3px);
+		width: calc( 33% - 3px );
+
+		&.spark-widgets {
+			width: calc( 50% - 3px );
+		}
 	}
 }

--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -31,14 +31,20 @@ export default class Delta extends Component {
 		if ( icon ) {
 			deltaIcon = icon;
 		} else {
-			deltaIcon = ( includes( className, 'is-increase' ) ) ? 'arrow-up' : 'arrow-down';
-			deltaIcon = ( includes( className, 'is-neutral' ) ) ? 'minus-small' : deltaIcon;
+			deltaIcon = ( includes( className, 'is-increase' ) || includes( className, 'is-undefined-increase' ) )
+				? 'arrow-up'
+				: 'arrow-down';
+			deltaIcon = ( includes( className, 'is-neutral' ) )
+				? 'minus-small'
+				: deltaIcon;
 		}
 		return (
 			<div className={ deltaClasses }>
 				<Gridicon className="delta__icon" icon={ deltaIcon } size={ iconSize } />
 				<span className="delta__labels">
-					<span className="delta__value">{ value }</span>
+					<span className="delta__value">
+						{ value }
+					</span>
 					{ suffix &&
 						<span className="delta__suffix">{ suffix }</span>
 					}

--- a/client/extensions/woocommerce/components/sparkline/index.js
+++ b/client/extensions/woocommerce/components/sparkline/index.js
@@ -21,6 +21,7 @@ export default class Sparkline extends Component {
 		highlightIndex: PropTypes.number,
 		highlightRadius: PropTypes.number,
 		margin: PropTypes.object,
+		maxHeight: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -59,9 +60,11 @@ export default class Sparkline extends Component {
 	};
 
 	handleResize = () => {
-		const { aspectRatio, data, margin } = this.props;
+		const { aspectRatio, data, margin, maxHeight } = this.props;
 		const newWidth = this.node.offsetWidth;
-		const newHeight = newWidth / aspectRatio;
+		const newHeight = ( maxHeight && maxHeight < ( newWidth / aspectRatio ) )
+			? maxHeight
+			: ( newWidth / aspectRatio );
 		this.setState( {
 			width: newWidth,
 			height: newHeight,

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -30,6 +30,7 @@
 	@import 'components/store-address/style';
 	@import 'app/store-stats/store-stats-chart/style';
 	@import 'app/store-stats/store-stats-navigation/style';
+	@import 'app/store-stats/store-stats-widget-list/style';
 	@import 'app/store-stats/style';
 	@import 'components/delta/style';
 


### PR DESCRIPTION
- Adding sparkline widgets to the store stats page.
- Add `formatCurrency` to chart tabs and widgets
- Update sparkline with `maxHeight`
- Fixes object equality bug in `store-stats-list`

Fixes #15536 

Known issues:
- Product, Category & Coupon pages don't support non-day periods - https://github.com/Automattic/wp-calypso/issues/15760
- Missing back nav in mobile view - https://github.com/Automattic/wp-calypso/issues/15761
- `statsOrders` data response from normalizers needs to be refactored into array, splitting up data and deltas - https://github.com/Automattic/wp-calypso/issues/15762
- Wrong columns showing for top-products - https://github.com/Automattic/wp-calypso/issues/15763

**Testing:**
- `ENABLE_FEATURES=woocommerce/extension-stats make run`
- go to http://calypso.localhost:3000/store/stats/orders/day/mercantile.wordpress.org