### PR TITLE
Woo-Connect Insights: add other currencies

### DIFF
--- a/client/lib/format-currency/currencies.js
+++ b/client/lib/format-currency/currencies.js
@@ -1,0 +1,968 @@
+export const CURRENCIES = {
+	AED: {
+		symbol: 'د.إ.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	AFN: {
+		symbol: '؋',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	ALL: {
+		symbol: 'Lek',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	AMD: {
+		symbol: '֏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	ANG: {
+		symbol: 'ƒ',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	AOA: {
+		symbol: 'Kz',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	ARS: {
+		symbol: '$',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	AUD: {
+		symbol: 'A$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	AWG: {
+		symbol: 'ƒ',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	AZN: {
+		symbol: '₼',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	BAM: {
+		symbol: 'КМ',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	BBD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	BDT: {
+		symbol: '৳',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	BGN: {
+		symbol: 'лв.',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	BHD: {
+		symbol: 'د.ب.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 3
+	},
+	BIF: {
+		symbol: 'FBu',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	BMD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	BND: {
+		symbol: '$',
+		grouping: '.',
+		decimal: ',',
+		precision: 0
+	},
+	BOB: {
+		symbol: 'Bs',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	BRL: {
+		symbol: 'R$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	BSD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	BTC: {
+		symbol: 'Ƀ',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	BTN: {
+		symbol: 'Nu.',
+		grouping: ',',
+		decimal: '.',
+		precision: 1
+	},
+	BWP: {
+		symbol: 'P',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	BYR: {
+		symbol: 'р.',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	BZD: {
+		symbol: 'BZ$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	CAD: {
+		symbol: 'C$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	CDF: {
+		symbol: 'FC',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	CHF: {
+		symbol: 'CHF',
+		grouping: "'",
+		decimal: '.',
+		precision: 2
+	},
+	CLP: {
+		symbol: '$',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	CNY: {
+		symbol: '¥',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	COP: {
+		symbol: '$',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	CRC: {
+		symbol: '₡',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	CUC: {
+		symbol: 'CUC',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	CUP: {
+		symbol: '$MN',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	CVE: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	CZK: {
+		symbol: 'Kč',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	DJF: {
+		symbol: 'Fdj',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	DKK: {
+		symbol: 'kr.',
+		grouping: '',
+		decimal: ',',
+		precision: 2
+	},
+	DOP: {
+		symbol: 'RD$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	DZD: {
+		symbol: 'د.ج.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	EGP: {
+		symbol: 'ج.م.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	ERN: {
+		symbol: 'Nfk',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	ETB: {
+		symbol: 'ETB',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	EUR: {
+		symbol: '€',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	FJD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	FKP: {
+		symbol: '£',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	GBP: {
+		symbol: '£',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	GEL: {
+		symbol: 'Lari',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	GHS: {
+		symbol: '₵',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	GIP: {
+		symbol: '£',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	GMD: {
+		symbol: 'D',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	GNF: {
+		symbol: 'FG',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	GTQ: {
+		symbol: 'Q',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	GYD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	HKD: {
+		symbol: 'HK$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	HNL: {
+		symbol: 'L.',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	HRK: {
+		symbol: 'kn',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	HTG: {
+		symbol: 'G',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	HUF: {
+		symbol: 'Ft',
+		grouping: '.',
+		decimal: ',',
+		precision: 0
+	},
+	IDR: {
+		symbol: 'Rp',
+		grouping: '.',
+		decimal: ',',
+		precision: 0
+	},
+	ILS: {
+		symbol: '₪',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	INR: {
+		symbol: '₹',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	IQD: {
+		symbol: 'د.ع.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	IRR: {
+		symbol: '﷼',
+		grouping: ',',
+		decimal: '/',
+		precision: 2
+	},
+	ISK: {
+		symbol: 'kr.',
+		grouping: '.',
+		decimal: ',',
+		precision: 0
+	},
+	JMD: {
+		symbol: 'J$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	JOD: {
+		symbol: 'د.ا.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 3
+	},
+	JPY: {
+		symbol: '¥',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	KES: {
+		symbol: 'S',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	KGS: {
+		symbol: 'сом',
+		grouping: ' ',
+		decimal: '-',
+		precision: 2
+	},
+	KHR: {
+		symbol: '៛',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	KMF: {
+		symbol: 'CF',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	KPW: {
+		symbol: '₩',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	KRW: {
+		symbol: '₩',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	KWD: {
+		symbol: 'د.ك.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 3
+	},
+	KYD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	KZT: {
+		symbol: '₸',
+		grouping: ' ',
+		decimal: '-',
+		precision: 2
+	},
+	LAK: {
+		symbol: '₭',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	LBP: {
+		symbol: 'ل.ل.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	LKR: {
+		symbol: '₨',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	LRD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	LSL: {
+		symbol: 'M',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	LYD: {
+		symbol: 'د.ل.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 3
+	},
+	MAD: {
+		symbol: 'د.م.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MDL: {
+		symbol: 'lei',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MGA: {
+		symbol: 'Ar',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	MKD: {
+		symbol: 'ден.',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	MMK: {
+		symbol: 'K',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MNT: {
+		symbol: '₮',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	MOP: {
+		symbol: 'MOP$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MRO: {
+		symbol: 'UM',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MTL: {
+		symbol: '₤',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MUR: {
+		symbol: '₨',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MVR: {
+		symbol: 'MVR',
+		grouping: ',',
+		decimal: '.',
+		precision: 1
+	},
+	MWK: {
+		symbol: 'MK',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MXN: {
+		symbol: 'MX$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MYR: {
+		symbol: 'RM',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	MZN: {
+		symbol: 'MT',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	NAD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	NGN: {
+		symbol: '₦',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	NIO: {
+		symbol: 'C$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	NOK: {
+		symbol: 'kr',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	NPR: {
+		symbol: '₨',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	NZD: {
+		symbol: 'NZ$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	OMR: {
+		symbol: '﷼',
+		grouping: ',',
+		decimal: '.',
+		precision: 3
+	},
+	PAB: {
+		symbol: 'B/.',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	PEN: {
+		symbol: 'S/.',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	PGK: {
+		symbol: 'K',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	PHP: {
+		symbol: '₱',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	PKR: {
+		symbol: '₨',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	PLN: {
+		symbol: 'zł',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	PYG: {
+		symbol: '₲',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	QAR: {
+		symbol: '﷼',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	RON: {
+		symbol: 'lei',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	RSD: {
+		symbol: 'Дин.',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	RUB: {
+		symbol: '₽',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	RWF: {
+		symbol: 'RWF',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	SAR: {
+		symbol: '﷼',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SBD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SCR: {
+		symbol: '₨',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SDD: {
+		symbol: 'LSd',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SDG: {
+		symbol: '£‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SEK: {
+		symbol: 'kr',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SGD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SHP: {
+		symbol: '£',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SLL: {
+		symbol: 'Le',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SOS: {
+		symbol: 'S',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SRD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	STD: {
+		symbol: 'Db',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SVC: {
+		symbol: '₡',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SYP: {
+		symbol: '£',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	SZL: {
+		symbol: 'E',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	THB: {
+		symbol: '฿',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	TJS: {
+		symbol: 'TJS',
+		grouping: ' ',
+		decimal: ';',
+		precision: 2
+	},
+	TMT: {
+		symbol: 'm',
+		grouping: ' ',
+		decimal: ',',
+		precision: 0
+	},
+	TND: {
+		symbol: 'د.ت.‏',
+		grouping: ',',
+		decimal: '.',
+		precision: 3
+	},
+	TOP: {
+		symbol: 'T$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	TRY: {
+		symbol: 'TL',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	TTD: {
+		symbol: 'TT$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	TVD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	TWD: {
+		symbol: 'NT$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	TZS: {
+		symbol: 'TSh',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	UAH: {
+		symbol: '₴',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	UGX: {
+		symbol: 'USh',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	USD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	UYU: {
+		symbol: '$U',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	UZS: {
+		symbol: 'сўм',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	VEB: {
+		symbol: 'Bs.',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	VEF: {
+		symbol: 'Bs. F.',
+		grouping: '.',
+		decimal: ',',
+		precision: 2
+	},
+	VND: {
+		symbol: '₫',
+		grouping: '.',
+		decimal: ',',
+		precision: 1
+	},
+	VUV: {
+		symbol: 'VT',
+		grouping: ',',
+		decimal: '.',
+		precision: 0
+	},
+	WST: {
+		symbol: 'WS$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	XAF: {
+		symbol: 'F',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	XCD: {
+		symbol: '$',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	XOF: {
+		symbol: 'F',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	XPF: {
+		symbol: 'F',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	YER: {
+		symbol: '﷼',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	ZAR: {
+		symbol: 'R',
+		grouping: ' ',
+		decimal: ',',
+		precision: 2
+	},
+	ZMW: {
+		symbol: 'ZK',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	},
+	WON: {
+		symbol: '₩',
+		grouping: ',',
+		decimal: '.',
+		precision: 2
+	}
+};

--- a/client/lib/format-currency/index.js
+++ b/client/lib/format-currency/index.js
@@ -3,86 +3,10 @@
  */
 import { numberFormat } from 'i18n-calypso';
 
-const CURRENCIES = {
-	USD: {
-		symbol: '$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	AUD: {
-		symbol: 'A$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	CAD: {
-		symbol: 'C$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	EUR: {
-		symbol: '€',
-		grouping: '.',
-		decimal: ',',
-		precision: 2
-	},
-	GBP: {
-		symbol: '£',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	JPY: {
-		symbol: '¥',
-		grouping: ',',
-		decimal: '.',
-		precision: 0
-	},
-	BRL: {
-		symbol: 'R$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	NZD: {
-		symbol: 'NZ$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	ILS: {
-		symbol: '₪',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	HUF: {
-		symbol: 'Ft',
-		grouping: '.',
-		decimal: ',',
-		precision: 0
-	},
-	SEK: {
-		symbol: 'kr',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	MXN: {
-		symbol: 'MX$',
-		grouping: ',',
-		decimal: '.',
-		precision: 2
-	},
-	RUB: {
-		symbol: '₽',
-		grouping: ' ',
-		decimal: ',',
-		precision: 2
-	}
-};
+/**
+ * Internal dependencies
+ */
+import { CURRENCIES } from './currencies';
 
 /**
  * Formats money with a given currency code


### PR DESCRIPTION
As we are now supporting a lot more currencies in Store Stats, we should support how they are formatted in Calypso. Ideally, this may be included in i18n-calypso and maintained as part of the locales.

Fixes #15846 