### PR TITLE
Store: Fix issues with product variations saving

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/product-variations/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-variations/index.js
@@ -56,7 +56,7 @@ export function handleProductVariationCreate( store, action ) {
 		return;
 	}
 
-	const updatedAction = ( dispatch, getState, data ) => {
+	const updatedAction = ( dispatch, getState, { data } ) => {
 		dispatch( productVariationUpdated( siteId, productId, data, action ) );
 
 		const props = { productId, sentData: variation, receivedData: data };
@@ -79,7 +79,7 @@ export function handleProductVariationUpdate( store, action ) {
 		return;
 	}
 
-	const updatedAction = ( dispatch, getState, data ) => {
+	const updatedAction = ( dispatch, getState, { data } ) => {
 		dispatch( productVariationUpdated( siteId, productId, data, action ) );
 
 		const props = { productId: productId, sentData: variation, receivedData: data };

--- a/client/extensions/woocommerce/state/data-layer/product-variations/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-variations/test/index.js
@@ -166,7 +166,7 @@ describe( 'handlers', () => {
 			const updatedSuccessAction = store.dispatch.firstCall.args[ 0 ].onSuccessAction;
 			expect( updatedSuccessAction ).to.be.a( 'function' );
 
-			updatedSuccessAction( store.dispatch, null, 'RECEIVED_DATA' );
+			updatedSuccessAction( store.dispatch, null, { data: 'RECEIVED_DATA' } );
 
 			expect( store.dispatch ).to.have.been.calledWith(
 				match( {
@@ -204,7 +204,7 @@ describe( 'handlers', () => {
 			const updatedSuccessAction = store.dispatch.firstCall.args[ 0 ].onSuccessAction;
 			expect( updatedSuccessAction ).to.be.a( 'function' );
 
-			updatedSuccessAction( store.dispatch, null, 'RECEIVED_DATA' );
+			updatedSuccessAction( store.dispatch, null, { data: 'RECEIVED_DATA' } );
 
 			expect( store.dispatch ).to.have.been.calledWith(
 				match( {
@@ -270,7 +270,7 @@ describe( 'handlers', () => {
 			const updatedSuccessAction = store.dispatch.firstCall.args[ 0 ].onSuccessAction;
 			expect( updatedSuccessAction ).to.be.a( 'function' );
 
-			updatedSuccessAction( store.dispatch, null, 'RECEIVED_DATA' );
+			updatedSuccessAction( store.dispatch, null, { data: 'RECEIVED_DATA' } );
 
 			expect( store.dispatch ).to.have.been.calledWith(
 				match( {
@@ -308,7 +308,7 @@ describe( 'handlers', () => {
 			const updatedSuccessAction = store.dispatch.firstCall.args[ 0 ].onSuccessAction;
 			expect( updatedSuccessAction ).to.be.a( 'function' );
 
-			updatedSuccessAction( store.dispatch, null, 'RECEIVED_DATA' );
+			updatedSuccessAction( store.dispatch, null, { data: 'RECEIVED_DATA' } );
 
 			expect( store.dispatch ).to.have.been.calledWith(
 				match( {
@@ -405,4 +405,3 @@ describe( 'handlers', () => {
 		} );
 	} );
 } );
-


### PR DESCRIPTION
While testing earlier I noticed two problems around variations:

1: Loading variations on the product edit form right after creating a variation wasn't displaying. I thought this had been fixed but it was still occurring in master.

This was because `productVariationUpdated` was being passed `data.data`. Requesting variations already destructured data, but updating and creating did not.  These are the changes I made in `product-variations/index.js`


2: The second issue was caused by me previously trying to return a list of product IDs affected by an action list (which is currently being used to get a permalink for a product for the success message). 

I was using `productIdMapping`, but this won't be set if you only update variation data and not product data. This was causing a JS error / error message, even though the variation data would save.

To Test:
* Run `npm run test-client client/extensions/woocommerce/state/` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/product/:site` and create a new product with variations (it helps if you are running WC-API-Dev 0.7.1 so it doesn't time out).
* Immediately go to the edit screen for this new product to make sure the variations are visible.
* Update a variation field like price, and DO NOT update any other product fields. Save and make sure you get a success message.
* Update a product field and update, without setting any variation fields, and make sure a success message shows.