### PR TITLE
Moves edit of payment method to dialog

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
@@ -8,7 +8,7 @@ import { isArray } from 'lodash';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
+import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormPasswordInput from 'components/forms/form-password-input';
@@ -31,15 +31,13 @@ class PaymentMethodEdit extends Component {
 			} ),
 		} ),
 		translate: PropTypes.func.isRequired,
+		onCancel: PropTypes.func.isRequired,
 		onEditField: PropTypes.func.isRequired,
+		onSave: PropTypes.func.isRequired,
 	};
 
 	onEditFieldHandler = ( e ) => {
 		this.props.onEditField( e.target.name, e.target.value );
-	}
-
-	onSaveHandler = () => {
-		this.props.onSave( this.props.method );
 	}
 
 	renderEditCheckbox = ( setting ) => {
@@ -110,16 +108,20 @@ class PaymentMethodEdit extends Component {
 		);
 	}
 
+	buttons = [
+		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
+		{ action: 'add', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
+	];
+
 	render() {
-		const { method, translate } = this.props;
+		const { method } = this.props;
 		const settingsFieldsKeys = method.settings && Object.keys( method.settings );
 		return (
-			<div className="payments__method-edit-fields">
+			<Dialog
+				buttons={ this.buttons }
+				isVisible="true">
 				{ settingsFieldsKeys.map( this.renderEditField ) }
-				<Button primary onClick={ this.onSaveHandler }>
-					{ translate( 'Save' ) }
-				</Button>
-			</div>
+			</Dialog>
 		);
 	}
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
@@ -110,7 +110,7 @@ class PaymentMethodEdit extends Component {
 
 	buttons = [
 		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
-		{ action: 'add', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
+		{ action: 'save', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
 	];
 
 	render() {
@@ -119,7 +119,7 @@ class PaymentMethodEdit extends Component {
 		return (
 			<Dialog
 				buttons={ this.buttons }
-				isVisible="true">
+				isVisible>
 				{ settingsFieldsKeys.map( this.renderEditField ) }
 			</Dialog>
 		);

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-edit-dialog.js
@@ -118,6 +118,7 @@ class PaymentMethodEdit extends Component {
 		const settingsFieldsKeys = method.settings && Object.keys( method.settings );
 		return (
 			<Dialog
+				additionalClassNames="payments__dialog woocommerce"
 				buttons={ this.buttons }
 				isVisible>
 				{ settingsFieldsKeys.map( this.renderEditField ) }

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -25,7 +25,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import ListItem from 'woocommerce/components/list/list-item';
 import ListItemField from 'woocommerce/components/list/list-item-field';
-import PaymentMethodEdit from './payment-method-edit';
+import PaymentMethodEditDialog from './payment-method-edit-dialog';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 import PaymentMethodPaypal from './payment-method-paypal';
 import PaymentMethodStripe from './payment-method-stripe';
@@ -143,6 +143,7 @@ class PaymentMethodItem extends Component {
 			return (
 				<PaymentMethodPaypal
 					method={ currentlyEditingMethod }
+					onCancel={ this.onCancel }
 					onEditField={ this.onEditField }
 					onSave={ this.onSave } />
 			);
@@ -151,13 +152,15 @@ class PaymentMethodItem extends Component {
 			return (
 				<PaymentMethodStripe
 					method={ currentlyEditingMethod }
+					onCancel={ this.onCancel }
 					onEditField={ this.onEditField }
 					onSave={ this.onSave } />
 			);
 		}
 		return (
-			<PaymentMethodEdit
+			<PaymentMethodEditDialog
 				method={ currentlyEditingMethod }
+				onCancel={ this.onCancel }
 				onEditField={ this.onEditField }
 				onSave={ this.onSave } />
 		);

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
@@ -51,6 +51,7 @@ class PaymentMethodPaypal extends Component {
 		const { method: { settings }, translate } = this.props;
 		return (
 			<Dialog
+				additionalClassNames="payments__dialog woocommerce"
 				buttons={ this.buttons }
 				isVisible>
 				<FormFieldset className="payments__method-edit-field-container">

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
+import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
@@ -29,7 +29,9 @@ class PaymentMethodPaypal extends Component {
 			} ),
 		} ),
 		translate: PropTypes.func.isRequired,
+		onCancel: PropTypes.func.isRequired,
 		onEditField: PropTypes.func.isRequired,
+		onSave: PropTypes.func.isRequired,
 	};
 
 	onEditFieldHandler = ( e ) => {
@@ -40,10 +42,17 @@ class PaymentMethodPaypal extends Component {
 		this.props.onSave( this.props.method );
 	}
 
+	buttons = [
+		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
+		{ action: 'add', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
+	];
+
 	render() {
 		const { method: { settings }, translate } = this.props;
 		return (
-			<div className="payments__method-edit-fields">
+			<Dialog
+				buttons={ this.buttons }
+				isVisible="true">
 				<FormFieldset className="payments__method-edit-field-container">
 					<FormLabel>{ translate( 'Your Paypal ID' ) }</FormLabel>
 					<FormTextInput
@@ -78,10 +87,7 @@ class PaymentMethodPaypal extends Component {
 						<span>{ translate( 'Authorize the customers credit card but charge manually' ) }</span>
 					</FormLabel>
 				</FormFieldset>
-				<Button primary onClick={ this.onSaveHandler }>
-					{ translate( 'Save' ) }
-				</Button>
-			</div>
+			</Dialog>
 		);
 	}
 }

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
@@ -44,7 +44,7 @@ class PaymentMethodPaypal extends Component {
 
 	buttons = [
 		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
-		{ action: 'add', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
+		{ action: 'save', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
 	];
 
 	render() {
@@ -52,7 +52,7 @@ class PaymentMethodPaypal extends Component {
 		return (
 			<Dialog
 				buttons={ this.buttons }
-				isVisible="true">
+				isVisible>
 				<FormFieldset className="payments__method-edit-field-container">
 					<FormLabel>{ translate( 'Your Paypal ID' ) }</FormLabel>
 					<FormTextInput

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -114,7 +114,7 @@ class PaymentMethodStripe extends Component {
 
 	buttons = [
 		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
-		{ action: 'add', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
+		{ action: 'save', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
 	];
 
 	render() {
@@ -122,7 +122,7 @@ class PaymentMethodStripe extends Component {
 		return (
 			<Dialog
 				buttons={ this.buttons }
-				isVisible="true">
+				isVisible>
 				<FormFieldset className="payments__method-edit-field-container">
 					<Notice showDismiss={ false } text={ translate( 'To use Stripe you need to register an account' ) }>
 						<NoticeAction href="https://dashboard.stripe.com/register">{ translate( 'Sign up' ) }</NoticeAction>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
+import Dialog from 'components/dialog';
 import ControlItem from 'components/segmented-control/item';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -33,7 +33,9 @@ class PaymentMethodStripe extends Component {
 			} ),
 		} ),
 		translate: PropTypes.func.isRequired,
+		onCancel: PropTypes.func.isRequired,
 		onEditField: PropTypes.func.isRequired,
+		onSave: PropTypes.func.isRequired,
 	};
 
 	onEditFieldHandler = ( e ) => {
@@ -110,10 +112,17 @@ class PaymentMethodStripe extends Component {
 		);
 	}
 
+	buttons = [
+		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
+		{ action: 'add', label: this.props.translate( 'Save' ), onClick: this.props.onSave, isPrimary: true },
+	];
+
 	render() {
 		const { method, translate } = this.props;
 		return (
-			<div className="payments__method-edit-fields">
+			<Dialog
+				buttons={ this.buttons }
+				isVisible="true">
 				<FormFieldset className="payments__method-edit-field-container">
 					<Notice showDismiss={ false } text={ translate( 'To use Stripe you need to register an account' ) }>
 						<NoticeAction href="https://dashboard.stripe.com/register">{ translate( 'Sign up' ) }</NoticeAction>
@@ -171,10 +180,7 @@ class PaymentMethodStripe extends Component {
 						) }
 					</span>
 				</FormFieldset>
-				<Button primary onClick={ this.onSaveHandler }>
-					{ translate( 'Save' ) }
-				</Button>
-			</div>
+			</Dialog>
 		);
 	}
 }

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -121,6 +121,7 @@ class PaymentMethodStripe extends Component {
 		const { method, translate } = this.props;
 		return (
 			<Dialog
+				additionalClassNames="payments__dialog woocommerce"
 				buttons={ this.buttons }
 				isVisible>
 				<FormFieldset className="payments__method-edit-field-container">

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -1,3 +1,20 @@
+&.payments__dialog {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+	max-height: 80%;
+	max-width: 600px;
+
+	.dialog__content {
+		height: 100%;
+		overflow-y: scroll;
+	}
+
+	.dialog__action-buttons {
+		overflow: visible;
+	}
+}
+
 .payments__address-currency-container {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
To test:

- http://calypso.localhost:3000/store/settings/payments/{store}
- Click setup/manage button to edit payment method
- observe that it is in a dialog