### PR TITLE
Media library: update GPhotos empty message

### DIFF
--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -67,6 +67,8 @@ class MediaLibraryListNoContent extends Component {
 					{ this.props.translate( 'Upload Media' ) }
 				</UploadButton>
 			);
+		} else if ( this.props.source ) {
+			line = this.props.translate( 'New photos may take a few minutes to appear.' );
 		}
 
 		return (


### PR DESCRIPTION
Updates the GPhotos empty message to clarify that sometimes it can take a few minutes for photos to show up.

<img width="475" alt="new_photos" src="https://user-images.githubusercontent.com/1277682/28309044-0c330d5a-6ba0-11e7-906f-1c6d2d4c9fd2.png">

Note that I fixed all the linting issues in this file by converting it to an ES6 class and using the localize component. There's one class name lint that's been disabled as it involves a bigger change to CSS elsewhere.

## Testing

1. View the GPhotos media library for a Google account with no media. Verify that the message is as above
1. View the WP media library for a WP account with no media. Verify that the message is as follows:

<img width="435" alt="wp_empty" src="https://user-images.githubusercontent.com/1277682/28309199-91750388-6ba0-11e7-946f-949238de7744.png">
  Note if you don't have a WP account without media then comment out [this](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/media-library/list.jsx#L224) and [this](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/media-library/list.jsx#L231) to force the empty content message to be shown.
