### PR TITLE
Activity log: Fix activity log day timestamp

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'gridicons';
 
 class ActivityLogConfirmDialog extends Component {
 	static propTypes = {
+		applySiteOffset: PropTypes.func.isRequired,
 		isVisible: PropTypes.bool.isRequired,
 		onClose: PropTypes.func.isRequired,
 		onConfirm: PropTypes.func.isRequired,
@@ -48,6 +49,7 @@ class ActivityLogConfirmDialog extends Component {
 
 	render() {
 		const {
+			applySiteOffset,
 			isVisible,
 			moment,
 			siteTitle,
@@ -75,7 +77,7 @@ class ActivityLogConfirmDialog extends Component {
 					{
 						translate( 'Restoring to {{b}}%(time)s{{/b}}', {
 							args: {
-								time: moment( timestamp ).format( 'LLL' ),
+								time: applySiteOffset( moment.utc( timestamp ) ).format( 'LLL' ),
 							},
 							components: { b: <b /> },
 						} )

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -20,7 +20,7 @@ class ActivityLogDay extends Component {
 		logs: PropTypes.array.isRequired,
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
-		tsDayStart: PropTypes.number.isRequired,
+		tsEndOfSiteDay: PropTypes.number.isRequired,
 	};
 
 	static defaultProps = {
@@ -30,12 +30,10 @@ class ActivityLogDay extends Component {
 
 	handleClickRestore = () => {
 		const {
-			applySiteOffset,
-			tsDayStart,
-			moment,
+			tsEndOfSiteDay,
 			requestRestore,
 		} = this.props;
-		requestRestore( applySiteOffset( moment.utc( tsDayStart ) ).endOf( 'day' ).valueOf() );
+		requestRestore( tsEndOfSiteDay );
 	};
 
 	/**
@@ -77,12 +75,12 @@ class ActivityLogDay extends Component {
 			logs,
 			moment,
 			translate,
-			tsDayStart,
+			tsEndOfSiteDay,
 		} = this.props;
 
 		return (
 			<div>
-				<div className="activity-log-day__day">{ applySiteOffset( moment.utc( tsDayStart ) ).format( 'LL' ) }</div>
+				<div className="activity-log-day__day">{ applySiteOffset( moment.utc( tsEndOfSiteDay ) ).format( 'LL' ) }</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -30,10 +30,12 @@ class ActivityLogDay extends Component {
 
 	handleClickRestore = () => {
 		const {
+			applySiteOffset,
+			day,
+			moment,
 			requestRestore,
-			timestamp,
 		} = this.props;
-		requestRestore( timestamp );
+		requestRestore( applySiteOffset( moment.utc( day ) ).endOf( 'day' ).valueOf() );
 	};
 
 	/**
@@ -71,14 +73,16 @@ class ActivityLogDay extends Component {
 	 */
 	getEventsHeading() {
 		const {
+			applySiteOffset,
 			logs,
+			moment,
 			translate,
 			day,
 		} = this.props;
 
 		return (
 			<div>
-				<div className="activity-log-day__day">{ day }</div>
+				<div className="activity-log-day__day">{ applySiteOffset( moment.utc( day ) ).format( 'LL' ) }</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -15,12 +15,12 @@ import ActivityLogItem from '../activity-log-item';
 class ActivityLogDay extends Component {
 	static propTypes = {
 		allowRestore: PropTypes.bool.isRequired,
+		applySiteOffset: PropTypes.func.isRequired,
 		isRewindActive: PropTypes.bool,
 		logs: PropTypes.array.isRequired,
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
-		day: PropTypes.string.isRequired,
-		applySiteOffset: PropTypes.func.isRequired,
+		tsDayStart: PropTypes.number.isRequired,
 	};
 
 	static defaultProps = {
@@ -31,11 +31,11 @@ class ActivityLogDay extends Component {
 	handleClickRestore = () => {
 		const {
 			applySiteOffset,
-			day,
+			tsDayStart,
 			moment,
 			requestRestore,
 		} = this.props;
-		requestRestore( applySiteOffset( moment.utc( day ) ).endOf( 'day' ).valueOf() );
+		requestRestore( applySiteOffset( moment.utc( tsDayStart ) ).endOf( 'day' ).valueOf() );
 	};
 
 	/**
@@ -77,12 +77,12 @@ class ActivityLogDay extends Component {
 			logs,
 			moment,
 			translate,
-			day,
+			tsDayStart,
 		} = this.props;
 
 		return (
 			<div>
-				<div className="activity-log-day__day">{ applySiteOffset( moment.utc( day ) ).format( 'LL' ) }</div>
+				<div className="activity-log-day__day">{ applySiteOffset( moment.utc( tsDayStart ) ).format( 'LL' ) }</div>
 				<div className="activity-log-day__events">{
 					translate( '%d Event', '%d Events', {
 						args: logs.length,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -291,6 +291,7 @@ class ActivityLog extends Component {
 			requestedRestoreTimestamp,
 			showRestoreConfirmDialog,
 		} = this.state;
+		const applySiteOffset = this.getSiteOffsetFunc();
 
 		return (
 			<Main wideLayout>
@@ -307,6 +308,7 @@ class ActivityLog extends Component {
 				{ this.renderErrorMessage() }
 				{ this.renderContent() }
 				<ActivityLogConfirmDialog
+					applySiteOffset={ applySiteOffset }
 					isVisible={ showRestoreConfirmDialog }
 					siteTitle={ siteTitle }
 					timestamp={ requestedRestoreTimestamp }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -234,17 +234,17 @@ class ActivityLog extends Component {
 		const logsGroupedByDay = map(
 			groupBy(
 				logsForMonth,
-				log => applySiteOffset( moment.utc( log.ts_utc ) ).startOf( 'day' ).valueOf()
+				log => applySiteOffset( moment.utc( log.ts_utc ) ).endOf( 'day' ).valueOf()
 			),
-			( daily_logs, tsDayStart ) => (
+			( daily_logs, tsEndOfSiteDay ) => (
 				<ActivityLogDay
 					allowRestore={ !! isPressable }
 					isRewindActive={ isRewindActive }
-					key={ tsDayStart }
+					key={ tsEndOfSiteDay }
 					logs={ daily_logs }
 					requestRestore={ this.handleRequestRestore }
 					siteId={ siteId }
-					tsDayStart={ +tsDayStart }
+					tsEndOfSiteDay={ +tsEndOfSiteDay }
 					applySiteOffset={ applySiteOffset }
 				/>
 			)

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -234,17 +234,17 @@ class ActivityLog extends Component {
 		const logsGroupedByDay = map(
 			groupBy(
 				logsForMonth,
-				log => applySiteOffset( moment.utc( log.ts_utc ) ).format( 'YYYY-MM-DD' )
+				log => applySiteOffset( moment.utc( log.ts_utc ) ).startOf( 'day' ).valueOf()
 			),
-			( daily_logs, day ) => (
+			( daily_logs, tsDayStart ) => (
 				<ActivityLogDay
 					allowRestore={ !! isPressable }
 					isRewindActive={ isRewindActive }
-					key={ day }
+					key={ tsDayStart }
 					logs={ daily_logs }
 					requestRestore={ this.handleRequestRestore }
 					siteId={ siteId }
-					day={ day }
+					tsDayStart={ +tsDayStart }
 					applySiteOffset={ applySiteOffset }
 				/>
 			)

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -234,7 +234,7 @@ class ActivityLog extends Component {
 		const logsGroupedByDay = map(
 			groupBy(
 				logsForMonth,
-				log => applySiteOffset( moment.utc( log.ts_utc ) ).format( 'LL' )
+				log => applySiteOffset( moment.utc( log.ts_utc ) ).format( 'YYYY-MM-DD' )
 			),
 			( daily_logs, day ) => (
 				<ActivityLogDay


### PR DESCRIPTION
Fixes undefined `timestamp` when restoring to a day.
Updates `ActivityLogDay` to rewind to the _end_ of the day.
Fixes dates passed to `ActivityLogDialog` to receive utc timestamp and display site-time date.