### PR TITLE
Data Layer dispatchRequest: add in validator to redirect from success handler --> failure handler

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -73,15 +73,20 @@ export const getProgress = action => get( action, 'meta.dataLayer.progress', nul
  *                                behavior of this optional handler is to do nothing.
  * @returns {?*} please ignore return values, they are undefined
  */
-export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = noop ) => ( store, action, next ) => {
+export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = noop, {
+	validator = () => true,
+} = {} ) => ( store, action, next ) => {
 	const error = getError( action );
 	if ( error ) {
 		return onError( store, action, next, error );
 	}
 
 	const data = getData( action );
-	if ( data ) {
+	const isValid = validator( data );
+	if ( data && isValid ) {
 		return onSuccess( store, action, next, data );
+	} else if ( data && ! isValid ) {
+		return onError( store, action, next, data );
 	}
 
 	const progress = getProgress( action );


### PR DESCRIPTION
When a response to a wordpress api request comes in, we dont' always follow rest procedures.  Instead of marking a request as failed, sometimes we will have something like a `success: false` in the body of the response.   In general, there isn't a uniform way that we report errors across wpcom responses.

How does this relate to the data-layer? As things are now we have lots of control code that will do if checks within success handlers to redirect to error handlers.  [example](https://github.com/Automattic/wp-calypso/blob/master/client/state/data-layer/wpcom/sites/blog-stickers/add/index.js#L32)

This PR seeks to make that a more enjoyable experience by baking it into the system via a provided optional `validator` function.  The validator function can/should be used to handle two cases:

1. response is a sneaky 200-bearing error
2. the api response format is unexpected

---

example:

Code that used to look like this:
```js
export function receiveBlogStickerAdd( store, action, next, response ) {
  // validate that it worked
  const isAdded = !! ( response && response.success );
  if ( ! isAdded ) {
    receiveBlogStickerAddError( store, action );
    return;
  }
  store.dispatch( ...  )
}
...
export default {
  [ SITES_BLOG_STICKER_ADD ]: [
    dispatchRequest( requestBlogStickerAdd, receiveBlogStickerAdd, receiveBlogStickerAddError ),
  ],
};
```

Can now look like this:
```js
const validator = response => response && response.sucess;
export function receiveBlogStickerAdd( store, action, next, response ) {
  store.dispatch( ...  )
}
...
export default {
  [ SITES_BLOG_STICKER_ADD ]: [
    dispatchRequest( requestBlogStickerAdd, receiveBlogStickerAdd, receiveBlogStickerAddError, { validator } ),
  ],
};