### PR TITLE
Image Editor: replace window.onresize and add transition animation

### DIFF
--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -55,7 +55,6 @@
 	position: absolute;
 	top: 50%;
 	left: 50%;
-
 	&.is-placeholder {
 		@include placeholder-dark();
 	}
@@ -65,6 +64,7 @@
 	position: absolute;
 	border: 1px solid $white;
 	cursor: move;
+	box-sizing: border-box;
 }
 
 .image-editor__crop-background {


### PR DESCRIPTION
Small PR to replace `window.onresize` with requestAnimationFrame loop, and animate workspace (canvas obj) to chosen crop area via transition. 

This fixes lagging reposition of crop box in Chrome -  only slightly better in Firefox. 

Better UX would be to hide it all together while resizing, until we can refactor to somehow consolidate the simultaneous resizing, repositioning and redraw of all the drag handler, background shadow and crop box areas.

Also updated styles to count 1px border in crop box width to remove the 1px gap between the shadow and crop box edges.

**Chrome/FF/IE11/Safari (before changes)**
<img width="465" alt="screen shot 2017-07-09 at 18 59 27" src="https://user-images.githubusercontent.com/6458278/27993136-beb5ed50-64e6-11e7-9f23-16cee7832da3.png">

**Chrome/FF/IE11/Safari (after  changes)**
<img width="463" alt="screen shot 2017-07-09 at 18 59 34" src="https://user-images.githubusercontent.com/6458278/27993139-c803ccce-64e6-11e7-9939-c65805d42ae1.png">

cc @gwwar 



