### PR TITLE
Remove comment editing for our initial release.

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -13,10 +13,10 @@ import { includes } from 'lodash';
 import Button from 'components/button';
 
 const commentActions = {
-	unapproved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
-	approved: [ 'like', 'approve', 'edit', 'spam', 'trash' ],
-	spam: [ 'approve', 'edit', 'delete' ],
-	trash: [ 'approve', 'edit', 'spam', 'delete' ],
+	unapproved: [ 'like', 'approve', 'spam', 'trash' ],
+	approved: [ 'like', 'approve', 'spam', 'trash' ],
+	spam: [ 'approve', 'delete' ],
+	trash: [ 'approve', 'spam', 'delete' ],
 };
 
 const hasAction = ( status, action ) => includes( commentActions[ status ], action );


### PR DESCRIPTION
Comment editing has been punted to M2; this PR removes the Edit button from the UI for now.

![screen shot 2017-07-17 at 2 45 54 pm](https://user-images.githubusercontent.com/349751/28291307-c0a39734-6afe-11e7-8873-cd763d85b685.png)
