### PR TITLE
Woo-Connect Insights: fix period in deltas to match selectedDate

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -146,7 +146,7 @@ function parseOrderDeltas( payload ) {
 	}
 	return payload.deltasv2.map( row => { // will be renamed to deltas
 		const notPeriodKeys = Object.keys( row ).filter( key => key !== 'period' );
-		const newRow = { period: row.period };
+		const newRow = { period: parseUnitPeriods( payload.unit, row.period ).format( 'YYYY-MM-DD' ) };
 		notPeriodKeys.forEach( key => {
 			newRow[ key ] = row[ key ].reduce( ( acc, curr, i ) => {
 				acc[ payload.delta_fields[ i ] ] = curr;


### PR DESCRIPTION
Periods were being left in the shorter version and compared to the long version from `selectedDate`.

Fixes #16024

To test:

- ENABLE_FEATURES=woocommerce/extension-stats make run
- browse to /store/stats/orders/day/{ slug } of a site with WooCommerce and Jetpack syncing
- check that 'week', 'month' and 'year' periods work and don't throw errors in the console