### PR TITLE
WooCommerce Orders: Add ability to update order status

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -21,6 +21,10 @@ import OrderCustomerInfo from './order-customer-info';
 import OrderDetails from './order-details';
 
 class Order extends Component {
+	state = {
+		order: {}
+	}
+
 	componentDidMount() {
 		const { siteId, orderId } = this.props;
 
@@ -33,6 +37,10 @@ class Order extends Component {
 		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
 			this.props.fetchOrder( newProps.siteId, newProps.orderId );
 		}
+	}
+
+	onUpdate = ( order ) => {
+		this.setState( { order } );
 	}
 
 	saveOrder = () => {}
@@ -54,7 +62,7 @@ class Order extends Component {
 				</ActionHeader>
 
 				<div className="order__container">
-					<OrderDetails order={ order } site={ site } />
+					<OrderDetails order={ order } onUpdate={ this.onUpdate } site={ site } />
 					<OrderActivityLog order={ order } />
 					<OrderCustomerInfo order={ order } />
 				</div>

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -64,7 +64,6 @@ class Order extends Component {
 			( <a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> ),
 			( <span>{ translate( 'Order Details' ) }</span> ),
 		];
-		console.log( isSaving );
 		return (
 			<Main className={ className }>
 				<ActionHeader breadcrumbs={ breadcrumbs }>

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -18,6 +18,7 @@ import SectionHeader from 'components/section-header';
 
 class OrderDetails extends Component {
 	static propTypes = {
+		onUpdate: PropTypes.func,
 		order: PropTypes.object.isRequired,
 		site: PropTypes.shape( {
 			ID: PropTypes.number.isRequired,
@@ -31,6 +32,8 @@ class OrderDetails extends Component {
 
 	updateStatus = ( event ) => {
 		this.setState( { status: event.target.value } );
+		// Send the order back to the parent component
+		this.props.onUpdate( { status: event.target.value } );
 	}
 
 	renderStatus = () => {

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -1,15 +1,17 @@
 /**
  * External dependencies
  */
+import { find } from 'lodash';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import FormSelect from 'components/forms/form-select';
 import OrderDetailsTable from './order-details-table';
 import OrderRefundCard from './order-refund-card';
 import SectionHeader from 'components/section-header';
@@ -24,13 +26,55 @@ class OrderDetails extends Component {
 	}
 
 	state = {
-		showRefundDialog: false,
+		status: this.props.order.status || false,
 	}
 
-	toggleRefundDialog = () => {
-		this.setState( {
-			showRefundDialog: ! this.state.showRefundDialog,
-		} );
+	updateStatus = ( event ) => {
+		this.setState( { status: event.target.value } );
+	}
+
+	renderStatus = () => {
+		const { order, translate } = this.props;
+		const classes = `order__status is-${ order.status }`;
+		const statuses = [ {
+			value: 'pending',
+			name: translate( 'Pending payment' ),
+		}, {
+			value: 'processing',
+			name: translate( 'Processing' ),
+		}, {
+			value: 'on-hold',
+			name: translate( 'On Hold' ),
+		}, {
+			value: 'completed',
+			name: translate( 'Completed' ),
+		}, {
+			value: 'cancelled',
+			name: translate( 'Cancelled' ),
+		}, {
+			value: 'refunded',
+			name: translate( 'Refunded' ),
+		}, {
+			value: 'failed',
+			name: translate( 'Payment Failed' ),
+		} ];
+
+		if ( 'pending' === order.status || 'on-hold' === order.status ) {
+			return (
+				<FormSelect id="select" value={ this.state.status } onChange={ this.updateStatus }>
+					{ statuses.map( ( status, i ) => {
+						return (
+							<option key={ i } value={ status.value }>{ status.name }</option>
+						);
+					} ) }
+				</FormSelect>
+			);
+		}
+
+		const statusLabel = find( statuses, { value: order.status } );
+		return (
+			<span className={ classes }>{ statusLabel.name }</span>
+		);
 	}
 
 	render() {
@@ -41,7 +85,9 @@ class OrderDetails extends Component {
 
 		return (
 			<div className="order__details">
-				<SectionHeader label={ translate( 'Order Details' ) } />
+				<SectionHeader label={ translate( 'Order Details' ) }>
+					<span>{ this.renderStatus() }</span>
+				</SectionHeader>
 				<Card className="order__details-card">
 					<OrderDetailsTable order={ order } site={ site } />
 					<OrderRefundCard order={ order } site={ site } />

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -26,8 +26,11 @@ class OrderDetails extends Component {
 		} ),
 	}
 
-	state = {
-		status: this.props.order.status || false,
+	constructor( props ) {
+		super( props );
+		this.state = {
+			status: this.props.order.status || false,
+		};
 	}
 
 	updateStatus = ( event ) => {
@@ -39,6 +42,7 @@ class OrderDetails extends Component {
 	renderStatus = () => {
 		const { order, translate } = this.props;
 		const classes = `order__status is-${ order.status }`;
+		// TODO: create a helper function for status labels
 		const statuses = [ {
 			value: 'pending',
 			name: translate( 'Pending payment' ),

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -35,6 +35,31 @@
 	}
 }
 
+.order__status {
+	display: inline-flex;
+	padding: 0px 12px;
+	line-height: 32px;
+	background: lighten( $gray, 20% );
+	border-radius: 4px;
+
+	&.is-failed {
+		background: lighten( $alert-red, 20% );
+		color: darken( $alert-red, 30% );
+	}
+
+	&.is-cancelled,
+	&.is-refunded,
+	&.is-completed {
+		background: $gray-light;
+		color: $gray-dark;
+	}
+
+	&.is-on-hold {
+		background: lighten( $alert-yellow, 20% );
+		color: darken( $alert-yellow, 30% );
+	}
+}
+
 .order__details-card {
 	padding-top: 0;
 	padding-bottom: 0;

--- a/client/extensions/woocommerce/state/sites/orders/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/reducer.js
@@ -140,6 +140,7 @@ export function totalPages( state = 1, action ) {
 export default combineReducers( {
 	isQueryLoading,
 	isLoading,
+	isUpdating,
 	items,
 	queries,
 	refunds,


### PR DESCRIPTION
Fixes #15674, allowing store owners to update the status of pending or on-hold orders. Depends on #15844.

<img width="739" alt="screen shot 2017-07-04 at 4 47 16 pm" src="https://user-images.githubusercontent.com/541093/27842486-7ad99936-60d8-11e7-9db7-be97c692bbdb.png">
<img width="734" alt="screen shot 2017-07-04 at 4 48 03 pm" src="https://user-images.githubusercontent.com/541093/27842501-963416b6-60d8-11e7-9fb6-84ad92703150.png">


To test:

- Open an order, `/store/order/:site/:orderId`
- If the order is completed, or refunded, etc, you'll see just a status label.
- If the order is pending payment (the customer used check payments, for example), you should see a dropdown to change status
- Click "Save Order" to save the new order status
- A green notice should appear that the order saved

Note: this also fixes an issue where the reducer wasn't exported correctly, missing the `isUpdating` state.