### PR TITLE
FormToggle: call the onChange handler with the new checked value as param

### DIFF
--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -26,19 +26,11 @@ export default class FormToggle extends PureComponent {
 
 	static idNum = 0;
 
-	constructor() {
-		super( ...arguments );
-
-		this.onKeyDown = this.onKeyDown.bind( this );
-		this.onClick = this.onClick.bind( this );
-		this.onLabelClick = this.onLabelClick.bind( this );
-	}
-
 	componentWillMount() {
 		this.id = this.constructor.idNum++;
 	}
 
-	onKeyDown( event ) {
+	onKeyDown = ( event ) => {
 		if ( this.props.disabled ) {
 			return;
 		}
@@ -51,13 +43,13 @@ export default class FormToggle extends PureComponent {
 		this.props.onKeyDown( event );
 	}
 
-	onClick() {
+	onClick = () => {
 		if ( ! this.props.disabled ) {
 			this.props.onChange( ! this.props.checked );
 		}
 	}
 
-	onLabelClick( event ) {
+	onLabelClick = ( event ) => {
 		if ( this.props.disabled ) {
 			return;
 		}

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -45,7 +45,7 @@ export default class FormToggle extends PureComponent {
 
 		if ( event.key === 'Enter' || event.key === ' ' ) {
 			event.preventDefault();
-			this.props.onChange();
+			this.props.onChange( ! this.props.checked );
 		}
 
 		this.props.onKeyDown( event );
@@ -53,7 +53,7 @@ export default class FormToggle extends PureComponent {
 
 	onClick() {
 		if ( ! this.props.disabled ) {
-			this.props.onChange();
+			this.props.onChange( ! this.props.checked );
 		}
 	}
 
@@ -65,7 +65,7 @@ export default class FormToggle extends PureComponent {
 		const nodeName = event.target.nodeName.toLowerCase();
 		if ( nodeName !== 'a' && nodeName !== 'input' && nodeName !== 'select' ) {
 			event.preventDefault();
-			this.props.onChange();
+			this.props.onChange( ! this.props.checked );
 		}
 	}
 

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -72,6 +72,24 @@ describe( 'FormToggle', function() {
 			} );
 		} );
 
+		it( 'should fire onChange event with value param when clicked', function( done ) {
+			const toggle = TestUtils.renderIntoDocument(
+				<FormToggle
+					checked={ false }
+					onChange={ function( checked ) {
+						assert( checked, 'onChange handler was called with a value param' );
+						done();
+					} }
+				/>,
+			);
+
+			TestUtils.Simulate.click(
+				ReactDom.findDOMNode(
+					TestUtils.findRenderedDOMComponentWithClass( toggle, 'form-toggle__switch' ),
+				),
+			);
+		} );
+
 		it( 'should not be disabled when disabled is false', function() {
 			var toggle = TestUtils.renderIntoDocument( <FormToggle checked={ false } disabled={ false }/> ),
 				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'form-toggle' );


### PR DESCRIPTION
When calling the `onChange` handler, pass the new value of `checked` as a boolean param. This makes the `FormToggle` API more compatible with the `redux-form` library which expects the `onChange` handler to have a parameter that is either a DOM `Event` (with a `target` property) or the value itself.

After this change, using `FormToggle` inside a `redux-form`'s `Field` component is easier, as it requires less boilerplate.

The second commit in this PR is janitorial change that converts `FormToggle` event handlers to class properties instead of manually binding them in the constructor.