### PR TITLE
Remove post-publish preview AB test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -84,13 +84,4 @@ module.exports = {
 		},
 		defaultVariation: 'original',
 	},
-	postPublishPreview: {
-		datestamp: '20170627',
-		allowExistingUsers: true,
-		variations: {
-			showPostPublishPreview: 50,
-			noShowPostPublishPreview: 50,
-		},
-		defaultVariation: 'noShowPostPublishPreview',
-	},
 };

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -9,7 +9,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -18,7 +17,6 @@ import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { isMobile } from 'lib/viewport';
-import { isSitePreviewable } from 'state/sites/selectors';
 
 export class EditorNotice extends Component {
 	static propTypes = {
@@ -29,10 +27,6 @@ export class EditorNotice extends Component {
 		typeObject: PropTypes.object,
 		message: PropTypes.string,
 		status: PropTypes.string,
-		action: PropTypes.string,
-		link: PropTypes.string,
-		onViewClick: PropTypes.func,
-		isPreviewable: PropTypes.bool,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object
 	}
@@ -180,30 +174,6 @@ export class EditorNotice extends Component {
 		}
 	}
 
-	renderNoticeAction() {
-		const {
-			action,
-			link,
-			isPreviewable,
-			onViewClick,
-		} = this.props;
-		if ( onViewClick && isPreviewable && link ) {
-			return (
-				<NoticeAction onClick={ onViewClick }>
-					{ this.getText( action ) }
-				</NoticeAction>
-			);
-		}
-
-		return (
-			link && (
-				<NoticeAction href={ link } external>
-					{ this.getText( action ) }
-				</NoticeAction>
-			)
-		);
-	}
-
 	render() {
 		const { siteId, message, status, onDismissClick } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
@@ -216,7 +186,6 @@ export class EditorNotice extends Component {
 						{ ...{ status, text, onDismissClick } }
 						showDismiss={ true }
 					>
-						{ this.renderNoticeAction() }
 					</Notice>
 				) }
 			</div>
@@ -236,6 +205,5 @@ export default connect( ( state ) => {
 		site: getSelectedSite( state ),
 		type: post.type,
 		typeObject: getPostType( state, siteId, post.type ),
-		isPreviewable: isSitePreviewable( state, siteId ),
 	};
 }, { setLayoutFocus } )( localize( EditorNotice ) );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -33,7 +33,6 @@ export class EditorNotice extends Component {
 		link: PropTypes.string,
 		onViewClick: PropTypes.func,
 		isPreviewable: PropTypes.bool,
-		isFullScreenPreview: PropTypes.bool,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object
 	}
@@ -134,40 +133,11 @@ export class EditorNotice extends Component {
 				} );
 
 			case 'publishedPrivately':
-				if ( this.props.isFullScreenPreview ) {
-					return translate( '{{strong}}Published privately.{{/strong}} Only admins and editors can view.', {
-						components: {
-							strong: <strong />,
-						},
-						comment: 'Editor: Message displayed when a post is published privately.',
-					} );
-				}
-
-				if ( ! site ) {
-					if ( 'page' === type ) {
-						return translate( 'Page privately published!' );
-					}
-
-					return translate( 'Post privately published!' );
-				}
-
-				if ( 'page' === type ) {
-					return translate( 'Page privately published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
-						components: {
-							siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>,
-							a: <a href={ `/page/${ site.slug }` } />,
-						},
-						comment: 'Editor: Message displayed when a page is published privately,' +
-							' with a link to the site it was published on.'
-					} );
-				}
-
-				return translate( 'Post privately published on {{siteLink/}}!', {
+				return translate( '{{strong}}Published privately.{{/strong}} Only admins and editors can view.', {
 					components: {
-						siteLink: <a href={ site.URL } target="_blank" rel="noopener noreferrer">{ site.title }</a>
+						strong: <strong />,
 					},
-					comment: 'Editor: Message displayed when a post is published privately,' +
-						' with a link to the site it was published on.'
+					comment: 'Editor: Message displayed when a post is published privately.',
 				} );
 
 			case 'view':
@@ -237,12 +207,9 @@ export class EditorNotice extends Component {
 	render() {
 		const { siteId, message, status, onDismissClick } = this.props;
 		const text = this.getErrorMessage() || this.getText( message );
-		const classes = classNames( 'editor-notice', {
-			'is-global': this.props.isFullScreenPreview,
-		} );
 
 		return (
-			<div className={ classes }>
+			<div className={ classNames( 'editor-notice', { 'is-global': true } ) }>
 				{ siteId && <QueryPostTypes siteId={ siteId } /> }
 				{ text && (
 					<Notice

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -12,7 +12,6 @@ import sinon from 'sinon';
  */
 import { EditorNotice } from '../';
 import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 
 describe( 'EditorNotice', () => {
 	it( 'should not render a notice if no message is specified', () => {
@@ -22,19 +21,14 @@ describe( 'EditorNotice', () => {
 	} );
 
 	it( 'should display an no content error message if recognized', () => {
-		const spy = sinon.stub();
-
 		const wrapper = shallow(
 			<EditorNotice
 				translate={ translate }
 				status="is-error"
 				message="publishFailure"
-				isPreviewable={ true }
-				onViewClick={ spy }
 				error={ new Error( 'NO_CONTENT' ) } />
 		);
 
-		expect( wrapper.find( Notice ) ).to.not.have.descendants( NoticeAction );
 		expect( wrapper.find( Notice ) ).to.have.prop( 'text' ).equal( 'You haven\'t written anything yet!' );
 		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-error' );
 		expect( wrapper.find( Notice ) ).to.have.prop( 'showDismiss' ).be.true;
@@ -63,8 +57,6 @@ describe( 'EditorNotice', () => {
 				message="published"
 				status="is-success"
 				type="page"
-				link="https://example.wordpress.com/published-page"
-				action="view"
 				site={ {
 					URL: 'https://example.wordpress.com',
 					title: 'Example Site',
@@ -81,8 +73,6 @@ describe( 'EditorNotice', () => {
 			} )
 		);
 		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-success' );
-		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'href' ).equal( 'https://example.wordpress.com/published-page' );
-		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'children' ).equal( 'View Page' );
 	} );
 
 	it( 'should display custom post type view label', () => {
@@ -97,8 +87,6 @@ describe( 'EditorNotice', () => {
 				} }
 				message="published"
 				status="is-success"
-				link="https://example.wordpress.com/published-project"
-				action="view"
 				site={ {
 					URL: 'https://example.wordpress.com',
 					title: 'Example Site'
@@ -113,42 +101,5 @@ describe( 'EditorNotice', () => {
 			} )
 		);
 		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-success' );
-		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'href' ).equal( 'https://example.wordpress.com/published-project' );
-		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'children' ).equal( 'View Project' );
-	} );
-
-	it( 'should use onViewClick function if provided a previewable site', () => {
-		const spy = sinon.spy();
-
-		const wrapper = shallow(
-			<EditorNotice
-				translate={ translate }
-				message="published"
-				status="is-success"
-				type="page"
-				link="https://example.wordpress.com/published-page"
-				action="view"
-				isPreviewable={ true }
-				onViewClick={ spy }
-				site={ {
-					URL: 'https://example.wordpress.com',
-					title: 'Example Site',
-					slug: 'example.wordpress.com',
-				} } />
-		);
-
-		expect( wrapper.find( Notice ) ).to.have.prop( 'text' ).eql(
-			translate( 'Page published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
-				components: {
-					siteLink: <a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">Example Site</a>,
-					a: <a href="/page/example.wordpress.com" />,
-				}
-			} )
-		);
-		expect( wrapper.find( Notice ) ).to.have.prop( 'status' ).equal( 'is-success' );
-		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'children' ).equal( 'View Page' );
-		expect( wrapper.find( NoticeAction ) ).to.have.prop( 'onClick' ).equal( spy );
-		wrapper.find( NoticeAction ).simulate( 'click' );
-		expect( spy ).to.have.been.calledOnce;
 	} );
 } );

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { translate } from 'i18n-calypso';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -705,7 +705,6 @@ export const PostEditor = React.createClass( {
 			showPreview: false,
 			isPostPublishPreview: false,
 			previewAction: null,
-			notice: null,
 		} );
 
 		return false;
@@ -719,7 +718,7 @@ export const PostEditor = React.createClass( {
 		const { post } = this.state;
 
 		if ( utils.isPublished( post ) ) {
-			this.onSaveSuccess( 'updated', 'view' );
+			this.onSaveSuccess( 'updated' );
 		} else {
 			this.onSaveSuccess();
 		}
@@ -810,7 +809,7 @@ export const PostEditor = React.createClass( {
 			this.setConfirmationSidebar( { status: 'closed', context: 'publish_success' } );
 		}
 
-		this.onSaveSuccess( message, ( message === 'published' ? 'view' : 'preview' ) );
+		this.onSaveSuccess( message );
 	},
 
 	onSaveFailure: function( error, message ) {
@@ -875,7 +874,7 @@ export const PostEditor = React.createClass( {
 		} );
 	},
 
-	onSaveSuccess: function( message, action ) {
+	onSaveSuccess: function( message ) {
 		const post = PostEditStore.get();
 		const isNotPrivateOrIsConfirmed = ( 'private' !== post.status ) || ( 'closed' !== this.state.confirmationSidebar );
 
@@ -900,8 +899,6 @@ export const PostEditor = React.createClass( {
 			nextState.notice = {
 				status: 'is-success',
 				message,
-				action,
-				link: null,
 			};
 
 			window.scrollTo( 0, 0 );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -388,10 +388,10 @@ export const PostEditor = React.createClass( {
 							revision={ get( this.state, 'post.revisions.length', 0 ) }
 						/>
 						: null }
-						<EditorNotice
-							{ ...this.state.notice }
-							onDismissClick={ this.hideNotice }
-							onViewClick={ this.onPreview } />
+					<EditorNotice
+						{ ...this.state.notice }
+						onDismissClick={ this.hideNotice }
+						onViewClick={ this.onPreview } />
 				</div>
 				{ isTrashed
 					? <RestorePostDialog


### PR DESCRIPTION
This PR removes the post-publish preview AB test and leaves the variation of always showing the preview in place.

This PR is a partial revert of 15580, and some additional code cleanup to remove inaccessible code branches.

To test:

- Check out branch and `make run`
- Create a new post.
- Publish the new post.
- A full-screen preview of the post should be shown onPublish, with a global-styled success notice. Verify that it works correctly.
- Run `npm run test-client -- --grep "editor-notice"` - all tests should pass
- Run `npm run test-client -- --grep "post-editor"` - all tests should pass