### PR TITLE
Magic Login: Disable the submit button if the field is empty

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -89,6 +89,7 @@ class RequestLoginEmailForm extends React.Component {
 		}
 
 		const submitEnabled = (
+			emailAddress.length &&
 			! isFetching &&
 			! emailRequested &&
 			! requestError


### PR DESCRIPTION
Currently, if you click the submit button with an empty field, it tries to submit the form. This just disables the submit until there's something to submit.

## To Test
* Visit https://calypso.live/log-in/link?branch=fix/magic-login-empty-submit in an incognito / logged-out window
* Attempt to submit an invalidly-formatted email -- it should not let you
* Attempt to submit a validly-formatted email -- it should work fine.