### PR TITLE
Editor Sidebar: use a single sidebar width (sidebar-width-max)

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -28,14 +28,14 @@
 
 .editor-confirmation-sidebar__sidebar {
 	@extend .sidebar;
-	width: $sidebar-width-min;
+	width: $sidebar-width-max;
 	background: $sidebar-bg-color;
 	border-left: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
 	box-sizing: border-box;
 	position: fixed;
 		left: auto;
-		right: -$sidebar-width-min;
+		right: -$sidebar-width-max;
 	z-index: z-index( 'root', '.editor-confirmation-sidebar__sidebar' );
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
 

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -22,7 +22,7 @@
 		}
 
 		.focus-sidebar & {
-			@media screen and ( max-width: ( 700px + $sidebar-width-min ) ) {
+			@media screen and ( max-width: ( 700px + $sidebar-width-max ) ) {
 				border-left-width: 0;
 				border-right-width: 0;
 			}
@@ -52,11 +52,11 @@
 		@include breakpoint( "660px-960px" ) {
 			.focus-sidebar &,
 			.has-chat & {
-				width: calc( 100% - ( #{ $sidebar-width-min + 1 } ) );
+				width: calc( 100% - ( #{ $sidebar-width-max + 1 } ) );
 			}
 
 			.focus-sidebar.has-chat & {
-				width: calc( 100% - ( #{ ( $sidebar-width-min * 2 ) + 1 } ) );
+				width: calc( 100% - ( #{ ( $sidebar-width-max * 2 ) + 1 } ) );
 			}
 		}
 	}

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -19,6 +19,12 @@
 		transition: none;
 	}
 
+	@include breakpoint( ">660px" ) {
+		border-right: 1px solid darken( $sidebar-bg-color, 5% );
+		width: $sidebar-width-max;
+	}
+
+
 	@include breakpoint( "<660px" ) {
 		position: relative;
 		top: 0;

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -24,9 +24,6 @@
 		padding: 0 #{ $side-margin + 20 }px 0 #{ $side-margin }px;
 		max-width: ( $sidebar-width-max - $accordion-padding * 2 );
 
-		@include breakpoint( "<960px" ) {
-			max-width: ( $sidebar-width-min - $accordion-padding * 2 );
-		}
 		@include breakpoint( "<660px" ) {
 			max-width: 100%;
 			min-width: ( $sidebar-width-max - $accordion-padding * 2 );

--- a/client/post-editor/editor-word-count/style.scss
+++ b/client/post-editor/editor-word-count/style.scss
@@ -14,12 +14,6 @@
 	.focus-sidebar & {
 		right: 273px;
 	}
-
-	@include breakpoint( "<960px" ) {
-		.focus-sidebar & {
-			right: 229px;
-		}
-	}
 }
 
 .editor-word-count__is-selected-text {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -62,15 +62,8 @@
 
 	.focus-sidebar &,
 	.focus-editor-confirmation-sidebar & {
-		@include breakpoint( ">960px" ) {
-			left: ( $sidebar-width-max / -2 );
-			width: calc( 100% - ( #{ $sidebar-width-max } ) ); // subtract sidebar width
-		}
-
-		@include breakpoint( "<960px" ) {
-			left: ( $sidebar-width-min / -2 );
-			width: calc( 100% - ( #{ $sidebar-width-min } ) ); // subtract sidebar width
-		}
+		left: ( $sidebar-width-max / -2 );
+		width: calc( 100% - ( #{ $sidebar-width-max } ) ); // subtract sidebar width
 	}
 }
 


### PR DESCRIPTION
This PR updates the editor-sidebar such that only one width is used (sidebar-width-max). This PR is part of a larger series of changes to improve the publishing flow. See p8F9tW-3F-p2.

![image](https://user-images.githubusercontent.com/363749/28217401-a4b20ece-687a-11e7-9fc5-9b2501780738.png)


To test:
* Confirm that the post-settings sidebar in the editor still functions and that nothing looks out of place.