### PR TITLE
Store Orders: Fix link on “All Orders”

### DIFF
--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -145,7 +145,7 @@ class Orders extends Component {
 	}
 
 	render() {
-		const { orders, translate } = this.props;
+		const { orders, site, translate } = this.props;
 		if ( ! orders.length ) {
 			return (
 				<div className="orders__container">
@@ -169,7 +169,7 @@ class Orders extends Component {
 			<div className="orders__container">
 				<SectionNav>
 					<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
-						<NavItem path="/orders" selected={ true }>{ translate( 'All orders' ) }</NavItem>
+						<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ true }>{ translate( 'All orders' ) }</NavItem>
 					</NavTabs>
 				</SectionNav>
 


### PR DESCRIPTION
The "All orders" filter link above the orders list currently links to `/orders`, which is not a valid path. This PR updates it to `/store/orders/:site`, which is redundant, but we'll have other filters here soon.

**To test**

- View `/store/orders/:site`
- Click "All orders", it should do nothing (but also not break)