### PR TITLE
Reader: avoid duplication of logic between Standard and Compact post cards

### DIFF
--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -8,32 +8,19 @@ import React from 'react';
  */
 import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
-import ReaderFeaturedVideo from 'blocks/reader-featured-video';
-import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
+import FeaturedAsset from './featured-asset';
 
 const CompactPost = ( { post, postByline, children, isDiscover } ) => {
-	const canonicalMedia = post.canonical_media;
-	let featuredAsset;
-	if ( ! canonicalMedia ) {
-		featuredAsset = null;
-	} else if ( canonicalMedia.mediaType === 'video' ) {
-		featuredAsset = (
-			<ReaderFeaturedVideo
-				{ ...canonicalMedia }
-				videoEmbed={ canonicalMedia }
-				allowPlaying={ false }
-			/>
-		);
-	} else {
-		featuredAsset = <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ post.URL } />;
-	}
-
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="reader-post-card__post">
-			{ featuredAsset }
+			<FeaturedAsset
+				canonicalMedia={ post.canonical_media }
+				postUrl={ post.URL }
+				allowVideoPlaying={ false }
+			/>
 			<div className="reader-post-card__post-details">
 				{ postByline }
 				<ReaderPostOptionsMenu

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -1,0 +1,50 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import ReaderFeaturedVideo from 'blocks/reader-featured-video';
+import ReaderFeaturedImage from 'blocks/reader-featured-image';
+
+const FeaturedAsset = ( {
+	canonicalMedia,
+	postUrl,
+	allowVideoPlaying,
+	onVideoThumbnailClick,
+	isVideoExpanded,
+} ) => {
+	if ( ! canonicalMedia ) {
+		return null;
+	}
+
+	if ( canonicalMedia.mediaType === 'video' ) {
+		return (
+			<ReaderFeaturedVideo
+				{ ...canonicalMedia }
+				videoEmbed={ canonicalMedia }
+				allowPlaying={ allowVideoPlaying }
+				onThumbnailClick={ onVideoThumbnailClick }
+				isExpanded={ isVideoExpanded }
+			/>
+		);
+	}
+
+	return <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ postUrl } />;
+};
+
+FeaturedAsset.propTypes = {
+	canonicalMedia: React.PropTypes.object,
+	postUrl: React.PropTypes.string,
+	allowVideoPlaying: React.PropTypes.bool,
+	onVideoThumbnailClick: React.PropTypes.func,
+	isVideoExpanded: React.PropTypes.bool,
+};
+
+FeaturedAsset.defaultProps = {
+	allowVideoPlaying: true,
+};
+
+export default FeaturedAsset;

--- a/client/blocks/reader-post-card/standard.jsx
+++ b/client/blocks/reader-post-card/standard.jsx
@@ -2,38 +2,29 @@
  * External Dependencies
  */
 import React from 'react';
-import { partial } from 'lodash';
+import { get, partial } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
-import ReaderFeaturedVideo from 'blocks/reader-featured-video';
-import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderExcerpt from 'blocks/reader-excerpt';
+import FeaturedAsset from './featured-asset';
 
 const StandardPost = ( { post, children, isDiscover, expandCard, postKey, isExpanded, site } ) => {
-	const canonicalMedia = post.canonical_media;
-	let featuredAsset;
-	if ( ! canonicalMedia ) {
-		featuredAsset = null;
-	} else if ( canonicalMedia.mediaType === 'video' ) {
-		featuredAsset = (
-			<ReaderFeaturedVideo
-				{ ...canonicalMedia }
-				videoEmbed={ canonicalMedia }
-				onThumbnailClick={ partial( expandCard, { postKey, post, site } ) }
-				isExpanded={ isExpanded }
-			/>
-		);
-	} else {
-		featuredAsset = <ReaderFeaturedImage imageUrl={ canonicalMedia.src } href={ post.URL } />;
+	let onVideoThumbnailClick = null;
+	if ( get( post, 'canonical_media.mediaType' ) === 'video' ) {
+		onVideoThumbnailClick = partial( expandCard, { postKey, post, site } );
 	}
-
 	return (
 		<div className="reader-post-card__post">
-			{ featuredAsset }
+			<FeaturedAsset
+				canonicalMedia={ post.canonical_media }
+				postUrl={ post.URL }
+				onVideoThumbnailClick={ onVideoThumbnailClick }
+				isVideoExpanded={ isExpanded }
+			/>
 			<div className="reader-post-card__post-details">
 				<AutoDirection>
 					<h1 className="reader-post-card__title">


### PR DESCRIPTION
Raised by @samouri in https://github.com/Automattic/wp-calypso/pull/16256#discussion_r128357830. In the new compact post card, we duplicated a lot of the featured asset logic already in use in the standard card.

This PR attempts to reduce repetition by moving the logic to a `FeaturedAsset` component.

No functional changes.

### To test

Verify that standard and compact cards still appear as expected, and that video expansion still works:

http://calypso.localhost:3000/read/blogs/122463145