### PR TITLE
Reader: add ability to set certain blog stickers from the post options menu

### DIFF
--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import { find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,11 +12,10 @@ import QueryBlogStickers from 'components/data/query-blog-stickers';
 import { getReaderTeams, getBlogStickers } from 'state/selectors';
 import BlogStickersList from 'blocks/blog-stickers/list';
 import InfoPopover from 'components/info-popover';
+import { isAutomatticTeamMember } from 'reader/lib/teams';
 
 const BlogStickers = ( { blogId, teams, stickers } ) => {
-	// If the user isn't in the a8c team, don't show the feature
-	const isTeamMember = !! find( teams, [ 'slug', 'a8c' ] );
-
+	const isTeamMember = isAutomatticTeamMember( teams );
 	if ( teams && ! isTeamMember ) {
 		return null;
 	}

--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -1,0 +1,48 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { connect } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import PopoverMenuItem from 'components/popover/menu-item';
+import { addBlogSticker } from 'state/sites/blog-stickers/actions';
+
+class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
+	static propTypes = {
+		blogId: React.PropTypes.number,
+		blogStickerName: React.PropTypes.string,
+		hasSticker: React.PropTypes.bool,
+	};
+
+	addSticker = () => {
+		if ( this.props.hasSticker ) {
+			return null;
+		}
+
+		this.props.addBlogSticker( this.props.blogId, this.props.blogStickerName );
+	};
+
+	render() {
+		const { hasSticker, blogStickerName, children } = this.props;
+		const classes = classnames( 'reader-post-options-menu__blog-sticker-menu-item', {
+			'has-sticker': hasSticker,
+		} );
+
+		return (
+			<PopoverMenuItem
+				icon="tag"
+				key={ blogStickerName }
+				className={ classes }
+				onClick={ this.addSticker }
+			>
+				{ children }
+			</PopoverMenuItem>
+		);
+	}
+}
+
+export default connect( null, { addBlogSticker } )( ReaderPostOptionsMenuBlogStickerMenuItem );

--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -34,7 +34,7 @@ class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 
 		return (
 			<PopoverMenuItem
-				icon="tag"
+				icon="flag"
 				key={ blogStickerName }
 				className={ classes }
 				onClick={ this.addSticker }

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { map } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenuItem from 'components/popover/menu-item';
+import { getBlogStickers } from 'state/selectors';
+
+class ReaderPostOptionsMenuBlogStickers extends React.Component {
+	static propTypes = {
+		siteId: React.PropTypes.number.isRequired,
+	};
+
+	render() {
+		const blogStickersOffered = [ 'dont-recommend', 'broken-in-reader' ];
+
+		// @todo
+		// - query blog stickers
+		// - highlighted state for stickers already set
+		// - onclick event for setting blog sticker
+		return (
+			<div className="reader-post-options-menu__blog-stickers">
+				{ map( blogStickersOffered, blogStickerName => (
+					<PopoverMenuItem
+						icon="tag"
+						key={ blogStickerName }
+						className="reader-post-options-menu__blog-stickers-item"
+					>
+						{ blogStickerName }
+					</PopoverMenuItem>
+				) ) }
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	return {
+		stickers: ownProps.siteId && ownProps.siteId > 0
+			? getBlogStickers( state, ownProps.blogId )
+			: undefined,
+	};
+} )( ReaderPostOptionsMenuBlogStickers );

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -10,10 +10,15 @@ import { connect } from 'react-redux';
  */
 import PopoverMenuItem from 'components/popover/menu-item';
 import { getBlogStickers } from 'state/selectors';
+import { addBlogSticker } from 'state/sites/blog-stickers/actions';
 
 class ReaderPostOptionsMenuBlogStickers extends React.Component {
 	static propTypes = {
 		siteId: React.PropTypes.number.isRequired,
+	};
+
+	addSticker = stickerName => {
+		this.props.addBlogSticker( this.props.siteId, stickerName );
 	};
 
 	render() {
@@ -30,6 +35,7 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 						icon="tag"
 						key={ blogStickerName }
 						className="reader-post-options-menu__blog-stickers-item"
+						onClick={ this.addSticker( blogStickerName ) }
 					>
 						{ blogStickerName }
 					</PopoverMenuItem>
@@ -39,10 +45,13 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	return {
-		stickers: ownProps.siteId && ownProps.siteId > 0
-			? getBlogStickers( state, ownProps.blogId )
-			: undefined,
-	};
-} )( ReaderPostOptionsMenuBlogStickers );
+export default connect(
+	( state, ownProps ) => {
+		return {
+			stickers: ownProps.siteId && ownProps.siteId > 0
+				? getBlogStickers( state, ownProps.blogId )
+				: undefined,
+		};
+	},
+	{ addBlogSticker }
+)( ReaderPostOptionsMenuBlogStickers );

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { map } from 'lodash';
+import { map, includes } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -11,35 +11,44 @@ import { connect } from 'react-redux';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { getBlogStickers } from 'state/selectors';
 import { addBlogSticker } from 'state/sites/blog-stickers/actions';
+import QueryBlogStickers from 'components/data/query-blog-stickers';
 
 class ReaderPostOptionsMenuBlogStickers extends React.Component {
 	static propTypes = {
-		siteId: React.PropTypes.number.isRequired,
+		blogId: React.PropTypes.number.isRequired,
 	};
 
 	addSticker = stickerName => {
-		this.props.addBlogSticker( this.props.siteId, stickerName );
+		this.props.addBlogSticker( this.props.blogId, stickerName );
 	};
 
 	render() {
 		const blogStickersOffered = [ 'dont-recommend', 'broken-in-reader' ];
+		const { blogId, stickers } = this.props;
 
-		// @todo
-		// - query blog stickers
-		// - highlighted state for stickers already set
-		// - onclick event for setting blog sticker
 		return (
 			<div className="reader-post-options-menu__blog-stickers">
-				{ map( blogStickersOffered, blogStickerName => (
-					<PopoverMenuItem
-						icon="tag"
-						key={ blogStickerName }
-						className="reader-post-options-menu__blog-stickers-item"
-						onClick={ this.addSticker( blogStickerName ) }
-					>
-						{ blogStickerName }
-					</PopoverMenuItem>
-				) ) }
+				{ map(
+					blogStickersOffered,
+					blogStickerName =>
+						( includes( blogStickerName, stickers )
+							? <PopoverMenuItem
+									icon="tag"
+									key={ blogStickerName }
+									className="reader-post-options-menu__blog-stickers-item has-sticker"
+								>
+									{ blogStickerName }
+								</PopoverMenuItem>
+							: <PopoverMenuItem
+									icon="tag"
+									key={ blogStickerName }
+									className="reader-post-options-menu__blog-stickers-item"
+									onClick={ this.addSticker( blogStickerName ) }
+								>
+									{ blogStickerName }
+								</PopoverMenuItem> )
+				) }
+				{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			</div>
 		);
 	}
@@ -48,7 +57,7 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 export default connect(
 	( state, ownProps ) => {
 		return {
-			stickers: ownProps.siteId && ownProps.siteId > 0
+			stickers: ownProps.blogId && ownProps.blogId > 0
 				? getBlogStickers( state, ownProps.blogId )
 				: undefined,
 		};

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -8,18 +8,13 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import PopoverMenuItem from 'components/popover/menu-item';
 import { getBlogStickers } from 'state/selectors';
-import { addBlogSticker } from 'state/sites/blog-stickers/actions';
 import QueryBlogStickers from 'components/data/query-blog-stickers';
+import ReaderPostOptionsMenuBlogStickerMenuItem from './blog-sticker-menu-item';
 
 class ReaderPostOptionsMenuBlogStickers extends React.Component {
 	static propTypes = {
 		blogId: React.PropTypes.number.isRequired,
-	};
-
-	addSticker = stickerName => {
-		this.props.addBlogSticker( this.props.blogId, stickerName );
 	};
 
 	render() {
@@ -28,39 +23,26 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 
 		return (
 			<div className="reader-post-options-menu__blog-stickers">
-				{ map(
-					blogStickersOffered,
-					blogStickerName =>
-						( includes( blogStickerName, stickers )
-							? <PopoverMenuItem
-									icon="tag"
-									key={ blogStickerName }
-									className="reader-post-options-menu__blog-stickers-item has-sticker"
-								>
-									{ blogStickerName }
-								</PopoverMenuItem>
-							: <PopoverMenuItem
-									icon="tag"
-									key={ blogStickerName }
-									className="reader-post-options-menu__blog-stickers-item"
-									onClick={ this.addSticker( blogStickerName ) }
-								>
-									{ blogStickerName }
-								</PopoverMenuItem> )
-				) }
+				{ map( blogStickersOffered, blogStickerName => (
+					<ReaderPostOptionsMenuBlogStickerMenuItem
+						key={ blogStickerName }
+						blogId={ blogId }
+						blogStickerName={ blogStickerName }
+						hasSticker={ includes( stickers, blogStickerName ) }
+					>
+						{ blogStickerName }
+					</ReaderPostOptionsMenuBlogStickerMenuItem>
+				) ) }
 				{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			</div>
 		);
 	}
 }
 
-export default connect(
-	( state, ownProps ) => {
-		return {
-			stickers: ownProps.blogId && ownProps.blogId > 0
-				? getBlogStickers( state, ownProps.blogId )
-				: undefined,
-		};
-	},
-	{ addBlogSticker }
-)( ReaderPostOptionsMenuBlogStickers );
+export default connect( ( state, ownProps ) => {
+	return {
+		stickers: ownProps.blogId && ownProps.blogId > 0
+			? getBlogStickers( state, ownProps.blogId )
+			: undefined,
+	};
+} )( ReaderPostOptionsMenuBlogStickers );

--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -41,8 +41,6 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 
 export default connect( ( state, ownProps ) => {
 	return {
-		stickers: ownProps.blogId && ownProps.blogId > 0
-			? getBlogStickers( state, ownProps.blogId )
-			: undefined,
+		stickers: ownProps.blogId ? getBlogStickers( state, ownProps.blogId ) : undefined,
 	};
 } )( ReaderPostOptionsMenuBlogStickers );

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -24,7 +24,8 @@ import QueryReaderFeed from 'components/data/query-reader-feed';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderTeams from 'components/data/query-reader-teams';
 import { isAutomatticTeamMember } from 'reader/lib/teams';
-import { getReaderTeams, getBlogStickers } from 'state/selectors';
+import { getReaderTeams } from 'state/selectors';
+import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {
@@ -59,7 +60,7 @@ class ReaderPostOptionsMenu extends React.Component {
 
 		window.open(
 			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ),
-			'_blank',
+			'_blank'
 		);
 	};
 
@@ -74,7 +75,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		stats.recordGaEvent( isMenuVisible ? 'Open Post Options Menu' : 'Close Post Options Menu' );
 		stats.recordTrackForPost(
 			'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ),
-			this.props.post,
+			this.props.post
 		);
 	};
 
@@ -105,7 +106,7 @@ class ReaderPostOptionsMenu extends React.Component {
 			isEditPossible = PostUtils.userCan( 'edit_post', post ),
 			isDiscoverPost = DiscoverHelper.isDiscoverPost( post ),
 			followUrl = this.getFollowUrl();
-		const { site, feed, teams /*, stickers*/ } = this.props;
+		const { site, feed, teams } = this.props;
 		const isTeamMember = isAutomatticTeamMember( teams );
 
 		let isBlockPossible = false;
@@ -137,10 +138,7 @@ class ReaderPostOptionsMenu extends React.Component {
 					popoverClassName="reader-post-options-menu__popover"
 					onToggle={ this.onMenuToggle }
 				>
-					{ isTeamMember &&
-						<PopoverMenuItem icon="pencil">
-							Stickers!
-						</PopoverMenuItem> }
+					{ isTeamMember && site && <ReaderPostOptionsMenuBlogStickers siteId={ +site.ID } /> }
 
 					{ this.props.showFollow &&
 						<FollowButton tagName={ PopoverMenuItem } siteUrl={ followUrl } /> }
@@ -177,11 +175,10 @@ export default connect(
 		return {
 			feed: feedId && feedId > 0 ? getFeed( state, feedId ) : undefined,
 			site: siteId && siteId > 0 ? getSite( state, siteId ) : undefined,
-			stickers: siteId && siteId > 0 ? getBlogStickers( state, ownProps.blogId ) : undefined,
 			teams: getReaderTeams( state ),
 		};
 	},
 	{
 		requestSiteBlock,
-	},
+	}
 )( localize( ReaderPostOptionsMenu ) );

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -60,7 +60,7 @@ class ReaderPostOptionsMenu extends React.Component {
 
 		window.open(
 			'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ),
-			'_blank'
+			'_blank',
 		);
 	};
 
@@ -75,7 +75,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		stats.recordGaEvent( isMenuVisible ? 'Open Post Options Menu' : 'Close Post Options Menu' );
 		stats.recordTrackForPost(
 			'calypso_reader_post_options_menu_' + ( isMenuVisible ? 'opened' : 'closed' ),
-			this.props.post
+			this.props.post,
 		);
 	};
 
@@ -180,5 +180,5 @@ export default connect(
 	},
 	{
 		requestSiteBlock,
-	}
+	},
 )( localize( ReaderPostOptionsMenu ) );

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -138,7 +138,7 @@ class ReaderPostOptionsMenu extends React.Component {
 					popoverClassName="reader-post-options-menu__popover"
 					onToggle={ this.onMenuToggle }
 				>
-					{ isTeamMember && site && <ReaderPostOptionsMenuBlogStickers siteId={ +site.ID } /> }
+					{ isTeamMember && site && <ReaderPostOptionsMenuBlogStickers blogId={ +site.ID } /> }
 
 					{ this.props.showFollow &&
 						<FollowButton tagName={ PopoverMenuItem } siteUrl={ followUrl } /> }

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -70,4 +70,14 @@
 	.gridicon {
 		fill: $alert-green;
 	}
+
+	&:hover,
+	&:focus {
+		color: $white;
+		background: $alert-green;
+
+		.gridicon {
+			fill: $white;
+		}
+	}
 }

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -60,11 +60,11 @@
 	}
 }
 
-.reader-post-options-menu__blog-stickers-item {
+.reader-post-options-menu__blog-sticker-menu-item {
 	width: 100%;
 }
 
-.reader-post-options-menu__blog-stickers-item.has-sticker {
+.reader-post-options-menu__blog-sticker-menu-item.has-sticker {
 	color: $alert-green;
 
 	.gridicon {
@@ -75,6 +75,7 @@
 	&:focus {
 		color: $white;
 		background: $alert-green;
+		cursor: default;
 
 		.gridicon {
 			fill: $white;

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -24,11 +24,12 @@
 .reader-post-options-menu__popover {
 
 	.popover__menu .follow-button {
+		padding: 9px 16px;
 
 		.gridicon {
 			position: absolute;
-				left: 14px;
-				top: 11px;
+				left: 17px;
+				top: 12px;
 		}
 
 		&:hover,
@@ -57,28 +58,40 @@
 
 	.popover__menu .follow-button__label {
 		display: inline-block;
+		margin-left: 26px;
 	}
 }
 
-.reader-post-options-menu__blog-sticker-menu-item {
+.popover__menu-item.reader-post-options-menu__blog-sticker-menu-item {
+	padding: 6px 16px 9px;
 	width: 100%;
-}
-
-.reader-post-options-menu__blog-sticker-menu-item.has-sticker {
-	color: $alert-green;
 
 	.gridicon {
-		fill: $alert-green;
+		position: relative;
+			left: -1px;
+			top: 1px;
 	}
 
-	&:hover,
-	&:focus {
-		color: $white;
-		background: $alert-green;
-		cursor: default;
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	&.has-sticker {
+		color: $alert-red;
 
 		.gridicon {
-			fill: $white;
+			fill: $alert-red;
+		}
+
+		&:hover,
+		&:focus {
+			color: $white;
+			background: $alert-red;
+			cursor: default;
+
+			.gridicon {
+				fill: $white;
+			}
 		}
 	}
 }

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -59,3 +59,7 @@
 		display: inline-block;
 	}
 }
+
+.reader-post-options-menu__blog-stickers-item {
+	width: 100%;
+}

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -63,3 +63,11 @@
 .reader-post-options-menu__blog-stickers-item {
 	width: 100%;
 }
+
+.reader-post-options-menu__blog-stickers-item.has-sticker {
+	color: $alert-green;
+
+	.gridicon {
+		fill: $alert-green;
+	}
+}

--- a/client/reader/lib/teams/index.js
+++ b/client/reader/lib/teams/index.js
@@ -1,0 +1,6 @@
+/**
+ * External Dependencies
+ */
+import { find } from 'lodash';
+
+export const isAutomatticTeamMember = teams => !! find( teams, [ 'slug', 'a8c' ] );

--- a/client/reader/lib/teams/test/index.js
+++ b/client/reader/lib/teams/test/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isAutomatticTeamMember } from '../';
+
+describe( 'isAutomatticTeamMember', () => {
+	it( 'should return true if teams include a8c', () => {
+		expect( isAutomatticTeamMember( [ { slug: 'a8c' }, { slug: 'okapi' } ] ) ).to.be.true;
+	} );
+
+	it( 'should return false if teams do include a8c', () => {
+		expect( isAutomatticTeamMember( [] ) ).to.be.false;
+		expect( isAutomatticTeamMember( [ { slug: 'okapi' } ] ) ).to.be.false;
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -24,7 +24,7 @@ export function requestBlogStickerList( { dispatch }, action ) {
 			apiVersion: '1.1',
 			onSuccess: action,
 			onFailure: action,
-		} )
+		} ),
 	);
 }
 
@@ -41,8 +41,8 @@ export function receiveBlogStickerList( store, action, next, response ) {
 export function receiveBlogStickerListError( { dispatch } ) {
 	dispatch(
 		errorNotice(
-			translate( 'Sorry, we had a problem retrieving blog stickers. Please try again.' )
-		)
+			translate( 'Sorry, we had a problem retrieving blog stickers. Please try again.' ),
+		),
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -11,7 +11,7 @@ import { SITES_BLOG_STICKER_LIST } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
-import { addBlogStickerHandler } from 'state/data-layer/wpcom/sites/blog-stickers/add';
+import addBlogStickerHandler from 'state/data-layer/wpcom/sites/blog-stickers/add';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveBlogStickers } from 'state/sites/blog-stickers/actions';
 
@@ -24,7 +24,7 @@ export function requestBlogStickerList( { dispatch }, action ) {
 			apiVersion: '1.1',
 			onSuccess: action,
 			onFailure: action,
-		} ),
+		} )
 	);
 }
 
@@ -41,8 +41,8 @@ export function receiveBlogStickerList( store, action, next, response ) {
 export function receiveBlogStickerListError( { dispatch } ) {
 	dispatch(
 		errorNotice(
-			translate( 'Sorry, we had a problem retrieving blog stickers. Please try again.' ),
-		),
+			translate( 'Sorry, we had a problem retrieving blog stickers. Please try again.' )
+		)
 	);
 }
 


### PR DESCRIPTION
This PR enables Automattic team members to set the blog stickers 'dont-recommend' and 'broken-in-reader' from the post options menu.

<img width="247" alt="screen shot 2017-07-06 at 15 24 40" src="https://user-images.githubusercontent.com/17325/27915825-431b3d32-625f-11e7-91f7-6d68ada0de57.png">
