### PR TITLE
Update/woocommerce egg dash copy

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -148,12 +148,12 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: taxesAreSetUp,
-				explanation: translate( 'Taxes. Everyone\'s favorite. We made it simple.' ),
-				label: translate( 'Set up taxes' ),
+				explanation: translate( 'We\'ve set up automatic tax calculations for you.' ),
+				label: translate( 'Review tax settings' ),
 				show: true,
 				actions: [
 					{
-						label: translate( 'Set up taxes' ),
+						label: translate( 'Review settings' ),
 						path: getLink( '/store/settings/taxes/:site', site ),
 						onClick: this.onClickTaxSettings,
 						analyticsProp: 'set-up-taxes',

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -122,12 +122,12 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: shippingIsSetUp,
-				explanation: translate( 'We\'ve set up shipping so that free shipping is available to customers in your country' ),
+				explanation: translate( 'We\'ve set up shipping so that free shipping is available to customers in your country.' ),
 				label: translate( 'Review shipping settings' ),
 				show: this.state.showShippingTask,
 				actions: [
 					{
-						label: translate( 'Set up shipping' ),
+						label: translate( 'Review settings' ),
 						path: getLink( '/store/settings/shipping/:site', site ),
 						analyticsProp: 'set-up-shipping',
 					}

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -122,7 +122,7 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: shippingIsSetUp,
-				explanation: translate( 'We\'ve set up shipping so that free shipping is available to customers in your country.' ),
+				explanation: translate( 'We\'ve set it up so that free shipping is available to customers in your country.' ),
 				label: translate( 'Review shipping settings' ),
 				show: this.state.showShippingTask,
 				actions: [

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -122,20 +122,14 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: shippingIsSetUp,
-				explanation: translate( 'Be ready to ship by the time your first order comes in.' ),
-				label: translate( 'Set up shipping' ),
+				explanation: translate( 'We\'ve set up shipping so that free shipping is available to customers in your country' ),
+				label: translate( 'Review shipping settings' ),
 				show: this.state.showShippingTask,
 				actions: [
 					{
 						label: translate( 'Set up shipping' ),
 						path: getLink( '/store/settings/shipping/:site', site ),
 						analyticsProp: 'set-up-shipping',
-					},
-					{
-						label: translate( 'I won\'t be shipping' ),
-						isSecondary: true,
-						onClick: this.onClickNoShip,
-						analyticsProp: 'not-shipping',
 					}
 				]
 			},

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -122,7 +122,7 @@ class SetupTasks extends Component {
 			},
 			{
 				checked: shippingIsSetUp,
-				explanation: translate( 'We\'ve set it up so that free shipping is available to customers in your country.' ),
+				explanation: translate( 'We\'ve set up shipping based on your store location.' ),
 				label: translate( 'Review shipping settings' ),
 				show: this.state.showShippingTask,
 				actions: [


### PR DESCRIPTION
Updates the copy on the dashboard egg to account for the fact that many users will not have to take any actions on the shipping/tax settings screens.

![egg-dash](https://cldup.com/wRgQCWJU4a.png)