### PR TITLE
Improve transfer out UX wrt 60 day transfer lock

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -10,19 +11,19 @@ import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import { getSelectedDomain } from 'lib/domains';
 import Button from 'components/button';
+import Notice from 'components/notice';
 import { requestTransferCode } from 'lib/upgrades/actions';
 import { displayRequestTransferCodeResponseNotice } from './shared';
 import support from 'lib/url/support';
 
-const Locked = React.createClass( {
-	getInitialState() {
-		return {
-			submitting: false,
-			showDialog: false
-		}
-	},
+export class Locked extends Component {
+	state = {
+		submitting: false,
+		showDialog: false,
+		transferButtonDisabled: true
+	};
 
-	unlockAndRequestTransferCode: function() {
+	unlockAndRequestTransferCode = () => {
 		const { privateDomain, hasPrivacyProtection } = getSelectedDomain( this.props );
 
 		const options = {
@@ -40,9 +41,9 @@ const Locked = React.createClass( {
 			}
 			displayRequestTransferCodeResponseNotice( error, getSelectedDomain( this.props ) );
 		} );
-	},
+	}
 
-	requestTransferCode() {
+	requestTransferCode = () => {
 		const options = {
 			siteId: this.props.selectedSite.ID,
 			domainName: this.props.selectedDomainName,
@@ -58,59 +59,108 @@ const Locked = React.createClass( {
 			}
 			displayRequestTransferCodeResponseNotice( error, getSelectedDomain( this.props ) );
 		} );
-	},
+	}
 
-	handleTransferClick() {
+	handleTransferClick = () => {
 		this.unlockAndRequestTransferCode();
-	},
+	}
 
-	isManualTransferRequired() {
+	isManualTransferRequired = () => {
 		return getSelectedDomain( this.props ).manualTransferRequired;
-	},
+	}
 
-	renderManualTransferInfo() {
+	renderManualTransferInfo = () => {
+		const { translate } = this.props;
+
 		return (
 			<p>
-				{ this.translate(
+				{ translate(
 					'This Top Level Domain (TLD) requires that we manually request a ' +
 					'transfer code on your behalf. After we have received it, we will ' +
 					'email it to you.'
 				) }
 			</p>
 		);
-	},
+	}
 
-	handleGiveMeTheCodeClick( event ) {
+	handleGiveMeTheCodeClick = ( event ) => {
 		event.preventDefault();
 		this.requestTransferCode();
-	},
+	}
+
+	renderFooter = () => {
+		const { translate } = this.props;
+
+		if ( this.state.showFooter ) {
+			return (
+				<div>
+					<p className="transfer-out__small-text">
+						<a href="" onClick={ this.handleGiveMeTheCodeClick }>{ translate( 'I just want the transfer code for now.' ) }</a>
+					</p>
+					{ this.isManualTransferRequired() && this.renderManualTransferInfo() }
+					<Button
+						className="transfer-out__action-button"
+						onClick={ this.handleTransferClick }
+						primary
+						disabled={ this.state.submitting }>
+						{ translate( 'Update Settings And Continue' ) }
+					</Button>
+				</div>
+			);
+		}
+	}
+
+	handleEnableTransferButtonClick = () => {
+		this.setState( { transferButtonDisabled: false } );
+	}
 
 	render() {
+		const { translate } = this.props;
 		const { privateDomain } = getSelectedDomain( this.props );
 		return (
 			<div>
-				<SectionHeader label={ this.translate( 'Transfer Domain' ) }/>
+				<SectionHeader label={ translate( 'Transfer Domain' ) } />
 				<Card className="transfer-card">
 					<div>
 						<p>
 							{ privateDomain
-								? this.translate( 'To transfer your domain, we must unlock it and remove Privacy Protection. ' +
+								? translate( 'To transfer your domain, we must unlock it and remove Privacy Protection. ' +
 									'Your contact information will be publicly available during the transfer period.' )
-								: this.translate( 'To transfer your domain, we must unlock it.' )
+								: translate( 'To transfer your domain, we must unlock it.' )
 							} <a
 									href={ support.TRANSFER_DOMAIN_REGISTRATION }
-									target="_blank" rel="noopener noreferrer">{ this.translate( 'Learn More.' ) }</a>
+									target="_blank" rel="noopener noreferrer">{ translate( 'Learn More.' ) }</a>
 						</p>
-						<p className="transfer__small-text">
-							<a href="" onClick={ this.handleGiveMeTheCodeClick }>{ this.translate( 'I just want the transfer code for now.' ) }</a>
+						<div>
+							<Notice
+								showDismiss={ false }>
+								<div>
+									The contact informaion for this domain was changed <strong>24 days ago</strong>. Under ICANN policy,
+									these changes trigger a 60-day transfer lock to be applied to the domain unless you opt out during
+									the process. <a>Learn more.</a>
+								</div>
+									<Button
+										className="transfer-out__show-footer"
+										onClick={ this.handleEnableTransferButtonClick }
+										primary
+										compact
+										disabled={ ! this.state.transferButtonDisabled }>
+										{ translate( 'I Understand' ) }
+									</Button>
+							</Notice>
+						</div>
+						<p className="transfer-out__small-text">
+							<a href="" onClick={ this.handleGiveMeTheCodeClick }>
+								{ translate( 'I just want the transfer code for now.' ) }
+							</a>
 						</p>
 						{ this.isManualTransferRequired() && this.renderManualTransferInfo() }
 						<Button
-							className="transfer__action-button"
+							className="transfer-out__action-button"
 							onClick={ this.handleTransferClick }
 							primary
-							disabled={ this.state.submitting }>
-							{ this.translate( 'Update Settings And Continue' ) }
+							disabled={ this.state.submitting || this.state.transferButtonDisabled }>
+							{ translate( 'Update Settings And Continue' ) }
 						</Button>
 					</div>
 				</Card>
@@ -118,5 +168,6 @@ const Locked = React.createClass( {
 		);
 	}
 
-} );
-export default Locked;
+}
+
+export default localize( Locked );

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
@@ -12,12 +12,16 @@
 	}
 }
 
-.transfer__action-button {
+.transfer-out__action-button {
 	float: right;
 	margin-right: 10px;
 	&:first-of-type {
 		margin-right: 0;
 	}
+}
+
+.transfer-out__show-footer {
+	float: right;
 }
 
 .transfer-card {
@@ -29,6 +33,7 @@
 	}
 }
 
-.transfer__small-text {
+.transfer-out__small-text {
+	float: left;
 	font-size: 12px;
 }


### PR DESCRIPTION
We'd like to be better about helping users understand that when a domain is transfer-locked, they can't transfer the domain until the lock period is over.

So, I'd like to be able to explain this to the user, let them know how long until the transfer-lock expires, and where they can find out more information.

Below is one initial proposal for a way to do this. Before going too much further with this UI work, I'm interested in getting some feedback and suggestions improvement.

This shows an example transfer dialog for a domain that has been transfer-locked for 24 days. The "Learn more." link in the notice section would take the user to: https://support.wordpress.com/update-contact-information/#email-or-name-changes

![2017-07-18 16 33 23](https://user-images.githubusercontent.com/1379730/28339459-2f2895e8-6bda-11e7-8d43-bb68f13ce8ec.gif)
