### PR TITLE
Prevent Navigation to non-store sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -38,6 +38,7 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
 import SiteSelectorAddSite from './add-site';
 import searchSites from 'components/search-sites';
+import { isPluginActive } from 'state/selectors';
 
 const ALL_SITES = 'ALL_SITES';
 
@@ -417,13 +418,14 @@ const navigateToSite = ( siteId, {
 	allSitesSingleUser,
 	siteBasePath,
 } ) => ( dispatch, getState ) => {
+	const state = getState();
 	const pathname = getPathnameForSite();
 	if ( pathname ) {
 		page( pathname );
 	}
 
 	function getPathnameForSite() {
-		const site = getSite( getState(), siteId );
+		const site = getSite( state, siteId );
 		debug( 'getPathnameForSite', siteId, site );
 
 		if ( siteId === ALL_SITES ) {
@@ -452,6 +454,13 @@ const navigateToSite = ( siteId, {
 
 		if ( path.match( /^\/domains\/manage\// ) ) {
 			path = '/domains/manage';
+		}
+
+		if ( path.match( /^\/store\/stats\// ) ) {
+			const isWooConnect = site.jetpack && isPluginActive( state, site.ID, 'woocommerce' );
+			if ( ! isWooConnect ) {
+				path = '/stats/day';
+			}
 		}
 
 		return path;

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -3,7 +3,6 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import page from 'page';
 import { moment, translate } from 'i18n-calypso';
 
 /**
@@ -29,12 +28,12 @@ import {
 	UNITS
 } from 'woocommerce/app/store-stats/constants';
 import { getUnitPeriod, getEndPeriod } from './utils';
-import { isJetpackSite } from 'state/sites/selectors';
-import { isPluginActive } from 'state/selectors';
+import { getJetpackSites } from 'state/selectors';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 
 class StoreStats extends Component {
 	static propTypes = {
-		isWooConnect: PropTypes.bool,
+		jetPackSites: PropTypes.array,
 		path: PropTypes.string.isRequired,
 		queryDate: PropTypes.string,
 		querystring: PropTypes.string,
@@ -44,14 +43,7 @@ class StoreStats extends Component {
 	};
 
 	render() {
-		const { isWooConnect, path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
-
-		// TODO: this is to handle users switching sites while on store stats
-		// unfortunately, we can't access the path when changing sites
-		if ( ! isWooConnect ) {
-			page.redirect( `/stats/day/${ slug }` );
-		}
-
+		const { jetPackSites, path, queryDate, selectedDate, siteId, slug, unit, querystring } = this.props;
 		const unitQueryDate = getUnitPeriod( queryDate, unit );
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const endSelectedDate = getEndPeriod( selectedDate, unit );
@@ -89,6 +81,7 @@ class StoreStats extends Component {
 
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
+				<QueryJetpackPlugins siteIds={ jetPackSites.map( site => site.ID ) } />
 				<div className="store-stats__sidebar-nav"><SidebarNavigation /></div>
 				<Navigation unit={ unit } type="orders" slug={ slug } />
 				<Chart
@@ -159,13 +152,9 @@ class StoreStats extends Component {
 }
 
 export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
-		return {
-			isWooConnect: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
-			slug: getSelectedSiteSlug( state ),
-			siteId,
-		};
-	}
+	state => ( {
+		slug: getSelectedSiteSlug( state ),
+		siteId: getSelectedSiteId( state ),
+		jetPackSites: getJetpackSites( state ),
+	} )
 )( StoreStats );

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -13,8 +13,6 @@ import DatePicker from 'my-sites/stats/stats-date-picker';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getUnitPeriod } from './utils';
 import HeaderCake from 'components/header-cake';
-import { isJetpackSite } from 'state/sites/selectors';
-import { isPluginActive } from 'state/selectors';
 import List from './store-stats-list';
 import Main from 'components/main';
 import Module from './store-stats-module';
@@ -27,6 +25,8 @@ import {
 	topCoupons,
 	UNITS
 } from 'woocommerce/app/store-stats/constants';
+import { getJetpackSites } from 'state/selectors';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 
 const listType = {
 	products: topProducts,
@@ -36,7 +36,7 @@ const listType = {
 
 class StoreStatsListView extends Component {
 	static propTypes = {
-		isWooConnect: PropTypes.bool,
+		jetPackSites: PropTypes.array,
 		path: PropTypes.string.isRequired,
 		selectedDate: PropTypes.string,
 		siteId: PropTypes.number,
@@ -57,12 +57,7 @@ class StoreStatsListView extends Component {
 	};
 
 	render() {
-		const { isWooConnect, siteId, slug, selectedDate, type, unit } = this.props;
-		// TODO: this is to handle users switching sites while on store stats
-		// unfortunately, we can't access the path when changing sites
-		if ( ! isWooConnect ) {
-			page.redirect( `/stats/${ slug }` );
-		}
+		const { jetPackSites, siteId, slug, selectedDate, type, unit } = this.props;
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const listviewQuery = {
 			unit,
@@ -71,6 +66,7 @@ class StoreStatsListView extends Component {
 		};
 		return (
 			<Main className="store-stats__list-view woocommerce" wideLayout={ true }>
+				<QueryJetpackPlugins siteIds={ jetPackSites.map( site => site.ID ) } />
 				<HeaderCake onClick={ this.goBack }>{ listType[ type ].title }</HeaderCake>
 				<StatsPeriodNavigation
 					date={ selectedDate }
@@ -117,13 +113,9 @@ class StoreStatsListView extends Component {
 }
 
 export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
-		return {
-			isWooConnect: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
-			slug: getSelectedSiteSlug( state ),
-			siteId: getSelectedSiteId( state ),
-		};
-	}
+	state => ( {
+		slug: getSelectedSiteSlug( state ),
+		siteId: getSelectedSiteId( state ),
+		jetPackSites: getJetpackSites( state ),
+	} )
 )( StoreStatsListView );


### PR DESCRIPTION
### Check path on site selection
When a user is viewing Store Stats for a valid site (ie jetpack and woocommerce), prevent accessing a non-valid site in Site Selection by checking if the site is jetpack and the plugin is active.

### Side Issue
Currently, I'm investigating why `state` does not reflect installed plugins while in Store Stats on rehydration of state. The following returns false negative as a result. 

```js
const isWooConnect = site.jetpack && isPluginActive( state, site.ID, 'woocommerce' );
```
To reproduce, while on a valid store, clear state.
```
localStorage.clear();
indexedDB.deleteDatabase( 'calypso' );
```
Refresh, then access another valid store from the Site Selector.

cc @greenafrican 

Fixes https://github.com/Automattic/wp-calypso/issues/16295