### PR TITLE
Fixed a React warning on the Shipping Zone page

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -165,7 +165,7 @@ export default connect(
 			zone,
 			isRestOfTheWorld,
 			locations: loaded && getCurrentlyEditingShippingZoneLocationsList( state, 20 ),
-			hasEdits: zone && 0 !== getSaveZoneActionListSteps( state ).length,
+			hasEdits: Boolean( zone && 0 !== getSaveZoneActionListSteps( state ).length ),
 		};
 	},
 	( dispatch ) => ( {


### PR DESCRIPTION
The following error appears in the dev console when any shipping zone is opened for edit/add:
<img width="738" alt="screen shot 2017-07-15 at 11 36 28" src="https://user-images.githubusercontent.com/800604/28238729-faa65d12-6951-11e7-80c1-dee03d6063b7.png">

This PR fixes it.