### PR TITLE
Activity log: Show Activity tab when on insights

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -48,7 +48,11 @@ const StatsInsights = ( props ) => {
 		<Main wideLayout>
 			<StatsFirstView />
 			<SidebarNavigation />
-			<StatsNavigation section="insights" slug={ siteSlug } />
+			<StatsNavigation
+				isJetpack={ isJetpack }
+				section="insights"
+				slug={ siteSlug }
+			/>
 			<div>
 				<PostingActivity />
 				<SectionHeader label={ translate( 'All Time Views' ) } />


### PR DESCRIPTION
The "Activity" tab was hidden when viewing the "Insights" tab. This PR correctly displays the "Activity" tab.

Add isJetpack to insights stats navigation to ensure the Activity tab displays correctly.

**To test:**
1. Visit `http://calypso.localhost:3000/stats/insights/JETPACK_SITE`
1. Ensure the Activity tab displays correctly
1. Visit `http://calypso.localhost:3000/stats/insights/WPCOM_SITE`
1. Ensure the Activity tab is not displayed

Reported by @beaulebens in p1499095813845123-slack-activity-log