### PR TITLE
WooCommerce: Fix document titles for store pages.

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -4,12 +4,14 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { canCurrentUser } from 'state/selectors';
 import config from 'config';
+import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer } from 'state/selectors';
 import route from 'lib/route';
@@ -18,6 +20,7 @@ class App extends Component {
 
 	static propTypes = {
 		siteId: PropTypes.number,
+		documentTitle: PropTypes.string,
 		canUserManageOptions: PropTypes.bool.isRequired,
 		currentRoute: PropTypes.string.isRequired,
 		isAtomicSite: PropTypes.bool.isRequired,
@@ -29,7 +32,7 @@ class App extends Component {
 	}
 
 	render = () => {
-		const { siteId, children, canUserManageOptions, isAtomicSite, currentRoute } = this.props;
+		const { siteId, children, canUserManageOptions, isAtomicSite, currentRoute, translate } = this.props;
 
 		// TODO This is temporary, until we have a valid "all sites" path to show.
 		// Calypso will detect if a user doesn't have access to a site at all, and redirects to the 'all sites'
@@ -56,9 +59,12 @@ class App extends Component {
 			}
 		}
 
+		const documentTitle = this.props.documentTitle || translate( 'Store' );
+
 		const className = 'woocommerce';
 		return (
 			<div className={ className }>
+				<DocumentHead title={ documentTitle } />
 				{ children }
 			</div>
 		);
@@ -78,4 +84,4 @@ function mapStateToProps( state ) {
 	};
 }
 
-export default connect( mapStateToProps )( App );
+export default connect( mapStateToProps )( localize( App ) );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -48,6 +48,7 @@ const getStorePages = () => {
 			container: Products,
 			configKey: 'woocommerce/extension-products',
 			path: '/store/products/:site',
+			documentTitle: translate( 'Products' ),
 			sidebarItem: {
 				icon: 'product',
 				isPrimary: true,
@@ -61,6 +62,7 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-products',
 			path: '/store/product/:site',
 			parentPath: '/store/products/:site',
+			documentTitle: translate( 'New Product' ),
 			sidebarItemButton: {
 				label: translate( 'Add' ),
 				parentSlug: 'products',
@@ -73,11 +75,13 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-products',
 			path: '/store/product/:site/:product',
 			parentPath: '/store/products/:site',
+			documentTitle: translate( 'Edit Product' ),
 		},
 		{
 			container: Orders,
 			configKey: 'woocommerce/extension-orders',
 			path: '/store/orders/:site',
+			documentTitle: translate( 'Orders' ),
 			sidebarItem: {
 				icon: 'pages',
 				isPrimary: true,
@@ -91,11 +95,13 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-orders',
 			path: '/store/order/:site/:order',
 			parentPath: '/store/orders/:site',
+			documentTitle: translate( 'Order Details' ),
 		},
 		{
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings',
 			path: '/store/settings/:site',
+			documentTitle: translate( 'Payment Settings' ),
 			sidebarItem: {
 				icon: 'cog',
 				isPrimary: false,
@@ -109,24 +115,28 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-settings-payments',
 			path: '/store/settings/payments/:site',
 			parentPath: '/store/settings/:site',
+			documentTitle: translate( 'Payment Settings' ),
 		},
 		{
 			container: Shipping,
 			configKey: 'woocommerce/extension-settings-shipping',
 			path: '/store/settings/shipping/:site',
 			parentPath: '/store/settings/:site',
+			documentTitle: translate( 'Shipping Settings' ),
 		},
 		{
 			container: ShippingZone,
 			configKey: 'woocommerce/extension-settings-shipping',
 			path: '/store/settings/shipping/zone/:site/:zone?',
 			parentPath: '/store/settings/:site',
+			documentTitle: translate( 'Shipping Settings' ),
 		},
 		{
 			container: SettingsTaxes,
 			configKey: 'woocommerce/extension-settings-tax',
 			path: '/store/settings/taxes/:site',
 			parentPath: '/store/settings/:site',
+			documentTitle: translate( 'Tax Settings' ),
 		},
 	];
 };
@@ -146,8 +156,9 @@ function getStoreSidebarItemButtons() {
 function addStorePage( storePage, storeNavigation ) {
 	page( storePage.path, siteSelection, storeNavigation, function( context ) {
 		const component = React.createElement( storePage.container, { params: context.params } );
+		const appProps = storePage.documentTitle && { documentTitle: storePage.documentTitle } || {};
 		renderWithReduxStore(
-			React.createElement( App, {}, component ),
+			React.createElement( App, appProps, component ),
 			document.getElementById( 'primary' ),
 			context.store
 		);


### PR DESCRIPTION
Fixes #15956.

We haven't been using `DocumentHead`, which allows us to set the `<title>` tag of our pages. This PR fixes that, and passes document titles that match what we do in similar Calypso pages. The fallback title is just 'Store' which gets used for the dashboard and setup tasks.

To Test:
* Go to `http://calypso.localhost:3000/store/:site` and start clicking around to different pages, making sure a title is set in your browser tab (instead of the previous title sticking around).