### PR TITLE
Woo: Refactor product variations edit reducer

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/product-variations/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-variations/index.js
@@ -57,7 +57,7 @@ export function handleProductVariationCreate( store, action ) {
 	}
 
 	const updatedAction = ( dispatch, getState, data ) => {
-		dispatch( productVariationUpdated( siteId, data, action ) );
+		dispatch( productVariationUpdated( siteId, productId, data, action ) );
 
 		const props = { productId, sentData: variation, receivedData: data };
 		dispatchWithProps( dispatch, getState, successAction, props );
@@ -80,7 +80,7 @@ export function handleProductVariationUpdate( store, action ) {
 	}
 
 	const updatedAction = ( dispatch, getState, data ) => {
-		dispatch( productVariationUpdated( siteId, data, action ) );
+		dispatch( productVariationUpdated( siteId, productId, data, action ) );
 
 		const props = { productId: productId, sentData: variation, receivedData: data };
 		dispatchWithProps( dispatch, getState, successAction, props );

--- a/client/extensions/woocommerce/state/data-layer/ui/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/index.js
@@ -13,6 +13,7 @@ import { editProductRemoveCategory } from 'woocommerce/state/ui/products/actions
 import { getAllProductEdits } from 'woocommerce/state/ui/products/selectors';
 import { getAllVariationEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { getAllProductCategoryEdits } from 'woocommerce/state/ui/product-categories/selectors';
+import { getVariationsForProduct } from 'woocommerce/state/sites/product-variations/selectors';
 import { createProduct, updateProduct } from 'woocommerce/state/sites/products/actions';
 import { createProductVariation, updateProductVariation } from 'woocommerce/state/sites/product-variations/actions';
 import { createProductCategory } from 'woocommerce/state/sites/product-categories/actions';
@@ -23,14 +24,25 @@ import {
 	actionListClear,
 } from 'woocommerce/state/action-list/actions';
 import {
+	WOOCOMMERCE_PRODUCT_EDIT,
+	WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT,
 	WOOCOMMERCE_PRODUCT_CATEGORY_EDIT,
 	WOOCOMMERCE_PRODUCT_ACTION_LIST_CREATE,
 } from 'woocommerce/state/action-types';
 
 export default {
+	[ WOOCOMMERCE_PRODUCT_EDIT ]: [ actionAppendProductVariations ],
+	[ WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT ]: [ actionAppendProductVariations ],
 	[ WOOCOMMERCE_PRODUCT_CATEGORY_EDIT ]: [ handleProductCategoryEdit ],
 	[ WOOCOMMERCE_PRODUCT_ACTION_LIST_CREATE ]: [ handleProductActionListCreate ],
 };
+
+export function actionAppendProductVariations( { getState }, action ) {
+	const { siteId } = action;
+	const { id: productId } = action.product;
+
+	action.productVariations = getVariationsForProduct( getState(), productId, siteId );
+}
 
 export function handleProductCategoryEdit( { dispatch, getState }, action ) {
 	const rootState = getState();

--- a/client/extensions/woocommerce/state/data-layer/ui/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/index.js
@@ -39,7 +39,7 @@ export default {
 
 export function actionAppendProductVariations( { getState }, action ) {
 	const { siteId } = action;
-	const { id: productId } = action.product;
+	const productId = action.product && action.product.id;
 
 	action.productVariations = getVariationsForProduct( getState(), productId, siteId );
 }

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import { isEqual, uniqueId } from 'lodash';
 import { createReducer } from 'state/utils';
 
 /**
@@ -57,7 +57,7 @@ function editProduct( array, product, data ) {
 
 	// Look for this object in the appropriate create or edit array first.
 	const _array = prevArray.map( ( p ) => {
-		if ( product.id === p.id ) {
+		if ( isEqual( product.id, p.id ) ) {
 			found = true;
 			return { ...p, ...data };
 		}
@@ -75,13 +75,14 @@ function editProduct( array, product, data ) {
 
 export function editProductAttribute( attributes, attribute, data ) {
 	const prevAttributes = attributes || [];
+	const name = attribute && attribute.name;
 	const uid = attribute && attribute.uid || uniqueId( 'edit_' ) + ( new Date().getTime() );
 
 	let found = false;
 
 	// Look for this attribute in the array of attributes first.
 	const _attributes = prevAttributes.map( ( a ) => {
-		if ( uid === a.uid ) {
+		if ( ( uid && isEqual( uid, a.uid ) ) || ( name && isEqual( name, a.name ) ) ) {
 			found = true;
 			return { ...a, ...data };
 		}

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find, isObject } from 'lodash';
+import { get, find, isEqual, isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ export function getProductEdits( state, productId, siteId = getSelectedSiteId( s
 	const bucket = ( isObject( productId ) ? 'creates' : 'updates' );
 	const array = get( edits, bucket, [] );
 
-	return find( array, ( p ) => productId === p.id );
+	return find( array, ( p ) => isEqual( productId, p.id ) );
 }
 
 /**
@@ -82,7 +82,7 @@ export function getProductListProducts( state, siteId = getSelectedSiteId( state
 	const products = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], {} );
 	const productIds = get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'list', 'productIds' ], [] );
 	if ( productIds.length ) {
-		return productIds.map( id => find( products, ( p ) => id === p.id ) );
+		return productIds.map( id => find( products, ( p ) => isEqual( id, p.id ) ) );
 	}
 	return false;
 }
@@ -120,7 +120,7 @@ export function getProductSearchResults( state, siteId = getSelectedSiteId( stat
 	const products = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], {} );
 	const productIds = get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'search', 'productIds' ], [] );
 	if ( productIds.length ) {
-		return productIds.map( id => find( products, ( p ) => id === p.id ) );
+		return productIds.map( id => find( products, ( p ) => isEqual( id, p.id ) ) );
 	}
 	return false;
 }

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -44,9 +44,10 @@ export default createReducer( null, {
  * @return {Object} The new, updated product edits to be used in state.
  */
 function updateProductEdits( edits, productId, doUpdate ) {
+	const prevEdits = edits || [];
 	let found = false;
 
-	const newEdits = edits.map( ( productEdits ) => {
+	const newEdits = prevEdits.map( ( productEdits ) => {
 		if ( isEqual( productId, productEdits.productId ) ) {
 			found = true;
 			return doUpdate( productEdits );
@@ -64,7 +65,7 @@ function updateProductEdits( edits, productId, doUpdate ) {
 function editProductAction( edits, action ) {
 	const { product, data, productVariations } = action;
 
-	if ( 'simple' === data.type ) {
+	if ( product && 'simple' === data.type ) {
 		// Ensure there are no variation edits for this product,
 		// and that any existing ones have deletes.
 		return updateProductEdits( edits, product.id, () => {
@@ -85,7 +86,7 @@ function editProductVariationAction( edits, action ) {
 
 	// Look for an existing product edits first.
 	const _edits = prevEdits.map( ( productEdits ) => {
-		if ( productId === productEdits.productId ) {
+		if ( isEqual( productId, productEdits.productId ) ) {
 			found = true;
 			const variationId = variation && variation.id || { index: Number( uniqueId() ) };
 			const _variation = variation || { id: variationId };
@@ -124,7 +125,7 @@ function editProductVariation( array, variation, data ) {
 
 	// Look for this object in the appropriate create or edit array first.
 	const _array = prevArray.map( ( v ) => {
-		if ( variation.id === v.id ) {
+		if ( isEqual( variation.id, v.id ) ) {
 			found = true;
 			return { ...v, ...data };
 		}

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { set } from 'lodash';
+import { set, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ describe( 'edits-reducer', () => {
 	const existingVariableProduct1 = {
 		id: 101,
 		type: 'variable',
-		name: 'Existing Simple Product',
+		name: 'Existing Variable Product',
 		attributes: [
 			{ uid: 'edit_1', name: 'Color', options: [ 'Black' ], variation: true },
 		],
@@ -45,7 +45,7 @@ describe( 'edits-reducer', () => {
 	};
 
 	const variationBlue = {
-		id: { index: 4 },
+		id: { index: 5 },
 		attributes: [
 			{ name: 'Color', option: 'Blue' },
 		],
@@ -174,7 +174,7 @@ describe( 'edits-reducer', () => {
 
 		const edits1 = reducer( undefined, editProductVariation( siteId, product, null, { regular_price: '1.99' } ) );
 		const productEdits1 = edits1.find( function( p ) {
-			if ( product.id === p.productId ) {
+			if ( isEqual( product.id, p.productId ) ) {
 				return p;
 			}
 		} );
@@ -183,7 +183,7 @@ describe( 'edits-reducer', () => {
 
 		const edits2 = reducer( edits1, editProductVariation( siteId, product, null, { regular_price: '2.99' } ) );
 		const productEdits2 = edits2.find( function( p ) {
-			if ( product.id === p.productId ) {
+			if ( isEqual( product.id, p.productId ) ) {
 				return p;
 			}
 		} );
@@ -197,7 +197,7 @@ describe( 'edits-reducer', () => {
 
 		const edits1 = reducer( undefined, editProductVariation( siteId, product, variation1, { regular_price: '1.99' } ) );
 		const _edits1 = edits1.find( function( p ) {
-			if ( product.id === p.productId ) {
+			if ( isEqual( product.id, p.productId ) ) {
 				return p;
 			}
 		} );


### PR DESCRIPTION
This refactors the first implementation of the product variations edit
reducer, which only supported the creation of variations. This now
supports the updating and deletion of variations. In addition, it will
automatically create and delete variations based on the variation types
available.

This PR also adds a lot of additional tests for the most likely scenarios of the product edit states.

To Test:
1. `npm test`
2. Visit store, Add a new product.
3. Make it a variable product and add variation types.
4. Observe the variation types and fill out some of the data there.

If that all works, there should be no regressions to the existing code.
Note that this PR doesn't contain the code required to add updates and deletes of product variations to the product action-list.