### PR TITLE
SSR: Allow server rendering of paths with query args

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -76,6 +76,7 @@ export function loggedIn( context, next ) {
 export function loggedOut( context, next ) {
 	if ( context.isServerSide && ! isEmpty( context.query ) ) {
 		// Don't server-render URLs with query params
+		context.disableSSR = true;
 		return next();
 	}
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -8,7 +8,7 @@ import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get, isEmpty, pick } from 'lodash';
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -122,13 +122,9 @@ function getCurrentCommitShortChecksum() {
 }
 
 function getDefaultContext( request ) {
-	let initialServerState = {};
-	// We don't cache routes with query params
-	if ( isEmpty( request.query ) ) {
-		// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
-		const serializeCachedServerState = stateCache.get( request.path ) || {};
-		initialServerState = getInitialServerState( serializeCachedServerState );
-	}
+	// context.pathname is set to request.path, see server/isomorphic-routing#getEnhancedContext()
+	const serializeCachedServerState = stateCache.get( request.path ) || {};
+	const initialServerState = getInitialServerState( serializeCachedServerState );
 
 	const context = Object.assign( {}, request.context, {
 		compileDebug: config( 'env' ) === 'development' ? true : false,

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -111,7 +111,7 @@ export function serverRender( req, res ) {
 		// Send state to client
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
 		// And cache on the server, too
-		if ( context.disableSSR ) {
+		if ( ! context.disableSSR ) {
 			const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
 			stateCache.set( context.pathname, serverState );
 		}

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -4,7 +4,7 @@
 import ReactDomServer from 'react-dom/server';
 import superagent from 'superagent';
 import Lru from 'lru';
-import { isEmpty, pick } from 'lodash';
+import { pick } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -86,7 +86,7 @@ export function serverRender( req, res ) {
 		config.isEnabled( 'server-side-rendering' ) &&
 		context.layout &&
 		! context.user &&
-		isEmpty( context.query ) &&
+		! context.disableSSR &&
 		isDefaultLocale( context.lang )
 	) {
 		// context.pathname doesn't include querystring, so it's a suitable cache key.
@@ -111,8 +111,7 @@ export function serverRender( req, res ) {
 		// Send state to client
 		context.initialReduxState = pick( context.store.getState(), reduxSubtrees );
 		// And cache on the server, too
-		if ( isEmpty( context.query ) ) {
-			// Don't cache if we have query params
+		if ( context.disableSSR ) {
 			const serverState = reducer( context.initialReduxState, { type: SERIALIZE } );
 			stateCache.set( context.pathname, serverState );
 		}


### PR DESCRIPTION
Fixes #14159

SSR and server caching of pages for any path with query args was previously disabled to avoid filling up the SSR caches with arbitrary theme search strings, for example:

`http://wordpress.com/themes?s=big`

The disadvantage to this is that pages with discrete query args such as login page with `redirect_to` param can never be server-rendered.

This change removes the no-query-arg condition for SSR, and adds a context field, `disableSSR`, so individual routes, such as /themes, can disable SSR for a condition such as query args.

**To Test**
* Be sure to rebuild after checking out, because the PR has server changes
* before building, use `export DEBUG="calypso:server-render"`
* Test various themes routes and check that paths with ? args do not server render (see build console)
* Test that themes routes without ? args server render as usual, for example http://calypso.localhost:3000/theme/mood
* Test login SSR routes
