### PR TITLE
Store: WooCommerce: Add a more-countries-coming-soon unselectable option to address view

### DIFF
--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -115,6 +115,9 @@ class AddressView extends Component {
 								<option key={ option.code } value={ option.code }>{ option.name }</option>
 							);
 						} ) }
+						<option key="XX" value="XX" disabled="disabled">
+							{ translate( 'More countries coming soon' ) }
+						</option>
 					</FormSelect>
 				</FormFieldSet>
 			</div>


### PR DESCRIPTION
Fixes #16237 

To test:
* Use the developer console to reset the set_store_address_during_initial_setup flag for the site
* Visit http://calypso.localhost:3000/store/{domain}
* Click on the country drop down and note the non-selectable message

<img width="712" alt="screen shot 2017-07-14 at 2 19 17 pm" src="https://user-images.githubusercontent.com/1595739/28231279-762bbaf8-689f-11e7-96d3-9959f657e6c4.png">
