### PR TITLE
Woo-Connect Insights: Add/wcss listview period selectors

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -83,6 +83,7 @@ export const UNITS = {
 		format: 'YYYY-MM-DD',
 		sinceFormat: 'MMM D',
 		chartFormat: 'labelDay',
+		title: translate( 'Days' )
 	},
 	week: {
 		quantity: 30,
@@ -91,6 +92,7 @@ export const UNITS = {
 		format: 'YYYY-[W]WW',
 		sinceFormat: 'MMM D',
 		chartFormat: 'labelWeek',
+		title: translate( 'Weeks' )
 	},
 	month: {
 		quantity: 12,
@@ -99,6 +101,7 @@ export const UNITS = {
 		format: 'YYYY-MM',
 		sinceFormat: 'MMM [\']YY',
 		chartFormat: 'labelMonth',
+		title: translate( 'Months' )
 	},
 	year: {
 		quantity: 10,
@@ -107,5 +110,6 @@ export const UNITS = {
 		format: 'YYYY',
 		sinceFormat: 'YYYY',
 		chartFormat: 'labelYear',
+		title: translate( 'Years' )
 	}
 };

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -9,21 +9,24 @@ import { moment } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import HeaderCake from 'components/header-cake';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import DatePicker from 'my-sites/stats/stats-date-picker';
-import Module from './store-stats-module';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getUnitPeriod } from './utils';
+import HeaderCake from 'components/header-cake';
+import { isJetpackSite } from 'state/sites/selectors';
+import { isPluginActive } from 'state/selectors';
 import List from './store-stats-list';
+import Main from 'components/main';
+import Module from './store-stats-module';
+import SectionNav from 'components/section-nav';
+import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
+import StoreStatsNavigationTabs from './store-stats-navigation/navtabs';
 import {
 	topProducts,
 	topCategories,
-	topCoupons
+	topCoupons,
+	UNITS
 } from 'woocommerce/app/store-stats/constants';
-import { getUnitPeriod } from './utils';
-import { isJetpackSite } from 'state/sites/selectors';
-import { isPluginActive } from 'state/selectors';
 
 const listType = {
 	products: topProducts,
@@ -86,6 +89,15 @@ class StoreStatsListView extends Component {
 						showQueryDate
 					/>
 				</StatsPeriodNavigation>
+				<SectionNav className="store-stats__list-view-navigation" selectedText={ UNITS[ unit ].title }>
+					<StoreStatsNavigationTabs
+						label={ 'Stats' }
+						slug={ slug }
+						type={ type }
+						unit={ unit }
+						units={ UNITS }
+					/>
+				</SectionNav>
 				<Module
 					siteId={ siteId }
 					emptyMessage={ listType[ type ].empty }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -8,33 +8,23 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
+import StoreStatsNavigationTabs from './navtabs';
 import FollowersCount from 'blocks/followers-count';
 import SegmentedControl from 'components/segmented-control';
+import { UNITS } from 'woocommerce/app/store-stats/constants';
 
 const StoreStatsNavigation = props => {
 	const { translate, slug, type, unit } = props;
-	const units = {
-		day: translate( 'Days' ),
-		week: translate( 'Weeks' ),
-		month: translate( 'Months' ),
-		year: translate( 'Years' ),
-	};
 	return (
 		<div className="store-stats-navigation">
-			<SectionNav selectedText={ units[ unit ] }>
-				<NavTabs label={ translate( 'Stats' ) }>
-					{ Object.keys( units ).map( key => (
-						<NavItem
-							key={ key }
-							path={ `/store/stats/${ type }/${ key }/${ slug }` }
-							selected={ unit === key }
-						>
-							{ units[ key ] }
-						</NavItem>
-					) ) }
-				</NavTabs>
+			<SectionNav selectedText={ UNITS[ unit ].title }>
+				<StoreStatsNavigationTabs
+					label={ 'Stats' }
+					slug={ slug }
+					type={ type }
+					unit={ unit }
+					units={ UNITS }
+				/>
 				<SegmentedControl
 					initialSelected="store"
 					options={ [

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
@@ -1,0 +1,38 @@
+/**
+ * External Dependencies
+ */
+import React, { PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+
+const StoreStatsNavigationTabs = props => {
+	const { label, slug, type, unit, units } = props;
+	return (
+		<NavTabs label={ label }>
+			{ Object.keys( units ).map( key => (
+				<NavItem
+					key={ key }
+					path={ `/store/stats/${ type }/${ key }/${ slug }` }
+					selected={ unit === key }
+				>
+					{ units[ key ].title }
+				</NavItem>
+			) ) }
+		</NavTabs>
+	);
+};
+
+StoreStatsNavigationTabs.propTypes = {
+	label: PropTypes.string,
+	slug: PropTypes.string,
+	type: PropTypes.string,
+	unit: PropTypes.string,
+	units: PropTypes.object,
+};
+
+export default localize( StoreStatsNavigationTabs );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React, { PropTypes } from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -35,4 +34,4 @@ StoreStatsNavigationTabs.propTypes = {
 	units: PropTypes.object,
 };
 
-export default localize( StoreStatsNavigationTabs );
+export default StoreStatsNavigationTabs;

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -8,6 +8,13 @@
 	width: 100%;
 }
 
+.store-stats__list-view-navigation {
+	&.section-nav {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+
 @include breakpoint( ">960px" ) {
 	.store-stats__widgets {
 		flex-direction: row;


### PR DESCRIPTION
Adds in period navigation to the `listview` pages for Store Stats:
![screen shot 2017-07-17 at 4 18 54 pm](https://user-images.githubusercontent.com/1160732/28272418-bbed5f06-6b0b-11e7-8f13-59279d44278b.png)

Fixes #16279 