### PR TITLE
Activity log: Improve progress banner ui

### DIFF
--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import ActivityLogBanner from './index';
 import ProgressBar from 'components/progress-bar';
 
-function SuccessBanner( {
+function ProgressBanner( {
 	moment,
 	percent,
 	status,
@@ -42,7 +42,7 @@ function SuccessBanner( {
 	);
 }
 
-SuccessBanner.propTypes = {
+ProgressBanner.propTypes = {
 	percent: PropTypes.number.isRequired,
 	status: PropTypes.oneOf( [
 		'queued',
@@ -51,4 +51,4 @@ SuccessBanner.propTypes = {
 	timestamp: PropTypes.number.isRequired,
 };
 
-export default localize( SuccessBanner );
+export default localize( ProgressBanner );

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -18,8 +18,8 @@ function ProgressBanner( {
 	translate,
 } ) {
 	const restoreStatusDescription = status === 'queued'
-		? translate( 'Hold tight, your restore will begin soon.' )
-		: translate( 'Sit back and relax, your site is currently being restored.' );
+		? translate( 'Your restore will start in a moment.' )
+		: translate( 'We\'re on it! Your site is being restored.' );
 
 	return (
 		<ActivityLogBanner

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -17,6 +17,10 @@ function ProgressBanner( {
 	timestamp,
 	translate,
 } ) {
+	const restoreStatusDescription = status === 'queued'
+		? translate( 'Hold tight, your restore will begin soon.' )
+		: translate( 'Sit back and relax, your site is currently being restored.' );
+
 	return (
 		<ActivityLogBanner
 			status="info"
@@ -29,14 +33,16 @@ function ProgressBanner( {
 			) }</p>
 
 			<div>
-				<em>{
-					/*
-					* FIXME: Do we have a detailed message or should this be removed?
-					* FIXME: Show a message for `queued` status before progress?
-					* */
-					translate( 'Currently restoring posts…' )
-				}</em>
-				<ProgressBar value={ percent } isPulsing={ status === 'running' } />
+				<em>{ restoreStatusDescription }</em>
+				<ProgressBar
+					className={
+						status === 'queued'
+							? 'activity-log-banner__progress-bar--queued'
+							: null
+					}
+					isPulsing
+					value={ status === 'queued' ? 100 : percent }
+				/>
 			</div>
 		</ActivityLogBanner>
 	);

--- a/client/my-sites/stats/activity-log-banner/style.scss
+++ b/client/my-sites/stats/activity-log-banner/style.scss
@@ -71,3 +71,14 @@
 	margin-top: -8px;
 	margin-right: -8px;
 }
+
+.activity-log-banner__progress-bar--queued.is-pulsing .progress-bar__progress {
+	$bar-color: $gray;
+	background-image: linear-gradient(
+		-45deg,
+		$bar-color 28%,
+		lighten( $bar-color, 5% ) 28%,
+		lighten( $bar-color, 5% ) 72%,
+		$bar-color 72%
+	);
+}


### PR DESCRIPTION
There was some inaccurate static text in the progress banner. I've updated it, as well as added some `queued`/`running` visual differences.

* Update the italic text above the bar depending on queued/running status.
* Update the bar styling depending on queued/running status.

Demo:

![banners](https://user-images.githubusercontent.com/841763/27917886-9bc373b0-626d-11e7-9e51-6f6cf3cb4625.gif)

To test:
* https://calypso.live/stats/activity?branch=update/activitylog-progress-banner
* Queued banner
   ```js
   dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: state.ui.selectedSiteId, timestamp: 1498168800000, restoreId: 123, errorCode: "", failureReason: "", message: "", percent: 0, status: "queued" })
  ```
* Running banner
   ```js
   dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: state.ui.selectedSiteId, timestamp: 1498168800000, restoreId: 123, errorCode: "", failureReason: "", message: "", percent: 20, status: "running" })
  ```

I'd love to have design/copy feedback cc/ @keoshi @michelleweber 