### PR TITLE
Site Settings: Disable Theme Setup for Jetpack sites properly.

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -171,7 +171,7 @@ const controller = {
 
 		renderPage(
 			context,
-			<ThemeSetup activeSiteDomain={ context.params.site_id } />
+			<ThemeSetup />
 		);
 	},
 

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -162,11 +162,11 @@ const controller = {
 	themeSetup( context ) {
 		const site = getSelectedSite( context.store.getState() );
 		if ( site && site.jetpack ) {
-			return page( '/settings/general/' + site.slug );
+			return page.redirect( '/settings/general/' + site.slug );
 		}
 
 		if ( ! config.isEnabled( 'settings/theme-setup' ) ) {
-			return page( '/settings/general/' + site.slug );
+			return page.redirect( '/settings/general/' + site.slug );
 		}
 
 		renderPage(

--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -66,7 +66,7 @@ class ThemeSetup extends Component {
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
-	const siteSlug = getSelectedSiteSlug( state );
+	const siteSlug = getSelectedSiteSlug( state ) || '';
 	const themeId = siteId && getActiveTheme( state, siteId );
 	const theme = themeId && getTheme( state, 'wpcom', themeId );
 	return {

--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -10,6 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryTheme from 'components/data/query-theme';
 import ThemeSetupCard from './theme-setup-card';
@@ -45,7 +46,7 @@ class ThemeSetup extends Component {
 		} = this.props;
 
 		return (
-			<div className="main theme-setup" role="main">
+			<Main className="theme-setup">
 				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
 				{ themeId && <QueryTheme siteId="wpcom" themeId={ themeId } /> }
 
@@ -58,7 +59,7 @@ class ThemeSetup extends Component {
 						onClick={ this.props.toggleDialog }
 						theme={ theme } />
 					: <ThemeSetupPlaceholder /> }
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -14,41 +14,71 @@ import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryTheme from 'components/data/query-theme';
 import ThemeSetupCard from './theme-setup-card';
 import ThemeSetupPlaceholder from './theme-setup-placeholder';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getActiveTheme, getTheme } from 'state/themes/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { toggleDialog } from 'state/ui/theme-setup/actions';
 
-let ThemeSetup = ( { site, themeId, theme, translate, activeSiteDomain, toggleDialog } ) => {
-	const onBack = () => {
-		page( '/settings/general/' + activeSiteDomain );
+class ThemeSetup extends Component {
+	componentDidUpdate( prevProps ) {
+		const {
+			siteIsJetpack,
+			siteId,
+		} = this.props;
+
+		if ( siteId !== prevProps.siteId && siteIsJetpack ) {
+			this.redirectToGeneral();
+		}
+	}
+
+	redirectToGeneral = () => {
+		const { siteSlug } = this.props;
+		page.redirect( '/settings/general/' + siteSlug );
 	};
 
-	return (
-		<div className="main theme-setup" role="main">
-			{ site && <QueryActiveTheme siteId={ site.ID } /> }
-			{ themeId && <QueryTheme siteId="wpcom" themeId={ themeId } /> }
-			<HeaderCake onClick={ onBack }><h1>{ translate( 'Theme Setup' ) }</h1></HeaderCake>
-			{ site && theme
-				? <ThemeSetupCard
-					onClick={ toggleDialog }
-					theme={ theme } />
-				: <ThemeSetupPlaceholder /> }
-		</div>
-	);
-};
+	render() {
+		const {
+			siteId,
+			theme,
+			themeId,
+			translate,
+		} = this.props;
 
-ThemeSetup = localize( ThemeSetup );
+		return (
+			<div className="main theme-setup" role="main">
+				{ siteId && <QueryActiveTheme siteId={ siteId } /> }
+				{ themeId && <QueryTheme siteId="wpcom" themeId={ themeId } /> }
+
+				<HeaderCake onClick={ this.redirectToGeneral }>
+					<h1>{ translate( 'Theme Setup' ) }</h1>
+				</HeaderCake>
+
+				{ siteId && theme
+					? <ThemeSetupCard
+						onClick={ this.props.toggleDialog }
+						theme={ theme } />
+					: <ThemeSetupPlaceholder /> }
+			</div>
+		);
+	}
+}
 
 const mapStateToProps = ( state ) => {
-	const site = getSelectedSite( state );
-	const themeId = site && getActiveTheme( state, site.ID );
+	const siteId = getSelectedSiteId( state );
+	const siteIsJetpack = isJetpackSite( state, siteId );
+	const siteSlug = getSelectedSiteSlug( state );
+	const themeId = siteId && getActiveTheme( state, siteId );
 	const theme = themeId && getTheme( state, 'wpcom', themeId );
 	return {
-		site,
+		siteId,
+		siteIsJetpack,
+		siteSlug,
 		themeId,
 		theme,
 	};
 };
 
-export default connect( mapStateToProps, { toggleDialog } )( ThemeSetup );
-
+export default connect(
+	mapStateToProps,
+	{ toggleDialog }
+)( localize( ThemeSetup ) );


### PR DESCRIPTION
The current **Theme Setup** page has several issues:

* If you load `/settings/theme-setup/:site` for a .com site and you switch to a Jetpack site, you remain in /settings/theme-setup. You should be redirected to General settings, as this settings page is not available for Jetpack sites.
* If you load `/settings/theme-setup/:site` for a Jetpack site with a clean Redux state, you'll unexpectedly get to the Theme Setup page. You should be redirected to General settings, as this settings page is not available for Jetpack sites.

This PR solves all of these issues.

To test:
* Checkout this branch
* Go to `/settings/theme-setup/:site` for a .com site and verify it loads correctly, looks and works like before.
* Switch to a Jetpack site and verify you're redirected properly to the general settings page of the Jetpack site, and the URL corresponds to that.
* Go to `/settings/theme-setup/:site` for a Jetpack site and verify you're redirected to the General settings, and the URL corresponds to that.
* Test the above cases with a clean Redux state and verify they work as expected.
* Clear your Redux state and visit `/settings/theme-setup/:site` for a Jetpack site. After the sites are loaded, verify you're redirected to the General settings, and the URL corresponds to that.