### PR TITLE
Store: Add view link to product update success message

### DIFF
--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -139,7 +139,13 @@ class ProductUpdate extends React.Component {
 			translate( '%(product)s successfully updated.', {
 				args: { product: product.name },
 			} ),
-			{ duration: 4000 }
+			{
+				duration: 8000,
+				button: translate( 'View' ),
+				onClick: () => {
+					window.open( product.permalink );
+				},
+			}
 		);
 
 		const failureAction = errorNotice(


### PR DESCRIPTION
This PR adds a view link to the product update success message.

To test:
* Edit an existing product and save
* The success message should contain a view link, opening the product in a new window