### PR TITLE
Possible fix for 16198

### DIFF
--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -46,7 +46,9 @@ const PostsMain = React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		this.setWarning( nextProps );
+		if ( nextProps.siteId !== this.props.siteId || nextProps.hasMinimumJetpackVersion !== this.props.hasMinimumJetpackVersion ) {
+			this.setWarning( nextProps );
+		}
 	},
 
 	showDrafts() {


### PR DESCRIPTION
While re-factoring minimum Jetpack version notice on plugins (to remove sites-list),  I checked for other uses of this notices and I found a bug in posts.

 This pull request proposes a solution based on an idea from @sirreal, it fixes #16198.

