### PR TITLE
Extensions: WPJM - Disable fields on Job Listings tab when fetching or saving

### DIFF
--- a/client/components/redux-forms/redux-form-radio/index.jsx
+++ b/client/components/redux-forms/redux-form-radio/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { Field } from 'redux-form';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,19 +16,27 @@ class ReduxFormRadio extends Component {
 		value: PropTypes.string,
 	};
 
-	renderRadio = defaultValue => ( { input: { name, onChange, value } } ) => (
-		<FormRadio
-			{ ...this.props }
-			checked={ value === defaultValue }
-			name={ name }
-			onChange={ this.updateRadio( onChange ) }
-			value={ defaultValue } />
-	)
+	renderRadio = defaultValue => ( { input: { name, onChange, value } } ) => {
+		const otherProps = omit( this.props, [ 'name', 'value' ] );
+
+		return (
+			<FormRadio
+				{ ...otherProps }
+				checked={ value === defaultValue }
+				name={ name }
+				onChange={ this.updateRadio( onChange ) }
+				value={ defaultValue } />
+		);
+	}
 
 	updateRadio = onChange => event => onChange( event.target.value );
 
 	render() {
-		return <Field component={ this.renderRadio( this.props.value ) } name={ this.props.name } />;
+		return (
+			<Field
+				component={ this.renderRadio( this.props.value ) }
+				name={ this.props.name } />
+		);
 	}
 }
 

--- a/client/components/redux-forms/redux-form-radio/index.jsx
+++ b/client/components/redux-forms/redux-form-radio/index.jsx
@@ -17,6 +17,7 @@ class ReduxFormRadio extends Component {
 
 	renderRadio = defaultValue => ( { input: { name, onChange, value } } ) => (
 		<FormRadio
+			{ ...this.props }
 			checked={ value === defaultValue }
 			name={ name }
 			onChange={ this.updateRadio( onChange ) }

--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { Field } from 'redux-form';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,12 +15,16 @@ class ReduxFormTextInput extends Component {
 		name: PropTypes.string,
 	};
 
-	renderTextInput = ( { input: { onChange, value } } ) => (
-		<FormTextInput
-			{ ...this.props }
-			onChange={ this.updateTextInput( onChange ) }
-			value={ value } />
-	)
+	renderTextInput = ( { input: { onChange, value } } ) => {
+		const otherProps = omit( this.props, 'name' );
+
+		return (
+			<FormTextInput
+				{ ...otherProps }
+				onChange={ this.updateTextInput( onChange ) }
+				value={ value } />
+		);
+	}
 
 	updateTextInput = onChange => event => onChange( event.target.value );
 

--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -24,7 +24,12 @@ class ReduxFormTextInput extends Component {
 	updateTextInput = onChange => event => onChange( event.target.value );
 
 	render() {
-		return <Field component={ this.renderTextInput } name={ this.props.name } />;
+		return (
+			<Field
+				{ ...this.props }
+				component={ this.renderTextInput }
+				name={ this.props.name } />
+		);
 	}
 }
 

--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -17,6 +17,7 @@ class ReduxFormToggle extends Component {
 
 	renderToggle = text => ( { input: { onChange, value } } ) => (
 		<FormToggle
+			{ ...this.props }
 			checked={ value || false }
 			onChange={ this.updateToggle( value, onChange ) }>
 			{ text }

--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { Field } from 'redux-form';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,19 +16,27 @@ class ReduxFormToggle extends Component {
 		text: PropTypes.string,
 	};
 
-	renderToggle = text => ( { input: { onChange, value } } ) => (
-		<FormToggle
-			{ ...this.props }
-			checked={ value || false }
-			onChange={ this.updateToggle( value, onChange ) }>
-			{ text }
-		</FormToggle>
-	)
+	renderToggle = text => ( { input: { onChange, value } } ) => {
+		const otherProps = omit( this.props, [ 'name', 'text' ] );
+
+		return (
+			<FormToggle
+				{ ...otherProps }
+				checked={ value || false }
+				onChange={ this.updateToggle( value, onChange ) }>
+				{ text }
+			</FormToggle>
+		);
+	}
 
 	updateToggle = ( value, onChange ) => () => onChange( ! value );
 
 	render() {
-		return <Field component={ this.renderToggle( this.props.text ) } name={ this.props.name } />;
+		return (
+			<Field
+				component={ this.renderToggle( this.props.text ) }
+				name={ this.props.name } />
+		);
 	}
 }
 

--- a/client/extensions/wp-job-manager/components/settings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/index.jsx
@@ -15,12 +15,13 @@ import Navigation from '../navigation';
 import QuerySettings from '../data/query-settings';
 import { saveSettings } from '../../state/settings/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSettings, isSavingSettings } from '../../state/settings/selectors';
+import { getSettings, isFetchingSettings, isSavingSettings } from '../../state/settings/selectors';
 
 class Settings extends Component {
 	static propTypes = {
 		children: PropTypes.element,
 		initialValues: PropTypes.object,
+		isFetching: PropTypes.bool,
 		isSaving: PropTypes.bool,
 		siteId: PropTypes.number,
 		tab: PropTypes.string,
@@ -33,12 +34,14 @@ class Settings extends Component {
 		const {
 			children,
 			initialValues,
+			isFetching,
 			isSaving,
 			siteId,
 			tab,
 			translate,
 		} = this.props;
 		const mainClassName = 'wp-job-manager__main';
+		const isDisabled = isFetching || isSaving;
 
 		return (
 			<Main className={ mainClassName }>
@@ -48,6 +51,7 @@ class Settings extends Component {
 				{
 					Children.map( children, child => cloneElement( child, {
 						initialValues,
+						isDisabled,
 						isSaving,
 						onSubmit: this.onSubmit,
 					} ) )
@@ -63,6 +67,7 @@ const connectComponent = connect(
 
 		return {
 			initialValues: getSettings( state, siteId ),
+			isFetching: isFetchingSettings( state, siteId ),
 			isSaving: isSavingSettings( state, siteId ),
 			siteId,
 		};

--- a/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
@@ -277,7 +277,7 @@ const connectComponent = connect(
 		const selector = formValueSelector( 'jobListings', () => state.extensions.wpJobManager.form );
 
 		return {
-			perPage: selector( state, 'perPage' ),
+			perPage: selector( state, 'listings.perPage' ),
 		};
 	}
 );

--- a/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
@@ -24,6 +24,7 @@ import SectionHeader from 'components/section-header';
 class JobListings extends Component {
 	static propTypes = {
 		handleSubmit: PropTypes.func,
+		isDisabled: PropTypes.bool,
 		isSaving: PropTypes.bool,
 		onSubmit: PropTypes.func,
 		translate: PropTypes.func,
@@ -32,7 +33,13 @@ class JobListings extends Component {
 	save = section => data => this.props.onSubmit( data[ section ] );
 
 	render() {
-		const { handleSubmit, isSaving, perPage, translate } = this.props;
+		const {
+			handleSubmit,
+			isDisabled,
+			isSaving,
+			perPage,
+			translate
+		} = this.props;
 
 		return (
 			<div>
@@ -40,6 +47,7 @@ class JobListings extends Component {
 					<FormSection name="listings">
 						<SectionHeader label={ translate( 'Listings' ) }>
 							<FormButton compact
+								disabled={ isDisabled }
 								isSubmitting={ isSaving }
 								onClick={ handleSubmit( this.save( 'listings' ) ) } />
 						</SectionHeader>
@@ -53,6 +61,7 @@ class JobListings extends Component {
 										components: {
 											listings:
 												<ReduxFormTextInput
+													disabled={ isDisabled }
 													min="0"
 													name="perPage"
 													step="1"
@@ -64,6 +73,7 @@ class JobListings extends Component {
 
 							<FormFieldset>
 								<ReduxFormToggle
+									disabled={ isDisabled }
 									name="hideFilledPositions"
 									text={ translate( 'Hide filled positions' ) } />
 								<FormSettingExplanation isIndented>
@@ -71,6 +81,7 @@ class JobListings extends Component {
 								</FormSettingExplanation>
 
 								<ReduxFormToggle
+									disabled={ isDisabled }
 									name="hideExpired"
 									text={ translate( 'Hide expired listings in job archives/search' ) } />
 								<FormSettingExplanation isIndented>
@@ -78,6 +89,7 @@ class JobListings extends Component {
 								</FormSettingExplanation>
 
 								<ReduxFormToggle
+									disabled={ isDisabled }
 									name="hideExpiredContent"
 									text={ translate( 'Hide content in expired single job listings' ) } />
 								<FormSettingExplanation isIndented>
@@ -94,12 +106,14 @@ class JobListings extends Component {
 					<FormSection name="categories">
 						<SectionHeader label={ translate( 'Categories' ) }>
 							<FormButton compact
+								disabled={ isDisabled }
 								isSubmitting={ isSaving }
 								onClick={ handleSubmit( this.save( 'categories' ) ) } />
 						</SectionHeader>
 						<Card>
 							<FormFieldset>
 								<ReduxFormToggle
+									disabled={ isDisabled }
 									name="enableCategories"
 									text={ translate( 'Enable listing categories' ) } />
 								<FormSettingExplanation isIndented>
@@ -108,6 +122,7 @@ class JobListings extends Component {
 								</FormSettingExplanation>
 
 								<ReduxFormToggle
+									disabled={ isDisabled }
 									name="enableDefaultCategory"
 									text={ translate( 'Default to category multiselect' ) } />
 								<FormSettingExplanation isIndented>
@@ -126,6 +141,7 @@ class JobListings extends Component {
 								</FormSettingExplanation>
 								<FormLabel>
 									<ReduxFormRadio
+										disabled={ isDisabled }
 										name="categoryFilterType"
 										value="any" />
 									<span>
@@ -135,6 +151,7 @@ class JobListings extends Component {
 
 								<FormLabel>
 									<ReduxFormRadio
+										disabled={ isDisabled }
 										name="categoryFilterType"
 										value="all" />
 									<span>
@@ -150,12 +167,14 @@ class JobListings extends Component {
 					<FormSection name="types">
 						<SectionHeader label={ translate( 'Types' ) }>
 							<FormButton compact
+								disabled={ isDisabled }
 								isSubmitting={ isSaving }
 								onClick={ handleSubmit( this.save( 'types' ) ) } />
 						</SectionHeader>
 						<Card>
 							<FormFieldset>
 								<ReduxFormToggle
+									disabled={ isDisabled }
 									name="enableTypes"
 									text={ translate( 'Enable listing types' ) } />
 								<FormSettingExplanation isIndented>
@@ -164,6 +183,7 @@ class JobListings extends Component {
 								</FormSettingExplanation>
 
 								<ReduxFormToggle
+									disabled={ isDisabled }
 									name="multiJobType"
 									text={ translate( 'Allow multiple types for listings' ) } />
 								<FormSettingExplanation isIndented>
@@ -180,6 +200,7 @@ class JobListings extends Component {
 					<FormSection name="format">
 						<SectionHeader label={ translate( 'Date Format' ) }>
 							<FormButton compact
+								disabled={ isDisabled }
 								isSubmitting={ isSaving }
 								onClick={ handleSubmit( this.save( 'format' ) ) } />
 						</SectionHeader>
@@ -190,6 +211,7 @@ class JobListings extends Component {
 								</FormSettingExplanation>
 								<FormLabel>
 									<ReduxFormRadio
+										disabled={ isDisabled }
 										name="dateFormat"
 										value="relative" />
 									<span>
@@ -199,6 +221,7 @@ class JobListings extends Component {
 
 								<FormLabel>
 									<ReduxFormRadio
+										disabled={ isDisabled }
 										name="dateFormat"
 										value="default" />
 									<span>
@@ -214,12 +237,15 @@ class JobListings extends Component {
 					<FormSection name="apiKey">
 						<SectionHeader label={ translate( 'Google Maps API Key' ) }>
 							<FormButton compact
+								disabled={ isDisabled }
 								isSubmitting={ isSaving }
 								onClick={ handleSubmit( this.save( 'apiKey' ) ) } />
 						</SectionHeader>
 						<Card>
 							<FormFieldset>
-								<ReduxFormTextInput name="googleMapsApiKey" />
+								<ReduxFormTextInput
+									disabled={ isDisabled }
+									name="googleMapsApiKey" />
 								<FormSettingExplanation>
 									{ translate(
 										'Google requires an API key to retrieve location information for job listings. ' +


### PR DESCRIPTION
The fields on the _Job Listings_ tab should be disabled while settings are being fetched or saved.

## Testing

To test, ensure that fields are disabled while fetching or saving, and are re-enabled when settings data is populated or saved.