### PR TITLE
Store: Load variations on product update if they have not been previously loaded

### DIFF
--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -59,14 +59,16 @@ class ProductUpdate extends React.Component {
 	};
 
 	componentDidMount() {
-		const { params, product, site } = this.props;
+		const { params, product, site, variations } = this.props;
 		const productId = Number( params.product );
 
 		if ( site && site.ID ) {
 			if ( ! product ) {
 				this.props.fetchProduct( site.ID, productId );
-				this.props.fetchProductVariations( site.ID, productId );
 				this.props.editProduct( site.ID, { id: productId }, {} );
+			}
+			if ( ! variations ) {
+				this.props.fetchProductVariations( site.ID, productId );
 			}
 			this.props.fetchProductCategories( site.ID );
 		}


### PR DESCRIPTION
Fixes #15961.

When selecting a product with variations from the product list, my variation types would load, but variations would not. This PR should fix that. I tested with existing products and new variable products.

To Test:
* Go to your product list
* Select a product with variations
* Make sure variations load in at the bottom