### PR TITLE
Editor: Add e2e data attributes to editor insert items

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -11,38 +11,38 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-const GridiconButton = ( { icon, label } ) => (
+const GridiconButton = ( { icon, label, insert } ) => (
 	<div>
 		<Gridicon className="wpcom-insert-menu__menu-icon" icon={ icon } />
-		<span className="wpcom-insert-menu__menu-label">{ label }</span>
+		<span className="wpcom-insert-menu__menu-label" data-e2e-insert-type={ insert }>{ label }</span>
 	</div>
 );
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
 const menuItems = [	{
 	name: 'insert_media_item',
-	item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } />,
+	item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } insert="media" />,
 	cmd: 'wpcomAddMedia'
 } ];
 
 if ( config.isEnabled( 'external-media' ) ) {
 	menuItems.push( {
 		name: 'insert_from_google',
-		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add from Google' ) } />,
+		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add from Google' ) } insert="google-media" />,
 		cmd: 'googleAddMedia'
 	} );
 }
 
 menuItems.push( {
 	name: 'insert_contact_form',
-	item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } />,
+	item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } insert="contact-form" />,
 	cmd: 'wpcomContactForm'
 } );
 
 if ( config.isEnabled( 'simple-payments' ) ) {
 	menuItems.push( {
 		name: 'insert_payment_button',
-		item: <GridiconButton icon="money" label={ i18n.translate( 'Add Payment Button' ) } />,
+		item: <GridiconButton icon="money" label={ i18n.translate( 'Add Payment Button' ) } insert="payment-button" />,
 		cmd: 'simplePaymentsButton'
 	} );
 }

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -11,38 +11,38 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-const GridiconButton = ( { icon, label, insert } ) => (
+const GridiconButton = ( { icon, label, e2e } ) => (
 	<div>
 		<Gridicon className="wpcom-insert-menu__menu-icon" icon={ icon } />
-		<span className="wpcom-insert-menu__menu-label" data-e2e-insert-type={ insert }>{ label }</span>
+		<span className="wpcom-insert-menu__menu-label" data-e2e-insert-type={ e2e }>{ label }</span>
 	</div>
 );
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
 const menuItems = [	{
 	name: 'insert_media_item',
-	item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } insert="media" />,
+	item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add Media' ) } e2e="media" />,
 	cmd: 'wpcomAddMedia'
 } ];
 
 if ( config.isEnabled( 'external-media' ) ) {
 	menuItems.push( {
 		name: 'insert_from_google',
-		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add from Google' ) } insert="google-media" />,
+		item: <GridiconButton icon="add-image" label={ i18n.translate( 'Add from Google' ) } e2e="google-media" />,
 		cmd: 'googleAddMedia'
 	} );
 }
 
 menuItems.push( {
 	name: 'insert_contact_form',
-	item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } insert="contact-form" />,
+	item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } e2e="contact-form" />,
 	cmd: 'wpcomContactForm'
 } );
 
 if ( config.isEnabled( 'simple-payments' ) ) {
 	menuItems.push( {
 		name: 'insert_payment_button',
-		item: <GridiconButton icon="money" label={ i18n.translate( 'Add Payment Button' ) } insert="payment-button" />,
+		item: <GridiconButton icon="money" label={ i18n.translate( 'Add Payment Button' ) } e2e="payment-button" />,
 		cmd: 'simplePaymentsButton'
 	} );
 }

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -469,7 +469,7 @@ export class EditorHtmlToolbar extends Component {
 				onClick={ this.openGoogleModal }
 			>
 				<Gridicon icon="add-image" />
-				<span>{ translate( 'Add from Google' ) }</span>
+				<span data-e2e-insert-type="google-media">{ translate( 'Add from Google' ) }</span>
 			</div>
 		);
 	}
@@ -487,7 +487,7 @@ export class EditorHtmlToolbar extends Component {
 				onClick={ null }
 			>
 				<Gridicon icon="money" />
-				<span>{ translate( 'Add Payment Button' ) }</span>
+				<span data-e2e-insert-type="payment-button">{ translate( 'Add Payment Button' ) }</span>
 			</div>
 		);
 	}
@@ -601,7 +601,7 @@ export class EditorHtmlToolbar extends Component {
 								onClick={ this.openMediaModal }
 							>
 								<Gridicon icon="add-image" />
-								<span>{ translate( 'Add Media' ) }</span>
+								<span data-e2e-insert-type="media">{ translate( 'Add Media' ) }</span>
 							</div>
 
 							{ this.renderExternal() }
@@ -611,7 +611,7 @@ export class EditorHtmlToolbar extends Component {
 								onClick={ this.openContactFormDialog }
 							>
 								<Gridicon icon="mention" />
-								<span>{ translate( 'Add Contact Form' ) }</span>
+								<span data-e2e-insert-type="contact-form">{ translate( 'Add Contact Form' ) }</span>
 							</div>
 
 							{ this.renderSimplePaymentsButton() }


### PR DESCRIPTION
This adds some data attributes to the insert options in the editor.

This is so that the e2e automated tests can appropriately identify the options. The e2e automated tests currently use the gridicon classes which are generic and can change with updates to the gridicon library. Also multiple menu items can use the same gridicon meaning this shouldn't be used for identification purposes.

**To Test**

Open the editor and choose insert and look at the rendered HTML for `data-e2e-insert-type` attributes on the menu items.

The PR to update the e2e automated tests is [here](https://github.com/Automattic/wp-e2e-tests/pull/610)