### PR TITLE
Site Settings: Remove JetpackDevModeNotice appear animation

### DIFF
--- a/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
+++ b/client/my-sites/site-settings/jetpack-dev-mode-notice.jsx
@@ -20,7 +20,7 @@ const JetpackDevModeNotice = ( {
 	translate
 } ) => {
 	return (
-		<div>
+		<div className="site-settings__jetpack-dev-mode-notice">
 			<QueryJetpackConnection siteId={ siteId } />
 
 			{

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -439,3 +439,7 @@
 		margin-top: 24px;
 	}
 }
+
+.site-settings__jetpack-dev-mode-notice .notice {
+	animation: none;
+}


### PR DESCRIPTION
As @sirreal suggested in https://github.com/Automattic/wp-calypso/pull/16138#pullrequestreview-49719116, we should disable the appearing animation of the Jetpack dev mode notice in site settings. This is what this PR does, essentially.

![](https://cldup.com/kDxkSAZRO7.png)

To test:
* Checkout this branch
* Go to /settings/general/:site, where :site is a Jetpack site in dev mode.
* Verify the dev mode notice appears immediately, without any delay.