### PR TITLE
Update prettier to the calypso-1.5 version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,10 @@
   "name": "wp-calypso",
   "version": "0.17.0",
   "dependencies": {
+    "@types/node": {
+      "version": "6.0.80",
+      "dev": true
+    },
     "5to6-codemod": {
       "version": "1.7.0",
       "from": "git://github.com/5to6/5to6-codemod.git#60306b71d8dde341e4d4bb968e6fbaf6875e19ae",
@@ -175,7 +179,7 @@
       "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.5"
+      "version": "2.0.6"
     },
     "asn1": {
       "version": "0.2.3"
@@ -832,7 +836,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000698"
+      "version": "1.0.30000699"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -1638,7 +1642,7 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.23"
+      "version": "0.10.24"
     },
     "es6-error": {
       "version": "4.0.2"
@@ -2670,6 +2674,10 @@
     "get-stdin": {
       "version": "4.0.1"
     },
+    "get-stream": {
+      "version": "3.0.0",
+      "dev": true
+    },
     "get-video-id": {
       "version": "2.1.4"
     },
@@ -2752,6 +2760,10 @@
     },
     "graceful-readlink": {
       "version": "1.0.1"
+    },
+    "graphql": {
+      "version": "0.10.1",
+      "dev": true
     },
     "gridicons": {
       "version": "1.1.0"
@@ -3340,6 +3352,10 @@
       "version": "1.1.1",
       "dev": true
     },
+    "iterall": {
+      "version": "1.1.1",
+      "dev": true
+    },
     "jade": {
       "version": "1.11.0",
       "from": "git://github.com/pugjs/jade.git#29784fd1ec6043397f4b43d45b4ee9e25177b940",
@@ -3516,7 +3532,7 @@
       "dev": true
     },
     "jest-matcher-utils": {
-      "version": "19.0.0",
+      "version": "20.0.3",
       "dev": true,
       "dependencies": {
         "chalk": {
@@ -3646,7 +3662,7 @@
       }
     },
     "jest-validate": {
-      "version": "19.0.0",
+      "version": "20.0.3",
       "dev": true,
       "dependencies": {
         "chalk": {
@@ -3811,6 +3827,10 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1"
+    },
+    "json-to-ast": {
+      "version": "2.0.0-alpha1.2",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2"
@@ -4073,6 +4093,14 @@
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
+      "dev": true
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
       "dev": true
     },
     "log-symbols": {
@@ -4352,7 +4380,7 @@
       "version": "0.1.17"
     },
     "node-emoji": {
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dev": true
     },
     "node-fetch": {
@@ -4797,7 +4825,11 @@
       }
     },
     "postcss-less": {
-      "version": "0.14.0",
+      "version": "1.1.0",
+      "dev": true
+    },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
       "dev": true
     },
     "postcss-reporter": {
@@ -4809,8 +4841,38 @@
       "dev": true
     },
     "postcss-scss": {
-      "version": "0.1.9",
-      "dev": true
+      "version": "1.0.0",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.1.0",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.6",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.2.0",
+          "dev": true
+        }
+      }
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
@@ -4818,6 +4880,12 @@
     },
     "postcss-value-parser": {
       "version": "3.3.0"
+    },
+    "postcss-values-parser": {
+      "version": "1.2.2",
+      "from": "git://github.com/shellscape/postcss-values-parser.git#5e351360479116f3fe309602cdd15b0a233bc29f",
+      "resolved": "git://github.com/shellscape/postcss-values-parser.git#5e351360479116f3fe309602cdd15b0a233bc29f",
+      "dev": true
     },
     "prebuild-install": {
       "version": "2.2.0",
@@ -4839,37 +4907,71 @@
       "version": "0.2.0"
     },
     "prettier": {
-      "version": "1.1.7",
-      "from": "git+https://github.com/Automattic/calypso-prettier.git#183198b79773dbe9bd6c64a45cf74d1e90d4db24",
-      "resolved": "git+https://github.com/Automattic/calypso-prettier.git#183198b79773dbe9bd6c64a45cf74d1e90d4db24",
+      "version": "1.5.2",
+      "from": "git+https://github.com/Automattic/calypso-prettier.git#16f324aebd861a8a0ef834ce71d4992cf0275670",
+      "resolved": "git+https://github.com/Automattic/calypso-prettier.git#16f324aebd861a8a0ef834ce71d4992cf0275670",
       "dev": true,
       "dependencies": {
-        "ast-types": {
-          "version": "0.9.8",
+        "babel-code-frame": {
+          "version": "7.0.0-alpha.12",
           "dev": true
         },
         "babylon": {
-          "version": "7.0.0-beta.8",
+          "version": "7.0.0-beta.13",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "dev": true
         },
+        "diff": {
+          "version": "3.2.0",
+          "dev": true
+        },
         "flow-parser": {
-          "version": "0.43.0",
+          "version": "0.47.0",
           "dev": true
         },
-        "get-stdin": {
-          "version": "5.0.1",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.1",
+        "has-flag": {
+          "version": "2.0.0",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
+          "dev": true
+        },
+        "parse5": {
+          "version": "3.0.2",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.6",
+          "dev": true,
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.1.0",
+              "dev": true
+            },
+            "chalk": {
+              "version": "2.0.1",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "4.2.0",
+              "dev": true
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
           "dev": true
         },
         "supports-color": {
@@ -4879,7 +4981,7 @@
       }
     },
     "pretty-format": {
-      "version": "19.0.0",
+      "version": "20.0.3",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
@@ -5904,6 +6006,14 @@
           "version": "3.9.2",
           "dev": true
         },
+        "postcss-less": {
+          "version": "0.14.0",
+          "dev": true
+        },
+        "postcss-scss": {
+          "version": "0.1.9",
+          "dev": true
+        },
         "readable-stream": {
           "version": "2.3.3",
           "dev": true,
@@ -6200,6 +6310,22 @@
     },
     "typedarray": {
       "version": "0.0.6"
+    },
+    "typescript": {
+      "version": "2.5.0-dev.20170617",
+      "dev": true
+    },
+    "typescript-eslint-parser": {
+      "version": "3.0.0",
+      "from": "git://github.com/eslint/typescript-eslint-parser.git#cfddbfe3ebf550530aef2f1c6c4ea1d9e738d9c1",
+      "resolved": "git://github.com/eslint/typescript-eslint-parser.git#cfddbfe3ebf550530aef2f1c6c4ea1d9e738d9c1",
+      "dev": true,
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "dev": true
+        }
+      }
     },
     "ua-parser-js": {
       "version": "0.7.13"

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "mockery": "1.7.0",
     "nock": "8.0.0",
     "nodemon": "1.4.1",
-    "prettier": "git+https://github.com/Automattic/calypso-prettier.git#calypso-1.1",
+    "prettier": "git+https://github.com/Automattic/calypso-prettier.git#calypso-1.5",
     "react-addons-test-utils": "15.4.0",
     "react-codemod": "github:reactjs/react-codemod",
     "react-test-env": "0.2.0",


### PR DESCRIPTION
Update to the latest version of our fork. Please check if there are any formatting regressions or bugs in your prettier-formatted code.

I'm not 100% sure about my `npm-shrinkwrap.json` update -- doing it for the first time. Some 👀 will be appreciated!