### PR TITLE
Buttons: enable focus shadow for borderless buttons

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -59,8 +59,7 @@ button {
 			border-width: 1px 1px 2px;
 		}
 	}
-	.accessible-focus & {
-		&:focus {
+	.accessible-focus &:focus {
 			border-color: $blue-medium;
 			box-shadow: 0 0 0 2px $blue-light;
 		}
@@ -144,8 +143,7 @@ button {
 		border-color: $alert-red;
 	}
 
-	.accessible-focus & {
-		&:focus {
+	.accessible-focus &:focus {
 			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
 		}
 	}

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -143,9 +143,13 @@ button {
 	&:focus {
 		border-color: $alert-red;
 	}
-	&:focus {
-		box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+
+	.accessible-focus & {
+		&:focus {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+		}
 	}
+
 	&[disabled],
 	&:disabled {
 		color: lighten( $alert-red, 30% );

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -175,11 +175,9 @@ button {
 	color: $gray-text-min;
 	padding-left: 0;
 	padding-right: 0;
-	border-radius: 0;
 
 	&:hover,
 	&:focus {
-		box-shadow: none;
 		color: $gray-dark;
 	}
 


### PR DESCRIPTION
This give move visibility to buttons while using the keyboard to
navigate. Also enabling border radius for style consistency.

Before/After

![screen shot 2017-07-12 at 4 39 41 pm](https://user-images.githubusercontent.com/618551/28141094-bee971a2-6720-11e7-8ff5-010b9d310fe3.png)
![screen shot 2017-07-12 at 4 39 25 pm](https://user-images.githubusercontent.com/618551/28141097-c0a80f26-6720-11e7-9db8-5932982b80d6.png)

## Question

The shadow is showing up when I click on `scary` borderless buttons but not on regular borderless buttons. Why? We don't want the shadow to show up while clicking. 

Happens in Chrome only 

![jul-12-2017 16-43-10](https://user-images.githubusercontent.com/618551/28141214-3cef1e30-6721-11e7-9a95-40c54623c64f.gif)

Also happens on regular big buttons, so it's an existing issue

![jul-12-2017 16-46-50](https://user-images.githubusercontent.com/618551/28141342-c9cc0afc-6721-11e7-8e01-26bc77d9d618.gif)

