### PR TITLE
WooCommerce: Fix action header top margin and responsive layout issue

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -77,7 +77,7 @@
 	}
 
 	.dashboard__setup-task-label-and-actions {
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( ">960px" ) {
 			display: flex;
 			align-items: center;
 		}
@@ -100,7 +100,7 @@
 		display: flex;
 		align-items: center;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( ">960px" ) {
 			display: block;
 			text-align: right;
 			width: 320px;
@@ -111,7 +111,7 @@
 				white-space: nowrap;
 				margin-right: 8px;
 
-				@include breakpoint( ">660px" ) {
+				@include breakpoint( ">960px" ) {
 					margin: 2px 0 2px 8px;
 				}
 			}

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -66,3 +66,7 @@
 		margin-bottom: 58px;
 	}
 }
+
+.woocommerce .is-sticky .sticky-panel__content {
+	margin-top: 0;
+}

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -67,6 +67,6 @@
 	}
 }
 
-.woocommerce .is-sticky .sticky-panel__content {
+& .sticky-panel.is-sticky .sticky-panel__content {
 	margin-top: 0;
 }


### PR DESCRIPTION
Fixes issue where the content was bleeding out of the card.

To test: View the egg dashboard and reduce the width of the browser to around 660px wide. Notice the nice layout. Also notice the sticky header up top is indeed stuck to the top and doesn't have an 8px gap.