### PR TITLE
Editor: remove overlay from EditorConfirmationSidebar

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -11,7 +11,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import RootChild from 'components/root-child';
 import Button from 'components/button';
 import EditorVisibility from 'post-editor/editor-visibility';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -148,55 +147,53 @@ class EditorConfirmationSidebar extends React.Component {
 		const isOverlayActive = this.props.status !== 'closed';
 
 		return (
-			<RootChild>
+			<div className={ classnames( {
+				'editor-confirmation-sidebar': true,
+				'is-active': isOverlayActive,
+			} ) } >
 				<div className={ classnames( {
-					'editor-confirmation-sidebar': true,
+					'editor-confirmation-sidebar__overlay': true,
 					'is-active': isOverlayActive,
-				} ) } >
-					<div className={ classnames( {
-						'editor-confirmation-sidebar__overlay': true,
-						'is-active': isOverlayActive,
-					} ) } onClick={ this.getCloseOverlayHandler( 'dismiss_overlay' ) }>
-						{ this.renderPublishingBusyButton() }
-					</div>
-					<div className={ classnames( {
-						'editor-confirmation-sidebar__sidebar': true,
-						'is-active': isSidebarActive,
-					} ) }>
-						<div className="editor-confirmation-sidebar__ground-control">
-							<div className="editor-confirmation-sidebar__close">
-								<Button
-									borderless
-									onClick={ this.getCloseOverlayHandler( 'dismiss_x' ) }
-									title={ this.props.translate( 'Close sidebar' ) }
-									aria-label={ this.props.translate( 'Close sidebar' ) }>
-									<Gridicon icon="cross" />
-								</Button>
-							</div>
-							<div className="editor-confirmation-sidebar__action">
-								{ this.renderPublishButton() }
-							</div>
-						</div>
-						<div className="editor-confirmation-sidebar__content-wrap">
-							<div className="editor-confirmation-sidebar__header">
-								{
-									this.props.translate( '{{strong}}Ready to go?{{/strong}} Double-check and then confirm to publish.', {
-										comment: 'This string appears as the header for the confirmation sidebar ' +
-											'when a user publishes a post or page.',
-										components: {
-											strong: <strong />
-										},
-									} )
-								}
-							</div>
-							<div className="editor-confirmation-sidebar__privacy-control">
-								{ this.renderPrivacyControl() }
-							</div>
-						</div>
-						{ this.renderNoticeDisplayPreferenceCheckbox() }
-					</div>
+				} ) } onClick={ this.getCloseOverlayHandler( 'dismiss_overlay' ) }>
+					{ this.renderPublishingBusyButton() }
 				</div>
-			</RootChild>
+				<div className={ classnames( {
+					'editor-confirmation-sidebar__sidebar': true,
+					'is-active': isSidebarActive,
+				} ) }>
+					<div className="editor-confirmation-sidebar__ground-control">
+						<div className="editor-confirmation-sidebar__close">
+							<Button
+								borderless
+								onClick={ this.getCloseOverlayHandler( 'dismiss_x' ) }
+								title={ this.props.translate( 'Close sidebar' ) }
+								aria-label={ this.props.translate( 'Close sidebar' ) }>
+								<Gridicon icon="cross" />
+							</Button>
+						</div>
+						<div className="editor-confirmation-sidebar__action">
+							{ this.renderPublishButton() }
+						</div>
+					</div>
+					<div className="editor-confirmation-sidebar__content-wrap">
+						<div className="editor-confirmation-sidebar__header">
+							{
+								this.props.translate( '{{strong}}Ready to go?{{/strong}} Double-check and then confirm to publish.', {
+									comment: 'This string appears as the header for the confirmation sidebar ' +
+										'when a user publishes a post or page.',
+									components: {
+										strong: <strong />
+									},
+								} )
+							}
+						</div>
+						<div className="editor-confirmation-sidebar__privacy-control">
+							{ this.renderPrivacyControl() }
+						</div>
+					</div>
+					{ this.renderNoticeDisplayPreferenceCheckbox() }
+				</div>
+			</div>
 		);
 	}
 }

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -151,12 +151,8 @@ class EditorConfirmationSidebar extends React.Component {
 				'editor-confirmation-sidebar': true,
 				'is-active': isOverlayActive,
 			} ) } >
-				<div className={ classnames( {
-					'editor-confirmation-sidebar__overlay': true,
-					'is-active': isOverlayActive,
-				} ) } onClick={ this.getCloseOverlayHandler( 'dismiss_overlay' ) }>
-					{ this.renderPublishingBusyButton() }
-				</div>
+				{ this.renderPublishingBusyButton() }
+
 				<div className={ classnames( {
 					'editor-confirmation-sidebar__sidebar': true,
 					'is-active': isSidebarActive,

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -30,12 +30,13 @@
 	@extend .sidebar;
 	width: $sidebar-width-min;
 	background: $sidebar-bg-color;
+	border-left: 1px solid darken( $sidebar-bg-color, 5% );
+	border-right: none;
+	box-sizing: border-box;
 	position: fixed;
 		left: auto;
 		right: -$sidebar-width-min;
 	z-index: z-index( 'root', '.editor-confirmation-sidebar__sidebar' );
-	border-left: 1px solid darken( $sidebar-bg-color, 5% );
-	border-right: none;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
 
 	&.is-active {

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -40,7 +40,7 @@
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
 
 	&.is-active {
-		transform: translateX( -$sidebar-width-min );
+		transform: translateX( -$sidebar-width-max );
 	}
 
 	@include breakpoint( ">960px" ) {

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -1,7 +1,7 @@
 .editor-confirmation-sidebar {
 	position: absolute;
 		top: -100px;
-		left: -100px;
+		right: -100px;
 		width: 0;
 		height: 0;
 	overflow: hidden;
@@ -10,28 +10,11 @@
 	&.is-active {
 		position: absolute;
 			top: 0;
-			left: 0;
+			right: 0;
 			width: auto;
 			height: auto;
 		overflow: auto;
 		visibility: visible;
-	}
-}
-
-.editor-confirmation-sidebar__overlay {
-	position: fixed;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-
-	z-index: z-index( 'root', '.editor-confirmation-sidebar__overlay' );
-	background: rgba( $white, 0.8 );
-
-	display: none;
-
-	&.is-active {
-		display: block;
 	}
 }
 

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -70,6 +70,10 @@
 .editor-ground-control__action-buttons .button.is-borderless {
 	padding: 0 12px;
 	line-height: 46px;
+
+	@include breakpoint( "<480px" ) {
+		padding: 0 4px;
+	}
 }
 
 .editor-ground-control__action-buttons .button.is-borderless svg {
@@ -104,6 +108,10 @@
 
 	&.is-standalone {
 		margin: 0 12px;
+
+		@include breakpoint( "<480px" ) {
+			margin: 0;
+		}
 	}
 }
 
@@ -116,6 +124,10 @@
 .editor-ground-control .is-standalone .editor-publish-button {
 	border-radius: 4px;
 	padding: 7px 16px;
+
+	@include breakpoint( "<480px" ) {
+		padding: 7px 10px;
+	}
 }
 
 .editor-ground-control__time-button {

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -92,13 +92,20 @@ export class EditorPublishButton extends Component {
 					return this.props.translate( 'Schedule…',
 						{ comment: 'Button label on the editor sidebar - a confirmation step will follow' } );
 				}
+
 				return this.props.translate( 'Schedule' );
 			case 'publish':
-				if ( this.props.isConfirmationSidebarEnabled ) {
-					return this.props.translate( 'Publish…',
-						{ context: 'Button label on the editor sidebar - a confirmation step will follow' } );
+				if ( ! this.props.isConfirmationSidebarEnabled ) {
+					return this.props.translate( 'Publish' );
 				}
-				return this.props.translate( 'Publish' );
+
+				if ( this.props.isPublishing ) {
+					return this.props.translate( 'Publishing…',
+						{ comment: 'Button label on the editor sidebar while publishing is in progress' } );
+				}
+
+				return this.props.translate( 'Publish…',
+					{ comment: 'Button label on the editor sidebar - a confirmation step will follow' } );
 			case 'requestReview':
 				return this.props.translate( 'Submit for Review' );
 		}

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -2,16 +2,17 @@
 	@extend .sidebar;
 	z-index: z-index( 'root', '.editor-sidebar' );
 	background: lighten( $gray, 30% );
-	left: auto;
-	right: -273px;
 	border-left: 1px solid darken( $sidebar-bg-color, 5% );
 	border-top: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
+	box-sizing: border-box;
 	top: 93px;
+	right: $sidebar-width-max;
+	left: auto;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
 
 	.focus-sidebar & {
-		transform: translateX(-273px);
+		transform: translateX( -$sidebar-width-max );
 	}
 
 	.focus-sidebar .is-loading & {

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -81,10 +81,6 @@ class EditorTitle extends Component {
 		stats.recordEvent( isPage ? 'Changed Page Title' : 'Changed Post Title' );
 	};
 
-	onBlur = event => {
-		this.onChange( event );
-	};
-
 	render() {
 		const { post, isPermalinkEditable, isNew, tabIndex, translate } = this.props;
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -520,6 +520,7 @@ export const PostEditor = React.createClass( {
 		}
 
 		this.debouncedSaveRawContent();
+		this.debouncedAutosave();
 	},
 
 	onEditorKeyUp: function() {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -144,10 +144,6 @@ export const PostEditor = React.createClass( {
 		} else {
 			this.props.markSaved();
 		}
-
-		if ( ( nextState.isDirty && ! this.state.isDirty ) || ( nextProps.dirty && ! this.props.dirty ) ) {
-			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit', nextProps } );
-		}
 	},
 
 	componentDidMount: function() {
@@ -203,20 +199,19 @@ export const PostEditor = React.createClass( {
 		return this.props.setLayoutFocus( 'content' );
 	},
 
-	setConfirmationSidebar: function( { status, context = null, nextProps } ) {
-		const props = nextProps || this.props;
+	setConfirmationSidebar: function( { status, context = null } ) {
 		const allowedStatuses = [ 'closed', 'open', 'publishing' ];
 		const confirmationSidebar = allowedStatuses.indexOf( status ) > -1 ? status : 'closed';
-		const editorSidebarPreference = props.editorSidebarPreference === 'open' ? 'sidebar' : 'content';
+		const editorSidebarPreference = this.props.editorSidebarPreference === 'open' ? 'sidebar' : 'content';
 		this.setState( { confirmationSidebar } );
 
 		switch ( confirmationSidebar ) {
 			case 'closed':
-				props.setLayoutFocus( editorSidebarPreference );
+				this.props.setLayoutFocus( editorSidebarPreference );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_close', { context } );
 				break;
 			case 'open':
-				props.setLayoutFocus( 'editor-confirmation-sidebar' );
+				this.props.setLayoutFocus( 'editor-confirmation-sidebar' );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_open' );
 				break;
 		}
@@ -227,11 +222,6 @@ export const PostEditor = React.createClass( {
 		if ( this.state.selectedText !== selectedText ) {
 			this.setState( { selectedText: selectedText || null } );
 		}
-	},
-
-	onEditorKeyUp: function() {
-		this.debouncedCopySelectedText();
-		this.debouncedSaveRawContent();
 	},
 
 	handleConfirmationSidebarPreferenceChange: function( event ) {
@@ -343,7 +333,7 @@ export const PostEditor = React.createClass( {
 								maxWidth={ 1462 } />
 							<div className="post-editor__header">
 								<EditorTitle
-									onChange={ this.debouncedAutosave }
+									onChange={ this.onEditorTitleChange }
 									tabIndex={ 1 } />
 								{ this.state.post && isPage && site
 									? <EditorPageSlug
@@ -516,9 +506,29 @@ export const PostEditor = React.createClass( {
 		this.setState( { isEditorInitialized: true } );
 	},
 
-	onEditorContentChange: function() {
-		this.debouncedSaveRawContent();
+	onEditorTitleChange() {
+		if ( 'open' === this.state.confirmationSidebar ) {
+			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit' } );
+		}
+
 		this.debouncedAutosave();
+	},
+
+	onEditorContentChange: function() {
+		if ( 'open' === this.state.confirmationSidebar ) {
+			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit' } );
+		}
+
+		this.debouncedSaveRawContent();
+	},
+
+	onEditorKeyUp: function() {
+		if ( 'open' === this.state.confirmationSidebar ) {
+			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit' } );
+		}
+
+		this.debouncedCopySelectedText();
+		this.debouncedSaveRawContent();
 	},
 
 	onEditorFocus: function() {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -146,7 +146,8 @@ export const PostEditor = React.createClass( {
 		}
 
 		if ( ( nextState.isDirty && ! this.state.isDirty ) || ( nextProps.dirty && ! this.props.dirty ) ) {
-			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit' } );
+			this.setState( { confirmationSidebar: 'closed' } );
+			analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_close', { context: 'content_edit' } );
 		}
 	},
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -146,7 +146,7 @@ export const PostEditor = React.createClass( {
 		}
 
 		if ( ( nextState.isDirty && ! this.state.isDirty ) || ( nextProps.dirty && ! this.props.dirty ) ) {
-			this.setState( { confirmationSidebar: 'closed' } );
+			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit' } );
 		}
 	},
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -206,9 +206,11 @@ export const PostEditor = React.createClass( {
 
 		switch ( confirmationSidebar ) {
 			case 'closed':
+				this.props.setLayoutFocus( 'content' );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_close', { context } );
 				break;
 			case 'open':
+				this.props.setLayoutFocus( 'sidebar' );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_open' );
 				break;
 		}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -145,7 +145,7 @@ export const PostEditor = React.createClass( {
 			this.props.markSaved();
 		}
 
-		if ( nextState.isDirty && ! this.state.isDirty ) {
+		if ( ( nextState.isDirty && ! this.state.isDirty ) || ( nextProps.dirty && ! this.props.dirty ) ) {
 			this.setState( { confirmationSidebar: 'closed' } );
 		}
 	},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -202,15 +202,16 @@ export const PostEditor = React.createClass( {
 	setConfirmationSidebar: function( { status, context = null } ) {
 		const allowedStatuses = [ 'closed', 'open', 'publishing' ];
 		const confirmationSidebar = allowedStatuses.indexOf( status ) > -1 ? status : 'closed';
+		const editorSidebarPreference = this.props.editorSidebarPreference === 'open' ? 'sidebar' : 'content';
 		this.setState( { confirmationSidebar } );
 
 		switch ( confirmationSidebar ) {
 			case 'closed':
-				this.props.setLayoutFocus( 'content' );
+				this.props.setLayoutFocus( editorSidebarPreference );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_close', { context } );
 				break;
 			case 'open':
-				this.props.setLayoutFocus( 'sidebar' );
+				this.props.setLayoutFocus( 'editor-confirmation-sidebar' );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_open' );
 				break;
 		}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -144,6 +144,10 @@ export const PostEditor = React.createClass( {
 		} else {
 			this.props.markSaved();
 		}
+
+		if ( nextState.isDirty && ! this.state.isDirty ) {
+			this.setState( { confirmationSidebar: 'closed' } );
+		}
 	},
 
 	componentDidMount: function() {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -146,8 +146,7 @@ export const PostEditor = React.createClass( {
 		}
 
 		if ( ( nextState.isDirty && ! this.state.isDirty ) || ( nextProps.dirty && ! this.props.dirty ) ) {
-			this.setState( { confirmationSidebar: 'closed' } );
-			analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_close', { context: 'content_edit' } );
+			this.setConfirmationSidebar( { status: 'closed', context: 'content_edit', nextProps } );
 		}
 	},
 
@@ -204,19 +203,20 @@ export const PostEditor = React.createClass( {
 		return this.props.setLayoutFocus( 'content' );
 	},
 
-	setConfirmationSidebar: function( { status, context = null } ) {
+	setConfirmationSidebar: function( { status, context = null, nextProps } ) {
+		const props = nextProps || this.props;
 		const allowedStatuses = [ 'closed', 'open', 'publishing' ];
 		const confirmationSidebar = allowedStatuses.indexOf( status ) > -1 ? status : 'closed';
-		const editorSidebarPreference = this.props.editorSidebarPreference === 'open' ? 'sidebar' : 'content';
+		const editorSidebarPreference = props.editorSidebarPreference === 'open' ? 'sidebar' : 'content';
 		this.setState( { confirmationSidebar } );
 
 		switch ( confirmationSidebar ) {
 			case 'closed':
-				this.props.setLayoutFocus( editorSidebarPreference );
+				props.setLayoutFocus( editorSidebarPreference );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_close', { context } );
 				break;
 			case 'open':
-				this.props.setLayoutFocus( 'editor-confirmation-sidebar' );
+				props.setLayoutFocus( 'editor-confirmation-sidebar' );
 				analytics.tracks.recordEvent( 'calypso_editor_confirmation_sidebar_open' );
 				break;
 		}

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -16,7 +16,8 @@
 }
 
 @include breakpoint( "<660px" ) {
-	.is-group-editor.focus-sidebar::before {
+	.is-group-editor.focus-sidebar::before,
+	.is-group-editor.focus-editor-confirmation-sidebar::before {
 		background-color: lighten( $gray, 30% );
 	}
 
@@ -59,7 +60,8 @@
 	margin: 0 auto; // born centered, so when width collapses for sidebar anim it doesn't move
 	left: 0;
 
-	.focus-sidebar & {
+	.focus-sidebar &,
+	.focus-editor-confirmation-sidebar & {
 		@include breakpoint( ">960px" ) {
 			left: ( $sidebar-width-max / -2 );
 			width: calc( 100% - ( #{ $sidebar-width-max } ) ); // subtract sidebar width


### PR DESCRIPTION
This PR allows the user to continue to proofread their changes while the `EditorConfirmationSidebar` is visible. The sidebar will be hidden if the user makes any edits to their post.

**Mock:**
<img width="1021" alt="screencapture_at_tue_jun_13_09_44_09_edt_2017" src="https://user-images.githubusercontent.com/942359/27807664-82cf5acc-6010-11e7-89f3-c5ba7a6f79d9.png">

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p8F9tW-3F-p2.

**To Test:**
- `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Draft a post.
- Click "Publish…" button.
- When confirmation sidebar is visible, post should remain visible and editable (no overlay), and be shifted to fit beside sidebar
- When post is edited, confirmation sidebar should close and post settings sidebar should follow whether or not it was displayed before "Publish…" was clicked.