### PR TITLE
Comments: Replace header action links with <Button>s

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -7,6 +7,11 @@ import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { includes } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
 const commentActions = {
 	unapproved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
 	approved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
@@ -34,7 +39,8 @@ export const CommentDetailActions = ( {
 	return (
 		<div className="comment-detail__actions">
 			{ hasAction( commentStatus, 'like' ) &&
-				<a
+				<Button
+					borderless
 					className={ classNames( 'comment-detail__action-like', { 'is-liked': commentIsLiked } ) }
 					onClick={ toggleLike }
 				>
@@ -44,11 +50,12 @@ export const CommentDetailActions = ( {
 							? translate( 'Liked' )
 							: translate( 'Like' )
 					}</span>
-				</a>
+				</Button>
 			}
 
 			{ hasAction( commentStatus, 'approve' ) &&
-				<a
+				<Button
+					borderless
 					className={ classNames( 'comment-detail__action-approve', { 'is-approved': isApproved } ) }
 					onClick={ toggleApprove }
 				>
@@ -58,18 +65,23 @@ export const CommentDetailActions = ( {
 							? translate( 'Approved' )
 							: translate( 'Approve' )
 					}</span>
-				</a>
+				</Button>
 			}
 
 			{ hasAction( commentStatus, 'edit' ) &&
-				<a className="comment-detail__action-edit" onClick={ edit }>
+				<Button
+					borderless
+					className="comment-detail__action-edit"
+					onClick={ edit }
+				>
 					<Gridicon icon="pencil" />
 					<span>{ translate( 'Edit' ) }</span>
-				</a>
+				</Button>
 			}
 
 			{ hasAction( commentStatus, 'spam' ) &&
-				<a
+				<Button
+					borderless
 					className={ classNames( 'comment-detail__action-spam', { 'is-spam': isSpam } ) }
 					onClick={ toggleSpam }
 				>
@@ -79,11 +91,12 @@ export const CommentDetailActions = ( {
 							? translate( 'Spammed' )
 							: translate( 'Spam' )
 					}</span>
-				</a>
+				</Button>
 			}
 
 			{ hasAction( commentStatus, 'trash' ) &&
-				<a
+				<Button
+					borderless
 					className={ classNames( 'comment-detail__action-trash', { 'is-trash': isTrash } ) }
 					onClick={ toggleTrash }
 				>
@@ -93,17 +106,18 @@ export const CommentDetailActions = ( {
 							? translate( 'Trashed' )
 							: translate( 'Trash' )
 					}</span>
-				</a>
+				</Button>
 			}
 
 			{ hasAction( commentStatus, 'delete' ) &&
-				<a
+				<Button
+					borderless
 					className="comment-detail__action-delete"
 					onClick={ deleteCommentPermanently }
 				>
 					<Gridicon icon="trash" />
 					<span>{ translate( 'Delete Permanently' ) }</span>
-				</a>
+				</Button>
 			}
 		</div>
 	);

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -11,6 +11,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Button from 'components/button';
 import CommentDetailActions from './comment-detail-actions';
 import Gravatar from 'components/gravatar';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -41,11 +42,14 @@ export const CommentDetailHeader = ( {
 	if ( isExpanded ) {
 		return (
 			<div className="comment-detail__header">
-				<div className="comment-detail__actions">
-					<a onClick={ toggleExpanded }>
-						<Gridicon icon="cross" />
-					</a>
-				</div>
+				<Button
+					borderless
+					className="comment-detail__action-collapse"
+					onClick={ toggleExpanded }
+				>
+					<Gridicon icon="cross" />
+				</Button>
+
 				<CommentDetailActions
 					edit={ edit }
 					commentIsLiked={ commentIsLiked }

--- a/client/blocks/comment-detail/comment-detail-placeholder.jsx
+++ b/client/blocks/comment-detail/comment-detail-placeholder.jsx
@@ -10,7 +10,7 @@ import Card from 'components/card';
 
 export const CommentDetailPlaceholder = () =>
 	<Card className="comment-detail comment-detail__placeholder is-expanded">
-		<div className="comment-detail__header">
+		<div className="comment-detail__header is-preview">
 			<div className="comment-detail__author-info">
 				<div className="comment-detail__author-avatar gravatar" />
 			</div>

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -60,10 +60,10 @@
 	align-items: center;
 	display: flex;
 	flex-flow: row nowrap;
-	padding: 12px 8px;
 
 	&.is-preview {
 		cursor: pointer;
+		padding: 12px 8px;
 	}
 
 	&.is-bulk-edit {
@@ -79,6 +79,21 @@
 			.external-link:focus {
 				outline: none;
 			}
+		}
+	}
+
+	.button.is-borderless {
+		padding: 12px 8px;
+
+		.gridicon {
+			margin-top: 0;
+			top: 0;
+		}
+
+		&.comment-detail__action-collapse {
+			flex-grow: 1;
+			padding-left: 12px;
+			text-align: left;
 		}
 	}
 
@@ -145,60 +160,54 @@
 
 .comment-detail__actions {
 	color: $gray;
+	padding-right: 4px;
 	user-select: none;
 
-	a {
-		color: $gray-text-min;
-		cursor: pointer;
-		padding: 8px;
-		white-space: nowrap;
-		&:focus,
-		&:hover {
-			color: $blue-wordpress;
-		}
-	}
-	span {
-		display: none;
+	.button.is-borderless {
+		span {
+			display: none;
+			font-weight: normal;
 
-		@include breakpoint( ">960px" ) {
-			display: inline;
+			@include breakpoint( ">960px" ) {
+				display: inline;
+			}
 		}
-	}
 
-	.comment-detail__action-like {
-		&:focus,
-		&:hover {
-			color: $orange-jazzy;
+		&.comment-detail__action-like {
+			&:focus,
+			&:hover {
+				color: $orange-jazzy;
+			}
 		}
-	}
 
-	.comment-detail__action-approve {
-		&:focus,
-		&:hover {
+		&.comment-detail__action-approve {
+			&:focus,
+			&:hover {
+				color: $alert-green;
+			}
+		}
+
+		&.comment-detail__action-spam,
+		&.comment-detail__action-trash,
+		&.comment-detail__action-delete {
+			&:focus,
+			&:hover {
+				color: $alert-red;
+			}
+		}
+
+		&.is-approved {
 			color: $alert-green;
 		}
-	}
-
-	.comment-detail__action-spam,
-	.comment-detail__action-trash,
-	.comment-detail__action-delete {
-		&:focus,
-		&:hover {
+		&.is-liked {
+			color: $orange-jazzy;
+		}
+		&.is-spam {
 			color: $alert-red;
 		}
-	}
-
-	.is-approved {
-		color: $alert-green;
-	}
-	.is-liked {
-		color: $orange-jazzy;
-	}
-	.is-spam {
-		color: $alert-red;
-	}
-	.is-trash {
-		color: $gray-dark;
+		&.is-trash {
+			color: $gray-dark;
+		}
 	}
 }
 


### PR DESCRIPTION
Replaces all action links in the <CommentDetail> header with <Button> components.

This increases the stylesheet specificity to override some `.button` rules, but should also allow for a better development experience than simple links.

As a side effect, this also expand the close button area to **all available space** to the left of the other actions, in order to give user an easier way to collapse open comments.

cc @Automattic/lannister 