### PR TITLE
Woo-Connect Insights: redirect to site stats if not isWooConnect

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -29,6 +29,8 @@ import {
 	UNITS
 } from 'woocommerce/app/store-stats/constants';
 import { getUnitPeriod, getEndPeriod } from './utils';
+import { isJetpackSite } from 'state/sites/selectors';
+import { isPluginActive } from 'state/selectors';
 
 class StoreStats extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import page from 'page';
 import { moment, translate } from 'i18n-calypso';
 
 /**
@@ -31,6 +32,7 @@ import { getUnitPeriod, getEndPeriod } from './utils';
 
 class StoreStats extends Component {
 	static propTypes = {
+		isWooConnect: PropTypes.bool.isRequired,
 		path: PropTypes.string.isRequired,
 		queryDate: PropTypes.string,
 		querystring: PropTypes.string,
@@ -40,7 +42,12 @@ class StoreStats extends Component {
 	};
 
 	render() {
-		const { path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
+		const { isWooConnect, path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
+		// TODO: this is to handle users switching sites while on store stats
+		// unfortunately, we can't access the path when changing sites
+		if ( ! isWooConnect ) {
+			page.redirect( `/stats/${ slug }` );
+		}
 		const unitQueryDate = getUnitPeriod( queryDate, unit );
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const endSelectedDate = getEndPeriod( selectedDate, unit );
@@ -148,8 +155,13 @@ class StoreStats extends Component {
 }
 
 export default connect(
-	state => ( {
-		slug: getSelectedSiteSlug( state ),
-		siteId: getSelectedSiteId( state ),
-	} )
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		return {
+			isWooConnect: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
+			slug: getSelectedSiteSlug( state ),
+			siteId,
+		};
+	}
 )( StoreStats );

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -22,6 +22,8 @@ import {
 	topCoupons
 } from 'woocommerce/app/store-stats/constants';
 import { getUnitPeriod } from './utils';
+import { isJetpackSite } from 'state/sites/selectors';
+import { isPluginActive } from 'state/selectors';
 
 const listType = {
 	products: topProducts,
@@ -51,7 +53,12 @@ class StoreStatsListView extends Component {
 	};
 
 	render() {
-		const { siteId, slug, selectedDate, type, unit } = this.props;
+		const { isWooConnect, siteId, slug, selectedDate, type, unit } = this.props;
+		// TODO: this is to handle users switching sites while on store stats
+		// unfortunately, we can't access the path when changing sites
+		if ( ! isWooConnect ) {
+			page.redirect( `/stats/${ slug }` );
+		}
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const listviewQuery = {
 			unit,
@@ -97,8 +104,13 @@ class StoreStatsListView extends Component {
 }
 
 export default connect(
-	state => ( {
-		slug: getSelectedSiteSlug( state ),
-		siteId: getSelectedSiteId( state ),
-	} )
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		return {
+			isWooConnect: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
+			slug: getSelectedSiteSlug( state ),
+			siteId: getSelectedSiteId( state ),
+		};
+	}
 )( StoreStatsListView );


### PR DESCRIPTION
Redirects the user to the site's site stats if `isWooConnect` (Jetpack & WooCommerce plugins) is false.

Fixes #15856 