### PR TITLE
Woo Customizer clicked complete

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -45,12 +45,15 @@ class SetupTask extends Component {
 						// Only the last primary action gets to be a primary button
 						const primary = ( index === primaryActions.length - 1 ) && ! taskCompleted;
 						const target = '/' === action.path.substring( 0, 1 ) ? '_self' : '_blank';
-						const trackClick = () => {
+						const trackClick = ( e ) => {
 							this.track( action.analyticsProp );
 							if ( target === '_self' ) {
 								page.redirect( action.path );
 							} else {
 								window.open( action.path );
+							}
+							if ( action.onClick ) {
+								action.onClick( e );
 							}
 						};
 						return (

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -82,6 +82,10 @@ class SetupTasks extends Component {
 		this.props.setOptedOutOfTaxesSetup( this.props.site.ID, true );
 	}
 
+	onClickOpenCustomizer = () => {
+		this.props.setTriedCustomizerDuringInitialSetup( this.props.site.ID, true );
+	}
+
 	getSetupTasks = () => {
 		const {
 			site,
@@ -167,7 +171,7 @@ class SetupTasks extends Component {
 					{
 						label: translate( 'Customize' ),
 						path: getLink( 'https://:site/wp-admin/customize.php?return=' + encodeURIComponent( '//' + site.slug ), site ),
-						// TODO use onClick here instead in order to hit setTriedCustomizerDuringInitialSetup,
+						onClick: this.onClickOpenCustomizer,
 						analyticsProp: 'view-and-customize',
 					}
 				]


### PR DESCRIPTION
This will show the customizer setup as complete when customizer button is clicked.

Set set_store_address_during_initial_setup to 1 and finished_initial_setup to 0 here: https://developer.wordpress.com/docs/api/console/
Load http://calypso.localhost:3000/store/{site}
Click customizer button
Close window that was opened
Check mark should be there next to customizer.