### PR TITLE
Site Settings: Remove button from Jetpack Sync panel

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Button from 'components/button';
 import Notice from 'components/notice';
 import ProgressBar from 'components/progress-bar';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -173,25 +172,25 @@ const JetpackSyncPanel = React.createClass( {
 		const { translate } = this.props;
 		return (
 			<CompactCard className="jetpack-sync-panel">
-				<div className="jetpack-sync-panel__action-group">
-					<div className="jetpack-sync-panel__description">
-						{ translate(
-							'{{strong}}Jetpack Sync keeps your WordPress.com dashboard up to date.{{/strong}} ' +
-							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience. ' +
-							'If you suspect some data is missing, you can initiate a sync manually.',
-							{
-								components: {
-									strong: <strong />
-								}
+				<div className="jetpack-sync-panel__action">
+					{ translate(
+						'Jetpack Sync keeps your WordPress.com dashboard up to date. ' +
+						'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience.',
+						{
+							components: {
+								strong: <strong />
 							}
-						) }
-					</div>
+						}
+					) }
 
-					<div className="jetpack-sync-panel__action">
-						<Button onClick={ this.onSyncRequestButtonClick } disabled={ this.shouldDisableSync() }>
-							{ translate( 'Perform full sync', { context: 'Button' } ) }
-						</Button>
-					</div>
+					{
+						! this.shouldDisableSync() &&
+						translate( 'If you suspect some data is missing, you can {{link}}initiate a sync manually{{/link}}.', {
+							components: {
+								link: <a href="" onClick={ this.onSyncRequestButtonClick } />
+							}
+						} )
+					}
 				</div>
 
 				{ this.renderErrorNotice() }

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -1,25 +1,5 @@
 .jetpack-sync-panel__action {
-	margin-top: 16px
-}
-
-@include breakpoint( ">660px" ) {
-	.jetpack-sync-panel__action-group {
-		display: flex;
-	}
-
-	.jetpack-sync-panel__description {
-		display: block;
-		flex-grow: 1;
-		padding-right: 8px;
-	}
-
-	.jetpack-sync-panel__action {
-		align-self: center;
-		flex-grow: 1;
-		flex-shrink: 0;
-		margin-top: 0;
-		padding-left: 8px;
-	}
+	font-style: italic;
 }
 
 .jetpack-sync-panel .progress-bar {


### PR DESCRIPTION
### Purpose

As part of #13232, this PR removes the sync button from the Jetpack Sync panel in favor of a less visible link. It also updates the copy to remove the "you can sync manually" part if sync is currently in progress. Also, as the mockups suggest, the copy there is now being italicized, and some unnecessary styles are being cleaned up. 

### Rationale

The rationale behind this change is to make the manual sync feature a little less prominent, as suggested in #13232. This PR addresses the suggested changes from #13232 in the Jetpack Sync panel, separately from #16353, which essentially moves the panel to the Manage Connection page.

### Preview

Note: Disregard the save/disconnect buttons, they're not related to the PR at all.

**Before (while not syncing)**
![](https://cldup.com/YJNFHuF95N.png)

**Before (while syncing)**
![](https://cldup.com/4l4NR2Cl1K.png)

**After (while not syncing)**
![](https://cldup.com/zbo4MS9vSl.png)

**After (while syncing)**
![](https://cldup.com/84Q8pedq2Y.png)

### To test
* Checkout this branch
* Go to `/settings/general/:site`, where `:site` is a Jetpack site.
* Verify the Jetpack card loads correctly, and looks as on the previews.
* Verify the sync link works correctly.