### PR TITLE
WooCommerce: Fix the products list when there are no products to display.

### DIFF
--- a/client/extensions/woocommerce/app/products/products-list.js
+++ b/client/extensions/woocommerce/app/products/products-list.js
@@ -48,7 +48,7 @@ const ProductsList = ( {
 	};
 
 	if ( currentPageLoaded === true && totalProducts === 0 ) {
-		return renderEmptyContent;
+		return renderEmptyContent();
 	}
 
 	const isRequesting = ( requestedPage && ! requestedPageLoaded ) || ! products ? true : false;


### PR DESCRIPTION
There was a typo with the products list code, so you would get console warnings on the products list if you have no products, instead of the `EmptyContent` message that was intended. This PR also adjusts some behavior with the search box, to prevent it from showing on the `EmptyContent` page.

To Test:
* Trash all your products temporarily from `wp-admin`
* Go to `http://calypso.localhost:3000/store/products/:site`
* Make sure you see the `You don't have any products yet.` message, with no search box.
* Add a product / untrash your products.
* Go back to the list and make sure you can see the search box with your product list.