### PR TITLE
Add statsd analytics to the server

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -35,6 +35,11 @@ const tracksDebug = debug( 'calypso:analytics:tracks' );
 
 import emitter from 'lib/mixins/emitter';
 
+import {
+	isStatsdAnalyticsAllowed,
+	statsdUrl
+} from 'lib/analytics/statsd';
+
 // Load tracking scripts
 window._tkq = window._tkq || [];
 window.ga = window.ga || function() {
@@ -284,41 +289,9 @@ const analytics = {
 		// ignore triggerName for now, it has no obvious place in statsd
 		/* eslint-enable no-unused-vars */
 
-			if ( config( 'boom_analytics_enabled' ) ) {
-				let featureSlug = pageUrl === '/' ? 'homepage' : pageUrl.replace( /^\//, '' ).replace( /\.|\/|:/g, '_' );
-				let matched;
-				// prevent explosion of read list metrics
-				// this is a hack - ultimately we want to report this URLs in a more generic way to
-				// google analytics
-				if ( startsWith( featureSlug, 'read_list' ) ) {
-					featureSlug = 'read_list';
-				} else if ( startsWith( featureSlug, 'tag_' ) ) {
-					featureSlug = 'tag__id';
-				} else if ( startsWith( featureSlug, 'domains_add_suggestion_' ) ) {
-					featureSlug = 'domains_add_suggestion__suggestion__domain';
-				} else if ( startsWith( document.location.pathname, '/plugins/browse/' ) ) {
-					featureSlug = 'plugins_browse__site';
-				} else if ( featureSlug.match( /^plugins_[^_].*__/ ) ) {
-					featureSlug = 'plugins__site__plugin';
-				} else if ( featureSlug.match( /^plugins_[^_]/ ) ) {
-					featureSlug = 'plugins__site__unknown'; // fail safe because there seems to be some URLs we're not catching
-				} else if ( startsWith( featureSlug, 'read_post_feed_' ) ) {
-					featureSlug = 'read_post_feed__id';
-				} else if ( startsWith( featureSlug, 'read_post_id_' ) ) {
-					featureSlug = 'read_post_id__id';
-				} else if ( ( matched = featureSlug.match( /^start_(.*)_(..)$/ ) ) != null ) {
-					featureSlug = `start_${ matched[ 1 ] }`;
-				}
-
-				const type = eventType.replace( '-', '_' );
-				const json = JSON.stringify( {
-					beacons: [
-						`calypso.${ config( 'boom_analytics_key' ) }.${ featureSlug }.${ type }:${ duration }|ms`
-					]
-				} );
-
-				const [ encodedUrl, jsonData ] = [ pageUrl, json ].map( encodeURIComponent );
-				new Image().src = `https://pixel.wp.com/boom.gif?v=calypso&u=${ encodedUrl }&json=${ jsonData }`;
+			if ( isStatsdAnalyticsAllowed() ) {
+				const imgUrl = statsdUrl( pageUrl, eventType, duration, document.location.pathname );
+				new Image().src = imgUrl;
 			}
 		}
 	},

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -35,10 +35,7 @@ const tracksDebug = debug( 'calypso:analytics:tracks' );
 
 import emitter from 'lib/mixins/emitter';
 
-import {
-	isStatsdAnalyticsAllowed,
-	statsdUrl
-} from 'lib/analytics/statsd';
+import { statsdUrl } from 'lib/analytics/statsd';
 
 // Load tracking scripts
 window._tkq = window._tkq || [];
@@ -289,7 +286,7 @@ const analytics = {
 		// ignore triggerName for now, it has no obvious place in statsd
 		/* eslint-enable no-unused-vars */
 
-			if ( isStatsdAnalyticsAllowed() ) {
+			if ( config( 'boom_analytics_enabled' ) ) {
 				const imgUrl = statsdUrl( pageUrl, eventType, duration, document.location.pathname );
 				new Image().src = imgUrl;
 			}

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -35,7 +35,7 @@ const tracksDebug = debug( 'calypso:analytics:tracks' );
 
 import emitter from 'lib/mixins/emitter';
 
-import { statsdUrl } from 'lib/analytics/statsd';
+import { statsdTimingUrl } from 'lib/analytics/statsd';
 
 // Load tracking scripts
 window._tkq = window._tkq || [];
@@ -287,7 +287,7 @@ const analytics = {
 		/* eslint-enable no-unused-vars */
 
 			if ( config( 'boom_analytics_enabled' ) ) {
-				const imgUrl = statsdUrl( pageUrl, eventType, duration, document.location.pathname );
+				const imgUrl = statsdTimingUrl( pageUrl, eventType, duration, document.location.pathname );
 				new Image().src = imgUrl;
 			}
 		}

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -287,7 +287,32 @@ const analytics = {
 		/* eslint-enable no-unused-vars */
 
 			if ( config( 'boom_analytics_enabled' ) ) {
-				const imgUrl = statsdTimingUrl( pageUrl, eventType, duration, document.location.pathname );
+				let featureSlug = pageUrl === '/' ? 'homepage' : pageUrl.replace( /^\//, '' ).replace( /\.|\/|:/g, '_' );
+				let matched;
+				// prevent explosion of read list metrics
+				// this is a hack - ultimately we want to report this URLs in a more generic way to
+				// google analytics
+				if ( startsWith( featureSlug, 'read_list' ) ) {
+					featureSlug = 'read_list';
+				} else if ( startsWith( featureSlug, 'tag_' ) ) {
+					featureSlug = 'tag__id';
+				} else if ( startsWith( featureSlug, 'domains_add_suggestion_' ) ) {
+					featureSlug = 'domains_add_suggestion__suggestion__domain';
+				} else if ( startsWith( document.location.pathname, '/plugins/browse/' ) ) {
+					featureSlug = 'plugins_browse__site';
+				} else if ( featureSlug.match( /^plugins_[^_].*__/ ) ) {
+					featureSlug = 'plugins__site__plugin';
+				} else if ( featureSlug.match( /^plugins_[^_]/ ) ) {
+					featureSlug = 'plugins__site__unknown'; // fail safe because there seems to be some URLs we're not catching
+				} else if ( startsWith( featureSlug, 'read_post_feed_' ) ) {
+					featureSlug = 'read_post_feed__id';
+				} else if ( startsWith( featureSlug, 'read_post_id_' ) ) {
+					featureSlug = 'read_post_id__id';
+				} else if ( ( matched = featureSlug.match( /^start_(.*)_(..)$/ ) ) != null ) {
+					featureSlug = `start_${ matched[ 1 ] }`;
+				}
+
+				const imgUrl = statsdTimingUrl( featureSlug, eventType, duration );
 				new Image().src = imgUrl;
 			}
 		}

--- a/client/lib/analytics/statsd.js
+++ b/client/lib/analytics/statsd.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import startsWith from 'lodash/startsWith';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+export function isStatsdAnalyticsAllowed() {
+	return config( 'boom_analytics_enabled' );
+}
+
+export function statsdUrl( path, eventType, duration, currentPath = undefined ) {
+	let featureSlug = path === '/' ? 'homepage' : path.replace( /^\//, '' ).replace( /\.|\/|:/g, '_' );
+	let matched;
+	// prevent explosion of read list metrics
+	// this is a hack - ultimately we want to report this URLs in a more generic way to
+	// google analytics
+	if ( startsWith( featureSlug, 'read_list' ) ) {
+		featureSlug = 'read_list';
+	} else if ( startsWith( featureSlug, 'tag_' ) ) {
+		featureSlug = 'tag__id';
+	} else if ( startsWith( featureSlug, 'domains_add_suggestion_' ) ) {
+		featureSlug = 'domains_add_suggestion__suggestion__domain';
+	} else if ( startsWith( currentPath, '/plugins/browse/' ) ) {
+		featureSlug = 'plugins_browse__site';
+	} else if ( featureSlug.match( /^plugins_[^_].*__/ ) ) {
+		featureSlug = 'plugins__site__plugin';
+	} else if ( featureSlug.match( /^plugins_[^_]/ ) ) {
+		featureSlug = 'plugins__site__unknown'; // fail safe because there seems to be some URLs we're not catching
+	} else if ( startsWith( featureSlug, 'read_post_feed_' ) ) {
+		featureSlug = 'read_post_feed__id';
+	} else if ( startsWith( featureSlug, 'read_post_id_' ) ) {
+		featureSlug = 'read_post_id__id';
+	} else if ( ( matched = featureSlug.match( /^start_(.*)_(..)$/ ) ) != null ) {
+		featureSlug = `start_${ matched[ 1 ] }`;
+	}
+
+	const type = eventType.replace( '-', '_' );
+	const json = JSON.stringify( {
+		beacons: [
+			`calypso.${ config( 'boom_analytics_key' ) }.${ featureSlug }.${ type }:${ duration }|ms`
+		]
+	} );
+
+	const [ encodedPath, jsonData ] = [ path, json ].map( encodeURIComponent );
+	return `https://pixel.wp.com/boom.gif?v=calypso&u=${ encodedPath }&json=${ jsonData }`;
+}

--- a/client/lib/analytics/statsd.js
+++ b/client/lib/analytics/statsd.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import startsWith from 'lodash/startsWith';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/lib/analytics/statsd.js
+++ b/client/lib/analytics/statsd.js
@@ -1,46 +1,17 @@
 /**
- * External dependencies
- */
-import { startsWith } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
 
-export function statsdTimingUrl( path, eventType, duration, currentPath = undefined ) {
-	let featureSlug = path === '/' ? 'homepage' : path.replace( /^\//, '' ).replace( /\.|\/|:/g, '_' );
-	let matched;
-	// prevent explosion of read list metrics
-	// this is a hack - ultimately we want to report this URLs in a more generic way to
-	// google analytics
-	if ( startsWith( featureSlug, 'read_list' ) ) {
-		featureSlug = 'read_list';
-	} else if ( startsWith( featureSlug, 'tag_' ) ) {
-		featureSlug = 'tag__id';
-	} else if ( startsWith( featureSlug, 'domains_add_suggestion_' ) ) {
-		featureSlug = 'domains_add_suggestion__suggestion__domain';
-	} else if ( startsWith( currentPath, '/plugins/browse/' ) ) {
-		featureSlug = 'plugins_browse__site';
-	} else if ( featureSlug.match( /^plugins_[^_].*__/ ) ) {
-		featureSlug = 'plugins__site__plugin';
-	} else if ( featureSlug.match( /^plugins_[^_]/ ) ) {
-		featureSlug = 'plugins__site__unknown'; // fail safe because there seems to be some URLs we're not catching
-	} else if ( startsWith( featureSlug, 'read_post_feed_' ) ) {
-		featureSlug = 'read_post_feed__id';
-	} else if ( startsWith( featureSlug, 'read_post_id_' ) ) {
-		featureSlug = 'read_post_id__id';
-	} else if ( ( matched = featureSlug.match( /^start_(.*)_(..)$/ ) ) != null ) {
-		featureSlug = `start_${ matched[ 1 ] }`;
-	}
-
+export function statsdTimingUrl( featureSlug, eventType, duration ) {
+	const slug = featureSlug.replace( /[.:-]/g, '_' );
 	const type = eventType.replace( '-', '_' );
 	const json = JSON.stringify( {
 		beacons: [
-			`calypso.${ config( 'boom_analytics_key' ) }.${ featureSlug }.${ type }:${ duration }|ms`
+			`calypso.${ config( 'boom_analytics_key' ) }.${ slug }.${ type }:${ duration }|ms`
 		]
 	} );
 
-	const [ encodedPath, jsonData ] = [ path, json ].map( encodeURIComponent );
-	return `https://pixel.wp.com/boom.gif?v=calypso&u=${ encodedPath }&json=${ jsonData }`;
+	const [ encodedSlug, jsonData ] = [ slug, json ].map( encodeURIComponent );
+	return `https://pixel.wp.com/boom.gif?v=calypso&u=${ encodedSlug }&json=${ jsonData }`;
 }

--- a/client/lib/analytics/statsd.js
+++ b/client/lib/analytics/statsd.js
@@ -8,10 +8,6 @@ import startsWith from 'lodash/startsWith';
  */
 import config from 'config';
 
-export function isStatsdAnalyticsAllowed() {
-	return config( 'boom_analytics_enabled' );
-}
-
 export function statsdUrl( path, eventType, duration, currentPath = undefined ) {
 	let featureSlug = path === '/' ? 'homepage' : path.replace( /^\//, '' ).replace( /\.|\/|:/g, '_' );
 	let matched;

--- a/client/lib/analytics/statsd.js
+++ b/client/lib/analytics/statsd.js
@@ -8,7 +8,7 @@ import startsWith from 'lodash/startsWith';
  */
 import config from 'config';
 
-export function statsdUrl( path, eventType, duration, currentPath = undefined ) {
+export function statsdTimingUrl( path, eventType, duration, currentPath = undefined ) {
 	let featureSlug = path === '/' ? 'homepage' : path.replace( /^\//, '' ).replace( /\.|\/|:/g, '_' );
 	let matched;
 	// prevent explosion of read list metrics

--- a/client/lib/analytics/test/statsd.js
+++ b/client/lib/analytics/test/statsd.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import url from 'url';
+
+/**
+ * Internal dependencies
+ */
+import { statsdUrl } from '../statsd';
+
+describe( 'StatsD Analytics', function() {
+	describe( 'statsdUrl', function() {
+		it( 'returns a URL for recording timing data to statsd', function() {
+			const sdUrl = url.parse(
+				statsdUrl( '/post/mysite.com', 'page-load', 150 ),
+				true,
+				true
+			);
+			expect( sdUrl.query.v ).to.eql( 'calypso' );
+			expect( sdUrl.query.u ).to.eql( '/post/mysite.com' );
+			expect( sdUrl.query.json ).to.eql( JSON.stringify( {
+				beacons: [
+					'calypso.development.post_mysite_com.page_load:150|ms'
+				]
+			} ) );
+		} );
+	} );
+} );

--- a/client/lib/analytics/test/statsd.js
+++ b/client/lib/analytics/test/statsd.js
@@ -13,12 +13,12 @@ describe( 'StatsD Analytics', function() {
 	describe( 'statsdTimingUrl', function() {
 		it( 'returns a URL for recording timing data to statsd', function() {
 			const sdUrl = url.parse(
-				statsdTimingUrl( '/post/mysite.com', 'page-load', 150 ),
+				statsdTimingUrl( 'post-mysite.com', 'page-load', 150 ),
 				true,
 				true
 			);
 			expect( sdUrl.query.v ).to.eql( 'calypso' );
-			expect( sdUrl.query.u ).to.eql( '/post/mysite.com' );
+			expect( sdUrl.query.u ).to.eql( 'post_mysite_com' );
 			expect( sdUrl.query.json ).to.eql( JSON.stringify( {
 				beacons: [
 					'calypso.development.post_mysite_com.page_load:150|ms'

--- a/client/lib/analytics/test/statsd.js
+++ b/client/lib/analytics/test/statsd.js
@@ -7,13 +7,13 @@ import url from 'url';
 /**
  * Internal dependencies
  */
-import { statsdUrl } from '../statsd';
+import { statsdTimingUrl } from '../statsd';
 
 describe( 'StatsD Analytics', function() {
-	describe( 'statsdUrl', function() {
+	describe( 'statsdTimingUrl', function() {
 		it( 'returns a URL for recording timing data to statsd', function() {
 			const sdUrl = url.parse(
-				statsdUrl( '/post/mysite.com', 'page-load', 150 ),
+				statsdTimingUrl( '/post/mysite.com', 'page-load', 150 ),
 				true,
 				true
 			);

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -181,5 +181,6 @@
 	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/",
 	"woocommerce_blog_id": 113771570,
 	"wpcom_signup_id": false,
-	"wpcom_signup_key": false
+	"wpcom_signup_key": false,
+	"max_request_time_logs_per_second": 50
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -183,5 +183,5 @@
 	"woocommerce_blog_id": 113771570,
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
-	"max_request_time_logs_per_second": 50
+	"statsd_analytics_response_time_max_logs_per_second": 50
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -2,6 +2,7 @@
 	"env": "shared",
 	"env_id": "shared",
 	"boom_analytics_enabled": false,
+	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": false,
 	"client_slug": false,
 	"discover_blog_id": 53424024,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -96,6 +96,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": true,
 	"boom_analytics_enabled": false,
+	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "desktop",
 	"google_analytics_enabled": true,
 	"google_analytics_key": "UA-10673494-10",

--- a/config/development.json
+++ b/config/development.json
@@ -14,6 +14,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,
 	"boom_analytics_enabled": false,
+	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -104,6 +104,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": true,
 	"boom_analytics_enabled": true,
+	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
 	"google_analytics_enabled": true,
 	"google_analytics_key": "UA-10673494-20",

--- a/config/production.json
+++ b/config/production.json
@@ -109,6 +109,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": true,
 	"boom_analytics_enabled": true,
+	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
 	"google_analytics_enabled": true,
 	"google_analytics_key": "UA-10673494-10",

--- a/config/stage.json
+++ b/config/stage.json
@@ -116,6 +116,7 @@
 	"google_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",
 	"boom_analytics_enabled": true,
+	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "stage",
 	"google_adwords_conversion_id": 1067250390,
 	"hotjar_enabled": true,

--- a/config/test.json
+++ b/config/test.json
@@ -12,6 +12,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,
 	"boom_analytics_enabled": false,
+	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -137,6 +137,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,
 	"boom_analytics_enabled": true,
+	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
 	"google_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",

--- a/server/lib/analytics/index.js
+++ b/server/lib/analytics/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import http from 'http';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isStatsdAnalyticsAllowed,
+	statsdUrl
+} from '../../../client/lib/analytics/statsd';
+
+const analytics = {
+	statsd: {
+		recordTiming: function( featureSlug, eventType, duration ) {
+			if ( isStatsdAnalyticsAllowed() ) {
+				const url = statsdUrl( featureSlug, eventType, duration );
+				http.get( url );
+			}
+		}
+	}
+};
+export default analytics;

--- a/server/lib/analytics/index.js
+++ b/server/lib/analytics/index.js
@@ -6,15 +6,13 @@ import superagent from 'superagent';
 /**
  * Internal dependencies
  */
-import {
-	isStatsdAnalyticsAllowed,
-	statsdUrl
-} from '../../../client/lib/analytics/statsd';
+import config from 'config';
+import { statsdUrl } from '../../../client/lib/analytics/statsd';
 
 const analytics = {
 	statsd: {
 		recordTiming: function( featureSlug, eventType, duration ) {
-			if ( isStatsdAnalyticsAllowed() ) {
+			if ( config( 'server_side_boom_analytics_enabled' ) ) {
 				const url = statsdUrl( featureSlug, eventType, duration );
 				superagent.get( url ).end();
 			}

--- a/server/lib/analytics/index.js
+++ b/server/lib/analytics/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import http from 'http';
+import superagent from 'superagent';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ const analytics = {
 		recordTiming: function( featureSlug, eventType, duration ) {
 			if ( isStatsdAnalyticsAllowed() ) {
 				const url = statsdUrl( featureSlug, eventType, duration );
-				http.get( url );
+				superagent.get( url ).end();
 			}
 		}
 	}

--- a/server/lib/analytics/index.js
+++ b/server/lib/analytics/index.js
@@ -7,13 +7,13 @@ import superagent from 'superagent';
  * Internal dependencies
  */
 import config from 'config';
-import { statsdUrl } from '../../../client/lib/analytics/statsd';
+import { statsdTimingUrl } from '../../../client/lib/analytics/statsd';
 
 const analytics = {
 	statsd: {
 		recordTiming: function( featureSlug, eventType, duration ) {
 			if ( config( 'server_side_boom_analytics_enabled' ) ) {
-				const url = statsdUrl( featureSlug, eventType, duration );
+				const url = statsdTimingUrl( featureSlug, eventType, duration );
 				superagent.get( url ).end();
 			}
 		}

--- a/server/lib/analytics/test/index.js
+++ b/server/lib/analytics/test/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import analytics from '../index';
+
+const statsd = require( '../../../../client/lib/analytics/statsd' );
+
+describe( 'Server-Side Analytics', function() {
+	describe( 'statsd.recordTiming', function() {
+		let http;
+
+		beforeEach( function() {
+			http = require( 'http' );
+			sinon.stub( http, 'get' );
+		} );
+
+		afterEach( function() {
+			http.get.restore();
+		} );
+
+		it( 'sends an HTTP request to the statsd URL', function() {
+			sinon.stub( statsd, 'isStatsdAnalyticsAllowed' ).returns( true );
+			sinon.stub( statsd, 'statsdUrl' ).returns( 'http://example.com/boom.gif' );
+
+			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
+
+			expect( statsd.statsdUrl ).to.have.been.calledWith( 'reader', 'page-render', 150 );
+			expect( http.get ).to.have.been.calledWith( 'http://example.com/boom.gif' );
+
+			statsd.isStatsdAnalyticsAllowed.restore();
+			statsd.statsdUrl.restore();
+		} );
+
+		it( 'does nothing if statsd analytics is not allowed', function() {
+			sinon.stub( statsd, 'isStatsdAnalyticsAllowed' ).returns( false );
+			sinon.stub( statsd, 'statsdUrl' );
+
+			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
+
+			expect( statsd.statsdUrl ).not.to.have.been.called;
+			expect( http.get ).not.to.have.been.called;
+
+			statsd.isStatsdAnalyticsAllowed.restore();
+			statsd.statsdUrl.restore();
+		} );
+	} );
+} );

--- a/server/lib/analytics/test/index.js
+++ b/server/lib/analytics/test/index.js
@@ -3,20 +3,28 @@
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-/**
- * Internal dependencies
- */
-import analytics from '../index';
-
-const statsd = require( '../../../../client/lib/analytics/statsd' );
+import useMockery from 'test/helpers/use-mockery';
 
 describe( 'Server-Side Analytics', function() {
 	describe( 'statsd.recordTiming', function() {
-		let superagent;
+		// Allow us to mock disabling statsd.
+		const mockConfig = {
+			server_side_boom_analytics_enabled: true
+		};
+
+		useMockery( mockery => {
+			mockery.registerMock( 'config', ( key ) => {
+				return mockConfig[ key ];
+			} );
+		} );
+
+		let superagent, analytics, statsd;
 
 		beforeEach( function() {
 			superagent = require( 'superagent' );
+			analytics = require( '../index' );
+			statsd = require( '../../../../client/lib/analytics/statsd' );
+
 			sinon.stub( superagent, 'get' ).returns( { end: () => {} } );
 		} );
 
@@ -25,7 +33,6 @@ describe( 'Server-Side Analytics', function() {
 		} );
 
 		it( 'sends an HTTP request to the statsd URL', function() {
-			sinon.stub( statsd, 'isStatsdAnalyticsAllowed' ).returns( true );
 			sinon.stub( statsd, 'statsdUrl' ).returns( 'http://example.com/boom.gif' );
 
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
@@ -33,12 +40,11 @@ describe( 'Server-Side Analytics', function() {
 			expect( statsd.statsdUrl ).to.have.been.calledWith( 'reader', 'page-render', 150 );
 			expect( superagent.get ).to.have.been.calledWith( 'http://example.com/boom.gif' );
 
-			statsd.isStatsdAnalyticsAllowed.restore();
 			statsd.statsdUrl.restore();
 		} );
 
 		it( 'does nothing if statsd analytics is not allowed', function() {
-			sinon.stub( statsd, 'isStatsdAnalyticsAllowed' ).returns( false );
+			mockConfig.server_side_boom_analytics_enabled = false;
 			sinon.stub( statsd, 'statsdUrl' );
 
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
@@ -46,7 +52,6 @@ describe( 'Server-Side Analytics', function() {
 			expect( statsd.statsdUrl ).not.to.have.been.called;
 			expect( superagent.get ).not.to.have.been.called;
 
-			statsd.isStatsdAnalyticsAllowed.restore();
 			statsd.statsdUrl.restore();
 		} );
 	} );

--- a/server/lib/analytics/test/index.js
+++ b/server/lib/analytics/test/index.js
@@ -33,26 +33,26 @@ describe( 'Server-Side Analytics', function() {
 		} );
 
 		it( 'sends an HTTP request to the statsd URL', function() {
-			sinon.stub( statsd, 'statsdUrl' ).returns( 'http://example.com/boom.gif' );
+			sinon.stub( statsd, 'statsdTimingUrl' ).returns( 'http://example.com/boom.gif' );
 
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
 
-			expect( statsd.statsdUrl ).to.have.been.calledWith( 'reader', 'page-render', 150 );
+			expect( statsd.statsdTimingUrl ).to.have.been.calledWith( 'reader', 'page-render', 150 );
 			expect( superagent.get ).to.have.been.calledWith( 'http://example.com/boom.gif' );
 
-			statsd.statsdUrl.restore();
+			statsd.statsdTimingUrl.restore();
 		} );
 
 		it( 'does nothing if statsd analytics is not allowed', function() {
 			mockConfig.server_side_boom_analytics_enabled = false;
-			sinon.stub( statsd, 'statsdUrl' );
+			sinon.stub( statsd, 'statsdTimingUrl' );
 
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
 
-			expect( statsd.statsdUrl ).not.to.have.been.called;
+			expect( statsd.statsdTimingUrl ).not.to.have.been.called;
 			expect( superagent.get ).not.to.have.been.called;
 
-			statsd.statsdUrl.restore();
+			statsd.statsdTimingUrl.restore();
 		} );
 	} );
 } );

--- a/server/lib/analytics/test/index.js
+++ b/server/lib/analytics/test/index.js
@@ -13,15 +13,15 @@ const statsd = require( '../../../../client/lib/analytics/statsd' );
 
 describe( 'Server-Side Analytics', function() {
 	describe( 'statsd.recordTiming', function() {
-		let http;
+		let superagent;
 
 		beforeEach( function() {
-			http = require( 'http' );
-			sinon.stub( http, 'get' );
+			superagent = require( 'superagent' );
+			sinon.stub( superagent, 'get' ).returns( { end: () => {} } );
 		} );
 
 		afterEach( function() {
-			http.get.restore();
+			superagent.get.restore();
 		} );
 
 		it( 'sends an HTTP request to the statsd URL', function() {
@@ -31,7 +31,7 @@ describe( 'Server-Side Analytics', function() {
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
 
 			expect( statsd.statsdUrl ).to.have.been.calledWith( 'reader', 'page-render', 150 );
-			expect( http.get ).to.have.been.calledWith( 'http://example.com/boom.gif' );
+			expect( superagent.get ).to.have.been.calledWith( 'http://example.com/boom.gif' );
 
 			statsd.isStatsdAnalyticsAllowed.restore();
 			statsd.statsdUrl.restore();
@@ -44,7 +44,7 @@ describe( 'Server-Side Analytics', function() {
 			analytics.statsd.recordTiming( 'reader', 'page-render', 150 );
 
 			expect( statsd.statsdUrl ).not.to.have.been.called;
-			expect( http.get ).not.to.have.been.called;
+			expect( superagent.get ).not.to.have.been.called;
 
 			statsd.isStatsdAnalyticsAllowed.restore();
 			statsd.statsdUrl.restore();

--- a/server/pages/analytics.js
+++ b/server/pages/analytics.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import analytics from '../lib/analytics';
+
+/*
+ * Middleware to log the response time of the node request for a
+ * section. Only logs if the request context contains a
+ * `sectionName` attribute.
+ */
+export function logSectionResponseTime( req, res, next ) {
+	const startRenderTime = new Date();
+
+	res.on( 'finish', function() {
+		const context = req.context || {};
+		if ( context.sectionName ) {
+			const duration = new Date() - startRenderTime;
+			analytics.statsd.recordTiming(
+				req.context.sectionName,
+				'response-time',
+				duration
+			);
+		}
+	} );
+
+	next();
+}

--- a/server/pages/analytics.js
+++ b/server/pages/analytics.js
@@ -10,7 +10,7 @@ import config from 'config';
 import analytics from '../lib/analytics';
 
 // Compute the number of milliseconds between each call to recordTiming
-const THROTTLE_MILLIS = 1000 / config( 'max_request_time_logs_per_second' );
+const THROTTLE_MILLIS = 1000 / config( 'statsd_analytics_response_time_max_logs_per_second' );
 
 const logAnalyticsThrottled = throttle( function( sectionName, duration ) {
 	analytics.statsd.recordTiming(

--- a/server/pages/analytics.js
+++ b/server/pages/analytics.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import throttle from 'lodash/throttle';
+import { throttle } from 'lodash';
 
 /**
  * Internal dependencies

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -23,6 +23,7 @@ import stateCache from 'state-cache';
 import { createReduxStore, reducer } from 'state';
 import { DESERIALIZE } from 'state/action-types';
 import { login } from 'lib/paths';
+import { logSectionResponseTime } from './analytics';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -306,6 +307,7 @@ module.exports = function() {
 
 	app.set( 'views', __dirname );
 
+	app.use( logSectionResponseTime );
 	app.use( cookieParser() );
 
 	// redirect homepage if the Reader is disabled
@@ -372,8 +374,10 @@ module.exports = function() {
 				const pathRegex = utils.pathToRegExp( path );
 
 				app.get( pathRegex, function( req, res, next ) {
+					req.context = Object.assign( {}, req.context, { sectionName: section.name } );
+
 					if ( config.isEnabled( 'code-splitting' ) ) {
-						req.context = Object.assign( {}, req.context, { chunk: section.name } );
+						req.context.chunk = section.name;
 					}
 
 					if ( section.secondary && req.context ) {

--- a/server/pages/test/analytics.js
+++ b/server/pages/test/analytics.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { useFakeTimers } from 'test/helpers/use-sinon';
+import events from 'events';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import analytics from '../../lib/analytics';
+import { logSectionResponseTime } from 'pages/analytics';
+
+const TWO_SECONDS = 2000;
+
+describe( 'index', function() {
+	describe( 'logResponseTime middleware', function() {
+		// Stub request, response, and next
+		let request, response, next;
+		beforeEach( function() {
+			request = { context: {} };
+			response = new events.EventEmitter();
+			next = noop;
+		} );
+
+		context( 'when rendering a section', function() {
+			useFakeTimers();
+
+			beforeEach( function() {
+				sinon.stub( analytics.statsd, 'recordTiming' );
+				request.context.sectionName = 'reader';
+			} );
+
+			afterEach( function() {
+				analytics.statsd.recordTiming.restore();
+			} );
+
+			it( 'logs response time analytics', function() {
+				logSectionResponseTime( request, response, next );
+
+				// Move time forward and mock the "finish" event
+				this.clock.tick( TWO_SECONDS );
+				response.emit( 'finish' );
+
+				expect( analytics.statsd.recordTiming ).to.have.been.calledWith(
+					'reader', 'response-time', TWO_SECONDS
+				);
+			} );
+		} );
+
+		context( 'when not rendering a section', function() {
+			beforeEach( function() {
+				sinon.stub( analytics.statsd, 'recordTiming' );
+			} );
+
+			afterEach( function() {
+				analytics.statsd.recordTiming.restore();
+			} );
+
+			it( 'does not log response time analytics', function() {
+				logSectionResponseTime( request, response, next );
+
+				// Mock the "finish" event
+				response.emit( 'finish' );
+
+				expect( analytics.statsd.recordTiming ).not.to.have.been.called;
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
In particular, this PR adds an `analytics` module to the server-side, and uses it to log to `statsd` the response time for requests.

## Testing

- Set `boom_analytics_enabled` to `true` in `config/development.json`

- If you have access to the `statsd` analytics created by requests to `https://pixel.wp.com/boom.gif`, you should be able to load any page in Calypso, and see the analytics data come through.

- If you do not have that access, one way to verify this feature is to change the URL in `client/lib/analytics/statsd.js`. Change `https://pixel.wp.com/boom.gif` to `http://calypso.localhost:3000/boom.gif`. Then, on loading any page in Calypso, you should see the `boom.gif` request in the server logs with the correct attributes.

## Concerns

- I extracted the `statsd` URL generation from `client/lib/analytics/index.js` to reuse it for the server-side analytics. I have two concerns with this:
  - There does not appear to be any test coverage for the previous functionality. I've tested the new file, but I worry about the lack of regression testing.
  - After extracting, I began using the new code on the server-side, even though it still exists in the `client` directory. Is there a better place to put the common code?

- Logging analytics for every request is probably too much. We should be able to log a percentage of them and still get statistically valid results, without flooding the `statsd` server.

## Future Work

I would also like to log the time spent in `renderToString`, and a single tick of the Node event loop.