### PR TITLE
Editor: Fix display of future label on post status

### DIFF
--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -61,7 +61,7 @@
 	color: $white;
 	display: inline-block;
 	font-size: 10px;
-	margin: -3px 4px 0 0;
+	margin-right: 4px;
 	overflow: hidden;
 	padding: 2px 6px 2px 6px;
 	text-overflow: ellipsis;


### PR DESCRIPTION
This fixes a small display issue in the `Future` label shown on the post status.

Before | After
------------ | -------------
<img width="277" alt="screen shot 2017-07-10 at 16 48 54" src="https://user-images.githubusercontent.com/448298/28039750-6cfef6f4-6591-11e7-9fb8-7041a24c6e79.png"> | <img width="276" alt="screen shot 2017-07-10 at 16 48 33" src="https://user-images.githubusercontent.com/448298/28039747-6a041c54-6591-11e7-8d18-902c2ae04293.png">

#### Testing instructions

1. Run `git checkout fix/post-status-label` and start your server.
2. Open a blog post or [start a new one](http://calypso.localhost:3000/post).
3. Click the `Status` link in the right sidebar to open the settings.
4. Click the date and choose a publish date in the future.
5. Assert the `Future` label looks correct as above.