### PR TITLE
Extensions: WPJM - Add new setting / small UI tweaks

### DIFF
--- a/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
@@ -121,7 +121,7 @@ class JobListings extends Component {
 									text={ translate( 'Enable listing categories' ) } />
 								<FormSettingExplanation isIndented>
 									{ translate( 'This lets users select from a list of categories when submitting a ' +
-										'job. Note!: an admin has to create categories before site users can select them.' ) }
+										'job. Note: an admin has to create categories before site users can select them.' ) }
 								</FormSettingExplanation>
 
 								<ReduxFormToggle
@@ -182,7 +182,7 @@ class JobListings extends Component {
 									text={ translate( 'Enable listing types' ) } />
 								<FormSettingExplanation isIndented>
 									{ translate( 'This lets users select from a list of types when submitting a job. ' +
-										'Note!: an admin has to create types before site users can select them.' ) }
+										'Note: an admin has to create types before site users can select them.' ) }
 								</FormSettingExplanation>
 
 								<ReduxFormToggle

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -38,6 +38,7 @@ class JobSubmission extends Component {
 	render() {
 		const {
 			enableRegistration,
+			generateUsername,
 			handleSubmit,
 			isFetching,
 			submissionDuration,
@@ -87,7 +88,7 @@ class JobSubmission extends Component {
 										</FormSettingExplanation>
 
 										<ReduxFormToggle
-											disabled={ isDisabled }
+											disabled={ isDisabled || generateUsername }
 											name="emailPassword"
 											text="Email new users a link to set a password" />
 										<FormSettingExplanation isIndented>
@@ -250,6 +251,7 @@ const selector = formValueSelector( form );
 const connectComponent = connect(
 	state => ( {
 		enableRegistration: selector( state, 'account.enableRegistration' ),
+		generateUsername: selector( state, 'account.generateUsername' ),
 		submissionDuration: selector( state, 'duration.submissionDuration' ),
 	} )
 );

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { FormSection, formValueSelector, reduxForm } from 'redux-form';
+import { change, FormSection, formValueSelector, reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 
@@ -25,13 +25,29 @@ const form = 'extensions.wpJobManager.submission';
 
 class JobSubmission extends Component {
 	static propTypes = {
+		change: PropTypes.func,
 		enableRegistration: PropTypes.bool,
+		generateUsername: PropTypes.bool,
 		handleSubmit: PropTypes.func,
 		isFetching: PropTypes.bool,
 		onSubmit: PropTypes.func,
 		submitting: PropTypes.bool,
 		translate: PropTypes.func,
 	};
+
+	componentWillReceiveProps( nextProps ) {
+		const { generateUsername } = nextProps;
+
+		if ( generateUsername === this.props.generateUsername ) {
+			return;
+		}
+
+		if ( ! generateUsername ) {
+			return;
+		}
+
+		this.props.change( 'account.sendPassword', generateUsername );
+	}
 
 	save = section => data => this.props.onSubmit( form, data[ section ] );
 
@@ -89,7 +105,7 @@ class JobSubmission extends Component {
 
 										<ReduxFormToggle
 											disabled={ isDisabled || generateUsername }
-											name="emailPassword"
+											name="sendPassword"
 											text="Email new users a link to set a password" />
 										<FormSettingExplanation isIndented>
 											{ translate( 'Sends an email to the user with their username and a link to set ' +
@@ -253,7 +269,8 @@ const connectComponent = connect(
 		enableRegistration: selector( state, 'account.enableRegistration' ),
 		generateUsername: selector( state, 'account.generateUsername' ),
 		submissionDuration: selector( state, 'duration.submissionDuration' ),
-	} )
+	} ),
+	{ change }
 );
 
 const createReduxForm = reduxForm( {

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -68,15 +68,6 @@ class JobSubmission extends Component {
 
 								<ReduxFormToggle
 									disabled={ isDisabled }
-									name="generateUsername"
-									text="Generate usernames from email addresses" />
-								<FormSettingExplanation isIndented>
-									{ translate( 'Automatically generates usernames for new accounts from the registrant\'s ' +
-										'email address. If this is not enabled, a "username" field will display instead.' ) }
-								</FormSettingExplanation>
-
-								<ReduxFormToggle
-									disabled={ isDisabled }
 									name="enableRegistration"
 									text={ translate( 'Enable account creation during submission' ) } />
 								<FormSettingExplanation isIndented>
@@ -84,15 +75,28 @@ class JobSubmission extends Component {
 										'non-registered users to create an account and submit a job listing simultaneously.' ) }
 								</FormSettingExplanation>
 
-								<ReduxFormToggle
-										disabled={ isDisabled }
-										name="emailPassword"
-										text="Email new users a link to set a password" />
-									<FormSettingExplanation isIndented>
-										{ translate( 'Sends an email to the user with their username and a link to set ' +
-											'their password. If this is not enabled, a "password" field will display instead, ' +
-											'and their email address won\'t be verified.' ) }
-									</FormSettingExplanation>
+								{ enableRegistration &&
+									<div>
+										<ReduxFormToggle
+											disabled={ isDisabled }
+											name="generateUsername"
+											text="Generate usernames from email addresses" />
+										<FormSettingExplanation isIndented>
+											{ translate( 'Automatically generates usernames for new accounts from the registrant\'s ' +
+												'email address. If this is not enabled, a "username" field will display instead.' ) }
+										</FormSettingExplanation>
+
+										<ReduxFormToggle
+											disabled={ isDisabled }
+											name="emailPassword"
+											text="Email new users a link to set a password" />
+										<FormSettingExplanation isIndented>
+											{ translate( 'Sends an email to the user with their username and a link to set ' +
+												'their password. If this is not enabled, a "password" field will display instead, ' +
+												'and their email address won\'t be verified.' ) }
+										</FormSettingExplanation>
+									</div>
+								}
 							</FormFieldset>
 
 							{ enableRegistration &&

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -83,6 +83,16 @@ class JobSubmission extends Component {
 									{ translate( 'Includes account creation on the listing submission form, to allow ' +
 										'non-registered users to create an account and submit a job listing simultaneously.' ) }
 								</FormSettingExplanation>
+
+								<ReduxFormToggle
+										disabled={ isDisabled }
+										name="emailPassword"
+										text="Email new users a link to set a password" />
+									<FormSettingExplanation isIndented>
+										{ translate( 'Sends an email to the user with their username and a link to set ' +
+											'their password. If this is not enabled, a "password" field will display instead, ' +
+											'and their email address won\'t be verified.' ) }
+									</FormSettingExplanation>
 							</FormFieldset>
 
 							{ enableRegistration &&

--- a/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
@@ -74,6 +74,7 @@ describe( '#updateExtensionSettings', () => {
 				generateUsername: undefined,
 				isAccountRequired: undefined,
 				role: undefined,
+				sendPassword: undefined,
 			},
 			apiKey: { googleMapsApiKey: undefined },
 			approval: {

--- a/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/utils.js
@@ -19,6 +19,7 @@ export const fromApi = ( {
 	job_manager_submission_duration,
 	job_manager_submission_requires_approval,
 	job_manager_submit_job_form_page_id,
+	job_manager_use_standard_password_setup_email,
 	job_manager_user_can_edit_pending_submissions,
 	job_manager_user_requires_account,
 } ) => ( {
@@ -27,6 +28,7 @@ export const fromApi = ( {
 		generateUsername: job_manager_generate_username_from_email,
 		isAccountRequired: job_manager_user_requires_account,
 		role: job_manager_registration_role,
+		sendPassword: job_manager_use_standard_password_setup_email,
 	},
 	apiKey: {
 		googleMapsApiKey: job_manager_google_maps_api_key,
@@ -87,6 +89,7 @@ export const toApi = ( {
 	multiJobType,
 	perPage,
 	role,
+	sendPassword,
 	submissionDuration,
 	submitFormPage,
 } ) => ( {
@@ -110,6 +113,7 @@ export const toApi = ( {
 	job_manager_submission_duration: submissionDuration,
 	job_manager_submission_requires_approval: isApprovalRequired,
 	job_manager_submit_job_form_page_id: submitFormPage,
+	job_manager_use_standard_password_setup_email: sendPassword,
 	job_manager_user_can_edit_pending_submissions: canEdit,
 	job_manager_user_requires_account: isAccountRequired,
 } );


### PR DESCRIPTION
This PR adds a new _Email new users a link to set a password_ setting that is disabled if _Generate usernames from email addresses_ is toggled on.

As well, the _Enable account creation during submission_ setting now controls the visibility of _Generate usernames from email addresses_, _Email new users a link to set a password_ and _Role_. When toggled off, these settings are hidden. As such, the _Enable account creation during submission_ setting was moved up in the UI.

![wpjm-settings](https://user-images.githubusercontent.com/1190420/28430164-7e544bd4-6d4d-11e7-95b2-da6dd6240013.jpg)

## Testing

The following things should be tested:

- The _Email new users a link to set a password_ setting appears and is set appropriately.
- _Email new users a link to set a password_ is disabled when _Generate usernames from email addresses_ is selected.
- Unselecting _Enable account creation during submission_ causes _Generate usernames from email addresses_, _Email new users a link to set a password_ and _Role_ to be hidden.