### PR TITLE
Jetpack Plugins: Fix PluginRatings propTypes warning

### DIFF
--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -15,7 +15,7 @@ export default React.createClass( {
 
 	propTypes: {
 		rating: React.PropTypes.number,
-		ratings: React.PropTypes.object,
+		ratings: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.array ] ),
 		downloaded: React.PropTypes.number,
 		slug: React.PropTypes.string,
 		numRatings: React.PropTypes.number


### PR DESCRIPTION
It appears that the WordPress.org plugin info API endpoint returns the plugin ratings in a rather unexpected form:

* If there are any ratings, it returns them as an object, where keys are the rating tiers: `{ 1: 5, 2: 11, 3: 123, 4: 1000, 5: 10000 }`
* If there aren't ratings it returns them as an empty array: `[]`

However we're only expecting an object, so if we view a plugin without any reviews, it'll display a React propTypes warning:

![](https://cldup.com/CCx8tlmNCt.png)

This PR addresses that by altering the component to also expect an array.

To test:
* Checkout this branch
* Go to `/plugins/woo-product-disclaimer/:site`, where `:site` is one of your Jetpack sites.
* Verify you don't see the React warning.