### PR TITLE
Comments: Add an `order` param to the `getSiteComments` selector.

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -341,8 +341,8 @@ export class CommentList extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { siteId, status } ) => {
-	const comments = getSiteComments( state, siteId, status );
+const mapStateToProps = ( state, { siteId, status, order } ) => {
+	const comments = getSiteComments( state, siteId, status, order );
 	const isLoading = ! hasSiteComments( state, siteId );
 	return {
 		comments,

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -44,6 +44,7 @@ export class CommentsManagement extends Component {
 					siteId={ siteId }
 					siteFragment={ siteFragment }
 					status={ status }
+					order={ 'desc' }
 				/>
 			</Main>
 		);

--- a/client/state/selectors/get-site-comments.js
+++ b/client/state/selectors/get-site-comments.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, get } from 'lodash';
+import { filter, get, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,16 +20,17 @@ function filterCommentsByStatus( comments, status ) {
  * @param {Object} state Redux state
  * @param {Number} siteId Site for whose comments to find
  * @param {String} [status=unapproved] Status to filter comments
+ * @param {String} [order=asc] Order in which to sort filtered comments
  * @returns {Array<Object>} Available comments for site, filtered by status
  */
 export const getSiteComments = createSelector(
-	( state, siteId, status = 'unapproved' ) => {
+	( state, siteId, status = 'unapproved', order = 'asc' ) => {
 		const comments = get( state, 'comments.items', {} );
 		const parsedComments = Object.keys( comments )
 			.filter( key => parseInt( key.split( '-', 1 ), 10 ) === siteId )
 			.reduce( ( list, key ) => [ ...list, ...comments[ key ] ], [] );
 
-		return filterCommentsByStatus( parsedComments, status );
+		return orderBy( filterCommentsByStatus( parsedComments, status ), 'date', order );
 	},
 	state => [ state.comments.items ]
 );


### PR DESCRIPTION
This will allow "newest-first" sorting, used by Comments Management. The Reader is not affected, as they are using the `getPostCommentsTree` [selector](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/comments/post-comment-list.jsx#L13) at the moment. Resolves #15939 .

**Testing**
* Load a valid comments route with comments, and verify they are listed newest-first.