### PR TITLE
Themes: allow to exclude child themes.

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -39,6 +39,7 @@ const ConnectedThemesSelection = connectOptions(
 	( props ) => {
 		return (
 			<ThemesSelection { ...props }
+				excludeChild={ true }
 				getOptions={ function( theme ) {
 					return pickBy(
 						addTracking( props.options ),

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -44,6 +44,7 @@ class ThemesSelection extends Component {
 			PropTypes.oneOf( [ 'wpcom', 'wporg' ] )
 		] ),
 		themes: PropTypes.array,
+		excludeChild: PropTypes.bool,
 		themesCount: PropTypes.number,
 		isRequesting: PropTypes.bool,
 		isLastPage: PropTypes.bool,
@@ -54,6 +55,7 @@ class ThemesSelection extends Component {
 	}
 
 	static defaultProps = {
+		excludeChild: false,
 		emptyContent: null,
 		showUploadButton: true
 	}
@@ -168,7 +170,7 @@ class ThemesSelection extends Component {
 }
 
 const ConnectedThemesSelection = connect(
-	( state, { filter, page, search, tier, vertical, siteId, source } ) => {
+	( state, { filter, page, search, tier, vertical, siteId, source, excludeChild } ) => {
 		const isJetpack = isJetpackSite( state, siteId );
 		let sourceSiteId;
 		if ( source === 'wpcom' || source === 'wporg' ) {
@@ -189,6 +191,9 @@ const ConnectedThemesSelection = connect(
 			filter: compact( [ filter, vertical ] ).join( ',' ),
 			number
 		};
+		if ( 'undefined' !== typeof excludeChild && excludeChild ) {
+			query.exclude_child = excludeChild;
+		}
 
 		return {
 			query,


### PR DESCRIPTION
Introduces a new property to `ThemesSelection` to allow to exclude child themes.

To test

1. apply D6302 to your sandbox
2. use this branch and look for Chronicle theme in a wpcom site and in a Jetpack site

It should show in the wpcom site, but not in the Jetpack site.

Verify that calls to endpoint `https://public-api.wordpress.com/rest/v1.2/themes` (with parameters or not) done from Calypso standing in the Jetpack site all have the `exclude_child` parameter.

<img width="168" alt="captura de pantalla 2017-07-06 a las 20 25 11" src="https://user-images.githubusercontent.com/1041600/27936828-3ff9402a-6289-11e7-834c-8d7e2b3b641d.png">

