### PR TITLE
Improve the routing of Comments-based URLs.

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -34,10 +34,10 @@ export const getRedirectUrl = ( status, siteFragment ) => {
 };
 
 export const redirect = function( context, next ) {
-	const { status } = context.params;
+	const { status, site } = context.params;
 	const siteFragment = route.getSiteFragment( context.path );
 	const redirectUrl = getRedirectUrl( status, siteFragment );
-	if ( redirectUrl && '/comments/' + status !== redirectUrl ) {
+	if ( redirectUrl && ( site || '/comments/' + status !== redirectUrl ) ) {
 		return page.redirect( redirectUrl );
 	}
 	next();

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -4,35 +4,55 @@
 import { renderWithReduxStore } from 'lib/react-helpers';
 import React from 'react';
 import page from 'page';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import route from 'lib/route';
 import CommentsManagement from './main';
-import controller from 'my-sites/controller';
+
+const VALID_STATUSES = [ 'pending', 'approved', 'spam', 'trash', 'all' ];
+
+export const isValidStatus = status => includes( VALID_STATUSES, status );
+
+export const getRedirectUrl = ( status, siteFragment ) => {
+	const statusValidity = isValidStatus( status );
+	if ( status === siteFragment ) {
+		return `/comments/pending/${ siteFragment }`;
+	}
+	if ( ! statusValidity && ! siteFragment ) {
+		return '/comments/pending';
+	}
+	if ( ! statusValidity && siteFragment ) {
+		return `/comments/pending/${ siteFragment }`;
+	}
+	if ( statusValidity && ! siteFragment ) {
+		return `/comments/${ status }`;
+	}
+	return null;
+};
+
+export const redirect = function( context, next ) {
+	const { status } = context.params;
+	const siteFragment = route.getSiteFragment( context.path );
+	const redirectUrl = getRedirectUrl( status, siteFragment );
+	if ( redirectUrl && '/comments/' + status !== redirectUrl ) {
+		return page.redirect( redirectUrl );
+	}
+	next();
+};
 
 export const comments = function( context ) {
+	const { status } = context.params;
 	const siteFragment = route.getSiteFragment( context.path );
-	const status = context.params.status === 'pending' ? 'unapproved' : context.params.status;
-
 	renderWithReduxStore(
 		<CommentsManagement
 			basePath={ context.path }
 			siteFragment={ siteFragment }
-			status={ status }
+			status={ 'pending' === status ? 'unapproved' : status }
 		/>,
 		'primary',
 		context.store
 	);
-};
-
-export const sites = function( context ) {
-	const { status } = context.params;
-	const siteFragment = route.getSiteFragment( context.path );
-
-	if ( status === siteFragment ) {
-		return page.redirect( `/comments/pending/${ siteFragment }` );
-	}
-	controller.sites( context );
 };

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -7,23 +7,20 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from 'my-sites/controller';
-import { comments, sites } from './controller';
+import { comments, redirect } from './controller';
 import config from 'config';
 
 export default function() {
 	if ( config.isEnabled( 'comments/management' ) ) {
-		page( '/comments',
+		page( '/comments/:status?',
 			controller.siteSelection,
+			redirect,
 			controller.sites
-		);
-
-		page( '/comments/:status',
-			controller.siteSelection,
-			sites,
 		);
 
 		page( '/comments/:status/:site',
 			controller.siteSelection,
+			redirect,
 			controller.navigation,
 			comments
 		);


### PR DESCRIPTION
Continuation of #15848 , which was erroneously rebased.

**Testing**
Go to each of the following URLs and be sure you end up in the right place, with no interrupted rendering (component starts re-rendering, then a full page reload kicks in from a redirect).

|URL|Site Selector|Redirect/Destination|
|-----|:-----:|------|
|/comments | :white_check_mark: | /comments/pending/**domain**|
|/comments/**domain** || /comments/pending/**domain**|
|/comments/**status** | :white_check_mark: | /comments/**status**/**domain**|
|/comments/asdfasdf || /comments|
|/comments/**status**/asdfasdf   | :white_check_mark: | /comments/**status**/**domain**|
|/comments/asdfasdf/**domain** || /comments/pending/**domain**|
|/comments/asdfasdf/asdfasdf || /comments/pending|