### PR TITLE
Jetpack Plans: Verify sites are initialized before displaying setup error 

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -32,6 +32,7 @@ import utils from 'lib/site/utils';
 // Redux actions & selectors
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isRequestingSites, getRawSite } from 'state/sites/selectors';
+import { hasInitializedSites } from 'state/selectors';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { requestSites } from 'state/sites/actions';
@@ -473,10 +474,13 @@ const PlansSetup = React.createClass( {
 	},
 
 	render() {
-		const { translate } = this.props;
+		const {
+			sitesInitialized,
+			translate
+		} = this.props;
 		const site = this.props.selectedSite;
 
-		if ( ! site && this.props.isRequestingSites ) {
+		if ( ! site && ( this.props.isRequestingSites || ! sitesInitialized ) ) {
 			return this.renderPlaceholder();
 		}
 
@@ -560,6 +564,7 @@ export default connect(
 			nextPlugin: getNextPlugin( state, siteId, whitelist ),
 			selectedSite: selectedSite,
 			isRequestingSites: isRequestingSites( state ),
+			sitesInitialized: hasInitializedSites( state ),
 			siteId
 		};
 	},

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -179,7 +179,9 @@ const PlansSetup = React.createClass( {
 	},
 
 	renderNoJetpackSiteSelected() {
-		this.trackConfigFinished( 'calypso_plans_autoconfig_error_wordpresscom' );
+		this.trackConfigFinished( 'calypso_plans_autoconfig_error_wordpresscom', {
+			referrer: document.referrer
+		} );
 		return (
 			<JetpackManageErrorPage
 				siteId={ this.props.siteId }


### PR DESCRIPTION
This PR fixes a bug with plugins setup process, occurring when we want to load `/plugins/setup/:site` with a clean Redux state, and the error message is incorrectly shown for a short while. This is caused by the small time difference between these 2 actions:

* Sites request completed, all sites being loaded
* UI being updated with the current site, current site is being initialized

If a re-render occurs between these 2 actions, it will cause the plan setup page to render an error message for a short while, thus tracking a `calypso_plans_autoconfig_error_wordpresscom` event incorrectly.

To fix this, this PR suggests that we display the placeholder if the current site hasn't initialized yet.

This PR also updates the `calypso_plans_autoconfig_error_wordpresscom` event to contain the referrer - this might help us find potential locations that lead to the error page.

To reproduce the bug:
* Type this in your console to see the analytics events: `localStorage.setItem('debug', 'calypso:analytics:*');`
* Go to `/plugins/setup` and after it loads, you'll see the error message, and the `calypso_plans_autoconfig_error_wordpresscom` event gets tracked. This is expected.
* Clean your Redux state.
* Go to `/plugins/setup/:site` for a Jetpack site with a paid plan, and after it loads, you'll see that the error message is shown for a very short while, and the event is recorded again. This should not be happening.

To test this PR:
* Type this in your console to see the analytics events: `localStorage.setItem('debug', 'calypso:analytics:*');`
* Go to `/plugins/setup` and after it loads, you'll see the error message, and the `calypso_plans_autoconfig_error_wordpresscom` event gets tracked. 
* Verify you see the `referrer` in the tracked event's data.
* Clean your Redux state.
* Go to `/plugins/setup/:site` for a Jetpack site with a paid plan, and after it loads, verify you never see the error message, and the event is no longer recorded.