### PR TITLE
Simple Payments: Insert button after submitting the "Add New" form

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -17,6 +17,7 @@ import FormTextarea from 'components/forms/form-textarea';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormToggle from 'components/forms/form-toggle';
+import FormInputValidation from 'components/forms/form-input-validation';
 
 const ProductImage = () => (
 	<div className="editor-simple-payments-modal__product-image">
@@ -25,38 +26,92 @@ const ProductImage = () => (
 );
 
 class ProductForm extends Component {
+	handleFieldChange = ( { currentTarget: { name, value } } ) => {
+		this.props.onFieldChange( name, value );
+	};
+
+	handleMultipleCheckboxChange = checked => {
+		this.props.onFieldChange( 'multiple', checked );
+	};
+
 	render() {
-		const { translate, currencyDefaults } = this.props;
+		const { translate, currencyDefaults, fieldValues, isFieldInvalid } = this.props;
+
+		const isTitleInvalid = isFieldInvalid( 'title' );
+		const isPriceInvalid = isFieldInvalid( 'price' );
+		const isEmailInvalid = isFieldInvalid( 'email' );
 
 		return (
 			<form className="editor-simple-payments-modal__form">
 				<ProductImage />
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>
-						<FormLabel htmlFor="productname">{ translate( 'What are you selling?' ) }</FormLabel>
-						<FormTextInput name="productname" id="productname" />
+						<FormLabel htmlFor="title">
+							{ translate( 'What are you selling?' ) }
+						</FormLabel>
+						<FormTextInput
+							name="title"
+							id="title"
+							value={ fieldValues.title }
+							onChange={ this.handleFieldChange }
+							isError={ isTitleInvalid }
+						/>
+						{ isTitleInvalid &&
+							<FormInputValidation
+								isError
+								text={ translate( 'Product name cannot be empty.' ) }
+							/> }
 					</FormFieldset>
 					<FormFieldset>
-						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
-						<FormTextarea name="description" id="description" />
+						<FormLabel htmlFor="description">
+							{ translate( 'Description' ) }
+						</FormLabel>
+						<FormTextarea
+							name="description"
+							id="description"
+							value={ fieldValues.description }
+							onChange={ this.handleFieldChange }
+						/>
 					</FormFieldset>
 					<FormFieldset>
-						<FormLabel htmlFor="price">{ translate( 'Price' ) }</FormLabel>
+						<FormLabel htmlFor="price">
+							{ translate( 'Price' ) }
+						</FormLabel>
 						<FormCurrencyInput
 							name="price"
 							id="price"
 							currencySymbolPrefix={ currencyDefaults.symbol }
 							placeholder="0.00"
+							value={ fieldValues.price }
+							onChange={ this.handleFieldChange }
+							isError={ isPriceInvalid }
 						/>
+						{ isPriceInvalid &&
+							<FormInputValidation isError text={ translate( 'Invalid price' ) } /> }
 					</FormFieldset>
 					<FormFieldset>
-						<FormToggle id="allowMultipleItems">
+						<FormToggle
+							name="multiple"
+							id="multiple"
+							checked={ !! fieldValues.multiple }
+							onChange={ this.handleMultipleCheckboxChange }
+						>
 							{ translate( 'Allow people to buy more than one item at a time.' ) }
 						</FormToggle>
 					</FormFieldset>
 					<FormFieldset>
-						<FormLabel htmlFor="email">{ translate( 'Email' ) }</FormLabel>
-						<FormTextInput name="email" id="email" />
+						<FormLabel htmlFor="email">
+							{ translate( 'Email' ) }
+						</FormLabel>
+						<FormTextInput
+							name="email"
+							id="email"
+							value={ fieldValues.email }
+							onChange={ this.handleFieldChange }
+							isError={ isEmailInvalid }
+						/>
+						{ isEmailInvalid &&
+							<FormInputValidation isError text={ translate( 'Invalid email' ) } /> }
 						<FormSettingExplanation>
 							{ translate(
 								'This is where PayPal will send your money.' +

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -19,11 +19,10 @@ import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormToggle from 'components/forms/form-toggle';
 import FormInputValidation from 'components/forms/form-input-validation';
 
-const ProductImage = () => (
+const ProductImage = () =>
 	<div className="editor-simple-payments-modal__product-image">
 		<Gridicon icon="add-image" size={ 36 } />
-	</div>
-);
+	</div>;
 
 class ProductForm extends Component {
 	handleFieldChange = ( { currentTarget: { name, value } } ) => {

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -6,21 +6,25 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import emailValidator from 'email-validator';
 
 /**
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSimplePayments } from 'state/selectors';
+import { addProduct, waitForResponse } from 'state/simple-payments/product-list/actions';
 import QuerySimplePayments from 'components/data/query-simple-payments';
+import QuerySitePlans from 'components/data/query-site-plans';
 import Dialog from 'components/dialog';
 import Button from 'components/button';
+import Notice from 'components/notice';
 import Navigation from './navigation';
 import ProductForm from './form';
 import ProductList from './list';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getCurrencyDefaults } from 'lib/format-currency';
-import QuerySitePlans from 'components/data/query-site-plans';
+import formState from 'lib/form-state';
 
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
@@ -32,28 +36,162 @@ class SimplePaymentsDialog extends Component {
 		onInsert: PropTypes.func.isRequired,
 	};
 
-	state = {
-		selectedPaymentId: null,
+	static initialFields = {
+		title: '',
+		description: '',
+		price: '',
+		multiple: false,
+		email: '',
 	};
+
+	constructor( props ) {
+		super( props );
+
+		this._isMounted = false;
+
+		this.formStateController = formState.Controller( {
+			initialFields: this.constructor.initialFields,
+			onNewState: form => this._isMounted && this.setState( { form } ),
+			validatorFunction: this.validateFormFields,
+		} );
+
+		this.state = {
+			selectedPaymentId: null,
+			form: this.formStateController.getInitialState(),
+			isSubmitting: false,
+			errorMessage: null,
+		};
+	}
+
+	componentDidMount() {
+		this._isMounted = true;
+	}
+
+	componentWillUnmount() {
+		this._isMounted = false;
+	}
+
+	handleFormFieldChange = ( name, value ) => {
+		this.formStateController.handleFieldChange( { name, value } );
+	};
+
+	isFormFieldInvalid = name => formState.isFieldInvalid( this.state.form, name );
+
+	getFormValues() {
+		return formState.getAllFieldValues( this.state.form );
+	}
+
+	validateFormFields( formValues, onComplete ) {
+		const formErrors = {};
+
+		if ( ! formValues.title ) {
+			formErrors.title = [ 'empty' ];
+		}
+
+		if ( ! formValues.price ) {
+			formErrors.price = [ 'empty' ];
+		}
+
+		if ( ! formValues.email ) {
+			formErrors.email = [ 'empty' ];
+		} else if ( ! emailValidator.validate( formValues.email ) ) {
+			formErrors.email = [ 'invalid' ];
+		}
+
+		onComplete( null, formErrors );
+	}
 
 	handleSelectedChange = selectedPaymentId => {
 		this.setState( { selectedPaymentId } );
 	};
 
-	handleInsert = () => {
-		this.props.onInsert( { id: this.state.selectedPaymentId } );
+	handleClose = () => {
+		// clear the form after a successful submit -- it'll be blank next time it's opened
+		this.formStateController.resetFields( this.constructor.initialFields );
+		this.props.onClose();
 	};
 
-	getActionButtons() {
-		const { activeTab, translate, onClose } = this.props;
+	dismissError = () => {
+		this.setState( { errorMessage: null } );
+	};
 
-		const insertEnabled = activeTab === 'paymentButtons' && this.state.selectedPaymentId !== null;
+	handleInsert = async () => {
+		this.setState( { isSubmitting: true } );
+
+		try {
+			const insertedProductId = await this.getInsertedProductId();
+			if ( insertedProductId ) {
+				this.props.onInsert( { id: insertedProductId } );
+				// clear the form after a successful submit -- it'll be blank next time it's opened
+				this.formStateController.resetFields( this.constructor.initialFields );
+			}
+		} catch ( error ) {
+			if ( this._isMounted ) {
+				this.setState( {
+					errorMessage: this.props.translate( 'The payment button could not be inserted.' ),
+				} );
+			}
+		}
+
+		this._isMounted && this.setState( { isSubmitting: false } );
+	};
+
+	/*
+	 * Asynchronously retrive the ID of the product to insert. In case of selection from
+	 * list of existing product, we know the ID right away. When inserting from a filled
+	 * form, we first need to issue a create request to the server, and wait for it to
+	 * return an ID.
+	 * @returns the ID, or null in case the form is not valid, or throws an exception in
+	 * case of error that should be displayed as a notice.
+	 */
+	async getInsertedProductId() {
+		const { activeTab, siteId, dispatch } = this.props;
+
+		if ( activeTab === 'paymentButtons' ) {
+			return this.state.selectedPaymentId;
+		}
+
+		if ( activeTab === 'addNew' ) {
+			// ask the form controller to validate the field values
+			const hasErrors = await new Promise( resolve =>
+				this.formStateController.handleSubmit( resolve ),
+			);
+
+			if ( hasErrors ) {
+				return null;
+			}
+
+			// ask the data layer to add a new product
+			const formValues = this.getFormValues();
+			const addProductAction = addProduct( siteId, formValues );
+			dispatch( addProductAction );
+
+			// wait for the response and return the assigned ID
+			const addedProduct = await waitForResponse( addProductAction.requestId );
+			return addedProduct.ID;
+		}
+
+		return null;
+	}
+
+	getActionButtons() {
+		const { activeTab, translate } = this.props;
+		const { isSubmitting } = this.state;
+
+		const insertDisabled =
+			( activeTab === 'addNew' && formState.hasErrors( this.state.form ) ) ||
+			( activeTab === 'paymentButtons' && this.state.selectedPaymentId === null );
 
 		return [
-			<Button onClick={ onClose }>
+			<Button onClick={ this.handleClose } disabled={ isSubmitting }>
 				{ translate( 'Cancel' ) }
 			</Button>,
-			<Button onClick={ this.handleInsert } disabled={ ! insertEnabled } primary>
+			<Button
+				onClick={ this.handleInsert }
+				busy={ isSubmitting }
+				disabled={ isSubmitting || insertDisabled }
+				primary
+			>
 				{ translate( 'Insert' ) }
 			</Button>,
 		];
@@ -69,6 +207,7 @@ class SimplePaymentsDialog extends Component {
 			paymentButtons,
 			currencyCode,
 		} = this.props;
+		const { errorMessage } = this.state;
 
 		const currencyDefaults = getCurrencyDefaults( currencyCode );
 
@@ -81,11 +220,18 @@ class SimplePaymentsDialog extends Component {
 			>
 				<QuerySimplePayments siteId={ siteId } />
 
-				{ ! currencyCode && <QuerySitePlans siteId={ siteId } />}
+				{ ! currencyCode && <QuerySitePlans siteId={ siteId } /> }
 
 				<Navigation { ...{ activeTab, onChangeTabs, paymentButtons } } />
+				{ errorMessage &&
+					<Notice status="is-error" text={ errorMessage } onDismissClick={ this.dismissError } /> }
 				{ activeTab === 'addNew'
-					? <ProductForm currencyDefaults={ currencyDefaults } />
+					? <ProductForm
+							currencyDefaults={ currencyDefaults }
+							fieldValues={ this.getFormValues() }
+							isFieldInvalid={ this.isFormFieldInvalid }
+							onFieldChange={ this.handleFormFieldChange }
+						/>
 					: <ProductList
 							paymentButtons={ paymentButtons }
 							selectedPaymentId={ this.state.selectedPaymentId }

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -122,9 +122,22 @@ class SimplePaymentsDialog extends Component {
 	};
 
 	handleInsert = () => {
-		const { siteId, dispatch, currencyCode } = this.props;
+		const { siteId, dispatch, currencyCode, activeTab } = this.props;
 
 		this.setState( { isSubmitting: true } );
+
+		if ( activeTab === 'paymentButtons' ) {
+			const productId = this.state.selectedPaymentId;
+
+			this.props.onInsert( { id: productId } );
+
+			// clear the form after a successful submit -- it'll be blank next time it's opened
+			this.formStateController.resetFields( this.constructor.initialFields );
+
+			this._isMounted && this.setState( { isSubmitting: false } );
+
+			return;
+		}
 
 		const productForm = this.getFormValues();
 
@@ -142,7 +155,6 @@ class SimplePaymentsDialog extends Component {
 
 				this.props.onInsert( { id: productId } );
 
-				// clear the form after a successful submit -- it'll be blank next time it's opened
 				this.formStateController.resetFields( this.constructor.initialFields );
 
 				this._isMounted && this.setState( { isSubmitting: false } );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -47,6 +47,7 @@ class SimplePaymentsDialog extends Component {
 		price: '',
 		multiple: false,
 		email: '',
+		currency: 'USD',
 	};
 
 	constructor( props ) {
@@ -121,11 +122,15 @@ class SimplePaymentsDialog extends Component {
 	};
 
 	handleInsert = () => {
-		const { siteId, dispatch } = this.props;
+		const { siteId, dispatch, currencyCode } = this.props;
 
 		this.setState( { isSubmitting: true } );
 
 		const productForm = this.getFormValues();
+
+		if ( currencyCode ) {
+			productForm.currency = currencyCode;
+		}
 
 		wpcom
 			.site( siteId )

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -35,6 +35,11 @@
 		flex: none;
 		margin: 0;
 	}
+
+	.notice {
+		flex: none;
+		margin-bottom: 0;
+	}
 }
 
 .editor-simple-payments-modal__navigation {

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -17,6 +17,7 @@ import {
 	receiveProduct,
 	receiveProductsList,
 	receiveUpdateProduct,
+	receiveUpdateProductError,
 	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
 import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
@@ -157,8 +158,11 @@ export function requestSimplePaymentsProductDelete( { dispatch }, action ) {
 	}, action ) );
 }
 
-export const addProduct = ( { dispatch }, { siteId }, next, newProduct ) =>
-	dispatch( receiveUpdateProduct( siteId, customPostToProduct( newProduct ) ) );
+export const addProduct = ( { dispatch }, { siteId, requestId }, next, newProduct ) =>
+	dispatch( receiveUpdateProduct( siteId, customPostToProduct( newProduct ), requestId ) );
+
+export const handleAddProductError = ( { dispatch }, { siteId, requestId }, next, error ) =>
+	dispatch( receiveUpdateProductError( siteId, error, requestId ) );
 
 export const deleteProduct = ( { dispatch }, { siteId }, next, deletedProduct ) =>
 	dispatch( receiveDeleteProduct( siteId, deletedProduct.ID ) );
@@ -182,8 +186,8 @@ export default {
 		[ dispatchRequest( requestSimplePaymentsProduct, listProduct, noop ) ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]:
 		[ dispatchRequest( requestSimplePaymentsProducts, listProducts, noop ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ dispatchRequest( requestSimplePaymentsProductAdd, addProduct, noop ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ dispatchRequest( requestSimplePaymentsProductEdit, addProduct, noop ) ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ dispatchRequest( requestSimplePaymentsProductAdd, addProduct, handleAddProductError ) ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ dispatchRequest( requestSimplePaymentsProductEdit, addProduct, handleAddProductError ) ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]:
 		[ dispatchRequest( requestSimplePaymentsProductDelete, deleteProduct, noop ) ],
 };

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -17,7 +17,6 @@ import {
 	receiveProduct,
 	receiveProductsList,
 	receiveUpdateProduct,
-	receiveUpdateProductError,
 	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
 import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
@@ -44,7 +43,7 @@ function reduceMetadata( sanitizedProductAttributes, current ) {
  * @param { Object } product raw /post endpoint response to format
  * @returns { Object } sanitized and formatted product
  */
-function customPostToProduct( product ) {
+export function customPostToProduct( product ) {
 	return Object.assign(
 		{
 			ID: product.ID,
@@ -60,7 +59,7 @@ function customPostToProduct( product ) {
  * @param { Object } product action with product payload
  * @returns { Object } custom post type data
  */
-function productToCustomPost( product ) {
+export function productToCustomPost( product ) {
 	return Object.keys( product ).reduce(
 		function( payload, current ) {
 			if ( metadataSchema[ current ] ) {
@@ -158,11 +157,8 @@ export function requestSimplePaymentsProductDelete( { dispatch }, action ) {
 	}, action ) );
 }
 
-export const addProduct = ( { dispatch }, { siteId, requestId }, next, newProduct ) =>
-	dispatch( receiveUpdateProduct( siteId, customPostToProduct( newProduct ), requestId ) );
-
-export const handleAddProductError = ( { dispatch }, { siteId, requestId }, next, error ) =>
-	dispatch( receiveUpdateProductError( siteId, error, requestId ) );
+export const addProduct = ( { dispatch }, { siteId }, next, newProduct ) =>
+	dispatch( receiveUpdateProduct( siteId, customPostToProduct( newProduct ) ) );
 
 export const deleteProduct = ( { dispatch }, { siteId }, next, deletedProduct ) =>
 	dispatch( receiveDeleteProduct( siteId, deletedProduct.ID ) );
@@ -186,8 +182,8 @@ export default {
 		[ dispatchRequest( requestSimplePaymentsProduct, listProduct, noop ) ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]:
 		[ dispatchRequest( requestSimplePaymentsProducts, listProducts, noop ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ dispatchRequest( requestSimplePaymentsProductAdd, addProduct, handleAddProductError ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ dispatchRequest( requestSimplePaymentsProductEdit, addProduct, handleAddProductError ) ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ dispatchRequest( requestSimplePaymentsProductAdd, addProduct, noop ) ],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ dispatchRequest( requestSimplePaymentsProductEdit, addProduct, noop ) ],
 	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]:
 		[ dispatchRequest( requestSimplePaymentsProductDelete, deleteProduct, noop ) ],
 };

--- a/client/state/simple-payments/product-list/actions.js
+++ b/client/state/simple-payments/product-list/actions.js
@@ -1,14 +1,42 @@
+/*
+ * External dependencies
+ */
+import { uniqueId } from 'lodash';
+
 /**
  * Internal dependencies
  */
 import {
 	SIMPLE_PAYMENTS_PRODUCT_GET,
-	SIMPLE_PAYMENTS_PRODUCTS_LIST,
 	SIMPLE_PAYMENTS_PRODUCT_RECEIVE,
+	SIMPLE_PAYMENTS_PRODUCTS_LIST,
+	SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_DELETE,
 } from 'state/action-types';
+
+const waitingRequests = {};
+
+/*
+ * Return a Promise that gets resolved or rejected once a response (or error) for
+ * the given `requestId` arrives.
+ */
+export function waitForResponse( requestId ) {
+	// Is there already a Promise for this `requestId`? Return it.
+	if ( waitingRequests[ requestId ] ) {
+		return waitingRequests[ requestId ].promise;
+	}
+
+	// Create a new Promise and save references to its `resolve` and `reject` functions
+	const waitingRequest = waitingRequests[ requestId ] = {};
+	waitingRequest.promise = new Promise( ( resolve, reject ) => {
+		waitingRequest.resolve = resolve;
+		waitingRequest.reject = reject;
+	} );
+
+	return waitingRequest.promise;
+}
 
 export const requestProducts = ( siteId ) => ( {
 	siteId,
@@ -19,6 +47,13 @@ export const requestProduct = ( siteId, productId ) => ( {
 	siteId,
 	productId,
 	type: SIMPLE_PAYMENTS_PRODUCT_GET,
+} );
+
+export const addProduct = ( siteId, product ) => ( {
+	type: SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD,
+	requestId: uniqueId( 'request_' ),
+	siteId,
+	product,
 } );
 
 export function receiveProductsList( siteId, posts ) {
@@ -37,11 +72,36 @@ export function receiveProduct( siteId, product ) {
 	};
 }
 
-export function receiveUpdateProduct( siteId, product ) {
-	return {
-		siteId,
-		type: SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE,
-		product
+export function receiveUpdateProduct( siteId, product, requestId ) {
+	return dispatch => {
+		dispatch( {
+			type: SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE,
+			siteId,
+			requestId,
+			product,
+		} );
+
+		// If there is someone waiting for this response, resolve the promise
+		if ( requestId ) {
+			const waitingRequest = waitingRequests[ requestId ];
+			if ( waitingRequest ) {
+				waitingRequest.resolve( product );
+				delete waitingRequests[ requestId ];
+			}
+		}
+	};
+}
+
+export function receiveUpdateProductError( siteId, error, requestId ) {
+	return () => {
+		// If there is someone waiting for the error response, reject the promise
+		if ( requestId ) {
+			const waitingRequest = waitingRequests[ requestId ];
+			if ( waitingRequest ) {
+				waitingRequest.reject( error );
+				delete waitingRequests[ requestId ];
+			}
+		}
 	};
 }
 

--- a/client/state/simple-payments/product-list/actions.js
+++ b/client/state/simple-payments/product-list/actions.js
@@ -1,42 +1,14 @@
-/*
- * External dependencies
- */
-import { uniqueId } from 'lodash';
-
 /**
  * Internal dependencies
  */
 import {
 	SIMPLE_PAYMENTS_PRODUCT_GET,
-	SIMPLE_PAYMENTS_PRODUCT_RECEIVE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST,
-	SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD,
+	SIMPLE_PAYMENTS_PRODUCT_RECEIVE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_DELETE,
 } from 'state/action-types';
-
-const waitingRequests = {};
-
-/*
- * Return a Promise that gets resolved or rejected once a response (or error) for
- * the given `requestId` arrives.
- */
-export function waitForResponse( requestId ) {
-	// Is there already a Promise for this `requestId`? Return it.
-	if ( waitingRequests[ requestId ] ) {
-		return waitingRequests[ requestId ].promise;
-	}
-
-	// Create a new Promise and save references to its `resolve` and `reject` functions
-	const waitingRequest = waitingRequests[ requestId ] = {};
-	waitingRequest.promise = new Promise( ( resolve, reject ) => {
-		waitingRequest.resolve = resolve;
-		waitingRequest.reject = reject;
-	} );
-
-	return waitingRequest.promise;
-}
 
 export const requestProducts = ( siteId ) => ( {
 	siteId,
@@ -47,13 +19,6 @@ export const requestProduct = ( siteId, productId ) => ( {
 	siteId,
 	productId,
 	type: SIMPLE_PAYMENTS_PRODUCT_GET,
-} );
-
-export const addProduct = ( siteId, product ) => ( {
-	type: SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD,
-	requestId: uniqueId( 'request_' ),
-	siteId,
-	product,
 } );
 
 export function receiveProductsList( siteId, posts ) {
@@ -72,36 +37,11 @@ export function receiveProduct( siteId, product ) {
 	};
 }
 
-export function receiveUpdateProduct( siteId, product, requestId ) {
-	return dispatch => {
-		dispatch( {
-			type: SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE,
-			siteId,
-			requestId,
-			product,
-		} );
-
-		// If there is someone waiting for this response, resolve the promise
-		if ( requestId ) {
-			const waitingRequest = waitingRequests[ requestId ];
-			if ( waitingRequest ) {
-				waitingRequest.resolve( product );
-				delete waitingRequests[ requestId ];
-			}
-		}
-	};
-}
-
-export function receiveUpdateProductError( siteId, error, requestId ) {
-	return () => {
-		// If there is someone waiting for the error response, reject the promise
-		if ( requestId ) {
-			const waitingRequest = waitingRequests[ requestId ];
-			if ( waitingRequest ) {
-				waitingRequest.reject( error );
-				delete waitingRequests[ requestId ];
-			}
-		}
+export function receiveUpdateProduct( siteId, product ) {
+	return {
+		siteId,
+		type: SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE_UPDATE,
+		product
 	};
 }
 


### PR DESCRIPTION
It's now possible to insert a new payment button by filling the "Add New" form and hitting "Insert".

The form uses `lib/form-state` to manage its state and validation. The product name, price and email fields are validated. Cc @iamtakashi for feedback on the validation error messages.

After hitting "Insert", we issue a request to the server to create a new CPT, and wait for the response that contains the new post ID. Then we use that ID as a property of the shortcode inserted to the editor.

If the request fails, an error notice is displayed on the Simple Payments dialog.

To be able to access the response to the `addProduct` request that's sent to the Data Layer, I had to tweak the `addProduct` action by setting an unique `requestId` property on it. Then I can use the new `waitForResponse(requestId)` function to register a Promise that waits for the response. The actions that receive the success or error responses check if there is someone waiting for that `requestId`, and resolve or reject the registered Promise in such case.

This is not an ideal solution, as it doesn't work when offline -- the insert will fail in this case. A much better solution would be to assign a temporary ID to the new payment object, issue a request to Data Layer to sync it to server at its convenience, and just insert a shortcode with the temporary ID. Then, when a real ID is assigned, the editor would somehow detect this state update and replace the temporary ID with a real one.

However, I feel this is a very deep rabbit hole that may require major changes to how the TinyMCE editor works right now. Or maybe not -- I'm not familiar at all how the editor works with its data. I'd rather postpone this research to a follow-up PR.

**How to test:**
- Click on "Add Payment Button" in the editor and open the insert dialog
- Fill out your product info in the form
- Check that the product name, price and email are validated. Currently, they must not be empty and the email must be valid. The price validation is very basic now and will be improved later.
- Check that you cannot submit a form that is not valid.
- Check that an error notice is displayed when the insert fails (the easiest way to simulate an error is to check "Offline" in devtools' Network tab)
<img width="739" alt="simple-payment-insert-error" src="https://user-images.githubusercontent.com/664258/28260313-bd28ba36-6ada-11e7-8127-922514e8b8e0.png">

- Turn the network back online and submit again. This time, we expect success.
- Check that the "Insert" button has "busy" state when submitting and that the "Cancel" button is disabled.
- Check that the new button was really inserted 🥇 