### PR TITLE
Revert "Revert "Login: Show a notice when we send the SMS code""

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -167,6 +167,7 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 						message: getSMSMessageFromResponse( response ),
 						status: 'is-success'
 					},
+					twoStepNonce: get( response, 'body.data.two_step_nonce_sms' )
 				} );
 			}
 		} ).catch( ( httpError ) => {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -160,7 +160,7 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 				data: response.body && response.body.data,
 			} );
 
-			if ( get( response, 'body.data.two_step_notification_sent', null ) === 'sms' ) {
+			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {
 				dispatch( {
 					type: TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS,
 					notice: {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -31,6 +31,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
 	USER_RECEIVE,
 } from 'state/action-types';
+import { login } from 'lib/paths';
 
 export const isRequesting = createReducer( false, {
 	[ LOGIN_REQUEST ]: () => true,
@@ -78,7 +79,13 @@ export const requestNotice = createReducer( null, {
 	[ TWO_FACTOR_AUTHENTICATION_SEND_SMS_CODE_REQUEST_SUCCESS ]: ( state, { notice } ) => notice,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: ( state, { notice } ) => notice,
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: () => null,
-	[ ROUTE_SET ]: () => null,
+	[ ROUTE_SET ]: ( state, action ) => {
+		// if we just navigated to the sms 2fa page, keep the notice (if any) from the loginUser action
+		if ( action.path === login( { isNative: true, twoFactorAuthType: 'sms' } ) ) {
+			return state;
+		}
+		return null;
+	},
 } );
 
 const updateTwoStepNonce = ( state, { twoStepNonce, nonceType } ) => Object.assign( {}, state, {


### PR DESCRIPTION
This was reverted because it caused an `empty_two_step_nonce` error. I have fixed the error. To test this follow the instructions in #16233, and also test logging in.

- [x] Code
- [x] Product
