### PR TITLE
WooCommerce: Default tax calculation to on

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -10,13 +10,10 @@ import React, { Component, PropTypes } from 'react';
  * Internal dependencies
  */
 import {
-	areTaxCalculationsEnabled,
-} from 'woocommerce/state/sites/settings/general/selectors';
-import {
 	areSetupChoicesLoading,
 	getOptedOutOfShippingSetup,
-	getOptedOutofTaxesSetup,
 	getTriedCustomizerDuringInitialSetup,
+	getCheckedTaxSetup,
 } from 'woocommerce/state/sites/setup-choices/selectors';
 import {
 	getTotalProducts
@@ -30,8 +27,8 @@ import {
 import {
 	fetchSetupChoices,
 	setOptedOutOfShippingSetup,
-	setOptedOutOfTaxesSetup,
 	setTriedCustomizerDuringInitialSetup,
+	setCheckedTaxSetup,
 } from 'woocommerce/state/sites/setup-choices/actions';
 import {
 	fetchSettingsGeneral,
@@ -55,7 +52,6 @@ class SetupTasks extends Component {
 		super( props );
 		this.state = {
 			showShippingTask: props.loading || ! props.optedOutOfShippingSetup,
-			showTaxesTask: props.loading || ! props.optedOutOfTaxesSetup,
 		};
 	}
 
@@ -91,12 +87,8 @@ class SetupTasks extends Component {
 		this.props.setOptedOutOfShippingSetup( this.props.site.ID, true );
 	}
 
-	onClickNoTaxes = () => {
-		event.preventDefault();
-		this.setState( {
-			showTaxesTask: false
-		} );
-		this.props.setOptedOutOfTaxesSetup( this.props.site.ID, true );
+	onClickTaxSettings = () => {
+		this.props.setCheckedTaxSetup( this.props.site.ID, true );
 	}
 
 	onClickOpenCustomizer = () => {
@@ -164,18 +156,13 @@ class SetupTasks extends Component {
 				checked: taxesAreSetUp,
 				explanation: translate( 'Taxes. Everyone\'s favorite. We made it simple.' ),
 				label: translate( 'Set up taxes' ),
-				show: this.state.showTaxesTask,
+				show: true,
 				actions: [
 					{
 						label: translate( 'Set up taxes' ),
 						path: getLink( '/store/settings/taxes/:site', site ),
+						onClick: this.onClickTaxSettings,
 						analyticsProp: 'set-up-taxes',
-					},
-					{
-						label: translate( 'I won\'t be charging sales tax' ),
-						isSecondary: true,
-						onClick: this.onClickNoTaxes,
-						analyticsProp: 'no-taxes',
 					}
 				]
 			},
@@ -225,12 +212,11 @@ function mapStateToProps( state ) {
 	return {
 		loading: areSetupChoicesLoading( state ),
 		optedOutOfShippingSetup: getOptedOutOfShippingSetup( state ),
-		optedOutOfTaxesSetup: getOptedOutofTaxesSetup( state ),
 		triedCustomizer: getTriedCustomizerDuringInitialSetup( state ),
 		hasProducts: getTotalProducts( state ) > 0,
 		paymentsAreSetUp: arePaymentsSetup( state ),
 		shippingIsSetUp: areAnyShippingMethodsEnabled( state ),
-		taxesAreSetUp: !! areTaxCalculationsEnabled( state ),
+		taxesAreSetUp: getCheckedTaxSetup( state ),
 	};
 }
 
@@ -242,7 +228,7 @@ function mapDispatchToProps( dispatch ) {
 			fetchSettingsGeneral,
 			fetchSetupChoices,
 			setOptedOutOfShippingSetup,
-			setOptedOutOfTaxesSetup,
+			setCheckedTaxSetup,
 			setTriedCustomizerDuringInitialSetup,
 		},
 		dispatch

--- a/client/extensions/woocommerce/state/sites/settings/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/actions.js
@@ -105,6 +105,11 @@ export const doInitialSetup = (
 			group_id: 'products',
 			id: 'woocommerce_weight_unit',
 			value: 'lbs',
+		},
+		{
+			group_id: 'general',
+			id: 'woocommerce_calc_taxes',
+			value: 'yes',
 		}
 	];
 

--- a/client/extensions/woocommerce/state/sites/setup-choices/actions.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/actions.js
@@ -92,6 +92,10 @@ export const setCreatedDefaultShippingZone = ( siteId, value ) => ( dispatch ) =
 	return updateSetupChoice( dispatch, siteId, 'created_default_shipping_zone', value );
 };
 
+export const setCheckedTaxSetup = ( siteId, value ) => ( dispatch ) => {
+	return updateSetupChoice( dispatch, siteId, 'checked_tax_setup', value );
+};
+
 export const setFinishedInstallOfRequiredPlugins = ( siteId, value ) => ( dispatch ) => {
 	return updateSetupChoice( dispatch, siteId, 'finished_initial_install_of_required_plugins', value );
 };

--- a/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
@@ -128,6 +128,17 @@ export function getFinishedPageSetup( state, siteId = getSelectedSiteId( state )
 }
 
 /**
+ * Gets whether the tax page was clicked through to during setup
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId wpcom site id. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean} Whether or not all the tax page was clicked through to during setup
+ */
+export function getCheckedTaxSetup( state, siteId = getSelectedSiteId( state ) ) {
+	return isChoiceTrue( state, siteId, 'checked_tax_setup' );
+}
+
+/**
  * Gets whether the merchant completed setting the store address during setup
  *
  * @param {Object} state Global state tree

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/actions.js
@@ -9,6 +9,7 @@ import { spy } from 'sinon';
  */
 import {
 	fetchSetupChoices,
+	setCheckedTaxSetup,
 	setFinishedInitialSetup,
 	setFinishedInstallOfRequiredPlugins,
 	setOptedOutOfShippingSetup,
@@ -474,6 +475,64 @@ describe( 'actions', () => {
 					siteId,
 					key: 'finished_page_setup',
 					value: true,
+				} );
+			} );
+		} );
+	} );
+
+	describe( '#setCheckedTaxSetup', () => {
+		const siteId = '123';
+
+		useSandbox();
+		useNock( ( nock ) => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/sites/123/calypso-preferences/woocommerce', {
+					checked_tax_setup: true,
+				} )
+				.reply( 200, {
+					finished_initial_setup: false,
+					opted_out_of_shipping_setup: false,
+					opted_out_of_taxes_setup: false,
+					tried_customizer_during_initial_setup: false,
+					created_default_shipping_zone: false,
+					finished_initial_install_of_required_plugins: false,
+					set_store_address_during_initial_setup: false,
+					checked_tax_setup: true,
+				} );
+		} );
+
+		it( 'should dispatch an action', () => {
+			const getState = () => ( {} );
+			const dispatch = spy();
+			setCheckedTaxSetup( siteId, true )( dispatch, getState );
+			expect( dispatch ).to.have.been.calledWith( {
+				type: WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST,
+				siteId,
+				key: 'checked_tax_setup',
+				value: true
+			} );
+		} );
+
+		it( 'should dispatch a success action with setup choices when request completes', () => {
+			const getState = () => ( {} );
+			const dispatch = spy();
+			const response = setCheckedTaxSetup( siteId, true )( dispatch, getState );
+
+			return response.then( () => {
+				expect( dispatch ).to.have.been.calledWith( {
+					type: WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST_SUCCESS,
+					siteId,
+					data: {
+						finished_initial_setup: false,
+						opted_out_of_shipping_setup: false,
+						opted_out_of_taxes_setup: false,
+						tried_customizer_during_initial_setup: false,
+						created_default_shipping_zone: false,
+						finished_initial_install_of_required_plugins: false,
+						set_store_address_during_initial_setup: false,
+						checked_tax_setup: true,
+					}
 				} );
 			} );
 		} );

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
@@ -17,6 +17,7 @@ import {
 	getSetStoreAddressDuringInitialSetup,
 	getTriedCustomizerDuringInitialSetup,
 	isDefaultShippingZoneCreated,
+	getCheckedTaxSetup,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -50,6 +51,7 @@ const loadedState = {
 						created_default_shipping_zone: true,
 						finished_initial_install_of_required_plugins: true,
 						set_store_address_during_initial_setup: true,
+						checked_tax_setup: true,
 					},
 				},
 				124: {
@@ -62,6 +64,7 @@ const loadedState = {
 						created_default_shipping_zone: false,
 						finished_initial_install_of_required_plugins: false,
 						set_store_address_during_initial_setup: false,
+						checked_tax_setup: false,
 					},
 				},
 			},
@@ -212,6 +215,20 @@ describe( 'selectors', () => {
 
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getFinishedPageSetup( loadedStateWithUi ) ).to.eql( true );
+		} );
+	} );
+
+	describe( '#getCheckedTaxSetup', () => {
+		it( 'should get whether taxes were checked during setup from the state (123-true).', () => {
+			expect( getCheckedTaxSetup( loadedState, 123 ) ).to.eql( true );
+		} );
+
+		it( 'should get whether whether taxes were checked during setup from the state (124-false).', () => {
+			expect( getCheckedTaxSetup( loadedState, 124 ) ).to.eql( false );
+		} );
+
+		it( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getCheckedTaxSetup( loadedStateWithUi ) ).to.eql( true );
 		} );
 	} );
 


### PR DESCRIPTION
This PR defaults tax calculation to 'on' during initial setup. It also changes the behavior of the checkmark for tax settings that shows on the setup dashboard. Now it will check once you click the button to review tax settings. Because of that change, I also removed the opt out link. They opt out of taxes by reviewing the settings turning off tax calculation.

Fixes #15904. cc @allendav. I also deployed D6293-code as part of this, for the new flag.

To Test:
* Reset your setup flags at `https://developer.wordpress.com/docs/api/console/`, so you can go through the store setup flow again.
* Once you end up on the dashboard with the checklist, the taxes box should be unchecked.
* Click the button, and you will be brought to the tax page. You should see tax calculation enabled. (You also must be on an Atomic site for this to work properly -- tax rates don't work on other test sites).
* Go back to the dashboard and make sure the check mark is checked.
* Run `npm run test-client client/extensions/woocommerce/state/` and make sure all tests pass.