### PR TITLE
Domains: Don't show unavailable domains when loading product list

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -8,6 +8,7 @@ import {
 	find,
 	flatten,
 	includes,
+	isEmpty,
 	noop,
 	reject,
 	startsWith,
@@ -443,7 +444,7 @@ const RegisterDomainStep = React.createClass( {
 			domainMappingSuggestion,
 			suggestions;
 
-		if ( this.isLoadingSuggestions() ) {
+		if ( this.isLoadingSuggestions() || isEmpty( this.props.products ) ) {
 			domainRegistrationSuggestions = times( INITIAL_SUGGESTION_QUANTITY + 1, function( n ) {
 				return <DomainSuggestion.Placeholder key={ 'suggestion-' + n } />;
 			} );

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -6,7 +6,6 @@ import page from 'page';
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -103,7 +102,7 @@ class DomainSearch extends Component {
 			} );
 		let content;
 
-		if ( ! this.state.domainRegistrationAvailable || isEmpty( this.props.productsList ) ) {
+		if ( ! this.state.domainRegistrationAvailable ) {
 			content = (
 				<EmptyContent
 					illustration="/calypso/images/illustrations/illustration-500.svg"


### PR DESCRIPTION
We were showing "Domain unavailable" empty screen when we were loading the product list.

Show suggestion placeholders while the product list is loading.