### PR TITLE
Comments: Add the Discussions menu item to the sidebar.

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -166,6 +166,7 @@ class ManageMenu extends PureComponent {
 			case 'jetpack-portfolio': icon = 'folder'; break;
 			case 'jetpack-testimonial': icon = 'quote'; break;
 			case 'media': icon = 'image'; break;
+			case 'conversations': icon = 'chat'; break;
 			default: icon = 'custom-post-type';
 		}
 

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -102,16 +102,18 @@ class ManageMenu extends PureComponent {
 			} );
 		}
 
-		items.push( {
-			name: 'discussions',
-			label: this.props.translate( 'Discussions' ),
-			capability: 'edit_posts', // TODO: should be 'moderate_comments'
-			queryable: true,
-			config: 'comments/management',
-			link: '/comments',
-			wpAdminLink: 'edit-comments.php',
-			showOnAllMySites: true,
-		} );
+		if ( config.isEnabled( 'comments/management' ) ) {
+			items.push( {
+				name: 'discussions',
+				label: this.props.translate( 'Discussions' ),
+				capability: 'edit_posts', // TODO: should be 'moderate_comments'
+				queryable: true,
+				config: 'comments/management',
+				link: '/comments',
+				wpAdminLink: 'edit-comments.php',
+				showOnAllMySites: true,
+			} );
+		}
 
 		return items;
 	}

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -21,7 +21,7 @@ import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
 import { getSite, getSiteAdminUrl, getSiteSlug, isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import { areAllSitesSingleUser, canCurrentUser } from 'state/selectors';
 
-class PublishMenu extends PureComponent {
+class ManageMenu extends PureComponent {
 	static propTypes = {
 		itemLinkClass: PropTypes.func,
 		onNavigate: PropTypes.func,
@@ -254,4 +254,4 @@ export default connect( ( state, { siteId } ) => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};
-} )( localize( PublishMenu ) );
+} )( localize( ManageMenu ) );

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -106,7 +106,7 @@ class ManageMenu extends PureComponent {
 			items.push( {
 				name: 'conversations',
 				label: this.props.translate( 'Conversations' ),
-				capability: 'edit_posts', // TODO: should be 'moderate_comments'
+				capability: 'edit_posts',
 				queryable: true,
 				config: 'comments/management',
 				link: '/comments',

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -104,8 +104,8 @@ class ManageMenu extends PureComponent {
 
 		if ( config.isEnabled( 'comments/management' ) ) {
 			items.push( {
-				name: 'discussions',
-				label: this.props.translate( 'Discussions' ),
+				name: 'conversations',
+				label: this.props.translate( 'Conversations' ),
 				capability: 'edit_posts', // TODO: should be 'moderate_comments'
 				queryable: true,
 				config: 'comments/management',

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -101,6 +101,18 @@ class ManageMenu extends PureComponent {
 				showOnAllMySites: false,
 			} );
 		}
+
+		items.push( {
+			name: 'discussions',
+			label: this.props.translate( 'Discussions' ),
+			capability: 'edit_posts', // TODO: should be 'moderate_comments'
+			queryable: true,
+			config: 'comments/management',
+			link: '/comments',
+			wpAdminLink: 'edit-comments.php',
+			showOnAllMySites: true,
+		} );
+
 		return items;
 	}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -16,7 +16,7 @@ import Button from 'components/button';
 import config from 'config';
 import CurrentSite from 'my-sites/current-site';
 import productsValues from 'lib/products-values';
-import PublishMenu from './publish-menu';
+import ManageMenu from './manage-menu';
 import Sidebar from 'layout/sidebar';
 import SidebarButton from 'layout/sidebar/button';
 import SidebarFooter from 'layout/sidebar/footer';
@@ -116,9 +116,9 @@ export class MySitesSidebar extends Component {
 		}, this );
 	}
 
-	publish() {
+	manage() {
 		return (
-			<PublishMenu siteId={ this.props.siteId }
+			<ManageMenu siteId={ this.props.siteId }
 				itemLinkClass={ this.itemLinkClass }
 				onNavigate={ this.onNavigate } />
 		);
@@ -547,7 +547,7 @@ export class MySitesSidebar extends Component {
 			);
 		}
 
-		const publish = !! this.publish(),
+		const manage = !! this.manage(),
 			configuration = ( !! this.sharing() || !! this.users() || !! this.siteSettings() || !! this.plugins() || !! this.upgrades() );
 
 		return (
@@ -561,10 +561,10 @@ export class MySitesSidebar extends Component {
 					</ul>
 				</SidebarMenu>
 
-				{ publish
+				{ manage
 					? <SidebarMenu>
-						<SidebarHeading>{ this.props.translate( 'Publish' ) }</SidebarHeading>
-						{ this.publish() }
+						<SidebarHeading>{ this.props.translate( 'Manage' ) }</SidebarHeading>
+						{ this.manage() }
 					</SidebarMenu>
 					: null
 				}

--- a/client/my-sites/sidebar/test/sidebar.jsx
+++ b/client/my-sites/sidebar/test/sidebar.jsx
@@ -19,7 +19,7 @@ describe( 'MySitesSidebar', () => {
 		mockery.registerMock( 'lib/analytics', {} );
 		mockery.registerMock( 'lib/products-values', {} );
 		mockery.registerMock( 'my-sites/current-site', EmptyComponent );
-		mockery.registerMock( './publish-menu', EmptyComponent );
+		mockery.registerMock( './manage-menu', EmptyComponent );
 		mockery.registerMock( 'layout/sidebar', EmptyComponent );
 		mockery.registerMock( 'components/tooltip', EmptyComponent );
 


### PR DESCRIPTION
This PR adds a "Discussions" Menu item to the My Sites sidebar, and changes the section heading from "Publish" to "Manage" (which is more appropriate to a section allowing comments management). Initially, it will point to the upcoming Comments Management page at `/comments`. See p3fqKv-4OZ-p2 for more info. Fixes #16306 .

![artboard-copy-19](https://user-images.githubusercontent.com/349751/28294196-44981a52-6b0d-11e7-889c-ef036aa09d44.png)
