### PR TITLE
Extensions: Fix environment check for "Edit plugin settings" link

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -422,7 +422,7 @@ class PluginMeta extends Component {
 		const section = find( sections, ( value => value.name === pluginSlug ) );
 		const env = get( section, 'envId', [] );
 
-		if ( ! includes( env, config( 'env' ) ) ) {
+		if ( ! includes( env, config( 'env_id' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Currently the _Edit plugin settings_ link for extensions is only visible in the development environment. This PR fixes it so that the link is visible when the Calypso environment matches one of the environments set in `env_id` of the extension's `package.json` file.

## Testing

Ensure that the link is still visible in the development environment. The true test will occur after merging and running the same test in the staging environment.