### PR TITLE
Media: enable external media in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -21,6 +21,7 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,
+		"external-media": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
Enables Google Photos on the staging server to get more user testing done. It's [currently enabled in development](https://github.com/Automattic/wp-calypso/blob/master/config/development.json#L52)

'Add from Google' will then be found in the post editor media dropdown on the staging server.

<img width="228" alt="dropdown" src="https://user-images.githubusercontent.com/1277682/27786981-2d0a10f8-5fdb-11e7-8e2e-11b64545fa59.png">
