### PR TITLE
Media Library: Fix delete button disability when it should be disabled

### DIFF
--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -66,12 +66,13 @@ class MediaModalSecondaryActions extends Component {
 		} );
 
 		if ( ModalViews.GALLERY !== view && canDeleteItems ) {
+			const isButtonDisabled = disabled || some( selectedItems, 'transient' );
 			buttons.push( {
 				key: 'delete',
 				icon: 'trash',
 				className: 'editor-media-modal__delete',
-				disabled: disabled || some( selectedItems, 'transient' ),
-				onClick: onDelete
+				disabled: isButtonDisabled,
+				onClick: ( isButtonDisabled ) ? noop : onDelete
 			} );
 		}
 


### PR DESCRIPTION
Hi,

fixes [#15706](https://github.com/Automattic/wp-calypso/issues/15706).