### PR TITLE
Woo-Connect Insights: use existing site-stats-module, refactor widget-list and styling

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -67,30 +67,22 @@ class StoreStats extends Component {
 		const widgetPath = `/${ unit }/${ slug }${ querystring ? '?' : '' }${ querystring || '' }`;
 
 		const widgetList1 = (
-			<div className="store-stats__widgets-column spark-widgets" key="sparkwidgets1">
-				<WidgetList
-					siteId={ siteId }
-					header={ null }
-					emptyMessage={ translate( 'No data found.' ) }
-					query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
-					selectedDate={ endSelectedDate }
-					statType="statsOrders"
-					widgets={ sparkWidgetList1 }
-				/>
-			</div>
-			);
+			<WidgetList
+				siteId={ siteId }
+				query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
+				selectedDate={ endSelectedDate }
+				statType="statsOrders"
+				widgets={ sparkWidgetList1 }
+			/>
+		);
 		const widgetList2 = (
-			<div className="store-stats__widgets-column spark-widgets" key="sparkwidgets2">
-				<WidgetList
-					siteId={ siteId }
-					header={ null }
-					emptyMessage={ translate( 'No data found.' ) }
-					query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
-					selectedDate={ endSelectedDate }
-					statType="statsOrders"
-					widgets={ sparkWidgetList2 }
-				/>
-			</div>
+			<WidgetList
+				siteId={ siteId }
+				query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
+				selectedDate={ endSelectedDate }
+				statType="statsOrders"
+				widgets={ sparkWidgetList2 }
+			/>
 		);
 
 		return (
@@ -123,8 +115,18 @@ class StoreStats extends Component {
 					/>
 				</StatsPeriodNavigation>
 				<div className="store-stats__widgets">
-					{ widgetList1 }
-					{ widgetList2 }
+					<div className="store-stats__widgets-column spark-widgets" key="sparkwidgets">
+						<Module
+							siteId={ siteId }
+							header={ null }
+							emptyMessage={ translate( 'No data found.' ) }
+							query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
+							statType="statsOrders"
+						>
+							{ widgetList1 }
+							{ widgetList2 }
+						</Module>
+					</div>
 					{ topWidgets.map( widget => {
 						const header = (
 							<SectionHeader href={ widget.basePath + widgetPath }>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -48,7 +48,7 @@ class StoreStatsModule extends Component {
 		const isLoading = ! loaded && ! ( data && data.length );
 		const hasEmptyData = loaded && data && data.length === 0;
 		return (
-			<div>
+			<div className="store-stats-module">
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				{ header }
 				{ isLoading && <Card><StatsModulePlaceholder isLoading={ isLoading } /></Card> }
@@ -61,8 +61,9 @@ class StoreStatsModule extends Component {
 
 export default connect(
 	( state, { siteId, statType, query } ) => {
+		const statsData = getSiteStatsNormalizedData( state, siteId, statType, query );
 		return {
-			data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+			data: ( statType === 'statsOrders' ) ? statsData.data : statsData,
 			requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
 		};
 	}

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -4,24 +4,20 @@
 import React, { PropTypes, Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { find, findIndex, isEqual } from 'lodash';
+import { find, findIndex } from 'lodash';
 import { moment, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import Delta from 'woocommerce/components/delta';
-import ErrorPanel from 'my-sites/stats/stats-error';
 import { formatValue } from '../utils';
 import { getPeriodFormat } from 'state/stats/lists/utils';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData
 } from 'state/stats/lists/selectors';
-import QuerySiteStats from 'components/data/query-site-stats';
 import Sparkline from 'woocommerce/components/sparkline';
-import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
 import Table from 'woocommerce/components/table';
 import TableItem from 'woocommerce/components/table/table-item';
 import TableRow from 'woocommerce/components/table/table-row';
@@ -29,27 +25,12 @@ import TableRow from 'woocommerce/components/table/table-row';
 class StoreStatsWidgetList extends Component {
 
 	static propTypes = {
-		data: PropTypes.object.isRequired, // TODO refactor to array :(
-		emptyMessage: PropTypes.string,
+		data: PropTypes.array.isRequired,
+		deltas: PropTypes.array.isRequired,
 		selectedDate: PropTypes.string.isRequired,
-		siteId: PropTypes.number,
-		statType: PropTypes.string,
 		query: PropTypes.object.isRequired,
 		widgets: PropTypes.array.isRequired,
 	};
-
-	state = {
-		loaded: false
-	};
-
-	componentWillReceiveProps( nextProps ) {
-		if ( ! nextProps.requesting && this.props.requesting ) {
-			this.setState( { loaded: true } );
-		}
-		if ( ! isEqual( nextProps.query, this.props.query ) && this.state.loaded ) {
-			this.setState( { loaded: false } );
-		}
-	}
 
 	getEndPeriod = ( date ) => {
 		const { unit } = this.props.query;
@@ -60,7 +41,7 @@ class StoreStatsWidgetList extends Component {
 	};
 
 	getDeltasBySelectedPeriod = () => {
-		return find( this.props.data.deltas, ( item ) =>
+		return find( this.props.deltas, ( item ) =>
 			item.period === this.props.selectedDate
 		);
 	};
@@ -74,111 +55,95 @@ class StoreStatsWidgetList extends Component {
 	};
 
 	render() {
-		const { siteId, statType, query, data, emptyMessage, widgets } = this.props;
-		const selectedIndex = this.getSelectedIndex( data.data );
-		const { loaded } = this.state;
-		const isLoading = ! loaded && ! ( data && data.data.length );
-		const hasEmptyData = loaded && data && data.data.length === 0;
-		let values = [];
-		let titles = null;
-		let widgetData = null;
-		let widgetList = null;
+		const { data, deltas, query, widgets } = this.props;
+		const selectedIndex = this.getSelectedIndex( data );
+		const firstRealKey = Object.keys( deltas[ selectedIndex ] ).filter( key => key !== 'period' )[ 0 ];
+		const sincePeriod = this.getDeltaByStat( firstRealKey );
+		const periodFormat = getPeriodFormat( query.unit, sincePeriod.reference_period );
+		const values = [
+			{
+				key: 'title',
+				label: translate( 'Stat' )
+			},
+			{
+				key: 'value',
+				label: translate( 'Value' )
+			},
+			{
+				key: 'sparkline',
+				label: translate( 'Trend' )
+			},
+			{
+				key: 'delta',
+				label: `${ translate( 'Since' ) } ${ moment( sincePeriod.reference_period, periodFormat ).format( 'MMM D' ) }`
+			}
+		];
 
-		if ( ! isLoading && ! hasEmptyData ) {
-			const firstRealKey = Object.keys( data.deltas[ selectedIndex ] ).filter( key => key !== 'period' )[ 0 ];
-			const sincePeriod = this.getDeltaByStat( firstRealKey );
-			const periodFormat = getPeriodFormat( query.unit, sincePeriod.reference_period );
-			values = [
-				{
-					key: 'title',
-					label: translate( 'Stat' )
-				},
-				{
-					key: 'value',
-					label: translate( 'Value' )
-				},
-				{
-					key: 'sparkline',
-					label: translate( 'Trend' )
-				},
-				{
-					key: 'delta',
-					label: `${ translate( 'Since' ) } ${ moment( sincePeriod.reference_period, periodFormat ).format( 'MMM D' ) }`
-				}
-			];
+		const titles = (
+			<TableRow isHeader>
+				{ values.map( ( value, i ) => {
+					return (
+						<TableItem
+							className={ classnames( 'store-stats-widget-list__table-item', value.key ) }
+							isHeader
+							key={ i }
+							isTitle={ 0 === i }
+						>
+							{ value.label }
+						</TableItem>
+					);
+				} ) }
+			</TableRow>
+		);
 
-			titles = (
-				<TableRow isHeader>
-					{ values.map( ( value, i ) => {
-						return (
-							<TableItem
-								className={ classnames( 'store-stats-widget-list__table-item', value.key ) }
-								isHeader
-								key={ i }
-								isTitle={ 0 === i }
-							>
-								{ value.label }
-							</TableItem>
-						);
-					} ) }
-				</TableRow>
-			);
-
-			widgetData = widgets.map( widget => {
-				const timeSeries = data.data.map( row => +row[ widget.key ] );
-				const delta = this.getDeltaByStat( widget.key );
-				const deltaValue = ( delta.direction === 'is-undefined-increase' )
-					? '-'
-					: Math.abs( Math.round( delta.percentage_change * 100 ) );
-				return {
-					title: widget.title,
-					value: formatValue( timeSeries[ selectedIndex ], widget.format, sincePeriod.currency ),
-					sparkline: <Sparkline
-						aspectRatio={ 3 }
-						data={ timeSeries }
-						highlightIndex={ selectedIndex }
-						maxHeight={ 50 }
-					/>,
-					delta: <Delta
-						value={ `${ deltaValue }%` }
-						className={ `${ delta.favorable } ${ delta.direction }` }
-					/>
-				};
-			} );
-			widgetList = (
-				<Table header={ titles }>
-					{ widgetData.map( ( row, i ) => (
-						<TableRow className="store-stats-widget-list__table-row" key={ i }>
-							{ values.map( ( value, j ) => (
-								<TableItem
-									className={ classnames( 'store-stats-widget-list__table-item', value.key ) }
-									key={ value.key }
-									isTitle={ 0 === j }
-								>
-									{ row[ value.key ] }
-								</TableItem>
-							) ) }
-						</TableRow>
-					) ) }
-				</Table>
-			);
-		}
+		const widgetData = widgets.map( widget => {
+			const timeSeries = data.map( row => +row[ widget.key ] );
+			const delta = this.getDeltaByStat( widget.key );
+			const deltaValue = ( delta.direction === 'is-undefined-increase' )
+				? '-'
+				: Math.abs( Math.round( delta.percentage_change * 100 ) );
+			return {
+				title: widget.title,
+				value: formatValue( timeSeries[ selectedIndex ], widget.format, sincePeriod.currency ),
+				sparkline: <Sparkline
+					aspectRatio={ 3 }
+					data={ timeSeries }
+					highlightIndex={ selectedIndex }
+					maxHeight={ 50 }
+				/>,
+				delta: <Delta
+					value={ `${ deltaValue }%` }
+					className={ `${ delta.favorable } ${ delta.direction }` }
+				/>
+			};
+		} );
 
 		return (
-			<div>
-				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
-				{ isLoading && <Card><StatsModulePlaceholder isLoading={ isLoading } /></Card> }
-				{ ! isLoading && hasEmptyData && <Card><ErrorPanel message={ emptyMessage } /></Card> }
-				{ ! isLoading && ! hasEmptyData && widgetList }
-			</div>
+			<Table className="store-stats-widget-list" header={ titles }>
+				{ widgetData.map( ( row, i ) => (
+					<TableRow className="store-stats-widget-list__table-row" key={ i }>
+						{ values.map( ( value, j ) => (
+							<TableItem
+								className={ classnames( 'store-stats-widget-list__table-item', value.key ) }
+								key={ value.key }
+								isTitle={ 0 === j }
+							>
+								{ row[ value.key ] }
+							</TableItem>
+						) ) }
+					</TableRow>
+				) ) }
+			</Table>
 		);
 	}
 }
 
 export default connect(
 	( state, { siteId, statType, query } ) => {
+		const siteStats = getSiteStatsNormalizedData( state, siteId, statType, query );
 		return {
-			data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+			data: siteStats.data,
+			deltas: siteStats.deltas,
 			requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
 		};
 	}

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -24,7 +24,27 @@
 		width: calc( 33% - 3px );
 
 		&.spark-widgets {
-			width: calc( 50% - 3px );
+			width: 100%;
+
+			.store-stats-module {
+				display: flex;
+				flex-direction: row;
+				flex-wrap: wrap;
+
+				.card {
+					width: 100%;
+				}
+
+				.store-stats-widget-list {
+					width: calc( 50% - 8px );
+					&:first-child {
+						margin-left: 0;
+					}
+					&:last-child {
+						margin-right: 0;
+					}
+				}
+			}
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/store-stats/test/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/test/utils.js
@@ -10,9 +10,10 @@ import { moment } from 'i18n-calypso';
 import {
 	calculateDelta,
 	formatValue,
+	getDelta,
+	getEndPeriod,
 	getQueryDate,
-	getUnitPeriod,
-	getEndPeriod
+	getUnitPeriod
 } from '../utils';
 import { UNITS } from '../constants';
 
@@ -204,5 +205,41 @@ describe( 'formatValue', () => {
 		const response = formatValue( 'string', 'text' );
 		assert.isString( response );
 		assert.strictEqual( response, 'string' );
+	} );
+} );
+
+const deltas = [
+	{
+		period: '2017-07-07',
+		right: {
+			right: true,
+			period: '2017-07-06'
+		},
+		wrong: {
+			right: false,
+			period: '2017-07-06'
+		}
+	},
+	{
+		period: '2017-07-06',
+		right: {
+			right: true,
+			period: '2017-07-06'
+		},
+		wrong: {
+			right: false,
+			period: '2017-07-06'
+		}
+	}
+];
+describe( 'getDelta', () => {
+	it( 'should return an Object', () => {
+		const delta = getDelta( deltas, '2017-07-06', 'right' );
+		assert.isObject( delta );
+	} );
+	it( 'should return the correct delta', () => {
+		const delta = getDelta( deltas, '2017-07-06', 'right' );
+		assert.strictEqual( delta.right, true );
+		assert.strictEqual( delta.period, '2017-07-06' );
 	} );
 } );

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
+import { find, includes } from 'lodash';
 import classnames from 'classnames';
 import { moment } from 'i18n-calypso';
 
@@ -122,4 +122,19 @@ export function formatValue( value, format, code ) {
 		default:
 			return value;
 	}
+}
+
+/**
+ * Given a date, return the delta object for a specific stat
+ *
+ * @param {array} deltas - an array of delta objects
+ * @param {string} selectedDate - string of date in 'YYYY-MM-DD'
+ * @param {string} stat - string of stat to be referenced
+ * @return {array} - array of delta objects matching selectedDate
+*/
+export function getDelta( deltas, selectedDate, stat ) {
+	const selectedDeltas = find( deltas, ( item ) =>
+		item.period === selectedDate
+	);
+	return selectedDeltas[ stat ];
 }

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -141,7 +141,7 @@ export function getSerializedStatsQuery( query = {} ) {
  * @return {array} - Array of data objects
  */
 function parseOrderDeltas( payload ) {
-	if ( ! payload || ! payload.deltas || ! payload.delta_fields || Object.keys( payload.deltas ).length === 0 ) {
+	if ( ! payload || ! payload.deltasv2 || ! payload.delta_fields || Object.keys( payload.deltasv2 ).length === 0 ) {
 		return [];
 	}
 	return payload.deltasv2.map( row => { // will be renamed to deltas


### PR DESCRIPTION
- removed redundant/duplicate code from `store-stats-widget-list` to use `store-stats-module`
- updated styling
- consolidated helper methods and added tests
- didn't quite get to refactor `statsOrders`, which is returned as an `Object` with data and deltas; ideally, there are 2 calls (1 for each) but these are coupled with the statType used to get the data from `getSiteStatsForQuery`

Fixes #15762 
