### PR TITLE
Discover: add follow source to discover follow buttons

### DIFF
--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import FollowButton from 'reader/follow-button';
 import { recordFollowToggle } from './stats';
+import { DISCOVER_POST } from 'reader/follow-button/follow-sources';
 
 class DiscoverFollowButton extends React.Component {
 	static propTypes = {
@@ -44,6 +45,7 @@ class DiscoverFollowButton extends React.Component {
 				onFollowToggle={ this.recordFollowToggle }
 				followLabel={ followLabel }
 				followingLabel={ followingLabel }
+				followSource={ DISCOVER_POST }
 			/>
 		);
 	}

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -9,3 +9,4 @@ export const READER_FOLLOWING_MANAGE_URL_INPUT = 'reader-following-manage-url-in
 export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-search-result';
 export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';
 export const TAG_PAGE = 'reader-tag-page';
+export const DISCOVER_POST = 'reader-discover-post';


### PR DESCRIPTION
currently we aren't adding a follow-source to discover follow buttons. this pr adds one.

To test:
- open up discover on this branch.  
- click the follow button within a discover post. 
- you should see the follow source be `reader-discover-post` in logs