### PR TITLE
Add blog sticker removal to data layer

### DIFF
--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -1,0 +1,65 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import { SITES_BLOG_STICKER_REMOVE } from 'state/action-types';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { addBlogSticker } from 'state/sites/blog-stickers/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
+
+export function requestBlogStickerRemove( { dispatch }, action ) {
+	dispatch(
+		http( {
+			method: 'POST',
+			path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${ action.payload.stickerName }`,
+			body: {}, // have to have an empty body to make wpcom-http happy
+			apiVersion: '1.1',
+			onSuccess: action,
+			onFailure: action,
+		} )
+	);
+}
+
+export function receiveBlogStickerRemove( store, action, next, response ) {
+	// validate that it worked
+	const isRemoved = !! ( response && response.success );
+	if ( ! isRemoved ) {
+		receiveBlogStickerRemoveError( store, action, next );
+		return;
+	}
+
+	store.dispatch(
+		successNotice(
+			translate( 'The sticker {{i}}%s{{/i}} has been successfully removed.', {
+				args: action.payload.stickerName,
+				components: {
+					i: <i />,
+				},
+			} )
+		)
+	);
+}
+
+export function receiveBlogStickerRemoveError( { dispatch }, action, next ) {
+	dispatch(
+		errorNotice( translate( 'Sorry, we had a problem removing that sticker. Please try again.' ) )
+	);
+	// Revert the removal
+	next( addBlogSticker( action.payload.blogId, action.payload.stickerName ) );
+}
+
+export default {
+	[ SITES_BLOG_STICKER_REMOVE ]: [
+		dispatchRequest(
+			requestBlogStickerRemove,
+			receiveBlogStickerRemove,
+			receiveBlogStickerRemoveError
+		),
+	],
+};

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -12,6 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { addBlogSticker } from 'state/sites/blog-stickers/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
+import { local } from 'state/data-layer/utils';
 
 export function requestBlogStickerRemove( { dispatch }, action ) {
 	dispatch(
@@ -22,7 +23,7 @@ export function requestBlogStickerRemove( { dispatch }, action ) {
 			apiVersion: '1.1',
 			onSuccess: action,
 			onFailure: action,
-		} )
+		} ),
 	);
 }
 
@@ -30,7 +31,7 @@ export function receiveBlogStickerRemove( store, action, next, response ) {
 	// validate that it worked
 	const isRemoved = !! ( response && response.success );
 	if ( ! isRemoved ) {
-		receiveBlogStickerRemoveError( store, action, next );
+		receiveBlogStickerRemoveError( store, action );
 		return;
 	}
 
@@ -41,17 +42,17 @@ export function receiveBlogStickerRemove( store, action, next, response ) {
 				components: {
 					i: <i />,
 				},
-			} )
-		)
+			} ),
+		),
 	);
 }
 
-export function receiveBlogStickerRemoveError( { dispatch }, action, next ) {
+export function receiveBlogStickerRemoveError( { dispatch }, action ) {
 	dispatch(
-		errorNotice( translate( 'Sorry, we had a problem removing that sticker. Please try again.' ) )
+		errorNotice( translate( 'Sorry, we had a problem removing that sticker. Please try again.' ) ),
 	);
 	// Revert the removal
-	next( addBlogSticker( action.payload.blogId, action.payload.stickerName ) );
+	dispatch( local( addBlogSticker( action.payload.blogId, action.payload.stickerName ) ) );
 }
 
 export default {
@@ -59,7 +60,7 @@ export default {
 		dispatchRequest(
 			requestBlogStickerRemove,
 			receiveBlogStickerRemove,
-			receiveBlogStickerRemoveError
+			receiveBlogStickerRemoveError,
 		),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
@@ -1,0 +1,92 @@
+/**
+ * External Dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal Dependencies
+ */
+import {
+	requestBlogStickerRemove,
+	receiveBlogStickerRemove,
+	receiveBlogStickerRemoveError,
+} from '../';
+import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+describe( 'blog-sticker-remove', () => {
+	describe( 'requestBlogStickerRemove', () => {
+		it( 'should dispatch an http request and call through next', () => {
+			const dispatch = spy();
+			const action = removeBlogSticker( 123, 'broken-in-reader' );
+			requestBlogStickerRemove( { dispatch }, action );
+			expect( dispatch ).to.have.been.calledWith(
+				http( {
+					method: 'POST',
+					path: '/sites/123/blog-stickers/remove/broken-in-reader',
+					body: {},
+					apiVersion: '1.1',
+					onSuccess: action,
+					onFailure: action,
+				} )
+			);
+		} );
+	} );
+
+	describe( 'receiveBlogStickerRemove', () => {
+		it( 'should dispatch a success notice', () => {
+			const dispatch = spy();
+			const nextSpy = spy();
+			receiveBlogStickerRemove(
+				{ dispatch },
+				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
+				nextSpy,
+				{ success: true }
+			);
+			expect( dispatch ).to.have.been.calledWithMatch( {
+				notice: {
+					status: 'is-success',
+				},
+			} );
+			expect( nextSpy ).to.not.have.been.called;
+		} );
+
+		it( 'should dispatch a sticker removal if it fails using next', () => {
+			const nextSpy = spy();
+			const dispatch = spy();
+			receiveBlogStickerRemove(
+				{ dispatch },
+				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
+				nextSpy,
+				{
+					success: false,
+				}
+			);
+			expect( nextSpy ).to.have.been.calledWith( addBlogSticker( 123, 'broken-in-reader' ) );
+			expect( dispatch ).to.have.been.calledWithMatch( {
+				notice: {
+					status: 'is-error',
+				},
+			} );
+		} );
+	} );
+
+	describe( 'receiveBlogStickerRemoveError', () => {
+		it( 'should dispatch an error notice and add sticker action using next', () => {
+			const dispatch = spy();
+			const nextSpy = spy();
+			receiveBlogStickerRemoveError(
+				{ dispatch },
+				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
+				nextSpy
+			);
+			expect( dispatch ).to.have.been.calledWithMatch( {
+				notice: {
+					status: 'is-error',
+				},
+			} );
+			expect( nextSpy ).to.have.been.calledWith( addBlogSticker( 123, 'broken-in-reader' ) );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
@@ -14,10 +14,11 @@ import {
 } from '../';
 import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { local } from 'state/data-layer/utils';
 
 describe( 'blog-sticker-remove', () => {
 	describe( 'requestBlogStickerRemove', () => {
-		it( 'should dispatch an http request and call through next', () => {
+		it( 'should dispatch an http request', () => {
 			const dispatch = spy();
 			const action = removeBlogSticker( 123, 'broken-in-reader' );
 			requestBlogStickerRemove( { dispatch }, action );
@@ -29,7 +30,7 @@ describe( 'blog-sticker-remove', () => {
 					apiVersion: '1.1',
 					onSuccess: action,
 					onFailure: action,
-				} )
+				} ),
 			);
 		} );
 	} );
@@ -37,33 +38,29 @@ describe( 'blog-sticker-remove', () => {
 	describe( 'receiveBlogStickerRemove', () => {
 		it( 'should dispatch a success notice', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
 			receiveBlogStickerRemove(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				nextSpy,
-				{ success: true }
+				null,
+				{ success: true },
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					status: 'is-success',
 				},
 			} );
-			expect( nextSpy ).to.not.have.been.called;
 		} );
 
-		it( 'should dispatch a sticker removal if it fails using next', () => {
-			const nextSpy = spy();
+		it( 'should dispatch a sticker removal if it fails', () => {
 			const dispatch = spy();
 			receiveBlogStickerRemove(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				nextSpy,
+				null,
 				{
 					success: false,
-				}
+				},
 			);
-			expect( nextSpy ).to.have.been.calledWith( addBlogSticker( 123, 'broken-in-reader' ) );
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					status: 'is-error',
@@ -73,20 +70,20 @@ describe( 'blog-sticker-remove', () => {
 	} );
 
 	describe( 'receiveBlogStickerRemoveError', () => {
-		it( 'should dispatch an error notice and add sticker action using next', () => {
+		it( 'should dispatch an error notice and add sticker action', () => {
 			const dispatch = spy();
-			const nextSpy = spy();
 			receiveBlogStickerRemoveError(
 				{ dispatch },
 				{ payload: { blogId: 123, stickerName: 'broken-in-reader' } },
-				nextSpy
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
 					status: 'is-error',
 				},
 			} );
-			expect( nextSpy ).to.have.been.calledWith( addBlogSticker( 123, 'broken-in-reader' ) );
+			expect( dispatch ).to.have.been.calledWith(
+				local( addBlogSticker( 123, 'broken-in-reader' ) ),
+			);
 		} );
 	} );
 } );

--- a/client/state/sites/blog-stickers/reducer.js
+++ b/client/state/sites/blog-stickers/reducer.js
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { includes, concat, compact } from 'lodash';
+import { includes, concat, compact, filter } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { SITES_BLOG_STICKER_LIST_RECEIVE, SITES_BLOG_STICKER_ADD } from 'state/action-types';
+import {
+	SITES_BLOG_STICKER_LIST_RECEIVE,
+	SITES_BLOG_STICKER_ADD,
+	SITES_BLOG_STICKER_REMOVE,
+} from 'state/action-types';
 import { combineReducers, createReducer } from 'state/utils';
 
 export const items = createReducer(
@@ -31,7 +35,20 @@ export const items = createReducer(
 				[ blogId ]: compact( concat( stickerName, state[ blogId ] ) ),
 			};
 		},
-	},
+		[ SITES_BLOG_STICKER_REMOVE ]: ( state, action ) => {
+			const { blogId, stickerName } = action.payload;
+
+			// If the blog doesn't have this sticker, do nothing
+			if ( ! includes( state[ blogId ], stickerName ) ) {
+				return state;
+			}
+
+			return {
+				...state,
+				[ blogId ]: compact( filter( state[ blogId ], sticker => sticker !== stickerName ) ),
+			};
+		},
+	}
 );
 
 export default combineReducers( {

--- a/client/state/sites/blog-stickers/reducer.js
+++ b/client/state/sites/blog-stickers/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, concat, compact, filter } from 'lodash';
+import { includes, concat, compact, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,10 +45,10 @@ export const items = createReducer(
 
 			return {
 				...state,
-				[ blogId ]: compact( filter( state[ blogId ], sticker => sticker !== stickerName ) ),
+				[ blogId ]: reject( state[ blogId ], sticker => sticker === stickerName ),
 			};
 		},
-	}
+	},
 );
 
 export default combineReducers( {

--- a/client/state/sites/blog-stickers/test/reducer.js
+++ b/client/state/sites/blog-stickers/test/reducer.js
@@ -7,7 +7,11 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { items } from '../reducer';
-import { SITES_BLOG_STICKER_LIST_RECEIVE, SITES_BLOG_STICKER_ADD } from 'state/action-types';
+import {
+	SITES_BLOG_STICKER_LIST_RECEIVE,
+	SITES_BLOG_STICKER_ADD,
+	SITES_BLOG_STICKER_REMOVE,
+} from 'state/action-types';
 
 describe( 'reducer', () => {
 	describe( 'items', () => {
@@ -22,8 +26,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_LIST_RECEIVE,
 						payload: { blogId: 123, stickers: [ 'dont-recommend' ] },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 123: [ 'dont-recommend' ] } );
 		} );
 
@@ -34,8 +38,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_LIST_RECEIVE,
 						payload: { blogId: 456, stickers: [ 'dont-recommend', 'broken-in-reader' ] },
-					},
-				),
+					}
+				)
 			).to.deep.equal( {
 				123: [ 'dont-recommend' ],
 				456: [ 'dont-recommend', 'broken-in-reader' ],
@@ -49,8 +53,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_LIST_RECEIVE,
 						payload: { blogId: 123, stickers: [ 'okapi-friendly', 'broken-in-reader' ] },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 123: [ 'okapi-friendly', 'broken-in-reader' ] } );
 		} );
 
@@ -61,8 +65,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_ADD,
 						payload: { blogId: 123, stickerName: 'okapi-friendly' },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 123: [ 'okapi-friendly' ], 456: [ 'dont-recommend' ] } );
 		} );
 
@@ -73,8 +77,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_ADD,
 						payload: { blogId: 123, stickerName: 'okapi-friendly' },
-					},
-				)[ 123 ],
+					}
+				)[ 123 ]
 			).to.have.members( [ 'okapi-friendly', 'dont-recommend' ] );
 		} );
 
@@ -85,9 +89,33 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_ADD,
 						payload: { blogId: 123, stickerName: 'dont-recommend' },
-					},
-				),
+					}
+				)
 			).to.deep.equal( { 123: [ 'dont-recommend' ] } );
+		} );
+
+		it( 'should remove a sticker', () => {
+			expect(
+				items(
+					{ 123: [ 'dont-recommend' ] },
+					{
+						type: SITES_BLOG_STICKER_REMOVE,
+						payload: { blogId: 123, stickerName: 'dont-recommend' },
+					}
+				)
+			).to.deep.equal( { 123: [] } );
+		} );
+
+		it( 'should not remove any stickers if the blog does not have that sticker', () => {
+			expect(
+				items(
+					{ 123: [ 'okapi-friendly' ] },
+					{
+						type: SITES_BLOG_STICKER_REMOVE,
+						payload: { blogId: 123, stickerName: 'dont-recommend' },
+					}
+				)
+			).to.deep.equal( { 123: [ 'okapi-friendly' ] } );
 		} );
 	} );
 } );

--- a/client/state/sites/blog-stickers/test/reducer.js
+++ b/client/state/sites/blog-stickers/test/reducer.js
@@ -94,7 +94,7 @@ describe( 'reducer', () => {
 					type: SITES_BLOG_STICKER_REMOVE,
 					payload: { blogId: 123, stickerName: 'dont-recommend' },
 				} ),
-			).to.deep.equal( initialState );
+			).to.equal( initialState );
 		} );
 	} );
 } );

--- a/client/state/sites/blog-stickers/test/reducer.js
+++ b/client/state/sites/blog-stickers/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -21,25 +22,19 @@ describe( 'reducer', () => {
 
 		it( 'should append a single sticker when received', () => {
 			expect(
-				items(
-					{},
-					{
-						type: SITES_BLOG_STICKER_LIST_RECEIVE,
-						payload: { blogId: 123, stickers: [ 'dont-recommend' ] },
-					},
-				),
+				items( deepFreeze( {} ), {
+					type: SITES_BLOG_STICKER_LIST_RECEIVE,
+					payload: { blogId: 123, stickers: [ 'dont-recommend' ] },
+				} ),
 			).to.deep.equal( { 123: [ 'dont-recommend' ] } );
 		} );
 
 		it( 'should append multiple stickers when received', () => {
 			expect(
-				items(
-					{ 123: [ 'dont-recommend' ] },
-					{
-						type: SITES_BLOG_STICKER_LIST_RECEIVE,
-						payload: { blogId: 456, stickers: [ 'dont-recommend', 'broken-in-reader' ] },
-					},
-				),
+				items( deepFreeze( { 123: [ 'dont-recommend' ] } ), {
+					type: SITES_BLOG_STICKER_LIST_RECEIVE,
+					payload: { blogId: 456, stickers: [ 'dont-recommend', 'broken-in-reader' ] },
+				} ),
 			).to.deep.equal( {
 				123: [ 'dont-recommend' ],
 				456: [ 'dont-recommend', 'broken-in-reader' ],
@@ -48,74 +43,58 @@ describe( 'reducer', () => {
 
 		it( 'should replace existing stickers for a blog when received', () => {
 			expect(
-				items(
-					{ 123: [ 'dont-recommend' ] },
-					{
-						type: SITES_BLOG_STICKER_LIST_RECEIVE,
-						payload: { blogId: 123, stickers: [ 'okapi-friendly', 'broken-in-reader' ] },
-					},
-				),
+				items( deepFreeze( { 123: [ 'dont-recommend' ] } ), {
+					type: SITES_BLOG_STICKER_LIST_RECEIVE,
+					payload: { blogId: 123, stickers: [ 'okapi-friendly', 'broken-in-reader' ] },
+				} ),
 			).to.deep.equal( { 123: [ 'okapi-friendly', 'broken-in-reader' ] } );
 		} );
 
 		it( 'should add a new sticker to a blog we do not yet have stickers for', () => {
 			expect(
-				items(
-					{ 456: [ 'dont-recommend' ] },
-					{
-						type: SITES_BLOG_STICKER_ADD,
-						payload: { blogId: 123, stickerName: 'okapi-friendly' },
-					},
-				),
+				items( deepFreeze( { 456: [ 'dont-recommend' ] } ), {
+					type: SITES_BLOG_STICKER_ADD,
+					payload: { blogId: 123, stickerName: 'okapi-friendly' },
+				} ),
 			).to.deep.equal( { 123: [ 'okapi-friendly' ], 456: [ 'dont-recommend' ] } );
 		} );
 
 		it( 'should add a new sticker to a blog we already have stickers for', () => {
 			expect(
-				items(
-					{ 123: [ 'dont-recommend' ] },
-					{
-						type: SITES_BLOG_STICKER_ADD,
-						payload: { blogId: 123, stickerName: 'okapi-friendly' },
-					},
-				)[ 123 ],
+				items( deepFreeze( { 123: [ 'dont-recommend' ] } ), {
+					type: SITES_BLOG_STICKER_ADD,
+					payload: { blogId: 123, stickerName: 'okapi-friendly' },
+				} )[ 123 ],
 			).to.have.members( [ 'okapi-friendly', 'dont-recommend' ] );
 		} );
 
 		it( 'should not add a duplicate sticker', () => {
+			const initialState = deepFreeze( { 123: [ 'dont-recommend' ] } );
 			expect(
-				items(
-					{ 123: [ 'dont-recommend' ] },
-					{
-						type: SITES_BLOG_STICKER_ADD,
-						payload: { blogId: 123, stickerName: 'dont-recommend' },
-					},
-				),
-			).to.deep.equal( { 123: [ 'dont-recommend' ] } );
+				items( initialState, {
+					type: SITES_BLOG_STICKER_ADD,
+					payload: { blogId: 123, stickerName: 'dont-recommend' },
+				} ),
+			).to.deep.equal( initialState );
 		} );
 
 		it( 'should remove a sticker', () => {
 			expect(
-				items(
-					{ 123: [ 'dont-recommend' ] },
-					{
-						type: SITES_BLOG_STICKER_REMOVE,
-						payload: { blogId: 123, stickerName: 'dont-recommend' },
-					},
-				),
+				items( deepFreeze( { 123: [ 'dont-recommend' ] } ), {
+					type: SITES_BLOG_STICKER_REMOVE,
+					payload: { blogId: 123, stickerName: 'dont-recommend' },
+				} ),
 			).to.deep.equal( { 123: [] } );
 		} );
 
 		it( 'should not remove any stickers if the blog does not have that sticker', () => {
+			const initialState = deepFreeze( { 123: [ 'okapi-friendly' ] } );
 			expect(
-				items(
-					{ 123: [ 'okapi-friendly' ] },
-					{
-						type: SITES_BLOG_STICKER_REMOVE,
-						payload: { blogId: 123, stickerName: 'dont-recommend' },
-					},
-				),
-			).to.deep.equal( { 123: [ 'okapi-friendly' ] } );
+				items( initialState, {
+					type: SITES_BLOG_STICKER_REMOVE,
+					payload: { blogId: 123, stickerName: 'dont-recommend' },
+				} ),
+			).to.deep.equal( initialState );
 		} );
 	} );
 } );

--- a/client/state/sites/blog-stickers/test/reducer.js
+++ b/client/state/sites/blog-stickers/test/reducer.js
@@ -26,8 +26,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_LIST_RECEIVE,
 						payload: { blogId: 123, stickers: [ 'dont-recommend' ] },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 123: [ 'dont-recommend' ] } );
 		} );
 
@@ -38,8 +38,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_LIST_RECEIVE,
 						payload: { blogId: 456, stickers: [ 'dont-recommend', 'broken-in-reader' ] },
-					}
-				)
+					},
+				),
 			).to.deep.equal( {
 				123: [ 'dont-recommend' ],
 				456: [ 'dont-recommend', 'broken-in-reader' ],
@@ -53,8 +53,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_LIST_RECEIVE,
 						payload: { blogId: 123, stickers: [ 'okapi-friendly', 'broken-in-reader' ] },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 123: [ 'okapi-friendly', 'broken-in-reader' ] } );
 		} );
 
@@ -65,8 +65,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_ADD,
 						payload: { blogId: 123, stickerName: 'okapi-friendly' },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 123: [ 'okapi-friendly' ], 456: [ 'dont-recommend' ] } );
 		} );
 
@@ -77,8 +77,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_ADD,
 						payload: { blogId: 123, stickerName: 'okapi-friendly' },
-					}
-				)[ 123 ]
+					},
+				)[ 123 ],
 			).to.have.members( [ 'okapi-friendly', 'dont-recommend' ] );
 		} );
 
@@ -89,8 +89,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_ADD,
 						payload: { blogId: 123, stickerName: 'dont-recommend' },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 123: [ 'dont-recommend' ] } );
 		} );
 
@@ -101,8 +101,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_REMOVE,
 						payload: { blogId: 123, stickerName: 'dont-recommend' },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 123: [] } );
 		} );
 
@@ -113,8 +113,8 @@ describe( 'reducer', () => {
 					{
 						type: SITES_BLOG_STICKER_REMOVE,
 						payload: { blogId: 123, stickerName: 'dont-recommend' },
-					}
-				)
+					},
+				),
 			).to.deep.equal( { 123: [ 'okapi-friendly' ] } );
 		} );
 	} );


### PR DESCRIPTION
Adds the data layer and Redux plumbing for removal of blog stickers.

### To test

`npm run test-client client/state/data-layer/wpcom/sites/blog-stickers`
`npm run test-client client/state/sites/blog-stickers`