### PR TITLE
Store Orders: Update refund error message

### DIFF
--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -118,7 +118,7 @@ class OrderRefundCard extends Component {
 		const { order, paymentMethod, site, translate } = this.props;
 		const maxRefund = parseFloat( order.total ) + this.getRefundedTotal( order );
 		if ( this.state.refundTotal > maxRefund ) {
-			this.setState( { errorMessage: translate( 'Refund must be less than order total.' ) } );
+			this.setState( { errorMessage: translate( 'Refund must be less than or equal to the order total.' ) } );
 			return;
 		} else if ( this.state.refundTotal <= 0 ) {
 			this.setState( { errorMessage: translate( 'Refund must be greater than zero.' ) } );

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -110,6 +110,7 @@
 		height: 100%;
 		overflow-y: scroll;
 		padding: 16px;
+		box-sizing: border-box;
 		color: $gray-text-min;
 
 		@include breakpoint( ">960px" ) {


### PR DESCRIPTION
Fixes #15860

It's possible to refund the exact order amount, so this PR updates the error message to be clear about that. It also fixes a CSS bug where the contents were expanding outside of the modal.

![screen shot 2017-07-11 at 10 34 01 am](https://user-images.githubusercontent.com/541093/28073681-81668e84-6624-11e7-8e56-9aee6ad868df.png)

To test:

1. Visit your orders list
2. Open an order
3. Click "Submit Refund", and enter a quantity higher than sold, or a higher shipping refund - either will work to increase the final refund over the order total
4. Click "Refund", see the error