### PR TITLE
Improve copy for Atomic site disk space limitations.

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -73,10 +73,11 @@ function getHoldMessages( siteSlug, translate ) {
 			),
 		},
 		EXCESSIVE_DISK_SPACE: {
-			title: translate( 'Site too large' ),
+			title: translate( 'We can\'t proceed with this upload' ),
 			description: translate(
-				'Try using a different site.'
+				'This site is not currently eligible for installing themes and plugins. Please contact support to straighten things out.'
 			),
+			supportUrl: 'https://support.wordpress.com/help-support-options/',
 		},
 	};
 }


### PR DESCRIPTION
Use a more generic message when a user's Business plan is ineligible because of excessive disk usage.

```
**Site not supported**
This site is not supported at this time. Contact support to resolve this issue.
```

Sites with more than 50GB of storage are ineligible for uploading plugins and themes. This messaging attempts to give the user direction when they're unable to proceed with a plugin or theme install.

Builds on #16147 .

cc/ @lamosty @jmdodd @gwwar 