### PR TITLE
Update TOS in login

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -21,6 +21,7 @@ import { getCurrentQueryArguments } from 'state/ui/selectors';
 import { loginUser } from 'state/login/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getRequestError } from 'state/login/selectors';
+import { preventWidows } from 'lib/formatting';
 import SocialLoginForm from './social';
 
 export class LoginForm extends Component {
@@ -176,6 +177,21 @@ export class LoginForm extends Component {
 							<span>{ this.props.translate( 'Keep me logged in' ) }</span>
 						</label>
 					</div>
+
+					<p className="login__form-terms">
+						{
+							preventWidows( this.props.translate(
+								// To make any changes to this copy please speak to the legal team
+								'By logging in via any of the options below, you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+								{
+									components: {
+										tosLink: <a href="//wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
+									}
+								}
+							), 5 )
+
+						}
+					</p>
 
 					<div className="login__form-action">
 						<FormsButton primary { ...isDisabled }>

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -54,6 +54,11 @@
 	}
 }
 
+.login__form-terms {
+	font-size: 11px;
+	text-align: center;
+}
+
 .login__social-text {
 	text-align: center;
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -57,6 +57,10 @@
 .login__form-terms {
 	font-size: 11px;
 	text-align: center;
+
+	a {
+		white-space: pre;
+	}
 }
 
 .login__social-text {


### PR DESCRIPTION
This pull request as TOS text to our login page, inline with our terms of service
  
<img width="535" alt="screen shot 2017-07-20 at 16 54 43" src="https://user-images.githubusercontent.com/275961/28426795-2b1b446c-6d6c-11e7-876a-da42095c9bff.png">
  
#### Testing instructions
  
1. Run `git checkout update/tos` and start your server
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Check that you see the TOS text above the Log In button
  
#### Additional notes
This exposes a limitation with `preventWidows`, when used strings that contain a link,  but that can be fixed in a different PR.
  
#### Reviews
  
- [x] Code
- [x] Product