### PR TITLE
FoldableCard:  Update to es6 and best practices

### DIFF
--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -12,6 +12,9 @@ import Button from 'components/button';
 export default class FoldableCardExample extends PureComponent {
 	static displayName = 'FoldableCardExample';
 
+	handleClick = () => console.log( 'Clicked!' );
+	handleClose = () => console.log( 'Closed!' );
+	handleOpen = () => console.log( 'Opened!' );
 
 	render() {
 		return (
@@ -65,6 +68,16 @@ export default class FoldableCardExample extends PureComponent {
 						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & a expanded summary component</small></div></div> }
 						summary={ <Button compact scary>Update</Button> }
 						expandedSummary={ <Button compact scary>Update</Button> }>
+						Nothing to see here. Keep walking!
+					</FoldableCard>
+				</div>
+				<div>
+					<FoldableCard
+						header="This card includes click, open and close actions. Check your console!"
+						onClick={ this.handleClick }
+						onClose={ this.handleClose }
+						onOpen={ this.handleOpen }
+					>
 						Nothing to see here. Keep walking!
 					</FoldableCard>
 				</div>

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import PureRenderMixin from 'react-pure-render/mixin';
+import React, { PureComponent } from 'react';
 
 /**
  * Internal dependencies
@@ -10,12 +9,11 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import FoldableCard from 'components/foldable-card';
 import Button from 'components/button';
 
-export default React.createClass( {
-	displayName: 'FoldableCard',
+export default class FoldableCardExample extends PureComponent {
+	static displayName = 'FoldableCardExample';
 
-	mixins: [ PureRenderMixin ],
 
-	render: function() {
+	render() {
 		return (
 			<div>
 				<div>
@@ -73,4 +71,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
-} );
+}

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -1,16 +1,18 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+
+import classNames from 'classnames';
+import noop from 'lodash/noop';
 
 /**
  * Internal Dependencies
  */
-var Card = require( 'components/card' ),
-	CompactCard = require( 'components/card/compact' ),
-	Gridicon = require( 'gridicons' );
+import Card from 'components/card';
+
+import CompactCard from 'components/card/compact';
+import Gridicon from 'gridicons';
 
 var FoldableCard = React.createClass( {
 

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -2,17 +2,14 @@
  * External Dependencies
  */
 import React from 'react';
-
-import { localize } from 'i18n-calypso';
-
 import classNames from 'classnames';
-import noop from 'lodash/noop';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import Card from 'components/card';
-
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 
@@ -161,4 +158,4 @@ var FoldableCard = React.createClass( {
 	}
 } );
 
-module.exports = localize(FoldableCard);
+module.exports = localize( FoldableCard );

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -113,13 +113,17 @@ class FoldableCard extends Component {
 	}
 
 	renderHeader() {
-		var summary = this.props.summary ? <span className="foldable-card__summary">{ this.props.summary } </span> : null,
-			expandedSummary = this.props.expandedSummary ? <span className="foldable-card__summary_expanded">{ this.props.expandedSummary } </span> : null,
-			headerClickAction = this.props.clickableHeader ? this.getClickAction() : null,
-			headerClasses = classNames( 'foldable-card__header', {
-				'is-clickable': !! this.props.clickableHeader,
-				'has-border': !! this.props.summary
-			} );
+		const summary = this.props.summary
+			? <span className="foldable-card__summary">{ this.props.summary } </span>
+			: null;
+		const expandedSummary = this.props.expandedSummary
+			? <span className="foldable-card__summary_expanded">{ this.props.expandedSummary } </span>
+			: null;
+		const headerClickAction = this.props.clickableHeader ? this.getClickAction() : null;
+		const headerClasses = classNames( 'foldable-card__header', {
+			'is-clickable': !! this.props.clickableHeader,
+			'has-border': !! this.props.summary
+		} );
 		return (
 			<div className={ headerClasses } onClick={ headerClickAction }>
 				<span className="foldable-card__main">{ this.props.header } </span>
@@ -133,16 +137,16 @@ class FoldableCard extends Component {
 	}
 
 	render() {
-		var Container = this.props.compact ? CompactCard : Card,
-			itemSiteClasses = classNames(
-				'foldable-card',
-				this.props.className,
-				{
-					'is-disabled': !! this.props.disabled,
-					'is-expanded': !! this.state.expanded,
-					'has-expanded-summary': !! this.props.expandedSummary
-				}
-			);
+		const Container = this.props.compact ? CompactCard : Card;
+		const itemSiteClasses = classNames(
+			'foldable-card',
+			this.props.className,
+			{
+				'is-disabled': !! this.props.disabled,
+				'is-expanded': !! this.state.expanded,
+				'has-expanded-summary': !! this.props.expandedSummary,
+			}
+		);
 
 		return (
 			<Container className={ itemSiteClasses }>

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -12,6 +12,7 @@ import { noop } from 'lodash';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
+import ScreenReaderText from 'components/screen-reader-text';
 
 class FoldableCard extends Component {
 	static propTypes = {
@@ -97,7 +98,7 @@ class FoldableCard extends Component {
 					type="button"
 					className="foldable-card__action foldable-card__expand"
 					onClick={ clickAction }>
-					<span className="screen-reader-text">{ screenReaderText }</span>
+					<ScreenReaderText>{ screenReaderText }</ScreenReaderText>
 					<Gridicon icon={ this.props.icon } size={ iconSize } />
 				</button>
 			);

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
@@ -13,48 +13,43 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 
-var FoldableCard = React.createClass( {
+class FoldableCard extends Component {
+	static propTypes = {
+		actionButton: PropTypes.element,
+		actionButtonExpanded: PropTypes.element,
+		cardKey: PropTypes.string,
+		compact: PropTypes.bool,
+		disabled: PropTypes.bool,
+		expandedSummary: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+		expanded: PropTypes.bool,
+		icon: PropTypes.string,
+		onClick: PropTypes.func,
+		onClose: PropTypes.func,
+		onOpen: PropTypes.func,
+		screenReaderText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+		summary: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] )
+	};
 
-	propTypes: {
-		actionButton: React.PropTypes.element,
-		actionButtonExpanded: React.PropTypes.element,
-		cardKey: React.PropTypes.string,
-		compact: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		expandedSummary: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ),
-		expanded: React.PropTypes.bool,
-		icon: React.PropTypes.string,
-		onClick: React.PropTypes.func,
-		onClose: React.PropTypes.func,
-		onOpen: React.PropTypes.func,
-		screenReaderText: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
-		summary: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] )
-	},
+	static defaultProps = {
+		onOpen: noop,
+		onClose: noop,
+		cardKey: '',
+		icon: 'chevron-down',
+		expanded: false,
+		screenReaderText: false,
+	};
 
-	getInitialState: function() {
-		return {
-			expanded: this.props.expanded
-		};
-	},
+	state = {
+		expanded: this.props.expanded
+	};
 
-	getDefaultProps: function() {
-		return {
-			onOpen: noop,
-			onClose: noop,
-			cardKey: '',
-			icon: 'chevron-down',
-			expanded: false,
-			screenReaderText: false,
-		};
-	},
-
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.expanded !== this.props.expanded ) {
 			this.setState( { expanded: nextProps.expanded } );
 		}
-	},
+	}
 
-	onClick: function() {
+	onClick = () => {
 		if ( this.props.children ) {
 			this.setState( { expanded: ! this.state.expanded } );
 		}
@@ -68,28 +63,28 @@ var FoldableCard = React.createClass( {
 		} else {
 			this.props.onOpen( this.props.cardKey );
 		}
-	},
+	}
 
-	getClickAction: function() {
+	getClickAction() {
 		if ( this.props.disabled ) {
 			return;
 		}
 		return this.onClick;
-	},
+	}
 
-	getActionButton: function() {
+	getActionButton() {
 		if ( this.state.expanded ) {
 			return this.props.actionButtonExpanded || this.props.actionButton;
 		}
 		return this.props.actionButton;
-	},
+	}
 
-	renderActionButton: function() {
+	renderActionButton() {
 		const clickAction = ! this.props.clickableHeader ? this.getClickAction() : null;
 		if ( this.props.actionButton ) {
 			return (
 				<div className="foldable-card__action" onClick={ clickAction }>
-				{ this.getActionButton() }
+					{ this.getActionButton() }
 				</div>
 			);
 		}
@@ -107,17 +102,17 @@ var FoldableCard = React.createClass( {
 				</button>
 			);
 		}
-	},
+	}
 
-	renderContent: function() {
+	renderContent() {
 		return (
 			<div className="foldable-card__content">
 				{ this.props.children }
 			</div>
 		);
-	},
+	}
 
-	renderHeader: function() {
+	renderHeader() {
 		var summary = this.props.summary ? <span className="foldable-card__summary">{ this.props.summary } </span> : null,
 			expandedSummary = this.props.expandedSummary ? <span className="foldable-card__summary_expanded">{ this.props.expandedSummary } </span> : null,
 			headerClickAction = this.props.clickableHeader ? this.getClickAction() : null,
@@ -135,9 +130,9 @@ var FoldableCard = React.createClass( {
 				</span>
 			</div>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		var Container = this.props.compact ? CompactCard : Card,
 			itemSiteClasses = classNames(
 				'foldable-card',
@@ -156,6 +151,6 @@ var FoldableCard = React.createClass( {
 			</Container>
 		);
 	}
-} );
+}
 
-module.exports = localize( FoldableCard );
+export default localize( FoldableCard );

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -117,7 +117,7 @@ class FoldableCard extends Component {
 			? <span className="foldable-card__summary">{ this.props.summary } </span>
 			: null;
 		const expandedSummary = this.props.expandedSummary
-			? <span className="foldable-card__summary_expanded">{ this.props.expandedSummary } </span>
+			? <span className="foldable-card__summary-expanded">{ this.props.expandedSummary } </span>
 			: null;
 		const headerClickAction = this.props.clickableHeader ? this.getClickAction() : null;
 		const headerClasses = classNames( 'foldable-card__header', {

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+import { localize } from 'i18n-calypso';
+
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
@@ -96,7 +98,7 @@ var FoldableCard = React.createClass( {
 		}
 		if ( this.props.children ) {
 			const iconSize = 24;
-			const screenReaderText = this.props.screenReaderText || this.translate( 'More' );
+			const screenReaderText = this.props.screenReaderText || this.props.translate( 'More' );
 			return (
 				<button
 					disabled={ this.props.disabled }
@@ -159,4 +161,4 @@ var FoldableCard = React.createClass( {
 	}
 } );
 
-module.exports = FoldableCard;
+module.exports = localize(FoldableCard);

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -27,7 +27,7 @@
 
 	&.has-border{
 		.foldable-card__summary,
-		.foldable-card__summary_expanded {
+		.foldable-card__summary-expanded {
 			margin-right: 48px;
 		}
 
@@ -140,7 +140,7 @@ button.foldable-card__action {
 }
 
 .foldable-card__summary,
-.foldable-card__summary_expanded {
+.foldable-card__summary-expanded {
 	margin-right: 40px;
 	color: $gray-text-min;
 	font-size: 12px;
@@ -171,7 +171,7 @@ button.foldable-card__action {
 	}
 }
 
-.foldable-card__summary_expanded {
+.foldable-card__summary-expanded {
 	display: none;
 
 	.foldable-card.is-expanded & {


### PR DESCRIPTION
This PR brings FoldableCard up to date including es6 and other best practices.

- Run commonjs-imports codemod
- Run i18n-mixin codemod
- Codemods manual cleanup
- Replace React.createClass with Component declaration
- Replace var declarations with const declarations
- Replace class summary_expanded with summary-expanded
- Use `ScreenReaderText` component over invalid class
- Updates devdocs example to es6
- Adds example which uses additional props (`onClick`, `onOpen`, `onClose`)

**To test**
* Visit: https://calypso.live/devdocs/design/foldable-card?branch=update/foldablecard-update
* Compare with current devdocs: https://wpcalypso.wordpress.com/devdocs/design/foldable-card
* Results should be identical with the exception of an additional example
* Test the additional example, it should log messages to the console demonstrating that the actions continue to work correctly.