### PR TITLE
Activity log: Expand day when header clicked

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -30,7 +30,8 @@ class ActivityLogDay extends Component {
 		isRewindActive: true,
 	};
 
-	handleClickRestore = () => {
+	handleClickRestore = ( event ) => {
+		event.stopPropagation();
 		const {
 			tsEndOfSiteDay,
 			requestRestore,
@@ -120,6 +121,7 @@ class ActivityLogDay extends Component {
 		return (
 			<div className="activity-log-day">
 				<FoldableCard
+					clickableHeader
 					expandedSummary={ this.getRewindButton() }
 					header={ this.getEventsHeading() }
 					onOpen={ this.trackOpenDay }


### PR DESCRIPTION
Fixes #16104 

To test:
* https://calypso.live/stats/activity?branch=update/activitylog-day-clickableheader
* Click on a day item to see it expand or collapse