### PR TITLE
Site Settings: Add API cache toggle to Manage Connection

### DIFF
--- a/client/my-sites/site-settings/manage-connection/api-cache.jsx
+++ b/client/my-sites/site-settings/manage-connection/api-cache.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { flowRight, pick } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import config from 'config';
+import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+
+const ApiCache = ( {
+	fields,
+	handleAutosavingToggle,
+	isRequestingSettings,
+	isSavingSettings,
+	supportsApiCacheCheckbox,
+	translate
+} ) => {
+	if ( ! config.isEnabled( 'jetpack/api-cache' ) || ! supportsApiCacheCheckbox ) {
+		return null;
+	}
+
+	return (
+		<CompactCard>
+			<CompactFormToggle
+				checked={ !! fields.api_cache }
+				disabled={ isRequestingSettings || isSavingSettings }
+				onChange={ handleAutosavingToggle( 'api_cache' ) }
+			>
+				{ translate(
+					'Use synchronized data to boost performance'
+				) } (a8c-only experimental feature)
+			</CompactFormToggle>
+		</CompactCard>
+	);
+};
+
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteIsJetpack = isJetpackSite( state, siteId );
+
+		return {
+			supportsApiCacheCheckbox: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.4.1' ),
+		};
+	}
+);
+
+const getFormSettings = ( settings ) => {
+	return pick( settings, [
+		'api_cache',
+	] );
+};
+
+export default flowRight(
+	connectComponent,
+	localize,
+	wrapSettingsForm( getFormSettings )
+)( ApiCache );

--- a/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
+++ b/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ApiCache from './api-cache';
 import CompactCard from 'components/card/compact';
 import JetpackSyncPanel from 'my-sites/site-settings/jetpack-sync-panel';
 import SectionHeader from 'components/section-header';
@@ -29,6 +30,7 @@ const DataSynchronization = ( {
 			<SectionHeader label={ translate( 'Data synchronization' ) } />
 
 			<JetpackSyncPanel />
+			<ApiCache />
 
 			<CompactCard href={ 'https://jetpack.com/support/debug/?url=' + siteUrl } target="_blank">
 				{ translate( 'Diagnose a connection problem' ) }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -213,7 +213,8 @@
 .site-settings__general-settings,
 .site-settings__writing-settings,
 .site-settings__traffic-settings,
-.site-settings__security-settings {
+.site-settings__security-settings,
+.manage-connection {
 	.form-toggle__label {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
This PR adds the API cache toggle to the Data Synchronization card in the Manage Connection page, as discussed with @rickybanister in https://github.com/Automattic/wp-calypso/pull/16353#issuecomment-316437732. Part of #13232.

We'll remove the toggle altogether with the Jetpack card from the General section in a subsequent PR.

Preview:

![](https://cldup.com/GqLMhvflST.png)

To test:
* Checkout this branch
* Go to `/settings/manage-connection/:site`, where `:site` is a Jetpack site.
* Verify you can see the API cache toggle in the Data Sync card, and it works like it does in the General settings section.