### PR TITLE
Move react-test-env import to external dependencies block.

### DIFF
--- a/test/test/helpers/use-fake-dom/index.js
+++ b/test/test/helpers/use-fake-dom/index.js
@@ -2,10 +2,6 @@
  * External dependencies
  */
 import { flow } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import reactTestEnvSetup from 'react-test-env';
 
 const useFakeDom = flow( [ reactTestEnvSetup.useFakeDom, () => {


### PR DESCRIPTION
`react-test-env` is an external dependency, not internal; this PR moves it into the external block, and removes the unused internal comment.