### PR TITLE
Config: Remove obsolete manage/export flag

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -18,12 +18,11 @@ import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
 import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
 import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
 import Button from 'components/button';
-import config from 'config';
 import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-dialog';
 import Dialog from 'components/dialog';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getSite, getSiteDomain, getSiteOption } from 'state/sites/selectors';
+import { getSite, getSiteDomain } from 'state/sites/selectors';
 import Notice from 'components/notice';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { deleteSite } from 'state/sites/actions';
@@ -128,11 +127,8 @@ class DeleteSite extends Component {
 	};
 
 	render() {
-		const { adminUrl, siteDomain, siteId, siteSlug, translate } = this.props;
-		const exportLink = config.isEnabled( 'manage/export' )
-			? '/settings/export/' + siteSlug
-			: adminUrl + 'tools.php?page=export-choices';
-		const exportTarget = config.isEnabled( 'manage/export' ) ? undefined : '_blank';
+		const { siteDomain, siteId, siteSlug, translate } = this.props;
+		const exportLink = '/settings/export/' + siteSlug;
 		const deleteDisabled =
 			typeof this.state.confirmDomain !== 'string' ||
 			this.state.confirmDomain.toLowerCase().replace( /\s/g, '' ) !== siteDomain;
@@ -188,8 +184,7 @@ class DeleteSite extends Component {
 							className="settings-action-panel__export-button"
 							disabled={ ! siteId }
 							onClick={ this._checkSiteLoaded }
-							href={ exportLink }
-							target={ exportTarget }>
+							href={ exportLink }>
 							{ strings.exportContent }
 							<Gridicon icon="external" />
 						</Button>
@@ -269,9 +264,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const siteDomain = getSiteDomain( state, siteId );
 		const siteSlug = getSelectedSiteSlug( state );
-		const adminUrl = getSiteOption( state, siteId, 'admin_url' );
 		return {
-			adminUrl,
 			hasLoadedSitePurchasesFromServer: hasLoadedSitePurchasesFromServer( state ),
 			siteDomain,
 			siteId,

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -42,14 +42,12 @@ module.exports = function() {
 		);
 	}
 
-	if ( config.isEnabled( 'manage/export' ) ) {
-		page(
-			'/settings/export/:site_id',
-			mySitesController.siteSelection,
-			mySitesController.navigation,
-			controller.exportSite
-		);
-	}
+	page(
+		'/settings/export/:site_id',
+		mySitesController.siteSelection,
+		mySitesController.navigation,
+		controller.exportSite
+	);
 
 	page(
 		'/settings/delete-site/:site_id',

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -28,7 +28,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/export": true,
 		"manage/import/medium": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
-		"manage/export": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/media": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/export": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/media": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,7 +30,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/export": true,
 		"manage/import/medium": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -35,7 +35,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/export": true,
 		"manage/import/medium": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": false,

--- a/config/test.json
+++ b/config/test.json
@@ -43,7 +43,6 @@
 		"keyboard-shortcuts": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/export": true,
 		"manage/import/medium": true,
 		"manage/media": true,
 		"manage/option_sync_non_public_post_stati": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,7 +43,6 @@
 		"manage/customize": true,
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
-		"manage/export": true,
 		"manage/export/guided-transfer": true,
 		"manage/import/medium": true,
 		"manage/media": true,


### PR DESCRIPTION
This PR removes the `manage/export` config flag, as it's already enabled in all environments. There should be no functional/behavioral/visual changes introduced by this PR.

To test:
* Checkout this branch or get it going on calypso.live.
* Let `:site` be a WordPress.com site.
* Verify there are no regressions on the following routes:
  * `/settings/delete-site/:site`
  * `/settings/export/:site`