### PR TITLE
Store: Fix scroll position when switching between store pages

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -27,6 +27,12 @@ class App extends Component {
 		children: PropTypes.element.isRequired,
 	};
 
+	componentWillReceiveProps( newProps ) {
+		if ( this.props.children !== newProps.children ) {
+			window.scrollTo( 0, 0 );
+		}
+	}
+
 	redirect = () => {
 		window.location.href = '/stats/day';
 	}

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -50,10 +50,6 @@ class StoreSidebar extends Component {
 		}
 	}
 
-	onNavigate = () => {
-		window.scrollTo( 0, 0 );
-	}
-
 	isItemLinkSelected = ( paths ) => {
 		if ( ! Array.isArray( paths ) ) {
 			paths = [ paths ];
@@ -80,7 +76,7 @@ class StoreSidebar extends Component {
 				icon="house"
 				label={ translate( 'Dashboard' ) }
 				link={ link }
-				onNavigate={ this.onNavigate } />
+			/>
 		);
 	}
 
@@ -101,7 +97,7 @@ class StoreSidebar extends Component {
 				icon="product"
 				label={ translate( 'Products' ) }
 				link={ link }
-				onNavigate={ this.onNavigate } >
+			>
 				<SidebarButton disabled={ ! site } href={ addLink } >
 					{ translate( 'Add' ) }
 				</SidebarButton>
@@ -127,7 +123,7 @@ class StoreSidebar extends Component {
 				icon="pages"
 				label={ translate( 'Orders' ) }
 				link={ link }
-				onNavigate={ this.onNavigate }>
+			>
 				{ orders.length
 					? <Count count={ orders.length } />
 					: null
@@ -157,7 +153,7 @@ class StoreSidebar extends Component {
 				icon="cog"
 				label={ translate( 'Settings' ) }
 				link={ link }
-				onNavigate={ this.onNavigate } />
+			/>
 		);
 	}
 


### PR DESCRIPTION
Fixes #16127.

We had some logic to scroll to the top of the page when switching between routes in the navigation, so if you clicked through to any new page from the sidebar you would end up at the correct position of the new page. This didn't happen if you clicked through from things like dashboard setup buttons or links from the products or orders list.

Since we now have a wrapper component, I moved that logic to `app/index.js`.

I'm a little surprised this is necessary, but it seems to be done other places in Calypso, and mentioned as an issue around the web and some npm packages exist for it. It seems like this could be handled at the router level, but this fixes the behavior for us.

To Test:
* Click around various links in our interface and make sure when you change routes you are brought to the top of the page.
* Make sure to scroll down to the bottom of a page (like the products list) and click a link and make sure you are brought to the top.