### PR TITLE
Framework: Remove sites-list dependency on plugins-browser

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -146,11 +146,9 @@ function renderPluginsBrowser( context ) {
 
 	renderWithReduxStore(
 		React.createElement( PluginBrowser, {
-			site: site ? site.slug : null,
 			path: context.path,
 			category,
-			sites,
-			search: searchTerm
+			search: searchTerm,
 		} ),
 		document.getElementById( 'primary' ),
 		context.store

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -270,7 +270,7 @@ const PluginsMain = React.createClass( {
 
 	renderPluginsContent() {
 		const { plugins = [] } = this.state;
-		const { filter, search, selectedSite } = this.props;
+		const { filter, search } = this.props;
 
 		const showInstalledPluginList = ! isEmpty( plugins ) || this.isFetchingPlugins();
 		const showSuggestedPluginsList = filter === 'all' || ( ! showInstalledPluginList && search );
@@ -313,11 +313,8 @@ const PluginsMain = React.createClass( {
 		const suggestedPluginsList = showSuggestedPluginsList && (
 			<PluginsBrowser
 				hideSearchForm
-				site={ selectedSite ? selectedSite.slug : null }
 				path={ this.context.path }
-				sites={ this.props.sites }
 				search={ search }
-				store={ this.context.store }
 				searchTitle={ searchTitle }
 			/>
 		);

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -306,7 +306,7 @@ const PluginsBrowser = React.createClass( {
 			return null;
 		}
 
-		const site = this.props.site ? '/' + this.props.site : '';
+		const site = this.props.siteSlug ? '/' + this.props.siteSlug : '';
 		return (
 			<HeaderButton
 				icon="cog"
@@ -325,8 +325,8 @@ const PluginsBrowser = React.createClass( {
 			return null;
 		}
 
-		const { site, translate } = this.props;
-		const uploadUrl = '/plugins/upload' + ( site ? '/' + site : '' );
+		const { siteSlug, translate } = this.props;
+		const uploadUrl = '/plugins/upload' + ( siteSlug ? '/' + siteSlug : '' );
 
 		return (
 			<HeaderButton
@@ -434,7 +434,6 @@ const PluginsBrowser = React.createClass( {
 export default connect(
 	state => {
 		const selectedSiteId = getSelectedSiteId( state );
-		const sites = getSelectedOrAllSitesJetpackCanManage( state );
 		return {
 			sitePlan: getSitePlan( state, selectedSiteId ),
 			isJetpackSite: isJetpackSite( state, selectedSiteId ),
@@ -445,7 +444,7 @@ export default connect(
 			selectedSiteId,
 			selectedSite: getSelectedSite( state ),
 			siteSlug: getSelectedSiteSlug( state ),
-			sites,
+			sites: getSelectedOrAllSitesJetpackCanManage( state ),
 		};
 	},
 	{


### PR DESCRIPTION
This PR removes sites-list dependency from plugins-browser.

It is dependent on the following PR:
- https://github.com/Automattic/wp-calypso/pull/16266 - make changes to lib/plugins that make it compatible with the new site object

Can not be merged before the PR it depends on!

Some functions are passed as props isJetpackSite: siteId => isJetpackSite( state, siteId ), this is a widely used technique in plug-ins I don't see a reason for it in most cases, and I will create a pull request that passes values instead of functions eg: isJetpackSite: isJetpackSite( state, siteId ).

To test:
Test the following URL combinations:
• http://calypso.localhost:3000/plugins/browse/{site/no-site/jetpack-site},
See if it is possible to browse the plug-ins without errors.
