### PR TITLE
Use the "created_default_shipping_zone" to make sure the default shipping zone is only created once.

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
@@ -32,7 +32,7 @@ class ShippingZoneList extends Component {
 	}
 
 	componentWillReceiveProps( { loaded } ) {
-		if ( ! this.props.loaded && loaded ) {
+		if ( ! this.props.loaded && loaded && ! this.props.savingZones ) {
 			this.props.actions.createAddDefultShippingZoneActionList();
 		}
 	}
@@ -101,12 +101,14 @@ class ShippingZoneList extends Component {
 
 export default connect(
 	( state ) => {
-		const loaded = areShippingZonesFullyLoaded( state ) && ! getActionList( state );
+		const savingZones = Boolean( getActionList( state ) );
+		const loaded = areShippingZonesFullyLoaded( state ) && ! savingZones;
 
 		return {
 			site: getSelectedSite( state ),
 			siteId: getSelectedSiteId( state ),
 			shippingZones: getShippingZones( state ),
+			savingZones,
 			loaded,
 			isValid: ! loaded || areShippingZonesLocationsValid( state ),
 		};

--- a/client/extensions/woocommerce/state/sites/setup-choices/actions.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/actions.js
@@ -88,6 +88,10 @@ export const setTriedCustomizerDuringInitialSetup = ( siteId, value ) => ( dispa
 	return updateSetupChoice( dispatch, siteId, 'tried_customizer_during_initial_setup', value );
 };
 
+export const setCreatedDefaultShippingZone = ( siteId, value ) => ( dispatch ) => {
+	return updateSetupChoice( dispatch, siteId, 'created_default_shipping_zone', value );
+};
+
 export const setFinishedInstallOfRequiredPlugins = ( siteId, value ) => ( dispatch ) => {
 	return updateSetupChoice( dispatch, siteId, 'finished_initial_install_of_required_plugins', value );
 };

--- a/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
@@ -97,6 +97,15 @@ export function getTriedCustomizerDuringInitialSetup( state, siteId = getSelecte
 }
 
 /**
+ * @param {Object} state Global state tree
+ * @param {Number} siteId wpcom site id. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean} Whether or not the local shipping zone was already automatically created
+ */
+export function isDefaultShippingZoneCreated( state, siteId = getSelectedSiteId( state ) ) {
+	return isChoiceTrue( state, siteId, 'created_default_shipping_zone' );
+}
+
+/**
  * Gets whether or not all required plugins were installed during setup for this site
  *
  * @param {Object} state Global state tree

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/actions.js
@@ -15,6 +15,7 @@ import {
 	setOptedOutOfTaxesSetup,
 	setSetStoreAddressDuringInitialSetup,
 	setTriedCustomizerDuringInitialSetup,
+	setCreatedDefaultShippingZone,
 	setUpStorePages,
 } from '../actions';
 import { LOADING } from 'woocommerce/state/constants';
@@ -42,6 +43,7 @@ describe( 'actions', () => {
 					opted_out_of_shipping_setup: true,
 					opted_out_of_taxes_setup: true,
 					tried_customizer_during_initial_setup: true,
+					created_default_shipping_zone: true,
 					finished_initial_install_of_required_plugins: true,
 					set_store_address_during_initial_setup: true,
 				} );
@@ -68,6 +70,7 @@ describe( 'actions', () => {
 						opted_out_of_shipping_setup: true,
 						opted_out_of_taxes_setup: true,
 						tried_customizer_during_initial_setup: true,
+						created_default_shipping_zone: true,
 						finished_initial_install_of_required_plugins: true,
 						set_store_address_during_initial_setup: true,
 					}
@@ -108,6 +111,7 @@ describe( 'actions', () => {
 					opted_out_of_shipping_setup: false,
 					opted_out_of_taxes_setup: false,
 					tried_customizer_during_initial_setup: false,
+					created_default_shipping_zone: false,
 					finished_initial_install_of_required_plugins: false,
 					set_store_address_during_initial_setup: false,
 				} );
@@ -139,6 +143,7 @@ describe( 'actions', () => {
 						opted_out_of_shipping_setup: false,
 						opted_out_of_taxes_setup: false,
 						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: false,
 						finished_initial_install_of_required_plugins: false,
 						set_store_address_during_initial_setup: false,
 					}
@@ -162,6 +167,7 @@ describe( 'actions', () => {
 					opted_out_of_shipping_setup: true,
 					opted_out_of_taxes_setup: false,
 					tried_customizer_during_initial_setup: false,
+					created_default_shipping_zone: false,
 					finished_initial_install_of_required_plugins: false,
 					set_store_address_during_initial_setup: false,
 				} );
@@ -193,6 +199,7 @@ describe( 'actions', () => {
 						opted_out_of_shipping_setup: true,
 						opted_out_of_taxes_setup: false,
 						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: false,
 						finished_initial_install_of_required_plugins: false,
 						set_store_address_during_initial_setup: false,
 					}
@@ -216,6 +223,7 @@ describe( 'actions', () => {
 					opted_out_of_shipping_setup: false,
 					opted_out_of_taxes_setup: true,
 					tried_customizer_during_initial_setup: false,
+					created_default_shipping_zone: false,
 					finished_initial_install_of_required_plugins: false,
 					set_store_address_during_initial_setup: false,
 				} );
@@ -247,6 +255,7 @@ describe( 'actions', () => {
 						opted_out_of_shipping_setup: false,
 						opted_out_of_taxes_setup: true,
 						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: false,
 						finished_initial_install_of_required_plugins: false,
 						set_store_address_during_initial_setup: false,
 					}
@@ -270,6 +279,7 @@ describe( 'actions', () => {
 					opted_out_of_shipping_setup: false,
 					opted_out_of_taxes_setup: false,
 					tried_customizer_during_initial_setup: true,
+					created_default_shipping_zone: false,
 					finished_initial_install_of_required_plugins: false,
 					set_store_address_during_initial_setup: false,
 				} );
@@ -301,6 +311,63 @@ describe( 'actions', () => {
 						opted_out_of_shipping_setup: false,
 						opted_out_of_taxes_setup: false,
 						tried_customizer_during_initial_setup: true,
+						created_default_shipping_zone: false,
+						finished_initial_install_of_required_plugins: false,
+						set_store_address_during_initial_setup: false,
+					}
+				} );
+			} );
+		} );
+	} );
+
+	describe( '#setCreatedDefaultShippingZone', () => {
+		const siteId = '123';
+
+		useSandbox();
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/sites/123/calypso-preferences/woocommerce', {
+					created_default_shipping_zone: true,
+				} )
+				.reply( 200, {
+					finished_initial_setup: false,
+					opted_out_of_shipping_setup: false,
+					opted_out_of_taxes_setup: false,
+					tried_customizer_during_initial_setup: false,
+					created_default_shipping_zone: true,
+					finished_initial_install_of_required_plugins: false,
+					set_store_address_during_initial_setup: false,
+				} );
+		} );
+
+		it( 'should dispatch an action', () => {
+			const getState = () => ( {} );
+			const dispatch = spy();
+			setCreatedDefaultShippingZone( siteId, true )( dispatch, getState );
+			expect( dispatch ).to.have.been.calledWith( {
+				type: WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST,
+				siteId,
+				key: 'created_default_shipping_zone',
+				value: true,
+			} );
+		} );
+
+		it( 'should dispatch a success action with setup choices when request completes', () => {
+			const getState = () => ( {} );
+			const dispatch = spy();
+			const response = setCreatedDefaultShippingZone( siteId, true )( dispatch, getState );
+
+			return response.then( () => {
+				expect( dispatch ).to.have.been.calledWith( {
+					type: WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST_SUCCESS,
+					siteId,
+					data: {
+						finished_initial_setup: false,
+						opted_out_of_shipping_setup: false,
+						opted_out_of_taxes_setup: false,
+						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: true,
 						finished_initial_install_of_required_plugins: false,
 						set_store_address_during_initial_setup: false,
 					}
@@ -324,6 +391,7 @@ describe( 'actions', () => {
 					opted_out_of_shipping_setup: false,
 					opted_out_of_taxes_setup: false,
 					tried_customizer_during_initial_setup: false,
+					created_default_shipping_zone: false,
 					finished_initial_install_of_required_plugins: true,
 					set_store_address_during_initial_setup: false,
 				} );
@@ -355,6 +423,7 @@ describe( 'actions', () => {
 						opted_out_of_shipping_setup: false,
 						opted_out_of_taxes_setup: false,
 						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: false,
 						finished_initial_install_of_required_plugins: true,
 						set_store_address_during_initial_setup: false,
 					}
@@ -425,6 +494,7 @@ describe( 'actions', () => {
 					opted_out_of_shipping_setup: false,
 					opted_out_of_taxes_setup: false,
 					tried_customizer_during_initial_setup: false,
+					created_default_shipping_zone: false,
 					finished_initial_install_of_required_plugins: false,
 					set_store_address_during_initial_setup: true,
 				} );
@@ -456,6 +526,7 @@ describe( 'actions', () => {
 						opted_out_of_shipping_setup: false,
 						opted_out_of_taxes_setup: false,
 						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: false,
 						finished_initial_install_of_required_plugins: false,
 						set_store_address_during_initial_setup: true,
 					}

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/reducer.js
@@ -37,6 +37,7 @@ describe( 'reducers', () => {
 				opted_out_of_shipping_setup: true,
 				opted_out_of_taxes_setup: true,
 				tried_customizer_during_initial_setup: true,
+				created_default_shipping_zone: true,
 				finished_initial_install_of_required_plugins: true,
 				set_store_address_during_initial_setup: true,
 			};
@@ -61,6 +62,7 @@ describe( 'reducers', () => {
 				opted_out_of_shipping_setup: true,
 				opted_out_of_taxes_setup: true,
 				tried_customizer_during_initial_setup: true,
+				created_default_shipping_zone: true,
 				finished_initial_install_of_required_plugins: true,
 				set_store_address_during_initial_setup: true,
 			};

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
@@ -16,6 +16,7 @@ import {
 	getOptedOutofTaxesSetup,
 	getSetStoreAddressDuringInitialSetup,
 	getTriedCustomizerDuringInitialSetup,
+	isDefaultShippingZoneCreated,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -46,6 +47,7 @@ const loadedState = {
 						opted_out_of_shipping_setup: true,
 						opted_out_of_taxes_setup: true,
 						tried_customizer_during_initial_setup: true,
+						created_default_shipping_zone: true,
 						finished_initial_install_of_required_plugins: true,
 						set_store_address_during_initial_setup: true,
 					},
@@ -57,6 +59,7 @@ const loadedState = {
 						opted_out_of_shipping_setup: false,
 						opted_out_of_taxes_setup: false,
 						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: false,
 						finished_initial_install_of_required_plugins: false,
 						set_store_address_during_initial_setup: false,
 					},
@@ -167,6 +170,20 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getTriedCustomizerDuringInitialSetup( loadedStateWithUi ) ).to.eql( true );
+		} );
+	} );
+
+	describe( '#isDefaultShippingZoneCreated', () => {
+		it( 'should get whether initial setup was completed from the state (123-true).', () => {
+			expect( isDefaultShippingZoneCreated( loadedState, 123 ) ).to.eql( true );
+		} );
+
+		it( 'should get whether initial setup was completed from the state (124-false).', () => {
+			expect( isDefaultShippingZoneCreated( loadedState, 124 ) ).to.eql( false );
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( isDefaultShippingZoneCreated( loadedStateWithUi ) ).to.eql( true );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes a bug in https://github.com/Automattic/wp-calypso/pull/15861

> If you remove all the shipping zones and go back to the Shipping Settings screen, the country zone & Free Shipping method is re-created. This must be just a 1-time thing, I'm working on fixing that but it shouldn't be a blocker.

When the default zone is created, the `created_default_shipping_zone` setting flag is set to `true` in the server, so after that, every time the user goes to the Zones screen, even if there are no Zones configured, the default "local country" zone won't be recreated.

To test:
* Remove all the zones and methods in WP-Admin.
* Go to the `Shipping` settings page in Calypso.
* You'll see a "country" zone created, with a `Free Shipping` method.
* Delete that Shipping Zone.
* Even if you refresh the papge, the zone won't be auto-generated again.