### PR TITLE
Prettify blocks/comments

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -33,7 +33,7 @@ const CommentActions = ( {
 	spamComment,
 	editComment,
 	editCommentCancel,
- } ) => {
+} ) => {
 	const showReplyButton = post && post.discussion && post.discussion.comments_open === true;
 	const showCancelReplyButton = activeReplyCommentID === commentId;
 	const showCancelEditButton = activeEditCommentId === commentId;
@@ -49,19 +49,18 @@ const CommentActions = ( {
 			{ showReplyButton &&
 				<button className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />
-					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
-				</button>
-			}
+					<span className="comments__comment-actions-reply-label">
+						{ translate( 'Reply' ) }
+					</span>
+				</button> }
 			{ showCancelReplyButton &&
 				<button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
 					{ translate( 'Cancel reply' ) }
-				</button>
-			}
+				</button> }
 			{ showCancelEditButton &&
 				<button className="comments__comment-actions-cancel-reply" onClick={ editCommentCancel }>
 					{ translate( 'Cancel' ) }
-				</button>
-			}
+				</button> }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
 				tagName="button"
@@ -74,45 +73,55 @@ const CommentActions = ( {
 					<CommentApproveAction { ...{ status, approveComment, unapproveComment } } />
 					<button className="comments__comment-actions-trash" onClick={ trashComment }>
 						<Gridicon icon="trash" size={ 18 } />
-						<span className="comments__comment-actions-like-label">{ translate( 'Trash' ) }</span>
+						<span className="comments__comment-actions-like-label">
+							{ translate( 'Trash' ) }
+						</span>
 					</button>
 					<button className="comments__comment-actions-spam" onClick={ spamComment }>
 						<Gridicon icon="spam" size={ 18 } />
-						<span className="comments__comment-actions-like-label">{ translate( 'Spam' ) }</span>
+						<span className="comments__comment-actions-like-label">
+							{ translate( 'Spam' ) }
+						</span>
 					</button>
 					<button className="comments__comment-actions-edit" onClick={ editComment }>
 						<Gridicon icon="pencil" size={ 18 } />
-						<span className="comments__comment-actions-like-label">{ translate( 'Edit' ) }</span>
+						<span className="comments__comment-actions-like-label">
+							{ translate( 'Edit' ) }
+						</span>
 					</button>
 					<EllipsisMenu toggleTitle={ translate( 'More' ) }>
 						<PopoverMenuItem
 							className={ classnames( 'comments__comment-actions-approve', {
-								'is-approved': isApproved
+								'is-approved': isApproved,
 							} ) }
 							icon="checkmark"
-							onClick={ ! isApproved ? approveComment : unapproveComment }>
+							onClick={ ! isApproved ? approveComment : unapproveComment }
+						>
 							{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }
 						</PopoverMenuItem>
-						<PopoverMenuItem icon="trash" onClick={ trashComment }>{ translate( 'Trash' ) }</PopoverMenuItem>
-						<PopoverMenuItem icon="spam" onClick={ spamComment }>{ translate( 'Spam' ) }</PopoverMenuItem>
+						<PopoverMenuItem icon="trash" onClick={ trashComment }>
+							{ translate( 'Trash' ) }
+						</PopoverMenuItem>
+						<PopoverMenuItem icon="spam" onClick={ spamComment }>
+							{ translate( 'Spam' ) }
+						</PopoverMenuItem>
 						<PopoverMenuSeparator />
-						<PopoverMenuItem icon="pencil" onClick={ editComment }>{ translate( 'Edit' ) }</PopoverMenuItem>
+						<PopoverMenuItem icon="pencil" onClick={ editComment }>
+							{ translate( 'Edit' ) }
+						</PopoverMenuItem>
 					</EllipsisMenu>
-				</div>
-			}
+				</div> }
 		</div>
 	);
 };
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {
-	const {
-		post: { site_ID: siteId, ID: postId },
-		commentId
-	} = ownProps;
+	const { post: { site_ID: siteId, ID: postId }, commentId } = ownProps;
 
 	return {
 		approveComment: () => dispatch( changeCommentStatus( siteId, postId, commentId, 'approved' ) ),
-		unapproveComment: () => dispatch( changeCommentStatus( siteId, postId, commentId, 'unapproved' ) ),
+		unapproveComment: () =>
+			dispatch( changeCommentStatus( siteId, postId, commentId, 'unapproved' ) ),
 		trashComment: () => dispatch( changeCommentStatus( siteId, postId, commentId, 'trash' ) ),
 		spamComment: () => dispatch( changeCommentStatus( siteId, postId, commentId, 'spam' ) ),
 	};

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -10,13 +10,15 @@ import classnames from 'classnames';
 const CommentApproveAction = ( { translate, status, approveComment, unapproveComment } ) => {
 	const isApproved = status === 'approved';
 	const buttonStyle = classnames( 'comments__comment-actions-approve', {
-		'is-approved': isApproved
+		'is-approved': isApproved,
 	} );
 
 	return (
 		<button className={ buttonStyle } onClick={ ! isApproved ? approveComment : unapproveComment }>
 			<Gridicon icon="checkmark" size={ 18 } />
-			<span className="comments__comment-actions-like-label">{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
+			<span className="comments__comment-actions-like-label">
+				{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }
+			</span>
 		</button>
 	);
 };
@@ -30,7 +32,7 @@ CommentApproveAction.propTypes = {
 
 CommentApproveAction.defaultProps = {
 	approveComment: noop,
-	unapproveComment: noop
+	unapproveComment: noop,
 };
 
 export default localize( CommentApproveAction );

--- a/client/blocks/comments/comment-count.jsx
+++ b/client/blocks/comments/comment-count.jsx
@@ -11,30 +11,28 @@ import { localize } from 'i18n-calypso';
 const CommentCount = ( { count, translate } ) => {
 	let countPhrase;
 	if ( count > 0 ) {
-		countPhrase = translate(
-			'%(commentCount)d comment',
-			'%(commentCount)d comments',
-			{
-				count,
-				args: {
-					commentCount: count
-				}
-			}
-		);
+		countPhrase = translate( '%(commentCount)d comment', '%(commentCount)d comments', {
+			count,
+			args: {
+				commentCount: count,
+			},
+		} );
 	} else {
 		countPhrase = translate( 'No comments' );
 	}
 
 	return (
 		<div className="comments__comment-count">
-			<span className="comments__comment-count-phrase">{ countPhrase }</span>
+			<span className="comments__comment-count-phrase">
+				{ countPhrase }
+			</span>
 			{ count === 0 && translate( ' - Add the first! ' ) }
 		</div>
 	);
 };
 
 CommentCount.propTypes = {
-	count: React.PropTypes.number.isRequired
+	count: React.PropTypes.number.isRequired,
 };
 
 export default localize( CommentCount );

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -14,10 +14,7 @@ import { translate } from 'i18n-calypso';
 import AutoDirection from 'components/auto-direction';
 import Notice from 'components/notice';
 import { editComment } from 'state/comments/actions';
-import {
-	recordAction,
-	recordGaEvent
-} from 'reader/stats';
+import { recordAction, recordGaEvent } from 'reader/stats';
 
 class PostCommentForm extends Component {
 	constructor( props ) {
@@ -25,13 +22,13 @@ class PostCommentForm extends Component {
 
 		this.state = {
 			commentText: props.commentText || '',
-			haveFocus: false
+			haveFocus: false,
 		};
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.setState( {
-			commentText: nextProps.commentText || ''
+			commentText: nextProps.commentText || '',
 		} );
 	}
 
@@ -51,19 +48,21 @@ class PostCommentForm extends Component {
 
 		const commentText = this.getCommentText();
 		const currentHeight = parseInt( commentTextNode.style.height, 10 ) || 0;
-		commentTextNode.style.height = commentText.length ? Math.max( commentTextNode.scrollHeight, currentHeight ) + 'px' : null;
+		commentTextNode.style.height = commentText.length
+			? Math.max( commentTextNode.scrollHeight, currentHeight ) + 'px'
+			: null;
 	}
 
-	handleTextAreaNode = ( textareaNode ) => {
+	handleTextAreaNode = textareaNode => {
 		this._textareaNode = textareaNode;
-	}
+	};
 
-	handleSubmit = ( event ) => {
+	handleSubmit = event => {
 		event.preventDefault();
 		this.submit();
-	}
+	};
 
-	handleKeyDown = ( event ) => {
+	handleKeyDown = event => {
 		// Use Ctrl+Enter to submit comment
 		if ( event.keyCode === 13 && ( event.ctrlKey || event.metaKey ) ) {
 			event.preventDefault();
@@ -74,26 +73,30 @@ class PostCommentForm extends Component {
 		if ( event.keyCode === 27 ) {
 			if ( this.props.placeholderId ) {
 				// remove the comment
-				this.props.deleteComment( this.props.post.site_ID, this.props.post.ID, this.props.placeholderId );
+				this.props.deleteComment(
+					this.props.post.site_ID,
+					this.props.post.ID,
+					this.props.placeholderId,
+				);
 			}
 		}
-	}
+	};
 
 	handleFocus = () => this.setState( { haveFocus: true } );
 
-	handleTextChange = ( event ) => {
+	handleTextChange = event => {
 		const commentText = event.target.value;
 
 		this.setState( { commentText } );
-	}
+	};
 
 	resetCommentText = () => {
 		this.setState( { commentText: '' } );
-	}
+	};
 
 	hasCommentText = () => {
 		return this.state.commentText.trim().length > 0;
-	}
+	};
 
 	submit() {
 		const post = this.props.post;
@@ -127,7 +130,9 @@ class PostCommentForm extends Component {
 
 		switch ( error.error ) {
 			case 'comment_duplicate':
-				message = translate( "Duplicate comment detected. It looks like you've already said that!" );
+				message = translate(
+					"Duplicate comment detected. It looks like you've already said that!",
+				);
 				break;
 
 			default:
@@ -135,18 +140,25 @@ class PostCommentForm extends Component {
 				break;
 		}
 
-		return <Notice text={ message } className="comments__notice" showDismiss={ false } status="is-error" />;
+		return (
+			<Notice
+				text={ message }
+				className="comments__notice"
+				showDismiss={ false }
+				status="is-error"
+			/>
+		);
 	}
 
 	render() {
 		const buttonClasses = classNames( {
 			'is-active': this.hasCommentText(),
-			'is-visible': this.state.haveFocus || this.hasCommentText()
+			'is-visible': this.state.haveFocus || this.hasCommentText(),
 		} );
 
 		const expandingAreaClasses = classNames( {
 			focused: this.state.haveFocus,
-			'expanding-area': true
+			'expanding-area': true,
 		} );
 
 		// How auto expand works for the textarea is covered in this article:
@@ -156,7 +168,12 @@ class PostCommentForm extends Component {
 				<fieldset>
 					<label>
 						<div className={ expandingAreaClasses }>
-							<pre><span>{ this.state.commentText }</span><br /></pre>
+							<pre>
+								<span>
+									{ this.state.commentText }
+								</span>
+								<br />
+							</pre>
 							<AutoDirection>
 								<textarea
 									value={ this.state.commentText }
@@ -173,7 +190,8 @@ class PostCommentForm extends Component {
 							ref="commentButton"
 							className={ buttonClasses }
 							disabled={ this.state.commentText.length === 0 }
-							onClick={ this.handleSubmit }>
+							onClick={ this.handleSubmit }
+						>
 							{ translate( 'Send' ) }
 						</button>
 						{ this.renderError() }
@@ -182,7 +200,6 @@ class PostCommentForm extends Component {
 			</form>
 		);
 	}
-
 }
 
 PostCommentForm.propTypes = {
@@ -192,11 +209,11 @@ PostCommentForm.propTypes = {
 	onCommentSubmit: React.PropTypes.func,
 
 	// connect()ed props:
-	editComment: React.PropTypes.func.isRequired
+	editComment: React.PropTypes.func.isRequired,
 };
 
 PostCommentForm.defaultProps = {
-	onCommentSubmit: noop
+	onCommentSubmit: noop,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators( { editComment }, dispatch );

--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -11,15 +11,8 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import LikeButton from 'blocks/like-button/button';
-import {
-	recordAction,
-	recordGaEvent,
-	recordTrack
-} from 'reader/stats';
-import {
-	likeComment,
-	unlikeComment
-} from 'state/comments/actions';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { likeComment, unlikeComment } from 'state/comments/actions';
 import { getCommentLike } from 'state/comments/selectors';
 
 class CommentLikeButtonContainer extends React.Component {
@@ -39,7 +32,7 @@ class CommentLikeButtonContainer extends React.Component {
 		recordGaEvent( liked ? 'Clicked Comment Like' : 'Clicked Comment Unlike' );
 		recordTrack( 'calypso_reader_' + ( liked ? 'liked' : 'unliked' ) + '_comment', {
 			blog_id: this.props.siteId,
-			comment_id: this.props.commentId
+			comment_id: this.props.commentId,
 		} );
 	}
 
@@ -49,12 +42,16 @@ class CommentLikeButtonContainer extends React.Component {
 		const iLike = get( this.props.commentLike, 'i_like' );
 		const likedLabel = translate( 'Liked' );
 
-		return <LikeButton { ...props }
+		return (
+			<LikeButton
+				{ ...props }
 				likeCount={ likeCount }
 				liked={ iLike }
 				onLikeToggle={ this.boundHandleLikeToggle }
 				likedLabel={ likedLabel }
-				iconSize={ 18 } />;
+				iconSize={ 18 }
+			/>
+		);
 	}
 }
 
@@ -68,15 +65,19 @@ CommentLikeButtonContainer.propTypes = {
 	// connected props:
 	commentLike: React.PropTypes.object.isRequired,
 	likeComment: React.PropTypes.func.isRequired,
-	unlikeComment: React.PropTypes.func.isRequired
+	unlikeComment: React.PropTypes.func.isRequired,
 };
 
 export default connect(
 	( state, props ) => ( {
-		commentLike: getCommentLike( state, props.siteId, props.postId, props.commentId )
+		commentLike: getCommentLike( state, props.siteId, props.postId, props.commentId ),
 	} ),
-	( dispatch ) => bindActionCreators( {
-		likeComment,
-		unlikeComment
-	}, dispatch )
+	dispatch =>
+		bindActionCreators(
+			{
+				likeComment,
+				unlikeComment,
+			},
+			dispatch,
+		),
 )( CommentLikeButtonContainer );

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -13,19 +13,9 @@ import { translate } from 'i18n-calypso';
 import AutoDirection from 'components/auto-direction';
 import Gravatar from 'components/gravatar';
 import Notice from 'components/notice';
-import {
-	getCurrentUser
-} from 'state/current-user/selectors';
-import {
-	writeComment,
-	deleteComment,
-	replyComment,
-} from 'state/comments/actions';
-import {
-	recordAction,
-	recordGaEvent,
-	recordTrackForPost
-} from 'reader/stats';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { writeComment, deleteComment, replyComment } from 'state/comments/actions';
+import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import { isCommentableDiscoverPost } from 'blocks/comments/helper';
 
 class PostCommentForm extends React.Component {
@@ -34,19 +24,19 @@ class PostCommentForm extends React.Component {
 
 		this.state = {
 			commentText: props.commentText || '',
-			haveFocus: false
+			haveFocus: false,
 		};
 
 		// bind event handlers to this instance
 		Object.getOwnPropertyNames( PostCommentForm.prototype )
-			.filter( ( prop ) => prop.indexOf( 'handle' ) === 0 )
-			.filter( ( prop ) => typeof this[ prop ] === 'function' )
-			.forEach( ( prop ) => this[ prop ] = this[ prop ].bind( this ) );
+			.filter( prop => prop.indexOf( 'handle' ) === 0 )
+			.filter( prop => typeof this[ prop ] === 'function' )
+			.forEach( prop => ( this[ prop ] = this[ prop ].bind( this ) ) );
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.setState( {
-			commentText: nextProps.commentText || ''
+			commentText: nextProps.commentText || '',
 		} );
 	}
 
@@ -66,7 +56,9 @@ class PostCommentForm extends React.Component {
 
 		const commentText = this.getCommentText();
 		const currentHeight = parseInt( commentTextNode.style.height, 10 ) || 0;
-		commentTextNode.style.height = commentText.length ? Math.max( commentTextNode.scrollHeight, currentHeight ) + 'px' : null;
+		commentTextNode.style.height = commentText.length
+			? Math.max( commentTextNode.scrollHeight, currentHeight ) + 'px'
+			: null;
 	}
 
 	handleTextAreaNode( textareaNode ) {
@@ -91,7 +83,11 @@ class PostCommentForm extends React.Component {
 				// sync the text to the upper level so it won't be lost
 				this.props.onUpdateCommentText( this.props.commentText );
 				// remove the comment
-				this.props.deleteComment( this.props.post.site_ID, this.props.post.ID, this.props.placeholderId );
+				this.props.deleteComment(
+					this.props.post.site_ID,
+					this.props.post.ID,
+					this.props.placeholderId,
+				);
 			}
 		}
 	}
@@ -112,7 +108,7 @@ class PostCommentForm extends React.Component {
 	resetCommentText() {
 		this.setState( { commentText: '' } );
 
-        // Update the comment text in the container's state
+		// Update the comment text in the container's state
 		this.props.onUpdateCommentText( '' );
 	}
 
@@ -142,7 +138,7 @@ class PostCommentForm extends React.Component {
 		recordAction( 'posted_comment' );
 		recordGaEvent( 'Clicked Post Comment Button' );
 		recordTrackForPost( 'calypso_reader_article_commented_on', post, {
-			parent_post_id: this.props.parentCommentID ? this.props.parentCommentID : undefined
+			parent_post_id: this.props.parentCommentID ? this.props.parentCommentID : undefined,
 		} );
 
 		this.resetCommentText();
@@ -163,7 +159,9 @@ class PostCommentForm extends React.Component {
 
 		switch ( error.error ) {
 			case 'comment_duplicate':
-				message = translate( "Duplicate comment detected. It looks like you've already said that!" );
+				message = translate(
+					"Duplicate comment detected. It looks like you've already said that!",
+				);
 				break;
 
 			default:
@@ -171,17 +169,33 @@ class PostCommentForm extends React.Component {
 				break;
 		}
 
-		return <Notice text={ message } className="comments__notice" showDismiss={ false } status="is-error" />;
+		return (
+			<Notice
+				text={ message }
+				className="comments__notice"
+				showDismiss={ false }
+				status="is-error"
+			/>
+		);
 	}
 
 	render() {
 		const post = this.props.post;
 
 		// Don't display the form if comments are closed
-		if ( post && post.discussion && post.discussion.comments_open === false && ! isCommentableDiscoverPost( post ) ) {
+		if (
+			post &&
+			post.discussion &&
+			post.discussion.comments_open === false &&
+			! isCommentableDiscoverPost( post )
+		) {
 			// If we already have some comments, show a 'comments closed message'
 			if ( post.discussion.comment_count && post.discussion.comment_count > 0 ) {
-				return <p className="comments__form-closed">{ translate( 'Comments are closed.' ) }</p>;
+				return (
+					<p className="comments__form-closed">
+						{ translate( 'Comments are closed.' ) }
+					</p>
+				);
 			}
 
 			return null;
@@ -189,12 +203,12 @@ class PostCommentForm extends React.Component {
 
 		const buttonClasses = classNames( {
 			'is-active': this.hasCommentText(),
-			'is-visible': this.state.haveFocus || this.hasCommentText()
+			'is-visible': this.state.haveFocus || this.hasCommentText(),
 		} );
 
 		const expandingAreaClasses = classNames( {
 			focused: this.state.haveFocus,
-			'expanding-area': true
+			'expanding-area': true,
 		} );
 
 		// How auto expand works for the textarea is covered in this article:
@@ -205,7 +219,12 @@ class PostCommentForm extends React.Component {
 					<Gravatar user={ this.props.currentUser } />
 					<label>
 						<div className={ expandingAreaClasses }>
-							<pre><span>{ this.state.commentText }</span><br /></pre>
+							<pre>
+								<span>
+									{ this.state.commentText }
+								</span>
+								<br />
+							</pre>
 							<AutoDirection>
 								<textarea
 									value={ this.state.commentText }
@@ -223,7 +242,8 @@ class PostCommentForm extends React.Component {
 							ref="commentButton"
 							className={ buttonClasses }
 							disabled={ this.state.commentText.length === 0 }
-							onClick={ this.handleSubmit }>
+							onClick={ this.handleSubmit }
+						>
 							{ translate( 'Send' ) }
 						</button>
 						{ this.renderError() }
@@ -232,7 +252,6 @@ class PostCommentForm extends React.Component {
 			</form>
 		);
 	}
-
 }
 
 PostCommentForm.propTypes = {
@@ -247,16 +266,16 @@ PostCommentForm.propTypes = {
 	currentUser: React.PropTypes.object.isRequired,
 	writeComment: React.PropTypes.func.isRequired,
 	deleteComment: React.PropTypes.func.isRequired,
-	replyComment: React.PropTypes.func.isRequired
+	replyComment: React.PropTypes.func.isRequired,
 };
 
 PostCommentForm.defaultProps = {
-	onCommentSubmit: noop
+	onCommentSubmit: noop,
 };
 
 export default connect(
-	( state ) => ( {
-		currentUser: getCurrentUser( state )
+	state => ( {
+		currentUser: getCurrentUser( state ),
 	} ),
-	{ writeComment, deleteComment, replyComment }
+	{ writeComment, deleteComment, replyComment },
 )( PostCommentForm );

--- a/client/blocks/comments/helper.jsx
+++ b/client/blocks/comments/helper.jsx
@@ -8,7 +8,11 @@ export function shouldShowComments( post ) {
 		return true;
 	}
 
-	if ( ! post.is_jetpack && post.discussion && ( post.discussion.comments_open || post.discussion.comment_count > 0 ) ) {
+	if (
+		! post.is_jetpack &&
+		post.discussion &&
+		( post.discussion.comments_open || post.discussion.comment_count > 0 )
+	) {
 		return true;
 	}
 
@@ -19,7 +23,10 @@ export function isCommentableDiscoverPost( post ) {
 	const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
 
 	if ( isDiscoverPost ) {
-		if ( DiscoverHelper.isInternalDiscoverPost( post ) && ! DiscoverHelper.isDiscoverSitePick( post ) ) {
+		if (
+			DiscoverHelper.isInternalDiscoverPost( post ) &&
+			! DiscoverHelper.isDiscoverSitePick( post )
+		) {
 			return true;
 		}
 	}

--- a/client/blocks/comments/post-comment-content.jsx
+++ b/client/blocks/comments/post-comment-content.jsx
@@ -8,18 +8,27 @@ export default class PostCommentContent extends React.Component {
 	render() {
 		// Don't trust comment content unless it was provided by the API
 		if ( this.props.isPlaceholder ) {
-			return ( <div className="comments__comment-content">{
-				this.props.content.split( '\n' ).map( ( item, key ) => {
-					return <span key={ key }>{ item }<br /></span>;
-				} )
-			}</div> );
+			return (
+				<div className="comments__comment-content">
+					{ this.props.content.split( '\n' ).map( ( item, key ) => {
+						return (
+							<span key={ key }>
+								{ item }
+								<br />
+							</span>
+						);
+					} ) }
+				</div>
+			);
 		}
 
 		/*eslint-disable react/no-danger*/
 		return (
 			<AutoDirection>
-				<div className="comments__comment-content" dangerouslySetInnerHTML={ { __html: this.props.content } }>
-				</div>
+				<div
+					className="comments__comment-content"
+					dangerouslySetInnerHTML={ { __html: this.props.content } }
+				/>
 			</AutoDirection>
 		);
 		/*eslint-enable react/no-danger*/
@@ -28,5 +37,5 @@ export default class PostCommentContent extends React.Component {
 
 PostCommentContent.propTypes = {
 	content: PropTypes.string.isRequired,
-	isPlaceholder: PropTypes.bool
+	isPlaceholder: PropTypes.bool,
 };

--- a/client/blocks/comments/post-comment-with-error.jsx
+++ b/client/blocks/comments/post-comment-with-error.jsx
@@ -11,20 +11,30 @@ import PostCommentForm from './form';
 export default class PostCommentWithError extends React.Component {
 	renderCommentForm() {
 		const post = this.props.post;
-		const commentText = this.props.commentsTree.getIn( [ this.props.commentId, 'data', 'content' ] );
+		const commentText = this.props.commentsTree.getIn( [
+			this.props.commentId,
+			'data',
+			'content',
+		] );
 		const commentParentId = this.props.commentsTree.getIn( [ this.props.commentId, 'parentId' ] );
-		const placeholderError = this.props.commentsTree.getIn( [ this.props.commentId, 'data', 'placeholderError' ] );
+		const placeholderError = this.props.commentsTree.getIn( [
+			this.props.commentId,
+			'data',
+			'placeholderError',
+		] );
 		const onUpdateCommentText = this.props.onUpdateCommentText;
 
-		return <PostCommentForm
-			ref="postCommentForm"
-			post={ post }
-			parentCommentID={ commentParentId }
-			commentText={ commentText }
-			onUpdateCommentText={ onUpdateCommentText }
-			placeholderId={ this.props.commentId }
-			error={ placeholderError }
-		/>;
+		return (
+			<PostCommentForm
+				ref="postCommentForm"
+				post={ post }
+				parentCommentID={ commentParentId }
+				commentText={ commentText }
+				onUpdateCommentText={ onUpdateCommentText }
+				placeholderId={ this.props.commentId }
+				error={ placeholderError }
+			/>
+		);
 	}
 
 	render() {
@@ -42,8 +52,6 @@ PostCommentWithError.propTypes = {
 	repliesList: React.PropTypes.object.isRequired,
 	commentsTree: React.PropTypes.object.isRequired,
 	onUpdateCommentText: React.PropTypes.func.isRequired,
-	commentId: React.PropTypes.oneOfType( [
-		React.PropTypes.string,
-		React.PropTypes.number
-	] ).isRequired
+	commentId: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.number ] )
+		.isRequired,
 };

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -11,16 +11,10 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import {
-	getCurrentUser
-} from 'state/current-user/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 import PostTime from 'reader/post-time';
 import Gravatar from 'components/gravatar';
-import {
-	recordAction,
-	recordGaEvent,
-	recordTrack
-} from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { getStreamUrl } from 'reader/route';
 import PostCommentContent from './post-comment-content';
 import PostCommentForm from './form';
@@ -33,28 +27,28 @@ import CommentActions from './comment-actions';
 
 class PostComment extends Component {
 	state = {
-		showReplies: false
+		showReplies: false,
 	};
 
 	handleToggleRepliesClick = () => {
 		this.setState( { showReplies: ! this.state.showReplies } );
-	}
+	};
 
 	handleReply = () => {
 		this.props.onReplyClick( this.props.commentId );
 		this.setState( { showReplies: true } ); // show the comments when replying
-	}
+	};
 
-	handleAuthorClick = ( event ) => {
+	handleAuthorClick = event => {
 		recordAction( 'comment_author_click' );
 		recordGaEvent( 'Clicked Author Name' );
 		recordTrack( 'calypso_reader_comment_author_click', {
 			blog_id: this.props.post.site_ID,
 			post_id: this.props.post.ID,
 			comment_id: this.props.commentId,
-			author_url: event.target.href
+			author_url: event.target.href,
 		} );
-	}
+	};
 
 	renderRepliesList() {
 		const commentChildrenIds = get( this.props.commentsTree, [ this.props.commentId, 'children' ] );
@@ -72,8 +66,8 @@ class PostComment extends Component {
 			'show %(numOfReplies)d replies',
 			{
 				count: commentChildrenIds.length,
-				args: { numOfReplies: commentChildrenIds.length }
-			}
+				args: { numOfReplies: commentChildrenIds.length },
+			},
 		);
 
 		const hideRepliesText = translate(
@@ -81,8 +75,8 @@ class PostComment extends Component {
 			'hide %(numOfReplies)d replies',
 			{
 				count: commentChildrenIds.length,
-				args: { numOfReplies: commentChildrenIds.length }
-			}
+				args: { numOfReplies: commentChildrenIds.length },
+			},
 		);
 
 		let replyVisibilityText = null;
@@ -90,23 +84,30 @@ class PostComment extends Component {
 			replyVisibilityText = this.state.showReplies ? hideRepliesText : showRepliesText;
 		}
 
-		return ( <div>
-			{ !! replyVisibilityText
-			? <button className="comments__view-replies-btn" onClick={ this.handleToggleRepliesClick }>
-				<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
-			</button> : null
-			}
-			{ showReplies
-				? <ol className="comments__list">
-					{
-						commentChildrenIds.map( ( childId ) =>
-							<PostComment { ...this.props } depth={ this.props.depth + 1 } key={ childId } commentId={ childId } />
-						)
-					}
-				</ol>
-				: null
-			}
-		</div> );
+		return (
+			<div>
+				{ !! replyVisibilityText
+					? <button
+							className="comments__view-replies-btn"
+							onClick={ this.handleToggleRepliesClick }
+						>
+							<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
+						</button>
+					: null }
+				{ showReplies
+					? <ol className="comments__list">
+							{ commentChildrenIds.map( childId =>
+								<PostComment
+									{ ...this.props }
+									depth={ this.props.depth + 1 }
+									key={ childId }
+									commentId={ childId }
+								/>,
+							) }
+						</ol>
+					: null }
+			</div>
+		);
 	}
 
 	renderCommentForm() {
@@ -114,13 +115,16 @@ class PostComment extends Component {
 			return null;
 		}
 
-		return <PostCommentForm
-			ref="postCommentForm"
-			post={ this.props.post }
-			parentCommentID={ this.props.commentId }
-			commentText={ this.props.commentText }
-			onUpdateCommentText={ this.props.onUpdateCommentText }
-			onCommentSubmit={ this.props.onCommentSubmit } />;
+		return (
+			<PostCommentForm
+				ref="postCommentForm"
+				post={ this.props.post }
+				parentCommentID={ this.props.commentId }
+				commentText={ this.props.commentText }
+				onUpdateCommentText={ this.props.onUpdateCommentText }
+				onCommentSubmit={ this.props.onCommentSubmit }
+			/>
+		);
 	}
 
 	render() {
@@ -129,8 +133,11 @@ class PostComment extends Component {
 		const comment = get( commentsTree, [ this.props.commentId, 'data' ] );
 
 		// todo: connect this constants to the state (new selector)
-		const haveReplyWithError = some( get( commentsTree, [ this.props.commentId, 'children' ] ),
-			( childId ) => get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR );
+		const haveReplyWithError = some(
+			get( commentsTree, [ this.props.commentId, 'children' ] ),
+			childId =>
+				get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR,
+		);
 
 		// If it's a pending comment, use the current user as the author
 		if ( comment.isPlaceholder ) {
@@ -163,15 +170,21 @@ class PostComment extends Component {
 				<div className="comments__comment-author">
 					{ authorUrl
 						? <a href={ authorUrl } onClick={ this.handleAuthorClick }>
-							<Gravatar user={ comment.author } />
-						</a>
+								<Gravatar user={ comment.author } />
+							</a>
 						: <Gravatar user={ comment.author } /> }
 
 					{ authorUrl
-						? <a href={ authorUrl } className="comments__comment-username" onClick={ this.handleAuthorClick }>
+						? <a
+								href={ authorUrl }
+								className="comments__comment-username"
+								onClick={ this.handleAuthorClick }
+							>
 								{ comment.author.name }
 							</a>
-						: <strong className="comments__comment-username">{ comment.author.name }</strong> }
+						: <strong className="comments__comment-username">
+								{ comment.author.name }
+							</strong> }
 					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>
 							<PostTime date={ comment.date } />
@@ -180,20 +193,25 @@ class PostComment extends Component {
 				</div>
 
 				{ comment.status && comment.status === 'unapproved'
-					? <p className="comments__comment-moderation">{ translate( 'Your comment is awaiting moderation.' ) }</p>
+					? <p className="comments__comment-moderation">
+							{ translate( 'Your comment is awaiting moderation.' ) }
+						</p>
 					: null }
 
 				{ this.props.activeEditCommentId !== this.props.commentId &&
-					<PostCommentContent content={ comment.content } isPlaceholder={ comment.isPlaceholder } />
-				}
+					<PostCommentContent
+						content={ comment.content }
+						isPlaceholder={ comment.isPlaceholder }
+					/> }
 
-				{ isEnabled( 'comments/moderation-tools-in-posts' ) && this.props.activeEditCommentId === this.props.commentId &&
+				{ isEnabled( 'comments/moderation-tools-in-posts' ) &&
+					this.props.activeEditCommentId === this.props.commentId &&
 					<CommentEditForm
 						post={ this.props.post }
 						commentId={ this.props.commentId }
 						commentText={ comment.content }
-						onCommentSubmit={ this.props.onEditCommentCancel } />
-				}
+						onCommentSubmit={ this.props.onEditCommentCancel }
+					/> }
 
 				<CommentActions
 					post={ this.props.post }
@@ -205,7 +223,8 @@ class PostComment extends Component {
 					editComment={ this.props.onEditCommentClick }
 					editCommentCancel={ this.props.onEditCommentCancel }
 					handleReply={ this.handleReply }
-					onReplyCancel={ this.props.onReplyCancel } />
+					onReplyCancel={ this.props.onReplyCancel }
+				/>
 
 				{ haveReplyWithError ? null : this.renderCommentForm() }
 				{ this.renderRepliesList() }
@@ -218,7 +237,7 @@ PostComment.propTypes = {
 	commentsTree: React.PropTypes.object.isRequired,
 	commentId: React.PropTypes.oneOfType( [
 		React.PropTypes.string, // can be 'placeholder-123'
-		React.PropTypes.number
+		React.PropTypes.number,
 	] ).isRequired,
 	onReplyClick: React.PropTypes.func,
 	depth: React.PropTypes.number,
@@ -227,7 +246,7 @@ PostComment.propTypes = {
 	onCommentSubmit: React.PropTypes.func,
 
 	// connect()ed props:
-	currentUser: React.PropTypes.object.isRequired
+	currentUser: React.PropTypes.object.isRequired,
 };
 
 PostComment.defaultProps = {
@@ -235,11 +254,9 @@ PostComment.defaultProps = {
 	errors: [],
 	depth: 1,
 	maxChildrenToShow: 5,
-	onCommentSubmit: noop
+	onCommentSubmit: noop,
 };
 
-export default connect(
-	( state ) => ( {
-		currentUser: getCurrentUser( state )
-	} )
-)( PostComment );
+export default connect( state => ( {
+	currentUser: getCurrentUser( state ),
+} ) )( PostComment );

--- a/client/blocks/comments/post-trackback.jsx
+++ b/client/blocks/comments/post-trackback.jsx
@@ -39,7 +39,9 @@ export default class PostTrackback extends React.Component {
 							>
 								{ unescapedAuthorName }
 							</a>
-						: <strong className="comments__comment-username">{ unescapedAuthorName }</strong> }
+						: <strong className="comments__comment-username">
+								{ unescapedAuthorName }
+							</strong> }
 
 					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>
@@ -47,7 +49,6 @@ export default class PostTrackback extends React.Component {
 						</a>
 					</div>
 				</div>
-
 			</li>
 		);
 	}


### PR DESCRIPTION
As part of the new Reader Conversations tool I'm doing some work in `blocks/comments`. I wanted to prettify the code separately so cosmetic changes don't clutter up my later PRs.

No functional changes, just prettier.