### PR TITLE
Signup: Remove hardcoded TLDs and load them from the API

### DIFF
--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -27,6 +27,7 @@ import { shouldFetchSitePlans } from 'lib/plans';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
+import { getProductsList } from 'state/products-list/selectors';
 
 const user = userFactory();
 
@@ -117,7 +118,7 @@ export default connect(
 		return {
 			googleAppsUsers,
 			googleAppsUsersLoaded: isLoaded( state ),
-			products: state.productsList.items,
+			products: getProductsList( state ),
 			sitePlans: getPlansBySite( state, selectedSite ),
 			selectedSite,
 		};

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -11,7 +11,7 @@ import { isProductsListFetching as isFetching } from 'state/products-list/select
 import { requestProductsList } from 'state/products-list/actions';
 
 class QueryProductsList extends Component {
-	componentWillMount() {
+	componentDidMount() {
 		if ( ! this.props.isFetching ) {
 			this.props.requestProductsList();
 		}

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -11,7 +11,7 @@ import { isProductsListFetching as isFetching } from 'state/products-list/select
 import { requestProductsList } from 'state/products-list/actions';
 
 class QueryProductsList extends Component {
-	componentDidMount() {
+	componentWillMount() {
 		if ( ! this.props.isFetching ) {
 			this.props.requestProductsList();
 		}

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -17,41 +17,6 @@ const registrar = {
 	MAINTENANCE: 'Registrar TLD Maintenance'
 };
 
-const tlds = {
-	com: 'domain_reg',
-	net: 'domain_reg',
-	org: 'domain_reg',
-	me: 'dotme_domain',
-	ca: 'dotca_domain',
-	co: 'dotco_domain',
-	'com.br': 'dotcomdotbr_domain',
-	info: 'dotinfo_domain',
-	'net.br': 'dotnetdotbr_domain',
-	biz: 'dotbiz_domain',
-	mobi: 'dotmobi_domain',
-	mx: 'dotmx_domain',
-	es: 'dotes_domain',
-	nl: 'dotnl_domain',
-	be: 'dotbe_domain',
-	fm: 'dotfm_domain',
-	tv: 'dottv_domain',
-	us: 'dotus_domain',
-	'in': 'dotin_domain',
-	wtf: 'dotwtf_domain',
-	coffee: 'dotcoffee_domain',
-	live: 'dotlive_domain',
-	wales: 'dotwales_domain',
-	blog: 'dotblog_domain',
-	rocks: 'dotrocks_domain',
-	site: 'dotsite_domain',
-	cloud: 'dotcloud_domain',
-	club: 'dotclub_domain',
-	today: 'dottoday_domain',
-	vip: 'dotvip_domain',
-	xyz: 'dotxyz_domain',
-	shop: 'dotshop_domain',
-};
-
 const domainAvailability = {
 	AVAILABLE: 'available',
 	MAPPABLE: 'mappable',
@@ -89,6 +54,5 @@ export default {
 	dnsTemplates,
 	domainAvailability,
 	registrar,
-	tlds,
 	type,
 };

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -22,6 +22,7 @@ import { currentUserHasFlag } from 'state/current-user/selectors';
 import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
+import { getProductsList } from 'state/products-list/selectors';
 import { recordAddDomainButtonClick, recordRemoveDomainButtonClick } from 'state/domains/actions';
 
 class DomainSearch extends Component {
@@ -154,7 +155,7 @@ export default connect(
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
-		productsList: state.productsList.items,
+		productsList: getProductsList( state )
 	} ),
 	{
 		recordAddDomainButtonClick,

--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -15,6 +15,7 @@ import SiteRedirectStep from './site-redirect-step';
 import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
+import { getProductsList } from 'state/products-list/selectors';
 
 class SiteRedirect extends Component {
 	static propTypes = {
@@ -77,6 +78,6 @@ export default connect(
 		selectedSiteId: getSelectedSiteId( state ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
-		productsList: state.productsList.items,
+		productsList: getProductsList( state ),
 	} )
 )( localize( SiteRedirect ) );

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -21,6 +21,7 @@ import { currentUserHasFlag } from 'state/current-user/selectors';
 import { isSiteUpgradeable } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
+import { getProductsList } from 'state/products-list/selectors';
 
 const wpcom = wp.undocumented();
 
@@ -156,6 +157,6 @@ export default connect(
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
-		productsList: state.productsList.items,
+		productsList: getProductsList( state ),
 	} )
 )( localize( MapDomain ) );

--- a/client/signup/steps/site-or-domain/choice.jsx
+++ b/client/signup/steps/site-or-domain/choice.jsx
@@ -17,7 +17,14 @@ export default class SiteOrDomainChoice extends Component {
 	};
 
 	render() {
-		const { choice } = this.props;
+		const { choice, isPlaceholder } = this.props;
+
+		if ( isPlaceholder ) {
+			return (
+				<div className="site-or-domain__choice is-placeholder" key={ choice.type }></div>
+			);
+		}
+
 		return (
 			<div className="site-or-domain__choice" key={ choice.type }>
 				<a className="site-or-domain__choice-link" onClick={ this.handleClickChoice }>

--- a/client/signup/steps/site-or-domain/choice.jsx
+++ b/client/signup/steps/site-or-domain/choice.jsx
@@ -21,7 +21,15 @@ export default class SiteOrDomainChoice extends Component {
 
 		if ( isPlaceholder ) {
 			return (
-				<div className="site-or-domain__choice is-placeholder" key={ choice.type }></div>
+				<div className="site-or-domain__choice" key={ choice.type }>
+					<Card compact className="site-or-domain__choice-image site-or-domain__is-placeholder" />
+					<Card compact className="site-or-domain__choice-text">
+						<div className="site-or-domain__choice-button">
+							<Button className="site-or-domain__is-placeholder" />
+						</div>
+						<p className="site-or-domain__is-placeholder" />
+					</Card>
+				</div>
 			);
 		}
 

--- a/client/signup/steps/site-or-domain/choice.jsx
+++ b/client/signup/steps/site-or-domain/choice.jsx
@@ -21,7 +21,7 @@ export default class SiteOrDomainChoice extends Component {
 
 		if ( isPlaceholder ) {
 			return (
-				<div className="site-or-domain__choice" key={ choice.type }>
+				<div className="site-or-domain__choice site-or-domain__choice-is-placeholder" key={ choice.type }>
 					<Card compact className="site-or-domain__choice-image site-or-domain__is-placeholder" />
 					<Card compact className="site-or-domain__choice-text">
 						<div className="site-or-domain__choice-button">

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -21,20 +21,17 @@ import ExistingSite from 'signup/steps/design-type-with-store/existing-site';
 import NavigationLink from 'signup/navigation-link';
 import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
+import { getTld } from 'lib/domains';
 
 class SiteOrDomain extends Component {
 	getDomainProductSlug( domain ) {
-		const domainParts = domain.split( '.' );
-		const tld = domainParts.slice( 1 ).join( '.' );
+		const tld = getTld( domain );
 
-		let productSlug = null;
 		if ( includes( [ 'com', 'net', 'org' ], tld ) ) {
-			productSlug = 'domain_reg';
-		} else {
-			productSlug = `dot${ tld }_domain`;
+			return 'domain_reg';
 		}
 
-		return productSlug;
+		return `dot${ tld }_domain`;
 	}
 
 	getDomainName() {
@@ -94,15 +91,13 @@ class SiteOrDomain extends Component {
 	}
 
 	renderChoices() {
-		const productsLoaded = ! isEmpty( this.props.productsList );
-
 		return (
 			<div className="site-or-domain__choices">
 				{ this.getChoices().map( ( choice, index ) => (
 					<SiteOrDomainChoice
 						choice={ choice }
 						handleClickChoice={ this.handleClickChoice }
-						isPlaceholder={ ! productsLoaded }
+						isPlaceholder={ ! this.props.productsLoaded }
 						key={ `site-or-domain-choice-${ index }` }
 					/>
 				) ) }
@@ -128,11 +123,9 @@ class SiteOrDomain extends Component {
 	}
 
 	renderScreen() {
-		const productsLoaded = ! isEmpty( this.props.productsList );
-
 		return (
 			<div>
-				{ ! productsLoaded && <QueryProductsList /> }
+				{ ! this.props.productsLoaded && <QueryProductsList /> }
 				{ this.renderChoices() }
 				{ this.renderBackLink() }
 			</div>
@@ -182,13 +175,12 @@ class SiteOrDomain extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
-		const productsLoaded = ! isEmpty( this.props.productsList );
+		const { translate, productsLoaded } = this.props;
 
 		if ( productsLoaded && ! this.getDomainName() ) {
 			const headerText = translate( 'Unsupported domain.' );
 			const subHeaderText = translate(
-				'Please visit {{a}}wordpress.com/domains{{/a}} to search for another domain.',
+				'Please visit {{a}}wordpress.com/domains{{/a}} to search for a domain.',
 				{
 					components: {
 						a: <a href={ 'https://wordpress.com/domains' } />
@@ -226,9 +218,13 @@ class SiteOrDomain extends Component {
 
 export default connect(
 	( state ) => {
+		const productsList = getProductsList( state );
+		const productsLoaded = ! isEmpty( productsList );
+
 		return {
 			isLoggedIn: !! getCurrentUserId( state ),
-			productsList: getProductsList( state )
+			productsList,
+			productsLoaded,
 		};
 	}
 )( localize( SiteOrDomain ) );

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -49,10 +49,6 @@
 
 .site-or-domain__choice-text {
 	color: $gray-dark;
-
-	p {
-		min-height: 105px;
-	}
 }
 
 @include breakpoint( ">480px" ) {

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -25,16 +25,6 @@
 		border-top: solid 1px $gray-light;
 		padding: 10px 15px;
 	}
-
-	&.is-placeholder {
-		cursor: default;
-		@include placeholder(23%);
-		height: 140px;
-
-		@include breakpoint( '>480px' ) {
-			height: 375px;
-		}
-	}
 }
 
 .site-or-domain__button {
@@ -46,6 +36,10 @@
 
 	.button {
 		text-transform: uppercase;
+
+		&.site-or-domain__is-placeholder {
+			width: 90%;
+		}
 	}
 }
 
@@ -55,6 +49,10 @@
 
 .site-or-domain__choice-text {
 	color: $gray-dark;
+
+	p {
+		min-height: 105px;
+	}
 }
 
 @include breakpoint( ">480px" ) {
@@ -78,4 +76,8 @@
 		display: flex;
 		flex-direction: column-reverse;
 	}
+}
+
+.site-or-domain__is-placeholder {
+	@include placeholder(23%);
 }

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -27,6 +27,7 @@
 	}
 
 	&.is-placeholder {
+		cursor: default;
 		@include placeholder(23%);
 		height: 140px;
 

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -25,6 +25,15 @@
 		border-top: solid 1px $gray-light;
 		padding: 10px 15px;
 	}
+
+	&.is-placeholder {
+		@include placeholder(23%);
+		height: 140px;
+
+		@include breakpoint( '>480px' ) {
+			height: 375px;
+		}
+	}
 }
 
 .site-or-domain__button {

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -27,6 +27,10 @@
 	}
 }
 
+.site-or-domain__choice-is-placeholder {
+	cursor: default;
+}
+
 .site-or-domain__button {
 	text-align: center;
 }

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -2,6 +2,10 @@ export function isProductsListFetching( state ) {
 	return state.productsList.isFetching;
 }
 
+export function getProductsList( state ) {
+	return state.productsList.items;
+}
+
 /**
  * Returns the display price of a product
  *


### PR DESCRIPTION
- Remove hardcoded TLDs, as we have to maintain them whenever
we add a new TLD, while we already have the list on the backend
- Add a placeholder state while the product list is loading
- Create product list selector
- Refactor to use product list selector
- Instead of redirect, show a message when a TLD is not supported

Test:
- Visit http://calypso.localhost:3000/start/domain-first?new=testing-something-good-ol.li1ve
- See:
![unsupported domain](https://user-images.githubusercontent.com/1103398/28436160-3a061068-6d96-11e7-8263-7d1a25b44842.png)

---------

- Visit http://calypso.localhost:3000/start/domain-first?new=testing-something-good-ol.live
- See:
![loading placeholders](https://user-images.githubusercontent.com/1103398/28622111-a37e2180-7213-11e7-95ff-d6063ff4d275.png)

- And after products being loaded:
![original](https://user-images.githubusercontent.com/1103398/28436202-5ab8acbc-6d96-11e7-9ec7-c51f6db1a640.png)

---------

- Go through the flow and make sure everything is still working.