### PR TITLE
Comments: Add reply and approve flow

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -43,14 +43,14 @@ export class CommentDetailReply extends Component {
 				? translate( 'Approve and reply to %(commentAuthor)s…', {
 					args: { commentAuthor: authorDisplayName }
 				} )
-				: 'Approve and reply to comment…';
+				: translate( 'Approve and reply to comment…' );
 		}
 
 		return authorDisplayName
 			? translate( 'Reply to %(commentAuthor)s…', {
 				args: { commentAuthor: authorDisplayName }
 			} )
-			: 'Reply to comment…';
+			: translate( 'Reply to comment…' );
 	}
 
 	handleTextChange = event => {

--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -35,11 +35,23 @@ export class CommentDetailReply extends Component {
 		return Math.max( TEXTAREA_HEIGHT_FOCUSED, textareaHeight );
 	}
 
-	getTextareaPlaceholder = () => this.props.authorDisplayName
-		? this.props.translate( 'Reply to %(commentAuthor)s…', {
-			args: { commentAuthor: this.props.authorDisplayName }
-		} )
-		: 'Reply to comment…';
+	getTextareaPlaceholder = () => {
+		const { authorDisplayName, commentStatus, translate } = this.props;
+
+		if ( 'approved' !== commentStatus ) {
+			return authorDisplayName
+				? translate( 'Approve and reply to %(commentAuthor)s…', {
+					args: { commentAuthor: authorDisplayName }
+				} )
+				: 'Approve and reply to comment…';
+		}
+
+		return authorDisplayName
+			? translate( 'Reply to %(commentAuthor)s…', {
+				args: { commentAuthor: authorDisplayName }
+			} )
+			: 'Reply to comment…';
+	}
 
 	handleTextChange = event => {
 		const { value } = event.target;
@@ -59,6 +71,7 @@ export class CommentDetailReply extends Component {
 	submit = () => {
 		const {
 			commentId,
+			commentStatus,
 			currentUser,
 			postId,
 			postTitle,
@@ -77,7 +90,7 @@ export class CommentDetailReply extends Component {
 			content: commentText,
 			URL: postUrl,
 		};
-		submitComment( comment );
+		submitComment( comment, { alsoApprove: 'approved' !== commentStatus } );
 		this.setState( { commentText: '' } );
 	}
 

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -106,8 +106,9 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 
 	setCommentsPage = commentsPage => this.setState( { commentsPage } );
 
-	submitComment = comment => {
+	submitComment = ( comment, options = { alsoApprove: false } ) => {
 		const { comments } = this.state;
+		const parentComment = comments[ comment.parentId ];
 
 		const newComment = {
 			...createPlaceholderComment( comment.content, comment.postId, comment.parentId ),
@@ -128,6 +129,10 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 		this.setState( {
 			comments: {
 				...comments,
+				[ parentComment.ID ]: {
+					...parentComment,
+					status: 'approved',
+				},
 				[ newComment.ID ]: newComment,
 			}
 		} );

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -208,6 +208,7 @@ export class CommentDetail extends Component {
 						<CommentDetailReply
 							authorDisplayName={ authorDisplayName }
 							commentId={ commentId }
+							commentStatus={ commentStatus }
 							postId={ postId }
 							postTitle={ postTitle }
 							submitComment={ submitComment }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -181,13 +181,29 @@ export class CommentList extends Component {
 		this.props.createNotice( type, message, options );
 	}
 
-	submitComment = comment => {
-		this.props.removeNotice( 'comment-submitted' );
-		this.props.createNotice( 'is-success', this.props.translate( 'Comment submitted.' ), {
-			duration: 5000,
-			id: 'comment-submitted',
-			isPersistent: true,
-		} );
+	submitComment = ( comment, options = { alsoApprove: false } ) => {
+		const { translate } = this.props;
+		const { alsoApprove } = options;
+
+		this.props.removeNotice( `comment-notice-${ comment.parentId }` );
+
+		const noticeMessage = alsoApprove
+			? translate( 'Comment approved and reply submitted.' )
+			: translate( 'Reply submitted.' );
+
+		const noticeOptions = Object.assign(
+			{
+				duration: 5000,
+				id: `comment-notice-${ comment.parentId }`,
+				isPersistent: true,
+			},
+			alsoApprove && {
+				button: translate( 'Undo' ),
+				onClick: () => this.setCommentStatus( comment.parentId, 'unapproved', { showNotice: false } ),
+			}
+		);
+
+		this.props.createNotice( 'is-success', noticeMessage, noticeOptions );
 		this.props.submitComment( comment );
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -191,17 +191,11 @@ export class CommentList extends Component {
 			? translate( 'Comment approved and reply submitted.' )
 			: translate( 'Reply submitted.' );
 
-		const noticeOptions = Object.assign(
-			{
-				duration: 5000,
-				id: `comment-notice-${ comment.parentId }`,
-				isPersistent: true,
-			},
-			alsoApprove && {
-				button: translate( 'Undo' ),
-				onClick: () => this.setCommentStatus( comment.parentId, 'unapproved', { showNotice: false } ),
-			}
-		);
+		const noticeOptions = {
+			duration: 5000,
+			id: `comment-notice-${ comment.parentId }`,
+			isPersistent: true,
+		};
 
 		this.props.createNotice( 'is-success', noticeMessage, noticeOptions );
 		this.props.submitComment( comment );


### PR DESCRIPTION
Closes #15937

Adds the "Reply and Approve" flow to Comment Management.
Replying to an unapproved comment automatically approves it.
A notice appears confirming the comment approval.

![jul-07-2017 12-22-49](https://user-images.githubusercontent.com/2070010/27956763-1fca2140-6313-11e7-9bff-427286311ff9.gif)

cc @Automattic/lannister 