### PR TITLE
Build: Let happypack use more cores when available

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,7 +150,8 @@ const webpackConfig = {
 			loaders: _.compact( [
 				process.env.NODE_ENV === 'development' && 'react-hot-loader',
 				babelLoader
-			] )
+			] ),
+			threads: Math.max( 1, os.cpus().length - 1 ) // use at least 1, at most all but one
 		} ),
 		new webpack.NamedModulesPlugin(),
 		new webpack.NamedChunksPlugin( chunk => {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -122,7 +122,7 @@ const webpackConfig = {
 		new webpack.DefinePlugin( {
 			'PROJECT_NAME': JSON.stringify( config( 'project' ) )
 		} ),
-		! isWindows && new HappyPack( { loaders: [ babelLoader ] } ),
+		! isWindows && new HappyPack( { loaders: [ babelLoader ], threads: Math.max( 1, os.cpus().length - 1 ) } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]sites-list$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]olark$/, 'lodash/noop' ), // Depends on DOM


### PR DESCRIPTION
Currently happypack always uses 3 threads when building calypso. Instead, detect the number of cores present in the system and use all but 1 for the build.

On my system, this cuts ~10% of the build time (2.9Ghz, 8 core, i7)