### PR TITLE
Store Sidebar: Refactor to enable state-connected menu items

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -36,122 +36,69 @@ const getStorePages = () => {
 			container: Dashboard,
 			configKey: 'woocommerce/extension-dashboard',
 			path: '/store/:site',
-			sidebarItem: {
-				icon: 'house',
-				isPrimary: true,
-				label: translate( 'Dashboard' ),
-				slug: 'dashboard',
-				showDuringSetup: true,
-			},
 		},
 		{
 			container: Products,
 			configKey: 'woocommerce/extension-products',
-			path: '/store/products/:site',
 			documentTitle: translate( 'Products' ),
-			sidebarItem: {
-				icon: 'product',
-				isPrimary: true,
-				label: translate( 'Products' ),
-				slug: 'products',
-				showDuringSetup: false,
-			},
+			path: '/store/products/:site',
 		},
 		{
 			container: ProductCreate,
 			configKey: 'woocommerce/extension-products',
-			path: '/store/product/:site',
-			parentPath: '/store/products/:site',
 			documentTitle: translate( 'New Product' ),
-			sidebarItemButton: {
-				label: translate( 'Add' ),
-				parentSlug: 'products',
-				slug: 'product-add',
-				showDuringSetup: false,
-			},
+			path: '/store/product/:site',
 		},
 		{
 			container: ProductUpdate,
 			configKey: 'woocommerce/extension-products',
-			path: '/store/product/:site/:product',
-			parentPath: '/store/products/:site',
 			documentTitle: translate( 'Edit Product' ),
+			path: '/store/product/:site/:product',
 		},
 		{
 			container: Orders,
 			configKey: 'woocommerce/extension-orders',
-			path: '/store/orders/:site',
 			documentTitle: translate( 'Orders' ),
-			sidebarItem: {
-				icon: 'pages',
-				isPrimary: true,
-				label: translate( 'Orders' ),
-				slug: 'orders',
-				showDuringSetup: false,
-			},
+			path: '/store/orders/:site',
 		},
 		{
 			container: Order,
 			configKey: 'woocommerce/extension-orders',
-			path: '/store/order/:site/:order',
-			parentPath: '/store/orders/:site',
 			documentTitle: translate( 'Order Details' ),
+			path: '/store/order/:site/:order',
 		},
 		{
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings',
-			path: '/store/settings/:site',
 			documentTitle: translate( 'Payment Settings' ),
-			sidebarItem: {
-				icon: 'cog',
-				isPrimary: false,
-				label: translate( 'Settings' ),
-				slug: 'settings',
-				showDuringSetup: false,
-			},
+			path: '/store/settings/:site',
 		},
 		{
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings-payments',
-			path: '/store/settings/payments/:site',
-			parentPath: '/store/settings/:site',
 			documentTitle: translate( 'Payment Settings' ),
+			path: '/store/settings/payments/:site',
 		},
 		{
 			container: Shipping,
 			configKey: 'woocommerce/extension-settings-shipping',
-			path: '/store/settings/shipping/:site',
-			parentPath: '/store/settings/:site',
 			documentTitle: translate( 'Shipping Settings' ),
+			path: '/store/settings/shipping/:site',
 		},
 		{
 			container: ShippingZone,
 			configKey: 'woocommerce/extension-settings-shipping',
-			path: '/store/settings/shipping/zone/:site/:zone?',
-			parentPath: '/store/settings/:site',
 			documentTitle: translate( 'Shipping Settings' ),
+			path: '/store/settings/shipping/zone/:site/:zone?',
 		},
 		{
 			container: SettingsTaxes,
 			configKey: 'woocommerce/extension-settings-tax',
-			path: '/store/settings/taxes/:site',
-			parentPath: '/store/settings/:site',
 			documentTitle: translate( 'Tax Settings' ),
+			path: '/store/settings/taxes/:site',
 		},
 	];
 };
-
-function getStoreSidebarItems() {
-	return getStorePages().filter( storePage => storePage.sidebarItem ).map( storePage => {
-		return { path: storePage.path, ...storePage.sidebarItem };
-	} );
-}
-
-function getStoreSidebarItemButtons() {
-	return getStorePages().filter( storePage => storePage.sidebarItemButton ).map( storePage => {
-		return { path: storePage.path, ...storePage.sidebarItemButton };
-	} );
-}
 
 function addStorePage( storePage, storeNavigation ) {
 	page( storePage.path, siteSelection, storeNavigation, function( context ) {
@@ -170,8 +117,6 @@ function createStoreNavigation( context, next, storePage ) {
 		React.createElement( StoreSidebar, {
 			path: context.path,
 			page: storePage,
-			sidebarItems: getStoreSidebarItems(),
-			sidebarItemButtons: getStoreSidebarItemButtons(),
 		} ),
 		document.getElementById( 'secondary' ),
 		context.store

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -24,7 +24,7 @@ import {
 	WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-export const fetchOrders = ( siteId, page ) => ( dispatch, getState ) => {
+export const fetchOrders = ( siteId, page = 1 ) => ( dispatch, getState ) => {
 	const state = getState();
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -143,9 +143,9 @@ class StoreSidebar extends Component {
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/settings' + siteSuffix;
 		const childLinks = [
-			'/store/settings/payments' + siteSuffix,
-			'/store/settings/shipping' + siteSuffix,
-			'/store/settings/taxes' + siteSuffix,
+			'/store/settings/payments',
+			'/store/settings/shipping',
+			'/store/settings/taxes',
 		];
 		const selected = this.isItemLinkSelected( [ link, ...childLinks ] );
 		const classes = classNames( {

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -80,8 +80,7 @@ class StoreSidebar extends Component {
 				icon="house"
 				label={ translate( 'Dashboard' ) }
 				link={ link }
-				onNavigate={ this.onNavigate }
-				preloadSectionName={ 'dashboard' } />
+				onNavigate={ this.onNavigate } />
 		);
 	}
 
@@ -102,8 +101,7 @@ class StoreSidebar extends Component {
 				icon="product"
 				label={ translate( 'Products' ) }
 				link={ link }
-				onNavigate={ this.onNavigate }
-				preloadSectionName={ 'products' } >
+				onNavigate={ this.onNavigate } >
 				<SidebarButton disabled={ ! site } href={ addLink } >
 					{ translate( 'Add' ) }
 				</SidebarButton>
@@ -129,8 +127,7 @@ class StoreSidebar extends Component {
 				icon="pages"
 				label={ translate( 'Orders' ) }
 				link={ link }
-				onNavigate={ this.onNavigate }
-				preloadSectionName={ 'orders' }>
+				onNavigate={ this.onNavigate }>
 				{ orders.length
 					? <Count count={ orders.length } />
 					: null
@@ -160,8 +157,7 @@ class StoreSidebar extends Component {
 				icon="cog"
 				label={ translate( 'Settings' ) }
 				link={ link }
-				onNavigate={ this.onNavigate }
-				preloadSectionName={ 'settings' } />
+				onNavigate={ this.onNavigate } />
 		);
 	}
 

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -91,6 +91,26 @@
 		flex-grow: 1;
 		min-height: 58px;
 	}
+
+	.sidebar__menu li {
+		.count {
+			margin: 13px 8px;
+			line-height: 16px;
+			border: 1px solid darken( $sidebar-bg-color, 10% );
+			background-color: $gray-light;
+			color: darken( $gray, 20% );
+		}
+
+		&.selected .count {
+			color: $gray-dark;
+			border: 1px solid darken( $sidebar-selected-color, 10% );
+		}
+
+		&:hover .count {
+			background-color: lighten( $sidebar-bg-color, 10% );
+			color: $sidebar-text-color;
+		}
+	}
 }
 
 .is-section-woocommerce.focus-sidebar {


### PR DESCRIPTION
Fixes #15869

This PR refactors the store sidebar. Instead of generating it from the pages list in `getStorePages`, we "hard code" each item in the sidebar itself. This way we can add a state-connected Orders item, which displays a count of new orders (if any exist).

![screen shot 2017-07-10 at 6 13 56 pm](https://user-images.githubusercontent.com/541093/28042508-8f8c65a8-659b-11e7-8b55-bf71575c2fdc.png)
![screen shot 2017-07-10 at 6 13 48 pm](https://user-images.githubusercontent.com/541093/28042507-8f8485d6-659b-11e7-82e1-2de0ab8c2c2d.png)

I noticed we're using `preloadSectionName=slug` in the generated `SidebarItem`s, do we have preloading set up? Should we be using an extension-scoped section name here? For example, `preloadSectionName=settings` loads the chunk for site settings. I've copied it over for this PR, but we should probably remove it before merging this (I don't think we need to worry about preloading yet...) — just looking for a second opinion.

**To test:**

- Load up this branch
- Click through pages and make sure links work, menu items are highlighted when they should be
- Make sure it works during setup, when only "Dashboard" should display