### PR TITLE
Customize: redirect to wp-admin customizer if jetpack

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -5,9 +5,7 @@ import React, { PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
 import url from 'url';
 import Qs from 'qs';
-import cloneDeep from 'lodash/cloneDeep';
-import get from 'lodash/get';
-import startsWith from 'lodash/startsWith';
+import { cloneDeep, get, startsWith } from 'lodash';
 import { connect } from 'react-redux';
 import debugFactory from 'debug';
 

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -22,6 +22,7 @@ var notices = require( 'notices' ),
 import { getCustomizerFocus } from './panels';
 import { getMenusUrl } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 var loadingTimer;
 
@@ -36,6 +37,8 @@ var Customize = React.createClass( {
 		query: React.PropTypes.object,
 		themeActivated: React.PropTypes.func.isRequired,
 		panel: React.PropTypes.string,
+		isJetpack: React.PropTypes.bool,
+		customizerUrl: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
@@ -70,9 +73,12 @@ var Customize = React.createClass( {
 	},
 
 	redirectIfNeeded: function( pathname ) {
-		const { menusUrl } = this.props;
+		const { menusUrl, isJetpack, customizerUrl } = this.props;
 		if ( startsWith( pathname, '/customize/menus' ) && pathname !== menusUrl ) {
 			page( menusUrl );
+		}
+		if ( isJetpack ) {
+			page( customizerUrl );
 		}
 	},
 
@@ -318,9 +324,13 @@ var Customize = React.createClass( {
 export default connect(
 	( state ) => {
 		const site = getSelectedSite( state );
+		const siteId = get( site, 'ID' );
 		return {
 			site,
-			menusUrl: getMenusUrl( state, get( site, 'ID' ) )
+			menusUrl: getMenusUrl( state, siteId ),
+			isJetpack: isJetpackSite( state, siteId ),
+			// TODO: include panel from props?
+			customizerUrl: getCustomizerUrl( state, siteId ),
 		};
 	},
 	{ themeActivated }

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -63,6 +63,9 @@ class Customize extends React.Component {
 		this.redirectIfNeeded( this.props.pathname );
 		this.listenToCustomizer();
 		this.waitForLoading();
+	}
+
+	componentDidMount() {
 		if ( window ) {
 			window.scrollTo( 0, 0 );
 		}


### PR DESCRIPTION
Currently if a site is a Jetpack site, and you click on the "Customize" sidebar link in the Calypso sidebar, you will be redirected to the wp-admin customizer page for your site rather than the `/customize` Calypso page. This is because the `/customize` page just loads the wp-admin customizer inside an iframe, and due to the different domain it's not possible to iframe a Jetpack site.

However, it is still possible to end up on the `/customize` page with a Jetpack site. There are other links around Calypso and other places, including support documents, which do not have this redirect in place. In those cases, the user will inevitably see an error message that the customizer failed to load. This is a very poor UX.

This PR adds code to the `/customize` page itself which will redirect to the wp-admin customizer if the site is a Jetpack site.

Fixes #14565

This also updates the `Customize` component to ES6, which is most of the changes.

## Testing

1. Using a WPCOM (non-Jetpack) site, visit http://calypso.localhost:3000/customize/[your-site-here].
2. Verify that the Customizer loads.
3. Verify that the URL has remained on Calypso and on the `/customize` route (the domain might change if there is a custom domain).
4. Using a Jetpack site, visit the same URL as step 1.
5. Verify that the Customizer loads.
6. Verify that the URL is now `/wp-admin/customize.php` for your site.

## Possible additional work

- Support passing a requested `panel` prop to the redirect so that URLs like https://calypso.localhost:3000/customize/widgets will still end up on the widgets panel (added in #5287)
- Support the `/customize/menus` path (this is related to the `panel` prop).
