### PR TITLE
Update the current URL when a new shipping zone is saved.

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -64,6 +64,11 @@ class Shipping extends Component {
 		if ( this.props.zone && ! zone ) {
 			page.redirect( getLink( '/store/settings/shipping/:site', site ) );
 		}
+
+		// If the zone didn't have a real ID before but it does now, change the URL from /zone/new to /zone/ID
+		if ( this.props.zone && isNaN( this.props.zone.id ) && zone && ! isNaN( zone.id ) ) {
+			page.replace( getLink( '/store/settings/shipping/:site/zone/' + zone.id, site ), null, false, false );
+		}
 	}
 
 	onSave() {


### PR DESCRIPTION
When creating a new shipping zone, the URL is `/store/:site/zone/new`. After the user hits "Save"
and the server replies with the created zone, now the URL is updated to `/store/:site/zone/27`
(or whatever ID the zone has). This is just a cosmetic change in the URL, without triggering
any route-related code or re-rendering the page or anything.