### PR TITLE
Site Settings: Display a placeholder instead of nothing while sites are loading

### DIFF
--- a/client/my-sites/guided-transfer/guided-transfer.jsx
+++ b/client/my-sites/guided-transfer/guided-transfer.jsx
@@ -16,6 +16,7 @@ import HostCredentialsPage from './host-credentials-page';
 import HostSelect from './host-select';
 import IssuesNotices from './issues-notices';
 import TransferUnavailableCard from './transfer-unavailable-card';
+import Placeholder from 'my-sites/site-settings/placeholder';
 
 const guidedTransferHosts = {
 	bluehost: {
@@ -65,6 +66,11 @@ export default React.createClass( {
 	},
 
 	render: function() {
+		const { siteId, siteSlug } = this.props;
+		if ( ! siteId ) {
+			return <Placeholder />;
+		}
+
 		const hostInfo = get( guidedTransferHosts, this.props.hostSlug );
 		const hosts = Object.keys( guidedTransferHosts ).map( hostSlug => {
 			return {
@@ -72,8 +78,6 @@ export default React.createClass( {
 				showHost: () => this.showHost( hostSlug )
 			};
 		} );
-
-		const { siteId, siteSlug } = this.props;
 
 		return (
 			<Main className="guided-transfer__main site-settings">

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -16,11 +16,16 @@ import GeneralSettings from './section-general';
 import SiteSettingsNavigation from './navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackDevModeNotice from './jetpack-dev-mode-notice';
+import Placeholder from 'my-sites/site-settings/placeholder';
 
 const SiteSettingsComponent = ( {
 	jetpackSettingsUiSupported,
 	siteId
 } ) => {
+	if ( ! siteId ) {
+		return <Placeholder />;
+	}
+
 	return (
 		<Main className="site-settings">
 			{ jetpackSettingsUiSupported && <JetpackDevModeNotice /> }

--- a/client/my-sites/site-settings/placeholder.jsx
+++ b/client/my-sites/site-settings/placeholder.jsx
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => (
+	<div className="site-settings__placeholder wpcom-site__logo noticon noticon-wordpress" />
+);

--- a/client/my-sites/site-settings/placeholder.jsx
+++ b/client/my-sites/site-settings/placeholder.jsx
@@ -2,7 +2,75 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
-export default () => (
-	<div className="site-settings__placeholder wpcom-site__logo noticon noticon-wordpress" />
-);
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Main from 'components/main';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import SectionHeader from 'components/section-header';
+import SectionNav from 'components/section-nav';
+
+const Placeholder = ( { translate } ) => {
+	const header = (
+		<div className="site-settings__placeholder-item">
+			General Settings
+		</div>
+	);
+
+	return (
+		<Main className="site-settings__placeholder">
+			<SectionNav>
+				<NavTabs>
+					<NavItem>
+						<span className="site-settings__placeholder-item">
+							{ translate( 'General' ) }
+						</span>
+					</NavItem>
+					<NavItem>
+						<span className="site-settings__placeholder-item">
+							{ translate( 'Writing' ) }
+						</span>
+					</NavItem>
+					<NavItem>
+						<span className="site-settings__placeholder-item">
+							{ translate( 'Discussion' ) }
+						</span>
+					</NavItem>
+					<NavItem>
+						<span className="site-settings__placeholder-item">
+							{ translate( 'Traffic' ) }
+						</span>
+					</NavItem>
+					<NavItem>
+						<span className="site-settings__placeholder-item">
+							{ translate( 'Security' ) }
+						</span>
+					</NavItem>
+				</NavTabs>
+			</SectionNav>
+
+			<SectionHeader label={ header } />
+
+			<Card>
+				<div className="site-settings__placeholder-item">
+					Example content here
+				</div>
+				<div className="site-settings__placeholder-item">
+					Example content here<br />
+					Example content here<br />
+					Example content here
+				</div>
+				<div className="site-settings__placeholder-item">
+					Example content here<br />
+					Example content here
+				</div>
+			</Card>
+		</Main>
+	);
+};
+
+export default localize( Placeholder );

--- a/client/my-sites/site-settings/section-export.jsx
+++ b/client/my-sites/site-settings/section-export.jsx
@@ -18,8 +18,13 @@ import {
 import { isJetpackSite } from 'state/sites/selectors';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
+import Placeholder from 'my-sites/site-settings/placeholder';
 
 const SiteSettingsExport = ( { isJetpack, site, siteSlug, translate } ) => {
+	if ( ! site ) {
+		return <Placeholder />;
+	}
+
 	return (
 		<Main>
 			<HeaderCake backHref={ '/settings/general/' + siteSlug }>

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -21,6 +21,7 @@ import EmailVerificationGate from 'components/email-verification/email-verificat
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
+import Placeholder from 'my-sites/site-settings/placeholder';
 
 class SiteSettingsImport extends Component {
 	static propTypes = {
@@ -77,7 +78,7 @@ class SiteSettingsImport extends Component {
 	render() {
 		const { site, siteSlug, translate } = this.props;
 		if ( ! site ) {
-			return null;
+			return <Placeholder />;
 		}
 
 		const { jetpack: isJetpack, options: { admin_url: adminUrl }, slug, title: siteTitle } = site;

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -13,22 +13,29 @@ import DocumentHead from 'components/data/document-head';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import DiscussionForm from 'my-sites/site-settings/form-discussion';
+import Placeholder from 'my-sites/site-settings/placeholder';
 import { getSelectedSite } from 'state/ui/selectors';
 
-const SiteSettingsWriting = ( {
+const SiteSettingsDiscussion = ( {
 	site,
 	translate,
-} ) => (
-	<Main className="settings-discussion__main site-settings">
-		<DocumentHead title={ translate( 'Site Settings' ) } />
-		<SidebarNavigation />
-		<SiteSettingsNavigation site={ site } section="discussion" />
-		<DiscussionForm />
-	</Main>
-);
+} ) => {
+	if ( ! site ) {
+		return <Placeholder />;
+	}
+
+	return (
+		<Main className="settings-discussion site-settings">
+			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<SidebarNavigation />
+			<SiteSettingsNavigation site={ site } section="discussion" />
+			<DiscussionForm />
+		</Main>
+	);
+};
 
 export default connect(
 	( state ) => ( {
 		site: getSelectedSite( state ),
 	} )
-)( localize( SiteSettingsWriting ) );
+)( localize( SiteSettingsDiscussion ) );

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -17,10 +17,11 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import Placeholder from 'my-sites/site-settings/placeholder';
 
 const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
 	if ( ! site ) {
-		return <div className="settings-security__loading wpcom-site__logo noticon noticon-wordpress" />;
+		return <Placeholder />;
 	}
 
 	if ( ! siteIsJetpack ) {

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -21,6 +21,7 @@ import RelatedPosts from 'my-sites/site-settings/related-posts';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
+import Placeholder from 'my-sites/site-settings/placeholder';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
@@ -39,49 +40,55 @@ const SiteSettingsTraffic = ( {
 	trackEvent,
 	translate,
 	updateFields,
-} ) => (
-	<Main className="settings-traffic__main site-settings">
-		<DocumentHead title={ translate( 'Site Settings' ) } />
-		<SidebarNavigation />
-		<SiteSettingsNavigation site={ site } section="traffic" />
+} ) => {
+	if ( ! site ) {
+		return <Placeholder />;
+	}
 
-		{ jetpackSettingsUiSupported &&
-			<JetpackSiteStats
+	return (
+		<Main className="settings-traffic site-settings">
+			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<SidebarNavigation />
+			<SiteSettingsNavigation site={ site } section="traffic" />
+
+			{ jetpackSettingsUiSupported &&
+				<JetpackSiteStats
+					handleAutosavingToggle={ handleAutosavingToggle }
+					setFieldValue={ setFieldValue }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			}
+			<RelatedPosts
+				onSubmitForm={ handleSubmitForm }
 				handleAutosavingToggle={ handleAutosavingToggle }
-				setFieldValue={ setFieldValue }
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
-		}
-		<RelatedPosts
-			onSubmitForm={ handleSubmitForm }
-			handleAutosavingToggle={ handleAutosavingToggle }
-			isSavingSettings={ isSavingSettings }
-			isRequestingSettings={ isRequestingSettings }
-			fields={ fields }
-		/>
-		{ isJetpack
-			? <AmpJetpack />
-			: <AmpWpcom
-				submitForm={ submitForm }
-				trackEvent={ trackEvent }
-				updateFields={ updateFields }
+			{ isJetpack
+				? <AmpJetpack />
+				: <AmpWpcom
+					submitForm={ submitForm }
+					trackEvent={ trackEvent }
+					updateFields={ updateFields }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			}
+			<AnalyticsSettings />
+			<SeoSettingsHelpCard />
+			<SeoSettingsMain />
+			<Sitemaps
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
-		}
-		<AnalyticsSettings />
-		<SeoSettingsHelpCard />
-		<SeoSettingsMain />
-		<Sitemaps
-			isSavingSettings={ isSavingSettings }
-			isRequestingSettings={ isRequestingSettings }
-			fields={ fields }
-		/>
-	</Main>
-);
+		</Main>
+	);
+};
 
 const connectComponent = connect(
 	( state ) => {

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -13,19 +13,26 @@ import DocumentHead from 'components/data/document-head';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import WritingForm from 'my-sites/site-settings/form-writing';
+import Placeholder from 'my-sites/site-settings/placeholder';
 import { getSelectedSite } from 'state/ui/selectors';
 
 const SiteSettingsWriting = ( {
 	site,
 	translate,
-} ) => (
-	<Main className="settings-writing__main site-settings">
-		<DocumentHead title={ translate( 'Site Settings' ) } />
-		<SidebarNavigation />
-		<SiteSettingsNavigation site={ site } section="writing" />
-		<WritingForm />
-	</Main>
-);
+} ) => {
+	if ( ! site ) {
+		return <Placeholder />;
+	}
+
+	return (
+		<Main className="settings-writing site-settings">
+			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<SidebarNavigation />
+			<SiteSettingsNavigation site={ site } section="writing" />
+			<WritingForm />
+		</Main>
+	);
+};
 
 export default connect(
 	( state ) => ( {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -427,3 +427,11 @@
 .site-settings__general-jetpack {
 	margin-bottom: 16px;
 }
+
+.site-settings__placeholder-item {
+	@include placeholder;
+
+	& + & {
+		margin-top: 24px;
+	}
+}


### PR DESCRIPTION
As I've been working on Settings in Calypso recently I had to test a lot of stuff with a clean Redux state. It was odd to me that while sites are loading we display an empty screen - we should display a placeholder instead.

This PR suggests that we have a (W) logo in these situations.

Before:
![](https://cldup.com/TcmeLdTSqs.png)

After:
![](https://cldup.com/woer3eamS9.png)

It's not ideal, I agree, but it's:
* Consistent with other loading areas in Calypso.
* Helpful for users to actually know that the screen they're loading is not broken, but it's loading.

A better solution, of course, would be to have a special placeholder for each settings section, or at least a better placeholder card with pulsating contents. I could totally go with implementing such a placeholder if any of the design folks have a good suggestion about how it could look.

Note: this placeholder has been in the Security settings section for months already, so this PR is applying it to the rest of the Settings sections.

To test:
* Checkout this branch, or get it going on calypso.live.
* You can clean your Redux state by typing `indexedDB.deleteDatabase( 'calypso' );` in your developer console.
* Visit any of the following pages for both WP.com and Jetpack sites after you clean the Redux state and verify you see the placeholder:
  * `/settings/general/:site`
  * `/settings/writing/:site`
  * `/settings/discussion/:site`
  * `/settings/traffic/:site`
  * `/settings/security/:site`
  * `/settings/import/:site`
  * `/settings/export/:site`
  * `/settings/export/guided/:site`
* Visit any of the above pages without clearing the Redux state and verify they load correctly as before.