### PR TITLE
Extensions: Check if plugin is available in environment before showing settings link

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -419,6 +419,11 @@ class PluginMeta extends Component {
 		const pluginSlug = get( plugin, 'slug', '' );
 		const sections = sectionsModule.get();
 		const section = find( sections, ( value => value.name === pluginSlug ) );
+		const env = get( section, 'envId', [] );
+
+		if ( ! includes( env, config( 'env' ) ) ) {
+			return;
+		}
 
 		return get( section, 'settings_path' );
 	}


### PR DESCRIPTION
Currently on wordpress.com, the _Edit plugin settings_ link for WP Job Manager is visible on the plugins page:

![edit-plugin-settings](https://user-images.githubusercontent.com/1190420/28023099-dc6b8fd4-655a-11e7-9225-cbf3f7aec7d0.jpg)

However, clicking on it goes to an error page:

![error-page](https://user-images.githubusercontent.com/1190420/28023102-dffaa3b0-655a-11e7-8378-b5dd60ef9477.jpg)

That's because the settings page is currently only available in the [`development` and `wpcalypso`](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/wp-job-manager/package.json#L6) environments.

This PR adds an environment check to ensure the plugin is available in the current environment before displaying the _Edit plugin settings_ link.

## Testing

Test to ensure that the _Edit plugin settings_ link still shows for WPSC and WPJM, but not for any other plugin. This same test will need to be run once the PR is on staging to ensure that the link *is* shown for WPSC but *is not* shown for WPJM or any other plugin.