### PR TITLE
Devdocs: Update EllipsisMenuExample to include a disabled item

### DIFF
--- a/client/components/ellipsis-menu/docs/example.jsx
+++ b/client/components/ellipsis-menu/docs/example.jsx
@@ -17,6 +17,7 @@ export default function EllipsisMenuDemo() {
 			<PopoverMenuItem icon="pencil">Option B</PopoverMenuItem>
 			<PopoverMenuSeparator />
 			<PopoverMenuItem icon="help">Option C</PopoverMenuItem>
+			<PopoverMenuItem disabled icon="cross-circle">Disabled option</PopoverMenuItem>
 		</EllipsisMenu>
 	);
 }

--- a/client/components/ellipsis-menu/docs/example.jsx
+++ b/client/components/ellipsis-menu/docs/example.jsx
@@ -10,7 +10,7 @@ import EllipsisMenu from '../';
 import PopoverMenuItem from 'components/popover/menu-item';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
 
-export default function EllipsisMenuDemo() {
+export default function EllipsisMenuExample() {
 	return (
 		<EllipsisMenu position="bottom right">
 			<PopoverMenuItem icon="add">Option A</PopoverMenuItem>
@@ -22,4 +22,4 @@ export default function EllipsisMenuDemo() {
 	);
 }
 
-EllipsisMenuDemo.displayName = 'EllipsisMenu';
+EllipsisMenuExample.displayName = 'EllipsisMenuExample';


### PR DESCRIPTION
Adds a disabled example to the EllipsisMenu.

![disabled disappears on hover](https://user-images.githubusercontent.com/841763/28180223-cc5ae872-6804-11e7-83fc-e7a7265a2ec4.gif)

See it here: https://calypso.live/devdocs/design/ellipsis-menu?branch=update/ellipsis-menu-example-disabled

Current: https://wpcalypso.wordpress.com/devdocs/design/ellipsis-menu

Will help diagnose #16203 