### PR TITLE
WooCommerce dashboard with orders: fix spacing

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -182,6 +182,9 @@
 }
 
 .dashboard__manage-has-orders {
+	@include breakpoint( ">960px" ) {
+		margin-top: 58px;
+	}
 	.dashboard__reports-widget {
 		overflow: hidden;
 		text-align: center;

--- a/client/extensions/woocommerce/components/process-orders-widget/style.scss
+++ b/client/extensions/woocommerce/components/process-orders-widget/style.scss
@@ -1,6 +1,7 @@
 .process-orders-widget__container {
 	display: flex;
 	justify-content: space-between;
+	align-items: center;
 
 	div {
 		min-width: 33%;
@@ -10,18 +11,14 @@
 			display: block;
 			font-size: 24px;
 		}
-		
+
 		.process-orders-widget__revenue-amount {
 			color: $alert-green;
 		}
-		
+
 		.process-orders-widget__revenue-label,
 		.process-orders-widget__order-label {
 			color: $gray-text-min;
-		}
-
-		a {
-			margin-top: 8px;
 		}
 	}
 }


### PR DESCRIPTION
Quick fix to add top padding on the dashboard containing orders. 

To test: view that dashboard and notice that the page content is no longer hidden behind the actionheader. 