### PR TITLE
Reader: add conversations list component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -29,6 +29,7 @@
 @import 'blocks/comment-button/style';
 @import 'blocks/comment-detail/style';
 @import 'blocks/comments/style';
+@import 'blocks/conversations/style';
 @import 'blocks/daily-post-button/style';
 @import 'blocks/disconnect-jetpack-dialog/style';
 @import 'blocks/dismissible-card/style';

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -3,260 +3,268 @@
  */
 import React, { Component } from 'react';
 import { get, noop, some } from 'lodash';
-import { connect } from 'react-redux';
-import { translate } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+// import { connect } from 'react-redux';
+// import { translate } from 'i18n-calypso';
+// import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
-import { getCurrentUser } from 'state/current-user/selectors';
-import PostTime from 'reader/post-time';
-import Gravatar from 'components/gravatar';
-import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-import { getStreamUrl } from 'reader/route';
-import PostCommentContent from './post-comment-content';
-import PostCommentForm from './form';
-import CommentEditForm from './comment-edit-form';
-import { PLACEHOLDER_STATE } from 'state/comments/constants';
-import { decodeEntities } from 'lib/formatting';
-import PostCommentWithError from './post-comment-with-error';
-import PostTrackback from './post-trackback.jsx';
-import CommentActions from './comment-actions';
+// import { isEnabled } from 'config';
+// import { getCurrentUser } from 'state/current-user/selectors';
+// import PostTime from 'reader/post-time';
+// import Gravatar from 'components/gravatar';
+// import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+// import { getStreamUrl } from 'reader/route';
+// import PostCommentContent from './post-comment-content';
+// import PostCommentForm from './form';
+// import CommentEditForm from './comment-edit-form';
+// import { PLACEHOLDER_STATE } from 'state/comments/constants';
+// import { decodeEntities } from 'lib/formatting';
+// import PostCommentWithError from './post-comment-with-error';
+// import PostTrackback from './post-trackback.jsx';
+// import CommentActions from './comment-actions';
 
 class PostComment extends Component {
-	state = {
-		showReplies: false,
-	};
+	// state = {
+	// 	showReplies: false,
+	// };
 
-	handleToggleRepliesClick = () => {
-		this.setState( { showReplies: ! this.state.showReplies } );
-	};
+	// handleToggleRepliesClick = () => {
+	// 	this.setState( { showReplies: ! this.state.showReplies } );
+	// };
 
-	handleReply = () => {
-		this.props.onReplyClick( this.props.commentId );
-		this.setState( { showReplies: true } ); // show the comments when replying
-	};
+	// handleReply = () => {
+	// 	this.props.onReplyClick( this.props.commentId );
+	// 	this.setState( { showReplies: true } ); // show the comments when replying
+	// };
 
-	handleAuthorClick = event => {
-		recordAction( 'comment_author_click' );
-		recordGaEvent( 'Clicked Author Name' );
-		recordTrack( 'calypso_reader_comment_author_click', {
-			blog_id: this.props.post.site_ID,
-			post_id: this.props.post.ID,
-			comment_id: this.props.commentId,
-			author_url: event.target.href,
-		} );
-	};
+	// handleAuthorClick = event => {
+	// 	recordAction( 'comment_author_click' );
+	// 	recordGaEvent( 'Clicked Author Name' );
+	// 	recordTrack( 'calypso_reader_comment_author_click', {
+	// 		blog_id: this.props.post.site_ID,
+	// 		post_id: this.props.post.ID,
+	// 		comment_id: this.props.commentId,
+	// 		author_url: event.target.href,
+	// 	} );
+	// };
 
-	renderRepliesList() {
-		const commentChildrenIds = get( this.props.commentsTree, [ this.props.commentId, 'children' ] );
-		// Hide children if more than maxChildrenToShow, but not if replying
-		const exceedsMaxChildrenToShow = commentChildrenIds.length < this.props.maxChildrenToShow;
-		const showReplies = this.state.showReplies || exceedsMaxChildrenToShow;
+	// renderRepliesList() {
+	// 	const commentChildrenIds = get( this.props.commentsTree, [ this.props.commentId, 'children' ] );
+	// 	// Hide children if more than maxChildrenToShow, but not if replying
+	// 	const exceedsMaxChildrenToShow = commentChildrenIds.length < this.props.maxChildrenToShow;
+	// 	const showReplies = this.state.showReplies || exceedsMaxChildrenToShow;
 
-		// No children to show
-		if ( ! commentChildrenIds || commentChildrenIds.length < 1 ) {
-			return null;
-		}
+	// 	// No children to show
+	// 	if ( ! commentChildrenIds || commentChildrenIds.length < 1 ) {
+	// 		return null;
+	// 	}
 
-		const showRepliesText = translate(
-			'show %(numOfReplies)d reply',
-			'show %(numOfReplies)d replies',
-			{
-				count: commentChildrenIds.length,
-				args: { numOfReplies: commentChildrenIds.length },
-			},
-		);
+	// 	const showRepliesText = translate(
+	// 		'show %(numOfReplies)d reply',
+	// 		'show %(numOfReplies)d replies',
+	// 		{
+	// 			count: commentChildrenIds.length,
+	// 			args: { numOfReplies: commentChildrenIds.length },
+	// 		},
+	// 	);
 
-		const hideRepliesText = translate(
-			'hide %(numOfReplies)d reply',
-			'hide %(numOfReplies)d replies',
-			{
-				count: commentChildrenIds.length,
-				args: { numOfReplies: commentChildrenIds.length },
-			},
-		);
+	// 	const hideRepliesText = translate(
+	// 		'hide %(numOfReplies)d reply',
+	// 		'hide %(numOfReplies)d replies',
+	// 		{
+	// 			count: commentChildrenIds.length,
+	// 			args: { numOfReplies: commentChildrenIds.length },
+	// 		},
+	// 	);
 
-		let replyVisibilityText = null;
-		if ( ! exceedsMaxChildrenToShow ) {
-			replyVisibilityText = this.state.showReplies ? hideRepliesText : showRepliesText;
-		}
+	// 	let replyVisibilityText = null;
+	// 	if ( ! exceedsMaxChildrenToShow ) {
+	// 		replyVisibilityText = this.state.showReplies ? hideRepliesText : showRepliesText;
+	// 	}
 
-		return (
-			<div>
-				{ !! replyVisibilityText
-					? <button
-							className="comments__view-replies-btn"
-							onClick={ this.handleToggleRepliesClick }
-						>
-							<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
-						</button>
-					: null }
-				{ showReplies
-					? <ol className="comments__list">
-							{ commentChildrenIds.map( childId =>
-								<PostComment
-									{ ...this.props }
-									depth={ this.props.depth + 1 }
-									key={ childId }
-									commentId={ childId }
-								/>,
-							) }
-						</ol>
-					: null }
-			</div>
-		);
-	}
+	// 	return (
+	// 		<div>
+	// 			{ !! replyVisibilityText
+	// 				? <button
+	// 						className="comments__view-replies-btn"
+	// 						onClick={ this.handleToggleRepliesClick }
+	// 					>
+	// 						<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
+	// 					</button>
+	// 				: null }
+	// 			{ showReplies
+	// 				? <ol className="comments__list">
+	// 						{ commentChildrenIds.map( childId =>
+	// 							<PostComment
+	// 								{ ...this.props }
+	// 								depth={ this.props.depth + 1 }
+	// 								key={ childId }
+	// 								commentId={ childId }
+	// 							/>,
+	// 						) }
+	// 					</ol>
+	// 				: null }
+	// 		</div>
+	// 	);
+	// }
 
-	renderCommentForm() {
-		if ( this.props.activeReplyCommentID !== this.props.commentId ) {
-			return null;
-		}
+	// renderCommentForm() {
+	// 	if ( this.props.activeReplyCommentID !== this.props.commentId ) {
+	// 		return null;
+	// 	}
 
-		return (
-			<PostCommentForm
-				ref="postCommentForm"
-				post={ this.props.post }
-				parentCommentID={ this.props.commentId }
-				commentText={ this.props.commentText }
-				onUpdateCommentText={ this.props.onUpdateCommentText }
-				onCommentSubmit={ this.props.onCommentSubmit }
-			/>
-		);
-	}
+	// 	return (
+	// 		<PostCommentForm
+	// 			ref="postCommentForm"
+	// 			post={ this.props.post }
+	// 			parentCommentID={ this.props.commentId }
+	// 			commentText={ this.props.commentText }
+	// 			onUpdateCommentText={ this.props.onUpdateCommentText }
+	// 			onCommentSubmit={ this.props.onCommentSubmit }
+	// 		/>
+	// 	);
+	// }
 
 	render() {
 		// todo: connect this constants to the state (new selector)
 		const commentsTree = this.props.commentsTree;
 		const comment = get( commentsTree, [ this.props.commentId, 'data' ] );
 
+		if ( ! comment ) {
+			return null;
+		}
+
 		// todo: connect this constants to the state (new selector)
-		const haveReplyWithError = some(
-			get( commentsTree, [ this.props.commentId, 'children' ] ),
-			childId =>
-				get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR,
-		);
+		// const haveReplyWithError = some(
+		// 	get( commentsTree, [ this.props.commentId, 'children' ] ),
+		// 	childId =>
+		// 		get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR,
+		// );
 
-		// If it's a pending comment, use the current user as the author
-		if ( comment.isPlaceholder ) {
-			comment.author = this.props.currentUser;
-			comment.author.name = this.props.currentUser.display_name;
-		} else {
-			comment.author.name = decodeEntities( comment.author.name );
-		}
+		// // If it's a pending comment, use the current user as the author
+		// if ( comment.isPlaceholder ) {
+		// 	comment.author = this.props.currentUser;
+		// 	comment.author.name = this.props.currentUser.display_name;
+		// } else {
+		// 	comment.author.name = decodeEntities( comment.author.name );
+		// }
 
-		// If we have an error, render the error component instead
-		if ( comment.isPlaceholder && comment.placeholderState === PLACEHOLDER_STATE.ERROR ) {
-			return <PostCommentWithError { ...this.props } repliesList={ this.renderRepliesList() } />;
-		}
+		// // If we have an error, render the error component instead
+		// if ( comment.isPlaceholder && comment.placeholderState === PLACEHOLDER_STATE.ERROR ) {
+		// 	return <PostCommentWithError { ...this.props } repliesList={ this.renderRepliesList() } />;
+		// }
 
-		// Trackback / Pingback
-		if ( comment.type === 'trackback' || comment.type === 'pingback' ) {
-			return <PostTrackback { ...this.props } />;
-		}
+		// // Trackback / Pingback
+		// if ( comment.type === 'trackback' || comment.type === 'pingback' ) {
+		// 	return <PostTrackback { ...this.props } />;
+		// }
 
-		// Author URL
-		let authorUrl;
-		if ( comment.author.site_ID ) {
-			authorUrl = getStreamUrl( null, comment.author.site_ID );
-		} else if ( comment.author.URL ) {
-			authorUrl = comment.author.URL;
-		}
+		// // Author URL
+		// let authorUrl;
+		// if ( comment.author.site_ID ) {
+		// 	authorUrl = getStreamUrl( null, comment.author.site_ID );
+		// } else if ( comment.author.URL ) {
+		// 	authorUrl = comment.author.URL;
+		// }
 
-		return (
-			<li className={ 'comments__comment depth-' + this.props.depth }>
-				<div className="comments__comment-author">
-					{ authorUrl
-						? <a href={ authorUrl } onClick={ this.handleAuthorClick }>
-								<Gravatar user={ comment.author } />
-							</a>
-						: <Gravatar user={ comment.author } /> }
+		return '<div>mysterious</div>';
 
-					{ authorUrl
-						? <a
-								href={ authorUrl }
-								className="comments__comment-username"
-								onClick={ this.handleAuthorClick }
-							>
-								{ comment.author.name }
-							</a>
-						: <strong className="comments__comment-username">
-								{ comment.author.name }
-							</strong> }
-					<div className="comments__comment-timestamp">
-						<a href={ comment.URL }>
-							<PostTime date={ comment.date } />
-						</a>
-					</div>
-				</div>
+		// return (
+		// 	<li className={ 'comments__comment depth-' + this.props.depth }>
+		// 		<div className="comments__comment-author">
+		// 			{ authorUrl
+		// 				? <a href={ authorUrl } onClick={ this.handleAuthorClick }>
+		// 						<Gravatar user={ comment.author } />
+		// 					</a>
+		// 				: <Gravatar user={ comment.author } /> }
 
-				{ comment.status && comment.status === 'unapproved'
-					? <p className="comments__comment-moderation">
-							{ translate( 'Your comment is awaiting moderation.' ) }
-						</p>
-					: null }
+		// 			{ authorUrl
+		// 				? <a
+		// 						href={ authorUrl }
+		// 						className="comments__comment-username"
+		// 						onClick={ this.handleAuthorClick }
+		// 					>
+		// 						{ comment.author.name }
+		// 					</a>
+		// 				: <strong className="comments__comment-username">
+		// 						{ comment.author.name }
+		// 					</strong> }
+		// 			<div className="comments__comment-timestamp">
+		// 				<a href={ comment.URL }>
+		// 					<PostTime date={ comment.date } />
+		// 				</a>
+		// 			</div>
+		// 		</div>
 
-				{ this.props.activeEditCommentId !== this.props.commentId &&
-					<PostCommentContent
-						content={ comment.content }
-						isPlaceholder={ comment.isPlaceholder }
-					/> }
+		// 		{ comment.status && comment.status === 'unapproved'
+		// 			? <p className="comments__comment-moderation">
+		// 					{ translate( 'Your comment is awaiting moderation.' ) }
+		// 				</p>
+		// 			: null }
 
-				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
-					this.props.activeEditCommentId === this.props.commentId &&
-					<CommentEditForm
-						post={ this.props.post }
-						commentId={ this.props.commentId }
-						commentText={ comment.content }
-						onCommentSubmit={ this.props.onEditCommentCancel }
-					/> }
+		// 		{ this.props.activeEditCommentId !== this.props.commentId &&
+		// 			<PostCommentContent
+		// 				content={ comment.content }
+		// 				isPlaceholder={ comment.isPlaceholder }
+		// 			/> }
 
-				<CommentActions
-					post={ this.props.post }
-					comment={ comment }
-					showModerationTools={ this.props.showModerationTools }
-					activeEditCommentId={ this.props.activeEditCommentId }
-					activeReplyCommentID={ this.props.activeReplyCommentID }
-					commentId={ this.props.commentId }
-					editComment={ this.props.onEditCommentClick }
-					editCommentCancel={ this.props.onEditCommentCancel }
-					handleReply={ this.handleReply }
-					onReplyCancel={ this.props.onReplyCancel }
-				/>
+		// 		{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
+		// 			this.props.activeEditCommentId === this.props.commentId &&
+		// 			<CommentEditForm
+		// 				post={ this.props.post }
+		// 				commentId={ this.props.commentId }
+		// 				commentText={ comment.content }
+		// 				onCommentSubmit={ this.props.onEditCommentCancel }
+		// 			/> }
 
-				{ haveReplyWithError ? null : this.renderCommentForm() }
-				{ this.renderRepliesList() }
-			</li>
-		);
+		// 		<CommentActions
+		// 			post={ this.props.post }
+		// 			comment={ comment }
+		// 			showModerationTools={ this.props.showModerationTools }
+		// 			activeEditCommentId={ this.props.activeEditCommentId }
+		// 			activeReplyCommentID={ this.props.activeReplyCommentID }
+		// 			commentId={ this.props.commentId }
+		// 			editComment={ this.props.onEditCommentClick }
+		// 			editCommentCancel={ this.props.onEditCommentCancel }
+		// 			handleReply={ this.handleReply }
+		// 			onReplyCancel={ this.props.onReplyCancel }
+		// 		/>
+
+		// 		{ haveReplyWithError ? null : this.renderCommentForm() }
+		// 		{ this.renderRepliesList() }
+		// 	</li>
+		// );
 	}
 }
 
-PostComment.propTypes = {
-	commentsTree: React.PropTypes.object.isRequired,
-	commentId: React.PropTypes.oneOfType( [
-		React.PropTypes.string, // can be 'placeholder-123'
-		React.PropTypes.number,
-	] ).isRequired,
-	onReplyClick: React.PropTypes.func,
-	depth: React.PropTypes.number,
-	post: React.PropTypes.object,
-	maxChildrenToShow: React.PropTypes.number,
-	onCommentSubmit: React.PropTypes.func,
+// PostComment.propTypes = {
+// 	commentsTree: React.PropTypes.object.isRequired,
+// 	commentId: React.PropTypes.oneOfType( [
+// 		React.PropTypes.string, // can be 'placeholder-123'
+// 		React.PropTypes.number,
+// 	] ).isRequired,
+// 	onReplyClick: React.PropTypes.func,
+// 	depth: React.PropTypes.number,
+// 	post: React.PropTypes.object,
+// 	maxChildrenToShow: React.PropTypes.number,
+// 	onCommentSubmit: React.PropTypes.func,
 
-	// connect()ed props:
-	currentUser: React.PropTypes.object.isRequired,
-};
+// 	// connect()ed props:
+// 	currentUser: React.PropTypes.object.isRequired,
+// };
 
-PostComment.defaultProps = {
-	onReplyClick: noop,
-	errors: [],
-	depth: 1,
-	maxChildrenToShow: 5,
-	onCommentSubmit: noop,
-};
+// PostComment.defaultProps = {
+// 	onReplyClick: noop,
+// 	errors: [],
+// 	depth: 1,
+// 	maxChildrenToShow: 5,
+// 	onCommentSubmit: noop,
+// };
 
-export default connect( state => ( {
-	currentUser: getCurrentUser( state ),
-} ) )( PostComment );
+export default PostComment;
+
+// export default connect( state => ( {
+// 	currentUser: getCurrentUser( state ),
+// } ) )( PostComment );

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -3,268 +3,260 @@
  */
 import React, { Component } from 'react';
 import { get, noop, some } from 'lodash';
-// import { connect } from 'react-redux';
-// import { translate } from 'i18n-calypso';
-// import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
+import { translate } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-// import { isEnabled } from 'config';
-// import { getCurrentUser } from 'state/current-user/selectors';
-// import PostTime from 'reader/post-time';
-// import Gravatar from 'components/gravatar';
-// import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
-// import { getStreamUrl } from 'reader/route';
-// import PostCommentContent from './post-comment-content';
-// import PostCommentForm from './form';
-// import CommentEditForm from './comment-edit-form';
-// import { PLACEHOLDER_STATE } from 'state/comments/constants';
-// import { decodeEntities } from 'lib/formatting';
-// import PostCommentWithError from './post-comment-with-error';
-// import PostTrackback from './post-trackback.jsx';
-// import CommentActions from './comment-actions';
+import { isEnabled } from 'config';
+import { getCurrentUser } from 'state/current-user/selectors';
+import PostTime from 'reader/post-time';
+import Gravatar from 'components/gravatar';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { getStreamUrl } from 'reader/route';
+import PostCommentContent from './post-comment-content';
+import PostCommentForm from './form';
+import CommentEditForm from './comment-edit-form';
+import { PLACEHOLDER_STATE } from 'state/comments/constants';
+import { decodeEntities } from 'lib/formatting';
+import PostCommentWithError from './post-comment-with-error';
+import PostTrackback from './post-trackback.jsx';
+import CommentActions from './comment-actions';
 
 class PostComment extends Component {
-	// state = {
-	// 	showReplies: false,
-	// };
+	state = {
+		showReplies: false,
+	};
 
-	// handleToggleRepliesClick = () => {
-	// 	this.setState( { showReplies: ! this.state.showReplies } );
-	// };
+	handleToggleRepliesClick = () => {
+		this.setState( { showReplies: ! this.state.showReplies } );
+	};
 
-	// handleReply = () => {
-	// 	this.props.onReplyClick( this.props.commentId );
-	// 	this.setState( { showReplies: true } ); // show the comments when replying
-	// };
+	handleReply = () => {
+		this.props.onReplyClick( this.props.commentId );
+		this.setState( { showReplies: true } ); // show the comments when replying
+	};
 
-	// handleAuthorClick = event => {
-	// 	recordAction( 'comment_author_click' );
-	// 	recordGaEvent( 'Clicked Author Name' );
-	// 	recordTrack( 'calypso_reader_comment_author_click', {
-	// 		blog_id: this.props.post.site_ID,
-	// 		post_id: this.props.post.ID,
-	// 		comment_id: this.props.commentId,
-	// 		author_url: event.target.href,
-	// 	} );
-	// };
+	handleAuthorClick = event => {
+		recordAction( 'comment_author_click' );
+		recordGaEvent( 'Clicked Author Name' );
+		recordTrack( 'calypso_reader_comment_author_click', {
+			blog_id: this.props.post.site_ID,
+			post_id: this.props.post.ID,
+			comment_id: this.props.commentId,
+			author_url: event.target.href,
+		} );
+	};
 
-	// renderRepliesList() {
-	// 	const commentChildrenIds = get( this.props.commentsTree, [ this.props.commentId, 'children' ] );
-	// 	// Hide children if more than maxChildrenToShow, but not if replying
-	// 	const exceedsMaxChildrenToShow = commentChildrenIds.length < this.props.maxChildrenToShow;
-	// 	const showReplies = this.state.showReplies || exceedsMaxChildrenToShow;
+	renderRepliesList() {
+		const commentChildrenIds = get( this.props.commentsTree, [ this.props.commentId, 'children' ] );
+		// Hide children if more than maxChildrenToShow, but not if replying
+		const exceedsMaxChildrenToShow = commentChildrenIds && commentChildrenIds.length < this.props.maxChildrenToShow;
+		const showReplies = this.state.showReplies || exceedsMaxChildrenToShow;
 
-	// 	// No children to show
-	// 	if ( ! commentChildrenIds || commentChildrenIds.length < 1 ) {
-	// 		return null;
-	// 	}
+		// No children to show
+		if ( ! commentChildrenIds || commentChildrenIds.length < 1 ) {
+			return null;
+		}
 
-	// 	const showRepliesText = translate(
-	// 		'show %(numOfReplies)d reply',
-	// 		'show %(numOfReplies)d replies',
-	// 		{
-	// 			count: commentChildrenIds.length,
-	// 			args: { numOfReplies: commentChildrenIds.length },
-	// 		},
-	// 	);
+		const showRepliesText = translate(
+			'show %(numOfReplies)d reply',
+			'show %(numOfReplies)d replies',
+			{
+				count: commentChildrenIds.length,
+				args: { numOfReplies: commentChildrenIds.length },
+			},
+		);
 
-	// 	const hideRepliesText = translate(
-	// 		'hide %(numOfReplies)d reply',
-	// 		'hide %(numOfReplies)d replies',
-	// 		{
-	// 			count: commentChildrenIds.length,
-	// 			args: { numOfReplies: commentChildrenIds.length },
-	// 		},
-	// 	);
+		const hideRepliesText = translate(
+			'hide %(numOfReplies)d reply',
+			'hide %(numOfReplies)d replies',
+			{
+				count: commentChildrenIds.length,
+				args: { numOfReplies: commentChildrenIds.length },
+			},
+		);
 
-	// 	let replyVisibilityText = null;
-	// 	if ( ! exceedsMaxChildrenToShow ) {
-	// 		replyVisibilityText = this.state.showReplies ? hideRepliesText : showRepliesText;
-	// 	}
+		let replyVisibilityText = null;
+		if ( ! exceedsMaxChildrenToShow ) {
+			replyVisibilityText = this.state.showReplies ? hideRepliesText : showRepliesText;
+		}
 
-	// 	return (
-	// 		<div>
-	// 			{ !! replyVisibilityText
-	// 				? <button
-	// 						className="comments__view-replies-btn"
-	// 						onClick={ this.handleToggleRepliesClick }
-	// 					>
-	// 						<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
-	// 					</button>
-	// 				: null }
-	// 			{ showReplies
-	// 				? <ol className="comments__list">
-	// 						{ commentChildrenIds.map( childId =>
-	// 							<PostComment
-	// 								{ ...this.props }
-	// 								depth={ this.props.depth + 1 }
-	// 								key={ childId }
-	// 								commentId={ childId }
-	// 							/>,
-	// 						) }
-	// 					</ol>
-	// 				: null }
-	// 		</div>
-	// 	);
-	// }
+		return (
+			<div>
+				{ !! replyVisibilityText
+					? <button
+							className="comments__view-replies-btn"
+							onClick={ this.handleToggleRepliesClick }
+						>
+							<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
+						</button>
+					: null }
+				{ showReplies
+					? <ol className="comments__list">
+							{ commentChildrenIds.map( childId =>
+								<PostComment
+									{ ...this.props }
+									depth={ this.props.depth + 1 }
+									key={ childId }
+									commentId={ childId }
+								/>,
+							) }
+						</ol>
+					: null }
+			</div>
+		);
+	}
 
-	// renderCommentForm() {
-	// 	if ( this.props.activeReplyCommentID !== this.props.commentId ) {
-	// 		return null;
-	// 	}
+	renderCommentForm() {
+		if ( this.props.activeReplyCommentID !== this.props.commentId ) {
+			return null;
+		}
 
-	// 	return (
-	// 		<PostCommentForm
-	// 			ref="postCommentForm"
-	// 			post={ this.props.post }
-	// 			parentCommentID={ this.props.commentId }
-	// 			commentText={ this.props.commentText }
-	// 			onUpdateCommentText={ this.props.onUpdateCommentText }
-	// 			onCommentSubmit={ this.props.onCommentSubmit }
-	// 		/>
-	// 	);
-	// }
+		return (
+			<PostCommentForm
+				ref="postCommentForm"
+				post={ this.props.post }
+				parentCommentID={ this.props.commentId }
+				commentText={ this.props.commentText }
+				onUpdateCommentText={ this.props.onUpdateCommentText }
+				onCommentSubmit={ this.props.onCommentSubmit }
+			/>
+		);
+	}
 
 	render() {
 		// todo: connect this constants to the state (new selector)
 		const commentsTree = this.props.commentsTree;
 		const comment = get( commentsTree, [ this.props.commentId, 'data' ] );
 
-		if ( ! comment ) {
-			return null;
+		// todo: connect this constants to the state (new selector)
+		const haveReplyWithError = some(
+			get( commentsTree, [ this.props.commentId, 'children' ] ),
+			childId =>
+				get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR,
+		);
+
+		// If it's a pending comment, use the current user as the author
+		if ( comment.isPlaceholder ) {
+			comment.author = this.props.currentUser;
+			comment.author.name = this.props.currentUser.display_name;
+		} else {
+			comment.author.name = decodeEntities( comment.author.name );
 		}
 
-		// todo: connect this constants to the state (new selector)
-		// const haveReplyWithError = some(
-		// 	get( commentsTree, [ this.props.commentId, 'children' ] ),
-		// 	childId =>
-		// 		get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR,
-		// );
+		// If we have an error, render the error component instead
+		if ( comment.isPlaceholder && comment.placeholderState === PLACEHOLDER_STATE.ERROR ) {
+			return <PostCommentWithError { ...this.props } repliesList={ this.renderRepliesList() } />;
+		}
 
-		// // If it's a pending comment, use the current user as the author
-		// if ( comment.isPlaceholder ) {
-		// 	comment.author = this.props.currentUser;
-		// 	comment.author.name = this.props.currentUser.display_name;
-		// } else {
-		// 	comment.author.name = decodeEntities( comment.author.name );
-		// }
+		// Trackback / Pingback
+		if ( comment.type === 'trackback' || comment.type === 'pingback' ) {
+			return <PostTrackback { ...this.props } />;
+		}
 
-		// // If we have an error, render the error component instead
-		// if ( comment.isPlaceholder && comment.placeholderState === PLACEHOLDER_STATE.ERROR ) {
-		// 	return <PostCommentWithError { ...this.props } repliesList={ this.renderRepliesList() } />;
-		// }
+		// Author URL
+		let authorUrl;
+		if ( comment.author.site_ID ) {
+			authorUrl = getStreamUrl( null, comment.author.site_ID );
+		} else if ( comment.author.URL ) {
+			authorUrl = comment.author.URL;
+		}
 
-		// // Trackback / Pingback
-		// if ( comment.type === 'trackback' || comment.type === 'pingback' ) {
-		// 	return <PostTrackback { ...this.props } />;
-		// }
+		return (
+			<li className={ 'comments__comment depth-' + this.props.depth }>
+				<div className="comments__comment-author">
+					{ authorUrl
+						? <a href={ authorUrl } onClick={ this.handleAuthorClick }>
+								<Gravatar user={ comment.author } />
+							</a>
+						: <Gravatar user={ comment.author } /> }
 
-		// // Author URL
-		// let authorUrl;
-		// if ( comment.author.site_ID ) {
-		// 	authorUrl = getStreamUrl( null, comment.author.site_ID );
-		// } else if ( comment.author.URL ) {
-		// 	authorUrl = comment.author.URL;
-		// }
+					{ authorUrl
+						? <a
+								href={ authorUrl }
+								className="comments__comment-username"
+								onClick={ this.handleAuthorClick }
+							>
+								{ comment.author.name }
+							</a>
+						: <strong className="comments__comment-username">
+								{ comment.author.name }
+							</strong> }
+					<div className="comments__comment-timestamp">
+						<a href={ comment.URL }>
+							<PostTime date={ comment.date } />
+						</a>
+					</div>
+				</div>
 
-		return '<div>mysterious</div>';
+				{ comment.status && comment.status === 'unapproved'
+					? <p className="comments__comment-moderation">
+							{ translate( 'Your comment is awaiting moderation.' ) }
+						</p>
+					: null }
 
-		// return (
-		// 	<li className={ 'comments__comment depth-' + this.props.depth }>
-		// 		<div className="comments__comment-author">
-		// 			{ authorUrl
-		// 				? <a href={ authorUrl } onClick={ this.handleAuthorClick }>
-		// 						<Gravatar user={ comment.author } />
-		// 					</a>
-		// 				: <Gravatar user={ comment.author } /> }
+				{ this.props.activeEditCommentId !== this.props.commentId &&
+					<PostCommentContent
+						content={ comment.content }
+						isPlaceholder={ comment.isPlaceholder }
+					/> }
 
-		// 			{ authorUrl
-		// 				? <a
-		// 						href={ authorUrl }
-		// 						className="comments__comment-username"
-		// 						onClick={ this.handleAuthorClick }
-		// 					>
-		// 						{ comment.author.name }
-		// 					</a>
-		// 				: <strong className="comments__comment-username">
-		// 						{ comment.author.name }
-		// 					</strong> }
-		// 			<div className="comments__comment-timestamp">
-		// 				<a href={ comment.URL }>
-		// 					<PostTime date={ comment.date } />
-		// 				</a>
-		// 			</div>
-		// 		</div>
+				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
+					this.props.activeEditCommentId === this.props.commentId &&
+					<CommentEditForm
+						post={ this.props.post }
+						commentId={ this.props.commentId }
+						commentText={ comment.content }
+						onCommentSubmit={ this.props.onEditCommentCancel }
+					/> }
 
-		// 		{ comment.status && comment.status === 'unapproved'
-		// 			? <p className="comments__comment-moderation">
-		// 					{ translate( 'Your comment is awaiting moderation.' ) }
-		// 				</p>
-		// 			: null }
+				<CommentActions
+					post={ this.props.post }
+					comment={ comment }
+					showModerationTools={ this.props.showModerationTools }
+					activeEditCommentId={ this.props.activeEditCommentId }
+					activeReplyCommentID={ this.props.activeReplyCommentID }
+					commentId={ this.props.commentId }
+					editComment={ this.props.onEditCommentClick }
+					editCommentCancel={ this.props.onEditCommentCancel }
+					handleReply={ this.handleReply }
+					onReplyCancel={ this.props.onReplyCancel }
+				/>
 
-		// 		{ this.props.activeEditCommentId !== this.props.commentId &&
-		// 			<PostCommentContent
-		// 				content={ comment.content }
-		// 				isPlaceholder={ comment.isPlaceholder }
-		// 			/> }
-
-		// 		{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
-		// 			this.props.activeEditCommentId === this.props.commentId &&
-		// 			<CommentEditForm
-		// 				post={ this.props.post }
-		// 				commentId={ this.props.commentId }
-		// 				commentText={ comment.content }
-		// 				onCommentSubmit={ this.props.onEditCommentCancel }
-		// 			/> }
-
-		// 		<CommentActions
-		// 			post={ this.props.post }
-		// 			comment={ comment }
-		// 			showModerationTools={ this.props.showModerationTools }
-		// 			activeEditCommentId={ this.props.activeEditCommentId }
-		// 			activeReplyCommentID={ this.props.activeReplyCommentID }
-		// 			commentId={ this.props.commentId }
-		// 			editComment={ this.props.onEditCommentClick }
-		// 			editCommentCancel={ this.props.onEditCommentCancel }
-		// 			handleReply={ this.handleReply }
-		// 			onReplyCancel={ this.props.onReplyCancel }
-		// 		/>
-
-		// 		{ haveReplyWithError ? null : this.renderCommentForm() }
-		// 		{ this.renderRepliesList() }
-		// 	</li>
-		// );
+				{ haveReplyWithError ? null : this.renderCommentForm() }
+				{ this.renderRepliesList() }
+			</li>
+		);
 	}
 }
 
-// PostComment.propTypes = {
-// 	commentsTree: React.PropTypes.object.isRequired,
-// 	commentId: React.PropTypes.oneOfType( [
-// 		React.PropTypes.string, // can be 'placeholder-123'
-// 		React.PropTypes.number,
-// 	] ).isRequired,
-// 	onReplyClick: React.PropTypes.func,
-// 	depth: React.PropTypes.number,
-// 	post: React.PropTypes.object,
-// 	maxChildrenToShow: React.PropTypes.number,
-// 	onCommentSubmit: React.PropTypes.func,
+PostComment.propTypes = {
+	commentsTree: React.PropTypes.object.isRequired,
+	commentId: React.PropTypes.oneOfType( [
+		React.PropTypes.string, // can be 'placeholder-123'
+		React.PropTypes.number,
+	] ).isRequired,
+	onReplyClick: React.PropTypes.func,
+	depth: React.PropTypes.number,
+	post: React.PropTypes.object,
+	maxChildrenToShow: React.PropTypes.number,
+	onCommentSubmit: React.PropTypes.func,
 
-// 	// connect()ed props:
-// 	currentUser: React.PropTypes.object.isRequired,
-// };
+	// connect()ed props:
+	currentUser: React.PropTypes.object.isRequired,
+};
 
-// PostComment.defaultProps = {
-// 	onReplyClick: noop,
-// 	errors: [],
-// 	depth: 1,
-// 	maxChildrenToShow: 5,
-// 	onCommentSubmit: noop,
-// };
+PostComment.defaultProps = {
+	onReplyClick: noop,
+	errors: [],
+	depth: 1,
+	maxChildrenToShow: 5,
+	onCommentSubmit: noop,
+};
 
-export default PostComment;
-
-// export default connect( state => ( {
-// 	currentUser: getCurrentUser( state ),
-// } ) )( PostComment );
+export default connect( state => ( {
+	currentUser: getCurrentUser( state ),
+} ) )( PostComment );

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ConversationCommentList } from 'blocks/conversations/list';
+
+const ConversationCommentListExample = () => {
+	const commentsTree = {
+		'123-12': [
+			{
+				ID: 1,
+				content: '<p>Good!</p>',
+			},
+			{
+				ID: 2,
+				content: '<p>Good!</p>',
+			},
+			{
+				ID: 3,
+				content: '<p>Good!</p>',
+			},
+		],
+	};
+
+	return (
+		<div className="design-assets__group">
+			<ConversationCommentList
+				commentsTree={ commentsTree }
+				blogId={ 123 }
+				postId={ 12 }
+				commentIds={ [ 1, 2, 3 ] }
+			/>
+		</div>
+	);
+};
+
+ConversationCommentListExample.displayName = 'ConversationCommentList';
+
+export default ConversationCommentListExample;

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -15,9 +15,9 @@ const ConversationCommentListExample = () => {
 		1: {
 			data: {
 				ID: 1,
-				content: '<p>Good!</p>',
+				content: '<p>Excellent!</p>',
 				author: {
-					name: 'testuser1',
+					name: 'Barnaby',
 				},
 				date: '2016-04-18T14:50:33+00:00',
 			},
@@ -25,9 +25,9 @@ const ConversationCommentListExample = () => {
 		2: {
 			data: {
 				ID: 2,
-				content: '<p>Good!</p>',
+				content: '<p>Marvellous!</p>',
 				author: {
-					name: 'testuser1',
+					name: 'Gertrude',
 				},
 				date: '2016-04-18T14:53:33+00:00',
 			},
@@ -35,9 +35,9 @@ const ConversationCommentListExample = () => {
 		3: {
 			data: {
 				ID: 3,
-				content: '<p>Good!</p>',
+				content: '<p>Splendid!</p>',
 				author: {
-					name: 'testuser1',
+					name: 'Minnie',
 				},
 				date: '2016-04-18T14:59:22+00:00',
 			},

--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -7,23 +7,41 @@ import React from 'react';
  * Internal dependencies
  */
 import { ConversationCommentList } from 'blocks/conversations/list';
+import { posts } from 'blocks/reader-post-card/docs/fixtures';
 
 const ConversationCommentListExample = () => {
+	const post = posts[ 0 ];
 	const commentsTree = {
-		'123-12': [
-			{
+		1: {
+			data: {
 				ID: 1,
 				content: '<p>Good!</p>',
+				author: {
+					name: 'testuser1',
+				},
+				date: '2016-04-18T14:50:33+00:00',
 			},
-			{
+		},
+		2: {
+			data: {
 				ID: 2,
 				content: '<p>Good!</p>',
+				author: {
+					name: 'testuser1',
+				},
+				date: '2016-04-18T14:53:33+00:00',
 			},
-			{
+		},
+		3: {
+			data: {
 				ID: 3,
 				content: '<p>Good!</p>',
+				author: {
+					name: 'testuser1',
+				},
+				date: '2016-04-18T14:59:22+00:00',
 			},
-		],
+		},
 	};
 
 	return (
@@ -33,6 +51,7 @@ const ConversationCommentListExample = () => {
 				blogId={ 123 }
 				postId={ 12 }
 				commentIds={ [ 1, 2, 3 ] }
+				post={ post }
 			/>
 		</div>
 	);

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/***
+ * Internal dependencies
+ */
+//import PostComment from 'blocks/comments/post-comment';
+import { getPostCommentsTree } from 'state/comments/selectors';
+
+class ConversationCommentList extends React.Component {
+	static propTypes = {
+		blogId: PropTypes.number.isRequired,
+		postId: PropTypes.number.isRequired,
+		commentIds: PropTypes.array,
+	};
+
+	render() {
+		return <div className="conversations__comment-list">Conversation comment list</div>;
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	return {
+		commentsTree: getPostCommentsTree( state, ownProps.blogId, ownProps.postId, 'all' ),
+		//comments: getCommentsById( ownProps.blogId, ownProps.commentIds ),
+	};
+} )( ConversationCommentList );

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -16,10 +16,11 @@ export class ConversationCommentList extends React.Component {
 		blogId: PropTypes.number.isRequired,
 		postId: PropTypes.number.isRequired,
 		commentIds: PropTypes.array.isRequired,
+		post: PropTypes.object, // required by PostComment
 	};
 
 	render() {
-		const { commentIds, commentsTree } = this.props;
+		const { commentIds, commentsTree, post } = this.props;
 		if ( ! commentIds ) {
 			return null;
 		}
@@ -27,12 +28,16 @@ export class ConversationCommentList extends React.Component {
 		return (
 			<div className="conversations__comment-list">
 				{ map( commentIds, commentId =>
-					<PostComment
-						commentsTree={ commentsTree }
-						key={ commentId }
-						commentId={ commentId }
-						maxChildrenToShow={ 0 }
-					/>,
+					// <PostComment
+					// 	commentsTree={ commentsTree }
+					// 	key={ commentId }
+					// 	commentId={ commentId }
+					// 	maxChildrenToShow={ 0 }
+					// 	post={ post }
+					// />,
+					<div>
+						{ commentId }
+					</div>,
 				) }
 			</div>
 		);

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -11,7 +11,7 @@ import { map } from 'lodash';
 import PostComment from 'blocks/comments/post-comment';
 import { getPostCommentsTree } from 'state/comments/selectors';
 
-class ConversationCommentList extends React.Component {
+export class ConversationCommentList extends React.Component {
 	static propTypes = {
 		blogId: PropTypes.number.isRequired,
 		postId: PropTypes.number.isRequired,
@@ -19,7 +19,7 @@ class ConversationCommentList extends React.Component {
 	};
 
 	render() {
-		const { commentIds, commentsTree } = this.props.commentIds;
+		const { commentIds, commentsTree } = this.props;
 		if ( ! commentIds ) {
 			return null;
 		}
@@ -39,8 +39,10 @@ class ConversationCommentList extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
+const ConnectedConversationCommentList = connect( ( state, ownProps ) => {
 	return {
 		commentsTree: getPostCommentsTree( state, ownProps.blogId, ownProps.postId, 'all' ),
 	};
 } )( ConversationCommentList );
+
+export default ConnectedConversationCommentList;

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -26,7 +26,7 @@ export class ConversationCommentList extends React.Component {
 		}
 
 		return (
-			<div className="conversations__comment-list">
+			<ul className="conversations__comment-list">
 				{ map( commentIds, commentId => {
 					return (
 						<PostComment
@@ -38,7 +38,7 @@ export class ConversationCommentList extends React.Component {
 						/>
 					);
 				} ) }
-			</div>
+			</ul>
 		);
 	}
 }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -27,18 +27,17 @@ export class ConversationCommentList extends React.Component {
 
 		return (
 			<div className="conversations__comment-list">
-				{ map( commentIds, commentId =>
-					// <PostComment
-					// 	commentsTree={ commentsTree }
-					// 	key={ commentId }
-					// 	commentId={ commentId }
-					// 	maxChildrenToShow={ 0 }
-					// 	post={ post }
-					// />,
-					<div>
-						{ commentId }
-					</div>,
-				) }
+				{ map( commentIds, commentId => {
+					return (
+						<PostComment
+							commentsTree={ commentsTree }
+							key={ commentId }
+							commentId={ commentId }
+							maxChildrenToShow={ 0 }
+							post={ post }
+						/>
+					);
+				} ) }
 			</div>
 		);
 	}

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -3,28 +3,44 @@
  */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { map } from 'lodash';
 
 /***
  * Internal dependencies
  */
-//import PostComment from 'blocks/comments/post-comment';
+import PostComment from 'blocks/comments/post-comment';
 import { getPostCommentsTree } from 'state/comments/selectors';
 
 class ConversationCommentList extends React.Component {
 	static propTypes = {
 		blogId: PropTypes.number.isRequired,
 		postId: PropTypes.number.isRequired,
-		commentIds: PropTypes.array,
+		commentIds: PropTypes.array.isRequired,
 	};
 
 	render() {
-		return <div className="conversations__comment-list">Conversation comment list</div>;
+		const { commentIds, commentsTree } = this.props.commentIds;
+		if ( ! commentIds ) {
+			return null;
+		}
+
+		return (
+			<div className="conversations__comment-list">
+				{ map( commentIds, commentId =>
+					<PostComment
+						commentsTree={ commentsTree }
+						key={ commentId }
+						commentId={ commentId }
+						maxChildrenToShow={ 0 }
+					/>,
+				) }
+			</div>
+		);
 	}
 }
 
 export default connect( ( state, ownProps ) => {
 	return {
 		commentsTree: getPostCommentsTree( state, ownProps.blogId, ownProps.postId, 'all' ),
-		//comments: getCommentsById( ownProps.blogId, ownProps.commentIds ),
 	};
 } )( ConversationCommentList );

--- a/client/blocks/conversations/style.scss
+++ b/client/blocks/conversations/style.scss
@@ -1,0 +1,4 @@
+.conversations__comment-list {
+	list-style-type: none;
+	margin-left: 0;
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -74,6 +74,7 @@ import ReaderShare from 'blocks/reader-share/docs/example';
 import Login from 'blocks/login/docs/example';
 import ReaderEmailSettings from 'blocks/reader-email-settings/docs/example';
 import UploadImage from 'blocks/upload-image/docs/example';
+import ConversationCommentList from 'blocks/conversations/docs/example';
 
 export default React.createClass( {
 	displayName: 'AppComponents',
@@ -164,6 +165,7 @@ export default React.createClass( {
 					<ReaderShare />
 					<ReaderEmailSettings />
 					<UploadImage />
+					<ConversationCommentList />
 				</Collection>
 			</Main>
 		);


### PR DESCRIPTION
For the upcoming Conversations tool. Accepts a blog ID, post ID and a list of comment IDs, then outputs a flat list of comments, like so:

<img width="567" alt="screen shot 2017-07-19 at 16 53 38" src="https://user-images.githubusercontent.com/17325/28376824-068fb55c-6ca3-11e7-99a6-75b6ba8a1d0b.png">

### To test

Take a look at Devdocs:

http://calypso.localhost:3000/devdocs/blocks/conversation-comment-list