### PR TITLE
Site Settings: Add public post types toggle to Manage Connection

### DIFF
--- a/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
+++ b/client/my-sites/site-settings/manage-connection/data-synchronization.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import ApiCache from './api-cache';
 import CompactCard from 'components/card/compact';
 import JetpackSyncPanel from 'my-sites/site-settings/jetpack-sync-panel';
+import PublicPostTypes from './public-post-types';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
@@ -31,6 +32,7 @@ const DataSynchronization = ( {
 
 			<JetpackSyncPanel />
 			<ApiCache />
+			<PublicPostTypes />
 
 			<CompactCard href={ 'https://jetpack.com/support/debug/?url=' + siteUrl } target="_blank">
 				{ translate( 'Diagnose a connection problem' ) }

--- a/client/my-sites/site-settings/manage-connection/public-post-types.jsx
+++ b/client/my-sites/site-settings/manage-connection/public-post-types.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { flowRight, pick } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import config from 'config';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+
+const PublicPostTypes = ( {
+	fields,
+	handleAutosavingToggle,
+	isRequestingSettings,
+	isSavingSettings,
+	supportsPublicPostTypesCheckbox,
+	translate
+} ) => {
+	if ( ! config.isEnabled( 'manage/option_sync_non_public_post_stati' ) || ! supportsPublicPostTypesCheckbox ) {
+		return null;
+	}
+
+	return (
+		<CompactCard>
+			<CompactFormToggle
+				checked={ !! fields.jetpack_sync_non_public_post_stati }
+				disabled={ isRequestingSettings || isSavingSettings }
+				onChange={ handleAutosavingToggle( 'jetpack_sync_non_public_post_stati' ) }
+			>
+				{ translate(
+					'Allow synchronization of Posts and Pages with non-public post statuses'
+				) }
+			</CompactFormToggle>
+			<FormSettingExplanation isIndented>
+				{ translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }
+			</FormSettingExplanation>
+		</CompactCard>
+	);
+};
+
+const connectComponent = connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteIsJetpack = isJetpackSite( state, siteId );
+
+		return {
+			supportsPublicPostTypesCheckbox: siteIsJetpack && ! isJetpackMinimumVersion( state, siteId, '4.2' ),
+		};
+	}
+);
+
+const getFormSettings = ( settings ) => {
+	return pick( settings, [
+		'jetpack_sync_non_public_post_stati',
+	] );
+};
+
+export default flowRight(
+	connectComponent,
+	localize,
+	wrapSettingsForm( getFormSettings )
+)( PublicPostTypes );


### PR DESCRIPTION
This PR adds the public post types toggle to the Data Synchronization card in the Manage Connection page, as discussed with @rickybanister in https://github.com/Automattic/wp-calypso/pull/16353#issuecomment-316437732. Part of #13232.

We'll remove the toggle altogether with the Jetpack card from the General section in a subsequent PR.

Preview:

![](https://cldup.com/wrYp-mn3xm.png)

To test:
* Checkout this branch
* Go to `/settings/manage-connection/:site`, where `:site` is a Jetpack site with Jetpack < 4.2.
* Verify you can see the public post types toggle in the Data Sync card, and it works like it does in the General settings section.
* Test with JP 4.2 or newer and verify the toggle is not shown.