### PR TITLE
Added basic tracks for "shipping methods added to shipping zones"

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
@@ -151,7 +151,7 @@ const getZoneMethodDeleteSteps = ( siteId, zoneId, method, state ) => {
 		description: translate( 'Deleting Shipping Method' ),
 		onStep: ( dispatch, actionList ) => {
 			analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_deleted', {
-				shippingMethod: methodType,
+				shipping_method: methodType,
 			} );
 			dispatch( deleteShippingZoneMethod(
 				siteId,
@@ -183,7 +183,7 @@ const getZoneMethodUpdateSteps = ( siteId, zoneId, method, state ) => {
 				const event = false !== methodProps.enabled
 					? 'calypso_woocommerce_shipping_method_enabled'
 					: 'calypso_woocommerce_shipping_method_disabled';
-				analytics.tracks.recordEvent( event, { shippingMethod: methodType } );
+				analytics.tracks.recordEvent( event, { shipping_method: methodType } );
 			}
 
 			dispatch( updateShippingZoneMethod(
@@ -211,7 +211,7 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, state ) => {
 		description: translate( 'Creating Shipping Method' ),
 		onStep: ( dispatch, actionList ) => {
 			analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_created', {
-				shippingMethod: methodType,
+				shipping_method: methodType,
 			} );
 			dispatch( createShippingZoneMethod(
 				siteId,
@@ -233,7 +233,7 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, state ) => {
 			description: translate( 'Updating Shipping Method' ), // Better not tell the user we're just tracking at this point
 			onStep: ( dispatch, actionList ) => {
 				analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_enabled', {
-					shippingMethod: methodType,
+					shipping_method: methodType,
 				} );
 				dispatch( actionListStepSuccess( actionList ) );
 			},

--- a/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
@@ -34,6 +34,7 @@ import { getRawShippingZoneLocations } from 'woocommerce/state/sites/shipping-zo
 import { getShippingZoneMethod } from 'woocommerce/state/sites/shipping-zone-methods/selectors';
 import { getZoneLocationsPriority } from 'woocommerce/state/sites/shipping-zone-locations/helpers';
 import { getAPIShippingZones } from 'woocommerce/state/sites/shipping-zones/selectors';
+import analytics from 'lib/analytics';
 
 const createShippingZoneSuccess = ( actionList ) => ( dispatch, getState, { sentData, receivedData } ) => {
 	const zoneIdMapping = {
@@ -190,6 +191,9 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, state ) => {
 	const steps = [ {
 		description: translate( 'Creating Shipping Method' ),
 		onStep: ( dispatch, actionList ) => {
+			analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_created', {
+				shippingMethod: methodType,
+			} );
 			dispatch( createShippingZoneMethod(
 				siteId,
 				getZoneId( zoneId, actionList ),

--- a/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
@@ -144,10 +144,15 @@ const getAutoOrderZonesSteps = ( siteId, zoneId, serverZones, allServerLocations
 	} ).filter( Boolean ) );
 };
 
-const getZoneMethodDeleteSteps = ( siteId, zoneId, method ) => {
+const getZoneMethodDeleteSteps = ( siteId, zoneId, method, state ) => {
+	const methodType = getShippingZoneMethod( state, method.id, siteId ).methodType;
+
 	return [ {
 		description: translate( 'Deleting Shipping Method' ),
 		onStep: ( dispatch, actionList ) => {
+			analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_deleted', {
+				shippingMethod: methodType,
+			} );
 			dispatch( deleteShippingZoneMethod(
 				siteId,
 				zoneId,
@@ -159,14 +164,28 @@ const getZoneMethodDeleteSteps = ( siteId, zoneId, method ) => {
 	} ];
 };
 
-const getZoneMethodUpdateSteps = ( siteId, zoneId, method ) => {
-	const { id, ...methodProps } = omit( method, 'methodType' );
+const getZoneMethodUpdateSteps = ( siteId, zoneId, method, state ) => {
+	const { id, ...methodProps } = method;
+	const methodType = methodProps.methodType || getShippingZoneMethod( state, id, siteId ).methodType;
+	delete methodProps.methodType;
 	if ( isEmpty( methodProps ) ) {
 		return [];
 	}
+
+	const isNew = 'number' !== typeof id;
+	const wasEnabled = ! isNew && getShippingZoneMethod( state, id, siteId ).enabled;
+	const enabledChanged = ! isNil( methodProps.enabled ) && wasEnabled !== methodProps.enabled;
+
 	return [ {
 		description: translate( 'Updating Shipping Method' ),
 		onStep: ( dispatch, actionList ) => {
+			if ( isNew || enabledChanged ) {
+				const event = false !== methodProps.enabled
+					? 'calypso_woocommerce_shipping_method_enabled'
+					: 'calypso_woocommerce_shipping_method_disabled';
+				analytics.tracks.recordEvent( event, { shippingMethod: methodType } );
+			}
+
 			dispatch( updateShippingZoneMethod(
 				siteId,
 				getZoneId( zoneId, actionList ),
@@ -207,7 +226,18 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, state ) => {
 	} ];
 
 	if ( ! isEmpty( methodProps ) ) {
-		steps.push.apply( steps, getZoneMethodUpdateSteps( siteId, zoneId, { id, ...methodProps } ) );
+		steps.push.apply( steps, getZoneMethodUpdateSteps( siteId, zoneId, { id, methodType, ...methodProps } ) );
+	} else {
+		// New methods are created "enabled" by default, so if there are no extra props, it means it was created enabled
+		steps.push.apply( steps, {
+			description: translate( 'Updating Shipping Method' ), // Better not tell the user we're just tracking at this point
+			onStep: ( dispatch, actionList ) => {
+				analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_enabled', {
+					shippingMethod: methodType,
+				} );
+				dispatch( actionListStepSuccess( actionList ) );
+			},
+		} );
 	}
 	return steps;
 };
@@ -237,8 +267,8 @@ export const getSaveZoneActionListSteps = ( state ) => {
 		...getZoneStepsFunc( siteId, zoneId, zoneProperties ),
 		...getAutoOrderZonesSteps( siteId, zoneId, serverZones, allServerLocations ),
 		...getUpdateShippingZoneLocationsSteps( siteId, zoneId, locations, serverLocations ),
-		...flatten( methodEdits.deletes.map( method => getZoneMethodDeleteSteps( siteId, zoneId, method ) ) ),
-		...flatten( methodEdits.updates.map( method => getZoneMethodUpdateSteps( siteId, zoneId, method ) ) ),
+		...flatten( methodEdits.deletes.map( method => getZoneMethodDeleteSteps( siteId, zoneId, method, state ) ) ),
+		...flatten( methodEdits.updates.map( method => getZoneMethodUpdateSteps( siteId, zoneId, method, state ) ) ),
 		...flatten( methodEdits.creates.map( method => getZoneMethodCreateSteps( siteId, zoneId, method, state ) ) ),
 	];
 };


### PR DESCRIPTION
Related to #15316

@kellychoffman @justinshreve What exactly do we want to track here? It wouldn't be hard to add more detailed tracking, but I didn't want to overdo it. This is what's implemented now:
* Every time a shipping method is **added** to a zone (and the zone is saved), a `tracks` event with the type of the method (`free_shipping`, `local_pickup` or `flat_rate`) is recorded.
* Every time the user changes the type of a shipping method, it's recorded too as if it was a new method creation (since that's what it is internally).
* The event is recorded even if the user saves a `DISABLED` method.

Do we want to track when the method is removed too? And when the method is toggled between enabled/disabled?