### PR TITLE
Framework: Update gridicons to 2.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -989,7 +989,7 @@
       "dev": true,
       "dependencies": {
         "commander": {
-          "version": "2.10.0",
+          "version": "2.11.0",
           "dev": true
         },
         "glob": {
@@ -2688,7 +2688,7 @@
       "version": "1.0.1"
     },
     "gridicons": {
-      "version": "1.1.0"
+      "version": "2.0.0"
     },
     "growl": {
       "version": "1.9.2",
@@ -2905,7 +2905,7 @@
           "version": "1.5.2"
         },
         "commander": {
-          "version": "2.10.0"
+          "version": "2.11.0"
         }
       }
     },
@@ -2989,7 +2989,7 @@
       "version": "1.0.5"
     },
     "irregular-plurals": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dev": true
     },
     "is-arrayish": {
@@ -3075,7 +3075,7 @@
       "dev": true,
       "dependencies": {
         "isobject": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "dev": true
         }
       }
@@ -4924,7 +4924,7 @@
           "version": "5.8.38"
         },
         "commander": {
-          "version": "2.10.0"
+          "version": "2.11.0"
         }
       }
     },
@@ -6240,7 +6240,7 @@
           "dev": true
         },
         "commander": {
-          "version": "2.10.0",
+          "version": "2.11.0",
           "dev": true
         },
         "content-disposition": {
@@ -6366,7 +6366,7 @@
           "dev": true
         },
         "commander": {
-          "version": "2.10.0",
+          "version": "2.11.0",
           "dev": true
         },
         "component-emitter": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "1.1.0",
+    "gridicons": "2.0.0",
     "hard-source-webpack-plugin": "0.0.42",
     "he": "0.5.0",
     "html-loader": "0.4.0",


### PR DESCRIPTION
This PR updates gridicons to 2.0.0.

The 2.0 release includes new icons, React 15.5 PropTypes, and the ability to pass through arbitrary props to the SVG.

### Testing Instructions
- No noticeable changes to Calypso
- Navigate to http://calypso.localhost:3000/devdocs/design/gridicons icons appear as expected
- Icons appear correctly in other sections

<img width="852" alt="screen shot 2017-06-30 at 5 46 20 pm" src="https://user-images.githubusercontent.com/1270189/27757854-2c5a6a3e-5dbc-11e7-98f1-e574347160c4.png">
