### PR TITLE
Add disabled styles to ensure correct visibility.

### DIFF
--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -179,6 +179,13 @@
 		}
 	}
 
+	&[ disabled ] {
+		color: lighten( $gray, 30% );
+		.gridicon {
+			color: lighten( $gray, 30% );
+		}
+	}
+
 	&[ disabled ]:hover,
 	&[ disabled ]:focus {
 		background: transparent;


### PR DESCRIPTION
Adds disabled styling to popover menu items. Applies same styling as disabled buttons.

### Before

![disabled disappears on hover](https://user-images.githubusercontent.com/841763/28180223-cc5ae872-6804-11e7-83fc-e7a7265a2ec4.gif)

### After

![after](https://user-images.githubusercontent.com/841763/28209316-4956e5d2-6892-11e7-9168-fb9c01468f47.gif)

**to test**
1. https://calypso.live/devdocs/design/ellipsis-menu?branch=fix/16203-disabled-menu-item-visibility
1. Ensure you can see the disable menu item correctly.

 Fixes #16203
Noticed in #15994