### PR TITLE
Site Settings: Introduce Data Sync card to Manage Connection page

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -175,7 +175,7 @@ const JetpackSyncPanel = React.createClass( {
 				<div className="jetpack-sync-panel__action">
 					{ translate(
 						'Jetpack Sync keeps your WordPress.com dashboard up to date. ' +
-						'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience.',
+						'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience. ',
 						{
 							components: {
 								strong: <strong />

--- a/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
+++ b/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import JetpackSyncPanel from 'my-sites/site-settings/jetpack-sync-panel';
+import SectionHeader from 'components/section-header';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { getSiteUrl } from 'state/selectors';
+
+const DataSynchronization = ( {
+	siteUrl,
+	supportsJetpackSync,
+	translate
+} ) => {
+	if ( ! supportsJetpackSync ) {
+		return null;
+	}
+
+	return (
+		<div>
+			<SectionHeader label={ translate( 'Data synchronization' ) } />
+
+			<JetpackSyncPanel />
+
+			<CompactCard href={ 'https://jetpack.com/support/debug/?url=' + siteUrl } target="_blank">
+				{ translate( 'Diagnose a connection problem' ) }
+			</CompactCard>
+		</div>
+	);
+};
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteIsJetpack = isJetpackSite( state, siteId );
+
+		return {
+			siteUrl: getSiteUrl( state, siteId ),
+			supportsJetpackSync: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.2-alpha' ),
+		};
+	}
+)( localize( DataSynchronization ) );

--- a/client/my-sites/site-settings/manage-connection/index.jsx
+++ b/client/my-sites/site-settings/manage-connection/index.jsx
@@ -9,6 +9,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import DataSynchronization from './data-synchronization';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
@@ -49,6 +50,7 @@ class ManageConnection extends Component {
 				</HeaderCake>
 
 				<SiteOwnership />
+				<DataSynchronization />
 			</Main>
 		);
 	}


### PR DESCRIPTION
This PR introduces a Data Synchronization card to the Manage Connection page, as suggested in #13232. 

Note: visual changes to the Jetpack Sync panel and cleanup of these cards from the General section are coming in subsequent PRs.

Questions to @rickybanister, related with what we currently have in the Jetpack card in settings/general:

* Should we also move over the API cache "Use synchronized data to boost performance" toggle too?
* Should we also move the legacy pre-JP-4.2 "Allow synchronization of Posts and Pages with non-public post statuses" toggle too?
* Should we remove the Jetpack card from the General tab entirely after introducing the Manage Connection page?

Preview of the new card:
![](https://cldup.com/_ywQ7qAI9r.png)

To test:
* Checkout this branch, or get it going on calypso.live
* Go to `/settings/manage-connection/:site` where `:site` is a Jetpack site.
* Verify the card loads correctly and works like it does in the Generals settings section.