### PR TITLE
Add storefront themes support for uploaded themes list.

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -63,6 +63,7 @@ import {
 	getThemeIdFromStylesheet,
 	isThemeMatchingQuery,
 	isThemeFromWpcom,
+	isStorefrontTheme,
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,
 	normalizeWporgTheme
@@ -118,9 +119,8 @@ export function receiveThemes( themes, siteId, query, foundCount ) {
 			const filterWpcom = shouldFilterWpcomThemes( getState(), siteId );
 			filteredThemes = filter(
 				themes,
-				theme => (
-					isThemeMatchingQuery( query, theme ) &&
-						! ( filterWpcom && isThemeFromWpcom( theme ) )
+				theme => ( isStorefrontTheme( theme ) || ( isThemeMatchingQuery( query, theme ) &&
+					! ( filterWpcom && isThemeFromWpcom( theme ) ) )
 				)
 			);
 			// Jetpack API returns all themes in one response (no paging)

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -216,6 +216,19 @@ export function isThemeFromWpcom( theme ) {
 }
 
 /**
+ * Check if theme is a Storefront theme.
+ *
+ * For AT themes, the wpcomsh plugin sets the `storefront_theme`
+ * field to true, for Jetpack API requests.
+ *
+ * @param  {Object} theme Theme object
+ * @return {Boolean}      Whether theme is a Storefront theme
+ */
+export function isStorefrontTheme( theme ) {
+	return true === theme.storefront_theme;
+}
+
+/**
  * Returns true if the theme matches the given query, or false otherwise.
  *
  * @param  {Object}  query Query object


### PR DESCRIPTION
Enables the display of Storefront themes in the _Uploaded Themes_ section for Atomic sites.

This is made possible by checking for the `storefront_theme` property from the API, which is added by wpcomsh, when detecting Storefront themes on atomic sites.