### PR TITLE
Allow refund for plan with only domain mapping

### DIFF
--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -33,30 +33,16 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 			if ( includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
 				text = [
 					i18n.translate(
-						'This plan includes the custom domain mapping for %(mappedDomain)s, normally a %(mappingCost)s purchase. ' +
-							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
+						'This plan includes the custom domain mapping for %(mappedDomain)s, the mapping will be removed ' +
+						'together with the plan, your domain %(mappedDomain)s will stop functioning and ' +
+						"you'll recieve refund of %(refundAmount)s.",
 						{
 							args: {
 								mappedDomain: includedDomainPurchase.meta,
-								mappingCost: includedDomainPurchase.priceText,
-							},
-						}
-					),
-					i18n.translate(
-						'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus ' +
-							'%(mappingCost)s for the domain mapping. To cancel the domain mapping with the ' +
-							'plan and ask for a full refund, please {{contactLink}}contact support{{/contactLink}}.',
-						{
-							args: {
-								planCost: purchase.priceText,
-								mappingCost: includedDomainPurchase.priceText,
 								refundAmount: purchase.refundText,
 							},
-							components: {
-								contactLink: <a href={ support.CALYPSO_CONTACT } />,
-							},
 						}
-					),
+					)
 				];
 
 				showSupportLink = false;

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -38,7 +38,6 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 						{
 							args: {
 								mappedDomain: includedDomainPurchase.meta,
-								wordpressSiteUrl: purchase.domain,
 							},
 						}
 					),

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -33,14 +33,31 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 			if ( includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
 				text = [
 					i18n.translate(
-						'This plan includes the custom domain mapping for %(mappedDomain)s, the mapping will be removed ' +
-						'together with the plan, your domain %(mappedDomain)s will stop functioning and ' +
-						"you'll recieve refund of %(refundAmount)s.",
+						'This plan includes mapping for the domain %(mappedDomain)s. ' +
+						"Cancelling will remove all the plan's features from your site, including the domain.",
 						{
 							args: {
 								mappedDomain: includedDomainPurchase.meta,
-								refundAmount: purchase.refundText,
+								wordpressSiteUrl: purchase.domain,
 							},
+						}
+					),
+					i18n.translate(
+						'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s',
+						{
+							args: {
+								mappedDomain: includedDomainPurchase.meta,
+								wordpressSiteUrl: purchase.domain,
+							},
+						}
+					),
+					i18n.translate(
+						'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
+						'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.',
+						{
+							args: {
+								mappedDomain: includedDomainPurchase.meta,
+							}
 						}
 					)
 				];


### PR DESCRIPTION
Fixes #13494 together with D6228:
Allows users to fully refund plan if they have not purchased a domain, and only have domain mapping.

![screen shot 2017-07-03 at 13 21 45](https://user-images.githubusercontent.com/326402/27788774-9b0e3522-5ff2-11e7-898c-95923b774258.png)

 
#### Testing instructions
Apply D6228
  
1. Run `git checkout update/allow-refund-for-plan-with-mapped-domain` and start your server, or open a [live branch](https://calypso.live/?branch=update/allow-refund-for-plan-with-mapped-domain)
2. Open the [`Home` page](http://calypso.localhost:3000/)
3. Create a new site with a premium plan
4. Add a domain mapping to the plan
5. Go to purchases and refund plan
6. Assert you were refunded full price - $99 at Billing History

![screen shot 2017-07-02 at 16 13 25](https://user-images.githubusercontent.com/326402/27770132-d973ffc4-5f41-11e7-940c-f951776a0956.png)

 
#### Reviews
  
- [x] Code
- [x] Product
