### PR TITLE
Magic Login: Hide the "Email me a login link" link when logged in

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -12,6 +12,7 @@ import page from 'page';
 import config, { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'gridicons';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { recordPageView, recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { login } from 'lib/paths';
@@ -88,6 +89,10 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
+		if ( this.props.currentUser ) {
+			return null;
+		}
+
 		return (
 			<a href="#" key="magic-login-link" onClick={ this.recordMagicLoginLinkClick }>
 				{ this.props.translate( 'Email me a login link' ) }
@@ -133,10 +138,14 @@ export class LoginLinks extends React.Component {
 	}
 }
 
+const mapState = ( state ) => ( {
+	currentUser: getCurrentUser( state ),
+} );
+
 const mapDispatch = {
 	recordPageView,
 	recordTracksEvent,
 	resetMagicLoginRequestForm,
 };
 
-export default connect( null, mapDispatch )( localize( LoginLinks ) );
+export default connect( mapState, mapDispatch )( localize( LoginLinks ) );


### PR DESCRIPTION
Clicking through when logged in will currently fall through to the Reader.

Going through the Magic Login flow is not currently supported when already logged in, so this just does not render the link when a "current user" is detected.

## To Test
* Visit http://calypso.localhost:3000/log-in while **LOGGED IN**
* The "Email me a login link" link **SHOULD NOT** be visible

* Visit http://calypso.localhost:3000/log-in while **NOT LOGGED IN**
* The "Email me a login link" link **SHOULD** be visible

| Logged In | Logged Out |
| ---------- | ------------ |
| <img width="445" alt="screen shot 2017-06-30 at 2 20 25 pm" src="https://user-images.githubusercontent.com/1587282/27748932-594c727a-5d9f-11e7-9ae6-b83e6d3feb05.png"> | <img width="433" alt="screen shot 2017-06-30 at 2 20 34 pm" src="https://user-images.githubusercontent.com/1587282/27748945-64197ed2-5d9f-11e7-9644-e7736eb4e341.png"> |