### PR TITLE
Fix tracks events for the publish confirmation sidebar.

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -281,10 +281,11 @@ PostActions = {
 	 * Calls out to API to save a Post object
 	 *
 	 * @param {object} attributes post attributes to change before saving
+	 * @param {object} context additional properties for recording the save event
 	 * @param {function} callback receives ( err, post ) arguments
 	 * @param {object} options object with optional recordSaveEvent property. True if you want to record the save event.
 	 */
-	saveEdited: function( attributes, callback, options ) {
+	saveEdited: function( attributes, context, callback, options ) {
 		var post, postHandle, query, changedAttributes, rawContent, mode, isNew;
 
 		Dispatcher.handleViewAction( {
@@ -334,7 +335,7 @@ PostActions = {
 		};
 
 		if ( ! options || options.recordSaveEvent !== false ) {
-			stats.recordSaveEvent(); // do this before changing status from 'future'
+			stats.recordSaveEvent( context ); // do this before changing status from 'future'
 		}
 
 		if ( ( changedAttributes && changedAttributes.status === 'future' && utils.isFutureDated( post ) ) ||

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -43,7 +43,7 @@ export function recordEvent( action, label, value ) {
 	analytics.ga.recordEvent( 'Editor', action, label, value );
 }
 
-export function recordSaveEvent() {
+export function recordSaveEvent( context ) {
 	const post = PostEditStore.get();
 	const savedPost = PostEditStore.getSavedPost();
 
@@ -69,7 +69,7 @@ export function recordSaveEvent() {
 	} else if ( 'publish' === nextStatus || 'private' === nextStatus ) {
 		tracksEventName += 'publish';
 		usageAction = 'new';
-		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+		if ( context && context.isConfirmationFeatureEnabled ) {
 			eventContext = 'confirmation_sidebar';
 		}
 	} else if ( 'pending' === nextStatus ) {
@@ -78,7 +78,7 @@ export function recordSaveEvent() {
 		tracksEventName += 'schedule';
 		statName = 'status-schedule';
 		statEvent = 'Scheduled Post';
-		if ( config.isEnabled( 'post-editor/delta-post-publish-flow' ) ) {
+		if ( context && context.isConfirmationFeatureEnabled ) {
 			eventContext = 'confirmation_sidebar';
 		}
 	}

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -188,7 +188,7 @@ describe( 'actions', function() {
 			const spy = sandbox.spy();
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( false );
 
-			PostActions.saveEdited( null, spy );
+			PostActions.saveEdited( null, {}, spy );
 
 			defer( () => {
 				expect( spy ).to.have.been.calledOnce;
@@ -204,7 +204,7 @@ describe( 'actions', function() {
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( true );
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( {} );
 
-			PostActions.saveEdited( null, spy );
+			PostActions.saveEdited( null, {}, spy );
 
 			defer( () => {
 				expect( spy ).to.have.been.calledOnce;
@@ -234,7 +234,7 @@ describe( 'actions', function() {
 			};
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( changedAttributes );
 
-			PostActions.saveEdited( null, ( error, data ) => {
+			PostActions.saveEdited( null, {}, ( error, data ) => {
 				const normalizedAttributes = {
 					ID: 777,
 					site_ID: 123,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -648,8 +648,13 @@ export const PostEditor = React.createClass( {
 
 		edits.content = this.editor.getContent();
 
+		const isConfirmationFeatureEnabled = (
+			config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+			this.props.isConfirmationSidebarEnabled
+		);
+
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.saveEdited( edits, function( error ) {
+		actions.saveEdited( edits, { isConfirmationFeatureEnabled: isConfirmationFeatureEnabled }, function( error ) {
 			if ( error && 'NO_CHANGE' !== error.message ) {
 				this.onSaveDraftFailure( error );
 			} else {
@@ -800,7 +805,7 @@ export const PostEditor = React.createClass( {
 		// to serialize when TinyMCE is the active mode
 		edits.content = this.editor.getContent();
 
-		actions.saveEdited( edits, function( error ) {
+		actions.saveEdited( edits, { isConfirmationFeatureEnabled: isConfirmationFeatureEnabled }, function( error ) {
 			if ( error && 'NO_CHANGE' !== error.message ) {
 				this.onPublishFailure( error );
 			} else {


### PR DESCRIPTION
This PR fixes the Tracks events for state changes to the confirmation sidebar. These events were introduced in #15000. A setting to disable the publish confirmation sidebar was introduced in #15661 and #15700 but the Tracks event recording has not taken it into account so far which is what this PR fixes.

This PR is part of a larger epic and is behind the `post-editor/delta-post-publish-flow` feature flag. See p8F9tW-3F-p2.

To test:
* Checkout branch and `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Set your console to log Tracks events: `localStorage.setItem('debug', 'calypso:analytics:tracks');`
* Draft a post in the editor and then click on "Publish...". Verify that a debug statement for the Tracks event is shown in the console when the sidebar opens.
* Close the sidebar by typing into the editor. Verify that a debug statement for the Tracks event is shown in the console when the sidebar closes. Verify that the context for that statement indicates that the closure occurred from the editor (content edit).
* Open the sidebar again by clicking "Publish..." and then close the sidebar, this time by clicking on the "X". Verify that a debug statement for the Tracks event is shown in the console when the sidebar closes. Verify that the context for that statement indicates that the closure occurred from the x.
* Open the sidebar again by clicking on "Publish...". Publish the post. You should see 2 events: one for the closure of the sidebar with a context indicating successful publishing, and another for the successful publishing of the post and a context indicating it was triggered via the sidebar.
* Failure state also results in the closure of the sidebar, and an event recorded with a context indicating failure. You can simulate this by attempting to publish while offline (or while throttling "offline" with Chrome's network tools).