### PR TITLE
Activity log: Add object queries to ActivityLogItem

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -21,6 +21,7 @@ import EllipsisMenu from 'components/ellipsis-menu';
 import FoldableCard from 'components/foldable-card';
 import PopoverMenuItem from 'components/popover/menu-item';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
+import Post from 'my-sites/posts/post';
 import QueryActivityObject from './query-activity-object';
 import { getSitePost } from 'state/posts/selectors';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
@@ -192,15 +193,28 @@ class ActivityLogItem extends Component {
 	// FIXME: Just for demonstration purposes
 	renderDescription() {
 		const {
+			applySiteOffset,
 			log,
 			moment,
+			postObject,
 			translate,
-			applySiteOffset,
 		} = this.props;
 		const {
 			name,
 			ts_utc,
 		} = log;
+
+		if (
+			log.group === 'post' &&
+			'post' === get( postObject, 'type' )
+		) {
+			return (
+				<div>
+					<Post post={ postObject } />
+					<div className="activity-log-item__id">ID { ts_utc }</div>
+				</div>
+			);
+		}
 
 		return (
 			<div>
@@ -357,10 +371,8 @@ class ActivityLogItem extends Component {
 }
 
 export default connect(
-	( state, { log, siteId } ) => {
-		return {
-			postObject: getSitePost( state, siteId, get( log, [ 'object', 'post', 'id' ], null ) )
-		};
-	},
+	( state, { log, siteId } ) => ( {
+		postObject: getSitePost( state, siteId, get( log, [ 'object', 'post', 'id' ], null ) ),
+	} ),
 	{ recordTracksEvent: recordTracksEventAction }
 )( localize( ActivityLogItem ) );

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityActor from './activity-actor';
 import ActivityIcon from './activity-icon';
+import QueryActivityObject from './query-activity-object';
 import ActivityTitle from './activity-title';
 import EllipsisMenu from 'components/ellipsis-menu';
 import FoldableCard from 'components/foldable-card';
@@ -281,16 +282,19 @@ class ActivityLogItem extends Component {
 		const {
 			className,
 			log,
+			siteId,
 		} = this.props;
 		const {
 			group,
 			name,
+			object,
 		} = log;
 
 		const classes = classNames( 'activity-log-item', className );
 
 		return (
 			<div className={ classes } >
+				<QueryActivityObject group={ group } object={ object } siteId={ siteId } />
 				<div className="activity-log-item__type">
 					{ this.renderTime() }
 					<ActivityIcon group={ group } name={ name } />

--- a/client/my-sites/stats/activity-log-item/query-activity-object.js
+++ b/client/my-sites/stats/activity-log-item/query-activity-object.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent, PropTypes } from 'react';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import QueryPosts from 'components/data/query-posts';
+
+export default class QueryActivityObject extends PureComponent {
+	static propTypes = {
+		group: PropTypes.oneOf( [
+			'attachment',
+			'comment',
+			'core',
+			'menu',
+			'plugin',
+			'post',
+			'term',
+			'theme',
+			'user',
+			'widget',
+		] ).isRequired,
+
+		object: PropTypes.shape( {
+			attachment: PropTypes.shape( {
+				mime_type: PropTypes.string,
+				id: PropTypes.number.isRequired,
+				title: PropTypes.string.isRequired,
+				url: PropTypes.shape( {
+					host: PropTypes.string.isRequired,
+					url: PropTypes.string.isRequired,
+					host_reversed: PropTypes.string.isRequired,
+				} ).isRequired,
+			} ),
+
+			comment: PropTypes.shape( {
+				approved: PropTypes.bool.isRequired,
+				id: PropTypes.number.isRequired,
+			} ),
+
+			core: PropTypes.shape( {
+				new_version: PropTypes.string,
+				old_version: PropTypes.string,
+			} ),
+
+			menu: PropTypes.shape( {
+				id: PropTypes.number,
+				name: PropTypes.string,
+			} ),
+
+			plugin: PropTypes.oneOfType( [
+				PropTypes.shape( {
+					name: PropTypes.string,
+					previous_version: PropTypes.string,
+					slug: PropTypes.string,
+					version: PropTypes.string,
+				} ),
+				PropTypes.arrayOf(
+					PropTypes.shape( {
+						name: PropTypes.string,
+						previous_version: PropTypes.string,
+						slug: PropTypes.string,
+						version: PropTypes.string,
+					} ),
+				),
+			] ),
+
+			post: PropTypes.shape( {
+				id: PropTypes.number.isRequired,
+				status: PropTypes.string.isRequired,
+				type: PropTypes.string,
+				title: PropTypes.string,
+			} ),
+
+			term: PropTypes.shape( {
+				id: PropTypes.number.isRequired,
+				title: PropTypes.string.isRequired,
+				type: PropTypes.string.isRequired,
+			} ),
+
+			theme: PropTypes.oneOfType( [
+				PropTypes.arrayOf(
+					PropTypes.shape( {
+						name: PropTypes.string,
+						slug: PropTypes.string,
+						uri: PropTypes.string,
+						version: PropTypes.string,
+					} )
+				),
+				PropTypes.shape( {
+					name: PropTypes.string,
+					slug: PropTypes.string,
+					uri: PropTypes.string,
+					version: PropTypes.string,
+				} ),
+			] ),
+
+			user: PropTypes.shape( {
+				display_name: PropTypes.string,
+				external_user_id: PropTypes.string,
+				login: PropTypes.string,
+				wpcom_user_id: PropTypes.number,
+			} ),
+
+			widget: PropTypes.shape( {
+				id: PropTypes.number,
+				name: PropTypes.string,
+				sidebar: PropTypes.string,
+			} ),
+		} ),
+
+		siteId: PropTypes.number.isRequired,
+	};
+
+	render() {
+		const {
+			group,
+			object,
+			siteId,
+		} = this.props;
+		switch ( group ) {
+			case 'post': {
+				const postId = get( object, [ 'post', 'id' ] );
+				return postId && (
+					<QueryPosts siteId={ siteId } postId={ postId } />
+				);
+			}
+			default:
+				return null;
+		}
+	}
+}
+


### PR DESCRIPTION
This is an exploration for querying the primary objects for activity items. It will lay the groundwork for displaying relevant actions.

Check it out: https://calypso.live/stats/activity?branch=try/query-activity-objects

Demo:

![post in AL](https://user-images.githubusercontent.com/841763/31233701-7e91aa9c-a9ed-11e7-9fc5-eb67678632f0.gif)
