### PR TITLE
Fix 2 warnings in unit tests

### DIFF
--- a/client/lib/react-pass-to-children/test/index.js
+++ b/client/lib/react-pass-to-children/test/index.js
@@ -80,24 +80,24 @@ describe( 'index', function() {
 	it( 'should preserve props passed to the children', function() {
 		var result;
 
-		renderer.render( <PassThrough><div preserve /></PassThrough> );
+		renderer.render( <PassThrough><div data-preserve /></PassThrough> );
 		result = renderer.getRenderOutput();
 
 		expect( result.type ).to.equal( 'div' );
 		expect( result.props ).to.eql( assign( {}, DUMMY_PROPS, {
-			preserve: true
+			'data-preserve': true
 		} ) );
 	} );
 
 	it( 'should preserve props passed to the instance itself', function() {
 		var result;
 
-		renderer.render( <PassThrough preserve><div /></PassThrough> );
+		renderer.render( <PassThrough data-preserve><div /></PassThrough> );
 		result = renderer.getRenderOutput();
 
 		expect( result.type ).to.equal( 'div' );
 		expect( result.props ).to.eql( assign( {}, DUMMY_PROPS, {
-			preserve: true
+			'data-preserve': true
 		} ) );
 	} );
 } );

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -18,7 +18,8 @@ describe( 'PostEditor', function() {
 	const defaultProps = {
 		translate: string => string,
 		markSaved: () => {},
-		markChanged: () => {}
+		markChanged: () => {},
+		setLayoutFocus: () => {}
 	};
 
 	useFakeDom();


### PR DESCRIPTION
Partial fix for #8274. Fixes the following 2 warnings:

In client/lib/react-pass-to-children:
Warning: Unknown prop `preserve` on \<div\> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop

In client/post-editor:
Warning: Failed prop type: The prop `setLayoutFocus` is marked as required in `PostEditor`, but its value is `undefined`.
