### PR TITLE
Editor: Add publish date component to confirmation sidebar

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -462,6 +462,7 @@
 @import 'post-editor/editor-post-type/style';
 @import 'post-editor/editor-post-type-unsupported/style';
 @import 'post-editor/editor-preview/style';
+@import 'post-editor/editor-publish-date/style';
 @import 'post-editor/editor-revisions/style';
 @import 'post-editor/editor-seo-accordion/style';
 @import 'post-editor/editor-sharing/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -113,6 +113,7 @@ $z-layers: (
 		'.select-dropdown.is-open .select-dropdown__container': 170,
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
 		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,
+		'.editor-publish-date.is-open .editor-publish-date__wrapper': 170,
 		'.first-view': 175,
 		'.editor-confirmation-sidebar__overlay': 176,
 		'.editor-confirmation-sidebar__sidebar': 177,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -151,6 +151,7 @@ class EditorConfirmationSidebar extends React.Component {
 
 		return (
 			<EditorPublishDate
+				post={ this.props.post }
 				postDate={ postDate }
 				setPostDate={ this.props.setPostDate }
 			/>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -144,7 +144,7 @@ class EditorConfirmationSidebar extends React.Component {
 		);
 	}
 
-	renderPublishDateSelector() {
+	renderPublishDateComponent() {
 		const postDate = this.props.post && this.props.post.date
 			? this.props.post.date
 			: null;
@@ -201,10 +201,10 @@ class EditorConfirmationSidebar extends React.Component {
 									} )
 							}
 						</div>
+						{ this.renderPublishDateComponent() }
 						<div className="editor-confirmation-sidebar__privacy-control">
 							{ this.renderPrivacyControl() }
 						</div>
-						{ this.renderPublishDateSelector() }
 					</div>
 					{ this.renderNoticeDisplayPreferenceCheckbox() }
 				</div>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -29,6 +29,7 @@ class EditorConfirmationSidebar extends React.Component {
 		onPublish: React.PropTypes.func,
 		post: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
+		setPostDate: React.PropTypes.func,
 		setStatus: React.PropTypes.func,
 		site: React.PropTypes.object,
 		status: React.PropTypes.string,
@@ -143,6 +144,19 @@ class EditorConfirmationSidebar extends React.Component {
 		);
 	}
 
+	renderPublishDateSelector() {
+		const postDate = this.props.post && this.props.post.date
+			? this.props.post.date
+			: null;
+
+		return (
+			<EditorPublishDate
+				postDate={ postDate }
+				setPostDate={ this.props.setPostDate }
+			/>
+		);
+	}
+
 	render() {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
@@ -189,7 +203,7 @@ class EditorConfirmationSidebar extends React.Component {
 						<div className="editor-confirmation-sidebar__privacy-control">
 							{ this.renderPrivacyControl() }
 						</div>
-						<EditorPublishDate />
+						{ this.renderPublishDateSelector() }
 					</div>
 					{ this.renderNoticeDisplayPreferenceCheckbox() }
 				</div>

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Button from 'components/button';
+import EditorPublishDate from 'post-editor/editor-publish-date';
 import EditorVisibility from 'post-editor/editor-visibility';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
@@ -188,6 +189,7 @@ class EditorConfirmationSidebar extends React.Component {
 						<div className="editor-confirmation-sidebar__privacy-control">
 							{ this.renderPrivacyControl() }
 						</div>
+						<EditorPublishDate />
 					</div>
 					{ this.renderNoticeDisplayPreferenceCheckbox() }
 				</div>

--- a/client/post-editor/editor-publish-date/README.md
+++ b/client/post-editor/editor-publish-date/README.md
@@ -1,0 +1,30 @@
+Editor Publish Date
+===================
+
+Editor Publish Date is a React component that allows the user to set a post's publish date inside the Editor.
+
+## Usage
+
+```jsx
+import EditorPublishDate from 'post-editor/editor-publish-date';
+
+export default function MyComponent() {
+	const props = {
+		post: post,
+		postDate: postDate,
+		setPostDate: setPostDate,
+	};
+
+	return (
+		<EditorPublishDate { ...props } />
+	);
+}
+```
+
+## Props
+
+The following props are used with the Editor Publish Date component:
+
+- `post`: (object) The post object
+- `postDate`: (string) The publish date for the post
+- `setPostDate`: (func) A callback that receives a Moment object with the updated date on change

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
@@ -25,23 +26,41 @@ export class EditorPublishDate extends React.Component {
 		super( props );
 
 		this.state = {
-			open: false,
+			isOpen: false,
 		};
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'click', this.handleOutsideClick );
+	}
+
+	componentDidUpdate() {
+		if ( this.state.isOpen ) {
+			window.addEventListener( 'click', this.handleOutsideClick );
+		} else {
+			window.removeEventListener( 'click', this.handleOutsideClick );
+		}
+	}
+
+	handleOutsideClick = event => {
+		if ( ! ReactDom.findDOMNode( this.refs.editorPublishDateWrapper ).contains( event.target ) ) {
+			this.setState( { isOpen: false } );
+		}
 	}
 
 	setImmediate = () => {
 		this.props.setPostDate( this.props.moment() );
-		this.setState( { open: false } );
+		this.setState( { isOpen: false } );
 	}
 
 	toggleOpenState = () => {
-		this.setState( { open: ! this.state.open } );
+		this.setState( { isOpen: ! this.state.isOpen } );
 	}
 
 	renderHeader() {
 		const isScheduled = utils.isFutureDated( this.props.post );
 		const className = classNames( 'editor-publish-date__header', {
-			'is-open': this.state.open,
+			'is-open': this.state.isOpen,
 			'is-scheduled': isScheduled,
 		} );
 
@@ -93,9 +112,9 @@ export class EditorPublishDate extends React.Component {
 	render() {
 		return (
 			<div className="editor-publish-date">
-				<div className="editor-publish-date__wrapper">
+				<div className="editor-publish-date__wrapper" ref="editorPublishDateWrapper">
 					{ this.renderHeader() }
-					{ this.state.open && this.renderSchedule() }
+					{ this.state.isOpen && this.renderSchedule() }
 				</div>
 			</div>
 		);

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import PostSchedule from 'components/post-schedule';
+
+export class EditorPublishDate extends React.Component {
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			open: false,
+		};
+	}
+
+	toggleOpenState = () => {
+		this.setState( { open: ! this.state.open } );
+	}
+
+	renderHeader() {
+		const className = classNames( 'editor-publish-date__header', { 'is-open': this.state.open } );
+
+		return (
+			<div className={ className } onClick={ this.toggleOpenState }>
+				<Gridicon icon="calendar" size={ 18 } /> Publish Now
+			</div>
+		);
+	}
+
+	renderSchedule() {
+		const className = classNames( 'editor-publish-date__schedule', {} );
+		return (
+			<div className={ className }>
+				<PostSchedule />
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div className="editor-publish-date">
+				<div className="editor-publish-date__wrapper">
+					{ this.renderHeader() }
+					{ this.state.open && this.renderSchedule() }
+				</div>
+			</div>
+		);
+	}
+
+}
+
+export default connect(
+	() => {
+		return {};
+	},
+	{}
+)( localize( EditorPublishDate ) );

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -6,6 +6,7 @@ import ReactDom from 'react-dom';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { intersection } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,7 +44,11 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	handleOutsideClick = event => {
-		if ( ! ReactDom.findDOMNode( this.refs.editorPublishDateWrapper ).contains( event.target ) ) {
+		const targetClasses = event.target.className.split( /\s/ );
+		const hasDatePickerDayClass = intersection( targetClasses, [ 'DayPicker-Day', 'date-picker__day' ] ).length > 0;
+		const isChildOfPublishDate = ReactDom.findDOMNode( this.refs.editorPublishDateWrapper ).contains( event.target );
+
+		if ( ! hasDatePickerDayClass && ! isChildOfPublishDate ) {
 			this.setState( { isOpen: false } );
 		}
 	}

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -10,10 +10,12 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import PostSchedule from 'components/post-schedule';
+import utils from 'lib/posts/utils';
 
 export class EditorPublishDate extends React.Component {
 
 	static propTypes = {
+		post: React.PropTypes.object,
 		postDate: React.PropTypes.string,
 		setPostDate: React.PropTypes.func,
 	};
@@ -31,11 +33,29 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	renderHeader() {
-		const className = classNames( 'editor-publish-date__header', { 'is-open': this.state.open } );
+		const isScheduled = utils.isFutureDated( this.props.post );
+		const className = classNames( 'editor-publish-date__header', {
+			'is-open': this.state.open,
+			'is-scheduled': isScheduled,
+		} );
 
 		return (
 			<div className={ className } onClick={ this.toggleOpenState }>
-				<Gridicon icon="calendar" size={ 18 } /> { this.props.translate( 'Publish Immediately' ) }
+				<Gridicon icon="calendar" size={ 18 } />
+				<div className="editor-publish-date__header-wrapper">
+					<div className="editor-publish-date__header-description">
+						{
+							isScheduled
+							? this.props.translate( 'Scheduled' )
+							: this.props.translate( 'Publish Immediately' )
+						}
+					</div>
+					{ isScheduled && (
+						<div className="editor-publish-date__header-chrono">
+							{ this.props.moment( this.props.postDate ).calendar() }
+						</div>
+					) }
+				</div>
 			</div>
 		);
 	}

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
@@ -13,6 +12,11 @@ import Gridicon from 'gridicons';
 import PostSchedule from 'components/post-schedule';
 
 export class EditorPublishDate extends React.Component {
+
+	static propTypes = {
+		postDate: React.PropTypes.string,
+		setPostDate: React.PropTypes.func,
+	};
 
 	constructor( props ) {
 		super( props );
@@ -31,16 +35,22 @@ export class EditorPublishDate extends React.Component {
 
 		return (
 			<div className={ className } onClick={ this.toggleOpenState }>
-				<Gridicon icon="calendar" size={ 18 } /> Publish Now
+				<Gridicon icon="calendar" size={ 18 } /> { this.props.translate( 'Publish Immediately' ) }
 			</div>
 		);
 	}
 
 	renderSchedule() {
 		const className = classNames( 'editor-publish-date__schedule', {} );
+		const selectedDay = this.props.postDate ? this.props.moment( this.props.postDate ) : null;
+
 		return (
 			<div className={ className }>
-				<PostSchedule displayInputChrono={ false } />
+				<PostSchedule
+					displayInputChrono={ false }
+					onDateChange={ this.props.setPostDate }
+					selectedDay={ selectedDay }
+					/>
 			</div>
 		);
 	}
@@ -58,9 +68,4 @@ export class EditorPublishDate extends React.Component {
 
 }
 
-export default connect(
-	() => {
-		return {};
-	},
-	{}
-)( localize( EditorPublishDate ) );
+export default localize( EditorPublishDate );

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -60,7 +60,6 @@ export class EditorPublishDate extends React.Component {
 	renderHeader() {
 		const isScheduled = utils.isFutureDated( this.props.post );
 		const className = classNames( 'editor-publish-date__header', {
-			'is-open': this.state.isOpen,
 			'is-scheduled': isScheduled,
 		} );
 
@@ -110,8 +109,12 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	render() {
+		const className = classNames( 'editor-publish-date', {
+			'is-open': this.state.isOpen,
+		} );
+
 		return (
-			<div className="editor-publish-date">
+			<div className={ className }>
 				<div className="editor-publish-date__wrapper" ref="editorPublishDateWrapper">
 					{ this.renderHeader() }
 					{ this.state.isOpen && this.renderSchedule() }

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import PostSchedule from 'components/post-schedule';
 import utils from 'lib/posts/utils';
 
@@ -26,6 +27,11 @@ export class EditorPublishDate extends React.Component {
 		this.state = {
 			open: false,
 		};
+	}
+
+	setImmediate = () => {
+		this.props.setPostDate( this.props.moment() );
+		this.setState( { open: false } );
 	}
 
 	toggleOpenState = () => {
@@ -60,12 +66,21 @@ export class EditorPublishDate extends React.Component {
 		);
 	}
 
+	renderImmediatePublishOption() {
+		return (
+			<Button borderless={ true } className="editor-publish-date__immediate" onClick={ this.setImmediate }>
+				{ this.props.translate( 'Publish Immediately' ) }
+			</Button>
+		);
+	}
+
 	renderSchedule() {
-		const className = classNames( 'editor-publish-date__schedule', {} );
 		const selectedDay = this.props.postDate ? this.props.moment( this.props.postDate ) : null;
+		const isScheduled = utils.isFutureDated( this.props.post );
 
 		return (
-			<div className={ className }>
+			<div className="editor-publish-date__schedule">
+				{ isScheduled && this.renderImmediatePublishOption() }
 				<PostSchedule
 					displayInputChrono={ false }
 					onDateChange={ this.props.setPostDate }

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -40,7 +40,7 @@ export class EditorPublishDate extends React.Component {
 		const className = classNames( 'editor-publish-date__schedule', {} );
 		return (
 			<div className={ className }>
-				<PostSchedule />
+				<PostSchedule displayInputChrono={ false } />
 			</div>
 		);
 	}

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -84,21 +84,14 @@ export class EditorPublishDate extends React.Component {
 		);
 	}
 
-	renderImmediatePublishOption() {
-		return (
-			<Button borderless={ true } className="editor-publish-date__immediate" onClick={ this.setImmediate }>
-				{ this.props.translate( 'Publish Immediately' ) }
-			</Button>
-		);
-	}
-
 	renderSchedule() {
 		const selectedDay = this.props.postDate ? this.props.moment( this.props.postDate ) : null;
-		const isScheduled = utils.isFutureDated( this.props.post );
 
 		return (
 			<div className="editor-publish-date__schedule">
-				{ isScheduled && this.renderImmediatePublishOption() }
+				<Button borderless={ true } className="editor-publish-date__immediate" onClick={ this.setImmediate }>
+					{ this.props.translate( 'Publish Immediately' ) }
+				</Button>
 				<PostSchedule
 					displayInputChrono={ false }
 					onDateChange={ this.props.setPostDate }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -1,0 +1,61 @@
+.editor-publish-date {
+	&.is-open {
+		.gridicons-chevron-down {
+			transform: rotate( 180deg );
+		}
+	}
+}
+
+.editor-publish-date__wrapper {
+	background: $white;
+	border: 1px solid lighten( $gray, 20% );
+	border-width: 1px 1px 2px;
+	border-radius: 4px;
+	margin: 0;
+	position: relative;
+	transition: all .15s ease-in-out;
+	width: 100%;
+}
+
+.editor-publish-date__header {
+	padding: 0 36px 0 16px;
+	height: #{ $option-height }px;
+	line-height: #{ $option-height }px;
+
+	color: $gray-dark;
+	font-size: 14px;
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	cursor: pointer;
+
+	.gridicon {
+		margin-right: #{ ( $side-margin / 2 ) }px;
+		vertical-align: text-bottom;
+	}
+
+	// down-arrow
+	&::after {
+		@include noticon( '\f431', 22px );
+
+		display: block;
+		width: 20px;
+		line-height: #{ $header-height - 1 }px;
+		color: rgba( $gray, 0.5 );
+
+		position: absolute;
+			right: 14px;
+			top: 0px;
+
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+	}
+
+	// up-arrow
+	&.is-open::after {
+		transform: rotate( 180deg );
+	}
+}
+
+.editor-publish-date__schedule {
+	padding: 0 10px;
+}

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -1,9 +1,5 @@
 .editor-publish-date {
-	&.is-open {
-		.gridicons-chevron-down {
-			transform: rotate( 180deg );
-		}
-	}
+	height: 43px;
 }
 
 .editor-publish-date__wrapper {
@@ -15,6 +11,10 @@
 	position: relative;
 	transition: all .15s ease-in-out;
 	width: 100%;
+
+	.editor-publish-date.is-open & {
+		z-index: z-index( 'root', '.editor-publish-date.is-open .editor-publish-date__wrapper' );
+	}
 }
 
 .editor-publish-date__header {
@@ -38,7 +38,7 @@
 		color: $blue-wordpress;
 	}
 
-	&.is-open {
+	.editor-publish-date.is-open & {
 		border-radius: 4px 4px 0 0;
 		box-shadow: none;
 		background-color: $gray-light;
@@ -56,12 +56,10 @@
 		position: absolute;
 			right: 14px;
 			top: 0px;
-
-		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
 	}
 
 	// up-arrow
-	&.is-open::after {
+	.editor-publish-date.is-open &::after {
 		transform: rotate( 180deg );
 	}
 }
@@ -102,6 +100,8 @@
 }
 
 .editor-publish-date__schedule {
+	overflow-y: auto;
+	position: static;
 	border-top: 1px solid lighten( $gray, 20% );
 	padding: 0 10px;
 }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -38,6 +38,12 @@
 		color: $blue-wordpress;
 	}
 
+	&.is-open {
+		border-radius: 4px 4px 0 0;
+		box-shadow: none;
+		background-color: $gray-light;
+	}
+
 	// down-arrow
 	&::after {
 		@include noticon( '\f431', 22px );
@@ -76,6 +82,19 @@
 	line-height: initial;
 }
 
+.editor-publish-date__immediate.button {
+	margin: 4px auto 0 auto;
+	display: block;
+	color: $blue-wordpress;
+	font-weight: normal;
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: $link-highlight;
+	}
+}
+
 .editor-publish-date__header-chrono {
 	font-size: 12px;
 	line-height: initial;
@@ -83,5 +102,6 @@
 }
 
 .editor-publish-date__schedule {
+	border-top: 1px solid lighten( $gray, 20% );
 	padding: 0 10px;
 }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -7,6 +7,7 @@
 	border: 1px solid lighten( $gray, 20% );
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
+	box-sizing: border-box;
 	margin: 0;
 	position: relative;
 	transition: all .15s ease-in-out;
@@ -23,7 +24,7 @@
 	line-height: #{ $option-height }px;
 
 	color: $gray-dark;
-	font-size: 13px;
+	font-size: 14px;
 	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -23,7 +23,7 @@
 	line-height: #{ $option-height }px;
 
 	color: $gray-dark;
-	font-size: 14px;
+	font-size: 13px;
 	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;
@@ -32,6 +32,10 @@
 	.gridicon {
 		margin-right: #{ ( $side-margin / 2 ) }px;
 		vertical-align: text-bottom;
+	}
+
+	&.is-scheduled {
+		color: $blue-wordpress;
 	}
 
 	// down-arrow
@@ -54,6 +58,28 @@
 	&.is-open::after {
 		transform: rotate( 180deg );
 	}
+}
+
+.editor-publish-date__header-wrapper {
+	vertical-align: text-top;
+	display: inline-block;
+	line-height: #{ $option-height }px;
+	height: #{ $option-height }px;
+}
+
+.editor-publish-date__header-description {
+	.editor-publish-date__header.is-scheduled & {
+		margin-top: -4px;
+		font-size: 10px;
+		line-height: initial;
+	}
+	line-height: initial;
+}
+
+.editor-publish-date__header-chrono {
+	font-size: 12px;
+	line-height: initial;
+	color: $gray-dark;
 }
 
 .editor-publish-date__schedule {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -277,6 +277,7 @@ export const PostEditor = React.createClass( {
 					onPublish={ this.onPublish }
 					post={ this.state.post }
 					savedPost={ this.state.savedPost }
+					setPostDate={ this.setPostDate }
 					setStatus={ this.setConfirmationSidebar }
 					site={ site }
 					status={ this.state.confirmationSidebar }


### PR DESCRIPTION
This PR adds the publish date component to the confirmation sidebar. This PR is part of a larger epic and is behind a feature flag. See p8F9tW-3F-p2.

![editor-publish-date](https://user-images.githubusercontent.com/363749/28433691-2cc1c404-6d52-11e7-9574-109ff102bed3.gif)

To Test:
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170713":"showPublishConfirmation"}')`
* Draft a new post, and then select "Publish..." to continue to the confirmation sidebar.
* Verify that the publish date component shows up and that changing the date updates the date for the post.
* Verify that when selecting a date in the future, that you see an option added to "Publish Immediately" above the calendar.
* Verify that clicking that option closes the dropdown and changes the selected option to "Publish Immediately"
* Verify that when the dropdown is open, clicking outside of the dropdown closes the dropdown.
* Verify that when selecting a future date the dropdown header shows "Scheduled" and the selected date beneath that.