### PR TITLE
Devdocs: fix Theme example

### DIFF
--- a/client/components/theme/docs/example.jsx
+++ b/client/components/theme/docs/example.jsx
@@ -1,29 +1,23 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Theme = require( '../' );
+import Theme from 'components/theme';
 
-/**
- * Component
- */
-var ThemeExample = React.createClass( {
-	displayName: 'Theme',
+const ThemeExample = () => {
+	const theme = {
+		id: 'twentyfifteen',
+		name: 'Twenty Fifteen',
+		screenshot: '//i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfifteen/screenshot.png',
+	};
 
-	render: function() {
-		const theme = {
-			id: 'twentyfifteen',
-			name: 'Twenty Fifteen',
-			screenshot: '//i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfifteen/screenshot.png',
-		};
-
-		return (
-			<div>
-				<Theme
+	return (
+		<div>
+			<Theme
 				theme={ theme }
 				buttonContents={ {
 					action1: {
@@ -37,9 +31,10 @@ var ThemeExample = React.createClass( {
 				} }
 				actionLabel="Click Action"
 				onScreenshotClick={ function() { console.log( 'onScreenshotClick triggered' ); } } />
-			</div>
-		);
-	}
-} );
+		</div>
+	);
+};
 
-module.exports = ThemeExample;
+ThemeExample.displayName = 'Theme';
+
+export default ThemeExample;


### PR DESCRIPTION
The Devdocs blocks page is currently broken:

http://wpcalypso.wordpress.com/devdocs/blocks

This PR switches the `Theme` component devdocs example from `React.createClass` to a stateless functional component, which appears to have fixed the issue.

### To test

Visit http://calypso.localhost:3000/devdocs/blocks, verify that the page loads and that you can see the `Theme` example as below:

![screen shot 2017-07-05 at 16 50 13](https://user-images.githubusercontent.com/17325/27872947-6863c8ba-61a2-11e7-931a-1e6eccfc1f1b.png)
