### PR TITLE
Activity log: Add restore analytics

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityLogBanner from './index';
 import Button from 'components/button';
+import TrackComponentView from 'lib/analytics/track-component-view';
 import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
 
 class ErrorBanner extends PureComponent {
@@ -37,7 +38,12 @@ class ErrorBanner extends PureComponent {
 	handleDismiss = () => this.props.dismissRewindRestoreProgress( this.props.siteId );
 
 	render() {
-		const { translate } = this.props;
+		const {
+			errorCode,
+			failureReason,
+			timestamp,
+			translate,
+		} = this.props;
 
 		return (
 			<ActivityLogBanner
@@ -46,6 +52,11 @@ class ErrorBanner extends PureComponent {
 				status="error"
 				title={ translate( 'Problem restoring your site' ) }
 			>
+				<TrackComponentView eventName="calypso_activity_log_error_banner_impression" eventProperties={ {
+					errorCode,
+					failureReason,
+					restoreTo: timestamp,
+				} } />
 				<p>{ translate( 'We came across a problem while trying to restore your site.' ) }</p>
 				<Button primary onClick={ this.handleClickRestore }>
 					{ translate( 'Try again' ) }

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -14,6 +14,8 @@ import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } fr
 
 class ErrorBanner extends PureComponent {
 	static propTypes = {
+		errorCode: PropTypes.string.isRequired,
+		failureReason: PropTypes.string.isRequired,
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 		timestamp: PropTypes.number.isRequired,
@@ -23,6 +25,11 @@ class ErrorBanner extends PureComponent {
 
 		// localize
 		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		errorCode: '',
+		failureReason: '',
 	};
 
 	handleClickRestore = () => this.props.requestRestore( this.props.timestamp );

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -52,7 +52,7 @@ class ErrorBanner extends PureComponent {
 				status="error"
 				title={ translate( 'Problem restoring your site' ) }
 			>
-				<TrackComponentView eventName="calypso_activity_log_error_banner_impression" eventProperties={ {
+				<TrackComponentView eventName="calypso_activitylog_errorbanner_impression" eventProperties={ {
 					errorCode,
 					failureReason,
 					restoreTo: timestamp,

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityLogBanner from './index';
 import Button from 'components/button';
+import TrackComponentView from 'lib/analytics/track-component-view';
 import { getSiteUrl } from 'state/selectors';
 import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
 
@@ -44,6 +45,9 @@ class SuccessBanner extends PureComponent {
 				status="success"
 				title={ translate( 'Your site has been successfully restored' ) }
 			>
+				<TrackComponentView eventName="calypso_activity_log_success_banner_impression" eventProperties={ {
+					restoreTo: timestamp,
+				} } />
 				<p>{ translate(
 					'We successfully restored your site back to %s!',
 					{ args: moment( timestamp ).format( 'LLLL' ) }

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -45,7 +45,7 @@ class SuccessBanner extends PureComponent {
 				status="success"
 				title={ translate( 'Your site has been successfully restored' ) }
 			>
-				<TrackComponentView eventName="calypso_activity_log_success_banner_impression" eventProperties={ {
+				<TrackComponentView eventName="calypso_activitylog_successbanner_impression" eventProperties={ {
 					restoreTo: timestamp,
 				} } />
 				<p>{ translate(

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -3,14 +3,16 @@
  */
 import React, { Component, PropTypes } from 'react';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import FoldableCard from 'components/foldable-card';
-import Button from 'components/button';
 import ActivityLogItem from '../activity-log-item';
+import Button from 'components/button';
+import FoldableCard from 'components/foldable-card';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 class ActivityLogDay extends Component {
 	static propTypes = {
@@ -34,6 +36,21 @@ class ActivityLogDay extends Component {
 			requestRestore,
 		} = this.props;
 		requestRestore( tsEndOfSiteDay, 'day' );
+	};
+
+	trackOpenDay = () => {
+		const {
+			logs,
+			moment,
+			recordTracksEvent,
+			tsEndOfSiteDay,
+		} = this.props;
+
+		recordTracksEvent( 'calypso_activity_log_day_expand', {
+			logCount: logs.length,
+			tsEndOfSiteDay,
+			utcDate: moment.utc( tsEndOfSiteDay ).format( 'YYYY-MM-DD' ),
+		} );
 	};
 
 	/**
@@ -103,9 +120,10 @@ class ActivityLogDay extends Component {
 		return (
 			<div className="activity-log-day">
 				<FoldableCard
-					header={ this.getEventsHeading() }
-					summary={ this.getRewindButton( 'primary' ) }
 					expandedSummary={ this.getRewindButton() }
+					header={ this.getEventsHeading() }
+					onOpen={ this.trackOpenDay }
+					summary={ this.getRewindButton( 'primary' ) }
 				>
 					{ logs.map( ( log, index ) => (
 						<ActivityLogItem
@@ -123,4 +141,6 @@ class ActivityLogDay extends Component {
 	}
 }
 
-export default localize( ActivityLogDay );
+export default connect( null, {
+	recordTracksEvent: recordTracksEventAction,
+} )( localize( ActivityLogDay ) );

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -33,7 +33,7 @@ class ActivityLogDay extends Component {
 			tsEndOfSiteDay,
 			requestRestore,
 		} = this.props;
-		requestRestore( tsEndOfSiteDay );
+		requestRestore( tsEndOfSiteDay, 'day' );
 	};
 
 	/**

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -46,7 +46,7 @@ class ActivityLogDay extends Component {
 			tsEndOfSiteDay,
 		} = this.props;
 
-		recordTracksEvent( 'calypso_activity_log_day_expand', {
+		recordTracksEvent( 'calypso_activitylog_day_expand', {
 			logCount: logs.length,
 			tsEndOfSiteDay,
 			utcDate: moment.utc( tsEndOfSiteDay ).format( 'YYYY-MM-DD' ),

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -141,13 +141,12 @@ class ActivityLogItem extends Component {
 
 	static defaultProps = { allowRestore: true };
 
-	// TODO: Add analytics
 	handleClickRestore = () => {
 		const {
 			requestRestore,
 			log,
 		} = this.props;
-		requestRestore( log.ts_utc );
+		requestRestore( log.ts_utc, 'item' );
 	};
 
 	handleOpen = () => debug( 'opened log', this.props.log );

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import debugFactory from 'debug';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +16,7 @@ import Gravatar from 'components/gravatar';
 import Gridicon from 'gridicons';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { addQueryArgs } from 'lib/route';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:activity-log:item' );
 
@@ -143,13 +145,31 @@ class ActivityLogItem extends Component {
 
 	handleClickRestore = () => {
 		const {
-			requestRestore,
 			log,
+			requestRestore,
 		} = this.props;
 		requestRestore( log.ts_utc, 'item' );
 	};
 
-	handleOpen = () => debug( 'opened log', this.props.log );
+	handleOpen = () => {
+		const {
+			log,
+			recordTracksEvent,
+		} = this.props;
+		const {
+			group,
+			name,
+			ts_utc,
+		} = log;
+
+		debug( 'opened log', log );
+
+		recordTracksEvent( 'calypso_activity_log_item_expand', {
+			group,
+			name,
+			timestamp: ts_utc,
+		} );
+	};
 
 	getIcon() {
 		const { log } = this.props;
@@ -356,10 +376,10 @@ class ActivityLogItem extends Component {
 				</div>
 				<FoldableCard
 					className="activity-log-item__card"
-					header={ this.renderHeader() }
-					summary={ this.renderSummary() }
 					expandedSummary={ this.renderSummary() }
+					header={ this.renderHeader() }
 					onOpen={ this.handleOpen }
+					summary={ this.renderSummary() }
 				>
 					{ this.renderDescription() }
 				</FoldableCard>
@@ -368,4 +388,6 @@ class ActivityLogItem extends Component {
 	}
 }
 
-export default localize( ActivityLogItem );
+export default connect( null, {
+	recordTracksEvent: recordTracksEventAction,
+} )( localize( ActivityLogItem ) );

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -164,7 +164,7 @@ class ActivityLogItem extends Component {
 
 		debug( 'opened log', log );
 
-		recordTracksEvent( 'calypso_activity_log_item_expand', {
+		recordTracksEvent( 'calypso_activitylog_item_expand', {
 			group,
 			name,
 			timestamp: ts_utc,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -94,8 +94,9 @@ class ActivityLog extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
-	handleRequestRestore = ( requestedRestoreTimestamp ) => {
+	handleRequestRestore = ( requestedRestoreTimestamp, from ) => {
 		this.props.recordTracksEvent( 'calypso_activity_log_request_restore', {
+			from,
 			timestamp: requestedRestoreTimestamp,
 		} );
 		this.setState( {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -33,6 +33,7 @@ import QuerySiteSettings from 'components/data/query-site-settings';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { rewindRestore as rewindRestoreAction } from 'state/activity-log/actions';
 import {
 	getActivityLogs,
@@ -94,22 +95,33 @@ class ActivityLog extends Component {
 	}
 
 	handleRequestRestore = ( requestedRestoreTimestamp ) => {
+		this.props.recordTracksEvent( 'calypso_activity_log_request_restore', {
+			timestamp: requestedRestoreTimestamp,
+		} );
 		this.setState( {
 			requestedRestoreTimestamp,
 			showRestoreConfirmDialog: true,
 		} );
 	};
 
-	handleRestoreDialogClose = () => this.setState( { showRestoreConfirmDialog: false } );
+	handleRestoreDialogClose = () => {
+		this.props.recordTracksEvent( 'calypso_activity_log_request_restore_dialog_cancel', {
+			timestamp: this.state.requestedRestoreTimestamp,
+		} );
+		this.setState( { showRestoreConfirmDialog: false } );
+	};
 
 	handleRestoreDialogConfirm = () => {
 		const {
+			recordTracksEvent,
 			rewindRestore,
 			siteId,
 		} = this.props;
-
 		const { requestedRestoreTimestamp } = this.state;
 
+		recordTracksEvent( 'calypso_activity_log_request_restore_dialog_confirm', {
+			timestamp: requestedRestoreTimestamp,
+		} );
 		debug( 'Restore requested for site %d to time %d', this.props.siteId, requestedRestoreTimestamp );
 		this.setState( { showRestoreConfirmDialog: false } );
 		rewindRestore( siteId, requestedRestoreTimestamp );
@@ -339,6 +351,7 @@ export default connect(
 			gmtOffset: getSiteGmtOffset( state, siteId ),
 		};
 	}, {
+		recordTracksEvent: recordTracksEventAction,
 		rewindRestore: rewindRestoreAction,
 	}
 )( localize( ActivityLog ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -32,7 +32,6 @@ import QueryActivityLog from 'components/data/query-activity-log';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
-import { recordGoogleEvent } from 'state/analytics/actions';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
 import { rewindRestore as rewindRestoreAction } from 'state/activity-log/actions';
 import {
@@ -263,7 +262,6 @@ class ActivityLog extends Component {
 					period="month"
 					date={ startOfMonth }
 					url={ `/stats/activity/${ slug }` }
-					recordGoogleEvent={ this.changePeriod }
 				>
 					<DatePicker
 						isActivity={ true }
@@ -341,7 +339,6 @@ export default connect(
 			gmtOffset: getSiteGmtOffset( state, siteId ),
 		};
 	}, {
-		recordGoogleEvent,
 		rewindRestore: rewindRestoreAction,
 	}
 )( localize( ActivityLog ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -35,12 +35,12 @@ import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
 import { rewindRestore as rewindRestoreAction } from 'state/activity-log/actions';
 import {
-	getRewindStatusError,
 	getActivityLogs,
 	getRestoreProgress,
-	isRewindActive as isRewindActiveSelector,
+	getRewindStatusError,
 	getSiteGmtOffset,
 	getSiteTimezoneValue,
+	isRewindActive as isRewindActiveSelector,
 } from 'state/selectors';
 
 const debug = debugFactory( 'calypso:activity-log' );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -95,7 +95,7 @@ class ActivityLog extends Component {
 	}
 
 	handleRequestRestore = ( requestedRestoreTimestamp, from ) => {
-		this.props.recordTracksEvent( 'calypso_activity_log_request_restore', {
+		this.props.recordTracksEvent( 'calypso_activitylog_restore_request', {
 			from,
 			timestamp: requestedRestoreTimestamp,
 		} );
@@ -106,7 +106,7 @@ class ActivityLog extends Component {
 	};
 
 	handleRestoreDialogClose = () => {
-		this.props.recordTracksEvent( 'calypso_activity_log_request_restore_dialog_cancel', {
+		this.props.recordTracksEvent( 'calypso_activitylog_restore_cancel', {
 			timestamp: this.state.requestedRestoreTimestamp,
 		} );
 		this.setState( { showRestoreConfirmDialog: false } );
@@ -120,7 +120,7 @@ class ActivityLog extends Component {
 		} = this.props;
 		const { requestedRestoreTimestamp } = this.state;
 
-		recordTracksEvent( 'calypso_activity_log_request_restore_dialog_confirm', {
+		recordTracksEvent( 'calypso_activitylog_restore_confirm', {
 			timestamp: requestedRestoreTimestamp,
 		} );
 		debug( 'Restore requested for site %d to time %d', this.props.siteId, requestedRestoreTimestamp );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -49,7 +49,7 @@ const StatsPeriodNavigation = props => {
 
 const connectComponent = connect( undefined, { recordGoogleEvent } );
 
-export default  flowRight(
+export default flowRight(
 	connectComponent,
 	localize,
 )( StatsPeriodNavigation );


### PR DESCRIPTION
Add analytics

- [x] View success banner
- [x] View error banner
- [x] request restore
- [x] request restore dialog confirm
- [x] request restore dialog cancel
- [x] track where restore requests are initiated _from_
- [x] day fold/unfold
- [x] item fold/unfold
- [x] ~See/open activity log~ ([#](https://github.com/Automattic/wp-calypso/blob/ecd94dbecc50c05484eccb3a53d5801c1297e018/client/my-sites/stats/controller.jsx#L393))
- [ ] Change start date

Fixes #15572 