### PR TITLE
Comments: Prevent the placeholder to wrap on small screens

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -533,6 +533,13 @@ a.comment-detail__author-more-element {
 	.comment-detail__comment-preview {
 		width: 100%;
 	}
+
+
+	@include breakpoint( "<960px" ) {
+		.comment-detail__header.is-preview {
+			flex-wrap: nowrap;
+		}
+	}
 }
 
 @keyframes comment-detail__author-more-info {


### PR DESCRIPTION
Fixes a small graphic glitch introduced in #16310.
Prevents the placeholder content to wrap on `<960px` screens.

| Before | After |
| --- | --- |
| <img width="437" alt="screen shot 2017-07-20 at 19 05 03" src="https://user-images.githubusercontent.com/2070010/28432394-a1149534-6d7f-11e7-88e3-64b9f03dbf10.png"> | <img width="491" alt="screen shot 2017-07-20 at 19 12 34" src="https://user-images.githubusercontent.com/2070010/28432395-a130cf92-6d7f-11e7-968b-c9d0075f85e1.png"> |

cc @Automattic/lannister 