### PR TITLE
Reader: always hide settings label in site search results (two-column)

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -410,9 +410,15 @@
 	}
 }
 
-.search-stream__results.is-two-columns .search-stream__site-results .gridicons-cog {
-	left: -2px;
-	top: 8px;
+.search-stream__results.is-two-columns .search-stream__site-results {
+	.gridicons-cog {
+		left: -2px;
+		top: 8px;
+	}
+
+	.reader-email-settings__button-label {
+		display: none;
+	}
 }
 
 .search-stream .reader-subscription-list-item .gridicons-cog {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/16336, in which @fraying reports that the email settings label is sometimes visible in the 'sites' column of Reader Search, obscuring the follow button.

Before:

<img width="235" alt="screen shot 2017-07-19 at 12 00 48" src="https://user-images.githubusercontent.com/17325/28363833-ecc79546-6c79-11e7-90a9-a18f07823c05.png">

After:

<img width="317" alt="screen shot 2017-07-19 at 12 01 23" src="https://user-images.githubusercontent.com/17325/28363861-0878f5c8-6c7a-11e7-8a49-f89a459f0d7c.png">

### To test

Visit http://calypso.localhost:3000/read/search?q=farm, follow the first site result, and ensure that the settings icon displays correctly.

Reduce the size of your browser window to ensure that the settings icon is still correctly displayed when the page is in tabbed mode, too.

<img width="471" alt="screen shot 2017-07-19 at 12 04 06" src="https://user-images.githubusercontent.com/17325/28363943-67cf8ac8-6c7a-11e7-9b94-fb6f108bb6e2.png">



