### PR TITLE
Progress bar: Update to es6 and ScreenReaderText

### DIFF
--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -4,6 +4,11 @@
 import React from 'react';
 import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import ScreenReaderText from 'components/screen-reader-text';
+
 module.exports = React.createClass( {
 
 	displayName: 'ProgressBar',
@@ -35,8 +40,8 @@ module.exports = React.createClass( {
 
 	renderBar() {
 		const title = this.props.title
-				? <span className="screen-reader-text">{ this.props.title }</span>
-				: null;
+			? <ScreenReaderText>{ this.props.title }</ScreenReaderText>
+			: null;
 
 		const styles = { width: this.getCompletionPercentage() + '%' };
 		if ( this.props.color ) {

--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -9,19 +9,14 @@ import classnames from 'classnames';
  */
 import ScreenReaderText from 'components/screen-reader-text';
 
-module.exports = React.createClass( {
+export default class ProgressBar extends PureComponent {
+	static defaultProps = {
+		total: 100,
+		compact: false,
+		isPulsing: false
+	};
 
-	displayName: 'ProgressBar',
-
-	getDefaultProps() {
-		return {
-			total: 100,
-			compact: false,
-			isPulsing: false
-		};
-	},
-
-	propTypes: {
+	static propTypes = {
 		value: React.PropTypes.number.isRequired,
 		total: React.PropTypes.number,
 		color: React.PropTypes.string,
@@ -29,14 +24,14 @@ module.exports = React.createClass( {
 		compact: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		isPulsing: React.PropTypes.bool
-	},
+	};
 
 	getCompletionPercentage() {
 		const percentage = Math.ceil( this.props.value / this.props.total * 100 );
 
 		// The percentage should not be allowed to be more than 100
 		return Math.min( percentage, 100 );
-	},
+	}
 
 	renderBar() {
 		const title = this.props.title
@@ -49,7 +44,7 @@ module.exports = React.createClass( {
 		}
 
 		return <div className="progress-bar__progress" style={ styles } >{ title }</div>;
-	},
+	}
 
 	render() {
 		const classes = classnames( this.props.className, 'progress-bar', {
@@ -62,4 +57,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}


### PR DESCRIPTION
Update ProgressBar to es6 `PureComponent`.
Uses `ScreenReaderText` component rather than class name.

The behavior of this component should remain identical.

**To test**
1. Visit https://calypso.live/devdocs/design/progress-bar?branch=update/progressbar-es6-best-practices
1. Verify that the progress bar is visually and structurally (HTML) identical to https://wpcalypso.wordpress.com/devdocs/design/progress-bar