### PR TITLE
Plugins: Add success and error notices for uploads

### DIFF
--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -30,7 +30,7 @@ export const uploadPlugin = ( { dispatch }, action ) => {
 
 const showSuccessNotice = ( dispatch, { name } ) => {
 	dispatch( successNotice(
-		translate( 'Successfully uploaded plugin %(name)s', {
+		translate( 'Successfully uploaded plugin %(name)s.', {
 			args: { name }
 		} ),
 		{ duration: 5000 }
@@ -42,7 +42,7 @@ const showErrorNotice = ( dispatch, error ) => {
 		exists: translate( 'Upload problem: Plugin already installed on site.' ),
 		'too large': translate( 'Upload problem: Plugin zip must be smaller than 10MB.' ),
 		incompatible: translate( 'Upload problem: Incompatible plugin.' ),
-		unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
+		unsupported_mime_type: translate( 'Upload problem: Not a valid zip file.' ),
 	};
 	const errorString = toLower( error.error + error.message );
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
@@ -52,12 +52,12 @@ const showErrorNotice = ( dispatch, error ) => {
 		return;
 	}
 	if ( error.error ) {
-		dispatch( errorNotice( translate( 'Upload problem: %(error)s', {
+		dispatch( errorNotice( translate( 'Upload problem: %(error)s.', {
 			args: { error: error.error }
 		} ) ) );
 		return;
 	}
-	dispatch( errorNotice( translate( 'Problem uploading plugin' ) ) );
+	dispatch( errorNotice( translate( 'Problem uploading plugin.' ) ) );
 };
 
 export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -30,7 +30,7 @@ export const uploadPlugin = ( { dispatch }, action ) => {
 
 const showSuccessNotice = ( dispatch, { name } ) => {
 	dispatch( successNotice(
-		translate( 'Successfully uploaded plugin %(name)s.', {
+		translate( "You've successfully uploaded the %(name)s plugin.", {
 			args: { name }
 		} ),
 		{ duration: 5000 }
@@ -39,10 +39,10 @@ const showSuccessNotice = ( dispatch, { name } ) => {
 
 const showErrorNotice = ( dispatch, error ) => {
 	const knownErrors = {
-		exists: translate( 'Upload problem: Plugin already installed on site.' ),
-		'too large': translate( 'Upload problem: Plugin zip must be smaller than 10MB.' ),
-		incompatible: translate( 'Upload problem: Incompatible plugin.' ),
-		unsupported_mime_type: translate( 'Upload problem: Not a valid zip file.' ),
+		exists: translate( 'This plugin is already installed on your site.' ),
+		'too large': translate( 'The plugin zip file must be smaller than 10MB.' ),
+		incompatible: translate( 'Not a compatible plugin.' ),
+		unsupported_mime_type: translate( 'Not a valid zip file.' ),
 	};
 	const errorString = toLower( error.error + error.message );
 	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
@@ -57,7 +57,7 @@ const showErrorNotice = ( dispatch, error ) => {
 		} ) ) );
 		return;
 	}
-	dispatch( errorNotice( translate( 'Problem uploading plugin.' ) ) );
+	dispatch( errorNotice( translate( 'Problem installing the plugin.' ) ) );
 };
 
 export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+import { find, includes, toLower } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { PLUGIN_UPLOAD, PLUGIN_INSTALL_REQUEST_SUCCESS } from 'state/action-types';
@@ -9,6 +15,7 @@ import {
 } from 'state/plugins/upload/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { successNotice, errorNotice } from 'state/notices/actions';
 
 export const uploadPlugin = ( { dispatch }, action ) => {
 	const { siteId, file } = action;
@@ -21,6 +28,38 @@ export const uploadPlugin = ( { dispatch }, action ) => {
 	}, action ) );
 };
 
+const showSuccessNotice = ( dispatch, { name } ) => {
+	dispatch( successNotice(
+		translate( 'Successfully uploaded plugin %(name)s', {
+			args: { name }
+		} ),
+		{ duration: 5000 }
+	) );
+};
+
+const showErrorNotice = ( dispatch, error ) => {
+	const knownErrors = {
+		exists: translate( 'Upload problem: Plugin already installed on site.' ),
+		'too large': translate( 'Upload problem: Plugin zip must be smaller than 10MB.' ),
+		incompatible: translate( 'Upload problem: Incompatible plugin.' ),
+		unsupported_mime_type: translate( 'Upload problem: Not a valid zip file' ),
+	};
+	const errorString = toLower( error.error + error.message );
+	const knownError = find( knownErrors, ( v, key ) => includes( errorString, key ) );
+
+	if ( knownError ) {
+		dispatch( errorNotice( knownError ) );
+		return;
+	}
+	if ( error.error ) {
+		dispatch( errorNotice( translate( 'Upload problem: %(error)s', {
+			args: { error: error.error }
+		} ) ) );
+		return;
+	}
+	dispatch( errorNotice( translate( 'Problem uploading plugin' ) ) );
+};
+
 export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
 	const { slug: pluginId } = data;
 	dispatch( completePluginUpload( siteId, pluginId ) );
@@ -30,9 +69,12 @@ export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
 		pluginId,
 		data
 	} );
+
+	showSuccessNotice( dispatch, data );
 };
 
 export const receiveError = ( { dispatch }, { siteId }, next, error ) => {
+	showErrorNotice( dispatch, error );
 	dispatch( pluginUploadError( siteId, error ) );
 };
 


### PR DESCRIPTION
<img width="978" alt="screen shot 2017-07-21 at 11 43 25" src="https://user-images.githubusercontent.com/7767559/28460421-e7a3c2c4-6e09-11e7-98bb-2d4b2ccc1f87.png">
<img width="979" alt="screen shot 2017-07-21 at 11 42 57" src="https://user-images.githubusercontent.com/7767559/28460422-e916b364-6e09-11e7-95d7-b86bd7b6f79f.png">

**To Test**
* Checkout this branch or use calypso.live
* Go to /plugins/upload/{jetpack_site}
* Upload a plugin
* Try uploading the same plugin again
* Try dragging in a file that is not a plugin zip

**Expected**
* An appropriate notice should be displayed
