### PR TITLE
Add tracks events to Store Stats

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -115,3 +115,10 @@ export const UNITS = {
 		title: translate( 'Years' )
 	}
 };
+
+export const chartTabs = [
+	{ label: translate( 'Gross Sales' ), attr: 'gross_sales', type: 'currency' },
+	{ label: translate( 'Net Sales' ), attr: 'net_sales', type: 'currency' },
+	{ label: translate( 'Orders' ), attr: 'orders', type: 'number' },
+	{ label: translate( 'Average Order Value' ), attr: 'avg_order_value', type: 'currency' },
+];

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -14,6 +14,8 @@ import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getQueryDate } from './utils';
+import analytics from 'lib/analytics';
+import titlecase from 'to-title-case';
 
 function isValidParameters( context ) {
 	const validParameters = {
@@ -31,6 +33,12 @@ export default function StatsController( context ) {
 	if ( ! isValidParameters( context ) ) {
 		page.redirect( `/store/stats/orders/day/${ context.params.site }` );
 	}
+
+	analytics.pageView.record(
+		`/store/stats/${ context.params.type }/${ context.params.unit }`,
+		`Store > Stats > ${ titlecase( context.params.type ) } > ${ titlecase( context.params.unit ) }`
+	);
+
 	const props = {
 		querystring: context.querystring,
 		type: context.params.type,

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -22,6 +22,8 @@ import Legend from 'components/chart/legend';
 import Tabs from 'my-sites/stats/stats-tabs';
 import Tab from 'my-sites/stats/stats-tabs/tab';
 import { UNITS } from 'woocommerce/app/store-stats/constants';
+import analytics from 'lib/analytics';
+import { chartTabs as tabs } from 'woocommerce/app/store-stats/constants';
 
 class StoreStatsChart extends Component {
 	static propTypes = {
@@ -47,6 +49,10 @@ class StoreStatsChart extends Component {
 		this.setState( {
 			selectedTabIndex: tab.index,
 		} );
+
+		analytics.tracks.recordEvent( 'calypso_woocommerce_stats_chart_tab_click', {
+			tab: tabs[ tab.index ]
+		} );
 	};
 
 	buildChartData = ( item, selectedTab, chartFormat ) => {
@@ -67,12 +73,6 @@ class StoreStatsChart extends Component {
 	render() {
 		const { data, deltas, selectedDate, unit } = this.props;
 		const { selectedTabIndex } = this.state;
-		const tabs = [
-			{ label: 'Gross Sales', attr: 'gross_sales', type: 'currency' },
-			{ label: 'Net Sales', attr: 'net_sales', type: 'currency' },
-			{ label: 'Orders', attr: 'orders', type: 'number' },
-			{ label: 'Average Order Value', attr: 'avg_order_value', type: 'currency' },
-		];
 		const selectedTab = tabs[ selectedTabIndex ];
 		const isLoading = ! data.length;
 		const chartFormat = UNITS[ unit ].chartFormat;


### PR DESCRIPTION
### Trigger analytics' recordPageView 
Results in `calypso_page_view` event in tracks.  ~**This initial commit has a placeholder string**~. This pull request can be used to track conversations around the events needed.

Resources
https://wpcalypso.wordpress.com/devdocs/client/lib/analytics/README.md?term=tracks

cc @greenafrican @westi 




