### PR TITLE
Site Settings: Introduce Jetpack Ads card

### DIFF
--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -1,0 +1,166 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CompactCard from 'components/card/compact';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import ExternalLink from 'components/external-link';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import InfoPopover from 'components/info-popover';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import SectionHeader from 'components/section-header';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { isJetpackModuleActive } from 'state/selectors';
+
+class JetpackAds extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {}
+	};
+
+	static propTypes = {
+		handleAutosavingToggle: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	isFormPending() {
+		const {
+			isRequestingSettings,
+			isSavingSettings,
+		} = this.props;
+
+		return isRequestingSettings || isSavingSettings;
+	}
+
+	renderToggle( name, isDisabled, label ) {
+		const { fields, handleAutosavingToggle } = this.props;
+		return (
+			<CompactFormToggle
+				checked={ !! fields[ name ] }
+				disabled={ this.isFormPending() || isDisabled }
+				onChange={ handleAutosavingToggle( name ) }
+			>
+				{ label }
+			</CompactFormToggle>
+		);
+	}
+
+	renderContent() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<div className="site-settings__info-link-container">
+					<InfoPopover position="left">
+						<ExternalLink href="https://jetpack.com/support/ads" icon target="_blank">
+							{ translate( 'Learn more about Ads.' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+
+				<div>
+					{ translate(
+						'Show ads on the first article on your home page or at the end of every page and post. ' +
+						'Place additional ads at the top of your site and to any widget area to increase your earnings.'
+					) }
+				</div>
+				<FormSettingExplanation>
+					{
+						translate( 'By activating ads, you agree to the Automattic Ads {{link}}Terms of Service{{/link}}.', {
+							components: {
+								link: (
+									<ExternalLink
+										href="https://wordpress.com/automattic-ads-tos/"
+										icon={ false }
+										target="_blank"
+									/>
+								)
+							}
+						} )
+					}
+				</FormSettingExplanation>
+			</div>
+		);
+	}
+
+	renderSettings() {
+		const {
+			selectedSiteId,
+			selectedSiteSlug,
+			wordadsModuleActive,
+			translate
+		} = this.props;
+		const formPending = this.isFormPending();
+
+		return (
+			<div>
+				<Card className="site-settings__card site-settings__traffic-settings">
+					<FormFieldset>
+						{ this.renderContent() }
+
+						<br />
+
+						<JetpackModuleToggle
+							siteId={ selectedSiteId }
+							moduleSlug="wordads"
+							label={ translate( 'Enable ads and display an ad below each post' ) }
+							disabled={ formPending }
+							/>
+
+						<div className="site-settings__child-settings">
+							{
+								this.renderToggle( 'enable_header_ad', ! wordadsModuleActive, translate(
+									'Display an additional ad at the top of each page'
+								) )
+							}
+						</div>
+					</FormFieldset>
+				</Card>
+
+				{
+					wordadsModuleActive && (
+						<CompactCard href={ `/ads/earnings/${ selectedSiteSlug }` }>
+							{ translate( 'View your earnings' ) }
+						</CompactCard>
+					)
+				}
+			</div>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Ads' ) } />
+
+				{ this.renderSettings() }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const selectedSiteSlug = getSelectedSiteSlug( state );
+
+		return {
+			selectedSiteId,
+			selectedSiteSlug,
+			wordadsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'wordads' ),
+		};
+	}
+)( localize( JetpackAds ) );

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Banner from 'components/banner';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
@@ -18,7 +19,12 @@ import InfoPopover from 'components/info-popover';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { hasFeature } from 'state/sites/plans/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
+import {
+	FEATURE_WORDADS_INSTANT,
+	PLAN_JETPACK_PREMIUM
+} from 'lib/plans/constants';
 
 class JetpackAds extends Component {
 	static defaultProps = {
@@ -41,6 +47,20 @@ class JetpackAds extends Component {
 		} = this.props;
 
 		return isRequestingSettings || isSavingSettings;
+	}
+
+	renderUpgradeBanner() {
+		const { translate } = this.props;
+
+		return (
+			<Banner
+				description={ translate( 'Add advertising to your site through our WordAds program and earn money from impressions.' ) }
+				event={ 'calypso_wordads_settings_upgrade_nudge' }
+				feature={ FEATURE_WORDADS_INSTANT }
+				plan={ PLAN_JETPACK_PREMIUM }
+				title={ translate( 'Enable WordAds by upgrading to Jetpack Premium' ) }
+			/>
+		);
 	}
 
 	renderToggle( name, isDisabled, label ) {
@@ -140,13 +160,20 @@ class JetpackAds extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const {
+			hasWordadsFeature,
+			translate
+		} = this.props;
 
 		return (
 			<div>
 				<SectionHeader label={ translate( 'Ads' ) } />
 
-				{ this.renderSettings() }
+				{
+					hasWordadsFeature
+						? this.renderSettings()
+						: this.renderUpgradeBanner()
+				}
 			</div>
 		);
 	}
@@ -156,8 +183,10 @@ export default connect(
 	( state ) => {
 		const selectedSiteId = getSelectedSiteId( state );
 		const selectedSiteSlug = getSelectedSiteSlug( state );
+		const hasWordadsFeature = hasFeature( state, selectedSiteId, FEATURE_WORDADS_INSTANT );
 
 		return {
+			hasWordadsFeature,
 			selectedSiteId,
 			selectedSiteSlug,
 			wordadsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'wordads' ),

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -17,6 +17,7 @@ import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
 import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
+import JetpackAds from 'my-sites/site-settings/jetpack-ads';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
@@ -55,6 +56,14 @@ const SiteSettingsTraffic = ( {
 				<JetpackSiteStats
 					handleAutosavingToggle={ handleAutosavingToggle }
 					setFieldValue={ setFieldValue }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			}
+			{ jetpackSettingsUiSupported &&
+				<JetpackAds
+					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
@@ -111,6 +120,7 @@ const getFormSettings = partialRight( pick, [
 	'hide_smile',
 	'count_roles',
 	'roles',
+	'enable_header_ad',
 	'jetpack_relatedposts_allowed',
 	'jetpack_relatedposts_enabled',
 	'jetpack_relatedposts_show_headline',

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -419,7 +419,8 @@
 	margin-top: 3px;
 }
 
-.site-settings__foldable-card + .card.is-compact:last-child {
+.site-settings__foldable-card + .card.is-compact:last-child,
+.site-settings__card + .card.is-compact:last-child {
 	margin-top: -16px;
 	margin-bottom: 16px;
 }


### PR DESCRIPTION
### Purpose

This PR introduces a new Jetpack Ads card to the Traffic settings section - fixes #14807. This card aims to reach parity with the corresponding card in Jetpack.

### How it works
The card allows Jetpack sites to manage the WordAds Jetpack module settings of a Jetpack site that has a Jetpack Premium or Jetpack Professional plan, and displays an upgrade banner in all other cases.

### Preview

**Jetpack site with Jetpack Premium or Jetpack Professional plan, WordAds module disabled**
![](https://cldup.com/_0_ekiVoPg.png)

**Jetpack site with Jetpack Premium or Jetpack Professional plan, WordAds module enabled**
![](https://cldup.com/2dOnDiyeEG.png)

**Jetpack site with a Free or Personal plan**
![](https://cldup.com/jP-_O8Pu-Y.png)

### To test
* Checkout this branch, or get it going on Calypso.live.
* Let `:site` is a Jetpack site with a Premium or Professional plan.
* Go to `/settings/traffic/:site`.
* Play with the new Ads card, the main module toggle and the setting toggle. Verify they're saved and retrieved correctly.
* Verify the "View your earnings" link is displayed only if the module is enabled. 
* Let `:site` is a Jetpack site with a Free or Personal plan.
* Go to `/settings/traffic/:site`.
* Verify you see the upgrade banner in the Ads card, and it works as expected, leading you to upgrade to Premium.