### PR TITLE
Update CSS styling of the Simple Payments modal dialog

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -43,6 +43,16 @@ class SimplePaymentsDialog extends Component {
 		return actionButtons;
 	}
 
+	renderAddNewForm() {
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		return <div className="editor-simple-payments-modal__form">Add new</div>;
+	}
+
+	renderList() {
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		return <div className="editor-simple-payments-modal__list">Payment Buttons List</div>;
+	}
+
 	render() {
 		const {
 			activeTab,
@@ -50,10 +60,6 @@ class SimplePaymentsDialog extends Component {
 			onChangeTabs,
 			onClose,
 		} = this.props;
-
-		const content = activeTab === 'addNew'
-			? <div>Add new</div>
-			: <div>Payment Buttons list</div>;
 
 		return (
 			<Dialog
@@ -63,7 +69,7 @@ class SimplePaymentsDialog extends Component {
 				additionalClassNames="editor-simple-payments-modal"
 			>
 				<Navigation { ...{ activeTab, onChangeTabs } } />
-				{ content }
+				{ activeTab === 'addNew' ? this.renderAddNewForm() : this.renderList() }
 			</Dialog>
 		);
 	}

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -2,8 +2,34 @@
 	// TODO: temporary values until we get some content
 	width: 550px;
 	height: 450px;
+
+	&.dialog.card {
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.dialog__content {
+		display: flex;
+		flex-direction: column;
+		flex: auto;
+		min-height: 0; // permits the to shrink below its min height and scroll
+	}
+
+	.dialog__action-buttons {
+		flex: none;
+		margin: 0;
+	}
 }
 
 .editor-simple-payments-modal__navigation {
-	// TODO: remove top, left and right borders, move to the top, remove left, right paddings
+	margin: 0;
+}
+
+.editor-simple-payments-modal__form {
+	padding: 16px;
+}
+
+.editor-simple-payments-modal__list {
+	padding: 8px 16px;
 }


### PR DESCRIPTION
- use vertical flex layout to align the header, content, and button footer of the modal.
- set proper padding and margin on the header (both in the SectionNav and HeaderCake variants).
- proper padding for the content stubs (add new form and the list).

This is how it looks like with the new styling:
<img width="558" alt="screen shot 2017-07-10 at 14 33 59" src="https://user-images.githubusercontent.com/664258/28018272-eda166f8-657c-11e7-9687-79845870c8cf.png">
<img width="559" alt="screen shot 2017-07-10 at 14 34 12" src="https://user-images.githubusercontent.com/664258/28018275-f1c50082-657c-11e7-8547-eb6cf880f549.png">
 