### PR TITLE
Store: Fix simple card stock_quantity prop type

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -135,7 +135,7 @@ ProductFormSimpleCard.propTypes = {
 		weight: PropTypes.string,
 		regular_price: PropTypes.string,
 		manage_stock: PropTypes.bool,
-		stock_quantity: PropTypes.string,
+		stock_quantity: PropTypes.number,
 		backorders: PropTypes.string,
 	} ),
 	editProduct: PropTypes.func.isRequired,


### PR DESCRIPTION
The API returns stock_quantity as an integer, not a string: https://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties

This fixes #16123:

> Warning: Failed prop type: Invalid prop `product.stock_quantity` of type `number` supplied to `ProductFormSimpleCard`, expected `string`.

Or other use of stock_quantity with a PropType (product list row) is already a number.

To Test:
* Go to `http://calypso.localhost:3000/store/product/:site/:product` for a product with stock
* Make sure no warning shows
* Go to `http://calypso.localhost:3000/store/product/:site/:product` for a product with no stock
* Make sure no warning shows
