### PR TITLE
Activity log: Add persistence to activity items

### DIFF
--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -4,15 +4,16 @@
  */
 import { logItemsSchema } from './schema';
 import { ACTIVITY_LOG_UPDATE } from 'state/action-types';
-import { createReducer, keyedReducer } from 'state/utils';
+import { createReducer, keyedReducer, withSchemaValidation } from 'state/utils';
 
 // FIXME: No-op reducers
 export const logError = keyedReducer( 'siteId', state => state );
 
-export const logItems = keyedReducer(
+const logItemsReducer = keyedReducer(
 	'siteId',
 	createReducer( [], {
 		[ ACTIVITY_LOG_UPDATE ]: ( state, { data } ) => data,
 	} )
 );
-logItems.schema = logItemsSchema;
+
+export const logItems = withSchemaValidation( logItemsSchema, logItemsReducer );

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -4,16 +4,15 @@
  */
 import { logItemsSchema } from './schema';
 import { ACTIVITY_LOG_UPDATE } from 'state/action-types';
-import { createReducer, keyedReducer, withSchemaValidation } from 'state/utils';
+import { createReducer, keyedReducer } from 'state/utils';
 
 // FIXME: No-op reducers
 export const logError = keyedReducer( 'siteId', state => state );
 
-const logItemsReducer = keyedReducer(
+export const logItems = keyedReducer(
 	'siteId',
 	createReducer( [], {
 		[ ACTIVITY_LOG_UPDATE ]: ( state, { data } ) => data,
 	} )
 );
-
-export const logItems = withSchemaValidation( logItemsSchema, logItemsReducer );
+logItems.schema = logItemsSchema;

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -1,19 +1,18 @@
+/** @format */
 /**
  * Internal dependencies
  */
 import { logItemsSchema } from './schema';
-import {
-	ACTIVITY_LOG_UPDATE,
-} from 'state/action-types';
-import {
-	createReducer,
-	keyedReducer,
-} from 'state/utils';
+import { ACTIVITY_LOG_UPDATE } from 'state/action-types';
+import { createReducer, keyedReducer } from 'state/utils';
 
 // FIXME: No-op reducers
 export const logError = keyedReducer( 'siteId', state => state );
 
-export const logItems = keyedReducer( 'siteId', createReducer( [], {
-	[ ACTIVITY_LOG_UPDATE ]: ( state, { data } ) => data,
-} ) );
+export const logItems = keyedReducer(
+	'siteId',
+	createReducer( [], {
+		[ ACTIVITY_LOG_UPDATE ]: ( state, { data } ) => data,
+	} )
+);
 logItems.schema = logItemsSchema;

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { logItemsSchema } from './schema';
 import {
 	ACTIVITY_LOG_UPDATE,
 } from 'state/action-types';
@@ -15,3 +16,4 @@ export const logError = keyedReducer( 'siteId', state => state );
 export const logItems = keyedReducer( 'siteId', createReducer( [], {
 	[ ACTIVITY_LOG_UPDATE ]: ( state, { data } ) => data,
 } ) );
+logItems.schema = logItemsSchema;

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -1,0 +1,24 @@
+export const logItemsSchema = {
+	type: 'object',
+	patternProperties: {
+		'^\\d+$': {
+			type: 'array',
+			items: {
+				type: 'object',
+				required: [
+					'name',
+					'ts_utc',
+				],
+				properties: {
+					actor: { type: 'object' },
+					group: { type: 'string' },
+					name: { type: 'string' },
+					object: { type: 'object' },
+					ts_utc: { type: 'integer' },
+				},
+				additionalProperties: false,
+			}
+		},
+	},
+	additionalProperties: false,
+};

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -16,7 +16,6 @@ export const logItemsSchema = {
 					object: { type: 'object' },
 					ts_utc: { type: 'integer' },
 				},
-				additionalProperties: false,
 			}
 		},
 	},

--- a/client/state/activity-log/log/test/reducer.js
+++ b/client/state/activity-log/log/test/reducer.js
@@ -1,0 +1,88 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { ACTIVITY_LOG_UPDATE, DESERIALIZE, SERIALIZE } from 'state/action-types';
+import { logItems } from '../reducer';
+import { useSandbox } from 'test/helpers/use-sinon';
+
+describe( 'reducer', () => {
+	useSandbox( sandbox => {
+		sandbox.stub( console, 'warn' );
+	} );
+
+	describe( '#logItems()', () => {
+		it( 'should default to an empty object', () => {
+			const state = logItems( undefined, {} );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should populate state with activity', () => {
+			const siteId = 12345;
+			const data = deepFreeze( [
+				{
+					ts_utc: 1502108367646,
+					name: 'user__failed_login_attempt',
+				},
+			] );
+			const state = logItems( undefined, {
+				type: ACTIVITY_LOG_UPDATE,
+				siteId,
+				data,
+			} );
+
+			expect( state ).to.eql( {
+				[ 12345 ]: data,
+			} );
+		} );
+
+		it( 'should persist state', () => {
+			const original = deepFreeze( {
+				12345: [
+					{
+						ts_utc: 1502108367646,
+						name: 'user__failed_login_attempt',
+					},
+				],
+			} );
+			const state = logItems( original, { type: SERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should load valid persisted state', () => {
+			const original = deepFreeze( {
+				12345: [
+					{
+						ts_utc: 1502108367646,
+						name: 'user__failed_login_attempt',
+					},
+				],
+			} );
+
+			const state = logItems( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				12345: [
+					{
+						name: 'user__failed_login_attempt',
+					},
+				],
+			} );
+			const state = logItems( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( {} );
+		} );
+	} );
+} );

--- a/client/state/activity-log/log/test/reducer.js
+++ b/client/state/activity-log/log/test/reducer.js
@@ -11,6 +11,9 @@ import deepFreeze from 'deep-freeze';
 import { ACTIVITY_LOG_UPDATE, DESERIALIZE, SERIALIZE } from 'state/action-types';
 import { logItems } from '../reducer';
 import { useSandbox } from 'test/helpers/use-sinon';
+import { withSchemaValidation } from 'state/utils';
+
+const logItemsReducer = withSchemaValidation( logItems.schema, logItems );
 
 describe( 'reducer', () => {
 	useSandbox( sandbox => {
@@ -19,7 +22,7 @@ describe( 'reducer', () => {
 
 	describe( '#logItems()', () => {
 		it( 'should default to an empty object', () => {
-			const state = logItems( undefined, {} );
+			const state = logItemsReducer( undefined, {} );
 
 			expect( state ).to.eql( {} );
 		} );
@@ -32,7 +35,7 @@ describe( 'reducer', () => {
 					name: 'user__failed_login_attempt',
 				},
 			] );
-			const state = logItems( undefined, {
+			const state = logItemsReducer( undefined, {
 				type: ACTIVITY_LOG_UPDATE,
 				siteId,
 				data,
@@ -52,7 +55,7 @@ describe( 'reducer', () => {
 					},
 				],
 			} );
-			const state = logItems( original, { type: SERIALIZE } );
+			const state = logItemsReducer( original, { type: SERIALIZE } );
 
 			expect( state ).to.eql( original );
 		} );
@@ -67,7 +70,7 @@ describe( 'reducer', () => {
 				],
 			} );
 
-			const state = logItems( original, { type: DESERIALIZE } );
+			const state = logItemsReducer( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( original );
 		} );
@@ -80,7 +83,7 @@ describe( 'reducer', () => {
 					},
 				],
 			} );
-			const state = logItems( original, { type: DESERIALIZE } );
+			const state = logItemsReducer( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
 		} );


### PR DESCRIPTION
Add persistence to log items state

**To test**
* https://calypso.live/stats/activity?branch=add/activitylog-persist-activity
* Try refreshing the page and throttling network.
* You should see that log items are maintained between requests _before_ the activity endpoint responds.

Closes #15385
Fixes #15241