### PR TITLE
Extensions: WPSC: Add Delete Debug Log Button

### DIFF
--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -8,7 +8,9 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Card from 'components/card';
+import ExternalLink from 'components/external-link';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -28,12 +30,18 @@ class DebugTab extends Component {
 		fields: {},
 	};
 
+	deleteLog = () => this.props.saveSettings( this.props.siteId, { wpsc_delete_log: true } );
+
 	render() {
 		const {
 			fields: {
-				wp_super_cache_debug,
+				cache_path,
+				cache_path_url,
 				wp_cache_debug_ip,
+				wp_cache_debug_log = '',
 				wp_super_cache_comments,
+				wp_super_cache_debug,
+				wp_cache_debug_username,
 				wp_super_cache_front_page_check,
 				wp_super_cache_front_page_clear,
 				wp_super_cache_front_page_text,
@@ -68,6 +76,42 @@ class DebugTab extends Component {
 							</FormToggle>
 						</FormFieldset>
 						<div className="wp-super-cache__debug-fieldsets">
+							{ wp_cache_debug_log &&
+								<table>
+									<tr>
+										<td>
+											{ wp_super_cache_debug
+												? translate( 'Currently logging to:' )
+												: translate( 'Last logged to:' )
+											}
+										</td>
+										<td>
+											<ExternalLink
+												href={ cache_path_url + wp_cache_debug_log }
+												target="_blank">
+												{ cache_path + wp_cache_debug_log }
+											</ExternalLink>
+										</td>
+										<td rowSpan="2">
+											<Button
+												compact
+												disabled={ isRequesting || isSaving }
+												onClick={ this.deleteLog }
+												scary>
+												{ translate( 'Delete' ) }
+											</Button>
+										</td>
+									</tr>
+									<tr>
+										<td>
+											{ translate( 'Username and Password:' ) }
+										</td>
+										<td>
+											{ wp_cache_debug_username }
+										</td>
+									</tr>
+								</table>
+							}
 							<FormFieldset>
 								<FormLabel htmlFor="ipAddress">
 									{ translate( 'IP Address' ) }
@@ -172,9 +216,13 @@ class DebugTab extends Component {
 
 const getFormSettings = settings => {
 	return pick( settings, [
-		'wp_super_cache_debug',
+		'cache_path',
+		'cache_path_url',
 		'wp_cache_debug_ip',
+		'wp_cache_debug_log',
 		'wp_super_cache_comments',
+		'wp_super_cache_debug',
+		'wp_cache_debug_username',
 		'wp_super_cache_front_page_check',
 		'wp_super_cache_front_page_clear',
 		'wp_super_cache_front_page_text',

--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -36,6 +36,7 @@ class DebugTab extends Component {
 		const {
 			fields: {
 				cache_path,
+				cache_path_url,
 				wp_cache_debug_ip,
 				wp_cache_debug_log = '',
 				wp_super_cache_comments,
@@ -83,11 +84,20 @@ class DebugTab extends Component {
 									}
 								</FormLabel>
 								<FormTextInput
-									disabled={ true }
+									disabled
 									id="debugLog"
 									value={ cache_path + wp_cache_debug_log } />
 								<Button
-									className="wp-super-cache__debug-delete-debug-log"
+									className="wp-super-cache__debug-log-button"
+									compact
+									disabled={ isRequesting || isSaving }
+									href={ cache_path_url + wp_cache_debug_log }
+									rel="noopener noreferrer"
+									target="_blank">
+									{ translate( 'View debug log' ) }
+								</Button>
+								<Button
+									className="wp-super-cache__debug-log-button"
 									compact
 									disabled={ isRequesting || isSaving }
 									onClick={ this.deleteLog }
@@ -206,6 +216,7 @@ class DebugTab extends Component {
 const getFormSettings = settings => {
 	return pick( settings, [
 		'cache_path',
+		'cache_path_url',
 		'wp_cache_debug_ip',
 		'wp_cache_debug_log',
 		'wp_super_cache_comments',

--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -10,7 +10,7 @@ import moment from 'moment';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import ExternalLink from 'components/external-link';
+import ClipboardButtonInput from 'components/clipboard-button-input';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -36,7 +36,6 @@ class DebugTab extends Component {
 		const {
 			fields: {
 				cache_path,
-				cache_path_url,
 				wp_cache_debug_ip,
 				wp_cache_debug_log = '',
 				wp_super_cache_comments,
@@ -76,42 +75,32 @@ class DebugTab extends Component {
 							</FormToggle>
 						</FormFieldset>
 						<div className="wp-super-cache__debug-fieldsets">
-							{ wp_cache_debug_log &&
-								<table>
-									<tr>
-										<td>
-											{ wp_super_cache_debug
-												? translate( 'Currently logging to:' )
-												: translate( 'Last logged to:' )
-											}
-										</td>
-										<td>
-											<ExternalLink
-												href={ cache_path_url + wp_cache_debug_log }
-												target="_blank">
-												{ cache_path + wp_cache_debug_log }
-											</ExternalLink>
-										</td>
-										<td rowSpan="2">
-											<Button
-												compact
-												disabled={ isRequesting || isSaving }
-												onClick={ this.deleteLog }
-												scary>
-												{ translate( 'Delete' ) }
-											</Button>
-										</td>
-									</tr>
-									<tr>
-										<td>
-											{ translate( 'Username and Password:' ) }
-										</td>
-										<td>
-											{ wp_cache_debug_username }
-										</td>
-									</tr>
-								</table>
-							}
+							<FormFieldset>
+								<FormLabel htmlFor="debugLog">
+									{ wp_super_cache_debug
+										? translate( 'Currently logging to:' )
+										: translate( 'Last logged to:' )
+									}
+								</FormLabel>
+								<FormTextInput
+									disabled={ true }
+									id="debugLog"
+									value={ cache_path + wp_cache_debug_log } />
+								<Button
+									className="wp-super-cache__debug-delete-debug-log"
+									compact
+									disabled={ isRequesting || isSaving }
+									onClick={ this.deleteLog }
+									scary>
+									{ translate( 'Reset debug log' ) }
+								</Button>
+							</FormFieldset>
+							<FormFieldset>
+								<FormLabel htmlFor="username">
+									{ translate( 'Username and Password:' ) }
+								</FormLabel>
+								<ClipboardButtonInput id="username" value={ wp_cache_debug_username } />
+							</FormFieldset>
 							<FormFieldset>
 								<FormLabel htmlFor="ipAddress">
 									{ translate( 'IP Address' ) }
@@ -217,7 +206,6 @@ class DebugTab extends Component {
 const getFormSettings = settings => {
 	return pick( settings, [
 		'cache_path',
-		'cache_path_url',
 		'wp_cache_debug_ip',
 		'wp_cache_debug_log',
 		'wp_super_cache_comments',

--- a/client/extensions/wp-super-cache/state/settings/schema.js
+++ b/client/extensions/wp-super-cache/state/settings/schema.js
@@ -24,6 +24,7 @@ export const itemsSchema = {
 				cache_mod_rewrite: { type: 'boolean' },
 				cache_next_gc: { type: 'integer' },
 				cache_path: { type: 'string' },
+				cache_path_url: { type: 'string' },
 				cache_rebuild: { type: 'boolean' },
 				cache_rejected_uri: { type: 'string' },
 				cache_rejected_user_agent: { type: 'string' },

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -242,3 +242,7 @@
 .wp-super-cache__debug-tab .form-fieldset .form-setting-explanation.is-indented {
 	margin-left: 36px;
 }
+
+.wp-super-cache__debug-delete-debug-log {
+	margin-top: 12px;
+}

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -243,6 +243,6 @@
 	margin-left: 36px;
 }
 
-.wp-super-cache__debug-delete-debug-log {
+.wp-super-cache__debug-log-button {
 	margin-top: 12px;
 }


### PR DESCRIPTION
Alternative to #16026 (after much discussion & deliberation) 😄 Companion to https://github.com/Automattic/wp-super-cache/pull/291.

Requires an up-to-date `master` branch of WPSC on the server side. 

![image](https://user-images.githubusercontent.com/96308/28268304-0ade5178-6afe-11e7-8880-f85c7cdfce5d.png)

wp-admin:

![image](https://user-images.githubusercontent.com/96308/28268400-7e09b688-6afe-11e7-9fe8-8f892f90cff4.png)

To test:
* SSH into your wpsandbox, `cd` to `$cache_path` (usually `wp-content/cache/`)
* Watch that cryptic hexadecimal `<someSHA>.php` log file. Note its file size. 
* Click the `Delete Log` button. The log file should shrink in size.
