### PR TITLE
EditGravatar: Disallow click while uploading

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -189,7 +189,8 @@ export class EditGravatar extends Component {
 			<div
 				className={
 					classnames( 'edit-gravatar',
-						{ 'is-unverified': ! user.email_verified }
+						{ 'is-unverified': ! user.email_verified },
+						{ 'is-uploading': isUploading }
 					)
 				}
 			>

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -115,6 +115,12 @@
 	}
 }
 
+.edit-gravatar.is-uploading {
+	.file-picker {
+		pointer-events: none;
+	}
+}
+
 .edit-gravatar .drop-zone {
 	border-radius: 50%;
 	width: 150px;


### PR DESCRIPTION
Previously, a user would be able to click the `EditGravatar` button and start another Gravatar upload while the previous upload was not yet finished. Here's what it looked like:

<img src="https://user-images.githubusercontent.com/11487924/28469587-b267968a-6e04-11e7-866b-409aef099e5c.gif">

Now, this is no longer possible:

<img src="https://user-images.githubusercontent.com/11487924/28469594-b7aca8d8-6e04-11e7-9b02-a2561d44be6c.gif">

To test:
1. Go to http://calypso.localhost:3000/me and try to upload a Gravatar