### PR TITLE
Reader: add blog sticker Redux

### DIFF
--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import React from 'react';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -10,7 +11,7 @@ import { SITES_BLOG_STICKER_ADD } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { removeBlogSticker } from 'state/sites/blog-stickers/actions';
-import { errorNotice } from 'state/notices/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
 
 export function requestBlogStickerAdd( { dispatch }, action ) {
 	dispatch(
@@ -32,6 +33,17 @@ export function receiveBlogStickerAdd( store, action, next, response ) {
 		receiveBlogStickerAddError( store, action, next );
 		return;
 	}
+
+	store.dispatch(
+		successNotice(
+			translate( 'The sticker {{i}}%s{{/i}} has been successfully added.', {
+				args: action.payload.stickerName,
+				components: {
+					i: <i />,
+				},
+			} ),
+		),
+	);
 }
 
 export function receiveBlogStickerAddError( { dispatch }, action, next ) {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
@@ -32,9 +32,31 @@ describe( 'blog-sticker-add', () => {
 
 	describe( 'receiveBlogStickerAdd', () => {
 		it( 'should do nothing if successful', () => {
+			const dispatch = spy();
 			const nextSpy = spy();
-			receiveBlogStickerAdd( null, null, nextSpy, { success: true } );
+			receiveBlogStickerAdd(
+				{ dispatch },
+				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
+				nextSpy,
+				{ success: true },
+			);
 			expect( nextSpy ).to.not.have.been.called;
+		} );
+
+		it( 'should dispatch a success notice', () => {
+			const dispatch = spy();
+			const nextSpy = spy();
+			receiveBlogStickerAdd(
+				{ dispatch },
+				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
+				nextSpy,
+				{ success: true },
+			);
+			expect( dispatch ).to.have.been.calledWithMatch( {
+				notice: {
+					status: 'is-success',
+				},
+			} );
 		} );
 
 		it( 'should dispatch a sticker removal if it fails using next', () => {
@@ -51,7 +73,7 @@ describe( 'blog-sticker-add', () => {
 			expect( nextSpy ).to.have.been.calledWith( removeBlogSticker( 123, 'broken-in-reader' ) );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem adding that sticker. Please try again.',
+					status: 'is-error',
 				},
 			} );
 		} );
@@ -68,7 +90,7 @@ describe( 'blog-sticker-add', () => {
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					text: 'Sorry, we had a problem adding that sticker. Please try again.',
+					status: 'is-error',
 				},
 			} );
 			expect( nextSpy ).to.have.been.calledWith( removeBlogSticker( 123, 'broken-in-reader' ) );

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
@@ -31,18 +31,6 @@ describe( 'blog-sticker-add', () => {
 	} );
 
 	describe( 'receiveBlogStickerAdd', () => {
-		it( 'should do nothing if successful', () => {
-			const dispatch = spy();
-			const nextSpy = spy();
-			receiveBlogStickerAdd(
-				{ dispatch },
-				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				nextSpy,
-				{ success: true },
-			);
-			expect( nextSpy ).to.not.have.been.called;
-		} );
-
 		it( 'should dispatch a success notice', () => {
 			const dispatch = spy();
 			const nextSpy = spy();
@@ -57,6 +45,7 @@ describe( 'blog-sticker-add', () => {
 					status: 'is-success',
 				},
 			} );
+			expect( nextSpy ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a sticker removal if it fails using next', () => {

--- a/client/state/sites/blog-stickers/reducer.js
+++ b/client/state/sites/blog-stickers/reducer.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { merge } from 'lodash';
+import { merge, includes, concat } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { SITES_BLOG_STICKER_LIST_RECEIVE } from 'state/action-types';
+import { SITES_BLOG_STICKER_LIST_RECEIVE, SITES_BLOG_STICKER_ADD } from 'state/action-types';
 import { combineReducers, createReducer } from 'state/utils';
 
 export const items = createReducer(
@@ -15,6 +15,18 @@ export const items = createReducer(
 		[ SITES_BLOG_STICKER_LIST_RECEIVE ]: ( state, action ) => {
 			return merge( {}, state, {
 				[ action.payload.blogId ]: action.payload.stickers,
+			} );
+		},
+		[ SITES_BLOG_STICKER_ADD ]: ( state, action ) => {
+			const { blogId, stickerName } = action.payload;
+
+			// If the blog already has this sticker, do nothing
+			if ( state[ blogId ] && includes( state[ blogId ], stickerName ) ) {
+				return state;
+			}
+
+			return merge( {}, state, {
+				[ blogId ]: state[ blogId ] ? concat( state[ blogId ], stickerName ) : [ stickerName ],
 			} );
 		},
 	},

--- a/client/state/sites/blog-stickers/reducer.js
+++ b/client/state/sites/blog-stickers/reducer.js
@@ -21,7 +21,7 @@ export const items = createReducer(
 			const { blogId, stickerName } = action.payload;
 
 			// If the blog already has this sticker, do nothing
-			if ( state[ blogId ] && includes( state[ blogId ], stickerName ) ) {
+			if ( includes( state[ blogId ], stickerName ) ) {
 				return state;
 			}
 

--- a/client/state/sites/blog-stickers/reducer.js
+++ b/client/state/sites/blog-stickers/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { merge, includes, concat } from 'lodash';
+import { includes, concat, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,9 +13,10 @@ export const items = createReducer(
 	{},
 	{
 		[ SITES_BLOG_STICKER_LIST_RECEIVE ]: ( state, action ) => {
-			return merge( {}, state, {
+			return {
+				...state,
 				[ action.payload.blogId ]: action.payload.stickers,
-			} );
+			};
 		},
 		[ SITES_BLOG_STICKER_ADD ]: ( state, action ) => {
 			const { blogId, stickerName } = action.payload;
@@ -25,9 +26,10 @@ export const items = createReducer(
 				return state;
 			}
 
-			return merge( {}, state, {
-				[ blogId ]: state[ blogId ] ? concat( state[ blogId ], stickerName ) : [ stickerName ],
-			} );
+			return {
+				...state,
+				[ blogId ]: compact( concat( stickerName, state[ blogId ] ) ),
+			};
 		},
 	},
 );

--- a/client/state/sites/blog-stickers/test/reducer.js
+++ b/client/state/sites/blog-stickers/test/reducer.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { items } from '../reducer';
-import { SITES_BLOG_STICKER_LIST_RECEIVE } from 'state/action-types';
+import { SITES_BLOG_STICKER_LIST_RECEIVE, SITES_BLOG_STICKER_ADD } from 'state/action-types';
 
 describe( 'reducer', () => {
 	describe( 'items', () => {
@@ -36,9 +36,10 @@ describe( 'reducer', () => {
 						payload: { blogId: 456, stickers: [ 'dont-recommend', 'broken-in-reader' ] },
 					},
 				),
-			).to.deep.equal(
-				{ 123: [ 'dont-recommend' ], 456: [ 'dont-recommend', 'broken-in-reader' ] },
-			);
+			).to.deep.equal( {
+				123: [ 'dont-recommend' ],
+				456: [ 'dont-recommend', 'broken-in-reader' ],
+			} );
 		} );
 
 		it( 'should replace existing stickers for a blog when received', () => {
@@ -51,6 +52,42 @@ describe( 'reducer', () => {
 					},
 				),
 			).to.deep.equal( { 123: [ 'okapi-friendly', 'broken-in-reader' ] } );
+		} );
+
+		it( 'should add a new sticker to a blog we do not yet have stickers for', () => {
+			expect(
+				items(
+					{ 456: [ 'dont-recommend' ] },
+					{
+						type: SITES_BLOG_STICKER_ADD,
+						payload: { blogId: 123, stickerName: 'okapi-friendly' },
+					},
+				),
+			).to.deep.equal( { 123: [ 'okapi-friendly' ], 456: [ 'dont-recommend' ] } );
+		} );
+
+		it( 'should add a new sticker to a blog we already have stickers for', () => {
+			expect(
+				items(
+					{ 123: [ 'dont-recommend' ] },
+					{
+						type: SITES_BLOG_STICKER_ADD,
+						payload: { blogId: 123, stickerName: 'okapi-friendly' },
+					},
+				)[ 123 ],
+			).to.have.members( [ 'okapi-friendly', 'dont-recommend' ] );
+		} );
+
+		it( 'should not add a duplicate sticker', () => {
+			expect(
+				items(
+					{ 123: [ 'dont-recommend' ] },
+					{
+						type: SITES_BLOG_STICKER_ADD,
+						payload: { blogId: 123, stickerName: 'dont-recommend' },
+					},
+				),
+			).to.deep.equal( { 123: [ 'dont-recommend' ] } );
 		} );
 	} );
 } );


### PR DESCRIPTION
Adds new blog stickers to the Redux state tree. Also adds a success notice to be dispatched when a blog sticker is successfully added.

### To test

```
npm run test-client client/state/data-layer/wpcom/sites/blog-stickers
npm run test-client client/state/sites/blog-stickers
```