### PR TITLE
Activity Log: Query activities after a completed restore

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -157,22 +157,22 @@ class ActivityLog extends Component {
 		} = restoreProgress;
 
 		if ( status === 'finished' ) {
-			return ( errorCode
-				? (
-					<ErrorBanner
+			return (
+				<div>
+					<QueryActivityLog siteId={ siteId } />
+					{ errorCode && <ErrorBanner
 						errorCode={ errorCode }
 						failureReason={ failureReason }
 						requestRestore={ this.handleRequestRestore }
 						siteId={ siteId }
 						siteTitle={ siteTitle }
 						timestamp={ timestamp }
-					/>
-				) : (
-					<SuccessBanner
+					/> }
+					{ ! errorCode && <SuccessBanner
 						siteId={ siteId }
 						timestamp={ timestamp }
-					/>
-				)
+					/> }
+				</div>
 			);
 		}
 		return (

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -160,18 +160,19 @@ class ActivityLog extends Component {
 			return (
 				<div>
 					<QueryActivityLog siteId={ siteId } />
-					{ errorCode && <ErrorBanner
-						errorCode={ errorCode }
-						failureReason={ failureReason }
-						requestRestore={ this.handleRequestRestore }
-						siteId={ siteId }
-						siteTitle={ siteTitle }
-						timestamp={ timestamp }
-					/> }
-					{ ! errorCode && <SuccessBanner
-						siteId={ siteId }
-						timestamp={ timestamp }
-					/> }
+					{ errorCode ? (
+						<ErrorBanner
+							errorCode={ errorCode }
+							failureReason={ failureReason }
+							requestRestore={ this.handleRequestRestore }
+							siteId={ siteId }
+							siteTitle={ siteTitle }
+							timestamp={ timestamp } />
+					) : (
+						<SuccessBanner
+							siteId={ siteId }
+							timestamp={ timestamp } />
+					) }
 				</div>
 			);
 		}


### PR DESCRIPTION
Because the act of restoring changes the activities in the log, so fetch the log again to update the display.

**To Test**
Currently, the performing a restore does not actually create any new activities. However, watching the 'network' tab in chrome should show a query once a restore is complete:

<img width="553" alt="screen shot 2017-07-06 at 16 57 20" src="https://user-images.githubusercontent.com/7767559/27920731-75da3aa8-626d-11e7-8561-de581f8420e9.png">

* Go to http://calypso.localhost:3000/stats/activity/{pressable site}
* Perform a restore
