### PR TITLE
Implemented NonSupportedJetpackVersionNotice Component

### DIFF
--- a/client/my-sites/plugins/not-supported-jetpack-version.jsx
+++ b/client/my-sites/plugins/not-supported-jetpack-version.jsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { warningNotice } from 'state/notices/actions';
+
+import {
+	isJetpackSite,
+	getSiteAdminUrl,
+	getSiteDomain,
+	siteHasMinimumJetpackVersion
+} from 'state/sites/selectors';
+
+class NonSupportedJetpackVersionNotice extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+		minimumJetpackVersionFailed: PropTypes.bool.isRequired,
+		adminUrl: PropTypes.string,
+		domain: PropTypes.string,
+	};
+
+	// TODO: Refactor to use Redux notices middleware after plugins have been migrated to use Redux
+	showWarning( {
+		adminUrl,
+		domain,
+		minimumJetpackVersionFailed,
+		siteId,
+		translate,
+		triggerNotice
+	} ) {
+		if ( minimumJetpackVersionFailed ) {
+			const jetpackMinVersion = config( 'jetpack_min_version' );
+			triggerNotice(
+				translate(
+					'Jetpack %(version)s is required to take full advantage of plugin management in %(site)s.',
+					{
+						args: {
+							version: jetpackMinVersion,
+							site: domain
+						}
+					}
+				), {
+					button: translate( 'Update now' ),
+					href: adminUrl,
+					id: `allSitesNotOnMinJetpackVersion-${ jetpackMinVersion }-${ siteId }`,
+					displayOnNextPage: true
+				}
+			);
+		}
+	}
+
+	componentWillMount() {
+		this.showWarning( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.showWarning( nextProps );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+		return {
+			siteId: selectedSiteId,
+			adminUrl: getSiteAdminUrl( state, selectedSiteId, 'plugins.php?plugin_status=upgrade' ),
+			domain: getSiteDomain( state, selectedSiteId ),
+			minimumJetpackVersionFailed: !! isJetpackSite( state, selectedSiteId ) &&
+				! siteHasMinimumJetpackVersion( state, selectedSiteId )
+		};
+	},
+	{
+		triggerNotice: warningNotice
+	}
+)( localize( NonSupportedJetpackVersionNotice ) );


### PR DESCRIPTION
In order to refactor access control in plugins (and remove sites-list) this PR creates a component that just handles the minimum Jetpack version notice. This PR just creates the component to make things easier to review, it is used in PR https://github.com/Automattic/wp-calypso/pull/15482/.

 The displayOnNextPage is set to true because if that was not the case we would have a big bug. The action to change the site would be triggered than our notices component detects that the selected siteId changed and immediately triggers a notice saying the site has no minimum Jetpack version. Meanwhile, a route change action is dispatched (after the site change action) and the notice is removed once the route changes so the notice just appears for half a second. 
