### PR TITLE
WPSC: Mini Style Fix

### DIFF
--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -235,10 +235,7 @@
 
 // Debug Tab
 
-.wp-super-cache__debug-fieldsets {
-	margin-left: 40px;
-}
-
+.wp-super-cache__debug-fieldsets,
 .wp-super-cache__debug-tab .form-fieldset .form-setting-explanation.is-indented {
 	margin-left: 36px;
 }


### PR DESCRIPTION
Follow-up from https://github.com/Automattic/wp-calypso/pull/16395#issuecomment-316757533:

> I think the 'check text for automatic clearing' fieldset is 'over-indented'—the indents should be a consistent 36px, not the 40px that seems to have been. I missed that in my assessment yesterday.