### PR TITLE
Activity log: Add log debug to ActivityLogItem expansion

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
+import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,6 +15,8 @@ import Gravatar from 'components/gravatar';
 import Gridicon from 'gridicons';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { addQueryArgs } from 'lib/route';
+
+const debug = debugFactory( 'calypso:activity-log:item' );
 
 class ActivityLogItem extends Component {
 
@@ -146,6 +149,8 @@ class ActivityLogItem extends Component {
 		} = this.props;
 		requestRestore( log.ts_utc );
 	};
+
+	handleOpen = () => debug( 'opened log', this.props.log );
 
 	getIcon() {
 		const { log } = this.props;
@@ -355,6 +360,7 @@ class ActivityLogItem extends Component {
 					header={ this.renderHeader() }
 					summary={ this.renderSummary() }
 					expandedSummary={ this.renderSummary() }
+					onOpen={ this.handleOpen }
 				>
 					{ this.renderDescription() }
 				</FoldableCard>


### PR DESCRIPTION
Adds debugging of the full log entry when you expand an ActivityLogItem card.

![logging-logs](https://user-images.githubusercontent.com/841763/27929306-b12b6652-6292-11e7-9a0d-06ad625e278d.gif)

**To test**
1. https://calypso.live/stats/activity?branch=add/activitylog-debug-log-item
1. Set `localStorage.setItem('debug', 'calypso:activity-log:item' )`
1. Expand a day
1. Expand an item to see the output