### PR TITLE
Comments: Replace links with <ExternalLink> where applicable

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -11,6 +11,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { urlToDomainAndPath } from 'lib/url';
@@ -33,6 +34,7 @@ export class CommentDetailAuthor extends Component {
 		blockUser: PropTypes.func,
 		commentDate: PropTypes.string,
 		commentStatus: PropTypes.string,
+		postUrl: PropTypes.string,
 		showAuthorInfo: PropTypes.bool,
 		siteId: PropTypes.number,
 	};
@@ -119,9 +121,9 @@ export class CommentDetailAuthor extends Component {
 					</div>
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="link" />
-						<span>
-							{ authorUrl }
-						</span>
+						<ExternalLink href={ authorUrl }>
+							{ urlToDomainAndPath( authorUrl ) }
+						</ExternalLink>
 					</div>
 					<div className="comment-detail__author-more-element">
 						<Gridicon icon="globe" />
@@ -154,6 +156,7 @@ export class CommentDetailAuthor extends Component {
 			authorDisplayName,
 			authorUrl,
 			commentStatus,
+			postUrl,
 			showAuthorInfo,
 			siteId,
 			translate,
@@ -175,13 +178,16 @@ export class CommentDetailAuthor extends Component {
 							<strong>
 								{ authorDisplayName }
 							</strong>
-							<span>
+							<ExternalLink href={ authorUrl }>
 								{ urlToDomainAndPath( authorUrl ) }
-							</span>
+							</ExternalLink>
 						</div>
-						<div className="comment-detail__author-info-element comment-detail__comment-date">
+						<ExternalLink
+							className="comment-detail__author-info-element comment-detail__comment-date"
+							href={ postUrl }
+						>
 							{ this.getFormattedDate() }
-						</div>
+						</ExternalLink>
 					</div>
 					{ 'unapproved' === commentStatus &&
 						<div className="comment-detail__status-label is-unapproved">

--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -25,6 +25,7 @@ export class CommentDetailComment extends Component {
 		commentContent: PropTypes.string,
 		commentDate: PropTypes.string,
 		commentStatus: PropTypes.string,
+		postUrl: PropTypes.string,
 		siteId: PropTypes.number,
 	};
 
@@ -41,6 +42,7 @@ export class CommentDetailComment extends Component {
 			commentContent,
 			commentDate,
 			commentStatus,
+			postUrl,
 			repliedToComment,
 			siteId,
 			translate,
@@ -60,6 +62,7 @@ export class CommentDetailComment extends Component {
 						blockUser={ blockUser }
 						commentDate={ commentDate }
 						commentStatus={ commentStatus }
+						postUrl={ postUrl }
 						siteId={ siteId }
 					/>
 					<AutoDirection>

--- a/client/blocks/comment-detail/comment-detail-post.jsx
+++ b/client/blocks/comment-detail/comment-detail-post.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import SiteIcon from 'blocks/site-icon';
 
@@ -39,9 +40,9 @@ export const CommentDetailPost = ( {
 							{ translate( '%(authorName)s:', { args: { authorName: parentCommentAuthorDisplayName } } ) }
 						</span>
 					}
-					<a href={ parentCommentUrl }>
+					<ExternalLink href={ parentCommentUrl }>
 						{ parentCommentContent }
-					</a>
+					</ExternalLink>
 				</div>
 			</div>
 		);

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -200,6 +200,7 @@ export class CommentDetail extends Component {
 							commentContent={ commentContent }
 							commentDate={ commentDate }
 							commentStatus={ commentStatus }
+							postUrl={ postUrl }
 							repliedToComment={ repliedToComment }
 							siteId={ siteId }
 						/>

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -48,6 +48,15 @@
 		color: $gray-text;
 		margin-right: 8px;
 	}
+
+	a {
+		color: $gray-text-min;
+		cursor: pointer;
+		&:focus,
+		&:hover {
+			color: $blue-wordpress;
+		}
+	}
 }
 
 .comment-detail__author-info-element {
@@ -401,7 +410,9 @@ a.comment-detail__author-more-element {
 
 	.comment-detail__author-info {
 		line-height: 1.2;
+		overflow: hidden;
 		padding-left: 8px;
+		text-overflow: ellipsis;
 	}
 }
 


### PR DESCRIPTION
Fixes #15807 

Replaces all links to external sites with `<ExternalLink>`.

- Post Title, linking to the comment permalink.
- Author URL (both in the author info preview, and in the currently hidden author more info), linking to the author URL.
- Comment Date, linking to the comment permalink.


_Also added a missing `text-overflow: ellipsis` to an element in author more info.
It's not relevant to this PR and to test it we need to flip [this variable](https://github.com/Automattic/wp-calypso/blob/60945489c41c873a765a3353f114ed2c2f8734c5/client/blocks/comment-detail/comment-detail-author.jsx#L43), but it's two CSS rules that I was bound to forget in 10 minutes._

cc @Automattic/lannister 