### PR TITLE
Prevent cancellation of a plan or domain on an AT site

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -15,6 +15,7 @@ import { get } from 'lodash';
  */
 import wpcom from 'lib/wp';
 import config from 'config';
+import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
@@ -261,6 +262,14 @@ class RemovePurchase extends Component {
 		);
 	};
 
+	getContactUsButton = () => {
+		return (
+			<Button className="remove-purchase__support-link-button" href="/help/contact/">
+				{ this.props.translate( 'Contact Us' ) }
+			</Button>
+		);
+	};
+
 	renderDomainDialog() {
 		const { translate } = this.props;
 		const buttons = [
@@ -425,8 +434,12 @@ class RemovePurchase extends Component {
 
 	renderAtomicDialog( purchase ) {
 		const { translate } = this.props;
+		const supportButton = this.state.isChatAvailable
+			? this.getChatButton()
+			: this.getContactUsButton();
+
 		const buttons = [
-			this.getChatButton(),
+			supportButton,
 			{
 				action: 'cancel',
 				disabled: this.state.isRemoving,
@@ -443,11 +456,12 @@ class RemovePurchase extends Component {
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
 			>
-				<FormSectionHeading>
-					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
-				</FormSectionHeading>
+				<FormSectionHeading />
 				<p>
-					{ translate( 'One does not simply remove %(productName)s.', { args: { productName } } ) }
+					{ translate(
+						'Unfortunately, you need to contact support to cancel your %(productName)s plan.',
+						{ args: { productName } }
+					) }
 				</p>
 			</Dialog>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -459,8 +459,11 @@ class RemovePurchase extends Component {
 				<FormSectionHeading />
 				<p>
 					{ translate(
-						'Unfortunately, you need to contact support to cancel your %(productName)s plan.',
-						{ args: { productName } }
+						'To cancel your %(productName)s plan, please contact our support team' +
+							'-- a Happiness Engineer will take care of it.',
+						{
+							args: { productName },
+						}
 					) }
 				</p>
 			</Dialog>


### PR DESCRIPTION
Cancelling the Business plan or a domain on an AT site leaves that site in an inconsistent state: the site is on Pressable, but no longer has the Business plan or a primary domain other than *.wordpress.com. In such state, not even the hard-revert script works.

When trying to remove a plan or domain purchase from an AT site, I show this dialog:

<img width="506" alt="screen shot 2017-07-06 at 14 21 37" src="https://user-images.githubusercontent.com/664258/27911408-4294cd7a-6259-11e7-9533-e9099bbe647b.png">

I need help with the text on the dialog, of course. @iamtakashi, can you help? The idea is that the user needs to contact support if they want to cancel the plan or the domain. There is the "Need to chat" button, but I'm not sure if that's the best solution. Chat isn't always available, which means no button is rendered, and maybe the wording could be better.

I also need to test this on cancelling a domain for the site -- so far, I tested only the plan cancellation, as the domain is usually included in the plan and cannot be cancelled separately anyway.

What's a bit strange that I can't add multiple domains to an AT site. The "Add Domain" button is not rendered. It's [because the site has a `jetpack` property](https://github.com/Automattic/wp-calypso/blob/90dec34daa06fe18c9de52c207492596f7a7180d/client/my-sites/upgrades/domain-management/list/index.jsx#L230) set to `true` on an AT site. @lamosty, isn't that a bug? Or is there a reason why an AT site shouldn't have multiple alternate domain names?

