### PR TITLE
Store - Fix logic that checks that payment methods are setup

### DIFF
--- a/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
@@ -68,7 +68,9 @@ export const getPaymentMethodsWithEdits = ( state, siteId = getSelectedSiteId( s
  * @return {Boolean} Bool indicating if payments are setup
  */
 export const arePaymentsSetup = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return !! filter( getPaymentMethodsWithEdits( state, siteId ), { enabled: true } ).length;
+	return !! filter( getPaymentMethodsWithEdits( state, siteId ), function( method ) {
+		return method.enabled && 'cheque' !== method.id;
+	} ).length;
 };
 
 /**


### PR DESCRIPTION
Fixes:  #15897

To test:
- go to Egg view 
- disabled all payment methods besides 'Check'
- observe no check mark on egg
- Enabled payment method besides 'Check'
- Observe check mark