### PR TITLE
Plugin uploads: Add data-layer handlers for uploading to jetpack site

### DIFF
--- a/client/state/data-layer/wpcom/sites/index.js
+++ b/client/state/data-layer/wpcom/sites/index.js
@@ -7,7 +7,17 @@ import automatedTransfer from './automated-transfer';
 import blogStickers from './blog-stickers';
 import comments from './comments';
 import media from './media';
+import plugins from './plugins';
 import posts from './posts';
 import simplePayments from './simple-payments';
 
-export default mergeHandlers( activity, automatedTransfer, blogStickers, comments, media, posts, simplePayments );
+export default mergeHandlers(
+	activity,
+	automatedTransfer,
+	blogStickers,
+	comments,
+	media,
+	plugins,
+	posts,
+	simplePayments,
+);

--- a/client/state/data-layer/wpcom/sites/plugins/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/index.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import newPlugin from './new';
+
+export default newPlugin;

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLUGIN_UPLOAD } from 'state/action-types';
+import { PLUGIN_UPLOAD, PLUGIN_INSTALL_REQUEST_SUCCESS } from 'state/action-types';
 import {
 	completePluginUpload,
 } from 'state/plugins/upload/actions';
@@ -20,8 +20,14 @@ const uploadPlugin = ( { dispatch }, action ) => {
 };
 
 const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
-	dispatch( completePluginUpload( siteId, data.pluginId ) );
-	// TODO (seear): save plugin details using existing action
+	const { pluginId } = data;
+	dispatch( completePluginUpload( siteId, pluginId ) );
+	dispatch( {
+		type: PLUGIN_INSTALL_REQUEST_SUCCESS,
+		siteId,
+		pluginId,
+		data
+	} );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -4,6 +4,8 @@
 import { PLUGIN_UPLOAD, PLUGIN_INSTALL_REQUEST_SUCCESS } from 'state/action-types';
 import {
 	completePluginUpload,
+	pluginUploadError,
+	updatePluginUploadProgress,
 } from 'state/plugins/upload/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -30,7 +32,20 @@ const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
 	} );
 };
 
+const receiveError = ( { dispatch }, { siteId }, next, error ) => {
+	dispatch( pluginUploadError( siteId, error ) );
+};
+
+const updateUploadProgress = ( { dispatch }, { siteId }, next, { loaded, total } ) => {
+	dispatch( updatePluginUploadProgress( siteId, loaded, total ) );
+};
+
 export default {
-	[ PLUGIN_UPLOAD ]: [ dispatchRequest( uploadPlugin, uploadComplete ) ]
+	[ PLUGIN_UPLOAD ]: [ dispatchRequest(
+		uploadPlugin,
+		uploadComplete,
+		receiveError,
+		updateUploadProgress
+	) ]
 };
 

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -21,8 +21,8 @@ const uploadPlugin = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
-const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
-	const { pluginId } = data;
+export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
+	const { id: pluginId } = data;
 	dispatch( completePluginUpload( siteId, pluginId ) );
 	dispatch( {
 		type: PLUGIN_INSTALL_REQUEST_SUCCESS,
@@ -32,11 +32,11 @@ const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
 	} );
 };
 
-const receiveError = ( { dispatch }, { siteId }, next, error ) => {
+export const receiveError = ( { dispatch }, { siteId }, next, error ) => {
 	dispatch( pluginUploadError( siteId, error ) );
 };
 
-const updateUploadProgress = ( { dispatch }, { siteId }, next, { loaded, total } ) => {
+export const updateUploadProgress = ( { dispatch }, { siteId }, next, { loaded, total } ) => {
 	dispatch( updatePluginUploadProgress( siteId, loaded, total ) );
 };
 

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import { PLUGIN_UPLOAD } from 'state/action-types';
+import {
+	completePluginUpload,
+} from 'state/plugins/upload/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+const uploadPlugin = ( { dispatch }, action ) => {
+	const { siteId, file } = action;
+
+	dispatch( http( {
+		method: 'POST',
+		path: `/sites/${ siteId }/plugins/new`,
+		apiVersion: '1',
+		formData: [ [ 'zip[]', file ] ],
+	}, action ) );
+};
+
+const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
+	dispatch( completePluginUpload( siteId, data.pluginId ) );
+	// TODO (seear): save plugin details using existing action
+};
+
+export default {
+	[ PLUGIN_UPLOAD ]: [ dispatchRequest( uploadPlugin, uploadComplete ) ]
+};
+

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -10,7 +10,7 @@ import {
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
-const uploadPlugin = ( { dispatch }, action ) => {
+export const uploadPlugin = ( { dispatch }, action ) => {
 	const { siteId, file } = action;
 
 	dispatch( http( {

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import {
+	uploadComplete,
+} from '../';
+import {
+	completePluginUpload,
+} from 'state/plugins/upload/actions';
+import { PLUGIN_INSTALL_REQUEST_SUCCESS } from 'state/action-types';
+
+const siteId = 77203074;
+const pluginId = 'hello-dolly/hello';
+
+const SUCCESS_RESPONSE = deepFreeze( {
+	active: false,
+	author: 'blah',
+	author_url: 'http://example.com',
+	autoupdate: false,
+	description: 'blah blah blah',
+	id: 'hello-dolly/hello',
+	name: 'Hello Dolly',
+	network: false,
+	plugin_url: 'http://wordpress.org/extend/plugins/hello-dolly/',
+	slug: 'hello-dolly',
+	version: '1.6',
+} );
+
+describe( 'uploadComplete', () => {
+	it( 'should dispatch plugin upload complete action', () => {
+		const dispatch = sinon.spy();
+		uploadComplete( { dispatch }, { siteId }, null, SUCCESS_RESPONSE );
+		expect( dispatch ).to.have.been.calledWith(
+			completePluginUpload( siteId, pluginId )
+		);
+	} );
+
+	it( 'should dispath plugin install request success', () => {
+		const dispatch = sinon.spy();
+		uploadComplete( { dispatch }, { siteId }, null, SUCCESS_RESPONSE );
+		expect( dispatch ).to.have.been.calledWith( {
+			type: PLUGIN_INSTALL_REQUEST_SUCCESS,
+			siteId,
+			pluginId,
+			data: SUCCESS_RESPONSE,
+		} );
+	} );
+} );
+

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -10,9 +10,13 @@ import sinon from 'sinon';
  */
 import {
 	uploadComplete,
+	receiveError,
+	updateUploadProgress,
 } from '../';
 import {
 	completePluginUpload,
+	pluginUploadError,
+	updatePluginUploadProgress,
 } from 'state/plugins/upload/actions';
 import { PLUGIN_INSTALL_REQUEST_SUCCESS } from 'state/action-types';
 
@@ -33,6 +37,11 @@ const SUCCESS_RESPONSE = deepFreeze( {
 	version: '1.6',
 } );
 
+const ERROR_RESPONSE = deepFreeze( {
+	error: 'folder_exists',
+	message: 'folder_exists',
+} );
+
 describe( 'uploadComplete', () => {
 	it( 'should dispatch plugin upload complete action', () => {
 		const dispatch = sinon.spy();
@@ -42,7 +51,7 @@ describe( 'uploadComplete', () => {
 		);
 	} );
 
-	it( 'should dispath plugin install request success', () => {
+	it( 'should dispatch plugin install request success', () => {
 		const dispatch = sinon.spy();
 		uploadComplete( { dispatch }, { siteId }, null, SUCCESS_RESPONSE );
 		expect( dispatch ).to.have.been.calledWith( {
@@ -54,3 +63,22 @@ describe( 'uploadComplete', () => {
 	} );
 } );
 
+describe( 'receiveError', () => {
+	it( 'should dispatch plugin upload error', () => {
+		const dispatch = sinon.spy();
+		receiveError( { dispatch }, { siteId }, null, ERROR_RESPONSE );
+		expect( dispatch ).to.have.been.calledWith(
+			pluginUploadError( siteId, ERROR_RESPONSE )
+		);
+	} );
+} );
+
+describe( 'updateUploadProgress', () => {
+	it( 'should dispatch plugin upload progress update', () => {
+		const dispatch = sinon.spy();
+		updateUploadProgress( { dispatch }, { siteId }, null, { loaded: 350, total: 400 } );
+		expect( dispatch ).to.have.been.calledWith(
+			updatePluginUploadProgress( siteId, 350, 400 )
+		);
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -9,9 +9,10 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import {
-	uploadComplete,
-	receiveError,
 	updateUploadProgress,
+	uploadComplete,
+	uploadPlugin,
+	receiveError,
 } from '../';
 import {
 	completePluginUpload,
@@ -40,6 +41,18 @@ const SUCCESS_RESPONSE = deepFreeze( {
 const ERROR_RESPONSE = deepFreeze( {
 	error: 'folder_exists',
 	message: 'folder_exists',
+} );
+
+describe( 'uploadPlugin', () => {
+	it( 'should distpatch an http request', () => {
+		const dispatch = sinon.spy();
+		uploadPlugin( { dispatch }, { siteId, file: 'xyz' } );
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			formData: [ [ 'zip[]', 'xyz' ] ],
+			method: 'POST',
+			path: `/sites/${ siteId }/plugins/new`,
+		} );
+	} );
 } );
 
 describe( 'uploadComplete', () => {


### PR DESCRIPTION
Part of #15665, this PR adds the data-layer handlers for uploading a plugin to a jetpack site:
* API request
* Actions on completion
* Actions on error
* Updating file upload progress

**To Test**
* Contains unit tests
* View the network request to upload a plugin by triggering this action from the console:
`dispatch( { type: 'PLUGIN_UPLOAD', siteId: '{jetpacksite}' } )`
(You should see an error response from the site, because no zip is uploaded).



