### PR TITLE
Settings: Add Tracks events for various site/SEO changes

### DIFF
--- a/client/my-sites/site-settings/amp/wpcom.jsx
+++ b/client/my-sites/site-settings/amp/wpcom.jsx
@@ -14,6 +14,7 @@ import SectionHeader from 'components/section-header';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class AmpWpcom extends Component {
 	static propTypes = {
@@ -33,7 +34,9 @@ class AmpWpcom extends Component {
 
 	handleToggle = () => {
 		const { fields, submitForm, trackEvent, updateFields } = this.props;
-		updateFields( { amp_is_enabled: ! fields.amp_is_enabled }, () => {
+		const ampEnabled = ! fields.amp_is_enabled;
+		this.props.recordTracksEvent( 'calypso_seo_settings_amp_updated', { amp_is_enabled: ampEnabled } );
+		updateFields( { amp_is_enabled: ampEnabled }, () => {
 			submitForm();
 			trackEvent( 'Toggled AMP Toggle' );
 		} );
@@ -104,5 +107,6 @@ class AmpWpcom extends Component {
 export default connect(
 	( state ) => ( {
 		siteSlug: getSelectedSiteSlug( state ),
-	} )
+	} ),
+	{ recordTracksEvent },
 )( localize( AmpWpcom ) );

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -246,7 +246,8 @@ export const SeoForm = React.createClass( {
 		const {
 			trackFormSubmitted,
 			trackTitleFormatsUpdated,
-			trackFrontPageMetaUpdated
+			trackFrontPageMetaUpdated,
+			trackSiteVerificationUpdated
 		} = this.props;
 
 		trackFormSubmitted();
@@ -257,6 +258,22 @@ export const SeoForm = React.createClass( {
 
 		if ( dirtyFields.has( 'frontPageMetaDescription' ) ) {
 			trackFrontPageMetaUpdated();
+		}
+
+		if ( dirtyFields.has( 'googleCode' ) ) {
+			trackSiteVerificationUpdated( 'google' );
+		}
+
+		if ( dirtyFields.has( 'bingCode' ) ) {
+			trackSiteVerificationUpdated( 'bing' );
+		}
+
+		if ( dirtyFields.has( 'pinterestCode' ) ) {
+			trackSiteVerificationUpdated( 'pinterest' );
+		}
+
+		if ( dirtyFields.has( 'yandexCode' ) ) {
+			trackSiteVerificationUpdated( 'yandex' );
 		}
 	},
 
@@ -563,6 +580,7 @@ const mapDispatchToProps = {
 	trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
 	trackTitleFormatsUpdated: partial( recordTracksEvent, 'calypso_seo_tools_title_formats_updated' ),
 	trackFrontPageMetaUpdated: partial( recordTracksEvent, 'calypso_seo_tools_front_page_meta_updated' ),
+	trackSiteVerificationUpdated: ( service ) => recordTracksEvent( 'calypso_seo_tools_site_verification_updated', { service: service } ),
 	activateModule,
 };
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -100,9 +100,28 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 
 		// Some Utils
 		handleSubmitForm = event => {
+			const { dirtyFields, fields, trackTracksEvent } = this.props;
+
 			if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
 				event.preventDefault();
 			}
+
+			dirtyFields.map( function( value ) {
+				switch ( value ) {
+					case 'blogdescription':
+						trackTracksEvent( 'calypso_settings_site_tagline_updated' );
+						break;
+					case 'blogname':
+						trackTracksEvent( 'calypso_settings_site_title_updated' );
+						break;
+					case 'blog_public':
+						trackTracksEvent( 'calypso_settings_site_privacy_updated', { privacy: fields.blog_public } );
+						break;
+					case 'wga':
+						trackTracksEvent( 'calypso_seo_settings_google_analytics_updated' );
+						break;
+				}
+			} );
 
 			this.submitForm();
 			this.props.trackEvent( 'Clicked Save Settings Button' );
@@ -254,9 +273,11 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				updateSettings,
 			}, dispatch );
 			const trackEvent = name => dispatch( recordGoogleEvent( 'Site Settings', name ) );
+			const trackTracksEvent = ( name, props ) => dispatch( recordTracksEvent( name, props ) );
 			return {
 				...boundActionCreators,
 				eventTracker: message => () => trackEvent( message ),
+				trackTracksEvent,
 				trackEvent,
 			};
 		}


### PR DESCRIPTION
This PR adds some additional Tracks events to monitor changes in the following items:
- Updated site title/tagline
- Changed site privacy
- Added site verification services under Traffic
- Deactivated/Activated Google AMP
- Added Google Analytics

This is part of some more in-depth digging @chrisfromthelc is doing along the lines of SEO and the Business plan.

### To test
1. Load up this branch. Use `localStorage.setItem('debug', 'calypso:analytics*');` to log out Tracks events to your console.
2. First, visit http://calypso.localhost:3000/settings/general/. Change the site title and tagline. Press "Save Settings." You should see the `calypso_settings_site_tagline/title_updated` event get recorded.
3. Next, change the site privacy on the same page and press "Save Settings". The `calypso_settings_site_privacy_updated` should get recorded with the privacy passed in as a prop.
4. Try adding some of the verification services under http://calypso.localhost:3000/settings/traffic/. The `calypso_seo_tools_site_verification_updated` event should fire with a prop of the verified service. I've pasted example codes to use at the bottom here for ease of reference.
5. Try deactivating/activating AMP on a WP.com site on /settings/traffic. `calypso_seo_settings_amp_updated` should get fired with a prop of whether AMP is enabled or not.
6. Fill out the Google Analytics field (example value below) and save the settings. `calypso_seo_settings_google_analytics_updated` should fire.

**Example verification codes**
These are the examples we provide to use for testing.
- Google: `<meta name="google-site-verification" content="f0w4NjmVso-ol9myrC9J4mbOnsZm_dj_rBK3VoOjNRo" />`
- Bing: `<meta name="msvalidate.01" content="1234" />`
- Pinterest: `<meta name="p:domain_verify" content="1234" />`
- Yandex: `<meta name="yandex-verification" content="1234" />`
- Google Analytics: UA-90363941-1