### PR TITLE
Store: Update keydownCallback and keyboard accessibility in tables and product variations

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-variations-modal.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-modal.js
@@ -16,7 +16,7 @@ import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormToggle from 'components/forms/form-toggle';
-import VerticalMenu from 'components/vertical-menu';
+import getKeyboardHandler from 'woocommerce/lib/get-keyboard-handler';
 
 class ProductFormVariationsModal extends React.Component {
 
@@ -89,9 +89,13 @@ class ProductFormVariationsModal extends React.Component {
 		const { selectedVariation } = this.state;
 		const variation = this.selectedVariation();
 
-		const navItems = variations && variations.map( function( v, i ) {
+		const navItems = variations && variations.map( ( v, i ) => {
 			return (
-				<ModalNavItem key={ i } variation={ v } selected={ selectedVariation } />
+				<ModalNavItem
+					key={ i }
+					variation={ v }
+					onClick={ this.switchVariation }
+					selected={ selectedVariation } />
 			);
 		} );
 
@@ -101,9 +105,9 @@ class ProductFormVariationsModal extends React.Component {
 			<div className="products__product-form-modal-wrapper">
 				<h1>{ translate( 'Variation details' ) }</h1>
 
-				<VerticalMenu onClick={ this.switchVariation } className="products__product-form-modal-menu">
-					{navItems}
-				</VerticalMenu>
+				<div className="products__product-form-modal-menu vertical-menu">
+					{ navItems }
+				</div>
 
 				<div className="products__product-form-modal-contents">
 					<h2>{ formattedVariationName( variation ) }</h2>
@@ -144,13 +148,7 @@ class ProductFormVariationsModal extends React.Component {
 
 }
 
-const ModalNavItem = props => {
-	const {
-		onClick,
-		variation,
-		selected,
-	} = props;
-
+const ModalNavItem = ( { onClick, variation, selected } ) => {
 	const classes = classNames(
 		'vertical-menu__items',
 		{ 'is-selected': ( variation.id === selected ) }
@@ -161,9 +159,14 @@ const ModalNavItem = props => {
 	};
 
 	return (
-		<li className={ classes } onClick={ clickHandler }>
+		<div
+			className={ classes }
+			role="button"
+			tabIndex="0"
+			onClick={ clickHandler }
+			onKeyDown={ getKeyboardHandler( clickHandler ) }>
 			{ formattedVariationName( variation ) }
-		</li>
+		</div>
 	);
 };
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -590,6 +590,10 @@
 	.vertical-menu__items {
 		padding-left: 16px;
 		min-height: 45px;
+
+		&:focus {
+			color: $blue-medium;
+		}
 	}
 
 	.products__product-form-modal-wrapper {

--- a/client/extensions/woocommerce/components/table/README.md
+++ b/client/extensions/woocommerce/components/table/README.md
@@ -42,18 +42,19 @@ render: function() {
 #### Props `<Table/>`
 
 * `header`: A `<TableRow />` element used to define the table's head.
-* `className`: Classes added to top level elment.
+* `className`: Classes added to top level element.
 * `compact`: Denotes a more compact table.
 
 #### Props `<TableRow/>`
 
-* `className`: Classes added to top level elment.
+* `className`: Classes added to top level element.
 * `isHeader`: Establishes row as being used for table head.
+* `href`: Optional link, if set, the row becomes clickable/focusable.
 
 #### Props `<TableItem/>`
 
 * `alignRight`: Apply `text-align: right` on an item.
-* `className`: Classes added to top level elment.
+* `className`: Classes added to top level element.
 * `isHeader`: Establishes item as being a column header.
 * `isRowHeader`: Establishes item as being a row header.
 * `isTitle`: Used to specify a main cell occupying the maximum available space in `compact` mode.

--- a/client/extensions/woocommerce/components/table/table-row/index.js
+++ b/client/extensions/woocommerce/components/table/table-row/index.js
@@ -8,7 +8,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import onKeyDownCallback from 'woocommerce/lib/keydown-callback';
+import getKeyboardHandler from 'woocommerce/lib/get-keyboard-handler';
 
 const TableRow = ( { className, isHeader, href, children, ...props } ) => {
 	const rowClasses = classnames( 'table-row', className, {
@@ -33,7 +33,7 @@ const TableRow = ( { className, isHeader, href, children, ...props } ) => {
 			role="button"
 			tabIndex="0"
 			onClick={ goToHref }
-			onKeyDown={ onKeyDownCallback( goToHref ) }
+			onKeyDown={ getKeyboardHandler( goToHref ) }
 			{ ...props }>
 			{ children }
 		</tr>

--- a/client/extensions/woocommerce/lib/get-keyboard-handler/README.md
+++ b/client/extensions/woocommerce/lib/get-keyboard-handler/README.md
@@ -1,0 +1,26 @@
+getKeyboardHandler
+==================
+
+## `getKeyboardHandler( callback: function )`
+
+This is an accessibility helper function for lists of items which have onClick events. It is an event handler, meant to be called on `onKeyDown`. It triggers the passed callback only if the key pressed is space or enter, to mirror [button functionality](https://www.w3.org/TR/wai-aria-practices/#button). It will also focus the next/previous sibling (if one exists) if the down/up arrows are pressed.
+
+This is meant to be used on a list of elements (`<tr>`, `<li>`, …), so that they can be made keyboard-accessible. Example:
+
+```jsx
+import getKeyboardHandler from 'woocommerce/lib/get-keyboard-handler';
+
+export default function ExampleNavList() {
+	return (
+		<ul>
+			<li role="button" tabIndex="0" onClick={ onClick } onKeyDown={ getKeyboardHandler( onClick ) }>{ complexChild }</li>
+			<li role="button" tabIndex="0" onClick={ onClick } onKeyDown={ getKeyboardHandler( onClick ) }>{ complexChild }</li>
+			<li role="button" tabIndex="0" onClick={ onClick } onKeyDown={ getKeyboardHandler( onClick ) }>{ complexChild }</li>
+		</ul>
+	);
+}
+```
+
+The `tabIndex` is what makes the `li`s focusable, so make sure you have that, and that you also add focus styles along with your hover styles.
+
+This is used in the [`<TableRow>` component](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/components/table/README.md) to make the table rows keyboard accessible.

--- a/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
+++ b/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
@@ -1,6 +1,8 @@
 /**
- * Helper function which triggers a callback on a keydown event, only
- * if the key pressed is space or enter - to mirror button functionality.
+ * Accessibility helper function for lists of navigation items which have onClick events.
+ * This triggers a callback on a keydown event, only if the key pressed is space or enter
+ * to mirror button functionality. It will also focus the next/previous sibling (if one
+ * exists) if the down/up arrows are pressed.
  *
  * @param {Function} callback A callback function
  * @return {Function} the callback to fire on a keydown event

--- a/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
+++ b/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
@@ -16,7 +16,7 @@ export default function( callback ) {
 				event.target.nextSibling.focus();
 			}
 		} else if ( event.key === 'ArrowUp' ) {
-			if ( event.target.nextSibling ) {
+			if ( event.target.previousSibling ) {
 				event.preventDefault();
 				event.target.previousSibling.focus();
 			}

--- a/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
+++ b/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
@@ -1,5 +1,3 @@
-// Helper function for keyboard-equivalents of onClick events
-
 /**
  * Helper function which triggers a callback on a keydown event, only
  * if the key pressed is space or enter - to mirror button functionality.
@@ -10,7 +8,18 @@
 export default function( callback ) {
 	return ( event ) => {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
 			callback( event );
+		} else if ( event.key === 'ArrowDown' ) {
+			if ( event.target.nextSibling ) {
+				event.preventDefault();
+				event.target.nextSibling.focus();
+			}
+		} else if ( event.key === 'ArrowUp' ) {
+			if ( event.target.nextSibling ) {
+				event.preventDefault();
+				event.target.previousSibling.focus();
+			}
 		}
 	};
 }


### PR DESCRIPTION
This PR follows on from https://github.com/Automattic/wp-calypso/pull/15404 — revisiting what we call the keydown callback handler, I've renamed it to `getKeyboardHandler`. This function serves to make an element keyboard-accessible, when it would usually just have an `onClick` handler.

I've also added some handling for arrow up & down, so that if there are siblings to this element it will move focus to previous or next items (respectively).

While looking at other accessibility issues, I noticed the product variations modal menu is not keyboard-friendly, so I've also updated that to use `getKeyboardHandler` (also to make sure this could be useful as a shared utility, rather than just a function in TableRow). 

**To test the tables:**

- View your list of orders or products, tab through items
- Verify that enter or space opens the item
- Verify the hitting up/down selects the prev/next item

**To test the product modal:**

- Edit a product with variations
- Open the variations modal by clicking on a variation
- Hit tab to cycle through the variations, verify that they're highlighted
- Verify that enter or space opens the item
- Verify the hitting up/down selects the prev/next item

There should be no visual different in either case.