### PR TITLE
Plugins: Show upload page at /plugins/upload

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -22,7 +22,7 @@ import PluginBrowser from './plugins-browser';
 import { renderWithReduxStore, renderPage } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 import { getSelectedSite, getSection } from 'state/ui/selectors';
-import Upload from 'my-sites/themes/theme-upload';
+import PluginUpload from './plugin-upload';
 
 /**
  * Module variables
@@ -231,7 +231,7 @@ const controller = {
 	},
 
 	upload( context ) {
-		renderPage( context, <Upload /> );
+		renderPage( context, <PluginUpload /> );
 	},
 
 	jetpackCanUpdate( filter, context, next ) {

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -19,9 +19,10 @@ import PluginEligibility from './plugin-eligibility';
 import PluginListComponent from './main';
 import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
-import { renderWithReduxStore } from 'lib/react-helpers';
+import { renderWithReduxStore, renderPage } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 import { getSelectedSite, getSection } from 'state/ui/selectors';
+import Upload from 'my-sites/themes/theme-upload';
 
 /**
  * Module variables
@@ -227,6 +228,10 @@ const controller = {
 
 	browsePlugins( context ) {
 		renderPluginsBrowser( context );
+	},
+
+	upload( context ) {
+		renderPage( context, <Upload /> );
 	},
 
 	jetpackCanUpdate( filter, context, next ) {

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -65,6 +65,15 @@ module.exports = function() {
 			pluginsController.plugins.bind( null, 'all' ),
 		);
 
+		if ( config.isEnabled( 'manage/plugins/upload' ) ) {
+			page( '/plugins/upload', controller.sites );
+			page( '/plugins/upload/:site_id',
+				controller.siteSelection,
+				controller.navigation,
+				pluginsController.upload
+			);
+		}
+
 		page( '/plugins',
 			controller.siteSelection,
 			controller.navigation,

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import HeaderCake from 'components/header-cake';
+import Card from 'components/card';
+import ProgressBar from 'components/progress-bar';
+import DropZone from 'components/drop-zone';
+import FilePicker from 'components/file-picker';
+import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getPluginUploadError,
+	getPluginUploadProgress,
+	getUploadedPluginId,
+	isPluginUploadComplete,
+	isPluginUploadInProgress,
+} from 'state/selectors';
+import notices from 'notices';
+import {
+	MAX_UPLOADED_THEME_SIZE
+} from 'lib/automated-transfer/constants';
+
+class PluginUpload extends React.Component {
+	back = () => {
+		page.back();
+	}
+
+	renderUploadCard() {
+		const { inProgress, complete } = this.props;
+		return (
+			<Card>
+				{ ! inProgress && ! complete && this.renderDropZone() }
+				{ inProgress && this.renderProgressBar() }
+			</Card>
+		);
+	}
+
+	onFileSelect = ( files ) => {
+		const { translate, siteId } = this.props;
+		const errorMessage = translate( 'Please drop a single zip file' );
+
+		if ( files.length !== 1 ) {
+			notices.error( errorMessage );
+			return;
+		}
+
+		// DropZone supplies an array, FilePicker supplies a FileList
+		const file = files[ 0 ] || files.item( 0 );
+
+		// TODO: plugin-specific constant
+		if ( file.size > MAX_UPLOADED_THEME_SIZE ) {
+			notices.error(
+				translate( 'Plugin zip is too large. Please upload a plugin under 50 MB.' )
+			);
+
+			return;
+		}
+
+		this.props.uploadPlugin( siteId, file );
+	}
+
+	renderDropZone() {
+		const { translate } = this.props;
+		const dropText = translate(
+			'Drop files or click here to upload'
+		);
+		const uploadInstructionsText = translate(
+			'Only single .zip files are accepted.'
+		);
+
+		return (
+			<div className="plugin-upload__dropzone">
+				<DropZone onFilesDrop={ this.onFileSelect } />
+				<FilePicker accept="application/zip" onPick={ this.onFileSelect } >
+					<Gridicon
+						className="plugin-upload__dropzone-icon"
+						icon="cloud-upload"
+						size={ 48 } />
+					{ dropText }
+					<span className="plugin-upload__dropzone-instructions">{ uploadInstructionsText }</span>
+				</FilePicker>
+			</div>
+		);
+	}
+
+	renderProgressBar() {
+		const { translate, progress, installing } = this.props;
+
+		const uploadingMessage = translate( 'Uploading your plugin' );
+		const installingMessage = translate( 'Installing your plugin' );
+
+		return (
+			<div>
+				<span className="plugin-upload__title">
+					{ installing ? installingMessage : uploadingMessage }
+				</span>
+				<ProgressBar
+					value={ progress }
+					title={ translate( 'Uploading progress' ) }
+					isPulsing={ installing }
+				/>
+			</div>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<Main>
+				<HeaderCake onClick={ this.back }>{ translate( 'Upload plugin' ) }</HeaderCake>
+				{ this.renderUploadCard() }
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const error = getPluginUploadError( state, siteId );
+		const progress = getPluginUploadProgress( state, siteId );
+		return {
+			siteId,
+			inProgress: isPluginUploadInProgress( state, siteId ),
+			complete: isPluginUploadComplete( state, siteId ),
+			failed: !! error,
+			pluginId: getUploadedPluginId( state, siteId ),
+			error,
+			progress,
+			installing: progress === 100,
+		};
+	},
+	{ uploadPlugin, clearPluginUpload }
+)( localize( PluginUpload ) );
+

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -23,6 +23,7 @@ import {
 	isPluginUploadComplete,
 	isPluginUploadInProgress,
 } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class PluginUpload extends React.Component {
 
@@ -47,10 +48,12 @@ class PluginUpload extends React.Component {
 	}
 
 	renderUploadCard() {
-		const { inProgress, complete } = this.props;
+		const { inProgress, complete, isJetpack } = this.props;
 		return (
 			<Card>
-				{ ! inProgress && ! complete && <UploadDropZone doUpload={ this.props.uploadPlugin } /> }
+				{ ! inProgress && ! complete && <UploadDropZone
+					doUpload={ this.props.uploadPlugin }
+					disabled={ ! isJetpack } /> }
 				{ inProgress && this.renderProgressBar() }
 			</Card>
 		);
@@ -96,6 +99,7 @@ export default connect(
 		return {
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
+			isJetpack: isJetpackSite( state, siteId ),
 			inProgress: isPluginUploadInProgress( state, siteId ),
 			complete: isPluginUploadComplete( state, siteId ),
 			failed: !! error,

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -15,7 +15,7 @@ import Card from 'components/card';
 import ProgressBar from 'components/progress-bar';
 import UploadDropZone from 'blocks/upload-drop-zone';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getPluginUploadError,
 	getPluginUploadProgress,
@@ -25,6 +25,23 @@ import {
 } from 'state/selectors';
 
 class PluginUpload extends React.Component {
+
+	componentDidMount() {
+		const { siteId, inProgress } = this.props;
+		! inProgress && this.props.clearPluginUpload( siteId );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.siteId !== this.props.siteId ) {
+			const { siteId, inProgress } = nextProps;
+			! inProgress && this.props.clearPluginUpload( siteId );
+		}
+
+		if ( nextProps.complete ) {
+			page( `/plugins/${ nextProps.pluginId }/${ nextProps.siteSlug }` );
+		}
+	}
+
 	back = () => {
 		page.back();
 	}
@@ -78,6 +95,7 @@ export default connect(
 		const progress = getPluginUploadProgress( state, siteId );
 		return {
 			siteId,
+			siteSlug: getSelectedSiteSlug( state ),
 			inProgress: isPluginUploadInProgress( state, siteId ),
 			complete: isPluginUploadComplete( state, siteId ),
 			failed: !! error,

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -14,8 +13,7 @@ import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import Card from 'components/card';
 import ProgressBar from 'components/progress-bar';
-import DropZone from 'components/drop-zone';
-import FilePicker from 'components/file-picker';
+import UploadDropZone from 'blocks/upload-drop-zone';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
@@ -25,10 +23,6 @@ import {
 	isPluginUploadComplete,
 	isPluginUploadInProgress,
 } from 'state/selectors';
-import notices from 'notices';
-import {
-	MAX_UPLOADED_THEME_SIZE
-} from 'lib/automated-transfer/constants';
 
 class PluginUpload extends React.Component {
 	back = () => {
@@ -39,57 +33,9 @@ class PluginUpload extends React.Component {
 		const { inProgress, complete } = this.props;
 		return (
 			<Card>
-				{ ! inProgress && ! complete && this.renderDropZone() }
+				{ ! inProgress && ! complete && <UploadDropZone doUpload={ this.props.uploadPlugin } /> }
 				{ inProgress && this.renderProgressBar() }
 			</Card>
-		);
-	}
-
-	onFileSelect = ( files ) => {
-		const { translate, siteId } = this.props;
-		const errorMessage = translate( 'Please drop a single zip file' );
-
-		if ( files.length !== 1 ) {
-			notices.error( errorMessage );
-			return;
-		}
-
-		// DropZone supplies an array, FilePicker supplies a FileList
-		const file = files[ 0 ] || files.item( 0 );
-
-		// TODO: plugin-specific constant
-		if ( file.size > MAX_UPLOADED_THEME_SIZE ) {
-			notices.error(
-				translate( 'Plugin zip is too large. Please upload a plugin under 50 MB.' )
-			);
-
-			return;
-		}
-
-		this.props.uploadPlugin( siteId, file );
-	}
-
-	renderDropZone() {
-		const { translate } = this.props;
-		const dropText = translate(
-			'Drop files or click here to upload'
-		);
-		const uploadInstructionsText = translate(
-			'Only single .zip files are accepted.'
-		);
-
-		return (
-			<div className="plugin-upload__dropzone">
-				<DropZone onFilesDrop={ this.onFileSelect } />
-				<FilePicker accept="application/zip" onPick={ this.onFileSelect } >
-					<Gridicon
-						className="plugin-upload__dropzone-icon"
-						icon="cloud-upload"
-						size={ 48 } />
-					{ dropText }
-					<span className="plugin-upload__dropzone-instructions">{ uploadInstructionsText }</span>
-				</FilePicker>
-			</div>
 		);
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -83,6 +83,7 @@
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,
+		"manage/plugins/upload": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,


### PR DESCRIPTION
Add a page at /plugins/upload/{site} that allows plugin zips to be uploaded to a jetpack site.

Addresses #15664. Full flow design: p6TEKc-1j6-p2

<img width="1248" alt="screen shot 2017-07-19 at 16 02 32" src="https://user-images.githubusercontent.com/7767559/28374184-e38e8d64-6c9b-11e7-955a-3c55e878f92c.png">
<img width="1248" alt="screen shot 2017-07-19 at 16 02 53" src="https://user-images.githubusercontent.com/7767559/28374187-e608760e-6c9b-11e7-9bbc-e55e4ce2c99e.png">
<img width="1247" alt="screen shot 2017-07-19 at 16 03 05" src="https://user-images.githubusercontent.com/7767559/28374190-e96edea0-6c9b-11e7-87fb-750f5af40069.png">

**To Test**
* Go to http://calypso.localhost:3000/plugins/upload/{jetpacksite} (or use calypso.live)
* Drag a plugin zip over the drop component, or click to pick with a file browser

**Expected:**
* Progress bar should move for file upload then pulse whilst waiting for response from site
* Any error (for example, plugin already installed on site) will not show. Notices will be added in a further PR
* Successful upload will result in the plugin page loading
* Custom plugins currently only display name and author


