### PR TITLE
Remove the Bulk Edit capability from comments management.

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -172,12 +172,6 @@ export class CommentNavigation extends Component {
 					) }
 				</NavTabs>
 
-				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
-					<Button compact onClick={ toggleBulkEdit }>
-						{ translate( 'Bulk Edit' ) }
-					</Button>
-				</CommentNavigationTab>
-
 				{ hasSearch &&
 					<Search
 						delaySearch

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -172,6 +172,12 @@ export class CommentNavigation extends Component {
 					) }
 				</NavTabs>
 
+				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
+					<Button compact onClick={ toggleBulkEdit }>
+						{ translate( 'Bulk Edit' ) }
+					</Button>
+				</CommentNavigationTab>
+
 				{ hasSearch &&
 					<Search
 						delaySearch

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -172,11 +172,13 @@ export class CommentNavigation extends Component {
 					) }
 				</NavTabs>
 
-				<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
-					<Button compact onClick={ toggleBulkEdit }>
-						{ translate( 'Bulk Edit' ) }
-					</Button>
-				</CommentNavigationTab>
+				{ config.isEnabled( 'manage/comments/bulk-actions' ) &&
+					<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
+						<Button compact onClick={ toggleBulkEdit }>
+							{ translate( 'Bulk Edit' ) }
+						</Button>
+					</CommentNavigationTab>
+				}
 
 				{ hasSearch &&
 					<Search

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -19,7 +19,7 @@ import NavTabs from 'components/section-nav/tabs';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 import UrlSearch from 'lib/url-search';
-import config from 'config';
+import { isEnabled } from 'config';
 
 const bulkActions = {
 	unapproved: [ 'approve', 'spam', 'trash' ],
@@ -53,7 +53,7 @@ export class CommentNavigation extends Component {
 			},
 		};
 
-		if ( config.isEnabled( 'comments/management/all-list' ) ) {
+		if ( isEnabled( 'comments/management/all-list' ) ) {
 			navItems.all = {
 				label: translate( 'All' ),
 			};
@@ -172,7 +172,7 @@ export class CommentNavigation extends Component {
 					) }
 				</NavTabs>
 
-				{ config.isEnabled( 'manage/comments/bulk-actions' ) &&
+				{ isEnabled( 'manage/comments/bulk-actions' ) &&
 					<CommentNavigationTab className="comment-navigation__actions comment-navigation__open-bulk">
 						<Button compact onClick={ toggleBulkEdit }>
 							{ translate( 'Bulk Edit' ) }

--- a/config/development.json
+++ b/config/development.json
@@ -42,6 +42,7 @@
 		"comments/moderation-tools-in-posts": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"manage/comments/bulk-actions": false,
 		"community-translator": true,
 		"css-hot-reload": true,
 		"desktop-promo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -21,6 +21,7 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/all-list": false,
+		"manage/comments/bulk-actions": false,
 		"community-translator": true,
 		"desktop-promo": true,
 		"devdocs": true,


### PR DESCRIPTION
This PR temporarily removes the Bulk Edit button from comments navigation – it's been moved to a later milestone, while we concentrate on releasing M1.

![screen shot 2017-07-17 at 2 58 26 pm](https://user-images.githubusercontent.com/349751/28291735-8fdc81d6-6b00-11e7-9cc5-60ab8ae41393.png)

**Testing**
* Load a valid `/comments` route and be sure that you don't have a button for enabling bulk actions.