### PR TITLE
Simple Payments: inserting shortcode from the list of existing products

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -6,7 +6,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,27 +29,34 @@ class SimplePaymentsDialog extends Component {
 		isEdit: PropTypes.bool.isRequired,
 		onChangeTabs: PropTypes.func.isRequired,
 		onClose: PropTypes.func.isRequired,
+		onInsert: PropTypes.func.isRequired,
+	};
+
+	state = {
+		selectedPaymentId: null,
+	};
+
+	handleSelectedChange = selectedPaymentId => {
+		this.setState( { selectedPaymentId } );
+	};
+
+	handleInsert = () => {
+		this.props.onInsert( { id: this.state.selectedPaymentId } );
 	};
 
 	getActionButtons() {
-		const { translate, onClose } = this.props;
+		const { activeTab, translate, onClose } = this.props;
 
-		const actionButtons = [
+		const insertEnabled = activeTab === 'paymentButtons' && this.state.selectedPaymentId !== null;
+
+		return [
 			<Button onClick={ onClose }>
 				{ translate( 'Cancel' ) }
 			</Button>,
+			<Button onClick={ this.handleInsert } disabled={ ! insertEnabled } primary>
+				{ translate( 'Insert' ) }
+			</Button>,
 		];
-
-		if ( this.props.activeTab === 'addNew' ) {
-			return [
-				...actionButtons,
-				<Button onClick={ noop } primary>
-					{ translate( 'Insert' ) }
-				</Button>,
-			];
-		}
-
-		return actionButtons;
 	}
 
 	render() {
@@ -80,7 +86,11 @@ class SimplePaymentsDialog extends Component {
 				<Navigation { ...{ activeTab, onChangeTabs, paymentButtons } } />
 				{ activeTab === 'addNew'
 					? <ProductForm currencyDefaults={ currencyDefaults } />
-					: <ProductList paymentButtons={ paymentButtons } /> }
+					: <ProductList
+							paymentButtons={ paymentButtons }
+							selectedPaymentId={ this.state.selectedPaymentId }
+							onSelectedChange={ this.handleSelectedChange }
+						/> }
 			</Dialog>
 		);
 	}

--- a/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
@@ -12,6 +12,7 @@ import { noop } from 'lodash';
  */
 import formatCurrency from 'lib/format-currency';
 import CompactCard from 'components/card/compact';
+import FormRadio from 'components/forms/form-radio';
 
 class ProductList extends Component {
 	static propTypes = {
@@ -39,9 +40,7 @@ class ProductList extends Component {
 
 					return (
 						<CompactCard className="editor-simple-payments-modal__list-item" key={ paymentId }>
-							<input
-								className="editor-simple-payments-modal__list-radio"
-								type="radio"
+							<FormRadio
 								name="selection"
 								id={ radioId }
 								value={ paymentId }

--- a/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
@@ -5,6 +5,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,18 +14,46 @@ import formatCurrency from 'lib/format-currency';
 import CompactCard from 'components/card/compact';
 
 class ProductList extends Component {
-	static propTypes = { paymentButtons: PropTypes.array.isRequired };
+	static propTypes = {
+		paymentButtons: PropTypes.array.isRequired,
+		selectedPaymentId: PropTypes.number,
+		onSelectedChange: PropTypes.func,
+	};
+
+	static defaultProps = {
+		selectedPaymentId: null,
+		onSelectedChange: noop,
+	};
+
+	handleRadioChange = event => {
+		this.props.onSelectedChange( parseInt( event.target.value ) );
+	};
 
 	render() {
-		const { paymentButtons } = this.props;
+		const { paymentButtons, selectedPaymentId } = this.props;
 
 		return (
 			<div className="editor-simple-payments-modal__list">
-				{ paymentButtons.map( ( { ID: id, title, price, currency } ) => (
-					<CompactCard key={ id }>
-						<div>{ title }</div><div>{ formatCurrency( price, currency ) }</div>
-					</CompactCard>
-				) ) }
+				{ paymentButtons.map( ( { ID: paymentId, title, price, currency } ) => {
+					const radioId = `simple-payments-list-item-radio-${ paymentId }`;
+
+					return (
+						<CompactCard className="editor-simple-payments-modal__list-item" key={ paymentId }>
+							<input
+								className="editor-simple-payments-modal__list-radio"
+								type="radio"
+								name="selection"
+								id={ radioId }
+								value={ paymentId }
+								checked={ selectedPaymentId === paymentId }
+								onChange={ this.handleRadioChange }
+							/>
+							<label className="editor-simple-payments-modal__list-label" htmlFor={ radioId }>
+								<div>{ title }</div><div>{ formatCurrency( price, currency ) }</div>
+							</label>
+						</CompactCard>
+					);
+				} ) }
 			</div>
 		);
 	}

--- a/client/components/tinymce/plugins/simple-payments/plugin.jsx
+++ b/client/components/tinymce/plugins/simple-payments/plugin.jsx
@@ -9,6 +9,7 @@ import { unmountComponentAtNode } from 'react-dom';
  * Internal Dependencies
  */
 import SimplePaymentsDialog from './dialog';
+import { serialize } from './shortcode-utils';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 const simplePayments = editor => {
@@ -16,9 +17,7 @@ const simplePayments = editor => {
 	const store = editor.getParam( 'redux_store' );
 
 	editor.on( 'init', () => {
-		node = editor.getContainer().appendChild(
-			document.createElement( 'div' )
-		);
+		node = editor.getContainer().appendChild( document.createElement( 'div' ) );
 	} );
 
 	editor.on( 'remove', () => {
@@ -39,6 +38,14 @@ const simplePayments = editor => {
 					showDialog: visibility === 'show',
 					activeTab,
 					isEdit,
+					onInsert( productData ) {
+						editor.execCommand(
+							'mceInsertContent',
+							false,
+							serialize( productData )
+						);
+						renderModal( 'hide', activeTab );
+					},
 					onClose() {
 						editor.focus();
 						renderModal( 'hide', activeTab );
@@ -48,7 +55,7 @@ const simplePayments = editor => {
 					},
 				} ),
 				node,
-				store
+				store,
 			);
 		}
 

--- a/client/components/tinymce/plugins/simple-payments/shortcode-utils.js
+++ b/client/components/tinymce/plugins/simple-payments/shortcode-utils.js
@@ -9,6 +9,18 @@ import { get } from 'lodash';
 import Shortcode from 'lib/shortcode';
 
 /**
+ * Serializes shortcode data (object with id property) to a Simple Payments shortcode.
+ * @returns {string} Serialized shortcode, e.g., `[simple-payment id="1"]`
+ */
+export function serialize( { id } ) {
+	return Shortcode.stringify( {
+		tag: 'simple-payment',
+		type: 'single',
+		attrs: { id }
+	} );
+}
+
+/**
  * Returns Simple Payments' shortcode data in an object.
  *
  * @param {string} shortcode Simple Payments shortcode (e.g. [simple-payment id="20"])

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -82,12 +82,12 @@
 .editor-simple-payments-modal__list-item {
 	display: flex;
 	align-items: center;
-}
 
-input[type="radio"].editor-simple-payments-modal__list-radio {
-	flex: none;
-	margin: 0;
-	margin-right: 24px;
+	.form-radio {
+		flex: none;
+		margin: 0;
+		margin-right: 24px;
+	}
 }
 
 .editor-simple-payments-modal__list-label {

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -75,7 +75,23 @@
 }
 
 .editor-simple-payments-modal__list {
-	padding: 8px 16px;
 	flex: auto;
 	overflow-y: auto;
+}
+
+.editor-simple-payments-modal__list-item {
+	display: flex;
+	align-items: center;
+}
+
+input[type="radio"].editor-simple-payments-modal__list-radio {
+	flex: none;
+	margin: 0;
+	margin-right: 24px;
+}
+
+.editor-simple-payments-modal__list-label {
+	flex: auto;
+	font-family: $serif;
+	font-weight: bold;
 }

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -17,7 +17,8 @@ import { Env } from 'tinymce/tinymce';
 /**
  * Internal dependencies
  */
-import { serialize } from 'components/tinymce/plugins/contact-form/shortcode-utils';
+import { serialize as serializeContactForm } from 'components/tinymce/plugins/contact-form/shortcode-utils';
+import { serialize as serializeSimplePayment } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import MediaUtils from 'lib/media/utils';
@@ -367,7 +368,7 @@ export class EditorHtmlToolbar extends Component {
 	}
 
 	onInsertContactForm = () => {
-		this.insertCustomContent( serialize( this.props.contactForm ), { paragraph: true } );
+		this.insertCustomContent( serializeContactForm( this.props.contactForm ), { paragraph: true } );
 		this.closeContactFormDialog();
 	}
 
@@ -451,6 +452,11 @@ export class EditorHtmlToolbar extends Component {
 		this.setState( {
 			simplePaymentsDialogTab: tab,
 		} );
+	};
+
+	insertSimplePayment = ( productData ) => {
+		this.insertCustomContent( serializeSimplePayment( productData ), { paragraph: true } );
+		this.closeSimplePaymentsDialog();
 	};
 
 	onFilesDrop = () => {
@@ -684,6 +690,7 @@ export class EditorHtmlToolbar extends Component {
 					isEdit={ false }
 					onClose={ this.closeSimplePaymentsDialog }
 					onChangeTabs={ this.changeSimplePaymentsDialogTab }
+					onInsert={ this.insertSimplePayment }
 				/>
 			</div>
 		);


### PR DESCRIPTION
- added selection radio inputs to the product list and started maintaining the selection state.
- enable the 'Insert' button iff some product is selected.
- when 'Insert' is clicked, serialize the product data into a shortcode and insert it.