### PR TITLE
Site Settings: Introduce a Disconnect card to Manage Connection page

### DIFF
--- a/client/my-sites/site-settings/manage-connection/disconnect-site.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site.jsx
@@ -1,0 +1,154 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import DisconnectJetpackDialog from 'blocks/disconnect-jetpack-dialog';
+import QuerySitePlans from 'components/data/query-site-plans';
+import SiteToolsLink from 'my-sites/site-settings/site-tools/link';
+import { recordGoogleEvent } from 'state/analytics/actions';
+import { disconnect } from 'state/jetpack/connection/actions';
+import { disconnectedSite as disconnectedSiteDeprecated } from 'lib/sites-list/actions';
+import { setAllSitesSelected } from 'state/ui/actions';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getPlanClass } from 'lib/plans/constants';
+import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
+
+class DisconnectSite extends Component {
+	state = {
+		dialogVisible: false,
+	}
+
+	handleClick = ( event ) => {
+		event.preventDefault();
+
+		this.setState( {
+			dialogVisible: true,
+		} );
+	}
+
+	handleHideDialog = () => {
+		this.setState( {
+			dialogVisible: false
+		} );
+	}
+
+	disconnectJetpack = () => {
+		const {
+			site,
+			siteId,
+			translate,
+			successNotice: showSuccessNotice,
+			errorNotice: showErrorNotice,
+			infoNotice: showInfoNotice,
+			removeNotice: removeInfoNotice,
+			disconnect: disconnectSite,
+			recordGoogleEvent: recordGAEvent
+		} = this.props;
+
+		this.setState( {
+			dialogVisible: false
+		} );
+
+		recordGAEvent( 'Jetpack', 'Clicked To Confirm Disconnect Jetpack Dialog' );
+
+		const { notice } = showInfoNotice(
+			translate( 'Disconnecting %(siteName)s.', { args: { siteName: site.title } } ),	{
+				isPersistent: true,
+				showDismiss: false,
+			}
+		);
+
+		disconnectSite( siteId ).then( () => {
+			// Removing the domain from a domain-only site results
+			// in the site being deleted entirely. We need to call
+			// `receiveDeletedSiteDeprecated` here because the site
+			// exists in `sites-list` as well as the global store.
+			disconnectedSiteDeprecated( site );
+			this.props.setAllSitesSelected();
+			removeInfoNotice( notice.noticeId );
+			showSuccessNotice( translate( 'Successfully disconnected %(siteName)s.', { args: { siteName: site.title } } ) );
+			recordGAEvent( 'Jetpack', 'Successfully Disconnected' );
+		}, () => {
+			removeInfoNotice( notice.noticeId );
+			showErrorNotice( translate( '%(siteName)s failed to disconnect', { args: { siteName: site.title } } ) );
+			recordGAEvent( 'Jetpack', 'Failed Disconnected Site' );
+		}, );
+
+		page.redirect( '/stats' );
+	}
+
+	render() {
+		const {
+			planClass,
+			site,
+			siteId,
+			siteSlug,
+			translate
+		} = this.props;
+
+		if ( ! site ) {
+			return null;
+		}
+
+		return (
+			<div>
+				<QuerySitePlans siteId={ siteId } />
+
+				<SiteToolsLink
+					href="#"
+					onClick={ this.handleClick }
+					title={ translate( 'Disconnect from WordPress.com' ) }
+					description={ translate(
+						'Your site will no longer send data to WordPress.com and Jetpack features will stop working.'
+					) }
+					isWarning
+				/>
+
+				<DisconnectJetpackDialog
+					isVisible={ this.state.dialogVisible }
+					onDisconnect={ this.disconnectJetpack }
+					onClose={ this.handleHideDialog }
+					plan={ planClass }
+					isBroken={ false }
+					siteName={ siteSlug }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
+		const siteSlug = getSelectedSiteSlug( state );
+		const plan = getCurrentPlan( state, siteId );
+		const planClass = plan && plan.productSlug
+			? getPlanClass( plan.productSlug )
+			: 'is-free-plan';
+
+		return {
+			planClass,
+			site,
+			siteId,
+			siteSlug,
+		};
+	},
+	{
+		setAllSitesSelected,
+		recordGoogleEvent,
+		disconnect,
+		successNotice,
+		errorNotice,
+		infoNotice,
+		removeNotice
+	}
+)( localize( DisconnectSite ) );

--- a/client/my-sites/site-settings/manage-connection/disconnect-site.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site.jsx
@@ -99,7 +99,7 @@ class DisconnectSite extends Component {
 		}
 
 		return (
-			<div>
+			<div className="manage-connection__disconnect-link">
 				<QuerySitePlans siteId={ siteId } />
 
 				<SiteToolsLink

--- a/client/my-sites/site-settings/manage-connection/disconnect-site.jsx
+++ b/client/my-sites/site-settings/manage-connection/disconnect-site.jsx
@@ -19,6 +19,7 @@ import { setAllSitesSelected } from 'state/ui/actions';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanClass } from 'lib/plans/constants';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 
 class DisconnectSite extends Component {
@@ -87,6 +88,7 @@ class DisconnectSite extends Component {
 
 	render() {
 		const {
+			isAutomatedTransfer,
 			planClass,
 			site,
 			siteId,
@@ -94,7 +96,7 @@ class DisconnectSite extends Component {
 			translate
 		} = this.props;
 
-		if ( ! site ) {
+		if ( ! site || isAutomatedTransfer ) {
 			return null;
 		}
 
@@ -136,6 +138,7 @@ export default connect(
 			: 'is-free-plan';
 
 		return {
+			isAutomatedTransfer: isSiteAutomatedTransfer( state, siteId ),
 			planClass,
 			site,
 			siteId,

--- a/client/my-sites/site-settings/manage-connection/index.jsx
+++ b/client/my-sites/site-settings/manage-connection/index.jsx
@@ -10,6 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import DataSynchronization from './data-synchronization';
+import DisconnectSite from './disconnect-site';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
@@ -51,6 +52,7 @@ class ManageConnection extends Component {
 
 				<SiteOwnership />
 				<DataSynchronization />
+				<DisconnectSite />
 			</Main>
 		);
 	}

--- a/client/my-sites/site-settings/manage-connection/style.scss
+++ b/client/my-sites/site-settings/manage-connection/style.scss
@@ -11,3 +11,7 @@
 		line-height: 24px;
 	}
 }
+
+.manage-connection__disconnect-link {
+	margin-top: 16px;
+}


### PR DESCRIPTION
This PR introduces a Disconnect site card to the Manage Connection page. The card works in a similar way to the disconnect button throughout Calypso.

The PR implements part of #13232. Relies on part of #16355 that recently introduced a separate component for the Site Tools links.

Preview:
![](https://cldup.com/XKfDapCN8V.png)

To test:
* Checkout this branch or get it going on calypso.live
* Go to `/settings/manage-connection/:site`, where `:site` is a Jetpack site.
* Verify the disconnect card appears properly.
* Test disconnection with a site on any plan (free, personal, premium, professional) and verify the disconnect dialog respects the current plan.
* Verify disconnection process works properly and user's redirected to `/stats`.