### PR TITLE
Site Settings: Cleanup General settings controller

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import i18n from 'i18n-calypso';
 import page from 'page';
 import React from 'react';
 
@@ -9,18 +8,13 @@ import React from 'react';
  * Internal Dependencies
  */
 import AsyncLoad from 'components/async-load';
-import analytics from 'lib/analytics';
 import config from 'config';
 import DeleteSite from './delete-site';
 import purchasesPaths from 'me/purchases/paths';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import route from 'lib/route';
-import { sectionify } from 'lib/route/path';
-import SiteSettingsComponent from 'my-sites/site-settings/main';
+import SiteSettingsMain from 'my-sites/site-settings/main';
 import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import titlecase from 'to-title-case';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser, isVipSite } from 'state/selectors';
@@ -85,32 +79,11 @@ const controller = {
 		}
 	},
 
-	siteSettings( context ) {
-		let analyticsPageTitle = 'Site Settings';
-		const basePath = route.sectionify( context.path );
-		const siteId = getSelectedSiteId( context.store.getState() );
-		const section = sectionify( context.path ).split( '/' )[ 2 ];
-		const state = context.store.getState();
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( i18n.translate( 'Site Settings', { textOnly: true } ) ) );
-
-		// if site loaded, but user cannot manage site, redirect
-		if ( siteId && ! canCurrentUser( state, siteId, 'manage_options' ) ) {
-			page.redirect( '/stats' );
-			return;
-		}
-
+	general( context ) {
 		renderPage(
 			context,
-			<SiteSettingsComponent section={ section } />
+			<SiteSettingsMain />
 		);
-
-		// analytics tracking
-		if ( 'undefined' !== typeof section ) {
-			analyticsPageTitle += ' > ' + titlecase( section );
-		}
-		analytics.pageView.record( basePath + '/:site', analyticsPageTitle );
 	},
 
 	importSite( context ) {
@@ -196,13 +169,6 @@ const controller = {
 		}
 		next();
 	},
-
-	setScroll( context, next ) {
-		window.scroll( 0, 0 );
-		next();
-	}
-
 };
 
 export default controller;
-

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -7,74 +7,74 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
-import controller from 'my-sites/controller';
-import settingsController from 'my-sites/site-settings/controller';
+import mySitesController from 'my-sites/controller';
+import controller from 'my-sites/site-settings/controller';
 
 module.exports = function() {
 	page(
 		'/settings',
-		controller.siteSelection,
-		settingsController.redirectToGeneral
+		mySitesController.siteSelection,
+		controller.redirectToGeneral
 	);
 	page(
 		'/settings/general/:site_id',
-		controller.siteSelection,
-		controller.navigation,
-		settingsController.setScroll,
-		settingsController.siteSettings
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		controller.setScroll,
+		controller.siteSettings
 	);
 
 	page(
 		'/settings/import/:site_id',
-		controller.siteSelection,
-		controller.navigation,
-		settingsController.importSite
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		controller.importSite
 	);
 
 	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
 		page(
 			'/settings/export/guided/:host_slug?/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			settingsController.guidedTransfer
+			mySitesController.siteSelection,
+			mySitesController.navigation,
+			controller.guidedTransfer
 		);
 	}
 
 	if ( config.isEnabled( 'manage/export' ) ) {
 		page(
 			'/settings/export/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			settingsController.exportSite
+			mySitesController.siteSelection,
+			mySitesController.navigation,
+			controller.exportSite
 		);
 	}
 
 	page(
 		'/settings/delete-site/:site_id',
-		controller.siteSelection,
-		controller.navigation,
-		settingsController.setScroll,
-		settingsController.deleteSite
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		controller.setScroll,
+		controller.deleteSite
 	);
 	page(
 		'/settings/start-over/:site_id',
-		controller.siteSelection,
-		controller.navigation,
-		settingsController.setScroll,
-		settingsController.startOver
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		controller.setScroll,
+		controller.startOver
 	);
 	page(
 		'/settings/theme-setup/:site_id',
-		controller.siteSelection,
-		controller.navigation,
-		settingsController.setScroll,
-		settingsController.themeSetup
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		controller.setScroll,
+		controller.themeSetup
 	);
 
 	page(
 		'/settings/:section',
-		settingsController.legacyRedirects,
-		controller.siteSelection,
-		controller.sites
+		controller.legacyRedirects,
+		mySitesController.siteSelection,
+		mySitesController.sites
 	);
 };

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -9,6 +9,7 @@ import page from 'page';
 import config from 'config';
 import mySitesController from 'my-sites/controller';
 import controller from 'my-sites/site-settings/controller';
+import settingsController from 'my-sites/site-settings/settings-controller';
 
 module.exports = function() {
 	page(
@@ -20,8 +21,9 @@ module.exports = function() {
 		'/settings/general/:site_id',
 		mySitesController.siteSelection,
 		mySitesController.navigation,
-		controller.setScroll,
-		controller.siteSettings
+		settingsController.setScroll,
+		settingsController.siteSettings,
+		controller.general,
 	);
 
 	page(
@@ -53,21 +55,21 @@ module.exports = function() {
 		'/settings/delete-site/:site_id',
 		mySitesController.siteSelection,
 		mySitesController.navigation,
-		controller.setScroll,
+		settingsController.setScroll,
 		controller.deleteSite
 	);
 	page(
 		'/settings/start-over/:site_id',
 		mySitesController.siteSelection,
 		mySitesController.navigation,
-		controller.setScroll,
+		settingsController.setScroll,
 		controller.startOver
 	);
 	page(
 		'/settings/theme-setup/:site_id',
 		mySitesController.siteSelection,
 		mySitesController.navigation,
-		controller.setScroll,
+		settingsController.setScroll,
 		controller.themeSetup
 	);
 

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -3,11 +3,13 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -19,10 +21,12 @@ import JetpackDevModeNotice from './jetpack-dev-mode-notice';
 
 const SiteSettingsComponent = ( {
 	jetpackSettingsUiSupported,
-	siteId
+	siteId,
+	translate
 } ) => {
 	return (
 		<Main className="site-settings">
+			<DocumentHead title={ translate( 'Site Settings' ) } />
 			{ jetpackSettingsUiSupported && <JetpackDevModeNotice /> }
 			<SidebarNavigation />
 			{ siteId && <SiteSettingsNavigation section={ 'general' } /> }
@@ -50,4 +54,4 @@ export default connect(
 			jetpackSettingsUiSupported: jetpackSite && jetpackUiSupported,
 		};
 	}
-)( SiteSettingsComponent );
+)( localize( SiteSettingsComponent ) );


### PR DESCRIPTION
As we were refactoring settings to split the codebase in separate chunks, we had to repeat some code in order to properly observe the chunk size changes. Now that we've finished splitting code, it's time for some cleanup.

This PR cleans up stuff from the main settings controller, and makes it use the shared settings controller instead (it's the one that the other settings sections use). This helps us clean up most of the code that we had to repeat during the splitting process.

In addition, since the `main.jsx` is now used only for the General settings section, we're renaming it accordingly.

To test:

* Checkout this branch
* Go to `/settings/general/:site` and verify it loads correctly, settings are retrieved and saved correctly, where:
  * `:site` is a WordPress.com site.
  * `:site` is a Jetpack site.
* Test the above steps with a clean Redux state.
* Play with the other settings sections and verify they also load correctly.