### PR TITLE
Reader: Fix the update pill on tags and like streams

### DIFF
--- a/client/lib/feed-post-store/post-fetcher.js
+++ b/client/lib/feed-post-store/post-fetcher.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { assign, noop, omit } from 'lodash';
+import { assign, noop, pick } from 'lodash';
 import Immutable from 'immutable';
 
 /**
@@ -23,7 +23,7 @@ function PostFetcher( options ) {
 assign( PostFetcher.prototype, {
 
 	add: function( postKey ) {
-		this.postsToFetch = this.postsToFetch.add( Immutable.fromJS( omit( postKey, 'localMoment' ) ) );
+		this.postsToFetch = this.postsToFetch.add( Immutable.fromJS( pick( postKey, [ 'feedId', 'blogId', 'postId' ] ) ) );
 
 		if ( ! this.batchQueued ) {
 			this.batchQueued = setTimeout( this.run.bind( this ), 100 );
@@ -31,7 +31,7 @@ assign( PostFetcher.prototype, {
 	},
 
 	remove: function( postKey ) {
-		this.postsToFetch = this.postsToFetch.delete( Immutable.fromJS( omit( postKey, 'localMoment' ) ) );
+		this.postsToFetch = this.postsToFetch.delete( Immutable.fromJS( pick( postKey, [ 'feedId', 'blogId', 'postId' ] ) ) );
 	},
 
 	run: function() {

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -8,7 +8,6 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import Dispatcher from 'dispatcher';
 import Emitter from 'lib/mixins/emitter';
 import FeedPostStore from 'lib/feed-post-store';
 import * as FeedStreamActions from './actions';
@@ -83,8 +82,6 @@ export default class FeedStream {
 		if ( action.id !== this.id ) {
 			return;
 		}
-
-		Dispatcher.waitFor( [ FeedPostStore.dispatchToken ] );
 
 		switch ( action.type ) {
 			case ActionTypes.RECEIVE_PAGE:
@@ -237,7 +234,7 @@ export default class FeedStream {
 		do {
 			const key = this.postKeys[ i ];
 			if ( ! key.isGap ) {
-				date = FeedPostStore.get( key )[ this.dateProperty ];
+				date = key[ this.dateProperty ];
 			}
 			--i;
 		} while ( ! date && i !== -1 );
@@ -256,7 +253,7 @@ export default class FeedStream {
 		do {
 			const key = this.postKeys[ i ];
 			if ( ! key.isGap ) {
-				date = FeedPostStore.get( key )[ this.dateProperty ];
+				date = key[ this.dateProperty ];
 			}
 			++i;
 		} while ( ! date && i < this.postKeys.length );
@@ -475,7 +472,7 @@ export default class FeedStream {
 			if ( postKeys.length > 0 ) {
 				this.pendingPostKeys = postKeys;
 				this.pendingDateAfter = moment(
-					FeedPostStore.get( this.keyMaker( data.posts[ data.posts.length - 1 ] ) )[
+					this.keyMaker( data.posts[ data.posts.length - 1 ] )[
 						this.dateProperty
 					],
 				);
@@ -495,7 +492,7 @@ export default class FeedStream {
 		} );
 
 		const mostRecentPostDate = moment(
-			FeedPostStore.get( this.postKeys[ 0 ] )[ this.dateProperty ],
+			this.postKeys[ 0 ][ this.dateProperty ],
 		);
 
 		if ( this.pendingDateAfter > mostRecentPostDate ) {
@@ -539,7 +536,7 @@ export default class FeedStream {
 		const beforeGap = this.postKeys.slice( 0, indexOfGap ),
 			afterGap = this.postKeys.slice( indexOfGap + 1 ),
 			gapItems = this.filterNewPosts( posts ),
-			afterGapDate = moment( FeedPostStore.get( afterGap[ 0 ] )[ this.dateProperty ] );
+			afterGapDate = moment( afterGap[ 0 ][ this.dateProperty ] );
 
 		if ( posts.length === this.gapFillCount ) {
 			if ( moment( posts[ posts.length - 1 ][ this.dateProperty ] ) > afterGapDate ) {

--- a/client/lib/feed-stream-store/paged-stream.js
+++ b/client/lib/feed-stream-store/paged-stream.js
@@ -9,7 +9,6 @@ const debug = debugFactory( 'calypso:feed-store:post-list-store' );
 /**
  * Internal Dependencies
  */
-import Dispatcher from 'dispatcher';
 import Emitter from 'lib/mixins/emitter';
 import FeedPostStore from 'lib/feed-post-store';
 import { action as ActionTypes } from './constants';
@@ -64,8 +63,6 @@ export default class PagedStream {
 		if ( action.id !== this.id ) {
 			return;
 		}
-
-		Dispatcher.waitFor( [ FeedPostStore.dispatchToken ] );
 
 		switch ( action.type ) {
 

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -23,25 +23,26 @@ describe( 'reader stream', () => {
 		injectRecommendations = utils.injectRecommendations;
 	} );
 
-	const postKey1 = { feedId: 'feed1', postId: 'postId1' };
-	const postKey2 = { feedId: 'feed1', postId: 'postId2' };
+	const today = moment( '1976-09-15' ).toDate();
+	const postKey1 = { feedId: 'feed1', postId: 'postId1', date: today };
+	const postKey2 = { feedId: 'feed1', postId: 'postId2', date: today };
 	const postIds34 = [ 'postId3', 'postId4' ];
 	const postIds57 = [ 'postId5', 'postId6', 'postId7' ];
 	const combinedCardPostKey1 = {
 		feedId: postKey1.feedId,
 		postIds: postIds34,
-		localMoment: undefined,
+		date: today,
 		isCombination: true,
 	};
 	const combinedCardPostKey2 = {
 		feedId: postKey1.feedId,
 		postIds: postIds57,
-		localMoment: undefined,
+		date: today,
 		isCombination: true,
 	};
 
 	describe( '#sameDay', () => {
-		const momentPostKey = localMoment => ( { localMoment } );
+		const momentPostKey = localMoment => ( { date: localMoment.toDate() } );
 		const today = moment();
 		const todayPostKey = momentPostKey( today );
 		const todayPostKey2 = momentPostKey( moment() );
@@ -103,7 +104,7 @@ describe( 'reader stream', () => {
 				feedId: postKey1.feedId,
 				postIds: [ postKey1.postId, postKey2.postId ],
 				isCombination: true,
-				localMoment: undefined,
+				date: today,
 			} );
 		} );
 
@@ -130,13 +131,13 @@ describe( 'reader stream', () => {
 	} );
 
 	describe( '#combineCards', () => {
-		const localMoment = moment();
-		const site1Key1 = { blogId: '1', postId: '11', localMoment };
-		const site1Key2 = { blogId: '1', postId: '12', localMoment };
-		const site1Key3 = { blogId: '1', postId: '13', localMoment };
-		const site2Key2 = { blogId: '2', postId: '22', localMoment };
-		const site3Key1 = { blogId: '3', postId: '31', localMoment };
-		const site4Key1 = { blogId: '4', postId: '41', localMoment };
+		const date = new Date();
+		const site1Key1 = { blogId: '1', postId: '11', date };
+		const site1Key2 = { blogId: '1', postId: '12', date };
+		const site1Key3 = { blogId: '1', postId: '13', date };
+		const site2Key2 = { blogId: '2', postId: '22', date };
+		const site3Key1 = { blogId: '3', postId: '31', date };
+		const site4Key1 = { blogId: '4', postId: '41', date };
 
 		it( 'should combine series with 2 in a rows', () => {
 			const postKeysSet1 = [ site1Key1, site1Key2 ];
@@ -170,12 +171,12 @@ describe( 'reader stream', () => {
 			const discoverFeedId = 41325786;
 			const discoverSiteId = 53424024;
 			const discoverFeedPostKeys = [
-				{ feedId: discoverFeedId, postId: '1', localMoment: moment() },
-				{ feedId: discoverFeedId, postId: '2', localMoment: moment() },
+				{ feedId: discoverFeedId, postId: '1', date },
+				{ feedId: discoverFeedId, postId: '2', date },
 			];
 			const discoverSitePostKeys = [
-				{ blogId: discoverSiteId, postId: '1', localMoment: moment() },
-				{ blogId: discoverSiteId, postId: '2', localMoment: moment() },
+				{ blogId: discoverSiteId, postId: '1', date },
+				{ blogId: discoverSiteId, postId: '2', date },
 			];
 			const combinedFeedItems = combineCards( discoverFeedPostKeys );
 			const combinedSiteItems = combineCards( discoverSitePostKeys );
@@ -185,8 +186,8 @@ describe( 'reader stream', () => {
 		} );
 
 		it( 'should not combine cards that are greater than a day apart', () => {
-			const theDistantPast = moment().year( -1 );
-			const postKeys = [ site1Key1, { ...site1Key2, localMoment: theDistantPast } ];
+			const theDistantPast = moment().year( -1 ).toDate();
+			const postKeys = [ site1Key1, { ...site1Key2, date: theDistantPast } ];
 			const combinedItems = combineCards( postKeys );
 			expect( combinedItems ).eql( postKeys );
 		} );

--- a/client/reader/stream/test/utils.js
+++ b/client/reader/stream/test/utils.js
@@ -23,7 +23,7 @@ describe( 'reader stream', () => {
 		injectRecommendations = utils.injectRecommendations;
 	} );
 
-	const today = moment( '1976-09-15' ).toDate();
+	const today = moment().toDate();
 	const postKey1 = { feedId: 'feed1', postId: 'postId1', date: today };
 	const postKey2 = { feedId: 'feed1', postId: 'postId2', date: today };
 	const postIds34 = [ 'postId3', 'postId4' ];
@@ -42,13 +42,12 @@ describe( 'reader stream', () => {
 	};
 
 	describe( '#sameDay', () => {
-		const momentPostKey = localMoment => ( { date: localMoment.toDate() } );
-		const today = moment();
-		const todayPostKey = momentPostKey( today );
-		const todayPostKey2 = momentPostKey( moment() );
-		const oneYearAgoPostKey = momentPostKey( moment().year( today.year() - 1 ) );
-		const oneYearInTheFuturePostKey = momentPostKey( moment().year( today.year() + 1 ) );
-		const oneMonthAgoPostKey = momentPostKey( moment().month( today.month() - 1 ) );
+		const datePostKey = date => ( { date } );
+		const todayPostKey = datePostKey( today );
+		const todayPostKey2 = datePostKey( new Date() );
+		const oneYearAgoPostKey = datePostKey( moment( today ).subtract( 1, 'year' ).toDate() );
+		const oneYearInTheFuturePostKey = datePostKey( moment( today ).add( 1, 'year' ).toDate() );
+		const oneMonthAgoPostKey = datePostKey( moment( today ).subtract( 1, 'month' ).toDate() );
 
 		it( 'should return true when two days are the same day', () => {
 			assert( sameDay( todayPostKey, todayPostKey2 ) );

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { flatMap, last } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ export function sameSite( postKey1, postKey2 ) {
 }
 
 export function sameDay( postKey1, postKey2 ) {
-	return postKey1.localMoment.isSame( postKey2.localMoment, 'day' );
+	return moment( postKey1.date ).isSame( postKey2.date, 'day' );
 }
 
 /**
@@ -51,10 +52,10 @@ export function combine( postKey1, postKey2 ) {
 
 	const combined = {
 		isCombination: true,
-		localMoment:
-			postKey1.localMoment && postKey1.localMoment.isBefore( postKey2.localMoment ) // keep the earliest moment
-				? postKey1.localMoment
-				: postKey2.localMoment,
+		date:
+			postKey1.date && postKey1.date < postKey2.date // keep the earliest moment
+				? postKey1.date
+				: postKey2.date,
 		postIds: [
 			...( postKey1.postIds || [ postKey1.postId ] ),
 			...( postKey2.postIds || [ postKey2.postId ] ),


### PR DESCRIPTION
Move the ordering key into postKey and change where the feed stream (and some utils) look for the ordering key. This makes the postKey the single source of truth for determining order and update polling.  

to test, pull up a frequently updated tag stream and wait. You should eventually see an update pill. Clicking on the pill will load the missing posts.

Also, test that the normal following stream still gets an update pill and that paging works as expected. 

A good test: http://calypso.localhost:3000/tag/photography