### PR TITLE
Framework: removed sites-list from lib/posts/post-counts-store.js

### DIFF
--- a/client/lib/posts/post-counts-store.js
+++ b/client/lib/posts/post-counts-store.js
@@ -19,7 +19,6 @@ const sum = obj => {
 var emitter = require( 'lib/mixins/emitter' ),
 	PostListStore = require( './post-list-store-factory' )(),
 	PostsStore = require( './posts-store' ),
-	sites = require( 'lib/sites-list' )(),
 	postUtils = require( 'lib/posts/utils' ),
 	Dispatcher = require( 'dispatcher' );
 
@@ -27,22 +26,12 @@ var _counts = {},
 	PostCountsStore;
 
 /**
- * Get a normalized numberic siteId
- * @param {String|Integer} id - A site id (numeric site ID, site.slug, or API $site path fragment
- * @return {Integer} - normalized numeric site id
+ * Get siteId to use
+ * @param {Integer} id - A site id (numeric site ID)
+ * @return {Integer} - Same site passed as argument or if site id is null a site id returned from PostListStore
  */
 function getSiteId( id ) {
-	var site, siteId;
-
-	id = id || PostListStore.getSiteId();
-
-	site = sites.getSite( id );
-
-	if ( site ) {
-		siteId = site.ID;
-	}
-
-	return siteId;
+	return id || PostListStore.getSiteId();
 }
 
 /**


### PR DESCRIPTION
This PR removes sites-list dependency from post-counts-store. In this store SitesList was only being used for siteId normalization, and I checked that all the use cases of the store already passed the numeric site id. So that normalization logic was not needed.
This pull request also seems to solve a small bug that was happening to me in production. If a reload with clean state happened (e.g after executing "localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );") the count of posts was not appearing, and with this change things look ok.

Before:
![2017-07-16_09-18-28](https://user-images.githubusercontent.com/11271197/28245890-719f58d6-6a08-11e7-90a7-0235b3c378bd.gif)

After:
![2017-07-16_09-18-58](https://user-images.githubusercontent.com/11271197/28245895-8755b60c-6a08-11e7-8f79-959fce456d78.gif)


To test:
Go to http://calypso.localhost:3000/posts/{site} and verify the count of posts is appearing ok.