### PR TITLE
Domains: Add new .xyz and .shop domains to domain search.

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -73,7 +73,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		let buttonClasses, buttonContent;
 
 		if ( domain ) {
-			const newTLDs = [ '.rocks', '.site', '.cloud', '.club', '.today', '.tube', '.ca' ];
+			const newTLDs = [ '.rocks', '.site', '.cloud', '.club', '.today', '.tube', '.ca', '.xyz', '.shop' ];
 			const testTLDs = [ '.de', '.fr' ];
 			// Grab everything after the first dot, so 'example.co.uk' will
 			// match '.co.uk' but not '.uk'

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -48,6 +48,8 @@ const tlds = {
 	club: 'dotclub_domain',
 	today: 'dottoday_domain',
 	vip: 'dotvip_domain',
+	xyz: 'dotxyz_domain',
+	shop: 'dotshop_domain',
 };
 
 const domainAvailability = {


### PR DESCRIPTION
This PR adds the `.xyz` and `.shop` TLDs and assigns the "New" flag to them.

#### Testing
Build Calypso locally and search for a .xyz and .shop domain. You should see the corresponding results with the green "New" flag next to these domains.