### PR TITLE
Checkout: AB Test PayPal logo instead of just name

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -112,5 +112,6 @@ module.exports = {
 		},
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -104,4 +104,13 @@ module.exports = {
 		defaultVariation: 'white',
 		assignmentMethod: 'userId',
 	},
+	paymentShowPaypalLogo: {
+		datestamp: '20170719',
+		variations: {
+			hide: 50,
+			show: 50,
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import { some } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -87,7 +88,7 @@ var CreditCardPaymentBox = React.createClass( {
 	progressBar: function() {
 		return (
 			<div className="credit-card-payment-box__progress-bar">
-				{ this.translate( 'Processing payment…' ) }
+				{ this.props.translate( 'Processing payment…' ) }
 				<ProgressBar value={ Math.round( this.state.progress ) } isPulsing />
 			</div>
 		);
@@ -99,9 +100,13 @@ var CreditCardPaymentBox = React.createClass( {
 			showPaymentChatButton = config.isEnabled( 'upgrades/presale-chat' ) &&
 				abtest( 'presaleChatButton' ) === 'showChatButton' &&
 				hasBusinessPlanInCart,
+			showPaypalLogo = abtest( 'paymentShowPaypalLogo' ) === 'show',
 			paypalButtonClasses = classnames( 'credit-card-payment-box__switch-link', {
-				'credit-card-payment-box__switch-link-left': showPaymentChatButton
-			} );
+				'credit-card-payment-box__switch-link-left': showPaymentChatButton,
+			} ),
+			paypalLinkContent = showPaypalLogo
+				? <img src="/calypso/images/upgrades/paypal.svg" alt="PayPal" width="80" />
+				: <span>PayPal</span>;
 
 		return (
 			<div className="payment-box__payment-buttons">
@@ -110,7 +115,12 @@ var CreditCardPaymentBox = React.createClass( {
 					transactionStep={ this.props.transactionStep } />
 
 				{ cartValues.isPayPalExpressEnabled( cart )
-					? <a className={ paypalButtonClasses } href="" onClick={ this.handleToggle }>{ this.translate( 'or use PayPal' ) }</a>
+					? <a className={ paypalButtonClasses } href="" onClick={ this.handleToggle }>
+						{ this.props.translate( 'or use {{paypal/}}', {
+							components: {
+								paypal: paypalLinkContent
+							}
+						} ) }</a>
 					: null
 				}
 
@@ -173,7 +183,7 @@ var CreditCardPaymentBox = React.createClass( {
 		return (
 			<PaymentBox
 				classSet="credit-card-payment-box"
-				title={ this.translate( 'Secure Payment' ) }>
+				title={ this.props.translate( 'Secure Payment' ) }>
 				{ this.content() }
 			</PaymentBox>
 		);
@@ -181,4 +191,4 @@ var CreditCardPaymentBox = React.createClass( {
 
 } );
 
-module.exports = CreditCardPaymentBox;
+module.exports = localize( CreditCardPaymentBox );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -841,6 +841,10 @@
 	font-size: 12px;
 	padding-bottom: 5px;
 
+	img {
+		margin-left:8px;
+	}
+
 	@include breakpoint( "<660px" ) {
 		border-bottom: 1px solid lighten( $gray, 30% );
 		margin: 10px 0 0 0;


### PR DESCRIPTION
AB Test the use of a PayPal logo instead of just the name.

Before:
<img width="747" alt="screen shot 2017-07-19 at 1 32 18" src="https://user-images.githubusercontent.com/844866/28342947-886713d4-6c23-11e7-9148-90e3eea7a0cc.png">

After:
<img width="742" alt="screen shot 2017-07-19 at 1 43 15" src="https://user-images.githubusercontent.com/844866/28342981-b006ac10-6c23-11e7-82fb-e41f2b224db2.png">

TODO:
- [ ] Design review/fix (logo positioning feels off)
- [ ] Limit AB test to specific country/locale

