### PR TITLE
Further tweak google photos connection text

### DIFF
--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -109,12 +109,12 @@ class SharingServiceDescription extends Component {
 			},
 			google_photos: function() {
 				if ( this.props.numberOfConnections > 0 ) {
-					return this.props.translate( 'Connected photos from your Google account.', {
+					return this.props.translate( 'Access photos stored in your connected Google account.', {
 						comment: 'Description for Google Photos when one or more accounts are connected'
 					} );
 				}
 
-				return this.props.translate( 'Connect photos from your Google account.', {
+				return this.props.translate( 'Access photos stored in your Google account.', {
 					comment: 'Description for Google Photos when no accounts are connected'
 				} );
 			}


### PR DESCRIPTION
Further tweak the Google Photos connection text, on suggestion from @michelleweber

The message now looks like:

<img width="457" alt="newmessage" src="https://user-images.githubusercontent.com/1277682/27902762-c408bb3a-622e-11e7-828f-4a4fca320690.png">

And when connected:

<img width="549" alt="after" src="https://user-images.githubusercontent.com/1277682/27902783-df2279ce-622e-11e7-83f8-b3e52385ed46.png">

Previous messages were 'Connect photos from your Google account' and 'Connected photos from your Google account'