### PR TITLE
Reader Tracks: combined cards are just normal cards. Tag pages are not undefined

### DIFF
--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -10,6 +10,7 @@ const exported = {
 	READER_FOLLOWING_MANAGE_URL_INPUT: 'reader-following-manage-url-input',
 	READER_FOLLOWING_MANAGE_SEARCH_RESULT: 'reader-following-manage-search-result',
 	READER_FOLLOWING_MANAGE_RECOMMENDATION: 'reader-following-manage-recommendation',
+	TAG_PAGES: 'reader-tag-pages',
 };
 
 export default exported;

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -1,29 +1,12 @@
 /* Follow Source Constants */
-const exported = {
-	IN_STREAM_RECOMMENDATION: 'in-stream-recommendation',
-	EMPTY_SEARCH_RECOMMENDATIONS: 'empty-search-rec',
-	SEARCH_RESULTS: 'search-results',
-	SEARCH_RESULTS_SITES: 'search-results-sites',
-	READER_SUBSCRIPTIONS: 'reader-subscriptions',
-	READER_FEED_SEARCH: 'reader-feed-search-result',
-	COMBINED_CARD: 'reader-combined-card',
-	READER_FOLLOWING_MANAGE_URL_INPUT: 'reader-following-manage-url-input',
-	READER_FOLLOWING_MANAGE_SEARCH_RESULT: 'reader-following-manage-search-result',
-	READER_FOLLOWING_MANAGE_RECOMMENDATION: 'reader-following-manage-recommendation',
-	TAG_PAGES: 'reader-tag-pages',
-};
-
-export default exported;
-
-export const {
-	IN_STREAM_RECOMMENDATION,
-	EMPTY_SEARCH_RECOMMENDATIONS,
-	SEARCH_RESULTS,
-	SEARCH_RESULTS_SITES,
-	READER_SUBSCRIPTIONS,
-	READER_FEED_SEARCH,
-	COMBINED_CARD,
-	READER_FOLLOWING_MANAGE_URL_INPUT,
-	READER_FOLLOWING_MANAGE_SEARCH_RESULT,
-	READER_FOLLOWING_MANAGE_RECOMMENDATION,
-} = exported;
+export const IN_STREAM_RECOMMENDATION = 'in-stream-recommendation';
+export const EMPTY_SEARCH_RECOMMENDATIONS = 'empty-search-rec';
+export const SEARCH_RESULTS = 'search-results';
+export const SEARCH_RESULTS_SITES = 'search-results-sites';
+export const READER_SUBSCRIPTIONS = 'reader-subscriptions';
+export const READER_FEED_SEARCH = 'reader-feed-search-result';
+export const COMBINED_CARD = 'reader-combined-card';
+export const READER_FOLLOWING_MANAGE_URL_INPUT = 'reader-following-manage-url-input';
+export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-search-result';
+export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';
+export const TAG_PAGE = 'reader-tag-page';

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -5,7 +5,6 @@ export const SEARCH_RESULTS = 'search-results';
 export const SEARCH_RESULTS_SITES = 'search-results-sites';
 export const READER_SUBSCRIPTIONS = 'reader-subscriptions';
 export const READER_FEED_SEARCH = 'reader-feed-search-result';
-export const COMBINED_CARD = 'reader-combined-card';
 export const READER_FOLLOWING_MANAGE_URL_INPUT = 'reader-following-manage-url-input';
 export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-search-result';
 export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -18,7 +18,7 @@ import RecommendedPosts from './recommended-posts';
 import XPostHelper, { isXPost } from 'reader/xpost-helper';
 import PostBlocked from 'blocks/reader-post-card/blocked';
 import Post from './post';
-import { IN_STREAM_RECOMMENDATION, COMBINED_CARD } from 'reader/follow-button/follow-sources';
+import { IN_STREAM_RECOMMENDATION } from 'reader/follow-button/follow-sources';
 import CombinedCard from 'blocks/reader-combined-card';
 import fluxPostAdapter from 'lib/reader-post-flux-adapter';
 import EmptySearchRecommendedPost from './empty-search-recommended-post';
@@ -82,7 +82,7 @@ export default class PostLifecycle extends React.PureComponent {
 
 	render() {
 		const post = this.state.post;
-		const { postKey, selectedPostKey, recStoreId } = this.props;
+		const { postKey, selectedPostKey, recStoreId, followSource } = this.props;
 
 		if ( postKey.isRecommendationBlock ) {
 			return (
@@ -100,7 +100,7 @@ export default class PostLifecycle extends React.PureComponent {
 					index={ this.props.index }
 					onClick={ this.props.handleClick }
 					selectedPostKey={ selectedPostKey }
-					followSource={ COMBINED_CARD }
+					followSource={ followSource }
 					showFollowButton={ this.props.showPrimaryFollowButtonOnCards }
 				/>
 			);

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -17,52 +17,48 @@ import {
 } from 'reader/controller-helper';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
+import { TAG_PAGE } from 'reader/follow-button/follow-sources';
 
 const analyticsPageTitle = 'Reader';
 
-const exported = {
-	tagListing( context ) {
-		var basePath = '/tag/:slug',
-			fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag,
-			tagSlug = trim( context.params.tag )
-				.toLowerCase()
-				.replace( /\s+/g, '-' )
-				.replace( /-{2,}/g, '-' ),
-			encodedTag = encodeURIComponent( tagSlug ).toLowerCase(),
-			tagStore = feedStreamFactory( 'tag:' + tagSlug ),
-			mcKey = 'topic';
+export const tagListing = context => {
+	const basePath = '/tag/:slug';
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag;
+	const tagSlug = trim( context.params.tag )
+		.toLowerCase()
+		.replace( /\s+/g, '-' )
+		.replace( /-{2,}/g, '-' );
+	const encodedTag = encodeURIComponent( tagSlug ).toLowerCase();
+	const tagStore = feedStreamFactory( 'tag:' + tagSlug );
+	const mcKey = 'topic';
 
-		ensureStoreLoading( tagStore, context );
+	ensureStoreLoading( tagStore, context );
 
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-		recordTrack( 'calypso_reader_tag_loaded', {
-			tag: tagSlug,
-		} );
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_tag_loaded', {
+		tag: tagSlug,
+	} );
 
-		renderWithReduxStore(
-			<AsyncLoad
-				require="reader/tag-stream/main"
-				key={ 'tag-' + encodedTag }
-				postsStore={ tagStore }
-				encodedTagSlug={ encodedTag }
-				decodedTagSlug={ tagSlug }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-				showBack={ !! context.lastRoute }
-				showPrimaryFollowButtonOnCards={ true }
-			/>,
-			document.getElementById( 'primary' ),
-			context.store
-		);
-	},
+	renderWithReduxStore(
+		<AsyncLoad
+			require="reader/tag-stream/main"
+			key={ 'tag-' + encodedTag }
+			postsStore={ tagStore }
+			encodedTagSlug={ encodedTag }
+			decodedTagSlug={ tagSlug }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey,
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			showBack={ !! context.lastRoute }
+			showPrimaryFollowButtonOnCards={ true }
+			followSource={ TAG_PAGE }
+		/>,
+		document.getElementById( 'primary' ),
+		context.store,
+	);
 };
-
-export default exported;
-
-export const { tagListing } = exported;

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -46,14 +46,14 @@ export const tagListing = context => {
 			postsStore={ tagStore }
 			encodedTagSlug={ encodedTag }
 			decodedTagSlug={ tagSlug }
-			trackScrollPage={ trackScrollPage.bind(
+			trackScrollPage={ trackScrollPage.bind( // eslint-disable-line
 				null,
 				basePath,
 				fullAnalyticsPageTitle,
 				analyticsPageTitle,
 				mcKey,
 			) }
-			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) } // eslint-disable-line
 			showBack={ !! context.lastRoute }
 			showPrimaryFollowButtonOnCards={ true }
 			followSource={ TAG_PAGE }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { find } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -18,7 +19,7 @@ import { getReaderFollowedTags, getReaderTags } from 'state/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
 import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
 import QueryReaderTag from 'components/data/query-reader-tag';
-import { find } from 'lodash';
+import { TAG_PAGES } from 'reader/follow-button/follow-sources';
 
 class TagStream extends React.Component {
 	static propTypes = {
@@ -112,6 +113,7 @@ class TagStream extends React.Component {
 				listName={ this.state.title }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
+				followSource={ TAG_PAGES }
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -19,12 +19,12 @@ import { getReaderFollowedTags, getReaderTags } from 'state/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
 import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
 import QueryReaderTag from 'components/data/query-reader-tag';
-import { TAG_PAGES } from 'reader/follow-button/follow-sources';
 
 class TagStream extends React.Component {
 	static propTypes = {
 		encodedTagSlug: React.PropTypes.string,
 		decodedTagSlug: React.PropTypes.string,
+		followSource: React.PropTypes.string.isRequired,
 	};
 
 	state = {
@@ -113,7 +113,6 @@ class TagStream extends React.Component {
 				listName={ this.state.title }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
-				followSource={ TAG_PAGES }
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />


### PR DESCRIPTION
This PR introduces two changes:
1. CombinedCards are now just regular cards when it comes to emitting `follow_source` instead of overriding with `reader-combined-card`
2. TagStream now has its own shiny `follow_source` called `reader-tag-page`

To Test:
- follow something from a tag page and check that the follow is set
- follow a combined card from anywhere.  easiest place to find them is also tag pages. confirm that it has the same follow_source as its surrounding regular cards