### PR TITLE
Framework: removed sites-list from plugin site list.

### DIFF
--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -1,59 +1,51 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import { compact } from 'lodash';
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import { connect } from 'react-redux';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
-var allSites = require( 'lib/sites-list' )(),
-	PluginSite = require( 'my-sites/plugins/plugin-site/plugin-site' ),
-	SectionHeader = require( 'components/section-header' ),
-	PluginsStore = require( 'lib/plugins/store' );
+import { isConnectedSecondaryNetworkSite, getNetworkSites } from 'state/selectors';
+import PluginSite from 'my-sites/plugins/plugin-site/plugin-site';
+import PluginsStore from 'lib/plugins/store';
+import SectionHeader from 'components/section-header';
 
-module.exports = React.createClass( {
+export class PluginSiteList extends Component {
+	static propTypes = {
+		notices: PropTypes.object,
+		plugin: PropTypes.object,
+		sites: PropTypes.array,
+		sitesWithSecondarySites: PropTypes.array,
+		title: PropTypes.string,
+	};
 
-	displayName: 'PluginSiteList',
-
-	propTypes: {
-		site: React.PropTypes.object,
-		plugin: React.PropTypes.object,
-		notices: React.PropTypes.object,
-		title: React.PropTypes.string
-	},
-
-	getSecondaryPluginSites: function( site ) {
-		let secondarySites = allSites.getNetworkSites( site );
-		let secondaryPluginSites = site.plugin
+	getSecondaryPluginSites( site, secondarySites ) {
+		const secondaryPluginSites = site.plugin
 			? PluginsStore.getSites( secondarySites, this.props.plugin.slug )
 			: secondarySites;
 		return compact( secondaryPluginSites );
-	},
+	}
 
-	renderPluginSite: function( site ) {
+	renderPluginSite( { site, secondarySites } ) {
 		return <PluginSite
 				key={ 'pluginSite' + site.ID }
 				site={ site }
-				secondarySites={ this.getSecondaryPluginSites( site ) }
+				secondarySites={ this.getSecondaryPluginSites( secondarySites ) }
 				plugin={ this.props.plugin }
 				wporg={ this.props.wporg }
 				notices={ this.props.notices } />;
-	},
+	}
 
-	render: function() {
+	render() {
 		if ( ! this.props.sites || this.props.sites.length === 0 ) {
 			return null;
 		}
 		const classes = classNames( 'plugin-site-list', this.props.className ),
-			pluginSites = this.props.sites.map( function( site ) {
-				if ( allSites.isConnectedSecondaryNetworkSite( site ) ) {
-					return;
-				}
-
-				return this.renderPluginSite( site );
-			}, this );
+			pluginSites = this.props.sitesWithSecondarySites.map( this.renderPluginSite, this );
 
 		return (
 			<div className={ classes } >
@@ -62,4 +54,19 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
+
+export default connect(
+	( state, props ) => {
+		const sitesWithSecondarySites = props.sites
+		.filter( ( site ) => ! isConnectedSecondaryNetworkSite( state, site.ID )	)
+		.map( ( site ) => ( {
+			site,
+			secondarySites: getNetworkSites( state, site.ID )
+		} ) );
+
+		return {
+			sitesWithSecondarySites
+		};
+	}
+)( PluginSiteList );

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -4,7 +4,8 @@
 import classNames from 'classnames';
 import { compact } from 'lodash';
 import { connect } from 'react-redux';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -35,7 +35,7 @@ export class PluginSiteList extends Component {
 		return <PluginSite
 				key={ 'pluginSite' + site.ID }
 				site={ site }
-				secondarySites={ this.getSecondaryPluginSites( secondarySites ) }
+				secondarySites={ this.getSecondaryPluginSites( site, secondarySites ) }
 				plugin={ this.props.plugin }
 				wporg={ this.props.wporg }
 				notices={ this.props.notices } />;

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -57,17 +57,16 @@ export class PluginSiteList extends Component {
 	}
 }
 
-export default connect(
-	( state, props ) => {
-		const sitesWithSecondarySites = props.sites
-		.filter( ( site ) => ! isConnectedSecondaryNetworkSite( state, site.ID )	)
-		.map( ( site ) => ( {
+// TODO: make this memoized after sites-list is removed and `sites` comes from Redux
+function getSitesWithSecondarySites( state, sites ) {
+	return sites
+		.filter( site => ! isConnectedSecondaryNetworkSite( state, site.ID ) )
+		.map( site => ( {
 			site,
-			secondarySites: getNetworkSites( state, site.ID )
+			secondarySites: getNetworkSites( state, site.ID ),
 		} ) );
+}
 
-		return {
-			sitesWithSecondarySites
-		};
-	}
-)( PluginSiteList );
+export default connect( ( state, props ) => ( {
+	sitesWithSecondarySites: getSitesWithSecondarySites( state, props.sites ),
+} ) )( PluginSiteList );

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -32,13 +33,16 @@ export class PluginSiteList extends Component {
 	}
 
 	renderPluginSite( { site, secondarySites } ) {
-		return <PluginSite
+		return (
+			<PluginSite
 				key={ 'pluginSite' + site.ID }
 				site={ site }
 				secondarySites={ this.getSecondaryPluginSites( site, secondarySites ) }
 				plugin={ this.props.plugin }
 				wporg={ this.props.wporg }
-				notices={ this.props.notices } />;
+				notices={ this.props.notices }
+			/>
+		);
 	}
 
 	render() {
@@ -49,7 +53,7 @@ export class PluginSiteList extends Component {
 			pluginSites = this.props.sitesWithSecondarySites.map( this.renderPluginSite, this );
 
 		return (
-			<div className={ classes } >
+			<div className={ classes }>
 				<SectionHeader label={ this.props.title } />
 				{ pluginSites }
 			</div>


### PR DESCRIPTION
Please be aware that the sites prop the component receives, is not a normal site object it’s an object with properties assigned by the Plugins Store, so we cannot compute it from the state (currently).

In order to not have errors in CircleCI in this pull request I also modernized the component (use classes, imports), although this would be material for another pull request.

The sitesWithSecondarySites computation is not a selector because its an operation applied on an array of sites that come from the plugin store ( plugin information was included in sites objects). Also this computation is just used in this component.

**To test:**
Go to http://calypso.localhost:3000/plugins select some plugin that you have installed on some site. Press it and make sure "Installed on" region appears with the list of sites where you have the plugin installed (make sure no current site is selected (to test this you need to be in all sites).

**Test Live:**
https://calypso.live/?branch=update/remove-sites-list-plugin-site-list