### PR TITLE
Don't disable the tax screen save button when there are no changes

### DIFF
--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -108,7 +108,7 @@ class SettingsTaxes extends Component {
 
 		const onSuccess = () => {
 			this.setState( { isSaving: false, userBeganEditing: false } );
-			return successNotice( translate( 'Settings updated successfully.' ) );
+			return successNotice( translate( 'Settings updated successfully.' ), { duration: 4000 } );
 		};
 
 		const onFailure = () => {
@@ -150,12 +150,10 @@ class SettingsTaxes extends Component {
 			( <span>{ translate( 'Taxes' ) }</span> ),
 		];
 
-		const saveButtonDisabled = this.state.isSaving || ! this.pageHasChanges();
-
 		return (
 			<Main className={ classNames( 'settings-taxes', className ) }>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
-					<Button disabled={ saveButtonDisabled } onClick={ this.onSave } primary>
+					<Button onClick={ this.onSave } primary>
 						{ translate( 'Save' ) }
 					</Button>
 				</ActionHeader>

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -48,7 +48,6 @@ class SettingsTaxes extends Component {
 			pricesIncludeTaxes: true,
 			shippingIsTaxable: true,
 			taxesEnabled: true,
-			userBeganEditing: false,
 		};
 	}
 
@@ -68,36 +67,14 @@ class SettingsTaxes extends Component {
 		}
 	}
 
-	componentWillReceiveProps = ( newProps ) => {
-		if ( ! this.state.userBeganEditing ) {
-			const { site } = this.props;
-			const newSiteId = newProps.site && newProps.site.ID || null;
-			const oldSiteId = site && site.ID || null;
-			if ( oldSiteId !== newSiteId ) {
-				this.props.fetchSettingsGeneral( newSiteId );
-				this.props.fetchTaxSettings( newSiteId );
-			}
-
-			this.setState( {
-				pricesIncludeTaxes: newProps.pricesIncludeTaxes,
-				shippingIsTaxable: newProps.shippingIsTaxable,
-				taxesEnabled: newProps.taxesEnabled,
-			} );
-		}
-	}
-
 	onEnabledChange = () => {
-		this.setState( { taxesEnabled: ! this.state.taxesEnabled, userBeganEditing: true } );
+		this.setState( { taxesEnabled: ! this.state.taxesEnabled } );
 	}
 
 	onCheckboxChange = ( event ) => {
 		const option = event.target.name;
 		const value = event.target.checked;
-		this.setState( { [ option ]: value, userBeganEditing: true } );
-	}
-
-	pageHasChanges = () => {
-		return this.state.userBeganEditing;
+		this.setState( { [ option ]: value } );
 	}
 
 	onSave = ( event ) => {
@@ -107,8 +84,8 @@ class SettingsTaxes extends Component {
 		this.setState( { isSaving: true } );
 
 		const onSuccess = () => {
-			this.setState( { isSaving: false, userBeganEditing: false } );
-			return successNotice( translate( 'Settings updated successfully.' ) );
+			this.setState( { isSaving: false } );
+			return successNotice( translate( 'Settings updated successfully.' ), { duration: 4000 } );
 		};
 
 		const onFailure = () => {
@@ -150,12 +127,10 @@ class SettingsTaxes extends Component {
 			( <span>{ translate( 'Taxes' ) }</span> ),
 		];
 
-		const saveButtonDisabled = this.state.isSaving || ! this.pageHasChanges();
-
 		return (
 			<Main className={ classNames( 'settings-taxes', className ) }>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
-					<Button disabled={ saveButtonDisabled } onClick={ this.onSave } primary>
+					<Button onClick={ this.onSave } primary>
 						{ translate( 'Save' ) }
 					</Button>
 				</ActionHeader>

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -48,6 +48,7 @@ class SettingsTaxes extends Component {
 			pricesIncludeTaxes: true,
 			shippingIsTaxable: true,
 			taxesEnabled: true,
+			userBeganEditing: false,
 		};
 	}
 
@@ -67,14 +68,36 @@ class SettingsTaxes extends Component {
 		}
 	}
 
+	componentWillReceiveProps = ( newProps ) => {
+		if ( ! this.state.userBeganEditing ) {
+			const { site } = this.props;
+			const newSiteId = newProps.site && newProps.site.ID || null;
+			const oldSiteId = site && site.ID || null;
+			if ( oldSiteId !== newSiteId ) {
+				this.props.fetchSettingsGeneral( newSiteId );
+				this.props.fetchTaxSettings( newSiteId );
+			}
+
+			this.setState( {
+				pricesIncludeTaxes: newProps.pricesIncludeTaxes,
+				shippingIsTaxable: newProps.shippingIsTaxable,
+				taxesEnabled: newProps.taxesEnabled,
+			} );
+		}
+	}
+
 	onEnabledChange = () => {
-		this.setState( { taxesEnabled: ! this.state.taxesEnabled } );
+		this.setState( { taxesEnabled: ! this.state.taxesEnabled, userBeganEditing: true } );
 	}
 
 	onCheckboxChange = ( event ) => {
 		const option = event.target.name;
 		const value = event.target.checked;
-		this.setState( { [ option ]: value } );
+		this.setState( { [ option ]: value, userBeganEditing: true } );
+	}
+
+	pageHasChanges = () => {
+		return this.state.userBeganEditing;
 	}
 
 	onSave = ( event ) => {
@@ -84,8 +107,8 @@ class SettingsTaxes extends Component {
 		this.setState( { isSaving: true } );
 
 		const onSuccess = () => {
-			this.setState( { isSaving: false } );
-			return successNotice( translate( 'Settings updated successfully.' ), { duration: 4000 } );
+			this.setState( { isSaving: false, userBeganEditing: false } );
+			return successNotice( translate( 'Settings updated successfully.' ) );
 		};
 
 		const onFailure = () => {
@@ -127,10 +150,12 @@ class SettingsTaxes extends Component {
 			( <span>{ translate( 'Taxes' ) }</span> ),
 		];
 
+		const saveButtonDisabled = this.state.isSaving || ! this.pageHasChanges();
+
 		return (
 			<Main className={ classNames( 'settings-taxes', className ) }>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
-					<Button onClick={ this.onSave } primary>
+					<Button disabled={ saveButtonDisabled } onClick={ this.onSave } primary>
 						{ translate( 'Save' ) }
 					</Button>
 				</ActionHeader>


### PR DESCRIPTION
The save button on the tax settings is now always interactive. This resolves confusion that may arise during initial store setup. It is also consistent with shipping zone saving.

This also sets a 4 second duration on the success notice. 