### PR TITLE
Add a confirmation message when the user leaves a Shipping Zone page with unsaved changes

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -29,6 +29,8 @@ import { getCurrentlyEditingShippingZoneLocationsList } from 'woocommerce/state/
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getLink } from 'woocommerce/lib/nav-utils';
+import { ProtectFormGuard } from 'lib/protect-form';
+import { getSaveZoneActionListSteps } from 'woocommerce/state/data-layer/ui/shipping-zones';
 
 class Shipping extends Component {
 	constructor() {
@@ -117,10 +119,11 @@ class Shipping extends Component {
 	}
 
 	render() {
-		const { siteId, className, loaded, zone, locations, isRestOfTheWorld } = this.props;
+		const { siteId, className, loaded, zone, locations, isRestOfTheWorld, hasEdits } = this.props;
 
 		return (
 			<Main className={ classNames( 'shipping', className ) }>
+				<ProtectFormGuard isChanged={ hasEdits } />
 				<QueryShippingZones siteId={ siteId } />
 				<ShippingZoneHeader
 					onSave={ this.onSave }
@@ -162,6 +165,7 @@ export default connect(
 			zone,
 			isRestOfTheWorld,
 			locations: loaded && getCurrentlyEditingShippingZoneLocationsList( state, 20 ),
+			hasEdits: zone && 0 !== getSaveZoneActionListSteps( state ).length,
 		};
 	},
 	( dispatch ) => ( {


### PR DESCRIPTION
I didn't know we had a regular React component to do this, I only knew about the HoC. With this is was almost too easy.

To test:
* Go to edit a shipping zone.
* Make some changes on the zone, any of the methods or the locations.
* Try to navigate away.
* You should see a popup prompting you to stay in the page. If you choose to leave, check that you navigate away normally.
* Save the changes.
* Try to navigate away.
* Note that you don't see the popup now.
* Open the zone again.
* Navigate away without making any changes.
* Note that you don't see the popup this time either.