### PR TITLE
lib/url: Add omitUrlParams utility.

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -1,8 +1,11 @@
 /**
  * External dependencies
  */
-import { parse as parseUrl } from 'url';
-import { startsWith } from 'lodash';
+import {
+	format as formatUrl,
+	parse as parseUrl,
+} from 'url';
+import { omit, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -154,6 +157,25 @@ function resemblesUrl( query ) {
 	return true;
 }
 
+/**
+ * Removes given params from a url.
+ *
+ * @param  {String} url URL to be cleaned
+ * @param  {Array|String}  paramsToOmit The collection of params or single param to reject
+ * @return {String} Url less the omitted params.
+ */
+function omitUrlParams( url, paramsToOmit ) {
+	if ( ! url ) {
+		return null;
+	}
+
+	const parsed = parseUrl( url, true );
+	parsed.query = omit( parsed.query, paramsToOmit );
+
+	delete parsed.search;
+	return formatUrl( parsed );
+}
+
 export default {
 	isOutsideCalypso,
 	isExternal,
@@ -166,4 +188,5 @@ export default {
 	// [TODO]: Move lib/route/add-query-args contents here
 	addQueryArgs,
 	resemblesUrl,
+	omitUrlParams,
 };

--- a/client/lib/url/test/index.js
+++ b/client/lib/url/test/index.js
@@ -14,6 +14,7 @@ import {
 	setUrlScheme,
 	urlToSlug,
 	resemblesUrl,
+	omitUrlParams,
 } from '../';
 
 describe( 'withoutHttp', () => {
@@ -326,5 +327,46 @@ describe( 'resemblesUrl()', () => {
 	it( 'should return false if the string is not a URL', () => {
 		const source = 'exampledotcom';
 		expect( resemblesUrl( source ) ).to.equal( false );
+	} );
+} );
+
+describe( 'omitUrlParams()', () => {
+	context( 'when no URL is supplied', () => {
+		it( 'should return null if the string is not a URL', () => {
+			const actual = omitUrlParams();
+			const expected = null;
+			expect( actual ).to.equal( expected );
+		} );
+	} );
+
+	context( 'when a URL is supplied', () => {
+		context( 'when no omitting params are supplied', () => {
+			it( 'should return the URL without modification', () => {
+				const url = 'http://example.com/path?query=banana&query2=pineapple&query3=avocado';
+				const actual = omitUrlParams( url );
+				const expected = 'http://example.com/path?query=banana&query2=pineapple&query3=avocado';
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+
+		context( 'when a single omitting param is supplied as a string', () => {
+			it( 'should return the URL with that param removed', () => {
+				const url = 'http://example.com/path?query=banana&query2=pineapple&query3=avocado';
+				const param = 'query2';
+				const actual = omitUrlParams( url, param );
+				const expected = 'http://example.com/path?query=banana&query3=avocado';
+				expect( actual ).to.equal( expected );
+			} );
+		} );
+
+		context( 'when an array of omitting params is supplied', () => {
+			it( 'should return the URL with each of those params removed', () => {
+				const url = 'http://example.com/path?query=banana&query2=pineapple&query3=avocado';
+				const params = [ 'query', 'query2' ];
+				const actual = omitUrlParams( url, params );
+				const expected = 'http://example.com/path?query3=avocado';
+				expect( actual ).to.equal( expected );
+			} );
+		} );
 	} );
 } );

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -3,13 +3,13 @@
  */
 import React from 'react';
 import url from 'url';
-import omit from 'lodash/omit';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { omitUrlParams } from 'lib/url';
 import WebPreview from 'components/web-preview';
 import WebPreviewContent from 'components/web-preview/content';
 
@@ -88,13 +88,7 @@ const EditorPreview = React.createClass( {
 	},
 
 	cleanExternalUrl( externalUrl ) {
-		if ( ! externalUrl ) {
-			return null;
-		}
-		const parsed = url.parse( externalUrl, true );
-		parsed.query = omit( parsed.query, 'iframe', 'frame-nonce' );
-		delete parsed.search;
-		return url.format( parsed );
+		return omitUrlParams( externalUrl, [ 'iframe', 'frame-nonce' ] );
 	},
 
 	render() {


### PR DESCRIPTION
As part of an effort to display a URL in `site-preview` that reflects the state of the site being previewed I aim to make some existing logic from the `editor-preview` more widely available.
This PR aims to move this particular chunk of logic in to `lib/url`. This seemed the most fitting new home for it, but I'm open to suggestions :)

### Testing
This one may be a little awkward to test.
- Go to the `post-editor` by clicking edit on one of your posts.
- Click on the 'View Post' (externally) button: <img width="23" alt="screen shot 2017-07-11 at 01 41 12" src="https://user-images.githubusercontent.com/4335450/28046440-83ccc7ea-65db-11e7-9c02-a667f7183372.png">

- Check that the URL shown in the new tab is free from the params: 'iframe' & 'frame-nonce'.

### Notes:
A quick way to see both the original URL and cleaned URL is to modify `cleanExternalUrl` a little:
```js
cleanExternalUrl( externalUrl ) {
	const newUrl = omitUrlParams( externalUrl, [ 'iframe', 'frame-nonce' ] );
	console.log( 'cleanExternalUrl', externalUrl, newUrl );
	return newUrl;
},
```

There is an issue with `collection[]=item1&collection[]=item2&collection[]=item3` formatted URLs, though this applies to the logic already in place. It may be a tricky nut to crack so I'm suggesting to either cross that bridge if ever we come to it, or handle this in another PR.
