### PR TITLE
Login: Only show the 2FA title on the 2FA step

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -138,12 +138,16 @@ class Login extends Component {
 	}
 
 	render() {
-		const { translate, twoStepNonce } = this.props;
+		const { translate, twoFactorEnabled, twoFactorAuthType } = this.props;
 
 		return (
 			<div>
 				<div className="login__form-header">
-					{ twoStepNonce ? translate( 'Two-Step Authentication' ) : translate( 'Log in to your account.' ) }
+					{
+						twoFactorEnabled && twoFactorAuthType
+							? translate( 'Two-Step Authentication.' )
+							: translate( 'Log in to your account.' )
+					}
 				</div>
 
 				<ErrorNotice />


### PR DESCRIPTION
This pull request fixes #14039 by only showing the "Two Step Authentication" title on the 2FA step.
  
#### Testing instructions
  
1. Run `git checkout fix/14039` and start your server
2. Open the [`Login` page](http://calypso.localhost:3000/)
3. Check that the title is "Log in to your account."
4. Log in with an account with 2FA enabled
5. Check that the page title is "Two-Step Authentication."
6. Click the back button in your browser
3. Check that the title is "Log in to your account."
  
#### Reviews
  
- [x] Code
- [x] Product
