### PR TITLE
WooCommerce: Redirect Settings Save Buttons During Setup Flow: Taxes & Shipping

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/finished-button.js
+++ b/client/extensions/woocommerce/app/settings/shipping/finished-button.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
+import {
+	areSetupChoicesLoading,
+	getFinishedInitialSetup,
+} from 'woocommerce/state/sites/setup-choices/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+
+class ShippingSettingsFinishedButton extends Component {
+
+	componentDidMount = () => {
+		const { site } = this.props;
+
+		if ( site && site.ID ) {
+			this.props.fetchSetupChoices( site.ID );
+		}
+	}
+
+	componentWillReceiveProps = ( newProps ) => {
+		const { site } = this.props;
+
+		const newSiteId = newProps.site ? newProps.site.ID : null;
+		const oldSiteId = site ? site.ID : null;
+
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchSetupChoices( newSiteId );
+		}
+	}
+
+	redirect = () => {
+		const { site } = this.props;
+		page.redirect( getLink( '/store/:site', site ) );
+	}
+
+	render() {
+		const { translate, loading, site, finishedInitialSetup } = this.props;
+
+		if ( loading || ! site ) {
+			return null;
+		}
+
+		if ( finishedInitialSetup ) {
+			return null;
+		}
+
+		return <Button onClick={ this.redirect } primary>{ translate( 'I\'m Finished' ) }</Button>;
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const loading = areSetupChoicesLoading( state );
+	const finishedInitialSetup = getFinishedInitialSetup( state );
+	return {
+		site,
+		finishedInitialSetup,
+		loading,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSetupChoices,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ShippingSettingsFinishedButton ) );

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -12,6 +12,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import SettingsNavigation from '../navigation';
+import ShippingSettingsFinishedButton from './finished-button';
 
 const ShippingHeader = ( { translate, site } ) => {
 	const breadcrumbs = [
@@ -20,7 +21,9 @@ const ShippingHeader = ( { translate, site } ) => {
 	];
 	return (
 		<div>
-			<ActionHeader breadcrumbs={ breadcrumbs } />
+			<ActionHeader breadcrumbs={ breadcrumbs }>
+				<ShippingSettingsFinishedButton />
+			</ActionHeader>
 			<SettingsNavigation activeSection="shipping" />
 		</div>
 	);

--- a/client/extensions/woocommerce/app/settings/taxes/save-button.js
+++ b/client/extensions/woocommerce/app/settings/taxes/save-button.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
+import {
+	areSetupChoicesLoading,
+	getFinishedInitialSetup,
+} from 'woocommerce/state/sites/setup-choices/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+
+class TaxSettingsSaveButton extends Component {
+
+	static propTypes = {
+		onSave: PropTypes.func.isRequired,
+	};
+
+	componentDidMount = () => {
+		const { site } = this.props;
+
+		if ( site && site.ID ) {
+			this.props.fetchSetupChoices( site.ID );
+		}
+	}
+
+	componentWillReceiveProps = ( newProps ) => {
+		const { site } = this.props;
+
+		const newSiteId = newProps.site ? newProps.site.ID : null;
+		const oldSiteId = site ? site.ID : null;
+
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchSetupChoices( newSiteId );
+		}
+	}
+
+	onSave = ( e ) => {
+		const { onSave, finishedInitialSetup, site } = this.props;
+
+		let onSuccessExtra = null;
+		if ( ! finishedInitialSetup ) {
+			onSuccessExtra = () => {
+				page.redirect( getLink( '/store/:site', site ) );
+			};
+		}
+
+		onSave( e, onSuccessExtra );
+	}
+
+	render() {
+		const { translate, loading, site, finishedInitialSetup } = this.props;
+
+		if ( loading || ! site ) {
+			return null;
+		}
+
+		const saveMessage = finishedInitialSetup ? translate( 'Save' ) : translate( 'Save & Finish' );
+
+		return (
+			<Button onClick={ this.onSave } primary>
+				{ saveMessage }
+			</Button>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const loading = areSetupChoicesLoading( state );
+	const finishedInitialSetup = getFinishedInitialSetup( state );
+	return {
+		site,
+		finishedInitialSetup,
+		loading,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSetupChoices,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( TaxSettingsSaveButton ) );


### PR DESCRIPTION
Fixes #15951.

This PR modifies the behavior of the settings save buttons slightly on the tax and shipping pages, if initial setup has not been completed. If initial setup is not complete, the taxes screen will show `Save & Finish` instead of `Save`. Clicking will save the settings like normal, but then redirect back to the dashboard so they can continue walking through the setup steps. If initial setup has been completed, then the button will function like normal.

For the shipping pages, since there are multiple zones/pages to configure, I talked with Kelly about what we wanted here. For this, there is a `I'm Finished` button that displays on the shipping settings page, as an easy way to get back to the dashboard setup steps. If initial setup is complete, this button will not show.

For payment settings, to work with the action list, see #16067. cc @belcherj 

This PR also fixes an issue I noticed with the tax settings, where sometimes the correct value would not be displayed (because we were not populating the initial state based on props).

To Test:
* Via https://developer.wordpress.com/docs/api/console/, make sure the `finished_initial_setup` flag is set to false/0.
* Go to tax settings. Verify that you see a "Save & Finish" button. Toggle something here, and click to save. Return to the page to make sure your settings saved.
* Go to shipping settings. Verify that you see an "I'm finished" button. Click it, and it should redirect you back to the dashboard.
* Set the `finished_initial_setup` back to true (or click the "I'm finished setting up" button on the main dashboard).
* Go back to the above setting screens, and make sure the buttons behave like normal.