### PR TITLE
Reader: Fix Tags going too far to right

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -276,14 +276,13 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 	display: flex;
 	flex-direction: row;
 	height: 20px;
-	white-space: nowrap;
 	margin-left: 10px;
 	overflow: hidden;
 	position: relative;
-	width: calc( 100% - 100px );
+	width: calc( 100% - 140px );
 
 	@include breakpoint( "<480px" ) {
-		max-width: 230px;
+		max-width: 500px;
 	}
 
 	&::after {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/16049

Example: http://calypso.dev:3000/read/search?isSuggestion=1&q=8duffels&sort=relevance

**Search results:**
<img width="863" alt="screenshot 2017-07-19 19 24 58" src="https://user-images.githubusercontent.com/4924246/28397689-07a10e0e-6cb8-11e7-9f5e-8f7273b9bd9e.png">

**Site Stream:**
<img width="814" alt="screenshot 2017-07-19 19 26 17" src="https://user-images.githubusercontent.com/4924246/28397712-313ff2de-6cb8-11e7-827a-892b683405ae.png">

