### PR TITLE
Woo-Connect Insights: include format to remove moment deprecation warning

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -86,7 +86,7 @@ export const UNITS = {
 		quantity: 30,
 		label: 'weeks',
 		durationFn: 'asWeeks',
-		format: 'YYYY',
+		format: 'YYYY-[W]WW',
 	},
 	month: {
 		quantity: 30,

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -20,6 +20,7 @@ import Tabs from 'my-sites/stats/stats-tabs';
 import Tab from 'my-sites/stats/stats-tabs/tab';
 import Delta from 'woocommerce/components/delta';
 import formatCurrency from 'lib/format-currency';
+import { getPeriodFormat } from 'state/stats/lists/utils';
 
 class StoreStatsChart extends Component {
 	static propTypes = {
@@ -74,7 +75,7 @@ class StoreStatsChart extends Component {
 	};
 
 	render() {
-		const { siteId, query, data } = this.props;
+		const { siteId, query, data, unit } = this.props;
 		const { selectedTabIndex } = this.state;
 		const orderData = data.data;
 		const tabs = [
@@ -104,6 +105,7 @@ class StoreStatsChart extends Component {
 							const itemChartData = this.buildChartData( orderData[ selectedIndex ], tabs[ tabIndex ] );
 							const delta = this.getDeltaByStat( tab.attr );
 							const deltaValue = Math.abs( Math.round( delta.percentage_change * 100 ) );
+							const periodFormat = getPeriodFormat( unit, delta.reference_period );
 							return (
 								<Tab
 									key={ tab.attr }
@@ -120,7 +122,7 @@ class StoreStatsChart extends Component {
 									<Delta
 										value={ `${ deltaValue }%` }
 										className={ `${ delta.favorable } ${ delta.direction }` }
-										suffix={ `since ${ moment( delta.reference_period ).format( 'MMM D' ) }` }
+										suffix={ `since ${ moment( delta.reference_period, periodFormat ).format( 'MMM D' ) }` }
 									/>
 								</Tab>
 							);

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -24,6 +24,7 @@ import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
 import Table from 'woocommerce/components/table';
 import TableItem from 'woocommerce/components/table/table-item';
 import TableRow from 'woocommerce/components/table/table-row';
+import { getPeriodFormat } from 'state/stats/lists/utils';
 
 class StoreStatsWidgetList extends Component {
 
@@ -52,9 +53,10 @@ class StoreStatsWidgetList extends Component {
 
 	getEndPeriod = ( date ) => {
 		const { unit } = this.props.query;
+		const periodFormat = getPeriodFormat( unit, date );
 		return ( unit === 'week' )
-			? moment( date ).endOf( 'isoWeek' ).format( 'YYYY-MM-DD' )
-			: moment( date ).endOf( unit ).format( 'YYYY-MM-DD' );
+			? moment( date, periodFormat ).endOf( 'isoWeek' ).format( 'YYYY-MM-DD' )
+			: moment( date, periodFormat ).endOf( unit ).format( 'YYYY-MM-DD' );
 	};
 
 	getDeltasBySelectedPeriod = () => {
@@ -85,6 +87,7 @@ class StoreStatsWidgetList extends Component {
 		if ( ! isLoading && ! hasEmptyData ) {
 			const firstRealKey = Object.keys( data.deltas[ selectedIndex ] ).filter( key => key !== 'period' )[ 0 ];
 			const sincePeriod = this.getDeltaByStat( firstRealKey );
+			const periodFormat = getPeriodFormat( query.unit, sincePeriod.reference_period );
 			values = [
 				{
 					key: 'title',
@@ -100,7 +103,7 @@ class StoreStatsWidgetList extends Component {
 				},
 				{
 					key: 'delta',
-					label: `${ translate( 'Since' ) } ${ moment( sincePeriod.reference_period ).format( 'MMM D' ) }`
+					label: `${ translate( 'Since' ) } ${ moment( sincePeriod.reference_period, periodFormat ).format( 'MMM D' ) }`
 				}
 			];
 

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -87,9 +87,7 @@ export function getQueryDate( context ) {
  * @return {string} - as required by the API, eg for unit 'week', '2017-W27' isoWeek returned
  */
 export function getUnitPeriod( date, unit ) {
-	return ( unit === 'week' )
-		? `${ moment( date ).format( UNITS[ unit ].format ) }-W${ moment( date ).isoWeek() }`
-		: moment( date ).format( UNITS[ unit ].format );
+	return moment( date ).format( UNITS[ unit ].format );
 }
 
 /**

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import {
+	getPeriodFormat,
 	getSerializedStatsQuery,
 	normalizers,
 	rangeOfPeriod,
@@ -16,6 +17,48 @@ import {
 } from '../utils';
 
 describe( 'utils', () => {
+	describe( 'getPeriodFormat', () => {
+		it( 'should return correctly day format for long formats', () => {
+			const response = getPeriodFormat( 'day', '2017-07-07' );
+			assert.strictEqual( response, 'YYYY-MM-DD' );
+		} );
+
+		it( 'should return correctly week format for long formats', () => {
+			const response = getPeriodFormat( 'week', '2017-07-07' );
+			assert.strictEqual( response, 'YYYY-MM-DD' );
+		} );
+
+		it( 'should return correctly month format for long formats', () => {
+			const response = getPeriodFormat( 'month', '2017-07-07' );
+			assert.strictEqual( response, 'YYYY-MM-DD' );
+		} );
+
+		it( 'should return correctly year format for long formats', () => {
+			const response = getPeriodFormat( 'year', '2017-07-07' );
+			assert.strictEqual( response, 'YYYY-MM-DD' );
+		} );
+
+		it( 'should return correctly day format for short (new) formats', () => {
+			const response = getPeriodFormat( 'day', '2017-07-07' );
+			assert.strictEqual( response, 'YYYY-MM-DD' );
+		} );
+
+		it( 'should return correctly week format for short (new) formats', () => {
+			const response = getPeriodFormat( 'week', '2017-W27' );
+			assert.strictEqual( response, 'YYYY-[W]WW' );
+		} );
+
+		it( 'should return correctly month format for short (new) formats', () => {
+			const response = getPeriodFormat( 'month', '2017-07' );
+			assert.strictEqual( response, 'YYYY-MM' );
+		} );
+
+		it( 'should return correctly year format for short (new) formats', () => {
+			const response = getPeriodFormat( 'year', '2017' );
+			assert.strictEqual( response, 'YYYY' );
+		} );
+	} );
+
 	describe( 'buildExportArray()', () => {
 		it( 'should an empty array if data not supplied', () => {
 			const data = buildExportArray( {} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -11,7 +11,7 @@ import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
 
 /**
- * Returns astring of the moment format for the period. Supports store stats
+ * Returns a string of the moment format for the period. Supports store stats
  * isoWeek and shortened formats.
  *
  * @param  {String} period Stats query

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -9,6 +9,34 @@ import { moment, translate } from 'i18n-calypso';
  */
 import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
 
+
+/**
+ * Returns astring of the moment format for the period. Supports store stats
+ * isoWeek and shortened formats.
+ *
+ * @param  {String} period Stats query
+ * @param  {String} date   Stats date
+ * @return {Object}        Period range
+ */
+export function getPeriodFormat( period, date ) {
+	const strDate = date.toString();
+	switch ( period ) {
+		case 'week':
+			return ( strDate.length === 8 && strDate.substr( 4, 2 ) === '-W' )
+				? 'YYYY-[W]WW'
+				:	'YYYY-MM-DD';
+		case 'month':
+			return ( strDate.length === 7 && strDate.substr( 4, 1 ) === '-' )
+				? 'YYYY-MM'
+				: 'YYYY-MM-DD';
+		case 'year':
+			return ( strDate.length === 4 ) ? 'YYYY' : 'YYYY-MM-DD';
+		case 'day':
+		default:
+			return 'YYYY-MM-DD';
+	}
+}
+
 /**
  * Returns an object with the startOf and endOf dates
  * for the given stats period and date
@@ -18,7 +46,8 @@ import { PUBLICIZE_SERVICES_LABEL_ICON } from './constants';
  * @return {Object}        Period range
  */
 export function rangeOfPeriod( period, date ) {
-	const momentDate = moment( date ).locale( 'en' );
+	const format = getPeriodFormat( period, date );
+	const momentDate = moment( date, format ).locale( 'en' );
 	const startOf = momentDate.clone().startOf( period );
 	const endOf = momentDate.clone().endOf( period );
 


### PR DESCRIPTION
Added `getPeriodFormat()` to stats list utils to support both the old full `YYYY-MM-DD` and then new period formats for store stats - https://github.com/Automattic/wp-calypso/issues/15104.

Updated moment to include appropriate format.

Fixes #15914 