### PR TITLE
Reader: enable blog sticker removal from post options menu

### DIFF
--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -19,8 +19,8 @@ class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 	};
 
 	toggleSticker = () => {
-		const action = this.props.hasSticker ? 'removeBlogSticker' : 'addBlogSticker';
-		this.props[ action ]( this.props.blogId, this.props.blogStickerName );
+		const toggle = this.props.hasSticker ? this.props.removeBlogSticker : this.props.addBlogSticker;
+		toggle( this.props.blogId, this.props.blogStickerName );
 	};
 
 	render() {

--- a/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
+++ b/client/blocks/reader-post-options-menu/blog-sticker-menu-item.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { addBlogSticker } from 'state/sites/blog-stickers/actions';
+import { addBlogSticker, removeBlogSticker } from 'state/sites/blog-stickers/actions';
 
 class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 	static propTypes = {
@@ -18,12 +18,9 @@ class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 		hasSticker: React.PropTypes.bool,
 	};
 
-	addSticker = () => {
-		if ( this.props.hasSticker ) {
-			return null;
-		}
-
-		this.props.addBlogSticker( this.props.blogId, this.props.blogStickerName );
+	toggleSticker = () => {
+		const action = this.props.hasSticker ? 'removeBlogSticker' : 'addBlogSticker';
+		this.props[ action ]( this.props.blogId, this.props.blogStickerName );
 	};
 
 	render() {
@@ -37,7 +34,7 @@ class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 				icon="flag"
 				key={ blogStickerName }
 				className={ classes }
-				onClick={ this.addSticker }
+				onClick={ this.toggleSticker }
 			>
 				{ children }
 			</PopoverMenuItem>
@@ -45,4 +42,6 @@ class ReaderPostOptionsMenuBlogStickerMenuItem extends React.Component {
 	}
 }
 
-export default connect( null, { addBlogSticker } )( ReaderPostOptionsMenuBlogStickerMenuItem );
+export default connect( null, { addBlogSticker, removeBlogSticker } )(
+	ReaderPostOptionsMenuBlogStickerMenuItem,
+);

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -87,7 +87,6 @@
 		&:focus {
 			color: $white;
 			background: $alert-red;
-			cursor: default;
 
 			.gridicon {
 				fill: $white;

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -31,6 +31,7 @@ export class Notice extends Component {
 			'is-info',
 			'is-success',
 			'is-warning',
+			'is-plain',
 		] ),
 		text: PropTypes.oneOfType( [
 			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) ),

--- a/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js
@@ -42,6 +42,9 @@ export function receiveBlogStickerAdd( store, action, next, response ) {
 					i: <i />,
 				},
 			} ),
+			{
+				duration: 5000,
+			},
 		),
 	);
 }

--- a/client/state/data-layer/wpcom/sites/blog-stickers/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/index.js
@@ -12,6 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import addBlogStickerHandler from 'state/data-layer/wpcom/sites/blog-stickers/add';
+import removeBlogStickerHandler from 'state/data-layer/wpcom/sites/blog-stickers/remove';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { receiveBlogStickers } from 'state/sites/blog-stickers/actions';
 
@@ -52,4 +53,8 @@ const listBlogStickersHandler = {
 	],
 };
 
-export default mergeHandlers( listBlogStickersHandler, addBlogStickerHandler );
+export default mergeHandlers(
+	listBlogStickersHandler,
+	addBlogStickerHandler,
+	removeBlogStickerHandler,
+);

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -11,7 +11,7 @@ import { SITES_BLOG_STICKER_REMOVE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { addBlogSticker } from 'state/sites/blog-stickers/actions';
-import { errorNotice, successNotice } from 'state/notices/actions';
+import { errorNotice, createNotice } from 'state/notices/actions';
 import { local } from 'state/data-layer/utils';
 
 export function requestBlogStickerRemove( { dispatch }, action ) {
@@ -36,13 +36,17 @@ export function receiveBlogStickerRemove( store, action, next, response ) {
 	}
 
 	store.dispatch(
-		successNotice(
-			translate( 'The sticker {{i}}%s{{/i}} has been successfully removed.', {
+		createNotice(
+			null,
+			translate( 'The sticker {{i}}%s{{/i}} has been removed.', {
 				args: action.payload.stickerName,
 				components: {
 					i: <i />,
 				},
 			} ),
+			{
+				duration: 5000,
+			},
 		),
 	);
 }

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -11,7 +11,7 @@ import { SITES_BLOG_STICKER_REMOVE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { addBlogSticker } from 'state/sites/blog-stickers/actions';
-import { errorNotice, createNotice } from 'state/notices/actions';
+import { errorNotice, plainNotice } from 'state/notices/actions';
 import { local } from 'state/data-layer/utils';
 
 export function requestBlogStickerRemove( { dispatch }, action ) {
@@ -36,8 +36,7 @@ export function receiveBlogStickerRemove( store, action, next, response ) {
 	}
 
 	store.dispatch(
-		createNotice(
-			null,
+		plainNotice(
 			translate( 'The sticker {{i}}%s{{/i}} has been removed.', {
 				args: action.payload.stickerName,
 				components: {

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/test/index.js
@@ -36,7 +36,7 @@ describe( 'blog-sticker-remove', () => {
 	} );
 
 	describe( 'receiveBlogStickerRemove', () => {
-		it( 'should dispatch a success notice', () => {
+		it( 'should dispatch a notice', () => {
 			const dispatch = spy();
 			receiveBlogStickerRemove(
 				{ dispatch },
@@ -46,7 +46,7 @@ describe( 'blog-sticker-remove', () => {
 			);
 			expect( dispatch ).to.have.been.calledWithMatch( {
 				notice: {
-					status: 'is-success',
+					status: 'is-plain',
 				},
 			} );
 		} );

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -42,3 +42,4 @@ export const successNotice = createNotice.bind( null, 'is-success' );
 export const errorNotice = createNotice.bind( null, 'is-error' );
 export const infoNotice = createNotice.bind( null, 'is-info' );
 export const warningNotice = createNotice.bind( null, 'is-warning' );
+export const plainNotice = createNotice.bind( null, 'is-plain' );


### PR DESCRIPTION
Following on from https://github.com/Automattic/wp-calypso/pull/15757, this PR allows Automattic users to remove blog stickers that have been set for a blog:

<img width="502" alt="screen shot 2017-07-10 at 17 18 55" src="https://user-images.githubusercontent.com/17325/28028261-e0e94f22-6593-11e7-9048-40895bf52c0c.png">

### To test

Pull up a site stream like:

http://calypso.localhost:3000/read/blogs/122463145

Verify that you can successfully add and remove the 'dont-recommend' and 'broken-in-reader' blog stickers.