### PR TITLE
Framework: Remove JetpackSite prototype function call from PluginSiteDisabledManage

### DIFF
--- a/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
+++ b/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -10,9 +12,16 @@ import { localize } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
+import { getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors';
 
-const PluginSiteDisabledManage = ( { isNetwork, site, plugin, translate } ) => {
-	const url = site.getRemoteManagementURL() + '&section=plugins';
+const PluginSiteDisabledManage = ( {
+	isNetwork,
+	plugin,
+	remoteManagementUrl,
+	site,
+	translate
+} ) => {
+	const url = remoteManagementUrl + '&section=plugins';
 	const message = isNetwork
 		? translate( 'Network management disabled' )
 		: translate( 'Management disabled' );
@@ -44,4 +53,8 @@ const PluginSiteDisabledManage = ( { isNetwork, site, plugin, translate } ) => {
 	);
 };
 
-export default localize( PluginSiteDisabledManage );
+export default connect(
+	( state, ownProps ) => ( {
+		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, get( ownProps, 'site.ID' ) )
+	} )
+)( localize( PluginSiteDisabledManage ) );


### PR DESCRIPTION
This is a very simple PR that removes JetpackSite prototype dependency from PluginSiteDisabledManage. The function call getRemoteManagementURL() was replaced with selector getJetpackSiteRemoteManagementUrl.

**To test:**
In a user with more than one site go to:
http://calypso.localhost:3000/plugins/hello-dolly

Make sure you have at least one Jetpack site with management disabled. 

Check that the URL of the enable button on "MANAGEMENT DISABLED" area is right:
![screen](https://user-images.githubusercontent.com/11271197/28240575-8e87d158-697c-11e7-98a5-d680e28f7c0c.png)
