### PR TITLE
Activity log: Restore progress polling proposal

### DIFF
--- a/client/components/data/poll-rewind-restore-status/index.js
+++ b/client/components/data/poll-rewind-restore-status/index.js
@@ -24,8 +24,6 @@ class PollRewindRestoreStatus extends PureComponent {
 		pollWait: 1500,
 	};
 
-	pollTimeout = null;
-
 	query( props ) {
 		const {
 			getRewindRestoreProgress,
@@ -34,18 +32,10 @@ class PollRewindRestoreStatus extends PureComponent {
 			timestamp,
 		} = props;
 		if ( siteId, timestamp, restoreId ) {
-			this.pollTimeout = setTimeout(
+			setTimeout(
 				() => getRewindRestoreProgress( siteId, timestamp, restoreId ),
 				props.pollWait
 			);
-		}
-	}
-
-	stopPolling() {
-		if ( this.pollTimeout ) {
-			debug( 'Clearing timeout' );
-			clearTimeout( this.pollTimeout );
-			this.pollTimeout = null;
 		}
 	}
 
@@ -58,18 +48,12 @@ class PollRewindRestoreStatus extends PureComponent {
 			freshness,
 			restoreId,
 		} = this.props;
-		debug( 'CWUpdate next: %o this: %o', this.props, nextProps );
 		if (
 			restoreId !== nextProps.restoreId ||
 			freshness !== nextProps.freshness
 		) {
-			this.stopPolling();
 			this.query( nextProps );
 		}
-	}
-
-	componentWillUnmount() {
-		this.stopPolling();
 	}
 
 	render() {

--- a/client/components/data/poll-rewind-restore-status/index.js
+++ b/client/components/data/poll-rewind-restore-status/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { PropTypes, PureComponent } from 'react';
-import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import { pick } from 'lodash';
 
@@ -11,8 +10,6 @@ import { pick } from 'lodash';
  */
 import { getRestoreProgress } from 'state/selectors';
 import { getRewindRestoreProgress as getRewindRestoreProgressAction } from 'state/activity-log/actions';
-
-const debug = debugFactory( 'calypso:activity-log:poll-restore-progress' );
 
 class PollRewindRestoreStatus extends PureComponent {
 	static propTypes = {
@@ -53,7 +50,6 @@ class PollRewindRestoreStatus extends PureComponent {
 	}
 
 	componentWillMount() {
-		debug( 'CWMount', this.props );
 		this.query( this.props );
 	}
 

--- a/client/components/data/poll-rewind-restore-status/index.js
+++ b/client/components/data/poll-rewind-restore-status/index.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { PropTypes, PureComponent } from 'react';
+import debugFactory from 'debug';
+import { connect } from 'react-redux';
+import { pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRestoreProgress } from 'state/selectors';
+import { getRewindRestoreProgress as getRewindRestoreProgressAction } from 'state/activity-log/actions';
+
+const debug = debugFactory( 'calypso:activity-log:poll-restore-progress' );
+
+class PollRewindRestoreStatus extends PureComponent {
+	static propTypes = {
+		freshness: PropTypes.number,
+		pollWait: PropTypes.number.isRequired,
+		restoreId: PropTypes.number,
+		siteId: PropTypes.number.isRequired,
+		timestamp: PropTypes.number,
+	};
+
+	static defaultProps = {
+		pollWait: 1500,
+	};
+
+	pollTimeout = null;
+
+	query( props ) {
+		const {
+			getRewindRestoreProgress,
+			restoreId,
+			siteId,
+			timestamp,
+		} = props;
+		if ( siteId, timestamp, restoreId ) {
+			this.pollTimeout = setTimeout(
+				() => getRewindRestoreProgress( siteId, timestamp, restoreId ),
+				props.pollWait
+			);
+		}
+	}
+
+	stopPolling() {
+		if ( this.pollTimeout ) {
+			debug( 'Clearing timeout' );
+			clearTimeout( this.pollTimeout );
+			this.pollTimeout = null;
+		}
+	}
+
+	componentWillMount() {
+		debug( 'CWMount', this.props );
+		this.query( this.props );
+	}
+
+	componentWillUpdate( nextProps ) {
+		const {
+			freshness,
+			restoreId,
+		} = this.props;
+		debug( 'CWUpdate next: %o this: %o', this.props, nextProps );
+		if (
+			restoreId !== nextProps.restoreId ||
+			freshness !== nextProps.freshness
+		) {
+			this.stopPolling();
+			this.query( nextProps );
+		}
+	}
+
+	componentWillUnmount() {
+		this.stopPolling();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state, { siteId } ) => pick( getRestoreProgress( state, siteId ), [
+		'freshness',
+		'restoreId',
+		'timestamp',
+	] ),
+	{
+		getRewindRestoreProgress: getRewindRestoreProgressAction,
+	}
+)( PollRewindRestoreStatus );

--- a/client/components/data/query-rewind-restore-status/README.md
+++ b/client/components/data/query-rewind-restore-status/README.md
@@ -1,0 +1,79 @@
+Query Rewind Restore Status
+===========================
+
+`QueryRewindRestoreStatus` is a React component which dispatches actions for querying the status of a Rewind restore.
+
+## Usage
+
+Render the component, passing `siteId` and `restoreId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+This query component differs slightly from other query components. It accepts `delay` and `freshness` props. When used in combination, these two props allow for "polling", i.e. repeating the same query. Whenever the `restoreId` or `freshness` props change, the component knows it should dispatch a new query. When the data is received, `freshness` should be change accordingly and the component will dispatch.
+
+This is very useful for checking the progress of a restore because by providing freshness we can poll for updates. We can also rely on persisted state to resume checking the status of a restore.
+
+```jsx
+import React from 'react';
+import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
+
+export default function MyComponent( props ) {
+	return (
+		<div>
+			<QueryRewindRestoreStatus
+				freshness={ freshness }
+				delay={ 1500 }
+				restoreId={ restoreId }
+				siteId={ siteId }
+			/>
+			<RewindRestore restoreProgress={ restoreProgress } />
+		</div>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which terms should be requested.
+
+### `restoreId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The restore ID to be queried. If not provided, no query will be dispatched.
+
+### `timestamp`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The requested restore timestamp. If not provided, no query will be dispatched.
+
+### `delay`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+	<tr><th>Default</th><td>0</td></tr>
+</table>
+
+The query will be delayed by this amount (ms).
+
+### `freshness`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Freshness will be compared when props are changed to know if a new query should be dispatched.

--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -3,7 +3,10 @@
  */
 import { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { pick } from 'lodash';
+import {
+	delay,
+	pick,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,17 +14,17 @@ import { pick } from 'lodash';
 import { getRestoreProgress } from 'state/selectors';
 import { getRewindRestoreProgress as getRewindRestoreProgressAction } from 'state/activity-log/actions';
 
-class PollRewindRestoreStatus extends PureComponent {
+class QueryRewindRestoreStatus extends PureComponent {
 	static propTypes = {
 		freshness: PropTypes.number,
-		pollWait: PropTypes.number.isRequired,
+		queryDelay: PropTypes.number.isRequired,
 		restoreId: PropTypes.number,
 		siteId: PropTypes.number.isRequired,
 		timestamp: PropTypes.number,
 	};
 
 	static defaultProps = {
-		pollWait: 1500,
+		queryDelay: 1500,
 	};
 
 	query( props ) {
@@ -32,9 +35,12 @@ class PollRewindRestoreStatus extends PureComponent {
 			timestamp,
 		} = props;
 		if ( siteId, timestamp, restoreId ) {
-			setTimeout(
-				() => getRewindRestoreProgress( siteId, timestamp, restoreId ),
-				props.pollWait
+			delay(
+				getRewindRestoreProgress,
+				props.queryDelay,
+				siteId,
+				timestamp,
+				restoreId,
 			);
 		}
 	}
@@ -70,4 +76,4 @@ export default connect(
 	{
 		getRewindRestoreProgress: getRewindRestoreProgressAction,
 	}
-)( PollRewindRestoreStatus );
+)( QueryRewindRestoreStatus );

--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -3,15 +3,11 @@
  */
 import { PropTypes, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import {
-	delay,
-	pick,
-} from 'lodash';
+import { delay } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getRestoreProgress } from 'state/selectors';
 import { getRewindRestoreProgress as getRewindRestoreProgressAction } from 'state/activity-log/actions';
 
 class QueryRewindRestoreStatus extends PureComponent {
@@ -30,6 +26,7 @@ class QueryRewindRestoreStatus extends PureComponent {
 	query( props ) {
 		const {
 			getRewindRestoreProgress,
+			queryDelay,
 			restoreId,
 			siteId,
 			timestamp,
@@ -37,7 +34,7 @@ class QueryRewindRestoreStatus extends PureComponent {
 		if ( siteId, timestamp, restoreId ) {
 			delay(
 				getRewindRestoreProgress,
-				props.queryDelay,
+				queryDelay,
 				siteId,
 				timestamp,
 				restoreId,
@@ -67,13 +64,6 @@ class QueryRewindRestoreStatus extends PureComponent {
 	}
 }
 
-export default connect(
-	( state, { siteId } ) => pick( getRestoreProgress( state, siteId ), [
-		'freshness',
-		'restoreId',
-		'timestamp',
-	] ),
-	{
-		getRewindRestoreProgress: getRewindRestoreProgressAction,
-	}
-)( QueryRewindRestoreStatus );
+export default connect( null, {
+	getRewindRestoreProgress: getRewindRestoreProgressAction,
+} )( QueryRewindRestoreStatus );

--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -24,7 +24,7 @@ class QueryRewindRestoreStatus extends PureComponent {
 	};
 
 	static defaultProps = {
-		queryDelay: 1500,
+		queryDelay: 0,
 	};
 
 	query( props ) {

--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -16,7 +16,7 @@ class QueryRewindRestoreStatus extends PureComponent {
 		queryDelay: PropTypes.number.isRequired,
 		restoreId: PropTypes.number,
 		siteId: PropTypes.number.isRequired,
-		timestamp: PropTypes.number,
+		timestamp: PropTypes.number.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityLogBanner from './index';
 import ProgressBar from 'components/progress-bar';
-import PollRewindRestoreStatus from 'components/data/poll-rewind-restore-status';
+import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
 
 function ProgressBanner( {
 	moment,
@@ -28,7 +28,7 @@ function ProgressBanner( {
 			status="info"
 			title={ translate( 'Currently restoring your site' ) }
 		>
-			<PollRewindRestoreStatus siteId={ siteId } />
+			<QueryRewindRestoreStatus siteId={ siteId } />
 			<p>{ translate(
 				"We're in the process of restoring your site back to %s. " +
 				"You'll be notified once it's complete.",

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -35,6 +35,7 @@ function ProgressBanner( {
 				queryDelay={ 1500 }
 				restoreId={ restoreId }
 				siteId={ siteId }
+				timestamp={ timestamp }
 			/>
 			<p>{ translate(
 				"We're in the process of restoring your site back to %s. " +

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -18,6 +18,8 @@ function ProgressBanner( {
 	siteId,
 	timestamp,
 	translate,
+	freshness,
+	restoreId,
 } ) {
 	const restoreStatusDescription = status === 'queued'
 		? translate( 'Your restore will start in a moment.' )
@@ -28,7 +30,12 @@ function ProgressBanner( {
 			status="info"
 			title={ translate( 'Currently restoring your site' ) }
 		>
-			<QueryRewindRestoreStatus siteId={ siteId } queryDelay={ 1500 } />
+			<QueryRewindRestoreStatus
+				freshness={ freshness }
+				queryDelay={ 1500 }
+				restoreId={ restoreId }
+				siteId={ siteId }
+			/>
 			<p>{ translate(
 				"We're in the process of restoring your site back to %s. " +
 				"You'll be notified once it's complete.",

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -28,7 +28,7 @@ function ProgressBanner( {
 			status="info"
 			title={ translate( 'Currently restoring your site' ) }
 		>
-			<QueryRewindRestoreStatus siteId={ siteId } />
+			<QueryRewindRestoreStatus siteId={ siteId } queryDelay={ 1500 } />
 			<p>{ translate(
 				"We're in the process of restoring your site back to %s. " +
 				"You'll be notified once it's complete.",

--- a/client/my-sites/stats/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/progress-banner.jsx
@@ -9,11 +9,13 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityLogBanner from './index';
 import ProgressBar from 'components/progress-bar';
+import PollRewindRestoreStatus from 'components/data/poll-rewind-restore-status';
 
 function ProgressBanner( {
 	moment,
 	percent,
 	status,
+	siteId,
 	timestamp,
 	translate,
 } ) {
@@ -26,6 +28,7 @@ function ProgressBanner( {
 			status="info"
 			title={ translate( 'Currently restoring your site' ) }
 		>
+			<PollRewindRestoreStatus siteId={ siteId } />
 			<p>{ translate(
 				"We're in the process of restoring your site back to %s. " +
 				"You'll be notified once it's complete.",
@@ -50,6 +53,7 @@ function ProgressBanner( {
 
 ProgressBanner.propTypes = {
 	percent: PropTypes.number.isRequired,
+	siteId: PropTypes.number,
 	status: PropTypes.oneOf( [
 		'queued',
 		'running',

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -150,7 +150,9 @@ class ActivityLog extends Component {
 		const {
 			errorCode,
 			failureReason,
+			freshness,
 			percent,
+			restoreId,
 			siteTitle,
 			status,
 			timestamp,
@@ -178,7 +180,9 @@ class ActivityLog extends Component {
 		}
 		return (
 			<ProgressBanner
+				freshness={ freshness }
 				percent={ percent }
+				restoreId={ restoreId }
 				siteId={ siteId }
 				status={ status }
 				timestamp={ timestamp }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -151,8 +151,8 @@ class ActivityLog extends Component {
 			errorCode,
 			failureReason,
 			percent,
-			status,
 			siteTitle,
+			status,
 			timestamp,
 		} = restoreProgress;
 
@@ -179,6 +179,7 @@ class ActivityLog extends Component {
 		return (
 			<ProgressBanner
 				percent={ percent }
+				siteId={ siteId }
 				status={ status }
 				timestamp={ timestamp }
 			/>

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -163,8 +163,9 @@ export function updateRewindRestoreProgress( siteId, timestamp, restoreId, progr
 	return {
 		type: REWIND_RESTORE_UPDATE_PROGRESS,
 		...progress,
-		siteId,
+		freshness: Date.now(),
 		restoreId,
+		siteId,
 		timestamp,
 	};
 }

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { restoreProgressSchema } from './schema';
 import {
 	REWIND_RESTORE,
 	REWIND_RESTORE_DISMISS_PROGRESS,
@@ -45,3 +46,4 @@ export const restoreProgress = keyedReducer( 'siteId', createReducer( {}, {
 	[ REWIND_RESTORE_DISMISS_PROGRESS ]: stubNull,
 	[ REWIND_RESTORE_UPDATE_PROGRESS ]: updateProgress,
 } ) );
+restoreProgress.schema = restoreProgressSchema;

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -17,6 +17,7 @@ const stubNull = () => null;
 const startProgress = ( state, { timestamp } ) => ( {
 	errorCode: '',
 	failureReason: '',
+	freshness: -Infinity,
 	message: '',
 	percent: 0,
 	status: 'queued',
@@ -26,6 +27,7 @@ const startProgress = ( state, { timestamp } ) => ( {
 const updateProgress = ( state, {
 	errorCode,
 	failureReason,
+	freshness,
 	message,
 	percent,
 	restoreId,
@@ -34,6 +36,7 @@ const updateProgress = ( state, {
 } ) => ( {
 	errorCode,
 	failureReason,
+	freshness,
 	message,
 	percent,
 	restoreId,

--- a/client/state/activity-log/restore/schema.js
+++ b/client/state/activity-log/restore/schema.js
@@ -1,0 +1,23 @@
+export const restoreProgressSchema = {
+	type: 'object',
+	patternProperties: {
+		'^\\d+$': {
+			type: 'object',
+			required: [
+				'restoreId',
+				'status',
+				'timestamp',
+			],
+			properties: {
+				errorCode: { type: 'string' },
+				failureReason: { type: 'string' },
+				message: { type: 'string' },
+				percent: { type: 'integer' },
+				restoreId: { type: 'integer' },
+				status: { type: 'string' },
+				timestamp: { type: 'integer' },
+			},
+		},
+	},
+	additionalProperties: false,
+};

--- a/client/state/activity-log/restore/schema.js
+++ b/client/state/activity-log/restore/schema.js
@@ -11,6 +11,7 @@ export const restoreProgressSchema = {
 			properties: {
 				errorCode: { type: 'string' },
 				failureReason: { type: 'string' },
+				freshness: { type: 'integer' },
 				message: { type: 'string' },
 				percent: { type: 'integer' },
 				restoreId: { type: 'integer' },

--- a/client/state/activity-log/restore/test/reducer.js
+++ b/client/state/activity-log/restore/test/reducer.js
@@ -30,6 +30,7 @@ describe( '#restoreProgress()', () => {
 		expect( state[ SITE_ID ] ).to.deep.equal( {
 			errorCode: '',
 			failureReason: '',
+			freshness: -Infinity,
 			message: '',
 			percent: 0,
 			status: 'queued',

--- a/client/state/activity-log/rewind-status/reducer.js
+++ b/client/state/activity-log/rewind-status/reducer.js
@@ -21,7 +21,6 @@ export const rewindStatus = keyedReducer( 'siteId', createReducer( {}, {
 		...state,
 		active: true,
 	} ),
-
 }, rewindStatusSchema ) );
 
 export const rewindStatusError = keyedReducer( 'siteId', createReducer( {}, {

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { delay } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -12,10 +11,7 @@ import { createNotice } from 'state/notices/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { REWIND_RESTORE_PROGRESS_REQUEST } from 'state/action-types';
-import {
-	getRewindRestoreProgress,
-	updateRewindRestoreProgress,
-} from 'state/activity-log/actions';
+import { updateRewindRestoreProgress } from 'state/activity-log/actions';
 
 const debug = debugFactory( 'calypso:data-layer:activity-log:rewind:restore-status' );
 
@@ -46,16 +42,11 @@ const fromApi = ( { restore_status = {} } ) => {
 };
 
 export const receiveRestoreProgress = ( { dispatch }, { siteId, timestamp, restoreId }, next, apiData ) => {
-	const POLLING_DELAY_MS = 1500;
-
 	const data = fromApi( apiData );
 
 	debug( 'Restore progress', data );
 
 	dispatch( updateRewindRestoreProgress( siteId, timestamp, restoreId, data ) );
-	if ( data.status !== 'finished' ) {
-		delay( dispatch, POLLING_DELAY_MS, getRewindRestoreProgress( siteId, timestamp, restoreId ) );
-	}
 };
 
 // FIXME: Could be a network Error (instanceof Error) or an API error. Handle each case correctly.

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
@@ -8,14 +8,8 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
-import { useFakeTimers } from 'test/helpers/use-sinon';
-import {
-	receiveRestoreProgress,
-} from '../';
-import {
-	updateRewindRestoreProgress,
-	getRewindRestoreProgress,
-} from 'state/activity-log/actions';
+import { receiveRestoreProgress } from '../';
+import { updateRewindRestoreProgress } from 'state/activity-log/actions';
 
 const siteId = 77203074;
 const timestamp = 1496768464;
@@ -33,49 +27,20 @@ const FINISHED_RESPONSE = deepFreeze( {
 	}
 } );
 
-const RUNNING_RESPONSE = deepFreeze( {
-	error: '',
-	ok: '',
-	restore_status: {
-		error_code: '',
-		failure_reason: '',
-		message: '',
-		percent: 32,
-		status: 'running',
-	}
-} );
-
 describe( 'receiveRestoreProgress', () => {
-	let clock;
-
-	useFakeTimers( fakeClock => clock = fakeClock );
-
 	it( 'should dispatch updateRewindRestoreProgress', () => {
 		const dispatch = sinon.spy();
 		receiveRestoreProgress( { dispatch }, { siteId, timestamp, restoreId }, null, FINISHED_RESPONSE );
-		expect( dispatch ).to.have.been.calledWith(
-			updateRewindRestoreProgress(
-				siteId, timestamp, restoreId, {
-					errorCode: '',
-					failureReason: '',
-					message: '',
-					percent: 100,
-					status: 'finished',
-				}
-			)
+		const expectedAction = updateRewindRestoreProgress(
+			siteId, timestamp, restoreId, {
+				errorCode: '',
+				failureReason: '',
+				message: '',
+				percent: 100,
+				status: 'finished',
+			}
 		);
-	} );
-
-	it( 'should dispatch another progress request if status not finished', () => {
-		const dispatch = sinon.spy();
-		receiveRestoreProgress( { dispatch }, { siteId, timestamp, restoreId }, null, RUNNING_RESPONSE );
-		clock.tick( 1600 );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith(
-			getRewindRestoreProgress(
-				siteId, timestamp, restoreId
-			)
-		);
+		expectedAction.freshness = sinon.match.number;
+		expect( dispatch ).to.have.been.calledWith( expectedAction );
 	} );
 } );


### PR DESCRIPTION
This adds a polling query component which resumes polling restore status with persisted state

**To test**
* Go to https://calypso.live/stats/activity?branch=try/activitylog-restoreprogress-resume
* Start a restore
* Move around
* Start a restore for a different site
* Refresh the page
* Close your browser
* Come back and see your restores status be refreshed as soon as you return 🔮 

Includes #15957 
Part of #15385 