### PR TITLE
Comments: Add custom datetime formats to CommentDetail

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -12,6 +12,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import Gravatar from 'components/gravatar';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import { urlToDomainAndPath } from 'lib/url';
 import {
 	defaultDateFormats,
@@ -154,6 +155,7 @@ export class CommentDetailAuthor extends Component {
 			authorUrl,
 			commentStatus,
 			showAuthorInfo,
+			siteId,
 			translate,
 		} = this.props;
 		const { isExpanded } = this.state;
@@ -164,6 +166,8 @@ export class CommentDetailAuthor extends Component {
 
 		return (
 			<div className={ classes }>
+				<QuerySiteSettings siteId={ siteId } />
+
 				<div className="comment-detail__author-preview">
 					<Gravatar user={ this.getAuthorObject() } />
 					<div className="comment-detail__author-info">

--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -13,6 +13,10 @@ import { get } from 'lodash';
  */
 import Gravatar from 'components/gravatar';
 import { urlToDomainAndPath } from 'lib/url';
+import {
+	defaultDateFormats,
+	defaultTimeFormats,
+} from 'my-sites/site-settings/date-time-format/default-formats';
 import { phpToMomentDatetimeFormat } from 'my-sites/site-settings/date-time-format/utils';
 import { getSiteSettings } from 'state/site-settings/selectors';
 
@@ -59,6 +63,14 @@ export class CommentDetailAuthor extends Component {
 		} = this.props;
 
 		const momentDate = moment( commentDate );
+
+		if ( ! dateFormat || ! timeFormat ) {
+			return phpToMomentDatetimeFormat(
+				momentDate,
+				defaultDateFormats[ 0 ] + ' ' + defaultTimeFormats[ 0 ]
+			);
+		}
+
 		const date = phpToMomentDatetimeFormat( momentDate, dateFormat );
 		const time = phpToMomentDatetimeFormat( momentDate, timeFormat );
 

--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -25,6 +25,7 @@ export class CommentDetailComment extends Component {
 		commentContent: PropTypes.string,
 		commentDate: PropTypes.string,
 		commentStatus: PropTypes.string,
+		siteId: PropTypes.number,
 	};
 
 	render() {
@@ -41,6 +42,7 @@ export class CommentDetailComment extends Component {
 			commentDate,
 			commentStatus,
 			repliedToComment,
+			siteId,
 			translate,
 		} = this.props;
 
@@ -58,6 +60,7 @@ export class CommentDetailComment extends Component {
 						blockUser={ blockUser }
 						commentDate={ commentDate }
 						commentStatus={ commentStatus }
+						siteId={ siteId }
 					/>
 					<AutoDirection>
 						<div className="comment-detail__comment-body"

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -201,6 +201,7 @@ export class CommentDetail extends Component {
 							commentDate={ commentDate }
 							commentStatus={ commentStatus }
 							repliedToComment={ repliedToComment }
+							siteId={ siteId }
 						/>
 						<CommentDetailReply
 							authorDisplayName={ authorDisplayName }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -22,7 +22,6 @@ import CommentFaker from 'blocks/comment-detail/docs/comment-faker';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
 import QuerySiteComments from 'components/data/query-site-comments';
-import QuerySiteSettings from 'components/data/query-site-settings';
 import { hasSiteComments } from 'state/selectors';
 
 export class CommentList extends Component {
@@ -240,7 +239,6 @@ export class CommentList extends Component {
 		return (
 			<div className="comment-list">
 				<QuerySiteComments siteId={ siteId } status="all" />
-				<QuerySiteSettings siteId={ siteId } />
 
 				<CommentNavigation
 					isBulkEdit={ isBulkEdit }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -22,6 +22,7 @@ import CommentFaker from 'blocks/comment-detail/docs/comment-faker';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
 import QuerySiteComments from 'components/data/query-site-comments';
+import QuerySiteSettings from 'components/data/query-site-settings';
 import { hasSiteComments } from 'state/selectors';
 
 export class CommentList extends Component {
@@ -239,6 +240,8 @@ export class CommentList extends Component {
 		return (
 			<div className="comment-list">
 				<QuerySiteComments siteId={ siteId } status="all" />
+				<QuerySiteSettings siteId={ siteId } />
+
 				<CommentNavigation
 					isBulkEdit={ isBulkEdit }
 					isSelectedAll={ this.isSelectedAll() }


### PR DESCRIPTION
Fixes #15808 

Introduce the custom date and time formats (available in site settings) into the Comment Management.

The comment date is a full datetime string such as `2017-06-20T11:33:31+00:00` and I believe the user expects to see both date and time, but we have two separated formats for the date and the time.
In the [codex](https://codex.wordpress.org/Function_Reference/wp_list_comments) there's an example that uses the "at" to link date and time:
```php
printf( __('%1$s at %2$s'), get_comment_date(),  get_comment_time() );
```
For lack of better opinions, I've used the very same approach.

### Sidenote
In the Reader we use a "from now" approach (see [Moment.js docs](http://momentjs.com/docs/#/displaying/fromnow/)).
While that's perfectly valid in the Reader, I believe Comments Management should be an accurate tool, and I'd rather have the actual datetime than some approximation that also requires me to do some math.

cc @Automattic/lannister + @yoavf for i18n question 