### PR TITLE
Plans: Fix plan upgrade track events attribute names

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -35,8 +35,8 @@ class PlanBillingPeriod extends Component {
 
 		addItem( planItem( yearlyPlanSlug ) );
 		this.props.recordTracksEvent( 'calypso_purchase_details_plan_upgrade_click', {
-			currentPlan: purchase.productSlug,
-			upgradingTo: yearlyPlanSlug,
+			current_plan: purchase.productSlug,
+			upgrading_to: yearlyPlanSlug,
 		} );
 		page( '/checkout/' + purchase.domain );
 	};

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -76,8 +76,8 @@ const PlanFeaturesActions = ( {
 			}
 
 			trackTracksEvent( 'calypso_plan_features_upgrade_click', {
-				currentPlan: currentSitePlan && currentSitePlan.productSlug,
-				upgradingTo: planType,
+				current_plan: currentSitePlan && currentSitePlan.productSlug,
+				upgrading_to: planType,
 			} );
 
 			onUpgradeClick();


### PR DESCRIPTION
This PR fixes the attributes of the plan upgrade tracks events, because capital letters are not allowed in the attribute names.