### PR TITLE
Reader: add compact post card

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -58,10 +58,12 @@ class PostByline extends React.Component {
 		feed: React.PropTypes.object,
 		isDiscoverPost: React.PropTypes.bool,
 		showSiteName: React.PropTypes.bool,
+		showAvatar: React.PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isDiscoverPost: false,
+		showAvatar: true,
 	};
 
 	recordDateClick = () => {
@@ -69,7 +71,7 @@ class PostByline extends React.Component {
 	};
 
 	render() {
-		const { post, site, feed, isDiscoverPost, showSiteName } = this.props;
+		const { post, site, feed, isDiscoverPost, showSiteName, showAvatar } = this.props;
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const siteName = getSiteName( { site, feed, post } );
@@ -92,14 +94,15 @@ class PostByline extends React.Component {
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
 			<div className="reader-post-card__byline ignore-click">
-				<ReaderAvatar
-					siteIcon={ siteIcon }
-					feedIcon={ feedIcon }
-					author={ post.author }
-					preferGravatar={ true }
-					siteUrl={ streamUrl }
-					isCompact={ true }
-				/>
+				{ showAvatar &&
+					<ReaderAvatar
+						siteIcon={ siteIcon }
+						feedIcon={ feedIcon }
+						author={ post.author }
+						preferGravatar={ true }
+						siteUrl={ streamUrl }
+						isCompact={ true }
+					/> }
 				<div className="reader-post-card__byline-details">
 					{ ( shouldDisplayAuthor || showSiteName ) &&
 						<div className="reader-post-card__byline-author-site">

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,0 +1,59 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { partial } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import AutoDirection from 'components/auto-direction';
+import Emojify from 'components/emojify';
+import ReaderFeaturedVideo from 'blocks/reader-featured-video';
+import ReaderFeaturedImage from 'blocks/reader-featured-image';
+import ReaderExcerpt from 'blocks/reader-excerpt';
+
+const CompactPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } ) => {
+	const canonicalMedia = post.canonical_media;
+	let featuredAsset;
+	if ( ! canonicalMedia ) {
+		featuredAsset = null;
+	} else if ( canonicalMedia.mediaType === 'video' ) {
+		featuredAsset = (
+			<ReaderFeaturedVideo
+				{ ...canonicalMedia }
+				videoEmbed={ canonicalMedia }
+				onThumbnailClick={ partial( expandCard, { postKey, post, site } ) }
+				isExpanded={ isExpanded }
+			/>
+		);
+	} else {
+		featuredAsset = <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ post.URL } />;
+	}
+
+	return (
+		<div className="reader-post-card__post">
+			{ featuredAsset }
+			<div className="reader-post-card__post-details">
+				<AutoDirection>
+					<h1 className="reader-post-card__title">
+						<a className="reader-post-card__title-link" href={ post.URL }>
+							<Emojify>
+								Compact: { post.title }
+							</Emojify>
+						</a>
+					</h1>
+				</AutoDirection>
+				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+				{ children }
+			</div>
+		</div>
+	);
+};
+
+CompactPost.propTypes = {
+	post: React.PropTypes.object.isRequired,
+	isDiscover: React.PropTypes.bool,
+};
+
+export default CompactPost;

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import { partial } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,7 +12,7 @@ import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 
-const CompactPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } ) => {
+const CompactPost = ( { post, children, isDiscover } ) => {
 	const canonicalMedia = post.canonical_media;
 	let featuredAsset;
 	if ( ! canonicalMedia ) {
@@ -23,8 +22,7 @@ const CompactPost = ( { post, children, isDiscover, expandCard, postKey, isExpan
 			<ReaderFeaturedVideo
 				{ ...canonicalMedia }
 				videoEmbed={ canonicalMedia }
-				onThumbnailClick={ partial( expandCard, { postKey, post, site } ) }
-				isExpanded={ isExpanded }
+				allowPlaying={ false }
 			/>
 		);
 	} else {
@@ -32,14 +30,14 @@ const CompactPost = ( { post, children, isDiscover, expandCard, postKey, isExpan
 	}
 
 	return (
-		<div className="reader-post-card__post">
+		<div className="reader-post-card__post reader-post-card__post-compact">
 			{ featuredAsset }
 			<div className="reader-post-card__post-details">
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
 							<Emojify>
-								Compact: { post.title }
+								{ post.title }
 							</Emojify>
 						</a>
 					</h1>

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -11,6 +11,7 @@ import Emojify from 'components/emojify';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
+import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 
 const CompactPost = ( { post, children, isDiscover } ) => {
 	const canonicalMedia = post.canonical_media;
@@ -29,10 +30,12 @@ const CompactPost = ( { post, children, isDiscover } ) => {
 		featuredAsset = <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ post.URL } />;
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="reader-post-card__post reader-post-card__post-compact">
 			{ featuredAsset }
 			<div className="reader-post-card__post-details">
+				<ReaderPostOptionsMenu className="ignore-click" showFollow={ true } post={ post } />
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>
@@ -47,6 +50,7 @@ const CompactPost = ( { post, children, isDiscover } ) => {
 			</div>
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 CompactPost.propTypes = {

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -32,10 +32,15 @@ const CompactPost = ( { post, children, isDiscover } ) => {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="reader-post-card__post reader-post-card__post-compact">
+		<div className="reader-post-card__post reader-post-card__compact">
 			{ featuredAsset }
 			<div className="reader-post-card__post-details">
-				<ReaderPostOptionsMenu className="ignore-click" showFollow={ true } post={ post } />
+				<ReaderPostOptionsMenu
+					className="ignore-click"
+					showFollow={ true }
+					post={ post }
+					position="bottom"
+				/>
 				<AutoDirection>
 					<h1 className="reader-post-card__title">
 						<a className="reader-post-card__title-link" href={ post.URL }>

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -32,7 +32,7 @@ const CompactPost = ( { post, children, isDiscover } ) => {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className="reader-post-card__post reader-post-card__compact">
+		<div className="reader-post-card__post">
 			{ featuredAsset }
 			<div className="reader-post-card__post-details">
 				<ReaderPostOptionsMenu

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -13,7 +13,7 @@ import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 
-const CompactPost = ( { post, children, isDiscover } ) => {
+const CompactPost = ( { post, postByline, children, isDiscover } ) => {
 	const canonicalMedia = post.canonical_media;
 	let featuredAsset;
 	if ( ! canonicalMedia ) {
@@ -35,6 +35,7 @@ const CompactPost = ( { post, children, isDiscover } ) => {
 		<div className="reader-post-card__post">
 			{ featuredAsset }
 			<div className="reader-post-card__post-details">
+				{ postByline }
 				<ReaderPostOptionsMenu
 					className="ignore-click"
 					showFollow={ true }
@@ -60,6 +61,7 @@ const CompactPost = ( { post, children, isDiscover } ) => {
 
 CompactPost.propTypes = {
 	post: React.PropTypes.object.isRequired,
+	postByline: React.PropTypes.string,
 	isDiscover: React.PropTypes.bool,
 };
 

--- a/client/blocks/reader-post-card/docs/example.jsx
+++ b/client/blocks/reader-post-card/docs/example.jsx
@@ -9,15 +9,15 @@ import React from 'react';
 import ReaderPostCardBlock from 'blocks/reader-post-card';
 import { posts, site } from './fixtures';
 
-const ReaderPostCard = () => (
+const ReaderPostCard = () =>
 	<div className="design-assets__group">
 		<div>
-			{ posts.map( item => (
-				<ReaderPostCardBlock key={ item.global_ID } post={ item } site={ site } />
-			) ) }
+			{ posts.map( item =>
+				<ReaderPostCardBlock key={ item.global_ID } post={ item } site={ site } />,
+			) }
+			<ReaderPostCardBlock compact key={ posts[ 0 ].global_ID } post={ posts[ 0 ] } site={ site } />
 		</div>
-	</div>
-);
+	</div>;
 
 ReaderPostCard.displayName = 'ReaderPostCard';
 

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -19,6 +19,7 @@ import PostByline from './byline';
 import GalleryPost from './gallery';
 import PhotoPost from './photo';
 import StandardPost from './standard';
+import CompactPost from './compact';
 import FollowButton from 'reader/follow-button';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
@@ -47,6 +48,7 @@ class ReaderPostCard extends React.Component {
 		followSource: PropTypes.string,
 		isDiscoverStream: PropTypes.bool,
 		postKey: PropTypes.object,
+		compact: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -121,6 +123,7 @@ class ReaderPostCard extends React.Component {
 			postKey,
 			isExpanded,
 			expandCard,
+			compact,
 		} = this.props;
 
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
@@ -166,7 +169,25 @@ class ReaderPostCard extends React.Component {
 		);
 
 		let readerPostCard;
-		if ( isPhotoPost ) {
+		if ( compact ) {
+			readerPostCard = (
+				<CompactPost
+					post={ post }
+					title={ title }
+					isDiscover={ isDiscover }
+					isExpanded={ isExpanded }
+					expandCard={ expandCard }
+					site={ site }
+					postKey={ postKey }
+				>
+					{ isDailyPostChallengeOrPrompt( post ) &&
+						site &&
+						<DailyPostButton post={ post } site={ site } tagName="span" /> }
+					{ discoverFollowButton }
+					{ readerPostActions }
+				</CompactPost>
+			);
+		} else if ( isPhotoPost ) {
 			readerPostCard = (
 				<PhotoPost
 					post={ post }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -184,7 +184,6 @@ class ReaderPostCard extends React.Component {
 						site &&
 						<DailyPostButton post={ post } site={ site } tagName="span" /> }
 					{ discoverFollowButton }
-					{ readerPostActions }
 				</CompactPost>
 			);
 		} else if ( isPhotoPost ) {
@@ -248,6 +247,7 @@ class ReaderPostCard extends React.Component {
 					site={ site }
 					feed={ feed }
 					showSiteName={ showSiteName || isDiscover }
+					showAvatar={ ! compact }
 				/>
 			);
 		}

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -142,7 +142,7 @@ class ReaderPostCard extends React.Component {
 
 		let discoverFollowButton;
 
-		if ( isDiscover ) {
+		if ( isDiscover && ! compact ) {
 			const discoverBlogName = getDiscoverBlogName( post ) || null;
 			discoverFollowButton =
 				discoverBlogName &&
@@ -170,22 +170,7 @@ class ReaderPostCard extends React.Component {
 
 		let readerPostCard;
 		if ( compact ) {
-			readerPostCard = (
-				<CompactPost
-					post={ post }
-					title={ title }
-					isDiscover={ isDiscover }
-					isExpanded={ isExpanded }
-					expandCard={ expandCard }
-					site={ site }
-					postKey={ postKey }
-				>
-					{ isDailyPostChallengeOrPrompt( post ) &&
-						site &&
-						<DailyPostButton post={ post } site={ site } tagName="span" /> }
-					{ discoverFollowButton }
-				</CompactPost>
-			);
+			readerPostCard = <CompactPost post={ post } title={ title } isDiscover={ isDiscover } />;
 		} else if ( isPhotoPost ) {
 			readerPostCard = (
 				<PhotoPost

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -169,9 +169,42 @@ class ReaderPostCard extends React.Component {
 			/>
 		);
 
+		// Set up post byline
+		let postByline;
+
+		if ( isDiscoverStream && ! isEmpty( discoverPick ) ) {
+			// create a post like object with some props from the discover post
+			const postForByline = Object.assign( {}, discoverPick.post || {}, {
+				date: post.date,
+				URL: post.URL,
+				primary_tag: post.primary_tag,
+			} );
+			postByline = (
+				<PostByline post={ postForByline } site={ discoverPick.site } showSiteName={ true } />
+			);
+		} else {
+			postByline = (
+				<PostByline
+					post={ post }
+					site={ site }
+					feed={ feed }
+					showSiteName={ showSiteName || isDiscover }
+					showAvatar={ ! compact }
+				/>
+			);
+		}
+
+		// Set up post card
 		let readerPostCard;
 		if ( compact ) {
-			readerPostCard = <CompactPost post={ post } title={ title } isDiscover={ isDiscover } />;
+			readerPostCard = (
+				<CompactPost
+					post={ post }
+					title={ title }
+					isDiscover={ isDiscover }
+					postByline={ postByline }
+				/>
+			);
 		} else if ( isPhotoPost ) {
 			readerPostCard = (
 				<PhotoPost
@@ -213,36 +246,11 @@ class ReaderPostCard extends React.Component {
 			);
 		}
 
-		// set up post byline
-		let postByline;
-
-		if ( isDiscoverStream && ! isEmpty( discoverPick ) ) {
-			// create a post like object with some props from the discover post
-			const postForByline = Object.assign( {}, discoverPick.post || {}, {
-				date: post.date,
-				URL: post.URL,
-				primary_tag: post.primary_tag,
-			} );
-			postByline = (
-				<PostByline post={ postForByline } site={ discoverPick.site } showSiteName={ true } />
-			);
-		} else {
-			postByline = (
-				<PostByline
-					post={ post }
-					site={ site }
-					feed={ feed }
-					showSiteName={ showSiteName || isDiscover }
-					showAvatar={ ! compact }
-				/>
-			);
-		}
-
 		const followUrl = feed ? feed.feed_URL : post.site_URL;
 
 		return (
 			<Card className={ classes } onClick={ ! isPhotoPost && this.handleCardClick }>
-				{ postByline }
+				{ ! compact && postByline }
 				{ showPrimaryFollowButton &&
 					followUrl &&
 					<FollowButton

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -138,6 +138,7 @@ class ReaderPostCard extends React.Component {
 			'is-selected': isSelected,
 			'is-discover': isDiscover,
 			'is-expanded-video': isVideo && isExpanded,
+			'is-compact': compact,
 		} );
 
 		let discoverFollowButton;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -696,3 +696,12 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .is-section-devdocs .reader-post-card.card {
 	padding: 16px;
 }
+
+// Compact cards
+.reader-post-card__compact {
+	.reader-post-options-menu {
+		position: absolute;
+		right: 14px;
+		top: 0;
+	}
+}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -315,14 +315,14 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	width: 100%;
 }
 
-/* Fix for IE11 unable to handle nested flexbox min-height.
- * See issue: https://github.com/Automattic/wp-calypso/issues/9412
- */
+// Fix for IE11 unable to handle nested flexbox min-height.
+// See issue: https://github.com/Automattic/wp-calypso/issues/9412
 .is-reader-page .reader-post-card.is-gallery .reader-post-card__post-details {
 	flex: inherit;
 }
 
 .reader-post-card__byline-author-site {
+	font-family: $sans;
 	overflow: hidden;
 	position: relative;
 	height: 20px;
@@ -338,9 +338,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 .reader-post-card__timestamp-and-tag {
+	align-items: flex-start;
 	display: flex;
 	flex-direction: row;
-	align-items: flex-start;
+	font-family: $sans;
 	margin-top: -2px;
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -172,29 +172,36 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		.reader-post-card__byline-details {
 			display: flex;
-			flex-direction: row;
-			max-height: 16px * 1.4;
-			max-width: calc( 100% - 30px );
+			flex-direction: column;
+			max-height: none;
+			max-width: calc( 100% - 60px );
 			overflow: hidden;
 			position: relative;
 
 			&::after {
 				@include long-content-fade( $size: 10% );
 			}
+
+			@include breakpoint( ">480px" ) {
+				flex-direction: row;
+				max-height: 16px * 1.4;
+				max-width: calc( 100% - 30px );
+			}
 		}
 
 		.reader-post-card__byline-author-site {
-			height: auto;
 			width: auto;
-
-			&::after {
-				display: none;
-			}
+			white-space: nowrap;
 		}
 
 		.reader-post-card__timestamp-and-tag {
 			margin-top: 0;
-			margin-left: 5px;
+			margin-left: 0;
+			white-space: nowrap;
+
+			@include breakpoint( ">480px" ) {
+				margin-left: 5px;
+			}
 		}
 
 		.reader-post-card__timestamp-link {
@@ -208,11 +215,22 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 		}
 
 		.reader-featured-image {
+			height: auto;
+			margin-bottom: 0;
 			margin-right: 15px;
 			max-width: 100px;
+			min-width: 100px;
 		}
 
 		.reader-post-card__post {
+			margin-top: 0;
+
+			@include breakpoint( "<960px" ) {
+				flex-direction: row;
+			}
+		}
+
+		.reader-post-card__post-details {
 			margin-top: 0;
 		}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -167,6 +167,65 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	.reader-post-actions {
 		margin: 4px 0 0;
 	}
+
+	&.is-compact {
+
+		.reader-post-card__byline-details {
+			display: flex;
+			flex-direction: row;
+			max-height: 16px * 1.4;
+			max-width: calc( 100% - 30px );
+			overflow: hidden;
+			position: relative;
+
+			&::after {
+				@include long-content-fade( $size: 10% );
+			}
+		}
+
+		.reader-post-card__byline-author-site {
+			height: auto;
+			width: auto;
+
+			&::after {
+				display: none;
+			}
+		}
+
+		.reader-post-card__timestamp-and-tag {
+			margin-top: 0;
+			margin-left: 5px;
+		}
+
+		.reader-post-card__timestamp-link {
+			color: $gray;
+		}
+
+		.reader-post-options-menu {
+			position: absolute;
+				right: 14px;
+				top: 0;
+		}
+
+		.reader-featured-image {
+			margin-right: 15px;
+			max-width: 100px;
+		}
+
+		.reader-post-card__post {
+			margin-top: 0;
+		}
+
+		.reader-post-card__post-details .reader-excerpt {
+			font-size: 15px;
+			font-weight: 100;
+			margin-top: 4px;
+			max-height: 16px * 1.4;
+			overflow: hidden;
+			position: relative;
+			word-wrap: break-word;
+		}
+	}
 }
 
 .reader-post-card__photo {
@@ -463,7 +522,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 }
 
 // 3 line excerpt for thumbnail cards
-.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-discover) {
+.reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-discover):not(.is-compact) {
 
 	.reader-excerpt {
 		max-height: 15px * 1.6 * 3;
@@ -695,13 +754,4 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 // For these borderless cards to look more presentable on Devdocs
 .is-section-devdocs .reader-post-card.card {
 	padding: 16px;
-}
-
-// Compact cards
-.reader-post-card__compact {
-	.reader-post-options-menu {
-		position: absolute;
-		right: 14px;
-		top: 0;
-	}
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -172,8 +172,8 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 		.reader-post-card__byline-details {
 			display: flex;
-			flex-direction: column;
-			max-height: none;
+			flex-direction: row;
+			max-height: 16px * 1.4;
 			max-width: calc( 100% - 40px );
 			overflow: hidden;
 			position: relative;
@@ -181,30 +181,24 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			&::after {
 				@include long-content-fade( $size: 10% );
 			}
-
-			@include breakpoint( ">480px" ) {
-				flex-direction: row;
-				max-height: 16px * 1.4;
-			}
 		}
 
 		.reader-post-card__byline-author-site {
 			flex: 0 0 auto;
 			width: auto;
-
-			&::after {
-				display: none;
-			}
 		}
 
 		.reader-post-card__timestamp-and-tag {
 			margin-top: 0;
 			margin-left: 0;
-			white-space: nowrap;
 
 			@include breakpoint( ">480px" ) {
 				margin-left: 5px;
 			}
+		}
+
+		.reader-post-card__byline-author-site,
+		.reader-post-card__timestamp-and-tag {
 
 			&::after {
 				display: none;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -174,7 +174,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			display: flex;
 			flex-direction: column;
 			max-height: none;
-			max-width: calc( 100% - 60px );
+			max-width: calc( 100% - 40px );
 			overflow: hidden;
 			position: relative;
 
@@ -185,13 +185,16 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 			@include breakpoint( ">480px" ) {
 				flex-direction: row;
 				max-height: 16px * 1.4;
-				max-width: calc( 100% - 30px );
 			}
 		}
 
 		.reader-post-card__byline-author-site {
+			flex: 0 0 auto;
 			width: auto;
-			white-space: nowrap;
+
+			&::after {
+				display: none;
+			}
 		}
 
 		.reader-post-card__timestamp-and-tag {
@@ -201,6 +204,10 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 			@include breakpoint( ">480px" ) {
 				margin-left: 5px;
+			}
+
+			&::after {
+				display: none;
 			}
 		}
 

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -33,6 +33,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		feed: React.PropTypes.object,
 		onBlock: React.PropTypes.func,
 		showFollow: React.PropTypes.bool,
+		position: React.PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -116,11 +117,10 @@ class ReaderPostOptionsMenu extends React.Component {
 	};
 
 	render() {
-		const post = this.props.post,
-			isEditPossible = PostUtils.userCan( 'edit_post', post ),
-			isDiscoverPost = DiscoverHelper.isDiscoverPost( post ),
-			followUrl = this.getFollowUrl();
-		const { site, feed, teams, translate } = this.props;
+		const { post, site, feed, teams, translate, position } = this.props;
+		const isEditPossible = PostUtils.userCan( 'edit_post', post );
+		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
+		const followUrl = this.getFollowUrl();
 		const isTeamMember = isAutomatticTeamMember( teams );
 
 		let isBlockPossible = false;
@@ -151,6 +151,7 @@ class ReaderPostOptionsMenu extends React.Component {
 					className="reader-post-options-menu__ellipsis-menu"
 					popoverClassName="reader-post-options-menu__popover"
 					onToggle={ this.onMenuToggle }
+					position={ position }
 				>
 					{ isTeamMember && site && <ReaderPostOptionsMenuBlogStickers blogId={ +site.ID } /> }
 


### PR DESCRIPTION
Add a new post card type for the Conversations tool:

![conversations2closed](https://user-images.githubusercontent.com/17325/28230257-121dda0c-68de-11e7-96f1-7ffc210e299c.png)

Activated by the `compact` prop. If `compact` is true, all post cards will use the compact card, irrespective of the display type.

Notes from @fraying: 

> Post info is super condensed because this view is all about the comments. I’m using a similar format to Combined Cards here. Poster name and site title link to the Site View, the rest links to the Fullpost in Reader. Poster avatar has been omitted entirely because it was potentially confusing – it made it hard to differentiate between the original post and the comments.
> 
> I tried a version of this that omitted the post images, but it became a bland wall of text and made it hard to differentiate between posts. So I’ve included the post images in their smallest state (same size as on Combined Cards). Most posts have images, but those that don’t would just slide left.

### To test

Check the Devdocs page for `reader-post-card`:

http://calypso.localhost:3000/devdocs/blocks/reader-post-card

It's the last one.