### PR TITLE
Comments: Get rid of CommentFaker

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,25 +71,12 @@ export class CommentDetailReply extends Component {
 		const {
 			commentId,
 			commentStatus,
-			currentUser,
 			postId,
-			postTitle,
-			postUrl,
-			submitComment,
+			replyComment,
 		} = this.props;
 		const { commentText } = this.state;
 
-		const comment = {
-			authorAvatarUrl: get( currentUser, 'avatar_URL', '' ),
-			authorName: get( currentUser, 'display_name', '' ),
-			authorUrl: get( currentUser, 'primary_blog_url', '' ),
-			parentId: commentId,
-			postId: postId,
-			postTitle: postTitle,
-			content: commentText,
-			URL: postUrl,
-		};
-		submitComment( comment, { alsoApprove: 'approved' !== commentStatus } );
+		replyComment( commentText, postId, commentId, { alsoApprove: 'approved' !== commentStatus } );
 		this.setState( { commentText: '' } );
 	}
 

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -54,9 +54,9 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 
 	setBulkStatus = ( commentIds, status ) => this.setCommentStatusOrLike( commentIds, { status } );
 
-	setCommentLike = ( commentId, postId, i_like ) => this.setCommentStatusOrLike( [ commentId ], { i_like } );
+	setCommentLike = ( commentId, i_like ) => this.setCommentStatusOrLike( [ commentId ], { i_like } );
 
-	setCommentStatus = ( commentId, postId, status ) => this.setCommentStatusOrLike( [ commentId ], { status } );
+	setCommentStatus = ( commentId, status ) => this.setCommentStatusOrLike( [ commentId ], { status } );
 
 	/**
 	 * Sets a status and/or a like value to a list of comments.

--- a/client/blocks/comment-detail/docs/comment-faker.jsx
+++ b/client/blocks/comment-detail/docs/comment-faker.jsx
@@ -54,9 +54,9 @@ export const CommentFaker = WrappedCommentList => class extends Component {
 
 	setBulkStatus = ( commentIds, status ) => this.setCommentStatusOrLike( commentIds, { status } );
 
-	setCommentLike = ( commentId, i_like ) => this.setCommentStatusOrLike( [ commentId ], { i_like } );
+	setCommentLike = ( commentId, postId, i_like ) => this.setCommentStatusOrLike( [ commentId ], { i_like } );
 
-	setCommentStatus = ( commentId, status ) => this.setCommentStatusOrLike( [ commentId ], { status } );
+	setCommentStatus = ( commentId, postId, status ) => this.setCommentStatusOrLike( [ commentId ], { status } );
 
 	/**
 	 * Sets a status and/or a like value to a list of comments.

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -40,9 +40,9 @@ export class CommentDetail extends Component {
 		postAuthorDisplayName: PropTypes.string,
 		postTitle: PropTypes.string,
 		repliedToComment: PropTypes.bool,
+		replyComment: PropTypes.func,
 		setCommentStatus: PropTypes.func,
 		siteId: PropTypes.number,
-		submitComment: PropTypes.func,
 		toggleCommentLike: PropTypes.func,
 		toggleCommentSelected: PropTypes.func,
 	};
@@ -133,8 +133,8 @@ export class CommentDetail extends Component {
 			postId,
 			postTitle,
 			repliedToComment,
+			replyComment,
 			siteId,
-			submitComment,
 		} = this.props;
 
 		const postUrl = `/read/blogs/${ siteId }/posts/${ postId }`;
@@ -212,7 +212,7 @@ export class CommentDetail extends Component {
 							commentStatus={ commentStatus }
 							postId={ postId }
 							postTitle={ postTitle }
-							submitComment={ submitComment }
+							replyComment={ replyComment }
 						/>
 					</div>
 				}

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -81,8 +81,8 @@ export class CommentDetail extends Component {
 	edit = () => noop;
 
 	toggleApprove = () => {
-		const { commentId, commentStatus, setCommentStatus } = this.props;
-		setCommentStatus( commentId, 'approved' === commentStatus ? 'unapproved' : 'approved' );
+		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
+		setCommentStatus( commentId, postId, 'approved' === commentStatus ? 'unapproved' : 'approved' );
 	}
 
 	toggleExpanded = () => {
@@ -90,8 +90,8 @@ export class CommentDetail extends Component {
 	}
 
 	toggleLike = () => {
-		const { commentId, toggleCommentLike } = this.props;
-		toggleCommentLike( commentId );
+		const { commentId, postId, toggleCommentLike } = this.props;
+		toggleCommentLike( commentId, postId );
 	}
 
 	toggleSelected = () => {
@@ -100,13 +100,13 @@ export class CommentDetail extends Component {
 	}
 
 	toggleSpam = () => {
-		const { commentId, commentStatus, setCommentStatus } = this.props;
-		setCommentStatus( commentId, 'spam' === commentStatus ? 'approved' : 'spam' );
+		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
+		setCommentStatus( commentId, postId, 'spam' === commentStatus ? 'approved' : 'spam' );
 	}
 
 	toggleTrash = () => {
-		const { commentId, commentStatus, setCommentStatus } = this.props;
-		setCommentStatus( commentId, 'trash' === commentStatus ? 'approved' : 'trash' );
+		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
+		setCommentStatus( commentId, postId, 'trash' === commentStatus ? 'approved' : 'trash' );
 	}
 
 	render() {
@@ -169,6 +169,7 @@ export class CommentDetail extends Component {
 					deleteCommentPermanently={ this.deleteCommentPermanently }
 					isBulkEdit={ isBulkEdit }
 					isExpanded={ isExpanded }
+					postId={ postId }
 					postTitle={ postTitle }
 					toggleApprove={ this.toggleApprove }
 					toggleExpanded={ this.toggleExpanded }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -72,9 +72,9 @@ export class CommentDetail extends Component {
 	}
 
 	deleteCommentPermanently = () => {
-		const { commentId, deleteCommentPermanently, translate } = this.props;
+		const { commentId, deleteCommentPermanently, postId, translate } = this.props;
 		if ( isUndefined( window ) || window.confirm( translate( 'Delete this comment permanently?' ) ) ) {
-			deleteCommentPermanently( commentId );
+			deleteCommentPermanently( commentId, postId );
 		}
 	}
 

--- a/client/components/data/query-site-comments/index.jsx
+++ b/client/components/data/query-site-comments/index.jsx
@@ -18,8 +18,8 @@ export class QuerySiteComments extends Component {
 		requestComments( this.props );
 	}
 
-	componentDidUpdate( { siteId } ) {
-		if ( siteId !== this.props.siteId ) {
+	componentDidUpdate( { siteId, status } ) {
+		if ( siteId !== this.props.siteId || status !== this.props.status ) {
 			requestComments( this.props );
 		}
 	}

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -35,8 +35,8 @@ export class CommentList extends Component {
 		likeComment: PropTypes.func, // real action
 		setBulkStatus: PropTypes.func,
 		setCommentLike: PropTypes.func, // CommentFaker
-		setCommentsPage: PropTypes.func, // CommentFaker
-		setCommentStatus: PropTypes.func,
+		setCommentsPage: PropTypes.func,
+		setCommentStatus: PropTypes.func, // CommentFaker
 		siteId: PropTypes.number,
 		status: PropTypes.string,
 		translate: PropTypes.func,

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, keyBy, keys, map, omit, size } from 'lodash';
+import { find, get, keyBy, keys, map, noop, omit, size } from 'lodash';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 /**
@@ -349,6 +349,7 @@ const mapStateToProps = ( state, { siteId } ) => {
 const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 	changeCommentStatus: ( commentId, postId, status ) => dispatch( changeCommentStatus( siteId, postId, commentId, status ) ),
 	createNotice: ( status, text, options ) => dispatch( createNotice( status, text, options ) ),
+	deleteComment: () => noop,
 	likeComment: ( commentId, postId ) => dispatch( likeComment( siteId, postId, commentId ) ),
 	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 	unlikeComment: ( commentId, postId ) => dispatch( unlikeComment( siteId, postId, commentId ) ),

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -222,13 +222,12 @@ export class CommentList extends Component {
 
 		if ( 'unapproved' === comment.status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
-			this.showNotice( commentId, postId, 'approved', 'unapproved' );
+			this.setCommentStatus( commentId, postId, 'approved' );
 		}
 
 		if ( comment.i_like ) {
 			this.props.unlikeComment( commentId, postId );
 		} else {
-			// Also automagically approves the comment
 			this.props.likeComment( commentId, postId );
 		}
 	}

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -35,7 +35,7 @@ export class CommentList extends Component {
 		comments: PropTypes.array,
 		commentsCount: PropTypes.number,
 		commentsPage: PropTypes.number,
-		deleteCommentPermanently: PropTypes.func,
+		deleteComment: PropTypes.func,
 		likeComment: PropTypes.func,
 		replyComment: PropTypes.func,
 		setBulkStatus: PropTypes.func,
@@ -68,11 +68,11 @@ export class CommentList extends Component {
 		this.props.setCommentsPage( page );
 	}
 
-	deleteCommentPermanently = commentId => {
+	deleteCommentPermanently = ( commentId, postId ) => {
 		this.props.removeNotice( `comment-notice-${ commentId }` );
-		this.showNotice( commentId, 'delete', 'trash' );
+		this.showNotice( commentId, postId, 'delete', 'trash' );
 
-		this.props.deleteCommentPermanently( commentId );
+		this.props.deleteComment( commentId, postId );
 	}
 
 	getComment = commentId => find( this.props.comments, [ 'ID', commentId ] );

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -16,7 +16,6 @@ import { getNotices } from 'state/notices/selectors';
 import getSiteComments from 'state/selectors/get-site-comments';
 import CommentDetail from 'blocks/comment-detail';
 import CommentDetailPlaceholder from 'blocks/comment-detail/comment-detail-placeholder';
-import CommentFaker from 'blocks/comment-detail/docs/comment-faker';
 import CommentNavigation from '../comment-navigation';
 import EmptyContent from 'components/empty-content';
 import Pagination from 'my-sites/stats/pagination';
@@ -277,7 +276,7 @@ export class CommentList extends Component {
 
 		return (
 			<div className="comment-list">
-				<QuerySiteComments siteId={ siteId } status="all" />
+				<QuerySiteComments siteId={ siteId } status={ status } />
 
 				<CommentNavigation
 					isBulkEdit={ isBulkEdit }
@@ -335,8 +334,8 @@ export class CommentList extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId } ) => {
-	const comments = getSiteComments( state, siteId );
+const mapStateToProps = ( state, { siteId, status } ) => {
+	const comments = getSiteComments( state, siteId, status );
 	const isLoading = ! hasSiteComments( state, siteId );
 	return {
 		comments,
@@ -355,4 +354,4 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 	unlikeComment: ( commentId, postId ) => dispatch( unlikeComment( siteId, postId, commentId ) ),
 } );
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentFaker( CommentList ) ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentList ) );

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -129,7 +129,8 @@ export function changeCommentStatus( siteId, postId, commentId, status ) {
 			type: COMMENTS_CHANGE_STATUS,
 			siteId,
 			postId,
-			commentId
+			commentId,
+			status
 		} );
 
 		return wpcom.site( siteId ).comment( commentId ).update( { status } ).then( data => dispatch( {

--- a/client/state/selectors/get-site-comments.js
+++ b/client/state/selectors/get-site-comments.js
@@ -1,27 +1,35 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { filter, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
 
+function filterCommentsByStatus( comments, status ) {
+	return 'all' === status
+		? filter( comments, comment => ( 'approved' === comment.status || 'unapproved' === comment.status ) )
+		: filter( comments, comment => ( status === comment.status ) );
+}
+
 /**
- * Returns list of loaded comments for a given site
+ * Returns list of loaded comments for a given site, filtered by status
  *
  * @param {Object} state Redux state
- * @param {Number} siteId site for whose comments to find
- * @returns {Array<Object>} available comments for site
+ * @param {Number} siteId Site for whose comments to find
+ * @param {String} [status=unapproved] Status to filter comments
+ * @returns {Array<Object>} Available comments for site, filtered by status
  */
 export const getSiteComments = createSelector(
-	( state, siteId ) => {
+	( state, siteId, status = 'unapproved' ) => {
 		const comments = get( state, 'comments.items', {} );
-
-		return Object.keys( comments )
+		const parsedComments = Object.keys( comments )
 			.filter( key => parseInt( key.split( '-', 1 ), 10 ) === siteId )
 			.reduce( ( list, key ) => [ ...list, ...comments[ key ] ], [] );
+
+		return filterCommentsByStatus( parsedComments, status );
 	},
 	state => [ state.comments.items ]
 );


### PR DESCRIPTION
This PR aims to remove the `CommentFaker` component, used for early user testing, and replace it with the real data and actions.

## What's Included

- The comment list, filterable by status.
- Like and unlike actions.
- Change status action.
- Undo change status.
- Like and approve logic (liking an unapproved comment also approves it).
- Undo like and approve.
- Reply to comment.
- Approve and reply logic (replying to an unapproved comment also approves it).

## What's not included

- Bulk actions.
- Undo approve and reply (slated to m2).
- Delete permanently (we don't have the action yet).
- Comments pagination.
- When loading Comment Management on an empty status list, we get an infinite placeholder. It gets fixed by simply changing status list. It will permanently fixed with #15891.

## Notes

- I'm not sure what would be the best approach for bulk actions: a loop of single dispatches? A new action that dispatches a list of comment IDs?

- I've noticed that the comment actions use `postId` everywhere and I wondered if (and why) it's really necessary.

cc @Automattic/lannister 