### PR TITLE
Comments: small breakpoints for list view

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -73,6 +73,10 @@
 	&.is-preview {
 		cursor: pointer;
 		padding: 12px 8px;
+
+		@include breakpoint( "<960px" ) {
+			flex-wrap: wrap;
+		}
 	}
 
 	&.is-bulk-edit {
@@ -115,6 +119,10 @@
 		padding: 0 8px;
 		width: 40%;
 
+		@include breakpoint( "<960px" ) {
+			width: 100%;
+		}
+
 		.external-link {
 			color: $gray-text-min;
 			&:hover,
@@ -133,6 +141,10 @@
 	padding: 0 8px;
 	position: relative;
 	width: 60%;
+
+	@include breakpoint( "<960px" ) {
+		width: 100%;
+	}
 
 	&:after {
 		background: linear-gradient(
@@ -323,6 +335,10 @@
 	.comment-detail__author-info {
 		line-height: 1.4;
 		padding: 0 8px;
+
+		@include breakpoint( "<960px" ) {
+			padding-right: 0;
+		}
 	}
 }
 .comment-detail.is-expanded .comment-detail__author-preview {


### PR DESCRIPTION
This adds breakpoints for small screens. I don't really like enabling it at 960px, but it's the only feasible option with the mobile breakpoints available.

fixes #16307 

Before

![download-3](https://user-images.githubusercontent.com/618551/28291373-c8f3ccea-6b0f-11e7-8209-063eac74459f.png)

![download-4](https://user-images.githubusercontent.com/618551/28291409-ef3de50c-6b0f-11e7-9547-23b50962080d.png)


After
 
![download-1](https://user-images.githubusercontent.com/618551/28291378-cbfb192a-6b0f-11e7-9fb5-792666d09709.png)

![download-5](https://user-images.githubusercontent.com/618551/28291411-f33c0fe4-6b0f-11e7-87e7-398c8d444663.png)