### PR TITLE
Site Settings: Move out Site Tools link as a separate component

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -8,12 +8,12 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
-import CompactCard from 'components/card/compact';
 import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-dialog';
 import config from 'config';
 import { tracks } from 'lib/analytics';
 import { localize } from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
+import SiteToolsLink from './link';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite, getSiteAdminUrl } from 'state/sites/selectors';
 import { isVipSite } from 'state/selectors';
@@ -87,64 +87,47 @@ class SiteTools extends Component {
 			<div className="site-tools">
 				<SectionHeader label={ translate( 'Site Tools' ) } />
 				{ showChangeAddress &&
-					<CompactCard
+					<SiteToolsLink
 						href={ changeAddressLink }
 						onClick={ this.trackChangeAddress }
-						className="site-tools__link">
-						<div className="site-tools__content">
-							<p className="site-tools__section-title">{ changeSiteAddress }</p>
-							<p className="site-tools__section-desc">{ changeAddressText }</p>
-						</div>
-					</CompactCard>
+						title={ changeSiteAddress }
+						description={ changeAddressText }
+					/>
 				}
-				<CompactCard
+				<SiteToolsLink
 					href={ importUrl }
-					className="site-tools__link">
-					<div className="site-tools__content">
-						<p className="site-tools__section-title">{ importTitle }</p>
-						<p className="site-tools__section-desc">{ importText }</p>
-					</div>
-				</CompactCard>
-				<CompactCard
+					title={ importTitle }
+					description={ importText }
+				/>
+				<SiteToolsLink
 					href={ exportUrl }
-					className="site-tools__link">
-					<div className="site-tools__content">
-						<p className="site-tools__section-title">{ exportTitle }</p>
-						<p className="site-tools__section-desc">{ exportText }</p>
-					</div>
-				</CompactCard>
+					title={ exportTitle }
+					description={ exportText }
+				/>
 				{ showThemeSetup &&
-					<CompactCard
+					<SiteToolsLink
 						href={ themeSetupLink }
 						onClick={ this.trackThemeSetup }
-						className="site-tools__link">
-						<div className="site-tools__content">
-							<p className="site-tools__section-title">{ themeSetup }</p>
-							<p className="site-tools__section-desc">{ themeSetupText }</p>
-						</div>
-					</CompactCard>
+						title={ themeSetup }
+						description={ themeSetupText }
+					/>
 				}
 				{ showDeleteContent &&
-					<CompactCard
+					<SiteToolsLink
 						href={ startOverLink }
 						onClick={ this.trackStartOver }
-						className="site-tools__link">
-						<div className="site-tools__content">
-							<p className="site-tools__section-title">{ startOver }</p>
-							<p className="site-tools__section-desc">{ startOverText }</p>
-						</div>
-					</CompactCard>
+						title={ startOver }
+						description={ startOverText }
+					/>
 				}
 				{ showDeleteSite &&
-					<CompactCard
+					<SiteToolsLink
 						href={ deleteSiteLink }
 						onClick={ this.checkForSubscriptions }
-						className="site-tools__link">
-						<div className="site-tools__content">
-							<p className="site-tools__section-title is-warning">{ deleteSite }</p>
-							<p className="site-tools__section-desc">{ deleteSiteText }</p>
-						</div>
-					</CompactCard>
+						title={ deleteSite }
+						description={ deleteSiteText }
+						isWarning
+					/>
 				}
 				<DeleteSiteWarningDialog
 					isVisible={ this.state.showDialog }

--- a/client/my-sites/site-settings/site-tools/link.jsx
+++ b/client/my-sites/site-settings/site-tools/link.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+
+const SiteToolsLink = ( {
+	description,
+	href,
+	isWarning,
+	onClick,
+	title,
+} ) => {
+	const titleClasses = classNames( 'site-tools__section-title', {
+		'is-warning': isWarning,
+	} );
+
+	return (
+		<CompactCard
+			href={ href }
+			onClick={ onClick }
+			className="site-tools__link"
+		>
+			<div className="site-tools__content">
+				<p className={ titleClasses }>{ title }</p>
+				<p className="site-tools__section-desc">{ description }</p>
+			</div>
+		</CompactCard>
+	);
+};
+
+SiteToolsLink.propTypes = {
+	description: PropTypes.string,
+	href: PropTypes.string,
+	isWarning: PropTypes.bool,
+	onClick: PropTypes.func,
+	title: PropTypes.string,
+};
+
+SiteToolsLink.defaultProps = {
+	isWarning: false,
+	onClick: noop,
+};
+
+export default SiteToolsLink;


### PR DESCRIPTION
This PR introduces a `SiteToolsLink` component and modifies all links in Site Tools to use that component. This serves two purposes:

* Reduces links code repetition in the `SiteTools` component.
* Allows the Site Tools links to be reused (I intend to reuse them for the disconnect site link as suggested in #13232).

To test:
* Checkout this branch.
* Go to `/settings/general/:site`, where `:site` is a WordPress.com site.
* Verify there are no visual/behavioral changes.
* Test the above for a Jetpack site.