### PR TITLE
Activity Log: Track month changes

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -102,7 +102,7 @@ class ActivityLog extends Component {
 
 	handlePeriodChange = ( { date, direction } ) => {
 		this.props.recordTracksEvent( 'calypso_activitylog_monthpicker_change', {
-			date,
+			date: date.utc().toISOString(),
 			direction,
 		} );
 	}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -100,6 +100,13 @@ class ActivityLog extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
+	handlePeriodChange = ( { date, direction } ) => {
+		this.props.recordTracksEvent( 'calypso_activitylog_monthpicker_change', {
+			date,
+			direction,
+		} );
+	}
+
 	handleRequestRestore = ( requestedRestoreTimestamp, from ) => {
 		this.props.recordTracksEvent( 'calypso_activitylog_restore_request', {
 			from,
@@ -293,8 +300,9 @@ class ActivityLog extends Component {
 		return (
 			<div>
 				<StatsPeriodNavigation
-					period="month"
 					date={ startOfMonth }
+					onPeriodChange={ this.handlePeriodChange }
+					period="month"
 					url={ `/stats/activity/${ slug }` }
 				>
 					<DatePicker

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -131,7 +131,7 @@ class StatsSite extends Component {
 							<DatePicker
 								period={ period }
 								date={ date }
-								query={ query }
+								query={ query }
 								statsType="statsTopPosts"
 								showQueryDate
 							/>
@@ -205,5 +205,5 @@ export default connect(
 			slug: getSelectedSiteSlug( state )
 		};
 	},
-	{  recordGoogleEvent }
+	{ recordGoogleEvent }
 )( localize( StatsSite ) );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -10,23 +10,43 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent as recordGoogleEventAction } from 'state/analytics/actions';
 
 class StatsPeriodNavigation extends PureComponent {
+	handleClickNext = () => {
+		this.handleClickArrow( 'next' );
+	}
+
+	handleClickPrevious = () => {
+		this.handleClickArrow( 'previous' );
+	}
+
+	handleClickArrow = arrow => {
+		const {
+			recordGoogleEvent,
+			period,
+		} = this.props;
+		recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } ${ period }` );
+	};
+
 	render() {
-		const { url, children, date, period, moment } = this.props;
+		const {
+			children,
+			date,
+			moment,
+			period,
+			url,
+		} = this.props;
+
 		const isToday = moment( date ).isSame( moment(), period );
 		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
 		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
-		const clickArrow = arrow => () => {
-			this.props.recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } ${ period }` );
-		};
 
 		return (
 			<div className="stats-period-navigation">
 				<a className="stats-period-navigation__previous"
 					href={ `${ url }?startDate=${ previousDay }` }
-					onClick={ clickArrow( 'previous' ) }>
+					onClick={ this.handleClickPrevious }>
 					<Gridicon icon="arrow-left" size={ 18 } />
 				</a>
 				<div className="stats-period-navigation__children">
@@ -35,7 +55,7 @@ class StatsPeriodNavigation extends PureComponent {
 				{ ! isToday &&
 					<a className="stats-period-navigation__next"
 						href={ `${ url }?startDate=${ nextDay }` }
-						onClick={ clickArrow( 'next' ) }>
+						onClick={ this.handleClickNext }>
 						<Gridicon icon="arrow-right" size={ 18 } />
 					</a>
 				}
@@ -49,7 +69,7 @@ class StatsPeriodNavigation extends PureComponent {
 	}
 }
 
-const connectComponent = connect( undefined, { recordGoogleEvent } );
+const connectComponent = connect( undefined, { recordGoogleEvent: recordGoogleEventAction } );
 
 export default flowRight(
 	connectComponent,

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -83,7 +83,7 @@ class StatsPeriodNavigation extends PureComponent {
 	}
 }
 
-const connectComponent = connect( undefined, { recordGoogleEvent: recordGoogleEventAction } );
+const connectComponent = connect( null, { recordGoogleEvent: recordGoogleEventAction } );
 
 export default flowRight(
 	connectComponent,

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { PropTypes, PureComponent } from 'react';
 import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -13,6 +13,10 @@ import Gridicon from 'gridicons';
 import { recordGoogleEvent as recordGoogleEventAction } from 'state/analytics/actions';
 
 class StatsPeriodNavigation extends PureComponent {
+	static propTypes = {
+		onPeriodChange: PropTypes.func,
+	};
+
 	handleClickNext = () => {
 		this.handleClickArrow( 'next' );
 	}
@@ -23,10 +27,20 @@ class StatsPeriodNavigation extends PureComponent {
 
 	handleClickArrow = arrow => {
 		const {
-			recordGoogleEvent,
+			date,
+			onPeriodChange,
 			period,
+			recordGoogleEvent,
 		} = this.props;
 		recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } ${ period }` );
+
+		if ( onPeriodChange ) {
+			onPeriodChange( {
+				date,
+				direction: arrow,
+				period,
+			} );
+		}
 	};
 
 	render() {

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { flowRight } from 'lodash';
-import { connect } from 'react-redux';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -12,40 +12,42 @@ import Gridicon from 'gridicons';
  */
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const StatsPeriodNavigation = props => {
-	const { url, children, date, period, moment } = props;
-	const isToday = moment( date ).isSame( moment(), period );
-	const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
-	const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
-	const clickArrow = arrow => () => {
-		props.recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } ${ period }` );
-	};
+class StatsPeriodNavigation extends PureComponent {
+	render() {
+		const { url, children, date, period, moment } = this.props;
+		const isToday = moment( date ).isSame( moment(), period );
+		const previousDay = moment( date ).subtract( 1, period ).format( 'YYYY-MM-DD' );
+		const nextDay = moment( date ).add( 1, period ).format( 'YYYY-MM-DD' );
+		const clickArrow = arrow => () => {
+			this.props.recordGoogleEvent( 'Stats Period Navigation', `Clicked ${ arrow } ${ period }` );
+		};
 
-	return (
-		<div className="stats-period-navigation">
-			<a className="stats-period-navigation__previous"
-				href={ `${ url }?startDate=${ previousDay }` }
-				onClick={ clickArrow( 'previous' ) }>
-				<Gridicon icon="arrow-left" size={ 18 } />
-			</a>
-			<div className="stats-period-navigation__children">
-				{ children }
-			</div>
-			{ ! isToday &&
-				<a className="stats-period-navigation__next"
-					href={ `${ url }?startDate=${ nextDay }` }
-					onClick={ clickArrow( 'next' ) }>
-					<Gridicon icon="arrow-right" size={ 18 } />
+		return (
+			<div className="stats-period-navigation">
+				<a className="stats-period-navigation__previous"
+					href={ `${ url }?startDate=${ previousDay }` }
+					onClick={ clickArrow( 'previous' ) }>
+					<Gridicon icon="arrow-left" size={ 18 } />
 				</a>
-			}
-			{ isToday &&
-				<span className="stats-period-navigation__next is-disabled">
-					<Gridicon icon="arrow-right" size={ 18 } />
-				</span>
-			}
-		</div>
-	);
-};
+				<div className="stats-period-navigation__children">
+					{ children }
+				</div>
+				{ ! isToday &&
+					<a className="stats-period-navigation__next"
+						href={ `${ url }?startDate=${ nextDay }` }
+						onClick={ clickArrow( 'next' ) }>
+						<Gridicon icon="arrow-right" size={ 18 } />
+					</a>
+				}
+				{ isToday &&
+					<span className="stats-period-navigation__next is-disabled">
+						<Gridicon icon="arrow-right" size={ 18 } />
+					</span>
+				}
+			</div>
+		);
+	}
+}
 
 const connectComponent = connect( undefined, { recordGoogleEvent } );
 

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';


### PR DESCRIPTION
Updates the StatsPeriodNavigation component. It changes the component to `PureComponent` to avoid creating handlers on every render.

Add the `onPeriodChange` prop to `StatsPeriodNavigation`.

Add `handlePeriodChange` to `ActivityLog` to add tracks events from the Activity Log.

## Testing
* https://calypso.live/stats/activity?branch=update/stats-period-navigation-onchange
* Execute `localStorage.setItem('debug', 'calypso:analytics:tracks' )` in the console so you can see tracks events
* Navigate and observe the tracks events

Closes #16175