### PR TITLE
Fixed the "Redirect a site" page to remove the target URL protocol

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -149,35 +149,6 @@ const EVENTS = {
 		}
 	},
 
-	siteRedirect: {
-		formSubmit( searchBoxValue ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Submitted Form in Site Redirect',
-				'Search Box Value',
-				searchBoxValue
-			);
-		},
-
-		inputFocus( searchBoxValue ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Focused On Search Box Input in Site Redirect',
-				'Search Box Value',
-				searchBoxValue
-			);
-		},
-
-		goButtonClick( searchBoxValue ) {
-			analytics.ga.recordEvent(
-				'Domain Search',
-				'Clicked "Go" Button in Site Redirect',
-				'Search Box Value',
-				searchBoxValue
-			);
-		}
-	},
-
 	domainManagement: {
 		addGoogleApps: {
 			addAnotherEmailAddressClick( domainName ) {

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -15,6 +15,7 @@ import { canRedirect } from 'lib/domains';
 import DomainProductPrice from 'components/domains/domain-product-price';
 import upgradesActions from 'lib/upgrades/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import { withoutHttp } from 'lib/url';
 
 class SiteRedirectStep extends React.Component {
 	static propTypes = {
@@ -74,7 +75,7 @@ class SiteRedirectStep extends React.Component {
 	};
 
 	setSearchQuery = ( event ) => {
-		this.setState( { searchQuery: event.target.value } );
+		this.setState( { searchQuery: withoutHttp( event.target.value ) } );
 	};
 
 	handleFormSubmit = ( event ) => {

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -1,33 +1,31 @@
 /**
  * External dependencies
  */
-var page = require( 'page' ),
-	React = require( 'react' );
+import page from 'page';
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var cartItems = require( 'lib/cart-values' ).cartItems,
-	notices = require( 'notices' ),
-	{ canRedirect } = require( 'lib/domains' ),
-	DomainProductPrice = require( 'components/domains/domain-product-price' ),
-	upgradesActions = require( 'lib/upgrades/actions' ),
-	analyticsMixin = require( 'lib/mixins/analytics' );
+import { cartItems } from 'lib/cart-values';
+import notices from 'notices';
+import { canRedirect } from 'lib/domains';
+import DomainProductPrice from 'components/domains/domain-product-price';
+import upgradesActions from 'lib/upgrades/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-var SiteRedirectStep = React.createClass( {
-	mixins: [ analyticsMixin( 'siteRedirect' ) ],
-
-	propTypes: {
+class SiteRedirectStep extends React.Component {
+	static propTypes = {
 		cart: React.PropTypes.object.isRequired,
 		products: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.object.isRequired,
-	},
+	};
 
-	getInitialState: function() {
-		return { searchQuery: '' };
-	},
+	state = { searchQuery: '' };
 
-	render: function() {
+	render() {
 		var price = this.props.products.offsite_redirect ? this.props.products.offsite_redirect.cost_display : null;
 
 		return (
@@ -36,7 +34,7 @@ var SiteRedirectStep = React.createClass( {
 
 					<div className="site-redirect-step__domain-description">
 						<p>
-							{ this.translate( 'Redirect {{strong}}%(domain)s{{/strong}} to this domain', {
+							{ this.props.translate( 'Redirect {{strong}}%(domain)s{{/strong}} to this domain', {
 								components: { strong: <strong /> },
 								args: { domain: this.props.selectedSite.slug }
 							} ) }
@@ -52,12 +50,12 @@ var SiteRedirectStep = React.createClass( {
 							className="site-redirect-step__external-domain"
 							type="text"
 							value={ this.state.searchQuery }
-							placeholder={ this.translate( 'Enter a domain', { textOnly: true } ) }
+							placeholder={ this.props.translate( 'Enter a domain', { textOnly: true } ) }
 							onChange={ this.setSearchQuery }
 							onClick={ this.recordInputFocus } />
 						<button className="site-redirect-step__go button is-primary"
 								onClick={ this.recordGoButtonClick }>
-							{ this.translate( 'Go', {
+							{ this.props.translate( 'Go', {
 								context: 'Upgrades: Label for adding Site Redirect'
 							} ) }
 						</button>
@@ -65,25 +63,25 @@ var SiteRedirectStep = React.createClass( {
 				</form>
 			</div>
 		);
-	},
+	}
 
-	recordInputFocus: function() {
-		this.recordEvent( 'inputFocus', this.state.searchQuery );
-	},
+	recordInputFocus = () => {
+		this.props.recordInputFocus( this.state.searchQuery );
+	};
 
-	recordGoButtonClick: function() {
-		this.recordEvent( 'goButtonClick', this.state.searchQuery );
-	},
+	recordGoButtonClick = () => {
+		this.props.recordGoButtonClick( this.state.searchQuery );
+	};
 
-	setSearchQuery: function( event ) {
+	setSearchQuery = ( event ) => {
 		this.setState( { searchQuery: event.target.value } );
-	},
+	};
 
-	handleFormSubmit: function( event ) {
+	handleFormSubmit = ( event ) => {
 		var domain;
 
 		event.preventDefault();
-		this.recordEvent( 'formSubmit', this.state.searchQuery );
+		this.props.recordFormSubmit( this.state.searchQuery );
 		domain = this.state.searchQuery;
 
 		if ( cartItems.hasProduct( this.props.cart, 'offsite_redirect' ) ) {
@@ -99,43 +97,71 @@ var SiteRedirectStep = React.createClass( {
 
 			this.addSiteRedirectToCart( domain );
 		}.bind( this ) );
-	},
+	};
 
-	addSiteRedirectToCart: function( domain ) {
+	addSiteRedirectToCart = ( domain ) => {
 		upgradesActions.addItem( cartItems.siteRedirect( { domain: domain } ) );
 
 		if ( this.isMounted() ) {
 			page( '/checkout/' + this.props.selectedSite.slug );
 		}
-	},
+	};
 
-	getValidationErrorMessage: function( domain, error ) {
+	getValidationErrorMessage = ( domain, error ) => {
 		switch ( error.code ) {
 			case 'invalid_domain':
-				return this.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
+				return this.props.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
 					args: { domain: domain }
 				} );
 
 			case 'invalid_tld':
-				return this.translate( 'Sorry, %(domain)s does not end with a valid domain extension.', {
+				return this.props.translate( 'Sorry, %(domain)s does not end with a valid domain extension.', {
 					args: { domain: domain }
 				} );
 
 			case 'empty_query':
-				return this.translate( 'Please enter a domain name or keyword.' );
+				return this.props.translate( 'Please enter a domain name or keyword.' );
 
 			case 'has_subscription':
-				return this.translate( "You already have Site Redirect upgrade and can't add another one to the same site." );
+				return this.props.translate( "You already have Site Redirect upgrade and can't add another one to the same site." );
 
 			case 'already_in_cart':
-				return this.translate( "You already have Site Redirect upgrade in the Shopping Cart and can't add another one" );
+				return this.props.translate( "You already have Site Redirect upgrade in the Shopping Cart and can't add another one" );
 
 			default:
-				return this.translate( 'There is a problem adding Site Redirect that points to %(domain)s.', {
+				return this.props.translate( 'There is a problem adding Site Redirect that points to %(domain)s.', {
 					args: { domain: domain }
 				} );
 		}
-	}
-} );
+	};
+}
 
-module.exports = SiteRedirectStep;
+const recordInputFocus = ( searchBoxValue ) => recordGoogleEvent(
+	'Domain Search',
+	'Focused On Search Box Input in Site Redirect',
+	'Search Box Value',
+	searchBoxValue
+);
+
+const recordGoButtonClick = ( searchBoxValue ) => recordGoogleEvent(
+	'Domain Search',
+	'Clicked "Go" Button in Site Redirect',
+	'Search Box Value',
+	searchBoxValue
+);
+
+const recordFormSubmit = ( searchBoxValue ) => recordGoogleEvent(
+	'Domain Search',
+	'Submitted Form in Site Redirect',
+	'Search Box Value',
+	searchBoxValue
+);
+
+export default connect(
+	null,
+	{
+		recordInputFocus,
+		recordGoButtonClick,
+		recordFormSubmit
+	}
+)( localize( SiteRedirectStep ) );

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -27,7 +27,8 @@ class SiteRedirectStep extends React.Component {
 	state = { searchQuery: '' };
 
 	render() {
-		var price = this.props.products.offsite_redirect ? this.props.products.offsite_redirect.cost_display : null;
+		const price = this.props.products.offsite_redirect ? this.props.products.offsite_redirect.cost_display : null;
+		const { translate } = this.props;
 
 		return (
 			<div className="site-redirect-step">
@@ -35,7 +36,7 @@ class SiteRedirectStep extends React.Component {
 
 					<div className="site-redirect-step__domain-description">
 						<p>
-							{ this.props.translate( 'Redirect {{strong}}%(domain)s{{/strong}} to this domain', {
+							{ translate( 'Redirect {{strong}}%(domain)s{{/strong}} to this domain', {
 								components: { strong: <strong /> },
 								args: { domain: this.props.selectedSite.slug }
 							} ) }
@@ -51,12 +52,12 @@ class SiteRedirectStep extends React.Component {
 							className="site-redirect-step__external-domain"
 							type="text"
 							value={ this.state.searchQuery }
-							placeholder={ this.props.translate( 'Enter a domain', { textOnly: true } ) }
+							placeholder={ translate( 'Enter a domain', { textOnly: true } ) }
 							onChange={ this.setSearchQuery }
 							onClick={ this.recordInputFocus } />
 						<button className="site-redirect-step__go button is-primary"
 								onClick={ this.recordGoButtonClick }>
-							{ this.props.translate( 'Go', {
+							{ translate( 'Go', {
 								context: 'Upgrades: Label for adding Site Redirect'
 							} ) }
 						</button>
@@ -79,11 +80,11 @@ class SiteRedirectStep extends React.Component {
 	};
 
 	handleFormSubmit = ( event ) => {
-		var domain;
-
 		event.preventDefault();
-		this.props.recordFormSubmit( this.state.searchQuery );
-		domain = this.state.searchQuery;
+
+		const domain = this.state.searchQuery;
+
+		this.props.recordFormSubmit( domain );
 
 		if ( cartItems.hasProduct( this.props.cart, 'offsite_redirect' ) ) {
 			notices.error( this.getValidationErrorMessage( domain, { code: 'already_in_cart' } ) );
@@ -106,28 +107,30 @@ class SiteRedirectStep extends React.Component {
 	};
 
 	getValidationErrorMessage = ( domain, error ) => {
+		const { translate } = this.props;
+
 		switch ( error.code ) {
 			case 'invalid_domain':
-				return this.props.translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
+				return translate( 'Sorry, %(domain)s does not appear to be a valid domain name.', {
 					args: { domain: domain }
 				} );
 
 			case 'invalid_tld':
-				return this.props.translate( 'Sorry, %(domain)s does not end with a valid domain extension.', {
+				return translate( 'Sorry, %(domain)s does not end with a valid domain extension.', {
 					args: { domain: domain }
 				} );
 
 			case 'empty_query':
-				return this.props.translate( 'Please enter a domain name or keyword.' );
+				return translate( 'Please enter a domain name or keyword.' );
 
 			case 'has_subscription':
-				return this.props.translate( "You already have Site Redirect upgrade and can't add another one to the same site." );
+				return translate( "You already have Site Redirect upgrade and can't add another one to the same site." );
 
 			case 'already_in_cart':
-				return this.props.translate( "You already have Site Redirect upgrade in the Shopping Cart and can't add another one" );
+				return translate( "You already have Site Redirect upgrade in the Shopping Cart and can't add another one" );
 
 			default:
-				return this.props.translate( 'There is a problem adding Site Redirect that points to %(domain)s.', {
+				return translate( 'There is a problem adding Site Redirect that points to %(domain)s.', {
 					args: { domain: domain }
 				} );
 		}

--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -102,10 +102,7 @@ class SiteRedirectStep extends React.Component {
 
 	addSiteRedirectToCart = ( domain ) => {
 		upgradesActions.addItem( cartItems.siteRedirect( { domain: domain } ) );
-
-		if ( this.isMounted() ) {
-			page( '/checkout/' + this.props.selectedSite.slug );
-		}
+		page( '/checkout/' + this.props.selectedSite.slug );
 	};
 
 	getValidationErrorMessage = ( domain, error ) => {

--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -21,7 +21,7 @@ class SiteRedirect extends Component {
 		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
-		isSiteUpgradeable: PropTypes.func.isRequired,
+		isSiteUpgradeable: PropTypes.bool.isRequired,
 		productsList: PropTypes.object.isRequired,
 		translate: PropTypes.func.isRequired,
 	};


### PR DESCRIPTION
...and to have it shown as prefix.

So we have a problem that the site redirect allowed the user to add `http(s)://` in the target URL. The problem is mostly on the backend where the protocol is saved in one of the tables but not the other, so when the user tries to cancel the site redirect his site is left in a limbo (still having active redirect but the subscription is not active).

This PR fixes the "Redirect a site" page to include the protocol in front of the target URL and to automatically strip it from the field. It also updates the component to use classes and extend the React.Component.

Here's the old look
<img width="742" alt="screen shot 2017-07-13 at 7 04 46 pm" src="https://user-images.githubusercontent.com/1355045/28175902-40c9e6ec-67fe-11e7-9b61-e5e12aadfe4d.png">

Here's the new look:
<img width="745" alt="screen shot 2017-07-13 at 7 03 37 pm" src="https://user-images.githubusercontent.com/1355045/28175913-48ecc56a-67fe-11e7-8a8b-3f892c31ada6.png">

I tried to make it look and behave more like the "Redirect settings" page:
<img width="740" alt="screen shot 2017-07-13 at 7 03 27 pm" src="https://user-images.githubusercontent.com/1355045/28175927-4ecf2cca-67fe-11e7-9d3e-2b491365da1e.png">

