### PR TITLE
Activity log: Fix sentence case string

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -96,7 +96,7 @@ class ActivityLogConfirmDialog extends Component {
 					className="activity-log-confirm-dialog__more-info-link"
 					href="https://help.vaultpress.com/one-click-restore/"
 				>
-					{ translate( 'Read More about Site Restores' ) }
+					{ translate( 'Read more about site restores' ) }
 				</a>
 			</Dialog>
 		);


### PR DESCRIPTION
This PR contains a small fix from a doc created by @beaulebens 

> When you click to Rewind, “Read More about Site Restores” should just be sentence case

## Testing

1. https://calypso.live/stats/activity?branch=fix/activitylog-misc-cleanup
1. Open a rewind dialog and confirm the text is correct.

## Screenshot

![dialog](https://user-images.githubusercontent.com/841763/28414822-8988e85c-6d4d-11e7-8f10-9f026310d652.png)
