### PR TITLE
Woocommerce Stats: Match widget styles to Site Stats

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -131,9 +131,7 @@ class StoreStats extends Component {
 					</div>
 					{ topWidgets.map( widget => {
 						const header = (
-							<SectionHeader href={ widget.basePath + widgetPath }>
-								{ widget.title }
-							</SectionHeader>
+							<SectionHeader href={ widget.basePath + widgetPath } label={ widget.title } />
 						);
 						return (
 							<div className="store-stats__widgets-column" key={ widget.basePath }>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -47,14 +47,20 @@ class StoreStatsModule extends Component {
 		const { loaded } = this.state;
 		const isLoading = ! loaded && ! ( data && data.length );
 		const hasEmptyData = loaded && data && data.length === 0;
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="store-stats-module">
 				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				{ header }
 				{ isLoading && <Card><StatsModulePlaceholder isLoading={ isLoading } /></Card> }
-				{ ! isLoading && hasEmptyData && <Card><ErrorPanel message={ emptyMessage } /></Card> }
+				{ ! isLoading && hasEmptyData &&
+					<Card className="stats-module is-showing-error has-no-data">
+						<ErrorPanel message={ emptyMessage } />
+					</Card>
+				}
 				{ ! isLoading && ! hasEmptyData && children }
 			</div>
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);
 	}
 }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/style.scss
@@ -1,0 +1,3 @@
+.store-stats-module .section-header__label {
+	color: inherit;
+}

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -6,10 +6,6 @@
 
 .store-stats__widgets-column {
 	width: 100%;
-
-	.module-content-text.is-error {
-		padding-top: 11px;
-	}
 }
 
 @include breakpoint( ">960px" ) {

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -30,6 +30,7 @@
 	@import 'components/store-address/style';
 	@import 'components/delta/style';
 	@import 'app/store-stats/store-stats-chart/style';
+	@import 'app/store-stats/store-stats-module/style';
 	@import 'app/store-stats/store-stats-navigation/style';
 	@import 'app/store-stats/store-stats-widget-list/style';
 	@import 'app/store-stats/style';


### PR DESCRIPTION
### Before
<img alt="screen shot 2017-06-17 at 12 52 18 pm" src="https://cldup.com/ktrdE9czuk-2000x2000.png">

### After
<img width="325" alt="screen shot 2017-07-17 at 2 19 32 pm" src="https://user-images.githubusercontent.com/1922453/28253842-be367be0-6afb-11e7-8dc7-a4d8e8fd2c14.png">

I re-used Site stats' styles and as a result had to disable the eslint error

