### PR TITLE
Extensions: Zoninator - Add routing & tabs navigation

### DIFF
--- a/client/extensions/zoninator/app/controller.js
+++ b/client/extensions/zoninator/app/controller.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+import titlecase from 'to-title-case';
+import { getSiteFragment, sectionify } from 'lib/route';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import Settings from '../components/settings';
+
+export const renderTab = ( component ) => ( context ) => {
+	const siteId = getSiteFragment( context.path );
+	const { zone = '' } = context.params;
+
+	let baseAnalyticsPath = sectionify( context.path );
+
+	if ( siteId ) {
+		baseAnalyticsPath += '/:site';
+	}
+
+	let analyticsPageTitle = 'WP Zone Manager';
+
+	if ( zone.length ) {
+		analyticsPageTitle += ` > ${ titlecase( zone ) }`;
+	} else {
+		analyticsPageTitle += ' > New Zone';
+	}
+
+	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
+
+	renderWithReduxStore(
+		<Settings tab={ zone }>
+			{ React.createElement( component ) }
+		</Settings>,
+		document.getElementById( 'primary' ),
+		context.store
+	);
+};

--- a/client/extensions/zoninator/components/navigation/index.jsx
+++ b/client/extensions/zoninator/components/navigation/index.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { find, flowRight, get, trimEnd } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import SectionNav from 'components/section-nav';
+import SectionNavTabs from 'components/section-nav/tabs';
+import SectionNavTabItem from 'components/section-nav/item';
+import SectionNavSegmented from 'components/section-nav/segmented';
+import Button from 'components/button';
+import sectionsModule from 'sections';
+import { getSiteSlug } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const getZones = () => {
+	return [
+		{ label: 'Foo', slug: 'foo' },
+		{ label: 'Bar', slug: 'bar' },
+		{ label: 'Baz', slug: 'baz' },
+		{ label: 'Boo', slug: 'boo' },
+	];
+};
+
+const Navigation = ( { activeTab, siteSlug, translate } ) => {
+	const getSettingsPath = () => {
+		const sections = sectionsModule.get();
+		const section = find( sections, ( value => value.name === 'zoninator' ) );
+
+		return get( section, 'settings_path' );
+	};
+
+	const renderTab = ( { label, slug } ) => {
+		const path = trimEnd( `${ getSettingsPath() }/${ siteSlug }/${ slug }`, '/' );
+
+		return (
+			<SectionNavTabItem
+				key={ slug }
+				path={ path }
+				selected={ activeTab === slug }>
+				{ label }
+			</SectionNavTabItem>
+		);
+	};
+
+	return (
+		<SectionNav>
+			<SectionNavTabs>
+				{ getZones().map( zone => renderTab( zone ) ) }
+			</SectionNavTabs>
+
+			<SectionNavSegmented label="actions">
+				<Button path={ `${ getSettingsPath() }/${ siteSlug }` }>
+					{ translate( 'New Zone' ) }
+				</Button>
+			</SectionNavSegmented>
+		</SectionNav>
+	);
+};
+
+Navigation.propTypes = {
+	activeTab: PropTypes.string,
+	site: PropTypes.object,
+};
+
+Navigation.defaultProps = {
+	activeTab: '',
+};
+
+const connectComponent = connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteSlug: getSiteSlug( state, siteId ),
+	};
+} );
+
+export default flowRight(
+	connectComponent,
+	localize,
+)( Navigation );

--- a/client/extensions/zoninator/components/navigation/index.jsx
+++ b/client/extensions/zoninator/components/navigation/index.jsx
@@ -65,7 +65,7 @@ const Navigation = ( { activeTab, siteSlug, translate } ) => {
 
 Navigation.propTypes = {
 	activeTab: PropTypes.string,
-	site: PropTypes.object,
+	siteSlug: PropTypes.string,
 };
 
 Navigation.defaultProps = {

--- a/client/extensions/zoninator/components/navigation/index.jsx
+++ b/client/extensions/zoninator/components/navigation/index.jsx
@@ -15,8 +15,7 @@ import SectionNavTabItem from 'components/section-nav/item';
 import SectionNavSegmented from 'components/section-nav/segmented';
 import Button from 'components/button';
 import sectionsModule from 'sections';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const getZones = () => {
 	return [
@@ -73,10 +72,8 @@ Navigation.defaultProps = {
 };
 
 const connectComponent = connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-
 	return {
-		siteSlug: getSiteSlug( state, siteId ),
+		siteSlug: getSelectedSiteSlug( state ),
 	};
 } );
 

--- a/client/extensions/zoninator/components/settings/index.jsx
+++ b/client/extensions/zoninator/components/settings/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import Navigation from '../navigation';
+
+const Settings = ( {
+	children,
+	tab,
+	translate
+} ) => {
+	return (
+		<Main className={ 'zoninator__main' }>
+			<DocumentHead title={ translate( 'WP Zone Manager' ) } />
+			<Navigation activeTab={ tab } />
+			{ children }
+		</Main>
+	);
+};
+
+Settings.propTypes = {
+	site: PropTypes.object,
+	tab: PropTypes.string,
+};
+
+Settings.defaultProps = {
+	tab: '',
+};
+
+export default localize( Settings );

--- a/client/extensions/zoninator/components/settings/index.jsx
+++ b/client/extensions/zoninator/components/settings/index.jsx
@@ -17,7 +17,7 @@ const Settings = ( {
 	translate
 } ) => {
 	return (
-		<Main className={ 'zoninator__main' }>
+       <Main className={ 'zoninator__main' }>
 			<DocumentHead title={ translate( 'WP Zone Manager' ) } />
 			<Navigation activeTab={ tab } />
 			{ children }
@@ -26,7 +26,6 @@ const Settings = ( {
 };
 
 Settings.propTypes = {
-	site: PropTypes.object,
 	tab: PropTypes.string,
 };
 

--- a/client/extensions/zoninator/components/settings/index.jsx
+++ b/client/extensions/zoninator/components/settings/index.jsx
@@ -16,8 +16,10 @@ const Settings = ( {
 	tab,
 	translate
 } ) => {
+	const mainClassName = 'zoninator__main';
+
 	return (
-       <Main className={ 'zoninator__main' }>
+		<Main className={ mainClassName }>
 			<DocumentHead title={ translate( 'WP Zone Manager' ) } />
 			<Navigation activeTab={ tab } />
 			{ children }

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -1,0 +1,5 @@
+const ZoneCreator = () => {
+	return null;
+};
+
+export default ZoneCreator;

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -1,0 +1,5 @@
+const Zone = () => {
+	return null;
+};
+
+export default Zone;

--- a/client/extensions/zoninator/index.js
+++ b/client/extensions/zoninator/index.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { navigation, sites, siteSelection } from 'my-sites/controller';
+import { renderTab } from './app/controller';
+import ZoneCreator from './components/settings/zone-creator';
+import Zone from './components/settings/zone';
+
+export default function() {
+	page( '/extensions/zoninator', sites );
+	page( '/extensions/zoninator/:site', siteSelection, navigation, renderTab( ZoneCreator ) );
+	page( '/extensions/zoninator/:site/:zone', siteSelection, navigation, renderTab( Zone ) );
+}

--- a/client/extensions/zoninator/package.json
+++ b/client/extensions/zoninator/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "zoninator",
+	"author": "Automattic",
+	"description": "Zone Manager (Zoninator)",
+	"version": "0.0.1",
+	"env_id": [ "development", "wpcalypso" ],
+	"section": {
+		"name": "zoninator",
+		"paths": [ "/extensions/zoninator" ],
+		"settings_path": "/extensions/zoninator",
+		"module": "zoninator",
+		"group": "sites",
+		"secondary": true
+	}
+}


### PR DESCRIPTION
This PR adds navigation and sets up routing for Zoninator's settings:

![screen shot 2017-07-12 at 18 11 53](https://user-images.githubusercontent.com/8056203/28127787-0182b3f4-672e-11e7-8ee1-ecd2924b46c5.png)

These settings are now also accessible through "Edit plugin settings" on the plugin details page:

![screen shot 2017-07-12 at 18 12 45](https://user-images.githubusercontent.com/8056203/28127786-017f6ce4-672e-11e7-9a7a-deb8ec62cb45.png)

# Testing

- Head over to *Zone Manager* (Zoninator) plugin details.
- Click **Edit plugin settings**.
- On the settings page, ensure the tabs as well as the url are changing correctly when you click through them.