### PR TITLE
Activity log: Disable rewind when restore is in progress

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -17,6 +17,7 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
 class ActivityLogDay extends Component {
 	static propTypes = {
 		applySiteOffset: PropTypes.func.isRequired,
+		disableRestore: PropTypes.bool.isRequired,
 		hideRestore: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
 		logs: PropTypes.array.isRequired,

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -114,12 +114,12 @@ class ActivityLogDay extends Component {
 
 	render() {
 		const {
+			applySiteOffset,
 			disableRestore,
 			hideRestore,
 			logs,
 			requestRestore,
 			siteId,
-			applySiteOffset,
 		} = this.props;
 
 		return (
@@ -133,13 +133,13 @@ class ActivityLogDay extends Component {
 				>
 					{ logs.map( ( log, index ) => (
 						<ActivityLogItem
-							key={ index }
-							disableRestore={ disableRestore }
-							siteId={ siteId }
-							requestRestore={ requestRestore }
-							log={ log }
 							applySiteOffset={ applySiteOffset }
+							disableRestore={ disableRestore }
 							hideRestore={ hideRestore }
+							key={ index }
+							log={ log }
+							requestRestore={ requestRestore }
+							siteId={ siteId }
 						/>
 					) ) }
 				</FoldableCard>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -16,8 +16,8 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
 
 class ActivityLogDay extends Component {
 	static propTypes = {
-		allowRestore: PropTypes.bool.isRequired,
 		applySiteOffset: PropTypes.func.isRequired,
+		hideRestore: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
 		logs: PropTypes.array.isRequired,
 		requestRestore: PropTypes.func.isRequired,
@@ -26,7 +26,6 @@ class ActivityLogDay extends Component {
 	};
 
 	static defaultProps = {
-		allowRestore: true,
 		disableRestore: false,
 		isRewindActive: true,
 	};
@@ -63,11 +62,11 @@ class ActivityLogDay extends Component {
 	 */
 	getRewindButton( type = '' ) {
 		const {
-			allowRestore,
 			disableRestore,
+			hideRestore,
 		} = this.props;
 
-		if ( ! allowRestore ) {
+		if ( hideRestore ) {
 			return null;
 		}
 
@@ -115,8 +114,8 @@ class ActivityLogDay extends Component {
 
 	render() {
 		const {
-			allowRestore,
 			disableRestore,
+			hideRestore,
 			logs,
 			requestRestore,
 			siteId,
@@ -135,12 +134,12 @@ class ActivityLogDay extends Component {
 					{ logs.map( ( log, index ) => (
 						<ActivityLogItem
 							key={ index }
-							allowRestore={ allowRestore }
 							disableRestore={ disableRestore }
 							siteId={ siteId }
 							requestRestore={ requestRestore }
 							log={ log }
 							applySiteOffset={ applySiteOffset }
+							hideRestore={ hideRestore }
 						/>
 					) ) }
 				</FoldableCard>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -27,6 +27,7 @@ class ActivityLogDay extends Component {
 
 	static defaultProps = {
 		allowRestore: true,
+		disableRestore: false,
 		isRewindActive: true,
 	};
 
@@ -61,7 +62,10 @@ class ActivityLogDay extends Component {
 	 * @returns { object } Button to display.
 	 */
 	getRewindButton( type = '' ) {
-		const { allowRestore } = this.props;
+		const {
+			allowRestore,
+			disableRestore,
+		} = this.props;
 
 		if ( ! allowRestore ) {
 			return null;
@@ -71,7 +75,7 @@ class ActivityLogDay extends Component {
 			<Button
 				className="activity-log-day__rewind-button"
 				compact
-				disabled={ ! this.props.isRewindActive }
+				disabled={ disableRestore || ! this.props.isRewindActive }
 				onClick={ this.handleClickRestore }
 				primary={ 'primary' === type }
 			>
@@ -112,6 +116,7 @@ class ActivityLogDay extends Component {
 	render() {
 		const {
 			allowRestore,
+			disableRestore,
 			logs,
 			requestRestore,
 			siteId,
@@ -131,6 +136,7 @@ class ActivityLogDay extends Component {
 						<ActivityLogItem
 							key={ index }
 							allowRestore={ allowRestore }
+							disableRestore={ disableRestore }
 							siteId={ siteId }
 							requestRestore={ requestRestore }
 							log={ log }

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -147,7 +147,10 @@ class ActivityLogItem extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	static defaultProps = { allowRestore: true };
+	static defaultProps = {
+		allowRestore: true,
+		disableRestore: false,
+	};
 
 	handleClickRestore = () => {
 		const {
@@ -260,6 +263,7 @@ class ActivityLogItem extends Component {
 	renderSummary() {
 		const {
 			allowRestore,
+			disableRestore,
 			translate,
 		} = this.props;
 
@@ -270,7 +274,11 @@ class ActivityLogItem extends Component {
 		return (
 			<div className="activity-log-item__action">
 				<EllipsisMenu position="bottom right">
-					<PopoverMenuItem onClick={ this.handleClickRestore } icon="undo">
+					<PopoverMenuItem
+						disabled={ disableRestore }
+						icon="undo"
+						onClick={ this.handleClickRestore }
+					>
 						{ translate( 'Rewind to this point' ) }
 					</PopoverMenuItem>
 				</EllipsisMenu>

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -23,10 +23,11 @@ const debug = debugFactory( 'calypso:activity-log:item' );
 class ActivityLogItem extends Component {
 
 	static propTypes = {
-		allowRestore: PropTypes.bool.isRequired,
 		siteId: PropTypes.number.isRequired,
 		requestRestore: PropTypes.func.isRequired,
 		applySiteOffset: PropTypes.func.isRequired,
+		hideRestore: PropTypes.bool,
+
 		log: PropTypes.shape( {
 			group: PropTypes.oneOf( [
 				'attachment',
@@ -148,7 +149,6 @@ class ActivityLogItem extends Component {
 	};
 
 	static defaultProps = {
-		allowRestore: true,
 		disableRestore: false,
 	};
 
@@ -262,12 +262,12 @@ class ActivityLogItem extends Component {
 
 	renderSummary() {
 		const {
-			allowRestore,
 			disableRestore,
+			hideRestore,
 			translate,
 		} = this.props;
 
-		if ( ! allowRestore ) {
+		if ( hideRestore ) {
 			return null;
 		}
 

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -23,10 +23,10 @@ const debug = debugFactory( 'calypso:activity-log:item' );
 class ActivityLogItem extends Component {
 
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
-		requestRestore: PropTypes.func.isRequired,
 		applySiteOffset: PropTypes.func.isRequired,
 		hideRestore: PropTypes.bool,
+		requestRestore: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
 
 		log: PropTypes.shape( {
 			group: PropTypes.oneOf( [

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -24,6 +24,7 @@ class ActivityLogItem extends Component {
 
 	static propTypes = {
 		applySiteOffset: PropTypes.func.isRequired,
+		disableRestore: PropTypes.bool.isRequired,
 		hideRestore: PropTypes.bool,
 		requestRestore: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -155,6 +155,13 @@ class ActivityLog extends Component {
 		};
 	}
 
+	isRestoreInProgress() {
+		return includes( [
+			'queued',
+			'running',
+		], get( this.props, [ 'restoreProgress', 'status' ] ) );
+	}
+
 	renderBanner() {
 		const {
 			restoreProgress,
@@ -242,16 +249,13 @@ class ActivityLog extends Component {
 			isRewindActive,
 			logs,
 			moment,
-			restoreProgress,
 			siteId,
 			slug,
 			startDate,
 		} = this.props;
 
-		const disableRestore = includes( [
-			'queued',
-			'running',
-		], get( restoreProgress, 'status' ) );
+		const disableRestore = this.isRestoreInProgress();
+
 		const applySiteOffset = this.getSiteOffsetFunc();
 
 		const YEAR_MONTH = 'YYYY-MM';

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -5,7 +5,13 @@ import React, { Component, PropTypes } from 'react';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { groupBy, map, get, filter } from 'lodash';
+import {
+	filter,
+	get,
+	groupBy,
+	includes,
+	map,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -236,11 +242,16 @@ class ActivityLog extends Component {
 			isRewindActive,
 			logs,
 			moment,
+			restoreProgress,
 			siteId,
 			slug,
 			startDate,
 		} = this.props;
 
+		const disableRestore = includes( [
+			'queued',
+			'running',
+		], get( restoreProgress, 'status' ) );
 		const applySiteOffset = this.getSiteOffsetFunc();
 
 		const YEAR_MONTH = 'YYYY-MM';
@@ -257,6 +268,7 @@ class ActivityLog extends Component {
 			( daily_logs, tsEndOfSiteDay ) => (
 				<ActivityLogDay
 					allowRestore={ !! isPressable }
+					disableRestore={ disableRestore }
 					isRewindActive={ isRewindActive }
 					key={ tsEndOfSiteDay }
 					logs={ daily_logs }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -271,8 +271,8 @@ class ActivityLog extends Component {
 			),
 			( daily_logs, tsEndOfSiteDay ) => (
 				<ActivityLogDay
-					allowRestore={ !! isPressable }
 					disableRestore={ disableRestore }
+					hideRestore={ ! isPressable }
 					isRewindActive={ isRewindActive }
 					key={ tsEndOfSiteDay }
 					logs={ daily_logs }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -271,6 +271,7 @@ class ActivityLog extends Component {
 			),
 			( daily_logs, tsEndOfSiteDay ) => (
 				<ActivityLogDay
+					applySiteOffset={ applySiteOffset }
 					disableRestore={ disableRestore }
 					hideRestore={ ! isPressable }
 					isRewindActive={ isRewindActive }
@@ -279,7 +280,6 @@ class ActivityLog extends Component {
 					requestRestore={ this.handleRequestRestore }
 					siteId={ siteId }
 					tsEndOfSiteDay={ +tsEndOfSiteDay }
-					applySiteOffset={ applySiteOffset }
 				/>
 			)
 		);


### PR DESCRIPTION

**To test**
1. https://calypso.live/stats/activity?branch=update/activitylog-disable-multiple-rewind
1. Do a restore 
1. While the restore is in progress (`queued` / `running`) the restore options will be disabled. This includes the day restores and the restores in the item dropdowns
1. When a restore is not in progress, restore actions should be available (before or after doing a restore).



Fixes #15450