### PR TITLE
Framework: Created new selectors (getJetpackSites, getSelectedOrAllSitesWithPlugins, getSelectedOrAllSitesJetpackCanManage)

### DIFF
--- a/client/state/selectors/get-jetpack-sites.js
+++ b/client/state/selectors/get-jetpack-sites.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getSites } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+/**
+ * Get all Jetpack sites
+ *
+ * @param {Object} state  Global state tree
+ * @return {Array}        Array of Jetpack Sites objects
+ */
+export default createSelector(
+	( state ) => getSites( state ).filter( site => isJetpackSite( state, site.ID ) ),
+	( state ) => state.sites.items
+);

--- a/client/state/selectors/get-selected-or-all-sites-jetpack-can-manage.js
+++ b/client/state/selectors/get-selected-or-all-sites-jetpack-can-manage.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getSelectedOrAllSites, canCurrentUser } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+/**
+ * Return an array with the selected site or all sites Jetpack can manage
+ *
+ * @param {Object} state  Global state tree
+ * @return {Array}        Array of Sites objects with the result
+ */
+export default createSelector(
+	( state ) => getSelectedOrAllSites( state ).filter( ( site ) =>	isJetpackSite( state, site.ID ) &&
+			site.canManage && canCurrentUser( state, site.ID, 'manage_options' ) ),
+	( state ) => [ state.ui.selectedSiteId, state.sites.items, state.currentUser.capabilities ]
+);

--- a/client/state/selectors/get-selected-or-all-sites-with-plugins.js
+++ b/client/state/selectors/get-selected-or-all-sites-with-plugins.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getSelectedOrAllSites, canCurrentUser } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+/**
+ * Return an array with the selected site or all sites able to have plugins
+ *
+ * @param {Object} state  Global state tree
+ * @return {Array}        Array of Sites objects with the result
+ */
+
+export default createSelector(
+	( state ) => getSelectedOrAllSites( state ).filter( ( site ) =>	isJetpackSite( state, site.ID ) &&
+			canCurrentUser( state, site.ID, 'manage_options' ) && ( site.visible || getSelectedSiteId( state ) ) ),
+	( state ) => [ state.ui.selectedSiteId, state.sites.items, state.currentUser.capabilities ]
+);

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -46,6 +46,7 @@ export getJetpackSetting from './get-jetpack-setting';
 export getJetpackSettings from './get-jetpack-settings';
 export getJetpackSettingsSaveError from './get-jetpack-settings-save-error';
 export getJetpackSettingsSaveRequestStatus from './get-jetpack-settings-save-request-status';
+export getJetpackSites from './get-jetpack-sites';
 export getJetpackUserConnection from './get-jetpack-user-connection';
 export getReaderFollowsLastSyncTime from './get-reader-follows-last-sync-time';
 export getRestoreProgress from './get-restore-progress';
@@ -87,6 +88,8 @@ export getReaderRecommendedSitesPagingOffset from './get-reader-recommended-site
 export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getSelectedOrAllSites from './get-selected-or-all-sites';
+export getSelectedOrAllSitesJetpackCanManage from './get-selected-or-all-sites-jetpack-can-manage';
+export getSelectedOrAllSitesWithPlugins from './get-selected-or-all-sites-with-plugins';
 export getSelectedOrPrimarySiteId from './get-selected-or-primary-site-id';
 export getScheduledPublicizeShareActionTime from './get-scheduled-publicize-share-action-time';
 export hasUserAskedADirectlyQuestion from './has-user-asked-a-directly-question';

--- a/client/state/selectors/test/fixtures/user-state.js
+++ b/client/state/selectors/test/fixtures/user-state.js
@@ -1,0 +1,13 @@
+export const userState = {
+	currentUser: {
+		id: 12345678,
+		capabilities: {}
+	},
+	users: {
+		items: {
+			12345678: {
+				primary_blog: 2916288
+			}
+		}
+	}
+};

--- a/client/state/selectors/test/get-jetpack-sites.js
+++ b/client/state/selectors/test/get-jetpack-sites.js
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getJetpackSites } from '../';
+import { userState } from './fixtures/user-state';
+
+describe( 'getJetpackSites()', () => {
+	it( 'should return an empty array if no sites exist in state', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {}
+			}
+		};
+		const sites = getJetpackSites( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return an empty array if the sites existing are not Jetpack sites', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916287: { ID: 2916287, name: 'WordPress.com Example Blog' },
+					2916286: { ID: 2916286, name: 'WordPress.com Example Blog' }
+				}
+			}
+		};
+		const sites = getJetpackSites( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return one Jetpack site if only one site exists and it is a Jetpack site', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916289: {
+						ID: 2916289,
+						jetpack: true,
+						options: {
+							unmapped_url: 'https://example.wordpress.com',
+						}
+					}
+				}
+			}
+		};
+		const sites = getJetpackSites( state );
+		expect( sites ).to.have.length( 1 );
+		expect( sites[ 0 ].ID ).to.eql( 2916289 );
+	} );
+
+	it( 'should return all the sites in state if all of them are Jetpack sites', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						jetpack: true,
+					},
+					2916289: {
+						ID: 2916289,
+						jetpack: true,
+						options: {
+							unmapped_url: 'https://example2.wordpress.com',
+						}
+					},
+
+				}
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getJetpackSites( state );
+		expect( sites ).to.have.length( 2 );
+		expect( sites[ 0 ].ID ).to.eql( 2916288 );
+		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+	} );
+
+	it( 'should return only the Jetpack sites if the state contains Jetpack and non Jetpack sites', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						jetpack: true,
+					},
+					2916287: {
+						ID: 2916287,
+						name: 'WordPress.com Example Blog'
+					},
+					2916289: {
+						ID: 2916289,
+						jetpack: true,
+					},
+					2916286: {
+						ID: 2916286,
+						name: 'WordPress.com Example Blog'
+					},
+				}
+			},
+			siteSettings: {
+				items: {},
+			},
+		};
+		const sites = getJetpackSites( state );
+		expect( sites ).to.have.length( 2 );
+		expect( sites[ 0 ].ID ).to.eql( 2916288 );
+		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+	} );
+} );

--- a/client/state/selectors/test/get-selected-or-all-sites-jetpack-can-manage.js
+++ b/client/state/selectors/test/get-selected-or-all-sites-jetpack-can-manage.js
@@ -1,0 +1,198 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedOrAllSitesJetpackCanManage } from '../';
+import { userState } from './fixtures/user-state';
+
+describe( 'getSelectedOrAllSitesJetpackCanManage()', () => {
+	it( 'should return an empty array if no sites exist in state', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {}
+			},
+			ui: { selectedSiteId: 2916284 },
+		};
+		const sites = getSelectedOrAllSitesJetpackCanManage( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return an empty array if the sites existing do not verify jetpack canManage conditions', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						visible: true,
+					},
+				}
+			},
+			ui: {},
+		};
+		const sites = getSelectedOrAllSitesJetpackCanManage( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return an array with one site if just one site exists and verifies jetpack canManage conditions', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916288: {
+						edit_pages: true,
+						manage_options: true,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						jetpack: true,
+						options: {
+							jetpack_version: '3.3',
+						},
+					},
+				}
+			},
+			ui: {},
+		};
+		const sites = getSelectedOrAllSitesJetpackCanManage( state );
+		expect( sites ).to.have.length( 1 );
+		expect( sites[ 0 ].ID ).to.eql( 2916288 );
+	} );
+
+	it( 'should return an array with all the sites that verify jetpack canManage conditions', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916286: {
+						edit_pages: true,
+						manage_options: true,
+					},
+					2916289: {
+						edit_pages: true,
+						manage_options: true,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916286: {
+						ID: 2916286,
+						jetpack: true,
+						options: {
+							active_modules: [ 'manage' ],
+							jetpack_version: '5.0'
+						}
+					},
+					2916287: {
+						ID: 2916287,
+					},
+					2916289: {
+						ID: 2916289,
+						jetpack: true,
+						options: {
+							jetpack_version: '3.4'
+						}
+					},
+				}
+			},
+			ui: {},
+		};
+		const sites = getSelectedOrAllSitesJetpackCanManage( state );
+		expect( sites ).to.have.length( 2 );
+		expect( sites[ 0 ].ID ).to.eql( 2916286 );
+		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+	} );
+
+	it( 'should return an array with the selected site if it verifies jetpack canManage conditions', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916286: {
+						edit_pages: true,
+						manage_options: true,
+					},
+					2916289: {
+						edit_pages: true,
+						manage_options: true,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916286: {
+						ID: 2916286,
+						jetpack: true,
+						options: {
+							active_modules: null,
+							jetpack_version: '3.5'
+						},
+					},
+					2916289: {
+						ID: 2916289,
+						jetpack: true,
+						options: {
+							active_modules: [ 'manage' ],
+							jetpack_version: '3.4'
+						},
+					},
+				}
+			},
+			ui: { selectedSiteId: 2916289 },
+		};
+		const sites = getSelectedOrAllSitesJetpackCanManage( state );
+		expect( sites ).to.have.length( 1 );
+		expect( sites[ 0 ].ID ).to.eql( 2916289 );
+	} );
+
+	it( 'should return an empty array if the selected site can not be managed', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916286: {
+						manage_options: true,
+					},
+					2916287: {
+						manage_options: false,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916286: {
+						ID: 2916286,
+						jetpack: true,
+						options: {
+							jetpack_version: '3.5'
+						},
+					},
+					2916287: {
+						ID: 2916287,
+						jetpack: true,
+						options: {
+							jetpack_version: '3.5'
+						},
+					}
+				}
+			},
+			ui: { selectedSiteId: 2916287 },
+		};
+		const sites = getSelectedOrAllSitesJetpackCanManage( state );
+		expect( sites ).to.eql( [] );
+	} );
+} );

--- a/client/state/selectors/test/get-selected-or-all-sites-with-plugins.js
+++ b/client/state/selectors/test/get-selected-or-all-sites-with-plugins.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedOrAllSitesWithPlugins } from '../';
+import { userState } from './fixtures/user-state';
+
+describe( 'getSelectedOrAllSitesWithPlugins()', () => {
+	it( 'should return an empty array if no sites exist in state', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {}
+			},
+			ui: { selectedSiteId: 2916284 },
+		};
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return an empty array if the sites existing are not able to contain plugins', () => {
+		const state = {
+			...userState,
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						visible: true,
+					},
+				}
+			},
+			ui: {},
+		};
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+		expect( sites ).to.eql( [] );
+	} );
+
+	it( 'should return an array with one site if just one site exists and the user is able to manage plugins there', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916288: {
+						manage_options: true,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916288: {
+						ID: 2916288,
+						jetpack: true,
+						visible: true,
+					},
+				}
+			},
+			ui: {},
+		};
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+		expect( sites ).to.have.length( 1 );
+		expect( sites[ 0 ].ID ).to.eql( 2916288 );
+	} );
+
+	it( 'should return an array with all the sites able to have plugins', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916286: {
+						manage_options: true,
+					},
+					2916289: {
+						manage_options: true,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916286: {
+						ID: 2916286,
+						jetpack: true,
+						visible: true,
+					},
+					2916287: {
+						ID: 2916287,
+						visible: true,
+					},
+					2916289: {
+						ID: 2916289,
+						jetpack: true,
+						visible: true,
+					},
+				}
+			},
+			ui: {},
+		};
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+		expect( sites ).to.have.length( 2 );
+		expect( sites[ 0 ].ID ).to.eql( 2916286 );
+		expect( sites[ 1 ].ID ).to.eql( 2916289 );
+	} );
+
+	it( 'should return an array with the selected site if it is able to have plugins', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916286: {
+						manage_options: true,
+					},
+					2916289: {
+						manage_options: true,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916286: {
+						ID: 2916286,
+						jetpack: true,
+						visible: true,
+					},
+					2916289: {
+						ID: 2916289,
+						jetpack: true,
+						visible: true,
+					},
+				}
+			},
+			ui: { selectedSiteId: 2916289 },
+		};
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+		expect( sites ).to.have.length( 1 );
+		expect( sites[ 0 ].ID ).to.eql( 2916289 );
+	} );
+
+	it( 'should return an empty array if the selected site is not able to have plugins', () => {
+		const state = {
+			users: userState.users,
+			currentUser: {
+				id: 12345678,
+				capabilities: {
+					2916286: {
+						manage_options: true,
+					},
+					2916287: {
+						manage_options: true,
+					},
+				}
+			},
+			sites: {
+				items: {
+					2916286: {
+						ID: 2916286,
+						jetpack: true,
+						visible: true,
+						capabilities: {
+							manage_options: true,
+						}
+					},
+					2916287: {
+						ID: 2916287,
+						visible: true,
+					}
+				}
+			},
+			ui: { selectedSiteId: 2916287 },
+		};
+		const sites = getSelectedOrAllSitesWithPlugins( state );
+		expect( sites ).to.eql( [] );
+	} );
+} );


### PR DESCRIPTION
The selectors will be used as a replacement of current site-list methods.

To test:
npm run test-client client/state/selectors/test