### PR TITLE
Simple Payments: Add product image

### DIFF
--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -31,6 +31,7 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `imageEditorProps`: (default: allowedAspectRatios set to 1X1) object of additional props to send to `ImageEditor`
 	component.
 - `onImageEditorDone`: (default: `noop`) function to call when user clicks on the "Done" button in `ImageEditor`.
+- `onError`: (default: `noop`) function to call when there's any error during file uploading/image editing.
 - `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
 - `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
 - `doneButtonText`: text on the "Done" button in Image Editor modal.

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -40,6 +40,7 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `addAnImageText`: text on the placeholder when selecting an image.
 - `dragUploadText`: text which shows when dragging an image to upload.
 
-There's also a way to design and supply your own HTML for the placeholder (when no image is selected) by supplying the
+There's a way to design and supply your own HTML for the placeholder (when no image is selected) by supplying the
 `placeholderContent` prop and for the uploading process (when image is being uploaded) by supplying the
-`uploadingContent` prop.
+`uploadingContent` prop. You can also supply your own HTML for when image is uploaded to Media library by passing the
+`uploadingDoneContent` prop.

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -6,10 +6,10 @@ Upload Image
 - in file explorer, select an image to upload
 - image is moved to `ImageEditor` where user can edit the image before uploading
 - after clicking on "Done", `UploadImage` calls the `onImageEditorDone` handler where you can perform any operation
- (such as actual uploading of the image).
- 
-The initial idea to create the block comes from the `edit-gravatar` one -- it's very similar but reusable and extensible.
+- after clicking on "Done", image is automatically uploaded to the supplied `siteId` Media library
+- after the upload is complete, `onUploadImageDone` is called with the uploaded image props (such as URL, ID, etc)
 
+If there's any error during the above flow, the error with its error code will be passed to the `onError` function.
 
 #### Basic usage:
 
@@ -18,7 +18,10 @@ import UploadImage from 'blocks/upload-image';
 
 render: function() {
 	return
-		<UploadImage onImageEditorDone={ ( imageBlob ) => console.log( URL.createObjectURL( imageBlob ) ) } />;
+		<UploadImage 
+			siteId={ <your-site-id> or currently selected siteId if not specified }
+			onUploadImageDone={ ( uploadedImage ) => console.log( uploadedImage.ID ) }
+		/>;
 }
 ```
 
@@ -26,20 +29,17 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 
 #### Props
 
-- `isUploading`: (default: false) whether to display a spinner over selected-n-edited image (use only after user 
-	selects an image in `onImageEditorDone`).
 - `imageEditorProps`: (default: allowedAspectRatios set to 1X1) object of additional props to send to `ImageEditor`
 	component.
 - `onImageEditorDone`: (default: `noop`) function to call when user clicks on the "Done" button in `ImageEditor`.
 - `onError`: (default: `noop`) function to call when there's any error during file uploading/image editing.
+- `onUploadImageDone`: (default: `noop`) function to call when the image is uploaded to specified `siteId` Media library.
 - `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
 - `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
 - `doneButtonText`: text on the "Done" button in Image Editor modal.
 - `addAnImageText`: text on the placeholder when selecting an image.
 - `dragUploadText`: text which shows when dragging an image to upload.
 
-## Additional notes
-
-This component could be made better (.e.g add error handling). If you need anything more of it, feel free to extend it
-as needed. It's main use is in the Simple Payments project ("Add Payment Button" in Editor) and it was built to
-accommodate its needs.
+There's also a way to design and supply your own HTML for the placeholder (when no image is selected) by supplying the
+`placeholderContent` prop and for the uploading process (when image is being uploaded) by supplying the
+`uploadingContent` prop.

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -35,7 +35,7 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
 - `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
 - `doneButtonText`: text on the "Done" button in Image Editor modal.
-- `addAnImage`: text on the placeholder when selecting an image.
+- `addAnImageText`: text on the placeholder when selecting an image.
 - `dragUploadText`: text which shows when dragging an image to upload.
 
 ## Additional notes

--- a/client/blocks/upload-image/constants.js
+++ b/client/blocks/upload-image/constants.js
@@ -1,1 +1,15 @@
-export const ALLOWED_FILE_EXTENSIONS = [ 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico' ];
+/**
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+
+export const ALLOWED_FILE_EXTENSIONS = [ 'jpg', 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico' ];
+
+export const ERROR_UNSUPPORTED_FILE = 'ERROR_UNSUPPORTED_FILE';
+
+export const ERROR_STRINGS = {
+	[ ERROR_UNSUPPORTED_FILE ]: () =>
+		i18n.translate(
+			'File you are trying to upload is not supported. Please select a valid image file.',
+		),
+};

--- a/client/blocks/upload-image/constants.js
+++ b/client/blocks/upload-image/constants.js
@@ -1,25 +1,5 @@
-/**
- * External dependencies
- */
-import i18n from 'i18n-calypso';
-
-/**
- * Internal dependencies
- */
-import { ValidationErrors } from 'lib/media/constants';
-
 export const ALLOWED_FILE_EXTENSIONS = [ 'jpg', 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico' ];
 
 export const ERROR_UNSUPPORTED_FILE = 'ERROR_UNSUPPORTED_FILE';
 export const ERROR_IMAGE_EDITOR_DONE = 'ERROR_IMAGE_EDITOR_DONE';
 export const ERROR_UPLOADING_IMAGE = 'ERROR_UPLOADING_IMAGE';
-
-export const ERROR_STRINGS = {
-	[ ERROR_UNSUPPORTED_FILE ]: () =>
-		i18n.translate(
-			'File you are trying to upload is not supported. Please select a valid image file.',
-		),
-
-	[ ValidationErrors.SERVER_ERROR ]: () =>
-		i18n.translate( 'File could not be uploaded because an error occurred while uploading.' ),
-};

--- a/client/blocks/upload-image/constants.js
+++ b/client/blocks/upload-image/constants.js
@@ -3,6 +3,11 @@
  */
 import i18n from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import { ValidationErrors } from 'lib/media/constants';
+
 export const ALLOWED_FILE_EXTENSIONS = [ 'jpg', 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico' ];
 
 export const ERROR_UNSUPPORTED_FILE = 'ERROR_UNSUPPORTED_FILE';
@@ -14,4 +19,7 @@ export const ERROR_STRINGS = {
 		i18n.translate(
 			'File you are trying to upload is not supported. Please select a valid image file.',
 		),
+
+	[ ValidationErrors.SERVER_ERROR ]: () =>
+		i18n.translate( 'File could not be uploaded because an error occurred while uploading.' ),
 };

--- a/client/blocks/upload-image/constants.js
+++ b/client/blocks/upload-image/constants.js
@@ -6,6 +6,8 @@ import i18n from 'i18n-calypso';
 export const ALLOWED_FILE_EXTENSIONS = [ 'jpg', 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico' ];
 
 export const ERROR_UNSUPPORTED_FILE = 'ERROR_UNSUPPORTED_FILE';
+export const ERROR_IMAGE_EDITOR_DONE = 'ERROR_IMAGE_EDITOR_DONE';
+export const ERROR_UPLOADING_IMAGE = 'ERROR_UPLOADING_IMAGE';
 
 export const ERROR_STRINGS = {
 	[ ERROR_UNSUPPORTED_FILE ]: () =>

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -31,8 +31,8 @@ class UploadImageExample extends Component {
 		console.log( 'Uploaded image:', uploadedImage );
 	};
 
-	onError = ( errorConstant, errorMessage ) => {
-		if ( errorConstant === ERROR_UPLOADING_IMAGE ) {
+	onError = ( errorCode, errorMessage ) => {
+		if ( errorCode === ERROR_UPLOADING_IMAGE ) {
 			console.log( 'There was an error uploading your image' );
 		} else {
 			console.log( 'UploadImage error:', errorMessage );

--- a/client/blocks/upload-image/docs/example.jsx
+++ b/client/blocks/upload-image/docs/example.jsx
@@ -2,45 +2,73 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import UploadImage from '../';
+import { ERROR_UPLOADING_IMAGE } from '../constants';
 import { AspectRatios } from 'state/ui/editor/image-editor/constants';
+import { getCurrentUser } from 'state/current-user/selectors';
 
-export default class UploadImageExample extends Component {
+class UploadImageExample extends Component {
 	state = {
-		isUploading: false,
-		uploadedImageDataUrl: null
+		editedImageDataUrl: null
 	};
 
-	onImageEditorDone = ( imageBlob ) => {
+	onImageEditorDone = ( imageBlob, imageEditorProps ) => {
+		// You can do whatever you want with the edited image here. However, it will be uploaded
+		// to site's Media library automatically on clicking the "Done" button in Image Editor.
 		this.setState( {
-			uploadedImageDataUrl: URL.createObjectURL( imageBlob ),
-			isUploading: true,
+			editedImageDataUrl: URL.createObjectURL( imageBlob ),
 		} );
+
+		console.log( 'Image Editor props:', imageEditorProps );
+	};
+
+	onUploadImageDone = ( uploadedImage ) => {
+		console.log( 'Uploaded image:', uploadedImage );
+	};
+
+	onError = ( errorConstant, errorMessage ) => {
+		if ( errorConstant === ERROR_UPLOADING_IMAGE ) {
+			console.log( 'There was an error uploading your image' );
+		} else {
+			console.log( 'UploadImage error:', errorMessage );
+		}
 	};
 
 	render() {
-		const { isUploading, uploadedImageDataUrl } = this.state;
+		const { primarySiteId } = this.props;
 
 		return (
 			<div className="docs__design-assets-group">
-				<h3>Default Upload Image</h3>
-				<UploadImage
-					isUploading={ isUploading }
-					onImageEditorDone={ this.onImageEditorDone }
-				/>
+				Note: image will be uploaded to your primary site's Media library.
 
-				<h3>Image is uploaded</h3>
 				<UploadImage
-					placeholderContent={ null }
-					uploadingContent={ null }
-				>
-					<img src="https://wordpress.com/calypso/images/reader/promo-app-icon.png"/>
-				</UploadImage>
+					siteId={ primarySiteId }
+					onImageEditorDone={ this.onImageEditorDone }
+					onUploadImageDone={ this.onUploadImageDone }
+					onError={ this.onError }
+				/>
 			</div>
 		);
 	}
 }
+
+const ConnectedUploadImageExample = connect( state => {
+	const user = getCurrentUser( state );
+
+	if ( ! user ) {
+		return {}
+	}
+
+	return {
+		primarySiteId: user.primary_blog,
+	}
+} )( UploadImageExample );
+
+ConnectedUploadImageExample.displayName = 'UploadImage';
+
+export default ConnectedUploadImageExample;

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -174,6 +174,8 @@ class UploadImage extends Component {
 				MediaStore.off( 'change', this.handleMediaStoreChange );
 
 				onUploadImageDone( uploadedImage );
+
+				return;
 			}
 
 			const validationErrors = errors[ this.uploadingImageTransientId ] || [];

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -45,9 +45,12 @@ class UploadImage extends Component {
 	};
 
 	static propTypes = {
+		// If not supplied, currently selected site will be used.
 		siteId: PropTypes.number,
+
 		// Additional props passed to ImageEditor component. See blocks/image-editor.
 		imageEditorProps: PropTypes.object,
+
 		additionalImageEditorClasses: PropTypes.string,
 		additionalClasses: PropTypes.string,
 		placeholderContent: PropTypes.element,
@@ -118,7 +121,7 @@ class UploadImage extends Component {
 		MediaStore.off( 'change', this.handleMediaStoreChange );
 		MediaValidationStore.off( 'change', this.storeValidationErrors );
 
-		this.props.onImageEditorDone( error, imageBlob, imageEditorProps );
+		this.props.onImageEditorDone( imageBlob, imageEditorProps );
 
 		this.uploadImage( imageBlob, imageEditorProps );
 

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -14,7 +14,6 @@ import { noop, uniqueId } from 'lodash';
  */
 import {
 	ALLOWED_FILE_EXTENSIONS,
-	ERROR_STRINGS,
 	ERROR_UNSUPPORTED_FILE,
 	ERROR_IMAGE_EDITOR_DONE,
 	ERROR_UPLOADING_IMAGE,
@@ -76,11 +75,18 @@ class UploadImage extends Component {
 	static uploadingImageTransientId = null;
 
 	receiveFiles = files => {
+		const { translate } = this.props;
+
 		const fileName = files[ 0 ].name;
 		const extension = path.extname( fileName ).toLowerCase().substring( 1 );
 
 		if ( ALLOWED_FILE_EXTENSIONS.indexOf( extension ) === -1 ) {
-			this.handleError( ERROR_UNSUPPORTED_FILE, ERROR_STRINGS[ ERROR_UNSUPPORTED_FILE ]() );
+			this.handleError(
+				ERROR_UNSUPPORTED_FILE,
+				translate(
+					'File you are trying to upload is not supported. Please select a valid image file.',
+				),
+			);
 
 			return;
 		}
@@ -95,13 +101,15 @@ class UploadImage extends Component {
 	};
 
 	handleError = ( errorConst, error = '' ) => {
-		const { onError } = this.props;
+		const { onError, translate } = this.props;
 
 		let message = error;
 
 		if ( errorConst === ERROR_UPLOADING_IMAGE ) {
 			if ( error.length && error[ 0 ] === ValidationErrors.SERVER_ERROR ) {
-				message = ERROR_STRINGS[ ValidationErrors.SERVER_ERROR ]();
+				message = translate(
+					'File could not be uploaded because an error occurred while uploading.',
+				);
 			}
 		}
 

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -54,6 +54,7 @@ class UploadImage extends Component {
 		additionalClasses: PropTypes.string,
 		placeholderContent: PropTypes.element,
 		uploadingContent: PropTypes.element,
+		uploadingDoneContent: PropTypes.element,
 		doneButtonText: PropTypes.string,
 		addAnImageText: PropTypes.string,
 		dragUploadText: PropTypes.string,
@@ -253,40 +254,64 @@ class UploadImage extends Component {
 		this.uploadingImageTransientId = null;
 	}
 
-	render() {
-		const { translate, additionalClasses, addAnImageText, dragUploadText } = this.props;
+	renderPlaceholderContent() {
+		const { placeholderContent, addAnImageText, translate } = this.props;
 
-		const { editedImage, isUploading, uploadedImage } = this.state;
-
-		let { placeholderContent, uploadingContent, uploadingDoneContent } = this.props;
-
-		if ( typeof placeholderContent === 'undefined' ) {
-			placeholderContent = (
-				<div className="upload-image__placeholder">
-					<Gridicon icon="add-image" size={ 36 } />
-					<span>
-						{ addAnImageText ? addAnImageText : translate( 'Add an Image' ) }
-					</span>
-				</div>
-			);
+		if ( placeholderContent ) {
+			return placeholderContent;
 		}
 
-		if ( typeof uploadingContent === 'undefined' ) {
-			uploadingContent = (
-				<div className="upload-image__uploading-container">
-					<img src={ editedImage } />
-					<Spinner className="upload-image__spinner" size={ 20 } />
-				</div>
-			);
+		return (
+			<div className="upload-image__placeholder">
+				<Gridicon icon="add-image" size={ 36 } />
+				<span>
+					{ addAnImageText || translate( 'Add an Image' ) }
+				</span>
+			</div>
+		);
+	}
+
+	renderUploadingContent() {
+		const { uploadingContent } = this.props;
+
+		const { editedImage } = this.state;
+
+		if ( uploadingContent ) {
+			return uploadingContent;
 		}
 
-		if ( typeof uploadingDoneContent === 'undefined' && uploadedImage && uploadedImage.URL ) {
-			uploadingDoneContent = (
+		return (
+			<div className="upload-image__uploading-container">
+				<img src={ editedImage } />
+				<Spinner className="upload-image__spinner" size={ 20 } />
+			</div>
+		);
+	}
+
+	renderUploadingDoneContent() {
+		const { uploadingDoneContent } = this.props;
+
+		const { uploadedImage } = this.state;
+
+		if ( uploadingDoneContent ) {
+			return uploadingDoneContent;
+		}
+
+		if ( uploadedImage && uploadedImage.URL ) {
+			return (
 				<div className="upload-image__uploading-done-container">
 					<img src={ uploadedImage.URL } />
 				</div>
 			);
 		}
+
+		return null;
+	}
+
+	render() {
+		const { translate, additionalClasses, dragUploadText } = this.props;
+
+		const { isUploading, uploadedImage } = this.state;
 
 		return (
 			<div className={ classnames( 'upload-image', additionalClasses ) }>
@@ -303,9 +328,9 @@ class UploadImage extends Component {
 							onFilesDrop={ this.receiveFiles }
 						/>
 
-						{ ! isUploading && ! uploadedImage && placeholderContent }
-						{ isUploading && uploadingContent }
-						{ ! isUploading && uploadedImage && uploadingDoneContent }
+						{ ! isUploading && ! uploadedImage && this.renderPlaceholderContent() }
+						{ isUploading && this.renderUploadingContent() }
+						{ ! isUploading && uploadedImage && this.renderUploadingDoneContent() }
 					</div>
 				</FilePicker>
 			</div>

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -276,7 +276,6 @@ class UploadImage extends Component {
 			uploadingDoneContent = (
 				<div className="upload-image__uploading-done-container">
 					<img src={ uploadedImage.URL } />
-					Image is uploaded
 				</div>
 			);
 		}

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -5,7 +5,6 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -18,11 +17,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormToggle from 'components/forms/form-toggle';
 import FormInputValidation from 'components/forms/form-input-validation';
-
-const ProductImage = () =>
-	<div className="editor-simple-payments-modal__product-image">
-		<Gridicon icon="add-image" size={ 36 } />
-	</div>;
+import UploadImage from 'blocks/upload-image';
 
 class ProductForm extends Component {
 	handleFieldChange = ( { currentTarget: { name, value } } ) => {
@@ -34,7 +29,14 @@ class ProductForm extends Component {
 	};
 
 	render() {
-		const { translate, currencyDefaults, fieldValues, isFieldInvalid } = this.props;
+		const {
+			translate,
+			currencyDefaults,
+			fieldValues,
+			isFieldInvalid,
+			onImageEditorDone,
+			onUploadImageError,
+		} = this.props;
 
 		const isTitleInvalid = isFieldInvalid( 'title' );
 		const isPriceInvalid = isFieldInvalid( 'price' );
@@ -42,7 +44,7 @@ class ProductForm extends Component {
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<ProductImage />
+				<UploadImage onImageEditorDone={ onImageEditorDone } onError={ onUploadImageError } />
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>
 						<FormLabel htmlFor="title">

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -28,13 +28,18 @@ class ProductForm extends Component {
 		this.props.onFieldChange( 'multiple', checked );
 	};
 
+	handleUploadImageError = ( errorCode, errorMessage ) => {
+		const { showError } = this.props;
+
+		showError( errorMessage );
+	};
+
 	render() {
 		const {
 			translate,
 			currencyDefaults,
 			fieldValues,
 			isFieldInvalid,
-			onUploadImageError,
 			onUploadImageDone,
 		} = this.props;
 
@@ -44,7 +49,7 @@ class ProductForm extends Component {
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<UploadImage onError={ onUploadImageError } onUploadImageDone={ onUploadImageDone } />
+				<UploadImage onError={ this.handleUploadImageError } onUploadImageDone={ onUploadImageDone } />
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>
 						<FormLabel htmlFor="title">

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -34,9 +34,8 @@ class ProductForm extends Component {
 			currencyDefaults,
 			fieldValues,
 			isFieldInvalid,
-			onImageEditorDone,
 			onUploadImageError,
-			uploadedImage,
+			onUploadImageDone,
 		} = this.props;
 
 		const isTitleInvalid = isFieldInvalid( 'title' );
@@ -45,9 +44,7 @@ class ProductForm extends Component {
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<UploadImage onImageEditorDone={ onImageEditorDone } onError={ onUploadImageError }>
-					{ uploadedImage && uploadedImage.URL && <img src={ uploadedImage.URL } /> }
-				</UploadImage>
+				<UploadImage onError={ onUploadImageError } onUploadImageDone={ onUploadImageDone } />
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>
 						<FormLabel htmlFor="title">

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -49,7 +49,10 @@ class ProductForm extends Component {
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<UploadImage onError={ this.handleUploadImageError } onUploadImageDone={ onUploadImageDone } />
+				<UploadImage
+					onError={ this.handleUploadImageError }
+					onUploadImageDone={ onUploadImageDone }
+				/>
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>
 						<FormLabel htmlFor="title">

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -36,6 +36,7 @@ class ProductForm extends Component {
 			isFieldInvalid,
 			onImageEditorDone,
 			onUploadImageError,
+			uploadedImage,
 		} = this.props;
 
 		const isTitleInvalid = isFieldInvalid( 'title' );
@@ -44,7 +45,9 @@ class ProductForm extends Component {
 
 		return (
 			<form className="editor-simple-payments-modal__form">
-				<UploadImage onImageEditorDone={ onImageEditorDone } onError={ onUploadImageError } />
+				<UploadImage onImageEditorDone={ onImageEditorDone } onError={ onUploadImageError }>
+					{ uploadedImage && uploadedImage.URL && <img src={ uploadedImage.URL } /> }
+				</UploadImage>
 				<div className="editor-simple-payments-modal__form-fields">
 					<FormFieldset>
 						<FormLabel htmlFor="title">

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -112,7 +112,7 @@ class SimplePaymentsDialog extends Component {
 		this.setState( { uploadedImageId: uploadedImage.ID } );
 	};
 
-	handleUploadImageError = ( errorCode, errorMessage ) => {
+	showError = errorMessage => {
 		this.setState( {
 			errorMessage,
 		} );
@@ -244,7 +244,7 @@ class SimplePaymentsDialog extends Component {
 							isFieldInvalid={ this.isFormFieldInvalid }
 							onFieldChange={ this.handleFormFieldChange }
 							onUploadImageDone={ this.handleUploadedImage }
-							onUploadImageError={ this.handleUploadImageError }
+							showError={ this.showError }
 						/>
 					: <ProductList
 							paymentButtons={ paymentButtons }

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -112,7 +112,7 @@ class SimplePaymentsDialog extends Component {
 		this.setState( { uploadedImageId: uploadedImage.ID } );
 	};
 
-	handleUploadImageError = ( errorConstant, errorMessage ) => {
+	handleUploadImageError = ( errorCode, errorMessage ) => {
 		this.setState( {
 			errorMessage,
 		} );

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -48,6 +48,7 @@ class SimplePaymentsDialog extends Component {
 		multiple: false,
 		email: '',
 		currency: 'USD',
+		featuredImageId: null,
 	};
 
 	constructor( props ) {
@@ -109,7 +110,7 @@ class SimplePaymentsDialog extends Component {
 	}
 
 	handleUploadedImage = uploadedImage => {
-		this.setState( { uploadedImageId: uploadedImage.ID } );
+		this.handleFormFieldChange( 'featuredImageId', uploadedImage.ID );
 	};
 
 	showError = errorMessage => {
@@ -154,12 +155,6 @@ class SimplePaymentsDialog extends Component {
 
 		if ( currencyCode ) {
 			productForm.currency = currencyCode;
-		}
-
-		const { uploadedImageId } = this.state;
-
-		if ( uploadedImageId ) {
-			productForm.featuredImageId = uploadedImageId;
 		}
 
 		wpcom

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -30,6 +30,7 @@ import {
 	productToCustomPost,
 } from 'state/data-layer/wpcom/sites/simple-payments/index.js';
 import { receiveUpdateProduct } from 'state/simple-payments/product-list/actions';
+import MediaActions from 'lib/media/actions';
 
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
@@ -106,6 +107,26 @@ class SimplePaymentsDialog extends Component {
 
 		onComplete( null, formErrors );
 	}
+
+	handleUploadImage = ( error, imageBlob, imageEditorProps ) => {
+		const { siteId } = this.props;
+
+		const { fileName, mimeType } = imageEditorProps;
+
+		const item = {
+			fileName: fileName,
+			fileContents: imageBlob,
+			mimeType: mimeType,
+		};
+
+		MediaActions.add( siteId, item );
+	};
+
+	handleUploadImageError = ( errorConstant, errorMessage ) => {
+		this.setState( {
+			errorMessage,
+		} );
+	};
 
 	handleSelectedChange = selectedPaymentId => {
 		this.setState( { selectedPaymentId } );
@@ -226,6 +247,8 @@ class SimplePaymentsDialog extends Component {
 							fieldValues={ this.getFormValues() }
 							isFieldInvalid={ this.isFormFieldInvalid }
 							onFieldChange={ this.handleFormFieldChange }
+							onImageEditorDone={ this.handleUploadImage }
+							onUploadImageError={ this.handleUploadImageError }
 						/>
 					: <ProductList
 							paymentButtons={ paymentButtons }

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -159,7 +159,7 @@ class SimplePaymentsDialog extends Component {
 		const { uploadedImageId } = this.state;
 
 		if ( uploadedImageId ) {
-			productForm.featuredImage = uploadedImageId;
+			productForm.featuredImageId = uploadedImageId;
 		}
 
 		wpcom

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -156,6 +156,12 @@ class SimplePaymentsDialog extends Component {
 			productForm.currency = currencyCode;
 		}
 
+		const { uploadedImageId } = this.state;
+
+		if ( uploadedImageId ) {
+			productForm.featuredImage = uploadedImageId;
+		}
+
 		wpcom
 			.site( siteId )
 			.addPost( productToCustomPost( productForm ) )

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -49,9 +49,10 @@ export function customPostToProduct( product ) {
 		{
 			ID: product.ID,
 			description: product.content,
-			title: product.title
+			title: product.title,
+			featuredImage: product.featured_image
 		},
-		product.metadata.reduce( reduceMetadata, {} )
+		product.metadata.reduce( reduceMetadata, {} ),
 	);
 }
 
@@ -87,7 +88,8 @@ export function productToCustomPost( product ) {
 			metadata: [],
 			title: product.title,
 			content: product.description,
-		}
+			featured_image: product.featuredImage ? product.featuredImage : '',
+		},
 	);
 }
 
@@ -100,10 +102,15 @@ export function productToCustomPost( product ) {
 export function requestSimplePaymentsProduct( { dispatch }, action ) {
 	const { siteId, productId } = action;
 
-	dispatch( http( {
-		method: 'GET',
-		path: `/sites/${ siteId }/posts/${ productId }`,
-	}, action ) );
+	dispatch(
+		http(
+			{
+				method: 'GET',
+				path: `/sites/${ siteId }/posts/${ productId }`,
+			},
+			action,
+		),
+	);
 }
 
 /**
@@ -115,14 +122,19 @@ export function requestSimplePaymentsProduct( { dispatch }, action ) {
 export function requestSimplePaymentsProducts( { dispatch }, action ) {
 	const { siteId } = action;
 
-	dispatch( http( {
-		method: 'GET',
-		path: `/sites/${ siteId }/posts`,
-		query: {
-			type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
-			status: 'publish'
-		},
-	}, action ) );
+	dispatch(
+		http(
+			{
+				method: 'GET',
+				path: `/sites/${ siteId }/posts`,
+				query: {
+					type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
+					status: 'publish',
+				},
+			},
+			action,
+		),
+	);
 }
 
 /**
@@ -133,11 +145,16 @@ export function requestSimplePaymentsProducts( { dispatch }, action ) {
 export function requestSimplePaymentsProductAdd( { dispatch }, action ) {
 	const { siteId, product } = action;
 
-	dispatch( http( {
-		method: 'POST',
-		path: `/sites/${ siteId }/posts/new`,
-		body: productToCustomPost( product ),
-	}, action ) );
+	dispatch(
+		http(
+			{
+				method: 'POST',
+				path: `/sites/${ siteId }/posts/new`,
+				body: productToCustomPost( product ),
+			},
+			action,
+		),
+	);
 }
 
 /**
@@ -148,11 +165,16 @@ export function requestSimplePaymentsProductAdd( { dispatch }, action ) {
 export function requestSimplePaymentsProductEdit( { dispatch }, action ) {
 	const { siteId, product, productId } = action;
 
-	dispatch( http( {
-		method: 'POST',
-		path: `/sites/${ siteId }/posts/${ productId }`,
-		body: productToCustomPost( product ),
-	}, action ) );
+	dispatch(
+		http(
+			{
+				method: 'POST',
+				path: `/sites/${ siteId }/posts/${ productId }`,
+				body: productToCustomPost( product ),
+			},
+			action,
+		),
+	);
 }
 
 /**
@@ -163,10 +185,15 @@ export function requestSimplePaymentsProductEdit( { dispatch }, action ) {
 export function requestSimplePaymentsProductDelete( { dispatch }, action ) {
 	const { siteId, productId } = action;
 
-	dispatch( http( {
-		method: 'POST',
-		path: `/sites/${ siteId }/posts/${ productId }/delete`,
-	}, action ) );
+	dispatch(
+		http(
+			{
+				method: 'POST',
+				path: `/sites/${ siteId }/posts/${ productId }/delete`,
+			},
+			action,
+		),
+	);
 }
 
 export const addProduct = ( { dispatch }, { siteId }, next, newProduct ) =>
@@ -190,12 +217,19 @@ export const listProducts = ( { dispatch }, { siteId }, next, { posts: products 
 };
 
 export default {
-	[ SIMPLE_PAYMENTS_PRODUCT_GET ]:
-		[ dispatchRequest( requestSimplePaymentsProduct, listProduct, noop ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]:
-		[ dispatchRequest( requestSimplePaymentsProducts, listProducts, noop ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [ dispatchRequest( requestSimplePaymentsProductAdd, addProduct, noop ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [ dispatchRequest( requestSimplePaymentsProductEdit, addProduct, noop ) ],
-	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]:
-		[ dispatchRequest( requestSimplePaymentsProductDelete, deleteProduct, noop ) ],
+	[ SIMPLE_PAYMENTS_PRODUCT_GET ]: [
+		dispatchRequest( requestSimplePaymentsProduct, listProduct, noop ),
+	],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST ]: [
+		dispatchRequest( requestSimplePaymentsProducts, listProducts, noop ),
+	],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_ADD ]: [
+		dispatchRequest( requestSimplePaymentsProductAdd, addProduct, noop ),
+	],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_EDIT ]: [
+		dispatchRequest( requestSimplePaymentsProductEdit, addProduct, noop ),
+	],
+	[ SIMPLE_PAYMENTS_PRODUCTS_LIST_DELETE ]: [
+		dispatchRequest( requestSimplePaymentsProductDelete, deleteProduct, noop ),
+	],
 };

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -89,7 +89,7 @@ export function productToCustomPost( product ) {
 			metadata: [],
 			title: product.title,
 			content: product.description,
-			featured_image: product.featuredImageId ? product.featuredImageId : '',
+			featured_image: product.featuredImageId || '',
 		},
 	);
 }

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -25,6 +25,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 import formatCurrency from 'lib/format-currency';
+import { getFeaturedImageId } from 'lib/posts/utils';
 
 /**
  * Reduce function for product attributes stored in post metadata
@@ -50,7 +51,7 @@ export function customPostToProduct( product ) {
 			ID: product.ID,
 			description: product.content,
 			title: product.title,
-			featuredImage: product.featured_image
+			featuredImageId: getFeaturedImageId( product ),
 		},
 		product.metadata.reduce( reduceMetadata, {} ),
 	);
@@ -88,7 +89,7 @@ export function productToCustomPost( product ) {
 			metadata: [],
 			title: product.title,
 			content: product.description,
-			featured_image: product.featuredImage ? product.featuredImage : '',
+			featured_image: product.featuredImageId ? product.featuredImageId : '',
 		},
 	);
 }


### PR DESCRIPTION
Improves the `UploadImage` component by actually uploading the selected&edited image to specified `siteId` Media library.

Integrates `UploadImage` component into Simple Payments "add new product" modal view and allows uploading a new product image.

## Testing Simple Payments

Try adding a new product. Before inserting it into a post, click on the "Add an image" placeholder. It should open a native dialog to select a file. Then, it should open Image Editor. After clicking on "Done", it should start uploading the image into your site's Media library and the image should appear with a spinner. After it's uploaded, (spinner is removed), insert the product into the post. It should appear with the image.

## Testing UploadImage

Similar to how you tested it in Simple Payments but you can use `UploadImage` devdocs to do so: http://calypso.localhost:3000/devdocs/blocks/upload-image.

## Future improvements

1. Implement better styling and follow @iamtakashi mockups more closely.
2. Set max image width/height (or static) so it doesn't change the width/height of the page if image is edited.
3. Block inserting a product until its image is not uploaded to Media library.

I'll work on the above in future PRs since this one is getting huge.