### PR TITLE
Magic Login: Improve width responsiveness & center form fields vertically

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -108,7 +108,7 @@ class RequestLoginEmailForm extends React.Component {
 				<h1 className="magic-login__form-header">
 					{ translate( 'Email me a login link.' ) }
 				</h1>
-				<p>
+				<p className="magic-login__description">
 					{ translate( 'Get a link sent to the email address associated ' +
 						'with your account to log in instantly without your password.' ) }
 				</p>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -121,7 +121,7 @@ class RequestLoginEmailForm extends React.Component {
 						} ) }</p>
 				}
 				<LoggedOutForm onSubmit={ this.onSubmit }>
-					<FormFieldset>
+					<FormFieldset className="magic-login__emailfields">
 						<FormTextInput
 							autoCapitalize="off"
 							autoFocus="true"

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -25,6 +25,10 @@
 	text-align: center;
 }
 
+.magic-login__emailfields {
+	margin: 10px 0;
+}
+
 .magic-login__form-action {
 	margin-top: 10px;
 	overflow: auto;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -1,3 +1,19 @@
+.magic-login__description {
+	margin: 0 auto 1.5em;
+	max-width: 400px;
+	text-align: center;
+
+	@media ( max-width: 480px ) {
+		& {
+			font-size: 90%;
+			margin: auto;
+			max-width: 340px;
+			min-width: 110px;
+			padding: 0 16px 16px;
+		}
+	}
+}
+
 .magic-login__request_link {
 	max-width: 400px;
 }


### PR DESCRIPTION
On mobile, the description text goes all the way to the left side of the screen, and the email/button aren’t centered vertically in the white box.

This change improves width responsiveness of the description text & centers the form fields vertically within the box.

| Before | After |
| ------- | ----- |
| <img width="551" src="https://user-images.githubusercontent.com/1587282/27754891-baf484de-5dba-11e7-9de6-1a84ae57d086.png"> | <img width="375" src="https://user-images.githubusercontent.com/1587282/27758569-8587c286-5de5-11e7-8909-f217f90d6515.png"> |

## To Test

* Open https://calypso.live/log-in?branch=fix/magic-login-mobile-styles in an incognito / logged out window
* Reload at various viewport sizes & emulated device settings & make sure the user / password form is still properly displayed
* Click the `Email me a login link` link
* Reload at various viewport sizes & emulated device settings & make sure the magic login request form is still properly displayed
* Request an email
* Click through the CTA in the email in the incognito window
* Make sure the screen is properly displayed & complete the flow
* Attempt to reuse the same link & make sure the "Invalid or Expired" page is properly displayed
