### PR TITLE
Fixed a memoized selector warning on the shipping zone page

### DIFF
--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -156,7 +156,7 @@ export const getShippingZoneLocations = createSelector(
 	},
 	( state, zoneId, siteId = getSelectedSiteId( state ) ) => {
 		const id = isObject( zoneId ) ? `i${ zoneId.index }` : zoneId;
-		return `${ state }${ id }${ siteId }`;
+		return `${ id }${ siteId }`;
 	}
 );
 
@@ -544,7 +544,7 @@ export const getShippingZoneLocationsList = createSelector(
 	},
 	( state, zoneId, maxCountries = 999, siteId = getSelectedSiteId( state ) ) => {
 		const id = isObject( zoneId ) ? `i${ zoneId.index }` : zoneId;
-		return `${ state }${ id }${ maxCountries }${ siteId }`;
+		return `${ id }${ maxCountries }${ siteId }`;
 	},
 );
 

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, forIn, isEmpty, orderBy } from 'lodash';
+import { every, forIn, isEmpty, isObject, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -153,6 +153,10 @@ export const getShippingZoneLocations = createSelector(
 			loaded,
 			loaded && getRawShippingZoneLocations( state, siteId )[ zoneId ],
 		];
+	},
+	( state, zoneId, siteId = getSelectedSiteId( state ) ) => {
+		const id = isObject( zoneId ) ? `i${ zoneId.index }` : zoneId;
+		return `${ state }${ id }${ siteId }`;
 	}
 );
 
@@ -537,7 +541,11 @@ export const getShippingZoneLocationsList = createSelector(
 		return [
 			getShippingZoneLocations( state, zoneId, siteId ),
 		];
-	}
+	},
+	( state, zoneId, maxCountries = 999, siteId = getSelectedSiteId( state ) ) => {
+		const id = isObject( zoneId ) ? `i${ zoneId.index }` : zoneId;
+		return `${ state }${ id }${ maxCountries }${ siteId }`;
+	},
 );
 
 /**


### PR DESCRIPTION
When opening a new shipping zone page in `master` the following warnings will appear in the console:
<img width="611" alt="screen shot 2017-07-19 at 15 07 17" src="https://user-images.githubusercontent.com/800604/28371532-2f876ca6-6c95-11e7-87aa-af0f4d54b1a0.png">

They are caused by a non-scalar variable (`zoneId={index:0}`) being passed to the memoized selectors. The way the shipping zones page works now, it shouldn't break anything, but could lead to more problems if we ever decide to allow adding more than one zone before saving.

This PR fixes it.