### PR TITLE
Domains: add .ca to list of tlds we offer. 

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -22,6 +22,7 @@ const tlds = {
 	net: 'domain_reg',
 	org: 'domain_reg',
 	me: 'dotme_domain',
+	ca: 'dotca_domain',
 	co: 'dotco_domain',
 	'com.br': 'dotcomdotbr_domain',
 	info: 'dotinfo_domain',


### PR DESCRIPTION
Otherwise starting with a .ca domain (/start/domain-first) redirects back to /domains.

