### PR TITLE
Login: localize links in footer

### DIFF
--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import find from 'lodash/find';
-import url from 'url';
+import { parse } from 'url';
 
 /**
  * Internal dependencies
@@ -63,10 +63,18 @@ const i18nUtils = {
 	 * @returns {string} original path with new locale slug
 	 */
 	addLocaleToPath: function( path, locale ) {
-		const urlParts = url.parse( path );
+		const urlParts = parse( path );
 		const queryString = urlParts.search || '';
 
 		return i18nUtils.removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
+	},
+
+	addLocaleToWpcomUrl: function( url, locale ) {
+		if ( locale && locale !== 'en' ) {
+			return url.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
+		}
+
+		return url;
 	},
 
 	/**
@@ -76,7 +84,7 @@ const i18nUtils = {
 	 * @returns {string} original path minus locale slug
 	 */
 	removeLocaleFromPath: function( path ) {
-		const urlParts = url.parse( path );
+		const urlParts = parse( path );
 		const queryString = urlParts.search || '';
 		const parts = getPathParts( urlParts.pathname );
 		const locale = parts.pop();

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -2,9 +2,10 @@
  * Internal dependencies
  */
 import { addQueryArgs } from 'lib/url';
+import { addLocaleToPath } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
-export function login( { isNative, redirectTo, twoFactorAuthType } = {} ) {
+export const login = ( { isNative, locale, redirectTo, twoFactorAuthType } = {} ) => {
 	let url = config( 'login_url' );
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {
@@ -15,7 +16,17 @@ export function login( { isNative, redirectTo, twoFactorAuthType } = {} ) {
 		}
 	}
 
-	return redirectTo
-		? addQueryArgs( { redirect_to: redirectTo }, url )
-		: url;
-}
+	if ( locale && locale !== 'en' ) {
+		if ( isNative ) {
+			url = addLocaleToPath( url, locale );
+		} else {
+			url = url.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
+		}
+	}
+
+	if ( redirectTo ) {
+		url = addQueryArgs( { redirect_to: redirectTo }, url );
+	}
+
+	return url;
+};

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { addQueryArgs } from 'lib/url';
-import { addLocaleToPath } from 'lib/i18n-utils';
+import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
 export const login = ( { isNative, locale, redirectTo, twoFactorAuthType } = {} ) => {
@@ -20,7 +20,7 @@ export const login = ( { isNative, locale, redirectTo, twoFactorAuthType } = {} 
 		if ( isNative ) {
 			url = addLocaleToPath( url, locale );
 		} else {
-			url = url.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
+			url = addLocaleToWpcomUrl( url, locale );
 		}
 	}
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -93,7 +93,7 @@ export class Login extends React.Component {
 							/>
 						</div>
 
-						<LoginLinks twoFactorAuthType={ twoFactorAuthType } />
+						<LoginLinks locale={ locale } twoFactorAuthType={ twoFactorAuthType } />
 					</div>
 				</Main>
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -9,7 +9,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config, { isEnabled } from 'config';
+import { addQueryArgs } from 'lib/url';
+import { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'gridicons';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -19,6 +20,7 @@ import { login } from 'lib/paths';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
+		locale: PropTypes.string.isRequired,
 		recordPageView: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		resetMagicLoginRequestForm: PropTypes.func.isRequired,
@@ -107,7 +109,7 @@ export class LoginLinks extends React.Component {
 
 		return (
 			<a
-				href={ config( 'login_url' ) + '?action=lostpassword' }
+				href={ addQueryArgs( { action: 'lostpassword' }, login( { locale: this.props.locale } ) ) }
 				key="lost-password-link"
 				onClick={ this.recordResetPasswordLinkClick }
 			>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -10,6 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { addQueryArgs } from 'lib/url';
+import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'gridicons';
@@ -56,6 +57,20 @@ export class LoginLinks extends React.Component {
 	recordResetPasswordLinkClick = () => {
 		this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
 	};
+
+	renderBackToWpcomLink() {
+		return (
+			<a
+				href={ addLocaleToWpcomUrl( 'https://wordpress.com', this.props.locale ) }
+				key="return-to-wpcom-link"
+				onClick={ this.recordBackToWpcomLinkClick }
+				rel="external"
+			>
+				<Gridicon icon="arrow-left" size={ 18 } />
+				{ this.props.translate( 'Back to WordPress.com' ) }
+			</a>
+		);
+	}
 
 	renderHelpLink() {
 		if ( ! this.props.twoFactorAuthType ) {
@@ -125,16 +140,7 @@ export class LoginLinks extends React.Component {
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
-
-				<a
-					href="https://wordpress.com"
-					key="return-to-wpcom-link"
-					onClick={ this.recordBackToWpcomLinkClick }
-					rel="external"
-				>
-					<Gridicon icon="arrow-left" size={ 18 } />
-					{ this.props.translate( 'Back to WordPress.com' ) }
-				</a>
+				{ this.renderBackToWpcomLink() }
 			</div>
 		);
 	}


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/16089 by localizing the `Lost your password?` and `Back to WordPress.com` links displayed at the bottom of the [`Login` page](http://calypso.localhost:3000/log-in) (i.e. to point those links to the version that matches the current locale):
 
<img width="277" alt="screenshot" src="https://user-images.githubusercontent.com/594356/28078961-e757e3ea-6666-11e7-9792-6af7b81338d0.png">

  
#### Testing instructions
 
1. Run `git checkout update/localize-login-links` and start your server, or open a [live branch](https://calypso.live/?branch=update/localize-login-links)
2. Open the [`Home` page](http://calypso.localhost:3000/log-in) in English
3. Assert that the `Lost your password?` link points to the English version
5. Assert that the `Back to WordPress.com` link points to the English version
6. Open the [`Home` page](http://calypso.localhost:3000/log-in) in French (or another language)
7. Assert that the `Mot de passe oublié ?` link points to the French version
8. Assert that the `Retour vers WordPress.com` link points to the French version 
 
#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests