### PR TITLE
data-layer http: provide defaults for functions

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -67,26 +67,28 @@ export const getProgress = action => get( action, 'meta.dataLayer.progress', nul
  *   onProgress :: ReduxStore -> Action -> Dispatcher -> ProgressData
  *
  * @param {Function} initiator called if action lacks response meta; should create HTTP request
- * @param {Function} onSuccess called if the action meta includes response data
- * @param {Function} onError called if the action meta includes error data
+ * @param {Function} [onSuccess] called if the action meta includes response data. The default
+ *                                behavior of this optional handler is to call `next( action )`
+ * @param {Function} [onError] called if the action meta includes error data. The default
+ *                                behavior of this optional handler is to call `next( action )`
  * @param {Function} [onProgress] called on progress events when uploading. The default
- *                                behavior of this optional handler is to do nothing.
+ *                                behavior of this optional handler is to call `next( action )`
  * @returns {?*} please ignore return values, they are undefined
  */
 export const dispatchRequest = ( initiator, onSuccess, onError, onProgress = noop ) => ( store, action, next ) => {
 	const error = getError( action );
 	if ( error ) {
-		return onError( store, action, next, error );
+		return ( onError ? onError( store, action, next, error ) : next( action ) );
 	}
 
 	const data = getData( action );
 	if ( data ) {
-		return onSuccess( store, action, next, data );
+		return ( onSuccess ? onSuccess( store, action, next, data ) : next( action ) );
 	}
 
 	const progress = getProgress( action );
 	if ( progress ) {
-		return onProgress( store, action, next, progress );
+		return ( onProgress ? onProgress( store, action, next, progress ) : next( action ) );
 	}
 
 	return initiator( store, action, next );


### PR DESCRIPTION
This is a conversation piece to discuss adding default `next( action )`
calls for the success/failure/progress handler functions.

The reason: For the case where a reducer is listening for the `data` or
`error` metadata and updating state accordingly, there is no other
action needed by the handler.

Question: Is this a preferred way to use the data layer http? It seems
to work well for adding fetched data to the store, and also for
rendering placeholders during load and rendering for errors when they
happen.

Still to do: If accepted, create unit tests that verify correct default functionality.
