### PR TITLE
Update/woocommerce language

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -50,9 +50,8 @@ class ManageNoOrdersView extends Component {
 				title={ translate( 'Looking for stats?' ) }
 			>
 				<p>
-					{ translate( 'This dashboard will evolve as your store grows.' +
-						' Statistics will form and order overviews will display as soon as' +
-						' your orders start arriving.' ) }
+					{ translate( 'Store statistic and reports can be found on the site stats screen.' +
+						' Keep an eye on revenues, order totals, popular products and more.' ) }
 				</p>
 			</BasicWidget>
 		);

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -89,7 +89,7 @@ class SettingsPaymentsLocationCurrency extends Component {
 						)
 					} />
 				<Card className="payments__address-currency-container">
-					<StoreAddress />
+					<StoreAddress showLabel={ false } />
 					<div className="payments__currency-container">
 						<FormLabel>
 							{ translate( 'Store Currency' ) }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
@@ -16,7 +16,7 @@ const ShippingOrigin = ( { translate } ) => {
 			<ExtendedHeader
 				label={ translate( 'Shipping Origin' ) }
 				description={ translate( 'The address of where you will be shipping from.' ) } />
-			<StoreAddress />
+			<StoreAddress showLabel={ false } />
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -160,7 +160,7 @@ class SettingsTaxes extends Component {
 				<SettingsNavigation activeSection="taxes" />
 				<div className="taxes__nexus">
 					<ExtendedHeader
-						label={ translate( 'Store Address / Tax Nexus' ) }
+						label={ translate( 'Store Address' ) }
 						description={ translate( 'The address of where your business is located for tax purposes.' ) } />
 					<StoreAddress className="taxes__store-address" onSetAddress={ this.onAddressChange } />
 				</div>

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -162,7 +162,7 @@ class SettingsTaxes extends Component {
 					<ExtendedHeader
 						label={ translate( 'Store Address' ) }
 						description={ translate( 'The address of where your business is located for tax purposes.' ) } />
-					<StoreAddress className="taxes__store-address" onSetAddress={ this.onAddressChange } />
+					<StoreAddress className="taxes__store-address" onSetAddress={ this.onAddressChange } showLabel={ false } />
 				</div>
 				<TaxesRates
 					taxesEnabled={ this.state.taxesEnabled }

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -130,9 +130,9 @@ class StoreAddress extends Component {
 		} else {
 			display = (
 				<div>
-					{ false != this.props.showLabel && (
+					{ this.props.showLabel && (
 						<FormLabel>{ translate( 'Store location' ) }</FormLabel>
-					)}
+					) }
 					<AddressView address={ this.state.address } />
 					<a onClick={ this.onShowDialog }>{ translate( 'Edit address' ) }</a>
 				</div>

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -48,6 +48,7 @@ class StoreAddress extends Component {
 		super( props );
 		this.state = {
 			showDialog: false,
+			showLabel: true,
 			address: props.address,
 		};
 	}
@@ -129,6 +130,9 @@ class StoreAddress extends Component {
 		} else {
 			display = (
 				<div>
+					{ false != this.props.showLabel && (
+						<FormLabel>{ translate( 'Store location' ) }</FormLabel>
+					)}
 					<AddressView address={ this.state.address } />
 					<a onClick={ this.onShowDialog }>{ translate( 'Edit address' ) }</a>
 				</div>
@@ -138,7 +142,6 @@ class StoreAddress extends Component {
 		const classes = classNames( 'store-address', { 'is-placeholder': ! site || loading }, className );
 		return (
 			<Card className={ classes }>
-				<FormLabel>{ translate( 'Store location' ) }</FormLabel>
 				<Dialog
 					buttons={ buttons }
 					isVisible={ this.state.showDialog }

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -23,6 +23,10 @@ import FormLabel from 'components/forms/form-label';
 
 class StoreAddress extends Component {
 
+	static defaultProps = {
+		showLabel: true,
+	};
+
 	componentDidMount = () => {
 		const { site } = this.props;
 
@@ -48,7 +52,6 @@ class StoreAddress extends Component {
 		super( props );
 		this.state = {
 			showDialog: false,
-			showLabel: true,
 			address: props.address,
 		};
 	}
@@ -110,7 +113,7 @@ class StoreAddress extends Component {
 	}
 
 	render() {
-		const { className, site, loading, translate } = this.props;
+		const { className, site, loading, translate, showLabel } = this.props;
 
 		const buttons = [
 			{ action: 'close', label: translate( 'Close' ) },
@@ -130,7 +133,7 @@ class StoreAddress extends Component {
 		} else {
 			display = (
 				<div>
-					{ this.props.showLabel && (
+					{ showLabel && (
 						<FormLabel>{ translate( 'Store location' ) }</FormLabel>
 					) }
 					<AddressView address={ this.state.address } />

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/actions.js
@@ -20,7 +20,7 @@ export const fetchShippingZoneLocations = ( siteId, zoneId ) => ( dispatch, getS
 		return;
 	}
 
-	//0 is Rest of the World zone, skip fetching locations
+	//0 is Locations not covered by your other zones zone, skip fetching locations
 	if ( 0 === zoneId ) {
 		dispatch( {
 			type: WOOCOMMERCE_SHIPPING_ZONE_LOCATIONS_REQUEST_SUCCESS,

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
@@ -54,7 +54,8 @@ export const areShippingZonesLocationsValid = ( reduxState, siteId = getSelected
 		if ( ! areShippingZoneLocationsLoaded( reduxState, zoneId, siteId ) ) {
 			continue;
 		}
-		if ( 0 === Number( zoneId ) ) { // The "Locations not covered by your other zones" zone is always valid, it doesn't have any locations
+		// The "Locations not covered by your other zones" zone is always valid, it doesn't have any locations
+		if ( 0 === Number( zoneId ) ) {
 			continue;
 		}
 

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/selectors.js
@@ -54,7 +54,7 @@ export const areShippingZonesLocationsValid = ( reduxState, siteId = getSelected
 		if ( ! areShippingZoneLocationsLoaded( reduxState, zoneId, siteId ) ) {
 			continue;
 		}
-		if ( 0 === Number( zoneId ) ) { // The "Rest of the world" zone is always valid, it doesn't have any locations
+		if ( 0 === Number( zoneId ) ) { // The "Locations not covered by your other zones" zone is always valid, it doesn't have any locations
 			continue;
 		}
 

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/test/selectors.js
@@ -132,7 +132,7 @@ describe( 'selectors', () => {
 			expect( areShippingZonesLocationsValid( state ) ).to.be.true;
 		} );
 
-		it( 'should return true for the "Rest of the world" zone.', () => {
+		it( 'should return true for the "Locations not covered by your other zones" zone.', () => {
 			const state = createState( {
 				site: {
 					shippingZoneLocations: {

--- a/client/extensions/woocommerce/state/sites/shipping-zones/README.md
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/README.md
@@ -19,7 +19,7 @@ This is saved on a per-site basis, either as "LOADING" (when requesting zones), 
 	// or
 	"shippingZones": [ {
 		"id": 0,
-		"name": "Rest of the World",
+		"name": "Locations not covered by your other zones",
 		"order": 0,
 	}, { … } ],
 }

--- a/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { findIndex, isArray } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,6 +21,13 @@ import {
 } from 'woocommerce/state/action-types';
 
 // TODO: Handle error
+
+const processZoneData = ( zoneData ) => {
+	if ( 0 !== zoneData.id ) {
+		return zoneData;
+	}
+	return { ...zoneData, name: translate( 'Locations not covered by your other zones' ) };
+};
 
 export default createReducer( null, {
 	[ WOOCOMMERCE_SHIPPING_ZONE_METHODS_REQUEST ]: ( state, { zoneId } ) => {
@@ -62,6 +70,7 @@ export default createReducer( null, {
 	},
 
 	[ WOOCOMMERCE_SHIPPING_ZONE_UPDATED ]: ( state, { data, originatingAction: { zone } } ) => {
+		data = processZoneData( data );
 		if ( ! isArray( state ) ) {
 			return state;
 		}
@@ -159,6 +168,6 @@ export default createReducer( null, {
 	},
 
 	[ WOOCOMMERCE_SHIPPING_ZONES_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data;
+		return data.map( processZoneData );
 	},
 } );

--- a/client/extensions/woocommerce/state/sites/shipping-zones/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/test/actions.js
@@ -29,7 +29,7 @@ describe( 'actions', () => {
 				.reply( 200, {
 					data: [ {
 						id: 0,
-						name: 'Rest of the World',
+						name: 'Locations not covered by your other zones',
 						order: 0,
 					} ]
 				} );
@@ -53,7 +53,7 @@ describe( 'actions', () => {
 					siteId,
 					data: [ {
 						id: 0,
-						name: 'Rest of the World',
+						name: 'Locations not covered by your other zones',
 						order: 0,
 					} ]
 				} );

--- a/client/extensions/woocommerce/state/sites/shipping-zones/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/test/reducer.js
@@ -28,7 +28,7 @@ describe( 'reducer', () => {
 	it( 'should store data from the action', () => {
 		const siteId = 123;
 		const zones = [
-			{ id: 0, name: 'Rest of the World' },
+			{ id: 0, name: 'Locations not covered by your other zones' },
 			{ id: 1, name: 'USA' },
 		];
 		const action = {

--- a/client/extensions/woocommerce/state/sites/shipping-zones/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/test/reducer.js
@@ -28,7 +28,7 @@ describe( 'reducer', () => {
 	it( 'should store data from the action', () => {
 		const siteId = 123;
 		const zones = [
-			{ id: 0, name: 'Locations not covered by your other zones' },
+			{ id: 0, name: 'Rest of the World (this name will be overwritten)' },
 			{ id: 1, name: 'USA' },
 		];
 		const action = {
@@ -38,6 +38,9 @@ describe( 'reducer', () => {
 		};
 		const newState = reducer( {}, action );
 		expect( newState[ siteId ] ).to.exist;
-		expect( newState[ siteId ].shippingZones ).to.eql( zones );
+		expect( newState[ siteId ].shippingZones ).to.eql( [
+			{ id: 0, name: 'Locations not covered by your other zones' },
+			{ id: 1, name: 'USA' },
+		] );
 	} );
 } );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -646,7 +646,7 @@ export const getOrderOperationsToSaveCurrentZone = ( state, siteId = getSelected
 	// to their priority, but for example that's not the case after the initial setup (the "home country" zone
 	// has order=0)
 	for ( const { id, order } of allZones ) {
-		// Skip over the "Rest of the World" zone, the current zone and zones with no locations
+		// Skip over the "Locations not covered by your other zones" zone, the current zone and zones with no locations
 		if ( currentZone.id === id || 0 === id ) {
 			continue;
 		}

--- a/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/selectors.js
@@ -30,7 +30,7 @@ const orderShippingZones = ( zones ) => {
 			return 1;
 		}
 
-		//Rest of the World should always be at the bottom
+		//Locations not covered by your other zones should always be at the bottom
 		if ( 0 === z1.id ) {
 			return 1;
 		}
@@ -138,7 +138,7 @@ export const areAnyShippingMethodsEnabled = ( state, siteId = getSelectedSiteId(
 /**
  * @param {Number|Object} zoneId Zone ID (can be a temporal ID)
  * @return {Boolean} Whether this zone is considered "editable". As a rule, every zone is editable,
- * except the "Rest Of The World" zone, which always has id = 0.
+ * except the "Locations not covered by your other zones" zone, which always has id = 0.
  */
 const isEditableShippingZone = ( zoneId ) => ! isNumber( zoneId ) || 0 !== zoneId;
 

--- a/client/extensions/woocommerce/state/ui/shipping/zones/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/test/selectors.js
@@ -154,7 +154,7 @@ describe( 'selectors', () => {
 			const state = createState( {
 				site: {
 					shippingZones: [
-						{ id: 0, methodIds: [], name: 'Rest of the world' },
+						{ id: 0, methodIds: [], name: 'Locations not covered by your other zones' },
 						{ id: 1, methodIds: [], name: 'Zone1' },
 						{ id: 2, methodIds: [], name: 'Zone2' },
 						{ id: 3, methodIds: [], name: 'Zone3', order: 2 },
@@ -176,7 +176,7 @@ describe( 'selectors', () => {
 				{ id: 2, methodIds: [], name: 'Zone2' },
 				{ id: 4, methodIds: [], name: 'Zone4', order: 1 },
 				{ id: 3, methodIds: [], name: 'Zone3', order: 2 },
-				{ id: 0, methodIds: [], name: 'Rest of the world' },
+				{ id: 0, methodIds: [], name: 'Locations not covered by your other zones' },
 			] );
 		} );
 
@@ -184,7 +184,7 @@ describe( 'selectors', () => {
 			const state = createState( {
 				site: {
 					shippingZones: [
-						{ id: 0, methodIds: [], name: 'Rest of the world' },
+						{ id: 0, methodIds: [], name: 'Locations not covered by your other zones' },
 						{ id: 1, methodIds: [], name: 'Zone1' },
 						{ id: 2, methodIds: [], name: 'Zone2' },
 						{ id: 3, methodIds: [], name: 'Zone3', order: 2 },
@@ -222,7 +222,7 @@ describe( 'selectors', () => {
 				{ id: 2, methodIds: [], name: 'EditedZone2' },
 				{ id: 4, methodIds: [], name: 'Zone4', order: 1 },
 				{ id: 3, methodIds: [], name: 'Zone3', order: 2 },
-				{ id: 0, methodIds: [], name: 'Rest of the world' },
+				{ id: 0, methodIds: [], name: 'Locations not covered by your other zones' },
 			] );
 		} );
 	} );
@@ -335,7 +335,7 @@ describe( 'selectors', () => {
 			expect( canEditShippingZoneLocations( zoneId ) ).to.be.true;
 		} );
 
-		it( 'is NOT editable when it\'s the "Rest Of The World" zone', () => {
+		it( 'is NOT editable when it\'s the "Locations not covered by your other zones" zone', () => {
 			const zoneId = 0;
 			expect( canChangeShippingZoneTitle( zoneId ) ).to.be.false;
 			expect( canRemoveShippingZone( zoneId ) ).to.be.false;


### PR DESCRIPTION
* https://cloudup.com/c3c9dDWZvEM - "Rest of the world" is not matching core. Should be "Locations not covered by your other zones"
* "Tax nexus" isn't user friendly language. I don't think we need this label. "Store location" is adequate.
* https://cloudup.com/cBFKEB6bPuN - Probably don't need the 'store location' label here. Same on taxes.
* https://cloudup.com/cDKih8BqGJR - Stats widget on Fledgling needs re-wording. Stats aren't going to appear on the dashboard.