### PR TITLE
Sign Up: Polish form spacing

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -14,7 +14,7 @@ import i18n, { localize } from 'i18n-calypso';
 import wpcom from 'lib/wp';
 import config from 'config';
 import analytics from 'lib/analytics';
-import ValidationFieldset from 'signup/validation-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -313,58 +313,64 @@ class SignupForm extends Component {
 
 		return (
 			<div>
-				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'email' ) }>
-					<FormLabel htmlFor="email">{ this.props.translate( 'Your email address' ) }</FormLabel>
-					<FormTextInput
-						autoFocus={ ! this.props.isSocialSignupEnabled }
-						autoCapitalize="off"
-						autoCorrect="off"
-						className="signup-form__input"
-						disabled={ this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput }
-						id="email"
-						name="email"
-						type="email"
-						value={ formState.getFieldValue( this.state.form, 'email' ) }
-						isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
-						isValid={ this.state.validationInitialized && isEmailValid }
-						onBlur={ this.handleBlur }
-						onChange={ this.handleChangeEvent } />
-					{ this.emailDisableExplanation() }
-				</ValidationFieldset>
+				<FormLabel htmlFor="email">{ this.props.translate( 'Your email address' ) }</FormLabel>
+				<FormTextInput
+					autoFocus={ ! this.props.isSocialSignupEnabled }
+					autoCapitalize="off"
+					autoCorrect="off"
+					className="signup-form__input"
+					disabled={ this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput }
+					id="email"
+					name="email"
+					type="email"
+					value={ formState.getFieldValue( this.state.form, 'email' ) }
+					isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
+					isValid={ this.state.validationInitialized && isEmailValid }
+					onBlur={ this.handleBlur }
+					onChange={ this.handleChangeEvent } />
+				{ this.emailDisableExplanation() }
 
-				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'username' ) }>
-					<FormLabel htmlFor="username">{ this.props.translate( 'Choose a username' ) }</FormLabel>
-					<FormTextInput
-						autoCapitalize="off"
-						autoCorrect="off"
-						className="signup-form__input"
-						disabled={ this.state.submitting || this.props.disabled }
-						id="username"
-						name="username"
-						value={ formState.getFieldValue( this.state.form, 'username' ) }
-						isError={ formState.isFieldInvalid( this.state.form, 'username' ) }
-						isValid={ formState.isFieldValid( this.state.form, 'username' ) }
-						onBlur={ this.handleBlur }
-						onChange={ this.handleChangeEvent } />
-				</ValidationFieldset>
+				{ formState.isFieldInvalid( this.state.form, 'email' ) && (
+					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'email' ) } />
+				) }
 
-				<ValidationFieldset errorMessages={ formState.getFieldErrorMessages( this.state.form, 'password' ) }>
-					<FormLabel htmlFor="password">{ this.props.translate( 'Choose a password' ) }</FormLabel>
-					<FormPasswordInput
-						className="signup-form__input"
-						disabled={ this.state.submitting || this.props.disabled }
-						id="password"
-						name="password"
-						value={ formState.getFieldValue( this.state.form, 'password' ) }
-						isError={ formState.isFieldInvalid( this.state.form, 'password' ) }
-						isValid={ formState.isFieldValid( this.state.form, 'password' ) }
-						onBlur={ this.handleBlur }
-						onChange={ this.handleChangeEvent }
-						submitting={ this.state.submitting || this.props.submitting } />
-					<FormSettingExplanation>
-						{ this.props.translate( 'Your password must be at least six characters long.' ) }
-					</FormSettingExplanation>
-				</ValidationFieldset>
+				<FormLabel htmlFor="username">{ this.props.translate( 'Choose a username' ) }</FormLabel>
+				<FormTextInput
+					autoCapitalize="off"
+					autoCorrect="off"
+					className="signup-form__input"
+					disabled={ this.state.submitting || this.props.disabled }
+					id="username"
+					name="username"
+					value={ formState.getFieldValue( this.state.form, 'username' ) }
+					isError={ formState.isFieldInvalid( this.state.form, 'username' ) }
+					isValid={ formState.isFieldValid( this.state.form, 'username' ) }
+					onBlur={ this.handleBlur }
+					onChange={ this.handleChangeEvent } />
+
+				{ formState.isFieldInvalid( this.state.form, 'username' ) && (
+					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'username' ) } />
+				) }
+
+				<FormLabel htmlFor="password">{ this.props.translate( 'Choose a password' ) }</FormLabel>
+				<FormPasswordInput
+					className="signup-form__input"
+					disabled={ this.state.submitting || this.props.disabled }
+					id="password"
+					name="password"
+					value={ formState.getFieldValue( this.state.form, 'password' ) }
+					isError={ formState.isFieldInvalid( this.state.form, 'password' ) }
+					isValid={ formState.isFieldValid( this.state.form, 'password' ) }
+					onBlur={ this.handleBlur }
+					onChange={ this.handleChangeEvent }
+					submitting={ this.state.submitting || this.props.submitting } />
+				<FormSettingExplanation>
+					{ this.props.translate( 'Your password must be at least six characters long.' ) }
+				</FormSettingExplanation>
+
+				{ formState.isFieldInvalid( this.state.form, 'password' ) && (
+					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'password' ) } />
+				) }
 			</div>
 		);
 	}

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -391,7 +391,7 @@ class SignupForm extends Component {
 		return (
 			<p className="signup-form__terms-of-service-link">{
 				this.props.translate(
-					'By creating an account you agree to our {{a}}fascinating Terms of Service{{/a}}.',
+					'By creating an account via any of the options below, you agree to our {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
 							a: <a

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -364,13 +364,7 @@ class SignupForm extends Component {
 					onBlur={ this.handleBlur }
 					onChange={ this.handleChangeEvent }
 					submitting={ this.state.submitting || this.props.submitting } />
-				<FormSettingExplanation>
-					{ this.props.translate( 'Your password must be at least six characters long.' ) }
-				</FormSettingExplanation>
-
-				{ formState.isFieldInvalid( this.state.form, 'password' ) && (
-					<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'password' ) } />
-				) }
+				{ this.passwordValidationExplanation() }
 			</div>
 		);
 	}
@@ -422,6 +416,26 @@ class SignupForm extends Component {
 				<FormSettingExplanation noValidate={ true }>{ this.props.disableEmailExplanation }</FormSettingExplanation>
 			);
 		}
+	}
+
+	passwordValidationExplanation() {
+		const passwordLength = formState.getFieldValue( this.state.form, 'password' ).length;
+
+		if ( formState.isFieldInvalid( this.state.form, 'password' ) ) {
+			return (
+				<FormInputValidation isError text={ this.getErrorMessagesWithLogin( 'password' ) } />
+			);
+		}
+
+		if ( passwordLength < 6 ) {
+			return (
+				<FormSettingExplanation>
+					{ this.props.translate( 'Your password must be at least six characters long.' ) }
+				</FormSettingExplanation>
+			);
+		}
+
+		return false;
 	}
 
 	formFooter() {

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -382,22 +382,39 @@ class SignupForm extends Component {
 	}
 
 	termsOfServiceLink() {
-		return (
-			<p className="signup-form__terms-of-service-link">{
-				this.props.translate(
-					'By creating an account via any of the options below, you agree to our {{a}}Terms of Service{{/a}}.',
-					{
-						components: {
-							a: <a
-								href={ this.getTermsOfServiceUrl() }
-								onClick={ this.handleOnClickTos }
-								target="_blank"
-								rel="noopener noreferrer" />
-						}
-					}
-				)
-			}</p>
+		const tosLink = <a
+			href={ this.getTermsOfServiceUrl() }
+			onClick={ this.handleOnClickTos }
+			target="_blank"
+			rel="noopener noreferrer" />;
+		const tosText = this.props.translate(
+			'By creating an account you agree to our {{a}}fascinating Terms of Service{{/a}}.',
+			{
+				components: {
+					a: tosLink
+				}
+			}
 		);
+
+		if ( this.props.isSocialSignupEnabled ) {
+			return (
+				<p className="signup-form__terms-of-service-link">{
+					this.props.translate(
+						'By creating an account via any of the options below, you agree to our {{a}}Terms of Service{{/a}}.',
+						{
+							components: {
+								a: tosLink
+							}
+						}
+					)
+				}</p>
+			);
+		}
+
+		return (
+			<p className="signup-form__terms-of-service-link">{ tosText }</p>
+		);
+
 	}
 
 	getNotice() {

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -419,7 +419,7 @@ class SignupForm extends Component {
 	}
 
 	passwordValidationExplanation() {
-		const passwordLength = formState.getFieldValue( this.state.form, 'password' ).length;
+		const passwordValue = formState.getFieldValue( this.state.form, 'password' );
 
 		if ( formState.isFieldInvalid( this.state.form, 'password' ) ) {
 			return (
@@ -427,7 +427,7 @@ class SignupForm extends Component {
 			);
 		}
 
-		if ( passwordLength < 6 ) {
+		if ( passwordValue && passwordValue < 6 ) {
 			return (
 				<FormSettingExplanation>
 					{ this.props.translate( 'Your password must be at least six characters long.' ) }

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -45,7 +45,7 @@ class SocialSignupForm extends Component {
 		return (
 			<Card className="signup-form__social">
 				<p>
-					{ preventWidows( this.props.translate( "Or create an account using your existing social profile to get started faster. We'll never post without your permission." ) ) }
+					{ preventWidows( this.props.translate( 'Or connect your existing profile to get started faster.' ) ) }
 				</p>
 
 				<div className="signup-form__social-buttons">

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -42,6 +42,10 @@
 	}
 }
 
+.social-buttons__button-container + .social-buttons__button-container {
+	margin-top: 10px;
+}
+
 .signup-form__social,
 .signup-form__notice.notice {
 	margin-left: auto;

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -3,13 +3,14 @@
 	margin-bottom: 20px;
 	transition: none;
 
-	&.is-error {
+	&.is-error,
+	&[type="password"] {
 		margin-bottom: 0;
 	}
 }
 
 .signup-form .logged-out-form__footer {
-	margin-top: 10px;
+	margin-top: 20px;
 }
 
 .signup-form__terms-of-service-link {

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -1,6 +1,11 @@
 /*rtl:ignore*/
-.signup-form__input {
-	direction: ltr;
+.signup-form .signup-form__input {
+	margin-bottom: 20px;
+	transition: none;
+
+	&.is-error {
+		margin-bottom: 0;
+	}
 }
 
 .signup-form .logged-out-form__footer {

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -91,20 +91,22 @@ class FacebookLoginButton extends Component {
 
 	render() {
 		return (
-			<button className="social-buttons__button button" onClick={ this.handleClick }>
-				<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-					{ /* eslint-disable max-len */ }
-					<path d="M18.86.041H1.14a1.1 1.1 0 0 0-1.099 1.1v17.718a1.1 1.1 0 0 0 1.1 1.1h9.539v-7.713H8.084V9.24h2.596V7.023c0-2.573 1.571-3.973 3.866-3.973 1.1 0 2.044.081 2.32.118v2.688l-1.592.001c-1.248 0-1.49.593-1.49 1.463v1.92h2.977l-.388 3.006h-2.59v7.713h5.076a1.1 1.1 0 0 0 1.1-1.1V1.14a1.1 1.1 0 0 0-1.1-1.099" fill="#3E68B5" fillRule="evenodd" />
-					{ /* eslint-enable max-len */ }
-				</svg>
+			<div className="social-buttons__button-container">
+				<button className="social-buttons__button button" onClick={ this.handleClick }>
+					<svg className="social-buttons__logo" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+						{ /* eslint-disable max-len */ }
+						<path d="M18.86.041H1.14a1.1 1.1 0 0 0-1.099 1.1v17.718a1.1 1.1 0 0 0 1.1 1.1h9.539v-7.713H8.084V9.24h2.596V7.023c0-2.573 1.571-3.973 3.866-3.973 1.1 0 2.044.081 2.32.118v2.688l-1.592.001c-1.248 0-1.49.593-1.49 1.463v1.92h2.977l-.388 3.006h-2.59v7.713h5.076a1.1 1.1 0 0 0 1.1-1.1V1.14a1.1 1.1 0 0 0-1.1-1.099" fill="#3E68B5" fillRule="evenodd" />
+						{ /* eslint-enable max-len */ }
+					</svg>
 
-				<span className="social-buttons__service-name">
-					{ this.props.translate( 'Continue with %(service)s', {
-						args: { service: 'Facebook' },
-						comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
-					} ) }
-				</span>
-			</button>
+					<span className="social-buttons__service-name">
+						{ this.props.translate( 'Continue with %(service)s', {
+							args: { service: 'Facebook' },
+							comment: '%(service)s is the name of a Social Network, e.g. "Google", "Facebook", "Twitter" ...'
+						} ) }
+					</span>
+				</button>
+			</div>
 		);
 	}
 }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -144,7 +144,7 @@ class GoogleLoginButton extends Component {
 		}
 
 		return (
-			<div>
+			<div className="social-buttons__button-container">
 				<button className={ classes } onMouseOver={ this.showError } onMouseOut={ this.hideError } onClick={ this.handleClick }>
 					{ /* eslint-disable max-len */ }
 					<svg className="social-buttons__logo enabled" width="20" height="20" viewBox="0 0 20 20"xmlns="http://www.w3.org/2000/svg">

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -145,7 +145,7 @@ export class UserStep extends Component {
 			return translate( 'Account created - Go to next step' );
 		}
 
-		return translate( 'Create My Account' );
+		return translate( 'Continue' );
 	}
 
 	renderSignupForm() {

--- a/client/signup/validation-fieldset/style.scss
+++ b/client/signup/validation-fieldset/style.scss
@@ -1,22 +1,6 @@
 .validation-fieldset {
 	margin-bottom: 0;
 	position: relative;
-
-	.form-setting-explanation {
-		max-height: 0;
-		overflow: hidden;
-		transition: all .3s ease-in-out;
-		
-		&.no-validate {
-			max-height: none;
-			overflow: auto;
-		}
-	}
-
-	input:focus + .form-setting-explanation {
-		max-height: 100px;
-	}
-
 }
 
 .validation-fieldset__validation-message {


### PR DESCRIPTION
This PR addresses some concerns with the signup screen with social buttons included. Feedback from @ranh:

> I think it's mostly that there's no balance between the "old" and new parts. The form is very spacious with tons of whitespace, the social options are packed together very tightly

The main reason it was so spacious was because we had the form validation always in the markup with a `min-height`. While this did help with the UI jumping a bit with validation errors, it's not essential. Especially because the UI still jumped with languages other than English where the error was longer. Also, the form fields felt more disconnected with so much whitespace between them.

**Before**
![image](https://user-images.githubusercontent.com/448298/28397879-53aae788-6cd2-11e7-9f53-b0747addfd09.png)

**After**
![image](https://user-images.githubusercontent.com/448298/28432720-fa4c0e08-6d56-11e7-9191-d7edbd0b9ef0.png)

#### Testing

1. Run `git checkout update/sign-up-screen-polish` and start your server, or open a [live branch](https://calypso.live/?branch=update/sign-up-screen-polish).
2. Visit the social signup screen at [`/start/social/user-social`](http://calypso.localhost:3000/start/social/user-social).
3. Assert the screen looks like the screenshot above.
4. Try signing up, try to break it.
5. Visit the regular signup flow at [`/start`](http://calypso.localhost:3000/start).
6. Assert it looks and works in the same way.

#### Review

- [x] Code
- [x] Product