### PR TITLE
Refactor the <FormLabel> component to our most recent ES6 style

### DIFF
--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -4,11 +4,13 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import { omit } from 'lodash';
+import { isObject, omit } from 'lodash';
 
 const renderRequiredBadge = ( translate ) => (
 	<small className="form-label__required">{ translate( 'Required' ) }</small>
 );
+
+const addKeys = elements => elements.map( ( elem, idx ) => isObject( elem ) ? { ...elem, key: idx } : elem );
 
 const FormLabel = ( { children, required, translate, className, ...extraProps } ) => {
 	children = React.Children.toArray( children ) || [];
@@ -18,7 +20,7 @@ const FormLabel = ( { children, required, translate, className, ...extraProps } 
 
 	return (
 		<label { ...omit( extraProps, 'moment', 'numberFormat' ) } className={ classnames( className, 'form-label' ) } >
-			{ children.length ? children : null }
+			{ children.length ? addKeys( children ) : null }
 		</label>
 	);
 };

--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -4,6 +4,7 @@
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import { omit } from 'lodash';
 
 const renderRequiredBadge = ( translate ) => (
 	<small className="form-label__required">{ translate( 'Required' ) }</small>
@@ -16,7 +17,7 @@ const FormLabel = ( { children, required, translate, className, ...extraProps } 
 	}
 
 	return (
-		<label { ...extraProps } className={ classnames( className, 'form-label' ) } >
+		<label { ...omit( extraProps, 'moment', 'numberFormat' ) } className={ classnames( className, 'form-label' ) } >
 			{ children.length ? children : null }
 		</label>
 	);

--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -1,27 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	omit = require( 'lodash/omit' ),
-	i18n = require( 'i18n-calypso' );
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import React from 'react';
 
-module.exports = React.createClass( {
+const FormLabel = ( { children, required, translate, className, ...extraProps } ) => {
+	return (
+		<label { ...extraProps } className={ classnames( className, 'form-label' ) } >
+			{ children }
+			{ required && <small className="form-label__required">{ translate( 'Required' ) }</small> }
+		</label>
+	);
+};
 
-	displayName: 'FormLabel',
+FormLabel.propTypes = {
+	required: React.PropTypes.bool,
+};
 
-	propTypes: {
-		required: React.PropTypes.bool,
-	},
-
-	render: function() {
-		return (
-			<label { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-label' ) } >
-				{ this.props.children }
-				{ this.props.required && (
-					<small className="form-label__required">{ i18n.translate( 'Required' ) }</small>
-				) }
-			</label>
-		);
-	}
-} );
+export default localize( FormLabel );

--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -6,10 +6,14 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 
 const FormLabel = ( { children, required, translate, className, ...extraProps } ) => {
+	children = React.Children.toArray( children ) || [];
+	if ( required ) {
+		children.push( <small className="form-label__required">{ translate( 'Required' ) }</small> );
+	}
+
 	return (
 		<label { ...extraProps } className={ classnames( className, 'form-label' ) } >
-			{ children }
-			{ required && <small className="form-label__required">{ translate( 'Required' ) }</small> }
+			{ children.length ? children : null }
 		</label>
 	);
 };

--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -5,10 +5,14 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 
+const renderRequiredBadge = ( translate ) => (
+	<small className="form-label__required">{ translate( 'Required' ) }</small>
+);
+
 const FormLabel = ( { children, required, translate, className, ...extraProps } ) => {
 	children = React.Children.toArray( children ) || [];
 	if ( required ) {
-		children.push( <small className="form-label__required">{ translate( 'Required' ) }</small> );
+		children.push( renderRequiredBadge( translate ) );
 	}
 
 	return (


### PR DESCRIPTION
Tracking down a bug in `woocommerce-services` I ended up refactoring the `<FormLabel>` component. I've updated it to follow our most recent standards (avoid `React.createClass`, use `import` instead of `require()`, etc).

The bug I've found is that `dangerouslySetInnerHTML` can't be used when the component has children. It spits this error:
`"Can only set one of 'children' or 'props.dangerouslySetInnerHTML'."`

Until a few months ago, the `<FormLabel>` component looked like this:

```js
render() {
  return <label { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-label' ) } >		
    { this.props.children }		
    </label>;
}
```

So when it was called like this:
```js
<FormLabel dangerouslySetInnerHTML={ { __html: 'blah <b>blah</b> blah' } } />
```
The `<label>` component ended up being called with `undefined` as its `children` prop, which is valid in the presence of `dangerouslySetInnerHTML`.

But after adding the `required` badge functionallity, the `<FormLabel>` component looked like this:
```js
render() {
  return <label { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-label' ) } >		
    { this.props.children }		
    { this.props.required && (		
      <small className="form-label__required">{ i18n.translate( 'Required' ) }</small>		
    ) }		
    </label>;
}
```

So when it was called like this:
```js
<FormLabel dangerouslySetInnerHTML={ { __html: 'blah <b>blah</b> blah' } } />
```
The `<label>` component ended up being called with `[ undefined, undefined ]` as its `children` prop, which is *not* valid in the presence of `dangerouslySetInnerHTML`.

I've tweaked the code to make sure that, if *nothing* is going to be rendered as children of the `<label>`, then the `<label>` component will have an empty (`null`) `children` prop, so it's compatible with `dangerouslySetInnerHTML`. Note that `<FormLabel required dangerouslySetInnerHTML={...} />` will fail, but in `woocommerce-services` we aren't using that.

This isn't an ideal solution more of a band-aid. Ideally we would get rid of our usages of `dangerouslySetInnerHTML`, but it's more important for us to be sure we can update our `wp-calypso` dependency (we were using a version that was months old).