### PR TITLE
Store: Fix save button for variation changes on product update form

### DIFF
--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -32,7 +32,10 @@ import {
 	editProductVariation,
 	clearProductVariationEdits,
 } from 'woocommerce/state/ui/products/variations/actions';
-import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
+import {
+	getProductVariationsWithLocalEdits,
+	getVariationEditsStateForProduct,
+} from 'woocommerce/state/ui/products/variations/selectors';
 import {
 	editProductCategory,
 	clearProductCategoryEdits,
@@ -191,7 +194,7 @@ function mapStateToProps( state, ownProps ) {
 
 	const site = getSelectedSiteWithFallback( state );
 	const product = getProductWithLocalEdits( state, productId );
-	const hasEdits = Boolean( getProductEdits( state, productId ) );
+	const hasEdits = Boolean( getProductEdits( state, productId ) ) || Boolean( getVariationEditsStateForProduct( state, productId ) );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
 	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );


### PR DESCRIPTION
Fixes #15958.

This PR fixes the save button/unsaved changes warning behavior for variations. Now if you make a change to a variation, the save button should become available. You should also get the "unsaved changes" warning like you would for a product change.

To Test:
* Go to a product with variations
* Make a change to a variation price or field and NOT any other product fields
* The save button should turn blue
* Click the breadcrumbs or another link to leave the page without saving. See the warning