### PR TITLE
Checkout: show savings in checkout summary

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,14 +68,6 @@ module.exports = {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	savingsInCheckoutSummary: {
-		datestamp: '20170516',
-		variations: {
-			hide: 50,
-			show: 50,
-		},
-		defaultVariation: 'show',
-	},
 	signupPlansCopyChanges: {
 		datestamp: '20170623',
 		variations: {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -25,21 +24,18 @@ import { localize } from 'i18n-calypso';
 
 const getIncludedDomain = cartItems.getIncludedDomain;
 
-const CartItem = React.createClass( {
-
-	removeFromCart: function( event ) {
+export class CartItem extends React.Component {
+	removeFromCart = ( event ) => {
 		event.preventDefault();
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Remove From Cart Icon', 'Product ID', this.props.cartItem.product_id );
 		upgradesActions.removeItem( this.props.cartItem, this.props.domainsWithPlansOnly );
-	},
+	}
 
-	price: function() {
-		var cost,
-			cart = this.props.cart,
-			cartItem = this.props.cartItem;
+	price() {
+		const { cart, cartItem, translate } = this.props;
 
 		if ( typeof cartItem.cost === 'undefined' ) {
-			return this.props.translate( 'Loading price' );
+			return translate( 'Loading price' );
 		}
 
 		if ( cartItem.free_trial ) {
@@ -50,17 +46,17 @@ const CartItem = React.createClass( {
 			return this.getDomainPlanPrice( cartItem );
 		}
 
-		cost = cartItem.cost * cartItem.volume;
+		const cost = cartItem.cost * cartItem.volume;
 
-		return this.props.translate( '%(cost)s %(currency)s', {
+		return translate( '%(cost)s %(currency)s', {
 			args: {
 				cost: cost,
 				currency: cartItem.currency
 			}
 		} );
-	},
+	}
 
-	monthlyPrice: function() {
+	monthlyPrice() {
 		const { cost, currency } = this.props.cartItem;
 
 		if ( typeof cost === 'undefined' ) {
@@ -85,10 +81,10 @@ const CartItem = React.createClass( {
 				currency
 			}
 		} );
-	},
+	}
 
-	getDomainPlanPrice: function( cartItem ) {
-		if ( abtest( 'savingsInCheckoutSummary' ) === 'show' && cartItem && cartItem.product_cost ) {
+	getDomainPlanPrice( cartItem ) {
+		if ( cartItem && cartItem.product_cost ) {
 			return (
 				<span>
 					<span className="cart__free-with-plan">{ cartItem.product_cost } { cartItem.currency }</span>
@@ -98,12 +94,10 @@ const CartItem = React.createClass( {
 		}
 
 		return <em>{ this.props.translate( 'Free with your plan' ) }</em>;
-	},
+	}
 
-	getFreeTrialPrice: function() {
-		var freeTrialText;
-
-		freeTrialText = this.props.translate( 'Free %(days)s Day Trial', {
+	getFreeTrialPrice() {
+		const freeTrialText = this.props.translate( 'Free %(days)s Day Trial', {
 			args: { days: '14' }
 		} );
 
@@ -112,11 +106,12 @@ const CartItem = React.createClass( {
 				{ freeTrialText }
 			</span>
 		);
-	},
+	}
 
 	getProductInfo() {
-		var domain = this.props.cartItem.meta || ( this.props.selectedSite && this.props.selectedSite.domain ),
-			info = null;
+		const domain = this.props.cartItem.meta || ( this.props.selectedSite && this.props.selectedSite.domain );
+		let info = null;
+
 		if ( isGoogleApps( this.props.cartItem ) && this.props.cartItem.extra.google_apps_users ) {
 			info = this.props.cartItem.extra.google_apps_users.map( user => <div>{ user.email }</div> );
 		} else if ( isCredits( this.props.cartItem ) ) {
@@ -129,10 +124,10 @@ const CartItem = React.createClass( {
 			info = domain;
 		}
 		return info;
-	},
+	}
 
-	render: function() {
-		var name = this.getProductName();
+	render() {
+		let name = this.getProductName();
 		if ( this.props.cartItem.bill_period && this.props.cartItem.bill_period !== -1 ) {
 			if ( isMonthly( this.props.cartItem ) ) {
 				name += ' - ' + this.props.translate( 'monthly subscription' );
@@ -163,17 +158,17 @@ const CartItem = React.createClass( {
 			</li>
 		);
 		/*eslint-enable wpcalypso/jsx-classname-namespace*/
-	},
+	}
 
-	getProductName: function() {
-		var cartItem = this.props.cartItem,
-			options = {
-				count: cartItem.volume,
-				args: {
-					volume: cartItem.volume,
-					productName: cartItem.product_name
-				}
-			};
+	getProductName() {
+		const cartItem = this.props.cartItem;
+		const options = {
+			count: cartItem.volume,
+			args: {
+				volume: cartItem.volume,
+				productName: cartItem.product_name,
+			},
+		};
 
 		if ( ! cartItem.volume ) {
 			return cartItem.product_name;
@@ -207,14 +202,16 @@ const CartItem = React.createClass( {
 					);
 			}
 		}
-	},
+	}
 
-	removeButton: function() {
+	removeButton() {
 		if ( canRemoveFromCart( this.props.cart, this.props.cartItem ) ) {
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return <button className="remove-item noticon noticon-close" onClick={ this.removeFromCart }></button>;
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}
 	}
-} );
+}
 
 export default connect(
 	state => ( {

--- a/client/my-sites/checkout/cart/cart-items.jsx
+++ b/client/my-sites/checkout/cart/cart-items.jsx
@@ -1,37 +1,43 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var CartItem = require( './cart-item' ),
-	cartItems = require( 'lib/cart-values' ).cartItems;
+import CartItem from './cart-item';
+import { cartItems } from 'lib/cart-values';
 
-var COLLAPSED_ITEMS_COUNT = 2;
+const COLLAPSED_ITEMS_COUNT = 2;
 
-var CartItems = React.createClass({
+export default class CartItems extends React.Component {
 
-	propTypes: {
+	static propTypes = {
 		collapse: React.PropTypes.bool.isRequired
-	},
+	};
 
-	getInitialState: function() {
-		return { isCollapsed: this.props.collapse };
-	},
+	constructor( props ) {
+		super( props );
 
-	handleExpand: function( event ) {
+		this.state = {
+			isCollapsed: props.collapse
+		};
+	}
+
+	handleExpand = ( event ) => {
 		event.preventDefault();
 
 		// If we call setState here directly, it would remove the expander from DOM,
 		// and then click-outside from Popover would consider it as an outside click,
 		// and it would close the Popover cart.
 		// event.stopPropagation() does not help.
-		setTimeout( this.setState.bind( this, { isCollapsed: false } ), 0 );
-	},
+		setTimeout( () => {
+			this.setState( { isCollapsed: false } );
+		} );
+	}
 
-	collapseItems: function( items ) {
+	collapseItems( items ) {
 		var collapsedItemsCount = items.length - COLLAPSED_ITEMS_COUNT,
 			collapsedItems = items.slice( 0, COLLAPSED_ITEMS_COUNT );
 
@@ -51,17 +57,16 @@ var CartItems = React.createClass({
 		);
 
 		return collapsedItems;
-	},
+	}
 
-	render: function() {
-		var cart = this.props.cart,
-			items;
+	render() {
+		const { cart } = this.props;
 
 		if ( ! cartItems.getAll( cart ) ) {
 			return;
 		}
 
-		items = cartItems.getAllSorted( cart ).map( function( cartItem ) {
+		let items = cartItems.getAllSorted( cart ).map( cartItem => {
 			return (
 				<CartItem
 					cart={ cart }
@@ -69,7 +74,7 @@ var CartItems = React.createClass({
 					selectedSite={ this.props.selectedSite }
 					key={ cartItem.product_id + '-' + cartItem.meta } />
 			);
-		}, this );
+		} );
 
 		if ( this.state.isCollapsed && items.length > COLLAPSED_ITEMS_COUNT + 1 ) {
 			items = this.collapseItems( items );
@@ -77,6 +82,4 @@ var CartItems = React.createClass({
 
 		return <ul className="cart-items">{ items }</ul>;
 	}
-});
-
-module.exports = CartItems;
+}


### PR DESCRIPTION
This PR will show how much users save with the plan they're about to purchase, as the test #14260 ended.

## How to test

- Apply this PR to your local Calypso or visit calypso.live of this branch.
- Choose the site with free plan.
- Select Plan menu on the sidebar and click "Upgrade" button on the plans page.
- You should find some strikethrough price and green "Free with your plan" text pairs in the checkout summary.

## Expected result

<img width="512" alt="expected_result" src="https://user-images.githubusercontent.com/212034/28105040-d8d8ae1e-6718-11e7-90fd-472cdb2b720c.png">
