### PR TITLE
Woo-Connect Insights: use currency codes in list and add tests (and fix isWoo bug)

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -7,17 +7,17 @@ export const sparkWidgetList1 = [
 	{
 		key: 'products',
 		title: translate( 'Products Purchased' ),
-		type: 'number'
+		format: 'number'
 	},
 	{
 		key: 'avg_products_per_order',
 		title: translate( 'Products Per Order' ),
-		type: 'number'
+		format: 'number'
 	},
 	{
 		key: 'coupons',
 		title: translate( 'Coupons Used' ),
-		type: 'number'
+		format: 'number'
 	}
 ];
 
@@ -25,17 +25,17 @@ export const sparkWidgetList2 = [
 	{
 		key: 'total_refund',
 		title: translate( 'Refunds' ),
-		type: 'currency'
+		format: 'currency'
 	},
 	{
 		key: 'total_shipping',
 		title: translate( 'Shipping' ),
-		type: 'currency'
+		format: 'currency'
 	},
 	{
 		key: 'total_tax',
 		title: translate( 'Tax' ),
-		type: 'currency'
+		format: 'currency'
 	}
 ];
 

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -34,7 +34,7 @@ import { isPluginActive } from 'state/selectors';
 
 class StoreStats extends Component {
 	static propTypes = {
-		isWooConnect: PropTypes.bool.isRequired,
+		isWooConnect: PropTypes.bool,
 		path: PropTypes.string.isRequired,
 		queryDate: PropTypes.string,
 		querystring: PropTypes.string,

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -33,6 +33,7 @@ const listType = {
 
 class StoreStatsListView extends Component {
 	static propTypes = {
+		isWooConnect: PropTypes.bool,
 		path: PropTypes.string.isRequired,
 		selectedDate: PropTypes.string,
 		siteId: PropTypes.number,

--- a/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-list/index.js
@@ -27,7 +27,7 @@ const StoreStatsList = ( { data, values } ) => {
 				<TableRow key={ i }>
 					{ values.map( ( value, j ) => (
 						<TableItem key={ value.key } isTitle={ 0 === j }>
-							{ formatValue( row[ value.key ], value.format ) }
+							{ formatValue( row[ value.key ], value.format, row.currency ) }
 						</TableItem>
 					) ) }
 				</TableRow>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -13,7 +13,8 @@ import { moment, translate } from 'i18n-calypso';
 import Card from 'components/card';
 import Delta from 'woocommerce/components/delta';
 import ErrorPanel from 'my-sites/stats/stats-error';
-import formatCurrency from 'lib/format-currency';
+import { formatValue } from '../utils';
+import { getPeriodFormat } from 'state/stats/lists/utils';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData
@@ -24,8 +25,6 @@ import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
 import Table from 'woocommerce/components/table';
 import TableItem from 'woocommerce/components/table/table-item';
 import TableRow from 'woocommerce/components/table/table-row';
-import { getPeriodFormat } from 'state/stats/lists/utils';
-import { formatValue } from '../utils';
 
 class StoreStatsWidgetList extends Component {
 

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -25,6 +25,7 @@ import Table from 'woocommerce/components/table';
 import TableItem from 'woocommerce/components/table/table-item';
 import TableRow from 'woocommerce/components/table/table-row';
 import { getPeriodFormat } from 'state/stats/lists/utils';
+import { formatValue } from '../utils';
 
 class StoreStatsWidgetList extends Component {
 
@@ -129,9 +130,7 @@ class StoreStatsWidgetList extends Component {
 				const delta = this.getDeltaByStat( widget.key );
 				return {
 					title: widget.title,
-					value: ( widget.type === 'currency' )
-						? formatCurrency( timeSeries[ selectedIndex ], sincePeriod.currency )
-						:	Math.round( timeSeries[ selectedIndex ] * 100 ) / 100,
+					value: formatValue( timeSeries[ selectedIndex ], widget.format, sincePeriod.currency ),
 					sparkline: <Sparkline
 						aspectRatio={ 3 }
 						data={ timeSeries }

--- a/client/extensions/woocommerce/app/store-stats/test/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/test/utils.js
@@ -170,7 +170,27 @@ describe( 'getEndPeriod', () => {
 } );
 
 describe( 'formatValue', () => {
-	it( 'should return a correctly formatted currency', () => {
+	it( 'should return a correctly formatted currency for NZD', () => {
+		const response = formatValue( 12.34, 'currency', 'NZD' );
+		assert.isString( response );
+		assert.strictEqual( response, 'NZ$12.34' );
+	} );
+	it( 'should return a correctly formatted currency for USD', () => {
+		const response = formatValue( 12.34, 'currency', 'USD' );
+		assert.isString( response );
+		assert.strictEqual( response, '$12.34' );
+	} );
+	it( 'should return a correctly formatted currency for ZAR', () => {
+		const response = formatValue( 12.34, 'currency', 'ZAR' );
+		assert.isString( response );
+		assert.strictEqual( response, 'R12,34' );
+	} );
+	it( 'should return a correctly formatted USD currency for unknown code', () => {
+		const response = formatValue( 12.34, 'currency', 'XXX' );
+		assert.isString( response );
+		assert.strictEqual( response, '$12.34' );
+	} );
+	it( 'should return a correctly formatted USD currency for missing code', () => {
 		const response = formatValue( 12.34, 'currency' );
 		assert.isString( response );
 		assert.strictEqual( response, '$12.34' );

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -109,12 +109,13 @@ export function getEndPeriod( date, unit ) {
  *
  * @param {(string|number)} value - string or number to be formatted
  * @param {string} format - string of 'text', 'number' or 'currency'
+ * @param {string} [code] - optional currency code
  * @return {string|number} - formatted number or string value
 */
-export function formatValue( value, format ) {
+export function formatValue( value, format, code ) {
 	switch ( format ) {
 		case 'currency':
-			return formatCurrency( value );
+			return formatCurrency( value, code );
 		case 'number':
 			return Math.round( value * 100 ) / 100;
 		case 'text':


### PR DESCRIPTION
- ensures that lists use the 3 character currency code from the API response
- renamed constant `type` to `format`
- new tests for a few currencies and missing currency values
- fix odd isWooConnect `isRequired` bug

Fixes #16033

To test:
-ENABLE_FEATURES=woocommerce/extension-stats make run
-browse to /store/stats/orders/day/{ slug } of a site with WooCommerce and Jetpack syncing
-ensure currency correctly formatted in top-* lists at the bottom and on list pages (click top-* list title)