### PR TITLE
Woo-Connect Insights: fall back to site selection if slug is missing or all-sites selected

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -25,6 +25,9 @@ function isValidParameters( context ) {
 }
 
 export default function StatsController( context ) {
+	if ( ! context.params.site || context.params.site === 'null' ) {
+		page.redirect( '/stats/day/' );
+	}
 	if ( ! isValidParameters( context ) ) {
 		page.redirect( `/store/stats/orders/day/${ context.params.site }` );
 	}

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -45,11 +45,13 @@ class StoreStats extends Component {
 
 	render() {
 		const { isWooConnect, path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
+
 		// TODO: this is to handle users switching sites while on store stats
 		// unfortunately, we can't access the path when changing sites
 		if ( ! isWooConnect ) {
-			page.redirect( `/stats/${ slug }` );
+			page.redirect( `/stats/day/${ slug }` );
 		}
+
 		const unitQueryDate = getUnitPeriod( queryDate, unit );
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const endSelectedDate = getEndPeriod( selectedDate, unit );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -10,6 +10,8 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import App from './app';
+
+import controller from 'my-sites/controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
@@ -179,6 +181,7 @@ export default function() {
 
 	// Add pages that use my-sites navigation instead
 	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
+		page( '/store/stats/:type/:unit', controller.siteSelection, controller.sites );
 		page( '/store/stats/:type/:unit/:site', siteSelection, navigation, StatsController );
 	}
 }


### PR DESCRIPTION
Similar to the way 'Media' handles the attempted switch to 'All Sites'.

I initially switched to '/stats/day/' but I feel ^^ is better.

Fixes #16083 