### PR TITLE
Store: Skip address, page, and smart default steps if products exist on the site

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -67,7 +67,7 @@ class Dashboard extends Component {
 		const newSiteId = newProps.selectedSite ? newProps.selectedSite.ID : null;
 		const oldSiteId = selectedSite ? selectedSite.ID : null;
 
-		if ( oldSiteId !== newSiteId ) {
+		if ( newSiteId && ( oldSiteId !== newSiteId ) ) {
 			this.props.fetchSetupChoices( newSiteId );
 			this.props.fetchOrders( newSiteId, 1 );
 

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -21,7 +21,9 @@ import {
 } from 'woocommerce/state/sites/setup-choices/selectors';
 import { areOrdersLoading, getOrders } from 'woocommerce/state/sites/orders/selectors';
 import { fetchOrders } from 'woocommerce/state/sites/orders/actions';
+import { fetchProducts } from 'woocommerce/state/sites/products/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { getTotalProducts, areProductsLoading, areProductsLoaded } from 'woocommerce/state/sites/products/selectors';
 import Main from 'components/main';
 import ManageNoOrdersView from './manage-no-orders-view';
 import ManageOrdersView from './manage-orders-view';
@@ -47,16 +49,20 @@ class Dashboard extends Component {
 	};
 
 	componentDidMount = () => {
-		const { selectedSite } = this.props;
+		const { selectedSite, productsLoaded } = this.props;
 
 		if ( selectedSite && selectedSite.ID ) {
 			this.props.fetchSetupChoices( selectedSite.ID );
 			this.props.fetchOrders( selectedSite.ID, 1 );
+
+			if ( ! productsLoaded ) {
+				this.props.fetchProducts( selectedSite.ID, 1 );
+			}
 		}
 	}
 
 	componentWillReceiveProps = ( newProps ) => {
-		const { selectedSite } = this.props;
+		const { selectedSite, productsLoaded } = this.props;
 
 		const newSiteId = newProps.selectedSite ? newProps.selectedSite.ID : null;
 		const oldSiteId = selectedSite ? selectedSite.ID : null;
@@ -64,6 +70,10 @@ class Dashboard extends Component {
 		if ( oldSiteId !== newSiteId ) {
 			this.props.fetchSetupChoices( newSiteId );
 			this.props.fetchOrders( newSiteId, 1 );
+
+			if ( ! productsLoaded ) {
+				this.props.fetchProducts( newSiteId, 1 );
+			}
 		}
 	}
 
@@ -73,18 +83,19 @@ class Dashboard extends Component {
 			finishedPageSetup,
 			finishedInitialSetup,
 			setStoreAddressDuringInitialSetup,
-			translate
+			translate,
+			hasProducts,
 		} = this.props;
 
 		if ( ! finishedInstallOfRequiredPlugins ) {
 			return translate( 'Installing Plugins' );
 		}
 
-		if ( ! finishedPageSetup ) {
+		if ( ! finishedPageSetup && ! hasProducts ) {
 			return translate( 'Setting Up Store Pages' );
 		}
 
-		if ( ! setStoreAddressDuringInitialSetup ) {
+		if ( ! setStoreAddressDuringInitialSetup && ! hasProducts ) {
 			return translate( 'Store Location' );
 		}
 
@@ -101,6 +112,7 @@ class Dashboard extends Component {
 			finishedPageSetup,
 			finishedInitialSetup,
 			hasOrders,
+			hasProducts,
 			selectedSite,
 			setStoreAddressDuringInitialSetup,
 		} = this.props;
@@ -109,11 +121,11 @@ class Dashboard extends Component {
 			return ( <RequiredPluginsInstallView site={ selectedSite } /> );
 		}
 
-		if ( ! finishedPageSetup ) {
+		if ( ! finishedPageSetup && ! hasProducts ) {
 			return ( <RequiredPagesSetupView site={ selectedSite } /> );
 		}
 
-		if ( ! setStoreAddressDuringInitialSetup ) {
+		if ( ! setStoreAddressDuringInitialSetup && ! hasProducts ) {
 			return ( <PreSetupView site={ selectedSite } /> );
 		}
 
@@ -148,14 +160,18 @@ class Dashboard extends Component {
 
 function mapStateToProps( state ) {
 	const selectedSite = getSelectedSiteWithFallback( state );
-	const loading = ( areOrdersLoading( state ) || areSetupChoicesLoading( state ) );
+	const loading = ( areOrdersLoading( state ) || areSetupChoicesLoading( state ) || areProductsLoading( state ) );
 	const hasOrders = getOrders( state ).length > 0;
+	const hasProducts = getTotalProducts( state ) > 0;
+	const productsLoaded = areProductsLoaded( state );
 	const finishedInitialSetup = getFinishedInitialSetup( state );
 	return {
 		finishedInitialSetup,
 		finishedInstallOfRequiredPlugins: getFinishedInstallOfRequiredPlugins( state ),
 		finishedPageSetup: getFinishedPageSetup( state ),
 		hasOrders,
+		hasProducts,
+		productsLoaded,
 		loading,
 		selectedSite,
 		setStoreAddressDuringInitialSetup: getSetStoreAddressDuringInitialSetup( state ),
@@ -167,6 +183,7 @@ function mapDispatchToProps( dispatch ) {
 		{
 			fetchOrders,
 			fetchSetupChoices,
+			fetchProducts,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -76,7 +76,7 @@ class SetupTasks extends Component {
 		const newSiteId = newProps.site && newProps.site.ID || null;
 		const oldSiteId = site && site.ID || null;
 
-		if ( oldSiteId !== newSiteId ) {
+		if ( newSiteId && ( oldSiteId !== newSiteId ) ) {
 			this.props.fetchSettingsGeneral( newSiteId );
 			this.props.fetchSetupChoices( newSiteId );
 			if ( ! areProductsLoaded ) {

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -16,7 +16,8 @@ import {
 	getCheckedTaxSetup,
 } from 'woocommerce/state/sites/setup-choices/selectors';
 import {
-	getTotalProducts
+	getTotalProducts,
+	areProductsLoaded,
 } from 'woocommerce/state/sites/products/selectors';
 import {
 	fetchProducts
@@ -60,9 +61,12 @@ class SetupTasks extends Component {
 
 		if ( site && site.ID ) {
 			this.props.fetchPaymentMethods( site.ID );
-			this.props.fetchProducts( site.ID, 1 );
 			this.props.fetchSettingsGeneral( site.ID );
 			this.props.fetchSetupChoices( site.ID );
+
+			if ( ! areProductsLoaded ) {
+				this.props.fetchProducts( site.ID, 1 );
+			}
 		}
 	}
 
@@ -73,9 +77,11 @@ class SetupTasks extends Component {
 		const oldSiteId = site && site.ID || null;
 
 		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchProducts( newSiteId, 1 );
 			this.props.fetchSettingsGeneral( newSiteId );
 			this.props.fetchSetupChoices( newSiteId );
+			if ( ! areProductsLoaded ) {
+				this.props.fetchProducts( newSiteId, 1 );
+			}
 		}
 	}
 
@@ -208,6 +214,7 @@ function mapStateToProps( state ) {
 		optedOutOfShippingSetup: getOptedOutOfShippingSetup( state ),
 		triedCustomizer: getTriedCustomizerDuringInitialSetup( state ),
 		hasProducts: getTotalProducts( state ) > 0,
+		productsLoaded: areProductsLoaded( state ),
 		paymentsAreSetUp: arePaymentsSetup( state ),
 		shippingIsSetUp: areAnyShippingMethodsEnabled( state ),
 		taxesAreSetUp: getCheckedTaxSetup( state ),


### PR DESCRIPTION
Fixes #16143.

After scraping a different attempt at fixing this, we talked in Slack and decided to just skip these steps (so we don't overwrite settings) if previous products were found on the site. They will still get the plugin step so they get `wc-api-dev`, services, and taxjar.

To Test:
* Go to `https://developer.wordpress.com/docs/api/console/` and set everything to 0/false.
* Make sure you have some products on your site (check via wp-admin)
* Go to `http://calypso.localhost:3000/store/:site` to kick-off the setup flow. You should see the plugin screen, and then be taken to the setup task screen.
* Delete your products making sure you have 0.
* Go to `https://developer.wordpress.com/docs/api/console/` and set everything to 0/false.
* Go to `http://calypso.localhost:3000/store/:site` to kick-off the setup flow. You should see all the normal setup steps.
