### PR TITLE
Comments: Remove text fade-out gradient if browser supports line-clamp

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -137,6 +137,9 @@
 		rgba( mix( $alert-yellow, $white, 8.5% ), 0 ),
 		rgba( mix( $alert-yellow, $white, 8.5% ), 1 ) 50%
 	);
+	@supports( -webkit-line-clamp: 2 ) {
+		background: transparent;
+	}
 }
 
 .comment-detail__actions {


### PR DESCRIPTION
Fixes a regression caused in #15590 where the text fade-out gradient was used on pending comments even on browsers that support `line-clamp`.

**Chrome**
<img width="711" alt="screen shot 2017-06-30 at 15 04 56" src="https://user-images.githubusercontent.com/2070010/27739165-90117638-5da5-11e7-9f45-e6764be9a020.png">

**Firefox**
<img width="713" alt="screen shot 2017-06-30 at 15 05 18" src="https://user-images.githubusercontent.com/2070010/27739164-900f09d4-5da5-11e7-89fe-a50064404286.png">
