### PR TITLE
Simple Payments Editor previews: add feature flag, don't render preview if product not found

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views.js
+++ b/client/components/tinymce/plugins/wpcom-view/views.js
@@ -15,6 +15,7 @@ import EmbedViewManager from './views/embed';
 import ContactFormView from './views/contact-form';
 import * as VideoView from './views/video';
 import SimplePaymentsView from './views/simple-payments';
+import { isEnabled } from 'config';
 
 /**
  * Module variables
@@ -24,8 +25,11 @@ let views = {
 	embed: new EmbedViewManager(),
 	contactForm: ContactFormView,
 	video: VideoView,
-	simplePayments: SimplePaymentsView,
 };
+
+if ( isEnabled( 'simple-payments' ) ) {
+	views.simplePayments = SimplePaymentsView;
+}
 
 const components = mapValues( views, ( view ) => {
 	if ( 'function' === typeof view.getComponent ) {

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -19,15 +19,10 @@ import QuerySimplePayments from 'components/data/query-simple-payments';
 
 class SimplePaymentsView extends Component {
 	render() {
-		const { productId, product, content, siteId } = this.props;
+		const { productId, product, siteId } = this.props;
 
 		if ( ! product ) {
-			return (
-				<div className="wpview-content wpview-type-simple-payments">
-					{ content }
-					<QuerySimplePayments siteId={ siteId } productId={ productId } />
-				</div>
-			);
+			return ( <QuerySimplePayments siteId={ siteId } productId={ productId } /> );
 		}
 
 		const { title, description, price, currency } = product;

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
-import { filter } from 'lodash';
+import { filter, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,8 +22,6 @@ import {
 import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { getRawSite } from 'state/sites/selectors';
-import { errorNotice } from 'state/notices/actions';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 
@@ -180,21 +177,13 @@ export const listProducts = ( { dispatch }, { siteId }, next, { posts: products 
 	dispatch( receiveProductsList( siteId, validProducts.map( customPostToProduct ) ) );
 };
 
-const announceListingProductsFailure = ( { dispatch, getState }, { siteId } ) => {
-	const site = getRawSite( getState(), siteId );
-	const error = site && site.name
-		? translate( 'Failed to retrieve products for site “%(siteName)s.”', { args: { siteName: site.name } } )
-		: translate( 'Failed to retrieve products for your site.' );
-
-	dispatch( errorNotice( error ) );
-};
-
 export default {
 	[ SIMPLE_PAYMENTS_PRODUCT_GET ]:
-		[ dispatchRequest( requestSimplePaymentsProduct, listProduct, announceListingProductsFailure ) ],
+		[ dispatchRequest( requestSimplePaymentsProduct, listProduct, noop ) ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]:
-		[ dispatchRequest( requestSimplePaymentsProducts, listProducts, announceListingProductsFailure ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ dispatchRequest( requestSimplePaymentsProductAdd, addProduct ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ dispatchRequest( requestSimplePaymentsProductEdit, addProduct ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]: [ dispatchRequest( requestSimplePaymentsProductDelete, deleteProduct ) ],
+		[ dispatchRequest( requestSimplePaymentsProducts, listProducts, noop ) ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ dispatchRequest( requestSimplePaymentsProductAdd, addProduct, noop ) ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ dispatchRequest( requestSimplePaymentsProductEdit, addProduct, noop ) ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]:
+		[ dispatchRequest( requestSimplePaymentsProductDelete, deleteProduct, noop ) ],
 };


### PR DESCRIPTION
Improved the Simple Payments Editor previews. Adds the previews under `simple-payments` feature flag and if no Simple Payments products are found for a shortcode, don't display it (same behavior as Gallery shortcode).

## Testing

1. Put `simple-payments` feature to `false` in `config/development` and run `make run` again;
2. Select a Jetpack site on which you have some products and put a shortcode into Editor (e.g. `[simple-payment id="<your-product-id>"]`;
3. Verify that the shortcode preview didn't render.

Now, let's enable `simple-payments` again and re-run `make run`. Put a shortcode with a non-existent product ID into the Editor: verify that you don't see any Calypso error notice that "product can't be found" and also verify that the shortcode preview doesn't render in Visual mode (only HTML mode).

