### PR TITLE
Comments: Reply textarea placeholder includes the comment author name

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -19,6 +19,12 @@ export class CommentDetailReply extends Component {
 		hasFocus: false,
 	};
 
+	getTextareaPlaceholder = () => this.props.authorDisplayName
+		? this.props.translate( 'Reply to %(commentAuthor)s…', {
+			args: { commentAuthor: this.props.authorDisplayName }
+		} )
+		: 'Reply to comment…';
+
 	handleTextChange = event => this.setState( { commentText: event.target.value } );
 
 	setFocus = () => this.setState( { hasFocus: true } );
@@ -64,7 +70,7 @@ export class CommentDetailReply extends Component {
 	unsetFocus = () => this.setState( { hasFocus: false } );
 
 	render() {
-		const { authorDisplayName, translate } = this.props;
+		const { translate } = this.props;
 		const { commentText, hasFocus } = this.state;
 
 		const hasCommentText = commentText.trim().length > 0;
@@ -88,9 +94,7 @@ export class CommentDetailReply extends Component {
 							onChange={ this.handleTextChange }
 							onFocus={ this.setFocus }
 							onKeyDown={ this.submitCommentOnCtrlEnter }
-							placeholder={ translate( 'Reply to %(commentAuthor)s…', {
-								args: { commentAuthor: authorDisplayName }
-							} ) }
+							placeholder={ this.getTextareaPlaceholder() }
 							value={ commentText }
 						/>
 					</AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -64,7 +64,7 @@ export class CommentDetailReply extends Component {
 	unsetFocus = () => this.setState( { hasFocus: false } );
 
 	render() {
-		const { translate } = this.props;
+		const { authorDisplayName, translate } = this.props;
 		const { commentText, hasFocus } = this.state;
 
 		const hasCommentText = commentText.trim().length > 0;
@@ -88,7 +88,9 @@ export class CommentDetailReply extends Component {
 							onChange={ this.handleTextChange }
 							onFocus={ this.setFocus }
 							onKeyDown={ this.submitCommentOnCtrlEnter }
-							placeholder={ translate( 'Enter your comment here…' ) }
+							placeholder={ translate( 'Reply to %(commentAuthor)s…', {
+								args: { commentAuthor: authorDisplayName }
+							} ) }
 							value={ commentText }
 						/>
 					</AutoDirection>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -203,6 +203,7 @@ export class CommentDetail extends Component {
 							repliedToComment={ repliedToComment }
 						/>
 						<CommentDetailReply
+							authorDisplayName={ authorDisplayName }
 							commentId={ commentId }
 							postId={ postId }
 							postTitle={ postTitle }


### PR DESCRIPTION
Fixes #15575 

Updates the reply textarea placeholder in order to include the comment author display name.

<img width="517" alt="screen shot 2017-07-04 at 17 22 54" src="https://user-images.githubusercontent.com/2070010/27837663-73ec6aea-60dd-11e7-92bb-a7d49bae3de2.png">

cc @Automattic/lannister 