### PR TITLE
Domains: Don't allow unverified email for domain registration and G Suite

### DIFF
--- a/client/components/email-verification/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-unverified-notice.jsx
@@ -86,7 +86,7 @@ export default class EmailUnverifiedNotice extends React.Component {
 
 	renderEmailSendError() {
 		const noticeText = [
-			<strong>{ i18n.translate( 'The email could not be sent.' ) }</strong>,
+			<strong key="email-send-error">{ i18n.translate( 'The email could not be sent.' ) }</strong>,
 			' ',
 			this.state.error.message,
 		];

--- a/client/my-sites/domains/domain-management/add-google-apps/index.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/index.jsx
@@ -1,27 +1,29 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	page = require( 'page' );
+import React from 'react';
+import page from 'page';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-const Main = require( 'components/main' ),
-	Header = require( 'my-sites/domains/domain-management/components/header' ),
-	AddEmailAddressesCard = require( './add-email-addresses-card' ),
-	paths = require( 'my-sites/domains/paths' ),
-	{ hasGoogleAppsSupportedDomain } = require( 'lib/domains' ),
-	SectionHeader = require( 'components/section-header' );
+import Main from 'components/main';
+import Header from 'my-sites/domains/domain-management/components/header';
+import AddEmailAddressesCard from './add-email-addresses-card';
+import paths from 'my-sites/domains/paths';
+import { hasGoogleAppsSupportedDomain } from 'lib/domains';
+import SectionHeader from 'components/section-header';
+import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 
-const AddGoogleApps = React.createClass( {
+class AddGoogleApps extends React.Component {
 	componentDidMount() {
 		this.ensureCanAddEmail();
-	},
+	}
 
 	componentDidUpdate() {
 		this.ensureCanAddEmail();
-	},
+	}
 
 	ensureCanAddEmail() {
 		const needsRedirect = (
@@ -37,35 +39,40 @@ const AddGoogleApps = React.createClass( {
 
 			page.replace( path );
 		}
-	},
+	}
 
 	render() {
+		const { translate } = this.props;
+
 		return (
-			<Main className="domain-management-add-google-apps">
+			<Main>
 				<Header
 					onClick={ this.goToEmail }
 					selectedDomainName={ this.props.selectedDomainName }>
-					{ this.translate( 'Add G Suite' ) }
+					{ translate( 'Add G Suite' ) }
 				</Header>
 
-				<SectionHeader label={ this.translate( 'Add G Suite' ) } />
-
-				<AddEmailAddressesCard
-					domains={ this.props.domains }
-					selectedDomainName={ this.props.selectedDomainName }
-					selectedSite={ this.props.selectedSite } />
+				<EmailVerificationGate
+					noticeText={ translate( 'You must verify your email to purchase G Suite.' ) }
+					noticeStatus="is-info">
+					<SectionHeader label={ translate( 'Add G Suite' ) } />
+					<AddEmailAddressesCard
+						domains={ this.props.domains }
+						selectedDomainName={ this.props.selectedDomainName }
+						selectedSite={ this.props.selectedSite } />
+				</EmailVerificationGate>
 			</Main>
 		);
-	},
+	}
 
-	goToEmail() {
+	goToEmail = () => {
 		const path = paths.domainManagementEmail(
 			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		);
 
 		page( path );
-	}
-} );
+	};
+}
 
-module.exports = AddGoogleApps;
+export default localize( AddGoogleApps );

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import page from 'page';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,20 +25,21 @@ import {
 	getSelectedDomain
 } from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
+import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 
-const Email = React.createClass( {
-	propTypes: {
-		domains: React.PropTypes.object.isRequired,
-		products: React.PropTypes.object.isRequired,
-		selectedDomainName: React.PropTypes.string,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
+class Email extends React.Component {
+	static propTypes = {
+		domains: PropTypes.object.isRequired,
+		products: PropTypes.object.isRequired,
+		selectedDomainName: PropTypes.string,
+		selectedSite: PropTypes.oneOfType( [
+			PropTypes.object,
+			PropTypes.bool
 		] ).isRequired,
-		user: React.PropTypes.object.isRequired,
-		googleAppsUsers: React.PropTypes.array.isRequired,
-		googleAppsUsersLoaded: React.PropTypes.bool.isRequired
-	},
+		user: PropTypes.object.isRequired,
+		googleAppsUsers: PropTypes.array.isRequired,
+		googleAppsUsersLoaded: PropTypes.bool.isRequired
+	};
 
 	render() {
 		return (
@@ -50,7 +52,7 @@ const Email = React.createClass( {
 				{ this.content() }
 			</Main>
 		);
-	},
+	}
 
 	headerOrUpgradesNavigation() {
 		if ( this.props.selectedDomainName ) {
@@ -58,7 +60,7 @@ const Email = React.createClass( {
 				<Header
 					onClick={ this.goToEditOrList }
 					selectedDomainName={ this.props.selectedDomainName }>
-					{ this.translate( 'Email' ) }
+					{ this.props.translate( 'Email' ) }
 				</Header>
 			);
 		}
@@ -68,10 +70,14 @@ const Email = React.createClass( {
 				cart={ this.props.cart }
 				selectedSite={ this.props.selectedSite } />
 		);
-	},
+	}
 
 	content() {
-		if ( ! ( this.props.domains.hasLoadedFromServer && this.props.googleAppsUsersLoaded && this.props.products.gapps ) ) {
+		if ( ! (
+			this.props.domains.hasLoadedFromServer &&
+			this.props.googleAppsUsersLoaded &&
+			this.props.products.gapps
+		) ) {
 			return <Placeholder />;
 		}
 
@@ -85,26 +91,27 @@ const Email = React.createClass( {
 			return this.addGoogleAppsCard();
 		}
 		return this.emptyContent();
-	},
+	}
 
 	emptyContent() {
 		const {
 			selectedSite,
 			selectedDomainName,
+			translate,
 			} = this.props;
 		let emptyContentProps;
 
 		if ( selectedDomainName ) {
 			emptyContentProps = {
-				title: this.translate( 'G Suite is not supported on this domain' ),
-				line: this.translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
-				secondaryAction: this.translate( 'Add Email Forwarding' ),
+				title: translate( 'G Suite is not supported on this domain' ),
+				line: translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
+				secondaryAction: translate( 'Add Email Forwarding' ),
 				secondaryActionURL: paths.domainManagementEmailForwarding( selectedSite.slug, selectedDomainName )
 			};
 		} else {
 			emptyContentProps = {
-				title: this.translate( "Enable powerful email features." ),
-				line: this.translate(
+				title: translate( 'Enable powerful email features.' ),
+				line: translate(
 					'To set up email forwarding, G Suite, and other email ' +
 					'services for your site, upgrade your site’s web address ' +
 					'to a professional custom domain.'
@@ -113,40 +120,44 @@ const Email = React.createClass( {
 		}
 		Object.assign( emptyContentProps, {
 			illustration: '/calypso/images/drake/drake-whoops.svg',
-			action: this.translate( 'Add a Custom Domain' ),
+			action: translate( 'Add a Custom Domain' ),
 			actionURL: '/domains/add/' + this.props.selectedSite.slug
 		} );
 
 		return (
 			<EmptyContent { ...emptyContentProps } />
 		);
-	},
+	}
 
 	googleAppsUsersCard() {
 		return <GoogleAppsUsersCard { ...this.props } />;
-	},
+	}
 
 	addGoogleAppsCard() {
 		return (
 			<div>
-				<AddGoogleAppsCard { ...this.props } />
+				<EmailVerificationGate
+					noticeText={ this.props.translate( 'You must verify your email to purchase G Suite.' ) }
+					noticeStatus="is-info">
+					<AddGoogleAppsCard { ...this.props } />
+				</EmailVerificationGate>
 				{ this.props.selectedDomainName && <VerticalNav>
 					<VerticalNavItem
 						path={ paths.domainManagementEmailForwarding( this.props.selectedSite.slug, this.props.selectedDomainName ) }>
-						{ this.translate( 'Email Forwarding' ) }
+						{ this.props.translate( 'Email Forwarding' ) }
 					</VerticalNavItem>
 				</VerticalNav> }
 			</div>
 		);
-	},
+	}
 
-	goToEditOrList() {
+	goToEditOrList = () => {
 		if ( this.props.selectedDomainName ) {
 			page( paths.domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 		} else {
 			page( paths.domainManagementList( this.props.selectedSite.slug ) );
 		}
-	}
-} );
+	};
+}
 
-module.exports = Email;
+export default localize( Email );

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -19,10 +19,11 @@ import Main from 'components/main';
 import upgradesActions from 'lib/upgrades/actions';
 import cartItems from 'lib/cart-values/cart-items';
 import { currentUserHasFlag } from 'state/current-user/selectors';
-import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
+import { isSiteUpgradeable } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
 import { recordAddDomainButtonClick, recordRemoveDomainButtonClick } from 'state/domains/actions';
+import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 
 class DomainSearch extends Component {
 	static propTypes = {
@@ -120,18 +121,22 @@ class DomainSearch extends Component {
 							cart={ this.props.cart }
 							selectedSite={ selectedSite } />
 
-						<RegisterDomainStep
-							path={ this.props.context.path }
-							suggestion={ this.props.context.params.suggestion }
-							domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-							onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
-							onAddDomain={ this.handleAddRemoveDomain }
-							onAddMapping={ this.handleAddMapping }
-							cart={ this.props.cart }
-							selectedSite={ selectedSite }
-							offerMappingOption
-							basePath={ this.props.basePath }
-							products={ this.props.productsList } />
+						<EmailVerificationGate
+							noticeText={ translate( 'You must verify your email to register new domains.' ) }
+							noticeStatus="is-info">
+							<RegisterDomainStep
+								path={ this.props.context.path }
+								suggestion={ this.props.context.params.suggestion }
+								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+								onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
+								onAddDomain={ this.handleAddRemoveDomain }
+								onAddMapping={ this.handleAddMapping }
+								cart={ this.props.cart }
+								selectedSite={ selectedSite }
+								offerMappingOption
+								basePath={ this.props.basePath }
+								products={ this.props.productsList } />
+						</EmailVerificationGate>
 					</div>
 				</span>
 			);


### PR DESCRIPTION
Hattip for the idea to @iamgabrielma in `p8Eqe3-aF-p2`.

Just to be clear: in this patch, we're only interested in the WPCOM's email verification, _not_ the ICANN one.

The WPCOM email is used by default for domain registration and G Suite purchases and it's important that it's a valid email. User might have made a typo in their email during registration and we should wait for them to verify the email before allowing further purchases that uses that email.
Domain mapping, site redirect and plans don't require email for verification, etc. so I did not restrict purchasing them.

I've started with a custom component, but then discovered we already have a very nice one used by different parts of our code, so I've used it to keep it consistent. It's also pretty cool and depends on Redux state - so as soon as you verify your email, it will disappear and re-activate the component it's "gating".

### Testing
* Check that Domains -> Add is gated like this when the email is not verified:
<img width="756" alt="screen shot 2017-07-13 at 02 09 30" src="https://user-images.githubusercontent.com/3392497/28145311-9357a724-6771-11e7-9fc8-33f525906723.png">

* Check that Domains -> Email is gated like this when the email is not verified:
<img width="957" alt="screen shot 2017-07-13 at 02 09 42" src="https://user-images.githubusercontent.com/3392497/28145310-93529c02-6771-11e7-81fa-b7952f111435.png">

* Check that Domains -> Email is gated like this when the email is not verified, **but!** Make sure the `Email Forwarding` option at the bottom is still accessible:
<img width="720" alt="screen shot 2017-07-13 at 02 11 19" src="https://user-images.githubusercontent.com/3392497/28145312-935da3fe-6771-11e7-98df-6eec412088b3.png">

* User should be able to manage existing G Suite users, regardless of the email's status:
<img width="961" alt="screen shot 2017-07-13 at 02 07 37" src="https://user-images.githubusercontent.com/3392497/28145308-9312889c-6771-11e7-828e-77edd7ce16ff.png">

* But if they try to add a new user, they should be blocked:
<img width="765" alt="screen shot 2017-07-13 at 02 08 25" src="https://user-images.githubusercontent.com/3392497/28145309-934df4ae-6771-11e7-949d-9648156c6404.png">

* Check that the user can buy domain mapping, site redirect and plans regardless of the email's status.

* Make sure that all of the above do _not_ impact NUX and signup.

For easier testing, you could just modify [the `isCurrentUserEmailVerified` selector](https://github.com/Automattic/wp-calypso/blob/fix/dont-allow-unverified-email-for-domain-reg/client/state/current-user/selectors.js#L131) to always return `true`.
Or, you know, just create a new user ;)

### Known issues and limitations
1. The most important one: once you verify your account, then even if you submit a new email and it's pending verification, your account is still marked as verified. So don't be surprised if you try to update your existing account's email and you won't see the above gates. Unfortunately, this other verification status is not stored with the user, but in user settings. Which we don't fetch other than in `/me`. The component I re-used does not check it either, so I stuck with it as-is for consistency's sake with the rest of the app. But if turns out that the email updates, not the first verification, is what causes the majority of the issues, we can revisit this.
2. Since we're blocking the whole domain search, we're also blocking the `Already own a domain?` part there (which is an integral part of the component and can't be easily excluded), so the user can't map a domain from there. They can still visit `Settings` and click the small link to `map` their domain there - of visit `domains/add/mapping/` ;P

cc @ehti for sanity check from Domain Guild perspective 🙇 