### PR TITLE
Editor: Add header message to EditorConfirmationSidebar.

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -46,7 +46,7 @@ class EditorConfirmationSidebar extends React.Component {
 			case 'update':
 				return this.props.translate( 'Update' );
 			case 'schedule':
-				return this.props.translate( 'Schedule' );
+				return this.props.translate( 'Schedule!' );
 			case 'publish':
 				return this.props.translate( 'Publish!' );
 			case 'requestReview':

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -178,6 +178,17 @@ class EditorConfirmationSidebar extends React.Component {
 							</div>
 						</div>
 						<div className="editor-confirmation-sidebar__content-wrap">
+							<div className="editor-confirmation-sidebar__header">
+								{
+									this.props.translate( '{{strong}}Ready to go?{{/strong}} Double-check and then confirm to publish.', {
+										comment: 'This string appears as the header for the confirmation sidebar ' +
+											'when a user publishes a post or page.',
+										components: {
+											strong: <strong />
+										},
+									} )
+								}
+							</div>
 							<div className="editor-confirmation-sidebar__privacy-control">
 								{ this.renderPrivacyControl() }
 							</div>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -48,7 +48,7 @@ class EditorConfirmationSidebar extends React.Component {
 			case 'schedule':
 				return this.props.translate( 'Schedule' );
 			case 'publish':
-				return this.props.translate( 'Publish' );
+				return this.props.translate( 'Publish!' );
 			case 'requestReview':
 				return this.props.translate( 'Submit for Review' );
 		}

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -125,6 +125,7 @@
 	padding: 0 24px 24px 24px
 }
 
+
 .editor-confirmation-sidebar__sidebar .editor-confirmation-sidebar__display-preference {
 	@extend .sidebar__footer;
 	background-color: lighten( $gray, 25% );
@@ -139,4 +140,10 @@
 
 input[type=checkbox].editor-confirmation-sidebar__display-preference-checkbox {
 	margin-top: 3px;
+}
+
+.editor-confirmation-sidebar__header {
+	color: $gray-text-min;
+	font-size: 14px;
+	padding-bottom: 16px;
 }


### PR DESCRIPTION
This PR adds a header message to the Editor Confirmation Sidebar.

**Mock:**
![publish-confirm2](https://user-images.githubusercontent.com/942359/27752533-7b713a2e-5daf-11e7-92b4-ca6080b1ec78.png)

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p8F9tW-3F-p2.

**To test:**

- `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Draft a post.
- Click on "Publish...".
- Make sure that the header message is displayed at the top of the confirmation sidebar.
- Make sure the publish button now reads "Publish!"
- Publish the post.
- Ta-da.