### PR TITLE
Jetpack Plans: HappinessSupport component - Show HappyChat button after acquiring a Jetpack Professional plan

### DIFF
--- a/client/components/happiness-support/README.md
+++ b/client/components/happiness-support/README.md
@@ -1,0 +1,27 @@
+Happiness Support
+===============
+
+This component renders a card presenting our support resources, including links to the support form and documentation. It can also render a button to open a Live chat window if the prop `showLiveChatButton` is `true`. 
+
+## Usage
+
+```js
+import React from 'react';
+import HappinessSupport from 'components/happiness-support';
+
+export default () => {
+    return (
+        <HappinessSupport
+            isJetpack
+            liveChatButtonEventName="calypso_chat_button_clicked"
+            showLiveChatButton
+        />
+    );
+};
+```
+
+## Props
+
+- *isJetpack* (boolean) – Indicates that the Happiness Support card is related to a Jetpack Plan.
+- *liveChatButtonEventName* (string) – event name that will be recorded when the `HappychatButton` is clicked.
+- *showLiveChatButton* (boolean) – Whether to show a `HappychatButton` instead of the support link `Button`

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import localize from 'i18n-calypso';
 import React from 'react';
 import sample from 'lodash/sample';
 
@@ -38,7 +39,7 @@ const HappinessSupport = React.createClass( {
 
 		return (
 			<Button href={ url } target={ target }>
-				{ this.translate( 'Ask a question' ) }
+				{ this.props.translate( 'Ask a question' ) }
 			</Button>
 		);
 	},
@@ -63,7 +64,7 @@ const HappinessSupport = React.createClass( {
 
 		return (
 			<Button href={ url } target="_blank" rel="noopener noreferrer">
-				{ this.translate( 'Search our support site' ) }
+				{ this.props.translate( 'Search our support site' ) }
 			</Button>
 		);
 	},
@@ -79,11 +80,11 @@ const HappinessSupport = React.createClass( {
 				{ this.renderGravatar() }
 
 				<h3 className="happiness-support__heading">
-					{ this.translate( 'Enjoy priority support from our Happiness Engineers' ) }
+					{ this.props.translate( 'Enjoy priority support from our Happiness Engineers' ) }
 				</h3>
 
 				<p className="happiness-support__text">
-					{ this.translate(
+					{ this.props.translate(
 						'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account or how to do just about anything.',
 						{
 							components: {
@@ -102,4 +103,4 @@ const HappinessSupport = React.createClass( {
 	}
 } );
 
-export default HappinessSupport;
+export default localize( HappinessSupport );

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
+import analytics from 'lib/analytics';
 import classNames from 'classnames';
-import localize from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import React from 'react';
 import sample from 'lodash/sample';
 
@@ -11,12 +13,23 @@ import sample from 'lodash/sample';
  */
 import Button from 'components/button';
 import Gravatar from 'components/gravatar';
+import { isHappychatAvailable } from 'state/happychat/selectors';
 import support from 'lib/url/support';
+import HappychatButton from 'components/happychat/button';
+import HappychatConnection from 'components/happychat/connection';
 
 const HappinessSupport = React.createClass( {
 	propTypes: {
 		isJetpack: React.PropTypes.bool,
-		isPlaceholder: React.PropTypes.bool
+		isPlaceholder: React.PropTypes.bool,
+		liveChatButtonEventName: React.PropTypes.string,
+		showLiveChatButton: React.PropTypes.bool,
+	},
+
+	getDefaultProps() {
+		return {
+			showLiveChatButton: false
+		};
 	},
 
 	getInitialState() {
@@ -26,6 +39,12 @@ const HappinessSupport = React.createClass( {
 				{ display_name: 'Luca', avatar_URL: '//gravatar.com/avatar/7f7ba3ba8305287770e0cba76d1eb3db' }
 			] )
 		};
+	},
+
+	onLiveChatButtonClick() {
+		if ( this.props.liveChatButtonEventName ) {
+			analytics.tracks.recordEvent( this.props.liveChatButtonEventName );
+		}
 	},
 
 	renderContactButton() {
@@ -41,6 +60,14 @@ const HappinessSupport = React.createClass( {
 			<Button href={ url } target={ target }>
 				{ this.props.translate( 'Ask a question' ) }
 			</Button>
+		);
+	},
+
+	renderLiveChatButton() {
+		return (
+			<HappychatButton borderless={ false } onClick={ this.onLiveChatButtonClick }>
+				{ this.props.translate( 'Ask a question' ) }
+			</HappychatButton>
 		);
 	},
 
@@ -74,6 +101,7 @@ const HappinessSupport = React.createClass( {
 			'happiness-support': true,
 			'is-placeholder': this.props.isPlaceholder
 		};
+		const { liveChatAvailable, showLiveChatButton } = this.props;
 
 		return (
 			<div className={ classNames( classes ) }>
@@ -95,7 +123,8 @@ const HappinessSupport = React.createClass( {
 				</p>
 
 				<div className="happiness-support__buttons">
-					{ this.renderContactButton() }
+					{ showLiveChatButton && <HappychatConnection /> }
+					{ showLiveChatButton && liveChatAvailable ? this.renderLiveChatButton() : this.renderContactButton() }
 					{ this.renderSupportButton() }
 				</div>
 			</div>
@@ -103,4 +132,10 @@ const HappinessSupport = React.createClass( {
 	}
 } );
 
-export default localize( HappinessSupport );
+export default connect(
+	state => {
+		return {
+			liveChatAvailable: isHappychatAvailable( state ),
+		};
+	}
+)( localize( HappinessSupport ) );

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -61,6 +61,8 @@ import Notice from 'components/notice';
 import ThankYouCard from 'components/thank-you-card';
 import domainsPaths from 'my-sites/domains/paths';
 import config from 'config';
+import { getSitePlanSlug } from 'state/sites/plans/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 function getPurchases( props ) {
 	return ( props.receipt.data && props.receipt.data.purchases ) || [];
@@ -203,6 +205,11 @@ const CheckoutThankYou = React.createClass( {
 		return page( `/stats/insights/${ this.props.selectedSite.slug }` );
 	},
 
+	isEligibleForLiveChat() {
+		const { planSlug } = this.props;
+		return planSlug === 'jetpack_business' || planSlug === 'jetpack_business_monthly';
+	},
+
 	isNewUser() {
 		return moment( this.props.userDate ).isAfter( moment().subtract( 2, 'hours' ) );
 	},
@@ -281,7 +288,11 @@ const CheckoutThankYou = React.createClass( {
 				</Card>
 
 				<Card className="checkout-thank-you__footer">
-					<HappinessSupport isJetpack={ wasJetpackPlanPurchased } />
+					<HappinessSupport
+						isJetpack={ wasJetpackPlanPurchased }
+						liveChatButtonEventName="calypso_plans_autoconfig_chat_initiated"
+						showLiveChatButton={ this.isEligibleForLiveChat() }
+					/>
 				</Card>
 			</Main>
 		);
@@ -391,7 +402,11 @@ const CheckoutThankYou = React.createClass( {
 
 export default connect(
 	( state, props ) => {
+		const siteId = getSelectedSiteId( state );
+		const planSlug = getSitePlanSlug( state, siteId );
+
 		return {
+			planSlug,
 			receipt: getReceiptById( state, props.receiptId ),
 			sitePlans: getPlansBySite( state, props.selectedSite ),
 			user: getCurrentUser( state ),

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -63,6 +63,10 @@ import domainsPaths from 'my-sites/domains/paths';
 import config from 'config';
 import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+} from 'lib/plans/constants';
 
 function getPurchases( props ) {
 	return ( props.receipt.data && props.receipt.data.purchases ) || [];
@@ -207,7 +211,7 @@ const CheckoutThankYou = React.createClass( {
 
 	isEligibleForLiveChat() {
 		const { planSlug } = this.props;
-		return planSlug === 'jetpack_business' || planSlug === 'jetpack_business_monthly';
+		return planSlug === PLAN_JETPACK_BUSINESS || planSlug === PLAN_JETPACK_BUSINESS_MONTHLY;
 	},
 
 	isNewUser() {

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -51,6 +51,11 @@ class CurrentPlanHeader extends Component {
 		isAutomatedTransfer: PropTypes.bool,
 	};
 
+	isEligibleForLiveChat = () => {
+		const { currentPlanSlug: planSlug } = this.props;
+		return planSlug === 'jetpack_business' || planSlug === 'jetpack_business_monthly';
+	};
+
 	renderPurchaseInfo() {
 		const {
 			currentPlan,
@@ -137,6 +142,8 @@ class CurrentPlanHeader extends Component {
 						<HappinessSupport
 							isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 							isPlaceholder={ isPlaceholder }
+							showLiveChatButton={ this.isEligibleForLiveChat() }
+							liveChatButtonEventName="calypso_plans_current_plan_chat_initiated"
 						/>
 					</div>
 				</div>

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -53,7 +53,7 @@ class CurrentPlanHeader extends Component {
 
 	isEligibleForLiveChat = () => {
 		const { currentPlanSlug: planSlug } = this.props;
-		return planSlug === 'jetpack_business' || planSlug === 'jetpack_business_monthly';
+		return planSlug === PLAN_JETPACK_BUSINESS || planSlug === PLAN_JETPACK_BUSINESS_MONTHLY;
 	};
 
 	renderPurchaseInfo() {


### PR DESCRIPTION
This PR is similar to #15608 but implements the chat button on the current post plans page instead of doing it in the Thank You Card which is behind a feature flag.

#### Changes introduced by this PR

* Makes the Thank you page after plan selection show the Happychat Button for Jetpack Professional plans.
* Makes the My Plan page show for Jetpack Professional Plan users
* Refactors the HappinessSupport component to accept `showLiveChatButton` and  `liveChatButtonEventName` props that make the "Ask a question button" be a HappychatButton instead of a Button link.
* Includes a commit that turns off a feature flag for the development environment so we can test the changes in a live branch. So It shouldn't be merged until the commit is removed.

#### Testing instructions

1. Get to the [live branch for this PR](https://calypso.live/?branch=update/jetpack-plans-help-button-to-happychat-button)
1. On another tab, log in into Happychat staging hud as an operator (this is just to ensure there's at least one operator and the HappychatButton shows. Otherwise you won't see it).
1. Back in the live branch tab, connect a Jetpack site and acquire a Professional plan.
1. Wait until you see the post plans page, and until the "Ask a question" button is shown.
1. Confirm that the "Ask a question button" when clicked, shows the chat window.
1. Please also check the flow for at least the following:
    * A free Jetpack plan (button should link to support pages).
    * A .com plan (button should link to support pages).

#### Screenshot

Looks the same as before, but the button will show the chat window instead of linking to the support pages

**Thank You Page after acquiring Jetpack Professional**

![image](https://user-images.githubusercontent.com/746152/28023517-831f4466-6564-11e7-87d5-0eaf600b0154.png)

*My Plan Page*

![image](https://user-images.githubusercontent.com/746152/28023478-64ce7388-6564-11e7-85e0-18e693881ee0.png)



