### PR TITLE
FormInputValidation: Add support for children

### DIFF
--- a/client/components/forms/README.md
+++ b/client/components/forms/README.md
@@ -26,8 +26,17 @@ The `FormSectionHeading` component allows you to add a section header to your se
 ### FormInputValidation
 The `FormInputValidation` component is used to display a validation notice to the user. You can use it like this:
 
+```jsx
 <FormInputValidation isError={ true } text="Usernames can only contain lowercase letters (a-z) and numbers." />
 <FormInputValidation text="That username is valid." />
+
+or add children to render if more than simple text is needed.
+
+<FormInputValidation isError={ true }>
+	<span> Your API key could not be verified. </span>
+	<Button> Try again </Button>
+</FormInputValidation>
+```
 
 ### MultiCheckbox
 

--- a/client/components/forms/form-input-validation/index.jsx
+++ b/client/components/forms/form-input-validation/index.jsx
@@ -31,7 +31,10 @@ export default React.createClass( {
 
 		return (
 			<div className={ classes }>
-				<span><Gridicon size={ 24 } icon={ this.props.icon ? this.props.icon : icon } /> { this.props.text }</span>
+				<span>
+					<Gridicon size={ 24 } icon={ this.props.icon ? this.props.icon : icon } />
+					{ this.props.text || this.props.children }
+				</span>
 			</div>
 		);
 	}


### PR DESCRIPTION
This adds support for children in the FormInputValidation component if
`text` is not set. This allows for more control over what is displayed
on an invalid form item, and potentially action buttons to deal with
them.

I'm looking for feedback on this change, more than just the code. To see if this is a "good idea". Thanks!
