### PR TITLE
Login: Fix automated retries failing with Jetpack Connect

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -43,6 +43,8 @@ class Login extends Component {
 			// Disallow access to the 2FA pages unless the user has 2FA enabled
 			page( login( { isNative: true } ) );
 		}
+
+		window.scrollTo( 0, 0 );
 	};
 
 	componentWillReceiveProps = ( nextProps ) => {

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -166,18 +166,18 @@ class LoggedInForm extends Component {
 
 	handleClickDisclaimer = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click' );
-	}
+	};
 
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
-	}
+	};
 
 	handleSignOut = () => {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 		const redirect = addQueryArgs( queryObject, window.location.href );
 		this.props.recordTracksEvent( 'calypso_jpc_signout_click' );
 		userUtilities.logout( redirect );
-	}
+	};
 
 	handleResolve = () => {
 		const { queryObject, authorizationCode } = this.props.jetpackConnectAuthorize;
@@ -195,7 +195,7 @@ class LoggedInForm extends Component {
 		// legacy functions on the client.
 		this.props.recordTracksEvent( 'calypso_jpc_resolve_xmlrpc_error_click' );
 		this.props.goToXmlrpcErrorFallbackUrl( queryObject, authorizationCode );
-	}
+	};
 
 	handleSubmit = () => {
 		const {
@@ -232,7 +232,7 @@ class LoggedInForm extends Component {
 
 		this.props.recordTracksEvent( 'calypso_jpc_approve_click' );
 		return this.props.authorize( queryObject );
-	}
+	};
 
 	isAuthorizing() {
 		const { isAuthorizing } = this.props.jetpackConnectAuthorize;

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -49,7 +49,7 @@ class LoggedOutForm extends Component {
 	handleSubmitSignup = ( form, userData ) => {
 		debug( 'submiting new account', form, userData );
 		this.props.createAccount( userData );
-	}
+	};
 
 	renderLoginUser() {
 		const { userData, bearerToken } = this.props.jetpackConnectAuthorize;

--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import HelpButton from './help-button';
 import { login } from 'lib/paths';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -92,7 +93,7 @@ class LoggedOutForm extends Component {
 
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
+				<LoggedOutFormLinkItem href={ login( { isNative: config.isEnabled( 'login/native-login-links' ), redirectTo } ) }>
 					{ this.props.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
 				<HelpButton onClick={ this.clickHelpButton } />

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -63,7 +63,7 @@ class JetpackConnectAuthorizeForm extends Component {
 		retryAuth: PropTypes.func,
 		siteSlug: PropTypes.string,
 		user: PropTypes.object,
-	}
+	};
 
 	componentWillMount() {
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );

--- a/client/jetpack-connect/install-step.jsx
+++ b/client/jetpack-connect/install-step.jsx
@@ -37,12 +37,12 @@ class JetpackInstallStep extends Component {
 	confirmJetpackInstalled = ( event ) => {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( true );
-	}
+	};
 
 	confirmJetpackNotInstalled = ( event ) => {
 		event.preventDefault();
 		this.props.confirmJetpackInstallStatus( false );
-	}
+	};
 
 	renderAlreadyHaveJetpackButton() {
 		return (

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -33,7 +33,7 @@ class JetpackConnectNotices extends Component {
 		] ).isRequired,
 		translate: PropTypes.func.isRequired,
 		url: PropTypes.string,
-	}
+	};
 
 	getNoticeValues() {
 		const {

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -27,7 +27,7 @@ class JetpackNewSite extends Component {
 		this.handleBack = this.handleBack.bind( this );
 	}
 
-	state = { jetpackUrl: '' }
+	state = { jetpackUrl: '' };
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_view' );
@@ -42,7 +42,7 @@ class JetpackNewSite extends Component {
 	handleJetpackSubmit = () => {
 		this.props.recordTracksEvent( 'calypso_jetpack_new_site_connect_click' );
 		page( '/jetpack/connect?url=' + this.state.jetpackUrl );
-	}
+	};
 
 	handleOnClickTos() {
 		this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -136,7 +136,7 @@ class JetpackConnectMain extends Component {
 			currentUrl: this.cleanUrl( url ),
 			shownUrl: url,
 		} );
-	}
+	};
 
 	cleanUrl( inputUrl ) {
 		let url = inputUrl.trim().toLowerCase();
@@ -163,7 +163,7 @@ class JetpackConnectMain extends Component {
 		} else {
 			this.checkUrl( this.state.currentUrl );
 		}
-	}
+	};
 
 	installJetpack = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
@@ -172,7 +172,7 @@ class JetpackConnectMain extends Component {
 		} );
 
 		this.props.goToPluginInstall( this.state.currentUrl );
-	}
+	};
 
 	activateJetpack = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
@@ -180,7 +180,7 @@ class JetpackConnectMain extends Component {
 			type: 'activate_jetpack'
 		} );
 		this.props.goToPluginActivation( this.state.currentUrl );
-	}
+	};
 
 	checkProperty( propName ) {
 		return this.state.currentUrl &&

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -65,7 +65,7 @@ class PlansLanding extends Component {
 		setTimeout( () => {
 			page.redirect( redirectUrl );
 		}, 25 );
-	}
+	};
 
 	render() {
 		const {

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -83,23 +83,23 @@ class JetpackSsoForm extends Component {
 
 		debug( 'Approving sso' );
 		this.props.authorizeSSO( siteId, ssoNonce, siteUrl );
-	}
+	};
 
 	onCancelClick = ( event ) => {
 		debug( 'Clicked return to site link' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_return_to_site_link_click' );
 		this.returnToSiteFallback( event );
-	}
+	};
 
 	onTryAgainClick = ( event ) => {
 		debug( 'Clicked try again link' );
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_try_again_link_click' );
 		this.returnToSiteFallback( event );
-	}
+	};
 
 	onClickSignInDifferentUser = () => {
 		analytics.tracks.recordEvent( 'calypso_jetpack_sso_sign_in_different_user_link_click' );
-	}
+	};
 
 	onClickSharedDetailsModal = ( event ) => {
 		event.preventDefault();
@@ -107,13 +107,13 @@ class JetpackSsoForm extends Component {
 		this.setState( {
 			showTermsDialog: true
 		} );
-	}
+	};
 
 	closeTermsDialog = () => {
 		this.setState( {
 			showTermsDialog: false
 		} );
-	}
+	};
 
 	returnToSiteFallback = ( event ) => {
 		// If, for some reason, the API request failed and we do not have the admin URL,
@@ -123,7 +123,7 @@ class JetpackSsoForm extends Component {
 			event.preventDefault();
 			window.history.back();
 		}
-	}
+	};
 
 	isButtonDisabled() {
 		const user = this.props.userModule.get();


### PR DESCRIPTION
This pull request, along with server-side patch D6310-code, fixes https://github.com/Automattic/wp-calypso/issues/15913 to make it possible to use the new Calypso-based [Login page](https://wordpress.com/log-in) within the Jetpack Connect flow.

Technically speaking, the problem mentioned in https://github.com/Automattic/wp-calypso/issues/15913#issuecomment-313459495 is fixed by the patch D6310-code. This pull request mainly focuses on enabling the new `Login` page in the Jetpack Connect flow in order to save a round trip with the API, and fixing a small scrolling issue that would happen when the user switches from a Jetpack page to the `Login` page.
 
#### Testing instructions
 
1. Run `git checkout fix/jetpack-with-new-login` and start your server, or open a [live branch](https://calypso.live/?branch=fix/jetpack-with-new-login)
2. Apply patch D6310-code to your sandbox
3. Point `wordpress.com` to your sandbox
4. [Generate](http://poopy.life/create?src=inquisitive-macaw&key=g57uqr8kfjjn0Pwi) a new Jetpack site 
5. Open the [`Jetpack Connect` page](http://calypso.localhost:3000/jetpack/connect) in an incognito window
6. Enter the url of the new Jetpack site in `Site Address` and submit the form
7. Assert that the `Already have an account? Sign in` link in the footer points to the new `Login` page
8. Click that link and assert that the viewport is scrolled back to the top of the page
9. Submit credentials of a regular WordPress.com account
10. Click the `Approve` button to complete the connection process
11. Check that you are presented with the [`Jetpack Plans` page](http://calypso.localhost:3000/jetpack/connect/plans/:site) (and that no error showed up)
12. Assert that the heading mentions `Your site is now connected!`

You should repeat steps #8 to #12 with an account that has 2FA enabled. You may also want to go through all these testing instructions again with some variants, e.g by logging into WordPress.com before starting the connection flow. Or by disabling the [`login/native-login-links` feature](https://github.com/Automattic/wp-calypso/blob/88747cbfd1c291b213c66b67e4380084a91c2d0d/config/development.json#L64) and restarting your server. Note that in that case it will redirect to https://wordpress.com/log-in which is not available when `wordpress.com` is sandboxed though (however you can just replace `https://wordpress.com` with `http://calypso.localhost:3000` in the url to continue the flow).

#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests