### PR TITLE
WCS-Stats: Query Site Stats only once per page

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/constants.js
+++ b/client/extensions/woocommerce/app/store-stats/constants.js
@@ -3,7 +3,7 @@
  */
 import { translate } from 'i18n-calypso';
 
-export const sparkWidgetList1 = [
+const sparkWidgetList1 = [
 	{
 		key: 'products',
 		title: translate( 'Products Purchased' ),
@@ -21,7 +21,7 @@ export const sparkWidgetList1 = [
 	}
 ];
 
-export const sparkWidgetList2 = [
+const sparkWidgetList2 = [
 	{
 		key: 'total_refund',
 		title: translate( 'Refunds' ),
@@ -38,6 +38,8 @@ export const sparkWidgetList2 = [
 		format: 'currency'
 	}
 ];
+
+export const sparkWidgets = [ sparkWidgetList1, sparkWidgetList2 ];
 
 export const topProducts = {
 	basePath: '/store/stats/products',

--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -20,8 +20,7 @@ import List from './store-stats-list';
 import WidgetList from './store-stats-widget-list';
 import SectionHeader from 'components/section-header';
 import {
-	sparkWidgetList1,
-	sparkWidgetList2,
+	sparkWidgets,
 	topProducts,
 	topCategories,
 	topCoupons,
@@ -30,6 +29,7 @@ import {
 import { getUnitPeriod, getEndPeriod } from './utils';
 import { getJetpackSites } from 'state/selectors';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import QuerySiteStats from 'components/data/query-site-stats';
 
 class StoreStats extends Component {
 	static propTypes = {
@@ -49,7 +49,7 @@ class StoreStats extends Component {
 		const endSelectedDate = getEndPeriod( selectedDate, unit );
 		const ordersQuery = {
 			unit,
-			date: queryDate,
+			date: unitQueryDate,
 			quantity: UNITS[ unit ].quantity,
 		};
 		const topQuery = {
@@ -60,33 +60,15 @@ class StoreStats extends Component {
 		const topWidgets = [ topProducts, topCategories, topCoupons ];
 		const widgetPath = `/${ unit }/${ slug }${ querystring ? '?' : '' }${ querystring || '' }`;
 
-		const widgetList1 = (
-			<WidgetList
-				siteId={ siteId }
-				query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
-				selectedDate={ endSelectedDate }
-				statType="statsOrders"
-				widgets={ sparkWidgetList1 }
-			/>
-		);
-		const widgetList2 = (
-			<WidgetList
-				siteId={ siteId }
-				query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
-				selectedDate={ endSelectedDate }
-				statType="statsOrders"
-				widgets={ sparkWidgetList2 }
-			/>
-		);
-
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
 				<QueryJetpackPlugins siteIds={ jetPackSites.map( site => site.ID ) } />
+				{ siteId && <QuerySiteStats statType="statsOrders" siteId={ siteId } query={ ordersQuery } /> }
 				<div className="store-stats__sidebar-nav"><SidebarNavigation /></div>
 				<Navigation unit={ unit } type="orders" slug={ slug } />
 				<Chart
 					path={ path }
-					query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
+					query={ ordersQuery }
 					selectedDate={ endSelectedDate }
 					siteId={ siteId }
 					unit={ unit }
@@ -110,24 +92,35 @@ class StoreStats extends Component {
 					/>
 				</StatsPeriodNavigation>
 				<div className="store-stats__widgets">
-					<div className="store-stats__widgets-column spark-widgets" key="sparkwidgets">
-						<Module
-							siteId={ siteId }
-							header={ null }
-							emptyMessage={ translate( 'No data found.' ) }
-							query={ Object.assign( {}, ordersQuery, { date: unitQueryDate } ) }
-							statType="statsOrders"
-						>
-							{ widgetList1 }
-							{ widgetList2 }
-						</Module>
-					</div>
+					{ sparkWidgets.map( ( widget, index ) => (
+						<div className="store-stats__widgets-column spark-widgets" key={ index }>
+							<Module
+								siteId={ siteId }
+								emptyMessage={ translate( 'No data found' ) }
+								query={ ordersQuery }
+								statType="statsOrders"
+							>
+								<WidgetList
+									siteId={ siteId }
+									query={ ordersQuery }
+									selectedDate={ endSelectedDate }
+									statType="statsOrders"
+									widgets={ widget }
+								/>
+							</Module>
+						</div>
+					) ) }
 					{ topWidgets.map( widget => {
 						const header = (
 							<SectionHeader href={ widget.basePath + widgetPath } label={ widget.title } />
 						);
 						return (
 							<div className="store-stats__widgets-column" key={ widget.basePath }>
+								{ siteId && <QuerySiteStats
+									statType={ widget.statType }
+									siteId={ siteId }
+									query={ topQuery }
+								/> }
 								<Module
 									siteId={ siteId }
 									header={ header }

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -27,6 +27,7 @@ import {
 } from 'woocommerce/app/store-stats/constants';
 import { getJetpackSites } from 'state/selectors';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import QuerySiteStats from 'components/data/query-site-stats';
 
 const listType = {
 	products: topProducts,
@@ -64,9 +65,11 @@ class StoreStatsListView extends Component {
 			date: unitSelectedDate,
 			limit: 100,
 		};
+		const statType = listType[ type ].statType;
 		return (
 			<Main className="store-stats__list-view woocommerce" wideLayout={ true }>
 				<QueryJetpackPlugins siteIds={ jetPackSites.map( site => site.ID ) } />
+				{ siteId && <QuerySiteStats statType={ statType } siteId={ siteId } query={ listviewQuery } /> }
 				<HeaderCake onClick={ this.goBack }>{ listType[ type ].title }</HeaderCake>
 				<StatsPeriodNavigation
 					date={ selectedDate }
@@ -81,7 +84,7 @@ class StoreStatsListView extends Component {
 								: selectedDate
 						}
 						query={ listviewQuery }
-						statsType={ listType[ type ].statType }
+						statsType={ statType }
 						showQueryDate
 					/>
 				</StatsPeriodNavigation>
@@ -98,13 +101,13 @@ class StoreStatsListView extends Component {
 					siteId={ siteId }
 					emptyMessage={ listType[ type ].empty }
 					query={ listviewQuery }
-					statType={ listType[ type ].statType }
+					statType={ statType }
 				>
 					<List
 						siteId={ siteId }
 						values={ listType[ type ].values }
 						query={ listviewQuery }
-						statType={ listType[ type ].statType }
+						statType={ statType }
 					/>
 				</Module>
 			</Main>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -19,7 +19,6 @@ import { getPeriodFormat } from 'state/stats/lists/utils';
 import { getDelta } from '../utils';
 import { getSiteStatsNormalizedData, isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import Legend from 'components/chart/legend';
-import QuerySiteStats from 'components/data/query-site-stats';
 import Tabs from 'my-sites/stats/stats-tabs';
 import Tab from 'my-sites/stats/stats-tabs/tab';
 import { UNITS } from 'woocommerce/app/store-stats/constants';
@@ -66,7 +65,7 @@ class StoreStatsChart extends Component {
 	};
 
 	render() {
-		const { data, deltas, query, selectedDate, siteId, unit } = this.props;
+		const { data, deltas, selectedDate, unit } = this.props;
 		const { selectedTabIndex } = this.state;
 		const tabs = [
 			{ label: 'Gross Sales', attr: 'gross_sales', type: 'currency' },
@@ -81,11 +80,6 @@ class StoreStatsChart extends Component {
 		const selectedIndex = findIndex( data, d => d.period === selectedDate );
 		return (
 			<Card className="store-stats-chart stats-module">
-				{ siteId && <QuerySiteStats
-					query={ query }
-					siteId={ siteId }
-					statType="statsOrders"
-				/> }
 				<Legend
 					activeTab={ selectedTab }
 				/>

--- a/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-module/index.js
@@ -9,7 +9,6 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import Card from 'components/card';
-import QuerySiteStats from 'components/data/query-site-stats';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData
@@ -43,14 +42,13 @@ class StoreStatsModule extends Component {
 	}
 
 	render() {
-		const { siteId, statType, header, query, children, data, emptyMessage } = this.props;
+		const { header, children, data, emptyMessage } = this.props;
 		const { loaded } = this.state;
 		const isLoading = ! loaded && ! ( data && data.length );
 		const hasEmptyData = loaded && data && data.length === 0;
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="store-stats-module">
-				{ siteId && statType && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
 				{ header }
 				{ isLoading && <Card><StatsModulePlaceholder isLoading={ isLoading } /></Card> }
 				{ ! isLoading && hasEmptyData &&

--- a/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-widget-list/index.js
@@ -13,10 +13,7 @@ import { moment, translate } from 'i18n-calypso';
 import Delta from 'woocommerce/components/delta';
 import { formatValue, getDelta } from '../utils';
 import { getPeriodFormat } from 'state/stats/lists/utils';
-import {
-	isRequestingSiteStatsForQuery,
-	getSiteStatsNormalizedData
-} from 'state/stats/lists/selectors';
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 import Sparkline from 'woocommerce/components/sparkline';
 import Table from 'woocommerce/components/table';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -125,7 +122,6 @@ export default connect(
 		return {
 			data: siteStats.data,
 			deltas: siteStats.deltas,
-			requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
 		};
 	}
 )( StoreStatsWidgetList );

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -27,27 +27,7 @@
 		width: calc( 33% - 3px );
 
 		&.spark-widgets {
-			width: 100%;
-
-			.store-stats-module {
-				display: flex;
-				flex-direction: row;
-				flex-wrap: wrap;
-
-				.card {
-					width: 100%;
-				}
-
-				.store-stats-widget-list {
-					width: calc( 50% - 8px );
-					&:first-child {
-						margin-left: 0;
-					}
-					&:last-child {
-						margin-right: 0;
-					}
-				}
-			}
+			width: calc( 50% - 6px );
 		}
 	}
 }


### PR DESCRIPTION
### Problem
`QuerySiteStats` component doesn't deal with multiple instances on the same page, even if the queries are identical. Several components including `<Module/>` and `<Chart/>` had included the query component.

### Solution
`QuerySiteStats` only once per page.

### Also
* Looped through SparklineWidgets and simplified CSS
* Cleanup of unused props and duplicate query objects