### PR TITLE
Fixed layout for devdocs and logged-out users

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -17,6 +17,22 @@
 	margin-left: 0;
 }
 
+.layout__content {
+	.is-section-devdocs & {
+		padding-left: $sidebar-width-max + 32px;
+
+		// Tablets
+		@include breakpoint( "<960px" ) {
+			padding-left: $sidebar-width-min + 24px;
+		}
+
+		// Mobile (Full Width)
+		@include breakpoint( "<660px" ) {
+			padding-left: 0;
+		}
+	}
+}
+
 .devdocs__title {
 	color: darken( $gray, 20% );
 	font-weight: 300;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -50,7 +50,7 @@
 		}
 
 		.is-section-preview & {
-			padding: 47px 0px 0px 228px;
+			padding: 47px 0 0 228px;
 		}
 	}
 }
@@ -59,15 +59,14 @@
 @include breakpoint( "<660px" ) {
 	.layout__content {
 		margin-left: 0;
-		padding: 0;
-		padding-top: 47px;
+		padding: 47px 0 0;
 
 		.has-no-sidebar & {
 			padding-left: 0;
 		}
 
 		.is-section-preview & {
-			padding: 47px 0 0 0;
+			padding: 47px 0 0;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #15831 

Added style to fix sidebar overlapping content when user is logged out on ```devdocs``` section.

Refactored SCSS which was on my way.