### PR TITLE
WooCommerce: Hide sidebar links until the address setup is complete, not entire store setup

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -11,7 +11,7 @@ import React, { Component, PropTypes } from 'react';
  * Internal dependencies
  */
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
-import { getFinishedInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
+import { getSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import Sidebar from 'layout/sidebar';
@@ -75,10 +75,10 @@ class StoreSidebar extends Component {
 	}
 
 	renderSidebarMenuItems = ( items, buttons, isDisabled ) => {
-		const { site, finishedInitialSetup, page } = this.props;
+		const { site, finishedAddressSetup, page } = this.props;
 
 		return items.map( function( item, index ) {
-			if ( ! item.showDuringSetup && ! finishedInitialSetup ) {
+			if ( ! item.showDuringSetup && ! finishedAddressSetup ) {
 				return null;
 			}
 			const isChild = ( 'undefined' !== typeof item.parentSlug );
@@ -166,9 +166,9 @@ class StoreSidebar extends Component {
 }
 
 function mapStateToProps( state ) {
-	const finishedInitialSetup = getFinishedInitialSetup( state );
+	const finishedAddressSetup = getSetStoreAddressDuringInitialSetup( state );
 	return {
-		finishedInitialSetup,
+		finishedAddressSetup,
 		site: getSelectedSiteWithFallback( state )
 	};
 }


### PR DESCRIPTION
Fixes #15895.

We were previously hiding the dashboard links all through the setup flow. This PR updates that so they appear after the address setup (when you can really start clicking around and changing settings, etc).

To Test:
* Go to https://developer.wordpress.com/docs/api/console/ and set `set_store_address_during_initial_setup` to 0 via the calypso-preferences endpoint.
* Go to `http://calypso.localhost:3000/store/:site`
* The address step should display, and the products, orders, etc links should be hidden.
* Finish the address setup. The links should load in the sidebar.