### PR TITLE
Editor: Update status calendar to show scheduled and published posts

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -26,6 +26,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import EditorVisibility from 'post-editor/editor-visibility';
+import PostListFetcher from 'components/post-list-fetcher';
 
 export class EditPostStatus extends Component {
 
@@ -142,7 +143,7 @@ export class EditPostStatus extends Component {
 
 					{ fullDate }
 					{ this.renderTZTooltop() }
-					{ this.renderPostSchedulePopover() }
+					{ this.schedulePostPopover() }
 				</span>
 				{ this.props.type === 'post' && ! isPostPrivate && ! isPasswordProtected &&
 					<label className="edit-post-status__sticky">
@@ -217,6 +218,32 @@ export class EditPostStatus extends Component {
 		);
 	}
 
+	schedulePostPopover() {
+		const postScheduler = this.renderPostSchedulePopover();
+
+		return (
+			<Popover
+					isVisible={ this.state.showPostSchedulePopover }
+					onClose={ this.togglePostSchedulePopover }
+					position={ 'bottom left' }
+					context={ this.refs && this.refs.postStatusTooltip }
+				>
+				<span className="edit-post-status__post-schedule">
+					{ postUtils.isPage( this.props.post )
+						? postScheduler
+						: <PostListFetcher
+							siteId={ this.props.siteId }
+							status="publish,future"
+							number={ 100 }
+						>
+							{ postScheduler }
+						</PostListFetcher>
+					}
+				</span>
+			</Popover>
+		);
+	}
+
 	renderPostSchedulePopover() {
 		const tz = siteUtils.timezone( this.props.site ),
 			gmt = siteUtils.gmtOffset( this.props.site ),
@@ -225,22 +252,14 @@ export class EditPostStatus extends Component {
 				: null;
 
 		return (
-			<Popover
-				context={ this.refs && this.refs.postStatusTooltip }
-				isVisible={ this.state.showPostSchedulePopover }
-				position="bottom left"
-				onClose={ this.togglePostSchedulePopover }
-			>
-				<div className="edit-post-status__post-schedule">
-					<AsyncLoad
-						require="components/post-schedule"
-						selectedDay={ selectedDay }
-						timezone={ tz }
-						gmtOffset={ gmt }
-						onDateChange={ this.props.setPostDate }
-					/>
-				</div>
-			</Popover>
+			<AsyncLoad
+				require="components/post-schedule"
+				selectedDay={ selectedDay }
+				timezone={ tz }
+				gmtOffset={ gmt }
+				onDateChange={ this.props.setPostDate }
+				site={ this.props.site }
+			/>
 		);
 	}
 


### PR DESCRIPTION
Currently, the calendar displayed when you click on the schedule clock and the one displayed when you click on the timestamp under status differ in appearance. The main schedule clock also shows other published and scheduled posts on the site. It also has an AM/PM selector.

This PR updates the calendar displayed when you click on "Status" so that it matches the appearance and features of the main scheduling clock that appears when you click the calendar icon next to "Publish."

## To test
1. Create a new post at calypso.localhost:3000/post
2. Click on the calendar icon next to "Publish." You should see a blue circle on today's date. Previously published posts and scheduled posts will be indicated with a grey circle.
3. Close that calendar.
4. Click on "Status" in the editor sidebar then on the timestamp shown. You should see a calendar with the same information as step 2 above including the AM/PM selector.

The AM/PM selector was missing before because the option is [pulled from the site settings](https://github.com/Automattic/wp-calypso/blob/master/client/components/post-schedule/clock.jsx#L255), but `site` wasn't provided previously.

## Screenshots

**Before:**

<img width="447" alt="before" src="https://user-images.githubusercontent.com/7240478/27737346-0bc9e9f4-5d65-11e7-964b-5c52ddd31a98.png">

**After:** (Compared to main scheduling calendar)

<img width="1274" alt="fix" src="https://user-images.githubusercontent.com/7240478/27737356-15e69db0-5d65-11e7-9654-288018bd03b2.png">


Addresses #15251.