### PR TITLE
Jetpack Plans: avoid pre-selecting a plan you already have

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -211,13 +211,14 @@ class Plans extends Component {
 		// clears whatever we had stored in local cache
 		this.props.selectPlanInAdvance( null, this.props.selectedSiteSlug );
 
+		if ( ! cartItem || cartItem.product_slug === PLAN_JETPACK_FREE ) {
+			return this.selectFreeJetpackPlan();
+		}
+
 		if ( cartItem.product_slug === get( this.props, 'selectedSite.plan.product_slug', null ) ) {
 			return this.redirect( CALYPSO_PLANS_PAGE );
 		}
 
-		if ( ! cartItem || cartItem.product_slug === PLAN_JETPACK_FREE ) {
-			return this.selectFreeJetpackPlan();
-		}
 		if ( cartItem.product_slug === PLAN_JETPACK_PERSONAL ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_submit_39', {
 				user: this.props.userId

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -209,6 +210,10 @@ class Plans extends Component {
 		const checkoutPath = `/checkout/${ this.props.selectedSite.slug }`;
 		// clears whatever we had stored in local cache
 		this.props.selectPlanInAdvance( null, this.props.selectedSiteSlug );
+
+		if ( cartItem.product_slug === get( this.props, 'selectedSite.plan.product_slug', null ) ) {
+			return this.redirect( CALYPSO_PLANS_PAGE );
+		}
 
 		if ( ! cartItem || cartItem.product_slug === PLAN_JETPACK_FREE ) {
 			return this.selectFreeJetpackPlan();


### PR DESCRIPTION
Solves https://github.com/Automattic/wp-calypso/issues/16195

When you visit /jetpack/connect/personal (or the other plans equivalents) we are pre-selecting a plan that gets into your cart the next time you connect a jetpack site. 

This is obviously wrong if you are connecting a site that already has the plan that is preselected... we shouldn't be asking users to pay for a plan they already have. This PR prevents this behaviour.

How to test
===========
0. You need a site that has a jetpack plan (for example, a personal plan)
1. go to http://calypso.localhost:3000/jetpack/connect/personal (or the equivalent for the plan your site has)
2. Enter your site url (and connect it if it's not connected... you can test with connected and unconnected sites, the final result should be the same)
3. You should end in /plans and not see the plans page neither the store checkout page