### PR TITLE
WooCommerce Stats: Ensure switcher pill always appear on main stats

### DIFF
--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	uniqBy,
 	omit,
 	findIndex,
 } from 'lodash';
@@ -58,7 +57,7 @@ const updatePlugin = function( state, action ) {
  */
 export const plugins = createReducer( {}, {
 	[ PLUGINS_REQUEST_SUCCESS ]: ( state, action ) => {
-		return { ...state, [ action.siteId ]: uniqBy( action.data, 'slug' ) };
+		return { ...state, [ action.siteId ]: action.data };
 	},
 	[ PLUGINS_REQUEST_FAILURE ]: ( state, action ) => {
 		return { ...state, [ action.siteId ]: [] };

--- a/client/state/selectors/is-plugin-active.js
+++ b/client/state/selectors/is-plugin-active.js
@@ -14,7 +14,7 @@ import { find } from 'lodash';
  */
 export default function isPluginActive( state, siteId, pluginSlug ) {
 	const sitePlugins = state.plugins.installed.plugins[ siteId ];
-	const plugin = find( sitePlugins, { slug: pluginSlug } );
+	const plugin = find( sitePlugins, { slug: pluginSlug, active: true } );
 	if ( ! plugin ) {
 		return false;
 	}


### PR DESCRIPTION
Ensure that a user who has multiple versions of the WooCommerce plugin installed for testing still gets the switcher pill.

Fixes #15746