### PR TITLE
Site Settings: Fix Array.includes usages in Traffic section

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -4,6 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -53,7 +54,7 @@ class JetpackSiteStats extends Component {
 			const { setFieldValue } = this.props;
 			let groupFields = this.getCurrentGroupFields( groupName );
 
-			if ( groupFields.includes( fieldName ) ) {
+			if ( includes( groupFields, fieldName ) ) {
 				groupFields = groupFields.filter( field => field !== fieldName );
 			} else {
 				groupFields.push( fieldName );
@@ -173,7 +174,7 @@ class JetpackSiteStats extends Component {
 								role => this.renderToggle(
 									'count_roles_' + role.name,
 									role.display_name,
-									this.getCurrentGroupFields( 'count_roles' ).includes( role.name ),
+									includes( this.getCurrentGroupFields( 'count_roles' ), role.name ),
 									this.onChangeToggleGroup( 'count_roles', role.name )
 								)
 							)
@@ -190,7 +191,7 @@ class JetpackSiteStats extends Component {
 								role => this.renderToggle(
 									'roles_' + role.name,
 									role.display_name,
-									this.getCurrentGroupFields( 'roles' ).includes( role.name ),
+									includes( this.getCurrentGroupFields( 'roles' ), role.name ),
 									this.onChangeToggleGroup( 'roles', role.name )
 								)
 							)


### PR DESCRIPTION
Since `Array.includes` is not very well supported in all modern browsers yet, so we have to use the lodash version.

This PR replaces several usages of `Array.includes` with the lodash alternative, fixing several warnings like this one:

![](https://cldup.com/i-iXm1wCVz.png)

To test:
* Checkout this branch
* Go to `/settings/traffic/:site`, where `:site` is one of your Jetpack sites.
* Verify you don't see any `Array.includes` errors in the sea of draft-js errors 😱 
* Expand the Site Stats card and verify the settings toggles work like they did before.