### PR TITLE
Post Copy: Prevent copying the automatic excerpt

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -120,7 +120,7 @@ function getPressThisContent( query ) {
 // - (Redux) editPost: to set every other attribute (in particular, to update the Category Selector, terms can only be set via Redux);
 // - (Flux) edit: to reliably show the updated post attributes before (auto)saving.
 function startEditingPostCopy( siteId, postToCopyId, context ) {
-	wpcom.site( siteId ).post( postToCopyId ).get().then( postToCopy => {
+	wpcom.site( siteId ).post( postToCopyId ).get( { context: 'edit' } ).then( postToCopy => {
 		const postAttributes = pick(
 			postToCopy,
 			'canonical_image',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/14507

Add `context: 'edit'` to the API call that retrieves the post to copy, in order to only obtain the manually changed fields and ignore the automatically generated ones.

### Testing instructions

- Create a post **without** excerpt.
- Copy the post and make sure the new post **has no excerpt**.
- Create a post **with** excerpt.
- Copy the post and make sure the new post **has the excerpt**.