### PR TITLE
Framework: ES Modules + Tree Shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -27,15 +27,14 @@
 					"kebabCase": true
 				}
 			}
-		],
-		"./inline-imports.js"
+		]
 	],
 	"env": {
 		"test": {
 			"plugins": [
 				[ "transform-builtin-extend", {
 					"globals": [ "Error" ]
-				} ],
+				} ]
 			]
 		}
 	}

--- a/client/boot/app.js
+++ b/client/boot/app.js
@@ -3,7 +3,7 @@
 import './polyfills';
 
 if ( process.env.NODE_ENV === 'development' ) {
-	require( 'lib/wrap-es6-functions' )();
+	require( 'lib/wrap-es6-functions' ).default();
 }
 
 /**

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -22,6 +22,9 @@ import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import { installPerfmonPageHandlers } from 'lib/perfmon';
 import { getSections, setupRoutes } from 'sections-middleware';
+import { checkFormHandler } from 'lib/protect-form';
+import notices from 'notices';
+import authController from 'auth/controller';
 
 const debug = debugFactory( 'calypso' );
 
@@ -112,7 +115,7 @@ const loggedOutMiddleware = currentUser => {
 const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {
 		// Forces OAuth users to the /login page if no token is present
-		page( '*', require( 'auth/controller' ).checkToken );
+		page( '*', authController.checkToken );
 	}
 };
 
@@ -126,12 +129,12 @@ const setRouteMiddleware = () => {
 
 const clearNoticesMiddleware = () => {
 	//TODO: remove this one when notices are reduxified - it is for old notices
-	page( '*', require( 'notices' ).clearNoticesOnNavigation );
+	page( '*', notices.clearNoticesOnNavigation );
 };
 
 const unsavedFormsMiddleware = () => {
 	// warn against navigating from changed, unsaved forms
-	page.exit( '*', require( 'lib/protect-form' ).checkFormHandler );
+	page.exit( '*', checkFormHandler );
 };
 
 export const locales = ( currentUser, reduxStore ) => {
@@ -156,7 +159,7 @@ export const utils = () => {
 	debug( 'Executing Calypso utils.' );
 
 	if ( process.env.NODE_ENV === 'development' ) {
-		require( './dev-modules' )();
+		require( './dev-modules' ).default();
 	}
 
 	// Infer touch screen by checking if device supports touch events

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -32,11 +32,15 @@ import { pruneStaleRecords } from 'lib/wp/sync-handler';
 import { setReduxStore as setSupportUserReduxStore } from 'lib/user/support-user-interop';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import Logger from 'lib/catch-js-errors';
+import setupMySitesRoute from 'my-sites';
+import setupGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
+import * as controller from 'controller';
 
 const debug = debugFactory( 'calypso' );
 
 function renderLayout( reduxStore ) {
-	const Layout = require( 'controller' ).ReduxWrappedLayout;
+	const Layout = controller.ReduxWrappedLayout;
 
 	const layoutElement = React.createElement( Layout, {
 		store: reduxStore,
@@ -89,7 +93,6 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		renderLayout( reduxStore );
 
 		if ( config.isEnabled( 'catch-js-errors' ) ) {
-			const Logger = require( 'lib/catch-js-errors' );
 			const errorLogger = new Logger();
 			//Save errorLogger to a singleton for use in arbitrary logging.
 			require( 'lib/catch-js-errors/log' ).registerLogger( errorLogger );
@@ -207,7 +210,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 		} );
 	}
 
-	require( 'my-sites' )();
+	setupMySitesRoute();
 
 	const state = reduxStore.getState();
 	if ( config.isEnabled( 'happychat' ) ) {
@@ -218,11 +221,11 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 	}
 
 	if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
-		require( 'lib/keyboard-shortcuts/global' )();
+		setupGlobalKeyboardShortcuts();
 	}
 
 	if ( config.isEnabled( 'desktop' ) ) {
-		require( 'lib/desktop' ).init();
+		require( 'lib/desktop' ).default.init();
 	}
 
 	if ( config.isEnabled( 'rubberband-scroll-disable' ) ) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -37,8 +37,6 @@ import QueryPreferences from 'components/data/query-preferences';
 /**
  * Internal dependencies
  */
-let KeyboardShortcutsMenu, SupportUser;
-
 import PropTypes from 'prop-types';
 import QuerySites from 'components/data/query-sites';
 import { isOffline } from 'state/application/selectors';
@@ -51,14 +49,9 @@ import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
+import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
+import SupportUser from 'support/support-user';
 
-if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
-	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
-}
-
-if ( config.isEnabled( 'support-user' ) ) {
-	SupportUser = require( 'support/support-user' );
-}
 /* eslint-disable react/no-deprecated */
 const Layout = createReactClass( {
 	/* eslint-enable react/no-deprecated */

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -3,9 +3,13 @@
 /**
  * External dependencies
  */
-
-import { memoize } from 'lodash';
+import { memoize, includes } from 'lodash';
 import shallowEqual from 'react-pure-render/shallowEqual';
+
+/**
+ * Internal dependencies
+ */
+import warn from 'lib/warn';
 
 /**
  * Constants
@@ -39,14 +43,7 @@ const DEFAULT_GET_DEPENDANTS = state => state;
  * @type {Function} Function returning cache key for memoized selector
  */
 const DEFAULT_GET_CACHE_KEY = ( () => {
-	let warn, includes;
-	if ( 'production' !== process.env.NODE_ENV ) {
-		// Webpack can optimize bundles if it can detect that a block will
-		// never be reached. Since `NODE_ENV` is defined using DefinePlugin,
-		// these debugging modules will be excluded from the production build.
-		warn = require( 'lib/warn' );
-		includes = require( 'lodash/includes' );
-	} else {
+	if ( 'production' === process.env.NODE_ENV ) {
 		return ( state, ...args ) => args.join();
 	}
 

--- a/client/lib/happychat/connection-ng.js
+++ b/client/lib/happychat/connection-ng.js
@@ -5,6 +5,7 @@
  */
 import IO from 'socket.io-client';
 import { isString } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -23,7 +24,7 @@ import {
 	requestTranscript,
 } from 'state/happychat/connection/actions';
 
-const debug = require( 'debug' )( 'calypso:happychat:connection' );
+const debug = debugFactory()( 'calypso:happychat:connection' );
 
 const buildConnection = socket =>
 	isString( socket )

--- a/client/lib/happychat/connection-ng.js
+++ b/client/lib/happychat/connection-ng.js
@@ -24,7 +24,7 @@ import {
 	requestTranscript,
 } from 'state/happychat/connection/actions';
 
-const debug = debugFactory()( 'calypso:happychat:connection' );
+const debug = debugFactory( 'calypso:happychat:connection' );
 
 const buildConnection = socket =>
 	isString( socket )

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -5,6 +5,7 @@
  */
 import IO from 'socket.io-client';
 import { isString } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -23,7 +24,7 @@ import {
 	requestTranscript,
 } from 'state/happychat/connection/actions';
 
-const debug = require( 'debug' )( 'calypso:happychat:connection' );
+const debug = debugFactory()( 'calypso:happychat:connection' );
 
 const buildConnection = socket =>
 	isString( socket )

--- a/client/lib/happychat/connection.js
+++ b/client/lib/happychat/connection.js
@@ -24,7 +24,7 @@ import {
 	requestTranscript,
 } from 'state/happychat/connection/actions';
 
-const debug = debugFactory()( 'calypso:happychat:connection' );
+const debug = debugFactory( 'calypso:happychat:connection' );
 
 const buildConnection = socket =>
 	isString( socket )

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -6,7 +6,8 @@
 
 import Dispatcher from 'dispatcher';
 import { flowRight, includes, partial } from 'lodash';
-const wpcom = require( 'lib/wp' ).undocumented();
+import wpLib from 'lib/wp';
+const wpcom = wpLib.undocumented();
 
 /**
  * Internal dependencies

--- a/client/lib/posts/post-list-cache-store.js
+++ b/client/lib/posts/post-list-cache-store.js
@@ -12,6 +12,7 @@ import debugFactory from 'debug';
  */
 import Dispatcher from 'dispatcher';
 import { cacheIndex } from 'lib/wp/sync-handler/cache-index';
+import PostListStoreFactory from './post-list-store-factory';
 
 let cache = {};
 const _canonicalCache = {};
@@ -114,8 +115,7 @@ function isListKeyFresh( listKey ) {
 
 PostsListCache.dispatchToken = Dispatcher.register( function( payload ) {
 	var action = payload.action,
-		PostListStore = require( './post-list-store-factory' )();
-
+		PostListStore = PostListStoreFactory();
 	Dispatcher.waitFor( [ PostListStore.dispatchToken ] );
 
 	switch ( action.type ) {

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -71,10 +71,18 @@ export const userCan = function( capability, post ) {
 	return hasCap;
 };
 
+export const isBackDatedPublished = function( post ) {
+	if ( ! post || post.status !== 'future' ) {
+		return false;
+	}
+
+	return moment( post.date ).isBefore( moment() );
+};
+
 export const isPublished = function( post ) {
 	return (
 		post &&
-		( post.status === 'publish' || post.status === 'private' || this.isBackDatedPublished( post ) )
+		( post.status === 'publish' || post.status === 'private' || isBackDatedPublished( post ) )
 	);
 };
 
@@ -96,14 +104,6 @@ export const getEditedTime = function( post ) {
 	}
 
 	return post.modified;
-};
-
-export const isBackDatedPublished = function( post ) {
-	if ( ! post || post.status !== 'future' ) {
-		return false;
-	}
-
-	return moment( post.date ).isBefore( moment() );
 };
 
 export const isFutureDated = function( post ) {
@@ -171,32 +171,6 @@ export const normalizeAsync = function( post, callback ) {
 	postNormalizer( post, [ postNormalizer.keepValidImages( 72, 72 ) ], callback );
 };
 
-export const getPermalinkBasePath = function( post ) {
-	if ( ! post ) {
-		return;
-	}
-
-	let path = post.URL;
-
-	// if we have a permalink_URL, utlize that
-	if ( ! this.isPublished( post ) && post.other_URLs && post.other_URLs.permalink_URL ) {
-		path = post.other_URLs.permalink_URL;
-	}
-
-	return this.removeSlug( path );
-};
-
-export const getPagePath = function( post ) {
-	if ( ! post ) {
-		return;
-	}
-	if ( ! this.isPublished( post ) ) {
-		return this.getPermalinkBasePath( post );
-	}
-
-	return this.removeSlug( post.URL );
-};
-
 export const removeSlug = function( path ) {
 	if ( ! path ) {
 		return;
@@ -206,6 +180,32 @@ export const removeSlug = function( path ) {
 	pathParts[ pathParts.length - 1 ] = '';
 
 	return pathParts.join( '/' );
+};
+
+export const getPermalinkBasePath = function( post ) {
+	if ( ! post ) {
+		return;
+	}
+
+	let path = post.URL;
+
+	// if we have a permalink_URL, utlize that
+	if ( ! isPublished( post ) && post.other_URLs && post.other_URLs.permalink_URL ) {
+		path = post.other_URLs.permalink_URL;
+	}
+
+	return removeSlug( path );
+};
+
+export const getPagePath = function( post ) {
+	if ( ! post ) {
+		return;
+	}
+	if ( ! isPublished( post ) ) {
+		getPermalinkBasePath( post );
+	}
+
+	return removeSlug( post.URL );
 };
 
 /**

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -7,7 +7,7 @@
 import url from 'url';
 import i18n from 'i18n-calypso';
 import moment from 'moment-timezone';
-import { includes, get } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -205,8 +205,7 @@ export const getPagePath = function( post ) {
 		return getPermalinkBasePath( post );
 	}
 
-	const postUrl = get( post, [ 'other_URLs', 'permalink_URL' ] ) || post.URL;
-	return removeSlug( postUrl );
+	return removeSlug( post.URL );
 };
 
 /**

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -202,7 +202,7 @@ export const getPagePath = function( post ) {
 		return;
 	}
 	if ( ! isPublished( post ) ) {
-		getPermalinkBasePath( post );
+		return getPermalinkBasePath( post );
 	}
 
 	const postUrl = get( post, [ 'other_URLs', 'permalink_URL' ] ) || post.URL;

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -7,7 +7,7 @@
 import url from 'url';
 import i18n from 'i18n-calypso';
 import moment from 'moment-timezone';
-import { includes } from 'lodash';
+import { includes, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -205,7 +205,8 @@ export const getPagePath = function( post ) {
 		getPermalinkBasePath( post );
 	}
 
-	return removeSlug( post.URL );
+	const postUrl = get( post, [ 'other_URLs', 'permalink_URL' ] ) || post.URL;
+	return removeSlug( postUrl );
 };
 
 /**

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -16,21 +16,23 @@ import config from 'config';
 import wpcomSupport from 'lib/wp/support';
 import { injectLocalization } from './localization';
 import { injectGuestSandboxTicketHandler } from './handlers/guest-sandbox-ticket';
+import * as oauthToken from 'lib/oauth-token';
+import wpcomXhrWrapper from 'lib/wpcom-xhr-wrapper';
+import wpcomProxyRequest from 'wpcom-proxy-request';
 
 const addSyncHandlerWrapper = config.isEnabled( 'sync-handler' );
 let wpcom;
 
 if ( config.isEnabled( 'oauth' ) ) {
-	const oauthToken = require( 'lib/oauth-token' );
 	const requestHandler = addSyncHandlerWrapper
-		? new SyncHandler( require( 'lib/wpcom-xhr-wrapper' ) )
-		: require( 'lib/wpcom-xhr-wrapper' );
+		? new SyncHandler( wpcomXhrWrapper )
+		: wpcomXhrWrapper;
 
 	wpcom = wpcomUndocumented( oauthToken.getToken(), requestHandler );
 } else {
 	const requestHandler = addSyncHandlerWrapper
-		? new SyncHandler( require( 'wpcom-proxy-request' ).default )
-		: require( 'wpcom-proxy-request' ).default;
+		? new SyncHandler( wpcomProxyRequest )
+		: wpcomProxyRequest;
 
 	wpcom = wpcomUndocumented( requestHandler );
 

--- a/client/lib/wp/node.js
+++ b/client/lib/wp/node.js
@@ -7,11 +7,13 @@
 import wpcomUndocumented from 'lib/wpcom-undocumented';
 import config from 'config';
 import { injectLocalization } from './localization';
+import wpSupportWrapper from 'lib/wp/support';
+import wpcomXhrRequest from 'wpcom-xhr-request';
 
-let wpcom = wpcomUndocumented( require( 'wpcom-xhr-request' ) );
+let wpcom = wpcomUndocumented( wpcomXhrRequest );
 
 if ( config.isEnabled( 'support-user' ) ) {
-	wpcom = require( 'lib/wp/support' )( wpcom );
+	wpcom = wpSupportWrapper( wpcom );
 }
 
 // Inject localization helpers to `wpcom` instance

--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -14,13 +14,13 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import AccountComponent from 'me/account/main';
+import username from 'lib/username';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
 	account( context, next ) {
-		const AccountComponent = require( 'me/account/main' );
-		const username = require( 'lib/username' );
 		const basePath = context.path;
 		let showNoticeInitially = false;
 

--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -5,17 +5,16 @@
  */
 
 import React from 'react';
+import BillingHistoryComponent from './main';
+import Receipt from './receipt';
 
 export default {
 	billingHistory( context, next ) {
-		const BillingHistoryComponent = require( './main' );
-
 		context.primary = React.createElement( BillingHistoryComponent );
 		next();
 	},
 
 	transaction( context, next ) {
-		const Receipt = require( './receipt' );
 		const receiptId = context.params.receiptId;
 
 		if ( receiptId ) {

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -17,13 +17,15 @@ import { sectionify } from 'lib/route';
 import userSettings from 'lib/user-settings';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
+import SidebarComponent from 'me/sidebar';
+import ProfileComponent from 'me/profile';
+import AppsComponent from 'me/get-apps';
+import NextSteps from './next-steps';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
 	sidebar( context, next ) {
-		const SidebarComponent = require( 'me/sidebar' );
-
 		context.secondary = React.createElement( SidebarComponent, {
 			context: context,
 		} );
@@ -32,8 +34,7 @@ export default {
 	},
 
 	profile( context, next ) {
-		const ProfileComponent = require( 'me/profile' ),
-			basePath = context.path;
+		const basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'My Profile', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 
@@ -47,7 +48,6 @@ export default {
 	},
 
 	apps( context, next ) {
-		const AppsComponent = require( 'me/get-apps' ).default;
 		const basePath = context.path;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Get Apps', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -62,9 +62,8 @@ export default {
 	},
 
 	nextSteps( context, next ) {
-		const analyticsBasePath = sectionify( context.path ),
-			NextSteps = require( './next-steps' ),
-			isWelcome = 'welcome' === context.params.welcome;
+		const analyticsBasePath = sectionify( context.path );
+		const isWelcome = 'welcome' === context.params.welcome;
 
 		context.store.dispatch( setTitle( i18n.translate( 'Next Steps', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -14,14 +14,20 @@ import i18n from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import notices from 'notices';
 import userSettings from 'lib/user-settings';
+import PasswordComponent from 'me/security/main';
+import accountPasswordData from 'lib/account-password-data';
+import SocialLoginComponent from 'me/social-login';
+import ConnectedAppsComponent from 'me/connected-applications';
+import connectedAppsData from 'lib/connected-applications-data';
+import appPasswordsData from 'lib/application-passwords-data';
+import TwoStepComponent from 'me/two-step';
+import AccountRecoveryComponent from 'me/security-account-recovery';
 
 const ANALYTICS_PAGE_TITLE = 'Me';
 
 export default {
 	password( context, next ) {
-		const PasswordComponent = require( 'me/security/main' );
 		const basePath = context.path;
-		const accountPasswordData = require( 'lib/account-password-data' );
 
 		if ( context.query && context.query.updated === 'password' ) {
 			notices.success( i18n.translate( 'Your password was saved successfully.' ), {
@@ -42,9 +48,7 @@ export default {
 	},
 
 	twoStep( context, next ) {
-		const TwoStepComponent = require( 'me/two-step' ),
-			basePath = context.path,
-			appPasswordsData = require( 'lib/application-passwords-data' );
+		const basePath = context.path;
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Two-Step Authentication' );
 
@@ -57,9 +61,7 @@ export default {
 	},
 
 	connectedApplications( context, next ) {
-		const ConnectedAppsComponent = require( 'me/connected-applications' ),
-			basePath = context.path,
-			connectedAppsData = require( 'lib/connected-applications-data' );
+		const basePath = context.path;
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Connected Applications' );
 
@@ -72,8 +74,7 @@ export default {
 	},
 
 	accountRecovery( context, next ) {
-		const AccountRecoveryComponent = require( 'me/security-account-recovery' ),
-			basePath = context.path;
+		const basePath = context.path;
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Recovery' );
 
@@ -85,7 +86,6 @@ export default {
 	},
 
 	socialLogin( context, next ) {
-		const SocialLoginComponent = require( 'me/social-login' );
 		const basePath = context.path;
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Social Login' );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -18,6 +18,11 @@ import productsFactory from 'lib/products-list';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GsuiteNudge from 'my-sites/checkout/gsuite-nudge';
+import Checkout from './checkout';
+import CheckoutData from 'components/data/checkout';
+import CartData from 'components/data/cart';
+import SecondaryCart from './cart/secondary-cart';
+import CheckoutThankYouComponent from './checkout-thank-you';
 
 /**
  * Module variables
@@ -34,13 +39,9 @@ const checkoutRoutes = [
 
 export default {
 	checkout: function( context, next ) {
-		const Checkout = require( './checkout' ),
-			CheckoutData = require( 'components/data/checkout' ),
-			CartData = require( 'components/data/cart' ),
-			SecondaryCart = require( './cart/secondary-cart' ),
-			{ routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes ),
-			product = context.params.product,
-			selectedFeature = context.params.feature;
+		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes );
+		const product = context.params.product;
+		const selectedFeature = context.params.feature;
 
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );
@@ -75,11 +76,6 @@ export default {
 	},
 
 	sitelessCheckout: function( context, next ) {
-		const Checkout = require( './checkout' ),
-			CheckoutData = require( 'components/data/checkout' ),
-			CartData = require( 'components/data/cart' ),
-			SecondaryCart = require( './cart/secondary-cart' );
-
 		analytics.pageView.record( '/checkout/no-site', 'Checkout' );
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
@@ -100,10 +96,9 @@ export default {
 	},
 
 	checkoutThankYou: function( context, next ) {
-		const CheckoutThankYouComponent = require( './checkout-thank-you' ),
-			{ routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes ),
-			receiptId = Number( context.params.receiptId ),
-			gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
+		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes );
+		const receiptId = Number( context.params.receiptId );
+		const gsuiteReceiptId = Number( context.params.gsuiteReceiptId ) || 0;
 
 		analytics.pageView.record( routePath, 'Checkout Thank You', routeParams );
 
@@ -130,7 +125,6 @@ export default {
 	},
 
 	gsuiteNudge( context, next ) {
-		const CartData = require( 'components/data/cart' );
 		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes );
 		const { domain, site, receiptId } = context.params;
 		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -58,6 +58,11 @@ import SitesComponent from 'my-sites/sites';
 import { isATEnabled } from 'lib/automated-transfer';
 import { warningNotice } from 'state/notices/actions';
 import { makeLayout, render as clientRender } from 'controller';
+import NoSitesMessage from 'components/empty-content/no-sites-message';
+import EmptyContentComponent from 'components/empty-content';
+import DomainOnly from 'my-sites/domains/domain-management/list/domain-only';
+import Main from 'components/main';
+import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -107,8 +112,6 @@ function removeSidebar( context ) {
 }
 
 function renderEmptySites( context ) {
-	const NoSitesMessage = require( 'components/empty-content/no-sites-message' );
-
 	removeSidebar( context );
 
 	context.primary = React.createElement( NoSitesMessage );
@@ -118,7 +121,6 @@ function renderEmptySites( context ) {
 }
 
 function renderNoVisibleSites( context ) {
-	const EmptyContentComponent = require( 'components/empty-content' );
 	const currentUser = user.get();
 	const hiddenSites = currentUser.site_count - currentUser.visible_site_count;
 	const signup_url = config( 'signup_url' );
@@ -154,8 +156,6 @@ function renderNoVisibleSites( context ) {
 }
 
 function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
-	const DomainOnly = require( 'my-sites/domains/domain-management/list/domain-only' );
-
 	reactContext.primary = <DomainOnly siteId={ selectedSite.ID } hasNotice={ false } />;
 
 	reactContext.secondary = createNavigation( reactContext );
@@ -447,8 +447,6 @@ export function navigation( context, next ) {
 
 export function jetPackWarning( context, next ) {
 	const { getState } = getStore( context );
-	const Main = require( 'components/main' );
-	const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
 	const basePath = sectionify( context.path );
 	const selectedSite = getSelectedSite( getState() );
 

--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -11,10 +11,10 @@ import React from 'react';
 import { sectionify } from 'lib/route';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import CustomizeComponent from 'my-sites/customize/main';
 
 export function customize( context, next ) {
-	const CustomizeComponent = require( 'my-sites/customize/main' ),
-		basePath = sectionify( context.path );
+	const basePath = sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Customizer' );
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -20,6 +20,12 @@ import productsFactory from 'lib/products-list';
 import { canCurrentUser } from 'state/selectors';
 import { getSelectedSiteId, getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+import CartData from 'components/data/cart';
+import DomainSearch from './domain-search';
+import SiteRedirect from './domain-search/site-redirect';
+import MapDomain from 'my-sites/domains/map-domain';
+import TransferDomain from 'my-sites/domains/transfer-domain';
+import GoogleApps from 'components/upgrades/google-apps';
 
 /**
  * Module variables
@@ -43,8 +49,6 @@ const domainsAddRedirectHeader = ( context, next ) => {
 };
 
 const domainSearch = ( context, next ) => {
-	const CartData = require( 'components/data/cart' );
-	const DomainSearch = require( './domain-search' );
 	const basePath = sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Domain Search > Domain Registration' );
@@ -66,8 +70,6 @@ const domainSearch = ( context, next ) => {
 };
 
 const siteRedirect = ( context, next ) => {
-	const CartData = require( 'components/data/cart' );
-	const SiteRedirect = require( './domain-search/site-redirect' );
 	const basePath = sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Domain Search > Site Redirect' );
@@ -84,8 +86,6 @@ const siteRedirect = ( context, next ) => {
 };
 
 const mapDomain = ( context, next ) => {
-	const CartData = require( 'components/data/cart' );
-	const MapDomain = require( 'my-sites/domains/map-domain' ).default;
 	const basePath = sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Domain Search > Domain Mapping' );
@@ -102,8 +102,6 @@ const mapDomain = ( context, next ) => {
 };
 
 const transferDomain = ( context, next ) => {
-	const CartData = require( 'components/data/cart' );
-	const TransferDomain = require( 'my-sites/domains/transfer-domain' ).default;
 	const basePath = sectionify( context.path );
 
 	analytics.pageView.record( basePath, 'Domain Search > Domain Transfer' );
@@ -119,9 +117,6 @@ const transferDomain = ( context, next ) => {
 };
 
 const googleAppsWithRegistration = ( context, next ) => {
-	const CartData = require( 'components/data/cart' );
-	const GoogleApps = require( 'components/upgrades/google-apps' );
-
 	const state = context.store.getState();
 	const siteSlug = getSelectedSiteSlug( state ) || '';
 

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -14,13 +14,13 @@ import { sectionify } from 'lib/route';
 import analytics from 'lib/analytics';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getSelectedSite } from 'state/ui/selectors';
+import MediaComponent from 'my-sites/media/main';
 
 export default {
 	media: function( context, next ) {
-		var MediaComponent = require( 'my-sites/media/main' ),
-			filter = context.params.filter,
-			search = context.query.s,
-			baseAnalyticsPath = sectionify( context.path );
+		const filter = context.params.filter;
+		const search = context.query.s;
+		let baseAnalyticsPath = sectionify( context.path );
 
 		const state = context.store.getState();
 		const selectedSite = getSelectedSite( state );

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -15,16 +15,16 @@ import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
 import trackScrollPage from 'lib/track-scroll-page';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import Pages from 'my-sites/pages/main';
 
 const controller = {
 	pages: function( context, next ) {
-		var Pages = require( 'my-sites/pages/main' ),
-			siteID = getSiteFragment( context.path ),
-			status = context.params.status,
-			search = context.query.s,
-			basePath = sectionify( context.path ),
-			analyticsPageTitle = 'Pages',
-			baseAnalyticsPath;
+		const siteID = getSiteFragment( context.path );
+		let status = context.params.status;
+		const search = context.query.s;
+		const basePath = sectionify( context.path );
+		let analyticsPageTitle = 'Pages';
+		let baseAnalyticsPath;
 
 		status = ! status || status === siteID ? '' : status;
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -13,12 +13,11 @@ import { get } from 'lodash';
  * Internal Dependencies
  */
 import { isValidFeatureKey } from 'lib/plans';
+import Plans from 'my-sites/plans/main';
+import CheckoutData from 'components/data/checkout';
 
 export default {
 	plans( context, next ) {
-		const Plans = require( 'my-sites/plans/main' ),
-			CheckoutData = require( 'components/data/checkout' );
-
 		context.primary = (
 			<CheckoutData>
 				<Plans

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -22,22 +22,22 @@ import { areAllSitesSingleUser } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import Posts from 'my-sites/posts/main';
 
 export default {
 	posts: function( context, next ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 
-		var Posts = require( 'my-sites/posts/main' ),
-			siteID = getSiteFragment( context.path ),
-			author = context.params.author === 'my' ? getCurrentUserId( state ) : null,
-			statusSlug = author ? context.params.status : context.params.author,
-			search = context.query.s,
-			category = context.query.category,
-			tag = context.query.tag,
-			basePath = sectionify( context.path ),
-			analyticsPageTitle = 'Blog Posts',
-			baseAnalyticsPath;
+		const siteID = getSiteFragment( context.path );
+		const author = context.params.author === 'my' ? getCurrentUserId( state ) : null;
+		let statusSlug = author ? context.params.status : context.params.author;
+		let search = context.query.s;
+		const category = context.query.category;
+		const tag = context.query.tag;
+		const basePath = sectionify( context.path );
+		let analyticsPageTitle = 'Blog Posts';
+		let baseAnalyticsPath;
 
 		function shouldRedirectMyPosts() {
 			if ( ! author ) {

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -22,6 +22,8 @@ import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
+import FollowList from 'lib/follow-list';
+
 const analyticsPageTitle = 'Stats';
 
 function rangeOfPeriod( period, date ) {
@@ -123,7 +125,6 @@ export default {
 	},
 
 	insights: function( context, next ) {
-		const FollowList = require( 'lib/follow-list' );
 		const basePath = sectionify( context.path );
 		const followList = new FollowList();
 
@@ -422,7 +423,6 @@ export default {
 
 	follows: function( context, next ) {
 		let siteId = context.params.site_id;
-		const FollowList = require( 'lib/follow-list' );
 		let pageNum = context.params.page_num;
 		const followList = new FollowList();
 		const basePath = sectionify( context.path );

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -77,7 +77,7 @@ function createPageDefinition( path, sectionDefinition ) {
 		preload( sectionDefinition.name )
 			.then( requiredModules => {
 				if ( ! _loadedSections[ sectionDefinition.module ] ) {
-					requiredModules.forEach( mod => mod( controller.clientRouter ) ); // if we do array
+					requiredModules.forEach( mod => mod.default( controller.clientRouter ) );
 					_loadedSections[ sectionDefinition.module ] = true;
 				}
 				return activateSection( sectionDefinition, context, next );

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -47,7 +47,10 @@ export default {
 	'site-title': SiteTitleComponent,
 	survey: SurveyStepComponent,
 	'survey-user': UserSignupComponent,
-	test: process.env.NODE_ENV === 'development' ? require( 'signup/steps/test-step' ) : undefined,
+	test:
+		process.env.NODE_ENV === 'development'
+			? require( 'signup/steps/test-step' ).default
+			: undefined,
 	themes: ThemeSelectionComponent,
 	'website-themes': ThemeSelectionComponent,
 	'blog-themes': ThemeSelectionComponent,

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -89,7 +89,9 @@ export const finishUserSettingsSave = ( { dispatch }, { settingsOverride }, data
 	// Refetch the user data after saving user settings
 	// The require() trick is used to avoid excessive mocking in unit tests.
 	// TODO: Replace it with standard 'import' when the `lib/user` module is Reduxized
-	require( 'lib/user' )().fetch();
+	require( 'lib/user' )
+		.default()
+		.fetch();
 };
 
 export default mergeHandlers(

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -89,9 +89,9 @@ export const finishUserSettingsSave = ( { dispatch }, { settingsOverride }, data
 	// Refetch the user data after saving user settings
 	// The require() trick is used to avoid excessive mocking in unit tests.
 	// TODO: Replace it with standard 'import' when the `lib/user` module is Reduxized
-	require( 'lib/user' )
-		.default()
-		.fetch();
+	const userLibModule = require( 'lib/user' );
+	const userLib = userLibModule.default ? userLibModule.default : userLibModule; // TODO: delete line after removing add-module-exports.
+	userLib().fetch();
 };
 
 export default mergeHandlers(

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -7,6 +7,7 @@
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware, compose } from 'redux';
 import { reducer as form } from 'redux-form';
+import { mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,7 +91,12 @@ import config from 'config';
  */
 
 // Consolidate the extension reducers under 'extensions' for namespacing.
-const extensions = combineReducers( extensionsModule.reducers() );
+const extensions = combineReducers(
+	mapValues(
+		extensionsModule.reducers(),
+		reducer => ( reducer.default ? reducer.default : reducer )
+	)
+);
 
 const reducers = {
 	analyticsTracking,

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -34,6 +34,7 @@ import {
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import keyboardShortcuts from 'lib/keyboard-shortcuts';
+import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 const debug = debugFactory( 'calypso:state:middleware' );
@@ -46,13 +47,13 @@ const globalKeyBoardShortcutsEnabled = config.isEnabled( 'keyboard-shortcuts' );
 let globalKeyboardShortcuts;
 
 if ( globalKeyBoardShortcutsEnabled ) {
-	globalKeyboardShortcuts = require( 'lib/keyboard-shortcuts/global' )();
+	globalKeyboardShortcuts = getGlobalKeyboardShortcuts();
 }
 
 const desktopEnabled = config.isEnabled( 'desktop' );
 let desktop;
 if ( desktopEnabled ) {
-	desktop = require( 'lib/desktop' );
+	desktop = require( 'lib/desktop' ).default;
 }
 
 /*

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -13,6 +13,8 @@ const path = require( 'path' ),
 	morgan = require( 'morgan' ),
 	pages = require( 'pages' );
 
+const analytics = require( '../lib/analytics' ).default;
+
 /**
  * Returns the server HTTP request handler "app".
  * @returns {object} The express app
@@ -80,7 +82,6 @@ function setup() {
 
 	// loaded when we detect stats blockers - see lib/analytics/index.js
 	app.get( '/nostats.js', function( request, response ) {
-		const analytics = require( '../lib/analytics' );
 		analytics.tracks.recordEvent(
 			'calypso_stats_blocked',
 			{

--- a/server/bundler/extensions-loader.js
+++ b/server/bundler/extensions-loader.js
@@ -15,7 +15,7 @@ function generateReducerRequireString( extensionDir ) {
 }
 
 function generateExtensionsModuleString( reducerRequires ) {
-	return `module.exports = {
+	return `export default {
 		reducers: function() {
 			return {
 				${ reducerRequires.join( ',\n' ) }

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -507,7 +507,9 @@ module.exports = function() {
 			} );
 
 			if ( section.isomorphic ) {
-				section.load()( serverRouter( app, setUpRoute, section ) );
+				// section.load() uses require on the server side so we also need to access the
+				// default export of it. See webpack/bundler/sections-loader.js
+				section.load().default( serverRouter( app, setUpRoute, section ) );
 			}
 		} );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,14 @@ const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
 	: ! isDevelopment;
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
+// load in the babel config from babelrc and disable commonjs transform
+// this enables static analysis from webpack including treeshaking
+// also disable add-module-exports. TODO: remove add-module-exports from babelrc. requires fixing tests
+const babelConfig = JSON.parse( fs.readFileSync( './.babelrc', { encoding: 'utf8' } ) );
+const babelPresetEnv = _.find( babelConfig.presets, preset => preset[ 0 ] === 'env' );
+babelPresetEnv[ 1 ].modules = false;
+_.remove( babelConfig.plugins, elem => elem === 'add-module-exports' );
+
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
  * {
@@ -62,10 +70,12 @@ function getAliasesForExtensions() {
 
 const babelLoader = {
 	loader: 'babel-loader',
-	options: {
+	options: Object.assign( {}, babelConfig, {
+		babelrc: false,
 		cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
 		cacheIdentifier: cacheIdentifier,
 		plugins: [
+			...babelConfig.plugins,
 			[
 				path.join(
 					__dirname,
@@ -76,8 +86,9 @@ const babelLoader = {
 				),
 				{ async: config.isEnabled( 'code-splitting' ) },
 			],
+			'inline-imports.js',
 		],
-	},
+	} ),
 };
 
 const webpackConfig = {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -26,6 +26,10 @@ const bundleEnv = config( 'env' );
  */
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
+// disable add-module-exports. TODO: remove add-module-exports from babelrc. requires fixing jest tests
+const babelConfig = JSON.parse( fs.readFileSync( './.babelrc', { encoding: 'utf8' } ) );
+_.remove( babelConfig.plugins, elem => elem === 'add-module-exports' );
+
 /**
  * This lists modules that must use commonJS `require()`s
  * All modules listed here need to be ES5.
@@ -70,7 +74,10 @@ function getExternals() {
 const babelLoader = {
 	loader: 'babel-loader',
 	options: {
+		...babelConfig,
+		babelrc: false,
 		plugins: [
+			...babelConfig.plugins,
 			[
 				path.join(
 					__dirname,


### PR DESCRIPTION
Webpack2 and Webpack 3 introduced a couple major features:

1. [native es6 modules + tree shaking](https://medium.com/webpack/webpack-2-and-beyond-40520af9067f).  This promises to make our modules smaller, compile times faster (less babel transpilation), and our code more correct (greater compile time checks).
2. [Scope Hoisting](https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b).  This feature is about making the code smaller and the runtime properties faster by removing wepback wrapper funcs in favor of direct inlining when possible.

Currently, we cant take advantage of either because we are still [transpiling](https://github.com/Automattic/wp-calypso/blob/master/.babelrc) to commonjs modules in our babel configuration.

In this PR I try to  find (and hopefully solve) all of the blockers towards disabling commonjs transpilation and enabling tree-shaking/scope hoisting.


To Test
---
Test everything on: https://dserve.a8c.com/?branch=try/scope-hoisting.
