### PR TITLE
Woo-Connect Insights: add sidebar nav back for store stats

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import page from 'page';
 import includes from 'lodash/includes';
-import { moment } from 'i18n-calypso';
+import { moment, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -12,6 +12,7 @@ import { moment } from 'i18n-calypso';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getQueryDate } from './utils';
 
 function isValidParameters( context ) {
@@ -35,6 +36,9 @@ export default function StatsController( context ) {
 		queryDate: getQueryDate( context ),
 		selectedDate: context.query.startDate || moment().format( 'YYYY-MM-DD' ),
 	};
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( translate( 'Stats', { textOnly: true } ) ) );
+
 	const asyncComponent = ( props.type === 'orders' )
 		? <AsyncLoad
 			/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -10,6 +10,7 @@ import { moment } from 'i18n-calypso';
  */
 import Main from 'components/main';
 import Navigation from './store-stats-navigation';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Chart from './store-stats-chart';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
@@ -63,6 +64,7 @@ class StoreStats extends Component {
 
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
+				<div className="store-stats__sidebar-nav"><SidebarNavigation /></div>
 				<Navigation unit={ unit } type="orders" slug={ slug } />
 				<Chart
 					path={ path }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -22,27 +22,29 @@ const StoreStatsNavigation = props => {
 		year: translate( 'Years' ),
 	};
 	return (
-		<SectionNav selectedText={ units[ unit ] }>
-			<NavTabs label={ translate( 'Stats' ) }>
-				{ Object.keys( units ).map( key => (
-					<NavItem
-						key={ key }
-						path={ `/store/stats/${ type }/${ key }/${ slug }` }
-						selected={ unit === key }
-					>
-						{ units[ key ] }
-					</NavItem>
-				) ) }
-			</NavTabs>
-			<SegmentedControl
-				initialSelected="store"
-				options={ [
-					{ value: 'site', label: translate( 'Site' ), path: `/stats/${ unit }/${ slug }` },
-					{ value: 'store', label: translate( 'Store' ) },
-				] }
-			/>
-			<FollowersCount />
-		</SectionNav>
+		<div className="store-stats-navigation__container">
+			<SectionNav selectedText={ units[ unit ] }>
+				<NavTabs label={ translate( 'Stats' ) }>
+					{ Object.keys( units ).map( key => (
+						<NavItem
+							key={ key }
+							path={ `/store/stats/${ type }/${ key }/${ slug }` }
+							selected={ unit === key }
+						>
+							{ units[ key ] }
+						</NavItem>
+					) ) }
+				</NavTabs>
+				<SegmentedControl
+					initialSelected="store"
+					options={ [
+						{ value: 'site', label: translate( 'Site' ), path: `/stats/${ unit }/${ slug }` },
+						{ value: 'store', label: translate( 'Store' ) },
+					] }
+				/>
+				<FollowersCount />
+			</SectionNav>
+		</div>
 	);
 };
 

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -22,7 +22,7 @@ const StoreStatsNavigation = props => {
 		year: translate( 'Years' ),
 	};
 	return (
-		<div className="store-stats-navigation__container">
+		<div className="store-stats-navigation">
 			<SectionNav selectedText={ units[ unit ] }>
 				<NavTabs label={ translate( 'Stats' ) }>
 					{ Object.keys( units ).map( key => (

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/style.scss
@@ -9,7 +9,7 @@
 }
 @include breakpoint( ">660px" ) {
  	&.store-stats {
-		.store-stats-navigation__container {
+		.store-stats-navigation {
 			.section-nav {
 				margin-top: 0;
 			}

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/style.scss
@@ -7,6 +7,16 @@
 		}
 	}
 }
+@include breakpoint( ">660px" ) {
+ 	&.store-stats {
+		.store-stats-navigation__container {
+			.section-nav {
+				margin-top: 0;
+			}
+		}
+	}
+}
+
 
 .segmented-control {
 	@include breakpoint( "<480px" ) {

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -27,3 +27,25 @@
 		width: calc(33% - 3px);
 	}
 }
+
+@include breakpoint( "<660px" ) {
+	&.store-stats {
+		.store-stats__sidebar-nav {
+			.site-icon,
+			.current-section__site-title,
+			.current-section__section-title {
+				display: block;
+			}
+			.current-section {
+				margin: 0 0 8px 0;
+				a {
+					position: relative;
+					z-index: inherit;
+					top: inherit;
+					background: white;
+					border: 1px solid #c8d7e1;
+				}
+			}
+		}
+	}
+}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -28,10 +28,10 @@
 	@import 'components/widget-group/style';
 	@import 'components/sparkline/style';
 	@import 'components/store-address/style';
+	@import 'components/delta/style';
 	@import 'app/store-stats/store-stats-chart/style';
 	@import 'app/store-stats/store-stats-navigation/style';
 	@import 'app/store-stats/style';
-	@import 'components/delta/style';
 
 	.components__action-header {
 		width: 100%;


### PR DESCRIPTION
The mobile side nav `<SidebarNavigation />` was missing from the store stats page.

Fixes #15761 