### PR TITLE
Activity Log: Update icons + colors

### DIFF
--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -4,7 +4,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { get } from 'lodash';
+import { get, startsWith } from 'lodash';
 
 export default class ActivityIcon extends PureComponent {
 
@@ -40,11 +40,10 @@ export default class ActivityIcon extends PureComponent {
 
 		switch ( group ) {
 			case 'attachment':
-				if ( 'application/zip' === get( object, [ 'attachment', 'mime_type' ] ) ) {
-					return 'attachment';
+				if ( startsWith( get( object, [ 'attachment', 'mime_type' ] ), 'image/' ) ) {
+					return 'image';
 				}
-
-				return 'image';
+				return 'attachment';
 
 			case 'comment':
 				return 'comment';

--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -4,6 +4,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 export default class ActivityIcon extends PureComponent {
 
@@ -21,12 +22,14 @@ export default class ActivityIcon extends PureComponent {
 			'widget',
 		] ).isRequired,
 		name: PropTypes.string.isRequired,
+		object: PropTypes.object.isRequired,
 	};
 
 	getIcon() {
 		const {
 			group,
 			name,
+			object,
 		} = this.props;
 
 		switch ( name ) {
@@ -37,6 +40,10 @@ export default class ActivityIcon extends PureComponent {
 
 		switch ( group ) {
 			case 'attachment':
+				if ( 'application/zip' === get( object, [ 'attachment', 'mime_type' ] ) ) {
+					return 'attachment';
+				}
+
 				return 'image';
 
 			case 'comment':

--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -75,6 +75,9 @@ export default class ActivityIcon extends PureComponent {
 				return 'is-error';
 
 			case 'attachment__uploaded':
+			case 'plugin__autoupdated':
+			case 'plugin__installed':
+			case 'plugin__installed_filesystem':
 			case 'term__created':
 			case 'theme__installed':
 			case 'user__registered':
@@ -82,6 +85,7 @@ export default class ActivityIcon extends PureComponent {
 
 			case 'comment__published_awaiting_approval':
 			case 'comment__unapproved':
+			case 'plugin__update_available':
 				return 'is-warning';
 		}
 

--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -33,7 +33,6 @@ export default class ActivityIcon extends PureComponent {
 			// Inline return makes alphabetizing and searching easier :)
 			case 'post__published': return 'create';
 			case 'post__trashed': return 'trash';
-			case 'user__registered': return 'user-add';
 		}
 
 		switch ( group ) {

--- a/client/my-sites/stats/activity-log-item/activity-icon.jsx
+++ b/client/my-sites/stats/activity-log-item/activity-icon.jsx
@@ -28,15 +28,8 @@ export default class ActivityIcon extends PureComponent {
 	getIcon() {
 		const {
 			group,
-			name,
 			object,
 		} = this.props;
-
-		switch ( name ) {
-			// Inline return makes alphabetizing and searching easier :)
-			case 'post__published': return 'create';
-			case 'post__trashed': return 'trash';
-		}
 
 		switch ( group ) {
 			case 'attachment':
@@ -80,11 +73,9 @@ export default class ActivityIcon extends PureComponent {
 			case 'widget__removed':
 				return 'is-error';
 
-			case 'attachment__uploaded':
 			case 'plugin__autoupdated':
 			case 'plugin__installed':
 			case 'plugin__installed_filesystem':
-			case 'term__created':
 			case 'theme__installed':
 			case 'user__registered':
 				return 'is-success';

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -285,6 +285,7 @@ class ActivityLogItem extends Component {
 		const {
 			group,
 			name,
+			object,
 		} = log;
 
 		const classes = classNames( 'activity-log-item', className );
@@ -293,7 +294,7 @@ class ActivityLogItem extends Component {
 			<div className={ classes } >
 				<div className="activity-log-item__type">
 					{ this.renderTime() }
-					<ActivityIcon group={ group } name={ name } />
+					<ActivityIcon group={ group } name={ name } object={ object } />
 				</div>
 				<FoldableCard
 					className="activity-log-item__card"


### PR DESCRIPTION
Updates some Activity Logs icons and colors. 

- Use single pictogram icons (user instead of user-add); delegate variation to bg color.
- Add more color use cases to plugin events.
- Add logic so we can have multiple attachment icons.

### Visuals

![image](https://user-images.githubusercontent.com/390760/28470077-729db4ea-6e30-11e7-8ab1-a1d5d9f9a0b4.png)

![image](https://user-images.githubusercontent.com/390760/28470069-673bba84-6e30-11e7-8993-63ee6ffae32c.png)

### Testing

- Open https://calypso.live/?branch=update/activity-log-icons
- Visit _Stats > Activity_