### PR TITLE
Extensions: Fix settings link visibility and redirection issues

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -436,7 +436,7 @@ class PluginMeta extends Component {
 		} );
 
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
-		const path = this.getExtensionSettingsPath( plugin );
+		const path = ( ! this.props.selectedSite || this.props.isInstalledOnSite ) && this.getExtensionSettingsPath( plugin );
 
 		return (
 			<div className="plugin-meta">

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import some from 'lodash/some';
 import get from 'lodash/get';
-import { find, includes } from 'lodash';
+import { find, includes, trimEnd } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
 import sectionsModule from 'sections';
@@ -459,7 +459,7 @@ class PluginMeta extends Component {
 
 				{ path &&
 					<CompactCard
-						href={ `${ path }/${ this.props.slug }` }>
+						href={ trimEnd( `${ path }/${ this.props.slug || '' }`, '/' ) }>
 						{ this.props.translate( 'Edit plugin settings' ) }
 					</CompactCard>
 				}

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -437,7 +437,7 @@ class PluginMeta extends Component {
 		} );
 
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
-		const path = ( ! this.props.selectedSite || this.props.isInstalledOnSite ) && this.getExtensionSettingsPath( plugin );
+		const path = ( ! this.props.selectedSite || plugin.active ) && this.getExtensionSettingsPath( plugin );
 
 		return (
 			<div className="plugin-meta">

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 import some from 'lodash/some';
 import get from 'lodash/get';
-import { find, includes, trimEnd } from 'lodash';
+import { find, includes } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
 import sectionsModule from 'sections';
@@ -41,6 +41,7 @@ import {
 	isBusiness,
 	isEnterprise
 } from 'lib/products-values';
+import { addSiteFragment } from 'lib/route/path';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isAutomatedTransferActive, isSiteAutomatedTransfer } from 'state/selectors';
@@ -459,7 +460,7 @@ class PluginMeta extends Component {
 
 				{ path &&
 					<CompactCard
-						href={ trimEnd( `${ path }/${ this.props.slug || '' }`, '/' ) }>
+						href={ addSiteFragment( path, this.props.slug ) }>
 						{ this.props.translate( 'Edit plugin settings' ) }
 					</CompactCard>
 				}


### PR DESCRIPTION
This PR aims to improve the functionality of extension settings link by implementing the following:

- Don't show the link before a plugin is installed on the currently selected site.
- Show the link when the plugin is installed, regardless if it's active or not.
- In case no site is selected, make it redirect to site selection.

![screen shot 2017-07-13 at 21 00 47](https://user-images.githubusercontent.com/8056203/28205528-b52b3070-6882-11e7-862c-eaf36c5c6f21.png)

# Testing

- Head over to the details page of a plugin with a calypso extension ( WPSC, WPJM, Zoninator ) on a free site and make sure the link isn't visible.
- Switch to a Jetpack/Business site without the plugin installed and make sure the link isn't visible.
- Switch to a Jetpack/Business site with the plugin installed and make sure the link is visible and working.
- Try (de)activating the plugin and verify the link remains visible.
- Open the plugin details page without any site selected and verify the link is visible and redirects to site selection.
