### PR TITLE
Simple Payments: add modal for creating payment button in Editor

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -38,6 +38,7 @@ import touchScrollToolbarPlugin from './plugins/touch-scroll-toolbar/plugin';
 import editorButtonAnalyticsPlugin from './plugins/editor-button-analytics/plugin';
 import calypsoAlertPlugin from './plugins/calypso-alert/plugin';
 import contactFormPlugin from './plugins/contact-form/plugin';
+import simplePaymentsPlugin from './plugins/simple-payments/plugin';
 import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
@@ -72,6 +73,7 @@ import wpEmojiPlugin from './plugins/wpemoji/plugin';
 	embedReversalPlugin,
 	markdownPlugin,
 	wpEmojiPlugin,
+	simplePaymentsPlugin,
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
@@ -142,6 +144,7 @@ const PLUGINS = [
 	'wpcom/trackpaste',
 	'wpcom/insertmenu',
 	'wpcom/markdown',
+	'wpcom/simplepayments',
 ];
 
 mentionsPlugin();

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -3,12 +3,15 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
 import Navigation from './navigation';
+import Button from 'components/button';
 
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
@@ -20,14 +23,20 @@ class SimplePaymentsDialog extends Component {
 	};
 
 	getActionButtons() {
+		const { translate, onClose } = this.props;
+
 		const actionButtons = [
-			// Cancel
+			<Button onClick={ onClose }>
+				{ translate( 'Cancel' ) }
+			</Button>
 		];
 
 		if ( this.props.activeTab === 'addNew' ) {
 			return [
-				// + Add
-				...actionButtons
+				...actionButtons,
+				<Button onClick={ noop } primary>
+					{ translate( 'Add' ) }
+				</Button>
 			];
 		}
 
@@ -62,4 +71,4 @@ class SimplePaymentsDialog extends Component {
 
 export default connect( state => {
 	return {};
-} )( SimplePaymentsDialog );
+} )( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -69,6 +69,4 @@ class SimplePaymentsDialog extends Component {
 	}
 }
 
-export default connect( state => {
-	return {};
-} )( localize( SimplePaymentsDialog ) );
+export default connect()( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import Navigation from './navigation';
+
+class SimplePaymentsDialog extends Component {
+	static propTypes = {
+		activeTab: PropTypes.oneOf( [ 'paymentButtons', 'addNew' ] ).isRequired,
+		showDialog: PropTypes.bool.isRequired,
+		isEdit: PropTypes.bool.isRequired,
+		onChangeTabs: PropTypes.func.isRequired,
+		onClose: PropTypes.func.isRequired,
+	};
+
+	getActionButtons() {
+		const actionButtons = [
+			// Cancel
+		];
+
+		if ( this.props.activeTab === 'addNew' ) {
+			return [
+				// + Add
+				...actionButtons
+			];
+		}
+
+		return actionButtons;
+	}
+
+	render() {
+		const {
+			activeTab,
+			showDialog,
+			onChangeTabs,
+			onClose,
+		} = this.props;
+
+		const content = activeTab === 'addNew'
+			? <div>Add new</div>
+			: <div>Payment Buttons list</div>;
+
+		return (
+			<Dialog
+				isVisible={ showDialog }
+				onClose={ onClose }
+				buttons={ this.getActionButtons() }
+				additionalClassNames="editor-simple-payments-modal"
+			>
+				<Navigation { ...{ activeTab, onChangeTabs } } />
+				{ content }
+			</Dialog>
+		);
+	}
+}
+
+export default connect( state => {
+	return {};
+} )( SimplePaymentsDialog );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -35,7 +35,7 @@ class SimplePaymentsDialog extends Component {
 			return [
 				...actionButtons,
 				<Button onClick={ noop } primary>
-					{ translate( 'Add' ) }
+					{ translate( 'Insert' ) }
 				</Button>
 			];
 		}

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
+
+export default localize( class SimplePaymentsDialogNavigation extends Component {
+	static propTypes = {
+		activeTab: PropTypes.oneOf( [ 'paymentButtons', 'addNew' ] ).isRequired,
+		onChangeTabs: PropTypes.func.isRequired
+	};
+
+	onChangeTabs = ( tab ) => () => this.props.onChangeTabs( tab );
+
+	render() {
+		const { activeTab, translate } = this.props;
+
+		// TODO: Get from store/as a prop.
+		const paymentButtons = [ 1 ];
+
+		if ( activeTab === 'addNew' && ! paymentButtons.length ) {
+			// We are on "Add New" view without previously made payment buttons.
+
+			return null;
+		} else if ( activeTab === 'addNew' ) {
+			// We are on "Add New" view with previously made payment buttons.
+
+			return <div>something</div>;
+		} else {
+			// We are on "Payment Buttons" view.
+
+			return (
+				<SectionHeader label={ translate( 'Payment Buttons' ) } count={ 2 }>
+					<Button
+						compact
+						onClick={ this.onChangeTabs( 'addNew' ) }
+					>
+						{ translate( '+ Add New' ) }
+					</Button>
+				</SectionHeader>
+			);
+		}
+
+	}
+} );

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -37,29 +37,28 @@ export default localize( class SimplePaymentsDialogNavigation extends Component 
 			return (
 				<HeaderCake
 					className={ classNames }
-					onClick={ this.onChangeTabs( 'paymentButtons') }
+					onClick={ this.onChangeTabs( 'paymentButtons' ) }
 					backText={ translate( 'Payment Buttons' ) }
 				>
 				</HeaderCake>
 			);
-		} else {
-			// We are on "Payment Buttons" view.
-
-			return (
-				<SectionHeader
-					className={ classNames }
-					label={ translate( 'Payment Buttons' ) }
-					count={ 2 }
-				>
-					<Button
-						compact
-						onClick={ this.onChangeTabs( 'addNew' ) }
-					>
-						{ translate( '+ Add New' ) }
-					</Button>
-				</SectionHeader>
-			);
 		}
 
+		// We are on "Payment Buttons" view.
+
+		return (
+			<SectionHeader
+				className={ classNames }
+				label={ translate( 'Payment Buttons' ) }
+				count={ 2 }
+			>
+				<Button
+					compact
+					onClick={ this.onChangeTabs( 'addNew' ) }
+				>
+					{ translate( '+ Add New' ) }
+				</Button>
+			</SectionHeader>
+		);
 	}
 } );

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -3,11 +3,13 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import SectionHeader from 'components/section-header';
+import HeaderCake from 'components/header-cake';
 import Button from 'components/button';
 
 export default localize( class SimplePaymentsDialogNavigation extends Component {
@@ -31,7 +33,13 @@ export default localize( class SimplePaymentsDialogNavigation extends Component 
 		} else if ( activeTab === 'addNew' ) {
 			// We are on "Add New" view with previously made payment buttons.
 
-			return <div>something</div>;
+			return (
+				<HeaderCake
+					onClick={ this.onChangeTabs( 'paymentButtons') }
+					backText={ translate( 'Payment Buttons' ) }
+				>
+				</HeaderCake>
+			);
 		} else {
 			// We are on "Payment Buttons" view.
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -26,6 +26,8 @@ export default localize( class SimplePaymentsDialogNavigation extends Component 
 		// TODO: Get from store/as a prop.
 		const paymentButtons = [ 1 ];
 
+		const classNames = 'editor-simple-payments-modal__navigation';
+
 		if ( activeTab === 'addNew' && ! paymentButtons.length ) {
 			// We are on "Add New" view without previously made payment buttons.
 
@@ -35,6 +37,7 @@ export default localize( class SimplePaymentsDialogNavigation extends Component 
 
 			return (
 				<HeaderCake
+					className={ classNames }
 					onClick={ this.onChangeTabs( 'paymentButtons') }
 					backText={ translate( 'Payment Buttons' ) }
 				>
@@ -44,7 +47,11 @@ export default localize( class SimplePaymentsDialogNavigation extends Component 
 			// We are on "Payment Buttons" view.
 
 			return (
-				<SectionHeader label={ translate( 'Payment Buttons' ) } count={ 2 }>
+				<SectionHeader
+					className={ classNames }
+					label={ translate( 'Payment Buttons' ) }
+					count={ 2 }
+				>
 					<Button
 						compact
 						onClick={ this.onChangeTabs( 'addNew' ) }

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -3,7 +3,6 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -46,6 +46,8 @@ export default localize( class SimplePaymentsDialogNavigation extends Component 
 
 		// We are on "Payment Buttons" view.
 
+		// TODO: update the count={ 2 } magic number with real data
+
 		return (
 			<SectionHeader
 				className={ classNames }

--- a/client/components/tinymce/plugins/simple-payments/plugin.jsx
+++ b/client/components/tinymce/plugins/simple-payments/plugin.jsx
@@ -41,7 +41,7 @@ const simplePayments = editor => {
 					isEdit,
 					onClose() {
 						editor.focus();
-						renderModal( 'hide' );
+						renderModal( 'hide', activeTab );
 					},
 					onChangeTabs( tab ) {
 						renderModal( 'show', tab );

--- a/client/components/tinymce/plugins/simple-payments/plugin.jsx
+++ b/client/components/tinymce/plugins/simple-payments/plugin.jsx
@@ -1,0 +1,61 @@
+/**
+ * External Dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+import { createElement } from 'react';
+import { unmountComponentAtNode } from 'react-dom';
+
+/**
+ * Internal Dependencies
+ */
+import SimplePaymentsDialog from './dialog';
+import { renderWithReduxStore } from 'lib/react-helpers';
+
+const simplePayments = editor => {
+	let node;
+	const store = editor.getParam( 'redux_store' );
+
+	editor.on( 'init', () => {
+		node = editor.getContainer().appendChild(
+			document.createElement( 'div' )
+		);
+	} );
+
+	editor.on( 'remove', () => {
+		unmountComponentAtNode( node );
+		node.parentNode.removeChild( node );
+		node = null;
+	} );
+
+	editor.addCommand( 'simplePaymentsButton', content => {
+		let isEdit = false;
+		if ( content ) {
+			isEdit = true;
+		}
+
+		function renderModal( visibility = 'show', activeTab = 'paymentButtons' ) {
+			renderWithReduxStore(
+				createElement( SimplePaymentsDialog, {
+					showDialog: visibility === 'show',
+					activeTab,
+					isEdit,
+					onClose() {
+						editor.focus();
+						renderModal( 'hide' );
+					},
+					onChangeTabs( tab ) {
+						renderModal( 'show', tab );
+					},
+				} ),
+				node,
+				store
+			);
+		}
+
+		renderModal();
+	} );
+};
+
+export default () => {
+	tinymce.PluginManager.add( 'wpcom/simplepayments', simplePayments );
+};

--- a/client/components/tinymce/plugins/simple-payments/plugin.jsx
+++ b/client/components/tinymce/plugins/simple-payments/plugin.jsx
@@ -33,7 +33,7 @@ const simplePayments = editor => {
 			isEdit = true;
 		}
 
-		function renderModal( visibility = 'show', activeTab = 'paymentButtons' ) {
+		function renderModal( visibility = 'show', activeTab = 'addNew' ) {
 			renderWithReduxStore(
 				createElement( SimplePaymentsDialog, {
 					showDialog: visibility === 'show',

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -1,0 +1,5 @@
+.editor-simple-payments-modal {
+	// TODO: temporary values until we get some content
+	width: 550px;
+	height: 450px;
+}

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -3,3 +3,7 @@
 	width: 550px;
 	height: 450px;
 }
+
+.editor-simple-payments-modal__navigation {
+	// TODO: remove top, left and right borders, move to the top, remove left, right paddings
+}

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -5,6 +5,7 @@
 @import 'plugins/wpcom-charmap/style';
 @import 'plugins/contact-form/style';
 @import 'plugins/mentions/style';
+@import 'plugins/simple-payments/style';
 
 .tinymce {
 	display: none;

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -39,6 +39,7 @@ import ContactFormDialog from 'components/tinymce/plugins/contact-form/dialog';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
 import config from 'config';
+import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog';
 
 /**
  * Module constant
@@ -72,6 +73,8 @@ export class EditorHtmlToolbar extends Component {
 		showLinkDialog: false,
 		showMediaModal: false,
 		source: '',
+		showSimplePaymentsDialog: false,
+		simplePaymentsDialogTab: 'addNew'
 	};
 
 	componentDidMount() {
@@ -432,6 +435,24 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( { showMediaModal: false } );
 	}
 
+	openSimplePaymentsDialog = () => {
+		this.setState( {
+			simplePaymentsDialogTab: 'addNew',
+			showSimplePaymentsDialog: true,
+			showInsertContentMenu: false,
+		} );
+	};
+
+	closeSimplePaymentsDialog = () => {
+		this.setState( { showSimplePaymentsDialog: false } );
+	};
+
+	changeSimplePaymentsDialogTab = ( tab ) => {
+		this.setState( {
+			simplePaymentsDialogTab: tab,
+		} );
+	};
+
 	onFilesDrop = () => {
 		const { site } = this.props;
 		// Find selected images. Non-images will still be uploaded, but not
@@ -484,7 +505,7 @@ export class EditorHtmlToolbar extends Component {
 		return (
 			<div
 				className="editor-html-toolbar__insert-content-dropdown-item"
-				onClick={ null }
+				onClick={ this.openSimplePaymentsDialog }
 			>
 				<Gridicon icon="money" />
 				<span>{ translate( 'Add Payment Button' ) }</span>
@@ -655,6 +676,14 @@ export class EditorHtmlToolbar extends Component {
 				<MediaLibraryDropZone
 					onAddMedia={ this.onFilesDrop }
 					site={ site }
+				/>
+
+				<SimplePaymentsDialog
+					showDialog={ this.state.showSimplePaymentsDialog }
+					activeTab={ this.state.simplePaymentsDialogTab }
+					isEdit={ false }
+					onClose={ this.closeSimplePaymentsDialog }
+					onChangeTabs={ this.changeSimplePaymentsDialogTab }
 				/>
 			</div>
 		);


### PR DESCRIPTION
After clicking on the "Add Payment Button" in Editor inserter, a new modal will open. If there is no previously created payment button, "Add new" modal will show:

![image](https://user-images.githubusercontent.com/4988512/27832571-6cbdfa08-60cf-11e7-9878-7f24e6c5905e.png)

If there are previously created payment buttons, "Payment buttons" modal will show instead: 

![image](https://user-images.githubusercontent.com/4988512/27832593-805a9c1a-60cf-11e7-8023-fac0b26a4f89.png)

After getting to the "Add new" view if there are previously created payment buttons, it will have a link to go back to "Payment buttons" view:

![image](https://user-images.githubusercontent.com/4988512/27832614-9d3a61bc-60cf-11e7-8055-2f46e7068252.png)

In this PR, we add the basic modal/dialog with the navigation and some initial components.

## Testing instructions

In Editor, click on "Add Payment Button". When the dialog opens, click on "Cancel" -- does it close the dialog? Open it again and click on "Add new" -- does it take you to the "Add new" screen?

Note: we'll style and add content to the dialog in future PRs.