### PR TITLE
Expose the link target when we are linking to an external site

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -64,6 +64,11 @@ module.exports = React.createClass( {
 		}
 	},
 
+	preventDefaultOnClick: function( event ) {
+		event.stopPropagation();
+		event.preventDefault();
+	},
+
 	onClick: function( event ) {
 		var gaEvent,
 			moduleName = titlecase( this.props.moduleName );
@@ -168,7 +173,8 @@ module.exports = React.createClass( {
 		label = labelData.map( function( labelItem, i ) {
 			var iconClassSetOptions = { avatar: true },
 				icon,
-				gridiconSpan;
+				gridiconSpan,
+				itemLabel;
 
 			if ( labelItem.labelIcon ) {
 				gridiconSpan = ( <Gridicon icon={ labelItem.labelIcon } /> );
@@ -191,7 +197,13 @@ module.exports = React.createClass( {
 				icon = ( <span className="stats-list__flag-icon" style={ style } /> );
 			}
 
-			return ( <span className={ wrapperClassSet } key={ i } >{ gridiconSpan }{ icon }<Emojify>{ labelItem.label }</Emojify></span> );
+			if ( data.link ) {
+				itemLabel = ( <a onclick={ this.preventDefaultOnClick } href={ data.link } >{ labelItem.label }</a> );
+			} else {
+				itemLabel = ( <Emojify>{ labelItem.label }</Emojify> );
+			}
+
+			return ( <span className={ wrapperClassSet } key={ i } >{ gridiconSpan }{ icon }{ itemLabel } </span> );
 		}, this );
 
 		return label;


### PR DESCRIPTION
When we display external links in the stats lists we should expose the external link on hover over the items so cautious users can verify the target before clicking the links.

See #1969