### PR TITLE
Add form for inserting/editing a Simple Payment

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 /**
  * External dependencies
  */
@@ -5,6 +7,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -12,6 +15,19 @@ import { noop } from 'lodash';
 import Dialog from 'components/dialog';
 import Navigation from './navigation';
 import Button from 'components/button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormCurrencyInput from 'components/forms/form-currency-input';
+import FormToggle from 'components/forms/form-toggle';
+
+const ProductImage = () => (
+	<div className="editor-simple-payments-modal__product-image">
+		<Gridicon icon="add-image" size={ 36 } />
+	</div>
+);
 
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
@@ -28,7 +44,7 @@ class SimplePaymentsDialog extends Component {
 		const actionButtons = [
 			<Button onClick={ onClose }>
 				{ translate( 'Cancel' ) }
-			</Button>
+			</Button>,
 		];
 
 		if ( this.props.activeTab === 'addNew' ) {
@@ -36,7 +52,7 @@ class SimplePaymentsDialog extends Component {
 				...actionButtons,
 				<Button onClick={ noop } primary>
 					{ translate( 'Insert' ) }
-				</Button>
+				</Button>,
 			];
 		}
 
@@ -44,22 +60,55 @@ class SimplePaymentsDialog extends Component {
 	}
 
 	renderAddNewForm() {
-		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-		return <div className="editor-simple-payments-modal__form">Add new</div>;
+		const { translate } = this.props;
+
+		return (
+			<form className="editor-simple-payments-modal__form">
+				<ProductImage />
+				<div className="editor-simple-payments-modal__form-fields">
+					<FormFieldset>
+						<FormLabel htmlFor="productname">{ translate( 'What are you selling?' ) }</FormLabel>
+						<FormTextInput name="productname" id="productname" />
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
+						<FormTextarea name="description" id="description" />
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="price">{ translate( 'Price' ) }</FormLabel>
+						<FormCurrencyInput
+							name="price"
+							id="price"
+							currencySymbolPrefix="$"
+							placeholder="0.00"
+						/>
+					</FormFieldset>
+					<FormFieldset>
+						<FormToggle id="allowMultipleItems">
+							{ translate( 'Allow people to buy more than one item at a time.' ) }
+						</FormToggle>
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
+						<FormTextInput name="email" id="email" />
+						<FormSettingExplanation>
+							{ translate(
+								'This is where PayPal will send your money.' +
+									" To claim a payment, you'll need a PayPal account connected to a bank account.",
+							) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				</div>
+			</form>
+		);
 	}
 
 	renderList() {
-		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		return <div className="editor-simple-payments-modal__list">Payment Buttons List</div>;
 	}
 
 	render() {
-		const {
-			activeTab,
-			showDialog,
-			onChangeTabs,
-			onClose,
-		} = this.props;
+		const { activeTab, showDialog, onChangeTabs, onClose } = this.props;
 
 		return (
 			<Dialog

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -1,12 +1,27 @@
 .editor-simple-payments-modal {
-	// TODO: temporary values until we get some content
-	width: 550px;
-	height: 450px;
-
 	&.dialog.card {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
 		padding: 0;
 		display: flex;
 		flex-direction: column;
+
+		@include breakpoint( ">660px" ) {
+			top: 5%;
+			bottom: 5%;
+			left: 5%;
+			right: 5%;
+			width: 90%;
+		}
+
+		@include breakpoint( ">960px" ) {
+			left: 12.5%;
+			right: 12.5%;
+			width: 75%;
+		}
 	}
 
 	.dialog__content {
@@ -24,12 +39,43 @@
 
 .editor-simple-payments-modal__navigation {
 	margin: 0;
+	flex: none;
 }
 
 .editor-simple-payments-modal__form {
 	padding: 16px;
+	flex: auto;
+	overflow-y: auto;
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+	}
+}
+
+.editor-simple-payments-modal__product-image {
+	width: 200px;
+	height: 200px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-bottom: 24px;
+	background-color: $gray-light;
+	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
+
+	@include breakpoint( ">660px" ) {
+		flex: none;
+		margin-right: 24px;
+	}
+}
+
+.editor-simple-payments-modal__form-fields {
+	@include breakpoint( ">660px" ) {
+		flex: auto;
+	}
 }
 
 .editor-simple-payments-modal__list {
 	padding: 8px 16px;
+	flex: auto;
+	overflow-y: auto;
 }


### PR DESCRIPTION
First version of the form that renders all the required fields and a dummy file uploader.

The file uploader renders in its own colum if the viewport is wide enough. The form is rendered as a single column in mobile.

There are responsive CSS breakpoints defined for the form and also for the whole modal. They will need some more fine tuning, but the basic structure is there. Most of the styling is reused from the `LanguagePicker` modal now.

The patch also includes some Prettier formatting changes on a few lines.

Here is how it looks like:
<img width="1004" alt="simple-payment-form" src="https://user-images.githubusercontent.com/664258/28031571-07986e82-65a8-11e7-8e58-da11f70a4d65.png">

As a next step, I'd like to make the form alive by connecting it to Redux state, and I'd like to use `redux-form` for state management, validation and submissions. It's already used in #15619 and described in p4TIVU-7nc-p2.