### PR TITLE
EditGravatar: Add missing translation

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -230,7 +230,9 @@ export class EditGravatar extends Component {
 					</FilePicker>
 				</div>
 				<div>
-					<p className="edit-gravatar__explanation">Your profile photo is public.</p>
+					<p className="edit-gravatar__explanation">
+						{ translate( 'Your profile photo is public.' ) }
+					</p>
 					<InfoPopover
 						className="edit-gravatar__pop-over"
 						position="left" >


### PR DESCRIPTION
This PR adds a single missing translation in the `EditGravatar` component for the string 'Your profile photo is public.' All other strings related to this component are already translated.