### PR TITLE
WooCommerce Orders: Add manual fulfillment to order

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -16,7 +16,6 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { isOrderUpdating, getOrder } from 'woocommerce/state/sites/orders/selectors';
 import Main from 'components/main';
-import OrderActivityLog from './order-activity-log';
 import OrderCustomerInfo from './order-customer-info';
 import OrderDetails from './order-details';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
@@ -72,7 +71,6 @@ class Order extends Component {
 
 				<div className="order__container">
 					<OrderDetails order={ order } onUpdate={ this.onUpdate } site={ site } />
-					<OrderActivityLog order={ order } />
 					<OrderCustomerInfo order={ order } />
 				</div>
 			</Main>

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -30,8 +30,9 @@ class OrderCustomerInfo extends Component {
 			<div className="order__customer-info">
 				<SectionHeader label={ translate( 'Customer Information' ) } />
 				<Card>
-					<h3 className="order__billing-details">{ translate( 'Billing Details' ) }</h3>
+					<div className="order__customer-info-container">
 					<div className="order__customer-billing">
+					<h3 className="order__billing-details">{ translate( 'Billing Details' ) }</h3>
 						<h4>{ translate( 'Address' ) }</h4>
 						<div className="order__billing-address">
 							<p>{ `${ billing.first_name } ${ billing.last_name }` }</p>
@@ -45,11 +46,11 @@ class OrderCustomerInfo extends Component {
 						<p>{ billing.email }</p>
 
 						<h4>{ translate( 'Phone' ) }</h4>
-						<p>{ billing.phone }</p>
+						<span>{ billing.phone }</span>
 					</div>
 
-					<h3 className="order__shipping-details">{ translate( 'Shipping Details' ) }</h3>
 					<div className="order__customer-shipping">
+					<h3 className="order__shipping-details">{ translate( 'Shipping Details' ) }</h3>
 						<h4>{ translate( 'Address' ) }</h4>
 						<div className="order__shipping-address">
 							<p>{ `${ shipping.first_name } ${ shipping.last_name }` }</p>
@@ -59,6 +60,7 @@ class OrderCustomerInfo extends Component {
 							<p>{ shipping.country }</p>
 						</div>
 					</div>
+				</div>
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -9,10 +9,10 @@ import React, { Component, PropTypes } from 'react';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
 import FormSelect from 'components/forms/form-select';
 import OrderDetailsTable from './order-details-table';
+import OrderFulfillment from './order-fulfillment';
 import OrderRefundCard from './order-refund-card';
 import SectionHeader from 'components/section-header';
 
@@ -98,16 +98,7 @@ class OrderDetails extends Component {
 				<Card className="order__details-card">
 					<OrderDetailsTable order={ order } site={ site } />
 					<OrderRefundCard order={ order } site={ site } />
-
-					<div className="order__details-fulfillment">
-						<div className="order__details-fulfillment-label">
-							<Gridicon icon="shipping" />
-							{ translate( 'Order needs to be fulfilled' ) }
-						</div>
-						<div className="order__details-fulfillment-action">
-							<Button primary>{ translate( 'Print label' ) }</Button>
-						</div>
-					</div>
+					<OrderFulfillment order={ order } site={ site } />
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { find } from 'lodash';
-import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -34,7 +34,7 @@ class OrderFulfillment extends Component {
 
 	state = {
 		errorMessage: false,
-		shouldEmail: true,
+		shouldEmail: false,
 		showDialog: false,
 		trackingNumber: '',
 	}

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormTextInput from 'components/forms/form-text-input';
+import Notice from 'components/notice';
+
+class OrderFulfillment extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			id: PropTypes.number.isRequired,
+		} ),
+		site: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+			slug: PropTypes.string.isRequired,
+		} ),
+	}
+
+	state = {
+		errorMessage: false,
+		showDialog: false,
+		trackingNumber: '',
+	}
+
+	toggleDialog = () => {
+		this.setState( {
+			showDialog: ! this.state.showDialog,
+		} );
+	}
+
+	updateTrackingNumber = ( event ) => {
+		this.setState( {
+			errorMessage: false,
+			trackingNumber: event.target.value,
+		} );
+	}
+
+	submit = () => {
+		this.setState( {
+			errorMessage: 'Testing, not saved yet.',
+		} );
+	}
+
+	render() {
+		const { order, translate } = this.props;
+		const { errorMessage, showDialog, trackingNumber } = this.state;
+		const dialogClass = 'woocommerce order__fulfillment'; // eslint/css specificity hack
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<div className="order__details-fulfillment">
+				<div className="order__details-fulfillment-label">
+					<Gridicon icon="shipping" />
+					{ translate( 'Order needs to be fulfilled' ) }
+				</div>
+				<div className="order__details-fulfillment-action">
+					<Button primary onClick={ this.toggleDialog }>{ translate( 'Print label' ) }</Button>
+				</div>
+				<Dialog isVisible={ showDialog } onClose={ this.toggleDialog } className={ dialogClass }>
+					<h1>{ translate( 'Fulfill order' ) }</h1>
+					<form>
+						<FormFieldset className="order__fulfillment-tracking">
+							<FormLabel className="order__fulfillment-tracking-label" htmlFor="tracking-number">
+								{ translate( 'Enter a tracking number (optional)' ) }
+							</FormLabel>
+							<FormTextInput
+								id="tracking-number"
+								className="order__fulfillment-value"
+								value={ trackingNumber }
+								onChange={ this.updateTrackingNumber }
+								placeholder={ translate( 'Tracking Number' ) } />
+						</FormFieldset>
+						<FormLabel className="order__fulfillment-email">
+							<FormInputCheckbox checked disabled />
+							<span>{ translate( 'Email tracking number to customer' ) }</span>
+						</FormLabel>
+						<div className="order__fulfillment-actions">
+							{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
+							<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>
+							<Button primary onClick={ this.submit }>{ translate( 'Fulfill' ) }</Button>
+						</div>
+					</form>
+				</Dialog>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderFulfillment );

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -38,6 +38,10 @@ class OrderFulfillment extends Component {
 		trackingNumber: '',
 	}
 
+	isShippable = ( order ) => {
+		return ( -1 === [ 'completed', 'failed', 'cancelled', 'refunded' ].indexOf( order.status ) );
+	}
+
 	toggleDialog = () => {
 		this.setState( {
 			showDialog: ! this.state.showDialog,
@@ -84,6 +88,22 @@ class OrderFulfillment extends Component {
 		}
 	}
 
+	getFulfillmentStatus = () => {
+		const { order, translate } = this.props;
+		switch ( order.status ) {
+			case 'completed':
+				return translate( 'Order has been fulfilled' );
+			case 'cancelled':
+				return translate( 'Order has been cancelled' );
+			case 'refunded':
+				return translate( 'Order has been refunded' );
+			case 'failed':
+				return translate( 'Order has failed' );
+			default:
+				return translate( 'Order needs to be fulfilled' );
+		}
+	}
+
 	render() {
 		const { order, translate } = this.props;
 		const { errorMessage, showDialog, trackingNumber } = this.state;
@@ -96,11 +116,15 @@ class OrderFulfillment extends Component {
 			<div className="order__details-fulfillment">
 				<div className="order__details-fulfillment-label">
 					<Gridicon icon="shipping" />
-					{ translate( 'Order needs to be fulfilled' ) }
+					{ this.getFulfillmentStatus() }
 				</div>
 				<div className="order__details-fulfillment-action">
-					<Button primary onClick={ this.toggleDialog }>{ translate( 'Fulfill' ) }</Button>
+					{ ( this.isShippable( order ) )
+						? <Button primary onClick={ this.toggleDialog }>{ translate( 'Fulfill' ) }</Button>
+						: null
+					}
 				</div>
+
 				<Dialog isVisible={ showDialog } onClose={ this.toggleDialog } className={ dialogClass }>
 					<h1>{ translate( 'Fulfill order' ) }</h1>
 					<form>

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
@@ -112,10 +113,15 @@ class OrderFulfillment extends Component {
 			return null;
 		}
 
+		const classes = classNames( {
+			'order__details-fulfillment': true,
+			'is-completed': 'completed' === order.status,
+		} );
+
 		return (
-			<div className="order__details-fulfillment">
+			<div className={ classes }>
 				<div className="order__details-fulfillment-label">
-					<Gridicon icon="shipping" />
+					<Gridicon icon={ 'completed' === order.status ? 'checkmark' : 'shipping' } />
 					{ this.getFulfillmentStatus() }
 				</div>
 				<div className="order__details-fulfillment-action">

--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -18,6 +18,7 @@ import FormLabel from 'components/forms/form-label';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormTextInput from 'components/forms/form-text-input';
 import Notice from 'components/notice';
+import { updateOrder } from 'woocommerce/state/sites/orders/actions';
 
 class OrderFulfillment extends Component {
 	static propTypes = {
@@ -66,7 +67,10 @@ class OrderFulfillment extends Component {
 			return;
 		}
 
-		// @todo set order to complete
+		this.props.updateOrder( site.ID, {
+			id: order.id,
+			status: 'completed',
+		} );
 
 		this.toggleDialog();
 		const note = {
@@ -129,5 +133,5 @@ class OrderFulfillment extends Component {
 
 export default connect(
 	undefined,
-	dispatch => bindActionCreators( { createNote }, dispatch )
+	dispatch => bindActionCreators( { createNote, updateOrder }, dispatch )
 )( localize( OrderFulfillment ) );

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -217,6 +217,14 @@
 
 .order__details-fulfillment {
 	background: lighten( $blue-light, 25% );
+
+	&.is-completed {
+		background: transparent;
+
+		.order__details-fulfillment-label .gridicon {
+			color: $alert-green;
+		}
+	}
 }
 
 .order__customer-info {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -227,6 +227,14 @@
 	}
 }
 
+.order__customer-info-container {
+	display: flex;
+}
+
+.order__customer-billing {
+	width: 50%;
+}
+
 .order__customer-info {
 	.order__billing-details,
 	.order__shipping-details {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -248,6 +248,37 @@
 	}
 }
 
+
+&.dialog__content {
+	@include breakpoint( ">960px" ) {
+		width: 720px;
+	}
+
+	.form-text-input,
+	.form-text-input-with-affixes input {
+		text-align: right;
+	}
+
+	.order__refund-actions,
+	.order__fulfillment-actions {
+		margin: 0 -24px;
+		padding: 24px 24px 0;
+		min-width: 100%;
+		border-top: 1px solid lighten( $gray, 30% );
+		text-align: right;
+
+		button + button {
+			margin-left: 8px;
+		}
+	}
+
+	&.order__fulfillment {
+		.form-text-input {
+			text-align: left;
+		}
+	}
+}
+
 .order__refund-container {
 	display: flex;
 	flex-wrap: wrap;
@@ -294,16 +325,9 @@
 		margin-bottom: 8px;
 		color: $gray-text-min;
 	}
+}
 
-	.order__refund-actions {
-		margin: 0 -24px;
-		padding: 24px 24px 0;
-		min-width: 100%;
-		border-top: 1px solid lighten( $gray, 30% );
-		text-align: right;
-
-		button + button {
-			margin-left: 8px;
-		}
-	}
+.order__fulfillment-tracking,
+.order__fulfillment-email {
+	margin: 0 0 24px;
 }

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -23,7 +23,6 @@ import {
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import { getSiteAdminUrl } from 'state/sites/selectors';
 import humanDate from 'lib/human-date';
 import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
 import NavItem from 'components/section-nav/item';
@@ -146,14 +145,13 @@ class Orders extends Component {
 	}
 
 	render() {
-		const { createOrderLink, orders, translate } = this.props;
+		const { orders, translate } = this.props;
 		if ( ! orders.length ) {
 			return (
 				<div className="orders__container">
 					<EmptyContent
 						title={ translate( 'Your orders will appear here as they come in.' ) }
-						action={ translate( 'Manually add an order' ) }
-						actionURL={ createOrderLink } />
+					/>
 				</div>
 			);
 		}
@@ -188,7 +186,6 @@ export default connect(
 	state => {
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site ? site.ID : false;
-		const createOrderLink = getSiteAdminUrl( state, siteId, 'post-new.php?post_type=shop_order' );
 		const currentPage = getOrdersCurrentPage( state, siteId );
 		const orders = getOrders( state, currentPage, siteId );
 		const ordersLoading = areOrdersLoading( state, currentPage, siteId );
@@ -196,7 +193,6 @@ export default connect(
 		const totalPages = getTotalOrdersPages( state, siteId );
 
 		return {
-			createOrderLink,
 			currentPage,
 			orders,
 			ordersLoading,

--- a/client/extensions/woocommerce/state/sites/orders/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/reducer.js
@@ -98,9 +98,6 @@ export function items( state = {}, action ) {
 		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
 			orders = { [ action.orderId ]: action.order };
 			return Object.assign( {}, state, orders );
-		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
-			orders = { [ action.orderId ]: action.order };
-			return Object.assign( {}, state, orders );
 		default:
 			return state;
 	}

--- a/client/extensions/woocommerce/state/sites/orders/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/reducer.js
@@ -98,6 +98,9 @@ export function items( state = {}, action ) {
 		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
 			orders = { [ action.orderId ]: action.order };
 			return Object.assign( {}, state, orders );
+		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
+			orders = { [ action.orderId ]: action.order };
+			return Object.assign( {}, state, orders );
 		default:
 			return state;
 	}


### PR DESCRIPTION
This PR creates an OrderFulfillment card, which displays the shipping status and a fulfillment button for shippable orders. This is a manual fulfillment process, so the store owner can enter a tracking number to be emailed to the user, or just click "fulfill" to complete the order. In either case, a note is added to the order with the tracking number (whether emailed or not).

Screenshots:

<img width="744" alt="screen shot 2017-07-03 at 11 45 48 pm" src="https://user-images.githubusercontent.com/541093/27814672-27ce6c80-604c-11e7-9082-9dcef5022856.png">
<img width="785" alt="screen shot 2017-07-03 at 11 46 00 pm" src="https://user-images.githubusercontent.com/541093/27814674-29c96242-604c-11e7-982d-ef07b0e4bed8.png">
<img width="753" alt="screen shot 2017-07-03 at 11 45 34 pm" src="https://user-images.githubusercontent.com/541093/27814675-2bce5ffc-604c-11e7-9601-4949a61616f3.png">

**To test:**

- Visit your orders page
- Click into an order
- If it's able to be fulfilled (not cancelled, failed, refunded, or already completed), there will be a "Fulfill" button
- Try with a tracking number, and see that you're sent an email
- Try without, and just complete an order

Relies on #15790, fixes #15677