### PR TITLE
Magic Login: Email Request Form improvements

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -49,6 +49,10 @@ class RequestLoginEmailForm extends React.Component {
 		this.setState( {
 			emailAddress: event.target.value,
 		} );
+
+		if ( this.props.requestError ) {
+			this.props.hideMagicLoginRequestNotice();
+		}
 	};
 
 	onNoticeDismiss = () => {
@@ -85,7 +89,6 @@ class RequestLoginEmailForm extends React.Component {
 		}
 
 		const submitEnabled = (
-			emailAddress.match( /^.+@.+/ ) &&
 			! isFetching &&
 			! emailRequested &&
 			! requestError
@@ -128,6 +131,7 @@ class RequestLoginEmailForm extends React.Component {
 							disabled={ isFetching || emailRequested }
 							name="emailAddress"
 							placeholder={ translate( 'Email address' ) }
+							type="email"
 							onChange={ this.onEmailAddressFieldChange }
 						/>
 


### PR DESCRIPTION
Changes in this branch:
* Use HTML5 input type email for pre-flight validation vs. a one-off regex to catch common typos
  * Supported by all major browsers: http://caniuse.com/#feat=input-email-tel-url
  * Looks like: <img width="477" alt="screen shot 2017-07-04 at 2 36 22 pm" src="https://user-images.githubusercontent.com/1587282/27840361-360ba400-60c6-11e7-9da5-ef0f78ebc8c8.png">

* Clear out the error notice & enable the submit button when entering text in the field after an error condition

## To Test

* Visit https://calypso.live/log-in/link?branch=improve/magic-login-email-validation in a logged out / incognito window
* Attempt to enter and submit an "invalid" email address
  * Your browser should prompt you to correct it using a Native UI element
* Attempt to enter and submit an email address you know does not resolve to a valid user
  * You should see an in-page notice & the submit button should be disabled
  * After 10 seconds of inactivity, the notice should clear & the submit button should be re-enabled
* Repeat the above (address of a non-existent user)
  * You should see an in-page notice & the submit button should be disabled
  * Changing the value of the email address form field should clear the notice & re-enable the submit button
* Attempt to enter and submit a **VALID** email address connected to a valid user
  * It should allow you to complete the flow
  * All email formats that WordPress.com supports should work here as well!