### PR TITLE
Added woocommerce-services extension

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/index.js
@@ -7,17 +7,24 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Main from 'components/main';
+import LabelSettings from 'woocommerce/woocommerce-services/views/label-settings';
+import Packages from 'woocommerce/woocommerce-services/views/packages';
 import ShippingHeader from './shipping-header';
 import ShippingOrigin from './shipping-origin';
 import ShippingZoneList from './shipping-zone-list';
 
 const Shipping = ( { className } ) => {
+	const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
+
 	return (
 		<Main className={ classNames( 'shipping', className ) }>
 			<ShippingHeader />
 			<ShippingOrigin />
 			<ShippingZoneList />
+			{ wcsEnabled && <LabelSettings /> }
+			{ wcsEnabled && <Packages /> }
 		</Main>
 	);
 };

--- a/client/extensions/woocommerce/app/settings/shipping/save-button.js
+++ b/client/extensions/woocommerce/app/settings/shipping/save-button.js
@@ -10,6 +10,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Button from 'components/button';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import {
@@ -19,7 +20,7 @@ import {
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 
-class ShippingSettingsFinishedButton extends Component {
+class ShippingSettingsSaveButton extends Component {
 
 	componentDidMount = () => {
 		const { site } = this.props;
@@ -40,23 +41,31 @@ class ShippingSettingsFinishedButton extends Component {
 		}
 	}
 
+	save = () => {
+		return null;
+	}
+
 	redirect = () => {
 		const { site } = this.props;
+		this.save();
 		page.redirect( getLink( '/store/:site', site ) );
 	}
 
 	render() {
 		const { translate, loading, site, finishedInitialSetup } = this.props;
+		const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
 
 		if ( loading || ! site ) {
 			return null;
 		}
 
 		if ( finishedInitialSetup ) {
-			return null;
+			return wcsEnabled
+				? <Button onClick={ this.save } primary>{ translate( 'Save' ) }</Button>
+				: null;
 		}
-
-		return <Button onClick={ this.redirect } primary>{ translate( 'I\'m Finished' ) }</Button>;
+		const label = wcsEnabled ? translate( 'Save and finish' ) : translate( 'I\'m Finished' );
+		return <Button onClick={ this.redirect } primary>{ label }</Button>;
 	}
 }
 
@@ -80,4 +89,4 @@ function mapDispatchToProps( dispatch ) {
 	);
 }
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( ShippingSettingsFinishedButton ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ShippingSettingsSaveButton ) );

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-header.js
@@ -12,7 +12,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import SettingsNavigation from '../navigation';
-import ShippingSettingsFinishedButton from './finished-button';
+import ShippingSettingsSaveButton from './save-button';
 
 const ShippingHeader = ( { translate, site } ) => {
 	const breadcrumbs = [
@@ -22,7 +22,7 @@ const ShippingHeader = ( { translate, site } ) => {
 	return (
 		<div>
 			<ActionHeader breadcrumbs={ breadcrumbs }>
-				<ShippingSettingsFinishedButton />
+				<ShippingSettingsSaveButton />
 			</ActionHeader>
 			<SettingsNavigation activeSection="shipping" />
 		</div>

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -1,8 +1,7 @@
 @import 'shipping-zone/style';
 @import 'shipping-zone/style';
 
-.shipping__zones-header,
-.shipping__packages-header {
+.shipping__zones-header {
 	font-weight: 600;
 }
 
@@ -34,8 +33,7 @@
 	padding: 0;
 }
 
-.shipping__zones-row,
-.shipping__packages-row {
+.shipping__zones-row {
 	display: flex;
 	flex-direction: row;
 	padding: 16px 0;
@@ -75,16 +73,14 @@
 	}
 }
 
-.shipping__zones-header,
-.shipping__packages-header {
+.shipping__zones-header{
 	padding: 12px 0;
 	font-size: 14px;
 	border-top: 0;
 	background: lighten( $gray, 35% );
 }
 
-.shipping__zones-row-icon,
-.shipping__packages-row-icon  {
+.shipping__zones-row-icon  {
 	width: 48px;
 	text-align: left;
 	padding-left: 16px;
@@ -103,8 +99,7 @@
 	width: 25%;
 }
 
-.shipping__zones-row-location-name,
-.shipping__packages-row-details-name {
+.shipping__zones-row-location-name {
 	margin-bottom: 0;
 	font-size: 14px;
 }
@@ -150,8 +145,7 @@
 	margin-bottom: 0;
 }
 
-.shipping__zones-row-actions,
-.shipping__packages-row-actions {
+.shipping__zones-row-actions {
 	width: 20%;
 	text-align: right;
 	padding-right: 16px;
@@ -159,57 +153,4 @@
 	@include breakpoint( ">480px" ) {
 		padding-right: 24px;
 	}
-}
-
-.shipping__labels-container.hidden {
-	height: 0;
-	padding: 0;
-	overflow: hidden;
-}
-
-.form-label.shipping__labels-paper-size,
-.form-label.shipping__cards-label {
-	margin-bottom: 4px;
-}
-
-.shipping__card {
-	margin-bottom: 14px;
-}
-
-.shipping__card-checkbox {
-	margin-top: 10px;
-	margin-right: 20px;
-}
-
-.payment-logo {
-	float: left;
-	margin-top: 10px;
-	margin-right: 14px;
-}
-
-.shipping__card-details {
-	float: left;
-}
-
-.shipping__card-number {
-	margin-bottom: 0;
-	font-weight: bold;
-}
-
-.shipping__card-date {
-	float: right;
-	color: $gray-text-min;
-	font-style: italic;
-}
-
-.shipping__packages {
-	padding: 0;
-}
-
-.shipping__packages-row-details {
-	width: 35%;
-}
-
-.shipping__packages-row-dimensions {
-	width: 35%;
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -34,6 +34,7 @@
 	@import 'app/store-stats/store-stats-navigation/style';
 	@import 'app/store-stats/store-stats-widget-list/style';
 	@import 'app/store-stats/style';
+	@import 'woocommerce-services/style';
 
 	.components__action-header {
 		width: 100%;

--- a/client/extensions/woocommerce/woocommerce-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/style.scss
@@ -1,0 +1,2 @@
+@import 'views/label-settings/style';
+@import 'views/packages/style';

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -17,7 +17,7 @@ import FormSelect from 'components/forms/form-select';
 import FormToggle from 'components/forms/form-toggle';
 import ShippingCard from './shipping-card';
 
-class ShippingLabels extends Component {
+class LabelSettings extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -78,7 +78,7 @@ class ShippingLabels extends Component {
 				<Card className={ classNames( 'shipping__labels-container', { hidden: ! this.state.visible } ) }>
 					<FormFieldSet>
 						<FormLabel
-							className="shipping__labels-paper-size"
+							className="label-settings__labels-paper-size"
 							htmlFor="paper-size">
 							{ translate( 'Paper size' ) }
 						</FormLabel>
@@ -91,10 +91,10 @@ class ShippingLabels extends Component {
 					</FormFieldSet>
 					<FormFieldSet>
 						<FormLabel
-							className="shipping__cards-label">
+							className="label-settings__cards-label">
 							{ translate( 'Credit card' ) }
 						</FormLabel>
-						<p className="shipping__credit-card-description">
+						<p className="label-settings__credit-card-description">
 							{ translate( 'Use your credit card on file to pay for the labels you print or add a new one.' ) }
 						</p>
 						{ this.state.cards.map( renderCard ) }
@@ -106,4 +106,4 @@ class ShippingLabels extends Component {
 	}
 }
 
-export default localize( ShippingLabels );
+export default localize( LabelSettings );

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/shipping-card.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/shipping-card.js
@@ -13,19 +13,19 @@ import PaymentLogo from 'components/payment-logo';
 
 const ShippingCard = ( { translate, selected, type, digits, name, date, onSelect } ) => {
 	return (
-		<CompactCard className="shipping__card">
+		<CompactCard className="label-settings__card">
 			<FormCheckbox
-				className="shipping__card-checkbox"
+				className="label-settings__card-checkbox"
 				checked={ selected }
 				onChange={ onSelect }
 			/>
-			<div className="shipping__card-info">
-				<PaymentLogo className="shipping__card-logo" type={ type.toLowerCase() } />
-				<div className="shipping__card-details">
-					<p className="shipping__card-number">{ type } ****{ digits }</p>
-					<p className="shipping__card-name">{ name }</p>
+			<div className="label-settings__card-info">
+				<PaymentLogo className="label-settings__card-logo" type={ type.toLowerCase() } />
+				<div className="label-settings__card-details">
+					<p className="label-settings__card-number">{ type } ****{ digits }</p>
+					<p className="label-settings__card-name">{ name }</p>
 				</div>
-				<div className="shipping__card-date">
+				<div className="label-settings__card-date">
 					{ translate( 'Expires %(date)s', {
 						args: { date: date },
 						context: 'date is of the form MM/YY'

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/style.scss
@@ -1,0 +1,42 @@
+
+
+.label-settings__labels-container.hidden {
+	height: 0;
+	padding: 0;
+	overflow: hidden;
+}
+
+.form-label.label-settings__labels-paper-size,
+.form-label.label-settings__cards-label {
+	margin-bottom: 4px;
+}
+
+.label-settings__card {
+	margin-bottom: 14px;
+}
+
+.label-settings__card-checkbox {
+	margin-top: 10px;
+	margin-right: 20px;
+}
+
+.payment-logo {
+	float: left;
+	margin-top: 10px;
+	margin-right: 14px;
+}
+
+.label-settings__card-details {
+	float: left;
+}
+
+.label-settings__card-number {
+	margin-bottom: 0;
+	font-weight: bold;
+}
+
+.label-settings__card-date {
+	float: right;
+	color: $gray-text-min;
+	font-style: italic;
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
@@ -12,7 +12,7 @@ import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import ShippingPackage from './shipping-package';
 
-class ShippingPackageList extends Component {
+class Packages extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -44,12 +44,12 @@ class ShippingPackageList extends Component {
 					description={ translate( 'Add the boxes, envelopes, and other packages you use most frequently.' ) }>
 					<Button>{ translate( 'Add package' ) }</Button>
 				</ExtendedHeader>
-				<Card className="shipping__packages">
-					<div className="shipping__packages-row shipping__packages-header">
-						<div className="shipping__packages-row-icon"></div>
-						<div className="shipping__packages-row-details">{ translate( 'Name' ) }</div>
-						<div className="shipping__packages-row-dimensions">{ translate( 'Dimensions' ) }</div>
-						<div className="shipping__packages-row-actions" />
+				<Card className="packages__packages">
+					<div className="packages__packages-row packages__packages-header">
+						<div className="packages__packages-row-icon"></div>
+						<div className="packages__packages-row-details">{ translate( 'Name' ) }</div>
+						<div className="packages__packages-row-dimensions">{ translate( 'Dimensions' ) }</div>
+						<div className="packages__packages-row-actions" />
 					</div>
 					{ this.state.packages.map( this.renderShippingPackage ) }
 				</Card>
@@ -58,4 +58,4 @@ class ShippingPackageList extends Component {
 	}
 }
 
-export default localize( ShippingPackageList );
+export default localize( Packages );

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/shipping-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/shipping-package.js
@@ -14,15 +14,15 @@ const ShippingPackage = ( { translate, type, name, dimensions } ) => {
 	const icon = 'envelope' === type ? 'mail' : 'product';
 
 	return (
-		<div className="shipping__packages-row">
-			<div className="shipping__packages-row-icon">
+		<div className="packages__packages-row">
+			<div className="packages__packages-row-icon">
 				<Gridicon icon={ icon } size={ 18 } />
 			</div>
-			<div className="shipping__packages-row-details">
-				<div className="shipping__packages-row-details-name">{ name }</div>
+			<div className="packages__packages-row-details">
+				<div className="packages__packages-row-details-name">{ name }</div>
 			</div>
-			<div className="shipping__packages-row-dimensions">{ dimensions }</div>
-			<div className="shipping__packages-row-actions">
+			<div className="packages__packages-row-dimensions">{ dimensions }</div>
+			<div className="packages__packages-row-actions">
 				<Button compact>{ translate( 'Edit' ) }</Button>
 			</div>
 		</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -1,0 +1,60 @@
+.packages__packages-row {
+	display: flex;
+	flex-direction: row;
+	padding: 16px 0;
+	align-items: center;
+
+	&:not( :last-child ) {
+		border-bottom: 1px solid lighten( $gray, 20% );
+	}
+}
+
+.packages__packages-header {
+	font-weight: 600;
+	padding: 12px 0;
+	font-size: 14px;
+	border-top: 0;
+	background: lighten( $gray, 35% );
+}
+
+.packages__packages-row-icon  {
+	width: 48px;
+	text-align: left;
+	padding-left: 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding-left: 24px;
+	}
+
+	svg {
+		margin-top: 6px;
+		width: 24px;
+	}
+}
+
+.packages__packages-row-details-name {
+	margin-bottom: 0;
+	font-size: 14px;
+}
+
+.packages__packages-row-actions {
+	width: 20%;
+	text-align: right;
+	padding-right: 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding-right: 24px;
+	}
+}
+
+.packages__packages {
+	padding: 0;
+}
+
+.packages__packages-row-details {
+	width: 35%;
+}
+
+.packages__packages-row-dimensions {
+	width: 35%;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -170,6 +170,7 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
+		"woocommerce/extension-wcservices": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -134,6 +134,7 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
+		"woocommerce/extension-wcservices": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
* Adds `woocommerce-services` to the `extensions` folder.
* Moved the dummy UI related to WCS to the new folder (label and package settings)
* Added `woocommerce-services/extension-enabled` config entry controlling the render of the WCS components
* Changed the header button behaviour in the shipping settings header: if WCS is enabled and setup is finished, it will always show and read "Save". If setup is not finished, it will read "Save and finish".

The plan is to copy the WCS views/state from https://github.com/Automattic/woocommerce-services to the new extension folder and apply minimal changes to make them work.

![screen shot 2017-07-20 at 13 55 38](https://user-images.githubusercontent.com/800604/28418317-2594b4a6-6d53-11e7-9332-67c5c993242e.png)
