### PR TITLE
Store: Pass success function to payments action list

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -60,22 +60,16 @@ class SettingsPayments extends Component {
 
 	onSave = () => {
 		const { translate, site, finishedInitialSetup } = this.props;
-
-		let successAction = successNotice(
-			translate( 'Payment settings saved.' ),
-			{ duration: 4000 }
-		);
-
-		if ( ! finishedInitialSetup ) {
-			successAction = () => {
+		const successAction = () => {
+			if ( ! finishedInitialSetup ) {
 				page.redirect( getLink( '/store/:site', site ) );
+			}
 
-				return successNotice(
-					translate( 'Payment settings saved.' ),
-					{ duration: 4000, displayOnNextPage: true }
-				);
-			};
-		}
+			return successNotice(
+				translate( 'Payment settings saved.' ),
+				{ duration: 4000, displayOnNextPage: true }
+			);
+		};
 
 		const failureAction = errorNotice(
 			translate( 'There was a problem saving the payment settings. Please try again.' )


### PR DESCRIPTION
In #16067, I updated the action list to accept a function so we could redirect and save in certain instances. We need to pass a function always. Without this the settings will save but you will get a failure message. This fixes that.

To Test:
* Go to payment settings and change something
* Hit save - make sure you get the green message