### PR TITLE
Activity log: Display notice when restore progress check fails

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -2,21 +2,20 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { pick, delay } from 'lodash';
+import { delay } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import {
-	REWIND_RESTORE_PROGRESS_REQUEST,
-} from 'state/action-types';
+import { createNotice } from 'state/notices/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { REWIND_RESTORE_PROGRESS_REQUEST } from 'state/action-types';
 import {
 	getRewindRestoreProgress,
 	updateRewindRestoreProgress,
-	rewindRestoreUpdateError
 } from 'state/activity-log/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { http } from 'state/data-layer/wpcom-http/actions';
 
 const debug = debugFactory( 'calypso:data-layer:activity-log:rewind:restore-status' );
 
@@ -63,11 +62,12 @@ export const receiveRestoreProgress = ( { dispatch }, { siteId, timestamp, resto
 export const receiveRestoreError = ( { dispatch }, { siteId, timestamp, restoreId }, next, error ) => {
 	debug( 'Restore progress error', error );
 
-	dispatch( rewindRestoreUpdateError(
-		siteId,
-		timestamp,
-		restoreId,
-		pick( error, [ 'error', 'status', 'message' ] )
+	dispatch( createNotice(
+		'is-warning',
+		translate(
+			'There was a problem checking the status of your restore. ' +
+			'Try refreshing the page.'
+		),
 	) );
 };
 

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -64,10 +64,7 @@ export const receiveRestoreError = ( { dispatch }, { siteId, timestamp, restoreI
 
 	dispatch( createNotice(
 		'is-warning',
-		translate(
-			'There was a problem checking the status of your restore. ' +
-			'Try refreshing the page.'
-		),
+		translate( "Hmm, we can't update the status of your restore. Please refresh this page." ),
 	) );
 };
 


### PR DESCRIPTION
When repeated checks to the restore endpoint fail, show a notice.

I think this is the most meaningful thing we can do at this point.

![notice](https://user-images.githubusercontent.com/841763/27838967-39eed5d8-60ee-11e7-8c30-65fb6f319ab5.png)

**To test**
* Open your network panel
* Trigger a restore
* Disable network
* You should see the requests fail (3), then the notice will appear.

Fixes #15451 

Follow up:
* We could probably do something smart with `CONNECTION_LOST` / `CONNECTION_RESTORED` events.
* Tests!