### PR TITLE
Support: Add concierge offer to contact form

### DIFF
--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -4,7 +4,7 @@
 import { identity } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,6 +17,8 @@ class ChatBusinessConciergeNotice extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
 		isBusinessPlanUser: PropTypes.bool.isRequired,
+		from: PropTypes.string.isRequired,
+		to: PropTypes.string.isRequired,
 	};
 
 	static defaultProps = {
@@ -29,6 +31,12 @@ class ChatBusinessConciergeNotice extends Component {
 
 	render = () => {
 		const { translate } = this.props;
+		const fromDate = i18n.moment( this.props.from );
+		const toDate = i18n.moment( this.props.to );
+
+		if ( ! i18n.moment().isAfter( fromDate ) || ! i18n.moment().isBefore( toDate ) ) {
+			return null;
+		}
 
 		if ( ! this.props.isBusinessPlanUser ) {
 			return (

--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -62,5 +62,5 @@ class ChatBusinessConciergeNotice extends Component {
 export default connect(
 	( state ) => ( {
 		isBusinessPlanUser: isBusinessPlanUser( state ),
-	} ),
+	} )
 )( localize( ChatBusinessConciergeNotice ) );

--- a/client/me/help/chat-business-concierge-notice/index.jsx
+++ b/client/me/help/chat-business-concierge-notice/index.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { identity } from 'lodash';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import HelpTeaserButton from '../help-teaser-button';
+import { isBusinessPlanUser } from 'state/selectors';
+
+class ChatBusinessConciergeNotice extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		isBusinessPlanUser: PropTypes.bool.isRequired,
+	};
+
+	static defaultProps = {
+		translate: identity,
+	};
+
+	trackCalendlyOfferClick = () => {
+		analytics.tracks.recordEvent( 'calypso_help_calendly_offer_click' );
+	};
+
+	render = () => {
+		const { translate } = this.props;
+
+		if ( ! this.props.isBusinessPlanUser ) {
+			return (
+				<HelpTeaserButton
+					title={ translate( 'Chat is temporarily closed.' ) }
+					description={ translate(
+						'We\'re still available over email in the meantime. ' +
+						'Chat will be back on Friday, July 21st!'
+					) } />
+			);
+		}
+
+		return (
+			<HelpTeaserButton
+				onClick={ this.trackCalendlyOfferClick }
+				href="https://calendly.com/wordpressdotcom/wordpress-com-business-site-setup/"
+				title={ translate( 'Chat with us over screenshare!' ) }
+				description={ translate( 'Click here to get one-on-one help with a Happiness Engineer.' ) } />
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		isBusinessPlanUser: isBusinessPlanUser( state ),
+	} ),
+)( localize( ChatBusinessConciergeNotice ) );

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -243,9 +243,8 @@ export const HelpContactForm = React.createClass( {
 				/>
 
 				{ formDescription && ( <p>{ formDescription }</p> ) }
-				<div>
-					<ChatBusinessConciergeNotice />
-				</div>
+
+				<ChatBusinessConciergeNotice />
 
 				{ showHowCanWeHelpField && (
 					<div>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -244,7 +244,10 @@ export const HelpContactForm = React.createClass( {
 
 				{ formDescription && ( <p>{ formDescription }</p> ) }
 
-				<ChatBusinessConciergeNotice />
+				<ChatBusinessConciergeNotice
+					from="2017-07-19T00:00:00Z"
+					to="2017-07-21T00:00:00Z"
+				/>
 
 				{ showHowCanWeHelpField && (
 					<div>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -27,6 +27,7 @@ import { selectSiteId } from 'state/help/actions';
 import { getHelpSelectedSite } from 'state/help/selectors';
 import wpcomLib from 'lib/wp';
 import HelpResults from 'me/help/help-results';
+import HelpTeaserButton from '../help-teaser-button';
 
 /**
  * Module variables
@@ -204,6 +205,33 @@ export const HelpContactForm = React.createClass( {
 		} );
 	},
 
+	renderCalendlyOffer() {
+		const { translate, isBusinessPlanUser } = this.props;
+
+		if ( ! isBusinessPlanUser ) {
+			return (
+				<HelpTeaserButton
+					title={ translate( 'Chat is temporarily closed.' ) }
+					description={ translate(
+						'We\'re still available over email in the meantime. ' +
+						'Chat will be back on Friday, July 21st!'
+					) } />
+			);
+		}
+
+		return (
+			<HelpTeaserButton
+				onClick={ this.trackCalendlyOfferClick }
+				href="https://calendly.com/wordpressdotcom/wordpress-com-business-site-setup/"
+				title={ translate( 'Chat with us over screenshare!' ) }
+				description={ translate( 'Click here to get one-on-one help with a Happiness Engineer.' ) } />
+		);
+	},
+
+	trackCalendlyOfferClick() {
+		analytics.tracks.recordEvent( 'calypso_help_calendly_offer_click' );
+	},
+
 	/**
 	 * Render the contact form
 	 * @return {object} ReactJS JSX object
@@ -240,7 +268,11 @@ export const HelpContactForm = React.createClass( {
 					from="2016-12-24T00:00:00Z"
 					to="2017-01-02T00:00:00Z"
 				/>
+
 				{ formDescription && ( <p>{ formDescription }</p> ) }
+				<div>
+					{ this.renderCalendlyOffer() }
+				</div>
 
 				{ showHowCanWeHelpField && (
 					<div>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -23,11 +23,11 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import ChatClosureNotice from '../chat-closure-notice';
+import ChatBusinessConciergeNotice from '../chat-business-concierge-notice';
 import { selectSiteId } from 'state/help/actions';
 import { getHelpSelectedSite } from 'state/help/selectors';
 import wpcomLib from 'lib/wp';
 import HelpResults from 'me/help/help-results';
-import HelpTeaserButton from '../help-teaser-button';
 
 /**
  * Module variables
@@ -205,33 +205,6 @@ export const HelpContactForm = React.createClass( {
 		} );
 	},
 
-	renderCalendlyOffer() {
-		const { translate, isBusinessPlanUser } = this.props;
-
-		if ( ! isBusinessPlanUser ) {
-			return (
-				<HelpTeaserButton
-					title={ translate( 'Chat is temporarily closed.' ) }
-					description={ translate(
-						'We\'re still available over email in the meantime. ' +
-						'Chat will be back on Friday, July 21st!'
-					) } />
-			);
-		}
-
-		return (
-			<HelpTeaserButton
-				onClick={ this.trackCalendlyOfferClick }
-				href="https://calendly.com/wordpressdotcom/wordpress-com-business-site-setup/"
-				title={ translate( 'Chat with us over screenshare!' ) }
-				description={ translate( 'Click here to get one-on-one help with a Happiness Engineer.' ) } />
-		);
-	},
-
-	trackCalendlyOfferClick() {
-		analytics.tracks.recordEvent( 'calypso_help_calendly_offer_click' );
-	},
-
 	/**
 	 * Render the contact form
 	 * @return {object} ReactJS JSX object
@@ -271,7 +244,7 @@ export const HelpContactForm = React.createClass( {
 
 				{ formDescription && ( <p>{ formDescription }</p> ) }
 				<div>
-					{ this.renderCalendlyOffer() }
+					<ChatBusinessConciergeNotice />
 				</div>
 
 				{ showHowCanWeHelpField && (

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
 import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
@@ -37,7 +36,6 @@ import { sendChatMessage as sendHappychatMessage, sendUserInfo } from 'state/hap
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
 import {
 	getCurrentUser,
-	getCurrentUserId,
 	getCurrentUserLocale,
 	getCurrentUserSiteCount,
 } from 'state/current-user/selectors';
@@ -45,15 +43,12 @@ import { askQuestion as askDirectlyQuestion, initialize as initializeDirectly } 
 import { isRequestingSites } from 'state/sites/selectors';
 import {
 	hasUserAskedADirectlyQuestion,
+	isBusinessPlanUser,
 	isDirectlyFailed,
 	isDirectlyReady,
 	isDirectlyUninitialized,
 } from 'state/selectors';
 import QueryUserPurchases from 'components/data/query-user-purchases';
-import {
-	getUserPurchases,
-} from 'state/purchases/selectors';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 /**
  * Module variables
@@ -673,7 +668,7 @@ const HelpContact = React.createClass( {
 				<HappychatConnection />
 				<QueryOlark />
 				<QueryTicketSupportConfiguration />
-				<QueryUserPurchases userId={ this.props.userId } />
+				<QueryUserPurchases userId={ this.props.currentUser.ID } />
 			</Main>
 		);
 	}
@@ -681,11 +676,7 @@ const HelpContact = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const userId = getCurrentUserId( state );
-		const purchases = getUserPurchases( state, userId );
-
 		return {
-			userId,
 			currentUserLocale: getCurrentUserLocale( state ),
 			currentUser: getCurrentUser( state ),
 			hasAskedADirectlyQuestion: hasUserAskedADirectlyQuestion( state ),
@@ -700,7 +691,7 @@ export default connect(
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			isRequestingSites: isRequestingSites( state ),
-			isBusinessPlanUser: purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS ),
+			isBusinessPlanUser: isBusinessPlanUser( state ),
 		};
 	},
 	{

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -43,7 +43,6 @@ import { askQuestion as askDirectlyQuestion, initialize as initializeDirectly } 
 import { isRequestingSites } from 'state/sites/selectors';
 import {
 	hasUserAskedADirectlyQuestion,
-	isBusinessPlanUser,
 	isDirectlyFailed,
 	isDirectlyReady,
 	isDirectlyUninitialized,
@@ -652,7 +651,7 @@ const HelpContact = React.createClass( {
 						showDismiss={ false }
 					/>
 				}
-				<HelpContactForm { ...contactFormProps } isBusinessPlanUser={ this.props.isBusinessPlanUser } />
+				<HelpContactForm { ...contactFormProps } />
 			</div>
 		);
 	},
@@ -691,7 +690,6 @@ export default connect(
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			isRequestingSites: isRequestingSites( state ),
-			isBusinessPlanUser: isBusinessPlanUser( state ),
 		};
 	},
 	{

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { find } from 'lodash';
 import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
@@ -36,6 +37,7 @@ import { sendChatMessage as sendHappychatMessage, sendUserInfo } from 'state/hap
 import { openChat as openHappychat } from 'state/ui/happychat/actions';
 import {
 	getCurrentUser,
+	getCurrentUserId,
 	getCurrentUserLocale,
 	getCurrentUserSiteCount,
 } from 'state/current-user/selectors';
@@ -47,6 +49,11 @@ import {
 	isDirectlyReady,
 	isDirectlyUninitialized,
 } from 'state/selectors';
+import QueryUserPurchases from 'components/data/query-user-purchases';
+import {
+	getUserPurchases,
+} from 'state/purchases/selectors';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 /**
  * Module variables
@@ -650,7 +657,7 @@ const HelpContact = React.createClass( {
 						showDismiss={ false }
 					/>
 				}
-				<HelpContactForm { ...contactFormProps } />
+				<HelpContactForm { ...contactFormProps } isBusinessPlanUser={ this.props.isBusinessPlanUser } />
 			</div>
 		);
 	},
@@ -666,6 +673,7 @@ const HelpContact = React.createClass( {
 				<HappychatConnection />
 				<QueryOlark />
 				<QueryTicketSupportConfiguration />
+				<QueryUserPurchases userId={ this.props.userId } />
 			</Main>
 		);
 	}
@@ -673,7 +681,11 @@ const HelpContact = React.createClass( {
 
 export default connect(
 	( state ) => {
+		const userId = getCurrentUserId( state );
+		const purchases = getUserPurchases( state, userId );
+
 		return {
+			userId,
 			currentUserLocale: getCurrentUserLocale( state ),
 			currentUser: getCurrentUser( state ),
 			hasAskedADirectlyQuestion: hasUserAskedADirectlyQuestion( state ),
@@ -688,6 +700,7 @@ export default connect(
 			ticketSupportRequestError: getTicketSupportRequestError( state ),
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			isRequestingSites: isRequestingSites( state ),
+			isBusinessPlanUser: purchases && !! find( purchases, purchase => purchase.productSlug === PLAN_BUSINESS ),
 		};
 	},
 	{

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -149,6 +149,7 @@ export isActivatingJetpackModule from './is-activating-jetpack-module';
 export isAmbiguousThemeFilterTerm from './is-ambiguous-theme-filter-term';
 export isAutomatedTransferActive from './is-automated-transfer-active';
 export isAutomatedTransferFailed from './is-automated-transfer-failed';
+export isBusinessPlanUser from './is-business-plan-user';
 export isDeactivatingJetpackJumpstart from './is-deactivating-jetpack-jumpstart';
 export isDeactivatingJetpackModule from './is-deactivating-jetpack-module';
 export isDeletingPublicizeShareAction from './is-deleting-publicize-share-action';

--- a/client/state/selectors/is-business-plan-user.js
+++ b/client/state/selectors/is-business-plan-user.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getUserPurchases } from 'state/purchases/selectors';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+
+/**
+ * Returns an boolean flag indicating if the current user is a business plan user.
+ *
+ * @param {Object}   state Global state tree
+ * @return {Boolean} If the current user is a business plan user.
+ */
+export default ( state ) => {
+	const userId = getCurrentUserId( state );
+
+	if ( ! userId ) {
+		return false;
+	}
+
+	const purchases = getUserPurchases( state, userId );
+
+	if ( ! purchases ) {
+		return false;
+	}
+
+	return purchases.some( ( purchase ) => PLAN_BUSINESS === purchase.productSlug );
+};

--- a/client/state/selectors/is-business-plan-user.js
+++ b/client/state/selectors/is-business-plan-user.js
@@ -6,7 +6,7 @@ import { getUserPurchases } from 'state/purchases/selectors';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 /**
- * Returns an boolean flag indicating if the current user is a business plan user.
+ * Returns a boolean flag indicating if the current user is a business plan user.
  *
  * @param {Object}   state Global state tree
  * @return {Boolean} If the current user is a business plan user.

--- a/client/state/selectors/is-business-plan-user.js
+++ b/client/state/selectors/is-business-plan-user.js
@@ -20,7 +20,7 @@ export default ( state ) => {
 
 	const purchases = getUserPurchases( state, userId );
 
-	if ( ! purchases ) {
+	if ( ! purchases || 0 === purchases.length ) {
 		return false;
 	}
 

--- a/client/state/selectors/test/is-business-plan-user.js
+++ b/client/state/selectors/test/is-business-plan-user.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { isBusinessPlanUser } from '../';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
+
+describe( 'isBusinessPlanUser()', () => {
+	it( 'should return true if any purchase is a business plan.', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						user_id: '123',
+						product_slug: 'some-other-plan',
+					},
+					{
+						user_id: '123',
+						product_slug: PLAN_BUSINESS,
+					}
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		assert.isTrue( isBusinessPlanUser( state ) );
+	} );
+
+	it( 'should return false if non of the purchases is a business plan.', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{
+						user_id: '123',
+						product_slug: 'some-other-plan',
+					},
+					{
+						user_id: '123',
+						product_slug: 'yet-another-plan',
+					}
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		assert.isFalse( isBusinessPlanUser( state ) );
+	} );
+
+	it( 'should return false if current user id is null.', () => {
+		const state = deepFreeze( {
+			currentUser: {}
+		} );
+
+		assert.isFalse( isBusinessPlanUser( state ) );
+	} );
+
+	it( 'should return false if purchasing data is null.', () => {
+		const state = deepFreeze( {
+			currentUser: {
+				id: 123,
+			},
+			purchases: {
+				data: [
+					{  // intentionally put a purchase that doesn't belong to the user 123 here.
+						user_id: '789',
+						product_slug: PLAN_BUSINESS,
+					}
+				],
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		} );
+
+		assert.isFalse( isBusinessPlanUser( state ) );
+	} );
+} );


### PR DESCRIPTION
This adds a screenshare offer to the contact form for Business users as part of the All Hands Business Concierge experiment that will be running in Happiness from 0 UTC on 7/19 to 0 UTC on 7/21. You can read more about that experiment in p7DVsv-2II-p2. **Please do not merge this until 0 UTC on 7/19.**

Business users should see the screenshare offering. Non-Business users should see a chat closure notice indicating when chat will reopen. They'll still be able to submit a ticket. Text is as follows:

- Biz: Chat with us over screenshare! Click here to get one-on-one help with a Happiness Engineer.
- Non-Biz: Chat is temporarily closed. We're still available over email in the meantime. Chat will be back on Friday, July 21st!

A bit of background work on this in 251-gh-hg.

### Testing
1. Load up this branch.
2. Visit http://calypso.localhost:3000/help/contact from a non-Business plan account. Note that you see the correct messaging. The message should not be clickable. Chat will likely still be available as it hasn't been turned off yet.
3. Visit the same page through a user account with the Business plan. You should see the concierge offer. Clicking the concierge offer should record `calypso_help_calendly_offer_click` via Tracks (you can log Tracks events to your console using `localStorage.setItem( 'debug', 'calypso:analytics*' );`).

### Screenshots

**Biz**
<img width="744" alt="screen shot 2017-07-12 at 8 39 32 am" src="https://user-images.githubusercontent.com/7240478/28123588-9025189a-66de-11e7-8ff7-61eb07f71f73.png">

**Non-Biz**
<img width="746" alt="screen shot 2017-07-12 at 8 39 24 am" src="https://user-images.githubusercontent.com/7240478/28123608-982566a8-66de-11e7-962a-34b5a9ea9cf8.png">

cc @dllh 