### PR TITLE
Implemented NoPermissionsError component

### DIFF
--- a/client/my-sites/plugins/no-permissions-error.jsx
+++ b/client/my-sites/plugins/no-permissions-error.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import EmptyContent from 'components/empty-content';
+import Main from 'components/main';
+import { preventWidows } from 'lib/formatting';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+
+const NoPermissionsError = ( { title, translate } ) => (
+	<Main>
+		{ title && <DocumentHead title={ title } /> }
+		<SidebarNavigation />
+		<EmptyContent
+			title={ preventWidows( translate( 'Oops! You don\'t have permission to manage plugins.' ) ) }
+			line={ preventWidows( translate( 'If you think you should, contact this site\'s administrator.' ) ) }
+			illustration="/calypso/images/illustrations/illustration-500.svg" />
+	</Main>
+);
+
+NoPermissionsError.propTypes = {
+	title: PropTypes.string,
+	translate: PropTypes.func.isRequired
+};
+
+export default localize( NoPermissionsError );


### PR DESCRIPTION
In order to refactor access control in plugins (and remove sites-list) this PR creates a component that just that just displays a message saying the user has no permissions to manage plugins. Before when the user had no permissions a page not found message has shown.
The message was the one proposed in PR #15482 by @michelleweber and @rickybanister.
For the illustration, I did not found the 404 illustration adequate to the new error message so I used the illustration-500 instead.

Before:
![chrome_2017-07-14_17-08-40](https://user-images.githubusercontent.com/11271197/28224162-fdb8bec8-68c5-11e7-9099-35c454cc6639.png)

After:
![chrome_2017-07-19_20-31-22](https://user-images.githubusercontent.com/11271197/28385979-030946ea-6cc2-11e7-99bd-07f9d8aa0718.png)
![chrome_2017-07-19_20-31-14](https://user-images.githubusercontent.com/11271197/28385985-07c09ada-6cc2-11e7-89ea-463267ac36c5.png)
![chrome_2017-07-19_20-42-14](https://user-images.githubusercontent.com/11271197/28386228-d1ddaa2e-6cc2-11e7-9f64-eaf1fd04b04c.png)


I don't know if for this cases we need a design review, if yes please tell me and I will update the PR.

This PR just creates the component to make things easier to review, the component it self is used in PR #15482.