### PR TITLE
Ads: Clarified Impressions Copy

### DIFF
--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -289,7 +289,7 @@ class AdsFormEarnings extends Component {
 							<tr>
 								<th className="ads__earnings-history-header">{ translate( 'Period' ) }</th>
 								<th className="ads__earnings-history-header">{ translate( 'Earnings' ) }</th>
-								<th className="ads__earnings-history-header">{ translate( 'Ad Impressions' ) }</th>
+								<th className="ads__earnings-history-header">{ translate( 'Attempted Impressions' ) }</th>
 								<th className="ads__earnings-history-header">{ translate( 'Status' ) }</th>
 							</tr>
 						</thead>


### PR DESCRIPTION
Updating copy to clarify that the impressions are attempted and not necessarily actual.

**To Test**
1) Go to site w/ WordAds enabled.
2) Click on `WordAds`/`Ads` link under Configure.
3) See copy says "Attempted Impressions" instead of "Ad Impressions".

<img width="1234" alt="screen shot 2017-07-12 at 12 28 00 pm" src="https://user-images.githubusercontent.com/273708/28136163-9334a220-66fd-11e7-8629-edd42be4b3e6.png">
