### PR TITLE
Reader: add email settings to feed header

### DIFF
--- a/client/blocks/reader-email-settings/index.jsx
+++ b/client/blocks/reader-email-settings/index.jsx
@@ -89,7 +89,10 @@ class ReaderEmailSettings extends Component {
 					ref={ this.saveSpanRef }
 				>
 					<Gridicon icon="cog" size={ 24 } ref={ this.saveIconRef } />
-					<span className="reader-email-settings__button-label">
+					<span
+						className="reader-email-settings__button-label"
+						title={ translate( 'Email settings' ) }
+					>
 						{ translate( 'Settings' ) }
 					</span>
 				</span>

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -4,6 +4,7 @@
 import classnames from 'classnames';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -18,6 +19,7 @@ import BlogStickers from 'blocks/blog-stickers';
 import ReaderFeedHeaderSiteBadge from './badge';
 import ReaderEmailSettings from 'blocks/reader-email-settings';
 import userSettings from 'lib/user-settings';
+import { isFollowing } from 'state/selectors';
 
 class FeedHeader extends Component {
 	static propTypes = {
@@ -39,7 +41,7 @@ class FeedHeader extends Component {
 	};
 
 	render() {
-		const { site, feed, showBack, translate } = this.props;
+		const { site, feed, showBack, translate, following } = this.props;
 		const followerCount = this.getFollowerCount( feed, site );
 		const ownerDisplayName = site && ! site.is_multi_author && site.owner && site.owner.name;
 		const description = getSiteDescription( { site, feed } );
@@ -71,6 +73,7 @@ class FeedHeader extends Component {
 								<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
 							</div> }
 						{ site &&
+							following &&
 							! isEmailBlocked &&
 							<div className="reader-feed-header__email-settings">
 								<ReaderEmailSettings siteId={ site.ID } />
@@ -111,4 +114,6 @@ class FeedHeader extends Component {
 	}
 }
 
-export default localize( FeedHeader );
+export default connect( ( state, ownProps ) => ( {
+	following: ownProps.feed && isFollowing( state, { feedUrl: ownProps.feed.feed_URL } ),
+} ) )( localize( FeedHeader ) );

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -16,6 +16,8 @@ import { getSiteDescription, getSiteName, getSiteUrl } from 'reader/get-helpers'
 import SiteIcon from 'blocks/site-icon';
 import BlogStickers from 'blocks/blog-stickers';
 import ReaderFeedHeaderSiteBadge from './badge';
+import ReaderEmailSettings from 'blocks/reader-email-settings';
+import userSettings from 'lib/user-settings';
 
 class FeedHeader extends Component {
 	static propTypes = {
@@ -43,6 +45,7 @@ class FeedHeader extends Component {
 		const description = getSiteDescription( { site, feed } );
 		const siteTitle = getSiteName( { feed, site } );
 		const siteUrl = getSiteUrl( { feed, site } );
+		const isEmailBlocked = userSettings.getSetting( 'subscription_delivery_email_blocked' );
 
 		const classes = classnames( 'reader-feed-header', {
 			'is-placeholder': ! site && ! feed,
@@ -66,6 +69,11 @@ class FeedHeader extends Component {
 							! feed.is_error &&
 							<div className="reader-feed-header__follow-button">
 								<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
+							</div> }
+						{ site &&
+							! isEmailBlocked &&
+							<div className="reader-feed-header__email-settings">
+								<ReaderEmailSettings siteId={ site.ID } />
 							</div> }
 					</div>
 				</div>

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -59,53 +59,86 @@
 
 	.reader-feed-header__back-and-follow {
 		display: flex;
+		justify-content: flex-end;
 		height: 0;
 		margin-left: auto;
 
 		@include breakpoint( "<960px" ) {
-			height: auto;
-			justify-content: center;
 			margin-left: 0;
 		}
+	}
 
-		.reader-feed-header__follow {
-			display: flex;
-			flex: 1 0 auto;
-			flex-direction: row;
-			justify-content: flex-end;
-			z-index: z-index( '.reader-feed-header__back-and-follow', '.reader-feed-header__follow' );
-				position: relative;
-					top: -4px;
+	// Follow count and Follow(ing) button
+	.reader-feed-header__follow {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		z-index: z-index( '.reader-feed-header__back-and-follow', '.reader-feed-header__follow' );
+			position: relative;
+				top: -4px;
 
-			@include breakpoint( "<960px" ) {
-				justify-content: center;
-				margin-bottom: 10px;
+		@include breakpoint( "<960px" ) {
+			margin-bottom: 10px;
+		}
+	}
+
+	.reader-feed-header__follow-count {
+		color: $gray;
+		font-size: 14px;
+
+		@include breakpoint( "<960px" ) {
+			display: none;
+		}
+	}
+
+	.reader-feed-header__follow-button .follow-button {
+		padding: 0;
+
+		@include breakpoint( ">960px" ) {
+			margin-left: 20px;
+			margin-right: 0;
+		}
+
+		.gridicon {
+			fill: $blue-medium;
+		}
+
+		.follow-button__label {
+			color: $blue-medium;
+
+			@include breakpoint( "<660px" ) {
+				display: inline-block;
+			}
+		}
+
+		&.is-following {
+
+			.gridicon {
+				fill: $alert-green;
+			}
+
+			.follow-button__label {
+				color: $alert-green;
 			}
 		}
 	}
 
-	.reader-feed-header__site {
-		z-index: z-index( '.reader-feed-header', '.reader-feed-header__site' );
+	.reader-feed-header__email-settings {
+		display: flex;
+		justify-content: flex-end;
+		padding-right: 8px;
+		width: 100%;
+
+		@include breakpoint( ">660px" ) {
+			padding-right: 12px;
+		}
 	}
 
 	&.has-back-button {
 
 		.header-cake .button {
 			max-width: none;
-		}
-
-		.reader-feed-header__back-and-follow {
-			height: 0;
-			flex-direction: row;
-			justify-content: space-between;
-			margin-left: 0;
-
-			.reader-feed-header__follow {
-				display: flex;
-				flex-direction: row;
-				flex: 1;
-				justify-content: flex-end;
-			}
 		}
 
 		.reader-feed-header__site {
@@ -137,37 +170,8 @@
 		}
 	}
 
-	.reader-feed-header__follow-count {
-		color: $gray-text-min;
-		font-size: 14px;
-	}
-
-	.reader-feed-header__follow-button .follow-button {
-		margin-left: 20px;
-		padding: 0;
-
-		.gridicon {
-			fill: $blue-medium;
-		}
-
-		.follow-button__label {
-			color: $blue-medium;
-
-			@include breakpoint( "<660px" ) {
-				display: inline-block;
-			}
-		}
-
-		&.is-following {
-
-			.gridicon {
-				fill: $alert-green;
-			}
-
-			.follow-button__label {
-				color: $alert-green;
-			}
-		}
+	.reader-feed-header__site {
+		z-index: z-index( '.reader-feed-header', '.reader-feed-header__site' );
 	}
 }
 
@@ -207,9 +211,14 @@
 }
 
 .reader-feed-header__email-settings .reader-email-settings__button-label {
+	display: inline;
+	margin-left: 4px;
+	position: relative;
+		top: -2px;
+
 	@include breakpoint( ">660px" ) {
 		font-size: 14px;
-		margin-left: 4px;
+		top: -1px;
 	}
 }
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -191,6 +191,28 @@
 	}
 }
 
+.reader-feed-header__email-settings .gridicons-cog {
+	top: 2px;
+	left: 4px;
+}
+
+.reader-feed-header__email-settings {
+	@include breakpoint( ">660px" ) {
+		margin-top: -1px;
+
+		.gridicons-cog {
+			top: 3px;
+		}
+	}
+}
+
+.reader-feed-header__email-settings .reader-email-settings__button-label {
+	@include breakpoint( ">660px" ) {
+		font-size: 14px;
+		margin-left: 4px;
+	}
+}
+
 // Loading placeholder
 .reader-feed-header.is-placeholder {
 	pointer-events: none;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -127,7 +127,7 @@
 	.reader-feed-header__email-settings {
 		display: flex;
 		justify-content: flex-end;
-		padding-right: 8px;
+		padding-right: 9px;
 		width: 100%;
 
 		@include breakpoint( ">660px" ) {
@@ -197,7 +197,11 @@
 
 .reader-feed-header__email-settings .gridicons-cog {
 	top: 2px;
-	left: 4px;
+	left: 1px;
+
+	@include breakpoint( ">660px" ) {
+		left: 5px;
+	}
 }
 
 .reader-feed-header__email-settings {
@@ -211,14 +215,16 @@
 }
 
 .reader-feed-header__email-settings .reader-email-settings__button-label {
+	font-size: 14px;
 	display: inline;
-	margin-left: 4px;
 	position: relative;
 		top: -2px;
+	margin-left: 2px;
 
 	@include breakpoint( ">660px" ) {
-		font-size: 14px;
 		top: -1px;
+		left: 3px;
+		margin-left: 4px;
 	}
 }
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -198,10 +198,6 @@
 .reader-feed-header__email-settings .gridicons-cog {
 	top: 2px;
 	left: 1px;
-
-	@include breakpoint( ">660px" ) {
-		left: 5px;
-	}
 }
 
 .reader-feed-header__email-settings {
@@ -209,6 +205,7 @@
 		margin-top: -1px;
 
 		.gridicons-cog {
+			left: 5px;
 			top: 3px;
 		}
 	}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -127,7 +127,7 @@
 	.reader-feed-header__email-settings {
 		display: flex;
 		justify-content: flex-end;
-		padding-right: 9px;
+		padding-right: 10px;
 		width: 100%;
 
 		@include breakpoint( ">660px" ) {
@@ -220,7 +220,7 @@
 
 	@include breakpoint( ">660px" ) {
 		top: -1px;
-		left: 3px;
+		left: 2px;
 		margin-left: 4px;
 	}
 }


### PR DESCRIPTION
Adds the new `reader-email-settings` block to the Reader feed header, as requested in https://github.com/Automattic/wp-calypso/issues/15457.

Fixes https://github.com/Automattic/wp-calypso/issues/15457.

### Todo
- [x] Only show when following site
- [x] Finalise appearance