### PR TITLE
Checkout: Make sure the privacy protection is added from the modal

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -10,7 +10,6 @@ import {
 	camelCase,
 	deburr,
 	first,
-	has,
 	head,
 	includes,
 	indexOf,
@@ -479,21 +478,18 @@ export class DomainDetailsForm extends PureComponent {
 		this.formStateController.handleSubmit( ( hasErrors ) => {
 			this.recordSubmit();
 
+			this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
+
 			if ( hasErrors || options.skipFinish ) {
-				this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
 				this.closeDialog();
 				return;
 			}
 
-			this.finish( options );
+			this.finish();
 		} );
 	}
 
-	finish( options = {} ) {
-		if ( has( options.addPrivacy ) ) {
-			this.setPrivacyProtectionSubscriptions( options.addPrivacy !== false );
-		}
-
+	finish() {
 		const allFieldValues = this.props.contactDetails;
 		debug( 'finish: allFieldValues:', allFieldValues );
 		setDomainDetails( allFieldValues );


### PR DESCRIPTION
Regression introduced in https://github.com/Automattic/wp-calypso/pull/14545

When buying a domain, don't select the checkbox for privacy protection.
When continuing to checkout, you'll be shown a dialog to add the privacy protection. Even if you selected that you do want privacy protection, it was not added to cart, but you could proceed to checkout as if nothing bad happened.

The reason for this is that `has` takes two parameters, not one. But either way, the logic here could be simplified to get rid of this check, so that's what I did.

Fixes #16107