### PR TITLE
Posts: Add support to filter by term (take 2)

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import page from 'page';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -57,6 +58,12 @@ class TaxonomyManagerListItem extends Component {
 		this.setState( {
 			showDeleteDialog: true
 		} );
+	};
+
+	viewPosts = () => {
+		const { siteSlug, taxonomy, term } = this.props;
+		this.props.recordGoogleEvent( 'Taxonomy Manager', `View ${ taxonomy }` );
+		page( `/posts/${ siteSlug }?${ taxonomy }=${ term.slug }` );
 	};
 
 	closeDeleteDialog = action => {
@@ -167,7 +174,12 @@ class TaxonomyManagerListItem extends Component {
 							{ translate( 'Delete' ) }
 						</PopoverMenuItem>
 					}
-					{ ! isJetpack &&
+
+					<PopoverMenuItem onClick={ this.viewPosts } icon="visible">
+						{ translate( 'View Posts' ) }
+					</PopoverMenuItem>
+
+					{ false && ! isJetpack && /* TODO remove this altogether */
 						<WithPreviewProps
 								url={ this.getTaxonomyLink() }
 								isPreviewable={ this.props.isPreviewable }>
@@ -207,6 +219,7 @@ export default connect(
 		const canSetAsDefault = taxonomy === 'category';
 		const isDefault = canSetAsDefault && get( siteSettings, [ 'default_category' ] ) === term.ID;
 		const isPreviewable = get( site, 'is_previewable' );
+		const siteSlug = get( site, 'slug' );
 		const siteUrl = get( site, 'URL' );
 
 		return {
@@ -215,6 +228,7 @@ export default connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			isPreviewable,
 			siteId,
+			siteSlug,
 			siteUrl,
 		};
 	},

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -18,10 +18,9 @@ import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
 import Tooltip from 'components/tooltip';
-import WithPreviewProps from 'components/web-preview/with-preview-props';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
-import { getSite, isJetpackSite } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
 import { decodeEntities } from 'lib/formatting';
 import { deleteTerm } from 'state/terms/actions';
 import { saveSiteSettings } from 'state/site-settings/actions';
@@ -39,7 +38,6 @@ class TaxonomyManagerListItem extends Component {
 		translate: PropTypes.func,
 		siteUrl: PropTypes.string,
 		slug: PropTypes.string,
-		isJetpack: PropTypes.bool,
 		isPreviewable: PropTypes.bool,
 		recordGoogleEvent: PropTypes.func,
 		bumpStat: PropTypes.func,
@@ -128,7 +126,7 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	render() {
-		const { canSetAsDefault, isDefault, onClick, term, translate, isJetpack } = this.props;
+		const { canSetAsDefault, isDefault, onClick, term, translate } = this.props;
 		const name = this.getName();
 		const className = classNames( 'taxonomy-manager__item', {
 			'is-default': isDefault
@@ -179,19 +177,6 @@ class TaxonomyManagerListItem extends Component {
 						{ translate( 'View Posts' ) }
 					</PopoverMenuItem>
 
-					{ false && ! isJetpack && /* TODO remove this altogether */
-						<WithPreviewProps
-								url={ this.getTaxonomyLink() }
-								isPreviewable={ this.props.isPreviewable }>
-							{ ( props ) =>
-								<PopoverMenuItem { ...props }
-										icon={ this.props.isPreviewable
-											? 'visible' : 'external' }>
-									{ translate( 'View Posts' ) }
-								</PopoverMenuItem>
-							}
-						</WithPreviewProps>
-					}
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
 					{ canSetAsDefault && ! isDefault &&
 						<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">
@@ -225,7 +210,6 @@ export default connect(
 		return {
 			canSetAsDefault,
 			isDefault,
-			isJetpack: isJetpackSite( state, siteId ),
 			isPreviewable,
 			siteId,
 			siteSlug,

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -59,8 +59,12 @@ class TaxonomyManagerListItem extends Component {
 	};
 
 	viewPosts = () => {
-		const { siteSlug, taxonomy, term } = this.props;
-		this.props.recordGoogleEvent( 'Taxonomy Manager', `View ${ taxonomy }` );
+		const { siteSlug, taxonomy: rawTaxonomy, term } = this.props;
+		const taxonomy = rawTaxonomy === 'post_tag'
+			? 'tag'
+			: rawTaxonomy;
+
+		this.props.recordGoogleEvent( 'Taxonomy Manager', `View ${ rawTaxonomy }` );
 		page( `/posts/${ siteSlug }?${ taxonomy }=${ term.slug }` );
 	};
 

--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -132,6 +132,7 @@ class TaxonomyManagerListItem extends Component {
 	render() {
 		const { canSetAsDefault, isDefault, onClick, term, translate } = this.props;
 		const name = this.getName();
+		const hasPosts = get( term, 'post_count', 0 ) > 0;
 		const className = classNames( 'taxonomy-manager__item', {
 			'is-default': isDefault
 		} );
@@ -176,11 +177,11 @@ class TaxonomyManagerListItem extends Component {
 							{ translate( 'Delete' ) }
 						</PopoverMenuItem>
 					}
-
-					<PopoverMenuItem onClick={ this.viewPosts } icon="visible">
-						{ translate( 'View Posts' ) }
-					</PopoverMenuItem>
-
+					{ hasPosts &&
+						<PopoverMenuItem onClick={ this.viewPosts } icon="visible">
+							{ translate( 'View Posts' ) }
+						</PopoverMenuItem>
+					}
 					{ canSetAsDefault && ! isDefault && <PopoverMenuSeparator /> }
 					{ canSetAsDefault && ! isDefault &&
 						<PopoverMenuItem onClick={ this.setAsDefault } icon="checkmark-circle">

--- a/client/components/post-list-fetcher/index.jsx
+++ b/client/components/post-list-fetcher/index.jsx
@@ -30,6 +30,8 @@ function queryPosts( props ) {
 		status: props.status,
 		author: props.author,
 		search: props.search,
+		category: props.category,
+		tag: props.tag,
 		exclude_tree: props.excludeTree,
 		orderBy: props.orderBy,
 		order: props.order,
@@ -74,6 +76,8 @@ function shouldQueryPosts( props, nextProps ) {
 		props.status !== nextProps.status ||
 		props.author !== nextProps.author ||
 		props.search !== nextProps.search ||
+		props.category !== nextProps.category ||
+		props.tag !== nextProps.tag ||
 		props.excludeTree !== nextProps.excludeTree ||
 		props.withCounts !== nextProps.withCounts ||
 		props.orderBy !== nextProps.orderBy ||
@@ -93,6 +97,8 @@ PostListFetcher = React.createClass( {
 		status: React.PropTypes.string,
 		author: React.PropTypes.number,
 		search: React.PropTypes.string,
+		category: React.PropTypes.string,
+		tag: React.PropTypes.string,
 		siteId: React.PropTypes.number,
 		withImages: React.PropTypes.bool,
 		withCounts: React.PropTypes.bool,

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -36,6 +36,8 @@ const _defaultQuery = {
 	order: 'DESC',
 	author: false,
 	search: false,
+	category: false,
+	tag: false,
 	perPage: 20
 };
 
@@ -348,6 +350,14 @@ export default function( id ) {
 				params.search = query.search;
 			}
 
+			if ( query.category ) {
+				params.category = query.category;
+			}
+
+			if ( query.tag ) {
+				params.tag = query.tag;
+			}
+
 			if ( ! params.siteId ) {
 				// Only query from visible sites
 				params.site_visibility = 'visible';
@@ -370,6 +380,14 @@ export default function( id ) {
 
 			if ( query.search ) {
 				params.search = query.search;
+			}
+
+			if ( query.category ) {
+				params.category = query.category;
+			}
+
+			if ( query.tag ) {
+				params.tag = query.tag;
 			}
 
 			if ( ! params.siteId ) {

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -32,6 +32,8 @@ module.exports = {
 			author = ( context.params.author === 'my' ) ? getCurrentUserId( state ) : null,
 			statusSlug = ( author ) ? context.params.status : context.params.author,
 			search = context.query.s,
+			category = context.query.category,
+			tag = context.query.tag,
 			basePath = route.sectionify( context.path ),
 			analyticsPageTitle = 'Blog Posts',
 			baseAnalyticsPath;
@@ -83,10 +85,12 @@ module.exports = {
 
 		renderWithReduxStore(
 			React.createElement( Posts, {
-				context: context,
-				author: author,
-				statusSlug: statusSlug,
-				search: search,
+				context,
+				author,
+				statusSlug,
+				search,
+				category,
+				tag,
 				trackScrollPage: trackScrollPage.bind(
 					null,
 					baseAnalyticsPath,

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -34,6 +34,8 @@ var PostList = React.createClass( {
 	propTypes: {
 		context: React.PropTypes.object,
 		search: React.PropTypes.string,
+		category: React.PropTypes.string,
+		tag: React.PropTypes.string,
 		hasSites: React.PropTypes.bool,
 		statusSlug: React.PropTypes.string,
 		siteId: React.PropTypes.number,
@@ -48,7 +50,10 @@ var PostList = React.createClass( {
 				author={ this.props.author }
 				withImages={ true }
 				withCounts={ true }
-				search={ this.props.search }>
+				search={ this.props.search }
+				category={ this.props.category }
+				tag={ this.props.tag }
+			>
 				<Posts
 					{ ...omit( this.props, 'children' ) }
 				/>


### PR DESCRIPTION
Take 2 of #15614, this time way less ambitious in that we don't try to switch Posts to Redux (yet).

Fixes #9942

Note that filtering on All Sites is seemingly broken due to a general issue with endpoint `/me/posts`'s search capabilities.

# Pre-merge checklist
- [x] Confirm that this new "View Posts" popover item supersedes the former, which showed the site front-end.
  - [x] Remove old "View Posts" popover item.
- [x] Confirm that the new analytics event is fitting.
- [x] Confirm that we don't need to exclude Jetpack anymore (term-filtered Posts view works for me on Jetpack sites).

^ @timmyc and/or @youknowriad: feel free to tick the _Confirm_ items if everything is alright with you.

![calypso-posts-filter-by-term](https://user-images.githubusercontent.com/150562/28466350-0776f2dc-6e24-11e7-8b10-7c861b878eae.gif)
