### PR TITLE
Woo: No longer create edit on product page loads

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -15,7 +15,7 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { editProduct, editProductAttribute, createProductActionList } from 'woocommerce/state/ui/products/actions';
 import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
-import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
+import { getCurrentlyEditingId, getProductWithLocalEdits } from 'woocommerce/state/ui/products/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
 import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
@@ -46,9 +46,7 @@ class ProductCreate extends React.Component {
 
 		if ( site && site.ID ) {
 			if ( ! product ) {
-				this.props.editProduct( site.ID, null, {
-					type: 'simple'
-				} );
+				this.props.editProduct( site.ID, null, {} );
 			}
 			this.props.fetchProductCategories( site.ID );
 		}
@@ -59,9 +57,7 @@ class ProductCreate extends React.Component {
 		const newSiteId = newProps.site && newProps.site.ID || null;
 		const oldSiteId = site && site.ID || null;
 		if ( oldSiteId !== newSiteId ) {
-			this.props.editProduct( newSiteId, null, {
-				type: 'simple'
-			} );
+			this.props.editProduct( newSiteId, null, {} );
 			this.props.fetchProductCategories( newSiteId );
 		}
 	}
@@ -127,7 +123,9 @@ class ProductCreate extends React.Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
-	const product = getCurrentlyEditingProduct( state );
+	const productId = getCurrentlyEditingId( state, site.id );
+	const combinedProduct = getProductWithLocalEdits( state, productId, site.id );
+	const product = combinedProduct || ( productId && { id: productId } );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
 	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -67,7 +67,7 @@ class ProductCreate extends React.Component {
 	}
 
 	onSave = () => {
-		const { product, translate } = this.props;
+		const { site, product, translate } = this.props;
 
 		const successAction = successNotice(
 			translate( '%(product)s successfully created.', {
@@ -82,12 +82,15 @@ class ProductCreate extends React.Component {
 			} )
 		);
 
+		if ( ! product.type ) {
+			// Product type was never switched, so set it before we save.
+			this.props.editProduct( site.ID, product, { type: 'simple' } );
+		}
 		this.props.createProductActionList( successAction, failureAction );
 	}
 
 	isProductValid( product = this.props.product ) {
 		return product &&
-			product.type &&
 			product.name && product.name.length > 0;
 	}
 
@@ -123,8 +126,8 @@ class ProductCreate extends React.Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
-	const productId = getCurrentlyEditingId( state, site.id );
-	const combinedProduct = getProductWithLocalEdits( state, productId, site.id );
+	const productId = getCurrentlyEditingId( state );
+	const combinedProduct = getProductWithLocalEdits( state, productId );
 	const product = combinedProduct || ( productId && { id: productId } );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
 	const productCategories = getProductCategoriesWithLocalEdits( state );

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -25,7 +25,7 @@ import {
 	editProductAttribute,
 	createProductActionList
 } from 'woocommerce/state/ui/products/actions';
-import { getCurrentlyEditingProduct } from 'woocommerce/state/ui/products/selectors';
+import { getProductEdits, getProductWithLocalEdits } from 'woocommerce/state/ui/products/selectors';
 import { editProductVariation } from 'woocommerce/state/ui/products/variations/actions';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
 import { editProductCategory } from 'woocommerce/state/ui/product-categories/actions';
@@ -139,11 +139,11 @@ class ProductUpdate extends React.Component {
 	}
 
 	render() {
-		const { site, product, className, variations, productCategories, actionList } = this.props;
+		const { site, product, hasEdits, className, variations, productCategories, actionList } = this.props;
 
 		const isValid = 'undefined' !== site && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
-		const saveEnabled = isValid && ! isBusy;
+		const saveEnabled = isValid && ! isBusy && hasEdits;
 
 		return (
 			<Main className={ className }>
@@ -171,9 +171,12 @@ class ProductUpdate extends React.Component {
 	}
 }
 
-function mapStateToProps( state ) {
+function mapStateToProps( state, ownProps ) {
+	const productId = Number( ownProps.params.product );
+
 	const site = getSelectedSiteWithFallback( state );
-	const product = getCurrentlyEditingProduct( state );
+	const product = getProductWithLocalEdits( state, productId );
+	const hasEdits = Boolean( getProductEdits( state, productId ) );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
 	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );
@@ -181,6 +184,7 @@ function mapStateToProps( state ) {
 	return {
 		site,
 		product,
+		hasEdits,
 		variations,
 		productCategories,
 		actionList,

--- a/client/extensions/woocommerce/state/ui/products/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/edits-reducer.js
@@ -25,6 +25,14 @@ function editProductAction( edits, action ) {
 	const _product = product || { id: { placeholder: uniqueId( 'product_' ) } };
 	const _array = editProduct( prevEdits[ bucket ], _product, data );
 
+	if ( isEqual( {}, data ) ) {
+		// If data is empty, only set the currentlyEditingId.
+		return {
+			...prevEdits,
+			currentlyEditingId: _product.id,
+		};
+	}
+
 	return {
 		...prevEdits,
 		[ bucket ]: _array,

--- a/client/extensions/woocommerce/state/ui/products/selectors.js
+++ b/client/extensions/woocommerce/state/ui/products/selectors.js
@@ -47,6 +47,20 @@ export function getProductWithLocalEdits( state, productId, siteId = getSelected
 }
 
 /**
+ * Gets the id of the currently editing product.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number|Object} Id of the currently editing product.
+ */
+export function getCurrentlyEditingId( state, siteId = getSelectedSiteId( state ) ) {
+	const edits = getAllProductEdits( state, siteId ) || {};
+	const { currentlyEditingId } = edits;
+
+	return currentlyEditingId;
+}
+
+/**
  * Gets the product being currently edited in the UI.
  *
  * @param {Object} state Global state tree
@@ -54,8 +68,7 @@ export function getProductWithLocalEdits( state, productId, siteId = getSelected
  * @return {Object} Product object that is merged between fetched data and edits
  */
 export function getCurrentlyEditingProduct( state, siteId = getSelectedSiteId( state ) ) {
-	const edits = getAllProductEdits( state, siteId ) || {};
-	const { currentlyEditingId } = edits;
+	const currentlyEditingId = getCurrentlyEditingId( state, siteId );
 
 	return getProductWithLocalEdits( state, currentlyEditingId, siteId );
 }

--- a/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/products/test/edits-reducer.js
@@ -244,4 +244,21 @@ describe( 'edits-reducer', () => {
 		} ) );
 		expect( edits1.currentlyEditingId ).to.eql( edits1.updates[ 0 ].id );
 	} );
+
+	it( 'should not add a create edit entry, only set currentlyEditingId, when data is empty', () => {
+		const edits1 = reducer( undefined, editProduct( siteId, null, {} ) );
+
+		expect( edits1.currentlyEditingId ).to.exist;
+		expect( edits1.currentlyEditingId.placeholder ).to.exist;
+		expect( edits1.creates ).to.not.exist;
+	} );
+
+	it( 'should not add an update edit entry, only set currentlyEditingId, when data is empty', () => {
+		const product1 = { id: 1 };
+		const edits1 = reducer( undefined, editProduct( siteId, product1, {} ) );
+
+		expect( edits1.currentlyEditingId ).to.exist;
+		expect( edits1.currentlyEditingId ).to.equal( 1 );
+		expect( edits1.updates ).to.not.exist;
+	} );
 } );


### PR DESCRIPTION
The previous code would create an edit on page load as a side effect of
setting the `currentlyEditingId`. This avoids that approach and only
sets the `currentlyEditingId`, which means that if an edit create or
update exists, there's a real data edit there.

This is required for checking if it's okay for a user to navigate away
from the page.

To Test:

1. `npm start`
2. Create a new product, verify all works correctly.
3. Go to update an existing product, click refresh on the browser (edit state removal still to come)
3. Update an existing product, verify all works correctly.
