### PR TITLE
Improve API error handling for the settings/general endpoint

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -17,7 +17,6 @@ import {
 	getNewOrders,
 	getNewOrdersRevenue,
 } from 'woocommerce/state/sites/orders/selectors';
-import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
@@ -25,6 +24,7 @@ import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/gen
 import ProcessOrdersWidget from 'woocommerce/components/process-orders-widget';
 import ShareWidget from 'woocommerce/components/share-widget';
 import Card from 'components/card';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
 class ManageOrdersView extends Component {
 	static propTypes = {
@@ -34,7 +34,6 @@ class ManageOrdersView extends Component {
 			URL: PropTypes.string.isRequired,
 		} ),
 		fetchOrders: PropTypes.func,
-		fetchSettingsGeneral: PropTypes.func,
 		currency: PropTypes.shape( {
 			value: PropTypes.string,
 		} ),
@@ -53,7 +52,6 @@ class ManageOrdersView extends Component {
 
 		if ( site && site.ID ) {
 			this.props.fetchOrders( site.ID );
-			this.props.fetchSettingsGeneral( site.ID );
 		}
 	}
 
@@ -64,7 +62,6 @@ class ManageOrdersView extends Component {
 
 		if ( oldSiteId !== newSiteId ) {
 			this.props.fetchOrders( newSiteId );
-			this.props.fetchSettingsGeneral( newSiteId );
 		}
 	}
 
@@ -100,6 +97,7 @@ class ManageOrdersView extends Component {
 		const { site, translate, orders, user } = this.props;
 		return (
 			<div className="dashboard__manage-has-orders">
+				<QuerySettingsGeneral siteId={ site && site.ID } />
 				<div className="dashboard__manage-has-orders-header">
 					<h2>
 						{ translate( 'Hi, {{storeOwnerName/}}.', {
@@ -162,7 +160,6 @@ function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
 			fetchOrders,
-			fetchSettingsGeneral,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -11,16 +11,16 @@ import React, { Component, PropTypes } from 'react';
  */
 import AddressView from 'woocommerce/components/address-view';
 import {
-	areSettingsGeneralLoading,
+	areSettingsGeneralLoaded,
 	getStoreLocation,
 } from 'woocommerce/state/sites/settings/general/selectors';
 import { errorNotice } from 'state/notices/actions';
-import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getCountryData, getCountries } from 'woocommerce/lib/countries';
 import { setSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/actions';
 import SetupFooter from './setup-footer';
 import SetupHeader from './setup-header';
 import { doInitialSetup } from 'woocommerce/state/sites/settings/actions';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
 class PreSetupView extends Component {
 	constructor( props ) {
@@ -38,23 +38,7 @@ class PreSetupView extends Component {
 		} ),
 	};
 
-	componentDidMount = () => {
-		const { site } = this.props;
-
-		if ( site && site.ID ) {
-			this.props.fetchSettingsGeneral( site.ID );
-		}
-	}
-
 	componentWillReceiveProps = ( newProps ) => {
-		const { site } = this.props;
-		const newSiteId = site.selectedSite ? newProps.selectedSite.ID : null;
-		const oldSiteId = site ? site.ID : null;
-
-		if ( newSiteId && ( oldSiteId !== newSiteId ) ) {
-			this.props.fetchSettingsGeneral( newSiteId );
-		}
-
 		if ( ! this.state.userBeganEditing ) {
 			this.setState( { address: newProps.address } );
 		}
@@ -121,11 +105,11 @@ class PreSetupView extends Component {
 	}
 
 	render = () => {
-		const { loading, site, translate } = this.props;
+		const { loaded, site, translate } = this.props;
 
-		if ( ! site || loading ) {
+		if ( ! loaded ) {
 			// TODO - maybe a loading placehoder
-			return null;
+			return <QuerySettingsGeneral siteId={ site && site.ID } />;
 		}
 
 		return (
@@ -154,24 +138,23 @@ class PreSetupView extends Component {
 }
 
 function mapStateToProps( state, ownProps ) {
-	let loading = true;
+	let loaded = false;
 	let address = {};
 
 	if ( ownProps.site ) {
 		address = getStoreLocation( state, ownProps.site.ID );
-		loading = areSettingsGeneralLoading( state, ownProps.site.ID );
+		loaded = areSettingsGeneralLoaded( state, ownProps.site.ID );
 	}
 
 	return {
 		address,
-		loading,
+		loaded,
 	};
 }
 
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			fetchSettingsGeneral,
 			doInitialSetup,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
@@ -22,6 +22,7 @@ import SetupFooter from './setup-footer';
 import SetupHeader from './setup-header';
 import SetupTasks from './setup-tasks';
 import QueryShippingZones from 'woocommerce/components/query-shipping-zones';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import { areAnyShippingMethodsEnabled } from 'woocommerce/state/ui/shipping/zones/selectors';
 
 class SetupTasksView extends Component {
@@ -46,6 +47,7 @@ class SetupTasksView extends Component {
 		return (
 			<div className="card dashboard__setup-wrapper">
 				<QueryShippingZones siteId={ site.ID } />
+				<QuerySettingsGeneral siteId={ site.ID } />
 				<SetupHeader
 					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
 					imageWidth={ 160 }

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -31,9 +31,7 @@ import {
 	setTriedCustomizerDuringInitialSetup,
 	setCheckedTaxSetup,
 } from 'woocommerce/state/sites/setup-choices/actions';
-import {
-	fetchSettingsGeneral,
-} from 'woocommerce/state/sites/settings/general/actions';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import {
 	arePaymentsSetup
 } from 'woocommerce/state/ui/payments/methods/selectors';
@@ -61,7 +59,6 @@ class SetupTasks extends Component {
 
 		if ( site && site.ID ) {
 			this.props.fetchPaymentMethods( site.ID );
-			this.props.fetchSettingsGeneral( site.ID );
 			this.props.fetchSetupChoices( site.ID );
 
 			if ( ! areProductsLoaded ) {
@@ -77,7 +74,6 @@ class SetupTasks extends Component {
 		const oldSiteId = site && site.ID || null;
 
 		if ( newSiteId && ( oldSiteId !== newSiteId ) ) {
-			this.props.fetchSettingsGeneral( newSiteId );
 			this.props.fetchSetupChoices( newSiteId );
 			if ( ! areProductsLoaded ) {
 				this.props.fetchProducts( newSiteId, 1 );
@@ -202,6 +198,7 @@ class SetupTasks extends Component {
 	render = () => {
 		return (
 			<div className="dashboard__setup-checklist">
+				<QuerySettingsGeneral siteId={ this.props.site.ID } />
 				{ this.getSetupTasks().map( this.renderSetupTask ) }
 			</div>
 		);
@@ -226,7 +223,6 @@ function mapDispatchToProps( dispatch ) {
 		{
 			fetchPaymentMethods,
 			fetchProducts,
-			fetchSettingsGeneral,
 			fetchSetupChoices,
 			setOptedOutOfShippingSetup,
 			setCheckedTaxSetup,

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -18,10 +18,10 @@ import FormSelect from 'components/forms/form-select';
 import StoreAddress from 'woocommerce/components/store-address';
 import { changeCurrency } from 'woocommerce/state/ui/payments/currency/actions';
 import { fetchCurrencies } from 'woocommerce/state/sites/currencies/actions';
-import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getCurrencies } from 'woocommerce/state/sites/currencies/selectors';
 import { getCurrencyWithEdits } from 'woocommerce/state/ui/payments/currency/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
 class SettingsPaymentsLocationCurrency extends Component {
 	static propTypes = {
@@ -29,7 +29,6 @@ class SettingsPaymentsLocationCurrency extends Component {
 		currencies: PropTypes.array,
 		currency: PropTypes.string,
 		fetchCurrencies: PropTypes.func.isRequired,
-		fetchSettingsGeneral: PropTypes.func.isRequired,
 		getCurrencyWithEdits: PropTypes.func.isRequired,
 		site: PropTypes.object,
 	};
@@ -39,7 +38,6 @@ class SettingsPaymentsLocationCurrency extends Component {
 
 		if ( site && site.ID ) {
 			this.props.fetchCurrencies( site.ID );
-			this.props.fetchSettingsGeneral( site.ID );
 		}
 	}
 
@@ -51,7 +49,6 @@ class SettingsPaymentsLocationCurrency extends Component {
 
 		if ( oldSiteId !== newSiteId ) {
 			this.props.fetchCurrencies( newSiteId );
-			this.props.fetchSettingsGeneral( newSiteId );
 		}
 	}
 
@@ -77,10 +74,11 @@ class SettingsPaymentsLocationCurrency extends Component {
 	}
 
 	render() {
-		const { currencies, currency, translate } = this.props;
+		const { currencies, currency, site, translate } = this.props;
 		const validCurrencies = [ 'USD', 'AUD', 'CAD', 'GBP', 'BRL' ];
 		return (
 			<div className="payments__location-currency">
+				<QuerySettingsGeneral siteId={ site && site.ID } />
 				<ExtendedHeader
 					label={ translate( 'Store location and currency' ) }
 					description={
@@ -125,7 +123,6 @@ function mapDispatchToProps( dispatch ) {
 		{
 			changeCurrency,
 			fetchCurrencies,
-			fetchSettingsGeneral,
 			getCurrencyWithEdits,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -95,8 +95,9 @@ class SettingsPaymentsLocationCurrency extends Component {
 						<FormSelect
 							className="payments__currency-select"
 							onChange={ this.onChange }
-							value={ currency }>
-							{ currencies && currencies.length && validCurrencies.map( this.renderOption ) }
+							value={ currency }
+							disabled={ ! currency }>
+							{ currency && currencies && currencies.length && validCurrencies.map( this.renderOption ) }
 						</FormSelect>
 					</div>
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
@@ -14,6 +14,8 @@ import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import ShippingZoneEntry from './shipping-zone-list-entry';
 import QueryShippingZones, { areShippingZonesFullyLoaded } from 'woocommerce/components/query-shipping-zones';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
+import { areSettingsGeneralLoaded, areSettingsGeneralLoadError } from 'woocommerce/state/sites/settings/general/selectors';
 import Notice from 'components/notice';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getShippingZones } from 'woocommerce/state/ui/shipping/zones/selectors';
@@ -38,13 +40,16 @@ class ShippingZoneList extends Component {
 	}
 
 	renderContent = () => {
-		const { siteId, loaded, shippingZones, isValid, translate } = this.props;
+		const { siteId, loaded, fetchError, shippingZones, isValid, translate } = this.props;
 
 		const renderShippingZone = ( zone, index ) => {
 			return ( <ShippingZoneEntry key={ index } siteId={ siteId } loaded={ loaded } isValid={ isValid } { ...zone } /> );
 		};
 
-		const zonesToRender = loaded ? shippingZones : [ {}, {}, {} ];
+		let zonesToRender = loaded ? shippingZones : [ {}, {}, {} ];
+		if ( fetchError ) {
+			zonesToRender = [];
+		}
 
 		return (
 			<div>
@@ -80,6 +85,7 @@ class ShippingZoneList extends Component {
 		return (
 			<div>
 				<QueryShippingZones siteId={ siteId } />
+				<QuerySettingsGeneral siteId={ siteId } />
 				<ExtendedHeader
 					label={ translate( 'Shipping Zones' ) }
 					description={ translate( 'These are the regions you’ll ship to. ' +
@@ -102,7 +108,7 @@ class ShippingZoneList extends Component {
 export default connect(
 	( state ) => {
 		const savingZones = Boolean( getActionList( state ) );
-		const loaded = areShippingZonesFullyLoaded( state ) && ! savingZones;
+		const loaded = areShippingZonesFullyLoaded( state ) && areSettingsGeneralLoaded( state ) && ! savingZones;
 
 		return {
 			site: getSelectedSite( state ),
@@ -110,6 +116,7 @@ export default connect(
 			shippingZones: getShippingZones( state ),
 			savingZones,
 			loaded,
+			fetchError: areSettingsGeneralLoadError( state ), // TODO: add shipping zones/methods fetch errors too
 			isValid: ! loaded || areShippingZonesLocationsValid( state ),
 		};
 	},

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -13,6 +13,8 @@ import page from 'page';
  */
 import Main from 'components/main';
 import QueryShippingZones, { areShippingZonesFullyLoaded } from 'woocommerce/components/query-shipping-zones';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
+import { areSettingsGeneralLoaded } from 'woocommerce/state/sites/settings/general/selectors';
 import ShippingZoneHeader from './shipping-zone-header';
 import ShippingZoneLocationList from './shipping-zone-location-list';
 import ShippingZoneMethodList from './shipping-zone-method-list';
@@ -119,6 +121,7 @@ class Shipping extends Component {
 			<Main className={ classNames( 'shipping', className ) }>
 				<ProtectFormGuard isChanged={ hasEdits } />
 				<QueryShippingZones siteId={ siteId } />
+				<QuerySettingsGeneral siteId={ siteId } />
 				<ShippingZoneHeader
 					onSave={ this.onSave }
 					onDelete={ this.onDelete } />
@@ -137,7 +140,7 @@ Shipping.propTypes = {
 
 export default connect(
 	( state ) => {
-		const loaded = areShippingZonesFullyLoaded( state );
+		const loaded = areShippingZonesFullyLoaded( state ) && areSettingsGeneralLoaded( state );
 		const zone = loaded && getCurrentlyEditingShippingZone( state );
 		const isRestOfTheWorld = zone && 0 === zone.id;
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -22,8 +22,9 @@ import { bindActionCreatorsWithSiteId } from 'woocommerce/lib/redux-utils';
 import { getCurrentlyEditingShippingZoneLocationsList } from 'woocommerce/state/ui/shipping/zones/locations/selectors';
 import { openEditLocations } from 'woocommerce/state/ui/shipping/zones/locations/actions';
 import { areShippingZonesFullyLoaded } from 'woocommerce/components/query-shipping-zones';
+import { areSettingsGeneralLoaded, areSettingsGeneralLoadError } from 'woocommerce/state/sites/settings/general/selectors';
 
-const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actions } ) => {
+const ShippingZoneLocationList = ( { siteId, loaded, fetchError, translate, locations, actions } ) => {
 	const getLocationFlag = ( location ) => {
 		if ( 'continent' === location.type ) {
 			return null;
@@ -101,7 +102,10 @@ const ShippingZoneLocationList = ( { siteId, loaded, translate, locations, actio
 		actions.openEditLocations();
 	};
 
-	const locationsToRender = loaded ? locations : [ {}, {}, {} ];
+	let locationsToRender = loaded ? locations : [ {}, {}, {} ];
+	if ( fetchError ) {
+		locationsToRender = [];
+	}
 
 	return (
 		<div className="shipping-zone__locations-container">
@@ -136,9 +140,10 @@ ShippingZoneLocationList.PropTypes = {
 
 export default connect(
 	( state ) => {
-		const loaded = areShippingZonesFullyLoaded( state );
+		const loaded = areShippingZonesFullyLoaded( state ) && areSettingsGeneralLoaded( state );
 		return {
 			loaded,
+			fetchError: areSettingsGeneralLoadError( state ), // TODO: add shipping zones/methods fetch errors too
 			locations: loaded && getCurrentlyEditingShippingZoneLocationsList( state, 20 ),
 		};
 	},

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-method-list.js
@@ -32,10 +32,12 @@ import {
 } from 'woocommerce/state/ui/shipping/zones/methods/selectors';
 import { getCurrencyWithEdits } from 'woocommerce/state/ui/payments/currency/selectors';
 import { areShippingZonesFullyLoaded } from 'woocommerce/components/query-shipping-zones';
+import { areSettingsGeneralLoaded, areSettingsGeneralLoadError } from 'woocommerce/state/sites/settings/general/selectors';
 
 const ShippingZoneMethodList = ( {
 		siteId,
 		loaded,
+		fetchError,
 		methods,
 		methodNamesMap,
 		newMethodTypeOptions,
@@ -100,7 +102,10 @@ const ShippingZoneMethodList = ( {
 		actions.addMethodToShippingZone( newType, methodNamesMap( newType ) );
 	};
 
-	const methodsToRender = loaded ? methods : [ {}, {}, {} ];
+	let methodsToRender = loaded ? methods : [ {}, {}, {} ];
+	if ( fetchError ) {
+		methodsToRender = [];
+	}
 
 	return (
 		<div className="shipping-zone__methods-container">
@@ -138,7 +143,8 @@ export default connect(
 		methodNamesMap: getShippingMethodNameMap( state ),
 		newMethodTypeOptions: getNewMethodTypeOptions( state ),
 		currency: getCurrencyWithEdits( state ),
-		loaded: areShippingZonesFullyLoaded( state ),
+		loaded: areShippingZonesFullyLoaded( state ) && areSettingsGeneralLoaded( state ),
+		fetchError: areSettingsGeneralLoadError( state ), // TODO: add shipping zones/methods fetch errors too
 	} ),
 	( dispatch, ownProps ) => ( {
 		actions: bindActionCreatorsWithSiteId( {

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
@@ -18,13 +18,18 @@ import {
 	getCurrentlyEditingShippingZone,
 	generateCurrentlyEditingZoneName,
 } from 'woocommerce/state/ui/shipping/zones/selectors';
+import { areSettingsGeneralLoaded, areSettingsGeneralLoadError } from 'woocommerce/state/sites/settings/general/selectors';
 
-const ShippingZoneName = ( { loaded, zoneName, generatedZoneName, actions, translate } ) => {
+const ShippingZoneName = ( { loaded, fetchError, zoneName, generatedZoneName, actions, translate } ) => {
 	const onNameChange = ( event ) => {
 		actions.changeShippingZoneName( event.target.value );
 	};
 
 	const renderContent = () => {
+		if ( fetchError ) {
+			return <div className="shipping-zone__name" />;
+		}
+
 		if ( ! loaded ) {
 			return (
 				<div className="shipping-zone__name is-placeholder">
@@ -62,10 +67,11 @@ ShippingZoneName.PropTypes = {
 
 export default connect(
 	( state ) => {
-		const loaded = areShippingZonesFullyLoaded( state );
+		const loaded = areShippingZonesFullyLoaded( state ) && areSettingsGeneralLoaded( state );
 		const zone = loaded && getCurrentlyEditingShippingZone( state );
 		return {
 			loaded,
+			fetchError: areSettingsGeneralLoadError( state ), // TODO: add shipping zones/methods fetch errors too
 			zoneName: zone && zone.name,
 			generatedZoneName: generateCurrentlyEditingZoneName( state ),
 		};

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -12,19 +12,19 @@ import { localize } from 'i18n-calypso';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import {
-	areSettingsGeneralLoading,
+	areSettingsGeneralLoaded,
 	areTaxCalculationsEnabled,
 } from 'woocommerce/state/sites/settings/general/selectors';
 import {
-	areTaxSettingsLoading,
+	areTaxSettingsLoaded,
 	getPricesIncludeTax,
 	getShippingIsTaxFree,
 } from 'woocommerce/state/sites/settings/tax/selectors';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import {
-	fetchSettingsGeneral,
 	updateTaxesEnabledSetting,
 } from 'woocommerce/state/sites/settings/general/actions';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import { fetchTaxRates } from 'woocommerce/state/sites/meta/taxrates/actions';
 import {
 	fetchTaxSettings,
@@ -63,7 +63,6 @@ class SettingsTaxes extends Component {
 		const { site } = this.props;
 
 		if ( site && site.ID ) {
-			this.props.fetchSettingsGeneral( site.ID );
 			this.props.fetchTaxSettings( site.ID );
 		}
 	}
@@ -74,7 +73,6 @@ class SettingsTaxes extends Component {
 			const newSiteId = newProps.site && newProps.site.ID || null;
 			const oldSiteId = site && site.ID || null;
 			if ( oldSiteId !== newSiteId ) {
-				this.props.fetchSettingsGeneral( newSiteId );
 				this.props.fetchTaxSettings( newSiteId );
 			}
 
@@ -141,11 +139,11 @@ class SettingsTaxes extends Component {
 	};
 
 	render = () => {
-		const { className, loading, site, translate } = this.props;
+		const { className, loaded, site, translate } = this.props;
 
-		if ( loading ) {
+		if ( ! loaded ) {
 			// TODO placeholder
-			return null;
+			return <QuerySettingsGeneral siteId={ site.ID } />;
 		}
 
 		const breadcrumbs = [
@@ -182,14 +180,14 @@ class SettingsTaxes extends Component {
 }
 
 function mapStateToProps( state ) {
-	const loading = areTaxSettingsLoading( state ) || areSettingsGeneralLoading( state );
+	const loaded = areTaxSettingsLoaded( state ) && areSettingsGeneralLoaded( state );
 	const site = getSelectedSiteWithFallback( state );
 	const pricesIncludeTaxes = getPricesIncludeTax( state );
 	const shippingIsTaxable = ! getShippingIsTaxFree( state ); // note the inversion
 	const taxesEnabled = areTaxCalculationsEnabled( state );
 
 	return {
-		loading,
+		loaded,
 		pricesIncludeTaxes,
 		shippingIsTaxable,
 		site,
@@ -200,7 +198,6 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			fetchSettingsGeneral,
 			fetchTaxRates,
 			fetchTaxSettings,
 			updateTaxesEnabledSetting,

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -27,13 +27,13 @@ import {
 } from 'woocommerce/lib/countries/constants';
 import { getCountryData, getStateData } from 'woocommerce/lib/countries';
 import ExtendedHeader from 'woocommerce/components/extended-header';
-import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { fetchTaxRates } from 'woocommerce/state/sites/meta/taxrates/actions';
 import FormToggle from 'components/forms/form-toggle';
 import Notice from 'components/notice';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
 class TaxesRates extends Component {
 
@@ -48,9 +48,7 @@ class TaxesRates extends Component {
 		const { address, loadedSettingsGeneral, loadedTaxRates, site } = this.props;
 
 		if ( site && site.ID ) {
-			if ( ! loadedSettingsGeneral ) {
-				this.props.fetchSettingsGeneral( site.ID );
-			} else if ( ! loadedTaxRates ) {
+			if ( loadedSettingsGeneral && ! loadedTaxRates ) {
 				this.props.fetchTaxRates( site.ID, address );
 			}
 		}
@@ -254,10 +252,10 @@ class TaxesRates extends Component {
 	}
 
 	render = () => {
-		const { loadedSettingsGeneral, loadedTaxRates, onEnabledChange, taxesEnabled, translate } = this.props;
+		const { site, loadedSettingsGeneral, loadedTaxRates, onEnabledChange, taxesEnabled, translate } = this.props;
 
 		if ( ! loadedSettingsGeneral ) {
-			return null;
+			return <QuerySettingsGeneral siteId={ site && site.ID } />;
 		}
 
 		if ( ! loadedTaxRates ) {
@@ -313,7 +311,6 @@ function mapStateToProps( state, ownProps ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			fetchSettingsGeneral,
 			fetchTaxRates,
 		},
 		dispatch

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -3,18 +3,17 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { omit } from 'lodash';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormTextInput from 'components/forms/form-text-input';
 import { getCurrencyObject } from 'lib/format-currency';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
 class PriceInput extends Component {
 
@@ -26,40 +25,24 @@ class PriceInput extends Component {
 		} ),
 	};
 
-	componentDidMount() {
-		const { siteId, currency } = this.props;
-
-		if ( siteId && ! currency ) {
-			this.props.fetchSettingsGeneral( siteId );
-		}
-	}
-
-	componentWillReceiveProps( newProps ) {
-		const { siteId, currency } = this.props;
-
-		if ( siteId !== newProps.siteId && ! currency ) {
-			this.props.fetchSettingsGeneral( newProps.siteId );
-		}
-	}
-
 	render() {
-		const { value, currency, currencySetting } = this.props;
-		const props = { ...omit( this.props, [ 'value', 'currency', 'currencySetting', 'siteId', 'fetchSettingsGeneral' ] ) };
+		const { siteId, value, currency, currencySetting } = this.props;
+		const props = { ...omit( this.props, [ 'value', 'currency', 'currencySetting', 'siteId' ] ) };
 		const displayCurrency = ! currency && currencySetting ? currencySetting.value : currency;
 		const currencyObject = getCurrencyObject( value, displayCurrency );
-		if ( ! currencyObject ) {
-			return (
-				<FormTextInput
-					value={ value }
-					{ ...omit( props, [ 'noWrap', 'min' ] ) } />
-			);
-		}
-
 		return (
-			<FormCurrencyInput
-				currencySymbolPrefix={ currencyObject.symbol }
-				value={ value }
-				{ ...props } />
+			<div>
+				<QuerySettingsGeneral siteId={ siteId } />
+				{ currencyObject
+					? <FormCurrencyInput
+							currencySymbolPrefix={ currencyObject.symbol }
+							value={ value }
+							{ ...props } />
+					: <FormTextInput
+							value={ value }
+							{ ...omit( props, [ 'noWrap', 'min' ] ) } />
+				}
+			</div>
 		);
 	}
 }
@@ -73,13 +56,4 @@ function mapStateToProps( state ) {
 	};
 }
 
-function mapDispatchToProps( dispatch ) {
-	return bindActionCreators(
-		{
-			fetchSettingsGeneral,
-		},
-		dispatch
-	);
-}
-
-export default connect( mapStateToProps, mapDispatchToProps )( PriceInput );
+export default connect( mapStateToProps )( PriceInput );

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -27,7 +27,7 @@ class PriceInput extends Component {
 
 	render() {
 		const { siteId, value, currency, currencySetting } = this.props;
-		const props = { ...omit( this.props, [ 'value', 'currency', 'currencySetting', 'siteId' ] ) };
+		const props = { ...omit( this.props, [ 'value', 'currency', 'currencySetting', 'siteId', 'dispatch' ] ) };
 		const displayCurrency = ! currency && currencySetting ? currencySetting.value : currency;
 		const currencyObject = getCurrencyObject( value, displayCurrency );
 		return (

--- a/client/extensions/woocommerce/components/query-settings-general/index.js
+++ b/client/extensions/woocommerce/components/query-settings-general/index.js
@@ -18,30 +18,41 @@ class QuerySettingsGeneral extends Component {
 		this.props.actions.fetchSettingsGeneral( siteId );
 	}
 
-	componentWillMount() {
-		const { siteId, loaded } = this.props;
+	showRetryNotice( siteId ) {
+		const noticeId = 'query-settings-general-retry';
+		this.props.actions.errorNotice( this.props.translate( 'Some of your site settings couldn\'t be retrieved.' ), {
+			id: noticeId,
+			showDismiss: false,
+			button: this.props.translate( 'Try again' ),
+			onClick: () => {
+				this.fetch( siteId );
+				this.props.actions.removeNotice( noticeId );
+			}
+		} );
+	}
 
-		if ( siteId && ! loaded ) {
-			this.fetch( siteId );
+	componentWillMount() {
+		const { siteId, loaded, error } = this.props;
+
+		if ( siteId ) {
+			if ( error ) {
+				this.showRetryNotice( siteId );
+			} else if ( ! loaded ) {
+				this.fetch( siteId );
+			}
 		}
 	}
 
-	componentWillReceiveProps( { siteId, loaded, error, translate } ) {
-		if ( siteId !== this.props.siteId && ! loaded ) {
+	componentWillReceiveProps( { siteId, loaded, error } ) {
+		if ( ! siteId ) {
+			return;
+		}
+		if ( ! this.props.error && error ) {
+			// just received an error fetching, show the notice to retry
+			this.showRetryNotice( siteId );
+		} else if ( siteId !== this.props.siteId && ! loaded ) {
 			// site ID changed, fetch new zones
 			this.fetch( siteId );
-		} else if ( ! this.props.error && error ) {
-			// just received an error fetching, show the notice to retry
-			const noticeId = 'query-settings-general-retry';
-			this.props.actions.errorNotice( translate( 'Some of your site settings couldn\'t be retrieved.' ), {
-				id: noticeId,
-				showDismiss: false,
-				button: translate( 'Try again' ),
-				onClick: () => {
-					this.fetch( siteId );
-					this.props.actions.removeNotice( noticeId );
-				}
-			} );
 		}
 	}
 

--- a/client/extensions/woocommerce/components/query-settings-general/index.js
+++ b/client/extensions/woocommerce/components/query-settings-general/index.js
@@ -5,7 +5,6 @@ import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -33,7 +32,7 @@ class QuerySettingsGeneral extends Component {
 			this.fetch( siteId );
 		} else if ( ! this.props.error && error ) {
 			// just received an error fetching, show the notice to retry
-			const noticeId = uniqueId();
+			const noticeId = 'query-settings-general-retry';
 			this.props.actions.errorNotice( translate( 'Some of your site settings couldn\'t be retrieved.' ), {
 				id: noticeId,
 				showDismiss: false,

--- a/client/extensions/woocommerce/components/query-settings-general/index.js
+++ b/client/extensions/woocommerce/components/query-settings-general/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+import { uniqueId } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
+import { areSettingsGeneralLoaded, areSettingsGeneralLoadError } from 'woocommerce/state/sites/settings/general/selectors';
+import { errorNotice, removeNotice } from 'state/notices/actions';
+
+class QuerySettingsGeneral extends Component {
+	fetch( siteId ) {
+		this.props.actions.fetchSettingsGeneral( siteId );
+	}
+
+	componentWillMount() {
+		const { siteId, loaded } = this.props;
+
+		if ( siteId && ! loaded ) {
+			this.fetch( siteId );
+		}
+	}
+
+	componentWillReceiveProps( { siteId, loaded, error, translate } ) {
+		if ( siteId !== this.props.siteId && ! loaded ) {
+			// site ID changed, fetch new zones
+			this.fetch( siteId );
+		} else if ( ! this.props.error && error ) {
+			// just received an error fetching, show the notice to retry
+			const noticeId = uniqueId();
+			this.props.actions.errorNotice( translate( 'Some of your site settings couldn\'t be retrieved.' ), {
+				id: noticeId,
+				showDismiss: false,
+				button: translate( 'Try again' ),
+				onClick: () => {
+					this.fetch( siteId );
+					this.props.actions.removeNotice( noticeId );
+				}
+			} );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QuerySettingsGeneral.propTypes = {
+	siteId: PropTypes.number,
+};
+
+export default connect(
+	( state ) => ( {
+		loaded: areSettingsGeneralLoaded( state ),
+		error: areSettingsGeneralLoadError( state ),
+	} ),
+	( dispatch ) => ( {
+		actions: bindActionCreators(
+			{
+				fetchSettingsGeneral,
+				errorNotice,
+				removeNotice,
+			}, dispatch
+		)
+	} ) )( localize( QuerySettingsGeneral ) );

--- a/client/extensions/woocommerce/components/query-shipping-zones/index.js
+++ b/client/extensions/woocommerce/components/query-shipping-zones/index.js
@@ -11,17 +11,14 @@ import { bindActionCreators } from 'redux';
 import { fetchShippingMethods } from 'woocommerce/state/sites/shipping-methods/actions';
 import { fetchShippingZones } from 'woocommerce/state/sites/shipping-zones/actions';
 import { fetchLocations } from 'woocommerce/state/sites/locations/actions';
-import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { areShippingZonesLoaded } from 'woocommerce/state/sites/shipping-zones/selectors';
 import { areShippingMethodsLoaded } from 'woocommerce/state/sites/shipping-methods/selectors';
 import { areLocationsLoaded } from 'woocommerce/state/sites/locations/selectors';
-import { areSettingsGeneralLoaded } from 'woocommerce/state/sites/settings/general/selectors';
 
 class QueryShippingZones extends Component {
 	fetch( siteId ) {
 		this.props.actions.fetchShippingZones( siteId );
 		this.props.actions.fetchShippingMethods( siteId );
-		this.props.actions.fetchSettingsGeneral( siteId );
 		this.props.actions.fetchLocations( siteId );
 	}
 
@@ -33,9 +30,9 @@ class QueryShippingZones extends Component {
 		}
 	}
 
-	componentWillReceiveProps( { siteId } ) {
-		//site ID changed, fetch new zones
-		if ( siteId !== this.props.siteId ) {
+	componentWillReceiveProps( { siteId, loaded } ) {
+		//site ID changed, fetch new settings
+		if ( siteId !== this.props.siteId && ! loaded ) {
 			this.fetch( siteId );
 		}
 	}
@@ -50,8 +47,7 @@ QueryShippingZones.propTypes = {
 };
 
 export const areShippingZonesFullyLoaded = ( state ) => {
-	return areSettingsGeneralLoaded( state ) &&
-		areShippingMethodsLoaded( state ) &&
+	return areShippingMethodsLoaded( state ) &&
 		areShippingZonesLoaded( state ) &&
 		areLocationsLoaded( state );
 };
@@ -63,7 +59,6 @@ export default connect(
 	( dispatch ) => ( {
 		actions: bindActionCreators(
 			{
-				fetchSettingsGeneral,
 				fetchShippingZones,
 				fetchLocations,
 				fetchShippingMethods,

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -14,12 +14,12 @@ import AddressView from 'woocommerce/components/address-view';
 import Card from 'components/card';
 import Dialog from 'components/dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
-import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import { getCountryData } from 'woocommerce/lib/countries';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getStoreLocation, areSettingsGeneralLoading } from 'woocommerce/state/sites/settings/general/selectors';
 import { setAddress } from 'woocommerce/state/sites/settings/actions';
 import FormLabel from 'components/forms/form-label';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
 class StoreAddress extends Component {
 
@@ -27,24 +27,7 @@ class StoreAddress extends Component {
 		showLabel: true,
 	};
 
-	componentDidMount = () => {
-		const { site } = this.props;
-
-		if ( site && site.ID ) {
-			this.props.fetchSettingsGeneral( site.ID );
-		}
-	}
-
 	componentWillReceiveProps = ( newProps ) => {
-		const { site } = this.props;
-
-		const newSiteId = newProps.site && newProps.site.ID || null;
-		const oldSiteId = site && site.ID || null;
-
-		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchSettingsGeneral( newSiteId );
-		}
-
 		this.setState( { address: newProps.address } );
 	}
 
@@ -145,6 +128,7 @@ class StoreAddress extends Component {
 		const classes = classNames( 'store-address', { 'is-placeholder': ! site || loading }, className );
 		return (
 			<Card className={ classes }>
+				<QuerySettingsGeneral siteId={ site && site.ID } />
 				<Dialog
 					buttons={ buttons }
 					isVisible={ this.state.showDialog }
@@ -172,7 +156,6 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			fetchSettingsGeneral,
 			setAddress,
 		},
 		dispatch

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -16,7 +16,11 @@ import Dialog from 'components/dialog';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getCountryData } from 'woocommerce/lib/countries';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
-import { getStoreLocation, areSettingsGeneralLoading } from 'woocommerce/state/sites/settings/general/selectors';
+import {
+	getStoreLocation,
+	areSettingsGeneralLoading,
+	areSettingsGeneralLoadError,
+} from 'woocommerce/state/sites/settings/general/selectors';
 import { setAddress } from 'woocommerce/state/sites/settings/actions';
 import FormLabel from 'components/forms/form-label';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
@@ -96,7 +100,7 @@ class StoreAddress extends Component {
 	}
 
 	render() {
-		const { className, site, loading, translate, showLabel } = this.props;
+		const { className, site, loading, fetchError, translate, showLabel } = this.props;
 
 		const buttons = [
 			{ action: 'close', label: translate( 'Close' ) },
@@ -104,7 +108,7 @@ class StoreAddress extends Component {
 		];
 
 		let display;
-		if ( ! site || loading ) {
+		if ( ! site || loading || fetchError ) {
 			display = (
 				<div>
 					<p></p>
@@ -145,11 +149,13 @@ class StoreAddress extends Component {
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
 	const loading = areSettingsGeneralLoading( state );
+	const fetchError = areSettingsGeneralLoadError( state );
 	const address = getStoreLocation( state );
 	return {
 		site,
 		address,
 		loading,
+		fetchError,
 	};
 }
 

--- a/client/extensions/woocommerce/state/sites/settings/general/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/reducer.js
@@ -41,7 +41,7 @@ export default createReducer( null, {
 	[ WOOCOMMERCE_SETTINGS_GENERAL_REQUEST ]: ( state, { meta: { dataLayer: { error, data } } } ) => {
 		// Don't set the loading indicator if data has previously been loaded,
 		// or if the data layer is dispatching with meta attached.
-		if ( ! data && ! error && isNull( state ) ) {
+		if ( ! data && ! error && ( isNull( state ) || ERROR === state ) ) {
 			return LOADING;
 		}
 		return state;

--- a/client/extensions/woocommerce/state/sites/settings/general/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/reducer.js
@@ -7,11 +7,9 @@ import { isNull } from 'lodash';
 import { updateSettings } from '../helpers';
 import {
 	WOOCOMMERCE_CURRENCY_UPDATE_SUCCESS,
-	WOOCOMMERCE_SETTINGS_BATCH_REQUEST,
 	WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS,
 	WOOCOMMERCE_SETTINGS_GENERAL_REQUEST,
 	WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
-	WOOCOMMERCE_TAXES_ENABLED_UPDATE,
 	WOOCOMMERCE_TAXES_ENABLED_UPDATE_SUCCESS,
 } from 'woocommerce/state/action-types';
 
@@ -27,10 +25,6 @@ export default createReducer( null, {
 			return setting;
 		} );
 		return newSettings;
-	},
-
-	[ WOOCOMMERCE_TAXES_ENABLED_UPDATE ]: ( state ) => {
-		return state;
 	},
 
 	[ WOOCOMMERCE_TAXES_ENABLED_UPDATE_SUCCESS ]: ( state, { data } ) => {
@@ -58,10 +52,6 @@ export default createReducer( null, {
 			return ERROR;
 		}
 		return data;
-	},
-
-	[ WOOCOMMERCE_SETTINGS_BATCH_REQUEST ]: ( state ) => {
-		return state;
 	},
 
 	[ WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS ]: ( state, { data } ) => {

--- a/client/extensions/woocommerce/state/sites/settings/general/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/selectors.js
@@ -7,7 +7,7 @@ import { find, get, isArray } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { LOADING } from 'woocommerce/state/constants';
+import { LOADING, ERROR } from 'woocommerce/state/constants';
 
 const getRawGeneralSettings = ( state, siteId ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'settings', 'general' ] );
@@ -29,6 +29,15 @@ export const areSettingsGeneralLoaded = ( state, siteId = getSelectedSiteId( sta
  */
 export const areSettingsGeneralLoading = ( state, siteId = getSelectedSiteId( state ) ) => {
 	return LOADING === getRawGeneralSettings( state, siteId );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean} Whether there has been an error fetching the general settings list from the server
+ */
+export const areSettingsGeneralLoadError = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return ERROR === getRawGeneralSettings( state, siteId );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/status/wc-api/actions.js
+++ b/client/extensions/woocommerce/state/sites/status/wc-api/actions.js
@@ -10,7 +10,9 @@ export function setError( siteId, originalAction, data, time = Date.now() ) {
 	return {
 		type: WOOCOMMERCE_ERROR_SET,
 		siteId,
-		payload: { originalAction, data, time },
+		originalAction,
+		data,
+		time,
 	};
 }
 

--- a/client/extensions/woocommerce/state/sites/status/wc-api/error-reducer.js
+++ b/client/extensions/woocommerce/state/sites/status/wc-api/error-reducer.js
@@ -20,8 +20,7 @@ export default createReducer( null, {
 	[ WOOCOMMERCE_ERROR_CLEAR ]: clearApiError,
 } );
 
-function setApiError( error, action ) {
-	const { data, originalAction, time } = action.payload;
+function setApiError( error, { data, originalAction, time } ) {
 	const newError = { data, originalAction, time };
 
 	debug( 'WC-API error occurred: ', newError );


### PR DESCRIPTION
On the line of "let's make WooCommerce resilient to network failures or timeouts", I've started to work on data fetching and retries. I've started with a "simple" endpoint, `settings/general`, so I can validate my approach before tackling other, more complex ones.

I've divied this PR in self-contained commits, here they are:
* https://github.com/Automattic/wp-calypso/pull/16303/commits/a15350a23b1ec80b755dcf9d656faacf47071bbc and https://github.com/Automattic/wp-calypso/pull/16303/commits/8b5209ae7270fd9c27c6958f5fe51bbb1e15863f are small cleanup commits. The `error` reducer still used the old `action = { type, payload: { ... } }` format, I converted it to the new, plain format. Also, reducers that just return the current state are pointless. I'll add them back if you feel they are helpful for readability, but I personally find them just noise :)
* In https://github.com/Automattic/wp-calypso/pull/16303/commits/b8426f4e4f6856e3bd60e1fc1fddddf3f1b1b8e0, I've fixed the `retries` logic. This will (probably) eventually be refactored to use the `data-layer`, but for now I didn't want to leave it broken (the `retries` counter wasn't being passed to the `fetch` function, so it ws always `0`). Also, I added an `ERROR` constant which can be used similarly to the `LOADING` constant in reducers & selectors, to mark that a piece of data is not being fetched, but wasn't loaded correctly either. For updating that into the reducer, I added a handler for the `WOOCOMMERCE_ERROR_SET` action. So, we have `SOMETHING_REQUEST`, `SOMETHING_REQUEST_SUCCESS` and `WOOCOMMERCE_ERROR_SET` with the `SOMETHING_REQUEST` type in its `originalAction` prop. We could also use `SOMETHING_FAILURE`, but in my view those 2 approaches seem redundant, so we should pick one or the other.
* In https://github.com/Automattic/wp-calypso/pull/16303/commits/da8d5b12ff39d46bf8459a4c14ba06f141c4c988 I created a `<QuerySettingsGeneral siteId={ siteId }>` component. The idea is that you drop it into the `render()` method of your component and it automatically fetches the settings if needed. That removes the noise of having that kind of code in the component's `componentDidMount` and `componentWillReceiveProps` lifecycle methods. In https://github.com/Automattic/wp-calypso/pull/16303/commits/d9a2cfcb94ae459a41797b66c7db2469fb3513f2 I replaced all those instances with the `<QuerySettingsGeneral>` component.
* In https://github.com/Automattic/wp-calypso/pull/16303/commits/adcf504cdf95411152c19a8813c83c627d1cee64 I improved the `<QuerySettingsGeneral>` component to add an error notice that shows if there was an error fetching. That notice has a button that can trigger a new fetch.
* In https://github.com/Automattic/wp-calypso/pull/16303/commits/14c25b7720e5d737ebca312e04750e4068270707 and https://github.com/Automattic/wp-calypso/pull/16303/commits/1ebdcce748b2f762fb2056da9d790130dac306a0 I've added logic to not keep the page in the "loading" pulsating state indefinitely if something failed. So the UI needs to have 3 states: `loaded`, `loading` and `error`. For now, the `error` state is just as if the list to show was empty (no zones / methods / locations etc). This can be improved at a later time with a custom message, this is still objetively better than having it be `loading` forever.

To test:
* Go to the Shipping Zones page (`http://calypso.localhost:3000/store/settings/shipping/[your-site]`), check that everything loads and works correctly.
* Break the `settings/general` endpoint. I went to `wp-includes/plugins/woocommerce/includes/api/class-wc-rest-setting-options-controller.php`, line `127` (the first line of the `get_items()` method) and added this inoffensive code: `$a::b; // explode`.
* Refresh the page. It will take a while (the fetch will go through 5 retries), but eventually you'll see an error notice saying that your settings couldn't be loaded.
* Click on the `Try again` button. Eventually the notice will appear again.
* Fix the `settings/general` endpoint.
* *Without* reloading the page, click the `Try again` button again. This time, everything should load and work just fine.

For the future:
* We should decide how to handle errors. This implements one possible approach, and if we go that way, se should ditch the `wc-api/error-reducer` reducer unless we have a good reason to keep it. Right now it isn't used anywhere, so it's basically dead code. It's also quite limited (only stores the last error).
* The `retries` logic should be moved to the `data-layer` eventually, or even to the `<QuerySettingsGeneral>` component.
* We're probably going to find ourselves writing a few extremely similar `<Query*>` components. That's OK for now, but eventually we could look into unifying them a bit.
