### PR TITLE
Prettier: add precommit hook for ensuring prettified files stay pretty

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -58,6 +58,7 @@ const shouldFormat = text => {
 files.map( file => path.join( __dirname, '../', file ) ).forEach( file => {
 	fs.readFile( file, 'utf8', ( err, text ) => {
 		if ( shouldFormat( text ) ) {
+			console.log( `Prettier formatting file: ${ file } because it contains the @format flag` );
 			const formattedText = prettier.format( text, {} );
 			fs.writeFileSync( file, formattedText );
 			execSync( `git add ${ file }` );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -23,21 +23,6 @@ const files = execSync( 'git diff --cached --name-only' )
 	.map( name => name.trim() )
 	.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
 
-const lintResult = spawnSync( 'eslint-eslines', [ ...files, '--', '--diff=index' ], {
-	shell: true,
-	stdio: 'inherit',
-} );
-
-if ( lintResult.status ) {
-	console.log(
-		chalk.red( 'COMMIT ABORTED:' ),
-		'The linter reported some problems. ' +
-		'If you are aware of them and it is OK, ' +
-		'repeat the commit command with --no-verify to avoid this check.'
-	);
-	process.exit( 1 );
-}
-
 /**
  * Returns true if the given text contains '@ format' (without the space after @).
  * within its first docblock. False otherwise.
@@ -79,3 +64,19 @@ files.map( file => path.join( __dirname, '../', file ) ).forEach( file => {
 		}
 	} );
 } );
+
+// linting should happen after formatting
+const lintResult = spawnSync( 'eslint-eslines', [ ...files, '--', '--diff=index' ], {
+	shell: true,
+	stdio: 'inherit',
+} );
+
+if ( lintResult.status ) {
+	console.log(
+		chalk.red( 'COMMIT ABORTED:' ),
+		'The linter reported some problems. ' +
+		'If you are aware of them and it is OK, ' +
+		'repeat the commit command with --no-verify to avoid this check.'
+	);
+	process.exit( 1 );
+}

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -6,7 +6,6 @@ const chalk = require( 'chalk' );
 const fs = require( 'fs' );
 const prettier = require( 'prettier' );
 const path = require( 'path' );
-const _ = require( 'lodash' );
 
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
@@ -33,25 +32,23 @@ const files = execSync( 'git diff --cached --name-only' )
  * @param {*} text text to scan for the format keyword within the first docblock
  */
 const shouldFormat = text => {
-	const firstDocBlockStart = /\/\*\*/;
-	const firstDocBlockEnd = /\*\//;
+	const docBlockStart = '/**';
+	const docBlockEnd = '*/';
 
-	const firstDocBlockStartIndex = _.get( firstDocBlockStart.exec( text ), 'index' );
+	const firstDocBlockStartIndex = text.indexOf( docBlockStart );
 
-	if ( ! _.isInteger( firstDocBlockStartIndex ) ) {
+	if ( -1 === firstDocBlockStartIndex ) {
 		return;
 	}
 
-	firstDocBlockEnd.lastIndex = firstDocBlockStartIndex; // docBlockEnd must come after the start
-	const firstDocBlockEndIndex = _.get( firstDocBlockEnd.exec( text ), 'index' );
+	const firstDocBlockEndIndex = text.indexOf( docBlockEnd, firstDocBlockStartIndex + 1 );
 
-	if ( ! _.isInteger( firstDocBlockEndIndex ) ) {
+	if ( -1 === firstDocBlockEndIndex ) {
 		return;
 	}
 
-	const firstDocBlockText = text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 2 );
-
-	return firstDocBlockText && /@format/.test( firstDocBlockText );
+	const firstDocBlockText = text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 1 );
+	return firstDocBlockText.indexOf( '@format' ) >= 0;
 };
 
 // run prettier for any files in the commit that have @format within their first docblock

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -10,8 +10,8 @@ const _ = require( 'lodash' );
 
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
-		'under the GNU General Public License v2 (or later). All materials must have ' +
-		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n',
+	'under the GNU General Public License v2 (or later). All materials must have ' +
+	'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n'
 );
 
 // Make quick pass over config files on every change
@@ -32,16 +32,20 @@ if ( lintResult.status ) {
 	console.log(
 		chalk.red( 'COMMIT ABORTED:' ),
 		'The linter reported some problems. ' +
-			'If you are aware of them and it is OK, ' +
-			'repeat the commit command with --no-verify to avoid this check.',
+		'If you are aware of them and it is OK, ' +
+		'repeat the commit command with --no-verify to avoid this check.'
 	);
 	process.exit( 1 );
 }
 
 /**
- * Returns true if the given text contains @format within its first docblock. False otherwise.
+ * Returns true if the given text contains '@ format' (without the space after @).
+ * within its first docblock. False otherwise.
  *
- * @param {*} text text to scan for @format within the first docblock
+ * Note: I only don't write out the actual @ f o r m a t, because then this
+ * file would also get formatted!
+ *
+ * @param {*} text text to scan for the format keyword within the first docblock
  */
 const shouldFormat = text => {
 	const firstDocBlockStart = /\/\*\*/;

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -10,7 +10,7 @@ const path = require( 'path' );
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
 		'under the GNU General Public License v2 (or later). All materials must have ' +
-		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n'
+		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n',
 );
 
 // Make quick pass over config files on every change
@@ -26,19 +26,19 @@ const files = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
  * Returns true if the given text contains @format.
  * within its first docblock. False otherwise.
  *
- * @param {*} text text to scan for the format keyword within the first docblock
+ * @param {String} text text to scan for the format keyword within the first docblock
  */
 const shouldFormat = text => {
 	const firstDocBlockStartIndex = text.indexOf( '/**' );
 
 	if ( -1 === firstDocBlockStartIndex ) {
-		return;
+		return false;
 	}
 
 	const firstDocBlockEndIndex = text.indexOf( '*/', firstDocBlockStartIndex + 1 );
 
 	if ( -1 === firstDocBlockEndIndex ) {
-		return;
+		return false;
 	}
 
 	const firstDocBlockText = text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 1 );
@@ -68,7 +68,7 @@ if ( lintResult.status ) {
 		chalk.red( 'COMMIT ABORTED:' ),
 		'The linter reported some problems. ' +
 			'If you are aware of them and it is OK, ' +
-			'repeat the commit command with --no-verify to avoid this check.'
+			'repeat the commit command with --no-verify to avoid this check.',
 	);
 	process.exit( 1 );
 }

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -32,16 +32,13 @@ const files = execSync( 'git diff --cached --name-only' )
  * @param {*} text text to scan for the format keyword within the first docblock
  */
 const shouldFormat = text => {
-	const docBlockStart = '/**';
-	const docBlockEnd = '*/';
-
-	const firstDocBlockStartIndex = text.indexOf( docBlockStart );
+	const firstDocBlockStartIndex = text.indexOf( '/**' );
 
 	if ( -1 === firstDocBlockStartIndex ) {
 		return;
 	}
 
-	const firstDocBlockEndIndex = text.indexOf( docBlockEnd, firstDocBlockStartIndex + 1 );
+	const firstDocBlockEndIndex = text.indexOf( '*/', firstDocBlockStartIndex + 1 );
 
 	if ( -1 === firstDocBlockEndIndex ) {
 		return;

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -3,6 +3,9 @@
 const execSync = require( 'child_process' ).execSync;
 const spawnSync = require( 'child_process' ).spawnSync;
 const chalk = require( 'chalk' );
+const fs = require( 'fs' );
+const prettier = require( 'prettier' );
+const path = require( 'path' );
 
 console.log( '\nBy contributing to this project, you license the materials you contribute ' +
 	'under the GNU General Public License v2 (or later). All materials must have ' +
@@ -28,3 +31,17 @@ if ( lintResult.status ) {
 		'repeat the commit command with --no-verify to avoid this check.' );
 	process.exit( 1 );
 }
+
+// run prettier for any files in the commit
+// that have a line with the contents: '// pretty'
+files
+	.map( file => path.join( __dirname, '../', file ) )
+	.forEach( file => {
+		fs.readFile( file, 'utf8', ( err, data ) => {
+			if ( data.match( /^\/\/ pretty$/m ) ) {
+				const formattedData = prettier.format( data, {} );
+				fs.writeFileSync( file, formattedData );
+				execSync( `git add ${ file }` );
+			}
+		} )
+} );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -16,7 +16,7 @@ console.log(
 // Make quick pass over config files on every change
 require( '../server/config/validate-config-keys' );
 
-const files = execSync( 'git diff --cached --name-only' )
+const files = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
 	.toString()
 	.split( '\n' )
 	.map( name => name.trim() )

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -6,6 +6,7 @@ const chalk = require( 'chalk' );
 const fs = require( 'fs' );
 const prettier = require( 'prettier' );
 const path = require( 'path' );
+const _ = require( 'lodash' );
 
 console.log( '\nBy contributing to this project, you license the materials you contribute ' +
 	'under the GNU General Public License v2 (or later). All materials must have ' +
@@ -32,16 +33,27 @@ if ( lintResult.status ) {
 	process.exit( 1 );
 }
 
-// run prettier for any files in the commit
-// that have a line with the contents: '// pretty'
+
+// run prettier for any files in the commit that have @format within their first docblock
+const formatRegex = /@format/;
+const firstDocBlockStart = /\/\*\*/;
+const firstDocBlockEnd = /\*\//;
+
 files
 	.map( file => path.join( __dirname, '../', file ) )
 	.forEach( file => {
 		fs.readFile( file, 'utf8', ( err, data ) => {
-			if ( data.match( /^\/\/ pretty$/m ) ) {
+			const firstDocBlockStartIndex = _.get( firstDocBlockStart.exec( data ), 'index' );
+			const firstDocBlockEndIndex = _.get( firstDocBlockEnd.exec( data ), 'index' );
+			const firstDocBlockText =
+				_.isInteger( firstDocBlockStartIndex ) &&
+				_.isInteger( firstDocBlockEndIndex ) &&
+				data.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 2 );
+
+			if ( firstDocBlockText && formatRegex.test( firstDocBlockText ) ) {
 				const formattedData = prettier.format( data, {} );
 				fs.writeFileSync( file, formattedData );
 				execSync( `git add ${ file }` );
 			}
-		} )
+		} );
 } );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -8,9 +8,11 @@ const prettier = require( 'prettier' );
 const path = require( 'path' );
 const _ = require( 'lodash' );
 
-console.log( '\nBy contributing to this project, you license the materials you contribute ' +
-	'under the GNU General Public License v2 (or later). All materials must have ' +
-	'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n' );
+console.log(
+	'\nBy contributing to this project, you license the materials you contribute ' +
+		'under the GNU General Public License v2 (or later). All materials must have ' +
+		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n',
+);
 
 // Make quick pass over config files on every change
 require( '../server/config/validate-config-keys' );
@@ -18,8 +20,8 @@ require( '../server/config/validate-config-keys' );
 const files = execSync( 'git diff --cached --name-only' )
 	.toString()
 	.split( '\n' )
-	.map( ( name ) => name.trim() )
-	.filter( ( name ) => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
+	.map( name => name.trim() )
+	.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
 
 const lintResult = spawnSync( 'eslint-eslines', [ ...files, '--', '--diff=index' ], {
 	shell: true,
@@ -27,33 +29,52 @@ const lintResult = spawnSync( 'eslint-eslines', [ ...files, '--', '--diff=index'
 } );
 
 if ( lintResult.status ) {
-	console.log( chalk.red( 'COMMIT ABORTED:' ), 'The linter reported some problems. ' +
-		'If you are aware of them and it is OK, ' +
-		'repeat the commit command with --no-verify to avoid this check.' );
+	console.log(
+		chalk.red( 'COMMIT ABORTED:' ),
+		'The linter reported some problems. ' +
+			'If you are aware of them and it is OK, ' +
+			'repeat the commit command with --no-verify to avoid this check.',
+	);
 	process.exit( 1 );
 }
 
+/**
+ * Returns true if the given text contains @format within its first docblock. False otherwise.
+ *
+ * @param {*} text text to scan for @format within the first docblock
+ */
+const shouldFormat = text => {
+	const firstDocBlockStart = /\/\*\*/;
+	const firstDocBlockEnd = /\*\//;
+
+	const firstDocBlockStartIndex = _.get( firstDocBlockStart.exec( text ), 'index' );
+
+	if ( ! firstDocBlockStartIndex ) {
+		return;
+	}
+
+	firstDocBlockEnd.lastIndex = firstDocBlockStartIndex; // docBlockEnd must come after the start
+	const firstDocBlockEndIndex = _.get( firstDocBlockEnd.exec( text ), 'index' );
+
+	if ( ! firstDocBlockEndIndex ) {
+		return;
+	}
+
+	const firstDocBlockText =
+		_.isInteger( firstDocBlockStartIndex ) &&
+		_.isInteger( firstDocBlockEndIndex ) &&
+		text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 2 );
+
+	return firstDocBlockText && /@format/.test( firstDocBlockText );
+};
 
 // run prettier for any files in the commit that have @format within their first docblock
-const formatRegex = /@format/;
-const firstDocBlockStart = /\/\*\*/;
-const firstDocBlockEnd = /\*\//;
-
-files
-	.map( file => path.join( __dirname, '../', file ) )
-	.forEach( file => {
-		fs.readFile( file, 'utf8', ( err, data ) => {
-			const firstDocBlockStartIndex = _.get( firstDocBlockStart.exec( data ), 'index' );
-			const firstDocBlockEndIndex = _.get( firstDocBlockEnd.exec( data ), 'index' );
-			const firstDocBlockText =
-				_.isInteger( firstDocBlockStartIndex ) &&
-				_.isInteger( firstDocBlockEndIndex ) &&
-				data.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 2 );
-
-			if ( firstDocBlockText && formatRegex.test( firstDocBlockText ) ) {
-				const formattedData = prettier.format( data, {} );
-				fs.writeFileSync( file, formattedData );
-				execSync( `git add ${ file }` );
-			}
-		} );
+files.map( file => path.join( __dirname, '../', file ) ).forEach( file => {
+	fs.readFile( file, 'utf8', ( err, text ) => {
+		if ( shouldFormat( text ) ) {
+			const formattedText = prettier.format( text, {} );
+			fs.writeFileSync( file, formattedText );
+			execSync( `git add ${ file }` );
+		}
+	} );
 } );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -53,21 +53,18 @@ const shouldFormat = text => {
 
 	const firstDocBlockStartIndex = _.get( firstDocBlockStart.exec( text ), 'index' );
 
-	if ( ! firstDocBlockStartIndex ) {
+	if ( ! _.isInteger( firstDocBlockStartIndex ) ) {
 		return;
 	}
 
 	firstDocBlockEnd.lastIndex = firstDocBlockStartIndex; // docBlockEnd must come after the start
 	const firstDocBlockEndIndex = _.get( firstDocBlockEnd.exec( text ), 'index' );
 
-	if ( ! firstDocBlockEndIndex ) {
+	if ( ! _.isInteger( firstDocBlockEndIndex ) ) {
 		return;
 	}
 
-	const firstDocBlockText =
-		_.isInteger( firstDocBlockStartIndex ) &&
-		_.isInteger( firstDocBlockEndIndex ) &&
-		text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 2 );
+	const firstDocBlockText = text.substring( firstDocBlockStartIndex, firstDocBlockEndIndex + 2 );
 
 	return firstDocBlockText && /@format/.test( firstDocBlockText );
 };

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -9,8 +9,8 @@ const path = require( 'path' );
 
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
-	'under the GNU General Public License v2 (or later). All materials must have ' +
-	'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n'
+		'under the GNU General Public License v2 (or later). All materials must have ' +
+		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n'
 );
 
 // Make quick pass over config files on every change
@@ -23,11 +23,8 @@ const files = execSync( 'git diff --cached --name-only --diff-filter=ACM' )
 	.filter( name => name.endsWith( '.js' ) || name.endsWith( '.jsx' ) );
 
 /**
- * Returns true if the given text contains '@ format' (without the space after @).
+ * Returns true if the given text contains @format.
  * within its first docblock. False otherwise.
- *
- * Note: I only don't write out the actual @ f o r m a t, because then this
- * file would also get formatted!
  *
  * @param {*} text text to scan for the format keyword within the first docblock
  */
@@ -70,8 +67,8 @@ if ( lintResult.status ) {
 	console.log(
 		chalk.red( 'COMMIT ABORTED:' ),
 		'The linter reported some problems. ' +
-		'If you are aware of them and it is OK, ' +
-		'repeat the commit command with --no-verify to avoid this check.'
+			'If you are aware of them and it is OK, ' +
+			'repeat the commit command with --no-verify to avoid this check.'
 	);
 	process.exit( 1 );
 }


### PR DESCRIPTION
Prettier is a tool that allows for the autoformatting of javascript files. [calypso-prettier](https://github.com/Automattic/calypso-prettier) is a fork that we have created that, for the most part, fully follows calypso coding standards.

The Reader Team along with a few other teams have been using it with a lot of success + enjoyment for the past couple of months.  Up until this PR, the only way to ensure files were `pretty` was to run the executable manually either via IDE or via command line. While the DevEx boost is still fantastic, its all too easy to forget to run, especially when quickly making smaller changes in files. 

In order to ensure that any prettified files _stay pretty_, this PR introduces a new ~~comment~~ docblock based flag to files. Any file ~~with a line matching the expression:`^// pretty$`~~ where the first docblock contains the string `@format` will run through prettier within the pre-commit hook.  All other files are exempt from tampering.

Example of file that would be prettified in pre-commit hook
```js
/** @format */

const myCode = 'will be pretty forever';
```

Example of a file that would be exempt:

```js
/** this would not be pretty */
/** @format because we only care about first docblock */
const thisFile = 'ugly duckling';
```

cc @dmsnell @gziolo @jsnajdr 

----

To Test:
- take a whack at committing things.  change a ton of files without the flag. change a ton with it. working as expected? does it feel fast?