### PR TITLE
Data-Layer: local actions re-issue bug

### DIFF
--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -135,4 +135,49 @@ describe( 'WordPress.com API Middleware', () => {
 		expect( doubler ).to.have.been.calledWith( store, action );
 		expect( next ).to.not.have.been.called;
 	} );
+
+	describe( 'network response', () => {
+		let adder;
+		let handlers;
+		const action = { type: 'ADD' };
+
+		beforeEach( () => {
+			adder = spy();
+			handlers = mergeHandlers( {
+				[ 'ADD' ]: [ adder ]
+			} );
+		} );
+
+		it( 'should not pass along actions for a network response that contains headers', () => {
+			const meta = { dataLayer: { headers: {} } };
+
+			middleware( handlers )( store )( next )( { ...action, meta } );
+
+			expect( next ).to.have.not.been.called;
+		} );
+
+		it( 'should not pass along actions for a network response that contains data', () => {
+			const meta = { dataLayer: { data: {} } };
+
+			middleware( handlers )( store )( next )( { ...action, meta } );
+
+			expect( next ).to.have.not.been.called;
+		} );
+
+		it( 'should not pass along actions for a network response that contains an error', () => {
+			const meta = { dataLayer: { error: {} } };
+
+			middleware( handlers )( store )( next )( { ...action, meta } );
+
+			expect( next ).to.have.not.been.called;
+		} );
+
+		it( 'should not pass along actions for a network response that contains a progress report', () => {
+			const meta = { dataLayer: { progress: { total: 1, loaded: 1 } } };
+
+			middleware( handlers )( store )( next )( { ...action, meta } );
+
+			expect( next ).to.have.not.been.called;
+		} );
+	} );
 } );

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -34,7 +34,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( store.dispatch ).to.not.have.been.called;
+		expect( store.dispatch ).to.not.have.beenCalled;
 		expect( next ).to.have.been.calledWith( action );
 	} );
 
@@ -48,7 +48,7 @@ describe( 'WordPress.com API Middleware', () => {
 		middleware( handlers )( store )( next )( action );
 
 		expect( next ).to.have.been.calledWith( action );
-		expect( adder ).to.not.have.been.called;
+		expect( adder ).to.not.have.beenCalled;
 	} );
 
 	it( 'should not pass along non-local actions with non data-layer meta', () => {
@@ -60,7 +60,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.not.have.beenCalled;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -73,7 +73,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.not.have.beenCalled;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -116,7 +116,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.not.have.beenCalled;
 	} );
 
 	it( 'should call all given handlers (different lists)', () => {
@@ -133,7 +133,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.not.have.beenCalled;
 	} );
 
 	describe( 'network response', () => {

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -34,7 +34,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( store.dispatch ).to.not.have.beenCalled;
+		expect( store.dispatch ).to.not.have.been.called;
 		expect( next ).to.have.been.calledWith( action );
 	} );
 
@@ -48,7 +48,7 @@ describe( 'WordPress.com API Middleware', () => {
 		middleware( handlers )( store )( next )( action );
 
 		expect( next ).to.have.been.calledWith( action );
-		expect( adder ).to.not.have.beenCalled;
+		expect( adder ).to.not.have.been.called;
 	} );
 
 	it( 'should not pass along non-local actions with non data-layer meta', () => {
@@ -60,7 +60,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -73,7 +73,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -116,7 +116,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 	} );
 
 	it( 'should call all given handlers (different lists)', () => {
@@ -133,6 +133,6 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 	} );
 } );

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -22,7 +22,7 @@ const shouldNext = action => {
 
 	const data = meta.dataLayer;
 	if ( ! data ) {
-		return true;
+		return false;
 	}
 
 	// is a network response, don't reissue

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -17,7 +17,7 @@ const mergedHandlers = mergeHandlers(
 const shouldNext = action => {
 	const meta = action.meta;
 	if ( ! meta ) {
-		return true;
+		return false;
 	}
 
 	const data = meta.dataLayer;
@@ -26,7 +26,7 @@ const shouldNext = action => {
 	}
 
 	// is a network response, don't reissue
-	if ( data.data || data.error || data.headers ) {
+	if ( data.data || data.error || data.headers || data.progress ) {
 		return false;
 	}
 

--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -17,12 +17,12 @@ const mergedHandlers = mergeHandlers(
 const shouldNext = action => {
 	const meta = action.meta;
 	if ( ! meta ) {
-		return false;
+		return true;
 	}
 
 	const data = meta.dataLayer;
 	if ( ! data ) {
-		return false;
+		return true;
 	}
 
 	// is a network response, don't reissue


### PR DESCRIPTION
This PR adds checks to `wpcom-api-middleware` to prevent actions to be passed along for actions with a data layer progress property.

It also makes minor changes by fixing the unit tests. The assumption for those fixes is that the tests are conceptually correct.

to test:

```sh
npm run test-client client/state/data-layer/test/wpcom-api-middleware.js
```