### PR TITLE
Connect SimplePaymentsDialog to Redux store

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -1,0 +1,73 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormCurrencyInput from 'components/forms/form-currency-input';
+import FormToggle from 'components/forms/form-toggle';
+
+const ProductImage = () => (
+	<div className="editor-simple-payments-modal__product-image">
+		<Gridicon icon="add-image" size={ 36 } />
+	</div>
+);
+
+class ProductForm extends Component {
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<form className="editor-simple-payments-modal__form">
+				<ProductImage />
+				<div className="editor-simple-payments-modal__form-fields">
+					<FormFieldset>
+						<FormLabel htmlFor="productname">{ translate( 'What are you selling?' ) }</FormLabel>
+						<FormTextInput name="productname" id="productname" />
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
+						<FormTextarea name="description" id="description" />
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="price">{ translate( 'Price' ) }</FormLabel>
+						<FormCurrencyInput
+							name="price"
+							id="price"
+							currencySymbolPrefix="$"
+							placeholder="0.00"
+						/>
+					</FormFieldset>
+					<FormFieldset>
+						<FormToggle id="allowMultipleItems">
+							{ translate( 'Allow people to buy more than one item at a time.' ) }
+						</FormToggle>
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
+						<FormTextInput name="email" id="email" />
+						<FormSettingExplanation>
+							{ translate(
+								'This is where PayPal will send your money.' +
+									" To claim a payment, you'll need a PayPal account connected to a bank account.",
+							) }
+						</FormSettingExplanation>
+					</FormFieldset>
+				</div>
+			</form>
+		);
+	}
+}
+
+export default localize( ProductForm );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -7,27 +7,18 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSimplePayments } from 'state/selectors';
+import QuerySimplePayments from 'components/data/query-simple-payments';
 import Dialog from 'components/dialog';
-import Navigation from './navigation';
 import Button from 'components/button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
-import FormTextarea from 'components/forms/form-textarea';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormCurrencyInput from 'components/forms/form-currency-input';
-import FormToggle from 'components/forms/form-toggle';
-
-const ProductImage = () => (
-	<div className="editor-simple-payments-modal__product-image">
-		<Gridicon icon="add-image" size={ 36 } />
-	</div>
-);
+import Navigation from './navigation';
+import ProductForm from './form';
+import ProductList from './list';
 
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
@@ -59,56 +50,8 @@ class SimplePaymentsDialog extends Component {
 		return actionButtons;
 	}
 
-	renderAddNewForm() {
-		const { translate } = this.props;
-
-		return (
-			<form className="editor-simple-payments-modal__form">
-				<ProductImage />
-				<div className="editor-simple-payments-modal__form-fields">
-					<FormFieldset>
-						<FormLabel htmlFor="productname">{ translate( 'What are you selling?' ) }</FormLabel>
-						<FormTextInput name="productname" id="productname" />
-					</FormFieldset>
-					<FormFieldset>
-						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
-						<FormTextarea name="description" id="description" />
-					</FormFieldset>
-					<FormFieldset>
-						<FormLabel htmlFor="price">{ translate( 'Price' ) }</FormLabel>
-						<FormCurrencyInput
-							name="price"
-							id="price"
-							currencySymbolPrefix="$"
-							placeholder="0.00"
-						/>
-					</FormFieldset>
-					<FormFieldset>
-						<FormToggle id="allowMultipleItems">
-							{ translate( 'Allow people to buy more than one item at a time.' ) }
-						</FormToggle>
-					</FormFieldset>
-					<FormFieldset>
-						<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
-						<FormTextInput name="email" id="email" />
-						<FormSettingExplanation>
-							{ translate(
-								'This is where PayPal will send your money.' +
-									" To claim a payment, you'll need a PayPal account connected to a bank account.",
-							) }
-						</FormSettingExplanation>
-					</FormFieldset>
-				</div>
-			</form>
-		);
-	}
-
-	renderList() {
-		return <div className="editor-simple-payments-modal__list">Payment Buttons List</div>;
-	}
-
 	render() {
-		const { activeTab, showDialog, onChangeTabs, onClose } = this.props;
+		const { activeTab, showDialog, onChangeTabs, onClose, siteId, paymentButtons } = this.props;
 
 		return (
 			<Dialog
@@ -117,11 +60,20 @@ class SimplePaymentsDialog extends Component {
 				buttons={ this.getActionButtons() }
 				additionalClassNames="editor-simple-payments-modal"
 			>
-				<Navigation { ...{ activeTab, onChangeTabs } } />
-				{ activeTab === 'addNew' ? this.renderAddNewForm() : this.renderList() }
+				<QuerySimplePayments siteId={ siteId } allProducts />
+				<Navigation { ...{ activeTab, onChangeTabs, paymentButtons } } />
+				{ activeTab === 'addNew'
+					? <ProductForm />
+					: <ProductList paymentButtons={ paymentButtons } /> }
 			</Dialog>
 		);
 	}
 }
 
-export default connect()( localize( SimplePaymentsDialog ) );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+		paymentButtons: getSimplePayments( state, siteId ) || [],
+	};
+} )( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -60,7 +60,7 @@ class SimplePaymentsDialog extends Component {
 				buttons={ this.getActionButtons() }
 				additionalClassNames="editor-simple-payments-modal"
 			>
-				<QuerySimplePayments siteId={ siteId } allProducts />
+				<QuerySimplePayments siteId={ siteId } />
 				<Navigation { ...{ activeTab, onChangeTabs, paymentButtons } } />
 				{ activeTab === 'addNew'
 					? <ProductForm />

--- a/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import formatCurrency from 'lib/format-currency';
 import CompactCard from 'components/card/compact';
 
 class ProductList extends Component {
@@ -21,7 +22,7 @@ class ProductList extends Component {
 			<div className="editor-simple-payments-modal__list">
 				{ paymentButtons.map( ( { ID: id, title, price, currency } ) => (
 					<CompactCard key={ id }>
-						<div>{ title }</div><div>{ price }&nbsp;{ currency }</div>
+						<div>{ title }</div><div>{ formatCurrency( price, currency ) }</div>
 					</CompactCard>
 				) ) }
 			</div>

--- a/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
@@ -1,0 +1,32 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+
+class ProductList extends Component {
+	static propTypes = { paymentButtons: PropTypes.array.isRequired };
+
+	render() {
+		const { paymentButtons } = this.props;
+
+		return (
+			<div className="editor-simple-payments-modal__list">
+				{ paymentButtons.map( ( { ID: id, title, price, currency } ) => (
+					<CompactCard key={ id }>
+						<div>{ title }</div><div>{ price }&nbsp;{ currency }</div>
+					</CompactCard>
+				) ) }
+			</div>
+		);
+	}
+}
+
+export default localize( ProductList );

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -11,56 +11,49 @@ import SectionHeader from 'components/section-header';
 import HeaderCake from 'components/header-cake';
 import Button from 'components/button';
 
-export default localize( class SimplePaymentsDialogNavigation extends Component {
+class SimplePaymentsDialogNavigation extends Component {
 	static propTypes = {
 		activeTab: PropTypes.oneOf( [ 'paymentButtons', 'addNew' ] ).isRequired,
-		onChangeTabs: PropTypes.func.isRequired
+		onChangeTabs: PropTypes.func.isRequired,
+		paymentButtons: PropTypes.array.isRequired,
 	};
 
-	onChangeTabs = ( tab ) => () => this.props.onChangeTabs( tab );
+	onChangeTabs = tab => () => this.props.onChangeTabs( tab );
 
 	render() {
-		const { activeTab, translate } = this.props;
-
-		// TODO: Get from store/as a prop.
-		const paymentButtons = [ 1 ];
+		const { paymentButtons, activeTab, translate } = this.props;
 
 		const classNames = 'editor-simple-payments-modal__navigation';
 
-		if ( activeTab === 'addNew' && ! paymentButtons.length ) {
-			// We are on "Add New" view without previously made payment buttons.
+		if ( activeTab === 'addNew' ) {
+			if ( ! paymentButtons.length ) {
+				// We are on "Add New" view without previously made payment buttons.
+				return null;
+			}
 
-			return null;
-		} else if ( activeTab === 'addNew' ) {
 			// We are on "Add New" view with previously made payment buttons.
-
 			return (
 				<HeaderCake
 					className={ classNames }
 					onClick={ this.onChangeTabs( 'paymentButtons' ) }
 					backText={ translate( 'Payment Buttons' ) }
-				>
-				</HeaderCake>
+				/>
 			);
 		}
 
 		// We are on "Payment Buttons" view.
-
-		// TODO: update the count={ 2 } magic number with real data
-
 		return (
 			<SectionHeader
 				className={ classNames }
 				label={ translate( 'Payment Buttons' ) }
-				count={ 2 }
+				count={ paymentButtons.length }
 			>
-				<Button
-					compact
-					onClick={ this.onChangeTabs( 'addNew' ) }
-				>
+				<Button compact onClick={ this.onChangeTabs( 'addNew' ) }>
 					{ translate( '+ Add New' ) }
 				</Button>
 			</SectionHeader>
 		);
 	}
-} );
+}
+
+export default localize( SimplePaymentsDialogNavigation );


### PR DESCRIPTION
Use `QuerySimplePayments` to fetch the product list and connect the `SimplePaymentDialog` to the Redux store.

The `Navigation` component now uses the real data instead of the mock ones, and the patch contains some Prettier formatting changes.

The `ProductForm` code has been moved to a separate component in its own file.

There is also a primitive version of the `ProductList` component, populated by the real data.