### PR TITLE
Move data layer middleware before side effects

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -149,13 +149,23 @@ export function createReduxStore( initialState = {} ) {
 
 	const middlewares = [
 		thunkMiddleware,
+		// We need the data layer middleware to be used as early
+		// as possible, before any side effects.
+		// The data layer dispatches actions on network events
+		// including success, failure, and progress updates
+		// Its way of issuing these is to wrap the originating action
+		// with special meta and dispatch it again each time.
+		// If another middleware jumps in before the data layer
+		// then it could mistakenly trigger on those network
+		// responses. Therefore we need to inject the data layer
+		// as early as possible into the middleware chain.
+		require( './data-layer/wpcom-api-middleware.js' ).default,
+		isBrowser && require( './data-layer/extensions-middleware.js' ).default,
 		noticesMiddleware,
 		isBrowser && require( './happychat/middleware.js' ).default(),
 		isBrowser && require( './analytics/middleware.js' ).analyticsMiddleware,
-		require( './data-layer/wpcom-api-middleware.js' ).default,
 		isBrowser && require( './lib/middleware.js' ).default,
 		isBrowser && config.isEnabled( 'restore-last-location' ) && require( './routing/middleware.js' ).default,
-		isBrowser && require( './data-layer/extensions-middleware.js' ).default,
 		isAudioSupported && require( './audio/middleware.js' ).default,
 		isBrowser && config.isEnabled( 'automated-transfer' ) && require( './automated-transfer/middleware.js' ).default,
 	].filter( Boolean );


### PR DESCRIPTION
# Testing

1. Check out #15636
2. Log analytics in the console using `localStorage.setItem('debug', 'calypso:analytics:*');`
3. Go to `/me` and try to upload an image (use a test account if you don't want your Gravatar changed!)
4. Notice that `calypso_edit_gravatar_upload_start` is logged more than once. It should be emitted only once.
5. Apply the changes in this PR
6. Try to upload a new Gravatar again, and notice that `calypso_edit_gravatar_upload_start` is logged only once.

More detailed discussion is here: https://github.com/Automattic/wp-calypso/pull/15636#issuecomment-313198582

h/t @gwwar for the fix idea 💡 

cc @gwwar @dmsnell 