### PR TITLE
Buttons: Remove border-radius from borderless buttons

### DIFF
--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -87,6 +87,7 @@
 
 .editor-ground-control__toggle-sidebar {
 	margin-right: 8px;
+	border-radius: 0;
 }
 
 .focus-sidebar .editor-ground-control__toggle-sidebar:hover,


### PR DESCRIPTION
This PR fixes #16308 by removing `border-radius` from `.button.is-borderless`.

## Testing
1. Visit https://calypso.live/devdocs/design/buttons?branch=fix/16308-post-settings-button-curved
1. Ensure that all buttons continue to display correctly.
1. Visit the post editor https://calypso.live/post/?branch=fix/16308-post-settings-button-curved
1. Ensure the issue from #16308 is fixed (see before).

## Before

![before](https://user-images.githubusercontent.com/841763/28359604-206d8588-6c73-11e7-9f0c-44574a5f580d.png)

## After

![after](https://user-images.githubusercontent.com/841763/28359606-221f7440-6c73-11e7-97c4-dfbe846c8755.png)

Fixes #16308