### PR TITLE
Comments: Add a Pagination component

### DIFF
--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { filter, get, isNil, keyBy, keys, map, maxBy, omit } from 'lodash';
+import { filter, isNil, keyBy, map, omit, slice } from 'lodash';
 
 import { createPlaceholderComment } from 'state/data-layer/wpcom/comments';
+
+const COMMENTS_PER_PAGE = 20;
 
 /**
  * `CommentFaker` is a HOC to easily test the Comments Management without the necessity of real data or actions.
@@ -18,6 +20,7 @@ import { createPlaceholderComment } from 'state/data-layer/wpcom/comments';
 export const CommentFaker = WrappedCommentList => class extends Component {
 	state = {
 		comments: {},
+		commentsPage: 1,
 	};
 
 	componentWillMount() {
@@ -29,6 +32,10 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 			this.props.siteId !== nextProps.siteId ) {
 				this.getCommentsFromProps( nextProps );
 		}
+
+		if ( this.props.status !== nextProps.status ) {
+			this.setState( { commentsPage: 1 } );
+		}
 	}
 
 	deleteCommentPermanently = commentId => this.setCommentStatusOrLike( [ commentId ], { status: 'delete' } );
@@ -38,6 +45,11 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 		: filter( this.state.comments, ( { status } ) => ( this.props.status === status ) );
 
 	getCommentsFromProps = ( { comments } ) => this.setState( { comments: keyBy( comments, 'ID' ) } );
+
+	getCommentsPage = comments => {
+		const startingIndex = ( this.state.commentsPage - 1 ) * COMMENTS_PER_PAGE;
+		return slice( comments, startingIndex, startingIndex + COMMENTS_PER_PAGE );
+	}
 
 	setBulkStatus = ( commentIds, status ) => this.setCommentStatusOrLike( commentIds, { status } );
 
@@ -90,6 +102,8 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 			...editedComments,
 		} } );
 	}
+
+	setCommentsPage = commentsPage => this.setState( { commentsPage } );
 
 	submitComment = comment => {
 		const { comments } = this.state;
@@ -144,17 +158,28 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 
 	undoBulkStatus = comments => this.undoSetCommentStatusOrLike( comments );
 
-	render = () =>
-		<WrappedCommentList
-			{ ...this.props }
-			comments={ this.filterCommentsByStatus() }
-			deleteCommentPermanently={ this.deleteCommentPermanently }
-			setBulkStatus={ this.setBulkStatus }
-			setCommentLike={ this.setCommentLike }
-			setCommentStatus={ this.setCommentStatus }
-			submitComment={ this.submitComment }
-			undoBulkStatus={ this.undoBulkStatus }
-		/>;
+	render = () => {
+		const { commentsPage } = this.state;
+
+		const filteredComments = this.filterCommentsByStatus();
+		const pageOfComments = this.getCommentsPage( filteredComments );
+
+		return(
+			<WrappedCommentList
+				{ ...this.props }
+				comments={ pageOfComments }
+				commentsCount={ filteredComments.length }
+				commentsPage={ commentsPage }
+				deleteCommentPermanently={ this.deleteCommentPermanently }
+				setBulkStatus={ this.setBulkStatus }
+				setCommentLike={ this.setCommentLike }
+				setCommentsPage={ this.setCommentsPage }
+				setCommentStatus={ this.setCommentStatus }
+				submitComment={ this.submitComment }
+				undoBulkStatus={ this.undoBulkStatus }
+			/>
+		);
+	}
 };
 
 export default CommentFaker;

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -6,7 +6,7 @@ import { filter, isNil, keyBy, map, omit, slice } from 'lodash';
 
 import { createPlaceholderComment } from 'state/data-layer/wpcom/comments';
 
-const COMMENTS_PER_PAGE = 20;
+const COMMENTS_PER_PAGE = 2;
 
 /**
  * `CommentFaker` is a HOC to easily test the Comments Management without the necessity of real data or actions.

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -25,7 +25,7 @@ import Pagination from 'my-sites/stats/pagination';
 import QuerySiteComments from 'components/data/query-site-comments';
 import { hasSiteComments } from 'state/selectors';
 
-const COMMENTS_PER_PAGE = 20;
+const COMMENTS_PER_PAGE = 2;
 
 export class CommentList extends Component {
 	static propTypes = {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -21,20 +21,31 @@ import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-place
 import CommentFaker from 'blocks/comment-detail/docs/comment-faker';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
+import Pagination from 'my-sites/stats/pagination';
 import QuerySiteComments from 'components/data/query-site-comments';
 import { hasSiteComments } from 'state/selectors';
+
+const COMMENTS_PER_PAGE = 20;
 
 export class CommentList extends Component {
 	static propTypes = {
 		comments: PropTypes.array,
+		commentsCount: PropTypes.number,
+		commentsPage: PropTypes.number,
 		deleteCommentPermanently: PropTypes.func,
 		setBulkStatus: PropTypes.func,
 		setCommentLike: PropTypes.func,
+		setCommentsPage: PropTypes.func,
 		setCommentStatus: PropTypes.func,
 		siteId: PropTypes.number,
 		status: PropTypes.string,
 		translate: PropTypes.func,
 		undoBulkStatus: PropTypes.func,
+	};
+
+	static defaultProps = {
+		commentsCount: 0,
+		commentsPage: 1,
 	};
 
 	state = {
@@ -220,7 +231,10 @@ export class CommentList extends Component {
 	render() {
 		const {
 			comments,
+			commentsCount,
+			commentsPage,
 			isLoading,
+			setCommentsPage,
 			siteId,
 			siteSlug,
 			status,
@@ -279,6 +293,16 @@ export class CommentList extends Component {
 						line={ emptyMessageLine }
 						title={ emptyMessageTitle }
 					/> }
+
+					{ ! showPlaceholder && ! showEmptyContent &&
+						<Pagination
+							key="comment-list-pagination"
+							page={ commentsPage }
+							pageClick={ setCommentsPage }
+							perPage={ COMMENTS_PER_PAGE }
+							total={ commentsCount }
+						/>
+					}
 				</ReactCSSTransitionGroup>
 			</div>
 		);

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -59,6 +59,11 @@ export class CommentList extends Component {
 		}
 	}
 
+	changePage = page => {
+		this.setState( { selectedComments: {} } );
+		this.props.setCommentsPage( page );
+	}
+
 	deleteCommentPermanently = commentId => {
 		this.props.removeNotice( `comment-notice-${ commentId }` );
 		this.showNotice( commentId, 'delete', 'trash' );
@@ -234,7 +239,6 @@ export class CommentList extends Component {
 			commentsCount,
 			commentsPage,
 			isLoading,
-			setCommentsPage,
 			siteId,
 			siteSlug,
 			status,
@@ -298,7 +302,7 @@ export class CommentList extends Component {
 						<Pagination
 							key="comment-list-pagination"
 							page={ commentsPage }
-							pageClick={ setCommentsPage }
+							pageClick={ this.changePage }
 							perPage={ COMMENTS_PER_PAGE }
 							total={ commentsCount }
 						/>

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -60,6 +60,10 @@
 	}
 }
 
+.comment-list .stats-pagination {
+	margin-top: 16px;
+}
+
 .comment-list__transition-enter {
 	display: none;
 


### PR DESCRIPTION
Closes #15016

Add a [`Pagination` component](https://github.com/Automattic/wp-calypso/tree/master/client/my-sites/stats/pagination) to the Comment Management.

The current comments per page value is `20` (the default in wp-admin).

I've decided to use the ready made `Pagination` component instead of going custom with `SegmentedControl` because after trying it, it actually looks better than I expected.
If we want to change its design, I'd say it's better to change the style instead of writing from scratch a component that already exists.

The gif is 1 comment per page for demo purposes only.

![jul-03-2017 18-14-28](https://user-images.githubusercontent.com/2070010/27802683-3c892a86-601d-11e7-95d4-c836c41f3591.gif)
