### PR TITLE
Reader: update searchType naming to be more clear

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -21,7 +21,6 @@ import PostResults from './post-results';
 import ReaderMain from 'components/reader-main';
 import { addQueryArgs } from 'lib/url';
 import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
-import withWidth from 'lib/with-width';
 import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
 import withDimensions from 'lib/with-dimensions';
 

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -20,7 +20,8 @@ import SiteResults from './site-results';
 import PostResults from './post-results';
 import ReaderMain from 'components/reader-main';
 import { addQueryArgs } from 'lib/url';
-import SearchStreamHeader, { POSTS } from './search-stream-header';
+import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
+import withWidth from 'lib/with-width';
 import { SORT_BY_RELEVANCE, SORT_BY_LAST_UPDATED } from 'state/reader/feed-searches/actions';
 import withDimensions from 'lib/with-dimensions';
 
@@ -65,7 +66,7 @@ class SearchStream extends React.Component {
 	};
 
 	state = {
-		selected: POSTS,
+		selected: SEARCH_TYPES.posts,
 		title: this.getTitle(),
 	};
 
@@ -135,7 +136,7 @@ class SearchStream extends React.Component {
 		} );
 
 		const singleColumnResultsClasses = classnames( 'search-stream__single-column-results', {
-			'is-post-results': searchType === POSTS && query,
+			'is-post-results': searchType === SEARCH_TYPES.posts && query,
 		} );
 
 		return (
@@ -191,7 +192,8 @@ class SearchStream extends React.Component {
 					</div> }
 				{ ! wideDisplay &&
 					<div className={ singleColumnResultsClasses }>
-						{ ( ( searchType === POSTS || ! query ) && <PostResults { ...this.props } /> ) ||
+						{ ( ( searchType === SEARCH_TYPES.posts || ! query ) &&
+							<PostResults { ...this.props } /> ) ||
 							<SiteResults
 								query={ query }
 								sort={ pickSort( sortOrder ) }

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -66,7 +66,7 @@ class SearchStream extends React.Component {
 	};
 
 	state = {
-		selected: SEARCH_TYPES.posts,
+		selected: SEARCH_TYPES.POSTS,
 		title: this.getTitle(),
 	};
 
@@ -136,7 +136,7 @@ class SearchStream extends React.Component {
 		} );
 
 		const singleColumnResultsClasses = classnames( 'search-stream__single-column-results', {
-			'is-post-results': searchType === SEARCH_TYPES.posts && query,
+			'is-post-results': searchType === SEARCH_TYPES.POSTS && query,
 		} );
 
 		return (
@@ -192,7 +192,7 @@ class SearchStream extends React.Component {
 					</div> }
 				{ ! wideDisplay &&
 					<div className={ singleColumnResultsClasses }>
-						{ ( ( searchType === SEARCH_TYPES.posts || ! query ) &&
+						{ ( ( searchType === SEARCH_TYPES.POSTS || ! query ) &&
 							<PostResults { ...this.props } /> ) ||
 							<SiteResults
 								query={ query }

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -12,9 +12,7 @@ import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
 import NavItem from 'components/section-nav/item';
 
-const posts = 'posts';
-const sites = 'sites';
-export const SEARCH_TYPES = { posts, sites };
+export const SEARCH_TYPES = { posts: 'posts', sites: 'sites' };
 
 class SearchStreamHeader extends Component {
 	static propTypes = {

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { noop, values } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -12,23 +12,24 @@ import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
 import NavItem from 'components/section-nav/item';
 
-export const POSTS = 'Posts';
-export const SITES = 'Sites';
+const posts = 'posts';
+const sites = 'sites';
+export const SEARCH_TYPES = { posts, sites };
 
 class SearchStreamHeader extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
 		wideDisplay: PropTypes.bool,
-		selected: PropTypes.oneOf( [ POSTS, SITES ] ),
+		selected: PropTypes.oneOf( values( SEARCH_TYPES ) ),
 		onSelection: PropTypes.func,
 	};
 	static defaultProps = {
 		onSelection: noop,
-		selected: POSTS,
-	}
+		selected: SEARCH_TYPES.posts,
+	};
 
-	handlePostsSelected = () => this.props.onSelection( POSTS );
-	handleSitesSelected = () => this.props.onSelection( SITES );
+	handlePostsSelected = () => this.props.onSelection( SEARCH_TYPES.posts );
+	handleSitesSelected = () => this.props.onSelection( SEARCH_TYPES.sites );
 
 	render() {
 		const { translate, wideDisplay, selected } = this.props;
@@ -48,14 +49,14 @@ class SearchStreamHeader extends Component {
 					<NavTabs>
 						<NavItem
 							key={ 'posts-nav' }
-							selected={ selected === POSTS }
+							selected={ selected === SEARCH_TYPES.posts }
 							onClick={ this.handlePostsSelected }
 						>
 							{ translate( 'Posts' ) }
 						</NavItem>
 						<NavItem
 							key={ 'sites-nav' }
-							selected={ selected === SITES }
+							selected={ selected === SEARCH_TYPES.sites }
 							onClick={ this.handleSitesSelected }
 						>
 							{ translate( 'Sites' ) }

--- a/client/reader/search-stream/search-stream-header.jsx
+++ b/client/reader/search-stream/search-stream-header.jsx
@@ -12,7 +12,7 @@ import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
 import NavItem from 'components/section-nav/item';
 
-export const SEARCH_TYPES = { posts: 'posts', sites: 'sites' };
+export const SEARCH_TYPES = { POSTS: 'posts', SITES: 'sites' };
 
 class SearchStreamHeader extends Component {
 	static propTypes = {
@@ -26,8 +26,8 @@ class SearchStreamHeader extends Component {
 		selected: SEARCH_TYPES.posts,
 	};
 
-	handlePostsSelected = () => this.props.onSelection( SEARCH_TYPES.posts );
-	handleSitesSelected = () => this.props.onSelection( SEARCH_TYPES.sites );
+	handlePostsSelected = () => this.props.onSelection( SEARCH_TYPES.POSTS );
+	handleSitesSelected = () => this.props.onSelection( SEARCH_TYPES.SITES );
 
 	render() {
 		const { translate, wideDisplay, selected } = this.props;
@@ -47,14 +47,14 @@ class SearchStreamHeader extends Component {
 					<NavTabs>
 						<NavItem
 							key={ 'posts-nav' }
-							selected={ selected === SEARCH_TYPES.posts }
+							selected={ selected === SEARCH_TYPES.POSTS }
 							onClick={ this.handlePostsSelected }
 						>
 							{ translate( 'Posts' ) }
 						</NavItem>
 						<NavItem
 							key={ 'sites-nav' }
-							selected={ selected === SEARCH_TYPES.sites }
+							selected={ selected === SEARCH_TYPES.SITES }
 							onClick={ this.handleSitesSelected }
 						>
 							{ translate( 'Sites' ) }

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -37,7 +37,7 @@ const exported = {
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
 			mcKey = 'search';
 
-		const { sort = 'relevance', q: searchSlug, show = SEARCH_TYPES.posts } = context.query;
+		const { sort = 'relevance', q: searchSlug, show = SEARCH_TYPES.POSTS } = context.query;
 
 		let store;
 		if ( searchSlug ) {

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -18,7 +18,7 @@ import {
 } from 'reader/controller-helper';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
-import { SEARCH_TYPES } from './search-stream-header';
+import { SEARCH_TYPES } from 'reader/search-stream/search-stream-header';
 
 const analyticsPageTitle = 'Reader';
 

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -18,6 +18,7 @@ import {
 } from 'reader/controller-helper';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
+import { SEARCH_TYPES } from './search-stream-header';
 
 const analyticsPageTitle = 'Reader';
 
@@ -36,7 +37,7 @@ const exported = {
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
 			mcKey = 'search';
 
-		const { sort = 'relevance', q: searchSlug, show = 'Posts' } = context.query;
+		const { sort = 'relevance', q: searchSlug, show = SEARCH_TYPES.posts } = context.query;
 
 		let store;
 		if ( searchSlug ) {
@@ -79,7 +80,7 @@ const exported = {
 					basePath,
 					fullAnalyticsPageTitle,
 					analyticsPageTitle,
-					mcKey
+					mcKey,
 				) }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
 				showBack={ false }
@@ -90,7 +91,7 @@ const exported = {
 				searchType={ show }
 			/>,
 			document.getElementById( 'primary' ),
-			context.store
+			context.store,
 		);
 	},
 };


### PR DESCRIPTION
a little janitorial work inspired by @bluefuton 

`POSTS` and `SITES` are a little unclear as to what they are.  This PR scopes them under a name that makes sense: `SEARCH_TYPES`