### PR TITLE
Fix external media mobile header

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -24,6 +24,7 @@ var SectionNav = React.createClass( {
 		hasPinnedItems: React.PropTypes.bool,
 		onMobileNavPanelOpen: React.PropTypes.func,
 		className: React.PropTypes.string,
+		allowDropdown: React.PropTypes.bool,
 	},
 
 	getInitialState: function() {
@@ -34,7 +35,8 @@ var SectionNav = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
-			onMobileNavPanelOpen: () => {}
+			onMobileNavPanelOpen: () => {},
+			allowDropdown: true,
 		};
 	},
 
@@ -52,6 +54,23 @@ var SectionNav = React.createClass( {
 		if ( ! this.hasSiblingControls ) {
 			this.closeMobilePanel();
 		}
+	},
+
+	renderDropdown() {
+		if ( ! this.props.allowDropdown ) {
+			return <div />;
+		}
+
+		return (
+			<div
+				className="section-nav__mobile-header"
+				onClick={ this.toggleMobileOpenState }
+			>
+				<span className="section-nav__mobile-header-text">
+					{ this.props.selectedText }
+				</span>
+			</div>
+		);
 	},
 
 	render: function() {
@@ -81,14 +100,7 @@ var SectionNav = React.createClass( {
 
 		return (
 			<div className={ className }>
-				<div
-					className="section-nav__mobile-header"
-					onClick={ this.toggleMobileOpenState }
-				>
-					<span className="section-nav__mobile-header-text">
-						{ this.props.selectedText }
-					</span>
-				</div>
+				{ this.renderDropdown() }
 
 				<div className="section-nav__panel">
 					{ children }

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -72,6 +72,15 @@ describe( 'section-nav', function() {
 				}
 			} );
 		} );
+
+		it( 'should not render a header if dropdown disabled', () => {
+			const component = createComponent( SectionNav, {
+				selectedText: 'test',
+				allowDropdown: false,
+			}, ( <p>mmyellow</p> ) );
+
+			assert.notEqual( component.props.children[ 0 ].className, 'section-nav__mobile-header' );
+		} );
 	} );
 
 	describe( 'interaction', function() {

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -160,9 +160,14 @@ export class MediaLibraryFilterBar extends Component {
 	}
 
 	render() {
+		// Dropdown is disabled when viewing any external data source
 		return (
 			<div className="media-library__filter-bar">
-				<SectionNav selectedText={ this.getFilterLabel( this.props.filter ) } hasSearch={ true }>
+				<SectionNav
+					selectedText={ this.getFilterLabel( this.props.filter ) }
+					hasSearch={ true }
+					allowDropdown={ ! this.props.source }
+				>
 					{ this.renderSectionTitle() }
 					{ this.renderTabItems() }
 					{ this.renderSearchSection() }


### PR DESCRIPTION
When the Google Photos media library is on a small screen a dropdown appears that blocks the grid/list toggle.

![dropdown](https://user-images.githubusercontent.com/1277682/28205689-fa5cb54a-687a-11e7-98e9-b112be924b1a.png)

This PR adds a new option to the `<SectionNav>` component to allow the dropdown to be disabled. It defaults to false so no other uses of the component will be affected.

When displaying the `<SectionNav>` in the media library we check the `source` value and disable the dropdown if it's anything other than the default (i.e. it's not WP)

The fixed display will be:

<img width="364" alt="new_dropdown" src="https://user-images.githubusercontent.com/1277682/28205851-aff2a0fe-687b-11e7-9ecd-4e588bd56f4b.png">

# Testing

Existing unit test verifies that other uses of SectionNav are unaffected. The new attached unit test verifies that the dropdown is disabled:

`npm run test-client client/components/section-nav`

Manually verifying:
- View the Google Photos media library with a small screen size - either resize the browser down, or use Chrome and set the device to a mobile device
- Verify that a dropdown is not shown
- Verify that the grid/list button is shown and works
- Verify the search button works
- View normal WP media library on a small screen size and verify that it still has a dropdown
- Verify that other uses of `<SectionNav>` are unaffected. For example, go to the Sharing page while in mobile device mode and verify that the Connections/Sharing Buttons dropdown still appears at the top of the page