### PR TITLE
Fix: wpcom-proxy-request was treating failed requests as successes

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,7 +3,7 @@
   "version": "0.17.0",
   "dependencies": {
     "@types/node": {
-      "version": "6.0.80",
+      "version": "6.0.84",
       "dev": true
     },
     "5to6-codemod": {
@@ -836,7 +836,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000699"
+      "version": "1.0.30000703"
     },
     "cardinal": {
       "version": "1.0.0",
@@ -943,7 +943,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.27",
+      "version": "3.4.28",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -1021,7 +1021,7 @@
       "dev": true
     },
     "color-name": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dev": true
     },
     "colorguard": {
@@ -2123,7 +2123,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.49.1",
+      "version": "0.50.0",
       "dev": true
     },
     "flux": {
@@ -3188,7 +3188,7 @@
       "dev": true
     },
     "is-plain-object": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dev": true,
       "dependencies": {
         "isobject": {
@@ -3299,7 +3299,7 @@
       }
     },
     "istanbul-api": {
-      "version": "1.1.10",
+      "version": "1.1.11",
       "dev": true,
       "dependencies": {
         "async": {
@@ -3317,7 +3317,7 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "1.7.3",
+      "version": "1.7.4",
       "dev": true,
       "dependencies": {
         "semver": {
@@ -4371,7 +4371,7 @@
       }
     },
     "node-abi": {
-      "version": "2.0.3"
+      "version": "2.1.0"
     },
     "node-contains": {
       "version": "1.0.0"
@@ -4861,7 +4861,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.6",
+          "version": "6.0.8",
           "dev": true
         },
         "source-map": {
@@ -4945,7 +4945,7 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.6",
+          "version": "6.0.8",
           "dev": true,
           "dependencies": {
             "ansi-styles": {
@@ -5132,8 +5132,8 @@
     },
     "react-codemod": {
       "version": "4.0.0",
-      "from": "git://github.com/reactjs/react-codemod.git#b1628643a9166fee2da03b24f33df04e0098fd57",
-      "resolved": "git://github.com/reactjs/react-codemod.git#b1628643a9166fee2da03b24f33df04e0098fd57",
+      "from": "git://github.com/reactjs/react-codemod.git#4a556555893dedcd070c9b18960b5a8ad40fa342",
+      "resolved": "git://github.com/reactjs/react-codemod.git#4a556555893dedcd070c9b18960b5a8ad40fa342",
       "dev": true,
       "dependencies": {
         "chalk": {
@@ -6116,7 +6116,7 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "dev": true,
           "dependencies": {
             "strip-ansi": {
@@ -6328,7 +6328,7 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.13"
+      "version": "0.7.14"
     },
     "uglify-js": {
       "version": "2.7.0",
@@ -6507,7 +6507,7 @@
       "dev": true
     },
     "watchpack": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "async": {
           "version": "2.5.0"
@@ -6899,7 +6899,7 @@
       }
     },
     "wpcom-proxy-request": {
-      "version": "3.0.0"
+      "version": "4.0.0-alpha.1"
     },
     "wpcom-xhr-request": {
       "version": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "webpack-hot-middleware": "2.15.0",
     "wpcom": "5.4.0",
     "wpcom-oauth": "0.3.3",
-    "wpcom-proxy-request": "3.0.0",
+    "wpcom-proxy-request": "4.0.0-alpha.1",
     "wpcom-xhr-request": "1.1.0"
   },
   "engines": {


### PR DESCRIPTION
When the network connection is completely disconnected then
`wpcom-proxy-request` was returning a status code of zero, incorrectly
passing a test for success.

The referenced branch makes an explicit test for success instead of the
former looser test. This patch is here to run tests against the branch
and confirm the fix. Once we determine that all is well we can merge the
branch in the `wpcom-proxy-request` library, then update the version in
Calypso.

**Testing**

 - E2E tests should pass
 - Navigate around the live branch as much as possible, trying to break stuff.
 - Make sure to disconnect network connection at random times to see what happens. We should not get back "successful" requests