### PR TITLE
Activity log: Expand ActivitLogItem when the card is clicked

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -20,6 +20,8 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
 
 const debug = debugFactory( 'calypso:activity-log:item' );
 
+const stopPropagation = event => event.stopPropagation();
+
 class ActivityLogItem extends Component {
 	static propTypes = {
 		applySiteOffset: PropTypes.func.isRequired,
@@ -248,7 +250,10 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div className="activity-log-item__action">
-				<EllipsisMenu position="bottom right">
+				<EllipsisMenu
+					onClick={ stopPropagation }
+					position="bottom right"
+				>
 					<PopoverMenuItem
 						disabled={ disableRestore }
 						icon="undo"
@@ -295,6 +300,7 @@ class ActivityLogItem extends Component {
 				</div>
 				<FoldableCard
 					className="activity-log-item__card"
+					clickableHeader
 					expandedSummary={ this.renderSummary() }
 					header={ this.renderHeader() }
 					onOpen={ this.handleOpen }


### PR DESCRIPTION
**Warning:** PR will produce buggy behavior if merged prior to #16302 ✅ .

Allow activity items to be expanded by clicking on the header

## To test
1. https://calypso.live/stats/activity?branch=update/activitylog-item-clickableheader
1. Expand a day
1. Click an item's header. It should expand an collapse.
1. ✅  ~Prior to #16302, clicking the `EllipsisMenu` will also trigger expand and collapse. The functionality exists in this PR to correct that.~

## Examples

![good](https://user-images.githubusercontent.com/841763/28284930-1a4a93f8-6b33-11e7-8a85-893f3c2583dc.gif)

<!-- FIX LANDED

### 👎  Without 😭 

![bad](https://user-images.githubusercontent.com/841763/28284928-1738da80-6b33-11e7-82f4-51f99904d067.gif)
-->

✅  Depends on #16302
Closes #16196 