### PR TITLE
Store: Fix spacing between nav and dashboard content for smaller screen sizes

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -1,12 +1,7 @@
+.dashboard__manage-has-orders,
+.dashboard__manage-no-orders,
 .dashboard__setup-wrapper {
-	@include breakpoint( ">960px" ) {
-		padding: 32px;
-		margin-top: 58px;
-	}
-}
-
-.dashboard__manage-no-orders {
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( ">660px" ) {
 		margin-top: 58px;
 	}
 }

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -40,9 +40,13 @@
 
 	.button {
 		white-space: nowrap;
-		margin-left: 24px;
-		@include breakpoint( "<660px" ) {
-			margin-left: 18px;
+
+		&:not( :first-child ) {
+			margin-left: 24px;
+
+			@include breakpoint( "<660px" ) {
+				margin-left: 18px;
+			}
 		}
 	}
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -92,6 +92,16 @@
 		min-height: 58px;
 	}
 
+	.sidebar__menu {
+		margin-top: 0;
+
+		ul {
+			li:first-child {
+				border-top-width: 0;
+			}
+		}
+	}
+
 	.sidebar__menu li {
 		.count {
 			margin: 13px 8px;


### PR DESCRIPTION
All the other components had spacing for screen sizes `>660` to account for the sticky bar. Dashboard got a sticky bar later and the content wasn't adjusted for that on screen sizes smaller than 960.

I clicked around our various sections and didn't see any other issues jump out, So this closes #16160. If we see others, we can raise/fix them.

To Test:
* Make your screen smaller than 990.
* View various dashboard views (with orders, without, and setup) to make sure the content has spacing between it and the nav bar.