### PR TITLE
Store: Show view link in product success message after product creation

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { head } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 
@@ -93,22 +94,28 @@ class ProductCreate extends React.Component {
 	onSave = () => {
 		const { site, product, translate } = this.props;
 
-		const successAction = () => {
+		const successAction = ( products ) => {
+			const newProduct = head( products );
 			page.redirect( getLink( '/store/products/:site', site ) );
-
 			return successNotice(
 				translate( '%(product)s successfully created.', {
 					args: { product: product.name },
 				} ),
-				{ duration: 4000, isPersistent: true }
+				{
+					displayOnNextPage: true,
+					duration: 8000,
+					button: translate( 'View' ),
+					onClick: () => {
+						window.open( newProduct.permalink );
+					},
+				}
 			);
 		};
 
 		const failureAction = errorNotice(
 			translate( 'There was a problem saving %(product)s. Please try again.', {
 				args: { product: product.name },
-			} ),
-			{ isPersistent: true },
+			} )
 		);
 
 		if ( ! product.type ) {

--- a/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
@@ -373,7 +373,7 @@ describe( 'handlers', () => {
 		} );
 
 		it( 'should create variations for a new product', () => {
-			const product1 = { id: { index: 0 }, name: 'Product #1', type: 'variable' };
+			const product1 = { id: { placeholder: 0 }, name: 'Product #1', type: 'variable' };
 
 			const productEdits = {
 				creates: [
@@ -383,7 +383,7 @@ describe( 'handlers', () => {
 
 			const variationEdits = [
 				{
-					productId: { index: 0 },
+					productId: { placeholder: 0 },
 					creates: [
 						variationBlackNew,
 					],
@@ -530,4 +530,3 @@ describe( 'handlers', () => {
 		} );
 	} );
 } );
-


### PR DESCRIPTION
Fixes #15693.

This PR adds a view link in the product success message that leads to a products permalink, so a new product can easily be viewed by the user.

It does this by passing an array of product objects created/updated by the product action list to the success action function, so that we can act upon the products that were created -- i.e. get permalinks of products we created, or IDs. This should be useful in the future as well for things like bulk edit.

It also fixes an issue where `productIdMapping` was using `sentData.id.index` even though we switched to `.placeholder` instead.

<img width="546" alt="screen shot 2017-07-13 at 3 21 49 pm" src="https://user-images.githubusercontent.com/689165/28190286-09a7c6e4-67df-11e7-8e22-1b05b8dcdd85.png">

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.
* Go to product add and create a new product.
* Click the view link in the success message. The product permalink should be opened in a new window.
* Test product update as well, just to make sure nothing has broken there.
