### PR TITLE
Checkout: use a localized date format for the renewal notice

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -316,7 +316,7 @@ const Checkout = React.createClass( {
 							args: {
 								productName: renewalItem.product_name,
 								duration: i18n.moment.duration( { days: renewalItem.bill_period } ).humanize(),
-								date: i18n.moment( product.expiry ).format( 'MMM DD, YYYY' ),
+								date: i18n.moment( product.expiry ).format( 'LL' ),
 								email: product.user_email
 							}
 						}


### PR DESCRIPTION
When using specific format like `'MMM DD, YYYY'` with `moment.format()`, the result is not localized. Example:
![screenshot_2017-07-11-08-36-10-276_com android chrome](https://user-images.githubusercontent.com/844866/28052649-e25ecca2-6614-11e7-898f-1bc80ffd19bb.png)
