### PR TITLE
Add Simple Payments feature flag and option to post menu

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -39,4 +39,12 @@ menuItems.push( {
 	cmd: 'wpcomContactForm'
 } );
 
+if ( config.isEnabled( 'simple-payments' ) ) {
+	menuItems.push( {
+		name: 'insert_payment_button',
+		item: <GridiconButton icon="money" label={ i18n.translate( 'Add Payment Button' ) } />,
+		cmd: 'simplePaymentsButton'
+	} );
+}
+
 export default menuItems;

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -71,6 +71,7 @@ export const FEATURE_BUSINESS_ONBOARDING = 'business-onboarding';
 export const FEATURE_UPLOAD_PLUGINS = 'upload-plugins';
 export const FEATURE_UPLOAD_THEMES = 'upload-themes';
 export const FEATURE_REPUBLICIZE = 'republicize';
+export const FEATURE_SIMPLE_PAYMENTS = 'simple-payments';
 export const FEATURE_ALL_FREE_FEATURES = 'all-free-features';
 export const FEATURE_ALL_PERSONAL_FEATURES = 'all-personal-features';
 export const FEATURE_ALL_PREMIUM_FEATURES = 'all-premium-features';
@@ -301,6 +302,7 @@ export const PLANS_LIST = {
 			isEnabled( 'automated-transfer' ) && FEATURE_UPLOAD_THEMES,
 			FEATURE_GOOGLE_ANALYTICS,
 			FEATURE_NO_BRANDING,
+			isEnabled( 'simple-payments' ) && FEATURE_SIMPLE_PAYMENTS,
 		] ),
 		getPromotedFeatures: () => [
 			FEATURE_UNLIMITED_STORAGE,
@@ -775,6 +777,12 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Advanced Social Media' ),
 		getDescription: () => i18n.translate(
 			'Schedule your social media updates in advance and promote your posts when it\'s best for you.' ),
+	},
+	[ FEATURE_SIMPLE_PAYMENTS ]: {
+		getSlug: () => FEATURE_SIMPLE_PAYMENTS,
+		getTitle: () => i18n.translate( 'Simple Payments' ),
+		getDescription: () => i18n.translate(
+			'Sell anything with a simple PayPal button.' ),
 	},
 	[ FEATURE_NO_BRANDING ]: {
 		getSlug: () => FEATURE_NO_BRANDING,

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -474,6 +474,24 @@ export class EditorHtmlToolbar extends Component {
 		);
 	}
 
+	renderSimplePaymentsButton() {
+		const { translate } = this.props;
+
+		if ( ! config.isEnabled( 'simple-payments' ) ) {
+			return null;
+		}
+
+		return (
+			<div
+				className="editor-html-toolbar__insert-content-dropdown-item"
+				onClick={ null }
+			>
+				<Gridicon icon="money" />
+				<span>{ translate( 'Add Payment Button' ) }</span>
+			</div>
+		);
+	}
+
 	render() {
 		const {
 			site,
@@ -595,6 +613,8 @@ export class EditorHtmlToolbar extends Component {
 								<Gridicon icon="mention" />
 								<span>{ translate( 'Add Contact Form' ) }</span>
 							</div>
+
+							{ this.renderSimplePaymentsButton() }
 						</div>
 					</div>
 				</div>

--- a/config/development.json
+++ b/config/development.json
@@ -141,6 +141,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"simple-payments": true,
 		"standalone-site-preview": false,
 		"support-user": true,
 		"sync-handler": true,


### PR DESCRIPTION
In this PR, we add a new feature + feature flag `simple-payments` for the Simple Payments project (p8RSuw-2w-p2). We also add a new menu item in the post menu to "Add Payment Button":

![image](https://user-images.githubusercontent.com/4988512/27734979-ac7f1f62-5d9d-11e7-873f-dc7aff8ca07a.png)

## Testing instructions

1. Make sure the "Simple Payments" feature shows on a WP.com Business plan features list when running dev version of Calypso (and doesn't show on any other);
2. Make sure the "Add Payment Button" shows on a WP.com Business site in post menu inserter when running dev version of Calypso (and doesn't show on any other);