### PR TITLE
Path Restore: Pull the moving parts out to a library

### DIFF
--- a/client/lib/restore-last-path/index.js
+++ b/client/lib/restore-last-path/index.js
@@ -19,26 +19,26 @@ function readLastPath() {
 	return localforage.getItem( LAST_PATH );
 }
 
+// Throws an Error when no path or an invalid path is provided
 function validatePath( path ) {
-	const errors = [];
+	if ( typeof path !== 'string' || ! path.length ) {
+		throw 'path is empty';
+	}
+
 	if ( ! isWhitelistedForRestoring( path ) ) {
-		errors.push( 'path is not whitelisted: ' + path );
+		throw 'path is not whitelisted: ' + path;
 	}
 
 	if ( isOutsideCalypso( path ) ) {
-		errors.push( 'path is "outside" Calypso: ' + path );
+		throw 'path is "outside" Calypso: ' + path;
 	}
-	return errors;
 }
 
 function getSavedPath() {
 	return new Promise( ( resolve, reject ) => {
 		readLastPath()
 			.then( ( lastPath ) => {
-				const errors = validatePath( lastPath );
-				if ( errors.length ) {
-					return reject( errors );
-				}
+				validatePath( lastPath );
 				resolve( lastPath );
 			} )
 			.catch( ( reason ) => reject( reason ) );
@@ -47,9 +47,10 @@ function getSavedPath() {
 
 function savePath( path ) {
 	return new Promise( ( resolve, reject ) => {
-		const errors = validatePath( path );
-		if ( errors.length ) {
-			return reject( errors );
+		try {
+			validatePath( path );
+		} catch ( e ) {
+			return reject( e );
 		}
 
 		readLastPath()

--- a/client/lib/restore-last-path/index.js
+++ b/client/lib/restore-last-path/index.js
@@ -1,0 +1,70 @@
+/**
+ * Internal dependencies
+ */
+import localforage from 'lib/localforage';
+
+/**
+ * External dependencies
+ */
+import { isOutsideCalypso } from 'lib/url';
+
+const LAST_PATH = 'last_path';
+const ALLOWED_PATHS_FOR_RESTORING = /^\/(read|stats|plans|view|posts|pages|media|types|themes|sharing|people|plugins|domains)/i;
+
+function isWhitelistedForRestoring( path ) {
+	return !! path.match( ALLOWED_PATHS_FOR_RESTORING );
+}
+
+function readLastPath() {
+	return localforage.getItem( LAST_PATH );
+}
+
+function validatePath( path ) {
+	const errors = [];
+	if ( ! isWhitelistedForRestoring( path ) ) {
+		errors.push( 'path is not whitelisted: ' + path );
+	}
+
+	if ( isOutsideCalypso( path ) ) {
+		errors.push( 'path is "outside" Calypso: ' + path );
+	}
+	return errors;
+}
+
+function getSavedPath() {
+	return new Promise( ( resolve, reject ) => {
+		readLastPath()
+			.then( ( lastPath ) => {
+				const errors = validatePath( lastPath );
+				if ( errors.length ) {
+					return reject( errors );
+				}
+				resolve( lastPath );
+			} )
+			.catch( ( reason ) => reject( reason ) );
+	} );
+}
+
+function savePath( path ) {
+	return new Promise( ( resolve, reject ) => {
+		const errors = validatePath( path );
+		if ( errors.length ) {
+			return reject( errors );
+		}
+
+		readLastPath()
+			.then( ( lastPath ) => {
+				if ( lastPath === path ) {
+					return reject( 'path is identical' );
+				}
+				localforage.setItem( LAST_PATH, path ).then( () => resolve() );
+			} )
+			.catch( ( reason ) => reject( reason ) );
+	} );
+}
+
+export default {
+	isWhitelistedForRestoring,
+	getSavedPath,
+	savePath,
+};

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
+import { isEmpty } from 'lodash';
 import page from 'page';
 
 /**
@@ -22,19 +23,19 @@ export const routingMiddleware = () => {
 			return next( action );
 		}
 
-		if ( Object.keys( action.query ).length !== 0 ) {
+		if ( ! isEmpty( action.query ) ) {
 			return next( action );
 		}
 
-		const firstRun = ! hasInitialized;
+		const isFirstRun = ! hasInitialized;
 		hasInitialized = true;
 
-		if ( firstRun && action.path === '/' ) {
+		if ( isFirstRun && action.path === '/' ) {
+			// Attempt to restore the last path on the first run
 			return getSavedPath()
 					.then( ( lastPath ) => {
 						debug( 'restoring: ' + lastPath );
 						page( lastPath );
-						return;
 					} )
 					.catch( ( reason ) => {
 						debug( 'cannot restore', reason );
@@ -42,6 +43,7 @@ export const routingMiddleware = () => {
 					} );
 		}
 
+		// Attempt to save the path so it might be restored in the future
 		savePath( action.path )
 			.then( () => debug( 'saved path: ' + action.path ) )
 			.catch( ( reason ) => debug( 'error saving path', reason ) );

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -7,50 +7,47 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import localforage from 'lib/localforage';
-import { isOutsideCalypso } from 'lib/url';
+import {
+	getSavedPath,
+	savePath,
+} from 'lib/restore-last-path';
 import { ROUTE_SET } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:restore-last-location' );
-const LAST_PATH = 'last_path';
-const ALLOWED_PATHS_FOR_RESTORING = /^\/(stats|plans|view|posts|pages|media|types|themes|sharing|people|plugins|domains)/i;
+let hasInitialized = false;
 
-const isWhitelistedForRestoring = ( path ) => {
-	return !! path.match( ALLOWED_PATHS_FOR_RESTORING );
-};
-
-export const restoreLastLocation = () => {
-	let hasInitialized = false;
-
+export const routingMiddleware = () => {
 	return ( next ) => ( action ) => {
 		if ( action.type !== ROUTE_SET || ! action.path || ! action.query ) {
 			return next( action );
 		}
 
-		localforage.getItem( LAST_PATH ).then(
-			( lastPath ) => {
-				if ( ! hasInitialized &&
-						lastPath && lastPath !== '/' &&
-						action.path === '/' && Object.keys( action.query ).length === 0 &&
-						! isOutsideCalypso( lastPath ) &&
-						isWhitelistedForRestoring( lastPath ) ) {
-					debug( 'redir to', lastPath );
-					page( lastPath );
-				} else if ( action.path !== lastPath &&
-						! isOutsideCalypso( action.path ) ) {
-					debug( 'saving', action.path );
-					localforage.setItem( LAST_PATH, action.path );
-				}
+		if ( Object.keys( action.query ).length !== 0 ) {
+			return next( action );
+		}
 
-				if ( ! hasInitialized ) {
-					hasInitialized = true;
-				}
+		const firstRun = ! hasInitialized;
+		hasInitialized = true;
 
-				return next( action );
-			},
-			() => next( action )
-		);
+		if ( firstRun && action.path === '/' ) {
+			return getSavedPath()
+					.then( ( lastPath ) => {
+						debug( 'restoring: ' + lastPath );
+						page( lastPath );
+						return;
+					} )
+					.catch( ( reason ) => {
+						debug( 'cannot restore', reason );
+						next( action );
+					} );
+		}
+
+		savePath( action.path )
+			.then( () => debug( 'saved path: ' + action.path ) )
+			.catch( ( reason ) => debug( 'error saving path', reason ) );
+
+		next( action );
 	};
 };
 
-export default restoreLastLocation;
+export default routingMiddleware;


### PR DESCRIPTION
This is a pared-down version of #15582 which only does the pulling-out of the IO pieces of the "session restore" / "restore last path" functionality to a new library called: `restore-last-path`

## To Test

Familiarize yourself with the existing behavior on the `master` branch: In dev, whitelisted routes will get saved on route change & that path will be "restored" when browsing to `/`.

* Prevent blocking state rehydration by running like so: `ENABLE_FEATURES=no-force-sympathy npm start`
* In your console, execute: `localStorage.setItem( 'debug', 'calypso:restore-last-location' )`
* Click around & watch the paths get saved in your console
* Browse directly to `/` & see the previously saved path get restored (after the Reader fully loads -- known issue)

Checkout this branch & repeat the above.

Behavior should be identical.