### PR TITLE
Pages: Reducing card padding for mobile screens.

### DIFF
--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -1,7 +1,11 @@
 .blog-posts-page {
 	display: flex;
 	align-items: center;
-	padding: 16px 24px;
+	padding: 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding: 16px 24px;	
+	}
 }
 
 .blog-posts-page__front-page-icon,


### PR DESCRIPTION
Updating the Blog Posts card on /pages/ to follow the same padding as
the page cards on mobile. Fixes #15896

Before:
<img width="376" alt="screen shot 2017-07-06 at 10 23 31 am" src="https://user-images.githubusercontent.com/191598/27915777-371fd0b2-6235-11e7-8a39-c75580760fa7.png">

After:
<img width="376" alt="screen shot 2017-07-06 at 10 22 46 am" src="https://user-images.githubusercontent.com/191598/27915788-3c95ea9a-6235-11e7-8892-c3af43cda762.png">
