### PR TITLE
WooCommerce: Fix shipping zone routes

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list-entry.js
@@ -90,7 +90,7 @@ const ShippingZoneEntry = ( { translate, id, name, methods, currency, loaded, is
 			<div className="shipping__zones-row-actions">
 				<Button
 					compact
-					href={ getLink( `/store/settings/shipping/:site/zone/${ id }`, site ) }
+					href={ getLink( `/store/settings/shipping/zone/:site/${ id }`, site ) }
 					disabled={ ! isValid }
 					onClick={ onEditClick }>
 					{ translate( 'Edit' ) }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
@@ -74,7 +74,7 @@ class ShippingZoneList extends Component {
 		const { site, siteId, loaded, isValid, translate } = this.props;
 
 		const addNewHref = loaded
-			? getLink( '/store/settings/shipping/:site/zone/new', site )
+			? getLink( '/store/settings/shipping/zone/:site/', site )
 			: '#';
 
 		return (

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -68,7 +68,7 @@ class Shipping extends Component {
 
 		// If the zone didn't have a real ID before but it does now, change the URL from /zone/new to /zone/ID
 		if ( this.props.zone && isNaN( this.props.zone.id ) && zone && ! isNaN( zone.id ) ) {
-			page.replace( getLink( '/store/settings/shipping/:site/zone/' + zone.id, site ), null, false, false );
+			page.replace( getLink( '/store/settings/shipping/zone/:site/' + zone.id, site ), null, false, false );
 		}
 	}
 

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -119,7 +119,7 @@ const getStorePages = () => {
 		{
 			container: ShippingZone,
 			configKey: 'woocommerce/extension-settings-shipping',
-			path: '/store/settings/shipping/:site/zone/:zone',
+			path: '/store/settings/shipping/zone/:site/:zone?',
 			parentPath: '/store/settings/:site',
 		},
 		{


### PR DESCRIPTION
Our shipping zone routes put `/zone/:id` after `:site` in the route, which is incorrect. Only the `:id` should come after `:site`.

These routes are also broken right now due to #16008 because Calypso will try to redirect to a route without the site fragment, and then my code will redirect.

This updates the shipping zone routes to 

`/store/settings/shipping/zone/:site/` for new zones, and `/store/settings/shipping/zone/:site/:zone` for editing an existing zone.

To Test:
* `npm start`
* Go to `http://calypso.localhost:3000/store/settings/shipping/:site` and click the zone related links. Make sure they load, etc. Try editing a zone.
