### PR TITLE
Reader: make long blog sticker lists viewable

### DIFF
--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -25,7 +25,9 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 			{ isTeamMember &&
 				stickers &&
 				stickers.length > 0 &&
-				<InfoPopover><BlogStickersList stickers={ stickers } /></InfoPopover> }
+				<InfoPopover rootClassName="blog-stickers__popover">
+					<BlogStickersList stickers={ stickers } />
+				</InfoPopover> }
 			{ ! stickers && <QueryBlogStickers blogId={ blogId } /> }
 			{ ! teams && <QueryReaderTeams /> }
 		</div>

--- a/client/blocks/blog-stickers/list.jsx
+++ b/client/blocks/blog-stickers/list.jsx
@@ -11,7 +11,11 @@ const BlogStickersList = ( { stickers, translate } ) => {
 			<h3 className="blog-stickers__list-title">{ translate( 'Blog Stickers' ) }</h3>
 			<ul className="blog-stickers__list-ul">
 				{ map( stickers, sticker => {
-					return <li className="blog-stickers__list-item" key={ sticker }>{ sticker }</li>;
+					return (
+						<li className="blog-stickers__list-item" key={ sticker }>
+							{ sticker }
+						</li>
+					);
 				} ) }
 			</ul>
 		</div>

--- a/client/blocks/blog-stickers/style.scss
+++ b/client/blocks/blog-stickers/style.scss
@@ -3,7 +3,7 @@
 }
 
 .blog-stickers__list {
-	overflow-y: scroll;
+	overflow-y: auto;
 	max-height: 210px;
 }
 

--- a/client/blocks/blog-stickers/style.scss
+++ b/client/blocks/blog-stickers/style.scss
@@ -20,11 +20,11 @@
 .blog-stickers__list-item {
 	padding-left: 15px;
 	position: relative;
-}
 
-.blog-stickers__list-item::before {
-	color: lighten( $gray, 10% );
-	content: " • ";
-	position: absolute;
-		left: 0;
+	&::before {
+		color: lighten( $gray, 10% );
+		content: " • ";
+		position: absolute;
+			left: 0;
+	}
 }

--- a/client/blocks/blog-stickers/style.scss
+++ b/client/blocks/blog-stickers/style.scss
@@ -3,8 +3,8 @@
 }
 
 .blog-stickers__list {
-	overflow-x: scroll;
-	max-height: 200px;
+	overflow-y: scroll;
+	max-height: 210px;
 }
 
 .blog-stickers__list-title {
@@ -13,19 +13,18 @@
 }
 
 .blog-stickers__list-ul {
+	list-style-type: none;
 	margin: 0;
-	list-style-type: square;
 }
 
 .blog-stickers__list-item {
-	display: inline;
+	padding-left: 15px;
+	position: relative;
+}
 
-	&:after {
-		content: " | ";
-	}
-
-
-	&:after:last-child {
-		content: "";
-	}
+.blog-stickers__list-item::before {
+	color: lighten( $gray, 10% );
+	content: " • ";
+	position: absolute;
+		left: 0;
 }

--- a/client/blocks/blog-stickers/style.scss
+++ b/client/blocks/blog-stickers/style.scss
@@ -2,6 +2,11 @@
 	display: inline;
 }
 
+.blog-stickers__list {
+	overflow-x: scroll;
+	max-height: 200px;
+}
+
 .blog-stickers__list-title {
 	font-weight: bold;
 	margin-bottom: 3px;
@@ -13,5 +18,14 @@
 }
 
 .blog-stickers__list-item {
-	margin-left: 16px;
+	display: inline;
+
+	&:after {
+		content: " | ";
+	}
+
+
+	&:after:last-child {
+		content: "";
+	}
 }


### PR DESCRIPTION
Some VIP sites have a very large number of blog stickers, e.g.

http://calypso.localhost:3000/read/feeds/33932

This PR makes the info popover that displays blog stickers scroll if there are a lot of stickers to show.

### To test

Try Time.com and verify that you can see all of the blog stickers:

http://calypso.localhost:3000/read/feeds/18743358