### PR TITLE
Store: keyboard accessibility cleanup

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -117,7 +117,7 @@ class ManageOrdersView extends Component {
 					className="dashboard__reports-widget"
 				>
 					<div className="dashboard__reports-widget-content-wrapper">
-						<img src="/calypso/images/extensions/woocommerce/woocommerce-reports.svg" />
+						<img src="/calypso/images/extensions/woocommerce/woocommerce-reports.svg" alt="" />
 						<div className="dashboard__reports-widget-content">
 							<h2>
 								{ translate( 'Reports' ) }

--- a/client/extensions/woocommerce/app/dashboard/setup-header.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-header.js
@@ -6,7 +6,7 @@ import React, { PropTypes } from 'react';
 const SetupHeader = ( { imageSource, imageWidth, subtitle, title, children } ) => {
 	return (
 		<div className="dashboard__setup-header">
-			{ imageSource && ( <img src={ imageSource } width={ imageWidth } className="dashboard__setup-header-image" /> ) }
+			{ imageSource && ( <img src={ imageSource } width={ imageWidth } className="dashboard__setup-header-image" alt="" /> ) }
 			{ <h2 className="dashboard__setup-header-title form-section-heading">{ title }</h2> }
 			{ subtitle && ( <p className="dashboard__setup-header-subtitle">{ subtitle }</p> ) }
 			{ children }

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -82,7 +82,7 @@ class SetupTask extends Component {
 							action.onClick( e );
 						};
 						return (
-							<a key={ index } onClick={ trackClick }>{ action.label }</a>
+							<Button borderless key={ index } onClick={ trackClick }>{ action.label }</Button>
 						);
 					} )
 				}

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -118,9 +118,10 @@
 		}
 
 		.dashboard__setup-task-secondary-actions {
-			a {
-				cursor: pointer;
+			.button {
+				padding: 0;
 				font-size: 12px;
+				font-weight: normal;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -177,9 +177,9 @@ class ProductFormVariationsRow extends Component {
 				<td className="products__product-id">
 					<div className="products__product-name-thumb">
 						{ this.renderImage() }
-						<span className="products__product-name products__variation-settings-link" onClick={ this.showDialog }>
+						<Button borderless className="products__product-name products__variation-settings-link" onClick={ this.showDialog }>
 							{ formattedVariationName( variation ) }
-						</span>
+						</Button>
 					</div>
 				</td>
 				<td>

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -17,9 +17,10 @@ function renderViewButton( product, translate ) {
 	const url = product && product.permalink;
 	return (
 		// TODO: Do more to validate this URL?
-		<a href={ url } className="products__header-view-link" target="_blank" rel="noopener noreferrer">
-			<Button borderless><Gridicon icon="visible" /><span> { translate( 'View' ) } </span></Button>
-		</a>
+		<Button borderless className="products__header-view-link" href={ url } target="_blank" rel="noopener noreferrer">
+			<Gridicon icon="visible" />
+			<span>{ translate( 'View' ) }</span>
+		</Button>
 	);
 }
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-dialog.js
@@ -112,13 +112,7 @@ const ShippingZoneMethodDialog = ( {
 				{ isNew ? translate( 'Add shipping method' ) : translate( 'Edit shipping method' ) }
 			</div>
 			<FormFieldSet className="shipping-zone__enable">
-				<span onClick={ onEnabledChange }>
-					{ translate( 'Enabled {{toggle/}}', {
-						components: {
-							toggle: <FormToggle checked={ enabled } />
-						}
-					} ) }
-				</span>
+				<FormToggle checked={ enabled } onChange={ onEnabledChange }>{ translate( 'Enabled' ) }</FormToggle>
 			</FormFieldSet>
 			<FormFieldSet>
 				<FormFieldSet>

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -75,13 +75,7 @@ const ShippingZoneMethodList = ( {
 					{ getMethodSummary( method, currency ) }
 				</ListItemField>
 				<ListItemField className="shipping-zone__enable-container">
-					<span onClick={ onEnabledToggle }>
-						{ translate( 'Enabled {{toggle/}}', {
-							components: {
-								toggle: <FormToggle checked={ method.enabled } />
-							}
-						} ) }
-					</span>
+					<FormToggle checked={ method.enabled } onChange={ onEnabledToggle }>{ translate( 'Enabled' ) }</FormToggle>
 				</ListItemField>
 				<ListItemField className="shipping-zone__method-actions">
 					<Button compact onClick={ onEditClick }>{ translate( 'Edit' ) }</Button>

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -3,11 +3,11 @@
 	margin-top: 58px;
 }
 
-.shipping-zone__name {	
+.shipping-zone__name {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-		
+
 	&.is-placeholder {
 		.gridicon, button, span {
 			@include placeholder();
@@ -165,7 +165,7 @@
 		}
 
 		.form-toggle__label-content {
-			margin-left: 0;
+			margin-left: 8px;
 		}
 	}
 
@@ -273,6 +273,7 @@
 	right: 16px;
 
 	span {
+		margin-left: 6px;
 		color: $gray;
 		font-size: 11px;
 		line-height: 16px;

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import AddressView from 'woocommerce/components/address-view';
+import Button from 'components/button';
 import Card from 'components/card';
 import Dialog from 'components/dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
@@ -137,7 +138,7 @@ class StoreAddress extends Component {
 						<FormLabel>{ translate( 'Store location' ) }</FormLabel>
 					) }
 					<AddressView address={ this.state.address } />
-					<a onClick={ this.onShowDialog }>{ translate( 'Edit address' ) }</a>
+					<Button borderless onClick={ this.onShowDialog }>{ translate( 'Edit address' ) }</Button>
 				</div>
 			);
 		}


### PR DESCRIPTION
This PR addresses a few places where we're not keyboard accessible (kind of in tandem with #16261).

- Add empty alt text for decorative images (I started to do this, then decided to focus on keyboard only)
- Switched a few `a`s with `onClick` to `Button`, which brings in keyboard handling, on
  - Secondary actions on the dashboard, of which there are none currently
  - The product form variation names
  - The "View" link in the product update header
  - The "Edit address" link on the store settings page
- Updates the toggles in shipping settings to pass the label as child of FormToggle, which gives us keyboard handling and a clickable label. The only change here is now "Enabled" is on the other side of the toggle, but it's on the "On" side, which makes more sense to me. If we're using a different pattern in store, I can probably tweak some CSS for this.

These are small tweaks, but it touches a few different places, so I'm trusting github's recommended reviewers -- but if anyone else has opinions let me know :)