### PR TITLE
Buttons: enable shadow for buttons while tabbing

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -59,11 +59,9 @@ button {
 			border-width: 1px 1px 2px;
 		}
 	}
-	.accessible-focus & {
-		&:focus {
+	.accessible-focus &:focus {
 			border-color: $blue-medium;
 			box-shadow: 0 0 0 2px $blue-light;
-		}
 	}
 	&.is-compact {
 		padding: 7px;
@@ -143,9 +141,11 @@ button {
 	&:focus {
 		border-color: $alert-red;
 	}
-	&:focus {
-		box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+
+	.accessible-focus &:focus {
+			box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
 	}
+
 	&[disabled],
 	&:disabled {
 		color: lighten( $alert-red, 30% );
@@ -175,11 +175,9 @@ button {
 	color: $gray-text-min;
 	padding-left: 0;
 	padding-right: 0;
-	border-radius: 0;
 
 	&:hover,
 	&:focus {
-		box-shadow: none;
 		color: $gray-dark;
 	}
 


### PR DESCRIPTION
Original PR #16163

It was reverted in #16251 because of a css error. There were 2 extra `}` that I overlooked. Hard to catch those in the diff view.

This gives move visibility to buttons while using the keyboard to
navigate. Also enabling border radius for style consistency.