### PR TITLE
Jetpack Connect: remove plans page for woo users

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -49,6 +49,7 @@ class LoggedInForm extends Component {
 		isFetchingSites: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isSSO: PropTypes.bool,
+		isWCS: PropTypes.bool,
 		jetpackConnectAuthorize: PropTypes.shape( {
 			authorizeError: PropTypes.oneOfType( [
 				PropTypes.object,
@@ -103,8 +104,9 @@ class LoggedInForm extends Component {
 			authorizeError
 		} = props.jetpackConnectAuthorize;
 
-		// SSO specific logic here.
-		if ( props.isSSO ) {
+		// For SSO or WooCommerce Services users, do not display plans page
+		// Instead, redirect back to admin as soon as we're connected
+		if ( props.isSSO || props.isWCS ) {
 			if ( ! isRedirectingToWpAdmin && authorizeSuccess ) {
 				return this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 			}
@@ -156,7 +158,7 @@ class LoggedInForm extends Component {
 	redirect() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 
-		if ( 'jpo' === queryObject.from || this.props.isSSO ) {
+		if ( 'jpo' === queryObject.from || this.props.isSSO || this.props.isWCS ) {
 			debug( 'Going back to WP Admin.', 'Connection initiated via: ', queryObject.from, 'SSO found:', this.props.isSSO );
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
 		} else {

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -82,6 +82,10 @@ class JetpackConnectAuthorizeForm extends Component {
 		);
 	}
 
+	isWCS() {
+		return 'woocommerce-services' === this.props.jetpackConnectAuthorize.queryObject.from;
+	}
+
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 	}
@@ -110,10 +114,12 @@ class JetpackConnectAuthorizeForm extends Component {
 				? <LoggedInForm
 					{ ...this.props }
 					isSSO={ this.isSSO() }
+					isWCS={ this.isWCS() }
 				/>
 				: <LoggedOutForm
 					{ ...this.props }
 					isSSO={ this.isSSO() }
+					isWCS={ this.isWCS() }
 				/>
 		);
 	}


### PR DESCRIPTION
This PR will skip the plans page for users connecting to Jetpack after clicking a WooCommerce Services connect button. The logic was [suggested](https://github.com/Automattic/wp-calypso/pull/15741#issuecomment-313214090) by @ebinnion, it's the same one that is used for SSO users.

He also mentioned:

> we continue to add to this, we may want to abstract it.

I propose that this change is approved (pending some discussion and work around A/B testing), and then I can spend some to see if it can be abstracted away. Suggestions welcome.

# To test
## Testing that it works
1. Install WooCommerce Services on your site
2. Deactivate Jetpack
3. Make sure Jetpack will use your local calypso install for the connection by following the instructions in P7rd6c-Me-p2
4. Go to the plugins page
5. See the WooCommerce Services connect banner, and use the button to connect to Jetpack
6. See that you are not taken through the plans page during the connection flow, and are auto-redirected

## Testing all other Jetpack flows are working 👍
- [ ] test any flow that uses this functionality already, for example any of the /jetpack/connect/store flow. See FG on "Jetpack + Calypso Testing".

# To do
I found a bug while testing this flow - there's a button that says 'Redirecting you back' and if it's clicked, it takes the user to the the plans page.
- [x] make sure the final button does not lead user to plans page