### PR TITLE
Config: Remove manage/jetpack config flag

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -102,12 +102,6 @@ const controller = {
 			return;
 		}
 
-		// if user went directly to jetpack settings page, redirect
-		if ( isJetpackSite( state, siteId ) && ! config.isEnabled( 'manage/jetpack' ) ) {
-			window.location.href = '//wordpress.com/manage/' + siteId;
-			return;
-		}
-
 		renderPage(
 			context,
 			<SiteSettingsComponent section={ section } />

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -28,7 +28,6 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/import/medium": true,
-		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,

--- a/config/development.json
+++ b/config/development.json
@@ -69,7 +69,6 @@
 		"manage/export": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,6 @@
 		"manage/export": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,

--- a/config/production.json
+++ b/config/production.json
@@ -29,7 +29,6 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/import/medium": true,
-		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -32,7 +32,6 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/import/medium": true,
-		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,

--- a/config/test.json
+++ b/config/test.json
@@ -45,7 +45,6 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/import/medium": true,
-		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,7 +44,6 @@
 		"manage/export": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
-		"manage/jetpack": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,


### PR DESCRIPTION
While I was working on Site Settings I noticed that the `manage/jetpack` flag is always enabled in all of the environments. So we can safely remove it, together with the logic that works in case it's disabled. This is what this PR does, essentially.

There should be no functional/behavioral changes, since the flag has been enabled on all environments for a while now.

To test:
* Checkout this branch
* Do a quick check that everything works properly and there are no regressions:
  * Load several settings sections fresh and verify they load properly.
  * Verify switching between settings sections works as expected.
  * Try with a clean Redux state