### PR TITLE
Jetpack Plans: Show better error descriptions and Happychat button in Thank You page for paid plans

### DIFF
--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -78,6 +78,15 @@ class PlanThankYouCard extends Component {
 		);
 	}
 
+	renderHeading() {
+		const { heading, translate } = this.props;
+		if ( heading ) {
+			return heading;
+		}
+
+		return translate( 'Thank you for your purchase!' );
+	}
+
 	render() {
 		const { siteUrl, siteId, translate } = this.props;
 		return (
@@ -88,7 +97,7 @@ class PlanThankYouCard extends Component {
 				<ThankYouCard
 					name={ this.renderPlanName() }
 					price={ this.renderPlanPrice() }
-					heading={ translate( 'Thank you for your purchase!' ) }
+					heading={ this.renderHeading() }
 					description={ this.renderDescription() }
 					buttonUrl={ siteUrl }
 					buttonText={ translate( 'Visit Your Site' ) }
@@ -101,12 +110,13 @@ class PlanThankYouCard extends Component {
 }
 
 PlanThankYouCard.propTypes = {
+	heading: PropTypes.string,
 	plan: PropTypes.object,
 	siteId: PropTypes.number.isRequired,
 	siteUrl: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 	action: PropTypes.node,
-	description: PropTypes.string
+	description: PropTypes.string,
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -30,7 +30,13 @@ import HappyChatButton from 'components/happychat/button';
 
 // Redux actions & selectors
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, isRequestingSites, getRawSite } from 'state/sites/selectors';
+import {
+	getRawSite,
+	isJetpackSite,
+	isJetpackSiteMainNetworkSite,
+	isJetpackSiteMultiSite,
+	isRequestingSites,
+} from 'state/sites/selectors';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { requestSites } from 'state/sites/actions';
@@ -335,7 +341,7 @@ class JetpackThankYouCard extends Component {
 	}
 
 	guessErrorReason() {
-		const { translate, selectedSite } = this.props;
+		const { isSiteMainNetworkSite, isSiteMultiSite, selectedSite, translate } = this.props;
 		if ( ! this.isErrored() ) {
 			return null;
 		}
@@ -353,7 +359,7 @@ class JetpackThankYouCard extends Component {
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error_jpversion', {
 				jetpack_version: selectedSite.options.jetpack_version
 			} );
-		} else if ( selectedSite.is_multisite && ! selectedSite.isMainNetworkSite() ) {
+		} else if ( isSiteMultiSite && ! isSiteMainNetworkSite ) {
 			reason = translate(
 				'Your site is part of a multi-site network, but is not the main network site.'
 			);
@@ -719,6 +725,8 @@ export default connect(
 			: site;
 		return {
 			wporg: state.plugins.wporg.items,
+			isSiteMultiSite: isJetpackSiteMultiSite( state, siteId ),
+			isSiteMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
 			isRequesting: isRequesting( state, siteId ),
 			hasRequested: hasRequested( state, siteId ),
 			isInstalling: isInstalling( state, siteId, whitelist ),

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -64,7 +64,14 @@ import {
 	getPlanClass
 } from 'lib/plans/constants';
 import { getPlan } from 'lib/plans';
-import { PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY } from 'lib/plans/constants';
+import {
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+} from 'lib/plans/constants';
 
 const vpFeatures = {
 	[ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY ]: true,
@@ -307,7 +314,9 @@ class JetpackThankYouCard extends Component {
 
 	isEligibleForLiveChat() {
 		const { planSlug } = this.props;
-		return planSlug === PLAN_JETPACK_BUSINESS || planSlug === PLAN_JETPACK_BUSINESS_MONTHLY;
+		return planSlug === PLAN_JETPACK_BUSINESS || planSlug === PLAN_JETPACK_BUSINESS_MONTHLY ||
+			planSlug === PLAN_JETPACK_PERSONAL || planSlug === PLAN_JETPACK_PERSONAL_MONTHLY ||
+			planSlug === PLAN_JETPACK_PREMIUM || planSlug === PLAN_JETPACK_PREMIUM_MONTHLY;
 	}
 
 	renderLiveChatButton() {

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -63,7 +63,8 @@ import {
 	FEATURES_LIST,
 	getPlanClass
 } from 'lib/plans/constants';
-import { isFreePlan, getPlan } from 'lib/plans';
+import { getPlan } from 'lib/plans';
+import { isCurrentPlanPaid } from 'state/sites/selectors';
 
 const vpFeatures = {
 	[ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY ]: true,
@@ -612,7 +613,6 @@ export default connect(
 		const planClass = plan && plan.productSlug
 			? getPlanClass( plan.productSlug )
 			: '';
-		const isJetpackFreePlan = isJetpackSite( state, siteId ) && plan && plan.productSlug && isFreePlan( plan.productSlug );
 		if ( plan ) {
 			plan = getPlan( plan.productSlug );
 		}
@@ -630,7 +630,7 @@ export default connect(
 			hasRequested: hasRequested( state, siteId ),
 			isInstalling: isInstalling( state, siteId, whitelist ),
 			isFinished: isFinished( state, siteId, whitelist ),
-			isJetpackPaidPlan: ! isJetpackFreePlan,
+			isJetpackPaidPlan: isJetpackSite( state, siteId ) && isCurrentPlanPaid( state, siteId ),
 			plugins: getPluginsForSite( state, siteId, whitelist ),
 			activePlugin: getActivePlugin( state, siteId, whitelist ),
 			nextPlugin: getNextPlugin( state, siteId, whitelist ),

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -599,9 +599,6 @@ class JetpackThankYouCard extends Component {
 	}
 
 	getProgress() {
-		if ( this.isErrored() ) {
-			return 0;
-		}
 
 		const features = this.getFeaturesWithStatus() || [ '' ];
 		const completed = this.shouldRenderPlaceholders()
@@ -620,9 +617,9 @@ class JetpackThankYouCard extends Component {
 	renderAction( progress = 0 ) {
 		const { selectedSite: site, translate } = this.props;
 		const buttonUrl = site && site.URL;
-		// We return an empty span for the error case becaue the default button will be displayed
-		// further down the tree if the action is falsey.
-		if ( this.isErrored() ) {
+		// We return instructions for setting up manually
+		// when we finish if something errored
+		if ( this.isErrored() && ! this.props.isInstalling ) {
 			return (
 				<div className="checkout-thank-you__jetpack-description-in-actions">
 					<p>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -64,7 +64,7 @@ import {
 	getPlanClass
 } from 'lib/plans/constants';
 import { getPlan } from 'lib/plans';
-import { isCurrentPlanPaid } from 'state/sites/selectors';
+import { PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY } from 'lib/plans/constants';
 
 const vpFeatures = {
 	[ FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY ]: true,
@@ -305,9 +305,13 @@ class JetpackThankYouCard extends Component {
 		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_chat_initiated' );
 	};
 
+	isEligibleForLiveChat() {
+		const { planSlug } = this.props;
+		return planSlug === PLAN_JETPACK_BUSINESS || planSlug === PLAN_JETPACK_BUSINESS_MONTHLY;
+	}
+
 	renderLiveChatButton() {
-		const { isJetpackPaidPlan } = this.props;
-		return isJetpackPaidPlan && (
+		return this.isEligibleForLiveChat() && (
 			<HappyChatButton
 				borderless={ false }
 				className="checkout-thank-you__happychat-button thank-you-card__button"
@@ -610,10 +614,12 @@ export default connect(
 		const site = getSelectedSite( state );
 		const whitelist = ownProps.whitelist || false;
 		let plan = getCurrentPlan( state, siteId );
+		let planSlug;
 		const planClass = plan && plan.productSlug
 			? getPlanClass( plan.productSlug )
 			: '';
 		if ( plan ) {
+			planSlug = plan.productSlug;
 			plan = getPlan( plan.productSlug );
 		}
 		const planFeatures = plan && plan.getFeatures
@@ -630,7 +636,6 @@ export default connect(
 			hasRequested: hasRequested( state, siteId ),
 			isInstalling: isInstalling( state, siteId, whitelist ),
 			isFinished: isFinished( state, siteId, whitelist ),
-			isJetpackPaidPlan: isJetpackSite( state, siteId ) && isCurrentPlanPaid( state, siteId ),
 			plugins: getPluginsForSite( state, siteId, whitelist ),
 			activePlugin: getActivePlugin( state, siteId, whitelist ),
 			nextPlugin: getNextPlugin( state, siteId, whitelist ),
@@ -638,7 +643,8 @@ export default connect(
 			isRequestingSites: isRequestingSites( state ),
 			siteId,
 			planFeatures,
-			planClass
+			planClass,
+			planSlug
 		};
 	},
 	dispatch => bindActionCreators( { requestSites, fetchPluginData, installPlugin }, dispatch )

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -638,13 +638,13 @@ class JetpackThankYouCard extends Component {
 
 		if ( 100 === progress ) {
 			return (
-				<div>
-					{ this.renderLiveChatButton() }
+				<div className="checkout-thank-you__jetpack-action-buttons">
 					<a
 						className={ classNames( 'button', 'thank-you-card__button', { 'is-placeholder': ! buttonUrl } ) }
 						href={ buttonUrl }>
 						{ translate( 'Visit Your Site' ) }
 					</a>
+					{ this.renderLiveChatButton() }
 				</div>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -641,7 +641,7 @@ class JetpackThankYouCard extends Component {
 				<div>
 					{ this.renderLiveChatButton() }
 					<a
-						className={ classNames( 'thank-you-card__button', { 'is-placeholder': ! buttonUrl } ) }
+						className={ classNames( 'button', 'thank-you-card__button', { 'is-placeholder': ! buttonUrl } ) }
 						href={ buttonUrl }>
 						{ translate( 'Visit Your Site' ) }
 					</a>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -664,6 +664,7 @@ class JetpackThankYouCard extends Component {
 	}
 
 	render() {
+		const translate = this.props.translate;
 		const site = this.props.selectedSite;
 		if ( ! site && this.props.isRequestingSites ) {
 			return (
@@ -686,6 +687,7 @@ class JetpackThankYouCard extends Component {
 				<PlanThankYouCard
 					siteId={ site.ID }
 					action={ this.renderAction( progress ) }
+					heading={ this.isErrored() && site.canUpdateFiles ? translate( "You're almost there!" ) : null }
 					description={ this.renderDescription( progress ) } />
 				{ this.renderFeatures() }
 			</div>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -163,8 +163,8 @@ class JetpackThankYouCard extends Component {
 	}
 
 	componentDidUpdate() {
-		const site = this.props.selectedSite;
-		const { plugins } = this.props;
+		const { nextPlugin, planFeatures, plugins, selectedSite: site } = this.props;
+		const { completedJetpackFeatures } = this.state;
 
 		if ( ! site ||
 			! site.jetpack ||
@@ -175,19 +175,21 @@ class JetpackThankYouCard extends Component {
 			return;
 		}
 
-		if ( this.props.planFeatures && ! site.canUpdateFiles && ! Object.keys( this.state.completedJetpackFeatures ).length ) {
+		if ( planFeatures && ! site.canUpdateFiles && ! Object.keys( completedJetpackFeatures ).length ) {
 			this.activateJetpackFeatures();
 		}
 
-		if ( site.canUpdateFiles && this.props.nextPlugin ) {
-			this.startNextPlugin( this.props.nextPlugin );
+		if ( site.canUpdateFiles && nextPlugin ) {
+			this.startNextPlugin( nextPlugin );
 		} else if (
 			site.canUpdateFiles &&
 			plugins &&
 			! this.shouldRenderPlaceholders() &&
 			! some( plugins, ( plugin ) => 'done' !== plugin.status ) &&
-			! Object.keys( this.state.completedJetpackFeatures ).length
+			! Object.keys( completedJetpackFeatures ).length
 		) {
+			this.activateJetpackFeatures();
+		} else if ( site.canUpdateFiles && ! nextPlugin && ! Object.keys( completedJetpackFeatures ).length ) {
 			this.activateJetpackFeatures();
 		}
 	}

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -331,3 +331,11 @@
 	color: inherit;
 	text-decoration: underline;
 }
+
+.checkout-thank-you__jetpack-action-buttons {
+	display:flex;
+}
+
+.checkout-thank-you__jetpack .thank-you-card__action .button {
+	max-width: 45%;
+}

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -264,11 +264,16 @@
 	align-items: center;
 	display: flex;
 	margin-right: 8px;
+	width: 18px;
 }
 
 .checkout-thank-you__jetpack-feature-status-text {
 	font-size: 16px;
 	text-align: left;
+}
+
+.checkout-thank-you__jetpack-feature.with-error .checkout-thank-you__jetpack-feature-status-text {
+	color: $gray-text-min;
 }
 
 .checkout-thank-you__jetpack-feature-status-icon .spinner,
@@ -320,4 +325,9 @@
 	font-size: 14px;
 	font-style: italic;
 	font-weight: 400;
+}
+
+.checkout-thank-you__jetpack-description-in-actions a {
+	color: inherit;
+	text-decoration: underline;
 }


### PR DESCRIPTION
#### Changes introduced by this PR

This PR implements the changes proposed in p6TEKc-1rT-p2

* Fixes checks of multisite environments (Specifically detection of a primary site in a multisite enviornments)
* Removes white card which previously included error details, link to manual installation and link to contact form.
* Moves error details into ThankYouCard's description section.
* Moves link to action section looking as a regular text link instead of a button. Text reads `"You will ned to set up your plan manually."`.
* Shows Happychat Button in the cards' actions section for all paid Jetpack Plans when an error is encountered (if operators are available).
* Makes the feature listing show features with errors in gray instead of prepending an error-y icon next to it. 
* Updates error details to a simplified version in each case. Stating just the condition that made us not be able to continue with auto config. (As opposed to always stating why akismet and vaultpress are related to our plans before each actual error is described )
* Updates the `PlanThankYouCard` component to accept a different heading instead of defaulting to `"Thank you for your purchase!"`
* Shows the heading `"You're almost there"` if we prompt the user to manual installation. 

#### Testing instructions

**Requirements**: Jetpack 5.3 is needed here to make sure that we're detecting the ability to write files properly. Jetpack 5.3 will do a full sync on connection and this behavior is not present in previous versions. This flag (`canUpdateFiles`) may be out of sync by this point in previous versions unless a full sync is triggered manually

1. Clone this branch and test it locally or use [the live branch](https://calypso.live/?branch=update/jetpack-thank-you-card-happychat-button).
1. **Log in into HappyChat staging as an operator** (this is just to ensure there's at least one operator and the HappyChatButton shows. Otherwise you won't see it).
1. Connect a Jetpack site and acquire a paid plan.
1. Wait until you see the Thank you card.

#### Simpler testing.

Instead of going through plan acquisition, one can go to `/checkout/thank-you/:site/:receiptId`. You can find receipt ids by visiting `/me/purchases/billing`. Clikcing on  `View receipt` link for your site  will take you to an URL with a receipt Id.
