### PR TITLE
Media: Allow to try to upload any file types to AT and Jetpack sites.

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -312,30 +312,6 @@ describe( 'MediaUtils', function() {
 		} );
 	} );
 
-	describe( '#isSiteAllowedFileTypesToBeTrusted()', function() {
-		it( 'should return false for versions of Jetpack where option is not synced', function() {
-			var site = new JetpackSite( {
-				jetpack: true,
-				options: {
-					jetpack_version: '3.8.0'
-				}
-			} );
-
-			expect( MediaUtils.isSiteAllowedFileTypesToBeTrusted( site ) ).to.be.false;
-		} );
-
-		it( 'should return true for versions of Jetpack where option is synced', function() {
-			var site = new JetpackSite( {
-				jetpack: true,
-				options: {
-					jetpack_version: '3.8.1'
-				}
-			} );
-
-			expect( MediaUtils.isSiteAllowedFileTypesToBeTrusted( site ) ).to.be.true;
-		} );
-	} );
-
 	describe( '#getAllowedFileTypesForSite()', function() {
 		it( 'should return an empty array for a falsey site', function() {
 			var extensions = MediaUtils.getAllowedFileTypesForSite();
@@ -387,18 +363,6 @@ describe( 'MediaUtils', function() {
 			} ) );
 
 			expect( isSupported ).to.be.true;
-		} );
-
-		it( 'should return false for versions of Jetpack where option is synced and extension is not supported', function() {
-			var isSupported = MediaUtils.isSupportedFileTypeForSite( { extension: 'exe' }, new JetpackSite( {
-				jetpack: true,
-				options: {
-					jetpack_version: '3.8.1',
-					allowed_file_types: [ 'pdf', 'gif' ]
-				}
-			} ) );
-
-			expect( isSupported ).to.be.false;
 		} );
 
 		it( 'should return true if the site supports the item\'s extension', function() {

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -20,7 +20,6 @@ import {
 	GalleryDefaultAttrs
 } from './constants';
 import Shortcode from 'lib/shortcode';
-import versionCompare from 'lib/version-compare';
 
 /**
  * Module variables
@@ -228,14 +227,14 @@ const MediaUtils = {
 	 * Returns true if the site can be trusted to accurately report its allowed
 	 * file types. Returns false otherwise.
 	 *
-	 * Jetpack versions 3.8.0 and earlier do not sync the allowed file types
+	 * Jetpack currently does not sync the allowed file types
 	 * option, so we must assume that all file types are supported.
 	 *
 	 * @param  {Object}  site Site object
 	 * @return {Boolean}      Site allowed file types are accurate
 	 */
 	isSiteAllowedFileTypesToBeTrusted: function( site ) {
-		return ! site || ! site.jetpack || versionCompare( site.options.jetpack_version, '3.8.1', '>=' );
+		return ! site || ! site.jetpack;
 	},
 
 	/**


### PR DESCRIPTION
This is a temporarily fix for users not being able to upload mp3 files to AT and JP sites.

`/me/sites` doesn’t return allowed file types accurately for JP sites.
See https://github.com/Automattic/jetpack/issues/7159

The solution on the API side needs to wait on a JP release. JP PR to come.



**How to Test**

* Try to upload a mp3 sites to a JP site