### PR TITLE
Fixed the "Save" button being permanently disabled for the Rest Of The World zone

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
@@ -49,7 +49,7 @@ export default connect(
 		return {
 			site: getSelectedSite( state ),
 			zone,
-			canSave: areCurrentlyEditingShippingZoneLocationsValid( state ),
+			canSave: isRestOfTheWorld || areCurrentlyEditingShippingZoneLocationsValid( state ),
 			showDelete: zone && 'number' === typeof zone.id && ! isRestOfTheWorld,
 			isSaving: Boolean( getActionList( state ) ),
 		};


### PR DESCRIPTION
The `Rest Of The World` zone is special as in it can always be saved (the "must have a valid set of locations" rule doesn't apply to it), so I've added a check to always enable the `Save` button in that case. That check must have been lost in a previous refactor.