### PR TITLE
Data Layer: Stop `next()`ing actions

### DIFF
--- a/client/state/data-layer/third-party/directly/index.js
+++ b/client/state/data-layer/third-party/directly/index.js
@@ -15,16 +15,12 @@ import {
 } from 'state/help/directly/actions';
 import * as directly from 'lib/directly';
 
-export function askQuestion( { dispatch }, action, next ) {
-	next( action );
-
+export function askQuestion( { dispatch }, action ) {
 	return directly.askQuestion( action.questionText, action.name, action.email )
 		.then( () => dispatch( recordTracksEvent( 'calypso_directly_ask_question' ) ) );
 }
 
-export function initialize( { dispatch, getState }, action, next ) {
-	next( action );
-
+export function initialize( { dispatch } ) {
 	dispatch( recordTracksEvent( 'calypso_directly_initialization_start' ) );
 
 	return directly.initialize()

--- a/client/state/data-layer/third-party/directly/test/index.js
+++ b/client/state/data-layer/third-party/directly/test/index.js
@@ -11,7 +11,6 @@ import * as analytics from 'state/analytics/actions';
 import * as directly from 'lib/directly';
 import {
 	DIRECTLY_ASK_QUESTION,
-	DIRECTLY_INITIALIZATION_START,
 	DIRECTLY_INITIALIZATION_SUCCESS,
 	DIRECTLY_INITIALIZATION_ERROR,
 } from 'state/action-types';
@@ -21,13 +20,11 @@ import {
 } from '..';
 
 describe( 'Directly data layer', () => {
-	let next;
 	let store;
 	let simulateInitializationSuccess;
 	let simulateInitializationError;
 
 	useSandbox( ( sandbox ) => {
-		next = sandbox.spy();
 		store = {
 			dispatch: sandbox.spy(),
 		};
@@ -60,41 +57,29 @@ describe( 'Directly data layer', () => {
 		} );
 
 		it( 'should invoke the corresponding Directly function', () => {
-			askQuestion( store, action, next );
+			askQuestion( store, action );
 			expect( directly.askQuestion ).to.have.been.calledWith( questionText, name, email );
 		} );
 
-		it( 'should pass the action through', () => {
-			askQuestion( store, action, next );
-			expect( next ).to.have.been.calledWith( action );
-		} );
-
 		it( 'should dispatch an analytics event', () => (
-			askQuestion( store, action, next )
+			askQuestion( store, action )
 				.then( () => expect( analytics.recordTracksEvent ).to.have.been.calledWith( 'calypso_directly_ask_question' ) )
 		) );
 	} );
 
 	describe( '#initialize', () => {
-		const action = { type: DIRECTLY_INITIALIZATION_START };
-
 		it( 'should invoke the corresponding Directly function', () => {
-			initialize( store, action, next );
+			initialize( store );
 			expect( directly.initialize ).to.have.been.calledOnce;
 		} );
 
-		it( 'should pass the action through', () => {
-			initialize( store, action, next );
-			expect( next ).to.have.been.calledWith( action );
-		} );
-
 		it( 'should dispatch an analytics event once initialization starts', () => {
-			initialize( store, action, next );
+			initialize( store );
 			expect( analytics.recordTracksEvent ).to.have.been.calledWith( 'calypso_directly_initialization_start' );
 		} );
 
 		it( 'should dispatch a success action if initialization completes', ( done ) => {
-			initialize( store, action, next )
+			initialize( store )
 				.then( () => expect( store.dispatch ).to.have.been.calledWithMatch( { type: DIRECTLY_INITIALIZATION_SUCCESS } ) )
 				.then( () => done() );
 
@@ -102,7 +87,7 @@ describe( 'Directly data layer', () => {
 		} );
 
 		it( 'should dispatch an analytics event if initialization completes', ( done ) => {
-			initialize( store, action, next )
+			initialize( store )
 				.then( () => expect( analytics.recordTracksEvent ).to.have.been.calledWith( 'calypso_directly_initialization_success' ) )
 				.then( () => done() );
 
@@ -110,7 +95,7 @@ describe( 'Directly data layer', () => {
 		} );
 
 		it( 'should dispatch an error action if initialization fails', ( done ) => {
-			initialize( store, action, next )
+			initialize( store )
 				.then( () => expect( store.dispatch ).to.have.been.calledWithMatch( { type: DIRECTLY_INITIALIZATION_ERROR } ) )
 				.then( () => done() );
 
@@ -118,7 +103,7 @@ describe( 'Directly data layer', () => {
 		} );
 
 		it( 'should dispatch an analytics event if initialization fails', ( done ) => {
-			initialize( store, action, next )
+			initialize( store )
 				.then( () => expect( analytics.recordTracksEvent ).to.have.been.calledWith(
 					'calypso_directly_initialization_error',
 					{ error: 'Error: Something went wrong' }

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -32,11 +32,11 @@ export const successMeta = ( data, headers ) => ( { meta: { dataLayer: { data, h
 export const failureMeta = ( error, headers ) => ( { meta: { dataLayer: { error, headers } } } );
 export const progressMeta = ( { total, loaded } ) => ( { meta: { dataLayer: { progress: { total, loaded } } } } );
 
-export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch }, rawAction, next ) => {
+export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch }, rawAction ) => {
 	const action = processOutbound( rawAction, dispatch );
 
 	if ( null === action ) {
-		return next( rawAction );
+		return;
 	}
 
 	const {
@@ -77,8 +77,6 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 	if ( 'POST' === method && onProgress ) {
 		request.upload.onprogress = event => dispatch( extendAction( onProgress, progressMeta( event ) ) );
 	}
-
-	return next( action );
 };
 
 export default {

--- a/client/state/data-layer/wpcom-http/test/index.js
+++ b/client/state/data-layer/wpcom-http/test/index.js
@@ -38,22 +38,18 @@ const getMe = {
 
 describe( '#queueRequest', () => {
 	let dispatch;
-	let next;
 
 	useNock();
 
 	beforeEach( () => {
 		dispatch = spy();
-		next = spy();
 	} );
 
 	it( 'should call `onSuccess` when a response returns with data', done => {
 		const data = { value: 1 };
 		nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/me' ).reply( 200, data );
 
-		http( { dispatch }, getMe, next );
-
-		expect( next ).to.have.been.calledWith( getMe );
+		http( { dispatch }, getMe );
 
 		setTimeout( () => {
 			expect( dispatch ).to.have.been.calledOnce;
@@ -66,9 +62,7 @@ describe( '#queueRequest', () => {
 		const error = { error: 'bad' };
 		nock( 'https://public-api.wordpress.com:443' ).get( '/rest/v1.1/me' ).replyWithError( error );
 
-		http( { dispatch }, getMe, next );
-
-		expect( next ).to.have.been.calledWith( getMe );
+		http( { dispatch }, getMe );
 
 		setTimeout( () => {
 			expect( dispatch ).to.have.been.calledOnce;

--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -15,6 +15,7 @@ import { follow } from 'state/reader/follows/actions';
 import { getFeedByFeedUrl } from 'state/reader/feeds/selectors';
 import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
 import { getSiteName } from 'reader/get-helpers';
+import { local } from 'state/data-layer/utils';
 
 export function requestUnfollow( { dispatch, getState }, action ) {
 	const { payload: { feedUrl } } = action;
@@ -49,13 +50,13 @@ export function requestUnfollow( { dispatch, getState }, action ) {
 
 export function receiveUnfollow( store, action, next, response ) {
 	if ( response && ! response.subscribed ) {
-		next( action );
+		store.dispatch( local( action ) );
 	} else {
-		unfollowError( store, action, next );
+		unfollowError( store, action );
 	}
 }
 
-export function unfollowError( { dispatch, getState }, action, next ) {
+export function unfollowError( { dispatch, getState }, action ) {
 	const feedUrl = action.payload.feedUrl;
 	const site = getSiteByFeedUrl( getState(), feedUrl );
 	const feed = getFeedByFeedUrl( getState(), feedUrl );
@@ -69,7 +70,7 @@ export function unfollowError( { dispatch, getState }, action, next ) {
 			} ),
 		),
 	);
-	next( follow( action.payload.feedUrl ) );
+	dispatch( local( follow( action.payload.feedUrl ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -11,6 +11,7 @@ import { NOTICE_CREATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { follow, unfollow } from 'state/reader/follows/actions';
 import { requestUnfollow, receiveUnfollow, unfollowError } from '../';
+import { local } from 'state/data-layer/utils';
 
 describe( 'following/mine/delete', () => {
 	describe( 'requestUnfollow', () => {
@@ -49,18 +50,16 @@ describe( 'following/mine/delete', () => {
 	describe( 'receiveUnfollow', () => {
 		it( 'should next the original action', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = unfollow( 'http://example.com' );
 			const response = {
 				subscribed: false,
 			};
-			receiveUnfollow( { dispatch }, action, next, response );
-			expect( next ).to.be.calledWith( action );
+			receiveUnfollow( { dispatch }, action, null, response );
+			expect( dispatch ).to.be.calledWith( local( action ) );
 		} );
 
 		it( 'should dispatch an error notice and refollow when subscribed is true', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = unfollow( 'http://example.com' );
 			const getState = () => ( {
 				reader: {
@@ -78,14 +77,13 @@ describe( 'following/mine/delete', () => {
 
 			receiveUnfollow( { dispatch, getState }, action, next, response );
 			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-			expect( next ).to.be.calledWith( follow( 'http://example.com' ) );
+			expect( dispatch ).to.be.calledWith( local( follow( 'http://example.com' ) ) );
 		} );
 	} );
 
 	describe( 'followError', () => {
 		it( 'should dispatch an error notice', () => {
 			const dispatch = spy();
-			const next = spy();
 			const action = unfollow( 'http://example.com' );
 			const getState = () => ( {
 				reader: {
@@ -98,9 +96,9 @@ describe( 'following/mine/delete', () => {
 				},
 			} );
 
-			unfollowError( { dispatch, getState }, action, next );
+			unfollowError( { dispatch, getState }, action );
 			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-			expect( next ).to.be.calledWith( follow( 'http://example.com' ) );
+			expect( dispatch ).to.be.calledWith( local( follow( 'http://example.com' ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -75,7 +75,7 @@ describe( 'following/mine/delete', () => {
 				subscribed: true,
 			};
 
-			receiveUnfollow( { dispatch, getState }, action, next, response );
+			receiveUnfollow( { dispatch, getState }, action, null, response );
 			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
 			expect( dispatch ).to.be.calledWith( local( follow( 'http://example.com' ) ) );
 		} );

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -16,6 +16,7 @@ import { subscriptionFromApi } from 'state/data-layer/wpcom/read/following/mine/
 import { getFeedByFeedUrl } from 'state/reader/feeds/selectors';
 import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
 import { getSiteName } from 'reader/get-helpers';
+import { local } from 'state/data-layer/utils';
 
 export function requestFollow( { dispatch, getState }, action ) {
 	const { payload: { feedUrl } } = action;
@@ -49,7 +50,7 @@ export function requestFollow( { dispatch, getState }, action ) {
 export function receiveFollow( store, action, next, response ) {
 	if ( response && response.subscribed ) {
 		const subscription = subscriptionFromApi( response.subscription );
-		next( follow( action.payload.feedUrl, subscription ) );
+		store.dispatch( local( follow( action.payload.feedUrl, subscription ) ) );
 	} else {
 		followError( store, action, next, response );
 	}
@@ -70,7 +71,7 @@ export function followError( { dispatch }, action, next, response ) {
 		dispatch( recordFollowError( action.payload.feedUrl, response.info ) );
 	}
 
-	next( unfollow( action.payload.feedUrl ) );
+	dispatch( local( unfollow( action.payload.feedUrl ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -11,6 +11,7 @@ import { NOTICE_CREATE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { follow, unfollow } from 'state/reader/follows/actions';
 import { requestFollow, receiveFollow, followError } from '../';
+import { local } from 'state/data-layer/utils';
 
 describe( 'requestFollow', () => {
 	it( 'should dispatch a http request', () => {
@@ -51,7 +52,6 @@ describe( 'requestFollow', () => {
 describe( 'receiveFollow', () => {
 	it( 'should dispatch updateFollow with new subscription info', () => {
 		const dispatch = spy();
-		const next = spy();
 		const action = follow( 'http://example.com' );
 		const response = {
 			subscribed: true,
@@ -65,8 +65,8 @@ describe( 'receiveFollow', () => {
 				is_owner: false,
 			},
 		};
-		receiveFollow( { dispatch }, action, next, response );
-		expect( next ).to.be.calledWith(
+		receiveFollow( { dispatch }, action, null, response );
+		expect( dispatch ).to.be.calledWith( local(
 			follow( 'http://example.com', {
 				ID: 1,
 				URL: 'http://example.com',
@@ -77,33 +77,31 @@ describe( 'receiveFollow', () => {
 				delivery_methods: {},
 				is_owner: false,
 			} ),
-		);
+		) );
 	} );
 
 	it( 'should dispatch an error notice when subscribed is false', () => {
 		const dispatch = spy();
-		const next = spy();
 		const action = follow( 'http://example.com' );
 		const response = {
 			subscribed: false,
 		};
 
-		receiveFollow( { dispatch }, action, next, response );
+		receiveFollow( { dispatch }, action, null, response );
 		expect( dispatch ).to.be.calledWithMatch(
 			{ type: NOTICE_CREATE, notice: { status: 'is-error' } },
 		);
-		expect( next ).to.be.calledWith( unfollow( 'http://example.com' ) );
+		expect( dispatch ).to.be.calledWith( local( unfollow( 'http://example.com' ) ) );
 	} );
 } );
 
 describe( 'followError', () => {
 	it( 'should dispatch an error notice', () => {
 		const dispatch = spy();
-		const next = spy();
 		const action = follow( 'http://example.com' );
 
-		followError( { dispatch }, action, next );
+		followError( { dispatch }, action );
 		expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE } );
-		expect( next ).to.be.calledWith( unfollow( 'http://example.com' ) );
+		expect( dispatch ).to.be.calledWith( local( unfollow( 'http://example.com' ) ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/index.js
@@ -11,6 +11,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
+import { local } from 'state/data-layer/utils';
 
 export function requestCommentEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
@@ -31,16 +32,16 @@ export function receiveCommentEmailUnsubscription( store, action, next, response
 	const subscribed = !! ( response && response.subscribed );
 	if ( subscribed ) {
 		// shoot. something went wrong.
-		receiveCommentEmailUnsubscriptionError( store, action, next );
+		receiveCommentEmailUnsubscriptionError( store, action );
 		return;
 	}
 }
 
-export function receiveCommentEmailUnsubscriptionError( { dispatch }, action, next ) {
+export function receiveCommentEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch(
 		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
 	);
-	next( subscribeToNewCommentEmail( action.payload.blogId ) );
+	dispatch( local( subscribeToNewCommentEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/delete/test/index.js
@@ -17,6 +17,7 @@ import {
 	unsubscribeToNewCommentEmail,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { local } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestCommentEmailUnsubscription', () => {
@@ -39,16 +40,15 @@ describe( 'comment-email-subscriptions', () => {
 
 	describe( 'receiveCommentEmailUnsubscription', () => {
 		it( 'should do nothing if successful', () => {
-			const nextSpy = spy();
+			const dispatch = spy();
 
-			receiveCommentEmailUnsubscription( null, null, nextSpy, { subscribed: false } );
-			expect( nextSpy ).to.not.have.been.called;
+			receiveCommentEmailUnsubscription( { dispatch }, null, null, { subscribed: false } );
+			expect( dispatch ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a subscribe if it fails using next', () => {
-			const nextSpy = spy();
 			const dispatch = spy();
-			receiveCommentEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+			receiveCommentEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
 				subscribed: true,
 			} );
 			expect( dispatch ).to.have.been.calledWithMatch( {
@@ -56,25 +56,23 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( subscribeToNewCommentEmail( 1234 ) );
+			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewCommentEmail( 1234 ) ) );
 		} );
 	} );
 
 	describe( 'receiveCommentEmailUnsubscriptionError', () => {
 		it( 'should dispatch an error notice and subscribe action through next', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
 			receiveCommentEmailUnsubscriptionError(
 				{ dispatch },
 				{ payload: { blogId: 1234 } },
-				nextSpy
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( subscribeToNewCommentEmail( 1234 ) );
+			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewCommentEmail( 1234 ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/index.js
@@ -11,6 +11,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { unsubscribeToNewCommentEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
+import { local } from 'state/data-layer/utils';
 
 export function requestCommentEmailSubscription( { dispatch }, action ) {
 	dispatch(
@@ -29,14 +30,14 @@ export function receiveCommentEmailSubscription( store, action, next, response )
 	// validate that it worked
 	const subscribed = !! ( response && response.subscribed );
 	if ( ! subscribed ) {
-		receiveCommentEmailSubscriptionError( store, action, next );
+		receiveCommentEmailSubscriptionError( store, action );
 		return;
 	}
 }
 
-export function receiveCommentEmailSubscriptionError( { dispatch }, action, next ) {
+export function receiveCommentEmailSubscriptionError( { dispatch }, action ) {
 	dispatch( errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ) );
-	next( unsubscribeToNewCommentEmail( action.payload.blogId ) );
+	dispatch( local( unsubscribeToNewCommentEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -17,6 +17,7 @@ import {
 	unsubscribeToNewCommentEmail,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { local } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestCommentEmailSubscription', () => {
@@ -39,18 +40,17 @@ describe( 'comment-email-subscriptions', () => {
 
 	describe( 'receiveCommentEmailSubscription', () => {
 		it( 'should do nothing if successful', () => {
-			const nextSpy = spy();
-			receiveCommentEmailSubscription( null, null, nextSpy, { subscribed: true } );
-			expect( nextSpy ).to.not.have.been.called;
+			const dispatch = spy();
+			receiveCommentEmailSubscription( { dispatch }, null, null, { subscribed: true } );
+			expect( dispatch ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch an unsubscribe if it fails using next', () => {
-			const nextSpy = spy();
 			const dispatch = spy();
-			receiveCommentEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+			receiveCommentEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
 				subscribed: false,
 			} );
-			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewCommentEmail( 1234 ) );
+			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewCommentEmail( 1234 ) ) );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
@@ -62,14 +62,13 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receiveCommentEmailSubscriptionError', () => {
 		it( 'should dispatch an error notice and unsubscribe action using next', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
-			receiveCommentEmailSubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, nextSpy );
+			receiveCommentEmailSubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, null );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewCommentEmail( 1234 ) );
+			expect( local ).to.have.been.calledWith( local( unsubscribeToNewCommentEmail( 1234 ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/comment-email-subscriptions/new/test/index.js
@@ -68,7 +68,7 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
 				},
 			} );
-			expect( local ).to.have.been.calledWith( local( unsubscribeToNewCommentEmail( 1234 ) ) );
+			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewCommentEmail( 1234 ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/index.js
@@ -11,6 +11,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { subscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
+import { local } from 'state/data-layer/utils';
 
 export function requestPostEmailUnsubscription( { dispatch }, action ) {
 	dispatch(
@@ -31,16 +32,16 @@ export function receivePostEmailUnsubscription( store, action, next, response ) 
 	const subscribed = !! ( response && response.subscribed );
 	if ( subscribed ) {
 		// shoot. something went wrong.
-		receivePostEmailUnsubscriptionError( store, action, next );
+		receivePostEmailUnsubscriptionError( store, action );
 		return;
 	}
 }
 
-export function receivePostEmailUnsubscriptionError( { dispatch }, action, next ) {
+export function receivePostEmailUnsubscriptionError( { dispatch }, action ) {
 	dispatch(
 		errorNotice( translate( 'Sorry, we had a problem unsubscribing. Please try again.' ) )
 	);
-	next( subscribeToNewPostEmail( action.payload.blogId ) );
+	dispatch( local( subscribeToNewPostEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/delete/test/index.js
@@ -14,6 +14,7 @@ import {
 } from '../';
 import { subscribeToNewPostEmail, unsubscribeToNewPostEmail } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { local } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestPostEmailUnsubscription', () => {
@@ -36,15 +37,14 @@ describe( 'comment-email-subscriptions', () => {
 
 	describe( 'receivePostEmailUnsubscription', () => {
 		it( 'should do nothing if successful', () => {
-			const nextSpy = spy();
-			receivePostEmailUnsubscription( null, null, nextSpy, { subscribed: false } );
-			expect( nextSpy ).to.not.have.been.called;
+			const dispatch = spy();
+			receivePostEmailUnsubscription( { dispatch }, null, null, { subscribed: false } );
+			expect( dispatch ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a subscribe if it fails using next', () => {
-			const nextSpy = spy();
 			const dispatch = spy();
-			receivePostEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+			receivePostEmailUnsubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
 				subscribed: true,
 			} );
 
@@ -53,21 +53,20 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( subscribeToNewPostEmail( 1234 ) );
+			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 
 	describe( 'receivePostEmailUnsubscriptionError', () => {
 		it( 'should dispatch an error notice and subscribe action using next', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
-			receivePostEmailUnsubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, nextSpy );
+			receivePostEmailUnsubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, null );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem unsubscribing. Please try again.',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( subscribeToNewPostEmail( 1234 ) );
+			expect( dispatch ).to.have.been.calledWith( local( subscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/index.js
@@ -16,6 +16,7 @@ import {
 } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { buildBody } from '../utils';
+import { local } from 'state/data-layer/utils';
 
 export function requestPostEmailSubscription( { dispatch }, action ) {
 	dispatch(
@@ -35,21 +36,21 @@ export function receivePostEmailSubscription( store, action, next, response ) {
 	const subscribed = !! ( response && response.subscribed );
 	if ( ! subscribed ) {
 		// shoot. something went wrong.
-		receivePostEmailSubscriptionError( store, action, next );
+		receivePostEmailSubscriptionError( store, action );
 		return;
 	}
 	// pass this on, but tack in the delivery_frequency that we got back from the API
-	next(
+	store.dispatch( local(
 		updateNewPostEmailSubscription(
 			action.payload.blogId,
 			get( response, [ 'subscription', 'delivery_frequency' ] )
 		)
-	);
+	) );
 }
 
-export function receivePostEmailSubscriptionError( { dispatch }, action, next ) {
+export function receivePostEmailSubscriptionError( { dispatch }, action ) {
 	dispatch( errorNotice( translate( 'Sorry, we had a problem subscribing. Please try again.' ) ) );
-	next( unsubscribeToNewPostEmail( action.payload.blogId ) );
+	dispatch( local( unsubscribeToNewPostEmail( action.payload.blogId ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/new/test/index.js
@@ -18,6 +18,7 @@ import {
 	updateNewPostEmailSubscription,
 } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { local } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestPostEmailSubscription', () => {
@@ -40,20 +41,19 @@ describe( 'comment-email-subscriptions', () => {
 
 	describe( 'receivePostEmailSubscription', () => {
 		it( 'should call next to update the subscription with the delivery frequency from the response', () => {
-			const nextSpy = spy();
-			receivePostEmailSubscription( null, subscribeToNewPostEmail( 1234 ), nextSpy, {
+			const dispatch = spy();
+			receivePostEmailSubscription( { dispatch }, subscribeToNewPostEmail( 1234 ), null, {
 				subscribed: true,
 				subscription: {
 					delivery_frequency: 'daily',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( updateNewPostEmailSubscription( 1234, 'daily' ) );
+			expect( dispatch ).to.have.been.calledWith( local( updateNewPostEmailSubscription( 1234, 'daily' ) ) );
 		} );
 
 		it( 'should dispatch an unsubscribe if it fails using next', () => {
-			const nextSpy = spy();
 			const dispatch = spy();
-			receivePostEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, nextSpy, {
+			receivePostEmailSubscription( { dispatch }, { payload: { blogId: 1234 } }, null, {
 				subscribed: false,
 			} );
 			expect( dispatch ).to.have.been.calledWithMatch( {
@@ -61,21 +61,20 @@ describe( 'comment-email-subscriptions', () => {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewPostEmail( 1234 ) );
+			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 
 	describe( 'receivePostEmailSubscriptionError', () => {
 		it( 'should dispatch an error notice and unsubscribe action using next', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
-			receivePostEmailSubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, nextSpy );
+			receivePostEmailSubscriptionError( { dispatch }, { payload: { blogId: 1234 } }, null );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					text: 'Sorry, we had a problem subscribing. Please try again.',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( unsubscribeToNewPostEmail( 1234 ) );
+			expect( dispatch ).to.have.been.calledWith( local( unsubscribeToNewPostEmail( 1234 ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/index.js
@@ -14,6 +14,7 @@ import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 import { errorNotice } from 'state/notices/actions';
 import { getReaderFollowForBlog } from 'state/selectors';
 import { buildBody } from '../utils';
+import { local } from 'state/data-layer/utils';
 
 export function requestUpdatePostEmailSubscription( { dispatch, getState }, action ) {
 	const actionWithRevert = merge( {}, action, {
@@ -40,21 +41,20 @@ export function requestUpdatePostEmailSubscription( { dispatch, getState }, acti
 export function receiveUpdatePostEmailSubscription( store, action, next, response ) {
 	if ( ! ( response && response.success ) ) {
 		// revert
-		receiveUpdatePostEmailSubscriptionError( store, action, next );
+		receiveUpdatePostEmailSubscriptionError( store, action );
 	}
 }
 
 export function receiveUpdatePostEmailSubscriptionError(
 	{ dispatch },
 	{ payload: { blogId }, meta: { previousState } },
-	next
  ) {
 	dispatch(
 		errorNotice(
 			translate( 'Sorry, we had a problem updating that subscription. Please try again.' )
 		)
 	);
-	next( updateNewPostEmailSubscription( blogId, previousState ) );
+	dispatch( local( updateNewPostEmailSubscription( blogId, previousState ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
+++ b/client/state/data-layer/wpcom/read/site/post-email-subscriptions/update/test/index.js
@@ -15,6 +15,7 @@ import {
 } from '../';
 import { updateNewPostEmailSubscription } from 'state/reader/follows/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { local } from 'state/data-layer/utils';
 
 describe( 'comment-email-subscriptions', () => {
 	describe( 'requestUpdatePostEmailSubscription', () => {
@@ -64,23 +65,20 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receiveUpdatePostEmailSubscription', () => {
 		it( 'should do nothing on success', () => {
 			const dispatch = spy();
-			const next = spy();
 			receiveUpdatePostEmailSubscription(
 				{ dispatch },
 				{
 					payload: { blogId: 1234 },
 					meta: { previousState: 'instantly' },
 				},
-				next,
+				null,
 				{ success: true }
 			);
 			expect( dispatch ).to.have.not.been.called;
-			expect( next ).to.have.not.been.called;
 		} );
 
 		it( 'should dispatch an update with the previous state if it is called with null', () => {
 			const dispatch = spy();
-			const next = spy();
 			const previousState = 'instantly';
 			receiveUpdatePostEmailSubscription(
 				{ dispatch },
@@ -88,17 +86,16 @@ describe( 'comment-email-subscriptions', () => {
 					payload: { blogId: 1234 },
 					meta: { previousState },
 				},
-				next,
+				null,
 				null
 			);
-			expect( next ).to.have.been.calledWith(
-				updateNewPostEmailSubscription( 1234, previousState )
+			expect( dispatch ).to.have.been.calledWith(
+				local( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
 
 		it( 'should dispatch an update with the previous state if it fails', () => {
 			const dispatch = spy();
-			const next = spy();
 			const previousState = 'instantly';
 			receiveUpdatePostEmailSubscription(
 				{ dispatch },
@@ -106,11 +103,11 @@ describe( 'comment-email-subscriptions', () => {
 					payload: { blogId: 1234 },
 					meta: { previousState },
 				},
-				next,
+				null,
 				{ success: false }
 			);
-			expect( next ).to.have.been.calledWith(
-				updateNewPostEmailSubscription( 1234, previousState )
+			expect( dispatch ).to.have.been.calledWith(
+				local( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 		} );
 	} );
@@ -118,7 +115,6 @@ describe( 'comment-email-subscriptions', () => {
 	describe( 'receiveUpdatePostEmailSubscriptionError', () => {
 		it( 'should dispatch an error and an update to the previous state', () => {
 			const dispatch = spy();
-			const next = spy();
 			const previousState = 'instantly';
 			receiveUpdatePostEmailSubscriptionError(
 				{ dispatch },
@@ -126,10 +122,10 @@ describe( 'comment-email-subscriptions', () => {
 					payload: { blogId: 1234 },
 					meta: { previousState },
 				},
-				next
+				null
 			);
-			expect( next ).to.have.been.calledWith(
-				updateNewPostEmailSubscription( 1234, previousState )
+			expect( dispatch ).to.have.been.calledWith(
+				local( updateNewPostEmailSubscription( 1234, previousState ) )
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: { text: 'Sorry, we had a problem updating that subscription. Please try again.' },

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -12,6 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
+import { local } from 'state/data-layer/utils';
 
 export function requestBlogStickerAdd( { dispatch }, action ) {
 	dispatch(
@@ -30,7 +31,7 @@ export function receiveBlogStickerAdd( store, action, next, response ) {
 	// validate that it worked
 	const isAdded = !! ( response && response.success );
 	if ( ! isAdded ) {
-		receiveBlogStickerAddError( store, action, next );
+		receiveBlogStickerAddError( store, action );
 		return;
 	}
 
@@ -46,11 +47,11 @@ export function receiveBlogStickerAdd( store, action, next, response ) {
 	);
 }
 
-export function receiveBlogStickerAddError( { dispatch }, action, next ) {
+export function receiveBlogStickerAddError( { dispatch }, action ) {
 	dispatch(
 		errorNotice( translate( 'Sorry, we had a problem adding that sticker. Please try again.' ) ),
 	);
-	next( removeBlogSticker( action.payload.blogId, action.payload.stickerName ) );
+	dispatch( local( removeBlogSticker( action.payload.blogId, action.payload.stickerName ) ) );
 }
 
 export default {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/test/index.js
@@ -10,6 +10,7 @@ import { spy } from 'sinon';
 import { requestBlogStickerAdd, receiveBlogStickerAdd, receiveBlogStickerAddError } from '../';
 import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { local } from 'state/data-layer/utils';
 
 describe( 'blog-sticker-add', () => {
 	describe( 'requestBlogStickerAdd', () => {
@@ -33,11 +34,10 @@ describe( 'blog-sticker-add', () => {
 	describe( 'receiveBlogStickerAdd', () => {
 		it( 'should dispatch a success notice', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
 			receiveBlogStickerAdd(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				nextSpy,
+				null,
 				{ success: true },
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
@@ -45,21 +45,19 @@ describe( 'blog-sticker-add', () => {
 					status: 'is-success',
 				},
 			} );
-			expect( nextSpy ).to.not.have.been.called;
 		} );
 
 		it( 'should dispatch a sticker removal if it fails using next', () => {
-			const nextSpy = spy();
 			const dispatch = spy();
 			receiveBlogStickerAdd(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				nextSpy,
+				null,
 				{
 					success: false,
 				},
 			);
-			expect( nextSpy ).to.have.been.calledWith( removeBlogSticker( 123, 'broken-in-reader' ) );
+			expect( dispatch ).to.have.been.calledWith( local( removeBlogSticker( 123, 'broken-in-reader' ) ) );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					status: 'is-error',
@@ -71,18 +69,16 @@ describe( 'blog-sticker-add', () => {
 	describe( 'receiveBlogStickerAddError', () => {
 		it( 'should dispatch an error notice and remove sticker action using next', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
 			receiveBlogStickerAddError(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				nextSpy,
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					status: 'is-error',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( removeBlogSticker( 123, 'broken-in-reader' ) );
+			expect( dispatch ).to.have.been.calledWith( local( removeBlogSticker( 123, 'broken-in-reader' ) ) );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -31,7 +31,7 @@ export function requestBlogStickerList( { dispatch }, action ) {
 export function receiveBlogStickerList( store, action, next, response ) {
 	// validate that it worked
 	if ( ! response || ! isArray( response ) ) {
-		receiveBlogStickerListError( store, action, next );
+		receiveBlogStickerListError( store, action );
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/sites/blog-stickers/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/test/index.js
@@ -7,7 +7,7 @@ import { spy } from 'sinon';
 /**
  * Internal Dependencies
  */
-import { requestBlogStickerList, receiveBlogStickerList, receiveBlogStickerListError } from '../';
+import { requestBlogStickerList, receiveBlogStickerListError } from '../';
 import { listBlogStickers } from 'state/sites/blog-stickers/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
@@ -27,16 +27,6 @@ describe( 'blog-sticker-list', () => {
 					onFailure: action,
 				} ),
 			);
-		} );
-	} );
-
-	describe( 'receiveBlogStickerList', () => {
-		it( 'should not call the next function if successful', () => {
-			const dispatch = spy();
-			const nextSpy = spy();
-			const action = { payload: { blogId: 123 } };
-			receiveBlogStickerList( { dispatch }, action, nextSpy, [ 'broken-in-reader' ] );
-			expect( nextSpy ).to.not.have.been.called;
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/users/test/index.js
+++ b/client/state/data-layer/wpcom/users/test/index.js
@@ -46,9 +46,8 @@ describe( '#fetchUsers', () => {
 	it( 'should dispatch HTTP request to users endpoint', () => {
 		const action = requestUsers( 12345678, [ 10, 11 ] );
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 
-		fetchUsers( { dispatch }, action, next );
+		fetchUsers( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( http( {
@@ -68,9 +67,8 @@ describe( '#fetchUsers', () => {
 		action.page = 2;
 		action.perPage = 42;
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 
-		fetchUsers( { dispatch }, action, next );
+		fetchUsers( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledOnce;
 		expect( dispatch ).to.have.been.calledWith( http( {
@@ -90,9 +88,8 @@ describe( '#receiveSuccess', () => {
 	it( 'should normalize the users and dispatch `receiveUser` for each one', () => {
 		const action = requestUsers( 12345678, [ 10, 11 ] );
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 
-		receiveSuccess( { dispatch }, action, next, [
+		receiveSuccess( { dispatch }, action, null, [
 			{ id: 10 },
 			{ id: 11 },
 		] );
@@ -114,7 +111,6 @@ describe( '#receiveSuccess', () => {
 
 		const action = requestUsers( 12345678, ids );
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 
 		receiveSuccess(
 			{ dispatch },
@@ -129,7 +125,7 @@ describe( '#receiveSuccess', () => {
 					},
 				},
 			},
-			next,
+			null,
 			usersChunks[ 0 ]
 		);
 
@@ -161,7 +157,6 @@ describe( '#receiveSuccess', () => {
 			perPage: perPage,
 		};
 		const dispatch = sinon.spy();
-		const next = sinon.spy();
 
 		receiveSuccess(
 			{ dispatch },
@@ -176,7 +171,7 @@ describe( '#receiveSuccess', () => {
 					},
 				},
 			},
-			next,
+			null,
 			usersChunks[ 0 ]
 		);
 


### PR DESCRIPTION
In #14354 we introduced a transitional `next()` function into the data
layer API which would only ever call the real `next()` once for each
action. This patch removes manual use of `next()` and replaces those
cases where we legitimataly need to pass an action along and bypass the
data layer with a call to `dispatch()` using `local()`

`local()` is the wrapper which adds meta data to an action to cause it
to bypass the data layer.

This should not cause any change in behavior. For those few handlers
calling `next()` to pass along the action there should be no change. For
those calling `next()` to skip the data layer the behavior should be
equivalent with `dispatch( local( ... ) )`

**Testing**
As this is a big PR please test the parts which you were a part of writing
and leave some comment here. This will make it much easier to test. We
can test with the live branch.