### PR TITLE
Enable external media in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,6 +22,7 @@
 		"devdocs": false,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
+		"external-media": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -21,6 +21,7 @@
 		"desktop-promo": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
+		"external-media": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -28,6 +28,7 @@
 		"dev/test-helper": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
+		"external-media": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,


### PR DESCRIPTION
Enable external media (Google Photos) in production, horizon, and wpcalypso.

This will make Photos from Google available from the post editor media dropdown on the above servers.

<img width="228" alt="dropdown" src="https://user-images.githubusercontent.com/1277682/27786981-2d0a10f8-5fdb-11e7-8e2e-11b64545fa59.png">

See #15775 for when it was enabled in staging.