### PR TITLE
Framework: Remove sites-list dependency from plugins/controller.

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -11,23 +11,22 @@ import { capitalize, some } from 'lodash';
  */
 import route from 'lib/route';
 import notices from 'notices';
-import sitesFactory from 'lib/sites-list';
 import analytics from 'lib/analytics';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginEligibility from './plugin-eligibility';
 import PluginListComponent from './main';
 import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
+import PluginUpload from './plugin-upload';
 import { renderWithReduxStore, renderPage } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 import { getSelectedSite, getSection } from 'state/ui/selectors';
-import PluginUpload from './plugin-upload';
+import { hasJetpackSites, getSelectedOrAllSitesWithPlugins } from 'state/selectors';
 
 /**
  * Module variables
  */
 const allowedCategoryNames = [ 'new', 'popular', 'featured' ];
-const sites = sitesFactory();
 
 let lastPluginsListVisited,
 	lastPluginsQuerystring;
@@ -196,7 +195,7 @@ const controller = {
 		const basePath = route.sectionify( context.path ).replace( '/' + filter, '' );
 
 		// bail if no site is selected and the user has no Jetpack sites.
-		if ( ! siteUrl && sites.getJetpack().length === 0 ) {
+		if ( ! siteUrl && ! hasJetpackSites( context.store.getState() ) ) {
 			return next();
 		}
 
@@ -231,11 +230,11 @@ const controller = {
 	},
 
 	jetpackCanUpdate( filter, context, next ) {
-		const selectedSites = sites.getSelectedOrAllWithPlugins();
+		const selectedSites = getSelectedOrAllSitesWithPlugins( context.store.getState() );
 		let redirectToPlugins = false;
 
 		if ( 'updates' === filter && selectedSites.length ) {
-			redirectToPlugins = ! some( sites.getSelectedOrAllWithPlugins(), function( site ) {
+			redirectToPlugins = ! some( selectedSites, function( site ) {
 				return site && site.jetpack && site.canUpdateFiles;
 			} );
 


### PR DESCRIPTION
This PR removes sites-list dependency on plugins controller

It is dependent on PRs https://github.com/Automattic/wp-calypso/pull/15743, https://github.com/Automattic/wp-calypso/pull/15766, https://github.com/Automattic/wp-calypso/pull/15766 that remove sites-list dependencies from the components this controller render.

Test the following url combinations:
• http://calypso.localhost:3000/plugins/{site/no-site/jetpack-site}, 
• http://calypso.localhost:3000/plugins/hello-dolly/{site/no-site/jetpack-site},
• http://calypso.localhost:3000/plugins/browse/{site/no-site/jetpack-site}

Use the plugins section and make sure everything is behaving as it should and no new bugs were created.