### PR TITLE
Store: Add request wrapper for WC API calls using wpcom-http

### DIFF
--- a/client/extensions/woocommerce/state/sites/http-request.js
+++ b/client/extensions/woocommerce/state/sites/http-request.js
@@ -1,0 +1,75 @@
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+/**
+ * Returns a proper WPCOM_HTTP_REQUEST action (http data layer) for dispatching requests
+ * in data-layer handlers.
+ * @param {String} method HTTP Request Method
+ * @param {String} path The WC API path to make a request to (after /wc/v#)
+ * @param {Number} siteId Site ID to make the request to
+ * @param {Object} body HTTP Body for POST and PUT Requests
+ * @param {Object} action The original requesting action
+ * @return {Object} WPCOM_HTTP_REQUEST Action
+ */
+const _request = ( method, path, siteId, body, action ) => {
+	// WPCOM API breaks if query parameters are passed after "?" instead of "&". Hide this hack from the calling code
+	path = path.replace( '?', '&' );
+	path = `/wc/v3/${ path }&_method=${ method }`;
+	return http( {
+		apiVersion: '1.1',
+		method: 'GET' === method ? 'GET' : 'POST',
+		path: `/jetpack-blogs/${ siteId }/rest-api/`,
+		query: {
+			path,
+			json: true,
+		},
+		body: body && JSON.stringify( body ),
+	}, action );
+};
+
+/**
+ * Provides a wrapper over the http data-layer, made specifically for making requests to
+ * WooCommerce endpoints without repeating things like /wc/v3.
+ * @param {Number} siteId Site ID to make the request to
+ * @param {Object} action The original requesting action
+ * @return {Object} An object with the properties "get", "post", "put" and "del", which are functions to
+ * make an HTTP GET, POST, PUT and DELETE request, respectively.
+ */
+export default ( siteId, action ) => ( {
+
+	/**
+	 * Sends a GET request to the API
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 */
+	get: ( path ) => _request( 'GET', path, siteId, null, action ),
+
+	/**
+	 * Sends a POST request to the API
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @param {Object} body Payload to send
+	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 */
+	post: ( path, body ) => _request( 'POST', path, siteId, body || {}, action ),
+
+	/**
+	 * Sends a PUT request to the API.
+	 * Note that the underlying request will be a POST, with an special URL parameter to
+	 * be interpreted by the WPCOM server as a PUT request.
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @param {Object} body Payload to send
+	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 */
+	put: ( path, body ) => _request( 'PUT', path, siteId, body || {}, action ),
+
+	/**
+	 * Sends a DELETE request to the API.
+	 * Note that the underlying request will be a POST, with an special URL parameter to
+	 * be interpreted by the WPCOM server as a DELETE request.
+	 * @param {String} path REST path to hit, omitting the "blog.url/wp-json/wc/v#/" prefix
+	 * @return {Object} WPCOM_HTTP_REQUEST Action
+	 */
+	del: ( path ) => _request( 'DELETE', path, siteId, null, action ),
+} );

--- a/client/extensions/woocommerce/state/sites/settings/general/handlers.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/handlers.js
@@ -3,7 +3,7 @@
  */
 import { areSettingsGeneralLoaded } from 'woocommerce/state/sites/settings/general/selectors';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { http } from 'state/data-layer/wpcom-http/actions';
+import request from 'woocommerce/state/sites/http-request';
 import {
 	WOOCOMMERCE_SETTINGS_GENERAL_REQUEST,
 	WOOCOMMERCE_SETTINGS_GENERAL_RECEIVE,
@@ -36,16 +36,7 @@ export const handleSettingsGeneral = ( { dispatch, getState }, action, next ) =>
 		return;
 	}
 
-	// TODO Create a wrapper for these kinds of calls
-	dispatch( http( {
-		apiVersion: '1.1',
-		method: 'GET',
-		path: `/jetpack-blogs/${ siteId }/rest-api/`,
-		query: {
-			path: '/wc/v3/settings/general&_method=GET',
-			json: true,
-		}
-	}, action ) );
+	dispatch( request( siteId, action ).get( 'settings/general' ) );
 	return next( action );
 };
 

--- a/client/extensions/woocommerce/state/sites/test/http-request.js
+++ b/client/extensions/woocommerce/state/sites/test/http-request.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import request from '../http-request';
+import { WPCOM_HTTP_REQUEST } from 'state/action-types';
+
+const siteId = '123';
+const originalAction = {
+	type: 'WOOCOMMERCE_TEST_ACTION',
+	siteId,
+};
+
+describe( 'request', () => {
+	describe( '#get', () => {
+		it( 'should return a request action', () => {
+			const action = request( siteId, originalAction ).get( 'placeholder_endpoint' );
+			expect( action ).to.include( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'GET',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+			} );
+			expect( action.query ).to.exist;
+			expect( action.query ).to.include( {
+				path: '/wc/v3/placeholder_endpoint&_method=GET',
+			} );
+		} );
+	} );
+	describe( '#post', () => {
+		const body = { name: 'placeholder post request', placeholder: true };
+
+		it( 'should return a request action', () => {
+			const action = request( siteId, originalAction ).post( 'placeholder_endpoint', body );
+			expect( action ).to.include( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+			} );
+			expect( action.body ).to.eql( JSON.stringify( body ) );
+			expect( action.query ).to.exist;
+			expect( action.query ).to.include( {
+				path: '/wc/v3/placeholder_endpoint&_method=POST',
+			} );
+		} );
+	} );
+	describe( '#put', () => {
+		const body = { name: 'placeholder post request', placeholder: true };
+
+		it( 'should return a request action', () => {
+			const action = request( siteId, originalAction ).put( 'placeholder_endpoint', body );
+			expect( action ).to.include( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST', // Note that this stays POST
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+			} );
+			expect( action.body ).to.eql( JSON.stringify( body ) );
+			expect( action.query ).to.exist;
+			expect( action.query ).to.include( {
+				path: '/wc/v3/placeholder_endpoint&_method=PUT',
+			} );
+		} );
+	} );
+
+	describe( '#del', () => {
+		it( 'should return a request action', () => {
+			const action = request( siteId, originalAction ).del( 'placeholder_endpoint' );
+			expect( action ).to.include( {
+				type: WPCOM_HTTP_REQUEST,
+				method: 'POST', // Note that this stays POST
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+			} );
+			expect( action.body ).to.be.null,
+			expect( action.query ).to.exist;
+			expect( action.query ).to.include( {
+				path: '/wc/v3/placeholder_endpoint&_method=DELETE',
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds a wrapper around the `http` action so that we can more easily make WC-API calls using it, without having to add the full API path & version every time. It's similar to the existing `request.js` in form, but also takes an action parameter of the originating action which is needed in the data layer.

It also updates the settings general handler (see #16317) to use it.

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.