### PR TITLE
Simple Payments: add Editor shortcode views

### DIFF
--- a/assets/stylesheets/editor.scss
+++ b/assets/stylesheets/editor.scss
@@ -2,5 +2,5 @@
 @import 'shared/typography';
 
 @import 'components/tinymce/iframe';
-
 @import 'components/tinymce/plugins/media/style';
+@import 'components/tinymce/plugins/wpcom-view/views/simple-payments/style';

--- a/client/components/tinymce/plugins/simple-payments/shortcode-utils.js
+++ b/client/components/tinymce/plugins/simple-payments/shortcode-utils.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Shortcode from 'lib/shortcode';
+
+/**
+ * Returns Simple Payments' shortcode data in an object.
+ *
+ * @param {string} shortcode Simple Payments shortcode (e.g. [simple-payment id="20"])
+ * @returns {object} Returns an object containing shortcode data.
+ */
+export function deserialize( shortcode ) {
+	if ( ! shortcode ) {
+		return null;
+	}
+
+	const parsed = Shortcode.parse( shortcode );
+
+	const shortcodeData = {};
+
+	const simplePaymentId = parseInt( get( parsed, 'attrs.named.id', null ) );
+
+	shortcodeData.id = isNaN( simplePaymentId ) ? null : simplePaymentId;
+
+	return shortcodeData;
+}

--- a/client/components/tinymce/plugins/wpcom-view/views.js
+++ b/client/components/tinymce/plugins/wpcom-view/views.js
@@ -14,6 +14,7 @@ import GalleryView from './gallery-view';
 import EmbedViewManager from './views/embed';
 import ContactFormView from './views/contact-form';
 import * as VideoView from './views/video';
+import SimplePaymentsView from './views/simple-payments';
 
 /**
  * Module variables
@@ -22,7 +23,8 @@ let views = {
 	gallery: GalleryView,
 	embed: new EmbedViewManager(),
 	contactForm: ContactFormView,
-	video: VideoView
+	video: VideoView,
+	simplePayments: SimplePaymentsView,
 };
 
 const components = mapValues( views, ( view ) => {

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 /**
  * External dependencies
  */

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -2,24 +2,40 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependecies
  */
 import shortcodeUtils from 'lib/shortcode';
+import { deserialize } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
 
 class SimplePaymentsView extends Component {
 	render() {
+		const { id } = this.props;
+
 		return (
 			<div className="wpview-content wpview-type-simple-payments">
 				Hello there!
+				{ id }
 			</div>
 		);
 	}
 }
 
-SimplePaymentsView = localize( SimplePaymentsView );
+SimplePaymentsView = connect( ( state, props ) => {
+	const { content: shortcode } = props;
+
+	const shortcodeData = deserialize( shortcode );
+
+	const { id = null } = shortcodeData;
+
+	return {
+		shortcodeData,
+		id,
+	};
+} )( localize( SimplePaymentsView ) );
 
 SimplePaymentsView.match = ( content ) => {
 	const match = shortcodeUtils.next( 'simple-payment', content );

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/* eslint-disable react/no-danger */
 
 /**
  * External dependencies
@@ -54,10 +53,8 @@ class SimplePaymentsView extends Component {
 						<div className="wpview-type-simple-payments__title">
 							{ title }
 						</div>
-						<div
-							className="wpview-type-simple-payments__description"
-							dangerouslySetInnerHTML={ { __html: description } }
-						>
+						<div className="wpview-type-simple-payments__description">
+							{ description }
 						</div>
 						<div className="wpview-type-simple-payments__price-part">
 							{ formatCurrency( price, currency ) }

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -15,15 +15,17 @@ import { deserialize } from 'components/tinymce/plugins/simple-payments/shortcod
 import { getSimplePayments } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import formatCurrency from 'lib/format-currency';
+import QuerySimplePayments from 'components/data/query-simple-payments';
 
 class SimplePaymentsView extends Component {
 	render() {
-		const { id, product, content } = this.props;
+		const { productId, product, content, siteId } = this.props;
 
 		if ( ! product ) {
 			return (
 				<div className="wpview-content wpview-type-simple-payments">
 					{ content }
+					<QuerySimplePayments siteId={ siteId } productId={ productId } />
 				</div>
 			);
 		}
@@ -68,14 +70,14 @@ SimplePaymentsView = connect( ( state, props ) => {
 
 	const shortcodeData = deserialize( shortcode );
 
-	const { id = null } = shortcodeData;
+	const { id: productId = null } = shortcodeData;
 	const siteId = getSelectedSiteId( state );
 
 	return {
 		shortcodeData,
-		id,
+		productId,
 		siteId,
-		product: getSimplePayments( state, siteId, id ),
+		product: getSimplePayments( state, siteId, productId ),
 	};
 } )( localize( SimplePaymentsView ) );
 

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -32,11 +32,18 @@ class SimplePaymentsView extends Component {
 
 		const { title, description, price, currency } = product;
 
+		const imageUrl = 'https://cldup.com/nKM0_KspYE.png';
+
 		return (
 			<div className="wpview-content wpview-type-simple-payments">
 				<div className="wpview-type-simple-payments__wrapper">
 					<div className="wpview-type-simple-payments__image-part">
-						Image here
+						<figure className="wpview-type-simple-payments__image-figure">
+							<img
+								className="wpview-type-simple-payments__image"
+								src={ imageUrl }
+							/>
+						</figure>
 					</div>
 					<div className="wpview-type-simple-payments__text-part">
 						<div className="wpview-type-simple-payments__title">
@@ -52,7 +59,12 @@ class SimplePaymentsView extends Component {
 						</div>
 						<div className="wpview-type-simple-payments__pay-part">
 							<div className="wpview-type-simple-payments__pay-quantity">
-								<input type="text" value="1" readOnly />
+								<input
+									className="wpview-type-simple-payments__pay-quantity-input"
+									type="text"
+									value="1"
+									readOnly
+								/>
 							</div>
 							<div className="wpview-type-simple-payments__pay-paypal-button">
 								Pay with PayPal

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -12,6 +12,7 @@ import shortcodeUtils from 'lib/shortcode';
 import { deserialize } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
 import { getSimplePayments } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import formatCurrency from 'lib/format-currency';
 
 class SimplePaymentsView extends Component {
 	render() {
@@ -43,11 +44,11 @@ class SimplePaymentsView extends Component {
 						>
 						</div>
 						<div className="wpview-type-simple-payments__price-part">
-							{ price }
+							{ formatCurrency( price, currency ) }
 						</div>
 						<div className="wpview-type-simple-payments__pay-part">
 							<div className="wpview-type-simple-payments__pay-quantity">
-								<input type="text" value="1" />
+								<input type="text" value="1" readOnly />
 							</div>
 							<div className="wpview-type-simple-payments__pay-paypal-button">
 								Pay with PayPal

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+/* eslint-disable react/no-danger */
 
 /**
  * External dependencies

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependecies
+ */
+import shortcodeUtils from 'lib/shortcode';
+
+class SimplePaymentsView extends Component {
+	render() {
+		return (
+			<div className="wpview-content wpview-type-simple-payments">
+				Hello there!
+			</div>
+		);
+	}
+}
+
+SimplePaymentsView = localize( SimplePaymentsView );
+
+SimplePaymentsView.match = ( content ) => {
+	const match = shortcodeUtils.next( 'simple-payment', content );
+
+	if ( match ) {
+		return {
+			index: match.index,
+			content: match.content,
+			options: {
+				shortcode: match.shortcode
+			}
+		};
+	}
+};
+
+SimplePaymentsView.serialize = ( content ) => {
+	return encodeURIComponent( content );
+};
+
+SimplePaymentsView.edit = ( editor, content ) => {
+	editor.execCommand( 'simplePaymentsButton', content );
+};
+
+export default SimplePaymentsView;

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -32,7 +32,11 @@ class SimplePaymentsView extends Component {
 
 		const { title, description, price, currency } = product;
 
+		// TODO: add from product.
 		const imageUrl = 'https://cldup.com/nKM0_KspYE.png';
+
+		// TODO: make proper icon and store on some proper place.
+		const paypalButtonImageUrl = 'https://cldup.com/DoIAwrACBs.png';
 
 		return (
 			<div className="wpview-content wpview-type-simple-payments">
@@ -66,8 +70,11 @@ class SimplePaymentsView extends Component {
 									readOnly
 								/>
 							</div>
-							<div className="wpview-type-simple-payments__pay-paypal-button">
-								Pay with PayPal
+							<div className="wpview-type-simple-payments__pay-paypal-button-wrapper">
+								<img
+									className="wpview-type-simple-payments__pay-paypal-button"
+									src={ paypalButtonImageUrl }
+								/>
 							</div>
 						</div>
 					</div>

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -10,15 +10,51 @@ import { localize } from 'i18n-calypso';
  */
 import shortcodeUtils from 'lib/shortcode';
 import { deserialize } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
+import { getSimplePayments } from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class SimplePaymentsView extends Component {
 	render() {
-		const { id } = this.props;
+		const { id, product, content } = this.props;
+
+		if ( ! product ) {
+			return (
+				<div className="wpview-content wpview-type-simple-payments">
+					{ content }
+				</div>
+			);
+		}
+
+		const { title, description, price, currency } = product;
 
 		return (
 			<div className="wpview-content wpview-type-simple-payments">
-				Hello there!
-				{ id }
+				<div className="wpview-type-simple-payments__wrapper">
+					<div className="wpview-type-simple-payments__image-part">
+						Image here
+					</div>
+					<div className="wpview-type-simple-payments__text-part">
+						<div className="wpview-type-simple-payments__title">
+							{ title }
+						</div>
+						<div
+							className="wpview-type-simple-payments__description"
+							dangerouslySetInnerHTML={ { __html: description } }
+						>
+						</div>
+						<div className="wpview-type-simple-payments__price-part">
+							{ price }
+						</div>
+						<div className="wpview-type-simple-payments__pay-part">
+							<div className="wpview-type-simple-payments__pay-quantity">
+								<input type="text" value="1" />
+							</div>
+							<div className="wpview-type-simple-payments__pay-paypal-button">
+								Pay with PayPal
+							</div>
+						</div>
+					</div>
+				</div>
 			</div>
 		);
 	}
@@ -30,10 +66,13 @@ SimplePaymentsView = connect( ( state, props ) => {
 	const shortcodeData = deserialize( shortcode );
 
 	const { id = null } = shortcodeData;
+	const siteId = getSelectedSiteId( state );
 
 	return {
 		shortcodeData,
 		id,
+		siteId,
+		product: getSimplePayments( state, siteId, id ),
 	};
 } )( localize( SimplePaymentsView ) );
 

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -8,7 +8,7 @@
 
 .wpview-type-simple-payments__title {
 	font-weight: bold;
-	margin-bottom: 5px;
+	margin-bottom: 10px;
 }
 
 .wpview-type-simple-payments__price-part {

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -1,5 +1,6 @@
 .wpview-type-simple-payments__wrapper {
 	display: flex;
+	margin: 10px;
 }
 
 .wpview-type-simple-payments__text-part {
@@ -18,4 +19,25 @@
 
 .wpview-type-simple-payments__pay-part {
 	display: flex;
+}
+
+.wpview-type-simple-payments__pay-quantity-input {
+	border: 1px solid lighten( $gray, 10% );
+	padding: 10px;
+	width: 70px;
+}
+
+.wpview-type-simple-payments__pay-paypal-button {
+	margin-left: 10px;
+}
+
+.wpview-type-simple-payments__image-figure {
+	margin: 0;
+	height: 100%;
+	border: 1px solid lighten( $gray, 10% );
+	background-color: lighten( $gray, 30% );
+}
+
+.wpview-type-simple-payments__image {
+	max-width: 200px;
 }

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -27,8 +27,12 @@
 	width: 70px;
 }
 
-.wpview-type-simple-payments__pay-paypal-button {
+.wpview-type-simple-payments__pay-paypal-button-wrapper {
 	margin-left: 10px;
+}
+
+.wpview-type-simple-payments__pay-paypal-button {
+	width: 150px;
 }
 
 .wpview-type-simple-payments__image-figure {

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -1,0 +1,21 @@
+.wpview-type-simple-payments__wrapper {
+	display: flex;
+}
+
+.wpview-type-simple-payments__text-part {
+	margin-left: 15px;
+}
+
+.wpview-type-simple-payments__title {
+	font-weight: bold;
+	margin-bottom: 5px;
+}
+
+.wpview-type-simple-payments__price-part {
+	margin: 20px 0;
+	font-weight: bold;
+}
+
+.wpview-type-simple-payments__pay-part {
+	display: flex;
+}

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -6,6 +6,7 @@
 @import 'plugins/contact-form/style';
 @import 'plugins/mentions/style';
 @import 'plugins/simple-payments/style';
+@import 'plugins/wpcom-view/views/simple-payments/style';
 
 .tinymce {
 	display: none;

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -6,7 +6,6 @@
 @import 'plugins/contact-form/style';
 @import 'plugins/mentions/style';
 @import 'plugins/simple-payments/style';
-@import 'plugins/wpcom-view/views/simple-payments/style';
 
 .tinymce {
 	display: none;


### PR DESCRIPTION
In this PR, we introduce the Editor shortcode views for Simple Payments project.

![image](https://user-images.githubusercontent.com/4988512/28076702-cd0914fc-665f-11e7-92b6-f1a5250327a0.png)

## Testing

1. Apply https://github.com/Automattic/jetpack/pull/7409 on a Jetpack site;
2. Create some Simple Payment products;
3. Add them manually as shortcodes to a post on that Jetpack site;
4. See how it looks/behaves.

## Further improvements:
1. We need to style it maybe a bit better ( @iamtakashi maybe you could help here :) );
2. Center the image in the figure and use a real image from the product;
3. Add proper PayPal button icon (couldn't find it on web, I had to screenshot this one and it's bad).
