### PR TITLE
Site Settings: Remove Net Neutrality setting

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -330,66 +330,6 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	netNeutralityOption() {
-		const { fields, isRequestingSettings, translate, handleToggle, moment, handleSubmitForm, isSavingSettings } = this.props;
-
-		const today = moment(),
-			lastDay = moment( { year: 2017, month: 6, day: 12 } );
-
-		if ( today.isAfter( lastDay, 'day' ) ) {
-			return null;
-		}
-
-		return (
-			<div>
-				<SectionHeader label={ translate( 'Net Neutrality' ) }>
-					<Button
-						compact={ true }
-						onClick={ handleSubmitForm }
-						primary={ true }
-
-						type="submit"
-						disabled={ isRequestingSettings || isSavingSettings }>
-							{ isSavingSettings
-								? translate( 'Saving…' )
-								: translate( 'Save Settings' )
-							}
-					</Button>
-				</SectionHeader>
-				<Card>
-					<FormFieldset>
-						<CompactFormToggle
-							checked={ !! fields.net_neutrality }
-							disabled={ isRequestingSettings }
-							onChange={ handleToggle( 'net_neutrality' ) }
-						>
-						{ translate(
-							'The FCC wants to repeal Net Neutrality. Without Net Neutrality, ' +
-							'big cable and telecom companies can divide the internet into fast ' +
-							'and slow lanes. What would the Internet look like without net neutrality? ' +
-							'Find out by enabling this banner on your site: it shows your support ' +
-							'for real net neutrality rules by displaying a message on the bottom ' +
-							'of your site and "slowing down" some of your posts. ' +
-							'{{netNeutralityLink}}Learn more about Net Neutrality{{/netNeutralityLink}}',
-							{
-								components: {
-									netNeutralityLink: (
-										<a
-											target="_blank"
-											rel="noopener noreferrer"
-											href={ 'https://en.blog.wordpress.com/2017/07/11/join-us-in-the-fight-for-net-neutrality/' }
-										/>
-									)
-								}
-							}
-						) }
-						</CompactFormToggle>
-					</FormFieldset>
-				</Card>
-			</div>
-		);
-	}
-
 	Timezone() {
 		const { fields, isRequestingSettings, siteIsJetpack, translate } = this.props;
 		if ( siteIsJetpack ) {
@@ -483,8 +423,6 @@ class SiteSettingsFormGeneral extends Component {
 		return (
 			<div className={ classNames( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
-
-				{ ! siteIsJetpack && this.netNeutralityOption() }
 
 				<SectionHeader label={ translate( 'Site Profile' ) }>
 					<Button
@@ -639,8 +577,7 @@ const getFormSettings = settings => {
 		admin_url: '',
 		jetpack_sync_non_public_post_stati: false,
 		holidaysnow: false,
-		api_cache: false,
-		net_neutrality: false
+		api_cache: false
 	};
 
 	if ( ! settings ) {
@@ -658,8 +595,7 @@ const getFormSettings = settings => {
 
 		holidaysnow: !! settings.holidaysnow,
 
-		api_cache: settings.api_cache,
-		net_neutrality: settings.net_neutrality,
+		api_cache: settings.api_cache
 	};
 
 	// handling `gmt_offset` and `timezone_string` values


### PR DESCRIPTION
Now that the net neutrality day is over, we can remove the setting for this feature. Afterwards, I can follow-up by removing the endpoint and WPCOM changes.

To test:

- Checkout branch
- Go to `/settings/general/$site` and ensure you can still modify and save settings correctly