### PR TITLE
Sidebar Navigation: increase font size for a11y

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -145,9 +145,6 @@
 
 		-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
 
-		@include breakpoint( "<660px" ) {
-			padding: 18px 16px 18px 53px;
-		}
 	}
 
 	a.plan-name {
@@ -157,11 +154,6 @@
 		color: darken( $gray, 20% );
 		font-weight: 600;
 		font-size: 12px;
-
-		@include breakpoint( "<660px" ) {
-			top: 16px;
-			right: 16px;
-		}
 	}
 
 	.gridicon,
@@ -189,9 +181,6 @@
 			margin-right: 0;
 
 
-			@include breakpoint( "<660px" ) {
-				top: 17px;
-			}
 		}
 	}
 }
@@ -216,6 +205,8 @@ a.sidebar__button, form.sidebar__button {
 
 	@include breakpoint( "<660px" ) {
 		font-size: 14px;
+		height: 30px;
+		line-height: 23px;
 	}
 }
 form.sidebar__button {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -199,12 +199,13 @@
 a.sidebar__button, form.sidebar__button {
 	display: flex;
 	position: relative;
+	align-self: center;
 	box-sizing: border-box;
 	white-space: nowrap;
 	overflow: hidden;
 	padding: 2px 8px 3px 8px;
 	height: 24px;
-	margin: 11px 8px 0 0;
+	margin-right: 8px;
 	line-height: 18px;
 	background-color: $gray-light;
 	color: darken( $gray, 20% );

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -131,12 +131,13 @@
 	a {
 		font-size: 13px;
 		position: relative;
-		padding: 14px 16px 14px 55px;
+		padding: 11px 16px 11px 18px;
 		color: $sidebar-text-color;
 		box-sizing: border-box;
 		white-space: nowrap;
 		overflow: hidden;
 		display: flex;
+		align-items: center;
 
 		&:focus {
 			outline: none;
@@ -166,12 +167,10 @@
 
 	.gridicon,
 	.jetpack-logo {
-		position: absolute;
-			top: 11px;
-			left: 20px;
 		fill: $gray;
 		height: 24px;
 		width: 24px;
+		margin-right: 6px;
 
 		@include breakpoint( "<660px" ) {
 				top: 15px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -130,6 +130,7 @@
 
 	a {
 		font-size: 14px;
+		line-height: 0;
 		position: relative;
 		padding: 11px 16px 11px 18px;
 		color: $sidebar-text-color;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -162,6 +162,7 @@
 		height: 24px;
 		width: 24px;
 		margin-right: 6px;
+		flex-shrink: 0;
 
 		@include breakpoint( "<660px" ) {
 				top: 15px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -216,9 +216,6 @@ a.sidebar__button, form.sidebar__button {
 
 	@include breakpoint( "<660px" ) {
 		font-size: 14px;
-		height: 35px;
-		padding: 8px 16px;
-		margin: 10px 10px 0 0;
 	}
 }
 form.sidebar__button {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -129,7 +129,7 @@
 	}
 
 	a {
-		font-size: 13px;
+		font-size: 14px;
 		position: relative;
 		padding: 11px 16px 11px 18px;
 		color: $sidebar-text-color;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -186,6 +186,8 @@
 				left: auto;
 			z-index: z-index( 'icon-parent', '.sidebar__menu .gridicon.gridicons-external' );
 			height: 18px;
+			margin-right: 0;
+
 
 			@include breakpoint( "<660px" ) {
 				top: 17px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -130,7 +130,7 @@
 
 	a {
 		font-size: 14px;
-		line-height: 0;
+		line-height: 1;
 		position: relative;
 		padding: 11px 16px 11px 18px;
 		color: $sidebar-text-color;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -152,12 +152,11 @@
 
 	a.plan-name {
 		padding: 3px 8px 4px 8px;
-		position: absolute;
-			top: 12px;
-			right: 8px;
-		color: darken( $gray, 10% );
+		margin-right: 8px;
+		align-self: center;
+		color: darken( $gray, 20% );
 		font-weight: 600;
-		font-size: 11px;
+		font-size: 12px;
 
 		@include breakpoint( "<660px" ) {
 			top: 16px;
@@ -208,7 +207,7 @@ a.sidebar__button, form.sidebar__button {
 	line-height: 18px;
 	background-color: $gray-light;
 	color: darken( $gray, 20% );
-	font-size: 11px;
+	font-size: 12px;
 	font-weight: 600;
 	border-radius: 3px;
 	border: 1px solid darken( $sidebar-bg-color, 10% );

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -57,10 +57,6 @@
 
 	-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
 
-	@include breakpoint( "<660px" ) {
-		padding: 18px 16px;
-	}
-
 	.gridicon {
 		fill: $gray;
 	}

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -43,7 +43,6 @@
 }
 
 .current-site__view-site {
-	font-size: 13px;
 	padding: 11px 16px;
 	color: $gray-dark;
 	box-sizing: border-box;
@@ -94,7 +93,7 @@
 	display: flex;
 	align-self: center;
 	color: $gray-dark;
-	font-size: 13px;
+	font-size: 14px;
 	width: 100%;
 }
 

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -52,7 +52,7 @@
 
 		.sidebar__heading {
 			margin: 0;
-			padding: 10px 16px 10px 55px;
+			padding: 10px 16px 10px 18px;
 			cursor: pointer;
 			position: relative;
 			transition: background-color 0.15s ease-in-out,
@@ -281,6 +281,7 @@
 				top: 0;
 				left: auto;
 			fill: $gray !important; // this needs to be more specific
+			margin-right: 0;
 		}
 
 

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -237,7 +237,6 @@
 
 	.sidebar__menu-add {
 		opacity: 0;
-		//transform: translateX( 100px );
 		transition: all 0.15s ease-in;
 		pointer-events: none;
 		padding: 0;


### PR DESCRIPTION
This is an effort to increase all important UI elements to at least a font size of 14px. Currently, the sidebar item text is 13px. 14px makes it more consistent with the text in the filterbar, buttons, masterbar, etc.

The 3 major changes here:
- font size of sidebar items and buttons have increased
- the vertical centering of the buttons and icons is now done with flex (was absolute positioning). This allows for dynamic centering if we ever change the font size in the future. ([exaggerated example](https://user-images.githubusercontent.com/618551/27978723-c9a15f08-6336-11e7-903f-681dc790ed40.png))
- mobile sidebar styles have changed quite a bit. The rows are now smaller in height, but still are within the recommended touch target size

Many things needed to be tweaked for the mobile styles and the reader.

Things to test:
- My Sites
- Me
- Reader
- mobile

Before|After
---|---
![before](https://user-images.githubusercontent.com/618551/27978752-f0014226-6336-11e7-8793-d36724d8b175.png)|![after](https://user-images.githubusercontent.com/618551/27978765-fdb7f6d0-6336-11e7-8151-3483a84ce07b.png)

Before and after gif:

![jul-07-2017 16-47-58](https://user-images.githubusercontent.com/618551/27978998-7367d6a6-6338-11e7-81d5-43c38153ec98.gif)

and for mobile:

![jul-07-2017 16-45-57](https://user-images.githubusercontent.com/618551/27979005-7e33c590-6338-11e7-8d69-18afd939a6b6.gif)



TODO

- [x] mobile sidebar styles
- [x] "Site Preview" button
- [x] reader sidebar styles
- [x] my sites sidebar styles
- [x] me sidebar styles
- [ ] frontend sidebar styles 😱 