### PR TITLE
WooCommerce - Added "no shipping methods" message

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
@@ -44,15 +44,25 @@ const ShippingZoneEntry = ( { translate, id, name, methods, currency, loaded, is
 		);
 	}
 
-	const renderMethod = ( methodKey ) => {
-		const method = methods[ methodKey ];
-
+	const renderMethodCell = ( title, summary = '', key = 0 ) => {
 		return (
-			<div key={ methodKey } className="shipping__zones-row-method">
-				<p className="shipping__zones-row-method-name">{ method.title }</p>
-				<p className="shipping__zones-row-method-description">{ getMethodSummary( method, currency ) }</p>
+			<div key={ key } className="shipping__zones-row-method">
+				<p className="shipping__zones-row-method-name">{ title }</p>
+				<p className="shipping__zones-row-method-description">{ summary }</p>
 			</div>
 		);
+	};
+
+	const renderMethod = ( methodKey ) => {
+		const method = methods[ methodKey ];
+		let summary = getMethodSummary( method, currency );
+		if ( ! method.enabled ) {
+			summary = translate( '%(summary)s - Disabled', {
+				args: { summary },
+				comment: 'Summary of a disabled shipping method in WooCommerce',
+			} );
+		}
+		return renderMethodCell( method.title, summary, methodKey );
 	};
 
 	const icon = 0 === id ? 'globe' : 'location';
@@ -73,7 +83,9 @@ const ShippingZoneEntry = ( { translate, id, name, methods, currency, loaded, is
 				{ /*<p className="shipping__zones-row-location-description">{ locationDescription }</p>*/ }
 			</div>
 			<div className="shipping__zones-row-methods">
-				{ Object.keys( methods ).map( renderMethod ) }
+				{ methods && methods.length
+					? Object.keys( methods ).map( renderMethod )
+					: renderMethodCell( translate( 'No shipping methods' ) ) }
 			</div>
 			<div className="shipping__zones-row-actions">
 				<Button

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -112,7 +112,8 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 				</Button>
 			</ExtendedHeader>
 			<List>
-				<ListHeader>
+				{ locationsToRender && locationsToRender.length
+				? <ListHeader>
 					<ListItemField className="shipping-zone__location-title">
 						{ translate( 'Location' ) }
 					</ListItemField>
@@ -120,6 +121,7 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 						{ translate( 'Details' ) }
 					</ListItemField>
 				</ListHeader>
+				: null }
 				{ locationsToRender.map( renderLocation ) }
 			</List>
 			<ShippingZoneLocationDialog siteId={ siteId } />

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -112,7 +112,7 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 				</Button>
 			</ExtendedHeader>
 			<List>
-				{ locationsToRender && locationsToRender.length
+				{ locationsToRender.length
 				? <ListHeader>
 					<ListItemField className="shipping-zone__location-title">
 						{ translate( 'Location' ) }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -110,7 +110,7 @@ const ShippingZoneMethodList = ( {
 				<Button onClick={ onAddMethod } disabled={ ! loaded } >{ translate( 'Add method' ) }</Button>
 			</ExtendedHeader>
 			<List>
-				{ methodsToRender && methodsToRender.length
+				{ methodsToRender.length
 					? <ListHeader>
 						<ListItemField className="shipping-zone__methods-column-title">
 							{ translate( 'Method' ) }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -110,14 +110,16 @@ const ShippingZoneMethodList = ( {
 				<Button onClick={ onAddMethod } disabled={ ! loaded } >{ translate( 'Add method' ) }</Button>
 			</ExtendedHeader>
 			<List>
-				<ListHeader>
-					<ListItemField className="shipping-zone__methods-column-title">
-						{ translate( 'Method' ) }
-					</ListItemField>
-					<ListItemField className="shipping-zone__methods-column-summary">
-						{ translate( 'Cost' ) }
-					</ListItemField>
-				</ListHeader>
+				{ methodsToRender && methodsToRender.length
+					? <ListHeader>
+						<ListItemField className="shipping-zone__methods-column-title">
+							{ translate( 'Method' ) }
+						</ListItemField>
+						<ListItemField className="shipping-zone__methods-column-summary">
+							{ translate( 'Cost' ) }
+						</ListItemField>
+					</ListHeader>
+					: null }
 				{ methodsToRender.map( renderMethod ) }
 			</List>
 			<ShippingZoneMethodDialog siteId={ siteId } />


### PR DESCRIPTION
Fixes #15908 

* adds "No shipping methods" message to the zone list if there are no shipping methods
* marks the methods as disabled on the zone list when needed
* on the individual zone page, removes the table headers when there are no methods or locations to show

<img width="736" alt="screen shot 2017-07-06 at 15 44 10" src="https://user-images.githubusercontent.com/800604/27916775-018b729e-6262-11e7-88ce-728ba1a14069.png">
