### PR TITLE
Comment likes: add module toggle for Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -181,6 +181,12 @@ class SiteSettingsFormDiscussion extends Component {
 					moduleSlug="gravatar-hovercards"
 					siteId={ siteId }
 				/>
+				<JetpackModuleToggle
+					disabled={ isRequestingSettings || isSavingSettings }
+					label={ translate( 'Enable comment likes' ) }
+					moduleSlug="comment-likes"
+					siteId={ siteId }
+				/>
 			</FormFieldset>
 		);
 	}


### PR DESCRIPTION
Add toggle for Comment likes module in order to sync it up with Discussion settings in Jetpack and enable managing this module from Calypso. For comparison, you can check `wp-admin/admin.php?page=jetpack#/discussion` page of your Jetpack site.

#### Testing instructions

1. In Calypso, navigate to `/settings/discussion/` of your test Jetpack site.
2. Verify that enabling and disabling of Comment likes module works as expected.
3. This toggle shouldn't be displayed for WP.com sites.