### PR TITLE
Activity log: Activity titles

### DIFF
--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+class ActivityTitle extends Component {
+
+	static propTypes = {
+		group: PropTypes.oneOf( [
+			'attachment',
+			'comment',
+			'core',
+			'plugin',
+			'post',
+			'term',
+			'theme',
+			'user',
+			'widget',
+		] ).isRequired,
+		name: PropTypes.string.isRequired,
+
+		object: PropTypes.shape( {
+			attachment: PropTypes.shape( {
+				mime_type: PropTypes.string,
+				id: PropTypes.number.isRequired,
+				title: PropTypes.string.isRequired,
+				url: PropTypes.shape( {
+					host: PropTypes.string.isRequired,
+					url: PropTypes.string.isRequired,
+					host_reversed: PropTypes.string.isRequired,
+				} ).isRequired,
+			} ),
+
+			comment: PropTypes.shape( {
+				approved: PropTypes.bool.isRequired,
+				id: PropTypes.number.isRequired,
+			} ),
+
+			core: PropTypes.shape( {
+				new_version: PropTypes.string,
+				old_version: PropTypes.string,
+			} ),
+
+			plugin: PropTypes.oneOfType( [
+				PropTypes.shape( {
+					name: PropTypes.string,
+					previous_version: PropTypes.string,
+					slug: PropTypes.string,
+					version: PropTypes.string,
+				} ),
+				PropTypes.arrayOf(
+					PropTypes.shape( {
+						name: PropTypes.string,
+						previous_version: PropTypes.string,
+						slug: PropTypes.string,
+						version: PropTypes.string,
+					} ),
+				),
+			] ),
+
+			post: PropTypes.shape( {
+				id: PropTypes.number.isRequired,
+				status: PropTypes.string.isRequired,
+				type: PropTypes.string,
+				title: PropTypes.string,
+			} ),
+
+			term: PropTypes.shape( {
+				id: PropTypes.number.isRequired,
+				title: PropTypes.string.isRequired,
+				type: PropTypes.string.isRequired,
+			} ),
+
+			theme: PropTypes.oneOfType( [
+				PropTypes.arrayOf(
+					PropTypes.shape( {
+						name: PropTypes.string,
+						slug: PropTypes.string,
+						uri: PropTypes.string,
+						version: PropTypes.string,
+					} )
+				),
+				PropTypes.shape( {
+					name: PropTypes.string,
+					slug: PropTypes.string,
+					uri: PropTypes.string,
+					version: PropTypes.string,
+				} ),
+			] ),
+
+			user: PropTypes.shape( {
+				display_name: PropTypes.string,
+				external_user_id: PropTypes.string,
+				login: PropTypes.string,
+				wpcom_user_id: PropTypes.number,
+			} ),
+
+			widget: PropTypes.shape( {
+				id: PropTypes.number,
+				name: PropTypes.string,
+				sidebar: PropTypes.string,
+			} ),
+		} ).isRequired,
+
+		// localize
+		moment: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	renderTitle() {
+		const { name } = this.props;
+
+		return name;
+	}
+
+	renderSubtitle() {
+		return null;
+	}
+
+	render() {
+		const title = this.renderTitle();
+		const subTitle = this.renderSubtitle();
+
+		return (
+			<div className="activity-log-item__title">
+				<div className="activity-log-item__title-title">{ title }</div>
+				{ subTitle && <div className="activity-log-item__title-subtitle">{ subTitle }</div> }
+			</div>
+		);
+	}
+}
+
+export default localize( ActivityTitle );

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 class ActivityTitle extends Component {
@@ -19,6 +20,11 @@ class ActivityTitle extends Component {
 			'widget',
 		] ).isRequired,
 		name: PropTypes.string.isRequired,
+
+		actor: PropTypes.shape( {
+			display_name: PropTypes.string,
+			login: PropTypes.string,
+		} ),
 
 		object: PropTypes.shape( {
 			attachment: PropTypes.shape( {
@@ -108,8 +114,55 @@ class ActivityTitle extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	getActorName() {
+		const displayName = get( this.props, [ 'actor', 'display_name' ] );
+		if ( displayName ) {
+			return displayName;
+		}
+
+		const login = get( this.props, [ 'actor', 'login' ] );
+		if ( login ) {
+			return login;
+		}
+	}
+
+	getPostName() {
+		return get( this.props, [ 'object', 'post', 'title' ], this.props.translate( 'A post' ) );
+	}
+
 	renderTitle() {
-		const { name } = this.props;
+		const {
+			name,
+			translate,
+		} = this.props;
+
+		switch ( name ) {
+			case 'post__published': {
+				const actorName = this.getActorName();
+				const postName = this.getPostName();
+				return actorName
+					? (
+						translate( '%(actorName)s published {{strong}}%(postName)s{{/strong}}', {
+							args: {
+								actorName,
+								postName,
+							},
+							components: {
+								strong: <strong />
+							},
+						} )
+					) : (
+						translate( 'An unknown user published {{strong}}%(postName)s{{/strong}}', {
+							args: {
+								postName,
+							},
+							components: {
+								strong: <strong />
+							},
+						} )
+					);
+			}
+		}
 
 		return name;
 	}

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -222,14 +222,14 @@ class ActivityTitle extends Component {
 				if ( title ) {
 					return title;
 				}
-				return 'an unknown menu';
+				return 'an unknown post';
 			}
 			case 'term': {
 				const name = get( object, [ 'term', 'name' ] );
 				if ( name ) {
 					return name;
 				}
-				return 'an unknown menu';
+				return 'an unknown term';
 			}
 			case 'theme':
 				return this.getThemeName();
@@ -245,7 +245,20 @@ class ActivityTitle extends Component {
 	// FIXME: This function is built with the MVP in mind. It purposefully avoids translations which
 	// will need to be revisited. They may be provided by the API.
 	renderTitle() {
+		const { group } = this.props;
 		const actorName = this.getActorName();
+
+		if (
+			group === 'post' &&
+			'customize_changeset' === get( this.props.object, [ 'post', 'type' ] )
+		) {
+			return (
+				<div className="activity-log-item__title-title">
+					{ `${ actorName } modified the site's customization` }
+				</div>
+			);
+		}
+
 		const action = this.getAction();
 		const objectName = this.getObjectName();
 

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -127,7 +127,7 @@ class ActivityTitle extends Component {
 		if ( displayName ) {
 			return displayName;
 		}
-		const login = get( actor, 'display_name' );
+		const login = get( actor, 'login' );
 		if ( login ) {
 			return login;
 		}
@@ -141,7 +141,7 @@ class ActivityTitle extends Component {
 		if ( displayName ) {
 			return displayName;
 		}
-		const login = get( user, 'display_name' );
+		const login = get( user, 'login' );
 		if ( login ) {
 			return login;
 		}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -211,6 +211,7 @@ class ActivityLogItem extends Component {
 
 	renderHeader() {
 		const {
+			action,
 			group,
 			name,
 		} = this.props.log;
@@ -221,6 +222,7 @@ class ActivityLogItem extends Component {
 			<div className="activity-log-item__card-header">
 				<ActivityActor actor={ actor } />
 				<ActivityTitle
+					action={ action }
 					actor={ actor }
 					group={ group }
 					name={ name }

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityActor from './activity-actor';
 import ActivityIcon from './activity-icon';
+import ActivityTitle from './activity-title';
 import EllipsisMenu from 'components/ellipsis-menu';
 import FoldableCard from 'components/foldable-card';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -180,22 +181,6 @@ class ActivityLogItem extends Component {
 		} );
 	};
 
-	renderContent() {
-		const { log } = this.props;
-		const {
-			name,
-		} = log;
-
-		const subTitle = null;
-
-		return (
-			<div className="activity-log-item__content">
-				<div className="activity-log-item__content-title">{ name }</div>
-				{ subTitle && <div className="activity-log-item__content-sub-title">{ subTitle }</div> }
-			</div>
-		);
-	}
-
 	// FIXME: Just for demonstration purposes
 	renderDescription() {
 		const {
@@ -225,12 +210,21 @@ class ActivityLogItem extends Component {
 	}
 
 	renderHeader() {
+		const {
+			group,
+			name,
+			object = {},
+		} = this.props.log;
 		const actor = get( this.props, [ 'log', 'actor' ] );
 
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor actor={ actor } />
-				{ this.renderContent() }
+				<ActivityTitle
+					group={ group }
+					name={ name }
+					object={ object }
+				/>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -213,14 +213,15 @@ class ActivityLogItem extends Component {
 		const {
 			group,
 			name,
-			object = {},
 		} = this.props.log;
 		const actor = get( this.props, [ 'log', 'actor' ] );
+		const object = get( this.props, [ 'log', 'object' ] );
 
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor actor={ actor } />
 				<ActivityTitle
+					actor={ actor }
 					group={ group }
 					name={ name }
 					object={ object }

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -104,7 +104,7 @@
 }
 
 .activity-log-item__title {
-	flex: 3 1;
+	flex: 2 1;
 }
 
 .activity-log-item__title-title {

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -103,15 +103,15 @@
 	color: $gray;
 }
 
-.activity-log-item__content {
+.activity-log-item__title {
 	flex: 3 1;
 }
 
-.activity-log-item__content-title {
+.activity-log-item__title-title {
 	font-size: 14px;
 }
 
-.activity-log-item__content-sub-title {
+.activity-log-item__title-subtitle {
 	font-size: 12px;
 	text-transform: uppercase;
 	color: $gray;


### PR DESCRIPTION
This PR adds better titles to Activity Log items.

Given that it's likely this logic will be moved to the API, this is a very rough approach aimed at presenting testing users with a reasonable title for activity.

Things like localization have been completely ignored in this PR. The `ActivityTitle` component is very rough and duplicates a lot of logic, but I consider this acceptable at this point because it's likely that so much will be thrown out.

**To test**
* https://calypso.live/stats/activity?branch=add/activitylog-post-styling
* See if event names are coherent.

![titles](https://user-images.githubusercontent.com/841763/28281653-1f747e8a-6b28-11e7-817a-465d21fb8b67.png)
