### PR TITLE
Comments: Replace avatar image with Gravatar component

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import Gravatar from 'components/gravatar';
 import { urlToDomainAndPath } from 'lib/url';
 
 export class CommentDetailAuthor extends Component {
@@ -38,13 +39,17 @@ export class CommentDetailAuthor extends Component {
 		this.setState( { isExpanded: ! this.state.isExpanded } );
 	};
 
+	getAuthorObject = () => ( {
+		avatar_URL: this.props.authorAvatarUrl,
+		display_name: this.props.authorDisplayName,
+	} );
+
 	authorMoreInfo() {
 		if ( ! this.props.showAuthorInfo ) {
 			return null;
 		}
 
 		const {
-			authorAvatarUrl,
 			authorDisplayName,
 			authorEmail,
 			authorIp,
@@ -58,7 +63,7 @@ export class CommentDetailAuthor extends Component {
 			<div className="comment-detail__author-more-info">
 				<div className="comment-detail__author-more-actions">
 					<div className="comment-detail__author-more-element comment-detail__author-more-element-author">
-						<img className="comment-detail__author-avatar" src={ authorAvatarUrl } />
+						<Gravatar user={ this.getAuthorObject() } />
 						<div className="comment-detail__author-info">
 							<div className="comment-detail__author-name">
 								<strong>
@@ -110,7 +115,6 @@ export class CommentDetailAuthor extends Component {
 
 	render() {
 		const {
-			authorAvatarUrl,
 			authorDisplayName,
 			authorUrl,
 			commentDate,
@@ -128,7 +132,7 @@ export class CommentDetailAuthor extends Component {
 		return (
 			<div className={ classes }>
 				<div className="comment-detail__author-preview">
-					<img className="comment-detail__author-avatar" src={ authorAvatarUrl } />
+					<Gravatar user={ this.getAuthorObject() } />
 					<div className="comment-detail__author-info">
 						<div className="comment-detail__author-info-element comment-detail__author-name">
 							<strong>

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -10,9 +10,10 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import CommentDetailActions from './comment-detail-actions';
-import FormCheckbox from 'components/forms/form-checkbox';
 import AutoDirection from 'components/auto-direction';
+import CommentDetailActions from './comment-detail-actions';
+import Gravatar from 'components/gravatar';
+import FormCheckbox from 'components/forms/form-checkbox';
 import { stripHTML, decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 
@@ -59,6 +60,11 @@ export const CommentDetailHeader = ( {
 		);
 	}
 
+	const author = {
+		avatar_URL: authorAvatarUrl,
+		display_name: authorDisplayName,
+	};
+
 	return (
 		<div
 			className={ classNames( 'comment-detail__header', 'is-preview', { 'is-bulk-edit': isBulkEdit } ) }
@@ -70,7 +76,7 @@ export const CommentDetailHeader = ( {
 				</label>
 			}
 			<div className="comment-detail__author-preview">
-				<img className="comment-detail__author-avatar" src={ authorAvatarUrl } />
+				<Gravatar user={ author } />
 				<div className="comment-detail__author-info">
 					<div className="comment-detail__author-info-element">
 						<strong>

--- a/client/blocks/comment-detail/comment-detail-placeholder.jsx
+++ b/client/blocks/comment-detail/comment-detail-placeholder.jsx
@@ -12,7 +12,7 @@ export const CommentDetailPlaceholder = () =>
 	<Card className="comment-detail comment-detail__placeholder is-expanded">
 		<div className="comment-detail__header">
 			<div className="comment-detail__author-info">
-				<div className="comment-detail__author-avatar" />
+				<div className="comment-detail__author-avatar gravatar" />
 			</div>
 			<div className="comment-detail__comment-preview" />
 		</div>

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Gravatar from 'components/gravatar';
 import SiteIcon from 'blocks/site-icon';
 
 export const CommentDetailPost = ( {
@@ -21,11 +22,16 @@ export const CommentDetailPost = ( {
 	translate,
 } ) => {
 	if ( parentCommentContent ) {
+		const author = {
+			avatar_URL: parentCommentAuthorAvatarUrl,
+			display_name: parentCommentAuthorDisplayName,
+		};
+
 		return (
 			<div className="comment-detail__post">
 				<div className="comment-detail__site-icon-author-avatar">
 					<SiteIcon siteId={ siteId } size={ 24 } />
-					<img className="comment-detail__author-avatar-image" src={ parentCommentAuthorAvatarUrl } />
+					<Gravatar user={ author } />
 				</div>
 				<div className="comment-detail__post-info">
 					{ parentCommentAuthorDisplayName &&

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -29,12 +29,13 @@
 		margin-right: 4px;
 		vertical-align: middle;
 	}
-}
 
-.comment-detail__author-avatar {
-	border-radius: 50%;
-	display: block;
-	flex-shrink: 0;
+
+	.gravatar {
+		border-radius: 50%;
+		display: block;
+		flex-shrink: 0;
+	}
 }
 
 .comment-detail__author-info {
@@ -224,7 +225,7 @@
 .comment-detail__site-icon-author-avatar {
 	position: relative;
 
-	.comment-detail__author-avatar-image {
+	.gravatar {
 		border: 2px solid $white;
 		border-radius: 50%;
 		position: absolute;
@@ -296,7 +297,7 @@
 	padding: 0 16px;
 	transition: padding-bottom .3s linear;
 
-	.comment-detail__author-avatar {
+	.gravatar {
 		height: 32px;
 		width: 32px;
 	}
@@ -362,6 +363,7 @@
 }
 
 .comment-detail__author-more-element {
+	align-items: center;
 	box-sizing: border-box;
 	display: block;
 	flex-shrink: 0;
@@ -392,7 +394,7 @@ a.comment-detail__author-more-element {
 	display: flex;
 	flex-flow: row nowrap;
 
-	.comment-detail__author-avatar {
+	.gravatar {
 		height: 24px;
 		width: 24px;
 	}
@@ -476,7 +478,7 @@ a.comment-detail__author-more-element {
 .comment-detail__placeholder {
 	@include placeholder();
 
-	.comment-detail__author-avatar,
+	.gravatar,
 	.comment-detail__comment-preview {
 		animation: loading-fade 1.6s ease-in-out infinite;
 		background-color: lighten( $gray, 30% );
@@ -492,7 +494,7 @@ a.comment-detail__author-more-element {
 		border: none;
 	}
 
-	.comment-detail__author-avatar {
+	.gravatar {
 		width: 32px;
 	}
 


### PR DESCRIPTION
Fixes #15604

Replace the author avatar `<img>` elements with the `<Gravatar>` component, fixing the occasional broken images.

| Before | After |
| --- | --- |
| <img width="313" alt="screen shot 2017-07-04 at 18 26 43" src="https://user-images.githubusercontent.com/2070010/27839110-c4f1c300-60e6-11e7-82c2-625ab7c09fb6.png"> | <img width="315" alt="screen shot 2017-07-04 at 18 25 56" src="https://user-images.githubusercontent.com/2070010/27839111-c4f5cf40-60e6-11e7-8ecf-ddc3cc5a585e.png"> |

cc @Automattic/lannister 