### PR TITLE
Reader Feed Header: move site badge to its own component

### DIFF
--- a/client/blocks/reader-feed-header/README.md
+++ b/client/blocks/reader-feed-header/README.md
@@ -1,8 +1,9 @@
 # Reader Feed Header
 
-A header for the new feed/site stream. This can combine information from a site and a feed object to come up with the final display.
+The header for the feed/site stream. This can combine information from a site and a feed object to come up with the final display.
 
 ## Props
 
 - `site`: The site to use for the header
 - `feed`: The feed to use for the header
+- `showBack`: Show the back button?

--- a/client/blocks/reader-feed-header/badge.jsx
+++ b/client/blocks/reader-feed-header/badge.jsx
@@ -1,0 +1,25 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import Gridicon from 'gridicons';
+
+const ReaderFeedHeaderSiteBadge = ( { site } ) => {
+	/* eslint-disable wpcalypso/jsx-gridicon-size */
+	if ( site && site.is_private ) {
+		return <Gridicon icon="lock" size={ 14 } />;
+	} else if ( site && site.options && site.options.is_redirect ) {
+		return <Gridicon icon="block" size={ 14 } />;
+	} else if ( site && site.options && site.options.is_domain_only ) {
+		return <Gridicon icon="domains" size={ 14 } />;
+	}
+
+	return null;
+	/* eslint-enable wpcalypso/jsx-gridicon-size */
+};
+
+ReaderFeedHeaderSiteBadge.propTypes = {
+	site: React.PropTypes.object,
+};
+
+export default ReaderFeedHeaderSiteBadge;

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -13,25 +13,14 @@ import ReaderFollowButton from 'reader/follow-button';
 import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 import HeaderBack from 'reader/header-back';
 import { getSiteDescription, getSiteName, getSiteUrl } from 'reader/get-helpers';
-import Gridicon from 'gridicons';
 import SiteIcon from 'blocks/site-icon';
 import BlogStickers from 'blocks/blog-stickers';
-
-const getBadgeForSite = site => {
-	/* eslint-disable wpcalypso/jsx-gridicon-size */
-	if ( site && site.is_private ) {
-		return <Gridicon icon="lock" size={ 14 } />;
-	} else if ( site && site.options && site.options.is_redirect ) {
-		return <Gridicon icon="block" size={ 14 } />;
-	} else if ( site && site.options && site.options.is_domain_only ) {
-		return <Gridicon icon="domains" size={ 14 } />;
-	}
-	return null;
-	/* eslint-enable wpcalypso/jsx-gridicon-size */
-};
+import ReaderFeedHeaderSiteBadge from './badge';
 
 class FeedHeader extends Component {
 	static propTypes = {
+		site: React.PropTypes.object,
+		feed: React.PropTypes.object,
 		showBack: React.PropTypes.bool,
 	};
 
@@ -48,37 +37,35 @@ class FeedHeader extends Component {
 	};
 
 	render() {
-		const { site, feed } = this.props;
+		const { site, feed, showBack, translate } = this.props;
 		const followerCount = this.getFollowerCount( feed, site );
 		const ownerDisplayName = site && ! site.is_multi_author && site.owner && site.owner.name;
 		const description = getSiteDescription( { site, feed } );
 		const siteTitle = getSiteName( { feed, site } );
-		const siteBadge = getBadgeForSite( site );
 		const siteUrl = getSiteUrl( { feed, site } );
 
 		const classes = classnames( 'reader-feed-header', {
 			'is-placeholder': ! site && ! feed,
-			'has-back-button': this.props.showBack,
+			'has-back-button': showBack,
 		} );
 
 		return (
 			<div className={ classes }>
 				<div className="reader-feed-header__back-and-follow">
-					{ this.props.showBack && <HeaderBack /> }
+					{ showBack && <HeaderBack /> }
 					<div className="reader-feed-header__follow">
-						{ followerCount
-							? <span className="reader-feed-header__follow-count">
-									{ ' ' }
-									{ this.props.translate( '%s follower', '%s followers', {
-										count: followerCount,
-										args: [ this.props.numberFormat( followerCount ) ],
-									} ) }
-								</span>
-							: null }
-						{ this.props.feed &&
-							! this.props.feed.is_error &&
+						{ followerCount &&
+							<span className="reader-feed-header__follow-count">
+								{ ' ' }
+								{ translate( '%s follower', '%s followers', {
+									count: followerCount,
+									args: [ this.props.numberFormat( followerCount ) ],
+								} ) }
+							</span> }
+						{ feed &&
+							! feed.is_error &&
 							<div className="reader-feed-header__follow-button">
-								<ReaderFollowButton siteUrl={ this.props.feed.feed_URL } iconSize={ 24 } />
+								<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
 							</div> }
 					</div>
 				</div>
@@ -89,7 +76,7 @@ class FeedHeader extends Component {
 					<div className="reader-feed-header__site-title">
 						{ site &&
 							<span className="reader-feed-header__site-badge">
-								{ siteBadge }
+								<ReaderFeedHeaderSiteBadge site={ site } />
 								<BlogStickers blogId={ site.ID } />
 							</span> }
 						<a className="reader-feed-header__site-title-link" href={ siteUrl }>
@@ -101,7 +88,7 @@ class FeedHeader extends Component {
 						{ ownerDisplayName &&
 							! isAuthorNameBlacklisted( ownerDisplayName ) &&
 							<span className="reader-feed-header__byline">
-								{ this.props.translate( 'by %(author)s', {
+								{ translate( 'by %(author)s', {
 									args: {
 										author: ownerDisplayName,
 									},


### PR DESCRIPTION
As suggested by @blowery, create a new component for the site badge in the Reader feed header.

### To test

You can see the feed header on any Reader site or feed stream, e.g.

http://calypso.localhost:3000/read/blogs/122463145

Visit a site stream for a private site and verify that the padlock icon still appears:

<img width="166" alt="screen shot 2017-07-01 at 08 56 27" src="https://user-images.githubusercontent.com/17325/27762217-b97d664e-5e3b-11e7-9e56-2f87a060a83d.png">
