### PR TITLE
Framework: Make plugins notices mixin not dependent on sites-list.

### DIFF
--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -67,7 +67,7 @@ module.exports = {
 	},
 
 	refreshPluginNotices() {
-		const site = this.props.sites.getSelectedSite();
+		const site = this.props.selectedSite;
 		return {
 			errors: PluginsUtil.filterNotices( PluginsLog.getErrors(), site, this.props.pluginSlug ),
 			inProgress: PluginsUtil.filterNotices( PluginsLog.getInProgress(), site, this.props.pluginSlug ),


### PR DESCRIPTION
This PR changes use of SitesList.getSelectedSite() to use selectedSite prop instead. The prop is already available on the components that use the mixin.

To test:
Test the following url combination:
• http://calypso.localhost:3000/plugins/{site/no-site/jetpack-site},
See that plugins list appear ok without errors.

Use the plugins section, applying changes, install, uninstall etc... and check if everything is behaving ok without errors.