### PR TITLE
Magic Login: Force a full page reload when clicking "Back to WordPress.com"

### DIFF
--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -12,7 +12,7 @@ import addQueryArgs from 'lib/route/add-query-args';
 import config from 'config';
 import EmptyContent from 'components/empty-content';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
-import page from 'page';
+import { goBackToWordPressDotCom } from 'state/login/magic-login/actions';
 import { recordPageView } from 'state/analytics/actions';
 
 const lostPasswordURL = addQueryArgs( {
@@ -38,10 +38,8 @@ class EmailedLoginLinkExpired extends React.Component {
 				/>
 				<EmptyContent
 					action={ translate( 'Return to WordPress.com' ) }
-					actionCallback={ function() {
-						page( '/' );
-					} }
-					actionURL={ '/' }
+					actionCallback={ goBackToWordPressDotCom }
+					actionURL="https://wordpress.com"
 					className="magic-login__link-expired"
 					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					illustrationWidth={ 500 }

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -37,7 +37,7 @@ class EmailedLoginLinkExpired extends React.Component {
 					replaceCurrentLocation={ true }
 				/>
 				<EmptyContent
-					action={ translate( 'Return to WordPress.com' ) }
+					action={ translate( 'Back to WordPress.com' ) }
 					actionCallback={ goBackToWordPressDotCom }
 					actionURL="https://wordpress.com"
 					className="magic-login__link-expired"

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -4,13 +4,13 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
+import { goBackToWordPressDotCom } from 'state/login/magic-login/actions';
 import { recordPageView } from 'state/analytics/actions';
 
 class EmailedLoginLinkSuccessfully extends React.Component {
@@ -45,10 +45,8 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 				/>
 				<EmptyContent
 					action={ translate( 'Back to WordPress.com' ) }
-					actionCallback={ function() {
-						page( '/' );
-					} }
-					actionURL={ '/' }
+					actionCallback={ goBackToWordPressDotCom }
+					actionURL="https://wordpress.com"
 					className="magic-login__check-email"
 					illustration={ '/calypso/images/drake/drake-all-done.svg' }
 					illustrationWidth={ 500 }

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -111,3 +111,7 @@ export const fetchMagicLoginAuthenticate = ( email, token, tt ) => dispatch => {
 			} );
 		} );
 };
+
+export function goBackToWordPressDotCom() {
+	window.location = 'https://wordpress.com';
+}


### PR DESCRIPTION
Thought to have been squashed in #15735, wpcalypso was still exhibiting the previous behavior:

On the “Check your email” screen and “Expired/Invalid link” screen the button “Back to WordPress.com” doesn’t appear to do anything despite the browser navigating to `/`.

This adds an explicit window.location call via a "pseudo" action function to trigger the route update & an explicit action URL of `https://wordpress.com` in each usage.

It also converges the CTA strings to `Back to WordPress.com` -- we don't need both that & `Return to WordPress.com`.

## To Test

Using an Incognito or logged-out window:

### Check the button on the "Check Your Email" page:
* Browse to: http://calypso.localhost:3000/log-in/link
* Issue in the console: `dispatch( { type: 'MAGIC_LOGIN_SHOW_CHECK_YOUR_EMAIL_PAGE' } )`
* Click the `Back to WordPress.com` button
* The route should change to `/` & the screen should change (in dev, you'll land at `/devdocs/start` since we redirect, but that's ok)

### Check the button on the "Link is Expired... page"
* Browse to: http://calypso.localhost:3000/log-in/link/use?client_id=.&email=example@example.com&token=.&tt=.
* Issue in the console: `dispatch( { type: 'MAGIC_LOGIN_SHOW_LINK_EXPIRED' } )`
* Click the `Return to WordPress.com` button
* The route should change to `/` & the screen should change (in dev, you'll land at `/devdocs/start` since we redirect, but that's ok)