### PR TITLE
Site Settings: Display Jetpack dev mode notice in all settings sections

### DIFF
--- a/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
+++ b/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
@@ -13,12 +13,18 @@ import NoticeAction from 'components/notice/notice-action';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSiteInDevelopmentMode } from 'state/selectors';
+import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 
 const JetpackDevModeNotice = ( {
 	isJetpackSiteInDevMode,
+	jetpackSettingsUiSupported,
 	siteId,
 	translate
 } ) => {
+	if ( ! jetpackSettingsUiSupported ) {
+		return null;
+	}
+
 	return (
 		<div>
 			<QueryJetpackConnection siteId={ siteId } />
@@ -41,10 +47,13 @@ const JetpackDevModeNotice = ( {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
+		const siteIsJetpack = isJetpackSite( state, siteId );
+		const jetpackUiSupported = siteSupportsJetpackSettingsUi( state, siteId );
 
 		return {
 			siteId,
 			isJetpackSiteInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
+			jetpackSettingsUiSupported: siteIsJetpack && jetpackUiSupported,
 		};
 	}
 )( localize( JetpackDevModeNotice ) );

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -13,7 +13,6 @@ import DocumentHead from 'components/data/document-head';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, siteSupportsJetpackSettingsUi } from 'state/sites/selectors';
 import GeneralSettings from './section-general';
 import SiteSettingsNavigation from './navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -21,7 +20,6 @@ import JetpackDevModeNotice from './jetpack-dev-mode-notice';
 import Placeholder from 'my-sites/site-settings/placeholder';
 
 const SiteSettingsComponent = ( {
-	jetpackSettingsUiSupported,
 	siteId,
 	translate
 } ) => {
@@ -32,7 +30,7 @@ const SiteSettingsComponent = ( {
 	return (
 		<Main className="site-settings">
 			<DocumentHead title={ translate( 'Site Settings' ) } />
-			{ jetpackSettingsUiSupported && <JetpackDevModeNotice /> }
+			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			{ siteId && <SiteSettingsNavigation section={ 'general' } /> }
 			<QueryProductsList />
@@ -45,18 +43,10 @@ const SiteSettingsComponent = ( {
 SiteSettingsComponent.propTypes = {
 	// Connected props
 	siteId: PropTypes.number,
-	jetpackSettingsUiSupported: PropTypes.bool
 };
 
 export default connect(
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
-		const jetpackSite = isJetpackSite( state, siteId );
-		const jetpackUiSupported = siteSupportsJetpackSettingsUi( state, siteId );
-
-		return {
-			siteId,
-			jetpackSettingsUiSupported: jetpackSite && jetpackUiSupported,
-		};
-	}
+	( state ) => ( {
+		siteId: getSelectedSiteId( state ),
+	} )
 )( localize( SiteSettingsComponent ) );

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -13,6 +13,7 @@ import DocumentHead from 'components/data/document-head';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import DiscussionForm from 'my-sites/site-settings/form-discussion';
+import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import Placeholder from 'my-sites/site-settings/placeholder';
 import { getSelectedSite } from 'state/ui/selectors';
 
@@ -27,6 +28,7 @@ const SiteSettingsDiscussion = ( {
 	return (
 		<Main className="settings-discussion site-settings">
 			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="discussion" />
 			<DiscussionForm />

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -15,6 +15,7 @@ import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import FormSecurity from 'my-sites/site-settings/form-security';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import Placeholder from 'my-sites/site-settings/placeholder';
@@ -60,6 +61,7 @@ const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
 	return (
 		<Main className="settings-security__main site-settings">
 			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="security" />
 			<JetpackMonitor />

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -16,6 +16,7 @@ import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
+import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
@@ -48,6 +49,7 @@ const SiteSettingsTraffic = ( {
 	return (
 		<Main className="settings-traffic site-settings">
 			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="traffic" />
 

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
+import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import WritingForm from 'my-sites/site-settings/form-writing';
@@ -27,6 +28,7 @@ const SiteSettingsWriting = ( {
 	return (
 		<Main className="settings-writing site-settings">
 			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="writing" />
 			<WritingForm />


### PR DESCRIPTION
This PR moves the Jetpack dev mode notice logic in the notice component, and renders the notice in all of the settings sections:

![](https://cldup.com/zZSGy2Qj9m-3000x3000.png)

Previously, it was only displayed in General settings.

To test:

* Checkout this branch
* For a Jetpack site with dev mode enabled, verify the dev mode notice appears for all settings sections.
* For a Jetpack site with dev mode disabled, verify the dev mode notice does not appear in any section.
* For a non-Jetpack site, verify the dev mode notice does not appear, and no network requests to fetch the connection status are being done.