### PR TITLE
Framework: removed site-list dependency from plugin.

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -63,7 +63,6 @@ function renderSinglePlugin( context, siteUrl ) {
 			path: context.path,
 			prevQuerystring: lastPluginsQuerystring,
 			prevPath,
-			sites,
 			pluginSlug,
 			siteUrl,
 		} ),

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -123,7 +123,7 @@ const PluginSiteJetpack = React.createClass( {
 			return null;
 		}
 
-		if ( ! this.props.site.canManage() ) {
+		if ( ! this.props.site.canManage ) {
 			return this.renderManageWarning();
 		}
 

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -123,7 +123,11 @@ const PluginSiteJetpack = React.createClass( {
 			return null;
 		}
 
-		if ( ! this.props.site.canManage ) {
+		if (
+			! ( typeof this.props.site.canManage === 'function'
+				? this.props.site.canManage()
+				: this.props.site.canManage )
+		) {
 			return this.renderManageWarning();
 		}
 

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -30,7 +30,7 @@ export default React.createClass( {
 	},
 
 	renderInstallButton: function() {
-		if ( ! this.props.site.canManage() ) {
+		if ( ! this.props.site.canManage ) {
 			return this.renderManageWarning();
 		}
 		const installInProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, 'INSTALL_PLUGIN' );
@@ -71,7 +71,7 @@ export default React.createClass( {
 	},
 
 	renderPluginActions: function() {
-		if ( ! this.props.site.canManage() ) {
+		if ( ! this.props.site.canManage ) {
 			return this.renderManageWarning();
 		}
 
@@ -113,7 +113,7 @@ export default React.createClass( {
 	},
 
 	renderSecondarySiteActions: function( site ) {
-		if ( ! site.canManage() ) {
+		if ( ! site.canManage ) {
 			return (
 				<div className="plugin-site-network__secondary-site-actions">
 					<PluginSiteDisabledManage site={ site } plugin={ site.plugin } />

--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -30,7 +30,11 @@ export default React.createClass( {
 	},
 
 	renderInstallButton: function() {
-		if ( ! this.props.site.canManage ) {
+		if (
+			! ( typeof this.props.site.canManage === 'function'
+				? this.props.site.canManage()
+				: this.props.site.canManage )
+		) {
 			return this.renderManageWarning();
 		}
 		const installInProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, 'INSTALL_PLUGIN' );
@@ -71,7 +75,11 @@ export default React.createClass( {
 	},
 
 	renderPluginActions: function() {
-		if ( ! this.props.site.canManage ) {
+		if (
+			! ( typeof this.props.site.canManage === 'function'
+				? this.props.site.canManage()
+				: this.props.site.canManage )
+		) {
 			return this.renderManageWarning();
 		}
 
@@ -113,7 +121,7 @@ export default React.createClass( {
 	},
 
 	renderSecondarySiteActions: function( site ) {
-		if ( ! site.canManage ) {
+		if ( ! ( site.canManage === 'function' ? site.canManage() : site.canManage ) ) {
 			return (
 				<div className="plugin-site-network__secondary-site-actions">
 					<PluginSiteDisabledManage site={ site } plugin={ site.plugin } />


### PR DESCRIPTION
This PR removes sites-list dependency on plugin.jsx


**To test:**
Test the following URL combinations:
• http://calypso.localhost:3000/plugins/hello-dolly/{site/no-site/jetpack-site},
See if it is possible to see the plugin and to execute the actions (install, remove, auto update, enable, disable) without any problem or error.


**Test Live:**
https://calypso.live/?branch=update/remove-sites-list-dependency-plugin
