### PR TITLE
Framework: Removed lib/site/computed-attributes dependency from state selectors.

### DIFF
--- a/client/state/plugins/installed/test/selectors.js
+++ b/client/state/plugins/installed/test/selectors.js
@@ -10,6 +10,7 @@ import { pick } from 'lodash';
  */
 import * as selectors from '../selectors';
 import { akismet, helloDolly, jetpack } from './fixtures/plugins';
+import { userState } from 'state/selectors/test/fixtures/user-state';
 import {
 	INSTALL_PLUGIN,
 	DEACTIVATE_PLUGIN,
@@ -73,7 +74,8 @@ const state = deepFreeze( {
 				name: 'Two Site'
 			}
 		}
-	}
+	},
+	...userState,
 } );
 
 describe( 'Installed plugin selectors', function() {

--- a/client/state/selectors/get-jetpack-sites.js
+++ b/client/state/selectors/get-jetpack-sites.js
@@ -13,5 +13,5 @@ import { isJetpackSite } from 'state/sites/selectors';
  */
 export default createSelector(
 	( state ) => getSites( state ).filter( site => isJetpackSite( state, site.ID ) ),
-	( state ) => state.sites.items
+	( state ) => [ state.sites.items, state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-network-sites.js
+++ b/client/state/selectors/get-network-sites.js
@@ -31,5 +31,5 @@ export default createSelector(
 		return siteIds.filter( secondarySiteId => isMainSiteOf( state, siteId, secondarySiteId ) )
 			.map( secondarySiteId => getSite( state, secondarySiteId ) );
 	},
-	( state ) => state.sites.items
+	( state ) => [ state.sites.items, state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-public-sites.js
+++ b/client/state/selectors/get-public-sites.js
@@ -16,5 +16,5 @@ export default createSelector(
 			.filter( site => ! site.is_private )
 			.map( site => getSite( state, site.ID ) );
 	},
-	( state ) => state.sites.items
+	( state ) => [ state.sites.items, state.currentUser.capabilities ]
 );

--- a/client/state/selectors/get-reader-follows.js
+++ b/client/state/selectors/get-reader-follows.js
@@ -26,7 +26,7 @@ const getReaderFollows = createSelector(
 			feed: getFeed( state, item.feed_ID ),
 		} ) );
 	},
-	state => [ state.reader.follows.items, state.reader.feeds.items, state.reader.sites.items ]
+	state => [ state.reader.follows.items, state.reader.feeds.items, state.reader.sites.items, state.currentUser.capabilities ]
 );
 
 export default getReaderFollows;

--- a/client/state/selectors/get-sites.js
+++ b/client/state/selectors/get-sites.js
@@ -28,5 +28,5 @@ export default createSelector(
 			...sortByNameAndUrl( sites )
 		].map( site => getSite( state, site.ID ) );
 	},
-	( state ) => state.sites.items
+	( state ) => [ state.sites.items, state.currentUser.capabilities ]
 );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -31,8 +31,8 @@ import { isHttps, withoutHttp, addQueryArgs, urlToSlug } from 'lib/url';
 import createSelector from 'lib/create-selector';
 import { fromApi as seoTitleFromApi } from 'components/seo/meta-title-editor/mappings';
 import versionCompare from 'lib/version-compare';
-import getComputedAttributes from 'lib/site/computed-attributes';
 import { getCustomizerFocus } from 'my-sites/customize/panels';
+import { getSiteComputedAttributes } from './utils';
 import { isSiteUpgradeable } from 'state/selectors';
 
 /**
@@ -86,14 +86,12 @@ export const getSite = createSelector(
 		// To avoid mutating the original site object, create a shallow clone
 		// before assigning computed properties
 		site = { ...site };
-		site.hasConflict = isSiteConflicting( state, siteId );
-		assign( site, getComputedAttributes( site ) );
+		assign( site, getSiteComputedAttributes( state, siteId ) );
 		assign( site, getJetpackComputedAttributes( state, siteId ) );
-		site.is_previewable = isSitePreviewable( state, siteId );
 
 		return site;
 	},
-	( state ) => state.sites.items
+	( state ) => [ state.sites.items, state.currentUser.capabilities ]
 );
 
 export function getJetpackComputedAttributes( state, siteId ) {

--- a/client/state/sites/test/utils.js
+++ b/client/state/sites/test/utils.js
@@ -67,6 +67,12 @@ describe( 'utils', () => {
 							URL: 'https://example.wordpress.com',
 							jetpack: false,
 							options
+						},
+						2916289: {
+							ID: 2916289,
+							name: 'WordPress.com Example Blog',
+							URL: 'https://example.wordpress.com',
+							jetpack: true,
 						}
 					}
 				}
@@ -77,7 +83,7 @@ describe( 'utils', () => {
 				title: 'WordPress.com Example Blog',
 				is_previewable: false,
 				is_customizable: false,
-				hasConflict: false,
+				hasConflict: true,
 				domain: 'unmapped-url.wordpress.com',
 				slug: 'unmapped-url.wordpress.com',
 				options,

--- a/client/state/sites/utils.js
+++ b/client/state/sites/utils.js
@@ -37,11 +37,14 @@ export const getSiteComputedAttributes = ( state, siteId ) => {
 		title: getSiteTitle( state, siteId )
 	};
 
+	// If a WordPress.com site has a mapped domain create a `wpcom_url`
+	// attribute to allow site selection with either domain.
 	if ( getSiteOption( state, siteId, 'is_mapped_domain' ) && ! isJetpackSite( state, siteId ) ) {
 		computedAttributes.wpcom_url = withoutHttp( getSiteOption( state, siteId, 'unmapped_url' ) );
 	}
 
-	if ( getSiteOption( state, siteId, 'is_redirect' ) || isSiteConflicting( state, siteId ) ) {
+	// we only need to use the unmapped URL for conflicting sites
+	if ( computedAttributes.hasConflict ) {
 		computedAttributes.URL = getSiteOption( state, siteId, 'unmapped_url' );
 	}
 


### PR DESCRIPTION
This PR removes lib/site/computed-attributes dependency from state/sites/selectors.js.

This PR is dependent on pull request https://github.com/Automattic/wp-calypso/pull/17154 that updates test cases to take into consideration that getSite selector requires user information in the state.

The getSiteComputedAttributes uses the canCurrentUser selector because is the recommended way to check for user capabilities.
This dependency has a big impact. 

The automated tests for sites needed to pass some user state which causes some tests to fail to overcome that the tests were updated to pass user state.

Another implication of the dependency from canCurrentUser is that right now getSite and every other selector that returns an object from getSite (e.g: getJetpackSite, getPlublicSites etc...) depends on state.currentUser.capabilities  part of the state and not just state.sites.items as before. So for the memorized selectors, it was needed to add this dependency.

**To test:**
Use the application giving more relevance to areas that make the most use of getSite selector (plugins/ posts/ settings) and check if no error or strange behaviour happens.