### PR TITLE
External media: add Google Photo caveats

### DIFF
--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -9,6 +9,7 @@ var ReactDom = require( 'react-dom' ),
 	findIndex = require( 'lodash/findIndex' );
 
 import { connect } from 'react-redux';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,6 +24,8 @@ var MediaActions = require( 'lib/media/actions' ),
 
 import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import { getPreference } from 'state/preferences/selectors';
+
+const GOOGLE_MAX_RESULTS = 1000;
 
 export const MediaLibraryList = React.createClass( {
 	displayName: 'MediaLibraryList',
@@ -198,6 +201,19 @@ export const MediaLibraryList = React.createClass( {
 		}, this );
 	},
 
+	renderTrailingItems() {
+		const { media, source } = this.props;
+
+		if ( source === 'google_photos' && media && media.length >= GOOGLE_MAX_RESULTS ) {
+			// Google Photos won't return more than 1000 photos - suggest ways round this to the user
+			const message = translate( 'Use the search button to access more photos. You can search for dates, locations, and things.' );
+
+			return <p><em>{ message }</em></p>;
+		}
+
+		return null;
+	},
+
 	render: function() {
 		var onFetchNextPage;
 
@@ -233,6 +249,7 @@ export const MediaLibraryList = React.createClass( {
 				getItemRef={ this.getItemRef }
 				renderItem={ this.renderItem }
 				renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
+				renderTrailingItems={ this.renderTrailingItems }
 				className="media-library__list" />
 		);
 	}

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -188,4 +188,44 @@ describe( 'MediaLibraryList item selection', function() {
 			expectSelectedItems( 4 );
 		} );
 	} );
+
+	context( 'google photos', () => {
+		let largeLibrary = [];
+
+		const getList = ( media, source ) => {
+			return mount(
+				<MediaList
+					filterRequiresUpgrade={ false }
+					site={ { ID: DUMMY_SITE_ID } }
+					media={ media }
+					mediaScale={ 0.24 }
+					source={ source }
+					single />
+				).find( MediaList ).get( 0 );
+		};
+
+		before( () => {
+			while ( largeLibrary.length < 1000 ) {
+				largeLibrary = largeLibrary.concat( fixtures.media );
+			}
+		} );
+
+		it( 'displays a trailing message when media library showing > 1000 google photos', () => {
+			const list = getList( largeLibrary, 'google_photos' );
+
+			expect( list.renderTrailingItems() ).to.not.be.null;
+		} );
+
+		it( 'doesnt displays a trailing message when media library showing > 1000 non-google photos', () => {
+			const list = getList( largeLibrary, '' );
+
+			expect( list.renderTrailingItems() ).to.be.null;
+		} );
+
+		it( 'doesnt display a trailing message when media library showing < 1000 photos', () => {
+			const list = getList( largeLibrary.slice( 0, 10 ), 'google_photos' );
+
+			expect( list.renderTrailingItems() ).to.be.null;
+		} );
+	} );
 } );

--- a/client/my-sites/sharing/connections/service-description.jsx
+++ b/client/my-sites/sharing/connections/service-description.jsx
@@ -114,7 +114,10 @@ class SharingServiceDescription extends Component {
 					} );
 				}
 
-				return this.props.translate( 'Access photos stored in your Google account.', {
+				return this.props.translate( 'Access photos stored in your Google account{{sup}}*{{/sup}}', {
+					components: {
+						sup: <sup />,
+					},
 					comment: 'Description for Google Photos when no accounts are connected'
 				} );
 			}

--- a/client/my-sites/sharing/connections/service-examples.jsx
+++ b/client/my-sites/sharing/connections/service-examples.jsx
@@ -111,9 +111,11 @@ class SharingServiceExamples extends Component {
 					)
 				},
 				label: this.props.translate(
-					'{{strong}}Connect{{/strong}} to use photos stored in your Google account directly inside the editor.', {
+					'{{strong}}Connect{{/strong}} to use photos stored in your Google account directly inside the editor. ' +
+					'{{sup}}*{{/sup}}Note that new photos may take a few minutes to appear', {
 						components: {
-							strong: <strong />
+							strong: <strong />,
+							sup: <sup />,
 						}
 					}
 				),


### PR DESCRIPTION
This PR clarifies some of the caveats when using Google Photos.

1) Show a message in the media library if the user is viewing > 1000 photos from Google

<img width="924" alt="search" src="https://user-images.githubusercontent.com/1277682/28205349-83d88bd4-6879-11e7-8887-8ce613e08e53.png">
2) Show a message on the sharing page that new photos may take a few minutes

<img width="735" alt="sharing" src="https://user-images.githubusercontent.com/1277682/28205237-0d9f4f8e-6879-11e7-9557-c72836aa684f.png">

## Testing

Run unit test:

`npm run test-client client/my-sites/media-library/test`

And manually verify:

- Go to the Sharing menu, disconnect from Google Photos, and verify the new message is as shown above
- It's tricky to test > 1000 Google Photos so the best way of doing this is to modify the code and fake the end of the list:
  - Change [GOOGLE_MAX_RESULTS](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/media-library/list.jsx) to 5
  - Change the [onFetchNextPage](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/media-library/list.jsx#L217) function to:

```js
		onFetchNextPage = function() {
			// InfiniteList passes its own parameter which would interfere
			// with the optional parameters expected by mediaOnFetchNextPage
			if ( !this.props.media )
				this.props.mediaOnFetchNextPage();
		}.bind( this );
```
  Verify that the message only appears for Google Photos, and that it only appears once the defined number of photos have been displayed.