### PR TITLE
Framework: remove sites list dependency on plugins main list (and plugins-list used by it).

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -93,7 +93,6 @@ function renderPluginList( context, basePath ) {
 			context,
 			filter: context.params.pluginFilter,
 			category: context.params.category,
-			sites,
 			search
 		} ),
 		'primary',

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -44,6 +44,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug
 } from 'state/ui/selectors';
+import { getSelectedOrAllSitesWithPlugins } from 'state/selectors';
 import HeaderButton from 'components/header-button';
 import { isEnabled } from 'config';
 
@@ -55,12 +56,10 @@ const PluginsMain = React.createClass( {
 	},
 
 	componentDidMount() {
-		this.props.sites.on( 'change', this.refreshPlugins );
 		PluginsStore.on( 'change', this.refreshPlugins );
 	},
 
 	componentWillUnmount() {
-		this.props.sites.removeListener( 'change', this.refreshPlugins );
 		PluginsStore.removeListener( 'change', this.refreshPlugins );
 	},
 
@@ -100,7 +99,7 @@ const PluginsMain = React.createClass( {
 	},
 
 	getPluginsState( nextProps ) {
-		const sites = this.props.sites.getSelectedOrAllWithPlugins(),
+		const sites = this.props.sites,
 			pluginUpdate = PluginsStore.getPlugins( sites, 'updates' );
 		return {
 			plugins: this.getPluginsFromStore( nextProps, sites ),
@@ -149,8 +148,7 @@ const PluginsMain = React.createClass( {
 	},
 
 	isFetchingPlugins() {
-		const sites = this.props.sites.getSelectedOrAllWithPlugins() || [];
-		return sites.some( PluginsStore.isFetchingSite );
+		return this.props.sites.some( PluginsStore.isFetchingSite );
 	},
 
 	getSelectedText() {
@@ -253,7 +251,7 @@ const PluginsMain = React.createClass( {
 		}
 
 		return some(
-			this.props.sites.getSelectedOrAllWithPlugins(),
+			this.props.sites,
 			site => site && this.props.isJetpackSite( site.ID ) && this.props.canJetpackSiteUpdateFiles( site.ID )
 		);
 	},
@@ -287,13 +285,11 @@ const PluginsMain = React.createClass( {
 		}
 
 		const installedPluginsList = showInstalledPluginList && (
-			<PluginsList
-				header={ this.props.translate( 'Installed Plugins' ) }
-				plugins={ plugins }
-				sites={ this.props.sites }
-				pluginUpdateCount={ this.state.pluginUpdateCount }
-				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
-			/>
+				<PluginsList
+					header={ this.props.translate( 'Installed Plugins' ) }
+					plugins={ plugins }
+					pluginUpdateCount={ this.state.pluginUpdateCount }
+					isPlaceholder= { this.shouldShowPluginListPlaceholders() } />
 		);
 
 		const morePluginsHeader = showInstalledPluginList && showSuggestedPluginsList && (
@@ -499,6 +495,7 @@ export default connect(
 	state => {
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteId = getSelectedSiteId( state );
+		const sites = getSelectedOrAllSitesWithPlugins( state );
 		return {
 			selectedSite,
 			selectedSiteId: selectedSiteId,
@@ -512,7 +509,8 @@ export default connect(
 			isRequestingSites: isRequestingSites( state ),
 			userCanManagePlugins: ( selectedSiteId
 				? canCurrentUser( state, selectedSiteId, 'manage_options' )
-				: canCurrentUserManagePlugins( state ) )
+				: canCurrentUserManagePlugins( state ) ),
+			sites,
 		};
 	},
 	{ wporgFetchPluginData, recordGoogleEvent }

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -285,11 +285,12 @@ const PluginsMain = React.createClass( {
 		}
 
 		const installedPluginsList = showInstalledPluginList && (
-				<PluginsList
-					header={ this.props.translate( 'Installed Plugins' ) }
-					plugins={ plugins }
-					pluginUpdateCount={ this.state.pluginUpdateCount }
-					isPlaceholder= { this.shouldShowPluginListPlaceholders() } />
+			<PluginsList
+				header={ this.props.translate( 'Installed Plugins' ) }
+				plugins={ plugins }
+				pluginUpdateCount={ this.state.pluginUpdateCount }
+				isPlaceholder={ this.shouldShowPluginListPlaceholders() }
+			/>
 		);
 
 		const morePluginsHeader = showInstalledPluginList && showSuggestedPluginsList && (
@@ -495,10 +496,10 @@ export default connect(
 	state => {
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteId = getSelectedSiteId( state );
-		const sites = getSelectedOrAllSitesWithPlugins( state );
 		return {
+			sites: getSelectedOrAllSitesWithPlugins( state ),
 			selectedSite,
-			selectedSiteId: selectedSiteId,
+			selectedSiteId,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			selectedSiteIsJetpack: selectedSite && isJetpackSite( state, selectedSiteId ),
 			canSelectedJetpackSiteManage: selectedSite && canJetpackSiteManage( state, selectedSiteId ),
@@ -509,8 +510,7 @@ export default connect(
 			isRequestingSites: isRequestingSites( state ),
 			userCanManagePlugins: ( selectedSiteId
 				? canCurrentUser( state, selectedSiteId, 'manage_options' )
-				: canCurrentUserManagePlugins( state ) ),
-			sites,
+				: canCurrentUserManagePlugins( state ) )
 		};
 	},
 	{ wporgFetchPluginData, recordGoogleEvent }

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -309,7 +309,7 @@ const PluginsMain = React.createClass( {
 		const suggestedPluginsList = showSuggestedPluginsList && (
 			<PluginsBrowser
 				hideSearchForm
-				path={ this.context.path }
+				path={ this.props.context.path }
 				search={ search }
 				searchTitle={ searchTitle }
 			/>

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -23,7 +23,6 @@ import SectionHeader from 'components/section-header';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 
 function checkPropsChange( nextProps, propArr ) {
 	let i, prop;
@@ -48,7 +47,6 @@ export const PluginsList = React.createClass( {
 			name: PropTypes.string,
 		} ) ).isRequired,
 		header: PropTypes.string.isRequired,
-		hasSingleSite: PropTypes.bool.isRequired,
 		selectedSite: PropTypes.object,
 		selectedSiteSlug: PropTypes.string,
 		pluginUpdateCount: PropTypes.number,
@@ -62,7 +60,7 @@ export const PluginsList = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps, nextState ) {
-		const propsToCheck = [ 'plugins', 'hasSingleSite', 'selectedSite', 'pluginUpdateCount', '' ];
+		const propsToCheck = [ 'plugins', 'sites', 'selectedSite', 'pluginUpdateCount' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
 			return true;
 		}
@@ -175,7 +173,7 @@ export const PluginsList = React.createClass( {
 	},
 
 	siteSuffix() {
-		return ( this.props.selectedSite || this.props.hasSingleSite ) ? '/' + this.props.selectedSiteSlug : '';
+		return this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '';
 	},
 
 	recordEvent( eventAction, includeSelectedPlugins ) {
@@ -530,7 +528,6 @@ export default connect(
 			selectedSite,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
-			hasSingleSite: getCurrentUserSiteCount( state ) === 1
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -23,6 +23,7 @@ import SectionHeader from 'components/section-header';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 
 function checkPropsChange( nextProps, propArr ) {
 	let i, prop;
@@ -47,7 +48,7 @@ export const PluginsList = React.createClass( {
 			name: PropTypes.string,
 		} ) ).isRequired,
 		header: PropTypes.string.isRequired,
-		sites: PropTypes.object.isRequired,
+		hasSingleSite: PropTypes.bool.isRequired,
 		selectedSite: PropTypes.object,
 		selectedSiteSlug: PropTypes.string,
 		pluginUpdateCount: PropTypes.number,
@@ -61,7 +62,7 @@ export const PluginsList = React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps, nextState ) {
-		const propsToCheck = [ 'plugins', 'sites', 'selectedSite', 'pluginUpdateCount', '' ];
+		const propsToCheck = [ 'plugins', 'hasSingleSite', 'selectedSite', 'pluginUpdateCount', '' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
 			return true;
 		}
@@ -166,7 +167,7 @@ export const PluginsList = React.createClass( {
 	},
 
 	hasNoSitesThatCanManage( plugin ) {
-		return ! plugin.sites.some( site => includes( site.modules || [], 'manage' ) );
+		return ! plugin.sites.some( site => site.canManage );
 	},
 
 	getSelected() {
@@ -174,8 +175,7 @@ export const PluginsList = React.createClass( {
 	},
 
 	siteSuffix() {
-		const hasSingleSite = this.props.sites && this.props.sites.get().length === 1;
-		return ( this.props.selectedSite || hasSingleSite ) ? '/' + this.props.selectedSiteSlug : '';
+		return ( this.props.selectedSite || this.props.hasSingleSite ) ? '/' + this.props.selectedSiteSlug : '';
 	},
 
 	recordEvent( eventAction, includeSelectedPlugins ) {
@@ -530,6 +530,7 @@ export default connect(
 			selectedSite,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, get( selectedSite, 'ID' ) ),
+			hasSingleSite: getCurrentUserSiteCount( state ) === 1
 		};
 	},
 	{

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -15,7 +15,7 @@ import { createReduxStore } from 'state';
 import { sites } from './fixtures';
 
 describe( 'PluginsList', () => {
-	let React, testRenderer, PluginsList, siteListMock, TestUtils;
+	let React, testRenderer, PluginsList, TestUtils;
 
 	useFakeDom();
 
@@ -28,7 +28,6 @@ describe( 'PluginsList', () => {
 		mockery.registerMock( 'my-sites/plugins/plugin-list-header', emptyComponent );
 
 		mockery.registerMock( 'lib/analytics', { ga: { recordEvent: noop } } );
-		mockery.registerMock( 'lib/sites-list', () => siteListMock );
 	} );
 
 	before( () => {
@@ -40,7 +39,6 @@ describe( 'PluginsList', () => {
 
 		testRenderer = TestUtils.renderIntoDocument;
 
-		siteListMock = { getSelectedSite: () => sites[ 0 ], get: () => sites, sync() {} };
 		PluginsList = require( '../' ).PluginsList;
 	} );
 
@@ -55,7 +53,6 @@ describe( 'PluginsList', () => {
 			props = {
 				plugins,
 				header: 'Plugins',
-				sites: siteListMock,
 				selectedSite: sites[ 0 ],
 				isPlaceholder: false,
 				pluginUpdateCount: plugins.length


### PR DESCRIPTION
In line "return ( this.props.selectedSite || this.props.hasSingleSite ) ? '/' + this.props.selectedSiteSlug : '';"
I used the the same logic has before just removed sites-list but I feel this may have a bug. Because if no site is selected this.props.selectedSiteSlug is null so I feel we should just use " this.props.selectedSite ? '/' + this.props.selectedSiteSlug : '' "
I think when the user has just one site that site is the selected one anyway so the condition hasSingleSite is not needed but even if it is needed I think as it is right now may not the correct way.

**To test:** 
Test the following url combination:
• http://calypso.localhost:3000/plugins/{site/no-site/jetpack-site}, 
See that plugins list appear ok without errors. 
If testing before PR's https://github.com/Automattic/wp-calypso/pull/16265  add the changes there to the your local test branch.

Execute the automatic tests: 
npm run test-client client/my-sites/plugins/plugins-list and verify they pass

**Test Live:**
https://calypso.live/?branch=update/remove-sites-list-plugins-list