### PR TITLE
WooCommerce: Make sure that US is the default country and fix misc address issues

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -16,7 +16,7 @@ import {
 } from 'woocommerce/state/sites/settings/general/selectors';
 import { errorNotice } from 'state/notices/actions';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
-import { getCountryData } from 'woocommerce/lib/countries';
+import { getCountryData, getCountries } from 'woocommerce/lib/countries';
 import { setSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/actions';
 import SetupFooter from './setup-footer';
 import SetupHeader from './setup-header';
@@ -94,14 +94,27 @@ class PreSetupView extends Component {
 			return errorNotice( translate( 'There was a problem saving the store address. Please try again.' ) );
 		};
 
+		// Provides fallbacks if the country & state options were never changed/toggled,
+		// or if an unsupported country was set in state (like WC's default GB country)
+		let country = null;
+		let state = null;
+		if ( ! this.state.address.country || ! find( getCountries(), { code: this.state.address.country } ) ) {
+			country = 'US';
+			const countryData = getCountryData( country );
+			state = this.state.address.state ? this.state.address.state : countryData.defaultState;
+		} else {
+			country = this.state.address.country;
+			state = this.state.address.state;
+		}
+
 		this.props.doInitialSetup(
 			site.ID,
 			this.state.address.street,
 			this.state.address.street2,
 			this.state.address.city,
-			this.state.address.state,
+			state,
 			this.state.address.postcode,
-			this.state.address.country,
+			country,
 			onSuccess,
 			onFailure
 		);

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -44,10 +44,15 @@ class AddressView extends Component {
 	renderEditable = () => {
 		const { onChange, translate } = this.props;
 		const { city, country, postcode, street, street2, state } = this.props.address;
-		const countryData = find( getCountries(), { code: country || 'US' } );
-		const foundCountry = Boolean( countryData );
-		const states = foundCountry ? countryData.states : [];
-		const statesLabel = foundCountry ? countryData.statesLabel : translate( 'State' );
+		let countryData = find( getCountries(), { code: country || 'US' } );
+
+		// If we still haven't found any country data, default to US.
+		// This will catch any case where `country` is defined, but not a supported country.
+		if ( ! Boolean( countryData ) ) {
+			countryData = find( getCountries(), { code: 'US' } );
+		}
+
+		const { states, statesLabel } = countryData;
 
 		return (
 			<div className="address-view__fields-editable">
@@ -78,7 +83,6 @@ class AddressView extends Component {
 					<FormFieldSet className="address-view__editable-state">
 						<FormLabel>{ statesLabel }</FormLabel>
 						<FormSelect
-							disabled={ ! foundCountry }
 							name="state"
 							onChange={ onChange }
 							value={ state }

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -15,6 +15,7 @@ import Card from 'components/card';
 import Dialog from 'components/dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
+import { getCountryData } from 'woocommerce/lib/countries';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getStoreLocation, areSettingsGeneralLoading } from 'woocommerce/state/sites/settings/general/selectors';
 import { setAddress } from 'woocommerce/state/sites/settings/actions';
@@ -53,7 +54,15 @@ class StoreAddress extends Component {
 
 	onChange = ( event ) => {
 		const addressEdits = { ...this.state.addressEdits };
-		addressEdits[ event.target.name ] = event.target.value;
+		const addressKey = event.target.name;
+		const newValue = event.target.value;
+		addressEdits[ addressKey ] = newValue;
+		// Did they change the country? Force an appropriate state default
+		if ( 'country' === addressKey ) {
+			const countryData = getCountryData( newValue );
+			addressEdits.state = countryData ? countryData.defaultState : '';
+		}
+
 		this.setState( { addressEdits } );
 	}
 

--- a/client/extensions/woocommerce/lib/countries/index.js
+++ b/client/extensions/woocommerce/lib/countries/index.js
@@ -16,8 +16,8 @@ import US from './US';
 
 export const getCountries = () => {
 	return [
-		CA(),
 		US(),
+		CA(),
 	];
 };
 


### PR DESCRIPTION
Fixes #15898. Fixes #15962. This PR fixes a couple annoyances with address setting:

* US is now at the top of the country list
* US is now default
* States not properly loading in either because a country hadn't been set yet, or because you had a non-supported country set from`wp-admin` or from WooCommerce core defaults
* A warning preventing the address from being saved if you don't touch the state or country dropdown (sorry people in Alabama!)

The address stuff in general definitely needs some love IMO post v1. Especially as we open up to more countries.. but this fixes some issues I was seeing around the address step for v1, at least.

To Test:
* Set the address flag via calypso-preferences via `https://developer.wordpress.com/docs/api/console/` to 0
* Go to `wp-admin` and set a base country besides US or CA. This simulates not having a country or state set since we don't support them yet.
* Go to `http://calypso.localhost:3000/store/:site` and make sure United States is default, with Alabama selected.
* You should either be able to submit these choices, or change your location.