### PR TITLE
Add getSimplePayments selector with tests

### DIFF
--- a/client/state/selectors/get-simple-payments.js
+++ b/client/state/selectors/get-simple-payments.js
@@ -30,7 +30,7 @@ export default createSelector(
 
 		const simplePaymentProduct = find( simplePaymentProducts, ( product ) => product.ID === simplePaymentId );
 
-		if ( typeof simplePaymentProduct === 'undefined' ) {
+		if ( ! simplePaymentProduct ) {
 			return null;
 		}
 

--- a/client/state/selectors/get-simple-payments.js
+++ b/client/state/selectors/get-simple-payments.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { get, find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+/**
+ * Get all Simple Payment or the one specified by `simplePaymentId`
+ *
+ * @param {Object} state           Global state tree
+ * @param {int}    siteId          Site which the Simple Payment belongs to.
+ * @param {int}    simplePaymentId The ID of the Simple Payment to get. Optional.
+ * @return {Array|Object|null}     Array of Simple Payment objects or an object if `simplePaymentId` specified.
+ */
+export default createSelector(
+	( state, siteId, simplePaymentId = null ) => {
+		if ( ! siteId ) {
+			return null;
+		}
+
+		const simplePaymentProducts = get( state, `simplePayments.productList.items.${ siteId }`, null );
+
+		if ( ! simplePaymentId ) {
+			return simplePaymentProducts;
+		}
+
+		const simplePaymentProduct = find( simplePaymentProducts, ( product ) => product.ID === simplePaymentId );
+
+		if ( typeof simplePaymentProduct === 'undefined' ) {
+			return null;
+		}
+
+		return simplePaymentProduct;
+	},
+	( state ) => state.simplePayments.productList.items
+);

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -92,6 +92,7 @@ export getScheduledPublicizeShareActionTime from './get-scheduled-publicize-shar
 export hasUserAskedADirectlyQuestion from './has-user-asked-a-directly-question';
 export isSchedulingPublicizeShareActionError from './is-scheduling-publicize-share-action-error';
 export getSharingButtons from './get-sharing-buttons';
+export getSimplePayments from './get-simple-payments';
 export getSiteComments from './get-site-comments';
 export getSiteConnectionStatus from './get-site-connection-status';
 export getSiteDefaultPostFormat from './get-site-default-post-format';

--- a/client/state/selectors/test/get-simple-payments.js
+++ b/client/state/selectors/test/get-simple-payments.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSimplePayments } from '../';
+
+const simplePayment1 = {
+	ID: 1,
+	title: 'Simple Payment 1',
+	description: 'Simple Payment 1 description',
+};
+
+const simplePayment2 = {
+	ID: 2,
+	title: 'Simple Payment 2',
+	description: 'Simple Payment 2 description',
+};
+
+describe( 'getSimplePayments()', () => {
+	it( 'should return null if siteId is not specified', () => {
+		const state = {
+			simplePayments: {
+				productList: {
+					items: {}
+				}
+			}
+		};
+
+		const simplePayments = getSimplePayments( state );
+
+		expect( simplePayments ).to.eql( null );
+	} );
+
+	it( "should return null if siteId can't be found in Simple Payments", () => {
+		const state = {
+			simplePayments: {
+				productList: {
+					items: {
+						1111: []
+					}
+				}
+			}
+		};
+
+		const simplePayments = getSimplePayments( state, 1234 );
+
+		expect( simplePayments ).to.eql( null );
+	} );
+
+	it( 'should return empty array if there are no simple payments', () => {
+		const state = {
+			simplePayments: {
+				productList: {
+					items: {
+						1234: [],
+					}
+				}
+			}
+		};
+
+		const simplePayments = getSimplePayments( state, 1234 );
+
+		expect( simplePayments ).to.eql( [] );
+	} );
+
+	it( 'should return all Simple Payments for a given siteId', () => {
+		const simplePaymentsInState = [
+			simplePayment1,
+			simplePayment2,
+		];
+
+		const state = {
+			simplePayments: {
+				productList: {
+					items: {
+						1234: simplePaymentsInState,
+					}
+				}
+			}
+		};
+
+		const simplePayments = getSimplePayments( state, 1234 );
+
+		expect( simplePayments ).to.eql( simplePaymentsInState );
+	} );
+
+	it( 'should return null if simplePaymentId was specified but is not found', () => {
+		const simplePaymentsInState = [
+			simplePayment1,
+			simplePayment2,
+		];
+
+		const state = {
+			simplePayments: {
+				productList: {
+					items: {
+						1234: simplePaymentsInState,
+					}
+				}
+			}
+		};
+
+		const simplePayment = getSimplePayments( state, 1234, 10 );
+
+		expect( simplePayment ).to.eql( null );
+	} );
+
+	it( 'should return a Simple Payment object if simplePaymentId is specified and found', () => {
+		const simplePaymentsInState = [
+			simplePayment1,
+			simplePayment2,
+		];
+
+		const state = {
+			simplePayments: {
+				productList: {
+					items: {
+						1234: simplePaymentsInState,
+					}
+				}
+			}
+		};
+
+		const simplePayment = getSimplePayments( state, 1234, 1 );
+
+		expect( simplePayment ).to.eql( simplePayment1 );
+	} );
+} );


### PR DESCRIPTION
`getSimplePayments` selector returns either all Simple Payment products for a given `siteId` or returns a single Simple Payment product if `simplePaymentId` is specified.

## Testing

Run tests with `npm run test-client client/state/selectors/test`. Do they pass?