### PR TITLE
Session Restore: Move to a controller

### DIFF
--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -20,6 +20,7 @@ import {
 	sidebar,
 	updateLastRoute,
 } from './controller';
+import { sessionRestore } from 'root/controller';
 import config from 'config';
 
 function forceTeamA8C( context, next ) {
@@ -29,7 +30,11 @@ function forceTeamA8C( context, next ) {
 
 export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
-		page( '/', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
+		if ( config.isEnabled( 'restore-last-location' ) ) {
+			page( '/', sessionRestore, preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
+		} else {
+			page( '/', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
+		}
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/' );

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -30,11 +30,14 @@ function forceTeamA8C( context, next ) {
 
 export default function() {
 	if ( config.isEnabled( 'reader' ) ) {
-		if ( config.isEnabled( 'restore-last-location' ) ) {
-			page( '/', sessionRestore, preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
-		} else {
-			page( '/', preloadReaderBundle, initAbTests, updateLastRoute, sidebar, following );
-		}
+		page( '/', ...[
+			config.isEnabled( 'restore-last-location' ) && sessionRestore,
+			preloadReaderBundle,
+			initAbTests,
+			updateLastRoute,
+			sidebar,
+			following,
+		].filter( Boolean ) );
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/' );

--- a/client/root/controller.js
+++ b/client/root/controller.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import { get } from 'lodash';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { getSavedPath } from 'lib/restore-last-path';
+
+const debug = debugFactory( 'calypso:restore-last-location' );
+
+function sessionRestore( context, next ) {
+	const querystring = get( context, 'querystring', '' );
+	if ( querystring.length ) {
+		debug( 'cannot restore: has query string' );
+		return next();
+	}
+
+	// Attempt to restore the last path on the first run
+	getSavedPath()
+		.then( ( lastPath ) => {
+			debug( 'restoring: ' + lastPath );
+			page( lastPath );
+		} )
+		.catch( ( reason ) => {
+			debug( 'cannot restore', reason );
+			next();
+		} );
+}
+
+export default {
+	sessionRestore,
+};

--- a/client/root/controller.js
+++ b/client/root/controller.js
@@ -12,7 +12,7 @@ import { getSavedPath } from 'lib/restore-last-path';
 
 const debug = debugFactory( 'calypso:restore-last-location' );
 
-function sessionRestore( context, next ) {
+export function sessionRestore( context, next ) {
 	const querystring = get( context, 'querystring', '' );
 	if ( querystring.length ) {
 		debug( 'cannot restore: has query string' );
@@ -30,7 +30,3 @@ function sessionRestore( context, next ) {
 			next();
 		} );
 }
-
-export default {
-	sessionRestore,
-};

--- a/client/state/routing/middleware.js
+++ b/client/state/routing/middleware.js
@@ -3,15 +3,11 @@
  */
 import debugFactory from 'debug';
 import { isEmpty } from 'lodash';
-import page from 'page';
 
 /**
  * Internal dependencies
  */
-import {
-	getSavedPath,
-	savePath,
-} from 'lib/restore-last-path';
+import { savePath } from 'lib/restore-last-path';
 import { ROUTE_SET } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:restore-last-location' );
@@ -30,17 +26,8 @@ export const routingMiddleware = () => {
 		const isFirstRun = ! hasInitialized;
 		hasInitialized = true;
 
-		if ( isFirstRun && action.path === '/' ) {
-			// Attempt to restore the last path on the first run
-			return getSavedPath()
-					.then( ( lastPath ) => {
-						debug( 'restoring: ' + lastPath );
-						page( lastPath );
-					} )
-					.catch( ( reason ) => {
-						debug( 'cannot restore', reason );
-						next( action );
-					} );
+		if ( isFirstRun || action.path === '/' ) {
+			return next( action );
 		}
 
 		// Attempt to save the path so it might be restored in the future


### PR DESCRIPTION
When the feature flag is enabled, browsing to the root (`/`), will apply the `sessionRestore` controller function which attempts to restore the previous path if it is present & valid in the browser's storage.
If the path is not restored, the existing chain of Reader controllers are applied.

This is another pared-down version of #15582 which does not establish any new sections for the root & allows for testing this behavior behind a feature flag.

This is enabled by the restore side being pulled out into a library in #16058.

See also:
- #14070
- #15051

## To Test

Familiarize yourself with the existing behavior on the `master` branch: In dev, whitelisted routes will get saved on route change & that path will be "restored" when browsing to `/`.

* Prevent blocking state rehydration by running like so: `ENABLE_FEATURES=no-force-sympathy npm start`
* In your console, execute: `localStorage.setItem( 'debug', 'calypso:restore-last-location' )`
* Click around & watch the paths get saved in your console
* Browse directly to `/` & see the previously saved path get restored (**Notice** the Reader fully loads before the redirect)

Checkout this branch & repeat the above. The Reader should **NOT** load before the redirect, so, consequentially, it should be much quicker and friendlier :)

Behavior should be otherwise identical.