### PR TITLE
Add property to hide date from PostSchedule component

### DIFF
--- a/client/components/post-schedule/README.md
+++ b/client/components/post-schedule/README.md
@@ -62,7 +62,7 @@ correction when the given timezone is different from the user's timezone. `timez
 
 `gmtOffset` - **optional** Number - Like as timezone-like manner, an offset correction will be applied if there is difference between the given gmtOffset and the user's gmtOffset. Ignored if `timezone` also passed.
 
-`displayInputChrono` - **optional** Boolean - True if an `InputChrono` (a React component that creates a Date object from a user-entered textual date description) should be displayed.
+`displayInputChrono` - **optional** Boolean - True if an `InputChrono` (a React component that creates a Date object from a user-entered textual date description) should be displayed. Default: true
 
 `onDateChange` - **optional** Called when user selects a new date on the calendar. Passed a moment Date object.
 

--- a/client/components/post-schedule/README.md
+++ b/client/components/post-schedule/README.md
@@ -62,6 +62,8 @@ correction when the given timezone is different from the user's timezone. `timez
 
 `gmtOffset` - **optional** Number - Like as timezone-like manner, an offset correction will be applied if there is difference between the given gmtOffset and the user's gmtOffset. Ignored if `timezone` also passed.
 
+`displayInputChrono` - **optional** Boolean - True if an `InputChrono` (a React component that creates a Date object from a user-entered textual date description) should be displayed.
+
 `onDateChange` - **optional** Called when user selects a new date on the calendar. Passed a moment Date object.
 
 `onMonthChange` - **optional** Called when the user selects a new month on the calendar. Passed a moment Date object representing the view date for the calendar, which can be used to determine the currently-showing month and year.

--- a/client/components/post-schedule/header.jsx
+++ b/client/components/post-schedule/header.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Local dependencies
  */
 import HeaderControl from './header-controls';
+import classNames from 'classnames';
 
 /**
  * Globals
@@ -16,11 +17,15 @@ var noop = () => {};
 export default React.createClass( {
 	propTypes: {
 		date: React.PropTypes.object,
+		inputChronoDisplayed: React.PropTypes.bool,
 		onDateChange: React.PropTypes.func,
 	},
 
 	getDefaultProps() {
-		return { onDateChange: noop };
+		return {
+			inputChronoDisplayed: true,
+			onDateChange: noop
+		};
 	},
 
 	getInitialState() {
@@ -51,8 +56,10 @@ export default React.createClass( {
 	},
 
 	render() {
+		const headerClasses = classNames( 'post-schedule__header', { 'is-input-chrono-displayed': this.props.inputChronoDisplayed } );
+
 		return (
-			<div className="post-schedule__header">
+			<div className={ headerClasses }>
 				<span
 					className="post-schedule__header-month"
 					onClick={ this.setToCurrentMonth }

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -225,6 +225,7 @@ class PostSchedule extends Component {
 				<Header
 					date={ this.state.calendarViewDate }
 					onDateChange={ this.setViewDate }
+					inputChronoDisplayed={ this.props.displayInputChrono }
 				/>
 
 				{ this.props.displayInputChrono && this.renderInputChrono() }

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -30,6 +30,7 @@ class PostSchedule extends Component {
 		timezone: PropTypes.string,
 		gmtOffset: PropTypes.number,
 		site: PropTypes.object,
+		displayInputChrono: PropTypes.bool,
 		onDateChange: PropTypes.func,
 		onMonthChange: PropTypes.func,
 		onDayMouseEnter: PropTypes.func,
@@ -39,6 +40,7 @@ class PostSchedule extends Component {
 	static defaultProps = {
 		posts: [],
 		events: [],
+		displayInputChrono: true,
 		onDateChange: noop,
 		onMonthChange: noop,
 		onDayMouseEnter: noop,
@@ -225,7 +227,7 @@ class PostSchedule extends Component {
 					onDateChange={ this.setViewDate }
 				/>
 
-				{ this.renderInputChrono() }
+				{ this.props.displayInputChrono && this.renderInputChrono() }
 
 				<DatePicker
 					events={ this.events() }

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -7,7 +7,7 @@
 	text-align: center;
 	position: absolute;
 	z-index: z-index( '.popover', '.post-schedule__header' );
-	top: 47px;
+	top: 11px;
 	font-size: 18px;
 	font-weight: 300;
 	width: 80%;
@@ -15,6 +15,10 @@
 
 	&:first-letter {
 		text-transform: uppercase;
+	}
+
+	&.is-input-chrono-displayed {
+		top: 47px;
 	}
 }
 


### PR DESCRIPTION
This PR adds a boolean property to display or hide the date from the `PostSchedule` component.

Default value is `true`, that is, no change is required where the component is currently used.

With date (default, `displayInputChrono={ true }` ):

![postpopover-with-chrono](https://user-images.githubusercontent.com/1017839/28320128-12b352a4-6bd0-11e7-9d99-e22c1e7f2ee1.png)

Without date (`displayInputChrono={ false }` ):

![postpopover-without-chrono](https://user-images.githubusercontent.com/1017839/28320176-2e26a298-6bd0-11e7-96d6-461b2be507a1.png)

This is part of a larger epic (See p3Ex-2ri-p2).

To test:

- Check out this branch
- `make run`
- Verify that `PostSchedule` looks and works as before (e.g. draft a new post and bring up the schedule popover)
- Hide the date at a usage of the component (e.g. add `displayInputChrono={ false }` in front of [this line](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-ground-control/index.jsx#L184) to modify the schedule popover)
- Verify that `PostSchedule` looks good and is functional