### PR TITLE
Site Settings: Update card order in Traffic section

### DIFF
--- a/client/my-sites/site-settings/seo-settings/main.jsx
+++ b/client/my-sites/site-settings/seo-settings/main.jsx
@@ -13,7 +13,6 @@ import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSitePurchases, hasLoadedSitePurchasesFromServer, getPurchasesError } from 'state/purchases/selectors';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import SeoForm from './form';
-import SiteVerification from './site-verification';
 
 export class SeoSettings extends Component {
 	componentWillReceiveProps( nextProps ) {
@@ -30,7 +29,6 @@ export class SeoSettings extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
 				{ site && <SeoForm site={ site } /> }
-				{ site && <SiteVerification /> }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -15,6 +15,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
+import SiteVerification from 'my-sites/site-settings/seo-settings/site-verification';
 import AnalyticsSettings from 'my-sites/site-settings/form-analytics';
 import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
@@ -89,14 +90,15 @@ const SiteSettingsTraffic = ( {
 					fields={ fields }
 				/>
 			}
-			<AnalyticsSettings />
 			<SeoSettingsHelpCard />
 			<SeoSettingsMain />
+			<AnalyticsSettings />
 			<Sitemaps
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
+			{ site && <SiteVerification /> }
 		</Main>
 	);
 };


### PR DESCRIPTION
This PR updates the order of cards within the Traffic site settings section to correspond to what we have in Jetpack settings in wp-admin. Fixes #12845.

**Previous order in Calypso:**

* Site Stats (Jetpack sites only)
* Ads (Jetpack sites only)
* Related Posts
* AMP
* Google Analytics
* SEO
* Page Title Structure
* Website Meta
* Site Verification Services
* Sitemaps

**Updated order in Calypso:**

* Site Stats (Jetpack sites only)
* Ads (Jetpack sites only)
* Related Posts
* AMP
* SEO
* Page Title Structure
* Website Meta
* **Google Analytics**
* Sitemaps
* **Site Verification Services**

**Current order in Jetpack:**

* Site Stats
* Ads
* Related Posts
* SEO (leading to WP.com SEO)
* Google Analytics
* Sitemaps
* Site Verification Services

To test:
* Checkout this branch or get it going on calypso.live
* Go to Traffic settings for a Jetpack site.
* Verify card order is the same as in wp-admin for your Jetpack site.
* Verify there are no regressions coming from this PR in the Traffic section.