### PR TITLE
Pages: Reset Page Counter when switching sites

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -43,6 +43,7 @@ export default class PageList extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.search !== this.props.search ||
+			nextProps.siteId !== this.props.siteId ||
 			nextProps.status !== this.props.status ) {
 			this.resetPage();
 		}


### PR DESCRIPTION
#16369 has another glitch: It doesn't reset the `page` counter state when switching sites. So when e.g. scrolling down a site's page list that has a lot of pages (e.g. Fieldguide), the page counter will end up at a rather high value. If you then switch to a site with way fewer pages, you'll continue to see the loading placeholder while `QueryPosts` attempts to fetch pages that aren't there.

The fix is to reset `page` counter state when switching sites.