### PR TITLE
Framework: removed sites-list from lib/posts/utils.js

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -107,7 +107,6 @@ PostActions = {
 
 		args = {
 			type: 'DRAFT_NEW_POST',
-			siteId: site.ID,
 			postType: options.type || 'post',
 			title: options.title,
 			content: options.content,

--- a/client/lib/posts/test/post-edit-store.js
+++ b/client/lib/posts/test/post-edit-store.js
@@ -55,7 +55,9 @@ describe( 'post-edit-store', () => {
 		dispatcherCallback( {
 			action: {
 				type: 'DRAFT_NEW_POST',
-				siteId: siteId,
+				site: {
+					ID: siteId,
+				},
 			},
 		} );
 
@@ -155,7 +157,9 @@ describe( 'post-edit-store', () => {
 		dispatcherCallback( {
 			action: {
 				type: 'DRAFT_NEW_POST',
-				siteId: 1234,
+				site: {
+					ID: 1234,
+				},
 			},
 		} );
 
@@ -190,7 +194,9 @@ describe( 'post-edit-store', () => {
 		dispatcherCallback( {
 			action: {
 				type: 'DRAFT_NEW_POST',
-				siteId: siteId,
+				site: {
+					ID: siteId,
+				},
 			},
 		} );
 
@@ -225,7 +231,9 @@ describe( 'post-edit-store', () => {
 		dispatcherCallback( {
 			action: {
 				type: 'DRAFT_NEW_POST',
-				siteId: siteId,
+				site: {
+					ID: siteId,
+				},
 			},
 		} );
 		dispatcherCallback( {
@@ -301,7 +309,9 @@ describe( 'post-edit-store', () => {
 		dispatcherCallback( {
 			action: {
 				type: 'DRAFT_NEW_POST',
-				siteId: siteId,
+				site: {
+					ID: siteId,
+				},
 			},
 		} );
 
@@ -417,7 +427,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -428,7 +440,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -450,7 +464,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -499,7 +515,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -510,7 +528,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -528,7 +548,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -546,7 +568,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -566,7 +590,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -577,7 +603,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -596,7 +624,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -615,7 +645,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -634,7 +666,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -653,7 +687,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -672,7 +708,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -691,7 +729,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -710,7 +750,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -728,7 +770,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 
@@ -762,7 +806,9 @@ describe( 'post-edit-store', () => {
 			dispatcherCallback( {
 				action: {
 					type: 'DRAFT_NEW_POST',
-					siteId: 1,
+					site: {
+						ID: 1,
+					},
 				},
 			} );
 

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -14,9 +14,6 @@ import { includes, memoize } from 'lodash';
  */
 import postNormalizer from 'lib/post-normalizer';
 /* eslint-disable no-restricted-imports */
-import sitesFactory from 'lib/sites-list';
-const sites = sitesFactory();
-/* eslint-enable no-restricted-imports */
 import { getFeaturedImageId } from './utils-ssr-ready';
 
 var utils = {
@@ -43,8 +40,8 @@ var utils = {
 		return `${ basePath }/${ post.type }/${ site.slug }/${ post.ID }`;
 	},
 
-	getPreviewURL: function( post ) {
-		var parsed, site, previewUrl;
+	getPreviewURL: function( post, site ) {
+		let parsed, previewUrl;
 
 		if ( ! post || ! post.URL || post.status === 'trash' ) {
 			return '';
@@ -62,7 +59,6 @@ var utils = {
 		}
 
 		if ( post.site_ID ) {
-			site = sites.getSite( post.site_ID );
 			if ( ! ( site && site.options ) ) {
 				// site info is still loading, just use what we already have until it does
 				return previewUrl;

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -40,7 +40,7 @@ var utils = {
 		return `${ basePath }/${ post.type }/${ site.slug }/${ post.ID }`;
 	},
 
-	getPreviewURL: function( post, site ) {
+	getPreviewURL: function( site, post ) {
 		let parsed, previewUrl;
 
 		if ( ! post || ! post.URL || post.status === 'trash' ) {

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -120,7 +120,7 @@ class Draft extends Component {
 	};
 
 	previewPost = () => {
-		window.open( utils.getPreviewURL( this.props.post ) );
+		window.open( utils.getPreviewURL( this.props.site, this.props.post ) );
 	};
 
 	publishPost = () => {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -471,7 +471,7 @@ const mapState = ( state, props ) => {
 		isFrontPage: isFrontPage( state, pageSiteId, props.page.ID ),
 		isPostsPage: isPostsPage( state, pageSiteId, props.page.ID ),
 		isPreviewable,
-		previewURL: getPreviewURL( props.page ),
+		previewURL: getPreviewURL( site, props.page ),
 		site,
 		siteSlugOrId,
 	};


### PR DESCRIPTION
In order to do removal, many files had to be updated to make sure site is available as an argument for function getPreviewURL.
The pull request is dependent on pull request https://github.com/Automattic/wp-calypso/issues/16017 that updates the actions needed to pass information to utils file.