### PR TITLE
Reader: Add in basic conversations stream support

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -137,6 +137,14 @@ class PostByline extends React.Component {
 									<PostTime date={ post.date } />
 								</a>
 							</span> }
+						{ post.last_comment_date_gmt &&
+							<span className="reader-post-card__timestamp">
+								<a className="reader-post-card__timestamp-link"
+									href={ `/read/blogs/${ post.site_ID }/posts/${ post.ID }#comments` }
+									>
+								{', '}Last comment <PostTime date={ post.last_comment_date_gmt } />
+								</a>
+							</span> }
 						{ tags.length > 0 &&
 							<span className="reader-post-card__tags">
 								<Gridicon icon="tag" />

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -137,14 +137,6 @@ class PostByline extends React.Component {
 									<PostTime date={ post.date } />
 								</a>
 							</span> }
-						{ post.last_comment_date_gmt &&
-							<span className="reader-post-card__timestamp">
-								<a className="reader-post-card__timestamp-link"
-									href={ `/read/blogs/${ post.site_ID }/posts/${ post.ID }#comments` }
-									>
-								{', '}Last comment <PostTime date={ post.last_comment_date_gmt } />
-								</a>
-							</span> }
 						{ tags.length > 0 &&
 							<span className="reader-post-card__tags">
 								<Gridicon icon="tag" />

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -243,9 +243,6 @@ export default class FeedStream {
 	}
 
 	getFirstItemWithDate() {
-		if ( this.newestPostDate ) {
-			return this.newestPostDate;
-		}
 		if ( this.postKeys.length === 0 ) {
 			return;
 		}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -243,6 +243,9 @@ export default class FeedStream {
 	}
 
 	getFirstItemWithDate() {
+		if ( this.newestPostDate ) {
+			return this.newestPostDate;
+		}
 		if ( this.postKeys.length === 0 ) {
 			return;
 		}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -310,7 +310,7 @@ export default class FeedStream {
 			orderBy: this.orderBy,
 			number: this.maxUpdates,
 			before: moment().toISOString(),
-			after: mostRecentDate,
+			after: moment( mostRecentDate ).toISOString,
 		};
 
 		this.onUpdateFetch( params );

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -310,7 +310,7 @@ export default class FeedStream {
 			orderBy: this.orderBy,
 			number: this.maxUpdates,
 			before: moment().toISOString(),
-			after: moment( mostRecentDate ).toISOString,
+			after: moment( mostRecentDate ).toISOString(),
 		};
 
 		this.onUpdateFetch( params );

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -421,6 +421,7 @@ export default class FeedStream {
 
 		this._isFetchingNextPage = false;
 		this.oldestPostDate = get( data, [ 'date_range', 'after' ] );
+		this.lastPageHandle = get( data, [ 'meta', 'next_page' ], null );
 
 		if ( error ) {
 			debug( 'Error fetching posts from API:', error );

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -171,20 +171,20 @@ function getStoreForSearch( storeId ) {
 	const stream =
 		sort === 'date'
 			? new FeedStream( {
-					id: storeId,
-					fetcher: fetcher,
-					keyMaker: siteKeyMaker,
-					perPage: 5,
-					onGapFetch: limitSiteParams,
-					onUpdateFetch: limitSiteParams,
-					maxUpdates: 20,
-				} )
+				id: storeId,
+				fetcher: fetcher,
+				keyMaker: siteKeyMaker,
+				perPage: 5,
+				onGapFetch: limitSiteParams,
+				onUpdateFetch: limitSiteParams,
+				maxUpdates: 20,
+			} )
 			: new PagedStream( {
-					id: storeId,
-					fetcher: fetcher,
-					keyMaker: siteKeyMaker,
-					perPage: 5,
-				} );
+				id: storeId,
+				fetcher: fetcher,
+				keyMaker: siteKeyMaker,
+				perPage: 5,
+			} );
 	stream.sortOrder = sort;
 
 	function fetcher( query, callback ) {

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -95,7 +95,7 @@ function limitSiteParamsForTags( params ) {
 
 function limitSiteParamsForConversations( params ) {
 	limitSiteParams( params );
-	params.fields += ',last_comment_date_gmt';
+	params.fields += ',last_comment_date_gmt,comments';
 }
 
 function trainTracksProxyForStream( stream, callback ) {
@@ -104,7 +104,7 @@ function trainTracksProxyForStream( stream, callback ) {
 		if ( response && response.algorithm ) {
 			stream.algorithm = response.algorithm;
 		}
-		forEach( response && response.posts, ( post ) => {
+		forEach( response && response.posts, post => {
 			if ( post.railcar ) {
 				if ( stream.isQuerySuggestion ) {
 					post.railcar.rec_result = 'suggestion';
@@ -126,7 +126,7 @@ function getStoreForFeed( storeId ) {
 		id: storeId,
 		fetcher: fetcher,
 		keyMaker: feedKeyMaker,
-		onNextPageFetch: addMetaToNextPageFetch
+		onNextPageFetch: addMetaToNextPageFetch,
 	} );
 }
 
@@ -142,7 +142,7 @@ function getStoreForTag( storeId ) {
 			id: storeId,
 			fetcher: fetcher,
 			keyMaker: siteKeyMaker,
-			perPage: 5
+			perPage: 5,
 		} );
 	}
 	return new FeedStream( {
@@ -151,7 +151,7 @@ function getStoreForTag( storeId ) {
 		keyMaker: buildNamedKeyMaker( 'tagged_on' ),
 		onGapFetch: limitSiteParamsForTags,
 		onUpdateFetch: limitSiteParamsForTags,
-		dateProperty: 'tagged_on'
+		dateProperty: 'tagged_on',
 	} );
 }
 
@@ -168,20 +168,23 @@ function getStoreForSearch( storeId ) {
 	const slug = idParts.slice( 2 ).join( ':' );
 	// We can use a feed stream when it's a strict date sort.
 	// This lets us go deeper than 20 pages and let's the results auto-update
-	const stream = sort === 'date' ? new FeedStream( {
-		id: storeId,
-		fetcher: fetcher,
-		keyMaker: siteKeyMaker,
-		perPage: 5,
-		onGapFetch: limitSiteParams,
-		onUpdateFetch: limitSiteParams,
-		maxUpdates: 20,
-	} ) : new PagedStream( {
-		id: storeId,
-		fetcher: fetcher,
-		keyMaker: siteKeyMaker,
-		perPage: 5
-	} );
+	const stream =
+		sort === 'date'
+			? new FeedStream( {
+					id: storeId,
+					fetcher: fetcher,
+					keyMaker: siteKeyMaker,
+					perPage: 5,
+					onGapFetch: limitSiteParams,
+					onUpdateFetch: limitSiteParams,
+					maxUpdates: 20,
+				} )
+			: new PagedStream( {
+					id: storeId,
+					fetcher: fetcher,
+					keyMaker: siteKeyMaker,
+					perPage: 5,
+				} );
 	stream.sortOrder = sort;
 
 	function fetcher( query, callback ) {
@@ -208,7 +211,7 @@ function getStoreForList( storeId ) {
 		fetcher: fetcher,
 		keyMaker: mixedKeyMaker,
 		onGapFetch: limitSiteParams,
-		onUpdateFetch: limitSiteParams
+		onUpdateFetch: limitSiteParams,
 	} );
 }
 
@@ -224,7 +227,7 @@ function getStoreForSite( storeId ) {
 		fetcher: fetcher,
 		keyMaker: siteKeyMaker,
 		onGapFetch: limitSiteParams,
-		onUpdateFetch: limitSiteParams
+		onUpdateFetch: limitSiteParams,
 	} );
 }
 
@@ -239,7 +242,7 @@ function getStoreForFeatured( storeId ) {
 		fetcher: fetcher,
 		keyMaker: siteKeyMaker,
 		onGapFetch: limitSiteParams,
-		onUpdateFetch: limitSiteParams
+		onUpdateFetch: limitSiteParams,
 	} );
 }
 
@@ -314,7 +317,7 @@ export default function feedStoreFactory( storeId ) {
 			id: storeId,
 			fetcher: wpcomUndoc.readFollowing.bind( wpcomUndoc ),
 			keyMaker: feedKeyMaker,
-			onNextPageFetch: addMetaToNextPageFetch
+			onNextPageFetch: addMetaToNextPageFetch,
 		} );
 	} else if ( storeId === 'conversations' ) {
 		store = new FeedStream( {
@@ -324,13 +327,14 @@ export default function feedStoreFactory( storeId ) {
 			onNextPageFetch: conversationsPager,
 			onUpdateFetch: limitSiteParamsForConversations,
 			onGapFetch: limitSiteParamsForConversations,
+			dateProperty: 'last_comment_date_gmt',
 		} );
 	} else if ( storeId === 'a8c' ) {
 		store = new FeedStream( {
 			id: storeId,
 			fetcher: wpcomUndoc.readA8C.bind( wpcomUndoc ),
 			keyMaker: feedKeyMaker,
-			onNextPageFetch: addMetaToNextPageFetch
+			onNextPageFetch: addMetaToNextPageFetch,
 		} );
 	} else if ( storeId === 'likes' ) {
 		store = new FeedStream( {
@@ -339,7 +343,7 @@ export default function feedStoreFactory( storeId ) {
 			keyMaker: buildNamedKeyMaker( 'date_liked' ),
 			onGapFetch: limitSiteParamsForLikes,
 			onUpdateFetch: limitSiteParamsForLikes,
-			dateProperty: 'date_liked'
+			dateProperty: 'date_liked',
 		} );
 	} else if ( storeId === 'recommendations_posts' ) {
 		store = getStoreForRecommendedPosts( storeId );

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -66,12 +66,8 @@ const conversationsKeyMaker = ( function() {
 function conversationsPager( params ) {
 	delete params.meta;
 	delete params.orderBy;
-	if ( params.before ) {
-		delete params.before;
-	}
-	if ( params.after ) {
-		delete params.after;
-	}
+	delete params.before;
+	delete params.after;
 	params.page_handle = this.lastPageHandle;
 }
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1133,6 +1133,15 @@ Undocumented.prototype.readA8C = function( query, fn ) {
 	return this.wpcom.req.get( '/read/a8c', query, fn );
 };
 
+Undocumented.prototype.readConversations = function( query, fn ) {
+	debug( '/read/conversations' );
+	const params = {
+		...query,
+		apiVersion: '1.2'
+	};
+	return this.wpcom.req.get( '/read/conversations', params, fn );
+};
+
 Undocumented.prototype.readFeed = function( query, fn ) {
 	var params = omit( query, 'ID' );
 	debug( '/read/feed' );

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -10,7 +10,8 @@ import route from 'lib/route';
 import { recordTrack } from 'reader/stats';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
-import { trackPageLoad } from 'reader/controller-helper';
+import { trackPageLoad, ensureStoreLoading } from 'reader/controller-helper';
+import feedStreamStore from 'lib/feed-stream-store';
 
 export function conversations( context ) {
 	const basePath = route.sectionify( context.path );
@@ -19,11 +20,15 @@ export function conversations( context ) {
 	trackPageLoad( basePath, 'Reader > Conversations', mcKey );
 	recordTrack( 'calypso_reader_discover_viewed' );
 
+	const convoStream = feedStreamStore( 'conversations' );
+	ensureStoreLoading( convoStream, context );
+
 	renderWithReduxStore(
 		<AsyncLoad
 			require="reader/conversations/stream"
 			key={ 'conversations' }
 			title="Conversations"
+			store={ convoStream }
 		/>,
 		document.getElementById( 'primary' ),
 		context.store,

--- a/client/reader/conversations/controller.js
+++ b/client/reader/conversations/controller.js
@@ -10,12 +10,13 @@ import route from 'lib/route';
 import { recordTrack } from 'reader/stats';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import AsyncLoad from 'components/async-load';
-import { trackPageLoad, ensureStoreLoading } from 'reader/controller-helper';
+import { trackPageLoad, trackScrollPage, ensureStoreLoading } from 'reader/controller-helper';
 import feedStreamStore from 'lib/feed-stream-store';
 
 export function conversations( context ) {
 	const basePath = route.sectionify( context.path );
 	const mcKey = 'conversations';
+	const title = 'Reader > Conversations';
 
 	trackPageLoad( basePath, 'Reader > Conversations', mcKey );
 	recordTrack( 'calypso_reader_discover_viewed' );
@@ -23,12 +24,15 @@ export function conversations( context ) {
 	const convoStream = feedStreamStore( 'conversations' );
 	ensureStoreLoading( convoStream, context );
 
+	const scrollTracker = trackScrollPage.bind( null, '/read/conversations', title, 'Reader', mcKey );
+
 	renderWithReduxStore(
 		<AsyncLoad
 			require="reader/conversations/stream"
 			key={ 'conversations' }
 			title="Conversations"
 			store={ convoStream }
+			trackScrollPage={ scrollTracker }
 		/>,
 		document.getElementById( 'primary' ),
 		context.store,

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -16,6 +16,7 @@ export default function( props ) {
 			shouldCombineCards={ false }
 			className="conversations__stream"
 			followSource="conversations"
+			trackScrollPage={ props.trackScrollPage }
 		/>
 	);
 }

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -3,6 +3,19 @@
  */
 import React from 'react';
 
-export default function() {
-	return <h1>Conversations</h1>;
+/**
+ * Internal Dependencies
+ */
+import Stream from 'reader/stream';
+
+export default function( props ) {
+	return (
+		<Stream
+			postsStore={ props.store }
+			key="conversations"
+			shouldCombineCards={ false }
+			className="conversations__stream"
+			followSource="conversations"
+		/>
+	);
 }


### PR DESCRIPTION
Adds in basic support for a conversations stream at `/read/conversations`. No support yet for showing the comments for each post, just shows the posts, but this is mostly a proof of concept to show the backing post stream.

To test, go to /read/conversations. You should see posts.

Things left to do:
- [x] rework how we check for updates. currently using the post date, which leads to catastrophe.
- [x] make sure this isn't breaking anything else that might be using page handles (search? recs?)