### PR TITLE
Reader: Bridge comments from Conversations API over to redux

### DIFF
--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -17,6 +17,7 @@ const config = require( 'config' ),
 	getSavedVariations = abtestModule.getSavedVariations, // used by logger
 	initializeHappychat = require( 'state/happychat/actions' ).initialize,
 	analytics = require( 'lib/analytics' ),
+	reduxBridge = require( 'lib/redux-bridge' ),
 	route = require( 'lib/route' ),
 	normalize = require( 'lib/route/normalize' ),
 	{ isLegacyRoute } = require( 'lib/route/legacy-routes' ),
@@ -60,6 +61,7 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing WordPress.com configure Redux store.' );
 
 	supportUser.setReduxStore( reduxStore );
+	reduxBridge.setReduxStore( reduxStore );
 
 	if ( currentUser.get() ) {
 		if ( config.isEnabled( 'push-notifications' ) ) {

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -11,6 +11,8 @@ import { action as ActionType } from './constants';
 import FeedPostStoreActions from 'lib/feed-post-store/actions';
 import feedPostListCache from './feed-stream-cache';
 import wpcom from 'lib/wp';
+import { reduxDispatch } from 'lib/redux-bridge';
+import { COMMENTS_RECEIVE } from 'state/action-types';
 
 function getNextPageParams( store ) {
 	const params = {
@@ -89,6 +91,15 @@ export function receivePage( id, error, data ) {
 				FeedPostStoreActions.receivePost( null, post, {
 					blogId: post.site_ID,
 					postId: post.ID
+				} );
+			}
+			if ( post.comments ) {
+				// conversations!
+				reduxDispatch( {
+					type: COMMENTS_RECEIVE,
+					siteId: post.site_ID,
+					postId: post.ID,
+					comments: post.comments,
 				} );
 			}
 		} );

--- a/client/lib/redux-bridge/README.md
+++ b/client/lib/redux-bridge/README.md
@@ -1,0 +1,5 @@
+A little bridge that consumes the current redux store and exposes the dispatch method as a singleton. 
+
+This helps flux and thunk action handlers move to redux in an incremental fashion. 
+
+NOTE: _Please don't use it as a general purpose method to get access to redux's dispatch._

--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -1,0 +1,15 @@
+let reduxStore = null;
+
+export function setReduxStore( store ) {
+	reduxStore = store;
+}
+
+/**
+ * Dispatch an action against the current redux store
+ */
+export function reduxDispatch( ...args ) {
+	if ( ! reduxStore ) {
+		return;
+	}
+	reduxStore.dispatch( ...args );
+}


### PR DESCRIPTION
This adds a bridge over the redux that the flux-based conversations actions can use to flow comments across. This lets us continue to use the current redux comment store without having to move all of streams over to redux.