### PR TITLE
Framework: Make lib/plugins compatible with new site object

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -256,7 +256,8 @@ const PluginsActions = {
 
 		const manageError = error => {
 			if ( error.name === 'PluginAlreadyInstalledError' ) {
-				if ( site.isMainNetworkSite() ) {
+				//TODO: compatibility with old site object (for now, remove when not needed)
+				if ( typeof site.isMainNetworkSite === 'function' ? site.isMainNetworkSite() : site.isMainNetworkSite ) {
 					return update( plugin )
 						.then( autoupdate )
 						.then( manageSuccess )
@@ -281,8 +282,8 @@ const PluginsActions = {
 		};
 
 		dispatchMessage( 'INSTALL_PLUGIN' );
-
-		if ( site.isMainNetworkSite() ) {
+		//TODO: compatibility with old site object (for now, remove when not needed)
+		if ( typeof site.isMainNetworkSite === 'function' ? site.isMainNetworkSite() : site.isMainNetworkSite ) {
 			return install()
 				.then( autoupdate )
 				.then( manageSuccess )

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -282,8 +282,9 @@ PluginsStore = {
 			if ( ! site.visible ) {
 				return false;
 			}
-
-			if ( site.jetpack && site.isSecondaryNetworkSite() ) {
+			//TODO: compatibility with old site object (for now, remove when not needed)
+			if ( site.jetpack &&
+				( typeof site.isSecondaryNetworkSite === 'function' ? site.isSecondaryNetworkSite() : site.isSecondaryNetworkSite ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
This PR makes lib/plugins compatible with new site object. So we don't need to remove all old object calls at the same time and can create separated pull requests. With is change it is now compatible with old JetpackSite object and with the new one. When all usages are removed the lib can be changed again to be compatible with just the new version.

To test:
Use the plugins section, applying changes, install, uninstall etc... and check if everything is behaving ok without errors.

Run the automated tests:
npm test