### PR TITLE
Extensions: WPJM - Add UI for Job Submission settings

### DIFF
--- a/client/components/redux-forms/redux-form-select/index.jsx
+++ b/client/components/redux-forms/redux-form-select/index.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { Field } from 'redux-form';
+import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormSelect from 'components/forms/form-select';
+
+class ReduxFormSelect extends Component {
+	static propTypes = {
+		name: PropTypes.string,
+	};
+
+	renderSelect = ( { input: { onChange, value } } ) => {
+		const otherProps = omit( this.props, 'name' );
+
+		return (
+			<FormSelect
+				{ ...otherProps }
+				onChange={ this.updateSelect( onChange ) }
+				value={ value } />
+		);
+	}
+
+	updateSelect = onChange => event => onChange( event.target.value );
+
+	render() {
+		return (
+			<Field
+				{ ...this.props }
+				component={ this.renderSelect }
+				name={ this.props.name } />
+		);
+	}
+}
+
+export default ReduxFormSelect;

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { formValueSelector, reduxForm } from 'redux-form';
+import { FormSection, formValueSelector, reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 
@@ -21,165 +21,173 @@ import ReduxFormTextInput from 'components/redux-forms/redux-form-text-input';
 import ReduxFormToggle from 'components/redux-forms/redux-form-toggle';
 import SectionHeader from 'components/section-header';
 
-const JobSubmission = ( { isDisabled, duration, translate } ) => {
+const JobSubmission = ( { isDisabled, submissionDuration, translate } ) => {
 	return (
 		<div>
 			<form>
-				<SectionHeader label={ translate( 'Account' ) }>
-					<FormButton compact
-						disabled={ isDisabled } />
-				</SectionHeader>
-				<Card>
-					<FormFieldset>
-						<ReduxFormToggle
-							disabled={ isDisabled }
-							name="job_manager_user_requires_account"
-							text={ translate( 'Require an account to submit listings' ) } />
-						<FormSettingExplanation isIndented>
-							{ translate( 'Limits job listing submissions to registered, logged-in users.' ) }
-						</FormSettingExplanation>
+				<FormSection name="account">
+					<SectionHeader label={ translate( 'Account' ) }>
+						<FormButton compact
+							disabled={ isDisabled } />
+					</SectionHeader>
+					<Card>
+						<FormFieldset>
+							<ReduxFormToggle
+								disabled={ isDisabled }
+								name="isRequired"
+								text={ translate( 'Require an account to submit listings' ) } />
+							<FormSettingExplanation isIndented>
+								{ translate( 'Limits job listing submissions to registered, logged-in users.' ) }
+							</FormSettingExplanation>
 
-						<ReduxFormToggle
-							disabled={ isDisabled }
-							name="job_manager_enable_registration"
-							text={ translate( 'Enable account creation during submission' ) } />
-						<FormSettingExplanation isIndented>
-							{ translate( 'Includes account creation on the listing submission form, to allow ' +
-								'non-registered users to create an account and submit a job listing simultaneously.' ) }
-						</FormSettingExplanation>
+							<ReduxFormToggle
+								disabled={ isDisabled }
+								name="enableRegistration"
+								text={ translate( 'Enable account creation during submission' ) } />
+							<FormSettingExplanation isIndented>
+								{ translate( 'Includes account creation on the listing submission form, to allow ' +
+									'non-registered users to create an account and submit a job listing simultaneously.' ) }
+							</FormSettingExplanation>
 
-						<ReduxFormToggle
-							disabled={ isDisabled }
-							name="job_manager_generate_username_from_email"
-							text="Generate usernames from email addresses" />
-						<FormSettingExplanation isIndented>
-							{ translate( 'Automatically generates usernames for new accounts from the registrant\'s ' +
-								'email address. If this is not enabled, a "username" field will display instead.' ) }
-						</FormSettingExplanation>
-					</FormFieldset>
+							<ReduxFormToggle
+								disabled={ isDisabled }
+								name="generateUsername"
+								text="Generate usernames from email addresses" />
+							<FormSettingExplanation isIndented>
+								{ translate( 'Automatically generates usernames for new accounts from the registrant\'s ' +
+									'email address. If this is not enabled, a "username" field will display instead.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
 
-					<FormFieldset>
-						<FormLabel>
-							{ translate( 'Role' ) }
-						</FormLabel>
-						<ReduxFormSelect
-							disabled={ isDisabled }
-							name="job_manager_registration_role">
-							<option value="editor">{ translate( 'Editor' ) }</option>
-							<option value="author">{ translate( 'Author' ) }</option>
-							<option value="contributor">{ translate( 'Contributor' ) }</option>
-							<option value="subscriber">{ translate( 'Subscriber' ) }</option>
-							<option value="teacher">{ translate( 'Teacher' ) }</option>
-							<option value="employer">{ translate( 'Employer' ) }</option>
-							<option value="customer">{ translate( 'Customer' ) }</option>
-							<option value="shop_manager">{ translate( 'Shop manager' ) }</option>
-						</ReduxFormSelect>
-						<FormSettingExplanation>
-							{ translate( 'Any new accounts created during submission will have this role.' ) }
-						</FormSettingExplanation>
-					</FormFieldset>
-				</Card>
+						<FormFieldset>
+							<FormLabel>
+								{ translate( 'Role' ) }
+							</FormLabel>
+							<ReduxFormSelect
+								disabled={ isDisabled }
+								name="role">
+								<option value="editor">{ translate( 'Editor' ) }</option>
+								<option value="author">{ translate( 'Author' ) }</option>
+								<option value="contributor">{ translate( 'Contributor' ) }</option>
+								<option value="subscriber">{ translate( 'Subscriber' ) }</option>
+								<option value="teacher">{ translate( 'Teacher' ) }</option>
+								<option value="employer">{ translate( 'Employer' ) }</option>
+								<option value="customer">{ translate( 'Customer' ) }</option>
+								<option value="shop_manager">{ translate( 'Shop manager' ) }</option>
+							</ReduxFormSelect>
+							<FormSettingExplanation>
+								{ translate( 'Any new accounts created during submission will have this role.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+					</Card>
+				</FormSection>
 			</form>
 
 			<form>
-				<SectionHeader label={ translate( 'Approval' ) }>
-					<FormButton compact
-						disabled={ isDisabled } />
-				</SectionHeader>
-				<Card>
-					<FormFieldset>
-						<ReduxFormToggle
-							disabled={ isDisabled }
-							name="job_manager_submission_requires_approval"
-							text={ translate( 'Require admin approval of all new listing submissions' ) } />
-						<FormSettingExplanation isIndented>
-							{ translate( 'Sets all new submissions to "pending." They will not appear on your ' +
-								'site until an admin approves them.' ) }
-						</FormSettingExplanation>
+				<FormSection name="approval">
+					<SectionHeader label={ translate( 'Approval' ) }>
+						<FormButton compact
+							disabled={ isDisabled } />
+					</SectionHeader>
+					<Card>
+						<FormFieldset>
+							<ReduxFormToggle
+								disabled={ isDisabled }
+								name="isRequired"
+								text={ translate( 'Require admin approval of all new listing submissions' ) } />
+							<FormSettingExplanation isIndented>
+								{ translate( 'Sets all new submissions to "pending." They will not appear on your ' +
+									'site until an admin approves them.' ) }
+							</FormSettingExplanation>
 
-						<ReduxFormToggle
-							disabled={ isDisabled }
-							name="job_manager_user_can_edit_pending_submissions"
-							text="Allow editing of pending listings" />
-						<FormSettingExplanation isIndented>
-							{ translate( 'Users can continue to edit pending listings until they are approved by an admin.' ) }
-						</FormSettingExplanation>
-					</FormFieldset>
-				</Card>
+							<ReduxFormToggle
+								disabled={ isDisabled }
+								name="canEdit"
+								text="Allow editing of pending listings" />
+							<FormSettingExplanation isIndented>
+								{ translate( 'Users can continue to edit pending listings until they are approved by an admin.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+					</Card>
+				</FormSection>
 			</form>
 
 			<form>
-				<SectionHeader label={ translate( 'Listing Duration' ) }>
-					<FormButton compact
-						disabled={ isDisabled } />
-				</SectionHeader>
-				<Card>
-					<FormFieldset>
-						{ translate(
-							'Display listings for {{days /}} day',
-							'Display listings for {{days /}} days',
-							{
-								count: duration,
-								components: {
-									days:
-										<ReduxFormTextInput
-											disabled={ isDisabled }
-											min="0"
-											name="job_manager_submission_duration"
-											step="1"
-											type="number" />
+				<FormSection name="duration">
+					<SectionHeader label={ translate( 'Listing Duration' ) }>
+						<FormButton compact
+							disabled={ isDisabled } />
+					</SectionHeader>
+					<Card>
+						<FormFieldset>
+							{ translate(
+								'Display listings for {{days /}} day',
+								'Display listings for {{days /}} days',
+								{
+									count: submissionDuration,
+									components: {
+										days:
+											<ReduxFormTextInput
+												disabled={ isDisabled }
+												min="0"
+												name="submissionDuration"
+												step="1"
+												type="number" />
+									}
 								}
-							}
-						) }
-						<FormSettingExplanation>
-							{ translate( 'Listings will display for the set number of days, then expire. ' +
-								'Leave this field blank if you don\'t want listings to have an expiration date.' ) }
-						</FormSettingExplanation>
-					</FormFieldset>
-				</Card>
+							) }
+							<FormSettingExplanation>
+								{ translate( 'Listings will display for the set number of days, then expire. ' +
+									'Leave this field blank if you don\'t want listings to have an expiration date.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+					</Card>
+				</FormSection>
 			</form>
 
 			<form>
-				<SectionHeader label={ translate( 'Application Method' ) }>
-					<FormButton compact
-						disabled={ isDisabled } />
-				</SectionHeader>
-				<Card>
-					<FormFieldset>
-						<FormSettingExplanation>
-							{ translate( 'Choose the contact method for listings.' ) }
-						</FormSettingExplanation>
-						<FormLabel>
-							<ReduxFormRadio
-								disabled={ isDisabled }
-								name="job_manager_allowed_application_method"
-								value="" />
-							<span>
-								{ translate( 'Email address or website URL' ) }
-							</span>
-						</FormLabel>
+				<FormSection name="method">
+					<SectionHeader label={ translate( 'Application Method' ) }>
+						<FormButton compact
+							disabled={ isDisabled } />
+					</SectionHeader>
+					<Card>
+						<FormFieldset>
+							<FormSettingExplanation>
+								{ translate( 'Choose the contact method for listings.' ) }
+							</FormSettingExplanation>
+							<FormLabel>
+								<ReduxFormRadio
+									disabled={ isDisabled }
+									name="applicationMethod"
+									value="" />
+								<span>
+									{ translate( 'Email address or website URL' ) }
+								</span>
+							</FormLabel>
 
-						<FormLabel>
-							<ReduxFormRadio
-								disabled={ isDisabled }
-								name="job_manager_allowed_application_method"
-								value="email" />
-							<span>
-								{ translate( 'Email addresses only' ) }
-							</span>
-						</FormLabel>
+							<FormLabel>
+								<ReduxFormRadio
+									disabled={ isDisabled }
+									name="applicationMethod"
+									value="email" />
+								<span>
+									{ translate( 'Email addresses only' ) }
+								</span>
+							</FormLabel>
 
-						<FormLabel>
-							<ReduxFormRadio
-								disabled={ isDisabled }
-								name="job_manager_allowed_application_method"
-								value="url" />
-							<span>
-								{ translate( 'Website URLs only' ) }
-							</span>
-						</FormLabel>
-					</FormFieldset>
-				</Card>
+							<FormLabel>
+								<ReduxFormRadio
+									disabled={ isDisabled }
+									name="applicationMethod"
+									value="url" />
+								<span>
+									{ translate( 'Website URLs only' ) }
+								</span>
+							</FormLabel>
+						</FormFieldset>
+					</Card>
+				</FormSection>
 			</form>
 		</div>
 	);
@@ -195,7 +203,7 @@ const connectComponent = connect(
 		const selector = formValueSelector( 'submission', () => state.extensions.wpJobManager.form );
 
 		return {
-			duration: selector( state, 'job_manager_submission_duration' ),
+			submissionDuration: selector( state, 'duration.submissionDuration' ),
 		};
 	}
 );

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -21,16 +21,18 @@ import ReduxFormTextInput from 'components/redux-forms/redux-form-text-input';
 import ReduxFormToggle from 'components/redux-forms/redux-form-toggle';
 import SectionHeader from 'components/section-header';
 
-const JobSubmission = ( { duration, translate } ) => {
+const JobSubmission = ( { isDisabled, duration, translate } ) => {
 	return (
 		<div>
 			<form>
 				<SectionHeader label={ translate( 'Account' ) }>
-					<FormButton compact primary />
+					<FormButton compact
+						disabled={ isDisabled } />
 				</SectionHeader>
 				<Card>
 					<FormFieldset>
 						<ReduxFormToggle
+							disabled={ isDisabled }
 							name="job_manager_user_requires_account"
 							text={ translate( 'Require an account to submit listings' ) } />
 						<FormSettingExplanation isIndented>
@@ -38,6 +40,7 @@ const JobSubmission = ( { duration, translate } ) => {
 						</FormSettingExplanation>
 
 						<ReduxFormToggle
+							disabled={ isDisabled }
 							name="job_manager_enable_registration"
 							text={ translate( 'Enable account creation during submission' ) } />
 						<FormSettingExplanation isIndented>
@@ -46,6 +49,7 @@ const JobSubmission = ( { duration, translate } ) => {
 						</FormSettingExplanation>
 
 						<ReduxFormToggle
+							disabled={ isDisabled }
 							name="job_manager_generate_username_from_email"
 							text="Generate usernames from email addresses" />
 						<FormSettingExplanation isIndented>
@@ -58,7 +62,9 @@ const JobSubmission = ( { duration, translate } ) => {
 						<FormLabel>
 							{ translate( 'Role' ) }
 						</FormLabel>
-						<ReduxFormSelect name="job_manager_registration_role">
+						<ReduxFormSelect
+							disabled={ isDisabled }
+							name="job_manager_registration_role">
 							<option value="editor">{ translate( 'Editor' ) }</option>
 							<option value="author">{ translate( 'Author' ) }</option>
 							<option value="contributor">{ translate( 'Contributor' ) }</option>
@@ -77,11 +83,13 @@ const JobSubmission = ( { duration, translate } ) => {
 
 			<form>
 				<SectionHeader label={ translate( 'Approval' ) }>
-					<FormButton compact primary />
+					<FormButton compact
+						disabled={ isDisabled } />
 				</SectionHeader>
 				<Card>
 					<FormFieldset>
 						<ReduxFormToggle
+							disabled={ isDisabled }
 							name="job_manager_submission_requires_approval"
 							text={ translate( 'Require admin approval of all new listing submissions' ) } />
 						<FormSettingExplanation isIndented>
@@ -90,6 +98,7 @@ const JobSubmission = ( { duration, translate } ) => {
 						</FormSettingExplanation>
 
 						<ReduxFormToggle
+							disabled={ isDisabled }
 							name="job_manager_user_can_edit_pending_submissions"
 							text="Allow editing of pending listings" />
 						<FormSettingExplanation isIndented>
@@ -101,7 +110,8 @@ const JobSubmission = ( { duration, translate } ) => {
 
 			<form>
 				<SectionHeader label={ translate( 'Listing Duration' ) }>
-					<FormButton compact primary />
+					<FormButton compact
+						disabled={ isDisabled } />
 				</SectionHeader>
 				<Card>
 					<FormFieldset>
@@ -113,6 +123,7 @@ const JobSubmission = ( { duration, translate } ) => {
 								components: {
 									days:
 										<ReduxFormTextInput
+											disabled={ isDisabled }
 											min="0"
 											name="job_manager_submission_duration"
 											step="1"
@@ -130,7 +141,8 @@ const JobSubmission = ( { duration, translate } ) => {
 
 			<form>
 				<SectionHeader label={ translate( 'Application Method' ) }>
-					<FormButton compact primary />
+					<FormButton compact
+						disabled={ isDisabled } />
 				</SectionHeader>
 				<Card>
 					<FormFieldset>
@@ -139,6 +151,7 @@ const JobSubmission = ( { duration, translate } ) => {
 						</FormSettingExplanation>
 						<FormLabel>
 							<ReduxFormRadio
+								disabled={ isDisabled }
 								name="job_manager_allowed_application_method"
 								value="" />
 							<span>
@@ -148,6 +161,7 @@ const JobSubmission = ( { duration, translate } ) => {
 
 						<FormLabel>
 							<ReduxFormRadio
+								disabled={ isDisabled }
 								name="job_manager_allowed_application_method"
 								value="email" />
 							<span>
@@ -157,6 +171,7 @@ const JobSubmission = ( { duration, translate } ) => {
 
 						<FormLabel>
 							<ReduxFormRadio
+								disabled={ isDisabled }
 								name="job_manager_allowed_application_method"
 								value="url" />
 							<span>
@@ -171,6 +186,7 @@ const JobSubmission = ( { duration, translate } ) => {
 };
 
 JobSubmission.propTypes = {
+	isDisabled: PropTypes.bool,
 	translate: PropTypes.func,
 };
 

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -1,5 +1,197 @@
-const JobSubmission = () => {
-	return null;
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { formValueSelector, reduxForm } from 'redux-form';
+import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import ReduxFormRadio from 'components/redux-forms/redux-form-radio';
+import ReduxFormSelect from 'components/redux-forms/redux-form-select';
+import ReduxFormTextInput from 'components/redux-forms/redux-form-text-input';
+import ReduxFormToggle from 'components/redux-forms/redux-form-toggle';
+import SectionHeader from 'components/section-header';
+
+const JobSubmission = ( { duration, translate } ) => {
+	return (
+		<div>
+			<form>
+				<SectionHeader label={ translate( 'Account' ) }>
+					<FormButton compact primary />
+				</SectionHeader>
+				<Card>
+					<FormFieldset>
+						<ReduxFormToggle
+							name="job_manager_user_requires_account"
+							text={ translate( 'Require an account to submit listings' ) } />
+						<FormSettingExplanation isIndented>
+							{ translate( 'Limits job listing submissions to registered, logged-in users.' ) }
+						</FormSettingExplanation>
+
+						<ReduxFormToggle
+							name="job_manager_enable_registration"
+							text={ translate( 'Enable account creation during submission' ) } />
+						<FormSettingExplanation isIndented>
+							{ translate( 'Includes account creation on the listing submission form, to allow ' +
+								'non-registered users to create an account and submit a job listing simultaneously.' ) }
+						</FormSettingExplanation>
+
+						<ReduxFormToggle
+							name="job_manager_generate_username_from_email"
+							text="Generate usernames from email addresses" />
+						<FormSettingExplanation isIndented>
+							{ translate( 'Automatically generates usernames for new accounts from the registrant\'s ' +
+								'email address. If this is not enabled, a "username" field will display instead.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel>
+							{ translate( 'Role' ) }
+						</FormLabel>
+						<ReduxFormSelect name="job_manager_registration_role">
+							<option value="editor">{ translate( 'Editor' ) }</option>
+							<option value="author">{ translate( 'Author' ) }</option>
+							<option value="contributor">{ translate( 'Contributor' ) }</option>
+							<option value="subscriber">{ translate( 'Subscriber' ) }</option>
+							<option value="teacher">{ translate( 'Teacher' ) }</option>
+							<option value="employer">{ translate( 'Employer' ) }</option>
+							<option value="customer">{ translate( 'Customer' ) }</option>
+							<option value="shop_manager">{ translate( 'Shop manager' ) }</option>
+						</ReduxFormSelect>
+						<FormSettingExplanation>
+							{ translate( 'Any new accounts created during submission will have this role.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				</Card>
+			</form>
+
+			<form>
+				<SectionHeader label={ translate( 'Approval' ) }>
+					<FormButton compact primary />
+				</SectionHeader>
+				<Card>
+					<FormFieldset>
+						<ReduxFormToggle
+							name="job_manager_submission_requires_approval"
+							text={ translate( 'Require admin approval of all new listing submissions' ) } />
+						<FormSettingExplanation isIndented>
+							{ translate( 'Sets all new submissions to "pending." They will not appear on your ' +
+								'site until an admin approves them.' ) }
+						</FormSettingExplanation>
+
+						<ReduxFormToggle
+							name="job_manager_user_can_edit_pending_submissions"
+							text="Allow editing of pending listings" />
+						<FormSettingExplanation isIndented>
+							{ translate( 'Users can continue to edit pending listings until they are approved by an admin.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				</Card>
+			</form>
+
+			<form>
+				<SectionHeader label={ translate( 'Listing Duration' ) }>
+					<FormButton compact primary />
+				</SectionHeader>
+				<Card>
+					<FormFieldset>
+						{ translate(
+							'Display listings for {{days /}} day',
+							'Display listings for {{days /}} days',
+							{
+								count: duration,
+								components: {
+									days:
+										<ReduxFormTextInput
+											min="0"
+											name="job_manager_submission_duration"
+											step="1"
+											type="number" />
+								}
+							}
+						) }
+						<FormSettingExplanation>
+							{ translate( 'Listings will display for the set number of days, then expire. ' +
+								'Leave this field blank if you don\'t want listings to have an expiration date.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				</Card>
+			</form>
+
+			<form>
+				<SectionHeader label={ translate( 'Application Method' ) }>
+					<FormButton compact primary />
+				</SectionHeader>
+				<Card>
+					<FormFieldset>
+						<FormSettingExplanation>
+							{ translate( 'Choose the contact method for listings.' ) }
+						</FormSettingExplanation>
+						<FormLabel>
+							<ReduxFormRadio
+								name="job_manager_allowed_application_method"
+								value="" />
+							<span>
+								{ translate( 'Email address or website URL' ) }
+							</span>
+						</FormLabel>
+
+						<FormLabel>
+							<ReduxFormRadio
+								name="job_manager_allowed_application_method"
+								value="email" />
+							<span>
+								{ translate( 'Email addresses only' ) }
+							</span>
+						</FormLabel>
+
+						<FormLabel>
+							<ReduxFormRadio
+								name="job_manager_allowed_application_method"
+								value="url" />
+							<span>
+								{ translate( 'Website URLs only' ) }
+							</span>
+						</FormLabel>
+					</FormFieldset>
+				</Card>
+			</form>
+		</div>
+	);
 };
 
-export default JobSubmission;
+JobSubmission.propTypes = {
+	translate: PropTypes.func,
+};
+
+const connectComponent = connect(
+	( state ) => {
+		const selector = formValueSelector( 'submission', () => state.extensions.wpJobManager.form );
+
+		return {
+			duration: selector( state, 'job_manager_submission_duration' ),
+		};
+	}
+);
+
+const createReduxForm = reduxForm( {
+	enableReinitialize: true,
+	form: 'submission',
+	getFormState: state => state.extensions.wpJobManager.form,
+} );
+
+export default flowRight(
+	connectComponent,
+	localize,
+	createReduxForm,
+)( JobSubmission );

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -76,7 +76,9 @@ const JobSubmission = ( { isDisabled, submissionDuration, translate } ) => {
 								<option value="shop_manager">{ translate( 'Shop manager' ) }</option>
 							</ReduxFormSelect>
 							<FormSettingExplanation>
-								{ translate( 'Any new accounts created during submission will have this role.' ) }
+								{ translate( 'Any new accounts created during submission will have this role. ' +
+									'If you haven\'t enabled account creation during submission in the options above, ' +
+									'your own method of assigning roles will apply.' ) }
 							</FormSettingExplanation>
 						</FormFieldset>
 					</Card>
@@ -154,7 +156,8 @@ const JobSubmission = ( { isDisabled, submissionDuration, translate } ) => {
 					<Card>
 						<FormFieldset>
 							<FormSettingExplanation>
-								{ translate( 'Choose the contact method for listings.' ) }
+								{ translate( 'Choose the application method job listers will need to provide. ' +
+									'Specify URL or email address only, or allow listers to choose which they prefer.' ) }
 							</FormSettingExplanation>
 							<FormLabel>
 								<ReduxFormRadio

--- a/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
@@ -71,23 +71,35 @@ describe( '#updateExtensionSettings', () => {
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( updateSettings( 12345678, {
-			listings: {
-				perPage: 25,
-				hideFilledPositions: true,
-				hideExpired: undefined,
-				hideExpiredContent: undefined
+			account: {
+				enableRegistration: undefined,
+				generateUsername: undefined,
+				isRequired: undefined,
+				role: undefined,
+			},
+			apiKey: { googleMapsApiKey: undefined },
+			approval: {
+				canEdit: undefined,
+				isRequired: undefined,
 			},
 			categories: {
 				enableCategories: undefined,
 				enableDefaultCategory: undefined,
 				categoryFilterType: undefined
 			},
+			duration: { submissionDuration: undefined },
+			format: { dateFormat: undefined },
+			listings: {
+				perPage: 25,
+				hideFilledPositions: true,
+				hideExpired: undefined,
+				hideExpiredContent: undefined
+			},
+			method: { applicationMethod: undefined },
 			types: {
 				enableTypes: undefined,
 				multiJobType: undefined
 			},
-			format: { dateFormat: undefined },
-			apiKey: { googleMapsApiKey: undefined }
 		} ) );
 	} );
 } );

--- a/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
@@ -1,24 +1,40 @@
 export const fromApi = data => ( {
-	listings: {
-		perPage: data.job_manager_per_page,
-		hideFilledPositions: data.job_manager_hide_filled_positions,
-		hideExpired: data.job_manager_hide_expired,
-		hideExpiredContent: data.job_manager_hide_expired_content,
+	account: {
+		enableRegistration: data.job_manager_enable_registration,
+		generateUsername: data.job_manager_generate_username_from_email,
+		isRequired: data.job_manager_user_requires_account,
+		role: data.job_manager_registration_role,
+	},
+	apiKey: {
+		googleMapsApiKey: data.job_manager_google_maps_api_key,
+	},
+	approval: {
+		canEdit: data.job_manager_user_can_edit_pending_submissions,
+		isRequired: data.job_manager_submission_requires_approval,
 	},
 	categories: {
 		enableCategories: data.job_manager_enable_categories,
 		enableDefaultCategory: data.job_manager_enable_default_category_multiselect,
 		categoryFilterType: data.job_manager_category_filter_type,
 	},
-	types: {
-		enableTypes: data.job_manager_enable_types,
-		multiJobType: data.job_manager_multi_job_type,
+	duration: {
+		submissionDuration: data.job_manager_submission_duration,
 	},
 	format: {
 		dateFormat: data.job_manager_date_format,
 	},
-	apiKey: {
-		googleMapsApiKey: data.job_manager_google_maps_api_key,
+	listings: {
+		perPage: data.job_manager_per_page,
+		hideFilledPositions: data.job_manager_hide_filled_positions,
+		hideExpired: data.job_manager_hide_expired,
+		hideExpiredContent: data.job_manager_hide_expired_content,
+	},
+	method: {
+		applicationMethod: data.job_manager_allowed_application_method,
+	},
+	types: {
+		enableTypes: data.job_manager_enable_types,
+		multiJobType: data.job_manager_multi_job_type,
 	},
 } );
 


### PR DESCRIPTION
This PR adds the UI and fetches live data for the WP Job Manager _Job Submission_ settings page.

_Job Submission Tab in Calypso_ (Updated)

![job-submission-upper](https://user-images.githubusercontent.com/1190420/28017415-2008e9b2-6547-11e7-8f8b-1a043f03b00b.jpg)
![job-submissino-lower](https://user-images.githubusercontent.com/1190420/28017418-216cce36-6547-11e7-98c9-2e8bee9ef77b.jpg)

_Job Submission Tab in Plugin_

![job-submission-plugin](https://user-images.githubusercontent.com/1190420/27828196-e233d04c-6088-11e7-9e4a-247a83a8c9fa.jpg)

## Testing

Testing should verify that real data is being fetched from the REST API and displayed, as well as ensuring that settings are initially disabled while data is being fetched.