### PR TITLE
Jetpack Connect: Restore help button click handler in authorization

### DIFF
--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -51,6 +51,10 @@ class LoggedOutForm extends Component {
 		this.props.createAccount( userData );
 	}
 
+	handleClickHelp = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
+	}
+
 	renderLoginUser() {
 		const { userData, bearerToken } = this.props.jetpackConnectAuthorize;
 
@@ -95,7 +99,7 @@ class LoggedOutForm extends Component {
 				<LoggedOutFormLinkItem href={ login( { redirectTo } ) }>
 					{ this.props.translate( 'Already have an account? Sign in' ) }
 				</LoggedOutFormLinkItem>
-				<HelpButton onClick={ this.clickHelpButton } />
+				<HelpButton onClick={ this.handleClickHelp } />
 			</LoggedOutFormLinks>
 		);
 	}

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -81,6 +81,10 @@ class JetpackConnectAuthorizeForm extends Component {
 		);
 	}
 
+	handleClickHelp = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
+	}
+
 	renderNoQueryArgsError() {
 		return (
 			<Main className="jetpack-connect__main-error">
@@ -93,7 +97,7 @@ class JetpackConnectAuthorizeForm extends Component {
 					actionURL="/jetpack/connect"
 				/>
 				<LoggedOutFormLinks>
-					<HelpButton onClick={ this.clickHelpButton } />
+					<HelpButton onClick={ this.handleClickHelp } />
 				</LoggedOutFormLinks>
 			</Main>
 		);


### PR DESCRIPTION
This PR fixes #15970, where in our latest JPC refactoring efforts we seem to have left out a wrong click handler for the help button on a couple of authorization cases.

To test:

* Checkout this branch
* Go through the auth flow as a logged out user.
* During authorization, click the help button below the "Already have an account? Sign in" link, and verify you see the right Redux action (recording `calypso_jpc_help_link_click` to tracks)
* Load http://calypso.localhost:3000/jetpack/connect/authorize directly, without starting the connection flow.
* Click the help button at the bottom, and verify you see the right Redux action (recording `calypso_jpc_help_link_click` to tracks)