### PR TITLE
Add tracking to subscription warning notices on individual purchase page

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -23,6 +23,7 @@ import { getPurchase, getSelectedSite } from '../utils';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { isMonthly } from 'lib/plans/constants';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 class PurchaseNotice extends Component {
 	static propTypes = {
@@ -87,6 +88,19 @@ class PurchaseNotice extends Component {
 		);
 	}
 
+	trackImpression( warning ) {
+		const eventProperties = {
+			warning,
+			position: 'individual-purchase'
+		};
+		return (
+			<TrackComponentView
+				eventName="calypso_subscription_warning_impression"
+				eventProperties={ eventProperties }
+			/>
+		);
+	}
+
 	renderPurchaseExpiringNotice() {
 		const { moment } = this.props;
 		const purchase = getPurchase( this.props );
@@ -107,6 +121,7 @@ class PurchaseNotice extends Component {
 				text={ this.getExpiringText( purchase ) }
 			>
 				{ this.renderRenewNoticeAction() }
+				{ this.trackImpression( 'purchase-expiring' ) }
 			</Notice>
 		);
 	}
@@ -145,6 +160,7 @@ class PurchaseNotice extends Component {
 							},
 						}
 					) }
+					{ this.trackImpression( 'credit-card-expiring' ) }
 				</Notice>
 			);
 		}
@@ -169,6 +185,7 @@ class PurchaseNotice extends Component {
 				text={ translate( 'This purchase has expired and is no longer in use.' ) }
 			>
 				{ this.renderRenewNoticeAction() }
+				{ this.trackImpression( 'purchase-expired' ) }
 			</Notice>
 		);
 	}

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -107,7 +107,9 @@ class PurchaseNotice extends Component {
 
 	handleExpiringNoticeRenewal = () => {
 		this.trackClick( 'purchase-expiring' );
-		this.props.handleRenew();
+		if ( this.props.handleRenew ) {
+			this.props.handleRenew();
+		}
 	}
 
 	renderPurchaseExpiringNotice() {
@@ -184,7 +186,9 @@ class PurchaseNotice extends Component {
 
 	handleExpiredNoticeRenewal = () => {
 		this.trackClick( 'purchase-expired' );
-		this.props.handleRenew();
+		if ( this.props.handleRenew ) {
+			this.props.handleRenew();
+		}
 	}
 
 	renderExpiredRenewNotice() {


### PR DESCRIPTION
This is a continuation of the work from #15493 to add tracks events for notices related to domain or purchase issues.

This PR adds tracking to the three kinds of notification that can appear on individual purchase pages (http://calypso.localhost:3000/me/purchases/$SITE_URL/$SUBSCRIPTION_ID).

# Testing

You can enable debug logging of tracks events in the console by running `localStorage.setItem('debug', 'calypso:analytics:tracks');` and then reloading.

It is possible to simulate each of the three warning conditions for a purchase by modifying the data received from the server for purchases in `client/state/purchases/reducer.js:94`:

```
	console.log( 'purchases', action.purchases );
	const seconds = 1000;
	const minutes = 60 * seconds;
	const hours = 60 * minutes;
	const days = 24 * hours;
	for (let i = 0; i < action.purchases.length; i++) {
		const purchase = action.purchases[i];
		if ( purchase.ID && purchase.ID === "8358369" ) {
			const now = ( new Date() ).getTime();
			const date = new Date( now - 3 * days );
			purchase.expiry_date = date.toISOString();
			purchase.expiry_status = 'expired'; // included, expired, expiring, auto-renewing
			purchase.payment_card_id = "12345";
			purchase.payment_type = "credit_card";
			purchase.payment_expiry = "07/17";
			purchase.payment_card_type = "visa";
			purchase.payment_details = "4321";
		}
	}
```

The subscription id (8358369 in this example) can be determined from the url for the individual purchase.

The three warnings are:

* purchase expired
* purchase expiring
* credit card expiring

The first two cases can be simulated by changing `expiry_date` for a chosen purchase and setting `expiry_status` to `expired` and `expiring` respectively.  You will also need to make sure either `is_redeemable` or `is_renewable` is `true` for a purchase that has expired to see the notice.  The credit card expiry can be testing by changing `expiry_status` to `auto-renewing` and `expiry_date` to any time after `payment_expiry`.

The expected tracks events are:

* purchase expired impression - `calypso_subscription_warning_impression` with properies `{ position: 'individual-purchase', warning: 'purchase-expired' }`
* purchase expired click - `calypso_subscription_warning_click` with properies `{ position: 'individual-purchase', warning: 'purchase-expired' }`
* purchase expiring impression - `calypso_subscription_warning_impression` with properies `{ position: 'individual-purchase', warning: 'purchase-expiring' }`
* purchase expiring click - `calypso_subscription_warning_click` with properies `{ position: 'individual-purchase', warning: 'purchase-expiring' }`
* credit card expiring impression - `calypso_subscription_warning_impression` with properies `{ position: 'individual-purchase', warning: 'credit-card-expiring' }`
* credit card expiring click - `calypso_subscription_warning_click` with properies `{ position: 'individual-purchase', warning: 'credit-card-expiring' }`