### PR TITLE
Add "Upload Image" block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -72,6 +72,7 @@
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';
 @import 'blocks/upload-drop-zone/style';
+@import 'blocks/upload-image/style';
 @import 'blocks/video-editor/style';
 @import 'components/accordion/style';
 @import 'components/animate/style';

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -1,0 +1,42 @@
+Upload Image
+=========
+
+`UploadImage` component is used to accommodate the following flow:
+- click on a designated place to open file explorer
+- in file exploerer, select an image to upload
+- image is moved to `ImageEditor` where user can edit the image before uploading
+- after clicking on "Done", `UploadImage` calls the `onImageEditorDone` handler where you can perform any operation
+ (such as actual uploading of the image).
+ 
+The initial idea to create the block comes from the `edit-gravatar` one -- it's very similar but reusable and extensible.
+
+
+#### Basic usage:
+
+```js
+import UploadImage from 'blocks/upload-image';
+
+render: function() {
+	return
+		<UploadImage onImageEditorDone={ ( imageBlob ) => console.log( URL.createObjectURL( imageBlob ) ) } />;
+}
+```
+
+To see a more complex example, have a look at `blocks/upload-image/docs/example`.
+
+#### Props
+
+- `isUploading`: (default: false) whether to display a spinner over selected-n-edited image (use only after user 
+	selects an image in `onImageEditorDone`).
+- `imageEditorProps`: (default: allowedAspectRatios set to 1X1) object of additional props to send to `ImageEditor`
+	component.
+- `texts`: (default: `{}`) object of different texts/messages to show.
+- `onImageEditorDone`: (default: `noop`) function to call when user clicks on the "Done" button in `ImageEditor`.
+- `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
+- `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
+
+## Additional notes
+
+This component could be made better (.e.g add error handling). If you need anything more of it, feel free to extend it
+as needed. It's main use is in the Simple Payments project ("Add Payment Button" in Editor) and it was built to
+accommodate its needs.

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -30,10 +30,12 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 	selects an image in `onImageEditorDone`).
 - `imageEditorProps`: (default: allowedAspectRatios set to 1X1) object of additional props to send to `ImageEditor`
 	component.
-- `texts`: (default: `{}`) object of different texts/messages to show.
 - `onImageEditorDone`: (default: `noop`) function to call when user clicks on the "Done" button in `ImageEditor`.
 - `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
 - `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
+- `doneButtonText`: text on the "Done" button in Image Editor modal.
+- `addAnImage`: text on the placeholder when selecting an image.
+- `dragUploadText`: text which shows when dragging an image to upload.
 
 ## Additional notes
 

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -3,7 +3,7 @@ Upload Image
 
 `UploadImage` component is used to accommodate the following flow:
 - click on a designated place to open file explorer
-- in file exploerer, select an image to upload
+- in file explorer, select an image to upload
 - image is moved to `ImageEditor` where user can edit the image before uploading
 - after clicking on "Done", `UploadImage` calls the `onImageEditorDone` handler where you can perform any operation
  (such as actual uploading of the image).

--- a/client/blocks/upload-image/constants.js
+++ b/client/blocks/upload-image/constants.js
@@ -1,0 +1,7 @@
+export const ALLOWED_FILE_EXTENSIONS = [
+	'jpg',
+	'jpeg',
+	'png',
+	'gif',
+	'bmp',
+];

--- a/client/blocks/upload-image/constants.js
+++ b/client/blocks/upload-image/constants.js
@@ -1,7 +1,1 @@
-export const ALLOWED_FILE_EXTENSIONS = [
-	'jpg',
-	'jpeg',
-	'png',
-	'gif',
-	'bmp',
-];
+export const ALLOWED_FILE_EXTENSIONS = [ 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico' ];

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -13,9 +13,6 @@ import UploadImage from '../';
 function UploadImageExample() {
 	return (
 		<div className="docs__design-assets-group">
-			<h2>
-				<a href="/devdocs/blocks/upload-image">Upload Image</a>
-			</h2>
 			<UploadImage isUploading={ false } onImageEditorDone={ () => console.log( 'hello' ) } />
 		</div>
 	);

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { partial } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import UploadImage from '../';
+
+function UploadImageExample() {
+	return (
+		<div className="docs__design-assets-group">
+			<h2>
+				<a href="/devdocs/blocks/upload-image">Upload Image</a>
+			</h2>
+			<UploadImage isUploading={ false } onImageEditorDone={ () => console.log( 'hello' ) } />
+		</div>
+	);
+}
+
+const ConnectedUploadImageExample = connect(
+	null,
+	null
+)( UploadImageExample );
+
+ConnectedUploadImageExample.displayName = 'UploadImage';
+
+export default ConnectedUploadImageExample;

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -13,7 +13,11 @@ import UploadImage from '../';
 function UploadImageExample() {
 	return (
 		<div className="docs__design-assets-group">
-			<UploadImage isUploading={ false } onImageEditorDone={ () => console.log( 'hello' ) } />
+			<h3>Default Upload Image</h3>
+			<UploadImage isUploading={ false } onImageEditorDone={ ( imageBlob ) => console.log( imageBlob ) } />
+
+			<h3>Image is uploading</h3>
+			<UploadImage isUploading={ true } />
 		</div>
 	);
 }

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -17,6 +17,14 @@ export default function UploadImageExample() {
 
 			<h3>Image is uploading</h3>
 			<UploadImage isUploading={ true } />
+
+			<h3>Image is uploaded</h3>
+			<UploadImage
+				placeholderContent={ null }
+				uploadingContent={ null }
+			>
+				<img src="https://cldup.com/mA_hqNVj0w.jpg" />
+			</UploadImage>
 		</div>
 	);
 }

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { partial } from 'lodash';
 
 /**
@@ -10,7 +9,7 @@ import { partial } from 'lodash';
  */
 import UploadImage from '../';
 
-function UploadImageExample() {
+export default function UploadImageExample() {
 	return (
 		<div className="docs__design-assets-group">
 			<h3>Default Upload Image</h3>
@@ -21,12 +20,3 @@ function UploadImageExample() {
 		</div>
 	);
 }
-
-const ConnectedUploadImageExample = connect(
-	null,
-	null
-)( UploadImageExample );
-
-ConnectedUploadImageExample.displayName = 'UploadImage';
-
-export default ConnectedUploadImageExample;

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { partial } from 'lodash';
 
 /**
@@ -9,22 +9,42 @@ import { partial } from 'lodash';
  */
 import UploadImage from '../';
 
-export default function UploadImageExample() {
-	return (
-		<div className="docs__design-assets-group">
-			<h3>Default Upload Image</h3>
-			<UploadImage isUploading={ false } onImageEditorDone={ ( imageBlob ) => console.log( imageBlob ) } />
+export default class UploadImageExample extends Component {
+	state = {
+		isUploading: false,
+		uploadedImageDataUrl: null
+	};
 
-			<h3>Image is uploading</h3>
-			<UploadImage isUploading={ true } />
+	render() {
+		const { isUploading, uploadedImageDataUrl } = this.state;
 
-			<h3>Image is uploaded</h3>
-			<UploadImage
-				placeholderContent={ null }
-				uploadingContent={ null }
-			>
-				<img src="https://cldup.com/mA_hqNVj0w.jpg" />
-			</UploadImage>
-		</div>
-	);
+		return (
+			<div className="docs__design-assets-group">
+				<h3>Default Upload Image</h3>
+				<UploadImage
+					isUploading={ isUploading }
+					onImageEditorDone={
+						(imageBlob) => {
+							this.setState( {
+								uploadedImageDataUrl: URL.createObjectURL( imageBlob ),
+								isUploading: true,
+							} );
+						}
+					}
+				>
+					{ uploadedImageDataUrl &&
+						<img src={ uploadedImageDataUrl }/>
+					}
+				</UploadImage>
+
+				<h3>Image is uploaded</h3>
+				<UploadImage
+					placeholderContent={ null }
+					uploadingContent={ null }
+				>
+					<img src="https://cldup.com/mA_hqNVj0w.jpg"/>
+				</UploadImage>
+			</div>
+		);
+	}
 }

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -8,6 +8,7 @@ import { partial } from 'lodash';
  * Internal dependencies
  */
 import UploadImage from '../';
+import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 
 export default class UploadImageExample extends Component {
 	state = {
@@ -31,6 +32,9 @@ export default class UploadImageExample extends Component {
 							} );
 						}
 					}
+					imageEditorProps={ {
+						defaultAspectRatio: AspectRatios.FREE,
+					} }
 				/>
 
 				<h3>Image is uploaded</h3>

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -25,7 +25,7 @@ export default class UploadImageExample extends Component {
 				<UploadImage
 					isUploading={ isUploading }
 					onImageEditorDone={
-						(imageBlob) => {
+						( imageBlob ) => {
 							this.setState( {
 								uploadedImageDataUrl: URL.createObjectURL( imageBlob ),
 								isUploading: true,

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -31,11 +31,7 @@ export default class UploadImageExample extends Component {
 							} );
 						}
 					}
-				>
-					{ uploadedImageDataUrl &&
-						<img src={ uploadedImageDataUrl }/>
-					}
-				</UploadImage>
+				/>
 
 				<h3>Image is uploaded</h3>
 				<UploadImage

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -31,9 +31,6 @@ export default class UploadImageExample extends Component {
 				<UploadImage
 					isUploading={ isUploading }
 					onImageEditorDone={ this.onImageEditorDone }
-					imageEditorProps={ {
-						defaultAspectRatio: AspectRatios.FREE,
-					} }
 				/>
 
 				<h3>Image is uploaded</h3>

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -38,7 +38,7 @@ export default class UploadImageExample extends Component {
 					placeholderContent={ null }
 					uploadingContent={ null }
 				>
-					<img src="https://cldup.com/mA_hqNVj0w.jpg"/>
+					<img src="https://wordpress.com/calypso/images/reader/promo-app-icon.png"/>
 				</UploadImage>
 			</div>
 		);

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +15,13 @@ export default class UploadImageExample extends Component {
 		uploadedImageDataUrl: null
 	};
 
+	onImageEditorDone = ( imageBlob ) => {
+		this.setState( {
+			uploadedImageDataUrl: URL.createObjectURL( imageBlob ),
+			isUploading: true,
+		} );
+	};
+
 	render() {
 		const { isUploading, uploadedImageDataUrl } = this.state;
 
@@ -24,14 +30,7 @@ export default class UploadImageExample extends Component {
 				<h3>Default Upload Image</h3>
 				<UploadImage
 					isUploading={ isUploading }
-					onImageEditorDone={
-						( imageBlob ) => {
-							this.setState( {
-								uploadedImageDataUrl: URL.createObjectURL( imageBlob ),
-								isUploading: true,
-							} );
-						}
-					}
+					onImageEditorDone={ this.onImageEditorDone }
 					imageEditorProps={ {
 						defaultAspectRatio: AspectRatios.FREE,
 					} }

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -42,6 +42,7 @@ class UploadImage extends Component {
 	static defaultProps = {
 		allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
 		texts: {},
+		backgroundContent: null,
 	};
 
 	onReceiveFile = ( files ) => {
@@ -115,33 +116,22 @@ class UploadImage extends Component {
 
 	render() {
 		const {
+			backgroundContent,
 			isUploading,
 			translate,
 			texts,
 		} = this.props;
 
 		let {
-			backgroundContent,
-			notUploadingContent,
+			placeholderContent,
 			uploadingContent,
 		} = this.props;
 
-		if ( ! backgroundContent ) {
-			backgroundContent = (
-				<div className="upload-image__content">
-				</div>
-			);
-		}
-
-		if ( ! notUploadingContent ) {
-			notUploadingContent = (
-				<div className="upload-image__label-container">
-					<span className="upload-image__label">
-						{ texts.uploadText
-							? texts.uploadText
-							: <Gridicon icon="add-image" size={ 36 } />
-						}
-					</span>
+		if ( ! placeholderContent ) {
+			placeholderContent = (
+				<div className="upload-image__placeholder">
+						<Gridicon icon="add-image" size={ 36 } />
+					<span>Add an image</span>
 				</div>
 			);
 		}
@@ -172,7 +162,7 @@ class UploadImage extends Component {
 
 						{ backgroundContent }
 
-						{ ! isUploading && notUploadingContent }
+						{ ! isUploading && placeholderContent }
 						{ isUploading && uploadingContent }
 					</div>
 				</FilePicker>

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -33,10 +33,11 @@ class UploadImage extends Component {
 
 	static propTypes = {
 		isUploading: PropTypes.bool,
-		imageEditorModalClassNames: PropTypes.string,
 		allowedAspectRatios: PropTypes.arrayOf( PropTypes.oneOf( AspectRatiosValues ) ),
 		texts: PropTypes.object,
 		onImageEditorDone: PropTypes.func,
+		additionalImageEditorClasses: PropTypes.string,
+		additionalClasses: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -89,12 +90,12 @@ class UploadImage extends Component {
 
 	renderImageEditor() {
 		const {
-			imageEditorModalClassNames,
+			additionalImageEditorClasses,
 			allowedAspectRatios,
 			texts,
 		} = this.props;
 
-		const classes = classnames( 'upload-image-modal', imageEditorModalClassNames );
+		const classes = classnames( 'upload-image-modal', additionalImageEditorClasses );
 
 		if ( this.state.isEditingImage ) {
 			return (
@@ -120,6 +121,7 @@ class UploadImage extends Component {
 			isUploading,
 			translate,
 			texts,
+			additionalClasses
 		} = this.props;
 
 		let {
@@ -141,7 +143,7 @@ class UploadImage extends Component {
 		}
 
 		return (
-			<div className={	classnames( 'upload-image' ) } >
+			<div className={ classnames( 'upload-image', additionalClasses ) } >
 				{ this.renderImageEditor() }
 
 				<FilePicker accept="image/*" onPick={ this.onReceiveFile }>

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -46,6 +46,7 @@ class UploadImage extends Component {
 		texts: {},
 		backgroundContent: null,
 		onImageEditorDone: noop,
+		isUploading: false,
 	};
 
 	onReceiveFile = ( files ) => {
@@ -119,7 +120,7 @@ class UploadImage extends Component {
 
 	render() {
 		const {
-			backgroundContent,
+			children,
 			isUploading,
 			translate,
 			texts,
@@ -131,7 +132,7 @@ class UploadImage extends Component {
 			uploadingContent,
 		} = this.props;
 
-		if ( ! placeholderContent ) {
+		if ( typeof placeholderContent === 'undefined' ) {
 			placeholderContent = (
 				<div className="upload-image__placeholder">
 						<Gridicon icon="add-image" size={ 36 } />
@@ -140,7 +141,7 @@ class UploadImage extends Component {
 			);
 		}
 
-		if ( ! uploadingContent ) {
+		if ( typeof uploadingContent === 'undefined' ) {
 			uploadingContent = ( <Spinner className="upload-image__spinner" /> );
 		}
 
@@ -164,7 +165,7 @@ class UploadImage extends Component {
 							onFilesDrop={ this.onReceiveFile }
 						/>
 
-						{ backgroundContent }
+						{ children }
 
 						{ ! isUploading && placeholderContent }
 						{ isUploading && uploadingContent }

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import path from 'path';
 import Gridicon from 'gridicons';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,6 +45,7 @@ class UploadImage extends Component {
 		allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
 		texts: {},
 		backgroundContent: null,
+		onImageEditorDone: noop,
 	};
 
 	onReceiveFile = ( files ) => {

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import path from 'path';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import { ALLOWED_FILE_EXTENSIONS } from './constants';
+import {
+	AspectRatios,
+	AspectRatiosValues,
+} from 'state/ui/editor/image-editor/constants';
+import Dialog from 'components/dialog';
+import FilePicker from 'components/file-picker';
+import {
+	resetAllImageEditorState
+} from 'state/ui/editor/image-editor/actions';
+import Spinner from 'components/spinner';
+import ImageEditor from 'blocks/image-editor';
+import DropZone from 'components/drop-zone';
+
+class UploadImage extends Component {
+	state = {
+		isEditingImage: false,
+		image: false,
+	};
+
+	static propTypes = {
+		isUploading: PropTypes.bool,
+		imageEditorModalClassNames: PropTypes.string,
+		allowedAspectRatios: PropTypes.arrayOf( PropTypes.oneOf( AspectRatiosValues ) ),
+		texts: PropTypes.object,
+		onImageEditorDone: PropTypes.func,
+	};
+
+	static defaultProps = {
+		allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
+		texts: {},
+	};
+
+	onReceiveFile = ( files ) => {
+		const extension = path.extname( files[ 0 ].name )
+			.toLowerCase()
+			.substring( 1 );
+
+		if ( ALLOWED_FILE_EXTENSIONS.indexOf( extension ) === -1 ) {
+			return;
+		}
+
+		const imageObjectUrl = URL.createObjectURL( files[ 0 ] );
+
+		this.setState( {
+			isEditingImage: true,
+			image: imageObjectUrl
+		} );
+	};
+
+	onImageEditorDone = ( error, imageBlob ) => {
+		this.hideImageEditor();
+
+		if ( error ) {
+			return;
+		}
+
+		this.props.onImageEditorDone( imageBlob );
+	};
+
+	hideImageEditor = () => {
+		const {
+			resetAllImageEditorState: resetAllImageEditorStateAction
+		} = this.props;
+
+		resetAllImageEditorStateAction();
+
+		URL.revokeObjectURL( this.state.image );
+
+		this.setState( {
+			isEditingImage: false,
+			image: false
+		} );
+	};
+
+	renderImageEditor() {
+		const {
+			imageEditorModalClassNames,
+			allowedAspectRatios,
+			texts,
+		} = this.props;
+
+		const classes = classnames( 'upload-image-modal', imageEditorModalClassNames );
+
+		if ( this.state.isEditingImage ) {
+			return (
+				<Dialog
+					additionalClassNames={ classes }
+					isVisible={ true }
+				>
+					<ImageEditor
+						allowedAspectRatios={ allowedAspectRatios }
+						media={ { src: this.state.image } }
+						onDone={ this.onImageEditorDone }
+						onCancel={ this.hideImageEditor }
+						doneButtonText={ texts.doneButtonText ? texts.doneButtonText : 'Done' }
+					/>
+				</Dialog>
+			);
+		}
+	}
+
+	render() {
+		const {
+			isUploading,
+			translate,
+			texts,
+		} = this.props;
+
+		let {
+			backgroundContent,
+			notUploadingContent,
+			uploadingContent,
+		} = this.props;
+
+		if ( ! backgroundContent ) {
+			backgroundContent = (
+				<div className="upload-image__content">
+				</div>
+			);
+		}
+
+		if ( ! notUploadingContent ) {
+			notUploadingContent = (
+				<div className="upload-image__label-container">
+					<span className="upload-image__label">
+						{ texts.uploadText
+							? texts.uploadText
+							: <Gridicon icon="add-image" size={ 36 } />
+						}
+					</span>
+				</div>
+			);
+		}
+
+		if ( ! uploadingContent ) {
+			uploadingContent = ( <Spinner className="upload-image__spinner" /> );
+		}
+
+		return (
+			<div className={	classnames( 'upload-image' ) } >
+				{ this.renderImageEditor() }
+
+				<FilePicker accept="image/*" onPick={ this.onReceiveFile }>
+					<div
+						className={
+							classnames( 'upload-image__image-container',
+								{ 'is-uploading': isUploading }
+							)
+						}
+					>
+						<DropZone
+							textLabel={ texts.dragUploadText
+								? texts.dragUploadText
+								: translate( 'Drop to upload image' )
+							}
+							onFilesDrop={ this.onReceiveFile }
+						/>
+
+						{ backgroundContent }
+
+						{ ! isUploading && notUploadingContent }
+						{ isUploading && uploadingContent }
+					</div>
+				</FilePicker>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		resetAllImageEditorState,
+	}
+)( localize( UploadImage ) );

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -141,8 +141,15 @@ class UploadImage extends Component {
 			);
 		}
 
+		const { image } = this.state;
+
 		if ( typeof uploadingContent === 'undefined' ) {
-			uploadingContent = ( <Spinner className="upload-image__spinner" /> );
+			uploadingContent = (
+				<div>
+					<img src={ image } />
+					<Spinner className="upload-image__spinner" />
+				</div>
+			);
 		}
 
 		return (

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -29,7 +29,8 @@ import DropZone from 'components/drop-zone';
 class UploadImage extends Component {
 	state = {
 		isEditingImage: false,
-		image: false,
+		uploadedImage: null,
+		editedImage: null,
 	};
 
 	static propTypes = {
@@ -62,7 +63,7 @@ class UploadImage extends Component {
 
 		this.setState( {
 			isEditingImage: true,
-			image: imageObjectUrl
+			uploadedImage: imageObjectUrl
 		} );
 	};
 
@@ -72,6 +73,8 @@ class UploadImage extends Component {
 		if ( error ) {
 			return;
 		}
+
+		this.setState( { editedImage: URL.createObjectURL( imageBlob ) } );
 
 		this.props.onImageEditorDone( imageBlob );
 	};
@@ -83,11 +86,11 @@ class UploadImage extends Component {
 
 		resetAllImageEditorStateAction();
 
-		URL.revokeObjectURL( this.state.image );
+		URL.revokeObjectURL( this.state.uploadedImage );
 
 		this.setState( {
 			isEditingImage: false,
-			image: false
+			uploadedImage: false
 		} );
 	};
 
@@ -98,9 +101,14 @@ class UploadImage extends Component {
 			texts,
 		} = this.props;
 
+		const {
+			isEditingImage,
+			uploadedImage
+		} = this.state;
+
 		const classes = classnames( 'upload-image-modal', additionalImageEditorClasses );
 
-		if ( this.state.isEditingImage ) {
+		if ( isEditingImage ) {
 			return (
 				<Dialog
 					additionalClassNames={ classes }
@@ -108,7 +116,7 @@ class UploadImage extends Component {
 				>
 					<ImageEditor
 						allowedAspectRatios={ allowedAspectRatios }
-						media={ { src: this.state.image } }
+						media={ { src: uploadedImage } }
 						onDone={ this.onImageEditorDone }
 						onCancel={ this.hideImageEditor }
 						doneButtonText={ texts.doneButtonText ? texts.doneButtonText : 'Done' }
@@ -141,13 +149,13 @@ class UploadImage extends Component {
 			);
 		}
 
-		const { image } = this.state;
-
 		if ( typeof uploadingContent === 'undefined' ) {
+			const { editedImage } = this.state;
+
 			uploadingContent = (
-				<div>
-					<img src={ image } />
-					<Spinner className="upload-image__spinner" />
+				<div className="upload-image__uploading-container">
+					<img src={ editedImage } />
+					<Spinner className="upload-image__spinner" size={ 40 } />
 				</div>
 			);
 		}

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -13,10 +13,7 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import { ALLOWED_FILE_EXTENSIONS } from './constants';
-import {
-	AspectRatios,
-	AspectRatiosValues,
-} from 'state/ui/editor/image-editor/constants';
+import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 import Dialog from 'components/dialog';
 import FilePicker from 'components/file-picker';
 import {
@@ -35,7 +32,8 @@ class UploadImage extends Component {
 
 	static propTypes = {
 		isUploading: PropTypes.bool,
-		allowedAspectRatios: PropTypes.arrayOf( PropTypes.oneOf( AspectRatiosValues ) ),
+		// Additional props passed to ImageEditor component. See blocks/image-editor.
+		imageEditorProps: PropTypes.object,
 		texts: PropTypes.object,
 		onImageEditorDone: PropTypes.func,
 		additionalImageEditorClasses: PropTypes.string,
@@ -43,7 +41,9 @@ class UploadImage extends Component {
 	};
 
 	static defaultProps = {
-		allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
+		imageEditorProps: {
+			allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
+		},
 		texts: {},
 		backgroundContent: null,
 		onImageEditorDone: noop,
@@ -97,7 +97,7 @@ class UploadImage extends Component {
 	renderImageEditor() {
 		const {
 			additionalImageEditorClasses,
-			allowedAspectRatios,
+			imageEditorProps,
 			texts,
 		} = this.props;
 
@@ -115,7 +115,7 @@ class UploadImage extends Component {
 					isVisible={ true }
 				>
 					<ImageEditor
-						allowedAspectRatios={ allowedAspectRatios }
+						{ ...imageEditorProps }
 						media={ { src: uploadedImage } }
 						onDone={ this.onImageEditorDone }
 						onCancel={ this.hideImageEditor }

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -38,6 +38,8 @@ class UploadImage extends Component {
 		onImageEditorDone: PropTypes.func,
 		additionalImageEditorClasses: PropTypes.string,
 		additionalClasses: PropTypes.string,
+		placeholderContent: PropTypes.element,
+		uploadingContent: PropTypes.element,
 	};
 
 	static defaultProps = {
@@ -50,7 +52,7 @@ class UploadImage extends Component {
 		isUploading: false,
 	};
 
-	onReceiveFile = ( files ) => {
+	receiveFiles = ( files ) => {
 		const extension = path.extname( files[ 0 ].name )
 			.toLowerCase()
 			.substring( 1 );
@@ -63,7 +65,7 @@ class UploadImage extends Component {
 
 		this.setState( {
 			isEditingImage: true,
-			uploadedImage: imageObjectUrl
+			uploadedImage: imageObjectUrl,
 		} );
 	};
 
@@ -90,40 +92,42 @@ class UploadImage extends Component {
 
 		this.setState( {
 			isEditingImage: false,
-			uploadedImage: false
+			uploadedImage: false,
 		} );
 	};
 
 	renderImageEditor() {
+		const {
+			isEditingImage,
+			uploadedImage,
+		} = this.state;
+
+		if ( ! isEditingImage ) {
+			return null;
+		}
+
 		const {
 			additionalImageEditorClasses,
 			imageEditorProps,
 			texts,
 		} = this.props;
 
-		const {
-			isEditingImage,
-			uploadedImage
-		} = this.state;
-
 		const classes = classnames( 'upload-image-modal', additionalImageEditorClasses );
 
-		if ( isEditingImage ) {
-			return (
-				<Dialog
-					additionalClassNames={ classes }
-					isVisible={ true }
-				>
-					<ImageEditor
-						{ ...imageEditorProps }
-						media={ { src: uploadedImage } }
-						onDone={ this.onImageEditorDone }
-						onCancel={ this.hideImageEditor }
-						doneButtonText={ texts.doneButtonText ? texts.doneButtonText : 'Done' }
-					/>
-				</Dialog>
-			);
-		}
+		return (
+			<Dialog
+				additionalClassNames={ classes }
+				isVisible={ true }
+			>
+				<ImageEditor
+					{ ...imageEditorProps }
+					media={ { src: uploadedImage } }
+					onDone={ this.onImageEditorDone }
+					onCancel={ this.hideImageEditor }
+					doneButtonText={ texts.doneButtonText ? texts.doneButtonText : 'Done' }
+				/>
+			</Dialog>
+		);
 	}
 
 	render() {
@@ -132,7 +136,7 @@ class UploadImage extends Component {
 			isUploading,
 			translate,
 			texts,
-			additionalClasses
+			additionalClasses,
 		} = this.props;
 
 		let {
@@ -144,7 +148,9 @@ class UploadImage extends Component {
 			placeholderContent = (
 				<div className="upload-image__placeholder">
 						<Gridicon icon="add-image" size={ 36 } />
-					<span>Add an image</span>
+					<span>
+						{ texts.addAnImage ? texts.addAnImage : translate( 'Add an image' ) }
+					</span>
 				</div>
 			);
 		}
@@ -164,7 +170,7 @@ class UploadImage extends Component {
 			<div className={ classnames( 'upload-image', additionalClasses ) } >
 				{ this.renderImageEditor() }
 
-				<FilePicker accept="image/*" onPick={ this.onReceiveFile }>
+				<FilePicker accept="image/*" onPick={ this.receiveFiles }>
 					<div
 						className={
 							classnames( 'upload-image__image-container',
@@ -177,7 +183,7 @@ class UploadImage extends Component {
 								? texts.dragUploadText
 								: translate( 'Drop to upload image' )
 							}
-							onFilesDrop={ this.onReceiveFile }
+							onFilesDrop={ this.receiveFiles }
 						/>
 
 						{ children }

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -44,7 +44,7 @@ class UploadImage extends Component {
 
 	static defaultProps = {
 		imageEditorProps: {
-			allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
+			defaultAspectRatio: AspectRatios.ORIGINAL,
 		},
 		backgroundContent: null,
 		onImageEditorDone: noop,

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -152,7 +152,7 @@ class UploadImage extends Component {
 			uploadingContent = (
 				<div className="upload-image__uploading-container">
 					<img src={ editedImage } />
-					<Spinner className="upload-image__spinner" size={ 40 } />
+					<Spinner className="upload-image__spinner" size={ 20 } />
 				</div>
 			);
 		}

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -32,19 +32,20 @@ class UploadImage extends Component {
 		isUploading: PropTypes.bool,
 		// Additional props passed to ImageEditor component. See blocks/image-editor.
 		imageEditorProps: PropTypes.object,
-		texts: PropTypes.object,
 		onImageEditorDone: PropTypes.func,
 		additionalImageEditorClasses: PropTypes.string,
 		additionalClasses: PropTypes.string,
 		placeholderContent: PropTypes.element,
 		uploadingContent: PropTypes.element,
+		doneButtonText: PropTypes.string,
+		addAnImage: PropTypes.string,
+		dragUploadText: PropTypes.string,
 	};
 
 	static defaultProps = {
 		imageEditorProps: {
 			allowedAspectRatios: [ AspectRatios.ASPECT_1X1 ],
 		},
-		texts: {},
 		backgroundContent: null,
 		onImageEditorDone: noop,
 		isUploading: false,
@@ -97,7 +98,7 @@ class UploadImage extends Component {
 			return null;
 		}
 
-		const { additionalImageEditorClasses, imageEditorProps, texts } = this.props;
+		const { additionalImageEditorClasses, imageEditorProps, doneButtonText } = this.props;
 
 		const classes = classnames( 'upload-image-modal', additionalImageEditorClasses );
 
@@ -108,7 +109,7 @@ class UploadImage extends Component {
 					media={ { src: uploadedImage } }
 					onDone={ this.onImageEditorDone }
 					onCancel={ this.hideImageEditor }
-					doneButtonText={ texts.doneButtonText ? texts.doneButtonText : 'Done' }
+					doneButtonText={ doneButtonText ? doneButtonText : 'Done' }
 				/>
 			</Dialog>
 		);
@@ -123,7 +124,14 @@ class UploadImage extends Component {
 	}
 
 	render() {
-		const { children, isUploading, translate, texts, additionalClasses } = this.props;
+		const {
+			children,
+			isUploading,
+			translate,
+			additionalClasses,
+			addAnImage,
+			dragUploadText,
+		} = this.props;
 
 		let { placeholderContent, uploadingContent } = this.props;
 
@@ -132,7 +140,7 @@ class UploadImage extends Component {
 				<div className="upload-image__placeholder">
 					<Gridicon icon="add-image" size={ 36 } />
 					<span>
-						{ texts.addAnImage ? texts.addAnImage : translate( 'Add an Image' ) }
+						{ addAnImage ? addAnImage : translate( 'Add an Image' ) }
 					</span>
 				</div>
 			);
@@ -160,9 +168,7 @@ class UploadImage extends Component {
 						} ) }
 					>
 						<DropZone
-							textLabel={
-								texts.dragUploadText ? texts.dragUploadText : translate( 'Drop to upload image' )
-							}
+							textLabel={ dragUploadText ? dragUploadText : translate( 'Drop to upload image' ) }
 							onFilesDrop={ this.receiveFiles }
 						/>
 

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -16,9 +16,7 @@ import { ALLOWED_FILE_EXTENSIONS } from './constants';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
 import Dialog from 'components/dialog';
 import FilePicker from 'components/file-picker';
-import {
-	resetAllImageEditorState
-} from 'state/ui/editor/image-editor/actions';
+import { resetAllImageEditorState } from 'state/ui/editor/image-editor/actions';
 import Spinner from 'components/spinner';
 import ImageEditor from 'blocks/image-editor';
 import DropZone from 'components/drop-zone';
@@ -52,10 +50,8 @@ class UploadImage extends Component {
 		isUploading: false,
 	};
 
-	receiveFiles = ( files ) => {
-		const extension = path.extname( files[ 0 ].name )
-			.toLowerCase()
-			.substring( 1 );
+	receiveFiles = files => {
+		const extension = path.extname( files[ 0 ].name ).toLowerCase().substring( 1 );
 
 		if ( ALLOWED_FILE_EXTENSIONS.indexOf( extension ) === -1 ) {
 			return;
@@ -82,9 +78,7 @@ class UploadImage extends Component {
 	};
 
 	hideImageEditor = () => {
-		const {
-			resetAllImageEditorState: resetAllImageEditorStateAction
-		} = this.props;
+		const { resetAllImageEditorState: resetAllImageEditorStateAction } = this.props;
 
 		resetAllImageEditorStateAction();
 
@@ -97,28 +91,18 @@ class UploadImage extends Component {
 	};
 
 	renderImageEditor() {
-		const {
-			isEditingImage,
-			uploadedImage,
-		} = this.state;
+		const { isEditingImage, uploadedImage } = this.state;
 
 		if ( ! isEditingImage ) {
 			return null;
 		}
 
-		const {
-			additionalImageEditorClasses,
-			imageEditorProps,
-			texts,
-		} = this.props;
+		const { additionalImageEditorClasses, imageEditorProps, texts } = this.props;
 
 		const classes = classnames( 'upload-image-modal', additionalImageEditorClasses );
 
 		return (
-			<Dialog
-				additionalClassNames={ classes }
-				isVisible={ true }
-			>
+			<Dialog additionalClassNames={ classes } isVisible={ true }>
 				<ImageEditor
 					{ ...imageEditorProps }
 					media={ { src: uploadedImage } }
@@ -131,25 +115,16 @@ class UploadImage extends Component {
 	}
 
 	render() {
-		const {
-			children,
-			isUploading,
-			translate,
-			texts,
-			additionalClasses,
-		} = this.props;
+		const { children, isUploading, translate, texts, additionalClasses } = this.props;
 
-		let {
-			placeholderContent,
-			uploadingContent,
-		} = this.props;
+		let { placeholderContent, uploadingContent } = this.props;
 
 		if ( typeof placeholderContent === 'undefined' ) {
 			placeholderContent = (
 				<div className="upload-image__placeholder">
-						<Gridicon icon="add-image" size={ 36 } />
+					<Gridicon icon="add-image" size={ 36 } />
 					<span>
-						{ texts.addAnImage ? texts.addAnImage : translate( 'Add an image' ) }
+						{ texts.addAnImage ? texts.addAnImage : translate( 'Add an Image' ) }
 					</span>
 				</div>
 			);
@@ -167,21 +142,18 @@ class UploadImage extends Component {
 		}
 
 		return (
-			<div className={ classnames( 'upload-image', additionalClasses ) } >
+			<div className={ classnames( 'upload-image', additionalClasses ) }>
 				{ this.renderImageEditor() }
 
 				<FilePicker accept="image/*" onPick={ this.receiveFiles }>
 					<div
-						className={
-							classnames( 'upload-image__image-container',
-								{ 'is-uploading': isUploading }
-							)
-						}
+						className={ classnames( 'upload-image__image-container', {
+							'is-uploading': isUploading,
+						} ) }
 					>
 						<DropZone
-							textLabel={ texts.dragUploadText
-								? texts.dragUploadText
-								: translate( 'Drop to upload image' )
+							textLabel={
+								texts.dragUploadText ? texts.dragUploadText : translate( 'Drop to upload image' )
 							}
 							onFilesDrop={ this.receiveFiles }
 						/>
@@ -197,9 +169,6 @@ class UploadImage extends Component {
 	}
 }
 
-export default connect(
-	null,
-	{
-		resetAllImageEditorState,
-	}
-)( localize( UploadImage ) );
+export default connect( null, {
+	resetAllImageEditorState,
+} )( localize( UploadImage ) );

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -114,6 +114,14 @@ class UploadImage extends Component {
 		);
 	}
 
+	componentWillUnmount() {
+		URL.revokeObjectURL( this.state.editedImage );
+
+		this.setState( {
+			editedImage: null,
+		} );
+	}
+
 	render() {
 		const { children, isUploading, translate, texts, additionalClasses } = this.props;
 

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -25,3 +25,20 @@
 .upload-image-modal .dialog__content {
 	height: 100%;
 }
+
+.upload-image__placeholder {
+	width: 200px;
+	height: 200px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	margin-bottom: 24px;
+	background-color: $gray-light;
+	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
+
+	@include breakpoint( ">660px" ) {
+		flex: none;
+		margin-right: 24px;
+	}
+}

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -1,0 +1,27 @@
+.upload-image-modal.dialog.card {
+	max-width: none;
+	padding: 0;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+
+	@include breakpoint( ">660px" ) {
+		top: 5%;
+		bottom: 5%;
+		left: 5%;
+		right: 5%;
+		width: 90%;
+	}
+
+	@include breakpoint( ">960px" ) {
+		left: 12.5%;
+		right: 12.5%;
+		width: 75%;
+	}
+}
+
+.upload-image-modal .dialog__content {
+	height: 100%;
+}

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -1,3 +1,7 @@
+.upload-image {
+	display: inline-block;
+}
+
 .upload-image-modal.dialog.card {
 	max-width: none;
 	padding: 0;
@@ -33,12 +37,6 @@
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;
-	margin-bottom: 24px;
 	background-color: $gray-light;
 	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
-
-	@include breakpoint( ">660px" ) {
-		flex: none;
-		margin-right: 24px;
-	}
 }

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -40,3 +40,14 @@
 	background-color: $gray-light;
 	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
 }
+
+.upload-image__uploading-container {
+	position: relative;
+
+}
+
+.upload-image__spinner {
+	position: absolute;
+	left: 50%;
+	top: 50%;
+}

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -43,7 +43,6 @@
 
 .upload-image__uploading-container {
 	position: relative;
-
 }
 
 .upload-image__spinner {

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -39,6 +39,11 @@
 	flex-direction: column;
 	background-color: $gray-light;
 	box-shadow: inset 0 0 0 1px lighten( $gray, 25% );
+	font-size: 14px;
+
+	&:hover {
+		cursor: pointer;
+	}
 }
 
 .upload-image__uploading-container {
@@ -49,4 +54,5 @@
 	position: absolute;
 	left: 50%;
 	top: 50%;
+	transform: translate( -50%, -50% );
 }

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -73,6 +73,7 @@ import SharingPreviewPane from 'blocks/sharing-preview-pane/docs/example';
 import ReaderShare from 'blocks/reader-share/docs/example';
 import Login from 'blocks/login/docs/example';
 import ReaderEmailSettings from 'blocks/reader-email-settings/docs/example';
+import UploadImage from 'blocks/upload-image/docs/example';
 
 export default React.createClass( {
 	displayName: 'AppComponents',
@@ -162,6 +163,7 @@ export default React.createClass( {
 					<SharingPreviewPane />
 					<ReaderShare />
 					<ReaderEmailSettings />
+					<UploadImage />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
Adds a new block which allows to upload and edit an image in `ImageEditor`. The difference between this block and `ImageEditor` is that while `ImageEditor` provides only modal for editing images, this block also provides a way to upload the image into the `ImageEditor`.

It will be used in the Simple Payments project so the inspiration for creating it came from there. Parts of it are inspired/copied from `edit-gravatar` block. I thought that instead of writing yet another flow of uploading an image into `ImageEditor`, let's create a reusable block for it.

Here it is.

## Testing

Navigate to `http://calypso.localhost:3000/devdocs/blocks/upload-image`. Click on the "Add an Image" field. Can you select an image? Does it show as "uploading" after you click "Done" in Image Editor?