### PR TITLE
Advanced social media: Fix ordering in published

### DIFF
--- a/client/state/selectors/get-post-share-published-actions.js
+++ b/client/state/selectors/get-post-share-published-actions.js
@@ -13,7 +13,7 @@ const getPublishedActions = ( state, siteId, postId ) => ( orderBy( get(
 	state,
 	[ 'sharing', 'publicize', 'sharePostActions', 'published', siteId, postId ],
 	[],
-), [ 'ID' ], [ 'desc' ] ) );
+), [ 'share_date' ], [ 'desc' ] ) );
 
 /**
  * Return a share-published-actions array propagaring data from publicize connections.


### PR DESCRIPTION
Ordering by ID gives us wrong order because keys are logstash keys which are alphanumeric.

we have to sort by date here

## Testing

1. Go to share -> published tab where you have many shares
2. Check order. It should be ok now.
