### PR TITLE
SitePreview: Update externalUrl to represent the iframes location

### DIFF
--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -8,6 +8,7 @@ import omit from 'lodash/omit';
 /**
  * Internal dependencies
  */
+import { withoutHttp } from 'lib/url';
 import ClipboardButton from 'components/forms/clipboard-button';
 import FormTextInput from 'components/forms/form-text-input';
 
@@ -17,7 +18,8 @@ export default React.createClass( {
 	propTypes: {
 		value: PropTypes.string,
 		disabled: PropTypes.bool,
-		className: PropTypes.string
+		className: PropTypes.string,
+		hideHttp: PropTypes.bool
 	},
 
 	getInitialState() {
@@ -51,13 +53,14 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { value, className, disabled } = this.props;
+		const { value, className, disabled, hideHttp } = this.props;
 		const classes = classnames( 'clipboard-button-input', className );
 
 		return (
 			<span className={ classes }>
 				<FormTextInput
-					{ ...omit( this.props, 'className' ) }
+					{ ...omit( this.props, 'className', 'hideHttp' ) }
+					value={ hideHttp ? withoutHttp( value ) : value }
 					type="text"
 					selectOnFocus
 					readOnly />

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -109,7 +109,14 @@ export class WebPreviewContent extends Component {
 			case 'partially-loaded':
 				this.setLoaded();
 				return;
+			case 'location-change':
+				this.handleLocationChange( data.payload );
+				return;
 		}
+	}
+
+	handleLocationChange = ( payload ) => {
+		this.props.onLocationUpdate( payload.pathname );
 	}
 
 	focusIfNeeded = () => {
@@ -277,6 +284,8 @@ WebPreviewContent.propTypes = {
 	// The function to call when the iframe is loaded. Will be passed the iframe document object.
 	// Only called if using previewMarkup.
 	onLoad: PropTypes.func,
+	// Called when the iframe's location updates
+	onLocationUpdate: PropTypes.func,
 	// Called when the preview is closed, either via the 'X' button or the escape key
 	onClose: PropTypes.func,
 	// Called when the edit button is clicked
@@ -305,6 +314,7 @@ WebPreviewContent.defaultProps = {
 	previewUrl: null,
 	previewMarkup: null,
 	onLoad: noop,
+	onLocationUpdate: noop,
 	onClose: noop,
 	onEdit: noop,
 	onDeviceUpdate: noop,

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -121,6 +121,7 @@ class PreviewToolbar extends Component {
 					<ClipboardButtonInput
 						className="web-preview__url-clipboard-input"
 						value={ externalUrl || previewUrl }
+						hideHttp
 					/>
 				}
 				<div className="web-preview__toolbar-actions">

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -62,7 +62,7 @@ class PreviewMain extends React.Component {
 			debug( 'loading', newUrl );
 			this.setState( {
 				previewUrl: newUrl,
-				externalUrl: baseUrl
+				externalUrl: this.props.site.URL,
 			} );
 		}
 	}
@@ -80,7 +80,7 @@ class PreviewMain extends React.Component {
 
 	updateSiteLocation = ( pathname ) => {
 		this.setState( {
-			externalUrl: this.getBasePreviewUrl() + ( startsWith( pathname, '/' ) ? '' : '/' ) + pathname
+			externalUrl: this.props.site.URL + ( startsWith( pathname, '/' ) ? '' : '/' ) + pathname
 		} );
 	}
 

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { startsWith } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -80,7 +79,7 @@ class PreviewMain extends React.Component {
 
 	updateSiteLocation = ( pathname ) => {
 		this.setState( {
-			externalUrl: this.props.site.URL + ( startsWith( pathname, '/' ) ? '' : '/' ) + pathname
+			externalUrl: this.props.site.URL + ( pathname === '/' ? '' : pathname )
 		} );
 	}
 

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { startsWith } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -31,6 +32,7 @@ class PreviewMain extends React.Component {
 
 	state = {
 		previewUrl: null,
+		externalUrl: null,
 	};
 
 	componentWillMount() {
@@ -41,20 +43,27 @@ class PreviewMain extends React.Component {
 		if ( ! this.props.site ) {
 			if ( this.state.previewUrl !== null ) {
 				debug( 'unloaded page' );
-				this.setState( { previewUrl: null } );
+				this.setState( {
+					previewUrl: null,
+					externalUrl: null,
+				} );
 			}
 			return;
 		}
 
+		const baseUrl = this.getBasePreviewUrl();
 		const newUrl = addQueryArgs( {
 			preview: true,
 			iframe: true,
 			'frame-nonce': this.props.site.options.frame_nonce
-		}, this.getBasePreviewUrl() );
+		}, baseUrl );
 
 		if ( this.iframeUrl !== newUrl ) {
 			debug( 'loading', newUrl );
-			this.setState( { previewUrl: newUrl } );
+			this.setState( {
+				previewUrl: newUrl,
+				externalUrl: baseUrl
+			} );
 		}
 	}
 
@@ -67,6 +76,12 @@ class PreviewMain extends React.Component {
 			debug( 'site change detected' );
 			this.updateUrl();
 		}
+	}
+
+	updateSiteLocation = ( pathname ) => {
+		this.setState( {
+			externalUrl: this.getBasePreviewUrl() + ( startsWith( pathname, '/' ) ? '' : '/' ) + pathname
+		} );
 	}
 
 	render() {
@@ -100,9 +115,11 @@ class PreviewMain extends React.Component {
 			<Main className="preview">
 				<DocumentHead title={ translate( 'Site Preview' ) } />
 				<WebPreviewContent
+					onLocationUpdate={ this.updateSiteLocation }
+					showUrl={ !! this.state.externalUrl }
 					showClose={ false }
 					previewUrl={ this.state.previewUrl }
-					externalUrl={ site.URL }
+					externalUrl={ this.state.externalUrl }
 				/>
 			</Main>
 		);


### PR DESCRIPTION
### Summary
These changes add the ability for the SitePreview to listen for location changes to the site being previewed and update a newly added URL bar and existing external link button accordingly.

<img width="964" alt="screen shot 2017-07-18 at 16 03 39" src="https://user-images.githubusercontent.com/4335450/28324246-bb31193c-6bd2-11e7-903c-f6a2e5bccec5.png">

To Do:
- Possibly update the way in which the URL is displayed? Should we be showing the <kbd>Copy</kbd> button?

### Test Plan
- Go to `calypso.localhost:3000/view/youramazingsite.wordpress.com` to preview your site.
- Navigate around your site and each time you click a link:
    - check first that the external link has a href that represents the current page: <img width="23" alt="screen shot 2017-07-11 at 01 41 12" src="https://user-images.githubusercontent.com/4335450/28046440-83ccc7ea-65db-11e7-9c02-a667f7183372.png">
    - check that the URL bar above the site preview also represents the current page

### Extra Testing
During reviews some points were raised, here are the steps to test that each issue has been squished (*In progress*):
- [x] Unmapped domain showing instead of mapped, primary domain:
    - Test with a site that has a mapped domain set to be primary
    - Ensure that the URL shows this domain and not the original `xx.wordpress.com` domain
    - Bonus points: switch the primary domain to another domain (can be `xx.wordpress.com`) and ensure that this domain now shows in the URL bar
- [x] Trailing slash appears after the iframe page loads, but is not shown while loading
    - Watch the URL bar when initially landing on`/view/your-site` note that when on your homepage there is no trailing `/`.
    - Navigate to a page on your site, there should also be no trailing `/` at the end of the path (i.e. `your-site.com/about` and not `your-site.com/about/`
- [x] trim the `scheme://` from the URL, to save some space and better display longer URLs.
    - Make sure that `https://` or `http://` is not shown in the bar.

