### PR TITLE
Show happychat button only for paid jetpack users

### DIFF
--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -17,7 +17,7 @@ import {
 	HAPPYCHAT_GROUP_JPOP,
 	HAPPYCHAT_CONNECTION_ERROR_PING_TIMEOUT
 } from './constants';
-import { isJetpackSite, getSite } from 'state/sites/selectors';
+import { isJetpackSite, getSite, isCurrentPlanPaid } from 'state/sites/selectors';
 import { isATEnabled } from 'lib/automated-transfer';
 
 // How much time needs to pass before we consider the session inactive:
@@ -46,7 +46,7 @@ export const getGroups = ( state, siteId ) => {
 	if ( isATEnabled( siteDetails ) ) {
 		// AT sites should go to WP.com even though they are jetpack also
 		groups.push( HAPPYCHAT_GROUP_WPCOM );
-	} else if ( isJetpackSite( state, siteId ) ) {
+	} else if ( isJetpackSite( state, siteId ) && isCurrentPlanPaid( state, siteId ) ) {
 		groups.push( HAPPYCHAT_GROUP_JPOP );
 	} else {
 		groups.push( HAPPYCHAT_GROUP_WPCOM );

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -312,7 +312,7 @@ describe( 'selectors', () => {
 			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_WPCOM ] );
 		} );
 
-		it( 'should return JPOP group for jetpack site', () => {
+		it( 'should return JPOP group for jetpack paid sites', () => {
 			const siteId = 1;
 			const state = {
 				currentUser: {
@@ -325,7 +325,13 @@ describe( 'selectors', () => {
 				},
 				sites: {
 					items: {
-						[ siteId ]: { jetpack: true }
+						[ siteId ]: {
+							jetpack: true,
+							plan: {
+								product_id: 2005,
+								product_slug: 'jetpack_personal'
+							}
+						}
 					}
 				}
 			};


### PR DESCRIPTION
## Summary
Currently if you select a free plan jetpack site in the help section dropdown happychat will be available. This PR updates that behavior sending only customers with a paid jetpack site selected to JPOP operators.

## Implementation
- Add `isCurrentPlanPaid` check for jetpack sites. 

## Testing steps
1. Setup 2 jetpack site in your account, one with paid plan and one with the free plan. (get some pressable ones search updateomattic for Would you like a Pressable Account?)
2. In HUD set your operator to only accept JPOP
3. Go to `help/contact` page
4. Select the free jetpack site -> Email form should be displayed
5. Select the paid jetpack site -> Happychat button should be available.