### PR TITLE
Fixed some bugs when editing and saving Shipping Zone Methods

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
@@ -217,6 +217,9 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, defaultOrder, state )
 			...omit( method, '_originalId' ),
 			order: originalMethod.order,
 		};
+		if ( isNil( method.enabled ) ) { // If the user didn't change the "Enabled" toggle, use the value from the original method
+			method.enabled = originalMethod.enabled;
+		}
 	} else if ( 'object' === typeof method._originalId ) {
 		method = {
 			...omit( method, '_originalId' ),

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
@@ -140,6 +140,8 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE ] = ( state ) => {
 				...state.creates,
 				{
 					...currentlyEditingChanges,
+					// If the "Enabled" toggle hasn't been modified in the current changes, use the value from the old method
+					enabled: isNil( currentlyEditingChanges.enabled ) ? ( method && method.enabled ) : currentlyEditingChanges.enabled,
 					id: nextCreateId( state ),
 					_originalId: originalId
 				}
@@ -199,6 +201,7 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CHANGE_TYPE ] = ( state, action ) => {
 		id: state.currentlyEditingId,
 		title,
 		methodType,
+		enabled: state.currentlyEditingChanges && state.currentlyEditingChanges.enabled,
 	};
 
 	return { ...state,

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/reducer.js
@@ -20,7 +20,7 @@ import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_TOGGLE_OPENED_ENABLED,
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_UPDATED,
 } from 'woocommerce/state/action-types';
-import { nextBucketIndex, getBucket } from 'woocommerce/state/ui/helpers';
+import { getBucket } from 'woocommerce/state/ui/helpers';
 import flatRate from './flat-rate/reducer';
 import freeShipping from './free-shipping/reducer';
 import localPickup from './local-pickup/reducer';
@@ -42,10 +42,23 @@ export const initialState = {
 
 const reducer = {};
 
+/**
+ * Gets the temporal ID object that the next created method should have.
+ * @param {Object} state Current edit state
+ * @return {Object} Object with an "index" property, guaranteed to be unique
+ */
+const nextCreateId = ( state ) => {
+	return {
+		index: isEmpty( state.creates )
+			? 0
+			: state.creates[ state.creates.length - 1 ].id.index + 1,
+	};
+};
+
 reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_ADD ] = ( state, action ) => {
 	const { methodType, title } = action;
-	const id = nextBucketIndex( state.creates );
-	let method = { id, methodType, enabled: true };
+	const id = nextCreateId( state );
+	let method = { id, methodType };
 	if ( builtInShippingMethods[ methodType ] ) {
 		method = {
 			...method,
@@ -127,7 +140,7 @@ reducer[ WOOCOMMERCE_SHIPPING_ZONE_METHOD_CLOSE ] = ( state ) => {
 				...state.creates,
 				{
 					...currentlyEditingChanges,
-					id: nextBucketIndex( state.creates ),
+					id: nextCreateId( state ),
 					_originalId: originalId
 				}
 			],

--- a/client/extensions/woocommerce/state/ui/shipping/zones/methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/methods/test/selectors.js
@@ -72,7 +72,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: 7, title: 'MyOldMethodTitle' } ] );
+			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: 7, title: 'MyOldMethodTitle', enabled: true } ] );
 		} );
 
 		it( 'should overlay method updates', () => {
@@ -105,7 +105,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: 7, title: 'MyNewMethodTitle' } ] );
+			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: 7, title: 'MyNewMethodTitle', enabled: true } ] );
 		} );
 
 		it( 'should overlay method deletes', () => {
@@ -139,7 +139,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: 8, title: 'Title8' } ] );
+			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: 8, title: 'Title8', enabled: true } ] );
 		} );
 
 		it( 'should overlay method creates', () => {
@@ -170,7 +170,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: { index: 0 }, title: 'NewMethod' } ] );
+			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [ { id: { index: 0 }, title: 'NewMethod', enabled: true } ] );
 		} );
 
 		it( 'should work for newly-created zones', () => {
@@ -199,7 +199,9 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getShippingZoneMethods( state, { index: 0 } ) ).to.deep.equal( [ { id: { index: 0 }, title: 'MyNewMethodTitle' } ] );
+			expect( getShippingZoneMethods( state, { index: 0 } ) ).to.deep.equal( [
+				{ id: { index: 0 }, title: 'MyNewMethodTitle', enabled: true },
+			] );
 		} );
 
 		it( 'should sort the shipping methods', () => {
@@ -242,10 +244,10 @@ describe( 'selectors', () => {
 			} );
 
 			expect( getShippingZoneMethods( state, 1 ) ).to.deep.equal( [
-				{ id: { index: 1 }, title: 'ConvertedMethod7', _originalId: 7 },
-				{ id: 8, title: 'NewTitle8', order: 2 },
-				{ id: { index: 2 }, title: 'ConvertedMethod0', _originalId: { index: 0 } },
-				{ id: { index: 3 }, title: 'NewMethod3' },
+				{ id: { index: 1 }, title: 'ConvertedMethod7', _originalId: 7, enabled: true },
+				{ id: 8, title: 'NewTitle8', order: 2, enabled: true },
+				{ id: { index: 2 }, title: 'ConvertedMethod0', _originalId: { index: 0 }, enabled: true },
+				{ id: { index: 3 }, title: 'NewMethod3', enabled: true },
 			] );
 		} );
 	} );
@@ -326,7 +328,7 @@ describe( 'selectors', () => {
 			} );
 
 			expect( getCurrentlyEditingShippingZoneMethods( state ) ).to.deep.equal( [
-				{ id: 7, title: 'MyNewMethodTitle', foo: 'bar' },
+				{ id: 7, title: 'MyNewMethodTitle', foo: 'bar', enabled: true },
 			] );
 		} );
 
@@ -369,7 +371,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getCurrentlyEditingShippingZoneMethods( state ) ).to.deep.equal( [ { id: 9, title: 'Title9' } ] );
+			expect( getCurrentlyEditingShippingZoneMethods( state ) ).to.deep.equal( [ { id: 9, title: 'Title9', enabled: true } ] );
 		} );
 
 		it( 'should overlay method creates in the zone currently being edited', () => {
@@ -407,7 +409,9 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getCurrentlyEditingShippingZoneMethods( state ) ).to.deep.equal( [ { id: { index: 0 }, title: 'NewMethod' } ] );
+			expect( getCurrentlyEditingShippingZoneMethods( state ) ).to.deep.equal( [
+				{ id: { index: 0 }, title: 'NewMethod', enabled: true },
+			] );
 		} );
 	} );
 
@@ -513,7 +517,7 @@ describe( 'selectors', () => {
 			const state = createState( {
 				site: {
 					shippingZones: [
-						{ id: 1, methodIds: [ 7, 8 ] },
+						{ id: 1, methodIds: [ 7 ] },
 					],
 					shippingZoneMethods: {
 						7: { id: 7, methodType: 'free_shipping' },
@@ -631,6 +635,7 @@ describe( 'selectors', () => {
 									updates: [],
 									deletes: [],
 									currentlyEditingId: 7,
+									currentlyEditingChanges: {},
 								}
 							},
 						},
@@ -638,7 +643,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( { id: 7, title: 'methodTitle' } );
+			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( { id: 7, title: 'methodTitle', enabled: true } );
 		} );
 
 		it( 'should overlay method updates', () => {
@@ -673,6 +678,7 @@ describe( 'selectors', () => {
 									updates: [],
 									deletes: [],
 									currentlyEditingId: 7,
+									currentlyEditingChanges: {},
 								}
 							},
 						},
@@ -680,7 +686,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( { id: 7, title: 'MyNewMethodTitle' } );
+			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( { id: 7, title: 'MyNewMethodTitle', enabled: true } );
 		} );
 
 		it( 'should work for newly-created methods', () => {
@@ -713,6 +719,7 @@ describe( 'selectors', () => {
 									updates: [],
 									deletes: [],
 									currentlyEditingId: { index: 0 },
+									currentlyEditingChanges: {},
 								}
 							},
 						},
@@ -720,7 +727,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( { id: { index: 0 }, title: 'NewMethod' } );
+			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( { id: { index: 0 }, title: 'NewMethod', enabled: true } );
 		} );
 
 		it( 'should overlay method updates and currently added changes', () => {
@@ -763,7 +770,12 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( { id: 7, title: 'MyNewMethodTitle', cost: 123 } );
+			expect( getCurrentlyOpenShippingZoneMethod( state ) ).to.deep.equal( {
+				id: 7,
+				title: 'MyNewMethodTitle',
+				cost: 123,
+				enabled: true
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
This PR groups the solution to 3 bugs related to editing methods inside a shipping zone. Each fix has its own commit to make it easier to review, but I thought it was better to group all into the same PR to make testing easier.

https://github.com/Automattic/wp-calypso/commit/8c588a23906f01230f0a6afd3752bf0faf7df7e0: If in the same save operation you both remove and add methods, sometimes 2 or more methods could get the same `order` property returned by the API, or even get the wrong `order` property. With this fix, methods that have been "changed" into another type will preserve their original order (so the illusion that you "changed" the method instead of nuking it and creating a new one is preserved), and new methods will be added at the end of the list, in order of creation. In `master`, sometimes after hitting the `Save` button, the methods would reorder themselves. That shouldn't hapen anymore.

https://github.com/Automattic/wp-calypso/commit/1e18f6e69c9d2b9c358b79bc77228249eaacdf1a: Create a new method. Create another new method. Delete the first one. Create another one. With those steps, in `master`, you would end up with 2 methods with the same "temporal ID", and if you edited one of them (its price, for example) it would change in both of them. With this fix, it should never happen again. Implementation note: `id: { index: N }` doesn't mean `position N in the creates array`, maybe in the future we should change that property name for something less error-prone.

https://github.com/Automattic/wp-calypso/commit/2986199f765a49e9d3008eb3b9fa6e105c2766b6: The handling of the `ENABLED`/`DISABLED` state was a mess. I've fixed it with a few key points:
* A method is `enabled` by default, unless it has been explicitly toggled to `disabled`. Thus, a simple `truthy` check isn't enough.
* If (and only **if**) the method `enabled` state has changed inside the modal, that state must be preserver.
* `enabled` state should be preserver when changing a method's type.

To test this last fix, play with the `Enabled` toggle. Disable a method and then immediately change its type, create a method but disable it before closing the modal, enable a method but cancel the modal, save the changes every now and then, etc. Go crazy. This should be rock-solid now.