### PR TITLE
Signup: update the text in the theme step to show we have more themes to pick from

### DIFF
--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -76,7 +76,7 @@ class ThemeSelectionStep extends Component {
 		const { translate } = this.props;
 		const headerText = translate( 'Choose a theme.' );
 		const subHeaderText = translate(
-			'No need to overthink it. You can always switch to a different theme later.',
+			'Pick one of our popular themes to get started or choose from hundreds more after you sign up.',
 			{ context: 'Themes step subheader in Signup' }
 		);
 


### PR DESCRIPTION
This PR updates the copy on the theme step in signup to show that we have more themes to pick from. 

Updated screenshot:
![image](https://user-images.githubusercontent.com/6981253/27916140-2f91bc2e-6236-11e7-8710-9c711a3b63a9.png)

## Testing
* Visit http://calypso.localhost:3000/start to start the signup process
* Pick a layout
* See the themes screen.

@markryall @taggon can you please review?