### PR TITLE
Update Confirmation Sidebar Header text.

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -174,13 +174,15 @@ class EditorConfirmationSidebar extends React.Component {
 					<div className="editor-confirmation-sidebar__content-wrap">
 						<div className="editor-confirmation-sidebar__header">
 							{
-								this.props.translate( '{{strong}}Ready to go?{{/strong}} Double-check and then confirm to publish.', {
-									comment: 'This string appears as the header for the confirmation sidebar ' +
+								this.props.translate( '{{strong}}Almost there!{{/strong}} ' +
+									'You can double-check your post’s settings below. When you’re happy, ' +
+									'use the big green button to send your post out into the world!', {
+										comment: 'This string appears as the header for the confirmation sidebar ' +
 										'when a user publishes a post or page.',
-									components: {
-										strong: <strong />
-									},
-								} )
+										components: {
+											strong: <strong />
+										},
+									} )
 							}
 						</div>
 						<div className="editor-confirmation-sidebar__privacy-control">


### PR DESCRIPTION
This PR updates the text for the Publish Confirmation Sidebar.

![screen shot 2017-07-12 at 11 02 54 pm](https://user-images.githubusercontent.com/1017839/28139935-8337f8b4-6756-11e7-9b01-ecd9fc2c92f2.png)

This PR is part of a larger epic. The feature is behind a feature-flag and is intentionally incomplete. See p8F9tW-3F-p2.

To test:

- Checkout this branch
- Run `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Draft a post
- Hit Publish
- Verify that the text has been updated
