### PR TITLE
Add real user currency to the "Add new" Simple Payments form

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -26,7 +26,7 @@ const ProductImage = () => (
 
 class ProductForm extends Component {
 	render() {
-		const { translate } = this.props;
+		const { translate, currencyDefaults } = this.props;
 
 		return (
 			<form className="editor-simple-payments-modal__form">
@@ -45,7 +45,7 @@ class ProductForm extends Component {
 						<FormCurrencyInput
 							name="price"
 							id="price"
-							currencySymbolPrefix="$"
+							currencySymbolPrefix={ currencyDefaults.symbol }
 							placeholder="0.00"
 						/>
 					</FormFieldset>

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -19,6 +19,9 @@ import Button from 'components/button';
 import Navigation from './navigation';
 import ProductForm from './form';
 import ProductList from './list';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getCurrencyDefaults } from 'lib/format-currency';
+import QuerySitePlans from 'components/data/query-site-plans';
 
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
@@ -51,7 +54,17 @@ class SimplePaymentsDialog extends Component {
 	}
 
 	render() {
-		const { activeTab, showDialog, onChangeTabs, onClose, siteId, paymentButtons } = this.props;
+		const {
+			activeTab,
+			showDialog,
+			onChangeTabs,
+			onClose,
+			siteId,
+			paymentButtons,
+			currencyCode,
+		} = this.props;
+
+		const currencyDefaults = getCurrencyDefaults( currencyCode );
 
 		return (
 			<Dialog
@@ -61,9 +74,12 @@ class SimplePaymentsDialog extends Component {
 				additionalClassNames="editor-simple-payments-modal"
 			>
 				<QuerySimplePayments siteId={ siteId } />
+
+				{ ! currencyCode && <QuerySitePlans siteId={ siteId } />}
+
 				<Navigation { ...{ activeTab, onChangeTabs, paymentButtons } } />
 				{ activeTab === 'addNew'
-					? <ProductForm />
+					? <ProductForm currencyDefaults={ currencyDefaults } />
 					: <ProductList paymentButtons={ paymentButtons } /> }
 			</Dialog>
 		);
@@ -72,8 +88,10 @@ class SimplePaymentsDialog extends Component {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
+
 	return {
 		siteId,
 		paymentButtons: getSimplePayments( state, siteId ) || [],
+		currencyCode: getCurrentUserCurrencyCode( state ),
 	};
 } )( localize( SimplePaymentsDialog ) );


### PR DESCRIPTION
In the "Add new" Simple Payments dialog form, we don't have a real user currency. Instead, we have a placeholder US dollar there. In this PR, we are fixing that:

![image](https://user-images.githubusercontent.com/4988512/28125190-29fa133e-6726-11e7-95c1-2c8a07401d57.png)

## Testing

1. Open the "Add new" Simple Payments dialog;
2. Verify that the price has your account's user currency there.