### PR TITLE
Reader: Drop Feed Header Follow and Settings labels mobile

### DIFF
--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -110,6 +110,10 @@
 			@include breakpoint( "<660px" ) {
 				display: inline-block;
 			}
+
+			@include breakpoint( "<480px" ) {
+				display: none;
+			}
 		}
 
 		&.is-following {
@@ -132,6 +136,10 @@
 
 		@include breakpoint( ">660px" ) {
 			padding-right: 12px;
+		}
+
+		@include breakpoint( "<480px" ) {
+			padding-right: 3px;
 		}
 	}
 
@@ -222,6 +230,10 @@
 		top: -1px;
 		left: 2px;
 		margin-left: 4px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
Screenshots from an iPhone 5. Not seeing the same issue on an iPhone 6.

**Before:**
![img_9312](https://user-images.githubusercontent.com/4924246/28398627-f6f1b4d2-6cbc-11e7-836b-c012f33960c2.PNG)

**After:**
![img_9313](https://user-images.githubusercontent.com/4924246/28398631-fc30cc94-6cbc-11e7-9d56-7a0d7ae9fb2f.PNG)
