### PR TITLE
Login: Show a notice when we send the SMS code

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -66,6 +66,15 @@ function getErrorMessageFromErrorCode( code ) {
 	return code;
 }
 
+function getSMSMessageFromResponse( response ) {
+	const phoneNumber = get( response, 'body.data.phone_number' );
+	return translate( 'Message sent to phone number ending in %(phoneNumber)s', {
+		args: {
+			phoneNumber
+		}
+	} );
+}
+
 const errorFields = {
 	empty_password: 'password',
 	empty_two_step_code: 'twoStepCode',
@@ -150,6 +159,19 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 				rememberMe,
 				data: response.body && response.body.data,
 			} );
+
+			if ( response.body.data.two_step_notification_sent === 'sms' ) {
+				const message = getSMSMessageFromResponse( response );
+				setTimeout( function() {
+					dispatch( {
+						type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
+						notice: {
+							message,
+							status: 'is-success'
+						},
+					} );
+				}, 100 );
+			}
 		} ).catch( ( httpError ) => {
 			const error = getErrorFromHTTPError( httpError );
 
@@ -305,12 +327,7 @@ export const sendSmsCode = () => ( dispatch, getState ) => {
 			client_secret: config( 'wpcom_signup_key' ),
 		} )
 		.then( ( response ) => {
-			const phoneNumber = get( response, 'body.data.phone_number' );
-			const message = translate( 'Message sent to phone number ending in %(phoneNumber)s', {
-				args: {
-					phoneNumber
-				}
-			} );
+			const message = getSMSMessageFromResponse( response );
 
 			dispatch( {
 				type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -160,17 +160,14 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 				data: response.body && response.body.data,
 			} );
 
-			if ( response.body.data.two_step_notification_sent === 'sms' ) {
-				const message = getSMSMessageFromResponse( response );
-				setTimeout( function() {
-					dispatch( {
-						type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
-						notice: {
-							message,
-							status: 'is-success'
-						},
-					} );
-				}, 100 );
+			if ( get( response, 'body.data.two_step_notification_sent', null ) === 'sms' ) {
+				dispatch( {
+					type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
+					notice: {
+						message: getSMSMessageFromResponse( response ),
+						status: 'is-success'
+					},
+				} );
 			}
 		} ).catch( ( httpError ) => {
 			const error = getErrorFromHTTPError( httpError );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -31,6 +31,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
 	USER_RECEIVE,
 } from 'state/action-types';
+import { login } from 'lib/paths';
 
 export const isRequesting = createReducer( false, {
 	[ LOGIN_REQUEST ]: () => true,
@@ -78,7 +79,13 @@ export const requestNotice = createReducer( null, {
 	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS ]: ( state, { notice } ) => notice,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: ( state, { notice } ) => notice,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: () => null,
-	[ ROUTE_SET ]: () => null,
+	[ ROUTE_SET ]: ( state, action ) => {
+		// if we just navigated to the sms 2fa page, keep the notice (if any) from the loginUser action
+		if ( action.path === login( { isNative: true, twoFactorAuthType: 'sms' } ) ) {
+			return state;
+		}
+		return null;
+	},
 } );
 
 const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) => Object.assign( {}, state, {


### PR DESCRIPTION
From #14173:

> Should we display the notice that confirms a code has been sent when a user has 2FA via SMS enabled?

This PR enables this message in the case where the SMS gets sent as the initial 2FA method:
  
#### Testing instructions
  
1. Run `git checkout add/2fa-sms-message` and start your server
2. Apply the patch D6404-code
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Log in to a 2FA account that uses SMS as their primary form of authentication
3. Check that the success notice shows
  
  
#### Reviews
  
- [x] Code
- [x] Product