### PR TITLE
Site Settings: Add net neutrality

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -331,12 +331,33 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	netNeutralityOption() {
-		const { fields, isRequestingSettings, translate, handleToggle } = this.props;
+		const { fields, isRequestingSettings, translate, handleToggle, moment, handleSubmitForm, isSavingSettings } = this.props;
+
+		const today = moment(),
+			lastDay = moment( { year: 2017, month: 6, day: 13 } );
+
+		if ( today.isAfter( lastDay, 'day' ) ) {
+			return null;
+		}
 
 		return (
-			<FormFieldset>
-				<ul>
-					<li>
+			<div>
+				<SectionHeader label={ translate( 'Net Neutrality' ) }>
+					<Button
+						compact={ true }
+						onClick={ handleSubmitForm }
+						primary={ true }
+
+						type="submit"
+						disabled={ isRequestingSettings || isSavingSettings }>
+							{ isSavingSettings
+								? translate( 'Saving…' )
+								: translate( 'Save Settings' )
+							}
+					</Button>
+				</SectionHeader>
+				<Card>
+					<FormFieldset>
 						<CompactFormToggle
 							checked={ !! fields.net_neutrality }
 							disabled={ isRequestingSettings }
@@ -344,9 +365,9 @@ class SiteSettingsFormGeneral extends Component {
 						>
 							{ translate( 'Help save the internet by displaying a net-neutrality banner on your site.' ) }
 						</CompactFormToggle>
-					</li>
-				</ul>
-			</FormFieldset>
+					</FormFieldset>
+				</Card>
+			</div>
 		);
 	}
 
@@ -444,29 +465,7 @@ class SiteSettingsFormGeneral extends Component {
 			<div className={ classNames( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
 
-				{ ! siteIsJetpack &&
-					<div>
-						<SectionHeader label={ translate( 'Net Neutrality' ) }>
-						<Button
-							compact={ true }
-							onClick={ handleSubmitForm }
-							primary={ true }
-
-							type="submit"
-							disabled={ isRequestingSettings || isSavingSettings }>
-								{ isSavingSettings
-									? translate( 'Saving…' )
-									: translate( 'Save Settings' )
-								}
-						</Button>
-						</SectionHeader>
-						<Card>
-							<form>
-								{ this.netNeutralityOption() }
-							</form>
-						</Card>
-					</div>
-				}
+				{ ! siteIsJetpack && this.netNeutralityOption() }
 
 				<SectionHeader label={ translate( 'Site Profile' ) }>
 					<Button

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -443,6 +443,31 @@ class SiteSettingsFormGeneral extends Component {
 		return (
 			<div className={ classNames( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
+
+				{ ! siteIsJetpack &&
+					<div>
+						<SectionHeader label={ translate( 'Net Neutrality' ) }>
+						<Button
+							compact={ true }
+							onClick={ handleSubmitForm }
+							primary={ true }
+
+							type="submit"
+							disabled={ isRequestingSettings || isSavingSettings }>
+								{ isSavingSettings
+									? translate( 'Saving…' )
+									: translate( 'Save Settings' )
+								}
+						</Button>
+						</SectionHeader>
+						<Card>
+							<form>
+								{ this.netNeutralityOption() }
+							</form>
+						</Card>
+					</div>
+				}
+
 				<SectionHeader label={ translate( 'Site Profile' ) }>
 					<Button
 						compact={ true }
@@ -486,30 +511,6 @@ class SiteSettingsFormGeneral extends Component {
 						{ this.visibilityOptions() }
 					</form>
 				</Card>
-
-				{ ! siteIsJetpack &&
-					<div>
-						<SectionHeader label={ translate( 'Net Neutrality' ) }>
-						<Button
-							compact={ true }
-							onClick={ handleSubmitForm }
-							primary={ true }
-
-							type="submit"
-							disabled={ isRequestingSettings || isSavingSettings }>
-								{ isSavingSettings
-									? translate( 'Saving…' )
-									: translate( 'Save Settings' )
-								}
-						</Button>
-						</SectionHeader>
-						<Card>
-							<form>
-								{ this.netNeutralityOption() }
-							</form>
-						</Card>
-					</div>
-				}
 
 				{
 					! siteIsJetpack && <div className="site-settings__footer-credit-container">

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -334,7 +334,7 @@ class SiteSettingsFormGeneral extends Component {
 		const { fields, isRequestingSettings, translate, handleToggle, moment, handleSubmitForm, isSavingSettings } = this.props;
 
 		const today = moment(),
-			lastDay = moment( { year: 2017, month: 6, day: 13 } );
+			lastDay = moment( { year: 2017, month: 6, day: 12 } );
 
 		if ( today.isAfter( lastDay, 'day' ) ) {
 			return null;

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -363,7 +363,14 @@ class SiteSettingsFormGeneral extends Component {
 							disabled={ isRequestingSettings }
 							onChange={ handleToggle( 'net_neutrality' ) }
 						>
-							{ translate( 'The FCC wants to repeal Net Neutrality. Without Net Neutrality, big cable and telecom companies can divide the internet into fast and slow lanes. What would the Internet look like without net neutrality? Find out by enabling this banner on your site: it shows your support for real net neutrality rules by displaying a message on the bottom of your site and "slowing down" some of your posts.' ) }
+							{ translate(
+								'The FCC wants to repeal Net Neutrality. Without Net Neutrality, ' +
+								'big cable and telecom companies can divide the internet into fast ' +
+								'and slow lanes. What would the Internet look like without net neutrality? ' +
+								'Find out by enabling this banner on your site: it shows your support ' +
+								'for real net neutrality rules by displaying a message on the bottom ' +
+								'of your site and "slowing down" some of your posts.'
+							) }
 						</CompactFormToggle>
 					</FormFieldset>
 				</Card>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -363,7 +363,7 @@ class SiteSettingsFormGeneral extends Component {
 							disabled={ isRequestingSettings }
 							onChange={ handleToggle( 'net_neutrality' ) }
 						>
-							{ translate( 'Help save the internet by displaying a net-neutrality banner on your site.' ) }
+							{ translate( 'The FCC wants to repeal Net Neutrality. Without Net Neutrality, big cable and telecom companies can divide the internet into fast and slow lanes. What would the Internet look like without net neutrality? Find out by enabling this banner on your site: it shows your support for real net neutrality rules by displaying a message on the bottom of your site and "slowing down" some of your posts.' ) }
 						</CompactFormToggle>
 					</FormFieldset>
 				</Card>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -330,6 +330,26 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	netNeutralityOption() {
+		const { fields, isRequestingSettings, translate, handleToggle } = this.props;
+
+		return (
+			<FormFieldset>
+				<ul>
+					<li>
+						<CompactFormToggle
+							checked={ !! fields.net_neutrality }
+							disabled={ isRequestingSettings }
+							onChange={ handleToggle( 'net_neutrality' ) }
+						>
+							{ translate( 'Help save the internet by displaying a net-neutrality banner on your site.' ) }
+						</CompactFormToggle>
+					</li>
+				</ul>
+			</FormFieldset>
+		);
+	}
+
 	Timezone() {
 		const { fields, isRequestingSettings, siteIsJetpack, translate } = this.props;
 		if ( siteIsJetpack ) {
@@ -467,6 +487,30 @@ class SiteSettingsFormGeneral extends Component {
 					</form>
 				</Card>
 
+				{ ! siteIsJetpack &&
+					<div>
+						<SectionHeader label={ translate( 'Net Neutrality' ) }>
+						<Button
+							compact={ true }
+							onClick={ handleSubmitForm }
+							primary={ true }
+
+							type="submit"
+							disabled={ isRequestingSettings || isSavingSettings }>
+								{ isSavingSettings
+									? translate( 'Saving…' )
+									: translate( 'Save Settings' )
+								}
+						</Button>
+						</SectionHeader>
+						<Card>
+							<form>
+								{ this.netNeutralityOption() }
+							</form>
+						</Card>
+					</div>
+				}
+
 				{
 					! siteIsJetpack && <div className="site-settings__footer-credit-container">
 						<SectionHeader label={ translate( 'Footer Credit' ) } />
@@ -577,6 +621,7 @@ const getFormSettings = settings => {
 		jetpack_sync_non_public_post_stati: false,
 		holidaysnow: false,
 		api_cache: false,
+		net_neutrality: false
 	};
 
 	if ( ! settings ) {
@@ -595,6 +640,7 @@ const getFormSettings = settings => {
 		holidaysnow: !! settings.holidaysnow,
 
 		api_cache: settings.api_cache,
+		net_neutrality: settings.net_neutrality,
 	};
 
 	// handling `gmt_offset` and `timezone_string` values


### PR DESCRIPTION
This PR seeks to add a time-sensitive and short-lived feature to push for the net neutrality campaign. See pb6Nl-c83-p2.

Pinging @MichaelArestad for design review and to modify how he sees fit.

To test:

- Checkout PR
- Select a WP.com site and go to `/settings/general/$site`
- Toggle net neutrality on or off
- Afterwards, check `/sites/%site` in API console, and ensure that setting is saved properly
- Alternatively, load `$site` and ensure that a few posts show the `loading` banner

Note: The functionality is currently not on WordPress.com.