### PR TITLE
Site Settings: Add Manage Connection link to Site Tools, remove Jetpack card

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -27,7 +27,6 @@ import FormRadio from 'components/forms/form-radio';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Timezone from 'components/timezone';
-import JetpackSyncPanel from './jetpack-sync-panel';
 import SiteIconSetting from './site-icon-setting';
 import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
@@ -232,50 +231,6 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	showPublicPostTypesCheckbox() {
-		const { supportsPublicPostTypesCheckbox } = this.props;
-
-		if ( ! config.isEnabled( 'manage/option_sync_non_public_post_stati' ) ) {
-			return false;
-		}
-
-		if ( ! supportsPublicPostTypesCheckbox ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	syncNonPublicPostTypes() {
-		const { fields, handleToggle, isRequestingSettings, translate } = this.props;
-		if ( ! this.showPublicPostTypesCheckbox() ) {
-			return null;
-		}
-
-		return (
-			<CompactCard>
-				<form>
-					<ul id="settings-jetpack">
-						<li>
-							<CompactFormToggle
-								checked={ !! fields.jetpack_sync_non_public_post_stati }
-								disabled={ isRequestingSettings }
-								onChange={ handleToggle( 'jetpack_sync_non_public_post_stati' ) }
-							>
-								{ translate(
-									'Allow synchronization of Posts and Pages with non-public post statuses'
-								) }
-							</CompactFormToggle>
-							<FormSettingExplanation isIndented>
-								{ translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }
-							</FormSettingExplanation>
-						</li>
-					</ul>
-				</form>
-			</CompactCard>
-		);
-	}
-
 	jetpackDisconnectOption() {
 		const { site, siteIsJetpack, translate } = this.props;
 		const isAutomatedTransfer = get( site, 'options.is_automated_transfer', false );
@@ -353,53 +308,6 @@ class SiteSettingsFormGeneral extends Component {
 				</FormSettingExplanation>
 			</FormFieldset>
 		);
-	}
-
-	renderJetpackSyncPanel() {
-		const { supportsJetpackSync } = this.props;
-		if ( ! supportsJetpackSync ) {
-			return null;
-		}
-
-		return (
-			<JetpackSyncPanel />
-		);
-	}
-
-	renderApiCache() {
-		const { fields, translate, isRequestingSettings, handleToggle } = this.props;
-
-		if ( ! this.showApiCacheCheckbox() ) {
-			return null;
-		}
-
-		return (
-			<CompactCard>
-				<CompactFormToggle
-					checked={ !! fields.api_cache }
-					disabled={ isRequestingSettings }
-					onChange={ handleToggle( 'api_cache' ) }
-				>
-					{ translate(
-						'Use synchronized data to boost performance'
-					) } (a8c-only experimental feature)
-				</CompactFormToggle>
-			</CompactCard>
-		);
-	}
-
-	showApiCacheCheckbox() {
-		const { supportsApiCacheCheckbox } = this.props;
-
-		if ( ! config.isEnabled( 'jetpack/api-cache' ) ) {
-			return false;
-		}
-
-		if ( ! supportsApiCacheCheckbox ) {
-			return false;
-		}
-
-		return true;
 	}
 
 	render() {
@@ -495,36 +403,6 @@ class SiteSettingsFormGeneral extends Component {
 						}
 					</div>
 				}
-
-				{ siteIsJetpack
-					? <div className="site-settings__general-jetpack">
-						<SectionHeader label={ translate( 'Jetpack' ) }>
-							{ this.jetpackDisconnectOption() }
-							{ this.showPublicPostTypesCheckbox() || this.showApiCacheCheckbox()
-								? <Button
-									compact={ true }
-									onClick={ handleSubmitForm }
-									primary={ true }
-									type="submit"
-									disabled={ isRequestingSettings || isSavingSettings }>
-									{ isSavingSettings
-										? translate( 'Saving…' )
-										: translate( 'Save Settings' )
-									}
-									</Button>
-								: null
-							}
-						</SectionHeader>
-
-						{ this.renderJetpackSyncPanel() }
-						{ this.renderApiCache() }
-						{ this.syncNonPublicPostTypes() }
-
-						<CompactCard href={ '../security/' + siteSlug }>
-							{ translate( 'View Jetpack Monitor Settings' ) }
-						</CompactCard>
-					</div>
-					: null }
 			</div>
 		);
 	}
@@ -556,10 +434,7 @@ const connectComponent = connect(
 		return {
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
-			supportsPublicPostTypesCheckbox: siteIsJetpack && ! isJetpackMinimumVersion( state, siteId, '4.2' ),
 			supportsHolidaySnowOption: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.0' ),
-			supportsJetpackSync: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.2-alpha' ),
-			supportsApiCacheCheckbox: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.4.1' ),
 		};
 	},
 	null,
@@ -575,9 +450,7 @@ const getFormSettings = settings => {
 		timezone_string: '',
 		blog_public: '',
 		admin_url: '',
-		jetpack_sync_non_public_post_stati: false,
 		holidaysnow: false,
-		api_cache: false
 	};
 
 	if ( ! settings ) {
@@ -591,11 +464,8 @@ const getFormSettings = settings => {
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
 		timezone_string: settings.timezone_string,
-		jetpack_sync_non_public_post_stati: settings.jetpack_sync_non_public_post_stati,
 
 		holidaysnow: !! settings.holidaysnow,
-
-		api_cache: settings.api_cache
 	};
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -52,12 +52,14 @@ class SiteTools extends Component {
 			showDeleteContent,
 			showDeleteSite,
 			showThemeSetup,
+			showManageConnection,
 		} = this.props;
 
 		const changeAddressLink = `/domains/manage/${ siteSlug }`;
 		const themeSetupLink = `/settings/theme-setup/${ siteSlug }`;
 		const startOverLink = `/settings/start-over/${ siteSlug }`;
 		const deleteSiteLink = `/settings/delete-site/${ siteSlug }`;
+		const manageConnectionLink = `/settings/manage-connection/${ siteSlug }`;
 
 		const themeSetupText = translate( 'Automatically make your site look like your theme\'s demo.' );
 		const changeSiteAddress = translate( 'Change your site address' );
@@ -71,6 +73,10 @@ class SiteTools extends Component {
 		const deleteSiteText = translate(
 			'Delete all your posts, pages, media and data, ' +
 			'and give up your site\'s address.'
+		);
+		const manageConnectionTitle = translate( 'Manage your connection' );
+		const manageConnectionText = translate(
+			'Sync your site content for a faster experience, change site owner, cycle or terminate your connection.'
 		);
 
 		const importTitle = translate( 'Import' );
@@ -127,6 +133,13 @@ class SiteTools extends Component {
 						title={ deleteSite }
 						description={ deleteSiteText }
 						isWarning
+					/>
+				}
+				{ showManageConnection &&
+					<SiteToolsLink
+						href={ manageConnectionLink }
+						title={ manageConnectionTitle }
+						description={ manageConnectionText }
 					/>
 				}
 				<DeleteSiteWarningDialog
@@ -189,6 +202,7 @@ export default connect(
 			showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
 			showDeleteContent: ! isJetpack && ! isVip,
 			showDeleteSite: ! isJetpack && ! isVip && sitePurchasesLoaded,
+			showManageConnection: isJetpack,
 		};
 	}
 )( localize( SiteTools ) );


### PR DESCRIPTION
### Purpose

This PR adds a "Manage Connection" link to Site Tools for Jetpack sites, and removes the Jetpack card from the General settings section, as what we needed from there is already in the Manage Connection page.

Fixes #13232.

### Preview

**General Settings (before)**
![](https://cldup.com/Og3Yc7PqtB.png)

**General Settings (after)**
![](https://cldup.com/fxDXnHtfUg.png)

### To test

* Checkout this branch, or get it going on calypso.live
* Go to `/settings/general/:site`, where `:site` is a Jetpack site.
* Verify you can no longer see the Jetpack card, and that the General section works properly.
* Verify you can see the "Manage Connection" link in Site Tools.
* Click on "Manage Connection" and verify it takes you to the new Manage Connection page.
* Test with a .com site and verify you don't see the Manage Connection link in Site Tools.