### PR TITLE
Site Settings: Move Import settings to a separate section

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -23,7 +23,6 @@ import titlecase from 'to-title-case';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser, isVipSite } from 'state/selectors';
-import ImportSettings from './section-import';
 import ExportSettings from './section-export';
 import { SITES_ONCE_CHANGED } from 'state/action-types';
 
@@ -118,10 +117,6 @@ const controller = {
 			analyticsPageTitle += ' > ' + titlecase( section );
 		}
 		analytics.pageView.record( basePath + '/:site', analyticsPageTitle );
-	},
-
-	importSite( context ) {
-		renderPage( context, <ImportSettings /> );
 	},
 
 	exportSite( context ) {

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -24,13 +24,6 @@ module.exports = function() {
 		settingsController.siteSettings
 	);
 
-	page(
-		'/settings/import/:site_id',
-		controller.siteSelection,
-		controller.navigation,
-		settingsController.importSite
-	);
-
 	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
 		page(
 			'/settings/export/guided/:host_slug?/:site_id',

--- a/client/my-sites/site-settings/settings-import/controller.js
+++ b/client/my-sites/site-settings/settings-import/controller.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithReduxStore } from 'lib/react-helpers';
+import ImportSettings from 'my-sites/site-settings/settings-import/main';
+
+export default {
+	importSite( context ) {
+		renderWithReduxStore(
+			<ImportSettings />,
+			document.getElementById( 'primary' ),
+			context.store
+		);
+	},
+};

--- a/client/my-sites/site-settings/settings-import/index.js
+++ b/client/my-sites/site-settings/settings-import/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import controller from './controller';
+import mySitesController from 'my-sites/controller';
+
+export default function() {
+	page(
+		'/settings/import/:site_id',
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		controller.importSite
+	);
+}

--- a/client/my-sites/site-settings/settings-import/main.jsx
+++ b/client/my-sites/site-settings/settings-import/main.jsx
@@ -113,10 +113,10 @@ class SiteSettingsImport extends Component {
 					<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
 					<CompactCard>
 						<header>
-							<h1 className="site-settings__importer-section-title importer__section-title">
+							<h1 className="settings-import__section-title site-settings__importer-section-title importer__section-title">
 								{ translate( 'Import Another Site' ) }
 							</h1>
-							<p className="importer__section-description">{ description }</p>
+							<p className="settings-import__section-description importer__section-description">{ description }</p>
 						</header>
 					</CompactCard>
 

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -122,6 +122,13 @@ const sections = [
 		group: 'sites'
 	},
 	{
+		name: 'settings-import',
+		paths: [ '/settings/import' ],
+		module: 'my-sites/site-settings/settings-import',
+		secondary: true,
+		group: 'sites'
+	},
+	{
 		name: 'settings',
 		paths: [ '/settings' ],
 		module: 'my-sites/site-settings',


### PR DESCRIPTION
This PR moves the Import settings section to a separate chunk, similar to how some of the rest of the settings sections are split. Currently in production we have one `settings` chunk that is over 600K:
![](https://cldup.com/C9kQMlohN5.png)

This PR splits out the Import to a separate section, which reduces the size of the general settings chunk:
![](https://cldup.com/eMd_slmd-3.png)
![](https://cldup.com/elEhjuxJU9.png)

The size of the general settings chunk will be reduced even more as we land #15778.

A potential improvement to this can be preloading the Import chunk when hovering the "Import" link in the Site Tools card. I intend to implement this in a future PR, but I'm planning to land a common preloading tool before that.

To test:

* Checkout this branch.
* Test the following path with both a JP and WP.com site and verify there are no regressions with them:
  * http://calypso.localhost:3000/settings/import/
  * http://calypso.localhost:3000/settings/import/$site
* Verify the Import functionality works properly (for a .com site).
* Verify the General settings are still loaded properly without regressions.