### PR TITLE
Fix padding on themes list

### DIFF
--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -2,12 +2,16 @@
 	display: flex;
 	flex-flow: row wrap;
 	list-style: none;
-	padding: 0 20px;
+	padding: 0;
 	margin: 0 -10px; // items flush against list edge
 
 	.feature-example & {
 		max-width: 1000px;
 		margin: auto;
+	}
+
+	.signup__steps & {
+		padding: 0 20px;
 	}
 }
 

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -9,10 +9,6 @@
 		max-width: 1000px;
 		margin: auto;
 	}
-
-	.signup__steps & {
-		padding: 0 20px;
-	}
 }
 
 .themes-list__spacer {

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -9,3 +9,7 @@
 		color: $gray-dark;
 	}
 }
+
+.step-wrapper__content .themes-list {
+	padding: 0 20px;
+}


### PR DESCRIPTION
This PR fixes a padding issue introduced in this PR: https://github.com/Automattic/wp-calypso/pull/15481/files/702c90d8d57206799e1c8cfa5fd640dea2908886#r125509170.

The PR localizes the CSS declaration to the signup screen. Updated themes screen:
![image](https://user-images.githubusercontent.com/6981253/27838750-88ca7dd0-60ba-11e7-9dfa-4d42090ea980.png)

@seear can you take a look.