### PR TITLE
Site Settings: AsyncLoad GuidedTransfer and simplify SiteSettingsComponent

### DIFF
--- a/client/my-sites/guided-transfer/guided-transfer.jsx
+++ b/client/my-sites/guided-transfer/guided-transfer.jsx
@@ -9,6 +9,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import QuerySiteGuidedTransfer from 'components/data/query-site-guided-transfer';
 import HeaderCake from 'components/header-cake';
 import HostCredentialsPage from './host-credentials-page';
@@ -75,7 +76,7 @@ export default React.createClass( {
 		const { siteId, siteSlug } = this.props;
 
 		return (
-			<div className="guided-transfer">
+			<Main className="guided-transfer__main site-settings">
 				<QuerySiteGuidedTransfer siteId={ siteId } />
 				<div className="guided-transfer__header-nav">
 					<HeaderCake
@@ -100,7 +101,7 @@ export default React.createClass( {
 					</div>
 					: <TransferUnavailableCard siteId={ siteId } siteSlug={ siteSlug } />
 				}
-			</div>
+			</Main>
 		);
 	}
 } );

--- a/client/my-sites/guided-transfer/style.scss
+++ b/client/my-sites/guided-transfer/style.scss
@@ -1,4 +1,4 @@
-.guided-transfer {
+.guided-transfer__main {
 	.guided-transfer__header-nav {
 		margin: 0 0 17px 0;
 	}

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -130,7 +130,10 @@ const controller = {
 	guidedTransfer( context ) {
 		renderPage(
 			context,
-			<SiteSettingsComponent section="guidedTransfer" hostSlug={ context.params.host_slug } />
+			<AsyncLoad
+				require="my-sites/guided-transfer"
+				hostSlug={ context.params.host_slug }
+			/>
 		);
 	},
 

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, Component } from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -17,48 +17,27 @@ import SiteSettingsNavigation from './navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackDevModeNotice from './jetpack-dev-mode-notice';
 
-export class SiteSettingsComponent extends Component {
+const SiteSettingsComponent = ( {
+	jetpackSettingsUiSupported,
+	siteId
+} ) => {
+	return (
+		<Main className="site-settings">
+			{ jetpackSettingsUiSupported && <JetpackDevModeNotice /> }
+			<SidebarNavigation />
+			{ siteId && <SiteSettingsNavigation section={ 'general' } /> }
+			<QueryProductsList />
+			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
+			{ siteId && <GeneralSettings /> }
+		</Main>
+	);
+};
 
-	static propTypes = {
-		section: PropTypes.string,
-		// Connected props
-		siteId: PropTypes.number,
-		jetpackSettingsUiSupported: PropTypes.bool
-	};
-
-	static defaultProps = {
-		section: 'general'
-	};
-
-	getSection() {
-		const { section } = this.props;
-
-		switch ( section ) {
-			case 'general':
-				return <GeneralSettings />;
-		}
-	}
-
-	render() {
-		const { siteId } = this.props;
-		const { jetpackSettingsUiSupported, section } = this.props;
-
-		return (
-			<Main className="site-settings">
-					{
-						jetpackSettingsUiSupported &&
-						<JetpackDevModeNotice />
-					}
-					<SidebarNavigation />
-					{ siteId && <SiteSettingsNavigation section={ section } /> }
-					<QueryProductsList />
-					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
-					{ siteId && this.getSection() }
-			</Main>
-		);
-	}
-
-}
+SiteSettingsComponent.propTypes = {
+	// Connected props
+	siteId: PropTypes.number,
+	jetpackSettingsUiSupported: PropTypes.bool
+};
 
 export default connect(
 	( state ) => {

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -13,7 +13,6 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import GeneralSettings from './section-general';
-import GuidedTransfer from 'my-sites/guided-transfer';
 import SiteSettingsNavigation from './navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackDevModeNotice from './jetpack-dev-mode-notice';
@@ -32,13 +31,11 @@ export class SiteSettingsComponent extends Component {
 	};
 
 	getSection() {
-		const { section, hostSlug } = this.props;
+		const { section } = this.props;
 
 		switch ( section ) {
 			case 'general':
 				return <GeneralSettings />;
-			case 'guidedTransfer':
-				return <GuidedTransfer hostSlug={ hostSlug } />;
 		}
 	}
 


### PR DESCRIPTION
Since we moved various settings sections to separate chunks, the `SiteSettingsComponent` is no longer used for rendering any of them but `GuidedTransfer` and `General` settings. However, `GuidedTransfer` does not need it at all, so we can simplify `SiteSettingsComponent` to be used only for the General settings.

This PR does this by:

* Updating `GuidedTransfer` to contain the `Main` wrapper.
* Updating `GuidedTransfer` to be loaded asynchronously through `AsyncLoad`.
* Updating `SiteSettingsComponent` to a stateless functional component and removing the `section` support as it's now obsolete.

To test:
* Checkout this branch
* Test all of the following routes with both WP.com and Jetpack sites and verify there are no regressions there:
  * http://calypso.localhost:3000/settings/general/:site
  * http://calypso.localhost:3000/settings/export/guided/:site