### PR TITLE
Upgrade wpcom-proxy-request to v4.0.5

### DIFF
--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -26,8 +26,8 @@ if ( config.isEnabled( 'oauth' ) ) {
 	wpcom = wpcomUndocumented( oauthToken.getToken(), requestHandler );
 } else {
 	const requestHandler = addSyncHandlerWrapper
-		? new SyncHandler( require( 'wpcom-proxy-request' ) )
-		: require( 'wpcom-proxy-request' );
+		? new SyncHandler( require( 'wpcom-proxy-request' ).default )
+		: require( 'wpcom-proxy-request' ).default;
 
 	wpcom = wpcomUndocumented( requestHandler );
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1607,7 +1607,7 @@
       }
     },
     "enhanced-resolve": {
-      "version": "3.3.0"
+      "version": "3.4.0"
     },
     "entities": {
       "version": "1.0.0"
@@ -6895,9 +6895,7 @@
       }
     },
     "wpcom-proxy-request": {
-      "version": "4.0.4",
-      "from": "git://github.com/automattic/wpcom-proxy-request.git#d8006f9c7e2c964d26ff76dc65f47dfe84eac446",
-      "resolved": "git://github.com/automattic/wpcom-proxy-request.git#d8006f9c7e2c964d26ff76dc65f47dfe84eac446"
+      "version": "4.0.5"
     },
     "wpcom-xhr-request": {
       "version": "1.1.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -936,7 +936,7 @@
       "version": "1.0.4"
     },
     "circular-json": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dev": true
     },
     "classnames": {
@@ -4380,7 +4380,7 @@
       "version": "0.1.17"
     },
     "node-emoji": {
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dev": true
     },
     "node-fetch": {
@@ -6896,8 +6896,8 @@
     },
     "wpcom-proxy-request": {
       "version": "4.0.4",
-      "from": "git://github.com/automattic/wpcom-proxy-request.git#59743fa4a36832e3417ffcec9275d1f8f1a8dc26",
-      "resolved": "git://github.com/automattic/wpcom-proxy-request.git#59743fa4a36832e3417ffcec9275d1f8f1a8dc26"
+      "from": "git://github.com/automattic/wpcom-proxy-request.git#fe120ddacbe27988efa0a8cfe5af5da3c45448cf",
+      "resolved": "git://github.com/automattic/wpcom-proxy-request.git#fe120ddacbe27988efa0a8cfe5af5da3c45448cf"
     },
     "wpcom-xhr-request": {
       "version": "1.1.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,7 +3,7 @@
   "version": "0.17.0",
   "dependencies": {
     "@types/node": {
-      "version": "6.0.84",
+      "version": "6.0.85",
       "dev": true
     },
     "5to6-codemod": {
@@ -679,7 +679,7 @@
       "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.8.0"
+      "version": "1.9.0"
     },
     "binary-search-bounds": {
       "version": "1.0.0"
@@ -4380,7 +4380,7 @@
       "version": "0.1.17"
     },
     "node-emoji": {
-      "version": "1.7.0",
+      "version": "1.8.0",
       "dev": true
     },
     "node-fetch": {
@@ -4845,7 +4845,7 @@
       "dev": true,
       "dependencies": {
         "ansi-styles": {
-          "version": "3.1.0",
+          "version": "3.2.0",
           "dev": true
         },
         "chalk": {
@@ -4869,7 +4869,7 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "dev": true
         }
       }
@@ -4888,7 +4888,7 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "minimist": {
           "version": "1.2.0"
@@ -4949,7 +4949,7 @@
           "dev": true,
           "dependencies": {
             "ansi-styles": {
-              "version": "3.1.0",
+              "version": "3.2.0",
               "dev": true
             },
             "chalk": {
@@ -4961,7 +4961,7 @@
               "dev": true
             },
             "supports-color": {
-              "version": "4.2.0",
+              "version": "4.2.1",
               "dev": true
             }
           }
@@ -4985,7 +4985,7 @@
       "dev": true,
       "dependencies": {
         "ansi-styles": {
-          "version": "3.1.0",
+          "version": "3.2.0",
           "dev": true
         }
       }
@@ -5922,10 +5922,6 @@
     },
     "string-width": {
       "version": "1.0.2"
-    },
-    "string.prototype.codepointat": {
-      "version": "0.2.0",
-      "dev": true
     },
     "string.prototype.padend": {
       "version": "3.0.0"
@@ -6899,7 +6895,9 @@
       }
     },
     "wpcom-proxy-request": {
-      "version": "3.0.0"
+      "version": "4.0.4",
+      "from": "git://github.com/automattic/wpcom-proxy-request.git#59743fa4a36832e3417ffcec9275d1f8f1a8dc26",
+      "resolved": "git://github.com/automattic/wpcom-proxy-request.git#59743fa4a36832e3417ffcec9275d1f8f1a8dc26"
     },
     "wpcom-xhr-request": {
       "version": "1.1.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -936,7 +936,7 @@
       "version": "1.0.4"
     },
     "circular-json": {
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dev": true
     },
     "classnames": {
@@ -6896,8 +6896,8 @@
     },
     "wpcom-proxy-request": {
       "version": "4.0.4",
-      "from": "git://github.com/automattic/wpcom-proxy-request.git#fe120ddacbe27988efa0a8cfe5af5da3c45448cf",
-      "resolved": "git://github.com/automattic/wpcom-proxy-request.git#fe120ddacbe27988efa0a8cfe5af5da3c45448cf"
+      "from": "git://github.com/automattic/wpcom-proxy-request.git#d8006f9c7e2c964d26ff76dc65f47dfe84eac446",
+      "resolved": "git://github.com/automattic/wpcom-proxy-request.git#d8006f9c7e2c964d26ff76dc65f47dfe84eac446"
     },
     "wpcom-xhr-request": {
       "version": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "webpack-hot-middleware": "2.15.0",
     "wpcom": "5.4.0",
     "wpcom-oauth": "0.3.3",
-    "wpcom-proxy-request": "3.0.0",
+    "wpcom-proxy-request": "Automattic/wpcom-proxy-request#fix/bad-ready-event",
     "wpcom-xhr-request": "1.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "webpack-hot-middleware": "2.15.0",
     "wpcom": "5.4.0",
     "wpcom-oauth": "0.3.3",
-    "wpcom-proxy-request": "Automattic/wpcom-proxy-request#fix/bad-ready-event",
+    "wpcom-proxy-request": "Automattic/wpcom-proxy-request#fix/bad-status-code",
     "wpcom-xhr-request": "1.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "webpack-hot-middleware": "2.15.0",
     "wpcom": "5.4.0",
     "wpcom-oauth": "0.3.3",
-    "wpcom-proxy-request": "Automattic/wpcom-proxy-request#fix/bad-status-code",
+    "wpcom-proxy-request": "4.0.5",
     "wpcom-xhr-request": "1.1.0"
   },
   "engines": {


### PR DESCRIPTION
This PR upgrades the `wpcom-proxy-request` to `4.0.5`.

This bump includes the following changes in the lib:
- Handle the ready event now emitted from the iframe https://github.com/Automattic/wpcom-proxy-request/pull/21
- Stop treating completely failed network requests as successes https://github.com/Automattic/wpcom-proxy-request/pull/20
- Make `wpcom.request( { metaAPI: ... } )` calls resolve nicely https://github.com/Automattic/wpcom-proxy-request/pull/22
- Fixes status code again (with server patch) https://github.com/Automattic/wpcom-proxy-request/pull/29

### Testing Instructions
- Boot the app `git checkout update/wpcom-proxy-request && npm install && npm start`
- Navigate to `Posts` for a site which has posts and publicize active
- click on ‘share’
- Schedule a share to Facebook
- Check that you don't have any error
- Follow the instructions on this comment: https://github.com/Automattic/wp-calypso/pull/15636#issuecomment-312750647 and check that there it fails as expected when there is no network

### Reviews
- [ ] Product