### PR TITLE
WooCommerce: Restrict access to store routes

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { findLast } from 'lodash';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { canCurrentUser } from 'state/selectors';
+import { getActionLog } from 'state/ui/action-log/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isSiteAutomatedTransfer } from 'state/selectors';
+import route from 'lib/route';
+import { ROUTE_SET } from 'state/action-types';
+
+class App extends Component {
+
+	static propTypes = {
+		canUserManageOptions: PropTypes.bool,
+		siteId: PropTypes.number,
+		component: PropTypes.node,
+		currentRoute: PropTypes.shape( {
+			path: PropTypes.string,
+		} ),
+		isAutomatedTransfer: PropTypes.bool,
+	};
+
+	// TODO This is temporary, until we have a valid "all sites" path to show.
+	// Calypso will detect if a user doesn't have access to a site at all, and redirects to the 'all sites'
+	// version of that URL. We don't want to render anything right now, so continue redirecting to my-sites.
+	componentWillReceiveProps( newProps ) {
+		if ( this.props.currentRoute !== newProps.currentRoute ) {
+			if ( newProps.currentRoute && ! route.getSiteFragment( newProps.currentRoute.path ) ) {
+				return page.redirect( '/stats/day' );
+			}
+		}
+	}
+
+	render = () => {
+		const { siteId, component, canUserManageOptions, isAutomatedTransfer } = this.props;
+
+		if ( ! siteId ) {
+			return null;
+		}
+
+		// Don't show anything for non Atomic sites right now
+		if ( ! isAutomatedTransfer ) {
+			page.redirect( '/stats/day' );
+			return null;
+		}
+
+		if ( ! canUserManageOptions ) {
+			page.redirect( '/stats/day' );
+			return null;
+		}
+
+		const className = 'woocommerce';
+		return (
+			<div className={ className }>
+				{ component }
+			</div>
+		);
+	}
+
+}
+
+function mapStateToProps( state ) {
+	const siteId = getSelectedSiteId( state );
+	const canUserManageOptions = siteId && canCurrentUser( state, siteId, 'manage_options' );
+	const currentRoute = findLast( getActionLog( state ), { type: ROUTE_SET } );
+	const isAutomatedTransfer = siteId && !! isSiteAutomatedTransfer( state, siteId );
+	return {
+		siteId,
+		canUserManageOptions,
+		currentRoute,
+		isAutomatedTransfer,
+	};
+}
+
+export default connect( mapStateToProps )( App );

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -1,4 +1,4 @@
-&.products__list {
+.products__list {
 
 	.empty-content.has-title-only {
 		margin-top: 42px;

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -9,6 +9,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import App from './app';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
@@ -144,8 +145,9 @@ function getStoreSidebarItemButtons() {
 
 function addStorePage( storePage, storeNavigation ) {
 	page( storePage.path, siteSelection, storeNavigation, function( context ) {
+		const component = React.createElement( storePage.container, { params: context.params } );
 		renderWithReduxStore(
-			React.createElement( storePage.container, { className: 'woocommerce', params: context.params } ),
+			React.createElement( App, { component } ),
 			document.getElementById( 'primary' ),
 			context.store
 		);


### PR DESCRIPTION
Fixes #14333.

This adds some checks before rending our store routes:

1) Is this a Atomic site
2) Does the user have the correct permissions to manage the store

After talking with Kelly, we decided to redirect to the my-sites/stats view if they don't have proper access.

I struggled a bit figuring out the best way to handle this, but I settled on wrapping everything in a root `App` component (which also handles applying the `woocommerce` class now), so we can do some checks there. 

To Test:
* Go to a store route for a site you do have access to, for example: `http://calypso.localhost:3000/store/products/:site`.
* Make sure everything loads correctly, click around, etc.
* Go to a store route for a WordPress.com or normal Jetpack Site. You should be redirected.
* Using a non SA account (create a test user), try to access a store you don't have access to. You should be redirected.
* Make this user a contributor on your site, so they have some access, but not all.
* Visit that route, and make sure you are redirected.