### PR TITLE
Comments: add tabbing styles to comment list view

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -78,7 +78,7 @@ $z-layers: (
 		'.editor-html-toolbar': 1,
 		'.thank-you-card__header': 1,
 		'.comment-detail.card.is-collapsed:hover': 1,
-		'.comment-detail.card.is-collapsed.accessible-focus:focus': 1,
+		'.comment-detail.card.accessible-focus:focus': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -77,6 +77,8 @@ $z-layers: (
 		'.domain-suggestion.is-clickable:hover': 1,
 		'.editor-html-toolbar': 1,
 		'.thank-you-card__header': 1,
+		'.comment-detail.card.is-collapsed:hover': 1,
+		'.comment-detail.card.is-collapsed.accessible-focus:focus': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, isUndefined, noop } from 'lodash';
+import ReactDom from 'react-dom';
 
 /**
  * Internal dependencies
@@ -109,7 +110,15 @@ export class CommentDetail extends Component {
 		setCommentStatus( commentId, postId, 'trash' === commentStatus ? 'approved' : 'trash' );
 	}
 
+	setCardRef = card => {
+		this.commentCard = card;
+	}
+
 	keyHandler = event => {
+		const commentHasFocus = document && this.commentCard && document.activeElement === ReactDom.findDOMNode( this.commentCard );
+		if ( this.state.isExpanded && ! commentHasFocus ) {
+			return;
+		}
 		switch ( event.keyCode ) {
 			case 32: // space
 			case 13: // enter
@@ -169,6 +178,7 @@ export class CommentDetail extends Component {
 		return (
 			<Card
 				onKeyDown={ this.keyHandler }
+				ref={ this.setCardRef }
 				className={ classes }
 				tabIndex="0"
 			>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -157,7 +157,7 @@ export class CommentDetail extends Component {
 		} );
 
 		return (
-			<Card className={ classes }>
+			<Card className={ classes } tabIndex="0">
 				<CommentDetailHeader
 					authorAvatarUrl={ authorAvatarUrl }
 					authorDisplayName={ authorDisplayName }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -109,6 +109,16 @@ export class CommentDetail extends Component {
 		setCommentStatus( commentId, postId, 'trash' === commentStatus ? 'approved' : 'trash' );
 	}
 
+	keyHandler = event => {
+		switch ( event.keyCode ) {
+			case 32: // space
+			case 13: // enter
+				event.preventDefault();
+				this.toggleExpanded();
+				break;
+		}
+	}
+
 	render() {
 		const {
 			authorAvatarUrl,
@@ -157,7 +167,11 @@ export class CommentDetail extends Component {
 		} );
 
 		return (
-			<Card className={ classes } tabIndex="0">
+			<Card
+				onKeyDown={ this.keyHandler }
+				className={ classes }
+				tabIndex="0"
+			>
 				<CommentDetailHeader
 					authorAvatarUrl={ authorAvatarUrl }
 					authorDisplayName={ authorDisplayName }

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -4,6 +4,11 @@
 	padding: 0;
 	transition: margin .15s linear;
 
+	.accessible-focus &:focus {
+		box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
+		z-index: z-index( 'root', '.comment-detail.card.is-collapsed.accessible-focus:focus' );
+	}
+
 	&.is-expanded {
 		margin: 16px auto;
 
@@ -16,11 +21,6 @@
 		&:hover {
 			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
 			z-index: z-index( 'root', '.comment-detail.card.is-collapsed:hover' );
-		}
-
-		.accessible-focus &:focus {
-			box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
-			z-index: z-index( 'root', '.comment-detail.card.is-collapsed.accessible-focus:focus' );
 		}
 	}
 

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -12,9 +12,16 @@
 		}
 	}
 
-	&.is-collapsed:hover {
-		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
-		z-index: 1;
+	&.is-collapsed {
+		&:hover {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
+			z-index: 1;
+		}
+
+		.accessible-focus &:focus {
+			box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
+			z-index: 1;
+		}
 	}
 
 	// If the comment is unapproved and collapsed, color it yellow.

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -6,7 +6,7 @@
 
 	.accessible-focus &:focus {
 		box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
-		z-index: z-index( 'root', '.comment-detail.card.is-collapsed.accessible-focus:focus' );
+		z-index: z-index( 'root', '.comment-detail.card.accessible-focus:focus' );
 	}
 
 	&.is-expanded {

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -15,12 +15,12 @@
 	&.is-collapsed {
 		&:hover {
 			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
-			z-index: 1;
+			z-index: z-index( 'root', '.comment-detail.card.is-collapsed:hover' );
 		}
 
 		.accessible-focus &:focus {
 			box-shadow: 0 0 0 1px $blue-medium, 0 0 0 3px $blue-light;
-			z-index: 1;
+			z-index: z-index( 'root', '.comment-detail.card.is-collapsed.accessible-focus:focus' );
 		}
 	}
 


### PR DESCRIPTION
Adds styles for tabbing through the comments in the list view. Before, the comment list was not focusable via keyboard, and there were no styles.

fixes #15940

todo: 

- [x] ~Remove tab index from comment-detail if the comment is expanded (focusing on this element is not needed when the comment is open)~ [do this instead](https://github.com/Automattic/wp-calypso/pull/16339#issuecomment-317773919)
- [x] Add enter action when focused (this will open the comment)
- [x] use _z-index.scss for box shadow

To test:

- make sure the blue shadow does not show for mouse interaction
- test with comments collapsed and expanded

![screen shot 2017-07-18 at 4 31 22 pm](https://user-images.githubusercontent.com/618551/28340793-a748cd8a-6bd6-11e7-9aa3-33e192fc13ab.png)