### PR TITLE
Simplify the implementation of ReduxFormToggle component

### DIFF
--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -3,40 +3,27 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { Field } from 'redux-form';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import FormToggle from 'components/forms/form-toggle/compact';
 
+// eslint-disable-next-line no-unused-vars
+const RenderToggle = ( { input, meta, text, type, ...otherProps } ) => (
+	<FormToggle { ...input } { ...otherProps }>
+		{ text }
+	</FormToggle>
+);
+
 class ReduxFormToggle extends Component {
 	static propTypes = {
-		name: PropTypes.string,
+		name: PropTypes.string.isRequired,
 		text: PropTypes.string,
 	};
 
-	renderToggle = text => ( { input: { onChange, value } } ) => {
-		const otherProps = omit( this.props, [ 'name', 'text' ] );
-
-		return (
-			<FormToggle
-				{ ...otherProps }
-				checked={ value || false }
-				onChange={ this.updateToggle( value, onChange ) }>
-				{ text }
-			</FormToggle>
-		);
-	}
-
-	updateToggle = ( value, onChange ) => () => onChange( ! value );
-
 	render() {
-		return (
-			<Field
-				component={ this.renderToggle( this.props.text ) }
-				name={ this.props.name } />
-		);
+		return <Field component={ RenderToggle } type="checkbox" { ...this.props } />;
 	}
 }
 


### PR DESCRIPTION
Use several smart features of the `redux-form`'s `Field` component:

After changes in #16129, the `FormToggle` component is more compatible
with the native HTML `input` component (`value` and `onChange` props with the right params).
The `input` prop that `Field` passes to its `component` is designed to be directly destructured
into props of such a component. We don't need to provide our own wrappers for `checked` and
`onChange` any more.

If the `Field` has a `type="checkbox"` prop, it will pass a boolean `checked` property in the
`input` object to its `component` instead of `value`. Let's use that.

All properties that `Field` doesn't know (like `name` or `component`), it automatically passes
down to the rendered `component`. Use this to pass `text` to `RenderToggle` in a much simpler
way than before.

Move the `renderToggle` method to a separate constant function. It doesn't need to access `this`
any more, as all info is passed to it as props. Avoid recreating a new instance of the function
on every render.

This PR requires #16129 to be landed first, otherwise the `FormToggle` won't work.

Most other `redux-form-*` components can be simplified in a similar way.