### PR TITLE
Comments: Give the post title a link to the post's Reader view.

### DIFF
--- a/client/blocks/comment-detail/comment-detail-author.jsx
+++ b/client/blocks/comment-detail/comment-detail-author.jsx
@@ -34,7 +34,7 @@ export class CommentDetailAuthor extends Component {
 		blockUser: PropTypes.func,
 		commentDate: PropTypes.string,
 		commentStatus: PropTypes.string,
-		postUrl: PropTypes.string,
+		commentUrl: PropTypes.string,
 		showAuthorInfo: PropTypes.bool,
 		siteId: PropTypes.number,
 	};
@@ -156,7 +156,7 @@ export class CommentDetailAuthor extends Component {
 			authorDisplayName,
 			authorUrl,
 			commentStatus,
-			postUrl,
+			commentUrl,
 			showAuthorInfo,
 			siteId,
 			translate,
@@ -184,7 +184,7 @@ export class CommentDetailAuthor extends Component {
 						</div>
 						<ExternalLink
 							className="comment-detail__author-info-element comment-detail__comment-date"
-							href={ postUrl }
+							href={ commentUrl }
 						>
 							{ this.getFormattedDate() }
 						</ExternalLink>

--- a/client/blocks/comment-detail/comment-detail-comment.jsx
+++ b/client/blocks/comment-detail/comment-detail-comment.jsx
@@ -25,7 +25,7 @@ export class CommentDetailComment extends Component {
 		commentContent: PropTypes.string,
 		commentDate: PropTypes.string,
 		commentStatus: PropTypes.string,
-		postUrl: PropTypes.string,
+		commentUrl: PropTypes.string,
 		siteId: PropTypes.number,
 	};
 
@@ -42,7 +42,7 @@ export class CommentDetailComment extends Component {
 			commentContent,
 			commentDate,
 			commentStatus,
-			postUrl,
+			commentUrl,
 			repliedToComment,
 			siteId,
 			translate,
@@ -62,7 +62,7 @@ export class CommentDetailComment extends Component {
 						blockUser={ blockUser }
 						commentDate={ commentDate }
 						commentStatus={ commentStatus }
-						postUrl={ postUrl }
+						commentUrl={ commentUrl }
 						siteId={ siteId }
 					/>
 					<AutoDirection>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -34,11 +34,11 @@ export class CommentDetail extends Component {
 		commentIsLiked: PropTypes.bool,
 		commentIsSelected: PropTypes.bool,
 		commentStatus: PropTypes.string,
+		commentUrl: PropTypes.string,
 		deleteCommentPermanently: PropTypes.func,
 		isBulkEdit: PropTypes.bool,
 		postAuthorDisplayName: PropTypes.string,
 		postTitle: PropTypes.string,
-		postUrl: PropTypes.string,
 		repliedToComment: PropTypes.bool,
 		setCommentStatus: PropTypes.func,
 		siteId: PropTypes.number,
@@ -123,6 +123,7 @@ export class CommentDetail extends Component {
 			commentIsLiked,
 			commentIsSelected,
 			commentStatus,
+			commentUrl,
 			isBulkEdit,
 			parentCommentAuthorAvatarUrl,
 			parentCommentAuthorDisplayName,
@@ -131,11 +132,12 @@ export class CommentDetail extends Component {
 			postAuthorDisplayName,
 			postId,
 			postTitle,
-			postUrl,
 			repliedToComment,
 			siteId,
 			submitComment,
 		} = this.props;
+
+		const postUrl = `/read/blogs/${ siteId }/posts/${ postId }`;
 
 		const {
 			authorIsBlocked,
@@ -168,7 +170,6 @@ export class CommentDetail extends Component {
 					isBulkEdit={ isBulkEdit }
 					isExpanded={ isExpanded }
 					postTitle={ postTitle }
-					postUrl={ postUrl }
 					toggleApprove={ this.toggleApprove }
 					toggleExpanded={ this.toggleExpanded }
 					toggleLike={ this.toggleLike }
@@ -200,7 +201,7 @@ export class CommentDetail extends Component {
 							commentContent={ commentContent }
 							commentDate={ commentDate }
 							commentStatus={ commentStatus }
-							postUrl={ postUrl }
+							commentUrl={ commentUrl }
 							repliedToComment={ repliedToComment }
 							siteId={ siteId }
 						/>
@@ -253,6 +254,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentId: comment.ID,
 		commentIsLiked: comment.i_like,
 		commentStatus: comment.status,
+		commentUrl: get( comment, 'URL' ),
 		parentCommentAuthorAvatarUrl: get( parentComment, 'author.avatar_URL' ),
 		parentCommentAuthorDisplayName: get( parentComment, 'author.name' ),
 		parentCommentContent,
@@ -260,7 +262,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		postAuthorDisplayName: get( comment, 'post.author.name' ), // TODO: not available in the current data structure
 		postId,
 		postTitle,
-		postUrl: get( comment, 'URL' ),
 		repliedToComment: comment.replied, // TODO: not available in the current data structure
 		siteId: comment.siteId || siteId,
 	} );


### PR DESCRIPTION
Currently, post titles in comment cards link directly to the comment's permalink; this PR switches that link to the post's Reader view instead.

![screen shot 2017-07-12 at 2 15 51 pm](https://user-images.githubusercontent.com/349751/28140376-f9cac910-670c-11e7-869b-0eed5fec90bd.png)

Fixes #15935 .

**Testing**
1. Find a site with comments on comments.
2. Make sure that the green links above are still linking directly to the comment permalink.
3. Make sure the red link goes to the post's Reader view.