### PR TITLE
Activity log: Replace fuzzy titles with 1:1 activity mapping

### DIFF
--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -3,10 +3,12 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { get } from 'lodash';
-import { localize } from 'i18n-calypso';
 
+/**
+ * TODO: This component is not localized. Much of the logic may be moved to the API so translation
+ * was ignored during testing phases.
+ */
 class ActivityTitle extends Component {
-
 	static propTypes = {
 		action: PropTypes.string,
 
@@ -111,15 +113,7 @@ class ActivityTitle extends Component {
 				sidebar: PropTypes.string,
 			} ),
 		} ),
-
-		// localize
-		moment: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
 	};
-
-	getAction() {
-		return this.props.action || this.props.name;
-	}
 
 	getActorName() {
 		const { actor } = this.props;
@@ -135,18 +129,16 @@ class ActivityTitle extends Component {
 		return 'An unknown user';
 	}
 
-	getUserName() {
-		const user = get( this.props.object, 'user' );
-		const displayName = get( user, 'display_name' );
-		if ( displayName ) {
-			return displayName;
+	getAttachmentTitle() {
+		const title = get( this.props.object, [ 'attachment', 'title' ] );
+		if ( title ) {
+			return title;
 		}
-		const login = get( user, 'login' );
-		if ( login ) {
-			return login;
-		}
+		return 'an unknown attachment';
+	}
 
-		return 'an unknown user';
+	getCommentId() {
+		return get( this.props.object, [ 'comment', 'id' ] );
 	}
 
 	getPluginName() {
@@ -167,6 +159,22 @@ class ActivityTitle extends Component {
 			: getName( pluginObject );
 	}
 
+	getPostTitle() {
+		const title = get( this.props.object, [ 'post', 'title' ] );
+		if ( title ) {
+			return title;
+		}
+		return 'an unknown post';
+	}
+
+	getTermTitle() {
+		const title = get( this.props.object, [ 'term', 'title' ] );
+		if ( title ) {
+			return title;
+		}
+		return 'an unknown term';
+	}
+
 	getThemeName() {
 		const themeObject = get( this.props.object, 'theme' );
 		const getName = theme => {
@@ -185,89 +193,295 @@ class ActivityTitle extends Component {
 			: getName( themeObject );
 	}
 
-	getObjectName() {
-		const {
-			group,
-			object,
-		} = this.props;
-
-		switch ( group ) {
-			case 'attachment': {
-				const title = get( object, [ 'attachment', 'title' ] );
-				if ( title ) {
-					return title;
-				}
-				return 'an unknown attachment';
-			}
-			case 'comment': {
-				const postTitle = get( object, [ 'post', 'title' ] );
-				if ( postTitle ) {
-					return `a comment on ${ postTitle }`;
-				}
-				return 'a comment on an unknown post';
-			}
-			case 'core':
-				return 'WordPress Core';
-			case 'menu': {
-				const name = get( object, [ 'menu', 'name' ] );
-				if ( name ) {
-					return name;
-				}
-				return 'an unknown menu';
-			}
-			case 'plugin':
-				return this.getPluginName( object );
-			case 'post': {
-				const title = get( object, [ 'post', 'title' ] );
-				if ( title ) {
-					return title;
-				}
-				return 'an unknown post';
-			}
-			case 'term': {
-				const name = get( object, [ 'term', 'name' ] );
-				if ( name ) {
-					return name;
-				}
-				return 'an unknown term';
-			}
-			case 'theme':
-				return this.getThemeName();
-			case 'user':
-				return this.getUserName();
-			case 'widget':
-				return 'a widget';
-			default:
-				return 'an unrecognized object';
+	getUserName() {
+		const user = get( this.props.object, 'user' );
+		const displayName = get( user, 'display_name' );
+		if ( displayName ) {
+			return displayName;
 		}
+		const login = get( user, 'login' );
+		if ( login ) {
+			return login;
+		}
+
+		return 'an unknown user';
 	}
 
-	// FIXME: This function is built with the MVP in mind. It purposefully avoids translations which
-	// will need to be revisited. They may be provided by the API.
-	renderTitle() {
-		const { group } = this.props;
-		const actorName = this.getActorName();
-
-		if (
-			group === 'post' &&
-			'customize_changeset' === get( this.props.object, [ 'post', 'type' ] )
-		) {
-			return (
-				<div className="activity-log-item__title-title">
-					{ `${ actorName } modified the site's customization` }
-				</div>
-			);
+	getWidgetName() {
+		const name = get( this.props.object, 'widget', 'name' );
+		if ( name ) {
+			return name;
 		}
 
-		const action = this.getAction();
-		const objectName = this.getObjectName();
+		return 'a widget';
+	}
 
-		return (
-			<div className="activity-log-item__title-title">
-				{ `${ actorName } ${ action } ` }
-				<em>{ objectName }</em>
-			</div>
-		);
+	getTitle() {
+		const { name } = this.props;
+
+		switch ( name ) {
+			/**
+			 * Attachment
+			 */
+			case 'attachment__deleted': {
+				const actorName = this.getActorName();
+				const attachmentTitle = this.getAttachmentTitle();
+				return `${ actorName } deleted attachment ${ attachmentTitle }`;
+			}
+			case 'attachment__updated': {
+				const actorName = this.getActorName();
+				const attachmentTitle = this.getAttachmentTitle();
+				return `${ actorName } updated attachment ${ attachmentTitle }`;
+			}
+			case 'attachment__uploaded': {
+				const actorName = this.getActorName();
+				return `${ actorName } added attachment`;
+			}
+
+			/**
+			 * Comment
+			 */
+			case 'comment__approved': {
+				const actorName = this.getActorName();
+				const commentId = this.getCommentId();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } approved comment ${ commentId } on post ${ postTitle }`;
+			}
+			case 'comment__content_modified': {
+				const actorName = this.getActorName();
+				const commentId = this.getCommentId();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } modified comment ${ commentId } on post ${ postTitle }`;
+			}
+			case 'comment__deleted': {
+				const actorName = this.getActorName();
+				const commentId = this.getCommentId();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } deleted comment ${ commentId } from post ${ postTitle }`;
+			}
+			case 'comment__published': {
+				const actorName = this.getActorName();
+				const commentId = this.getCommentId();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } posted comment ${ commentId } on post ${ postTitle }`;
+			}
+			case 'comment__spammed': {
+				const actorName = this.getActorName();
+				const commentId = this.getCommentId();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } marked comment ${ commentId } as spam on post ${ postTitle }`;
+			}
+			case 'comment__trashed': {
+				const actorName = this.getActorName();
+				const commentId = this.getCommentId();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } trashed comment ${ commentId } on post ${ postTitle }`;
+			}
+			case 'comment__unapproved': {
+				const actorName = this.getActorName();
+				const commentId = this.getCommentId();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } unapproved comment ${ commentId } on post ${ postTitle }`;
+			}
+
+			/**
+			 * Menu
+			 */
+			case 'menu__added': {
+				const actorName = this.getActorName();
+				return `${ actorName } created a menu.`;
+			}
+			case 'menu__updated': {
+				const actorName = this.getActorName();
+				return `${ actorName } modified a menu.`;
+			}
+
+			/**
+			 * Plugin
+			 */
+			case 'plugin__activated': {
+				const actorName = this.getActorName();
+				const pluginName = this.getPluginName();
+				return `${ actorName } activated plugin ${ pluginName }`;
+			}
+			case 'plugin__deactivated': {
+				const actorName = this.getActorName();
+				const pluginName = this.getPluginName();
+				return `${ actorName } deactivated plugin ${ pluginName }`;
+			}
+			case 'plugin__deleted': {
+				const actorName = this.getActorName();
+				const pluginName = this.getPluginName();
+				return `${ actorName } deleted plugin ${ pluginName }`;
+			}
+			case 'plugin__edited': {
+				const actorName = this.getActorName();
+				const pluginName = this.getPluginName();
+				return `${ actorName } modified plugin ${ pluginName }`;
+			}
+			case 'plugin__installed': {
+				const actorName = this.getActorName();
+				const pluginName = this.getPluginName();
+				return `${ actorName } installed plugin ${ pluginName }`;
+			}
+			case 'plugin__network_activated': {
+				const pluginName = this.getPluginName();
+				return `Plugin ${ pluginName } was network activated.`;
+			}
+			case 'plugin__update_available': {
+				const pluginName = this.getPluginName();
+				return `Plugin ${ pluginName } has an update available.`;
+			}
+			case 'plugin__updated': {
+				const actorName = this.getActorName();
+				return `${ actorName } updated plugin <title, link>.`;
+			}
+
+			/**
+			 * Post
+			 */
+			case 'post__deleted': {
+				const actorName = this.getActorName();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } permanently deleted post ${ postTitle }.`;
+			}
+			case 'post__published': {
+				const actorName = this.getActorName();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } published post ${ postTitle }.`;
+			}
+			case 'post__trashed': {
+				const actorName = this.getActorName();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } trashed post ${ postTitle }.`;
+			}
+			case 'post__updated': {
+				const actorName = this.getActorName();
+				const postTitle = this.getPostTitle();
+				return `${ actorName } modified post ${ postTitle }.`;
+			}
+
+			/**
+			 * Term
+			 */
+			case 'term__created': {
+				const actorName = this.getActorName();
+				const termTitle = this.getTermTitle();
+				return `${ actorName } created term ${ termTitle }.`;
+			}
+			case 'term__deleted': {
+				const actorName = this.getActorName();
+				const termTitle = this.getTermTitle();
+				return `${ actorName } deleted term ${ termTitle }.`;
+			}
+
+			/**
+			 * Theme
+			 */
+			case 'theme__deleted': {
+				const actorName = this.getActorName();
+				const themeName = this.getThemeName();
+				return `${ actorName } deleted theme ${ themeName }.`;
+			}
+			case 'theme__edited': {
+				const actorName = this.getActorName();
+				const themeName = this.getThemeName();
+				return `${ actorName } modified theme ${ themeName }.`;
+			}
+			case 'theme__installed': {
+				const actorName = this.getActorName();
+				const themeName = this.getThemeName();
+				return `${ actorName } installed theme ${ themeName }.`;
+			}
+			case 'theme__network_disabled': {
+				const themeName = this.getThemeName();
+				return `Theme ${ themeName } was network deactivated.`;
+			}
+			case 'theme__network_enabled': {
+				const themeName = this.getThemeName();
+				return `Theme ${ themeName } was network activated.`;
+			}
+			case 'theme__switched': {
+				const actorName = this.getActorName();
+				const themeName = this.getThemeName();
+				return `${ actorName } activated theme ${ themeName }.`;
+			}
+			case 'theme__update_available': {
+				const themeName = this.getThemeName();
+				return `Theme ${ themeName } has an update available.`;
+			}
+			case 'theme__updated': {
+				const actorName = this.getActorName();
+				const themeName = this.getThemeName();
+				return `${ actorName } updated theme ${ themeName }.`;
+			}
+
+			/**
+			 * User
+			 */
+			case 'user__added': {
+				const actorName = this.getActorName();
+				const userName = this.getUserName();
+				return `${ actorName } added user ${ userName }.`;
+			}
+			case 'user__deleted': {
+				const actorName = this.getActorName();
+				const userName = this.getUserName();
+				return `${ actorName } deleted user ${ userName }.`;
+			}
+			case 'user__failed_login_attempt': {
+				const actorName = this.getActorName();
+				return `${ actorName } attempted and failed to login.`;
+			}
+			case 'user__login': {
+				const actorName = this.getActorName();
+				return `${ actorName } logged in successfully.`;
+			}
+			case 'user__registered': {
+				const actorName = this.getActorName();
+				const userName = this.getUserName();
+				return `${ actorName } created user ${ userName }.`;
+			}
+			case 'user__removed': {
+				const actorName = this.getActorName();
+				const userName = this.getUserName();
+				return `${ actorName } removed user ${ userName }.`;
+			}
+			case 'user__updated': {
+				const actorName = this.getActorName();
+				const userName = this.getUserName();
+				return `${ actorName } modified user ${ userName }.`;
+			}
+
+			/**
+			 * Widget
+			 */
+			case 'widget__added': {
+				const actorName = this.getActorName();
+				const widgetName = this.getWidgetName();
+				return `${ actorName } added ${ widgetName } widget.`;
+			}
+			case 'widget__edited': {
+				const actorName = this.getActorName();
+				const widgetName = this.getWidgetName();
+				return `${ actorName } modified ${ widgetName } widget.`;
+			}
+			case 'widget__removed': {
+				const actorName = this.getActorName();
+				const widgetName = this.getWidgetName();
+				return `${ actorName } removed ${ widgetName } widget.`;
+			}
+
+			/**
+			 * Default
+			 *
+			 * FIXME: This is placed here for testing purposes. It will help to identify missing
+			 * activity. It should be removed and a robust fallback solution should be provided
+			 * before this feature goes into production.
+			 */
+			default:
+				return `The activity ${ name } is missing a title.`;
+		}
 	}
 
 	renderSubtitle() {
@@ -279,11 +493,13 @@ class ActivityTitle extends Component {
 
 		return (
 			<div className="activity-log-item__title">
-				{ this.renderTitle() }
+				<div className="activity-log-item__title-title">
+					{ this.getTitle() }
+				</div>
 				{ subTitle && <div className="activity-log-item__title-subtitle">{ subTitle }</div> }
 			</div>
 		);
 	}
 }
 
-export default localize( ActivityTitle );
+export default ActivityTitle;

--- a/client/my-sites/stats/activity-log-item/activity-title.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-title.jsx
@@ -216,7 +216,7 @@ class ActivityTitle extends Component {
 		return 'a widget';
 	}
 
-	getTitle() {
+	renderTitle() {
 		const { name } = this.props;
 
 		switch ( name ) {
@@ -480,7 +480,7 @@ class ActivityTitle extends Component {
 			 * before this feature goes into production.
 			 */
 			default:
-				return `The activity ${ name } is missing a title.`;
+				return <em>{ `The activity ${ name } is missing a title.` }</em>;
 		}
 	}
 
@@ -494,7 +494,7 @@ class ActivityTitle extends Component {
 		return (
 			<div className="activity-log-item__title">
 				<div className="activity-log-item__title-title">
-					{ this.getTitle() }
+					{ this.renderTitle() }
 				</div>
 				{ subTitle && <div className="activity-log-item__title-subtitle">{ subTitle }</div> }
 			</div>


### PR DESCRIPTION
Rather than use a fuzzy matching system that builds titles dynamically, this PR seeks to match 1:1 activity names to titles. It also makes it clear in the UI what titles are missing to allow them to be quickly identified in the UI.

## Testing
1. https://calypso.live/stats/activity?branch=update/activitylog-titles
1. Observe the activities and whether they have coherent appropriate titles.

## Screenshot

![activity](https://user-images.githubusercontent.com/841763/28462270-ccaace52-6e1a-11e7-8f8e-b5839a278098.png)

☝️  Note the Jetpack activity "The activity plugin__autoupdated is missing a title"