### PR TITLE
Prevent redirect loop on login when cookie expires

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -22,6 +22,7 @@ import { serverRender } from 'render';
 import stateCache from 'state-cache';
 import { createReduxStore, reducer } from 'state';
 import { DESERIALIZE } from 'state/action-types';
+import { login } from 'lib/paths';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -208,7 +209,8 @@ function setUpLoggedInRoute( req, res, next ) {
 
 		protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
 
-		redirectUrl = config( 'login_url' ) + '?' + qs.stringify( {
+		redirectUrl = login( {
+			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirect_to: protocol + '://' + config( 'hostname' ) + req.originalUrl
 		} );
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -228,6 +228,7 @@ function setUpLoggedInRoute( req, res, next ) {
 			if ( error ) {
 				if ( error.error === 'authorization_required' ) {
 					debug( 'User public API authorization required. Redirecting to %s', redirectUrl );
+					res.clearCookie( 'wordpress_logged_in', { path: '/', httpOnly: true, domain: '.wordpress.com' } );
 					res.redirect( redirectUrl );
 				} else {
 					if ( error.error ) {


### PR DESCRIPTION
This patch aim to fix a redirect loop bug which happens when the `wordpress_logged_in` cookie expires (the timestamp inside the cookie's value not the cookie's expiration date).

This is happening because the calypso server considers that the user is logged in if the cookie exists. When bootstrapping the user however, the request can fail if the cookie is invalid and the user is redirected to https://wordpress.com/ which in turns redirects to https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F and load the user bootstrap code again. We need to clear this cookie if the request to `/me` fails.

### Testing Instructions

This is a bit tricky to test locally as you need to sandbox wordpress.com

#### Set up your environment

1. Generate a self-signed certificate
- `git clone git@github.com:Automattic/node-sw-cache.git`
- `cd node-sw-cache`
- `npm install`
- `bin/sw-cache.js --target "http://localhost:3000" --proxy https://wordpress.com`
- type enter until the certificate is generated then enter your password so the certificate is added to the OS keystore
- Hit `Ctrl-C` to shutdown the proxy

2. Install nginx (for mac)
- `brew install nginx`
- `sudo cp /usr/local/opt/nginx/*.plist /Library/LaunchDaemons`
- `vi /usr/local/etc/nginx/servers/default.conf` copy paste config:
```
server {
    listen 80;
    server_name wordpress.com;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;
    server_name wordpress.com;

    ssl on;
    ssl_certificate /Users/tug/Work/Automattic/node-sw-cache/certificates/wordpress.com.crt;
    ssl_certificate_key /Users/tug/Work/Automattic/node-sw-cache/certificates/wordpress.com.key;

    location / {
        proxy_pass http://127.0.0.1:3000;
    }

    location /wp-login.php {
        proxy_pass https://192.0.78.9;
        proxy_set_header Host $http_host;
    }

    location /wp-admin {
        proxy_pass https://192.0.78.9;
        proxy_set_header Host $http_host;
    }

    location /wp-includes {
        proxy_pass https://192.0.78.9;
        proxy_set_header Host $http_host;
    }

    location /calypso {
        proxy_pass http://127.0.0.1:3000;
    }

    location /sites {
        proxy_pass http://127.0.0.1:3000;
    }
}
```
- Update node-sw-cache path with your path
- Run `sudo launchctl load -w /Library/LaunchDaemons/homebrew.mxcl.nginx.plist` to start nginx

3. Create a `secrets.json` file
- `cp config/empty-secrets.json config/secrets.json`
- Enter a valid value for `wpcom_calypso_rest_api_key` in `config/secrets.json`

4. Point wordpress.com to localhost
- Edit your `/etc/hosts` file to make `wordpress.com` point to `localhost`:
```
127.0.0.1		wordpress.com
```

#### Test the PR
- Apply this patch and run the server with `CALYPSO_ENV=production npm start`
- Go to https://wordpress.com
- You should be redirected to https://wordpress.com/log-in
- Log in with your credentials
- Edit your cookie expiration timestamp by replacing `wordpress_logged_in=<username>%7C1593705138%7Cxxxxx...` with `<username>%7C1%7Cxxxxx...`. This can be done on chrome from devtools > Application > Cookies > https://wordpress.com
- Reload the https://wordpress.com
- You should be redirected to to https://wordpress.com/log-in

### Reviews
- [x] Code
- [x] Product