### PR TITLE
Framework: update gridicons to 2.0.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2123,7 +2123,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.50.0",
+      "version": "0.51.0",
       "dev": true
     },
     "flux": {
@@ -2766,7 +2766,7 @@
       "dev": true
     },
     "gridicons": {
-      "version": "1.1.0"
+      "version": "2.0.1"
     },
     "growl": {
       "version": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "1.1.0",
+    "gridicons": "2.0.1",
     "happypack": "4.0.0-beta.1",
     "hard-source-webpack-plugin": "0.3.12",
     "he": "0.5.0",


### PR DESCRIPTION
This PR updates gridicons to 2.0.1.

The 2.0.1 release includes new icons, React 15.5 PropTypes, and the ability to pass through arbitrary props to the SVG.

### Testing Instructions
- No noticeable changes to Calypso
- class names passed to gridicons are available, along with the defaults (gridicon + icon name)
- Navigate to http://calypso.localhost:3000/devdocs/design/gridicons icons appear as expected
- Icons appear correctly in other sections

<img width="852" alt="screen shot 2017-06-30 at 5 46 20 pm" src="https://user-images.githubusercontent.com/1270189/27757854-2c5a6a3e-5dbc-11e7-98f1-e574347160c4.png">


