### PR TITLE
Woo Shipping - changed modal button labels

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog.js
@@ -21,7 +21,7 @@ import {
 	areCurrentlyEditingShippingZoneLocationsValid,
 } from 'woocommerce/state/ui/shipping/zones/locations/selectors';
 
-const ShippingZoneLocationDialog = ( { siteId, isVisible, translate, actions, canSave } ) => {
+const ShippingZoneLocationDialog = ( { siteId, isVisible, isAdding, translate, actions, canSave } ) => {
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -37,7 +37,13 @@ const ShippingZoneLocationDialog = ( { siteId, isVisible, translate, actions, ca
 
 	const buttons = [
 		{ action: 'cancel', label: translate( 'Cancel' ) },
-		{ action: 'add', label: translate( 'Save' ), onClick: onClose, disabled: ! canSave, isPrimary: true },
+		{
+			action: 'add',
+			label: isAdding ? translate( 'Add' ) : translate( 'Done' ),
+			onClick: onClose,
+			disabled: ! canSave,
+			isPrimary: true
+		},
 	];
 
 	return (
@@ -57,6 +63,7 @@ const ShippingZoneLocationDialog = ( { siteId, isVisible, translate, actions, ca
 
 ShippingZoneLocationDialog.propTypes = {
 	siteId: PropTypes.number,
+	isAdding: PropTypes.bool,
 };
 
 export default connect(

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -122,7 +122,7 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 				</ListHeader>
 				{ locationsToRender.map( renderLocation ) }
 			</List>
-			<ShippingZoneLocationDialog siteId={ siteId } />
+			<ShippingZoneLocationDialog siteId={ siteId } isAdding={ isEmpty( locations ) } />
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -90,7 +90,7 @@ const ShippingZoneMethodDialog = ( {
 
 	const buttons = [
 		{ action: 'cancel', label: translate( 'Cancel' ) },
-		{ action: 'add', label: translate( 'Save' ), onClick: onClose, isPrimary: true },
+		{ action: 'add', label: isNew ? translate( 'Add' ) : translate( 'Done' ), onClick: onClose, isPrimary: true },
 	];
 
 	if ( ! isNew ) {


### PR DESCRIPTION
Fixes #15949 

The buttons will show "Add" if a new method is added or the location list is empty before the modal is opened. Otherwise they will read "Done"