### PR TITLE
Reader: remove initial margin in sites/posts search

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -26,6 +26,10 @@
 	}
 }
 
+.search-stream__fixed-area .section-nav-tabs.is-dropdown {
+	margin: 0,
+}
+
 .search-stream .reader__content .reader-post-card:first-child {
 	margin-top: 120px;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -27,7 +27,7 @@
 }
 
 .search-stream__fixed-area .section-nav-tabs.is-dropdown {
-	margin: 0,
+	margin: 0;
 }
 
 .search-stream .reader__content .reader-post-card:first-child {


### PR DESCRIPTION
When initially entering a medium/small width search results page, you sometimes see the spacing off like this:
<img width="492" alt="screen shot 2017-07-01 at 1 07 48 pm" src="https://user-images.githubusercontent.com/4656974/27800478-90e356a0-5fe7-11e7-8990-f59563e65990.png">


This PR removes the extra margins so that instead it always looks like:
<img width="492" alt="screen shot 2017-07-01 at 1 08 00 pm" src="https://user-images.githubusercontent.com/4656974/27800493-9c475c80-5fe7-11e7-9d20-34ba6ca77d64.png">
