### PR TITLE
WooCommerce: Update payment settings save button to redirect during initial setup

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -69,6 +69,11 @@ class SettingsPayments extends Component {
 		if ( ! finishedInitialSetup ) {
 			successAction = () => {
 				page.redirect( getLink( '/store/:site', site ) );
+
+				return successNotice(
+					translate( 'Payment settings saved.' ),
+					{ duration: 4000, displayOnNextPage: true }
+				);
 			};
 		}
 

--- a/client/extensions/woocommerce/state/data-layer/ui/payments/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/payments/index.js
@@ -121,7 +121,7 @@ export default {
 			 * @param {Function} dispatch - dispatch function
 			 */
 			const onSuccess = ( dispatch ) => {
-				dispatch( successAction );
+				dispatch( successAction( dispatch ) );
 				dispatch( actionListClear() );
 			};
 			/**


### PR DESCRIPTION
See #16065 and #15951.
Depends on #15995.

This PR applies similar logic to #16065, where the user will be redirected after a successful save, if they are in the initial setup flow.

To Test:
* Via https://developer.wordpress.com/docs/api/console/, make sure the `finished_initial_setup` flag is set to false/0.
* Go to payment settings. Verify that you see a "Save & Finish" button. Toggle something here, and click to save. Return to the page to make sure your settings saved.
* Set the `finished_initial_setup` back to true (or click the "I'm finished setting up" button on the main dashboard).
* Go back to the above setting screens, and make sure the buttons behave like normal.