### PR TITLE
WPSC: Update Preload button caption

### DIFF
--- a/client/extensions/wp-super-cache/state/cache/actions.js
+++ b/client/extensions/wp-super-cache/state/cache/actions.js
@@ -102,7 +102,7 @@ export const preloadCache = ( siteId ) => {
 			{ path: `/jetpack-blogs/${ siteId }/rest-api/` },
 			{ path: '/wp-super-cache/v1/preload', body: JSON.stringify( { enable: true } ), json: true } )
 			.then( () => {
-				dispatch( { type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS, siteId } );
+				dispatch( { type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS, siteId, preloading: true } );
 				dispatch( successNotice(
 					translate( 'Cache preload started successfully on %(siteTitle)s.',
 						{ args: { siteTitle: getSiteTitle( getState(), siteId ) } }
@@ -135,7 +135,7 @@ export const cancelPreloadCache = ( siteId ) => {
 			{ path: `/jetpack-blogs/${ siteId }/rest-api/` },
 			{ path: '/wp-super-cache/v1/preload', body: JSON.stringify( { enable: false } ), json: true } )
 			.then( () => {
-				dispatch( { type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS, siteId } );
+				dispatch( { type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS, siteId, preloading: false } );
 				dispatch( successNotice(
 					translate( 'Cache preload cancelled successfully on %(siteTitle)s.',
 						{ args: { siteTitle: getSiteTitle( getState(), siteId ) } }

--- a/client/extensions/wp-super-cache/state/cache/test/actions.js
+++ b/client/extensions/wp-super-cache/state/cache/test/actions.js
@@ -155,6 +155,7 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
 					siteId,
+					preloading: true,
 				} );
 			} );
 		} );
@@ -198,6 +199,7 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
 					siteId,
+					preloading: false,
 				} );
 			} );
 		} );

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -5,6 +5,7 @@ import { combineReducers, createReducer } from 'state/utils';
 
 import { itemsSchema } from './schema';
 import {
+	WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,
 	WP_SUPER_CACHE_REQUEST_SETTINGS,
 	WP_SUPER_CACHE_REQUEST_SETTINGS_FAILURE,
@@ -89,6 +90,13 @@ export const restoring = createReducer( {}, {
  */
 const items = createReducer( {}, {
 	[ WP_SUPER_CACHE_RECEIVE_SETTINGS ]: ( state, { siteId, settings } ) => ( { ...state, [ siteId ]: settings } ),
+	[ WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS ]: ( state, { siteId, preloading } ) => ( {
+		...state,
+		[ siteId ]: {
+			...state[ siteId ],
+			is_preloading: preloading
+		}
+	} )
 }, itemsSchema );
 
 export default combineReducers( {

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -88,7 +88,7 @@ export const restoring = createReducer( {}, {
  * @param  {Object} action Action object
  * @return {Object} Updated settings
  */
-const items = createReducer( {}, {
+export const items = createReducer( {}, {
 	[ WP_SUPER_CACHE_RECEIVE_SETTINGS ]: ( state, { siteId, settings } ) => ( { ...state, [ siteId ]: settings } ),
 	[ WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS ]: ( state, { siteId, preloading } ) => ( {
 		...state,

--- a/client/extensions/wp-super-cache/state/settings/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/test/reducer.js
@@ -9,6 +9,7 @@ import deepFreeze from 'deep-freeze';
  */
 import { useSandbox } from 'test/helpers/use-sinon';
 import {
+	WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
 	WP_SUPER_CACHE_RECEIVE_SETTINGS,
 	WP_SUPER_CACHE_REQUEST_SETTINGS,
 	WP_SUPER_CACHE_REQUEST_SETTINGS_FAILURE,
@@ -24,8 +25,10 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
-import reducer from '../reducer';
-import { restoring } from '../reducer';
+import reducer, {
+	items,
+	restoring,
+} from '../reducer';
 
 describe( 'reducer', () => {
 	const primarySiteId = 123456;
@@ -379,6 +382,40 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.items ).to.eql( {} );
+		} );
+
+		it( 'should set is_preloading to true after switching preloading on', () => {
+			const state = items(
+				{
+					[ primarySiteId ]: {
+						is_preloading: false
+					}
+				},
+				{
+					type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
+					siteId: primarySiteId,
+					preloading: true,
+				}
+			);
+
+			expect( state[ primarySiteId ].is_preloading ).to.be.true;
+		} );
+
+		it( 'should set is_preloading to false after switching preloading off', () => {
+			const state = items(
+				{
+					[ primarySiteId ]: {
+						is_preloading: true
+					}
+				},
+				{
+					type: WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
+					siteId: primarySiteId,
+					preloading: false,
+				}
+			);
+
+			expect( state[ primarySiteId ].is_preloading ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
Essentially continuing discussion from https://github.com/Automattic/wp-calypso/pull/14327#issuecomment-303539098

Updates the 'Preload Cache' button label right after receiving a response from the network.
* If cache preloading was previously disabled, enable caching, and update the label to 'Cancel Cache Preload'
* If cache preloading was previously enabled, disable caching, and update the label to 'Preload Cache Now'

This mimics wp-admin behavior more closely and is more intuitively. If preloading finishes after a while, the label isn't updated (since we don't poll), but that, too, reflects wp-admin :slightly_smiling_face: 

![image](https://user-images.githubusercontent.com/96308/28419204-93cc9ef6-6d5e-11e7-86d6-e308ff5794f2.png)