### PR TITLE
Comments: CommentFaker now sort comments in reverse chronological order

### DIFF
--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { filter, isNil, keyBy, map, omit, slice } from 'lodash';
+import { filter, isNil, keyBy, map, omit, orderBy, slice } from 'lodash';
 
 import { createPlaceholderComment } from 'state/data-layer/wpcom/comments';
 
@@ -48,7 +48,8 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 
 	getCommentsPage = comments => {
 		const startingIndex = ( this.state.commentsPage - 1 ) * COMMENTS_PER_PAGE;
-		return slice( comments, startingIndex, startingIndex + COMMENTS_PER_PAGE );
+		const orderedComments = orderBy( comments, 'date', 'desc' );
+		return slice( orderedComments, startingIndex, startingIndex + COMMENTS_PER_PAGE );
 	}
 
 	setBulkStatus = ( commentIds, status ) => this.setCommentStatusOrLike( commentIds, { status } );


### PR DESCRIPTION
Add `_.orderBy` to the `CommentFaker` to order comments by date, from most to least recent.

This is related to https://github.com/Automattic/wp-calypso/issues/15939, but it's not a fix as it only impacts the current fake system, while we'll eventually need to sort the real comments.

cc @Automattic/lannister 