### PR TITLE
Net Neutrality: Adds link to release post

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -363,14 +363,22 @@ class SiteSettingsFormGeneral extends Component {
 							disabled={ isRequestingSettings }
 							onChange={ handleToggle( 'net_neutrality' ) }
 						>
-							{ translate(
-								'The FCC wants to repeal Net Neutrality. Without Net Neutrality, ' +
-								'big cable and telecom companies can divide the internet into fast ' +
-								'and slow lanes. What would the Internet look like without net neutrality? ' +
-								'Find out by enabling this banner on your site: it shows your support ' +
-								'for real net neutrality rules by displaying a message on the bottom ' +
-								'of your site and "slowing down" some of your posts.'
-							) }
+						{ translate(
+							'The FCC wants to repeal Net Neutrality. Without Net Neutrality, ' +
+							'big cable and telecom companies can divide the internet into fast ' +
+							'and slow lanes. What would the Internet look like without net neutrality? ' +
+							'Find out by enabling this banner on your site: it shows your support ' +
+							'for real net neutrality rules by displaying a message on the bottom ' +
+							'of your site and "slowing down" some of your posts. ' +
+							'{{netNeutralityLink}}Read the release post{{/netNeutralityLink}}',
+							{
+								components: {
+									netNeutralityLink: (
+										<a target="_blank" href={ 'https://en.blog.wordpress.com/2017/07/11/join-us-in-the-fight-for-net-neutrality/' } />
+									)
+								}
+							}
+						) }
 						</CompactFormToggle>
 					</FormFieldset>
 				</Card>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -370,7 +370,7 @@ class SiteSettingsFormGeneral extends Component {
 							'Find out by enabling this banner on your site: it shows your support ' +
 							'for real net neutrality rules by displaying a message on the bottom ' +
 							'of your site and "slowing down" some of your posts. ' +
-							'{{netNeutralityLink}}Read the release post{{/netNeutralityLink}}',
+							'{{netNeutralityLink}}Learn more about Net Neutrality{{/netNeutralityLink}}',
 							{
 								components: {
 									netNeutralityLink: (

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -374,7 +374,11 @@ class SiteSettingsFormGeneral extends Component {
 							{
 								components: {
 									netNeutralityLink: (
-										<a target="_blank" href={ 'https://en.blog.wordpress.com/2017/07/11/join-us-in-the-fight-for-net-neutrality/' } />
+										<a
+											target="_blank"
+											rel="noopener noreferrer"
+											href={ 'https://en.blog.wordpress.com/2017/07/11/join-us-in-the-fight-for-net-neutrality/' }
+										/>
 									)
 								}
 							}


### PR DESCRIPTION
Added a "Learn more" link to the setting. I'll be adding something similar in the plugin as well.

![image](https://user-images.githubusercontent.com/1123119/28095886-d33e93d4-6659-11e7-9f00-c9484e69b64c.png)
