### PR TITLE
Allow both site slugs and numerical IDs to be used in `comments` routes.

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -240,7 +240,7 @@ export class CommentList extends Component {
 			commentsPage,
 			isLoading,
 			siteId,
-			siteSlug,
+			siteFragment,
 			status,
 		} = this.props;
 		const {
@@ -263,7 +263,7 @@ export class CommentList extends Component {
 					isSelectedAll={ this.isSelectedAll() }
 					selectedCount={ size( selectedComments ) }
 					setBulkStatus={ this.setBulkStatus }
-					siteSlug={ siteSlug }
+					siteFragment={ siteFragment }
 					status={ status }
 					toggleBulkEdit={ this.toggleBulkEdit }
 					toggleSelectAll={ this.toggleSelectAll }

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -58,8 +58,8 @@ export class CommentNavigation extends Component {
 	}
 
 	getStatusPath = status => 'unapproved' !== status
-		? `/comments/${ status }/${ this.props.siteSlug }`
-		: `/comments/pending/${ this.props.siteSlug }`;
+		? `/comments/${ status }/${ this.props.siteFragment }`
+		: `/comments/pending/${ this.props.siteFragment }`;
 
 	statusHasAction = action => includes( bulkActions[ this.props.status ], action );
 

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -13,13 +13,13 @@ import CommentsManagement from './main';
 import controller from 'my-sites/controller';
 
 export const comments = function( context ) {
-	const siteSlug = route.getSiteFragment( context.path );
+	const siteFragment = route.getSiteFragment( context.path );
 	const status = context.params.status === 'pending' ? 'unapproved' : context.params.status;
 
 	renderWithReduxStore(
 		<CommentsManagement
 			basePath={ context.path }
-			siteSlug={ siteSlug }
+			siteFragment={ siteFragment }
 			status={ status }
 		/>,
 		'primary',
@@ -29,10 +29,10 @@ export const comments = function( context ) {
 
 export const sites = function( context ) {
 	const { status } = context.params;
-	const siteSlug = route.getSiteFragment( context.path );
+	const siteFragment = route.getSiteFragment( context.path );
 
-	if ( status === siteSlug ) {
-		return page.redirect( `/comments/pending/${ siteSlug }` );
+	if ( status === siteFragment ) {
+		return page.redirect( `/comments/pending/${ siteFragment }` );
 	}
 	controller.sites( context );
 };

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -19,7 +19,10 @@ export class CommentsManagement extends Component {
 		basePath: PropTypes.string,
 		comments: PropTypes.array,
 		siteId: PropTypes.number,
-		siteSlug: PropTypes.string.isRequired,
+		siteFragment: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.number,
+		] ),
 		status: PropTypes.string,
 		translate: PropTypes.func,
 	};
@@ -28,7 +31,7 @@ export class CommentsManagement extends Component {
 		const {
 			basePath,
 			siteId,
-			siteSlug,
+			siteFragment,
 			status,
 			translate,
 		} = this.props;
@@ -39,7 +42,7 @@ export class CommentsManagement extends Component {
 				<DocumentHead title={ translate( 'Manage Comments' ) } />
 				<CommentList
 					siteId={ siteId }
-					siteSlug={ siteSlug }
+					siteFragment={ siteFragment }
 					status={ status }
 				/>
 			</Main>
@@ -47,8 +50,8 @@ export class CommentsManagement extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteSlug } ) => ( {
-	siteId: getSiteId( state, siteSlug ),
+const mapStateToProps = ( state, { siteFragment } ) => ( {
+	siteId: getSiteId( state, siteFragment ),
 } );
 
 export default connect( mapStateToProps )( localize( CommentsManagement ) );


### PR DESCRIPTION
For the purpose of our redirect URLs, we've been assuming a site slug format (eg. `/comments/pending/example.com`) for the site fragment (the site identifier in the URL). This PR allows site IDs to be passed through, keeping URLs consistent with whichever format was used in the URL.

**Testing**

1. Use both URL formats to load comments management:
* `/comments/pending/example.com`
* `comments/pending/12345678`
2. Be sure there are no console errors and the URL format remains consistent when switching between statuses.