### PR TITLE
Data-Layer: updates spy expectations to match chai API

### DIFF
--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -35,7 +35,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		config.middleware( store )( next )( action );
 
-		expect( store.dispatch ).to.not.have.beenCalled;
+		expect( store.dispatch ).to.not.have.been.called;
 		expect( next ).to.have.been.calledWith( action );
 	} );
 
@@ -52,7 +52,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 		config.middleware( store )( next )( action );
 
 		expect( next ).to.have.been.calledWith( action );
-		expect( adder ).to.not.have.beenCalled;
+		expect( adder ).to.not.have.been.called;
 	} );
 
 	it( 'should not pass along non-local actions with non data-layer meta', () => {
@@ -67,7 +67,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		config.middleware( store )( next )( action );
 
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -83,7 +83,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		config.middleware( store )( next )( action );
 
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -138,7 +138,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 	} );
 
 	it( 'should call all given handlers (different lists)', () => {
@@ -162,7 +162,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 	} );
 
 	it( 'should no longer call handlers that have been removed', () => {
@@ -182,7 +182,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 		removeHandlers( 'my-extension', config );
 
 		config.middleware( store )( next )( action );
-		expect( adder ).to.not.have.beenCalled;
+		expect( adder ).to.not.have.been.called;
 	} );
 
 	it( 'should still call handlers even after some handlers have been removed', () => {

--- a/client/state/data-layer/test/extensions-middleware.js
+++ b/client/state/data-layer/test/extensions-middleware.js
@@ -55,7 +55,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 		expect( adder ).to.not.have.been.called;
 	} );
 
-	it( 'should not pass along non-local actions with non data-layer meta', () => {
+	it( 'should pass along non-local actions with non data-layer meta', () => {
 		const adder = spy();
 		const handlers = {
 			[ 'ADD' ]: [ adder ],
@@ -67,11 +67,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		config.middleware( store )( next )( action );
 
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.have.been.calledOnce;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
-	it( 'should not pass along non-local actions with data-layer meta but no bypass', () => {
+	it( 'should pass along non-local actions with data-layer meta but no bypass', () => {
 		const adder = spy();
 		const handlers = {
 			[ 'ADD' ]: [ adder ],
@@ -79,11 +79,11 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		const config = configureMiddleware( Object.create( null ), Object.create( null ) );
 		addHandlers( 'my-extension', handlers, config );
-		const action = { type: 'ADD', meta: { dataLayer: { data: 42 } } };
+		const action = { type: 'ADD', meta: { dataLayer: { groupoid: 42 } } };
 
 		config.middleware( store )( next )( action );
 
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.have.been.called;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -138,7 +138,6 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.been.called;
 	} );
 
 	it( 'should call all given handlers (different lists)', () => {
@@ -162,7 +161,6 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.been.called;
 	} );
 
 	it( 'should no longer call handlers that have been removed', () => {
@@ -181,6 +179,7 @@ describe( 'Calypso Extensions Data Layer Middleware', () => {
 
 		removeHandlers( 'my-extension', config );
 
+		adder.reset();
 		config.middleware( store )( next )( action );
 		expect( adder ).to.not.have.been.called;
 	} );

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -51,7 +51,7 @@ describe( 'WordPress.com API Middleware', () => {
 		expect( adder ).to.not.have.been.called;
 	} );
 
-	it( 'should not pass along non-local actions with non data-layer meta', () => {
+	it( 'should pass along non-local actions with non data-layer meta', () => {
 		const adder = spy();
 		const handlers = mergeHandlers( {
 			[ 'ADD' ]: [ adder ],
@@ -60,20 +60,20 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.have.been.calledOnce;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
-	it( 'should not pass along non-local actions with data-layer meta but no bypass', () => {
+	it( 'should pass non-local actions with data-layer meta but no bypass', () => {
 		const adder = spy();
 		const handlers = mergeHandlers( {
 			[ 'ADD' ]: [ adder ],
 		} );
-		const action = { type: 'ADD', meta: { dataLayer: { data: 42 } } };
+		const action = { type: 'ADD', meta: { dataLayer: { groupoid: 42 } } };
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.have.been.calledOnce;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -116,7 +116,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.have.been.calledOnce;
 	} );
 
 	it( 'should call all given handlers (different lists)', () => {
@@ -133,6 +133,6 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.been.called;
+		expect( next ).to.have.been.calledOnce;
 	} );
 } );

--- a/client/state/data-layer/test/wpcom-api-middleware.js
+++ b/client/state/data-layer/test/wpcom-api-middleware.js
@@ -34,7 +34,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( store.dispatch ).to.not.have.beenCalled;
+		expect( store.dispatch ).to.not.have.been.called;
 		expect( next ).to.have.been.calledWith( action );
 	} );
 
@@ -48,7 +48,7 @@ describe( 'WordPress.com API Middleware', () => {
 		middleware( handlers )( store )( next )( action );
 
 		expect( next ).to.have.been.calledWith( action );
-		expect( adder ).to.not.have.beenCalled;
+		expect( adder ).to.not.have.been.called;
 	} );
 
 	it( 'should not pass along non-local actions with non data-layer meta', () => {
@@ -60,7 +60,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -73,7 +73,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		middleware( handlers )( store )( next )( action );
 
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 		expect( adder ).to.have.been.calledWith( store, action );
 	} );
 
@@ -116,7 +116,7 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 	} );
 
 	it( 'should call all given handlers (different lists)', () => {
@@ -133,6 +133,6 @@ describe( 'WordPress.com API Middleware', () => {
 
 		expect( adder ).to.have.been.calledWith( store, action );
 		expect( doubler ).to.have.been.calledWith( store, action );
-		expect( next ).to.not.have.beenCalled;
+		expect( next ).to.not.have.been.called;
 	} );
 } );

--- a/client/state/data-layer/wpcom-http/test/utils.js
+++ b/client/state/data-layer/wpcom-http/test/utils.js
@@ -82,44 +82,44 @@ describe( 'WPCOM HTTP Data Layer', () => {
 				dispatcher( store, empty, next );
 
 				expect( initiator ).to.have.been.calledWith( store, empty, next );
-				expect( onSuccess ).to.not.have.beenCalled;
-				expect( onFailure ).to.not.have.beenCalled;
-				expect( onProgress ).to.not.have.beenCalled;
+				expect( onSuccess ).to.not.have.been.called;
+				expect( onFailure ).to.not.have.been.called;
+				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onSuccess if meta includes response data', () => {
 				dispatcher( store, success, next );
 
-				expect( initiator ).to.not.have.beenCalled;
+				expect( initiator ).to.not.have.been.called;
 				expect( onSuccess ).to.have.been.calledWith( store, success, next, data );
-				expect( onFailure ).to.not.have.beenCalled;
-				expect( onProgress ).to.not.have.beenCalled;
+				expect( onFailure ).to.not.have.been.called;
+				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onFailure if meta includes error data', () => {
 				dispatcher( store, failure, next );
 
-				expect( initiator ).to.not.have.beenCalled;
-				expect( onSuccess ).to.not.have.beenCalled;
+				expect( initiator ).to.not.have.been.called;
+				expect( onSuccess ).to.not.have.been.called;
 				expect( onFailure ).to.have.been.calledWith( store, failure, next, error );
-				expect( onProgress ).to.not.have.beenCalled;
+				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onFailure if meta includes both response data and error data', () => {
 				dispatcher( store, both, next );
 
-				expect( initiator ).to.not.have.beenCalled;
-				expect( onSuccess ).to.not.have.beenCalled;
+				expect( initiator ).to.not.have.been.called;
+				expect( onSuccess ).to.not.have.been.called;
 				expect( onFailure ).to.have.been.calledWith( store, both, next, error );
-				expect( onProgress ).to.not.have.beenCalled;
+				expect( onProgress ).to.not.have.been.called;
 			} );
 
 			it( 'should call onProgress if meta includes progress data', () => {
 				dispatcher( store, progress, next );
 
-				expect( initiator ).to.not.have.beenCalled;
-				expect( onSuccess ).to.not.have.beenCalled;
-				expect( onFailure ).to.not.have.beenCalled;
+				expect( initiator ).to.not.have.been.called;
+				expect( onSuccess ).to.not.have.been.called;
+				expect( onFailure ).to.not.have.been.called;
 				expect( onProgress ).to.have.been.calledWith( store, progress, next, progressInfo );
 			} );
 


### PR DESCRIPTION
this PR changes `not.beenCalled` to `not.been.called` on the data-layer tests.

to test:

```
npm run test-client client/state/data-layer/
```