### PR TITLE
WooCommerce: Fix some UI issues with the product edit view

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import i18n from 'i18n-calypso';
-import { trim, debounce } from 'lodash';
+import { trim, debounce, isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,6 +86,19 @@ export default class ProductFormDetailsCard extends Component {
 		editProduct( siteId, product, { images } );
 	}
 
+	renderTinyMCE = () => {
+		const { product } = this.props;
+
+		if ( ( isNumber( product.id ) && 'undefined' === typeof product.description ) || 'undefined' === typeof product.id ) {
+			return <div className="products__product-form-tinymce-placeholder"></div>;
+		}
+
+		return <CompactTinyMCE
+			initialValue={ product.description || '' }
+			onContentsChange={ this.debouncedSetDescription }
+		/>;
+	}
+
 	render() {
 		const { product } = this.props;
 		const images = product.images || [];
@@ -122,10 +135,7 @@ export default class ProductFormDetailsCard extends Component {
 						</FormFieldSet>
 						<FormFieldSet className="products__product-form-details-basic-description">
 							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>
-							<CompactTinyMCE
-								value={ product.description || '' }
-								onContentsChange={ this.debouncedSetDescription }
-							/>
+							{ this.renderTinyMCE() }
 						</FormFieldSet>
 					</div>
 				</div>

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -41,6 +41,12 @@ class ProductFormImages extends Component {
 		};
 	}
 
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.images !== this.props.images ) {
+			this.setState( { images: nextProps.images } );
+		}
+	}
+
 	onUpload = ( file ) => {
 		const { onUpload } = this.props;
 		onUpload( file );

--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -53,7 +53,7 @@ class ProductFormVariationsModal extends React.Component {
 			editProductVariation( siteId, product, variation, { description } );
 		}, 200 );
 		return <CompactTinyMCE
-				value={ variation.description || '' }
+				initialValue={ variation.description || '' }
 				onContentsChange={ setDescription }
 			/>;
 	}

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
-import { find, isNumber } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -112,15 +112,13 @@ class ProductFormVariationsTable extends React.Component {
 		);
 	}
 
-	renderVariationRow( variation ) {
+	renderVariationRow = ( variation, index ) => {
 		const { siteId, product, variations, editProductVariation } = this.props;
-		const id = isNumber( variation.id ) && variation.id || 'index_' + variation.id.index;
 		const manageStock = ( find( variations, ( v ) => v.manage_stock ) ) ? true : false;
-
 		return (
 			<ProductFormVariationsRow
 				siteId={ siteId }
-				key={ id }
+				key={ index }
 				product={ product }
 				variation={ variation }
 				manageStock={ manageStock }
@@ -203,7 +201,7 @@ class ProductFormVariationsTable extends React.Component {
 						</thead>
 						<tbody>
 							{ this.renderBulkRow() }
-							{ variations.map( ( v ) => this.renderVariationRow( v ) ) }
+							{ variations.map( this.renderVariationRow ) }
 						</tbody>
 					</table>
 					{ this.renderModal() }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -249,6 +249,13 @@
 	resize: vertical;
 }
 
+.products__product-form-tinymce-placeholder {
+	@include placeholder();
+	background: lighten( $gray, 35% );
+	height: 225px;
+	border: 1px solid lighten( $gray, 20% );
+}
+
 .products__product-form-details-basic-description.form-fieldset {
 	margin-bottom: 0;
 }

--- a/client/extensions/woocommerce/app/products/product-variation-types-form.js
+++ b/client/extensions/woocommerce/app/products/product-variation-types-form.js
@@ -74,11 +74,11 @@ export default class ProductVariationTypesForm extends Component {
 		editProductAttribute( siteId, product, attribute, { options: values } );
 	}
 
-	renderInputs( attribute ) {
+	renderInputs( attribute, index ) {
 		const { attributeNames } = this.state;
 		const attributeName = attributeNames && attributeNames[ attribute.uid ] || attribute.name;
 		return (
-			<div key={ attribute.uid } className="products__variation-types-form-fieldset">
+			<div key={ index } className="products__variation-types-form-fieldset">
 				<FormTextInput
 					placeholder={ i18n.translate( 'Color' ) }
 					value={ attributeName }

--- a/client/extensions/woocommerce/components/compact-tinymce/index.js
+++ b/client/extensions/woocommerce/components/compact-tinymce/index.js
@@ -26,13 +26,13 @@ class CompactTinyMCE extends Component {
 		onContentsChange: PropTypes.func.isRequired,
 		height: PropTypes.number,
 		className: PropTypes.string,
-		value: PropTypes.string,
+		initialValue: PropTypes.string,
 	}
 
 	static defaultProps = {
 		height: 250,
 		className: '',
-		value: '',
+		initialValue: '',
 		onContentsChange: noop,
 	}
 
@@ -56,9 +56,9 @@ class CompactTinyMCE extends Component {
 				return;
 			}
 
-			const { value, onContentsChange } = this.props;
+			const { initialValue, onContentsChange } = this.props;
 			editor.on( 'init', () => {
-				this.editor.setContent( wpautop( value ) );
+				this.editor.setContent( wpautop( initialValue ) );
 			} );
 			if ( onContentsChange ) {
 				editor.on( 'change', () => {


### PR DESCRIPTION
Fixes #15645, #15696, #15646.

This PR fixes a few issues with the product form when loading it in edit product mode:

* It fixes images not always loading in the image component.
* It fixes the product description not loading, by not loading the TinyMCE instance until we are ready.
* A minor (non-breaking) JS warning with variation types form.


To Test:
* Note that during these steps, when visiting the add and edit routes, you will need to refresh until #14609 is resolved.
* Edit a product that you know has a description.
* Make sure that the product description loads in.
* Edit a product with no description, and make sure TinyMCE loads.
* Go to add a new product and make sure TinyMCE loads.
* Edit a product with images, and make sure the images load in.
* Edit a variation with images, and make sure the images load in.