### PR TITLE
Stats: Fix invalid stats click handler.

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -192,7 +192,11 @@ module.exports = React.createClass( {
 				icon = ( <span className="stats-list__flag-icon" style={ style } /> );
 			}
 
-			itemLabel = ( <Emojify>{ labelItem.label }</Emojify> );
+			if ( data.link ) {
+				itemLabel = ( <span title={ data.link } >{ labelItem.label }</span> );
+			} else {
+				itemLabel = ( <Emojify>{ labelItem.label }</Emojify> );
+			}
 
 			return ( <span className={ wrapperClassSet } key={ i } >{ gridiconSpan }{ icon }{ itemLabel } </span> );
 		}, this );

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -64,11 +64,6 @@ module.exports = React.createClass( {
 		}
 	},
 
-	preventDefaultOnClick: function( event ) {
-		event.stopPropagation();
-		event.preventDefault();
-	},
-
 	onClick: function( event ) {
 		var gaEvent,
 			moduleName = titlecase( this.props.moduleName );
@@ -197,11 +192,7 @@ module.exports = React.createClass( {
 				icon = ( <span className="stats-list__flag-icon" style={ style } /> );
 			}
 
-			if ( data.link ) {
-				itemLabel = ( <a onclick={ this.preventDefaultOnClick } href={ data.link } >{ labelItem.label }</a> );
-			} else {
-				itemLabel = ( <Emojify>{ labelItem.label }</Emojify> );
-			}
+			itemLabel = ( <Emojify>{ labelItem.label }</Emojify> );
 
 			return ( <span className={ wrapperClassSet } key={ i } >{ gridiconSpan }{ icon }{ itemLabel } </span> );
 		}, this );

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -192,11 +192,7 @@ module.exports = React.createClass( {
 				icon = ( <span className="stats-list__flag-icon" style={ style } /> );
 			}
 
-			if ( data.link ) {
-				itemLabel = ( <span title={ data.link } >{ labelItem.label }</span> );
-			} else {
-				itemLabel = ( <Emojify>{ labelItem.label }</Emojify> );
-			}
+			itemLabel = ( <Emojify>{ labelItem.label }</Emojify> );
 
 			return ( <span className={ wrapperClassSet } key={ i } >{ gridiconSpan }{ icon }{ itemLabel } </span> );
 		}, this );
@@ -227,6 +223,37 @@ module.exports = React.createClass( {
 		}
 
 		return value;
+	},
+
+	renderListItem: function( rightClassOptions, mobileActionToggle, actions, toggleIcon ) {
+		return (
+			<div>
+				<span className="module-content-list-item-wrapper" onClick={ this.onClick } tabIndex="0">
+					<span className={ classNames( rightClassOptions ) }>
+						{ mobileActionToggle }
+						{ actions }
+						<span className="module-content-list-item-value">{ this.props.data.value ? this.buildValue() : null }</span>
+					</span>
+					<span className="module-content-list-item-label">{ toggleIcon }{ this.buildLabel() }</span>
+				</span>
+				{ this.props.children }
+			</div>
+		);
+	},
+
+	renderExternalLink: function( rightClassOptions, mobileActionToggle, actions, toggleIcon ) {
+		return (
+			<a href={ this.props.data.link }>
+				<span className='module-content-list-item-wrapper' onClick={ this.onClick } tabIndex="0">
+					<span className={ classNames( rightClassOptions ) }>
+						{ mobileActionToggle }
+						{ actions }
+						<span className="module-content-list-item-value">{ this.props.data.value ? this.buildValue() : null }</span>
+					</span>
+					<span className="module-content-list-item-label">{ toggleIcon }{ this.buildLabel() }</span>
+				</span>
+			</a>
+		);
 	},
 
 	render: function() {
@@ -282,15 +309,10 @@ module.exports = React.createClass( {
 
 		return (
 			<li key={ this.key } data-group={ this.key } className={ groupClassName }>
-				<span className='module-content-list-item-wrapper' onClick={ this.onClick } tabIndex="0">
-					<span className={ classNames( rightClassOptions ) }>
-						{ mobileActionToggle }
-						{ actions }
-						<span className="module-content-list-item-value">{ data.value ? this.buildValue() : null }</span>
-					</span>
-					<span className="module-content-list-item-label">{ toggleIcon }{ this.buildLabel() }</span>
-				</span>
-				{ this.props.children }
+				{ this.props.data.link && ! this.props.children
+					? this.renderExternalLink( rightClassOptions, mobileActionToggle, actions, toggleIcon )
+					: this.renderListItem( rightClassOptions, mobileActionToggle, actions, toggleIcon )
+				}
 			</li>
 		);
 	}

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -64,6 +64,11 @@ module.exports = React.createClass( {
 		}
 	},
 
+	preventDefaultOnClick: function( event ) {
+		event.stopPropagation();
+		event.preventDefault();
+	},
+
 	onClick: function( event ) {
 		var gaEvent,
 			moduleName = titlecase( this.props.moduleName );
@@ -243,7 +248,7 @@ module.exports = React.createClass( {
 
 	renderExternalLink: function( rightClassOptions, mobileActionToggle, actions, toggleIcon ) {
 		return (
-			<a href={ this.props.data.link }>
+			<a className="stats-list__anchor" onClick={ this.preventDefaultActionClick } href={ this.props.data.link }>
 				<span className='module-content-list-item-wrapper' onClick={ this.onClick } tabIndex="0">
 					<span className={ classNames( rightClassOptions ) }>
 						{ mobileActionToggle }

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -706,6 +706,10 @@ ul.module-content-list-legend {
 	}
 }
 
+.stats-list__anchor {
+	display: block;
+}
+
 // Module Content List Item style: Toggle
 // (this item's main action is to show an enclosed sublist or something else)
 


### PR DESCRIPTION
While testing #16124 , I noticed this warning:

![screen shot 2017-07-18 at 10 25 13 am](https://user-images.githubusercontent.com/349751/28333611-460fd2f8-6bad-11e7-9157-f691c5afcb45.png)

Due to a typo [here](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/stats/stats-list/stats-list-item.jsx#L201), event defaults weren't being blocked as intended, and clicking on these stats links result in both the Calypso page and the newly-opened external tab loading the link. Fixing the `onClick` handler doesn't help either though, because a user clicking right on the `anchor` tag (rather than the list item) will have nothing happen (the anchor event is defeated, and the list item event isn't triggered). Removing the `data.link` [check](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/stats/stats-list/stats-list-item.jsx#L200-L202) (and therefore the anchor tag) gives us the expected behaviour.

![screen shot 2017-07-18 at 12 35 49 pm](https://user-images.githubusercontent.com/349751/28336132-ad717e6c-6bb5-11e7-9fb2-94482690f503.png)
_Example link affected_