### PR TITLE
Tests: Fix broken my-sites/upgrades/paths module path

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -1,12 +1,10 @@
 /**
  * External Dependencies
  */
-import page from 'page';
-import qs from 'qs';
 import i18n from 'i18n-calypso';
 import ReactDom from 'react-dom';
 import React from 'react';
-import { get, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -17,12 +15,7 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import productsFactory from 'lib/products-list';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import { canCurrentUser } from 'state/selectors';
-import {
-	getSelectedSiteId,
-	getSelectedSite,
-} from 'state/ui/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 
 /**
  * Module variables

--- a/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
@@ -55,7 +55,7 @@ describe( 'mapped-domain', () => {
 	} );
 
 	it( 'should use selectedSite.slug for URLs', sinon.test( function() {
-		const paths = require( 'my-sites/upgrades/paths' );
+		const paths = require( 'my-sites/domains/paths' );
 		const dnsStub = this.stub( paths, 'domainManagementDns' );
 		const emailStub = this.stub( paths, 'domainManagementEmail' );
 

--- a/client/my-sites/domains/map-domain/test/map-domain.js
+++ b/client/my-sites/domains/map-domain/test/map-domain.js
@@ -11,7 +11,7 @@ import { spy } from 'sinon';
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
-import paths from 'my-sites/upgrades/paths';
+import paths from 'my-sites/domains/paths';
 
 describe( 'MapDomain component', () => {
 	const pageSpy = spy();


### PR DESCRIPTION
Some files were moved around in https://github.com/Automattic/wp-calypso/pull/15931 and this route was not updated. The module no longer exists at this location and is causing test failures.

**To test**
* Ensure the tests pass