### PR TITLE
Fix keyedReducer to omit key with undefined value

### DIFF
--- a/client/state/README.md
+++ b/client/state/README.md
@@ -123,6 +123,30 @@ state.users === {
 }
 ```
 
+**NOTE:** There may be some cases where you wish to respond to an action by removing a key. In those cases, you may return `undefined` from the reducer to explicitly indicate there is no longer state associated with the key, and `keyedReducer` will omit that key from the state.
+
+#### Example
+
+```javascript
+const deleteableUserReducer = ( state, action ) =>
+    DELETE === action.type
+        ? undefined
+        : userReducer( state, action );
+
+export default keyedReducer( 'username', deleteableUserReducer );
+
+state.users === {
+    hunter02: {
+        age: 1,
+        title: 'grunt',
+    }
+}
+
+dispatch( { type: DELETE, username: 'hunter02' } );
+
+state.users === {}
+```
+
 ### withSchemaValidation( schema, reducer )
 
 When Calypso boots up it loads the last-known state out of persistent storage in the browser.

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -282,12 +282,15 @@ describe( 'utils', () => {
 	describe( '#keyedReducer', () => {
 		const grow = name => ( { type: 'GROW', name } );
 		const reset = name => ( { type: 'RESET', name } );
+		const remove = name => ( { type: 'REMOVE', name } );
 
 		const age = ( state = 0, action ) => {
 			if ( 'GROW' === action.type ) {
 				return state + 1;
 			} else if ( 'RESET' === action.type ) {
 				return 0;
+			} else if ( 'REMOVE' === action.type ) {
+				return undefined;
 			}
 			return state;
 		};
@@ -367,6 +370,11 @@ describe( 'utils', () => {
 		it( 'should remove keys if set back to initialState', () => {
 			const keyed = keyedReducer( 'name', age );
 			expect( keyed( { 10: 10 }, reset( '10' ) ) ).to.eql( { } );
+		} );
+
+		it( 'should remove keys if set to undefined', () => {
+			const keyed = keyedReducer( 'name', age );
+			expect( keyed( { 10: 10 }, remove( '10' ) ) ).to.eql( { } );
 		} );
 	} );
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -116,9 +116,9 @@ export const keyedReducer = ( keyName, reducer ) => {
 			return state;
 		}
 
-		// remove key from state if setting back to initial state
+		// remove key from state if setting to undefined or back to initial state
 		// if it didn't exist anyway, then do nothing.
-		if ( isEqual( newItemState, initialState ) ) {
+		if ( undefined === newItemState || isEqual( newItemState, initialState ) ) {
 			return state.hasOwnProperty( itemKey )
 				? omit( state, itemKey )
 				: state;


### PR DESCRIPTION
This change updates `state/utils.keyedReducer` to remove keys whose value is set to `undefined`. This allows inner reducers to explicitly indicate when keys should be removed.

While working on the Share a Draft feature under #16002, I encountered the need to indicate key removal in response to an action, and @dmsnell suggested we might consider this change.

I like this approach and believe the result is readable and intuitive, but is there any concern that `undefined` can also be an accidental return value for a reducer that fails to explicitly return new or existing state?

cc @nb 