### PR TITLE
WooCommerce: Remove the order activity log and 'add an order' button.

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -16,7 +16,6 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { isOrderUpdating, getOrder } from 'woocommerce/state/sites/orders/selectors';
 import Main from 'components/main';
-import OrderActivityLog from './order-activity-log';
 import OrderCustomerInfo from './order-customer-info';
 import OrderDetails from './order-details';
 import { updateOrder } from 'woocommerce/state/sites/orders/actions';
@@ -72,7 +71,6 @@ class Order extends Component {
 
 				<div className="order__container">
 					<OrderDetails order={ order } onUpdate={ this.onUpdate } site={ site } />
-					<OrderActivityLog order={ order } />
 					<OrderCustomerInfo order={ order } />
 				</div>
 			</Main>

--- a/client/extensions/woocommerce/app/order/order-customer-info.js
+++ b/client/extensions/woocommerce/app/order/order-customer-info.js
@@ -30,8 +30,9 @@ class OrderCustomerInfo extends Component {
 			<div className="order__customer-info">
 				<SectionHeader label={ translate( 'Customer Information' ) } />
 				<Card>
-					<h3 className="order__billing-details">{ translate( 'Billing Details' ) }</h3>
+					<div className="order__customer-info-container">
 					<div className="order__customer-billing">
+					<h3 className="order__billing-details">{ translate( 'Billing Details' ) }</h3>
 						<h4>{ translate( 'Address' ) }</h4>
 						<div className="order__billing-address">
 							<p>{ `${ billing.first_name } ${ billing.last_name }` }</p>
@@ -45,11 +46,11 @@ class OrderCustomerInfo extends Component {
 						<p>{ billing.email }</p>
 
 						<h4>{ translate( 'Phone' ) }</h4>
-						<p>{ billing.phone }</p>
+						<span>{ billing.phone }</span>
 					</div>
 
-					<h3 className="order__shipping-details">{ translate( 'Shipping Details' ) }</h3>
 					<div className="order__customer-shipping">
+					<h3 className="order__shipping-details">{ translate( 'Shipping Details' ) }</h3>
 						<h4>{ translate( 'Address' ) }</h4>
 						<div className="order__shipping-address">
 							<p>{ `${ shipping.first_name } ${ shipping.last_name }` }</p>
@@ -59,6 +60,7 @@ class OrderCustomerInfo extends Component {
 							<p>{ shipping.country }</p>
 						</div>
 					</div>
+				</div>
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -227,6 +227,14 @@
 	}
 }
 
+.order__customer-info-container {
+	display: flex;
+}
+
+.order__customer-billing {
+	width: 50%;
+}
+
 .order__customer-info {
 	.order__billing-details,
 	.order__shipping-details {

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -23,7 +23,6 @@ import {
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import { getSiteAdminUrl } from 'state/sites/selectors';
 import humanDate from 'lib/human-date';
 import { setCurrentPage } from 'woocommerce/state/ui/orders/actions';
 import NavItem from 'components/section-nav/item';
@@ -146,14 +145,13 @@ class Orders extends Component {
 	}
 
 	render() {
-		const { createOrderLink, orders, translate } = this.props;
+		const { orders, translate } = this.props;
 		if ( ! orders.length ) {
 			return (
 				<div className="orders__container">
 					<EmptyContent
 						title={ translate( 'Your orders will appear here as they come in.' ) }
-						action={ translate( 'Manually add an order' ) }
-						actionURL={ createOrderLink } />
+					/>
 				</div>
 			);
 		}
@@ -188,7 +186,6 @@ export default connect(
 	state => {
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site ? site.ID : false;
-		const createOrderLink = getSiteAdminUrl( state, siteId, 'post-new.php?post_type=shop_order' );
 		const currentPage = getOrdersCurrentPage( state, siteId );
 		const orders = getOrders( state, currentPage, siteId );
 		const ordersLoading = areOrdersLoading( state, currentPage, siteId );
@@ -196,7 +193,6 @@ export default connect(
 		const totalPages = getTotalOrdersPages( state, siteId );
 
 		return {
-			createOrderLink,
 			currentPage,
 			orders,
 			ordersLoading,


### PR DESCRIPTION
Removes the order activity log and 'add an order' button, since we support neither in v1.

To Test:
* Go to `http://calypso.localhost:3000/store/orders/:site` with no orders and make sure no button is present for `EmptyContent`.
* View a order and make sure the activity log is gone.