### PR TITLE
Site Settings: Move Site Verification to a separate component

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -9,7 +9,6 @@ import {
 	includes,
 	isArray,
 	isEqual,
-	isString,
 	mapValues,
 	omit,
 	overSome,
@@ -24,15 +23,12 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import Button from 'components/button';
 import SectionHeader from 'components/section-header';
-import ExternalLink from 'components/external-link';
 import MetaTitleEditor from 'components/seo/meta-title-editor';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import notices from 'notices';
 import { protectForm } from 'lib/protect-form';
-import FormInput from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
-import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
@@ -75,13 +71,6 @@ import {
 	saveSiteSettings
 } from 'state/site-settings/actions';
 
-const serviceIds = {
-	google: 'google-site-verification',
-	bing: 'msvalidate.01',
-	pinterest: 'p:domain_verify',
-	yandex: 'yandex-verification'
-};
-
 // Basic matching for HTML tags
 // Not perfect but meets the needs of this component well
 const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
@@ -99,35 +88,8 @@ function getJetpackPluginUrl( slug ) {
 function stateForSite( site ) {
 	return {
 		frontPageMetaDescription: get( site, 'options.advanced_seo_front_page_description', '' ),
-		googleCode: get( site, 'options.verification_services_codes.google', '' ),
-		bingCode: get( site, 'options.verification_services_codes.bing', '' ),
-		pinterestCode: get( site, 'options.verification_services_codes.pinterest', '' ),
-		yandexCode: get( site, 'options.verification_services_codes.yandex', '' ),
 		isFetchingSettings: get( site, 'fetchingSettings', false )
 	};
-}
-
-function getMetaTag( serviceName = '', content = '' ) {
-	if ( ! content ) {
-		return '';
-	}
-
-	if ( includes( content, '<meta' ) ) {
-		// We were passed a meta tag already!
-		return content;
-	}
-
-	return `<meta name="${ get( serviceIds, serviceName, '' ) }" content="${ content }" />`;
-}
-
-function isValidCode( serviceName = '', content = '' ) {
-	if ( ! content.length ) {
-		return true;
-	}
-
-	content = getMetaTag( serviceName, content );
-
-	return includes( content, serviceIds[ serviceName ] );
 }
 
 export const SeoForm = React.createClass( {
@@ -144,13 +106,6 @@ export const SeoForm = React.createClass( {
 			dirtyFields: Set(),
 			invalidatedSiteObject: this.props.selectedSite,
 		};
-	},
-
-	componentWillMount() {
-		this.changeGoogleCode = this.handleVerificationCodeChange( 'googleCode' );
-		this.changeBingCode = this.handleVerificationCodeChange( 'bingCode' );
-		this.changePinterestCode = this.handleVerificationCodeChange( 'pinterestCode' );
-		this.changeYandexCode = this.handleVerificationCodeChange( 'yandexCode' );
 	},
 
 	componentDidMount() {
@@ -224,32 +179,6 @@ export const SeoForm = React.createClass( {
 		) );
 	},
 
-	handleVerificationCodeChange( serviceCode ) {
-		return event => {
-			const { dirtyFields } = this.state;
-
-			if ( ! this.state.hasOwnProperty( serviceCode ) ) {
-				return;
-			}
-
-			// Show an error if the user types into the field
-			if ( event.target.value.length === 1 ) {
-				this.setState( {
-					showPasteError: true,
-					invalidCodes: [ serviceCode.replace( 'Code', '' ) ]
-				} );
-				return;
-			}
-
-			this.setState( {
-				invalidCodes: [],
-				showPasteError: false,
-				[ serviceCode ]: event.target.value,
-				dirtyFields: dirtyFields.add( serviceCode )
-			} );
-		};
-	},
-
 	updateTitleFormats( seoTitleFormats ) {
 		const { dirtyFields } = this.state;
 
@@ -265,7 +194,6 @@ export const SeoForm = React.createClass( {
 			storedTitleFormats,
 			showAdvancedSeo,
 			showWebsiteMeta,
-			translate,
 		} = this.props;
 
 		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
@@ -273,27 +201,6 @@ export const SeoForm = React.createClass( {
 		}
 
 		notices.clearNotices( 'notices' );
-
-		const verificationCodes = {
-			google: this.state.googleCode,
-			bing: this.state.bingCode,
-			pinterest: this.state.pinterestCode,
-			yandex: this.state.yandexCode
-		};
-
-		const filteredCodes = pickBy( verificationCodes, isString );
-		const invalidCodes = Object.keys(
-			pickBy(
-				filteredCodes,
-				( name, content ) => ! isValidCode( content, name )
-			)
-		);
-
-		this.setState( { invalidCodes } );
-		if ( invalidCodes.length > 0 ) {
-			notices.error( translate( 'Invalid site verification tag entered.' ) );
-			return;
-		}
 
 		this.setState( {
 			isSubmittingForm: true
@@ -312,7 +219,6 @@ export const SeoForm = React.createClass( {
 			advanced_seo_title_formats: seoTitleToApi(
 				pickBy( this.state.seoTitleFormats, hasChanges )
 			),
-			verification_services_codes: filteredCodes
 		};
 
 		// Update this option only if advanced SEO is enabled or grandfathered in order to
@@ -367,17 +273,6 @@ export const SeoForm = React.createClass( {
 		}
 	},
 
-	getVerificationError( isPasteError ) {
-		const { translate } = this.props;
-		return (
-			<FormInputValidation isError={ true } text={
-				isPasteError
-					? translate( 'Verification code should be copied and pasted into this field.' )
-					: translate( 'Invalid site verification tag.' )
-			} />
-		);
-	},
-
 	showPreview() {
 		this.setState( { showPreview: true } );
 	},
@@ -411,7 +306,6 @@ export const SeoForm = React.createClass( {
 			isSeoToolsActive,
 			isSitePrivate,
 			isSiteHidden,
-			isVerificationToolsActive,
 			activePlugins,
 			translate,
 		} = this.props;
@@ -430,29 +324,14 @@ export const SeoForm = React.createClass( {
 			showPreview = false
 		} = this.state;
 
-		let { googleCode, bingCode, pinterestCode, yandexCode } = this.state;
-
 		const activateSeoTools = () => this.props.activateModule( siteId, 'seo-tools' );
-		const activateVerificationServices = () => this.props.activateModule( siteId, 'verification-tools' );
 		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
 		const isDisabled = isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
 		const isSeoDisabled = isDisabled || isSeoToolsActive === false;
-		const isVerificationDisabled = isDisabled || isVerificationToolsActive === false;
 		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
 
 		const generalTabUrl = getGeneralTabUrl( slug );
 		const jetpackUpdateUrl = getJetpackPluginUrl( slug );
-		const placeholderTagContent = '1234';
-
-		// The API returns 'false' for an empty array value, so we force it to an empty string if needed
-		googleCode = getMetaTag( 'google', googleCode || '' );
-		bingCode = getMetaTag( 'bing', bingCode || '' );
-		pinterestCode = getMetaTag( 'pinterest', pinterestCode || '' );
-		yandexCode = getMetaTag( 'yandex', yandexCode || '' );
-
-		const hasError = function( service ) {
-			return includes( invalidCodes, service );
-		};
 
 		const nudgeTitle = siteIsJetpack
 			? translate( 'Enable SEO Tools features by upgrading to Jetpack Professional' )
@@ -632,138 +511,8 @@ export const SeoForm = React.createClass( {
 							</Card>
 						</div>
 					}
-
-					{ siteIsJetpack && isVerificationToolsActive === false &&
-						<Notice
-							status="is-warning"
-							showDismiss={ false }
-							text={ translate(
-								'Site Verification Services are disabled in Jetpack.'
-							) }
-						>
-							<NoticeAction onClick={ activateVerificationServices }>
-								{ translate( 'Enable' ) }
-							</NoticeAction>
-						</Notice>
-					}
-
-					<SectionHeader label={ translate( 'Site Verification Services' ) }>
-						<Button
-							compact
-							primary
-							onClick={ this.submitSeoForm }
-							type="submit"
-							disabled={ isSaveDisabled || isVerificationDisabled }
-						>
-							{ isSubmittingForm
-								? translate( 'Saving…' )
-								: translate( 'Save Settings' )
-							}
-						</Button>
-					</SectionHeader>
-					<Card>
-						<p>
-							{ translate(
-								'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order' +
-								' for your site to be indexed by search engines. To use these advanced search engine tools' +
-								' and verify your site with a service, paste the HTML Tag code below. Read the' +
-								' {{support}}full instructions{{/support}} if you are having trouble. Supported verification services:' +
-								' {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}},' +
-								' {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
-								{
-									components: {
-										b: <strong />,
-										support: <a href="https://en.support.wordpress.com/webmaster-tools/" />,
-										google: (
-											<ExternalLink
-												icon={ true }
-												target="_blank"
-												href="https://www.google.com/webmasters/tools/"
-											/>
-										),
-										bing: (
-											<ExternalLink
-												icon={ true }
-												target="_blank"
-												href="https://www.bing.com/webmaster/"
-											/>
-										),
-										pinterest: (
-											<ExternalLink
-												icon={ true }
-												target="_blank"
-												href="https://pinterest.com/website/verify/"
-											/>
-										),
-										yandex: (
-											<ExternalLink
-												icon={ true }
-												target="_blank"
-												href="https://webmaster.yandex.com/sites/"
-											/>
-										),
-									}
-								}
-							) }
-						</p>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Google' ) }
-								name="verification_code_google"
-								type="text"
-								value={ googleCode }
-								id="verification_code_google"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ hasError( 'google' ) }
-								placeholder={ getMetaTag( 'google', placeholderTagContent ) }
-								onChange={ this.changeGoogleCode } />
-							{ hasError( 'google' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Bing' ) }
-								name="verification_code_bing"
-								type="text"
-								value={ bingCode }
-								id="verification_code_bing"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ hasError( 'bing' ) }
-								placeholder={ getMetaTag( 'bing', placeholderTagContent ) }
-								onChange={ this.changeBingCode } />
-							{ hasError( 'bing' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Pinterest' ) }
-								name="verification_code_pinterest"
-								type="text"
-								value={ pinterestCode }
-								id="verification_code_pinterest"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ hasError( 'pinterest' ) }
-								placeholder={ getMetaTag( 'pinterest', placeholderTagContent ) }
-								onChange={ this.changePinterestCode } />
-							{ hasError( 'pinterest' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-						<FormFieldset>
-							<FormInput
-								prefix={ translate( 'Yandex' ) }
-								name="verification_code_yandex"
-								type="text"
-								value={ yandexCode }
-								id="verification_code_yandex"
-								spellCheck="false"
-								disabled={ isVerificationDisabled }
-								isError={ hasError( 'yandex' ) }
-								placeholder={ getMetaTag( 'yandex', placeholderTagContent ) }
-								onChange={ this.changeYandexCode } />
-							{ hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
-						</FormFieldset>
-					</Card>
 				</form>
+
 				<WebPreview
 					showPreview={ showPreview }
 					onClose={ this.hidePreview }
@@ -800,7 +549,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 		isSiteHidden: isHiddenSite( state, siteId ),
 		isSitePrivate: isPrivateSite( state, siteId ),
-		isVerificationToolsActive: isJetpackModuleActive( state, siteId, 'verification-tools' ),
 		activePlugins: getPlugins( state, [ { ID: siteId } ], 'active' ),
 		hasAdvancedSEOFeature: hasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),

--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -13,6 +13,7 @@ import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import SeoForm from './form';
+import SiteVerification from './site-verification';
 
 export class SeoSettings extends Component {
 	componentWillReceiveProps( nextProps ) {
@@ -29,6 +30,7 @@ export class SeoSettings extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
 				{ site && <SeoForm site={ site } /> }
+				{ site && <SiteVerification /> }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -1,0 +1,445 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import notices from 'notices';
+import { Set } from 'immutable';
+import { connect } from 'react-redux';
+import { get, includes, isString, omit, partial, pickBy } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import ExternalLink from 'components/external-link';
+import FormInput from 'components/forms/form-text-input-with-affixes';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormFieldset from 'components/forms/form-fieldset';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import QuerySiteSettings from 'components/data/query-site-settings';
+import SectionHeader from 'components/section-header';
+import { activateModule } from 'state/jetpack/modules/actions';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackModuleActive } from 'state/selectors';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isSiteSettingsSaveSuccessful, getSiteSettingsSaveError } from 'state/site-settings/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { requestSite } from 'state/sites/actions';
+import { requestSiteSettings, saveSiteSettings } from 'state/site-settings/actions';
+import { protectForm } from 'lib/protect-form';
+
+class SiteVerification extends Component {
+	static serviceIds = {
+		google: 'google-site-verification',
+		bing: 'msvalidate.01',
+		pinterest: 'p:domain_verify',
+		yandex: 'yandex-verification'
+	};
+
+	state = {
+		...this.stateForSite( this.props.site ),
+		dirtyFields: Set(),
+		invalidatedSiteObject: this.props.site,
+	};
+
+	componentWillMount() {
+		this.changeGoogleCode = this.handleVerificationCodeChange( 'googleCode' );
+		this.changeBingCode = this.handleVerificationCodeChange( 'bingCode' );
+		this.changePinterestCode = this.handleVerificationCodeChange( 'pinterestCode' );
+		this.changeYandexCode = this.handleVerificationCodeChange( 'yandexCode' );
+	}
+
+	componentDidMount() {
+		this.refreshSite();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const {
+			siteId: prevSiteId,
+			translate
+		} = this.props;
+		const {
+			site: nextSite,
+			siteId: nextSiteId,
+		} = nextProps;
+		const { dirtyFields } = this.state;
+
+		// save success
+		if ( this.state.isSubmittingForm && nextProps.isSaveSuccess ) {
+			this.props.markSaved();
+			this.props.requestSiteSettings( nextProps.siteId );
+			this.refreshSite();
+			this.setState( { isSubmittingForm: false } );
+		}
+
+		// save error
+		if ( this.state.isSubmittingForm && nextProps.saveError ) {
+			this.setState( { isSubmittingForm: false } );
+			notices.error( translate( 'There was a problem saving your changes. Please, try again.' ) );
+		}
+
+		// if we are changing sites, everything goes
+		if ( prevSiteId !== nextSiteId ) {
+			return this.setState( {
+				...this.stateForSite( nextSite ),
+				invalidatedSiteObject: nextSite,
+				dirtyFields: Set(),
+			}, this.refreshSite );
+		}
+
+		let nextState = {
+			...this.stateForSite( nextProps.site ),
+		};
+
+		// Don't update state for fields the user has edited
+		nextState = omit( nextState, dirtyFields.toArray() );
+
+		this.setState( {
+			...nextState
+		} );
+	}
+
+	stateForSite( site ) {
+		return {
+			googleCode: get( site, 'options.verification_services_codes.google', '' ),
+			bingCode: get( site, 'options.verification_services_codes.bing', '' ),
+			pinterestCode: get( site, 'options.verification_services_codes.pinterest', '' ),
+			yandexCode: get( site, 'options.verification_services_codes.yandex', '' ),
+			isFetchingSettings: get( site, 'fetchingSettings', false ),
+		};
+	}
+
+	refreshSite() {
+		const {
+			site,
+			siteId
+		} = this.props;
+
+		if ( site ) {
+			this.setState( {
+				invalidatedSiteObject: site,
+			}, () => this.props.requestSite( siteId ) );
+		}
+	}
+
+	getMetaTag( serviceName = '', content = '' ) {
+		if ( ! content ) {
+			return '';
+		}
+
+		if ( includes( content, '<meta' ) ) {
+			// We were passed a meta tag already!
+			return content;
+		}
+
+		return `<meta name="${ get( SiteVerification.serviceIds, serviceName, '' ) }" content="${ content }" />`;
+	}
+
+	isValidCode( serviceName = '', content = '' ) {
+		if ( ! content.length ) {
+			return true;
+		}
+
+		content = this.getMetaTag( serviceName, content );
+
+		return includes( content, SiteVerification.serviceIds[ serviceName ] );
+	}
+
+	hasError( service ) {
+		const {
+			invalidCodes = [],
+		} = this.state;
+
+		return includes( invalidCodes, service );
+	}
+
+	handleVerificationCodeChange( serviceCode ) {
+		return event => {
+			const { dirtyFields } = this.state;
+
+			if ( ! this.state.hasOwnProperty( serviceCode ) ) {
+				return;
+			}
+
+			// Show an error if the user types into the field
+			if ( event.target.value.length === 1 ) {
+				this.setState( {
+					showPasteError: true,
+					invalidCodes: [ serviceCode.replace( 'Code', '' ) ]
+				} );
+				return;
+			}
+
+			this.setState( {
+				invalidCodes: [],
+				showPasteError: false,
+				[ serviceCode ]: event.target.value,
+				dirtyFields: dirtyFields.add( serviceCode )
+			} );
+		};
+	}
+
+	activateVerificationServices = () => {
+		const { siteId } = this.props;
+
+		this.props.activateModule( siteId, 'verification-tools' );
+	};
+
+	getVerificationError( isPasteError ) {
+		const { translate } = this.props;
+
+		return (
+			<FormInputValidation isError={ true } text={
+				isPasteError
+					? translate( 'Verification code should be copied and pasted into this field.' )
+					: translate( 'Invalid site verification tag.' )
+			} />
+		);
+	}
+
+	handleFormSubmit = ( event ) => {
+		const {
+			siteId,
+			translate,
+		} = this.props;
+
+		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
+			event.preventDefault();
+		}
+
+		notices.clearNotices( 'notices' );
+
+		const verificationCodes = {
+			google: this.state.googleCode,
+			bing: this.state.bingCode,
+			pinterest: this.state.pinterestCode,
+			yandex: this.state.yandexCode
+		};
+
+		const filteredCodes = pickBy( verificationCodes, isString );
+		const invalidCodes = Object.keys(
+			pickBy(
+				filteredCodes,
+				( name, content ) => ! this.isValidCode( content, name )
+			)
+		);
+
+		this.setState( { invalidCodes } );
+		if ( invalidCodes.length > 0 ) {
+			notices.error( translate( 'Invalid site verification tag entered.' ) );
+			return;
+		}
+
+		this.setState( {
+			isSubmittingForm: true
+		} );
+
+		const updatedOptions = {
+			verification_services_codes: filteredCodes
+		};
+
+		this.props.saveSiteSettings( siteId, updatedOptions );
+		this.props.trackFormSubmitted();
+	}
+
+	render() {
+		const {
+			isVerificationToolsActive,
+			jetpackVersionSupportsSeo,
+			siteId,
+			siteIsJetpack,
+			translate
+		} = this.props;
+		const {
+			isSubmittingForm,
+			isFetchingSettings,
+			showPasteError = false,
+			invalidCodes = [],
+		} = this.state;
+		const isJetpackUnsupported = siteIsJetpack && ! jetpackVersionSupportsSeo;
+		const isDisabled = isJetpackUnsupported || isSubmittingForm || isFetchingSettings;
+		const isVerificationDisabled = isDisabled || isVerificationToolsActive === false;
+		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
+		const placeholderTagContent = '1234';
+
+		// The API returns 'false' for an empty array value, so we force it to an empty string if needed
+		let { googleCode, bingCode, pinterestCode, yandexCode } = this.state;
+		googleCode = this.getMetaTag( 'google', googleCode || '' );
+		bingCode = this.getMetaTag( 'bing', bingCode || '' );
+		pinterestCode = this.getMetaTag( 'pinterest', pinterestCode || '' );
+		yandexCode = this.getMetaTag( 'yandex', yandexCode || '' );
+
+		return (
+			<div>
+				<QuerySiteSettings siteId={ siteId } />
+				{
+					siteIsJetpack &&
+					<QueryJetpackModules siteId={ siteId } />
+				}
+
+				{ siteIsJetpack && isVerificationToolsActive === false &&
+					<Notice
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate(
+							'Site Verification Services are disabled in Jetpack.'
+						) }
+					>
+						<NoticeAction onClick={ this.activateVerificationServices }>
+							{ translate( 'Enable' ) }
+						</NoticeAction>
+					</Notice>
+				}
+
+				<SectionHeader label={ translate( 'Site Verification Services' ) }>
+					<Button
+						compact
+						primary
+						onClick={ this.handleFormSubmit }
+						type="submit"
+						disabled={ isSaveDisabled || isVerificationDisabled }
+					>
+						{ isSubmittingForm
+							? translate( 'Saving…' )
+							: translate( 'Save Settings' )
+						}
+					</Button>
+				</SectionHeader>
+				<Card>
+					<p>
+						{ translate(
+							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order' +
+							' for your site to be indexed by search engines. To use these advanced search engine tools' +
+							' and verify your site with a service, paste the HTML Tag code below. Read the' +
+							' {{support}}full instructions{{/support}} if you are having trouble. Supported verification services:' +
+							' {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}},' +
+							' {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
+							{
+								components: {
+									b: <strong />,
+									support: <a href="https://en.support.wordpress.com/webmaster-tools/" />,
+									google: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://www.google.com/webmasters/tools/"
+										/>
+									),
+									bing: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://www.bing.com/webmaster/"
+										/>
+									),
+									pinterest: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://pinterest.com/website/verify/"
+										/>
+									),
+									yandex: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://webmaster.yandex.com/sites/"
+										/>
+									),
+								}
+							}
+						) }
+					</p>
+					<form onChange={ this.props.markChanged } className="seo-settings__seo-form">
+						<FormFieldset>
+							<FormInput
+								prefix={ translate( 'Google' ) }
+								name="verification_code_google"
+								type="text"
+								value={ googleCode }
+								id="verification_code_google"
+								spellCheck="false"
+								disabled={ isVerificationDisabled }
+								isError={ this.hasError( 'google' ) }
+								placeholder={ this.getMetaTag( 'google', placeholderTagContent ) }
+								onChange={ this.changeGoogleCode } />
+							{ this.hasError( 'google' ) && this.getVerificationError( showPasteError ) }
+						</FormFieldset>
+						<FormFieldset>
+							<FormInput
+								prefix={ translate( 'Bing' ) }
+								name="verification_code_bing"
+								type="text"
+								value={ bingCode }
+								id="verification_code_bing"
+								spellCheck="false"
+								disabled={ isVerificationDisabled }
+								isError={ this.hasError( 'bing' ) }
+								placeholder={ this.getMetaTag( 'bing', placeholderTagContent ) }
+								onChange={ this.changeBingCode } />
+							{ this.hasError( 'bing' ) && this.getVerificationError( showPasteError ) }
+						</FormFieldset>
+						<FormFieldset>
+							<FormInput
+								prefix={ translate( 'Pinterest' ) }
+								name="verification_code_pinterest"
+								type="text"
+								value={ pinterestCode }
+								id="verification_code_pinterest"
+								spellCheck="false"
+								disabled={ isVerificationDisabled }
+								isError={ this.hasError( 'pinterest' ) }
+								placeholder={ this.getMetaTag( 'pinterest', placeholderTagContent ) }
+								onChange={ this.changePinterestCode } />
+							{ this.hasError( 'pinterest' ) && this.getVerificationError( showPasteError ) }
+						</FormFieldset>
+						<FormFieldset>
+							<FormInput
+								prefix={ translate( 'Yandex' ) }
+								name="verification_code_yandex"
+								type="text"
+								value={ yandexCode }
+								id="verification_code_yandex"
+								spellCheck="false"
+								disabled={ isVerificationDisabled }
+								isError={ this.hasError( 'yandex' ) }
+								placeholder={ this.getMetaTag( 'yandex', placeholderTagContent ) }
+								onChange={ this.changeYandexCode } />
+							{ this.hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
+						</FormFieldset>
+					</form>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
+			isVerificationToolsActive: isJetpackModuleActive( state, siteId, 'verification-tools' ),
+			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
+			saveError: getSiteSettingsSaveError( state, siteId ),
+			site,
+			siteId,
+			siteIsJetpack: isJetpackSite( state, siteId ),
+		};
+	},
+	{
+		requestSite,
+		requestSiteSettings,
+		saveSiteSettings,
+		trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
+		activateModule,
+	},
+	undefined,
+	{ pure: false } // defaults to true, but this component has internal state
+)( protectForm( localize( SiteVerification ) ) );


### PR DESCRIPTION
In order to match the order of settings cards of the Traffic section in the Jetpack plugin, we need to move the Site Verification card away from the SEO settings cards. To do this, we need to move the Site Verification card to a separate component.

This PR approaches this task with minimum refactoring efforts, because it's already large, and if we refactor stuff, it'll become impossible to review and test properly. There should be no functional/behavioral/visual changes introduced by this PR.

This PR is necessary to be able to complete #12845.

To test:
* Checkout this branch, or get it going on calypso.live.
* Go to /settings/traffic/:site, where :site is one of your WordPress.com sites.
* Play with the Site Verification Services card, and verify there are no regressions or changes from what we currently have in production.
* Play with the SEO Tools cards (Page Title Structure and Website Meta), and verify there are no regressions or changes from what we currently have in production.
* In your testing, verify retrieving and storing of data within all three cards (Site Verification Services, Page Title Structure, Website Meta) works like before.
* Don't forget to test clearing the Redux state and switching between sites.
* Test the steps above with a Jetpack site.