### PR TITLE
date-picker: fix weekdays depending on locale

### DIFF
--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { PropTypes, PureComponent } from 'react';
 import DayPicker from 'react-day-picker';
-import { noop, merge, map, filter } from 'lodash';
+import { noop, merge, map, filter, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -75,7 +75,8 @@ class DatePicker extends PureComponent {
 	locale() {
 		const { moment } = this.props;
 		const localeData = moment().localeData();
-
+		const firstDayOfWeek = localeData.firstDayOfWeek();
+		const weekdays = moment.weekdaysMin();
 		const locale = {
 			formatDay: function( date ) {
 				return moment( date ).format( 'llll' );
@@ -86,7 +87,7 @@ class DatePicker extends PureComponent {
 			},
 
 			formatWeekdayShort: function( day ) {
-				return moment().weekday( day ).format( 'dd' )[ 0 ];
+				return get( weekdays, day, ' ' )[ 0 ];
 			},
 
 			formatWeekdayLong: function( day ) {
@@ -94,7 +95,7 @@ class DatePicker extends PureComponent {
 			},
 
 			getFirstDayOfWeek: function() {
-				return Number( localeData.firstDayOfWeek() );
+				return firstDayOfWeek;
 			}
 		};
 


### PR DESCRIPTION
This PR fixes #15615. The bug happens when the language is changed and the _first day of the weeks_ doesn't match with `Sunday`. Please read the issue to dive even more.

### How to test it

1) After applying the patch change the user language going to the user account page: http://calypso.localhost:3000/me/account

2) Change to a language where the first day of the week isn't `Sunday`, for instance, `ar`, `nl`, `es`, `pl`, etc.

3) Check that `today` dark-grey circle into the calendar is under right day column. You could get the calendar easily going to the new post page: `http://calypso.localhost:3000/post/<your-testing-blog>` under the status section on the sidebar.


<img src="https://user-images.githubusercontent.com/77539/28109813-c5eb4868-66c6-11e7-9ad6-5a6b584600da.png" width="400px" />

Above is how it looks for me today (Wednesday, July 12) with English ((UK) `en-br` language.