### PR TITLE
Woo Shipping - Added default and min value for flat rate shipping

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/flat-rate.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-methods/flat-rate.js
@@ -39,7 +39,8 @@ const FreeShippingMethod = ( { id, cost, tax_status, currency, translate, action
 			<PriceInput
 				currency={ currency }
 				value={ cost }
-				onChange={ onCostChange } />
+				onChange={ onCostChange }
+				min={ 0.01 } />
 		);
 	};
 

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -51,7 +51,7 @@ class PriceInput extends Component {
 			return (
 				<FormTextInput
 					value={ value }
-					{ ...omit( props, [ 'noWrap' ] ) } />
+					{ ...omit( props, [ 'noWrap', 'min' ] ) } />
 			);
 		}
 

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/flat-rate/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/flat-rate/reducer.js
@@ -9,7 +9,7 @@ import {
 
 const initialState = {
 	tax_status: 'none',
-	cost: 0,
+	cost: 5,
 };
 
 const reducer = {};


### PR DESCRIPTION
The default cost of flat rate shipping is 5
The minimum cost of flat rate shipping is 0.01 (this is controlled only by the `min` attribute on the `number` input, some browsers will still allow to manually enter any value)