### PR TITLE
Comments: Fix temporary noops.

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -355,10 +355,11 @@ const mapStateToProps = ( state, { siteId, status } ) => {
 const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 	changeCommentStatus: ( commentId, postId, status ) => dispatch( changeCommentStatus( siteId, postId, commentId, status ) ),
 	createNotice: ( status, text, options ) => dispatch( createNotice( status, text, options ) ),
-	deleteComment: () => noop,
+	deleteComment: noop,
 	likeComment: ( commentId, postId ) => dispatch( likeComment( siteId, postId, commentId ) ),
 	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 	replyComment: ( commentText, postId, parentCommentId ) => dispatch( replyComment( commentText, siteId, postId, parentCommentId ) ),
+	setBulkStatus: noop,
 	unlikeComment: ( commentId, postId ) => dispatch( unlikeComment( siteId, postId, commentId ) ),
 } );
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -360,6 +360,7 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 	replyComment: ( commentText, postId, parentCommentId ) => dispatch( replyComment( commentText, siteId, postId, parentCommentId ) ),
 	setBulkStatus: noop,
+	undoBulkStatus: noop,
 	unlikeComment: ( commentId, postId ) => dispatch( unlikeComment( siteId, postId, commentId ) ),
 } );
 


### PR DESCRIPTION
Fix errors from `noop`s being passed as props into `CommentDetail`.

Testing

Perform a "Delete Permanently" action from a comment in the Trash, and any action with Bulk Status active; you should see a notification, rather than an error:

![screen shot 2017-07-13 at 11 12 41 am](https://user-images.githubusercontent.com/349751/28181109-3a2f5818-67bc-11e7-8920-ad64bac4e7e3.png)
