### PR TITLE
If connecting via WooCommerce Services, pre-select the free Jetpack plan

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -64,10 +64,10 @@ const jetpackNewSiteSelector = ( context ) => {
 };
 
 export default {
-	redirectWithoutLocaleifLoggedIn( context, next ) {
+	redirectWithoutLocaleIfLoggedIn( context, next ) {
 		if ( userModule.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
 			const urlWithoutLocale = i18nUtils.removeLocaleFromPath( context.path );
-			debug( 'redirectWithoutLocaleifLoggedIn to %s', urlWithoutLocale );
+			debug( 'redirectWithoutLocaleIfLoggedIn to %s', urlWithoutLocale );
 			return page.redirect( urlWithoutLocale );
 		}
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -19,7 +19,7 @@ import JetpackNewSite from './jetpack-new-site/index';
 import JetpackConnectAuthorizeForm from './authorize-form';
 import { setSection } from 'state/ui/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
+import { JETPACK_CONNECT_QUERY_SET, JETPACK_CONNECT_SELECT_PLAN_IN_ADVANCE } from 'state/action-types';
 import userFactory from 'lib/user';
 import jetpackSSOForm from './sso';
 import i18nUtils from 'lib/i18n-utils';
@@ -81,6 +81,13 @@ export default {
 				type: JETPACK_CONNECT_QUERY_SET,
 				queryObject: context.query
 			} );
+			if ( 'woocommerce-services' === context.query.from ) {
+				context.store.dispatch( {
+					type: JETPACK_CONNECT_SELECT_PLAN_IN_ADVANCE,
+					plan: 'free',
+					site: '*',
+				} );
+			}
 			page.redirect( context.pathname );
 		}
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -20,7 +20,7 @@ export default function() {
 	page( '/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?', controller.connect );
 
 	page( '/jetpack/connect/:type(install)/:locale?',
-		controller.redirectWithoutLocaleifLoggedIn,
+		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.connect
 	);
 
@@ -30,14 +30,14 @@ export default function() {
 
 	page(
 		'/jetpack/connect/authorize/:localeOrInterval?',
-		controller.redirectWithoutLocaleifLoggedIn,
+		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.saveQueryObject,
 		controller.authorizeForm
 	);
 
 	page(
 		'/jetpack/connect/authorize/:interval/:locale',
-		controller.redirectWithoutLocaleifLoggedIn,
+		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.saveQueryObject,
 		controller.authorizeForm
 	);
@@ -53,7 +53,7 @@ export default function() {
 
 	page(
 		'/jetpack/connect/:locale?',
-		controller.redirectWithoutLocaleifLoggedIn,
+		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.connect
 	);
 

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -39,9 +39,9 @@ function isLocale( pathFragment ) {
 	return ! isEmpty( i18nUtils.getLanguage( pathFragment ) );
 }
 
-export function redirectWithoutLocaleifLoggedIn( context, next ) {
+export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 	if ( user.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
-		let urlWithoutLocale = i18nUtils.removeLocaleFromPath( context.path );
+		const urlWithoutLocale = i18nUtils.removeLocaleFromPath( context.path );
 		return page.redirect( urlWithoutLocale );
 	}
 

--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -6,12 +6,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { acceptInvite, redirectWithoutLocaleifLoggedIn } from './controller';
+import { acceptInvite, redirectWithoutLocaleIfLoggedIn } from './controller';
 
 export default () => {
 	page(
 		'/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
-		redirectWithoutLocaleifLoggedIn,
+		redirectWithoutLocaleIfLoggedIn,
 		acceptInvite
 	);
 };


### PR DESCRIPTION
If the Jetpack connect query string contains `from: woocommerce-services`, we want to auto select the free plan and take the user back to their self-hosted site as soon as they authorize.

While I was browsing the code I saw a few instance of the function `redirectWithoutLocaleifLoggedIn`. This looks like a typo to me so I went ahead and fixed it.

Note: Right now the plans page is still shown for a brief moment before redirecting to wp-admin. I think it would be nicer if it just immediately went to wp-admin without first showing this page. However, since this might affect other flows, I decided not to make this change.

To Test:
- Install Jetpack, WooCommerce and WooCommerce services
- Disconnect Jetpack
- Try connecting it from the Jetpack dashboard: It should ask you to select a plan
- Try connecting from the WCS banner (shown on the plugins page for example): It should skip the plans page


