### PR TITLE
Woo: Update product placeholder ids

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -15,7 +15,7 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { editProduct, editProductAttribute, createProductActionList } from 'woocommerce/state/ui/products/actions';
 import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
-import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
+import { getCurrentlyEditingId, getProductWithLocalEdits } from 'woocommerce/state/ui/products/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
 import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
@@ -46,9 +46,7 @@ class ProductCreate extends React.Component {
 
 		if ( site && site.ID ) {
 			if ( ! product ) {
-				this.props.editProduct( site.ID, null, {
-					type: 'simple'
-				} );
+				this.props.editProduct( site.ID, null, {} );
 			}
 			this.props.fetchProductCategories( site.ID );
 		}
@@ -59,9 +57,7 @@ class ProductCreate extends React.Component {
 		const newSiteId = newProps.site && newProps.site.ID || null;
 		const oldSiteId = site && site.ID || null;
 		if ( oldSiteId !== newSiteId ) {
-			this.props.editProduct( newSiteId, null, {
-				type: 'simple'
-			} );
+			this.props.editProduct( newSiteId, null, {} );
 			this.props.fetchProductCategories( newSiteId );
 		}
 	}
@@ -71,7 +67,7 @@ class ProductCreate extends React.Component {
 	}
 
 	onSave = () => {
-		const { product, translate } = this.props;
+		const { site, product, translate } = this.props;
 
 		const successAction = successNotice(
 			translate( '%(product)s successfully created.', {
@@ -86,12 +82,15 @@ class ProductCreate extends React.Component {
 			} )
 		);
 
+		if ( ! product.type ) {
+			// Product type was never switched, so set it before we save.
+			this.props.editProduct( site.ID, product, { type: 'simple' } );
+		}
 		this.props.createProductActionList( successAction, failureAction );
 	}
 
 	isProductValid( product = this.props.product ) {
 		return product &&
-			product.type &&
 			product.name && product.name.length > 0;
 	}
 
@@ -127,7 +126,9 @@ class ProductCreate extends React.Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
-	const product = getCurrentlyEditingProduct( state );
+	const productId = getCurrentlyEditingId( state );
+	const combinedProduct = getProductWithLocalEdits( state, productId );
+	const product = combinedProduct || ( productId && { id: productId } );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
 	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -25,7 +25,7 @@ import {
 	editProductAttribute,
 	createProductActionList
 } from 'woocommerce/state/ui/products/actions';
-import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
+import { getProductEdits, getProductWithLocalEdits } from 'woocommerce/state/ui/products/selectors';
 import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
@@ -139,11 +139,11 @@ class ProductUpdate extends React.Component {
 	}
 
 	render() {
-		const { site, product, className, variations, productCategories, actionList } = this.props;
+		const { site, product, hasEdits, className, variations, productCategories, actionList } = this.props;
 
 		const isValid = 'undefined' !== site && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
-		const saveEnabled = isValid && ! isBusy;
+		const saveEnabled = isValid && ! isBusy && hasEdits;
 
 		return (
 			<Main className={ className }>
@@ -171,9 +171,12 @@ class ProductUpdate extends React.Component {
 	}
 }
 
-function mapStateToProps( state ) {
+function mapStateToProps( state, ownProps ) {
+	const productId = Number( ownProps.params.product );
+
 	const site = getSelectedSiteWithFallback( state );
-	const product = getCurrentlyEditingProduct( state );
+	const product = getProductWithLocalEdits( state, productId );
+	const hasEdits = Boolean( getProductEdits( state, productId ) );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
 	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );
@@ -181,6 +184,7 @@ function mapStateToProps( state ) {
 	return {
 		site,
 		product,
+		hasEdits,
 		variations,
 		productCategories,
 		actionList,

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -25,6 +25,14 @@ function editProductAction( edits, action ) {
 	const _product = product || { id: { placeholder: uniqueId( 'product_' ) } };
 	const _array = editProduct( prevEdits[ bucket ], _product, data );
 
+	if ( isEqual( {}, data ) ) {
+		// If data is empty, only set the currentlyEditingId.
+		return {
+			...prevEdits,
+			currentlyEditingId: _product.id,
+		};
+	}
+
 	return {
 		...prevEdits,
 		[ bucket ]: _array,

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -11,7 +11,7 @@ import {
 	WOOCOMMERCE_PRODUCT_EDIT,
 	WOOCOMMERCE_PRODUCT_ATTRIBUTE_EDIT,
 } from 'woocommerce/state/action-types';
-import { nextBucketIndex, getBucket } from '../helpers';
+import { getBucket } from '../helpers';
 
 export default createReducer( null, {
 	[ WOOCOMMERCE_PRODUCT_EDIT ]: editProductAction,
@@ -22,7 +22,7 @@ function editProductAction( edits, action ) {
 	const { product, data } = action;
 	const prevEdits = edits || {};
 	const bucket = getBucket( product );
-	const _product = product || { id: nextBucketIndex( prevEdits[ bucket ] ) };
+	const _product = product || { id: { placeholder: uniqueId( 'product_' ) } };
 	const _array = editProduct( prevEdits[ bucket ], _product, data );
 
 	return {
@@ -39,7 +39,7 @@ function editProductAttributeAction( edits, action ) {
 	const prevEdits = edits || {};
 	const bucket = getBucket( product );
 	const _attributes = editProductAttribute( attributes, attribute, data );
-	const _product = product || { id: nextBucketIndex( prevEdits[ bucket ] ) };
+	const _product = product || { id: { placeholder: uniqueId( 'product_' ) } };
 	const _array = editProduct( prevEdits[ bucket ], _product, { attributes: _attributes } );
 
 	return {

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -47,6 +47,20 @@ export function getProductWithLocalEdits( state, productId, siteId = getSelected
 }
 
 /**
+ * Gets the id of the currently editing product.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number|Object} Id of the currently editing product.
+ */
+export function getCurrentlyEditingId( state, siteId = getSelectedSiteId( state ) ) {
+	const edits = getAllProductEdits( state, siteId ) || {};
+	const { currentlyEditingId } = edits;
+
+	return currentlyEditingId;
+}
+
+/**
  * Gets the product being currently edited in the UI.
  *
  * @param {Object} state Global state tree
@@ -54,8 +68,7 @@ export function getProductWithLocalEdits( state, productId, siteId = getSelected
  * @return {Object} Product object that is merged between fetched data and edits
  */
 export function getCurrentlyEditingProduct( state, siteId = getSelectedSiteId( state ) ) {
-	const edits = getAllProductEdits( state, siteId ) || {};
-	const { currentlyEditingId } = edits;
+	const currentlyEditingId = getCurrentlyEditingId( state, siteId );
 
 	return getProductWithLocalEdits( state, currentlyEditingId, siteId );
 }

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -17,7 +17,7 @@ export function getAllProductEdits( state, siteId ) {
  * Gets the accumulated edits for a product, if any.
  *
  * @param {Object} state Global state tree
- * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} productId The id of the product (or { placeholder: # } )
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The current accumulated edits
  */
@@ -33,7 +33,7 @@ export function getProductEdits( state, productId, siteId = getSelectedSiteId( s
  * Gets a product with local edits overlayed on top of fetched data.
  *
  * @param {Object} state Global state tree
- * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} productId The id of the product (or { placeholder: # } )
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The product data merged between the fetched data and edits
  */

--- a/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
@@ -71,7 +71,8 @@ describe( 'edits-reducer', () => {
 		expect( edits ).to.not.equal( null );
 		expect( edits.creates ).to.exist;
 		expect( edits.creates[ 0 ] ).to.exist;
-		expect( edits.creates[ 0 ].id ).to.eql( { index: 0 } );
+		expect( edits.creates[ 0 ].id ).to.exist;
+		expect( edits.creates[ 0 ].id.placeholder ).to.exist;
 		expect( edits.creates[ 0 ].name ).to.eql( 'A new product' );
 	} );
 
@@ -101,10 +102,14 @@ describe( 'edits-reducer', () => {
 			name: 'Second product',
 		} ) );
 
-		expect( edits2.creates[ 0 ].id ).to.eql( { index: 0 } );
+		expect( edits2.creates[ 0 ].id ).to.exist;
+		expect( edits2.creates[ 0 ].id.placeholder ).to.exist;
 		expect( edits2.creates[ 0 ].name ).to.eql( 'First product' );
-		expect( edits2.creates[ 1 ].id ).to.eql( { index: 1 } );
+		expect( edits2.creates[ 1 ].id ).to.exist;
+		expect( edits2.creates[ 1 ].id.placeholder ).to.exist;
 		expect( edits2.creates[ 1 ].name ).to.eql( 'Second product' );
+
+		expect( edits2.creates[ 1 ].id ).to.not.eql( edits2.creates[ 0 ].id );
 	} );
 
 	it( 'should create new product in "creates" when editing attribute the first time', () => {

--- a/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
@@ -244,4 +244,21 @@ describe( 'edits-reducer', () => {
 		} ) );
 		expect( edits1.currentlyEditingId ).to.eql( edits1.updates[ 0 ].id );
 	} );
+
+	it( 'should not add a create edit entry, only set currentlyEditingId, when data is empty', () => {
+		const edits1 = reducer( undefined, editProduct( siteId, null, {} ) );
+
+		expect( edits1.currentlyEditingId ).to.exist;
+		expect( edits1.currentlyEditingId.placeholder ).to.exist;
+		expect( edits1.creates ).to.not.exist;
+	} );
+
+	it( 'should not add an update edit entry, only set currentlyEditingId, when data is empty', () => {
+		const product1 = { id: 1 };
+		const edits1 = reducer( undefined, editProduct( siteId, product1, {} ) );
+
+		expect( edits1.currentlyEditingId ).to.exist;
+		expect( edits1.currentlyEditingId ).to.equal( 1 );
+		expect( edits1.updates ).to.not.exist;
+	} );
 } );

--- a/client/extensions/woocommerce/state/ui/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/test/selectors.js
@@ -134,7 +134,7 @@ describe( 'selectors', () => {
 
 	describe( 'getProductEdits', () => {
 		it( 'should get a product from "creates"', () => {
-			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const newProduct = { id: { placeholder: 'product_0' }, name: 'New Product' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
 			set( uiProducts, [ siteId, 'edits', 'creates' ], [ newProduct ] );
 
@@ -151,13 +151,13 @@ describe( 'selectors', () => {
 
 		it( 'should return undefined if no edits are found for productId', () => {
 			expect( getProductEdits( state, 1 ) ).to.not.exist;
-			expect( getProductEdits( state, { index: 9 } ) ).to.not.exist;
+			expect( getProductEdits( state, { placeholder: 'product_9' } ) ).to.not.exist;
 		} );
 	} );
 
 	describe( 'getProductWithLocalEdits', () => {
 		it( 'should get just edits for a product in "creates"', () => {
-			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const newProduct = { id: { placeholder: 'product_0' }, name: 'New Product' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
 			set( uiProducts, [ siteId, 'edits', 'creates' ], [ newProduct ] );
 
@@ -182,7 +182,7 @@ describe( 'selectors', () => {
 
 		it( 'should return undefined if no product is found for productId', () => {
 			expect( getProductWithLocalEdits( state, 42 ) ).to.not.exist;
-			expect( getProductWithLocalEdits( state, { index: 42 } ) ).to.not.exist;
+			expect( getProductWithLocalEdits( state, { placeholder: 'product_42' } ) ).to.not.exist;
 		} );
 	} );
 
@@ -192,7 +192,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should get the last edited product', () => {
-			const newProduct = { id: { index: 0 }, name: 'New Product' };
+			const newProduct = { id: { placeholder: 'product_0' }, name: 'New Product' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
 			set( uiProducts, [ siteId, 'edits', 'creates' ], [ newProduct ] );
 			set( uiProducts, [ siteId, 'edits', 'currentlyEditingId' ], newProduct.id );

--- a/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/edits-reducer.js
@@ -88,7 +88,7 @@ function editProductVariationAction( edits, action ) {
 	const _edits = prevEdits.map( ( productEdits ) => {
 		if ( isEqual( productId, productEdits.productId ) ) {
 			found = true;
-			const variationId = variation && variation.id || { index: Number( uniqueId() ) };
+			const variationId = variation && variation.id || { placeholder: uniqueId( 'product_variation_' ) };
 			const _variation = variation || { id: variationId };
 			const _array = editProductVariation( productEdits[ bucket ], _variation, data );
 			return {
@@ -103,7 +103,7 @@ function editProductVariationAction( edits, action ) {
 
 	if ( ! found ) {
 		// product not in edits, so add it now.
-		const variationId = variation && variation.id || { index: Number( uniqueId() ) };
+		const variationId = variation && variation.id || { placeholder: uniqueId( 'product_variation_' ) };
 		const _variation = variation || { id: variationId };
 
 		const _array = editProductVariation( null, _variation, data );
@@ -174,8 +174,7 @@ function updateVariationCreates( creates, calculatedVariations, productVariation
 		if ( ! find( productVariations, { attributes: calculatedVariation.attributes } ) ) {
 			// This calculated variation doesn't exist in server data, but it should now. Create it.
 			return {
-				// TODO: Replace this faux index with a proper placeholder.
-				id: { index: Number( uniqueId() ) },
+				id: { placeholder: uniqueId( 'product_variation_' ) },
 				attributes: calculatedVariation.attributes,
 				sku: calculatedVariation.sku,
 				status: 'publish',

--- a/client/extensions/woocommerce/state/ui/products/variations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/selectors.js
@@ -23,8 +23,8 @@ export function getVariationEditsStateForProduct( state, productId, siteId = get
  * Gets the accumulated edits for a variation, if any.
  *
  * @param {Object} state Global state tree
- * @param {any} productId The id of the product (or { index: # } )
- * @param {any} variationId The id of the variation (or { index: # } )
+ * @param {any} productId The id of the product (or { placeholder: # } )
+ * @param {any} variationId The id of the variation (or { placeholder: # } )
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The current accumulated edits
  */
@@ -39,8 +39,8 @@ export function getVariationEdits( state, productId, variationId, siteId = getSe
  * Gets a variation with local edits overlayed on top of fetched data.
  *
  * @param {Object} state Global state tree
- * @param {any} productId The id of the product (or { index: # } )
- * @param {any} variationId The id of the variation (or { index: # } )
+ * @param {any} productId The id of the product (or { placeholder: # } )
+ * @param {any} variationId The id of the variation (or { placeholder: # } )
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} The product data merged between the fetched data and edits
  */
@@ -57,7 +57,7 @@ export function getVariationWithLocalEdits( state, productId, variationId, siteI
  * Gets the variation being currently edited in the UI.
  *
  * @param {Object} state Global state tree
- * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} productId The id of the product (or { placeholder: # } )
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Object} Variation object that is merged between fetched data and edits
  */
@@ -72,7 +72,7 @@ export function getCurrentlyEditingVariation( state, productId, siteId = getSele
  * Gets an array of variation objects for a product, including new ones being edited in the UI.
  *
  * @param {Object} state Global state tree
- * @param {any} productId The id of the product (or { index: # } )
+ * @param {any} productId The id of the product (or { placeholder: # } )
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} Array of variation objects.
  */
@@ -84,7 +84,7 @@ export function getProductVariationsWithLocalEdits( state, productId, siteId = g
 	const deletes = get( edits, 'deletes', undefined );
 
 	const updatedVariations = compact( ( variations || [] ).map( ( variation ) => {
-		const isDeleted = Boolean( find( deletes, ( deletedId ) => variation.id === deletedId ) );
+		const isDeleted = Boolean( find( deletes, ( deletedId ) => isEqual( variation.id, deletedId ) ) );
 
 		if ( isDeleted ) {
 			return undefined;

--- a/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/edits-reducer.js
@@ -20,7 +20,7 @@ const siteId = 123;
 
 describe( 'edits-reducer', () => {
 	const newVariableProduct1 = {
-		id: { index: 1 },
+		id: { placeholder: 'product_1' },
 		type: 'variable',
 		name: 'New Variable Product',
 		attributes: [
@@ -38,14 +38,14 @@ describe( 'edits-reducer', () => {
 	};
 
 	const variationBlack = {
-		id: { index: 4 },
+		id: { placeholder: 'product_variation_4' },
 		attributes: [
 			{ name: 'Color', option: 'Black' },
 		],
 	};
 
 	const variationBlue = {
-		id: { index: 5 },
+		id: { placeholder: 'product_variation_4' },
 		attributes: [
 			{ name: 'Color', option: 'Blue' },
 		],
@@ -337,7 +337,7 @@ describe( 'edits-reducer', () => {
 				{
 					productId: existingVariableProduct1.id,
 					updates: [ {
-						id: { index: 4 },
+						id: { placeholder: 'product_variation_4' },
 						regular_price: '5.99',
 					} ],
 				},
@@ -358,7 +358,7 @@ describe( 'edits-reducer', () => {
 			expect( variationEditsAfter[ 0 ].productId ).to.eql( existingVariableProduct1.id );
 			expect( variationEditsAfter[ 0 ].updates ).to.exist;
 			expect( variationEditsAfter[ 0 ].updates.length ).to.equal( 1 );
-			expect( variationEditsAfter[ 0 ].updates[ 0 ].id ).to.eql( { index: 4 } );
+			expect( variationEditsAfter[ 0 ].updates[ 0 ].id ).to.eql( { placeholder: 'product_variation_4' } );
 			expect( variationEditsAfter[ 0 ].updates[ 0 ].regular_price ).to.eql( '5.99' );
 			expect( variationEditsAfter[ 0 ].creates ).to.exist;
 			expect( variationEditsAfter[ 0 ].creates.length ).to.equal( 1 );
@@ -403,7 +403,7 @@ describe( 'edits-reducer', () => {
 				{
 					productId: existingVariableProduct1.id,
 					updates: [ {
-						id: { index: 4 },
+						id: { placeholder: 'product_variation_4' },
 						attributes: [
 							{ name: 'Color', option: 'Darker than Black' },
 						],

--- a/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/variations/test/selectors.js
@@ -49,8 +49,8 @@ describe( 'selectors', () => {
 
 	describe( 'getVariationEdits', () => {
 		it( 'should get a variation from "creates"', () => {
-			const newVariation = { id: { index: 1 }, sku: 'new-variation' };
-			const productId = { index: 0 };
+			const newVariation = { id: { placeholder: 'product_variation_1' }, sku: 'new-variation' };
+			const productId = { placeholder: 'product_0' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], productId );
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );
@@ -69,20 +69,20 @@ describe( 'selectors', () => {
 
 		it( 'should return undefined if no edits are found for productId', () => {
 			expect( getVariationEdits( state, 15, 102919 ) ).to.not.exist;
-			expect( getVariationEdits( state, 15, { index: 9 } ) ).to.not.exist;
+			expect( getVariationEdits( state, 15, { placeholder: 'product_variation_9' } ) ).to.not.exist;
 		} );
 
 		it( 'should return undefined if no edits are found for variationId', () => {
 			const uiVariations = state.extensions.woocommerce.ui.products.variations;
 			set( uiVariations, 'edits[0].productId', 15 );
 			expect( getVariationEdits( state, 15, 102919 ) ).to.not.exist;
-			expect( getVariationEdits( state, 15, { index: 9 } ) ).to.not.exist;
+			expect( getVariationEdits( state, 15, { placeholder: 'product_variation_9' } ) ).to.not.exist;
 		} );
 	} );
 
 	describe( 'getVariationWithLocalEdits', () => {
 		it( 'should get just edits for a variation in "creates"', () => {
-			const newVariation = { id: { index: 0 }, sku: 'new-variation' };
+			const newVariation = { id: { placeholder: 'product_variation_0' }, sku: 'new-variation' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 2 );
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );
@@ -112,12 +112,12 @@ describe( 'selectors', () => {
 			const uiVariations = state.extensions.woocommerce.ui.products.variations;
 			set( uiVariations, 'edits[0].productId', 42 );
 			expect( getVariationWithLocalEdits( state, 42, 201202 ) ).to.not.exist;
-			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { placeholder: 'product_variation_55' } ) ).to.not.exist;
 		} );
 
 		it( 'should return undefined if no product is found for productId', () => {
 			expect( getVariationWithLocalEdits( state, 42, 102382 ) ).to.not.exist;
-			expect( getVariationWithLocalEdits( state, 42, { index: 55 } ) ).to.not.exist;
+			expect( getVariationWithLocalEdits( state, 42, { placeholder: 'product_variation_55' } ) ).to.not.exist;
 		} );
 	} );
 
@@ -127,7 +127,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should get the last edited variation', () => {
-			const newVariation = { id: { index: 0 }, sku: 'new-variation' };
+			const newVariation = { id: { placeholder: 'product_variation_0' }, sku: 'new-variation' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 15 );
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );
@@ -143,7 +143,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should get variations from "creates"', () => {
-			const newVariation = { id: { index: 0 }, sku: 'new-variation' };
+			const newVariation = { id: { placeholder: 'product_variation_0' }, sku: 'new-variation' };
 			const uiProducts = state.extensions.woocommerce.ui.products;
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'productId' ], 15 );
 			set( uiProducts, [ siteId, 'variations', 'edits', '0', 'creates' ], [ newVariation ] );


### PR DESCRIPTION
*Note for testing: Edit state is not being cleared completely yet, so you'll need to do a browser refresh after you save any changes.*

This updates product and product variations to use a "placeholder"
`uniqueId` value instead of an index.

The reason for doing this on products is the next change that will be to
set the currentlyEditingId for products without actually adding an edit
yet. This invalidates the concept of an index.

The reason for doing this on product variations is that "index" was
already a generated `uniqueId`.

This also updates a lot of places where === comparisons were being done
for ids when they should be `isEqual` calls (state can be serialized).

To Test:

1. `npm test`
2. `npm start`
3. Create a new product, add variations, etc. Verify all works.
4. Edit an existing product with variations. Verify all works.

Addresses #15333 for products and product variations
