### PR TITLE
Activity log: Change tracks property names to valid formats

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -53,9 +53,9 @@ class ErrorBanner extends PureComponent {
 				title={ translate( 'Problem restoring your site' ) }
 			>
 				<TrackComponentView eventName="calypso_activitylog_errorbanner_impression" eventProperties={ {
-					errorCode,
-					failureReason,
-					restoreTo: timestamp,
+					error_code: errorCode,
+					failure_reason: failureReason,
+					restore_to: timestamp,
 				} } />
 				<p>{ translate( 'We came across a problem while trying to restore your site.' ) }</p>
 				<Button primary onClick={ this.handleClickRestore }>

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -46,7 +46,7 @@ class SuccessBanner extends PureComponent {
 				title={ translate( 'Your site has been successfully restored' ) }
 			>
 				<TrackComponentView eventName="calypso_activitylog_successbanner_impression" eventProperties={ {
-					restoreTo: timestamp,
+					restore_to: timestamp,
 				} } />
 				<p>{ translate(
 					'We successfully restored your site back to %s!',

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -47,9 +47,9 @@ class ActivityLogDay extends Component {
 		} = this.props;
 
 		recordTracksEvent( 'calypso_activitylog_day_expand', {
-			logCount: logs.length,
-			tsEndOfSiteDay,
-			utcDate: moment.utc( tsEndOfSiteDay ).format( 'YYYY-MM-DD' ),
+			log_count: logs.length,
+			ts_end_site_day: tsEndOfSiteDay,
+			utc_date: moment.utc( tsEndOfSiteDay ).format( 'YYYY-MM-DD' ),
 		} );
 	};
 


### PR DESCRIPTION
These events were being rejected by tracks:

```
eventname or eventprops failed "^[a-z_][a-z0-9_]*$" pattern
```

This should fix that.