### PR TITLE
Magic Login: Redirect to `/` with `page` on clicking "Back to WordPress.com"

### DIFF
--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -12,6 +12,7 @@ import addQueryArgs from 'lib/route/add-query-args';
 import config from 'config';
 import EmptyContent from 'components/empty-content';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
+import page from 'page';
 import { recordPageView } from 'state/analytics/actions';
 
 const lostPasswordURL = addQueryArgs( {
@@ -37,6 +38,9 @@ class EmailedLoginLinkExpired extends React.Component {
 				/>
 				<EmptyContent
 					action={ translate( 'Return to WordPress.com' ) }
+					actionCallback={ function() {
+						page( '/' );
+					} }
 					actionURL={ '/' }
 					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					illustrationWidth={ 500 }

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -44,6 +45,9 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 				/>
 				<EmptyContent
 					action={ translate( 'Back to WordPress.com' ) }
+					actionCallback={ function() {
+						page( '/' );
+					} }
 					actionURL={ '/' }
 					illustration={ '/calypso/images/drake/drake-all-done.svg' }
 					illustrationWidth={ 500 }


### PR DESCRIPTION
On the “Check your email” screen and “Expired/Invalid link” screen the button “Back to WordPress.com” doesn’t appear to do anything despite the browser navigating to `/`.

This adds a `page` call to `/` to trigger the route update.

## To Test

### Check the button on the "Check Your Email" page:
* Browse to: http://calypso.localhost:3000/log-in/link
* Issue in the console: `dispatch( { type: 'MAGIC_LOGIN_SHOW_CHECK_YOUR_EMAIL_PAGE' } )`
* Click the `Back to WordPress.com` button
* The route should change to `/` & the screen should change (in dev, you'll land at `/devdocs/start` since we redirect, but that's ok)

### Check the button on the "Link is Expired... page"
* Browse to: http://calypso.localhost:3000/log-in/link/use?client_id=.&email=example@example.com&token=.&tt=.
* Issue in the console: `dispatch( { type: 'MAGIC_LOGIN_SHOW_LINK_EXPIRED' } )`
* Click the `Return to WordPress.com` button
* The route should change to `/` & the screen should change (in dev, you'll land at `/devdocs/start` since we redirect, but that's ok)

## Considerations
* I considered simply hardcoding `https://wordpress.com` in the `action` props, but it would just hide this issue until Calypso serves something at `/` one day :)
* We should consider converging these strings? They're so close to one another.
* Are these buttons even useful in either place?