### PR TITLE
WooCommerce: Connect the delete icon to the delete action.

### DIFF
--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -27,7 +27,7 @@ function renderTrashButton( onTrash, product, isBusy, translate ) {
 	return onTrash && (
 		<Button borderless scary onClick={ onTrash }>
 			<Gridicon icon="trash" />
-			<span>{ translate( 'Trash' ) } </span>
+			<span>{ translate( 'Delete' ) } </span>
 		</Button>
 	);
 }

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -118,7 +118,9 @@ export const deleteProduct = (
 
 	dispatch( deleteAction );
 
-	return request( siteId ).del( `products/${ productId }` )
+	// ?force=true deletes a product instead of trashing
+	// In v1, we don't have trash management. Later we can trash instead.
+	return request( siteId ).del( `products/${ productId }?force=true` )
 		.then( ( data ) => {
 			dispatch( deleteProductSuccess( siteId, data ) );
 			if ( successAction ) {


### PR DESCRIPTION
Closes #13628.

This PR hooks up the delete/trash icon that displays on `Edit Product` to the action that actually deletes it. @kellychoffman I renamed the icon to `Delete`, and the action *deletes* the product, instead of trash. Until we have a concept of trash management (post-v1 feature), I think `Delete` makes more sense.

On successful delete, a success notice displays, and you are redirected back to the product list.

To Test:
* Go to your products list and select a product
* [Refresh the page], there is still a bug with `edit product` that is being fixed, where the current product isn't correctly set in state always. A refresh should pull in everything correctly.
* Click the `Delete` icon.
* Your product should be deleted, and you should be redirected.