### PR TITLE
Activity log: Add restore progress persistence

### DIFF
--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { restoreProgressSchema } from './schema';
 import {
 	REWIND_RESTORE,
 	REWIND_RESTORE_DISMISS_PROGRESS,
@@ -45,3 +46,4 @@ export const restoreProgress = keyedReducer( 'siteId', createReducer( {}, {
 	[ REWIND_RESTORE_DISMISS_PROGRESS ]: stubNull,
 	[ REWIND_RESTORE_UPDATE_PROGRESS ]: updateProgress,
 } ) );
+restoreProgress.schema = restoreProgressSchema;

--- a/client/state/activity-log/restore/schema.js
+++ b/client/state/activity-log/restore/schema.js
@@ -1,0 +1,23 @@
+export const restoreProgressSchema = {
+	type: 'object',
+	patternProperties: {
+		'^\\d+$': {
+			type: 'object',
+			required: [
+				'restoreId',
+				'status',
+				'timestamp',
+			],
+			properties: {
+				errorCode: { type: 'string' },
+				failureReason: { type: 'string' },
+				message: { type: 'string' },
+				percent: { type: 'integer' },
+				restoreId: { type: 'integer' },
+				status: { type: 'string' },
+				timestamp: { type: 'integer' },
+			},
+		},
+	},
+	additionalProperties: false,
+};

--- a/client/state/activity-log/rewind-status/reducer.js
+++ b/client/state/activity-log/rewind-status/reducer.js
@@ -21,7 +21,6 @@ export const rewindStatus = keyedReducer( 'siteId', createReducer( {}, {
 		...state,
 		active: true,
 	} ),
-
 }, rewindStatusSchema ) );
 
 export const rewindStatusError = keyedReducer( 'siteId', createReducer( {}, {


### PR DESCRIPTION
Add persistence to restore progress state

**To test**
* https://calypso.live/stats/activity?branch=add/activitylog-restoreprogress-persist
* ```js
  dispatch({ type: 'REWIND_RESTORE_UPDATE_PROGRESS', siteId: state.ui.selectedSiteId, timestamp: 1498168800000, restoreId: 123, errorCode: "", failureReason: "", message: "", percent: 0, status: "running" })
  ```
* You should see a progress banner.
* Refresh. If you still see the progress banner, success!
* Make sure state wasn't flushed by sympathy, watch the console for the red message.

Included in #16092, can be reviewed there.

Part of #15385