### PR TITLE
Extensions: WPJM - Implement Pages tab

### DIFF
--- a/client/components/redux-forms/redux-form-select/index.jsx
+++ b/client/components/redux-forms/redux-form-select/index.jsx
@@ -12,7 +12,7 @@ import FormSelect from 'components/forms/form-select';
 
 class ReduxFormSelect extends Component {
 	static propTypes = {
-		name: PropTypes.string,
+		name: PropTypes.string.isRequired,
 	};
 
 	renderSelect = ( { input: { onChange, value } } ) => {

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -18,7 +18,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import PageDropdown from './page-dropdown';
 import QueryPosts from 'components/data/query-posts';
 import SectionHeader from 'components/section-header';
-import { getSitePosts, isRequestingSitePostsForQuery } from 'state/posts/selectors';
+import { isRequestingSitePostsForQuery } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 const query = { type: 'page' };
@@ -27,7 +27,6 @@ class Pages extends Component {
 	static propTypes = {
 		isDisabled: PropTypes.bool,
 		isRequesting: PropTypes.bool,
-		pages: PropTypes.array,
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
 	};
@@ -35,7 +34,6 @@ class Pages extends Component {
 	render() {
 		const {
 			isRequesting,
-			pages,
 			siteId,
 			translate,
 		} = this.props;
@@ -66,8 +64,7 @@ class Pages extends Component {
 								<PageDropdown
 									disabled={ isDisabled }
 									id="submitFormPage"
-									name="submitFormPage"
-									pages={ pages } />
+									name="submitFormPage" />
 							</FormFieldset>
 
 							<FormFieldset>
@@ -81,8 +78,7 @@ class Pages extends Component {
 								<PageDropdown
 									disabled={ isDisabled }
 									id="dashboardPage"
-									name="dashboardPage"
-									pages={ pages } />
+									name="dashboardPage" />
 							</FormFieldset>
 
 							<FormFieldset>
@@ -96,8 +92,7 @@ class Pages extends Component {
 								<PageDropdown
 									disabled={ isDisabled }
 									id="listingsPage"
-									name="listingsPage"
-									pages={ pages } />
+									name="listingsPage" />
 							</FormFieldset>
 						</Card>
 					</FormSection>
@@ -113,7 +108,6 @@ const connectComponent = connect(
 
 		return {
 			isRequesting: isRequestingSitePostsForQuery( state, siteId, query ),
-			pages: ( siteId && getSitePosts( state, siteId ) ) || [],
 			siteId,
 		};
 	}

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -60,8 +60,8 @@ class Pages extends Component {
 									name="submitFormPage"
 									pages={ pages } />
 								<FormSettingExplanation>
-									{ translate( 'Select the page where you have placed the [submit_job_form] shortcode. ' +
-										'This lets the plugin know where the form is located.' ) }
+									{ translate( 'Select the page where you\'ve used the [submit_job_form] shortcode. ' +
+										'This lets the plugin know the location of the form.' ) }
 								</FormSettingExplanation>
 							</FormFieldset>
 
@@ -74,8 +74,8 @@ class Pages extends Component {
 									name="dashboardPage"
 									pages={ pages } />
 								<FormSettingExplanation>
-									{ translate( 'Select the page where you have placed the [job_dashboard] shortcode. ' +
-										'This lets the plugin know where the dashboard is located.' ) }
+									{ translate( 'Select the page where you\'ve used the [job_dashboard] shortcode. ' +
+										'This lets the plugin know the location of the dashboard.' ) }
 								</FormSettingExplanation>
 							</FormFieldset>
 
@@ -88,8 +88,8 @@ class Pages extends Component {
 									name="listingsPage"
 									pages={ pages } />
 								<FormSettingExplanation>
-									{ translate( 'Select the page where you have placed the [jobs] shortcode. ' +
-										'This lets the plugin know where the job listings page is located.' ) }
+									{ translate( 'Select the page where you\'ve used the [jobs] shortcode. ' +
+										'This lets the plugin know the location of the job listings page.' ) }
 								</FormSettingExplanation>
 							</FormFieldset>
 						</Card>

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -18,11 +18,13 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import PageDropdown from './page-dropdown';
 import QueryPosts from 'components/data/query-posts';
 import SectionHeader from 'components/section-header';
-import { getSitePosts } from 'state/posts/selectors';
+import { getSitePosts, isRequestingSitePostsForQuery } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 class Pages extends Component {
 	static propTypes = {
+		isDisabled: PropTypes.bool,
+		isRequesting: PropTypes.bool,
 		pages: PropTypes.array,
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
@@ -30,10 +32,13 @@ class Pages extends Component {
 
 	render() {
 		const {
+			isRequesting,
 			pages,
 			siteId,
 			translate,
 		} = this.props;
+
+		const isDisabled = this.props.isDisabled || isRequesting;
 
 		return (
 			<div>
@@ -42,7 +47,8 @@ class Pages extends Component {
 				<form>
 					<FormSection name="pages">
 						<SectionHeader label={ translate( 'Pages' ) }>
-							<FormButton compact />
+							<FormButton compact
+								disabled={ isDisabled } />
 						</SectionHeader>
 						<Card>
 							<FormFieldset>
@@ -50,6 +56,7 @@ class Pages extends Component {
 									{ translate( 'Submit Job Form Page' ) }
 								</FormLabel>
 								<PageDropdown
+									disabled={ isDisabled }
 									name="submitFormPage"
 									pages={ pages } />
 								<FormSettingExplanation>
@@ -63,6 +70,7 @@ class Pages extends Component {
 									{ translate( 'Job Dashboard Page' ) }
 								</FormLabel>
 								<PageDropdown
+									disabled={ isDisabled }
 									name="dashboardPage"
 									pages={ pages } />
 								<FormSettingExplanation>
@@ -76,6 +84,7 @@ class Pages extends Component {
 									{ translate( 'Job Listings Page' ) }
 								</FormLabel>
 								<PageDropdown
+									disabled={ isDisabled }
 									name="listingsPage"
 									pages={ pages } />
 								<FormSettingExplanation>
@@ -94,9 +103,12 @@ class Pages extends Component {
 const connectComponent = connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const pages = getSitePosts( state, siteId );
 
-		return { pages, siteId };
+		return {
+			isRequesting: isRequestingSitePostsForQuery( state, siteId, { type: 'page' } ),
+			pages: getSitePosts( state, siteId ),
+			siteId,
+		};
 	}
 );
 

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -55,45 +55,45 @@ class Pages extends Component {
 								<FormLabel htmlFor="submitFormPage">
 									{ translate( 'Submit Job Form Page' ) }
 								</FormLabel>
+								<FormSettingExplanation>
+									{ translate( 'Select the page where you\'ve used the [submit_job_form] shortcode. ' +
+										'This lets the plugin know the location of the form.' ) }
+								</FormSettingExplanation>
 								<PageDropdown
 									disabled={ isDisabled }
 									id="submitFormPage"
 									name="submitFormPage"
 									pages={ pages } />
-								<FormSettingExplanation>
-									{ translate( 'Select the page where you\'ve used the [submit_job_form] shortcode. ' +
-										'This lets the plugin know the location of the form.' ) }
-								</FormSettingExplanation>
 							</FormFieldset>
 
 							<FormFieldset>
 								<FormLabel htmlFor="dashboardPage">
 									{ translate( 'Job Dashboard Page' ) }
 								</FormLabel>
+								<FormSettingExplanation>
+									{ translate( 'Select the page where you\'ve used the [job_dashboard] shortcode. ' +
+										'This lets the plugin know the location of the dashboard.' ) }
+								</FormSettingExplanation>
 								<PageDropdown
 									disabled={ isDisabled }
 									id="dashboardPage"
 									name="dashboardPage"
 									pages={ pages } />
-								<FormSettingExplanation>
-									{ translate( 'Select the page where you\'ve used the [job_dashboard] shortcode. ' +
-										'This lets the plugin know the location of the dashboard.' ) }
-								</FormSettingExplanation>
 							</FormFieldset>
 
 							<FormFieldset>
 								<FormLabel htmlFor="listingsPage">
 									{ translate( 'Job Listings Page' ) }
 								</FormLabel>
+								<FormSettingExplanation>
+									{ translate( 'Select the page where you\'ve used the [jobs] shortcode. ' +
+										'This lets the plugin know the location of the job listings page.' ) }
+								</FormSettingExplanation>
 								<PageDropdown
 									disabled={ isDisabled }
 									id="listingsPage"
 									name="listingsPage"
 									pages={ pages } />
-								<FormSettingExplanation>
-									{ translate( 'Select the page where you\'ve used the [jobs] shortcode. ' +
-										'This lets the plugin know the location of the job listings page.' ) }
-								</FormSettingExplanation>
 							</FormFieldset>
 						</Card>
 					</FormSection>

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -42,7 +42,9 @@ class Pages extends Component {
 
 		return (
 			<div>
-				<QueryPosts siteId={ siteId } query={ { type: 'page' } } />
+				{ siteId &&
+					<QueryPosts siteId={ siteId } query={ { type: 'page' } } />
+				}
 
 				<form>
 					<FormSection name="pages">
@@ -109,7 +111,7 @@ const connectComponent = connect(
 
 		return {
 			isRequesting: isRequestingSitePostsForQuery( state, siteId, { type: 'page' } ),
-			pages: getSitePosts( state, siteId ),
+			pages: ( siteId && getSitePosts( state, siteId ) ) || [],
 			siteId,
 		};
 	}

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -52,11 +52,12 @@ class Pages extends Component {
 						</SectionHeader>
 						<Card>
 							<FormFieldset>
-								<FormLabel>
+								<FormLabel htmlFor="submitFormPage">
 									{ translate( 'Submit Job Form Page' ) }
 								</FormLabel>
 								<PageDropdown
 									disabled={ isDisabled }
+									id="submitFormPage"
 									name="submitFormPage"
 									pages={ pages } />
 								<FormSettingExplanation>
@@ -66,11 +67,12 @@ class Pages extends Component {
 							</FormFieldset>
 
 							<FormFieldset>
-								<FormLabel>
+								<FormLabel htmlFor="dashboardPage">
 									{ translate( 'Job Dashboard Page' ) }
 								</FormLabel>
 								<PageDropdown
 									disabled={ isDisabled }
+									id="dashboardPage"
 									name="dashboardPage"
 									pages={ pages } />
 								<FormSettingExplanation>
@@ -80,11 +82,12 @@ class Pages extends Component {
 							</FormFieldset>
 
 							<FormFieldset>
-								<FormLabel>
+								<FormLabel htmlFor="listingsPage">
 									{ translate( 'Job Listings Page' ) }
 								</FormLabel>
 								<PageDropdown
 									disabled={ isDisabled }
+									id="listingsPage"
 									name="listingsPage"
 									pages={ pages } />
 								<FormSettingExplanation>

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -1,5 +1,113 @@
-const Pages = () => {
-	return null;
-};
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { FormSection, reduxForm } from 'redux-form';
+import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
 
-export default Pages;
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import PageDropdown from './page-dropdown';
+import QueryPosts from 'components/data/query-posts';
+import SectionHeader from 'components/section-header';
+import { getSitePosts } from 'state/posts/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class Pages extends Component {
+	static propTypes = {
+		pages: PropTypes.array,
+		siteId: PropTypes.number,
+		translate: PropTypes.func,
+	};
+
+	render() {
+		const {
+			pages,
+			siteId,
+			translate,
+		} = this.props;
+
+		return (
+			<div>
+				<QueryPosts siteId={ siteId } query={ { type: 'page' } } />
+
+				<form>
+					<FormSection name="pages">
+						<SectionHeader label={ translate( 'Pages' ) }>
+							<FormButton compact />
+						</SectionHeader>
+						<Card>
+							<FormFieldset>
+								<FormLabel>
+									{ translate( 'Submit Job Form Page' ) }
+								</FormLabel>
+								<PageDropdown
+									name="submitFormPage"
+									pages={ pages } />
+								<FormSettingExplanation>
+									{ translate( 'Select the page where you have placed the [submit_job_form] shortcode. ' +
+										'This lets the plugin know where the form is located.' ) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormLabel>
+									{ translate( 'Job Dashboard Page' ) }
+								</FormLabel>
+								<PageDropdown
+									name="dashboardPage"
+									pages={ pages } />
+								<FormSettingExplanation>
+									{ translate( 'Select the page where you have placed the [job_dashboard] shortcode. ' +
+										'This lets the plugin know where the dashboard is located.' ) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormLabel>
+									{ translate( 'Job Listings Page' ) }
+								</FormLabel>
+								<PageDropdown
+									name="listingsPage"
+									pages={ pages } />
+								<FormSettingExplanation>
+									{ translate( 'Select the page where you have placed the [jobs] shortcode. ' +
+										'This lets the plugin know where the job listings page is located.' ) }
+								</FormSettingExplanation>
+							</FormFieldset>
+						</Card>
+					</FormSection>
+				</form>
+			</div>
+		);
+	}
+}
+
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const pages = getSitePosts( state, siteId );
+
+		return { pages, siteId };
+	}
+);
+
+const createReduxForm = reduxForm( {
+	enableReinitialize: true,
+	form: 'pages',
+	getFormState: state => state.extensions.wpJobManager.form,
+} );
+
+export default flowRight(
+	connectComponent,
+	localize,
+	createReduxForm,
+)( Pages );

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -21,6 +21,8 @@ import SectionHeader from 'components/section-header';
 import { getSitePosts, isRequestingSitePostsForQuery } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
+const query = { type: 'page' };
+
 class Pages extends Component {
 	static propTypes = {
 		isDisabled: PropTypes.bool,
@@ -43,7 +45,7 @@ class Pages extends Component {
 		return (
 			<div>
 				{ siteId &&
-					<QueryPosts siteId={ siteId } query={ { type: 'page' } } />
+					<QueryPosts siteId={ siteId } query={ query } />
 				}
 
 				<form>
@@ -110,7 +112,7 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			isRequesting: isRequestingSitePostsForQuery( state, siteId, { type: 'page' } ),
+			isRequesting: isRequestingSitePostsForQuery( state, siteId, query ),
 			pages: ( siteId && getSitePosts( state, siteId ) ) || [],
 			siteId,
 		};

--- a/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
@@ -8,9 +8,9 @@ import React, { PropTypes } from 'react';
  */
 import ReduxFormSelect from 'components/redux-forms/redux-form-select';
 
-const PageDropdown = ( { disabled, name, pages } ) => {
+const PageDropdown = ( { name, pages, ...otherProps } ) => {
 	return (
-		<ReduxFormSelect disabled={ disabled } name={ name }>
+		<ReduxFormSelect name={ name } { ...otherProps }>
 			{ pages.map( ( { ID, title } ) => (
 				<option key={ ID } value={ ID }>
 					{ title }

--- a/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
@@ -2,13 +2,17 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import ReduxFormSelect from 'components/redux-forms/redux-form-select';
+import { getSitePosts } from 'state/posts/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-const PageDropdown = ( { name, pages, ...otherProps } ) => {
+// eslint-disable-next-line no-unused-vars
+const PageDropdown = ( { dispatch, name, pages, ...otherProps } ) => {
 	return (
 		<ReduxFormSelect name={ name } { ...otherProps }>
 			{ pages.map( ( { ID, title } ) => (
@@ -25,4 +29,14 @@ PageDropdown.propTypes = {
 	pages: PropTypes.array,
 };
 
-export default PageDropdown;
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			pages: ( siteId && getSitePosts( state, siteId ) ) || [],
+		};
+	}
+);
+
+export default connectComponent( PageDropdown );

--- a/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ReduxFormSelect from 'components/redux-forms/redux-form-select';
+
+const PageDropdown = ( { disabled, name, pages } ) => {
+	return (
+		<ReduxFormSelect disabled={ disabled } name={ name }>
+			{ pages.map( ( { ID, title } ) => (
+				<option key={ ID } value={ ID }>
+					{ title }
+				</option>
+			) ) }
+		</ReduxFormSelect>
+	);
+};
+
+PageDropdown.propTypes = {
+	name: PropTypes.string,
+	pages: PropTypes.array,
+};
+
+export default PageDropdown;

--- a/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/page-dropdown.jsx
@@ -21,7 +21,7 @@ const PageDropdown = ( { disabled, name, pages } ) => {
 };
 
 PageDropdown.propTypes = {
-	name: PropTypes.string,
+	name: PropTypes.string.isRequired,
 	pages: PropTypes.array,
 };
 

--- a/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
@@ -96,6 +96,11 @@ describe( '#updateExtensionSettings', () => {
 				hideExpiredContent: undefined
 			},
 			method: { applicationMethod: undefined },
+			pages: {
+				dashboardPage: undefined,
+				listingsPage: undefined,
+				submitFormPage: undefined,
+			},
 			types: {
 				enableTypes: undefined,
 				multiJobType: undefined

--- a/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
@@ -11,11 +11,14 @@ export const fromApi = ( {
 	job_manager_hide_expired,
 	job_manager_hide_expired_content,
 	job_manager_hide_filled_positions,
+	job_manager_job_dashboard_page_id,
+	job_manager_jobs_page_id,
 	job_manager_multi_job_type,
 	job_manager_per_page,
 	job_manager_registration_role,
 	job_manager_submission_duration,
 	job_manager_submission_requires_approval,
+	job_manager_submit_job_form_page_id,
 	job_manager_user_can_edit_pending_submissions,
 	job_manager_user_requires_account,
 } ) => ( {
@@ -51,6 +54,11 @@ export const fromApi = ( {
 	},
 	method: {
 		applicationMethod: job_manager_allowed_application_method,
+	},
+	pages: {
+		dashboardPage: job_manager_job_dashboard_page_id,
+		listingsPage: job_manager_jobs_page_id,
+		submitFormPage: job_manager_submit_job_form_page_id,
 	},
 	types: {
 		enableTypes: job_manager_enable_types,


### PR DESCRIPTION
This PR adds the UI and fetches live data for the WP Job Manager _Pages_ tab.

_Pages Tab in Calypso_

![wpjm-pages](https://user-images.githubusercontent.com/1190420/28363829-01e2a080-6c50-11e7-9adf-5efadaf596f2.jpg)

_Pages Tab in Plugin_

![pages-plugin](https://user-images.githubusercontent.com/1190420/28270301-ef8812e0-6ad2-11e7-9b58-1e620f231412.jpg)

## Testing

Testing should verify that real data is being fetched from the REST API and displayed on the _Pages_ tab, as well as ensuring that settings are initially disabled while data is being fetched. Need to be running [this branch](https://github.com/Automattic/WP-Job-Manager/tree/features/rest-api) of WP Job Manager.