### PR TITLE
WooCommerce: Fix property name for tracking payment method usage

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -84,11 +84,11 @@ class PaymentMethodItem extends Component {
 
 		if ( enabled ) {
 			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_enabled', {
-				paymentMethod: method.id,
+				payment_method: method.id,
 			} );
 		} else {
 			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_disabled', {
-				paymentMethod: method.id,
+				payment_method: method.id,
 			} );
 		}
 


### PR DESCRIPTION
Per https://fieldguide.automattic.com/tracks-naming-conventions/

> Property names should also be lowercase and use underscores instead of dashes, but do not need to be prefixed by the service name because the event they are tied to already provides that information. 

The use of camel case here causes the events to go into the events tracks "rejects" table.

See #15330, #15825

To Test:
* Paste `localStorage.setItem('debug', 'calypso:analytics:*');` into your developer console.
* Go to `https://wpcalypso.wordpress.com/store/settings/:site`
* Enable a payment method
* Disable a payment method
* Make sure you see some debug for each of these: `calypso:analytics:tracks Recording event...`