### PR TITLE
Pages: Reduxify PageList

### DIFF
--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -45,7 +45,6 @@ const controller = {
 
 		renderWithReduxStore(
 			React.createElement( Pages, {
-				context: context,
 				siteID: siteID,
 				status: status,
 				search: search,

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -101,14 +101,12 @@ const Pages = localize( React.createClass( {
 		siteId: PropTypes.any,
 		hasSites: PropTypes.bool.isRequired,
 		trackScrollPage: PropTypes.func.isRequired,
-		hasRecentError: PropTypes.bool.isRequired
 	},
 
 	getDefaultProps() {
 		return {
 			perPage: 100,
 			loading: false,
-			hasRecentError: false,
 			lastPage: false,
 			page: 0,
 			pages: [],
@@ -117,7 +115,7 @@ const Pages = localize( React.createClass( {
 	},
 
 	fetchPages( options ) {
-		if ( this.props.loading || this.props.lastPage || this.props.hasRecentError ) {
+		if ( this.props.loading || this.props.lastPage ) {
 			return;
 		}
 		if ( options.triggeredByScroll ) {
@@ -177,49 +175,41 @@ const Pages = localize( React.createClass( {
 			);
 		}
 
-		const { site, siteId } = this.props;
+		const { site, siteId, status = 'published' } = this.props;
 		const sitePart = site && site.slug || siteId;
 		const newPageLink = this.props.siteId ? '/page/' + sitePart : '/page';
 		let attributes;
 
-		if ( this.props.hasRecentError ) {
-			attributes = {
-				title: translate( 'Oh, no! We couldn\'t fetch your pages.' ),
-				line: translate( 'Please check your internet connection.' )
-			};
-		} else {
-			const status = this.props.status || 'published';
-			switch ( status ) {
-				case 'drafts':
-					attributes = {
-						title: translate( 'You don\'t have any drafts.' ),
-						line: translate( 'Would you like to create one?' ),
-						action: translate( 'Start a Page' ),
-						actionURL: newPageLink
-					};
-					break;
-				case 'scheduled':
-					attributes = {
-						title: translate( 'You don\'t have any scheduled pages yet.' ),
-						line: translate( 'Would you like to create one?' ),
-						action: translate( 'Start a Page' ),
-						actionURL: newPageLink
-					};
-					break;
-				case 'trashed':
-					attributes = {
-						title: translate( 'You don\'t have any pages in your trash folder.' ),
-						line: translate( 'Everything you write is solid gold.' )
-					};
-					break;
-				default:
-					attributes = {
-						title: translate( 'You haven\'t published any pages yet.' ),
-						line: translate( 'Would you like to publish your first page?' ),
-						action: translate( 'Start a Page' ),
-						actionURL: newPageLink
-					};
-			}
+		switch ( status ) {
+			case 'drafts':
+				attributes = {
+					title: translate( 'You don\'t have any drafts.' ),
+					line: translate( 'Would you like to create one?' ),
+					action: translate( 'Start a Page' ),
+					actionURL: newPageLink
+				};
+				break;
+			case 'scheduled':
+				attributes = {
+					title: translate( 'You don\'t have any scheduled pages yet.' ),
+					line: translate( 'Would you like to create one?' ),
+					action: translate( 'Start a Page' ),
+					actionURL: newPageLink
+				};
+				break;
+			case 'trashed':
+				attributes = {
+					title: translate( 'You don\'t have any pages in your trash folder.' ),
+					line: translate( 'Everything you write is solid gold.' )
+				};
+				break;
+			default:
+				attributes = {
+					title: translate( 'You haven\'t published any pages yet.' ),
+					line: translate( 'Would you like to publish your first page?' ),
+					action: translate( 'Start a Page' ),
+					actionURL: newPageLink
+				};
 		}
 
 		attributes.illustration = '/calypso/images/pages/illustration-pages.svg';

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -92,7 +92,7 @@ const Pages = localize( React.createClass( {
 
 	propTypes: {
 		incrementPage: PropTypes.func.isRequired,
-		lastPage: PropTypes.bool.isRequired,
+		lastPage: PropTypes.bool,
 		loading: PropTypes.bool.isRequired,
 		page: PropTypes.number.isRequired,
 		pages: PropTypes.array.isRequired,

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -121,7 +121,7 @@ const Pages = localize( React.createClass( {
 		if ( options.triggeredByScroll ) {
 			this.props.trackScrollPage( this.props.page + 1 );
 		}
-		//this.props.incrementPage();
+		this.props.incrementPage();
 	},
 
 	_insertTimeMarkers( pages ) {


### PR DESCRIPTION
_Requires D6443-code to work in all-sites mode._

Use `<QueryPosts />` and related selectors instead of `<PostListFetcher />`. I opted to continue to use the `infiniteScroll` mixin for now since that allowed me to keep the PR reasonably small. Migrating to a different infinite scroll technology (`react-virtualized`?) can be done in an independent subsequent step.

To test:
* Make sure `/pages` still works as before (try both single-site and all-sites modes).
* Try both a site with few pages (for hierarchical view) and one with 100+ pages (Fieldguide!). Don't forget to scroll down!
