### PR TITLE
Comments: Persist after status change

### DIFF
--- a/client/blocks/comment-detail/comment-detail-reply.jsx
+++ b/client/blocks/comment-detail/comment-detail-reply.jsx
@@ -35,9 +35,13 @@ export class CommentDetailReply extends Component {
 	}
 
 	getTextareaPlaceholder = () => {
-		const { authorDisplayName, commentStatus, translate } = this.props;
+		const {
+			authorDisplayName,
+			comment: { status },
+			translate,
+		} = this.props;
 
-		if ( 'approved' !== commentStatus ) {
+		if ( 'approved' !== status ) {
 			return authorDisplayName
 				? translate( 'Approve and reply to %(commentAuthor)s…', {
 					args: { commentAuthor: authorDisplayName }
@@ -69,14 +73,12 @@ export class CommentDetailReply extends Component {
 
 	submit = () => {
 		const {
-			commentId,
-			commentStatus,
-			postId,
+			comment,
 			replyComment,
 		} = this.props;
 		const { commentText } = this.state;
 
-		replyComment( commentText, postId, commentId, { alsoApprove: 'approved' !== commentStatus } );
+		replyComment( commentText, comment );
 		this.setState( { commentText: '' } );
 	}
 

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -82,7 +82,10 @@ export class CommentDetail extends Component {
 
 	toggleApprove = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
-		setCommentStatus( commentId, postId, 'approved' === commentStatus ? 'unapproved' : 'approved' );
+		setCommentStatus( commentId, postId, 'approved' === commentStatus ? 'unapproved' : 'approved', {
+			persist: ( 'approved' === commentStatus || 'unapproved' === commentStatus ),
+			showNotice: true,
+		} );
 		this.setState( { isExpanded: false } );
 	}
 
@@ -103,13 +106,11 @@ export class CommentDetail extends Component {
 	toggleSpam = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
 		setCommentStatus( commentId, postId, 'spam' === commentStatus ? 'approved' : 'spam' );
-		this.setState( { isExpanded: false } );
 	}
 
 	toggleTrash = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
 		setCommentStatus( commentId, postId, 'trash' === commentStatus ? 'approved' : 'trash' );
-		this.setState( { isExpanded: false } );
 	}
 
 	render() {

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -82,10 +82,16 @@ export class CommentDetail extends Component {
 
 	toggleApprove = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
+		const isPersisted = 'approved' === commentStatus || 'unapproved' === commentStatus;
+
 		setCommentStatus( commentId, postId, 'approved' === commentStatus ? 'unapproved' : 'approved', {
-			persist: ( 'approved' === commentStatus || 'unapproved' === commentStatus ),
+			persist: isPersisted,
 			showNotice: true,
 		} );
+
+		if ( isPersisted ) {
+			this.setState( { isExpanded: false } );
+		}
 	}
 
 	toggleExpanded = () => {
@@ -93,8 +99,14 @@ export class CommentDetail extends Component {
 	}
 
 	toggleLike = () => {
-		const { commentId, postId, toggleCommentLike } = this.props;
+		const { commentId, commentIsLiked, commentStatus, postId, toggleCommentLike } = this.props;
+		const isPersisted = 'unapproved' === commentStatus && ! commentIsLiked;
+
 		toggleCommentLike( commentId, postId );
+
+		if ( isPersisted ) {
+			this.setState( { isExpanded: false } );
+		}
 	}
 
 	toggleSelected = () => {

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -83,6 +83,7 @@ export class CommentDetail extends Component {
 	toggleApprove = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
 		setCommentStatus( commentId, postId, 'approved' === commentStatus ? 'unapproved' : 'approved' );
+		this.setState( { isExpanded: false } );
 	}
 
 	toggleExpanded = () => {
@@ -102,11 +103,13 @@ export class CommentDetail extends Component {
 	toggleSpam = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
 		setCommentStatus( commentId, postId, 'spam' === commentStatus ? 'approved' : 'spam' );
+		this.setState( { isExpanded: false } );
 	}
 
 	toggleTrash = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
 		setCommentStatus( commentId, postId, 'trash' === commentStatus ? 'approved' : 'trash' );
+		this.setState( { isExpanded: false } );
 	}
 
 	render() {

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -19,6 +19,24 @@ import { decodeEntities, stripHTML } from 'lib/formatting';
 import { getPostCommentsTree } from 'state/comments/selectors';
 import getSiteComment from 'state/selectors/get-site-comment';
 
+/**
+ * Creates a stripped down comment object containing only the information needed by
+ * CommentList's change status functions and their respective undos.
+ *
+ * @param {Object} props The CommentDetail props object.
+ * @param {Number} props.commentId The comment ID.
+ * @param {Boolean} props.commentIsLiked The current comment i_like value.
+ * @param {String} props.commentStatus The current comment status.
+ * @param {Number} props.postId The comment's post ID.
+ * @returns {Object} A stripped down comment object.
+ */
+const getCommentStatusAction = ( { commentId, commentIsLiked, commentStatus, postId } ) => ( {
+	commentId,
+	isLiked: commentIsLiked,
+	postId,
+	status: commentStatus,
+} );
+
 export class CommentDetail extends Component {
 	static propTypes = {
 		authorAvatarUrl: PropTypes.string,
@@ -81,19 +99,12 @@ export class CommentDetail extends Component {
 
 	edit = () => noop;
 
-	getCommentObject = () => ( {
-		commentId: this.props.commentId,
-		isLiked: this.props.commentIsLiked,
-		postId: this.props.postId,
-		status: this.props.commentStatus,
-	} );
-
 	toggleApprove = () => {
 		const { commentStatus, setCommentStatus } = this.props;
 		const shouldPersist = 'approved' === commentStatus || 'unapproved' === commentStatus;
 
 		setCommentStatus(
-			this.getCommentObject(),
+			getCommentStatusAction( this.props ),
 			( 'approved' === commentStatus ) ? 'unapproved' : 'approved',
 			{
 				doPersist: shouldPersist,
@@ -114,7 +125,7 @@ export class CommentDetail extends Component {
 		const { commentIsLiked, commentStatus, toggleCommentLike } = this.props;
 		const shouldPersist = 'unapproved' === commentStatus && ! commentIsLiked;
 
-		toggleCommentLike( this.getCommentObject() );
+		toggleCommentLike( getCommentStatusAction( this.props ) );
 
 		if ( shouldPersist ) {
 			this.setState( { isExpanded: false } );
@@ -129,7 +140,7 @@ export class CommentDetail extends Component {
 	toggleSpam = () => {
 		const { commentStatus, setCommentStatus } = this.props;
 		setCommentStatus(
-			this.getCommentObject(),
+			getCommentStatusAction( this.props ),
 			( 'spam' === commentStatus ) ? 'approved' : 'spam'
 		);
 	}
@@ -137,7 +148,7 @@ export class CommentDetail extends Component {
 	toggleTrash = () => {
 		const { commentStatus, setCommentStatus } = this.props;
 		setCommentStatus(
-			this.getCommentObject(),
+			getCommentStatusAction( this.props ),
 			( 'trash' === commentStatus ) ? 'approved' : 'trash'
 		);
 	}
@@ -240,7 +251,7 @@ export class CommentDetail extends Component {
 						/>
 						<CommentDetailReply
 							authorDisplayName={ authorDisplayName }
-							comment={ this.getCommentObject() }
+							comment={ getCommentStatusAction( this.props ) }
 							postTitle={ postTitle }
 							replyComment={ replyComment }
 						/>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -17,6 +17,7 @@ import CommentDetailPost from './comment-detail-post';
 import CommentDetailReply from './comment-detail-reply';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { getPostCommentsTree } from 'state/comments/selectors';
+import getSiteComment from 'state/selectors/get-site-comment';
 
 export class CommentDetail extends Component {
 	static propTypes = {
@@ -237,13 +238,8 @@ export class CommentDetail extends Component {
 }
 
 const mapStateToProps = ( state, ownProps ) => {
-	// TODO: replace `const comment = ownProps.comment;` with
-	// `const comment = ownProps.comment || getComment( ownProps.commentId );`
-	// when the selector is ready.
-	const {
-		comment,
-		siteId,
-	} = ownProps;
+	const { commentId, siteId } = ownProps;
+	const comment = getSiteComment( state, siteId, commentId );
 
 	const postId = get( comment, 'post.ID' );
 
@@ -251,7 +247,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const postTitle = decodeEntities( get( comment, 'post.title' ) );
 
 	const commentsTree = getPostCommentsTree( state, siteId, postId, 'all' );
-	const parentCommentId = get( commentsTree, [ comment.ID, 'data', 'parent', 'ID' ], 0 );
+	const parentCommentId = get( commentsTree, [ commentId, 'data', 'parent', 'ID' ], 0 );
 	const parentComment = get( commentsTree, [ parentCommentId, 'data' ], {} );
 
 	// TODO: eventually it will be returned already decoded from the data layer.
@@ -264,23 +260,23 @@ const mapStateToProps = ( state, ownProps ) => {
 		authorId: get( comment, 'author.ID' ),
 		authorIp: get( comment, 'author.ip' ), // TODO: not available in the current data structure
 		authorIsBlocked: get( comment, 'author.isBlocked' ), // TODO: not available in the current data structure
-		authorUrl: get( comment, 'author.URL' ),
+		authorUrl: get( comment, 'author.URL', '' ),
 		authorUsername: get( comment, 'author.nice_name' ),
-		commentContent: comment.content,
-		commentDate: comment.date,
-		commentId: comment.ID,
-		commentIsLiked: comment.i_like,
-		commentStatus: comment.status,
+		commentContent: get( comment, 'content' ),
+		commentDate: get( comment, 'date' ),
+		commentId,
+		commentIsLiked: get( comment, 'i_like' ),
+		commentStatus: get( comment, 'status' ),
 		commentUrl: get( comment, 'URL' ),
 		parentCommentAuthorAvatarUrl: get( parentComment, 'author.avatar_URL' ),
 		parentCommentAuthorDisplayName: get( parentComment, 'author.name' ),
 		parentCommentContent,
-		parentCommentUrl: get( parentComment, 'URL' ),
+		parentCommentUrl: get( parentComment, 'URL', '' ),
 		postAuthorDisplayName: get( comment, 'post.author.name' ), // TODO: not available in the current data structure
 		postId,
 		postTitle,
-		repliedToComment: comment.replied, // TODO: not available in the current data structure
-		siteId: comment.siteId || siteId,
+		repliedToComment: get( comment, 'replied' ), // TODO: not available in the current data structure
+		siteId: get( comment, 'siteId', siteId ),
 	} );
 };
 

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -92,10 +92,14 @@ export class CommentDetail extends Component {
 		const { commentStatus, setCommentStatus } = this.props;
 		const shouldPersist = 'approved' === commentStatus || 'unapproved' === commentStatus;
 
-		setCommentStatus( this.getCommentObject(), 'approved' === commentStatus ? 'unapproved' : 'approved', {
-			doPersist: shouldPersist,
-			showNotice: true,
-		} );
+		setCommentStatus(
+			this.getCommentObject(),
+			( 'approved' === commentStatus ) ? 'unapproved' : 'approved',
+			{
+				doPersist: shouldPersist,
+				showNotice: true,
+			}
+		);
 
 		if ( shouldPersist ) {
 			this.setState( { isExpanded: false } );
@@ -124,12 +128,18 @@ export class CommentDetail extends Component {
 
 	toggleSpam = () => {
 		const { commentStatus, setCommentStatus } = this.props;
-		setCommentStatus( this.getCommentObject(), 'spam' === commentStatus ? 'approved' : 'spam' );
+		setCommentStatus(
+			this.getCommentObject(),
+			( 'spam' === commentStatus ) ? 'approved' : 'spam'
+		);
 	}
 
 	toggleTrash = () => {
 		const { commentStatus, setCommentStatus } = this.props;
-		setCommentStatus( this.getCommentObject(), 'trash' === commentStatus ? 'approved' : 'trash' );
+		setCommentStatus(
+			this.getCommentObject(),
+			( 'trash' === commentStatus ) ? 'approved' : 'trash'
+		);
 	}
 
 	render() {

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -86,7 +86,6 @@ export class CommentDetail extends Component {
 			persist: ( 'approved' === commentStatus || 'unapproved' === commentStatus ),
 			showNotice: true,
 		} );
-		this.setState( { isExpanded: false } );
 	}
 
 	toggleExpanded = () => {

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -142,7 +142,6 @@ export class CommentDetail extends Component {
 			authorUsername,
 			commentContent,
 			commentDate,
-			commentId,
 			commentIsLiked,
 			commentIsSelected,
 			commentStatus,
@@ -231,9 +230,7 @@ export class CommentDetail extends Component {
 						/>
 						<CommentDetailReply
 							authorDisplayName={ authorDisplayName }
-							commentId={ commentId }
-							commentStatus={ commentStatus }
-							postId={ postId }
+							comment={ this.getCommentObject() }
 							postTitle={ postTitle }
 							replyComment={ replyComment }
 						/>

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -82,14 +82,14 @@ export class CommentDetail extends Component {
 
 	toggleApprove = () => {
 		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
-		const isPersisted = 'approved' === commentStatus || 'unapproved' === commentStatus;
+		const shouldPersist = 'approved' === commentStatus || 'unapproved' === commentStatus;
 
 		setCommentStatus( commentId, postId, 'approved' === commentStatus ? 'unapproved' : 'approved', {
-			persist: isPersisted,
+			doPersist: shouldPersist,
 			showNotice: true,
 		} );
 
-		if ( isPersisted ) {
+		if ( shouldPersist ) {
 			this.setState( { isExpanded: false } );
 		}
 	}
@@ -100,11 +100,11 @@ export class CommentDetail extends Component {
 
 	toggleLike = () => {
 		const { commentId, commentIsLiked, commentStatus, postId, toggleCommentLike } = this.props;
-		const isPersisted = 'unapproved' === commentStatus && ! commentIsLiked;
+		const shouldPersist = 'unapproved' === commentStatus && ! commentIsLiked;
 
 		toggleCommentLike( commentId, postId );
 
-		if ( isPersisted ) {
+		if ( shouldPersist ) {
 			this.setState( { isExpanded: false } );
 		}
 	}

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -81,11 +81,18 @@ export class CommentDetail extends Component {
 
 	edit = () => noop;
 
+	getCommentObject = () => ( {
+		commentId: this.props.commentId,
+		postId: this.props.postId,
+		previousIsLiked: this.props.commentIsLiked,
+		previousStatus: this.props.commentStatus,
+	} );
+
 	toggleApprove = () => {
-		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
+		const { commentStatus, setCommentStatus } = this.props;
 		const shouldPersist = 'approved' === commentStatus || 'unapproved' === commentStatus;
 
-		setCommentStatus( commentId, postId, 'approved' === commentStatus ? 'unapproved' : 'approved', {
+		setCommentStatus( this.getCommentObject(), 'approved' === commentStatus ? 'unapproved' : 'approved', {
 			doPersist: shouldPersist,
 			showNotice: true,
 		} );
@@ -100,10 +107,10 @@ export class CommentDetail extends Component {
 	}
 
 	toggleLike = () => {
-		const { commentId, commentIsLiked, commentStatus, postId, toggleCommentLike } = this.props;
+		const { commentIsLiked, commentStatus, toggleCommentLike } = this.props;
 		const shouldPersist = 'unapproved' === commentStatus && ! commentIsLiked;
 
-		toggleCommentLike( commentId, postId );
+		toggleCommentLike( this.getCommentObject() );
 
 		if ( shouldPersist ) {
 			this.setState( { isExpanded: false } );
@@ -116,13 +123,13 @@ export class CommentDetail extends Component {
 	}
 
 	toggleSpam = () => {
-		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
-		setCommentStatus( commentId, postId, 'spam' === commentStatus ? 'approved' : 'spam' );
+		const { commentStatus, setCommentStatus } = this.props;
+		setCommentStatus( this.getCommentObject(), 'spam' === commentStatus ? 'approved' : 'spam' );
 	}
 
 	toggleTrash = () => {
-		const { commentId, commentStatus, postId, setCommentStatus } = this.props;
-		setCommentStatus( commentId, postId, 'trash' === commentStatus ? 'approved' : 'trash' );
+		const { commentStatus, setCommentStatus } = this.props;
+		setCommentStatus( this.getCommentObject(), 'trash' === commentStatus ? 'approved' : 'trash' );
 	}
 
 	render() {

--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -83,9 +83,9 @@ export class CommentDetail extends Component {
 
 	getCommentObject = () => ( {
 		commentId: this.props.commentId,
+		isLiked: this.props.commentIsLiked,
 		postId: this.props.postId,
-		previousIsLiked: this.props.commentIsLiked,
-		previousStatus: this.props.commentStatus,
+		status: this.props.commentStatus,
 	} );
 
 	toggleApprove = () => {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -224,21 +224,16 @@ export class CommentList extends Component {
 			return;
 		}
 
-		const options = {
+		const noticeOptions = {
 			button: translate( 'Undo' ),
 			duration: 5000,
 			id: `comment-notice-${ commentId }`,
 			isPersistent: true,
-			onClick: () => this.setCommentStatus(
-				commentId,
-				postId,
-				previousStatus,
-				{
-					isUndo: true,
-					persist: options.persist,
-					showNotice: false,
-				}
-			),
+			onClick: () => this.setCommentStatus( commentId, postId, previousStatus, {
+				isUndo: true,
+				persist: options.persist,
+				showNotice: false,
+			} ),
 		};
 
 		this.props.createNotice( type, message, noticeOptions );

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -110,14 +110,14 @@ export class CommentList extends Component {
 		persistedComments: persistedComments.filter( c => c !== commentId ),
 	} ) );
 
-	replyComment = ( commentText, comment, options = { alsoApprove: false } ) => {
+	replyComment = ( commentText, parentComment ) => {
 		const { translate } = this.props;
 		const {
 			commentId: parentCommentId,
 			postId,
 			status,
-		} = comment;
-		const { alsoApprove } = options;
+		} = parentComment;
+		const alsoApprove = 'approved' !== status;
 
 		this.props.removeNotice( `comment-notice-${ parentCommentId }` );
 
@@ -131,7 +131,7 @@ export class CommentList extends Component {
 			isPersistent: true,
 		};
 
-		if ( 'approved' !== status ) {
+		if ( alsoApprove ) {
 			this.setCommentStatus( comment, 'approved', { doPersist: true, showNotice: false } );
 		}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -314,6 +314,7 @@ export class CommentList extends Component {
 
 	render() {
 		const {
+			comments,
 			commentsCount,
 			commentsPage,
 			isLoading,
@@ -325,8 +326,6 @@ export class CommentList extends Component {
 			isBulkEdit,
 			selectedComments,
 		} = this.state;
-
-		const comments = this.getComments();
 
 		const zeroComments = size( comments ) <= 0;
 		const showPlaceholder = ( ! siteId || isLoading ) && zeroComments;
@@ -354,13 +353,13 @@ export class CommentList extends Component {
 					transitionLeaveTimeout={ 150 }
 					transitionName="comment-list__transition"
 				>
-					{ map( comments, comment =>
+					{ map( comments, commentId =>
 						<CommentDetail
-							comment={ comment }
+							commentId={ commentId }
 							deleteCommentPermanently={ this.deleteCommentPermanently }
 							isBulkEdit={ isBulkEdit }
-							commentIsSelected={ this.isCommentSelected( comment.ID ) }
-							key={ `comment-${ siteId }-${ comment.ID }` }
+							commentIsSelected={ this.isCommentSelected( commentId ) }
+							key={ `comment-${ siteId }-${ commentId }` }
 							replyComment={ this.replyComment }
 							setCommentStatus={ this.setCommentStatus }
 							siteId={ siteId }
@@ -395,7 +394,7 @@ export class CommentList extends Component {
 }
 
 const mapStateToProps = ( state, { siteId, status, order } ) => {
-	const comments = getSiteComments( state, siteId, status, order );
+	const comments = map( getSiteComments( state, siteId, status, order ), 'ID' );
 	const isLoading = ! hasSiteComments( state, siteId );
 	return {
 		comments,

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -103,7 +103,7 @@ export class CommentList extends Component {
 
 	isCommentSelected = commentId => !! this.state.selectedComments[ commentId ];
 
-	isSelectedAll = () => this.props.comments.length === size( this.state.selectedComments );
+	isSelectedAll = () => this.getComments().length === size( this.state.selectedComments );
 
 	removeFromPersistedComments = commentId => this.setState( {
 		persistedComments: reject( this.state.persistedComments, { ID: commentId } ),
@@ -294,7 +294,7 @@ export class CommentList extends Component {
 		this.setState( {
 			selectedComments: this.isSelectedAll()
 				? {}
-				: keyBy( map( this.props.comments, ( { ID, i_like, status } ) => ( { ID, i_like, status } ) ), 'ID' ),
+				: keyBy( map( this.getComments(), ( { ID, i_like, status } ) => ( { ID, i_like, status } ) ), 'ID' ),
 		} );
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -132,7 +132,7 @@ export class CommentList extends Component {
 		};
 
 		if ( alsoApprove ) {
-			this.setCommentStatus( comment, 'approved', { doPersist: true, showNotice: false } );
+			this.setCommentStatus( parentComment, 'approved', { doPersist: true, showNotice: false } );
 		}
 
 		this.props.createNotice( 'is-success', noticeMessage, noticeOptions );

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -255,23 +255,25 @@ export class CommentList extends Component {
 					i_like: false,
 				} );
 			}
-		} else {
-			this.props.likeComment( commentId, postId );
 
-			if ( 'unapproved' === comment.status ) {
-				this.props.removeNotice( `comment-notice-${ commentId }` );
-				this.setCommentStatus( commentId, postId, 'approved' );
-				this.updatePersistedComments( {
-					...comment,
-					i_like: true,
-					status: 'approved',
-				} );
-			} else if ( isPersisted ) {
-				this.updatePersistedComments( {
-					...comment,
-					i_like: true,
-				} );
-			}
+			return;
+		}
+
+		this.props.likeComment( commentId, postId );
+
+		if ( 'unapproved' === comment.status ) {
+			this.props.removeNotice( `comment-notice-${ commentId }` );
+			this.setCommentStatus( commentId, postId, 'approved' );
+			this.updatePersistedComments( {
+				...comment,
+				i_like: true,
+				status: 'approved',
+			} );
+		} else if ( isPersisted ) {
+			this.updatePersistedComments( {
+				...comment,
+				i_like: true,
+			} );
 		}
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -205,7 +205,7 @@ export class CommentList extends Component {
 
 	showNotice = ( comment, newStatus, options = { doPersist: false } ) => {
 		const { translate } = this.props;
-		const { commentId, previousStatus } = comment;
+		const { commentId, status: previousStatus } = comment;
 
 		const [ type, message ] = get( {
 			approved: [ 'is-success', translate( 'Comment approved.' ) ],
@@ -236,9 +236,9 @@ export class CommentList extends Component {
 	toggleBulkEdit = () => this.setState( { isBulkEdit: ! this.state.isBulkEdit } );
 
 	toggleCommentLike = comment => {
-		const { commentId, postId, previousIsLiked, previousStatus } = comment;
+		const { commentId, isLiked, postId, status } = comment;
 
-		if ( previousIsLiked ) {
+		if ( isLiked ) {
 			this.props.unlikeComment( commentId, postId );
 
 			if ( this.isCommentPersisted( commentId ) ) {
@@ -250,7 +250,7 @@ export class CommentList extends Component {
 
 		this.props.likeComment( commentId, postId );
 
-		if ( 'unapproved' === previousStatus ) {
+		if ( 'unapproved' === status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
 			this.setCommentStatus( comment, 'approved' );
 		}

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -54,15 +54,15 @@ export class CommentList extends Component {
 	};
 
 	state = {
-		changedComments: [],
 		isBulkEdit: false,
+		persistedComments: [],
 		selectedComments: {},
 	};
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.status !== nextProps.status ) {
 			this.setState( {
-				changedComments: [],
+				persistedComments: [],
 				selectedComments: {},
 			} );
 		}
@@ -82,7 +82,7 @@ export class CommentList extends Component {
 	getComment = commentId => find( this.getComments(), [ 'ID', commentId ] );
 
 	getComments = () => orderBy(
-		uniqBy( [ ...this.state.changedComments, ...this.props.comments ], 'ID' ),
+		uniqBy( [ ...this.state.persistedComments, ...this.props.comments ], 'ID' ),
 		'date',
 		'desc'
 	);
@@ -105,8 +105,8 @@ export class CommentList extends Component {
 
 	isSelectedAll = () => this.props.comments.length === size( this.state.selectedComments );
 
-	removeFromChangedComments = commentId => this.setState( {
-		changedComments: reject( this.state.changedComments, { ID: commentId } ),
+	removeFromPersistedComments = commentId => this.setState( {
+		persistedComments: reject( this.state.persistedComments, { ID: commentId } ),
 	} );
 
 	replyComment = ( commentText, postId, parentCommentId, options = { alsoApprove: false } ) => {
@@ -157,13 +157,13 @@ export class CommentList extends Component {
 		}
 
 		if ( persist ) {
-			this.updateChangedComments( {
+			this.updatePersistedComments( {
 				...comment,
 				i_like: 'approved' !== status ? false : comment.i_like,
 				status,
 			}, isUndo );
 		} else {
-			this.removeFromChangedComments( commentId );
+			this.removeFromPersistedComments( commentId );
 		}
 
 		this.props.removeNotice( `comment-notice-${ commentId }` );
@@ -253,7 +253,7 @@ export class CommentList extends Component {
 		if ( 'unapproved' === comment.status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
 			this.setCommentStatus( commentId, postId, 'approved' );
-			this.updateChangedComments( {
+			this.updatePersistedComments( {
 				...comment,
 				i_like: true,
 				status: 'approved',
@@ -295,10 +295,10 @@ export class CommentList extends Component {
 		this.props.undoBulkStatus( selectedComments );
 	}
 
-	updateChangedComments = ( comment, isUndo ) => isUndo
-		? this.removeFromChangedComments( comment.ID )
-		: this.setState( { changedComments: [
-			...reject( this.state.changedComments, { ID: comment.ID } ),
+	updatePersistedComments = ( comment, isUndo ) => isUndo
+		? this.removeFromPersistedComments( comment.ID )
+		: this.setState( { persistedComments: [
+			...reject( this.state.persistedComments, { ID: comment.ID } ),
 			comment,
 		] } );
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -146,8 +146,8 @@ export class CommentList extends Component {
 		} );
 	};
 
-	setCommentStatus = ( commentId, postId, status, options = { isUndo: false, persist: false, showNotice: true } ) => {
-		const { isUndo, persist, showNotice } = options;
+	setCommentStatus = ( commentId, postId, status, options = { isUndo: false, doPersist: false, showNotice: true } ) => {
+		const { isUndo, doPersist, showNotice } = options;
 
 		// TODO: Replace with Redux getComment()
 		const comment = this.getComment( commentId );
@@ -156,7 +156,7 @@ export class CommentList extends Component {
 			return;
 		}
 
-		if ( persist ) {
+		if ( doPersist ) {
 			this.updatePersistedComments( {
 				...comment,
 				i_like: 'approved' !== status ? false : comment.i_like,
@@ -169,7 +169,7 @@ export class CommentList extends Component {
 		this.props.removeNotice( `comment-notice-${ commentId }` );
 
 		if ( showNotice ) {
-			this.showNotice( commentId, postId, status, comment.status, { persist } );
+			this.showNotice( commentId, postId, status, comment.status, { doPersist } );
 		}
 
 		this.props.changeCommentStatus( commentId, postId, status );
@@ -210,7 +210,7 @@ export class CommentList extends Component {
 		this.props.createNotice( type, message, options );
 	}
 
-	showNotice = ( commentId, postId, newStatus, previousStatus, options = { persist: false } ) => {
+	showNotice = ( commentId, postId, newStatus, previousStatus, options = { doPersist: false } ) => {
 		const { translate } = this.props;
 
 		const [ type, message ] = get( {
@@ -231,7 +231,7 @@ export class CommentList extends Component {
 			isPersistent: true,
 			onClick: () => this.setCommentStatus( commentId, postId, previousStatus, {
 				isUndo: true,
-				persist: options.persist,
+				doPersist: options.doPersist,
 				showNotice: false,
 			} ),
 		};

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -56,6 +56,7 @@ export class CommentList extends Component {
 	state = {
 		isBulkEdit: false,
 		persistedComments: [],
+		// TODO: replace {} with [] after persistedComments is merged
 		selectedComments: {},
 	};
 
@@ -79,6 +80,7 @@ export class CommentList extends Component {
 		this.props.deleteComment( commentId, postId );
 	}
 
+	// TODO: remove after persistedComments is merged
 	getComment = commentId => find( this.getComments(), [ 'ID', commentId ] );
 
 	getComments = () => uniq( [ ...this.state.persistedComments, ...this.props.comments ] ).sort( ( a, b ) => b - a );
@@ -99,6 +101,7 @@ export class CommentList extends Component {
 
 	isCommentPersisted = commentId => -1 !== this.state.persistedComments.indexOf( commentId );
 
+	// TODO: replace with array logic after persistedComments is merged
 	isCommentSelected = commentId => !! this.state.selectedComments[ commentId ];
 
 	isSelectedAll = () => this.getComments().length === size( this.state.selectedComments );
@@ -131,6 +134,7 @@ export class CommentList extends Component {
 		this.props.replyComment( commentText, postId, parentCommentId );
 	}
 
+	// TODO: rewrite after persistedComments is merged
 	setBulkStatus = status => () => {
 		this.props.removeNotice( 'comment-notice-bulk' );
 
@@ -168,6 +172,7 @@ export class CommentList extends Component {
 		}
 	}
 
+	// TODO: rewrite after persistedComments is merged
 	showBulkNotice = ( newStatus, selectedComments ) => {
 		const { translate } = this.props;
 
@@ -267,6 +272,7 @@ export class CommentList extends Component {
 		} );
 	}
 
+	// TODO: rewrite after persistedComments is merged
 	toggleSelectAll = () => {
 		this.setState( {
 			selectedComments: this.isSelectedAll()
@@ -275,6 +281,7 @@ export class CommentList extends Component {
 		} );
 	}
 
+	// TODO: rewrite after persistedComments is merged
 	undoBulkStatus = selectedComments => {
 		this.props.removeNotice( 'comment-notice-bulk' );
 		this.props.undoBulkStatus( selectedComments );

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -210,7 +210,12 @@ export class CommentList extends Component {
 
 	showNotice = ( comment, newStatus, options = { doPersist: false } ) => {
 		const { translate } = this.props;
-		const { commentId, status: previousStatus } = comment;
+		const {
+			commentId,
+			isLiked: previousIsLiked,
+			postId,
+			status: previousStatus,
+		} = comment;
 
 		const [ type, message ] = get( {
 			approved: [ 'is-success', translate( 'Comment approved.' ) ],
@@ -228,11 +233,16 @@ export class CommentList extends Component {
 			duration: 5000,
 			id: `comment-notice-${ commentId }`,
 			isPersistent: true,
-			onClick: () => this.setCommentStatus( comment, previousStatus, {
-				isUndo: true,
-				doPersist: options.doPersist,
-				showNotice: false,
-			} ),
+			onClick: () => {
+				this.setCommentStatus( comment, previousStatus, {
+					isUndo: true,
+					doPersist: options.doPersist,
+					showNotice: false,
+				} );
+				if ( previousIsLiked ) {
+					this.props.likeComment( commentId, postId );
+				}
+			},
 		};
 
 		this.props.createNotice( type, message, noticeOptions );
@@ -257,6 +267,7 @@ export class CommentList extends Component {
 		}
 	}
 
+	// TODO: rewrite after persistedComments is merged
 	toggleCommentSelected = commentId => {
 		// TODO: Replace with Redux getComment()
 		const { i_like, status } = this.getComment( commentId );

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -245,11 +245,6 @@ export class CommentList extends Component {
 
 		if ( isLiked ) {
 			this.props.unlikeComment( commentId, postId );
-
-			if ( this.isCommentPersisted( commentId ) ) {
-				this.updatePersistedComments( commentId );
-			}
-
 			return;
 		}
 
@@ -258,8 +253,8 @@ export class CommentList extends Component {
 		if ( 'unapproved' === status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
 			this.setCommentStatus( comment, 'approved' );
+			this.updatePersistedComments( commentId );
 		}
-		this.updatePersistedComments( commentId );
 	}
 
 	toggleCommentSelected = commentId => {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -105,9 +105,9 @@ export class CommentList extends Component {
 
 	isSelectedAll = () => this.getComments().length === size( this.state.selectedComments );
 
-	removeFromPersistedComments = commentId => this.setState( {
-		persistedComments: reject( this.state.persistedComments, { ID: commentId } ),
-	} );
+	removeFromPersistedComments = commentId => this.setState( ( { persistedComments } ) => ( {
+		persistedComments: reject( persistedComments, { ID: commentId } ),
+	} ) );
 
 	replyComment = ( commentText, postId, parentCommentId, options = { alsoApprove: false } ) => {
 		const { translate } = this.props;
@@ -305,10 +305,10 @@ export class CommentList extends Component {
 
 	updatePersistedComments = ( comment, isUndo ) => isUndo
 		? this.removeFromPersistedComments( comment.ID )
-		: this.setState( { persistedComments: [
-			...reject( this.state.persistedComments, { ID: comment.ID } ),
+		: this.setState( ( { persistedComments } ) => ( { persistedComments: [
+			...reject( persistedComments, { ID: comment.ID } ),
 			comment,
-		] } );
+		] } ) );
 
 	render() {
 		const {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -106,9 +106,11 @@ export class CommentList extends Component {
 
 	isSelectedAll = () => this.getComments().length === size( this.state.selectedComments );
 
-	removeFromPersistedComments = commentId => this.setState( ( { persistedComments } ) => ( {
-		persistedComments: persistedComments.filter( c => c !== commentId ),
-	} ) );
+	removeFromPersistedComments = commentId => this.setState(
+		( { persistedComments } ) => ( {
+			persistedComments: persistedComments.filter( c => c !== commentId ),
+		} )
+	);
 
 	replyComment = ( commentText, parentComment ) => {
 		const { translate } = this.props;
@@ -302,9 +304,11 @@ export class CommentList extends Component {
 		if ( isUndo ) {
 			this.removeFromPersistedComments( commentId );
 		} else if ( ! this.isCommentPersisted( commentId ) ) {
-			this.setState( ( { persistedComments } ) => ( {
-				persistedComments: persistedComments.concat( commentId ),
-			} ) );
+			this.setState(
+				( { persistedComments } ) => ( {
+					persistedComments: persistedComments.concat( commentId ),
+				} )
+			);
 		}
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -244,21 +244,34 @@ export class CommentList extends Component {
 	toggleCommentLike = ( commentId, postId ) => {
 		// TODO: Replace with Redux getComment()
 		const comment = this.getComment( commentId );
-
-		if ( 'unapproved' === comment.status ) {
-			this.props.removeNotice( `comment-notice-${ commentId }` );
-			this.setCommentStatus( commentId, postId, 'approved' );
-			this.updatePersistedComments( {
-				...comment,
-				i_like: true,
-				status: 'approved',
-			} );
-		}
+		const isPersisted = !! find( this.state.persistedComments, [ 'ID', commentId ] );
 
 		if ( comment.i_like ) {
 			this.props.unlikeComment( commentId, postId );
+
+			if ( isPersisted ) {
+				this.updatePersistedComments( {
+					...comment,
+					i_like: false,
+				} );
+			}
 		} else {
 			this.props.likeComment( commentId, postId );
+
+			if ( 'unapproved' === comment.status ) {
+				this.props.removeNotice( `comment-notice-${ commentId }` );
+				this.setCommentStatus( commentId, postId, 'approved' );
+				this.updatePersistedComments( {
+					...comment,
+					i_like: true,
+					status: 'approved',
+				} );
+			} else if ( isPersisted ) {
+				this.updatePersistedComments( {
+					...comment,
+					i_like: true,
+				} );
+			}
 		}
 	}
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -157,7 +157,11 @@ export class CommentList extends Component {
 		}
 
 		if ( persist ) {
-			this.updateChangedComments( comment, status, isUndo );
+			this.updateChangedComments( {
+				...comment,
+				i_like: 'approved' !== status ? false : comment.i_like,
+				status,
+			}, isUndo );
 		} else {
 			this.removeFromChangedComments( commentId );
 		}
@@ -244,11 +248,16 @@ export class CommentList extends Component {
 
 	toggleCommentLike = ( commentId, postId ) => {
 		// TODO: Replace with Redux getComment()
-		const comment = find( this.props.comments, [ 'ID', commentId ] );
+		const comment = this.getComment( commentId );
 
 		if ( 'unapproved' === comment.status ) {
 			this.props.removeNotice( `comment-notice-${ commentId }` );
-			this.setCommentStatus( commentId, postId, 'approved', { persist: true, showNotice: true } );
+			this.setCommentStatus( commentId, postId, 'approved' );
+			this.updateChangedComments( {
+				...comment,
+				i_like: true,
+				status: 'approved',
+			} );
 		}
 
 		if ( comment.i_like ) {
@@ -286,11 +295,11 @@ export class CommentList extends Component {
 		this.props.undoBulkStatus( selectedComments );
 	}
 
-	updateChangedComments = ( comment, status, isUndo ) => isUndo
+	updateChangedComments = ( comment, isUndo ) => isUndo
 		? this.removeFromChangedComments( comment.ID )
 		: this.setState( { changedComments: [
 			...reject( this.state.changedComments, { ID: comment.ID } ),
-			{ ...comment, status },
+			comment,
 		] } );
 
 	render() {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -110,8 +110,13 @@ export class CommentList extends Component {
 		persistedComments: persistedComments.filter( c => c !== commentId ),
 	} ) );
 
-	replyComment = ( commentText, postId, parentCommentId, options = { alsoApprove: false } ) => {
+	replyComment = ( commentText, comment, options = { alsoApprove: false } ) => {
 		const { translate } = this.props;
+		const {
+			commentId: parentCommentId,
+			postId,
+			status,
+		} = comment;
 		const { alsoApprove } = options;
 
 		this.props.removeNotice( `comment-notice-${ parentCommentId }` );
@@ -126,8 +131,8 @@ export class CommentList extends Component {
 			isPersistent: true,
 		};
 
-		if ( alsoApprove ) {
-			this.setCommentStatus( parentCommentId, postId, 'approved', { showNotice: false } );
+		if ( 'approved' !== status ) {
+			this.setCommentStatus( comment, 'approved', { doPersist: true, showNotice: false } );
 		}
 
 		this.props.createNotice( 'is-success', noticeMessage, noticeOptions );


### PR DESCRIPTION
Introduce a `persistedComments` list that keeps track of all the comments toggling between `approved` and `unapproved` statuses (including if the toggle happens as a side-effect of `like` or `reply`).
Persisted comments are left in their original list until navigating to a different tab.

![jul-20-2017 18-54-57](https://user-images.githubusercontent.com/2070010/28431675-0e3bc7c0-6d7d-11e7-8c14-a4a0c09ee556.gif)

cc @Automattic/lannister 