### PR TITLE
External media: enable on desktop

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -21,6 +21,7 @@
 		"desktop-promo": false,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
+		"external-media": true,
 		"fluid-width": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
Enable the external media feature flag in the desktop environment.

## To test

Use this branch in the desktop app and confirm that the Google Photos option can be found in the post editor media dropdown:

<img width="228" alt="dropdown" src="https://user-images.githubusercontent.com/1277682/27786981-2d0a10f8-5fdb-11e7-8e2e-11b64545fa59.png">

Clicking this and using the Google media library should function the same as it does in a browser.