### PR TITLE
Magic Login: Shrink the illustration at landscape mobile sizes

### DIFF
--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -42,6 +42,7 @@ class EmailedLoginLinkExpired extends React.Component {
 						page( '/' );
 					} }
 					actionURL={ '/' }
+					className="magic-login__link-expired"
 					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					illustrationWidth={ 500 }
 					line={ translate( 'Maybe try resetting your password instead' ) }

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -49,6 +49,7 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 						page( '/' );
 					} }
 					actionURL={ '/' }
+					className="magic-login__check-email"
 					illustration={ '/calypso/images/drake/drake-all-done.svg' }
 					illustrationWidth={ 500 }
 					line={ line }

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -68,7 +68,7 @@ class MagicLogin extends React.Component {
 		);
 
 		const classes = classNames( 'magic-login', {
-			'magic-login__request_link': ! showCheckYourEmail,
+			'magic-login__request-link': ! showCheckYourEmail,
 		} );
 
 		return (

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -121,7 +121,7 @@ class RequestLoginEmailForm extends React.Component {
 						} ) }</p>
 				}
 				<LoggedOutForm onSubmit={ this.onSubmit }>
-					<FormFieldset className="magic-login__emailfields">
+					<FormFieldset className="magic-login__email-fields">
 						<FormTextInput
 							autoCapitalize="off"
 							autoFocus="true"

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -14,7 +14,23 @@
 	}
 }
 
-.magic-login__request_link {
+@media ( max-height: 450px ) {
+	.magic-login__handle-link, .magic-login__check-email, .magic-login__link-expired {
+		img {
+			margin-top: -45px;
+			max-height: 180px;
+		}
+		.empty-content__title {
+			font-size: 90%;
+		}
+		.empty-content__line {
+			font-size: 60%;
+			margin-bottom: 20px;
+		}
+	}
+}
+
+.magic-login__request-link {
 	max-width: 400px;
 }
 
@@ -25,7 +41,7 @@
 	text-align: center;
 }
 
-.magic-login__emailfields {
+.magic-login__email-fields {
 	margin: 10px 0;
 }
 


### PR DESCRIPTION
As @spen pointed out in #15754, small screens in a landscape orientation weren't looking and feeling that great due to oversized images, text, & whitespace. 

## Before

![](https://user-images.githubusercontent.com/4335450/27843793-3044da1a-6110-11e7-9a3c-82d9b5db5ab3.png) ![](https://user-images.githubusercontent.com/4335450/27843794-30451d0e-6110-11e7-8dd8-9ef94234f9cc.png)

## After

![link-is-expired-iphone6](https://user-images.githubusercontent.com/1587282/27893819-1cdb02e4-61d6-11e7-8e4c-50a283c0ebda.png) ![check-your-email-landscape-iphone6](https://user-images.githubusercontent.com/1587282/27893826-25c2e23c-61d6-11e7-9d91-a57f5b79e06e.png) ![interstitial-iphone6](https://user-images.githubusercontent.com/1587282/27893837-2f0ca0bc-61d6-11e7-9ede-12cc86607f2c.png)

This also takes the opportunity to fix up a couple of other class names so everything is consistent.

## To Test

Follow the test plan in #15754.