### PR TITLE
Color Schemes: Adding theming support via CSS custom properties

### DIFF
--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -1,15 +1,25 @@
+/**
+ * Colors
+ *
+ * Color variables based on the design handbook
+ * See wordpress.com/design-handbook/colors/ for more info.
+ */
+
 // Primary Accent (Blues)
 $blue-wordpress:         #0087be;
 $blue-light:             #78dcfa;
 $blue-medium:            #00aadc;
 $blue-dark:              #005082;
 
-// Jetpack Green
-$green-jetpack:          #8cc258;
-
 // Grays
 $gray:                   #87a6bc;
 $gray-light:             lighten( $gray, 33% ); //#f3f6f8
+$gray-lighten-30:        lighten( $gray, 30% ); //#e9eff3
+$gray-lighten-20:        lighten( $gray, 20% ); //#c8d7e1
+$gray-lighten-10:        lighten( $gray, 10% ); //#a8bece
+$gray-darken-10:         darken( $gray, 10% ); //#668eaa
+$gray-darken-20:         darken( $gray, 20% ); //#4f748e
+$gray-darken-30:         darken( $gray, 30% ); //#3d596d
 $gray-dark:              darken( $gray, 38% ); //#2e4453
 
 // $gray-text: ideal for standard, non placeholder text
@@ -17,58 +27,57 @@ $gray-dark:              darken( $gray, 38% ); //#2e4453
 $gray-text:              $gray-dark;
 $gray-text-min:          darken( $gray, 18% ); //#537994
 
-// $gray color functions:
-// lighten( $gray, 10% ) //#a8bece
-// lighten( $gray, 20% ) //#c8d7e1
-// lighten( $gray, 30% ) //#e9eff3
-// darken( $gray, 10% ) //#668eaa
-// darken( $gray, 20% ) //#4f748e
-// darken( $gray, 30% ) //#3d596d
-//
-// See wordpress.com/design-handbook/colors/ for more info.
-
 // Secondary Accent (Oranges)
-$orange-jazzy:           #f0821e;
 $orange-fire:            #d54e21;
+$orange-jazzy:           #f0821e;
 
-// Alerts
-$alert-yellow:           #f0b849;
-$alert-red:              #d94f4f;
-$alert-green:            #4ab866;
-$alert-purple:           #855DA6;
-
-// Link hovers
-$link-highlight:         tint($blue-medium, 20%);
+// Validations and Alerts
+$green-valid:            #4ab866;
+$yellow-warning:         #f0b849;
+$red-error:              #d94f4f;
+$alert-yellow:           $yellow-warning;
+$alert-red:              $red-error;
+$alert-green:            $green-valid;
 
 // Essentials
 $white:                  rgba(255,255,255,1);
 $transparent:            rgba(255,255,255,0);
 
+//Additional colors
+
+//Alerts
+$alert-purple:           #855DA6;
+
+// Jetpack
+$green-jetpack:          #8cc258;
+
+//Social media colors
+$color-facebook:         #39579a;
+$color-twitter:          #55ACEE;
+$color-gplus:            #df4a32;
+$color-tumblr:           #35465c;
+$color-linkedin:         #0976b4;
+$color-path:             #df3b2f;
+$color-instagram:        #d93174;
+$color-eventbrite:       #ff8000;
+$color-stumbleupon:      #eb4924;
+$color-reddit:           #5f99cf;
+$color-pinterest:        #cc2127;
+$color-pocket:           #ee4256;
+$color-email:            #f8f8f8;
+$color-print:            #f8f8f8;
+$color-skype:            #00AFF0;
+$color-telegram:         #0088cc;
+$color-whatsapp:         #43d854;
+
 // Uncommon
 $border-ultra-light-gray: #e8f0f5;
 
+// Link hovers
+$link-highlight:          tint($blue-medium, 20%);
+
 // Layout
-$masterbar-color:          $blue-wordpress;
-$sidebar-bg-color:         lighten( $gray, 30% );
-$sidebar-text-color:       $gray-dark;
-$sidebar-selected-color:   $gray-text-min;
-
-
-//Social media colors
-$color-facebook: #39579a;
-$color-twitter: #55ACEE;
-$color-gplus: #df4a32;
-$color-tumblr: #35465c;
-$color-linkedin: #0976b4;
-$color-path: #df3b2f;
-$color-instagram: #d93174;
-$color-eventbrite: #ff8000;
-$color-stumbleupon: #eb4924;
-$color-reddit: #5f99cf;
-$color-pinterest: #cc2127;
-$color-pocket: #ee4256;
-$color-email: #f8f8f8;
-$color-print: #f8f8f8;
-$color-skype: #00AFF0;
-$color-telegram: #0088cc;
-$color-whatsapp: #43d854;
+$masterbar-color:         $blue-wordpress;
+$sidebar-bg-color:        lighten( $gray, 30% );
+$sidebar-text-color:      $gray-dark;
+$sidebar-selected-color:  $gray-text-min;

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -45,13 +45,13 @@ $transparent:            rgba(255,255,255,0);
 
 //Additional colors
 
-//Alerts
+// Alerts
 $alert-purple:           #855DA6;
 
 // Jetpack
 $green-jetpack:          #8cc258;
 
-//Social media colors
+// Social media colors
 $color-facebook:         #39579a;
 $color-twitter:          #55ACEE;
 $color-gplus:            #df4a32;

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -75,9 +75,3 @@ $border-ultra-light-gray: #e8f0f5;
 
 // Link hovers
 $link-highlight:          tint($blue-medium, 20%);
-
-// Layout
-$masterbar-color:         $blue-wordpress;
-$sidebar-bg-color:        lighten( $gray, 30% );
-$sidebar-text-color:      $gray-dark;
-$sidebar-selected-color:  $gray-text-min;

--- a/assets/stylesheets/shared/_themes.scss
+++ b/assets/stylesheets/shared/_themes.scss
@@ -1,11 +1,29 @@
+// ==========================================================================
+// Themes
+//
+// Theming variables and color scheme definitions
+//
+// 1.0 Theme variables
+// 2.0 Color scheme definitions
+// 3.0 Theming classes
+//
+// Usage:
+//
+// Add a new theme variable:
+// I.) Add a new theme variable to section 1.0 of this file
+// II.) Add new custom property matching the theme variable name to $color-schemes > default
+// III.) Add the same custom property to each theme in $color-schemes
+//
+// Add a new theme:
+// I.) Add a new block to $color-schemes by copying $color-schemes > default
+// II.) Change name of new color scheme to desired name for the new theme
+// III.) Change color values assigned to the custom properties of the new theme
+// ==========================================================================
+
 /**
- * Themes
+ * 1.0 Theme variables
  *
- * Theming variables and color scheme definitions
- *
- * 1.) Declare theme variables and assign default colors
- * 2.) Assign theme variables to custom properties
- * 3.) Define new theme by adding new map to $color-schemes
+ * Declare theme variables and assign default colors
  */
 
 // Layout
@@ -14,24 +32,54 @@ $sidebar-bg-color:        $gray-lighten-30;
 $sidebar-text-color:      $gray-dark;
 $sidebar-selected-color:  $gray-text-min;
 
-// Define color schemes based on theming variables
+/**
+ * 2.0 Color scheme definitions
+ *
+ * Assign color variables to custom properties
+ * Note: theme variable names have to match custom property names in 'default' theme
+ */
+
 $color-schemes: (
 	default: (
-		'--masterbar-primary-color':			$masterbar-color,
+		'--masterbar-color':					$masterbar-color,
 		'--sidebar-bg-color':					$sidebar-bg-color,
 		'--sidebar-text-color':					$sidebar-text-color,
 		'--sidebar-selected-color':				$sidebar-selected-color
 	),
 	light: (
-		'--masterbar-primary-color':			$white,
+		'--masterbar-color':					$gray,
 		'--sidebar-bg-color':					$white,
 		'--sidebar-text-color':					$sidebar-text-color,
 		'--sidebar-selected-color':				$sidebar-selected-color
 	),
 	dark: (
-		'--masterbar-primary-color':			$gray-dark,
+		'--masterbar-color':					$gray-dark,
 		'--sidebar-bg-color':					$gray-dark,
 		'--sidebar-text-color':					$white,
 		'--sidebar-selected-color':				$sidebar-selected-color
 	)
 );
+
+/**
+ * 3.0 Theming classes
+ *
+ * Assign values for themes at :root level
+ * This enables us to change the theme via a single class
+ */
+
+:root {
+	@each $color-scheme, $color-scheme-values in $color-schemes {
+		@if $color-scheme == 'default' {
+			@each $custom-property, $sass-variable in map-get( $color-schemes, 'default' ) {
+				#{ $custom-property } :  $sass-variable;
+			}
+		}
+		@else {
+			&.is-#{$color-scheme}-theme {
+				@each $custom-property, $sass-variable in map-get( $color-schemes, $color-scheme ) {
+					#{ $custom-property } :  $sass-variable;
+				}
+			}
+		}
+	}
+}

--- a/assets/stylesheets/shared/_themes.scss
+++ b/assets/stylesheets/shared/_themes.scss
@@ -27,10 +27,16 @@
  */
 
 // Layout
-$masterbar-color:         $blue-wordpress;
-$sidebar-bg-color:        $gray-lighten-30;
-$sidebar-text-color:      $gray-dark;
-$sidebar-selected-color:  $gray-text-min;
+$masterbar-color:                  $white;
+$masterbar-bg-color:               $blue-wordpress;
+$masterbar-border-color:           darken( $masterbar-bg-color, 4% );
+$masterbar-item-active-bg-color:   darken( $masterbar-bg-color, 17% );
+$masterbar-item-hover-bg-color:    lighten( $masterbar-bg-color, 5% );
+$masterbar-item-new-color:         $blue-wordpress;
+
+$sidebar-bg-color:                 $gray-lighten-30;
+$sidebar-text-color:               $gray-dark;
+$sidebar-selected-color:           $gray-text-min;
 
 /**
  * 2.0 Color scheme definitions
@@ -41,22 +47,28 @@ $sidebar-selected-color:  $gray-text-min;
 
 $color-schemes: (
 	default: (
-		'--masterbar-color':					$masterbar-color,
-		'--sidebar-bg-color':					$sidebar-bg-color,
-		'--sidebar-text-color':					$sidebar-text-color,
-		'--sidebar-selected-color':				$sidebar-selected-color
+		'--masterbar-color':                    $masterbar-color,
+		'--masterbar-bg-color':                 $masterbar-bg-color,
+		'--masterbar-border-color':             $masterbar-border-color,
+		'--masterbar-item-active-bg-color':     $masterbar-item-active-bg-color,
+		'--masterbar-item-hover-bg-color':      $masterbar-item-hover-bg-color,
+		'--masterbar-item-new-color':           $masterbar-item-new-color,
 	),
 	light: (
-		'--masterbar-color':					$gray,
-		'--sidebar-bg-color':					$white,
-		'--sidebar-text-color':					$sidebar-text-color,
-		'--sidebar-selected-color':				$sidebar-selected-color
+		'--masterbar-color':                    $gray-text,
+		'--masterbar-bg-color':                 $gray-lighten-20,
+		'--masterbar-border-color':             $gray-lighten-10,
+		'--masterbar-item-active-bg-color':     $gray-lighten-10,
+		'--masterbar-item-hover-bg-color':      $gray-lighten-30,
+		'--masterbar-item-new-color':           $gray-text,
 	),
 	dark: (
-		'--masterbar-color':					$gray-dark,
-		'--sidebar-bg-color':					$gray-dark,
-		'--sidebar-text-color':					$white,
-		'--sidebar-selected-color':				$sidebar-selected-color
+		'--masterbar-color':                    $masterbar-color,
+		'--masterbar-bg-color':                 $gray-dark,
+		'--masterbar-border-color':             $gray-darken-10,
+		'--masterbar-item-active-bg-color':     $gray-text-min,
+		'--masterbar-item-hover-bg-color':      $gray-darken-10,
+		'--masterbar-item-new-color':           $masterbar-item-new-color,
 	)
 );
 

--- a/assets/stylesheets/shared/_themes.scss
+++ b/assets/stylesheets/shared/_themes.scss
@@ -1,0 +1,11 @@
+/**
+ * Themes
+ *
+ * Theming variables and color scheme defintions
+ */
+
+// Layout
+$masterbar-color:         $blue-wordpress;
+$sidebar-bg-color:        $gray-lighten-30;
+$sidebar-text-color:      $gray-dark;
+$sidebar-selected-color:  $gray-text-min;

--- a/assets/stylesheets/shared/_themes.scss
+++ b/assets/stylesheets/shared/_themes.scss
@@ -1,7 +1,11 @@
 /**
  * Themes
  *
- * Theming variables and color scheme defintions
+ * Theming variables and color scheme definitions
+ *
+ * 1.) Declare theme variables and assign default colors
+ * 2.) Assign theme variables to custom properties
+ * 3.) Define new theme by adding new map to $color-schemes
  */
 
 // Layout

--- a/assets/stylesheets/shared/_themes.scss
+++ b/assets/stylesheets/shared/_themes.scss
@@ -13,3 +13,25 @@ $masterbar-color:         $blue-wordpress;
 $sidebar-bg-color:        $gray-lighten-30;
 $sidebar-text-color:      $gray-dark;
 $sidebar-selected-color:  $gray-text-min;
+
+// Define color schemes based on theming variables
+$color-schemes: (
+	default: (
+		'--masterbar-primary-color':			$masterbar-color,
+		'--sidebar-bg-color':					$sidebar-bg-color,
+		'--sidebar-text-color':					$sidebar-text-color,
+		'--sidebar-selected-color':				$sidebar-selected-color
+	),
+	light: (
+		'--masterbar-primary-color':			$white,
+		'--sidebar-bg-color':					$white,
+		'--sidebar-text-color':					$sidebar-text-color,
+		'--sidebar-selected-color':				$sidebar-selected-color
+	),
+	dark: (
+		'--masterbar-primary-color':			$gray-dark,
+		'--sidebar-bg-color':					$gray-dark,
+		'--sidebar-text-color':					$white,
+		'--sidebar-selected-color':				$sidebar-selected-color
+	)
+);

--- a/assets/stylesheets/shared/functions/_functions.scss
+++ b/assets/stylesheets/shared/functions/_functions.scss
@@ -1,1 +1,2 @@
+@import 'map-deep-get';
 @import 'z-index';

--- a/assets/stylesheets/shared/functions/_map-deep-get.scss
+++ b/assets/stylesheets/shared/functions/_map-deep-get.scss
@@ -1,0 +1,20 @@
+
+// ==========================================================================
+// Map deep get
+//
+// Allows us to get values from nested maps.
+//
+// Usage:
+// map-deep-get( $map, $keys... );
+// ==========================================================================
+
+@function map-deep-get( $map, $keys... ) {
+	@each $key in $keys {
+		@if not map-has-key( $map, $key) {
+			@warn "No item found for `#{$key}` of `[#{ $keys }]` in provided map. Property omitted.";
+			@return map-get( $map, $key );
+		}
+		$map: map-get( $map, $key );
+	}
+	@return $map;
+}

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -259,18 +259,6 @@ $z-layers: (
 	)
 );
 
-// allows us to do a nested fetch
-@function map-deep-get( $map, $keys... ) {
-	@each $key in $keys {
-		@if not map-has-key( $map, $key) {
-			@warn "No layer found for `#{$key}` of `[#{ $keys }]` in $z-layers map. Property omitted.";
-			@return map-get( $map, $key );
-		}
-		$map: map-get( $map, $key );
-	}
-	@return $map;
-}
-
 @function z-index( $keys... ) {
 	@return map-deep-get( $z-layers, $keys... );
 }

--- a/assets/stylesheets/shared/mixins/_custom-properties.scss
+++ b/assets/stylesheets/shared/mixins/_custom-properties.scss
@@ -1,0 +1,25 @@
+// ==========================================================================
+// Custom properties mixin
+//
+// Mixins for using custom properties and providing fallbacks
+//
+// Usage:
+// @include custom-property( color, --text-color, $text-color );
+// @include custom-property-from-map( color, --text-color, $text-color );
+// @include theme( color, --text-color );
+// ==========================================================================
+
+@mixin custom-property( $property, $custom-property, $fallback ) {
+	#{ $property }: $fallback;
+	#{ $property }: var( $custom-property, $fallback );
+}
+
+@mixin custom-property-from-map( $property, $custom-property, $map, $keys... ) {
+	#{ $property }: map-deep-get( $map, $keys... );
+	#{ $property }: var( $custom-property, map-deep-get( $map, $keys... ) );
+}
+
+// custom mixin for theming with custom properties based on $color-schemes map (see _themes.scss)
+@mixin theme( $property, $custom-property ) {
+	@include custom-property-from-map( $property, $custom-property, $color-schemes, 'default', $custom-property );
+}

--- a/assets/stylesheets/shared/mixins/_custom-properties.scss
+++ b/assets/stylesheets/shared/mixins/_custom-properties.scss
@@ -7,6 +7,9 @@
 // @include custom-property( color, --text-color, $text-color );
 // @include custom-property-from-map( color, --text-color, $text-color );
 // @include theme( color, --text-color );
+// @include theme-multiple(
+//   ('color': --text-color, 'background': --bg-color, 'border-color': --border-color);
+// )
 // ==========================================================================
 
 @mixin custom-property( $property, $custom-property, $fallback ) {
@@ -19,7 +22,13 @@
 	#{ $property }: var( $custom-property, map-deep-get( $map, $keys... ) );
 }
 
-// custom mixin for theming with custom properties based on $color-schemes map (see _themes.scss)
+// custom mixins for theming with custom properties based on $color-schemes map (see _themes.scss)
 @mixin theme( $property, $custom-property ) {
 	@include custom-property-from-map( $property, $custom-property, $color-schemes, 'default', $custom-property );
+}
+
+@mixin theme-multiple ($theme-properties) {
+	@each $property, $custom-property in $theme-properties {
+		@include theme( $property, $custom-property );
+	}
 }

--- a/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/assets/stylesheets/shared/mixins/_mixins.scss
@@ -2,6 +2,7 @@
 @import 'calc';
 @import 'clear-fix';
 @import 'clear-text';
+@import 'custom-properties';
 @import 'dropdown-menu';
 @import 'heading';
 @import 'hide-content-accessibly';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -6,6 +6,7 @@
 @import 'shared/functions';                    // functions that we've used from Compass, ported over
 @import 'shared/functions/functions';          // sass functions for z-index, etc.
 @import 'shared/colors';                       // import all of our wpcom colors
+@import 'shared/themes';                       // theming variables and color scheme definitions
 @import 'shared/typography';                   // all the typographic rules, variables, etc.
 @import 'shared/mixins/mixins';                // sass mixins for gradients, bordius radii, etc.
 @import 'shared/extends';                      // sass extends for commonly used styles

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -3,7 +3,7 @@
 	display: flex;
 	flex-direction: column;
 	padding: 56px 20px 28px;
-	background-color: $masterbar-color;
+	background-color: $masterbar-bg-color;
 
 	&:not(.is-collapsed) .sub-masterbar-nav__select {
 		background-color: $blue-dark;
@@ -89,7 +89,7 @@
 
 	&:hover,
  	&:focus {
-		background: lighten( $masterbar-color, 5% );
+		background: lighten( $masterbar-bg-color, 5% );
 		color: $white;
 		outline: 0;
 		transition: all 200ms ease-out;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -3,9 +3,14 @@ $autobar-height: 20px;
 
 // The WordPress.com Masterbar
 .masterbar {
-	background: $masterbar-color;
-	border-bottom: 1px solid darken( $masterbar-color, 4% );
-	color: $white;
+	border-bottom: 1px solid;
+	@include theme-multiple(
+		(
+			'background': --masterbar-bg-color,
+			'border-color': --masterbar-border-color,
+			'color': --masterbar-color,
+		)
+	);
 	font-size: 16px;
 	display: flex;
 	height: $masterbar-height;
@@ -38,7 +43,7 @@ $autobar-height: 20px;
 	display: flex;
 		align-items: center;
 	position: relative;
-	color: $white;
+	@include theme( color, --masterbar-color );
 	font-size: 14px;
 	height: $masterbar-height;
 	line-height: $masterbar-height;
@@ -48,7 +53,7 @@ $autobar-height: 20px;
 	transition: all 150ms ease-in;
 
 	&:visited {
-		color: $white;
+		@include theme( color, --masterbar-color );
 	}
 
 	&[href] {
@@ -56,7 +61,7 @@ $autobar-height: 20px;
 	}
 
 	.masterbar__item-content {
-		color: $white;
+		@include theme( color, --masterbar-color );
 	}
 
 	.gridicon + .masterbar__item-content {
@@ -65,13 +70,13 @@ $autobar-height: 20px;
 
 	&:hover,
 	&:focus {
-		background: lighten( $masterbar-color, 5% );
-		color: $white;
+		@include theme( background, --masterbar-item-hover-bg-color );
+		@include theme( color, --masterbar-color );
 		outline: 0;
 	}
 
 	&.is-active {
-		background: darken( $masterbar-color, 17% );
+		@include theme( background, --masterbar-item-active-bg-color );
 	}
 
 	.is-support-user &.is-active {
@@ -140,13 +145,13 @@ $autobar-height: 20px;
 .masterbar__item-new {
 	background: $white;
 	border-radius: 3px;
-	color: $blue-wordpress;
+	@include theme( color, --masterbar-item-new-color );
 	height: 36px;
 	margin: 5px 8px;
 	transition: all 0.2s ease-out;
 
 	&:visited {
-		color: $blue-wordpress;
+		@include theme( color, --masterbar-item-new-color );
 	}
 
 	&.is-active {
@@ -156,11 +161,11 @@ $autobar-height: 20px;
 	&:hover,
 	&:focus {
 		background: $gray-light;
-		color: $blue-wordpress;
+		@include theme( color, --masterbar-item-new-color );
 	}
 
 	.masterbar__item-content {
-		color: $blue-wordpress;
+		@include theme( color, --masterbar-item-new-color );
 		display: none;
 
 		@include breakpoint( ">960px" ) {
@@ -182,7 +187,7 @@ $autobar-height: 20px;
 
 	// active state when editing
 	.is-group-editor & {
-		background: darken( $masterbar-color, 17% );
+		background: darken( $masterbar-bg-color, 17% );
 		color: $white;
 	}
 
@@ -192,7 +197,7 @@ $autobar-height: 20px;
 	}
 
 	.is-group-editor &:hover {
-		background: darken( $masterbar-color, 13% );
+		background: darken( $masterbar-bg-color, 13% );
 	}
 
 }
@@ -237,7 +242,7 @@ $autobar-height: 20px;
 	}
 
 	.masterbar__notifications-bubble {
-		border: solid 2px $masterbar-color;
+		border: solid 2px $masterbar-bg-color;
 		border-radius: 50%;
 		display: none;
 		font-size: 8px;
@@ -259,11 +264,11 @@ $autobar-height: 20px;
 	}
 
 	&:hover .masterbar__notifications-bubble {
-		border-color: lighten( $masterbar-color, 5% );
+		border-color: lighten( $masterbar-bg-color, 5% );
 	}
 
 	&.is-active .masterbar__notifications-bubble {
-		border-color: darken( $masterbar-color, 10% );
+		border-color: darken( $masterbar-bg-color, 10% );
 	}
 
 	&.has-unread .masterbar__notifications-bubble {
@@ -358,8 +363,8 @@ $autobar-height: 20px;
 	}
 
 	.is-group-editor & {
-		background: darken( $masterbar-color, 12% );
-		border-left: 1px solid darken( $masterbar-color, 5% );
+		background: darken( $masterbar-bg-color, 12% );
+		border-left: 1px solid darken( $masterbar-bg-color, 5% );
 
 		.count {
 			color: $gray-light;
@@ -367,7 +372,7 @@ $autobar-height: 20px;
 	}
 
 	.is-group-editor &:hover {
-		background: darken( $masterbar-color, 17% );
+		background: darken( $masterbar-bg-color, 17% );
 
 		.count {
 			color: $white;


### PR DESCRIPTION
This PR is the first in a series aiming to provide support for Color Schemes in Calypso. 
This PR focuses on adding theming support via CSS custom properties.

### Notable additions in this PR:
- `_theme.scss` define theme variables and color schemes
- `_custom-properties.scss` mixins for supporting CSS custom properties
- dark & light color scheme for the Masterbar (to demonstrate theming using this approach)

### How to test
The PR is designed to have no visual impact by default in order to make it easier to get these changes into master. By default the masterbar color scheme matches the current look 1:1. The current look also serves as the fallback for browsers not supporting CSS custom properties as well as for any hypothetically undefined variables.

The dark / light color schemes for the masterbar can be viewed by toggling their respective classes on the `:root` (e.g. `document.documentElement.classList.toggle('is-dark-theme')`).

### The core ideas behind the PR and its approach are:
- conveniently define a new theme in a single location
- easily change predefined themes via a single class
- enable instant preview of (user generated) color schemes
- allow for support of user generated color schemes in the future
- neatly integrates into the current CSS architecture
- prevent increase in build time or overall complexity
- prevent increase of overall CSS file size
- keep current theme exactly as it is
- treat it as a progressive enhancement (current theme remains the default)

For a more detailed description of the approach and its advantages feel free to check out my post on the subject: p4TIVU-75d-p2 (internal reference).

### Screenshots of different color schemes (Masterbar):

:boom: **Note:** This is just a first draft to give an idea of what the color schemes could look like. As the main goal for this PR is to demonstrate how the theming will work, the visual changes are intentionally limited to the Masterbar.

![default](https://user-images.githubusercontent.com/1562646/28224518-0910f0f8-68d8-11e7-9039-79fbc7f1c7b6.png)

![dark](https://user-images.githubusercontent.com/1562646/28224688-c478f3a4-68d8-11e7-9b66-3ce869d6d482.png)

![light](https://user-images.githubusercontent.com/1562646/28224740-ebb87390-68d8-11e7-886d-8d4be85632ed.png)

