### PR TITLE
Reader: Comment Deep Linking (Permalinks)

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { get, size, takeRight } from 'lodash';
+import { get, size, takeRight, defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -112,7 +112,8 @@ class PostCommentList extends React.Component {
 		}
 
 		if ( this.shouldScrollToComment( nextProps ) ) {
-			this.scrollToComment();
+			// defer so that the above/below comments load
+			defer( () => this.scrollToComment(), 50 );
 		}
 	}
 
@@ -221,6 +222,7 @@ class PostCommentList extends React.Component {
 	 * 3. we haven't already scrolled to it yet
 	 * 4. we have loaded some comments above + below it already (or there is only 1 comment)
 	 *
+	 * @param {object} props - the propes to use when evaluating if window should be scrolled down to a comment.
 	 * @returns {boolean} - whether or not we should scroll to a comment
 	 */
 	shouldScrollToComment = ( props = this.props ) =>

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -14,6 +14,7 @@ import {
 	getPostTotalCommentsCount,
 	haveEarlierCommentsToFetch,
 	haveLaterCommentsToFetch,
+	haveReceivedBeforeAndAfter,
 } from 'state/comments/selectors';
 import { requestPostComments, requestComment } from 'state/comments/actions';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from 'state/comments/constants';
@@ -39,6 +40,7 @@ class PostCommentList extends React.Component {
 		// connect()ed props:
 		commentsTree: React.PropTypes.object, //TODO: Find a lib that provides immutable shape
 		totalCommentsCount: React.PropTypes.number,
+		haveReceivedBeforeAndAfter: React.PropTypes.bool,
 		haveEarlierCommentsToFetch: React.PropTypes.bool,
 		haveLaterCommentsToFetch: React.PropTypes.bool,
 		requestPostComments: React.PropTypes.func.isRequired,
@@ -109,7 +111,7 @@ class PostCommentList extends React.Component {
 			} );
 		}
 
-		if ( this.shouldScrollToComment() ) {
+		if ( this.shouldScrollToComment( nextProps ) ) {
 			this.scrollToComment();
 		}
 	}
@@ -221,14 +223,12 @@ class PostCommentList extends React.Component {
 	 *
 	 * @returns {boolean} - whether or not we should scroll to a comment
 	 */
-	shouldScrollToComment = () =>
-		this.props.startingCommentId &&
-		this.props.commentsTree[ this.props.startingCommentId ] &&
+	shouldScrollToComment = ( props = this.props ) =>
+		props.startingCommentId &&
+		props.commentsTree[ this.props.startingCommentId ] &&
+		props.haveReceivedBeforeAndAfter &&
 		! this.hasScrolledToComment &&
-		this.alreadyLoadedInitialSet &&
-		( this.getCommentsCount( this.props.commentsTree.children ) > 1 ||
-			this.props.commentCount === 1 ) &&
-		window.document.getElementsByName( `comment-${ this.props.startingCommentId }` ).length > 0;
+		window.document.getElementsByName( `comment-${ props.startingCommentId }` ).length > 0;
 
 	getCommentsCount = commentIds => {
 		// we always count prevSum, children sum, and +1 for the current processed comment
@@ -252,9 +252,7 @@ class PostCommentList extends React.Component {
 			return null;
 		}
 
-		const displayedComments = this.props.startingCommentId
-			? commentIds
-			: takeRight( commentIds, numberToTake );
+		const displayedComments = takeRight( commentIds, numberToTake );
 
 		return {
 			displayedComments,
@@ -397,6 +395,11 @@ export default connect(
 			ownProps.post.site_ID,
 			ownProps.post.ID,
 			ownProps.commentCount,
+		),
+		haveReceivedBeforeAndAfter: haveReceivedBeforeAndAfter(
+			state,
+			ownProps.post.site_ID,
+			ownProps.post.ID,
 		),
 	} ),
 	{ requestPostComments, requestComment },

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -19,7 +19,6 @@ import CommentCount from './comment-count';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 
-// eslint-disable
 /**
  * PostCommentList, as the name would suggest, displays a list of comments for a post.
  * It has the capability of either starting from the latest comment for a post,
@@ -36,7 +35,7 @@ import SegmentedControlItem from 'components/segmented-control/item';
  *    This also activates a "Show More" button at the end of the comment list instead of just at the top
  *
  */
-// eslint-enable
+
 class PostCommentList extends React.Component {
 	static propTypes = {
 		post: React.PropTypes.shape( {

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -87,12 +87,12 @@ class PostCommentList extends React.Component {
 		props.commentsFetchingStatus.hasReceivedBefore &&
 		props.commentsFetchingStatus.hasReceivedAfter &&
 		! this.hasScrolledToComment &&
-		window.document.getElementsByName( `comment-${ props.startingCommentId }` ).length > 0;
+		window.document.getElementById( `comment-${ props.startingCommentId }` );
 
-	shouldFetchInitialComment = ( { startingCommentId, commentsTree } ) =>
-		startingCommentId && commentsTree && ! commentsTree[ startingCommentId ];
+	shouldFetchInitialComment = ( { startingCommentId, initialComment } ) =>
+		startingCommentId && ! initialComment;
 
-	shouldFetchInitialPages = ( { commentsTree, startingCommentId } ) =>
+	shouldFetchInitialPages = ( { startingCommentId, commentsTree } ) =>
 		startingCommentId &&
 		commentsTree[ startingCommentId ] &&
 		this.props.commentsTree[ startingCommentId ] &&
@@ -121,9 +121,9 @@ class PostCommentList extends React.Component {
 		 *  2. the commentId does not exist for the site
 		 */
 		const commentIdBail =
-			( currentInitialComment !== nextInitialComment &&
-				( nextInitialComment.post && nextInitialComment.post.ID !== nextPostId ) ) ||
-			nextInitialComment.errors;
+			currentInitialComment !== nextInitialComment &&
+			( nextInitialComment.error ||
+				( nextInitialComment.post && nextInitialComment.post.ID !== nextPostId ) );
 
 		return ( propsExist && propChanged ) || commentIdBail;
 	};
@@ -147,7 +147,7 @@ class PostCommentList extends React.Component {
 		const postId = get( nextProps, 'post.ID' );
 		const status = get( nextProps, 'commentsFilter' );
 
-		if ( this.shouldFetchInitialComment( nextProps ) && ! nextProps.initialComment ) {
+		if ( this.shouldFetchInitialComment( nextProps ) ) {
 			this.props.requestComment( { siteId, commentId: nextProps.startingCommentId } );
 			this.hasScrolledToComment = false;
 		} else if ( this.shouldFetchInitialPages( nextProps ) ) {
@@ -256,7 +256,7 @@ class PostCommentList extends React.Component {
 	};
 
 	scrollToComment = () => {
-		const comment = window.document.getElementsByName( window.location.hash.substring( 1 ) )[ 0 ];
+		const comment = window.document.getElementById( window.location.hash.substring( 1 ) );
 		comment.scrollIntoView();
 		window.scrollBy( 0, -50 );
 		this.hasScrolledToComment = true;

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -115,6 +115,7 @@ class PostCommentList extends React.Component {
 
 		if ( this.shouldFetchInitialComment( nextProps ) ) {
 			this.props.requestComment( { siteId: nextSiteId, commentId: nextProps.startingCommentId } );
+			this.hasScrolledToComment = false;
 		} else if ( this.shouldFetchInitialPages( nextProps ) ) {
 			this.viewEarlierCommentsHandler();
 			this.viewLaterCommentsHandler();

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
-import { get, size, takeRight, defer } from 'lodash';
+import { get, size, takeRight, delay } from 'lodash';
 
 /**
  * Internal dependencies
@@ -145,7 +145,7 @@ class PostCommentList extends React.Component {
 
 		if ( this.shouldScrollToComment( nextProps ) ) {
 			// defer so that the above/below comments have time to render
-			defer( () => this.scrollToComment(), 50 );
+			delay( () => this.scrollToComment(), 50 );
 		}
 	}
 

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -116,6 +116,7 @@ class PostCommentList extends React.Component {
 		const nextSiteId = get( nextProps, 'post.site_ID' );
 		const nextPostId = get( nextProps, 'post.ID' );
 		const nextCommentsFilter = get( nextProps, 'commentsFilter' );
+		const nextInitialComment = nextProps.initialComment;
 
 		if ( this.shouldFetchInitialComment( nextProps ) && ! nextProps.initialComment ) {
 			this.props.requestComment( { siteId: nextSiteId, commentId: nextProps.startingCommentId } );
@@ -131,8 +132,9 @@ class PostCommentList extends React.Component {
 				( this.props.post.site_ID !== nextSiteId ||
 					this.props.post.ID !== nextPostId ||
 					this.props.commentsFilter !== nextCommentsFilter ) ) ||
-			( this.props.initialComment !== nextProps.initialComment &&
-				nextProps.initialComment.post.ID !== nextPostId )
+			( this.props.initialComment !== nextInitialComment &&
+				( ( nextInitialComment.post && nextInitialComment.post.ID !== nextPostId ) ||
+					nextInitialComment.error ) )
 		) {
 			nextProps.requestPostComments( {
 				siteId: nextSiteId,

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -31,7 +31,7 @@ import SegmentedControlItem from 'components/segmented-control/item';
  * Depending on where the list starts, there is slightly different behavior:
  * 1. from the last comments:
  *    this is the simplest case. Initially onMount we request the latest comments
- *    and while only displaying a subset of them.  When the user clicks "Show More" we load more comments
+ *    and only display a subset of them.  When the user clicks "Show More" we load more comments
  *
  * 2. from a specific commentId:
  *    this is activated by specifying the commentId prop. onMount we request the specific comment and then

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -176,13 +176,16 @@ class PostComment extends Component {
 
 					{ authorUrl
 						? <a
-								href={ authorUrl }
-								className="comments__comment-username"
-								onClick={ this.handleAuthorClick }
+							href={ authorUrl }
+							className="comments__comment-username"
+							onClick={ this.handleAuthorClick }
+							name={ `comment-${ this.props.commentId }` }
 							>
 								{ comment.author.name }
 							</a>
-						: <strong className="comments__comment-username">
+						: <strong
+							className="comments__comment-username"
+							>
 								{ comment.author.name }
 							</strong> }
 					<div className="comments__comment-timestamp">

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -179,13 +179,13 @@ class PostComment extends Component {
 							href={ authorUrl }
 							className="comments__comment-username"
 							onClick={ this.handleAuthorClick }
-							name={ `comment-${ this.props.commentId }` }
+							id={ `comment-${ this.props.commentId }` }
 							>
 								{ comment.author.name }
 							</a>
 						: <strong
 							className="comments__comment-username"
-							name={ `comment-${ this.props.commentId }` }
+							id={ `comment-${ this.props.commentId }` }
 							>
 								{ comment.author.name }
 							</strong> }

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -185,6 +185,7 @@ class PostComment extends Component {
 							</a>
 						: <strong
 							className="comments__comment-username"
+							name={ `comment-${ this.props.commentId }` }
 							>
 								{ comment.author.name }
 							</strong> }

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -454,7 +454,7 @@ a.comments__comment-username {
 	}
 }
 
-.comments__view-earlier {
+.comments__view-more {
 	color: $gray;
 	cursor: pointer;
 	display: block !important; // to overwrite inline-block rule

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -94,15 +94,6 @@ export class FullPostView extends React.Component {
 		if ( this.hasCommentAnchor && ! this.hasScrolledToCommentAnchor ) {
 			this.scrollToComments();
 		}
-
-		if ( startsWith( window.location.hash, '#comment-' ) ) {
-			this.checkForCommentInterval = setInterval( () => {
-				if ( this.shouldScrollToComment() ) {
-					this.scrollToComment();
-					clearInterval( this.checkForCommentInterval );
-				}
-			}, 200 );
-		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -197,24 +188,12 @@ export class FullPostView extends React.Component {
 	};
 
 	/**
-	 * Should we scroll down to a comment? Only if we have satisfied these three conditions: *
-	 * 1. there is a comment specified in the url via hash
-	 * 2. the comment has loaded and is on the DOM
-	 * 3. we haven't already scrolled to it yet
-	 *
-	 * @returns {boolean} - whether or not we should scroll to a comment
+	 * @returns {number} - the commentId in the url of the form #comment-${id}
 	 */
-	shouldScrollToComment = () =>
-		startsWith( window.location.hash, '#comment-' ) &&
-		window.document.getElementsByName( window.location.hash.substring( 1 ) ).length > 0 &&
-		! this.hasScrolledToComment;
-
-	scrollToComment = () => {
-		const comment = window.document.getElementsByName( window.location.hash.substring( 1 ) )[ 0 ];
-		comment.scrollIntoView();
-		window.scrollBy( 0, -50 );
-		this.hasScrolledToComment = true;
-	};
+	getCommentIdFromUrl = () =>
+		startsWith( window.location.hash, '#comment-' )
+			? +window.location.hash.split( '-' )[ 1 ]
+			: undefined;
 
 	// Scroll to the top of the comments section.
 	scrollToComments = () => {
@@ -446,7 +425,8 @@ export class FullPostView extends React.Component {
 											post={ post }
 											initialSize={ 10 }
 											pageSize={ 25 }
-											onCommentsUpdate={ this.checkForCommentAnchor }
+											startingCommentId={ this.getCommentIdFromUrl() }
+											commentCount= { post.discussion.comment_count }
 										/>
 									: null }
 							</div>

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -296,6 +296,8 @@ export class FullPostView extends React.Component {
 
 		const externalHref = isDiscoverPost( referralPost ) ? referralPost.URL : post.URL;
 		const isLoading = ! post || post._state === 'pending' || post._state === 'minimal';
+		const startingCommentId = this.getCommentIdFromUrl();
+		const commentCount = get( post, 'discussion.comment_count' );
 
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
@@ -342,7 +344,7 @@ export class FullPostView extends React.Component {
 						{ shouldShowComments( post ) &&
 							<CommentButton
 								key="comment-button"
-								commentCount={ post.discussion.comment_count }
+								commentCount={ commentCount }
 								onClick={ this.handleCommentClick }
 								tagName="div"
 							/> }
@@ -423,10 +425,10 @@ export class FullPostView extends React.Component {
 									? <Comments
 											ref="commentsList"
 											post={ post }
-											initialSize={ 10 }
+											initialSize={ startingCommentId ? commentCount : 10 }
 											pageSize={ 25 }
-											startingCommentId={ this.getCommentIdFromUrl() }
-											commentCount= { post.discussion.comment_count }
+											startingCommentId={ startingCommentId }
+											commentCount={ commentCount }
 										/>
 									: null }
 							</div>

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -300,6 +300,7 @@ class Post extends Component {
 				{ this.state.showComments &&
 					<Comments
 						showCommentCount={ false }
+						commentCount = { this.props.post.discussion.comment_count }
 						post={ this.props.post }
 						showFilters={ isEnabled( 'comments/filters-in-posts' ) }
 						showModerationTools={ isEnabled( 'comments/moderation-tools-in-posts' ) }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -380,7 +380,7 @@
 	margin-top: -4px;
 }
 
-.post .comments__view-earlier {
+.post .comments__view-more {
 	margin-top: 15px;
 }
 

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -31,6 +31,12 @@ function renderPostNotFound() {
 	);
 }
 
+const scrollTopIfNoHash = () => defer( () => {
+	if ( typeof window !== 'undefined' && ! window.location.hash ) {
+		window.scrollTo( 0, 0 );
+	}
+} );
+
 export function blogPost( context ) {
 	const blogId = context.params.blog,
 		postId = context.params.post,
@@ -57,11 +63,7 @@ export function blogPost( context ) {
 		document.getElementById( 'primary' ),
 		context.store,
 	);
-	defer( function() {
-		if ( typeof window !== 'undefined' ) {
-			window.scrollTo( 0, 0 );
-		}
-	} );
+	scrollTopIfNoHash();
 }
 
 export function feedPost( context ) {
@@ -87,9 +89,5 @@ export function feedPost( context ) {
 		document.getElementById( 'primary' ),
 		context.store,
 	);
-	defer( function() {
-		if ( typeof window !== 'undefined' ) {
-			window.scrollTo( 0, 0 );
-		}
-	} );
+	scrollTopIfNoHash();
 }

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -50,7 +50,7 @@ export function requestPostComments( {
 		postId,
 		direction,
 		query: {
-			order: 'DESC',
+			order: direction === 'before' ? 'DESC' : 'ASC',
 			number: NUMBER_OF_COMMENTS_PER_FETCH,
 			status,
 		},

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -34,7 +34,12 @@ export const requestComment = ( { siteId, commentId } ) => ( {
  * @param {String} status status filter. Defaults to approved posts
  * @returns {Function} thunk that requests comments for a given post
  */
-export function requestPostComments( siteId, postId, status = 'approved' ) {
+export function requestPostComments( {
+	siteId,
+	postId,
+	status = 'approved',
+	direction = 'before'
+} ) {
 	if ( ! isEnabled( 'comments/filters-in-posts' ) ) {
 		status = 'approved';
 	}
@@ -43,6 +48,7 @@ export function requestPostComments( siteId, postId, status = 'approved' ) {
 		type: COMMENTS_REQUEST,
 		siteId,
 		postId,
+		direction,
 		query: {
 			order: 'DESC',
 			number: NUMBER_OF_COMMENTS_PER_FETCH,
@@ -136,7 +142,7 @@ export function changeCommentStatus( siteId, postId, commentId, status ) {
 			siteId,
 			postId,
 			commentId,
-			status
+			status,
 		} );
 
 		return wpcom

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -125,8 +125,15 @@ export const hasMoreComments = createReducer(
 	{},
 	{
 		[ COMMENTS_RECEIVE ]: ( state, action ) => {
-			const { siteId, postId, direction } = action;
+			const { siteId, postId, direction, commentById } = action;
 			const stateKey = getStateKey( siteId, postId );
+
+			if ( commentById ) {
+				return state[ stateKey ]
+					? state
+					: { ...state, [ stateKey ]: { before: true, after: true } };
+			}
+
 			const nextState = {
 				...( state[ stateKey ] || { before: true, after: true } ),
 				[ direction ]: action.comments.length === NUMBER_OF_COMMENTS_PER_FETCH,

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -107,13 +107,23 @@ export function items( state = {}, action ) {
 	return state;
 }
 
+export const hasMoreCommentsInitialState = {
+	before: true,
+	after: true,
+	hasReceivedBefore: false,
+	hasReceivedAfter: false,
+};
+
 /***
- * Stores whether or not there are more comments, and in which directions, for a particular post,
+ * Stores whether or not there are more comments, and in which directions, for a particular post.
+ * Also includes whether or not a before/after has ever been queried
  * Example state:
  *  {
  *     [ siteId-postId ]: {
- *       before: true,
- *       after: false,
+ *       before: bool,
+ *       after: bool,
+ *       hasReceivedBefore: bool,
+ *       hasReceivedAfter: bool,
  *     }
  *  }
  *
@@ -129,14 +139,16 @@ export const hasMoreComments = createReducer(
 			const stateKey = getStateKey( siteId, postId );
 
 			if ( commentById ) {
-				return state[ stateKey ]
-					? state
-					: { ...state, [ stateKey ]: { before: true, after: true } };
+				return state;
 			}
 
+			const hasReceivedDirection =
+				direction === 'before' ? 'hasReceivedBefore' : 'hasReceivedAfter';
+
 			const nextState = {
-				...( state[ stateKey ] || { before: true, after: true } ),
+				...( state[ stateKey ] || hasMoreCommentsInitialState ),
 				[ direction ]: action.comments.length === NUMBER_OF_COMMENTS_PER_FETCH,
+				[ hasReceivedDirection ]: true,
 			};
 
 			return isEqual( state[ stateKey ], nextState )

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -107,7 +107,7 @@ export function items( state = {}, action ) {
 	return state;
 }
 
-export const hasMoreCommentsInitialState = {
+export const fetchStatusInitialState = {
 	before: true,
 	after: true,
 	hasReceivedBefore: false,
@@ -131,7 +131,7 @@ export const hasMoreCommentsInitialState = {
  * @param {Object} action redux action
  * @returns {Object} new redux state
  */
-export const hasMoreComments = createReducer(
+export const fetchStatus = createReducer(
 	{},
 	{
 		[ COMMENTS_RECEIVE ]: ( state, action ) => {
@@ -146,7 +146,7 @@ export const hasMoreComments = createReducer(
 				direction === 'before' ? 'hasReceivedBefore' : 'hasReceivedAfter';
 
 			const nextState = {
-				...( state[ stateKey ] || hasMoreCommentsInitialState ),
+				...( state[ stateKey ] || fetchStatusInitialState ),
 				[ direction ]: action.comments.length === NUMBER_OF_COMMENTS_PER_FETCH,
 				[ hasReceivedDirection ]: true,
 			};
@@ -186,6 +186,6 @@ export function totalCommentsCount( state = {}, action ) {
 
 export default combineReducers( {
 	items,
-	hasMoreComments,
+	fetchStatus,
 	totalCommentsCount,
 } );

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isUndefined, orderBy, has, map, unionBy, reject, isEqual } from 'lodash';
+import { isUndefined, orderBy, has, map, unionBy, reject, isEqual, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -143,6 +143,7 @@ export const fetchStatus = createReducer(
 			const { siteId, postId, direction, commentById } = action;
 			const stateKey = getStateKey( siteId, postId );
 
+			// we can't deduce anything from a commentById fetch.
 			if ( commentById ) {
 				return state;
 			}
@@ -151,7 +152,7 @@ export const fetchStatus = createReducer(
 				direction === 'before' ? 'hasReceivedBefore' : 'hasReceivedAfter';
 
 			const nextState = {
-				...( state[ stateKey ] || fetchStatusInitialState ),
+				...get( state, stateKey, fetchStatusInitialState ),
 				[ direction ]: action.comments.length === NUMBER_OF_COMMENTS_PER_FETCH,
 				[ hasReceivedDirection ]: true,
 			};
@@ -188,6 +189,19 @@ export function totalCommentsCount( state = {}, action ) {
 
 	return state;
 }
+
+/**
+ * Houses errors by `siteId-commentId`
+ */
+export const errors = createReducer(
+	{},
+	{
+		[ COMMENTS_ERROR ]: ( state, action ) => ( {
+			...state,
+			[ `${ action.siteId }-${ action.commentId }` ]: { error: true },
+		} ),
+	},
+);
 
 export default combineReducers( {
 	items,

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -52,6 +52,12 @@ const updateComment = ( commentId, newProperties ) => comment => {
  */
 export function items( state = {}, action ) {
 	const { type, siteId, postId, commentId, like_count } = action;
+
+	// cannot construct stateKey without both
+	if ( ! siteId || ! postId ) {
+		return state;
+	}
+
 	const stateKey = getStateKey( siteId, postId );
 
 	switch ( type ) {
@@ -190,15 +196,24 @@ export const totalCommentsCount = createReducer(
 export const errors = createReducer(
 	{},
 	{
-		[ COMMENTS_ERROR ]: ( state, action ) => ( {
-			...state,
-			[ `${ action.siteId }-${ action.commentId }` ]: { error: true },
-		} ),
+		[ COMMENTS_ERROR ]: ( state, action ) => {
+			const key = `${ action.siteId }-${ action.commentId }`;
+
+			if ( state[ key ] ) {
+				return state;
+			}
+
+			return {
+				...state,
+				[ key ]: { error: true },
+			};
+		},
 	},
 );
 
 export default combineReducers( {
 	items,
 	fetchStatus,
+	errors,
 	totalCommentsCount,
 } );

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -24,6 +24,11 @@ const getCommentDate = ( { date } ) => new Date( date );
 
 export const getStateKey = ( siteId, postId ) => `${ siteId }-${ postId }`;
 
+export const deconstructStateKey = key => {
+	const [ siteId, postId ] = key.split( '-' );
+	return { siteId: +siteId, postId: +postId };
+};
+
 const updateComment = ( commentId, newProperties ) => comment => {
 	if ( comment.ID !== commentId ) {
 		return comment;

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -170,25 +170,19 @@ export const fetchStatus = createReducer(
  * @param {Object} action redux action
  * @returns {Object} new redux state
  */
-export function totalCommentsCount( state = {}, action ) {
-	const { siteId, postId } = action;
-	const stateKey = getStateKey( siteId, postId );
-
-	switch ( action.type ) {
-		case COMMENTS_COUNT_RECEIVE:
-			return {
-				...state,
-				[ stateKey ]: action.totalCommentsCount,
-			};
-		case COMMENTS_COUNT_INCREMENT:
-			return {
-				...state,
-				[ stateKey ]: state[ stateKey ] + 1,
-			};
-	}
-
-	return state;
-}
+export const totalCommentsCount = createReducer(
+	{},
+	{
+		[ COMMENTS_COUNT_RECEIVE ]: ( state, action ) => {
+			const key = getStateKey( action.siteId, action.postId );
+			return { ...state, [ key ]: action.totalCommentsCount };
+		},
+		[ COMMENTS_COUNT_INCREMENT ]: ( state, action ) => {
+			const key = getStateKey( action.siteId, action.postId );
+			return { ...state, [ key ]: state[ key ] + 1 };
+		},
+	},
+);
 
 /**
  * Houses errors by `siteId-commentId`

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -7,7 +7,7 @@ import { filter, find, get, keyBy, last, first, map, size } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { getStateKey } from './reducer';
+import { getStateKey, hasMoreCommentsInitialState } from './reducer';
 
 /***
  * Gets comment items for post
@@ -116,12 +116,24 @@ export const haveMoreCommentsToFetch = createSelector(
 export const haveEarlierCommentsToFetch = ( state, siteId, postId, commentTotal = 0 ) =>
 	( haveMoreCommentsToFetch( state, siteId, postId ) ||
 		commentTotal > size( getPostCommentItems( state, siteId, postId ) ) ) &&
-	!! get( state.comments.hasMoreComments, getStateKey( siteId, postId ), {} ).before;
+	get( state.comments.hasMoreComments, getStateKey( siteId, postId ), hasMoreCommentsInitialState )
+		.before;
 
 export const haveLaterCommentsToFetch = ( state, siteId, postId, commentTotal = 0 ) =>
 	( haveMoreCommentsToFetch( state, siteId, postId ) ||
 		commentTotal > size( getPostCommentItems( state, siteId, postId ) ) ) &&
-	!! get( state.comments.hasMoreComments, getStateKey( siteId, postId ), {} ).after;
+	get( state.comments.hasMoreComments, getStateKey( siteId, postId ), hasMoreCommentsInitialState )
+		.after;
+
+export const haveReceivedBeforeAndAfter = ( state, siteId, postId ) => {
+	const hasMoreComments = get(
+		state.comments.hasMoreComments,
+		getStateKey( siteId, postId ),
+		hasMoreCommentsInitialState,
+	);
+	const { hasReceivedAfter, hasReceivedBefore } = hasMoreComments;
+	return hasReceivedBefore && hasReceivedAfter;
+};
 
 /***
  * Gets likes stats for the comment

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -7,6 +7,7 @@ import { filter, find, get, keyBy, last, first, map, size } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+import { getStateKey } from './reducer';
 
 /***
  * Gets comment items for post
@@ -109,11 +110,16 @@ export const haveMoreCommentsToFetch = createSelector(
 		const totalCommentsCount = getPostTotalCommentsCount( state, siteId, postId );
 		return items && totalCommentsCount ? size( items ) < totalCommentsCount : undefined;
 	},
-	( state, siteId, postId ) => [
-		getPostCommentItems( state, siteId, postId ),
-		getPostTotalCommentsCount( state, siteId, postId ),
-	],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ), getPostTotalCommentsCount( state, siteId, postId ) ]
 );
+
+export const haveEarlierCommentsToFetch = ( state, siteId, postId ) =>
+	haveMoreCommentsToFetch( state, siteId, postId ) &&
+	!! get( state.comments.hasMoreComments, getStateKey( siteId, postId ), {} ).before;
+
+export const haveLaterCommentsToFetch = ( state, siteId, postId ) =>
+	haveMoreCommentsToFetch( state, siteId, postId ) &&
+	!! get( state.comments.hasMoreComments, getStateKey( siteId, postId ), {} ).after;
 
 /***
  * Gets likes stats for the comment

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -40,7 +40,7 @@ export const getPostMostRecentCommentDate = createSelector( ( state, siteId, pos
 }, getPostCommentItems );
 
 /***
- * Get most old (earliest) comment date for a given post
+ * Get most oldest comment date for a given post
  * @param {Object} state redux state
  * @param {Number} siteId site identification
  * @param {Number} postId site identification
@@ -50,6 +50,21 @@ export const getPostOldestCommentDate = createSelector( ( state, siteId, postId 
 	const items = getPostCommentItems( state, siteId, postId );
 	return items && last( items ) ? new Date( get( last( items ), 'date' ) ) : undefined;
 }, getPostCommentItems );
+
+/***
+ * Get newest comment date for a given post
+ * @param {Object} state redux state
+ * @param {Number} siteId site identification
+ * @param {Number} postId site identification
+ * @return {Date} earliest comment date
+ */
+export const getPostNewestCommentDate = createSelector(
+	( state, siteId, postId ) => {
+		const items = getPostCommentItems( state, siteId, postId );
+		return items && first( items ) ? new Date( get( first( items ), 'date' ) ) : undefined;
+	},
+	getPostCommentItems
+);
 
 /***
  * Gets comment tree for a given post

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -1,13 +1,13 @@
 /***
  * External dependencies
  */
-import { filter, find, get, keyBy, last, first, map, size } from 'lodash';
+import { filter, find, get, keyBy, last, first, map, size, flatMap } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { getStateKey, fetchStatusInitialState } from './reducer';
+import { getStateKey, deconstructStateKey, fetchStatusInitialState } from './reducer';
 
 /***
  * Gets comment items for post
@@ -19,6 +19,14 @@ import { getStateKey, fetchStatusInitialState } from './reducer';
 export const getPostCommentItems = ( state, siteId, postId ) =>
 	get( state.comments.items, `${ siteId }-${ postId }` );
 
+export const getCommentById = createSelector( ( { state, commentId, siteId } ) => {
+	const commentsForSite = flatMap(
+		filter( state.comments && state.comments.items, ( comment, key ) => {
+			return deconstructStateKey( key ).siteId === siteId;
+		} ),
+	);
+	return find( commentsForSite, comment => commentId === comment.ID );
+}, ( { state } ) => state.comments && state.comments.items );
 /***
  * Get total number of comments on the server for a given post
  * @param {Object} state redux state

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -20,7 +20,7 @@ export const getPostCommentItems = ( state, siteId, postId ) =>
 	get( state.comments.items, `${ siteId }-${ postId }` );
 
 export const getCommentById = createSelector( ( { state, commentId, siteId } ) => {
-	if ( get( state, 'comments.items', {} )[ `${ siteId }-error-${ commentId }` ] ) {
+	if ( get( state, 'comments.errors', {} )[ `${ siteId }-${ commentId }` ] ) {
 		return { siteId, commentId, error: true };
 	}
 

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -20,6 +20,10 @@ export const getPostCommentItems = ( state, siteId, postId ) =>
 	get( state.comments.items, `${ siteId }-${ postId }` );
 
 export const getCommentById = createSelector( ( { state, commentId, siteId } ) => {
+	if ( get( state, 'comments.items', {} )[ `${ siteId }-error-${ commentId }` ] ) {
+		return { siteId, commentId, error: true };
+	}
+
 	const commentsForSite = flatMap(
 		filter( state.comments && state.comments.items, ( comment, key ) => {
 			return deconstructStateKey( key ).siteId === siteId;

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -19,18 +19,21 @@ import { getStateKey, deconstructStateKey, fetchStatusInitialState } from './red
 export const getPostCommentItems = ( state, siteId, postId ) =>
 	get( state.comments.items, `${ siteId }-${ postId }` );
 
-export const getCommentById = createSelector( ( { state, commentId, siteId } ) => {
-	if ( get( state, 'comments.errors', {} )[ `${ siteId }-${ commentId }` ] ) {
-		return { siteId, commentId, error: true };
-	}
+export const getCommentById = createSelector(
+	( { state, commentId, siteId } ) => {
+		if ( get( state, 'comments.errors', {} )[ `${ siteId }-${ commentId }` ] ) {
+			return state.comments.errors[ `${ siteId }-${ commentId }` ];
+		}
 
-	const commentsForSite = flatMap(
-		filter( state.comments && state.comments.items, ( comment, key ) => {
-			return deconstructStateKey( key ).siteId === siteId;
-		} ),
-	);
-	return find( commentsForSite, comment => commentId === comment.ID );
-}, ( { state } ) => state.comments && state.comments.items );
+		const commentsForSite = flatMap(
+			filter( state.comments && state.comments.items, ( comment, key ) => {
+				return deconstructStateKey( key ).siteId === siteId;
+			} ),
+		);
+		return find( commentsForSite, comment => commentId === comment.ID );
+	},
+	( { state } ) => [ get( state.comments, 'items' ), get( state.comments, 'errors' ) ],
+);
 /***
  * Get total number of comments on the server for a given post
  * @param {Object} state redux state

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -36,7 +36,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should return a comment request action', function() {
-			const action = requestPostComments( SITE_ID, POST_ID, 'trash' );
+			const action = requestPostComments( { siteId: SITE_ID, postId: POST_ID, status: 'trash' } );
 
 			expect( action ).to.eql( {
 				type: COMMENTS_REQUEST,
@@ -47,16 +47,18 @@ describe( 'actions', () => {
 					number: NUMBER_OF_COMMENTS_PER_FETCH,
 					status: 'trash',
 				},
+				direction: 'before',
 			} );
 		} );
 
 		it( 'should return a comment request action with a default status of approved', function() {
-			const action = requestPostComments( SITE_ID, POST_ID, undefined );
+			const action = requestPostComments( { siteId: SITE_ID, postId: POST_ID, status: undefined } );
 
 			expect( action ).to.eql( {
 				type: COMMENTS_REQUEST,
 				siteId: SITE_ID,
 				postId: POST_ID,
+				direction: 'before',
 				query: {
 					order: 'DESC',
 					number: NUMBER_OF_COMMENTS_PER_FETCH,

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -8,7 +8,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { items, totalCommentsCount } from '../reducer';
+import { items, totalCommentsCount, fetchStatus, fetchStatusInitialState } from '../reducer';
 import {
 	COMMENTS_LIKE,
 	COMMENTS_UNLIKE,
@@ -126,6 +126,47 @@ describe( 'reducer', () => {
 
 			expect( result[ '1-1' ][ 0 ].placeholderState ).to.equal( PLACEHOLDER_STATE.ERROR );
 			expect( result[ '1-1' ][ 0 ].placeholderError ).to.equal( 'error_message' );
+		} );
+	} );
+
+	describe( '#fetchStatus', () => {
+		const actionWithComments = {
+			type: COMMENTS_RECEIVE,
+			siteId: '123',
+			postId: '456',
+			direction: 'before',
+			comments: [ {}, {} ],
+		};
+		const actionWithCommentId = {
+			type: COMMENTS_RECEIVE,
+			siteId: '123',
+			commentById: true,
+			comments: [ {} ],
+			direction: 'after',
+		};
+
+		it( 'should default to an empty object', () => {
+			expect( fetchStatus( undefined, { type: 'okapi' } ) ).eql( {} );
+		} );
+
+		it( 'should set hasReceived and before/after when receiving commments', () => {
+			const prevState = {};
+			const nextState = fetchStatus( prevState, actionWithComments );
+			expect( nextState ).eql( {
+				[ `${ actionWithComments.siteId }-${ actionWithComments.postId }` ]: {
+					before: false,
+					after: true,
+					hasReceivedBefore: true,
+					hasReceivedAfter: false,
+				},
+			} );
+		} );
+
+		it( 'fetches by id should not modify the state', () => {
+			const prevState = { [ actionWithCommentId.siteId ]: fetchStatusInitialState };
+			const nextState = fetchStatus( prevState, actionWithCommentId );
+
+			expect( nextState ).equal( prevState );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { get, isDate, startsWith } from 'lodash';
+import { get, isDate, startsWith, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { createNotice, errorNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
-import { getPostOldestCommentDate } from 'state/comments/selectors';
+import { getPostOldestCommentDate, getPostNewestCommentDate } from 'state/comments/selectors';
 import getSiteComment from 'state/selectors/get-site-comment';
 
 /***
@@ -48,8 +48,21 @@ export function createPlaceholderComment( commentText, postId, parentCommentId )
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/replies/
 export const fetchPostComments = ( { dispatch, getState }, action ) => {
-	const { siteId, postId, query } = action;
-	const before = getPostOldestCommentDate( getState(), siteId, postId );
+	const { siteId, postId, query, direction } = action;
+	const oldestDate = getPostOldestCommentDate( getState(), siteId, postId );
+	const newestDate = getPostNewestCommentDate( getState(), siteId, postId );
+
+	const before =
+		direction === 'before' &&
+		isDate( oldestDate ) &&
+		oldestDate.toISOString &&
+		oldestDate.toISOString();
+
+	const after =
+		direction === 'after' &&
+		isDate( newestDate ) &&
+		newestDate.toISOString &&
+		newestDate.toISOString();
 
 	dispatch(
 		http(
@@ -57,14 +70,11 @@ export const fetchPostComments = ( { dispatch, getState }, action ) => {
 				method: 'GET',
 				path: `/sites/${ siteId }/posts/${ postId }/replies`,
 				apiVersion: '1.1',
-				query: {
+				query: pickBy( {
 					...query,
-					...( before &&
-					isDate( before ) &&
-					before.toISOString && {
-						before: before.toISOString(),
-					} ),
-				},
+					after,
+					before,
+				} ),
 			},
 			action,
 		),
@@ -105,12 +115,14 @@ export const writePostComment = ( { dispatch }, action ) => {
 	);
 };
 
-export const addComments = ( { dispatch }, { siteId, postId }, next, { comments, found } ) => {
+export const addComments = ( { dispatch }, action, next, { comments, found } ) => {
+	const { siteId, postId, direction } = action;
 	dispatch( {
 		type: COMMENTS_RECEIVE,
 		siteId,
 		postId,
 		comments,
+		direction,
 	} );
 
 	// if the api have returned comments count, dispatch it

--- a/client/state/data-layer/wpcom/comments/test/index.js
+++ b/client/state/data-layer/wpcom/comments/test/index.js
@@ -63,6 +63,7 @@ describe( 'wpcom-api', () => {
 					siteId: '2916284',
 					postId: '1010',
 					query,
+					direction: 'before',
 				};
 				const dispatch = spy();
 				const getState = () => ( {
@@ -103,6 +104,7 @@ describe( 'wpcom-api', () => {
 				const action = {
 					siteId: 2916284,
 					postId: 1010,
+					direction: 'before',
 				};
 				const data = {
 					comments: [],
@@ -117,6 +119,7 @@ describe( 'wpcom-api', () => {
 					siteId: 2916284,
 					postId: 1010,
 					comments: [],
+					direction: 'before',
 				} );
 			} );
 
@@ -125,6 +128,7 @@ describe( 'wpcom-api', () => {
 				const action = {
 					siteId: 2916284,
 					postId: 1010,
+					direction: 'before',
 				};
 				const data = {
 					comments: [ {}, {} ],
@@ -139,6 +143,7 @@ describe( 'wpcom-api', () => {
 					siteId: 2916284,
 					postId: 1010,
 					comments: [ {}, {} ],
+					direction: 'before',
 				} );
 
 				expect( dispatch ).to.have.been.calledWith( {

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -39,6 +39,7 @@ export const receiveCommentSuccess = ( store, action, next, response ) => {
 		siteId,
 		postId,
 		comments: [ response ],
+		commentById: true,
 	} );
 };
 

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -8,7 +8,12 @@ import { forEach, groupBy } from 'lodash';
  * Internal dependencies
  */
 import { mergeHandlers } from 'state/action-watchers/utils';
-import { COMMENTS_LIST_REQUEST, COMMENTS_RECEIVE, COMMENT_REQUEST } from 'state/action-types';
+import {
+	COMMENTS_LIST_REQUEST,
+	COMMENTS_RECEIVE,
+	COMMENT_REQUEST,
+	COMMENTS_ERROR,
+} from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import replies from './replies';
@@ -54,6 +59,16 @@ export const receiveCommentError = ( store, action ) => {
 			} ),
 		),
 	);
+
+	if ( action.commentId ) {
+		store.dispatch( {
+			type: COMMENTS_ERROR,
+			siteId: action.siteId,
+			postId: `error-${ action.commentId }`,
+			commentId: action.commentId,
+			commentById: true,
+		} );
+	}
 };
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -60,15 +60,11 @@ export const receiveCommentError = ( store, action ) => {
 		),
 	);
 
-	if ( action.commentId ) {
-		store.dispatch( {
-			type: COMMENTS_ERROR,
-			siteId: action.siteId,
-			postId: `error-${ action.commentId }`,
-			commentId: action.commentId,
-			commentById: true,
-		} );
-	}
+	store.dispatch( {
+		type: COMMENTS_ERROR,
+		siteId: action.siteId,
+		commentId: action.commentId,
+	} );
 };
 
 // @see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -149,6 +149,7 @@ describe( '#receiveCommentSuccess', () => {
 			siteId,
 			postId: response.post.ID,
 			comments: [ response ],
+			commentById: true,
 		} );
 	} );
 } );


### PR DESCRIPTION
Currently the Reader doesn't support linking directly to a comment. 
This in particular is a blocker for https://github.com/Automattic/wp-calypso/pull/14396, as well as other improvements we have planned down the line.

In order to get us all the way to being capable of linking directly to comments there are a few steps:
1.  [x] enable bidirectional paging from any comment to earlier/later comments
2. [x] enable loading a specific comment directly.  https://github.com/Automattic/wp-calypso/pull/16006
3. [x] make full-post pay attention to anchors in the url and start from the specified comment


To Test:
- [x] comments in My Sites still render properly.  
- [x] comments in Reader still render properly when not deep linking
- [x] going to a Reader full-post url that ends in #comment-${id} renders / scrolls you to that specific comment with the ability to paginate if necessary in either direction.  I recommend testing multiple posts with different number of comments: 100s, < 10, and 1.
- [x] works with invalid commentIds (doesnt break calypso)
- [x] works with valid commentId but for the wrong post.