### PR TITLE
Reader: add intro illustration A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -4,9 +4,9 @@ module.exports = {
 		variations: {
 			singlePurchaseFlow: 10,
 			popupCart: 45,
-			keepSearchingInGapps: 45
+			keepSearchingInGapps: 45,
 		},
-		defaultVariation: 'singlePurchaseFlow'
+		defaultVariation: 'singlePurchaseFlow',
 	},
 	signupSurveyStep: {
 		datestamp: '20170329',
@@ -28,7 +28,7 @@ module.exports = {
 		datestamp: '20170328',
 		variations: {
 			showChatButton: 20,
-			original: 80
+			original: 80,
 		},
 		defaultVariation: 'original',
 		localeTargets: 'any',
@@ -93,5 +93,15 @@ module.exports = {
 			noPublishConfirmation: 70,
 		},
 		defaultVariation: 'noPublishConfirmation',
+	},
+	readerIntroIllustration: {
+		datestamp: '20170718',
+		variations: {
+			blue: 33,
+			lightBlue: 33,
+			white: 34,
+		},
+		defaultVariation: 'white',
+		assignmentMethod: 'userId',
 	},
 };

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -17,6 +17,8 @@ import { recordTrack } from 'reader/stats';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'state/ui/guided-tours/contexts';
 import { abtest } from 'lib/abtest';
 
+const abtestVariant = abtest( 'readerIntroIllustration' );
+
 class FollowingIntro extends React.Component {
 	componentDidMount() {
 		this.recordRenderTrack();
@@ -44,7 +46,6 @@ class FollowingIntro extends React.Component {
 		const linkElement = <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />;
 
 		// A/B test three variants of the new illustration
-		const abtestVariant = abtest( 'readerIntroIllustration' );
 		let variantClassname = null;
 		if ( abtestVariant === 'blue' ) {
 			variantClassname = 'following__intro-blue';

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -15,6 +15,7 @@ import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import { recordTrack } from 'reader/stats';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'state/ui/guided-tours/contexts';
+import { abtest } from 'lib/abtest';
 
 class FollowingIntro extends React.Component {
 	componentDidMount() {
@@ -35,34 +36,48 @@ class FollowingIntro extends React.Component {
 
 	render() {
 		const { isNewReader, translate, dismiss, isNewUser } = this.props;
-		const linkElement = <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />;
 
 		if ( ! isNewReader || ! isNewUser ) {
 			return null;
 		}
 
+		const linkElement = <a onClick={ this.props.handleManageLinkClick } href="/following/manage" />;
+
+		// A/B test three variants of the new illustration
+		const abtestVariant = abtest( 'readerIntroIllustration' );
+		let variantClassname = null;
+		if ( abtestVariant === 'blue' ) {
+			variantClassname = 'following__intro-blue';
+		} else if ( abtestVariant === 'lightBlue' ) {
+			variantClassname = 'following__intro-light-blue';
+		} else if ( abtestVariant === 'white' ) {
+			variantClassname = 'following__intro-white';
+		} else {
+			variantClassname = 'following__intro';
+		}
+
 		return (
-			<header className="following__intro">
+			<header className={ variantClassname }>
 				<QueryPreferences />
 				<div className="following__intro-header">
 					<div className="following__intro-copy">
 						<span>
-						{ translate(
-							'{{strong}}Welcome!{{/strong}} Reader is a custom magazine. ' +
-								'{{link}}Follow your favorite sites{{/link}} and their latest ' +
-								'posts will appear here. {{span}}Read, like, and comment in a ' +
-								'distraction-free environment.{{/span}}',
-							{
-								components: {
-									link: linkElement,
-									strong: <strong />,
-									span: <span className="following__intro-copy-hidden" />,
+							{ translate(
+								'{{strong}}Welcome!{{/strong}} Reader is a custom magazine. ' +
+									'{{link}}Follow your favorite sites{{/link}} and their latest ' +
+									'posts will appear here. {{span}}Read, like, and comment in a ' +
+									'distraction-free environment.{{/span}}',
+								{
+									components: {
+										link: linkElement,
+										strong: <strong />,
+										span: <span className="following__intro-copy-hidden" />,
+									},
 								},
-							},
-						) }
+							) }
 						</span>
 					</div>
-					<div className="following__intro-character"></div>
+					<div className="following__intro-character" />
 
 					<div
 						className="following__intro-close"

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -53,8 +53,10 @@ class FollowingIntro extends React.Component {
 			variantClassname = 'following__intro-light-blue';
 		} else if ( abtestVariant === 'white' ) {
 			variantClassname = 'following__intro-white';
-		} else {
-			variantClassname = 'following__intro';
+		}
+
+		if ( ! variantClassname ) {
+			return null;
 		}
 
 		return (

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -8,9 +8,34 @@
 	z-index: z-index( 'root', '.reader-following-search' );
 }
 
+// Following intro blue
+.following__intro-blue {
+	background: url( '/calypso/images/reader/reader-intro-background-blue.svg' ) #04a9dd no-repeat 100% 20px;
+
+	.following__intro-copy {
+		color: $white;
+		text-shadow: 1px 1px 1px rgba( 0, 0, 0, 0.1 );
+		margin-left: 24px;
+
+		a {
+			color: #c9eaf5;
+			border-bottom: 1px #c9eaf5 solid;
+
+			&:hover {
+				color: $white;
+				border-bottom: 1px $white solid;
+			}
+		}
+	}
+
+	.following__intro-character {
+		background: url( '/calypso/images/reader/reader-intro-character-light-blue.svg' ) no-repeat 8px bottom;
+	}
+}
+
 // Following intro light blue
 .following__intro-light-blue {
-	background: url( '/calypso/images/reader/reader-intro-background-light-blue.svg' ) #7fd3f1 no-repeat 100%20px;
+	background: url( '/calypso/images/reader/reader-intro-background-light-blue.svg' ) #7fd3f1 no-repeat 100% 20px;
 
 	.following__intro-copy {
 		color: #045182;
@@ -33,7 +58,7 @@
 
 // Following intro white
 .following__intro-white {
-	background: url( '/calypso/images/reader/reader-intro-background-white.svg' ) $white no-repeat 100%20px;
+	background: url( '/calypso/images/reader/reader-intro-background-white.svg' ) $white no-repeat 100% 20px;
 	border: 1px solid lighten( $gray, 30% );
 
 	.following__intro-copy {
@@ -188,103 +213,5 @@
 
 	.following__intro-close-icon-bg {
 		background-color: $white;
-	}
-}
-
-// Following intro original
-.following__intro {
-	background: url( '/calypso/images/reader/reader-intro-background.jpg' );
-	background-position: 100% 0;
-	background-repeat: no-repeat;
-	background-size: cover;
-
-	+ .following__search {
-		margin-top: 30px;
-
-		@include breakpoint( "<660px" ) {
-			margin-top: 8px;
-		}
-	}
-
-	@media ( max-width: 900px ) {
-		background-position: 75% 0;
-	}
-}
-
-.following__intro-header {
-	display: flex;
-	width: 100%;
-}
-
-.following__intro-close {
-	position: relative;
-	margin-left: auto;
-	margin-top: 8px;
-	margin-right: 8px;
-	height: 24px;
-	width: 24px;
-
-	.following__intro-close-icon {
-		position: absolute;
-		z-index: z-index( 'root', '.following__intro-close-icon' );
-		fill: $white;
-
-		// Fix for 1px (0.5pt) misalignment in Safari under retina. See
-		// https://github.com/Automattic/wp-calypso/pull/11282/#issuecomment-289837131
-		transform: scale( 1 );
-
-		&:hover {
-			cursor: pointer;
-			fill: darken( #62a9a7, 15% );
-		}
-
-		&:hover + .following__intro-close-icon-bg {
-			background-color: lighten( #62a9a7, 50% );
-			box-shadow: 0 0 0 2px lighten( #62a9a7, 40% );
-		}
-	}
-
-	.following__intro-close-icon-bg {
-		display: block;
-		position: absolute;
-		height: 20px;
-		width: 20px;
-		top: 2px;
-		left: 2px;
-		z-index: z-index( 'root', '.following__intro-close-icon-bg' );
-		background-color: #5ca8a6;
-		border-radius: 10px;
-	}
-}
-
-.following__intro-copy {
-	color: $white;
-	font-size: 16px;
-	margin-left: 24px;
-	margin-top: 23px;
-	margin-bottom: 24px;
-	max-width: 69%;
-	text-shadow: 1px 1px 1px rgba( 0, 0, 0, 0.1 );
-
-	a {
-		color: #f3db51;
-		border-bottom: 1px #f3db51 solid;
-
-		&:hover {
-			color: $white;
-			border-bottom: 1px $white solid;
-		}
-	}
-
-	@media ( max-width: 900px ) {
-		max-width: 64%;
-	}
-
-	@include breakpoint( "<660px" ) {
-
-		.following__intro-copy-hidden {
-			display: none;
-			visibility: hidden;
-		}
 	}
 }


### PR DESCRIPTION
Adds an A/B/C test to try out the three new variations of the intro illustration added in https://github.com/Automattic/wp-calypso/pull/16167.

The three variations are blue, light blue and white background.

<img width="849" alt="screen shot 2017-07-18 at 16 20 19" src="https://user-images.githubusercontent.com/17325/28325189-14092ec6-6bd5-11e7-8425-2a92fb9ce3be.png">

### To test 

Create a brand new user on WordPress.com so you're shown the intro banner on your Following stream. Use the A/B test widget to choose each of the variations:

<img width="542" alt="screen shot 2017-07-18 at 16 15 06" src="https://user-images.githubusercontent.com/17325/28325011-b6cb2408-6bd4-11e7-9181-a747e4c9a042.png">
