### PR TITLE
Stats: Remove pulsing dot animation from date picker

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes, Component } from 'react';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { connect } from 'react-redux';
@@ -117,13 +118,18 @@ class StatsDatePicker extends Component {
 		const today = moment();
 		const date = moment( queryDate );
 		const isToday = today.isSame( date, 'day' );
-		return translate( 'Last update: %(time)s', {
-			args: { time: isToday ? date.format( 'LT' ) : date.fromNow() }
-		} );
+		return (
+			<span>
+				{ translate( 'Last update: %(time)s', {
+					args: { time: isToday ? date.format( 'LT' ) : date.fromNow() }
+				} ) }
+				<Gridicon icon="info-outline" size={ 18 } />
+			</span>
+		);
 	}
 
-	bindPulsingDot = ( ref ) => {
-		this.pulsingDot = ref;
+	bindStatusIndicator = ( ref ) => {
+		this.statusIndicator = ref;
 	}
 
 	render() {
@@ -160,25 +166,23 @@ class StatsDatePicker extends Component {
 					: <div className="stats-section-title">
 							<h3>{ sectionTitle }</h3>
 							{ showQueryDate && isAutoRefreshAllowedForQuery( query ) &&
-								<div className="stats-date-picker__refresh-status">
+								<div
+									className="stats-date-picker__refresh-status"
+									ref={ this.bindStatusIndicator }
+									onMouseEnter={ this.showTooltip }
+									onMouseLeave={ this.hideTooltip }
+								>
 									<span className="stats-date-picker__update-date">
 										{ this.renderQueryDate() }
-									</span>
-									<div className="stats-date-picker__pulsing-dot-wrapper"
-										ref={ this.bindPulsingDot }
-										onMouseEnter={ this.showTooltip }
-										onMouseLeave={ this.hideTooltip }
-									>
-										<div className="stats-date-picker__pulsing-dot" />
 										<Tooltip
 											isVisible={ this.state.isTooltipVisible }
 											onClose={ this.hideTooltip }
 											position="bottom"
-											context={ this.pulsingDot }
+											context={ this.statusIndicator }
 										>
 											{ translate( 'Auto-refreshing every 3 minutes' )}
 										</Tooltip>
-									</div>
+									</span>
 								</div>
 							}
 						</div>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Tooltip from 'components/tooltip';
 import { getSiteStatsQueryDate } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
@@ -35,6 +36,14 @@ class StatsDatePicker extends Component {
 
 	state = {
 		isTooltipVisible: false
+	};
+
+	showTooltip = () => {
+		this.setState( { isTooltipVisible: true } );
+	};
+
+	hideTooltip = () => {
+		this.setState( { isTooltipVisible: false } );
 	};
 
 	dateForSummarize() {
@@ -113,6 +122,10 @@ class StatsDatePicker extends Component {
 		} );
 	}
 
+	bindPulsingDot = ( ref ) => {
+		this.pulsingDot = ref;
+	}
+
 	render() {
 		const { summary, translate, query, showQueryDate, isActivity } = this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
@@ -151,6 +164,21 @@ class StatsDatePicker extends Component {
 									<span className="stats-date-picker__update-date">
 										{ this.renderQueryDate() }
 									</span>
+									<div className="stats-date-picker__pulsing-dot-wrapper"
+										ref={ this.bindPulsingDot }
+										onMouseEnter={ this.showTooltip }
+										onMouseLeave={ this.hideTooltip }
+									>
+										<div className="stats-date-picker__pulsing-dot" />
+										<Tooltip
+											isVisible={ this.state.isTooltipVisible }
+											onClose={ this.hideTooltip }
+											position="bottom"
+											context={ this.pulsingDot }
+										>
+											{ translate( 'Auto-refreshing every 3 minutes' )}
+										</Tooltip>
+									</div>
 								</div>
 							}
 						</div>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Tooltip from 'components/tooltip';
 import { getSiteStatsQueryDate } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
@@ -36,14 +35,6 @@ class StatsDatePicker extends Component {
 
 	state = {
 		isTooltipVisible: false
-	};
-
-	showTooltip = () => {
-		this.setState( { isTooltipVisible: true } );
-	};
-
-	hideTooltip = () => {
-		this.setState( { isTooltipVisible: false } );
 	};
 
 	dateForSummarize() {
@@ -122,10 +113,6 @@ class StatsDatePicker extends Component {
 		} );
 	}
 
-	bindPulsingDot = ( ref ) => {
-		this.pulsingDot = ref;
-	}
-
 	render() {
 		const { summary, translate, query, showQueryDate, isActivity } = this.props;
 		const isSummarizeQuery = get( query, 'summarize' );
@@ -164,21 +151,6 @@ class StatsDatePicker extends Component {
 									<span className="stats-date-picker__update-date">
 										{ this.renderQueryDate() }
 									</span>
-									<div className="stats-date-picker__pulsing-dot-wrapper"
-										ref={ this.bindPulsingDot }
-										onMouseEnter={ this.showTooltip }
-										onMouseLeave={ this.hideTooltip }
-									>
-										<div className="stats-date-picker__pulsing-dot" />
-										<Tooltip
-											isVisible={ this.state.isTooltipVisible }
-											onClose={ this.hideTooltip }
-											position="bottom"
-											context={ this.pulsingDot }
-										>
-											{ translate( 'Auto-refreshing every 3 minutes' )}
-										</Tooltip>
-									</div>
 								</div>
 							}
 						</div>

--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -5,29 +5,10 @@
 		color: $gray;
 		display: inline-block;
 		font-size: 13px;
-	}
 
-	.stats-date-picker__pulsing-dot-wrapper {
-		display: inline-block;
-		padding: 0 10px;
-
-		.stats-date-picker__pulsing-dot {
-			display: inline-block;
-			background: $gray;
-			transform: translate3d( 0, 0, 0 );
-			width: 6px;
-			height: 6px;
-			border: none;
-			box-shadow: 0 0 0 0 rgba( 168, 190, 206, 0.7 );
-			border-radius: 100%;
-			animation: stats-dot-pulse 1.25s infinite cubic-bezier( 0.66, 0, 0, 1 );
-			vertical-align: middle;
-		}
-	}
-
-	@keyframes stats-dot-pulse {
-		to {
-			box-shadow: 0 0 0 5px rgba( 90, 153, 220, 0 );
+		.gridicon {
+			padding: 0 5px;
+			vertical-align: bottom;
 		}
 	}
 }

--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -6,28 +6,4 @@
 		display: inline-block;
 		font-size: 13px;
 	}
-
-	.stats-date-picker__pulsing-dot-wrapper {
-		display: inline-block;
-		padding: 0 10px;
-
-		.stats-date-picker__pulsing-dot {
-			display: inline-block;
-			background: $gray;
-			transform: translate3d( 0, 0, 0 );
-			width: 6px;
-			height: 6px;
-			border: none;
-			box-shadow: 0 0 0 0 rgba( 168, 190, 206, 0.7 );
-			border-radius: 100%;
-			animation: stats-dot-pulse 1.25s infinite cubic-bezier( 0.66, 0, 0, 1 );
-			vertical-align: middle;
-		}
-	}
-
-	@keyframes stats-dot-pulse {
-		to {
-			box-shadow: 0 0 0 5px rgba( 90, 153, 220, 0 );
-		}
-	}
 }

--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -6,4 +6,28 @@
 		display: inline-block;
 		font-size: 13px;
 	}
+
+	.stats-date-picker__pulsing-dot-wrapper {
+		display: inline-block;
+		padding: 0 10px;
+
+		.stats-date-picker__pulsing-dot {
+			display: inline-block;
+			background: $gray;
+			transform: translate3d( 0, 0, 0 );
+			width: 6px;
+			height: 6px;
+			border: none;
+			box-shadow: 0 0 0 0 rgba( 168, 190, 206, 0.7 );
+			border-radius: 100%;
+			animation: stats-dot-pulse 1.25s infinite cubic-bezier( 0.66, 0, 0, 1 );
+			vertical-align: middle;
+		}
+	}
+
+	@keyframes stats-dot-pulse {
+		to {
+			box-shadow: 0 0 0 5px rgba( 90, 153, 220, 0 );
+		}
+	}
 }


### PR DESCRIPTION
The animation, which was hinging on `box-shadow`, was a very expensive one: on my 2015 MBP, `/stats/day/:blogId` was idling at ~30–35% CPU. This PR brings that number down to ~3%.

Although this is a design change, it was discussed on Slack that this is a non-standard animation which should be removed anyway. The _last updated_ mention will still appear, informing the user who has stayed more than a few seconds on the page that it will update itself.

<img width="353" alt="screen shot 2017-07-03 at 15 02 29" src="https://user-images.githubusercontent.com/150562/27796102-aec5d5f8-6000-11e7-8473-c8813003c963.png">

For the record, I considered not removing the animation altogether and instead applying the following:

```diff
diff --git a/client/my-sites/stats/stats-date-picker/style.scss b/client/my-sites/stats/stats-date-picker/style.scss
index b6b22dbff..1eb9c4f1e 100644
--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -20,14 +20,14 @@
 			border: none;
 			box-shadow: 0 0 0 0 rgba( 168, 190, 206, 0.7 );
 			border-radius: 100%;
-			animation: stats-dot-pulse 1.25s infinite cubic-bezier( 0.66, 0, 0, 1 );
+			animation: stats-dot-pulse 2.5s infinite cubic-bezier( 0.66, 0, 0, 1 );
 			vertical-align: middle;
 		}
 	}
 
 	@keyframes stats-dot-pulse {
 		to {
-			box-shadow: 0 0 0 5px rgba( 90, 153, 220, 0 );
+			opacity: 0;
 		}
 	}
 }
```

which also yielded a big improvement, yet CPU was still in the ~5–7% range.