### PR TITLE
CreditCardForm: fix React warning about undefined form field values

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -61,7 +61,7 @@ const CreditCardForm = React.createClass( {
 		this._mounted = true;
 
 		const fields = this.fieldNames.reduce( ( result, fieldName ) => {
-			return { ...result, [ fieldName ]: undefined };
+			return { ...result, [ fieldName ]: '' };
 		}, {} );
 
 		if ( this.props.initialValues ) {


### PR DESCRIPTION
When initializing form field values to something "empty", then `undefined` is not a good option -- `undefined` value means that the field is [uncontrolled](https://facebook.github.io/react/docs/forms.html#controlled-components). When the value is then changed later on a state update, React issues a warning:

>Warning: FormTextInput is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component.

This PR fixes the warning by initializing the values to `''`.

To test: go to `/me/purchases/add-credit-card` and check that the warning is not logged to console any more.

I discovered this when looking at components that use `lib/form-state`.

Related to https://github.com/Automattic/wp-calypso/pull/7632