### PR TITLE
Editor: Update EditorVisibility label and order.

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -10,6 +10,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import AsyncLoad from 'components/async-load';
 import Button from 'components/button';
 import FormToggle from 'components/forms/form-toggle/compact';
@@ -123,6 +124,8 @@ export class EditPostStatus extends Component {
 			siteUtils.gmtOffset( this.props.site )
 		).format( 'll LT' );
 
+		const isPostPublishFlow = config.isEnabled( 'post-editor/delta-post-publish-flow' );
+
 		return (
 			<div className="edit-post-status">
 				<span
@@ -144,6 +147,11 @@ export class EditPostStatus extends Component {
 					{ this.renderTZTooltop() }
 					{ this.renderPostSchedulePopover() }
 				</span>
+				{
+					isPostPublishFlow
+						? this.renderPostVisibility()
+						: null
+				}
 				{ this.props.type === 'post' && ! isPostPrivate && ! isPasswordProtected &&
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
@@ -183,7 +191,11 @@ export class EditPostStatus extends Component {
 						<Gridicon icon="undo" size={ 18 } /> { translate( 'Revert to draft' ) }
 					</Button>
 				}
-				{ this.renderPostVisibility() }
+				{
+					! isPostPublishFlow
+						? this.renderPostVisibility()
+						: null
+				}
 				<Revisions
 					revisions={ this.props.post && this.props.post.revisions }
 					adminUrl={ adminUrl }

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -42,7 +42,7 @@
 .edit-post-status__full-date {
 	color: $gray-text;
 	font-size: 13px;
-	display: inline-block;
+	display: flex;
 	margin-bottom: 4px;
 	padding-right: 5px;
 	cursor: pointer;

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -462,9 +462,6 @@ const EditorVisibility = React.createClass( {
 		return (
 			<div className="editor-visibility__dropdown">
 				<FormFieldset className="editor-fieldset">
-					<FormLegend className="editor-fieldset__legend">
-						{ this.props.translate( 'Post Visibility' ) }
-					</FormLegend>
 					<SelectDropdown
 						selectedText={ selectedItem ? selectedItem.label : this.props.translate( 'Select an option' ) }
 						selectedIcon={ selectedItem.icon }

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -486,15 +486,17 @@ const EditorVisibility = React.createClass( {
 
 	render() {
 		const visibility = this.getVisibility();
+		const isDropdown = config.isEnabled( 'post-editor/delta-post-publish-flow' );
 		const classes = classNames( 'editor-visibility', {
 			'is-dialog-open': this.state.showPopover,
-			'is-touch': touchDetect.hasTouch()
+			'is-touch': touchDetect.hasTouch(),
+			'is-dropdown': isDropdown,
 		} );
 
 		return (
 			<div className={ classes }>
 				{
-					config.isEnabled( 'post-editor/delta-post-publish-flow' )
+					isDropdown
 						? this.renderPrivacyDropdown( visibility )
 						: this.renderPrivacyPopover( visibility )
 				}

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -4,6 +4,10 @@
 	justify-content: space-between;
 	align-items: center;
 	margin: 0;
+
+	&.is-dropdown {
+		margin: 8px 0;
+	}
 }
 
 .editor-visibility__dropdown {


### PR DESCRIPTION
This PR removes the label from the dropdown version of the EditorVisibility component and conditionally changes its order within the post editor's post status area.

**Before (no flag)** | **After (w/flag)**
------------ | -------------
<img width="273" alt="before" src="https://user-images.githubusercontent.com/942359/27755054-9166c1d0-5dbb-11e7-8412-d89777a0b77a.png"> | <img width="271" alt="after" src="https://user-images.githubusercontent.com/942359/27755072-9570e576-5dbb-11e7-90ed-c0936239655f.png">

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p8F9tW-3F-p2.

**To Test:**
- `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Draft a post.
- Verify EditorVisibility dropdown position (at top), without label.
- Disable flag.
- Draft post.
- Verify EditorVisibility icon+text position (at bottom), also without label.