### PR TITLE
Reader: Fix descenders cropped in mobile Safari

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -429,7 +429,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 
 	.reader-excerpt {
 		overflow: hidden;
-		max-height: 15px * 1.6 * 3;
+		max-height: 15px * 1.6 * 3.2;
 
 
 		// Clamp to 2 lines on wider viewports
@@ -465,7 +465,7 @@ $reader-post-card-breakpoint-small: "( max-width: 550px )";
 .reader-post-card.card.has-thumbnail:not(.is-gallery):not(.is-discover) {
 
 	.reader-excerpt {
-		max-height: 15px * 1.6 * 3;
+		max-height: 15px * 1.6 * 3.2;
 		overflow: hidden;
 	}
 }

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -577,7 +577,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 				}
 
 				@include breakpoint( "<480px" ) {
-					max-height: 120px;
+					max-height: 125px;
 				}
 			}
 		}


### PR DESCRIPTION
This fixes https://github.com/Automattic/wp-calypso/issues/16434.

## Stream:
**Before:**
![img_4561](https://user-images.githubusercontent.com/4924246/28444148-ebc2345c-6d6f-11e7-9669-36024218549b.png)

**After:**
![img_4563](https://user-images.githubusercontent.com/4924246/28444155-f547960c-6d6f-11e7-9731-87d75f911b02.PNG)

## In-stream recs:

**Before:**
![screenshot 2017-07-20 17 51 53](https://user-images.githubusercontent.com/4924246/28444734-3132eb22-6d74-11e7-9c6d-4cc3ed4692fd.png)

**After:**
![screenshot 2017-07-20 17 51 59](https://user-images.githubusercontent.com/4924246/28444737-385ba8ee-6d74-11e7-98c1-3a1bc67e57b6.png)
