### PR TITLE
Log in: Fix Jetpack banner padding bug

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,7 +1,7 @@
 .is-section-login {
 	padding-bottom: 47px;
 	position: relative;
-	min-height: calc( 100vh - 47px );
+	min-height: calc( 100% - 47px );
 
 	.layout__content {
 		position: static;

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -45,4 +45,9 @@
 		left: 0;
 	text-align: center;
 	width: 100%;
+
+	img {
+		display: block;
+		margin: 0 auto;
+	}
 }


### PR DESCRIPTION
Fixes #15373 by removing some extra padding on the bottom of the viewport in Firefox and Safari/iOS.

**Before**
<img width="1548" alt="screen shot 2017-07-11 at 16 19 53" src="https://user-images.githubusercontent.com/448298/28088781-cf5427de-6654-11e7-937b-d26456190c48.png">
**After**
<img width="1548" alt="screen shot 2017-07-11 at 16 11 54" src="https://user-images.githubusercontent.com/448298/28088712-92bc57b0-6654-11e7-8f9b-8ee5cdfb6208.png">


#### Testing

1. Run `git checkout fix/jetpack-banner-padding` or open a [live branch](https://calypso.live/?branch=fix/jetpack-banner-padding).
2. Visit http://calypso.localhost:3000/log-in in Firefox.
3. Assert there is no extra space below the Jetpack banner even if trying to scroll down.
4. Visit `/log-in` in Safari.
5. Zoom out the view.
6. Assert the Jetpack banner sticks to the bottom of the viewport without extra space below it.

#### Review

- [x] Code
- [x] Product