### PR TITLE
Activity log: Accept query parameters in activity data-layer

### DIFF
--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -48,9 +48,10 @@ export function rewindActivateFailure( siteId ) {
 	};
 }
 
-export function activityLogRequest( siteId ) {
+export function activityLogRequest( siteId, params ) {
 	return {
 		type: ACTIVITY_LOG_REQUEST,
+		params,
 		siteId,
 	};
 }

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -48,6 +48,29 @@ export function rewindActivateFailure( siteId ) {
 	};
 }
 
+/**
+ * Activity endpoint query parameters.
+ *
+ * The API is subject to change, this documentation has been provided as a basis. For up to
+ * date information, it's best to check the current state of the API.
+ *
+ * @typdef {Object} ActivityParams
+ *
+ * @property {number} date_start Filter activity after this date (utc microtime timestamp).
+ * @property {number} date_end   Filter activity before this date (utc microtime timestamp).
+ * @property {number} number     Maximum number of results to return.
+ */
+
+/**
+ * Requests activity from the API
+ *
+ * You may optionally pass an object of parameters for the query to this action.
+ * @see ActivityParams
+ *
+ * @param  {number}         siteId site ID
+ * @param  {ActivityParams} params Optional. Parameters to pass to the endpoint
+ * @return {Object}                The request action
+ */
 export function activityLogRequest( siteId, params ) {
 	return {
 		type: ACTIVITY_LOG_REQUEST,

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -19,7 +19,10 @@ const activityLogRequest = ( { dispatch }, action ) => {
 		apiVersion: '1',
 		method: 'GET',
 		path: `/sites/${ action.siteId }/activity`,
-		query: { number: 1000 },
+		query: {
+			number: 1000,
+			...action.params,
+		},
 	}, action ) );
 };
 

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -14,7 +14,7 @@ import {
 	activityLogUpdate,
 } from 'state/activity-log/actions';
 
-const activityLogRequest = ( { dispatch }, action ) => {
+export const handleActivityLogRequest = ( { dispatch }, action ) => {
 	dispatch( http( {
 		apiVersion: '1',
 		method: 'GET',
@@ -42,7 +42,7 @@ export const receiveActivityLogError = ( { dispatch }, { siteId }, next, error )
 
 export default {
 	[ ACTIVITY_LOG_REQUEST ]: [ dispatchRequest(
-		activityLogRequest,
+		handleActivityLogRequest,
 		receiveActivityLog,
 		receiveActivityLogError
 	) ],

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -8,12 +8,15 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
+import { http } from 'state/data-layer/wpcom-http/actions';
 import {
+	handleActivityLogRequest,
 	receiveActivityLogError,
 	receiveActivityLog,
 } from '..';
 import {
 	activityLogError,
+	activityLogRequest,
 	activityLogUpdate,
 } from 'state/activity-log/actions';
 
@@ -97,5 +100,51 @@ describe( 'receiveActivityLogError', () => {
 				message: 'Unknown blog'
 			} )
 		);
+	} );
+} );
+
+describe( 'handleActivityLogRequest', () => {
+	it( 'should dispatch HTTP action with default when no params are passed', () => {
+		const action = activityLogRequest( SITE_ID );
+		const dispatch = sinon.spy();
+
+		handleActivityLogRequest( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWith( http( {
+			apiVersion: '1',
+			method: 'GET',
+			path: `/sites/${ SITE_ID }/activity`,
+			query: {
+				number: 1000,
+			},
+		}, action ) );
+	} );
+
+	it( 'should dispatch HTTP action with provided parameters', () => {
+		const action = activityLogRequest( SITE_ID, {
+			date_end: 1500300000000,
+			date_start: 1500000000000,
+			group: 'post',
+			name: 'post__published',
+			number: 10,
+		} );
+		const dispatch = sinon.spy();
+
+		handleActivityLogRequest( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWith( http( {
+			apiVersion: '1',
+			method: 'GET',
+			path: `/sites/${ SITE_ID }/activity`,
+			query: {
+				date_end: 1500300000000,
+				date_start: 1500000000000,
+				group: 'post',
+				name: 'post__published',
+				number: 10,
+			},
+		}, action ) );
 	} );
 } );


### PR DESCRIPTION
This PR adds `params` to the `activityLogRequest` action creator as well as the data-layer. This will allow us to take advantage of filtering provided by the endpoint like `date_start`, `date_end`, `number`, and eventually paging or other methods for dealing with management of large amounts of data.

## Testing
1. https://calypso.live/stats/activity?branch=update/activitylog-datalayer-accept-params
1. Dispatch this action:
   ```js
   dispatch( { type: 'ACTIVITY_LOG_REQUEST', params: { number: 3 }, siteId: state.ui.selectedSiteId } )
   ```
1. You should see that only 3 activities are loaded, and the network tab will display the provided params as well `number=3`.
1. Try passing other parameters and you should see them in the network requests.