### PR TITLE
Framework: Removed sites-list dependency from post-list-cache-store.js

### DIFF
--- a/client/lib/posts/post-list-cache-store.js
+++ b/client/lib/posts/post-list-cache-store.js
@@ -10,14 +10,12 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import sitesFactory from 'lib/sites-list';
 import Dispatcher from 'dispatcher';
 import { cacheIndex } from 'lib/wp/sync-handler/cache-index';
 
 let cache = {};
 const _canonicalCache = {};
 const TTL_IN_MS = 5 * 60 * 1000; // five minutes
-const sites = sitesFactory();
 const PostsListCache = {
 	get,
 	_reset: function() {
@@ -60,8 +58,7 @@ function set( list ) {
 	}
 }
 
-function markDirty( post, oldStatus ) {
-	const site = sites.getSite( post.site_ID );
+function markDirty( post, oldStatus, site ) {
 	const affectedSites = [ site.slug, site.ID, false ];
 	const affectedStatuses = [ post.status, oldStatus ];
 	let listStatuses, key, entry, list;
@@ -136,7 +133,7 @@ PostsListCache.dispatchToken = Dispatcher.register( function( payload ) {
 		case 'RECEIVE_UPDATED_POST':
 		case 'RECEIVE_POST_BEING_EDITED':
 			if ( action.post ) {
-				markDirty( action.post, action.original ? action.original.status : null );
+				markDirty( action.post, action.original ? action.original.status : null, action.site );
 				set( PostListStore.get() );
 			}
 			break;

--- a/client/lib/posts/post-list-cache-store.js
+++ b/client/lib/posts/post-list-cache-store.js
@@ -58,7 +58,7 @@ function set( list ) {
 	}
 }
 
-function markDirty( post, oldStatus, site ) {
+function markDirty( site, post, oldStatus ) {
 	const affectedSites = [ site.slug, site.ID, false ];
 	const affectedStatuses = [ post.status, oldStatus ];
 	let listStatuses, key, entry, list;
@@ -133,7 +133,7 @@ PostsListCache.dispatchToken = Dispatcher.register( function( payload ) {
 		case 'RECEIVE_UPDATED_POST':
 		case 'RECEIVE_POST_BEING_EDITED':
 			if ( action.post ) {
-				markDirty( action.post, action.original ? action.original.status : null, action.site );
+				markDirty( action.site, action.post, action.original ? action.original.status : null );
 				set( PostListStore.get() );
 			}
 			break;


### PR DESCRIPTION
Removed sites-list dependency from post-list-cache-store.js.

This PR is dependent on PR https://github.com/Automattic/wp-calypso/pull/16017 that updates the required actions and components to pass the required information.