### PR TITLE
Checks if the domain supports privacy before adding privacy to the cart

### DIFF
--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -80,7 +80,7 @@ class DomainSearch extends Component {
 			cartItems.domainRegistration( { domain: suggestion.domain_name, productSlug: suggestion.product_slug } )
 		];
 
-		if ( cartItems.isNextDomainFree( this.props.cart ) ) {
+		if ( suggestion.supports_privacy && cartItems.isNextDomainFree( this.props.cart ) ) {
 			items.push( cartItems.domainPrivacyProtection( {
 				domain: suggestion.domain_name
 			} ) );


### PR DESCRIPTION
When a domain is added that does not support privacy we should not add privacy item in the cart. This happens only in case you have active plan (or plan in the cart).

This depends on D6288-code