### PR TITLE
Login: Disable form when loading and redirecting

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -40,7 +40,7 @@ export class LoginForm extends Component {
 	};
 
 	componentDidMount() {
-		this.setState( { isDisabled: false } );
+		this.setState( { isDisabled: false } ); // eslint-disable-line react/no-did-mount-set-state
 	}
 
 	onChangeField = ( event ) => {


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/15479 by disabling all form elements when the page loads as well as when the user is redirected to the `Reader` page upon successful login:
 
<img width="456" alt="screenshot" src="https://user-images.githubusercontent.com/594356/27833467-4a6216de-60d3-11e7-9a67-9bae4fdfe121.png">
  
#### Testing instructions
 
1. Run `git checkout update/login-page` and start your server, or open a [live branch](https://calypso.live/?branch=update/login-page)
2. Throttle your connection
3. Open the [`Login` page](http://calypso.localhost:3000/log-in)
4. Check that form elements are disabled until the bundle has loaded
5. Enter credentials and submit the form
6. Check that form elements stay disabled once the form is submitted
7. Check that they are enabled again only upon error
 
#### Additional notes
 
This pull request does not update the two-step authentication pages (https://github.com/Automattic/wp-calypso/issues/14220).
 
#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests