### PR TITLE
View Site: Add device mockups

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -227,7 +227,7 @@ export class WebPreviewContent extends Component {
 						className={ classNames( 'web-preview__frame-wrapper', {
 							'is-resizable': ! this.props.isModalWindow
 						} ) }
-						style={ { display: ( 'seo' === this.state.device ? 'none' : 'inherit' ) } }
+						style={ { display: ( 'seo' === this.state.device ? 'none' : null ) } }
 					>
 						<div className="web-preview__device-mockup">
 							<iframe

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -194,6 +194,7 @@ export class WebPreviewContent extends Component {
 		const className = classNames( this.props.className, 'web-preview__inner', {
 			'is-touch': this._hasTouch,
 			'is-with-sidebar': this.props.hasSidebar,
+			'is-with-device-mockup': this.props.showDeviceMockups,
 			'is-visible': this.props.showPreview,
 			'is-computer': this.state.device === 'computer',
 			'is-tablet': this.state.device === 'tablet',
@@ -228,13 +229,15 @@ export class WebPreviewContent extends Component {
 						} ) }
 						style={ { display: ( 'seo' === this.state.device ? 'none' : 'inherit' ) } }
 					>
-						<iframe
-							ref={ this.setIframeInstance }
-							className="web-preview__frame"
-							src="about:blank"
-							onLoad={ this.setLoaded }
-							title={ this.props.iframeTitle || translate( 'Preview' ) }
-						/>
+						<div className="web-preview__device-mockup">
+							<iframe
+								ref={ this.setIframeInstance }
+								className="web-preview__frame"
+								src="about:blank"
+								onLoad={ this.setLoaded }
+								title={ this.props.iframeTitle || translate( 'Preview' ) }
+							/>
+						</div>
 					</div>
 					{ 'seo' === this.state.device &&
 						<SeoPreviewPane

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -264,15 +264,16 @@ a.web-preview__external.button {
 	}
 
 	.is-phone & {
-		max-width: 460px;
+		max-width: 360px;
+		max-height: 550px;
 	}
 
 	.is-with-device-mockup.is-tablet &,
 	.is-with-device-mockup.is-phone & {
 		background-color: darken( $gray, 10% );
-		margin: 2% auto;
-		border-radius: 24px;
-		height: 98%;
+	    margin: auto;
+	    border-radius: 24px;
+	    padding: 48px 24px;
 	}
 }
 
@@ -282,6 +283,10 @@ a.web-preview__external.button {
 		left: 0;
 	height: 100%;
 	width: 100%;
+	display: flex;
+	align-content: center;
+	flex-direction: column;
+	align-items: center;
 
 	&.is-resizable {
 		background: $gray-light;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -249,6 +249,31 @@ a.web-preview__external.button {
 	.is-loaded & {
 		opacity: 1;
 	}
+
+	.is-with-device-mockup.is-phone & {
+
+	}
+}
+
+.web-preview__device-mockup {
+	height: 100%;
+	width: 100%;
+
+	.is-tablet & {
+		max-width: 783px;
+	}
+
+	.is-phone & {
+		max-width: 460px;
+	}
+
+	.is-with-device-mockup.is-tablet &,
+	.is-with-device-mockup.is-phone & {
+		background-color: darken( $gray, 10% );
+		margin: 2% auto;
+		border-radius: 24px;
+		height: 98%;
+	}
 }
 
 .web-preview__frame-wrapper {
@@ -260,16 +285,6 @@ a.web-preview__external.button {
 
 	&.is-resizable {
 		background: $gray-light;
-
-		.web-preview__frame {
-			.is-tablet & {
-				max-width: 783px;
-			}
-
-			.is-phone & {
-				max-width: 460px;
-			}
-		}
 	}
 }
 

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -103,6 +103,7 @@ class PreviewMain extends React.Component {
 					showClose={ false }
 					previewUrl={ this.state.previewUrl }
 					externalUrl={ site.URL }
+					showDeviceMockups={ true }
 				/>
 			</Main>
 		);


### PR DESCRIPTION
A little experiment to make the responsive preview more understandable to users by showing a "device" around the site frame.