### PR TITLE
Add onClick to EllipsisMenu to allow event handling

### DIFF
--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -24,6 +24,28 @@ export default function MyComponent( { onMenuItemClick } ) {
 
 ## Props
 
+### `onClick`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>noop</code></td></tr>
+</table>
+
+Callback that will be invoked when menu button is clicked.
+Will be passed the click event.
+
+### `onToggle`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>noop</code></td></tr>
+</table>
+
+Callback that will be invoked when menu is toggled.
+Will be passed the boolean visibility of the menu.
+
 ### `toggleTitle`
 
 <table>

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -20,12 +20,14 @@ class EllipsisMenu extends Component {
 		position: PropTypes.string,
 		children: PropTypes.node,
 		disabled: PropTypes.bool,
+		onClick: PropTypes.func,
 		onToggle: PropTypes.func,
 		popoverClassName: PropTypes.string,
 	};
 
 	static defaultProps = {
-		onToggle: noop
+		onClick: noop,
+		onToggle: noop,
 	}
 
 	constructor() {
@@ -41,6 +43,19 @@ class EllipsisMenu extends Component {
 
 		this.setPopoverContext = this.setPopoverContext.bind( this );
 	}
+
+	handleClick = ( event ) => {
+		const { onClick } = this.props;
+		const { isMenuVisible } = this.state;
+		if ( onClick ) {
+			onClick( event );
+		}
+		if ( isMenuVisible ) {
+			this.hideMenu();
+		} else {
+			this.showMenu();
+		}
+	};
 
 	setPopoverContext( popoverContext ) {
 		if ( popoverContext ) {
@@ -68,7 +83,7 @@ class EllipsisMenu extends Component {
 			<span className={ classes }>
 				<Button
 					ref={ this.setPopoverContext }
-					onClick={ isMenuVisible ? this.hideMenu : this.showMenu }
+					onClick={ this.handleClick }
 					title={ toggleTitle || translate( 'Toggle menu' ) }
 					borderless
 					disabled={ disabled }

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -47,9 +47,9 @@ class EllipsisMenu extends Component {
 	handleClick = ( event ) => {
 		const { onClick } = this.props;
 		const { isMenuVisible } = this.state;
-		if ( onClick ) {
-			onClick( event );
-		}
+
+		onClick( event );
+
 		if ( isMenuVisible ) {
 			this.hideMenu();
 		} else {


### PR DESCRIPTION
This PR adds an `onClick` prop to the `EllipsisMenu`, which will be called with the event when the menu toggling button is clicked.

This is important because otherwise this event is swallowed by the component. When used inside of another component, the event cannot be `stopPropagation`ed in order to not trigger the container events.

Below example behavior before the change (real use case). Note how the menu and card expand and collapse together.

![bad](https://user-images.githubusercontent.com/841763/28284586-cb95edc6-6b31-11e7-9449-935b74b917ac.gif)

Here is the same component passing a `stopPropagation` event handler to the `EllipsisMenu` after the change:

![good](https://user-images.githubusercontent.com/841763/28284626-f0eddc5a-6b31-11e7-930b-efa22e28e786.gif)

Here are the `EllipsisMenu` devdocs after the change showing continued normal functionality.

![ok](https://user-images.githubusercontent.com/841763/28284651-0016c804-6b32-11e7-90c6-dc2c3a625fd8.gif)

## Testing
1. https://calypso.live/devdocs/design/ellipsis-menu?branch=udpate/ellipsis-menu-event-handling
1. Ensure the menu opens and closes as expected.
1. Be sure to test key commands like arrow navigation and <kbd>esc</kbd> to close after keyboard navigating the menu. Compare behavior with [https://wpcalypso.wordpress.com/devdocs/design/ellipsis-menu](wpcalypso) as the keyboard event handling is a bit peculiar.

## Alternatives

This provides the flexible and well known `onClick` prop. A simple alternative would be to provide a `stopPropagation` prop, which would handle calling `event.stopPropagation()` on the click event and likely cover all use cases. I'm open to discussion if anyone thinks the later would be a better approach.


Required for #16301