### PR TITLE
Woo: Product action-list support for variation deletes

### DIFF
--- a/client/extensions/woocommerce/lib/generate-variations/test/index.js
+++ b/client/extensions/woocommerce/lib/generate-variations/test/index.js
@@ -174,4 +174,43 @@ describe( 'generateVariations', () => {
 		expect( variations[ 0 ].sku ).to.equal( 'red-small' );
 		expect( variations[ 1 ].sku ).to.equal( 'blue-small' );
 	} );
+
+	it( 'copies id and sku from existing product variations, where available', () => {
+		const product = { id: 2, attributes: [
+			{
+				name: 'Color',
+				options: [ 'Red', 'Blue' ],
+				variation: true,
+				uid: 'edit_0',
+			},
+			{
+				name: 'Size',
+				options: [ 'Small' ],
+				variation: true,
+				uid: 'edit_1',
+			},
+		] };
+
+		const productVariations = [
+			{ id: 25, sku: 'its-red-and-small', attributes: [
+				{ id: 0, name: 'Color', option: 'Red' },
+				{ id: 1, name: 'Size', option: 'Small' },
+			] },
+			{ sku: 'its-blue-and-small', attributes: [
+				{ id: 2, name: 'Color', option: 'Blue' },
+				{ id: 1, name: 'Size', option: 'Small' },
+			] },
+		];
+
+		const variations = generateVariations( product, productVariations );
+
+		expect( variations[ 0 ].id ).to.equal( 25 );
+		expect( variations[ 0 ].sku ).to.equal( 'its-red-and-small' );
+		expect( variations[ 0 ].attributes[ 0 ].id ).to.equal( 0 );
+		expect( variations[ 0 ].attributes[ 1 ].id ).to.equal( 1 );
+		expect( variations[ 1 ].id ).to.not.exist;
+		expect( variations[ 1 ].sku ).to.equal( 'its-blue-and-small' );
+		expect( variations[ 1 ].attributes[ 0 ].id ).to.equal( 2 );
+		expect( variations[ 1 ].attributes[ 1 ].id ).to.equal( 1 );
+	} );
 } );

--- a/client/extensions/woocommerce/state/data-layer/product-variations/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-variations/index.js
@@ -57,7 +57,7 @@ export function handleProductVariationCreate( store, action ) {
 	}
 
 	const updatedAction = ( dispatch, getState, data ) => {
-		dispatch( productVariationUpdated( siteId, data, action ) );
+		dispatch( productVariationUpdated( siteId, productId, data, action ) );
 
 		const props = { productId, sentData: variation, receivedData: data };
 		dispatchWithProps( dispatch, getState, successAction, props );
@@ -80,7 +80,7 @@ export function handleProductVariationUpdate( store, action ) {
 	}
 
 	const updatedAction = ( dispatch, getState, data ) => {
-		dispatch( productVariationUpdated( siteId, data, action ) );
+		dispatch( productVariationUpdated( siteId, productId, data, action ) );
 
 		const props = { productId: productId, sentData: variation, receivedData: data };
 		dispatchWithProps( dispatch, getState, successAction, props );

--- a/client/extensions/woocommerce/state/data-layer/ui/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/index.js
@@ -15,7 +15,7 @@ import { getAllVariationEdits } from 'woocommerce/state/ui/products/variations/s
 import { getAllProductCategoryEdits } from 'woocommerce/state/ui/product-categories/selectors';
 import { getVariationsForProduct } from 'woocommerce/state/sites/product-variations/selectors';
 import { createProduct, updateProduct } from 'woocommerce/state/sites/products/actions';
-import { createProductVariation, updateProductVariation } from 'woocommerce/state/sites/product-variations/actions';
+import { createProductVariation, updateProductVariation, deleteProductVariation } from 'woocommerce/state/sites/product-variations/actions';
 import { createProductCategory } from 'woocommerce/state/sites/product-categories/actions';
 import {
 	actionListStepNext,
@@ -290,19 +290,24 @@ export function makeProductVariationSteps( rootState, siteId, productEdits, vari
 
 	let variationCreates = [];
 	let variationUpdates = [];
+	let variationDeletes = [];
 
-	variationEdits.map( ( { productId, creates, updates } ) => {
+	variationEdits.map( ( { productId, creates, updates, deletes } ) => {
 		variationCreates = ( creates || [] ).map( ( variation ) => {
 			return variationCreateStep( siteId, productId, variation );
 		} );
 		variationUpdates = ( updates || [] ).map( ( variation ) => {
 			return variationUpdateStep( siteId, productId, variation );
 		} );
+		variationDeletes = ( deletes || [] ).map( ( variationId ) => {
+			return variationDeleteStep( siteId, productId, variationId );
+		} );
 	} );
 
 	return [
 		...variationCreates,
 		...variationUpdates,
+		...variationDeletes,
 	];
 }
 
@@ -331,6 +336,21 @@ function variationUpdateStep( siteId, productId, variation ) {
 				siteId,
 				productId,
 				variation,
+				actionListStepSuccess( actionList ),
+				actionListStepFailure( actionList ),
+			) );
+		},
+	};
+}
+
+function variationDeleteStep( siteId, productId, variationId ) {
+	return {
+		description: translate( 'Deleting variation' ),
+		onStep: ( dispatch, actionList ) => {
+			dispatch( deleteProductVariation(
+				siteId,
+				productId,
+				variationId,
 				actionListStepSuccess( actionList ),
 				actionListStepFailure( actionList ),
 			) );

--- a/client/extensions/woocommerce/state/data-layer/ui/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/index.js
@@ -39,7 +39,7 @@ export default {
 
 export function actionAppendProductVariations( { getState }, action ) {
 	const { siteId } = action;
-	const { id: productId } = action.product;
+	const productId = action.product && action.product.id;
 
 	action.productVariations = getVariationsForProduct( getState(), productId, siteId );
 }

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import { isEqual, uniqueId } from 'lodash';
 import { createReducer } from 'state/utils';
 
 /**
@@ -57,7 +57,7 @@ function editProduct( array, product, data ) {
 
 	// Look for this object in the appropriate create or edit array first.
 	const _array = prevArray.map( ( p ) => {
-		if ( product.id === p.id ) {
+		if ( isEqual( product.id, p.id ) ) {
 			found = true;
 			return { ...p, ...data };
 		}
@@ -75,13 +75,14 @@ function editProduct( array, product, data ) {
 
 export function editProductAttribute( attributes, attribute, data ) {
 	const prevAttributes = attributes || [];
+	const name = attribute && attribute.name;
 	const uid = attribute && attribute.uid || uniqueId( 'edit_' ) + ( new Date().getTime() );
 
 	let found = false;
 
 	// Look for this attribute in the array of attributes first.
 	const _attributes = prevAttributes.map( ( a ) => {
-		if ( uid === a.uid ) {
+		if ( ( uid && isEqual( uid, a.uid ) ) || ( name && isEqual( name, a.name ) ) ) {
 			found = true;
 			return { ...a, ...data };
 		}

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -84,7 +84,7 @@ export function editProductAttribute( attributes, attribute, data ) {
 	const _attributes = prevAttributes.map( ( a ) => {
 		if ( ( uid && isEqual( uid, a.uid ) ) || ( name && isEqual( name, a.name ) ) ) {
 			found = true;
-			return { ...a, ...data };
+			return { ...attribute, ...data, uid };
 		}
 
 		return a;

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find, isObject } from 'lodash';
+import { get, find, isEqual, isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,7 @@ export function getProductEdits( state, productId, siteId = getSelectedSiteId( s
 	const bucket = ( isObject( productId ) ? 'creates' : 'updates' );
 	const array = get( edits, bucket, [] );
 
-	return find( array, ( p ) => productId === p.id );
+	return find( array, ( p ) => isEqual( productId, p.id ) );
 }
 
 /**
@@ -82,7 +82,7 @@ export function getProductListProducts( state, siteId = getSelectedSiteId( state
 	const products = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], {} );
 	const productIds = get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'list', 'productIds' ], [] );
 	if ( productIds.length ) {
-		return productIds.map( id => find( products, ( p ) => id === p.id ) );
+		return productIds.map( id => find( products, ( p ) => isEqual( id, p.id ) ) );
 	}
 	return false;
 }
@@ -120,7 +120,7 @@ export function getProductSearchResults( state, siteId = getSelectedSiteId( stat
 	const products = get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], {} );
 	const productIds = get( state, [ 'extensions', 'woocommerce', 'ui', 'products', siteId, 'search', 'productIds' ], [] );
 	if ( productIds.length ) {
-		return productIds.map( id => find( products, ( p ) => id === p.id ) );
+		return productIds.map( id => find( products, ( p ) => isEqual( id, p.id ) ) );
 	}
 	return false;
 }

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -144,7 +144,7 @@ function editProductVariation( array, variation, data ) {
 function editProductAttributeAction( edits, action ) {
 	const { product, attribute, data, productVariations } = action;
 	const attributes = editProductAttribute( product.attributes, attribute, data );
-	const calculatedVariations = generateVariations( { ...product, attributes } );
+	const calculatedVariations = generateVariations( { ...product, attributes }, productVariations );
 
 	return updateProductEdits( edits, product.id, ( productEdits ) => {
 		const creates = ( productEdits ? productEdits.creates : [] );

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -44,9 +44,10 @@ export default createReducer( null, {
  * @return {Object} The new, updated product edits to be used in state.
  */
 function updateProductEdits( edits, productId, doUpdate ) {
+	const prevEdits = edits || [];
 	let found = false;
 
-	const newEdits = edits.map( ( productEdits ) => {
+	const newEdits = prevEdits.map( ( productEdits ) => {
 		if ( isEqual( productId, productEdits.productId ) ) {
 			found = true;
 			return doUpdate( productEdits );
@@ -64,7 +65,7 @@ function updateProductEdits( edits, productId, doUpdate ) {
 function editProductAction( edits, action ) {
 	const { product, data, productVariations } = action;
 
-	if ( 'simple' === data.type ) {
+	if ( product && 'simple' === data.type ) {
 		// Ensure there are no variation edits for this product,
 		// and that any existing ones have deletes.
 		return updateProductEdits( edits, product.id, () => {
@@ -85,7 +86,7 @@ function editProductVariationAction( edits, action ) {
 
 	// Look for an existing product edits first.
 	const _edits = prevEdits.map( ( productEdits ) => {
-		if ( productId === productEdits.productId ) {
+		if ( isEqual( productId, productEdits.productId ) ) {
 			found = true;
 			const variationId = variation && variation.id || { index: Number( uniqueId() ) };
 			const _variation = variation || { id: variationId };
@@ -124,7 +125,7 @@ function editProductVariation( array, variation, data ) {
 
 	// Look for this object in the appropriate create or edit array first.
 	const _array = prevArray.map( ( v ) => {
-		if ( variation.id === v.id ) {
+		if ( isEqual( variation.id, v.id ) ) {
 			found = true;
 			return { ...v, ...data };
 		}

--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, find, isNumber, isEqual } from 'lodash';
+import { compact, get, find, isNumber, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -81,11 +81,18 @@ export function getProductVariationsWithLocalEdits( state, productId, siteId = g
 	const edits = getVariationEditsStateForProduct( state, productId, siteId );
 	const creates = get( edits, 'creates', undefined );
 	const updates = get( edits, 'updates', undefined );
+	const deletes = get( edits, 'deletes', undefined );
 
-	const updatedVariations = ( variations || [] ).map( ( variation ) => {
+	const updatedVariations = compact( ( variations || [] ).map( ( variation ) => {
+		const isDeleted = Boolean( find( deletes, ( deletedId ) => variation.id === deletedId ) );
+
+		if ( isDeleted ) {
+			return undefined;
+		}
+
 		const update = find( updates, { id: variation.id } );
 		return { ...variation, ...update };
-	} );
+	} ) );
 
 	return ( creates || variations ? [ ...creates || [], ...updatedVariations || [] ] : undefined );
 }

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { set } from 'lodash';
+import { set, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ describe( 'edits-reducer', () => {
 	const existingVariableProduct1 = {
 		id: 101,
 		type: 'variable',
-		name: 'Existing Simple Product',
+		name: 'Existing Variable Product',
 		attributes: [
 			{ uid: 'edit_1', name: 'Color', options: [ 'Black' ], variation: true },
 		],
@@ -45,7 +45,7 @@ describe( 'edits-reducer', () => {
 	};
 
 	const variationBlue = {
-		id: { index: 4 },
+		id: { index: 5 },
 		attributes: [
 			{ name: 'Color', option: 'Blue' },
 		],
@@ -174,7 +174,7 @@ describe( 'edits-reducer', () => {
 
 		const edits1 = reducer( undefined, editProductVariation( siteId, product, null, { regular_price: '1.99' } ) );
 		const productEdits1 = edits1.find( function( p ) {
-			if ( product.id === p.productId ) {
+			if ( isEqual( product.id, p.productId ) ) {
 				return p;
 			}
 		} );
@@ -183,7 +183,7 @@ describe( 'edits-reducer', () => {
 
 		const edits2 = reducer( edits1, editProductVariation( siteId, product, null, { regular_price: '2.99' } ) );
 		const productEdits2 = edits2.find( function( p ) {
-			if ( product.id === p.productId ) {
+			if ( isEqual( product.id, p.productId ) ) {
 				return p;
 			}
 		} );
@@ -197,7 +197,7 @@ describe( 'edits-reducer', () => {
 
 		const edits1 = reducer( undefined, editProductVariation( siteId, product, variation1, { regular_price: '1.99' } ) );
 		const _edits1 = edits1.find( function( p ) {
-			if ( product.id === p.productId ) {
+			if ( isEqual( product.id, p.productId ) ) {
 				return p;
 			}
 		} );

--- a/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { set } from 'lodash';
+import { find, set } from 'lodash';
 
 /**
  * Internal dependencies
@@ -175,6 +175,20 @@ describe( 'selectors', () => {
 			expect( variations[ 0 ].id ).to.equal( existingVariation.id );
 			expect( variations[ 0 ].sku ).to.equal( existingVariation.sku );
 			expect( variations[ 0 ].price ).to.equal( '9.00' );
+		} );
+
+		it( 'should omit variations that have been deleted in the edits', () => {
+			const variationsBefore = getProductVariationsWithLocalEdits( state, 15, 123 );
+			expect( variationsBefore ).to.exist;
+			expect( find( variationsBefore, { id: 733 } ) ).to.exist;
+
+			const uiProducts = state.extensions.woocommerce.ui.products;
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 15 );
+			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'deletes' ], [ 733 ] );
+
+			const variationsAfter = getProductVariationsWithLocalEdits( state, 15, 123 );
+			expect( variationsAfter ).to.exist;
+			expect( find( variationsAfter, { id: 733 } ) ).to.not.exist;
 		} );
 	} );
 } );


### PR DESCRIPTION
This adds support to the edit state and action-list for
variation deletes. It omits variations that have a delete edit from
the combined view of edits and API data, and it adds the
deletes to the action list.

*Note for testing: Edit state is not being cleared completely yet, so you'll need to do a browser refresh after you save any changes.*

To test:

1. `npm test`
2. `npm start`
3. Visit `http://calypso.localhost:3000/store/product/<site_id>/<product_id>`
4. Ensure product is variable with several variations (edit and save them if needed, then refresh).
5. Click the "x" next to a variation type option.
6. Observe the variation type option disappears, and the variations involved with that option disappear as well.
7. Click "Update" to save changes via API.
8. Verify that the variation type option no longer exists either by refreshing the page or checking wp-admin interface.
