### PR TITLE
Editor: Pass null context when autosaving post

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -197,7 +197,7 @@ PostActions = {
 				callback( error, data );
 			} );
 		} else {
-			PostActions.saveEdited( null, callback, { recordSaveEvent: false } );
+			PostActions.saveEdited( null, null, callback, { recordSaveEvent: false } );
 		}
 	},
 


### PR DESCRIPTION
This PR fixes #16298, which was introduced with #16253 

To test that fix works:

1. Starting at URL: https://wordpress.com/post/example.wordpress.com
2. Type some text in the body of the post
3. Click Preview or wait for the post to auto-save

Verify that draft is saved and no console error is thrown.

