### PR TITLE
Framework: Removed sites-list dependency from lib/posts/stats.js

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -353,7 +353,7 @@ PostActions = {
 		}
 
 		if ( ! options || options.recordSaveEvent !== false ) {
-			recordSaveEvent( context, site ); // do this before changing status from 'future'
+			recordSaveEvent( site, context ); // do this before changing status from 'future'
 		}
 
 		if (

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -1,5 +1,4 @@
 /**
- * /*
  * External dependencies
  *
  * @format
@@ -8,24 +7,21 @@
 import debugModule from 'debug';
 import { noop } from 'lodash';
 
-/*
+/**
  * Internal dependencies
  */
 import config from 'config';
 import analytics from 'lib/analytics';
 import PostEditStore from 'lib/posts/post-edit-store';
 import utils from 'lib/posts/utils';
-import SitesList from 'lib/sites-list';
 
-/*
+/**
  * Module variables
  */
 const debug = debugModule( 'calypso:posts:stats' );
-const sites = new SitesList();
 
-function recordUsageStats( action, postType ) {
+function recordUsageStats( action, postType, site ) {
 	let source;
-	const site = sites.getSelectedSite();
 
 	analytics.mc.bumpStat( 'editor_usage', action );
 
@@ -47,7 +43,7 @@ export function recordEvent( action, label, value ) {
 	analytics.ga.recordEvent( 'Editor', action, label, value );
 }
 
-export function recordSaveEvent( context ) {
+export function recordSaveEvent( context, site ) {
 	const post = PostEditStore.get();
 	const savedPost = PostEditStore.getSavedPost();
 
@@ -88,7 +84,7 @@ export function recordSaveEvent( context ) {
 	}
 
 	if ( usageAction ) {
-		recordUsageStats( usageAction, post.type );
+		recordUsageStats( usageAction, post.type, site );
 	}
 
 	// if this action has an mc stat name, record it

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -20,7 +20,7 @@ import utils from 'lib/posts/utils';
  */
 const debug = debugModule( 'calypso:posts:stats' );
 
-function recordUsageStats( action, postType, site ) {
+function recordUsageStats( site, action, postType ) {
 	let source;
 
 	analytics.mc.bumpStat( 'editor_usage', action );
@@ -43,7 +43,7 @@ export function recordEvent( action, label, value ) {
 	analytics.ga.recordEvent( 'Editor', action, label, value );
 }
 
-export function recordSaveEvent( context, site ) {
+export function recordSaveEvent( site, context ) {
 	const post = PostEditStore.get();
 	const savedPost = PostEditStore.getSavedPost();
 
@@ -84,7 +84,7 @@ export function recordSaveEvent( context, site ) {
 	}
 
 	if ( usageAction ) {
-		recordUsageStats( usageAction, post.type, site );
+		recordUsageStats( site, usageAction, post.type );
 	}
 
 	// if this action has an mc stat name, record it


### PR DESCRIPTION
This pull request remove sites-list dependency from lib/posts/stats.js.

It is dependent on PR https://github.com/Automattic/wp-calypso/pull/16019 and https://github.com/Automattic/wp-calypso/pull/16017, that update the actions and components to pass down the site need in stats.js.