### PR TITLE
Media library: check site exists before changing source for media

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -103,7 +103,7 @@ export class EditorMediaModal extends Component {
 		if ( nextProps.visible ) {
 			this.setState( this.getDefaultState( nextProps ) );
 
-			if ( nextProps.source && this.state.source !== nextProps.source ) {
+			if ( nextProps.source && this.state.source !== nextProps.source && nextProps.site ) {
 				// Signal that we're coming from another data source
 				MediaActions.sourceChanged( nextProps.site.ID );
 			}


### PR DESCRIPTION
Stops an error being thrown if the source is changed before the site has loaded. This typically only occurs when the editor is in HTML mode, and is caused by #15781. This PR makes the external media source change more resilient.

### Testing

In master:
1. Open the post editor and switch to HTML mode with devtools console open. You may see some unrelated warnings
1. Refresh the page and while the page still says 'loading' in the top right corner, click the media dropdown and pick 'add from google'
1. Note that an error is thrown

<img width="643" alt="error" src="https://user-images.githubusercontent.com/1277682/27790580-fa471d74-5fe8-11e7-932f-fafab9c3efc1.png">

Repeat above in `fix/external-media-site-checker` and note that an error is not thrown.

If you have difficulty clicking the dropdown before the page has loaded then use the API through a sandbox, or throttle your connection.