### PR TITLE
Themes: Add a `noindex` meta tag to retired theme sheets

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -534,6 +534,13 @@ const ThemeSheet = React.createClass( {
 			} );
 		}
 
+		if ( this.props.retired ) {
+			metas.push( {
+				name: 'robots',
+				content: 'noindex'
+			} );
+		}
+
 		const links = [ { rel: 'canonical', href: canonicalUrl } ];
 
 		return (


### PR DESCRIPTION
* Retired theme sheets are mainly for customers and support staff.
* They shouldn't be indexed once a theme is retired.
* Avoids potential confusion with the same themes being still available on WordPress.org.

To test, switch to branch and visit:

* Retired premium theme (tag should be there): `/theme/mh-magazine`
* Retired free theme (tag should be there): `/theme/banana-smoothie`
* Worth also visiting some other themes that aren't retired. Like `/theme/verity` (tag shouldn't be there).

See:
![screen shot 2017-07-06 at 2 44 22 pm](https://user-images.githubusercontent.com/1473618/27927468-da6b7b26-6259-11e7-82bb-d373a90202f0.png)

Also, see docs on the [noindex meta tag](https://developers.google.com/search/reference/robots_meta_tag).