### PR TITLE
Jetpack modules: use consistent notice messages

### DIFF
--- a/client/state/notices/jetpack-modules/index.js
+++ b/client/state/notices/jetpack-modules/index.js
@@ -26,19 +26,19 @@ export const onJetpackModuleActivationActionMessage = ( dispatch, { type, module
 
 	switch ( type ) {
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:
-			message = message || translate( 'Turned on successfully.' );
+			message = message || translate( 'Settings saved successfully!' );
 			messageType = 'success';
 			break;
 		case JETPACK_MODULE_DEACTIVATE_SUCCESS:
-			message = message || translate( 'Turned off successfully.' );
+			message = message || translate( 'Settings saved successfully!' );
 			messageType = 'success';
 			break;
 		case JETPACK_MODULE_ACTIVATE_FAILURE:
-			message = message || translate( 'An error occurred during activation.' );
+			message = message || translate( 'There was a problem saving your changes. Please try again.' );
 			messageType = 'error';
 			break;
 		case JETPACK_MODULE_DEACTIVATE_FAILURE:
-			message = message || translate( 'An error occurred during deactivation.' );
+			message = message || translate( 'There was a problem saving your changes. Please try again.' );
 			messageType = 'error';
 			break;
 	}


### PR DESCRIPTION
Changing the module activation notice messages to make them consistent with the other settings Calypso. These were requested in https://github.com/Automattic/wp-calypso/pull/15893 PR feedback.