### PR TITLE
Add a fn to check if a product is a valid Simple Payment product

### DIFF
--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -1,0 +1,1 @@
+export const SIMPLE_PAYMENTS_PRODUCT_POST_TYPE = 'jp_pay_product';

--- a/client/lib/simple-payments/utils.js
+++ b/client/lib/simple-payments/utils.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
+
+export const isValidSimplePaymentsProduct = ( product ) =>
+	product.type === SIMPLE_PAYMENTS_PRODUCT_POST_TYPE;

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -24,6 +24,8 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { getRawSite } from 'state/sites/selectors';
 import { errorNotice } from 'state/notices/actions';
+import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
+import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 
 /**
  * Reduce function for product attributes stored in post metadata
@@ -71,7 +73,7 @@ function productToCustomPost( product ) {
 			return payload;
 		},
 		{
-			type: 'jp_pay_product',
+			type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
 			metadata: [],
 			title: product.title,
 			content: product.description,
@@ -107,7 +109,7 @@ export function requestSimplePaymentsProducts( { dispatch }, action ) {
 		method: 'GET',
 		path: `/sites/${ siteId }/posts`,
 		query: {
-			type: 'jp_pay_product',
+			type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
 			status: 'publish'
 		},
 	}, action ) );
@@ -163,8 +165,13 @@ export const addProduct = ( { dispatch }, { siteId }, next, newProduct ) =>
 export const deleteProduct = ( { dispatch }, { siteId }, next, deletedProduct ) =>
 	dispatch( receiveDeleteProduct( siteId, deletedProduct.ID ) );
 
-export const listProduct = ( { dispatch }, { siteId }, next, product ) =>
+export const listProduct = ( { dispatch }, { siteId }, next, product ) => {
+	if ( ! isValidSimplePaymentsProduct( product ) ) {
+		return;
+	}
+
 	dispatch( receiveProduct( siteId, customPostToProduct( product ) ) );
+};
 
 export const listProducts = ( { dispatch }, { siteId }, next, { found: numOfProducts, posts: products } ) =>
 	dispatch( receiveProductsList( siteId, numOfProducts, products.map( customPostToProduct ) ) );

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -174,10 +174,10 @@ export const listProduct = ( { dispatch }, { siteId }, next, product ) => {
 	dispatch( receiveProduct( siteId, customPostToProduct( product ) ) );
 };
 
-export const listProducts = ( { dispatch }, { siteId }, next, { found: numOfProducts, posts: products } ) => {
+export const listProducts = ( { dispatch }, { siteId }, next, { posts: products } ) => {
 	const validProducts = filter( products, isValidSimplePaymentsProduct );
 
-	dispatch( receiveProductsList( siteId, numOfProducts, validProducts.map( customPostToProduct ) ) );
+	dispatch( receiveProductsList( siteId, validProducts.map( customPostToProduct ) ) );
 };
 
 const announceListingProductsFailure = ( { dispatch, getState }, { siteId } ) => {

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import { filter } from 'lodash';
 
 /**
  * Internal dependencies
@@ -173,8 +174,11 @@ export const listProduct = ( { dispatch }, { siteId }, next, product ) => {
 	dispatch( receiveProduct( siteId, customPostToProduct( product ) ) );
 };
 
-export const listProducts = ( { dispatch }, { siteId }, next, { found: numOfProducts, posts: products } ) =>
-	dispatch( receiveProductsList( siteId, numOfProducts, products.map( customPostToProduct ) ) );
+export const listProducts = ( { dispatch }, { siteId }, next, { found: numOfProducts, posts: products } ) => {
+	const validProducts = filter( products, isValidSimplePaymentsProduct );
+
+	dispatch( receiveProductsList( siteId, numOfProducts, validProducts.map( customPostToProduct ) ) );
+};
 
 const announceListingProductsFailure = ( { dispatch, getState }, { siteId } ) => {
 	const site = getRawSite( getState(), siteId );

--- a/client/state/simple-payments/product-list/actions.js
+++ b/client/state/simple-payments/product-list/actions.js
@@ -21,7 +21,7 @@ export const requestProduct = ( siteId, productId ) => ( {
 	type: SIMPLE_PAYMENTS_PRODUCT_GET,
 } );
 
-export function receiveProductsList( siteId, numOfProducts, posts ) {
+export function receiveProductsList( siteId, posts ) {
 	return {
 		type: SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE,
 		siteId,


### PR DESCRIPTION
Helps to fix retrieving and storing standard posts as Simple Payments products.

In https://github.com/Automattic/wp-calypso/pull/16028#issuecomment-314494683, @artpi noticed that you can display a Simple Payments product even for a standard post on a Jetpack site. The problem lies in the `requestSimplePaymentsProduct` getter -- it doesn't check if the retrieved custom post is of `jp_pay_product` type.

In this PR, we add a helper `isValidSimplePaymentsProduct` to check if a received post is a Simple Payment product.

## Testing

First, let's repro the original bug:

- Don't checkout this branch;
- In your Jetpack site, create a simple post;
- In Calypso, dispatch:
```
dispatch({
type: 'SIMPLE_PAYMENTS_PRODUCT_GET',
siteId: <your-jetpack-blog-id>,
productId: <your-simple-post-id>
});
```
- Look into Redux tree: you should see the simple post inside `simplePayments` sub-tree -- bad

Now, let's see if this PR fixes it:
- Checkout this branch;
- Do the same steps as above;
- Is the simple post in the Redux tree? If not -- great.

Also, verify that you can retrieve a Simple Payments product by changing the `productId` to a real product post ID.