### PR TITLE
Fix editor-sidebar class to follow CSS guidelines

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -77,7 +77,7 @@ $z-layers: (
 		'.domain-suggestion.is-clickable:hover': 1,
 		'.editor-html-toolbar': 1,
 		'.thank-you-card__header': 1,
-		'.post-editor__sidebar': 2,
+		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,
 		'.reader-update-notice': 22,

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -68,7 +68,7 @@
 	}
 }
 
-.post-editor__sidebar .editor-action-bar {
+.editor-sidebar .editor-action-bar {
 	@include breakpoint( ">660px" ) {
 		display: none;
 	}

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -42,7 +42,7 @@ export default class EditorSidebar extends Component {
 		} = this.props;
 
 		return (
-			<div className="post-editor__sidebar">
+			<div className="editor-sidebar">
 				<EditorSidebarHeader toggleSidebar={ toggleSidebar } />
 				<EditorActionBar
 					isNew={ isNew }

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -1,6 +1,6 @@
-.post-editor__sidebar {
+.editor-sidebar {
 	@extend .sidebar;
-	z-index: z-index( 'root', '.post-editor__sidebar' );
+	z-index: z-index( 'root', '.editor-sidebar' );
 	background: lighten( $gray, 30% );
 	left: auto;
 	right: -273px;


### PR DESCRIPTION
This fixes the main editor-sidebar CSS class to conform to the CSS guidelines for component class names. I am updating the sidebar as part of #16002 and would like to correct the class name before using it in additional rules.

Please let me know if there's anything else I should provide to help land this change.

Thank you!

cc @nb @dmsnell 