### PR TITLE
Component: Add ListEnd component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -140,6 +140,7 @@
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
+@import 'components/list-end/style';
 @import 'components/logged-out-form/style';
 @import 'components/language-picker/style';
 @import 'components/locale-suggestions/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -34,7 +34,7 @@ $z-layers: (
 	'root': (
 		'.community-translator__translator-invitation:before': -1,
 		'.NuxWelcome:before': -1,
-		'.infinite-scroll-end:before': -1,
+		'.list-end:before': -1,
 		'.is-group-editor::before': -1,
 		'.site-icon.is-blank .gridicon': 0,
 		'.chart__bar-section.is-spacer': 0,

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -14,7 +14,6 @@
 @import 'shared/dropdowns';                    // dropdown styling
 @import 'shared/livechat';                     // styles for the popup livechat box
 @import 'shared/welcome';                      // welcome messages
-@import 'shared/infinite-scroll-end';          // Last page marker once infinite scroll has reached end
 
 // Main
 @import 'main';                                // global layout and responsive styles

--- a/client/components/list-end/docs/example.js
+++ b/client/components/list-end/docs/example.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ListEnd from 'components/list-end';
+
+export default function ListEndExample() {
+	return <ListEnd />;
+}
+ListEndExample.displayName = 'ListEndExample';

--- a/client/components/list-end/index.js
+++ b/client/components/list-end/index.js
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 
+// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+const listEnd = <div className="list-end" />;
 export default function ListEnd() {
-	return <div className="list-end" />;
+	return listEnd;
 }

--- a/client/components/list-end/index.js
+++ b/client/components/list-end/index.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default function ListEnd() {
+	return <div className="list-end" />;
+}

--- a/client/components/list-end/style.scss
+++ b/client/components/list-end/style.scss
@@ -1,8 +1,7 @@
 /**
  * List End:
  * ------
- * Marker that gets appended to the end of a list (e.g. posts) once
- * infinite scroll has reached the last page.
+ * Marker that can be appended to indicate the end of a list (e.g. posts).
  */
 
 .list-end {

--- a/client/components/list-end/style.scss
+++ b/client/components/list-end/style.scss
@@ -1,11 +1,11 @@
 /**
-* Infinite Scroll End:
+* List End:
 * ------
 * Marker that gets appended to the end of a list (e.g. posts) once
 * infinite scroll has reached the last page.
 */
 
-.infinite-scroll-end {
+.list-end {
   position: relative;
   width: 100%;
   margin-top: (15 / 15) * 1em;
@@ -16,7 +16,7 @@
     top: 50%;
     left: 0;
     right: 0;
-    z-index: z-index( 'root', '.infinite-scroll-end:before' );
+    z-index: z-index( 'root', '.list-end:before' );
     border-bottom: solid 1px lighten( $gray, 25% );
   }
   &:after {

--- a/client/components/list-end/style.scss
+++ b/client/components/list-end/style.scss
@@ -1,29 +1,29 @@
 /**
-* List End:
-* ------
-* Marker that gets appended to the end of a list (e.g. posts) once
-* infinite scroll has reached the last page.
-*/
+ * List End:
+ * ------
+ * Marker that gets appended to the end of a list (e.g. posts) once
+ * infinite scroll has reached the last page.
+ */
 
 .list-end {
-  position: relative;
-  width: 100%;
-  margin-top: (15 / 15) * 1em;
-  text-align: center;
-  &:before {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 0;
-    right: 0;
-    z-index: z-index( 'root', '.list-end:before' );
-    border-bottom: solid 1px lighten( $gray, 25% );
-  }
-  &:after {
-    @include noticon( '\f205', (24 / 15) * 1em );
-    color: $gray;
-    font-size: (22 / 15) * 1em;
-    padding: 0 (8 / 22) * 1em;
-    background-color: $gray-light;
-  }
+	position: relative;
+	width: 100%;
+	margin-top: (15 / 15) * 1em;
+	text-align: center;
+	&:before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 0;
+		right: 0;
+		z-index: z-index( 'root', '.list-end:before' );
+		border-bottom: solid 1px lighten( $gray, 25% );
+	}
+	&:after {
+		@include noticon( '\f205', (24 / 15) * 1em );
+		color: $gray;
+		font-size: (22 / 15) * 1em;
+		padding: 0 (8 / 22) * 1em;
+		background-color: $gray-light;
+	}
 }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -75,6 +75,7 @@ import FormattedHeader from 'components/formatted-header/docs/example';
 import EmptyContent from 'components/empty-content/docs/example';
 import ScreenReaderTextExample from 'components/screen-reader-text/docs/example';
 import PaginationExample from 'components/pagination/docs/example';
+import ListEnd from 'components/list-end/docs/example';
 
 let DesignAssets = React.createClass( {
 	displayName: 'DesignAssets',
@@ -148,6 +149,7 @@ let DesignAssets = React.createClass( {
 					<Tooltip />
 					<InputChrono />
 					<LanguagePicker />
+					<ListEnd />
 					<Notices />
 					<PaginationExample />
 					<PaymentLogo />

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import ListEnd from 'components/list-end';
 import QueryPosts from 'components/data/query-posts';
 import Page from './page';
 import infiniteScroll from 'lib/mixins/infinite-scroll';
@@ -307,7 +308,7 @@ const Pages = localize( React.createClass( {
 			<div id="pages" className="pages__page-list">
 				{ blogPostsPage }
 				{ rows }
-				{ this.props.lastPage && pages.length ? <div className="infinite-scroll-end" /> : null }
+				{ this.props.lastPage && pages.length ? <ListEnd /> : null }
 			</div>
 		);
 	},

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -24,6 +24,7 @@ const PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	accept = require( 'lib/accept' ),
 	analytics = require( 'lib/analytics' );
 import Button from 'components/button';
+import ListEnd from 'components/list-end';
 
 const maxFollowers = 1000;
 
@@ -212,7 +213,7 @@ const Followers = localize( class FollowersComponent extends Component {
 				<Card className={ listClass }>
 					{ followers }
 				</Card>
-				{ this.isLastPage() && <div className="infinite-scroll-end" /> }
+				{ this.isLastPage() && <ListEnd /> }
 			</div>
 		);
 	}

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -17,6 +17,7 @@ var Card = require( 'components/card' ),
 	NoResults = require( 'my-sites/no-results' ),
 	analytics = require( 'lib/analytics' ),
 	PeopleListSectionHeader = require( 'my-sites/people/people-list-section-header' );
+import ListEnd from 'components/list-end';
 
 /**
  * Module Variables
@@ -101,7 +102,7 @@ var Team = React.createClass( {
 				<Card className={ listClass }>
 					{ people }
 				</Card>
-				{ this.isLastPage() && <div className="infinite-scroll-end" /> }
+				{ this.isLastPage() && <ListEnd /> }
 			</div>
 		);
 	},

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -17,6 +17,7 @@ var PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	EmptyContent = require( 'components/empty-content' ),
 	analytics = require( 'lib/analytics' ),
 	accept = require( 'lib/accept' );
+import ListEnd from 'components/list-end';
 
 let Viewers = React.createClass( {
 
@@ -158,7 +159,7 @@ let Viewers = React.createClass( {
 				<Card className={ listClass }>
 					{ viewers }
 				</Card>
-				{ this.isLastPage() && <div className="infinite-scroll-end" /> }
+				{ this.isLastPage() && <ListEnd /> }
 			</div>
 		);
 	}

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -21,6 +21,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	route = require( 'lib/route' ),
 	mapStatus = route.mapPostStatus;
 
+import ListEnd from 'components/list-end';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { hasInitializedSites } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -298,7 +299,7 @@ var Posts = React.createClass( {
 		return (
 			<div>
 				{ postList }
-				{ this.props.lastPage && posts.length ? <div className="infinite-scroll-end" /> : null }
+				{ this.props.lastPage && posts.length ? <ListEnd /> : null }
 			</div>
 		);
 	}

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -217,7 +217,7 @@
 	}
 }
 
-.post-editor .drafts__list + .infinite-scroll-end::after {
+.post-editor .drafts__list + .list-end::after {
 	background-color: lighten( $gray, 30% );
 }
 

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -394,10 +394,10 @@
 	margin-top: 0;
 }
 
-/* = Infinite scroll end (shown at end of streams)
+/* = List end (shown at end of streams)
  --------------------------------------------------------------- */
 
-.is-reader-page .infinite-scroll-end {
+.is-reader-page .list-end {
 	&:before {
 		border-bottom: none;
 	}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -25,6 +25,7 @@ import {
 import LikeStore from 'lib/like-store/like-store';
 import LikeStoreActions from 'lib/like-store/actions';
 import LikeHelper from 'reader/like-helper';
+import ListEnd from 'components/list-end';
 import InfiniteList from 'components/infinite-list';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import PostPlaceholder from './post-placeholder';
@@ -484,7 +485,7 @@ class ReaderStream extends React.Component {
 				{ this.props.children }
 				{ body }
 				{ showingStream && store.isLastPage() && this.state.posts.length
-					? <div className="infinite-scroll-end" />
+					? <ListEnd />
 					: null }
 			</TopLevel>
 		);


### PR DESCRIPTION
This is a proposal for a new component to replace usage of the `.infinite-scroll-end` class. See #14941 for a similar change.

The `.infinite-scroll-end` class will cause lint error when used in new components. This PR handles that by making a simple reusable component `ListEnd`. I've dropped "infinite" from the title, as there's no reason this can only be used with infinite lists.

## To test
* Visit https://calypso.live/devdocs/design/list-end?branch=add/list-end-component and confirm the component displays correctly
* Visit various places the `.infinite-scroll-end` class has been replaced and confirm there are no regressions:
  * Reader stream
  * Followers list
  * Team list
  * Viewer list
  * Post list
  * Page list

## Screenshots

### /posts

![posts](https://user-images.githubusercontent.com/841763/28424489-0d13e1ac-6d6e-11e7-8db3-f1828adbc78a.png)

### /devdocs/design/list-end

![devdocs](https://user-images.githubusercontent.com/841763/28424484-09570da0-6d6e-11e7-8eb0-7e1f050d2eef.png)
