### PR TITLE
Comments: Replace the like button with the LikeButton component

### DIFF
--- a/client/blocks/comment-detail/comment-detail-actions.jsx
+++ b/client/blocks/comment-detail/comment-detail-actions.jsx
@@ -11,6 +11,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import LikeButton from 'blocks/like-button/button';
 
 const commentActions = {
 	unapproved: [ 'like', 'approve', 'spam', 'trash' ],
@@ -22,10 +23,11 @@ const commentActions = {
 const hasAction = ( status, action ) => includes( commentActions[ status ], action );
 
 export const CommentDetailActions = ( {
-	edit,
 	commentIsLiked,
+	commentLikeCount,
 	commentStatus,
 	deleteCommentPermanently,
+	edit,
 	toggleApprove,
 	toggleLike,
 	toggleSpam,
@@ -41,15 +43,14 @@ export const CommentDetailActions = ( {
 			{ hasAction( commentStatus, 'like' ) &&
 				<Button
 					borderless
-					className={ classNames( 'comment-detail__action-like', { 'is-liked': commentIsLiked } ) }
+					className={ 'comment-detail__action-like' }
 					onClick={ toggleLike }
 				>
-					<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
-					<span>{
-						commentIsLiked
-							? translate( 'Liked' )
-							: translate( 'Like' )
-					}</span>
+					<LikeButton
+						likeCount={ commentLikeCount }
+						liked={ commentIsLiked }
+						tagName="span"
+					/>
 				</Button>
 			}
 

--- a/client/blocks/comment-detail/comment-detail-header.jsx
+++ b/client/blocks/comment-detail/comment-detail-header.jsx
@@ -25,6 +25,7 @@ export const CommentDetailHeader = ( {
 	commentContent,
 	commentIsLiked,
 	commentIsSelected,
+	commentLikeCount,
 	commentStatus,
 	deleteCommentPermanently,
 	edit,
@@ -51,10 +52,11 @@ export const CommentDetailHeader = ( {
 				</Button>
 
 				<CommentDetailActions
-					edit={ edit }
 					commentIsLiked={ commentIsLiked }
+					commentLikeCount={ commentLikeCount }
 					commentStatus={ commentStatus }
 					deleteCommentPermanently={ deleteCommentPermanently }
+					edit={ edit }
 					toggleApprove={ toggleApprove }
 					toggleLike={ toggleLike }
 					toggleSpam={ toggleSpam }

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -33,6 +33,7 @@ export class CommentDetail extends Component {
 		commentId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
 		commentIsLiked: PropTypes.bool,
 		commentIsSelected: PropTypes.bool,
+		commentLikeCount: PropTypes.number,
 		commentStatus: PropTypes.string,
 		commentUrl: PropTypes.string,
 		deleteCommentPermanently: PropTypes.func,
@@ -122,6 +123,7 @@ export class CommentDetail extends Component {
 			commentId,
 			commentIsLiked,
 			commentIsSelected,
+			commentLikeCount,
 			commentStatus,
 			commentUrl,
 			isBulkEdit,
@@ -165,6 +167,7 @@ export class CommentDetail extends Component {
 					commentContent={ commentContent }
 					commentIsLiked={ commentIsLiked }
 					commentIsSelected={ commentIsSelected }
+					commentLikeCount={ commentLikeCount }
 					commentStatus={ commentStatus }
 					deleteCommentPermanently={ this.deleteCommentPermanently }
 					isBulkEdit={ isBulkEdit }
@@ -255,6 +258,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		commentDate: comment.date,
 		commentId: comment.ID,
 		commentIsLiked: comment.i_like,
+		commentLikeCount: comment.like_count,
 		commentStatus: comment.status,
 		commentUrl: get( comment, 'URL' ),
 		parentCommentAuthorAvatarUrl: get( parentComment, 'author.avatar_URL' ),

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -183,9 +183,36 @@
 		}
 
 		&.comment-detail__action-like {
-			&:focus,
-			&:hover {
-				color: $orange-jazzy;
+			overflow: visible;
+
+			.like-button {
+				color: $gray-text-min;
+				display: inline;
+				padding: 0;
+
+				&:focus,
+				&:hover {
+					color: $gray-dark;
+				}
+			}
+
+			.like-button__like-icons {
+				display: inline;
+				margin-right: 4px;
+			}
+			.gridicon {
+				margin: 0;
+			}
+			.gridicons-star {
+				width: 0;
+			}
+			.is-liked {
+				.gridicons-star {
+					width: 24px;
+				}
+				.gridicons-star-outline {
+					width: 0;
+				}
 			}
 		}
 


### PR DESCRIPTION
Closes #13910

Alternative to #15932

In the previous PR started by @rodrigoi and continued by me, we created a new `CommentLikes` component from scratch to add to Comment Management a multi-state like button that also showed the like count.
Initially it was a fully connected component, pulling the like information from the state and autonomously dispatch the like and unlike actions.
To reduce the additional burdens on the data layer, I've removed the dispatches but left the Redux connection for the state.

I had some doubts about creating a new `CommentLikes` component, considering we already have several similar components around, used by the Reader and the Post List.
On top of that, at some point I realized that `CommentDetail` already has all the like information we need, de facto removing the need to pull them from the state.

So, instead of creating `CommentLikes`, I'm proposing to simply reuse `LikeButton`, which already takes care of showing the like count and even has a nice little animation (it can be disabled, if it looks too different compared to the other actions).

There are two possible downsides though:

- `LikeButton` has quite a different structure, and required a bit of CSS rework.
Nothing major, and in my opinion is better to have ~30 new CSS lines than a whole new component that might be confusing.

- Even if `LikeButton` _has_ the "Liked" label state (that should appear when the comment has only one like, and that like is from the current user), it's only displayed if we choose to _not_ display the like count (making the button a "Like/Liked", which is basically what we currently have).
Instead, it appears as "1 Like" with the orange highlight color.
It's worth noting that this is the current behaviour of both the Reader and the Post List.
Though, we could make some minor changes to `LikeButton` to make it display "Liked" anyway.

---

Props to @rodrigoi for introducing the like count in Comment Management and @kwight for making me realize we already had a `LikeButton` component.

cc @Automattic/lannister 