### PR TITLE
Media library: tweak Google Photos text

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -89,7 +89,7 @@ export class MediaLibraryFilterBar extends Component {
 		const { translate } = this.props;
 
 		if ( this.props.source === 'google_photos' ) {
-			return <TitleItem>{ translate( 'Photos from Google' ) }</TitleItem>;
+			return <TitleItem>{ translate( 'Recent photos from Google' ) }</TitleItem>;
 		}
 
 		return null;

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -109,12 +109,12 @@ class SharingServiceDescription extends Component {
 			},
 			google_photos: function() {
 				if ( this.props.numberOfConnections > 0 ) {
-					return this.props.translate( 'Connected to your Google account.', {
+					return this.props.translate( 'Connected photos from your Google account.', {
 						comment: 'Description for Google Photos when one or more accounts are connected'
 					} );
 				}
 
-				return this.props.translate( 'Connect to your Google account.', {
+				return this.props.translate( 'Connect photos from your Google account.', {
 					comment: 'Description for Google Photos when no accounts are connected'
 				} );
 			}


### PR DESCRIPTION
Improve the wording around Google Photos to make it more explicit that the keyring connection is for recent photos.

The message shown to unconnected users on the sharing page will change from 'Connect to your Google account' to:

<img width="422" alt="sharing" src="https://user-images.githubusercontent.com/1277682/27787061-79579624-5fdb-11e7-96ca-0de84fae263a.png">

Also the title of the media library modal will change from 'Photos from Google' to 'Recent photos from Google'.

<img width="241" alt="recent" src="https://user-images.githubusercontent.com/1277682/27787119-b3df519c-5fdb-11e7-9d8a-52d7c9fadee6.png">

Note: we are not directly using the term 'Google Photos'

### Testing

Verify the above text changes.