### PR TITLE
Extensions: WPSC: Fix Debug Tab Styling

### DIFF
--- a/client/extensions/wp-super-cache/components/debug/index.jsx
+++ b/client/extensions/wp-super-cache/components/debug/index.jsx
@@ -48,7 +48,7 @@ class DebugTab extends Component {
 		} = this.props;
 
 		return (
-			<div>
+			<div className="wp-super-cache__debug-tab">
 				<form>
 					<SectionHeader label={ translate( 'Debug' ) }>
 						<FormButton
@@ -90,7 +90,7 @@ class DebugTab extends Component {
 									onChange={ handleAutosavingToggle( 'wp_super_cache_comments' ) }>
 									{ translate( 'Cache Status Messages' ) }
 								</FormToggle>
-								<FormSettingExplanation>
+								<FormSettingExplanation isIndented>
 									{ translate(
 											'Display comments at the end of every page like this:'
 									) }
@@ -127,7 +127,7 @@ class DebugTab extends Component {
 								onChange={ handleAutosavingToggle( 'wp_super_cache_front_page_check' ) }>
 								{ translate( 'Check front page every 5 minutes.' ) }
 							</FormToggle>
-							<FormSettingExplanation>
+							<FormSettingExplanation isIndented>
 								{ translate( ' If there are errors you\'ll receive an email.' ) }
 							</FormSettingExplanation>
 						</FormFieldset>

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -240,5 +240,5 @@
 }
 
 .wp-super-cache__debug-tab .form-fieldset .form-setting-explanation.is-indented {
-		margin-left: 36px;
+	margin-left: 36px;
 }

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -14,6 +14,10 @@
 	margin-right: 8px;
 }
 
+.wp-super-cache__main .form-fieldset:last-child {
+	margin-bottom: 0;
+}
+
 // Easy Tab
 .wp-super-cache__notice-hug-card {
 	margin-top: -15px;
@@ -198,8 +202,7 @@
 }
 
 .wp-super-cache__lock-down-container,
-.wp-super-cache__cdn-fieldsets,
-.wp-super-cache__debug-fieldsets {
+.wp-super-cache__cdn-fieldsets {
 	margin-left: 40px;
 }
 
@@ -228,4 +231,14 @@
 	font-style: normal;
 	display: block;
 	white-space: pre;
+}
+
+// Debug Tab
+
+.wp-super-cache__debug-fieldsets {
+	margin-left: 40px;
+}
+
+.wp-super-cache__debug-tab .form-fieldset .form-setting-explanation.is-indented {
+		margin-left: 36px;
 }


### PR DESCRIPTION
Follow-up from https://github.com/Automattic/wp-calypso/pull/16282#issuecomment-316543874, implementing this mockup:

![image](https://user-images.githubusercontent.com/437258/28393315-1727beda-6cb4-11e7-8d5f-f612e2701201.png)

> * I indented all the description text
> * I removed the bottom margin from the last fieldset in each card—we can probably target something like `.card .fieldset:last-child { margin-bottom: 0; }` or similar to fix that everywhere (or just see how it's being done elsewhere)