### PR TITLE
Enable mobile app banners, and update deferred deep link

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -14,7 +14,12 @@ import Card from 'components/card';
 import { getSectionName } from 'state/ui/selectors';
 import { getPreference, isFetchingPreferences } from 'state/preferences/selectors';
 import { isNotificationsOpen } from 'state/selectors';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics
+} from 'state/analytics/actions';
 import { savePreference } from 'state/preferences/actions';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import {
@@ -117,6 +122,8 @@ class AppBanner extends Component {
 					eventProperties={ {
 						page: currentSection,
 					} }
+					statGroup="calypso_mobile_app_banner"
+					statName="impression"
 				/>
 				<div className="app-banner__text-content">
 					<div className="app-banner__title">
@@ -158,9 +165,15 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = {
-	recordAppBannerOpen: ( sectionName ) => recordTracksEvent( 'calypso_mobile_app_banner_open', { page: sectionName } ),
+	recordAppBannerOpen: ( sectionName ) => composeAnalytics(
+		recordTracksEvent( 'calypso_mobile_app_banner_open', { page: sectionName } ),
+		bumpStat( 'calypso_mobile_app_banner', 'banner_open' )
+	),
 	saveDismissTime: ( sectionName, currentDimissTimes ) => withAnalytics(
-		recordTracksEvent( 'calypso_mobile_app_banner_dismiss', { page: sectionName } ),
+		composeAnalytics(
+			recordTracksEvent( 'calypso_mobile_app_banner_dismiss', { page: sectionName } ),
+			bumpStat( 'calypso_mobile_app_banner', 'banner_dismiss' )
+		),
 		savePreference( APP_BANNER_DISMISS_TIMES_PREFERENCE, getNewDismissTimes( sectionName, currentDimissTimes ) )
 	),
 };

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -129,8 +129,6 @@ class AppBanner extends Component {
 				<div className="app-banner__buttons">
 					<Button
 						className="app-banner__open-button"
-						target="_blank"
-						rel="noopener noreferrer"
 						onClick={ this.openApp }
 						href={ this.getDeepLink() }
 					>

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -98,27 +98,23 @@ class AppBanner extends Component {
 	};
 
 	getDeepLink() {
-		const { currentSection, siteId } = this.props;
-		// TODO: update with real deep links when we get them
-		// just linking to respective app stores for now
+		const { currentSection } = this.props;
+
 		if ( this.isAndroid() ) {
+			//TODO: update when section deep links are available.
 			switch ( currentSection ) {
 				case EDITOR:
-					'intent://editor/#Intent;scheme=wordpress;package=org.wordpress.android;end';
+					return 'intent://editor/#Intent;scheme=wordpress;package=org.wordpress.android;end';
 				case NOTES:
-					return 'intent://viewnotifications/#Intent;scheme=wordpress;package=org.wordpress.android;end';
+					return 'intent://editor/#Intent;scheme=wordpress;package=org.wordpress.android;end';
 				case READER:
-					return 'intent://viewpost/#Intent;scheme=wordpress;package=org.wordpress.android;end';
+					return 'intent://editor/#Intent;scheme=wordpress;package=org.wordpress.android;end';
 				case STATS:
-					if ( siteId ) {
-						return `intent://viewstats/?siteId=${ siteId }#Intent;scheme=wordpress;package=org.wordpress.android;end'`;
-					}
-					return 'intent://viewstats/#Intent;scheme=wordpress;package=org.wordpress.android;end';
-				default:
 					return 'intent://editor/#Intent;scheme=wordpress;package=org.wordpress.android;end';
 			}
 		}
 
+		//TODO: update when deferred deep links are available
 		if ( this.isiOS() ) {
 			return 'itms://itunes.apple.com/us/app/wordpress/id335703880?mt=8';
 		}

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -83,7 +83,7 @@ class AppBanner extends Component {
 		// TODO: update with real deep links when we get them
 		// just linking to respective app stores for now
 		if ( this.isAndroid() ) {
-			return 'market://details?id=org.wordpress.android';
+			return 'intent://editor/#Intent;scheme=wordpress;package=org.wordpress.android;end';
 		}
 
 		if ( this.isiOS() ) {

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -64,5 +64,5 @@ a.app-banner__no-thanks-button {
 	text-decoration: none;
 	font-weight: 500;
 	font-size: 14px;
-	line-height: 21px;
+	line-height: 24px;
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -40,6 +40,7 @@ import SitePreview from 'blocks/site-preview';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import DocumentHead from 'components/data/document-head';
 import NpsSurveyNotice from 'layout/nps-survey-notice';
+import AppBanner from 'blocks/app-banner';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -167,6 +168,7 @@ Layout = React.createClass( {
 					isActive={ translator.isActivated() } />
 				{ this.renderPreview() }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && <AsyncLoad require="components/happychat" /> }
+				<AppBanner />
 			</div>
 		);
 	}


### PR DESCRIPTION
Follow up to #15228 this closes #16469 and partially implements #16380.

This component will be shown on mobile devices for Editor, Stats, and Reader pages, or on any other page provided that Notification panel is open. Our goal here is to increase the number of native app downloads.

See also #16124, for the last PR

### Testing instructions
1. Use your physical Mobile device using this calypso.live branch: https://calypso.live/?branch=enable/app-banner
2. Visit the reader, stats, editor, and notifications
3. Banners should be visible and behave as expected.

In Desktop Chrome:
1. This banner should not be visible on any page in non-mobile browsers.
2. In order to test it, you can open up DevTools in Chrome and use `Toggle device toolbar`. Along making the screen size smaller, this will also change the `userAgent` which we use to test whether the app banner should be shown. Another option would be to select the `userAgent` manually in Chrome DevTools by following option 2 of [this guide](https://www.technipages.com/google-chrome-change-user-agent-string).
3. Verify that app banner is shown on stats, reader, and editor pages. It should also be shown on any page when notification panel is open.
4. Verify that correct text and icons are shown for each page as described in https://github.com/Automattic/wp-calypso/issues/15228.
5. Verify that impression tracks event has been recorded upon banner rendering.
6. Verify that `Open in app` redirects to app store and that appropriate tracks event/stat bump is recorded.
7. Verify that `No thanks` closes the banner and that appropriate tracks event/stat bump is recorded.

**_Note:_** If you've dismissed the widget and want to bring it back for testing in current session, you can run the following line in your console: 
```javascript
dispatch( { type: 'PREFERENCES_SET', key: 'appBannerDismissTimes', value: null } );
```

### Visual changes (stats example):

<img src="https://user-images.githubusercontent.com/1182160/28293508-bdd14fa0-6b54-11e7-94bf-77cec8f282cb.png" width="300px" alt="stats-example" />

### Expected Analytics Events:
You can see this by setting `localStorage.debug = 'calypso:analytics:*'`
<img width="802" alt="screen shot 2017-07-21 at 3 27 14 pm" src="https://user-images.githubusercontent.com/1270189/28484823-912ce25c-6e29-11e7-8842-f4558cb7a879.png">

