### PR TITLE
Domains: point expired and expiring domains nudge to checkout

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -67,8 +67,10 @@ class DomainWarnings extends React.PureComponent {
 			}
 		);
 		const compactMessage = translate( 'Renew', { context: 'Call to action link for renewing an expiring/expired domain' } );
+		const domain = domains[ 0 ].name;
+		const subscriptionId = domains[ 0 ].subscriptionId;
 		const link = count === 1
-			? purchasesPaths.managePurchase( selectedSite.slug, domains[ 0 ].subscriptionId )
+			? `/checkout/domain_map:${ domain }/renew/${ subscriptionId }/${ selectedSite.slug }`
 			: purchasesPaths.purchasesRoot();
 		return (
 			<NoticeAction href={ link }>


### PR DESCRIPTION
Second attempt on #15721 because many domains-related components have been refactored.

Users with expired or expiring domains see a nudge that invites them to renew. Instead of displaying a checkout though, it points them to /me/purchases, where they are two clicks away from renewing.

This will only handle users with exactly one expiring or expired domain.

Here is how it looks:

![update-nudge](https://user-images.githubusercontent.com/82778/27738324-b57ad5aa-5db3-11e7-988f-9a96d07d4f4e.gif)

To test:
0. Apply D6217-code
1. Expire a domain
2. Go to Calypso and verify that the nudge is there and works fine
3. Repeat with a domain that's near expiration
4. On a site with 2 expired domains, verify that the link points to /me/purchases

Note:
It's also possible to implement such page for renewing all expiring domains at once, but we've never had that. We should consider doing it. If all domains are added to the cart, it should just work.