### PR TITLE
View Site: Enable for staging and development

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -77,7 +77,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
-		"standalone-site-preview": true,
+		"standalone-site-preview": false,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -77,6 +77,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
+		"standalone-site-preview": true,
 		"ui/first-view": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/development.json
+++ b/config/development.json
@@ -144,7 +144,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"simple-payments": true,
-		"standalone-site-preview": false,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -87,6 +87,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -87,7 +87,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
-		"standalone-site-preview": true,
+		"standalone-site-preview": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -89,7 +89,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
-		"standalone-site-preview": true,
+		"standalone-site-preview": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -89,6 +89,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,6 +96,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/test.json
+++ b/config/test.json
@@ -93,6 +93,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/test.json
+++ b/config/test.json
@@ -93,7 +93,7 @@
 		"settings/theme-setup": false,
 		"signup/domain-first-flow": true,
 		"signup/social": false,
-		"standalone-site-preview": true,
+		"standalone-site-preview": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,6 +108,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
+		"standalone-site-preview": true,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,7 @@
 		"settings/theme-setup": true,
 		"signup/domain-first-flow": true,
 		"signup/social": true,
-		"standalone-site-preview": true,
+		"standalone-site-preview": false,
 		"support-user": true,
 		"sync-handler": true,
 		"ui/first-view": true,


### PR DESCRIPTION
This enables "View Site" menu item for staging and development.

Test: 
- boot on development or staging env
- we no longer have "Site Preview" button to open modal
- we have a new regular menu item called "View Site" that opens new Calypso page: `/view/:slug`

| current menu | new menu | 
| - | - |
| <img width="272" alt="screen shot 2017-07-26 at 15 33 53" src="https://user-images.githubusercontent.com/156676/28624052-25d338ce-7218-11e7-9482-ebe07f33f42f.png"> | <img width="271" alt="screen shot 2017-07-26 at 15 40 21" src="https://user-images.githubusercontent.com/156676/28624242-d677381a-7218-11e7-86c9-da11de2e12b1.png"> |

| current modal preview | new preview |
| - | - |
| <img width="1434" alt="screen shot 2017-07-26 at 15 41 42" src="https://user-images.githubusercontent.com/156676/28624300-07b6cc2e-7219-11e7-92a2-b4c12202cdb1.png"> | <img width="1435" alt="screen shot 2017-07-26 at 15 42 00" src="https://user-images.githubusercontent.com/156676/28624310-0f7378cc-7219-11e7-8968-de1f8e2f9bde.png"> |