### PR TITLE
Set chat group only after happychat is connected

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -663,7 +663,7 @@ const HelpContact = React.createClass( {
 				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>
-				{ ! this.props.isRequestingSites && <HappychatConnection /> }
+				<HappychatConnection />
 				<QueryOlark />
 				<QueryTicketSupportConfiguration />
 			</Main>


### PR DESCRIPTION
## Summary
This PR is addressing an issue in targeting Happychat JPOP operators from the help page. More information in 668-gh-happychat. 

This should also fix https://github.com/Automattic/wp-calypso/issues/15819 because we don't use the selectedSiteId on first load anymore.

## Issue Description
The problem was that we initialise the happychat connection using the group of the selected site which on first load most probably is the customer's primary site. 
However if the customer changes the site from the dropdown between `happychat connection initialisation` and `happychat connection established` the targeted group will not change resulting in chats being misdistributed. 
In order to avoid this, the chat will always be initialized with default group (WP.COM) and whenever the connection is established the chat will be updated with the groups of the selected site at that point in time.

## Testing scenarios
### Initial load error should be gone https://github.com/Automattic/wp-calypso/issues/15819
- Clean localStorage and IndexDb "localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );"
- Go to http://calypso.localhost:3000/help/contact check that things look fine and no crash happens.

### Happychat should target proper group based on selected Id
- Go to /help/contact
- Using websocket inspector from developer tools check that the `init` call has default `groups: ['WP.COM']` no matter what primary site is.
- Using websocket inspector from developer tools check that there always should be a `preferences` event emitted with the group having the proper value for the site selected in the dropdown. https://cloudup.com/crYxGOzVhtw
- Switching the site in the dropdown should emit a `preferences` event every time. Check that it sends `jpop` when you select a JPOP site.

**More testing information can be found in my comment from the 1st of may in the 346-gh-happychat ticket**