### PR TITLE
Domains: Don't allow saving the same WHOIS info

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -4,7 +4,10 @@
 import React from 'react';
 import {
 	endsWith,
-	omit
+	isEqual,
+	keys,
+	omit,
+	pick,
 } from 'lodash';
 import page from 'page';
 import { bindActionCreators } from 'redux';
@@ -227,9 +230,12 @@ class EditContactInfoFormCard extends React.Component {
 	}
 
 	render() {
-		const { translate } = this.props,
-			saveButtonLabel = translate( 'Save Contact Info' ),
-			canUseDesignatedAgent = this.props.selectedDomain.transferLockOnWhoisUpdateOptional;
+		const { translate } = this.props;
+		const saveButtonLabel = translate( 'Save Contact Info' );
+		const canUseDesignatedAgent = this.props.selectedDomain.transferLockOnWhoisUpdateOptional;
+		const currentContactInformation = formState.getAllFieldValues( this.state.form );
+		const initialContactInformation = pick( this.props.contactInformation, keys( currentContactInformation ) );
+		const isSaveButtonDisabled = this.state.formSubmitting || isEqual( initialContactInformation, currentContactInformation );
 
 		return (
 			<Card>
@@ -329,7 +335,7 @@ class EditContactInfoFormCard extends React.Component {
 
 					<FormFooter>
 						<FormButton
-							disabled={ this.state.formSubmitting }
+							disabled={ isSaveButtonDisabled }
 							onClick={ this.requiresConfirmation() ? this.showNonDaConfirmationDialog : this.saveContactInfo }>
 							{ saveButtonLabel }
 						</FormButton>


### PR DESCRIPTION
When updating WHOIS info, we should prevent the user from saving the save WHOIS info. It creates unnecessary noise in our logs, but most importantly it prevents some processes (for example, opting out of the transfer lock) from starting/completing on the registrar side.

### Testing
* Go to Domains -> `example.com` -> Contact & Privacy -> Edit Contact Info.
* Make sure the `Save Contact Info` button is disabled.
* Make some changes - the button is enabled.
* Revert those changes - the button should be disabled again.

Known issues: https://github.com/Automattic/wp-calypso/issues/16239

Fixes #13408