### PR TITLE
Site Settings: Introduce a Manage Connection page with Site Ownership card

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -371,6 +371,7 @@
 @import 'my-sites/site-settings/site-tools/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';
+@import 'my-sites/site-settings/manage-connection/style';
 @import 'my-sites/site-settings/press-this/style';
 @import 'my-sites/site-settings/publishing-tools/style';
 @import 'my-sites/site-settings/related-posts/style';

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -15,6 +15,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteSettingsMain from 'my-sites/site-settings/main';
 import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
+import ManageConnection from './manage-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser, isVipSite } from 'state/selectors';
@@ -145,6 +146,13 @@ const controller = {
 		renderPage(
 			context,
 			<ThemeSetup />
+		);
+	},
+
+	manageConnection( context ) {
+		renderPage(
+			context,
+			<ManageConnection />
 		);
 	},
 

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -74,6 +74,14 @@ module.exports = function() {
 	);
 
 	page(
+		'/settings/manage-connection/:site_id',
+		controller.siteSelection,
+		controller.navigation,
+		settingsController.setScroll,
+		settingsController.manageConnection
+	);
+
+	page(
 		'/settings/:section',
 		controller.legacyRedirects,
 		mySitesController.siteSelection,

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -75,10 +75,10 @@ module.exports = function() {
 
 	page(
 		'/settings/manage-connection/:site_id',
-		controller.siteSelection,
-		controller.navigation,
+		mySitesController.siteSelection,
+		mySitesController.navigation,
 		settingsController.setScroll,
-		settingsController.manageConnection
+		controller.manageConnection
 	);
 
 	page(

--- a/client/my-sites/site-settings/manage-connection/index.jsx
+++ b/client/my-sites/site-settings/manage-connection/index.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
+import SiteOwnership from './site-ownership';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+class ManageConnection extends Component {
+	componentDidMount() {
+		this.verifySiteIsJetpack();
+	}
+
+	componentDidUpdate() {
+		this.verifySiteIsJetpack();
+	}
+
+	verifySiteIsJetpack() {
+		if ( this.props.siteIsJetpack === false ) {
+			this.redirectToGeneral();
+		}
+	}
+
+	redirectToGeneral = () => {
+		const { siteSlug } = this.props;
+
+		page( '/settings/general/' + siteSlug );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<Main className="manage-connection site-settings">
+				<DocumentHead title={ translate( 'Site Settings' ) } />
+
+				<HeaderCake onClick={ this.redirectToGeneral }>
+					{ translate( 'Manage connection' ) }
+				</HeaderCake>
+
+				<SiteOwnership />
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		siteIsJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+		siteSlug: getSelectedSiteSlug( state ),
+	} )
+)( localize( ManageConnection ) );

--- a/client/my-sites/site-settings/manage-connection/index.jsx
+++ b/client/my-sites/site-settings/manage-connection/index.jsx
@@ -45,7 +45,7 @@ class ManageConnection extends Component {
 				<DocumentHead title={ translate( 'Site Settings' ) } />
 
 				<HeaderCake onClick={ this.redirectToGeneral }>
-					{ translate( 'Manage connection' ) }
+					{ translate( 'Manage Connection' ) }
 				</HeaderCake>
 
 				<SiteOwnership />

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -17,6 +17,7 @@ import Site from 'blocks/site';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QueryJetpackUserConnection from 'components/data/query-jetpack-user-connection';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import {
 	isJetpackSiteConnected,
 	isJetpackSiteInDevelopmentMode,
@@ -84,13 +85,14 @@ class SiteOwnership extends PureComponent {
 		const {
 			siteId,
 			siteIsConnected,
+			siteIsJetpack,
 			translate,
 		} = this.props;
 
 		return (
 			<div>
-				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }
-				{ siteId && <QueryJetpackUserConnection siteId={ siteId } /> }
+				{ siteIsJetpack && <QueryJetpackConnection siteId={ siteId } /> }
+				{ siteIsJetpack && <QueryJetpackUserConnection siteId={ siteId } /> }
 
 				<SectionHeader label={ translate( 'Site ownership' ) } />
 
@@ -111,6 +113,7 @@ export default connect(
 			site: getSelectedSite( state ),
 			siteId,
 			siteIsConnected: isJetpackSiteConnected( state, siteId ),
+			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteIsInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
 			userIsMaster: isJetpackUserMaster( state, siteId ),
 		};

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLegend from 'components/forms/form-legend';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import SectionHeader from 'components/section-header';
+import Site from 'blocks/site';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+import QueryJetpackUserConnection from 'components/data/query-jetpack-user-connection';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isJetpackSiteConnected,
+	isJetpackSiteInDevelopmentMode,
+	isJetpackUserMaster,
+} from 'state/selectors';
+
+class SiteOwnership extends PureComponent {
+	renderPlaceholder() {
+		return (
+			<Card className="manage-connection__card site-settings__card is-placeholder">
+				<div />
+			</Card>
+		);
+	}
+
+	renderConnectionDetails() {
+		const {
+			site,
+			siteIsConnected,
+			siteIsInDevMode,
+			translate,
+			userIsMaster,
+		} = this.props;
+
+		if ( siteIsConnected === false ) {
+			return translate( 'The site is not connected.' );
+		}
+
+		if ( siteIsInDevMode ) {
+			return (
+				<FormSettingExplanation>
+					{ translate( 'Your site is in Development Mode, so it can not be connected to WordPress.com.' ) }
+				</FormSettingExplanation>
+			);
+		}
+
+		return (
+			<div>
+				<FormSettingExplanation>
+					{
+						userIsMaster
+							? translate( 'You are the owner of this site\'s connection to WordPress.com.' )
+							: translate( 'Somebody else owns this site\'s connection to WordPress.com.' )
+					}
+				</FormSettingExplanation>
+				<Site site={ site } indicator={ false } compact />
+			</div>
+		);
+	}
+
+	renderCardContent() {
+		const { translate } = this.props;
+
+		return (
+			<Card>
+				<FormFieldset>
+					<FormLegend>{ translate( 'Connection owner' ) }</FormLegend>
+					{ this.renderConnectionDetails() }
+				</FormFieldset>
+			</Card>
+		);
+	}
+
+	render() {
+		const {
+			siteId,
+			siteIsConnected,
+			translate,
+		} = this.props;
+
+		return (
+			<div>
+				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }
+				{ siteId && <QueryJetpackUserConnection siteId={ siteId } /> }
+
+				<SectionHeader label={ translate( 'Site ownership' ) } />
+
+				{ siteIsConnected === null
+					? this.renderPlaceholder()
+					: this.renderCardContent()
+				}
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			site: getSelectedSite( state ),
+			siteId,
+			siteIsConnected: isJetpackSiteConnected( state, siteId ),
+			siteIsInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
+			userIsMaster: isJetpackUserMaster( state, siteId ),
+		};
+	}
+)( localize( SiteOwnership ) );

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -12,11 +12,12 @@ import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import Gravatar from 'components/gravatar';
 import SectionHeader from 'components/section-header';
-import Site from 'blocks/site';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QueryJetpackUserConnection from 'components/data/query-jetpack-user-connection';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import {
 	isJetpackSiteConnected,
@@ -24,7 +25,7 @@ import {
 	isJetpackUserMaster,
 } from 'state/selectors';
 
-class SiteOwnership extends PureComponent {
+class SiteOwnership extends Component {
 	renderPlaceholder() {
 		return (
 			<Card className="manage-connection__card site-settings__card is-placeholder">
@@ -33,9 +34,24 @@ class SiteOwnership extends PureComponent {
 		);
 	}
 
+	renderCurrentUser() {
+		const { currentUser } = this.props;
+		if ( ! currentUser ) {
+			return;
+		}
+
+		return (
+			<div className="manage-connection__user">
+				<Gravatar user={ currentUser } size={ 24 } />
+				<span className="manage-connection__user-name">
+					{ currentUser.display_name }
+				</span>
+			</div>
+		);
+	}
+
 	renderConnectionDetails() {
 		const {
-			site,
 			siteIsConnected,
 			siteIsInDevMode,
 			translate,
@@ -63,7 +79,10 @@ class SiteOwnership extends PureComponent {
 							: translate( 'Somebody else owns this site\'s connection to WordPress.com.' )
 					}
 				</FormSettingExplanation>
-				<Site site={ site } indicator={ false } compact />
+				{
+					userIsMaster &&
+					this.renderCurrentUser()
+				}
 			</div>
 		);
 	}
@@ -110,7 +129,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			site: getSelectedSite( state ),
+			currentUser: getCurrentUser( state ),
 			siteId,
 			siteIsConnected: isJetpackSiteConnected( state, siteId ),
 			siteIsJetpack: isJetpackSite( state, siteId ),

--- a/client/my-sites/site-settings/manage-connection/style.scss
+++ b/client/my-sites/site-settings/manage-connection/style.scss
@@ -1,0 +1,13 @@
+.manage-connection__user {
+	padding-top: 5px;
+
+	.gravatar {
+		margin-right: 10px;
+	}
+
+	.manage-connection__user-name {
+		display: inline-block;
+		vertical-align: top;
+		line-height: 24px;
+	}
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -201,6 +201,10 @@
 		}
 	}
 
+	.site.is-compact .site__content {
+		padding: 0;
+	}
+
 	.composing__publish-confirmation .form-toggle__label-content {
 		font-weight: 600;
 	}


### PR DESCRIPTION
### Purpose

This PR introduces a new **Manage Connection** page under Site Settings, with the first card embedded in it - **Site Ownership**.

### Why

This PR is part of #13232, and a natural next step after we landed the necessary Redux functionality in #15599 and #15600. We will be adding the rest of the cards in subsequent PRs, and at the end, we'll add a link to this new page in the **Site Tools** section in **General** settings. Prior to that, it will be reachable from `/settings/manage-connection/$site` for Jetpack sites.

### Preview

**When current user is the connection owner**
![](https://cldup.com/14W3sR6rYy.png)

**When another user is the connection owner**
![](https://cldup.com/20pajGlXhb.png)

**When the site is in development mode**
![](https://cldup.com/fU6Aixuy55.png)

### Notes

In this initial version, there is no way to change the connection owner (contrary to the designs in #13232), this is done on purpose. We'll first need to integrate the API base for changing connection ownership, so for the first version we're going with read-only connection ownership information. *Small Moves, Ellie. Small Moves.*

### To test

* Checkout this branch, or get it going on calypso.live
* Let `:site` is one of your Jetpack sites, and you own the connection.
  * Go to `/settings/manage-connection/:site`
  * Verify you see the proper message that you're the connection owner.
* Let `:site` is one of your Jetpack sites, and somebody else owns the connection.
  * Go to `/settings/manage-connection/:site`
  * Verify you see the proper message that somebody else owns the connection.
* Let `:site` is one of your Jetpack sites that is in development mode.
  * Go to `/settings/manage-connection/:site`
  * Verify you see the expected message that your site is in dev mode and can't be connected.
* Let `:site` is one of your .com sites.
  * Go to `/settings/manage-connection/:site`
  * Verify you're redirected to the General settings section.
* Test all of the above with clean Redux state and verify they work properly.