### PR TITLE
Store orders: use Button component’s `busy` as a saving indicator

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -66,7 +66,7 @@ class Order extends Component {
 		return (
 			<Main className={ className }>
 				<ActionHeader breadcrumbs={ breadcrumbs }>
-					<Button primary onClick={ this.saveOrder } disabled={ isSaving }>{ translate( 'Save Order' ) }</Button>
+					<Button primary onClick={ this.saveOrder } busy={ isSaving }>{ translate( 'Save Order' ) }</Button>
 				</ActionHeader>
 
 				<div className="order__container">


### PR DESCRIPTION
See #15674, #15849

This very simple PR just switches from disabling the button while saving the order, to using the busy state. This matches the product save experience.