### PR TITLE
Pass domain suggestion token specifier to API.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -125,7 +125,7 @@ const RegisterDomainStep = React.createClass( {
 		onSave: React.PropTypes.func,
 		onAddMapping: React.PropTypes.func,
 		onAddDomain: React.PropTypes.func,
-		suggestionToken: React.PropTypes.string
+		tldWeightOverrides: React.PropTypes.array
 	},
 
 	getDefaultProps: function() {
@@ -135,7 +135,7 @@ const RegisterDomainStep = React.createClass( {
 			onSave: noop,
 			onAddMapping: noop,
 			onAddDomain: noop,
-			suggestionToken: 'default'
+			tldWeightOverrides: []
 		};
 	},
 
@@ -355,7 +355,7 @@ const RegisterDomainStep = React.createClass( {
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
 							include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
-							suggestion_token: this.props.suggestionToken,
+							tld_weight_overrides: this.props.tldWeightOverrides.join( ',' ),
 							vendor: searchVendor,
 							vertical: this.props.surveyVertical,
 						},

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -125,7 +125,7 @@ const RegisterDomainStep = React.createClass( {
 		onSave: React.PropTypes.func,
 		onAddMapping: React.PropTypes.func,
 		onAddDomain: React.PropTypes.func,
-		designType: React.PropTypes.string
+		designType: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
@@ -134,7 +134,7 @@ const RegisterDomainStep = React.createClass( {
 			analyticsSection: 'domains',
 			onSave: noop,
 			onAddMapping: noop,
-			onAddDomain: noop
+			onAddDomain: noop,
 		};
 	},
 
@@ -148,7 +148,7 @@ const RegisterDomainStep = React.createClass( {
 			lastDomainStatus: null,
 			loadingResults: Boolean( suggestion ),
 			notice: null,
-			searchResults: null
+			searchResults: null,
 		};
 	},
 
@@ -296,7 +296,7 @@ const RegisterDomainStep = React.createClass( {
 			lastDomainSearched: null,
 			loadingResults: Boolean( getFixedDomainSearch( searchQuery ) ),
 			notice: null,
-			searchResults: null
+			searchResults: null,
 		} );
 	},
 
@@ -430,7 +430,7 @@ const RegisterDomainStep = React.createClass( {
 
 				this.setState( {
 					searchResults: suggestions,
-					loadingResults: false
+					loadingResults: false,
 				}, this.save );
 			}
 		);
@@ -573,6 +573,6 @@ module.exports = connect( ( state, props ) => {
 	return {
 		currentUser: getCurrentUser( state ),
 		defaultSuggestions: getDomainsSuggestions( state, queryObject ),
-		defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject )
+		defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
 	};
 } )( localize( RegisterDomainStep ) );

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -134,7 +134,7 @@ const RegisterDomainStep = React.createClass( {
 			analyticsSection: 'domains',
 			onSave: noop,
 			onAddMapping: noop,
-			onAddDomain: noop,
+			onAddDomain: noop
 		};
 	},
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -10,6 +10,7 @@ import {
 	includes,
 	isEmpty,
 	noop,
+	pick,
 	reject,
 	startsWith,
 	times,
@@ -301,7 +302,9 @@ const RegisterDomainStep = React.createClass( {
 	},
 
 	getSuggestionToken: function() {
-		if ( SignupDependencyStore.get().designType === 'blog' ) {
+		const store = pick( SignupDependencyStore.get(), 'designType' );
+
+		if ( store && store.designType === 'blog' ) {
 			return 'blog';
 		}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -302,12 +302,7 @@ const RegisterDomainStep = React.createClass( {
 
 	getTldWeightOverrides: function() {
 		const { designType } = this.props;
-
-		if ( designType && designType === 'blog' ) {
-			return 'design_type_blog';
-		}
-
-		return null;
+		return designType && designType === 'blog' ? 'design_type_blog' : null;
 	},
 
 	onSearch: function( searchQuery ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -10,7 +10,6 @@ import {
 	includes,
 	isEmpty,
 	noop,
-	pick,
 	reject,
 	startsWith,
 	times,
@@ -24,7 +23,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import SignupDependencyStore from 'lib/signup/dependency-store';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import { checkDomainAvailability, getFixedDomainSearch } from 'lib/domains';
@@ -126,7 +124,8 @@ const RegisterDomainStep = React.createClass( {
 		showExampleSuggestions: React.PropTypes.bool,
 		onSave: React.PropTypes.func,
 		onAddMapping: React.PropTypes.func,
-		onAddDomain: React.PropTypes.func
+		onAddDomain: React.PropTypes.func,
+		suggestionToken: React.PropTypes.string
 	},
 
 	getDefaultProps: function() {
@@ -135,7 +134,8 @@ const RegisterDomainStep = React.createClass( {
 			analyticsSection: 'domains',
 			onSave: noop,
 			onAddMapping: noop,
-			onAddDomain: noop
+			onAddDomain: noop,
+			suggestionToken: 'default'
 		};
 	},
 
@@ -301,16 +301,6 @@ const RegisterDomainStep = React.createClass( {
 		} );
 	},
 
-	getSuggestionToken: function() {
-		const store = pick( SignupDependencyStore.get(), 'designType' );
-
-		if ( store && store.designType === 'blog' ) {
-			return 'blog';
-		}
-
-		return 'default';
-	},
-
 	onSearch: function( searchQuery ) {
 		const domain = getFixedDomainSearch( searchQuery );
 
@@ -365,7 +355,7 @@ const RegisterDomainStep = React.createClass( {
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
 							include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
-							suggestion_token: this.getSuggestionToken(),
+							suggestion_token: this.props.suggestionToken,
 							vendor: searchVendor,
 							vertical: this.props.surveyVertical,
 						},

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -125,7 +125,7 @@ const RegisterDomainStep = React.createClass( {
 		onSave: React.PropTypes.func,
 		onAddMapping: React.PropTypes.func,
 		onAddDomain: React.PropTypes.func,
-		tldWeightOverrides: React.PropTypes.array
+		designType: React.PropTypes.string
 	},
 
 	getDefaultProps: function() {
@@ -135,7 +135,6 @@ const RegisterDomainStep = React.createClass( {
 			onSave: noop,
 			onAddMapping: noop,
 			onAddDomain: noop,
-			tldWeightOverrides: []
 		};
 	},
 
@@ -301,6 +300,16 @@ const RegisterDomainStep = React.createClass( {
 		} );
 	},
 
+	getTldWeightOverrides: function() {
+		const { designType } = this.props;
+
+		if ( designType && designType === 'blog' ) {
+			return 'design_type_blog';
+		}
+
+		return null;
+	},
+
 	onSearch: function( searchQuery ) {
 		const domain = getFixedDomainSearch( searchQuery );
 
@@ -355,7 +364,7 @@ const RegisterDomainStep = React.createClass( {
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
 							include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
-							tld_weight_overrides: this.props.tldWeightOverrides.join( ',' ),
+							tld_weight_overrides: this.getTldWeightOverrides(),
 							vendor: searchVendor,
 							vertical: this.props.surveyVertical,
 						},

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -23,6 +23,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import SignupDependencyStore from 'lib/signup/dependency-store';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import { checkDomainAvailability, getFixedDomainSearch } from 'lib/domains';
@@ -299,6 +300,14 @@ const RegisterDomainStep = React.createClass( {
 		} );
 	},
 
+	getSuggestionToken: function() {
+		if ( SignupDependencyStore.get().designType === 'blog' ) {
+			return 'blog';
+		}
+
+		return 'default';
+	},
+
 	onSearch: function( searchQuery ) {
 		const domain = getFixedDomainSearch( searchQuery );
 
@@ -353,6 +362,7 @@ const RegisterDomainStep = React.createClass( {
 							quantity: SUGGESTION_QUANTITY,
 							include_wordpressdotcom: this.props.includeWordPressDotCom,
 							include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
+							suggestion_token: this.getSuggestionToken(),
 							vendor: searchVendor,
 							vertical: this.props.surveyVertical,
 						},

--- a/client/lib/signup/dependency-store.js
+++ b/client/lib/signup/dependency-store.js
@@ -18,10 +18,6 @@ import steps from 'signup/config/steps';
 
 const SignupDependencyStore = {
 	get: function() {
-		if ( ! SignupDependencyStore.reduxStore ) {
-			return null;
-		}
-
 		return getSignupDependencyStore( SignupDependencyStore.reduxStore.getState() );
 	},
 	reset: function() {

--- a/client/lib/signup/dependency-store.js
+++ b/client/lib/signup/dependency-store.js
@@ -18,6 +18,10 @@ import steps from 'signup/config/steps';
 
 const SignupDependencyStore = {
 	get: function() {
+		if ( ! SignupDependencyStore.reduxStore ) {
+			return null;
+		}
+
 		return getSignupDependencyStore( SignupDependencyStore.reduxStore.getState() );
 	},
 	reset: function() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -4,7 +4,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import defer from 'lodash/defer';
-import pick from 'lodash/pick';
 import page from 'page';
 import i18n from 'i18n-calypso';
 
@@ -23,7 +22,6 @@ import analyticsMixin from 'lib/mixins/analytics';
 import signupUtils from 'signup/utils';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import { recordAddDomainButtonClick, recordAddDomainButtonClickInMapDomain } from 'state/domains/actions';
-import SignupDependencyStore from 'lib/signup/dependency-store';
 
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
@@ -173,17 +171,6 @@ const DomainsStep = React.createClass( {
 		} );
 	},
 
-	getTldWeightOverrides: function() {
-		const store = pick( SignupDependencyStore.get(), 'designType' );
-		const tldWeightOverrides = [];
-
-		if ( store && store.designType === 'blog' ) {
-			tldWeightOverrides.push( 'design_type_blog' );
-		}
-
-		return tldWeightOverrides;
-	},
-
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 		const includeDotBlogSubdomain = ( this.props.flowName === 'subdomain' );
@@ -207,7 +194,7 @@ const DomainsStep = React.createClass( {
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' }
-				tldWeightOverrides={ this.getTldWeightOverrides() } />
+				designType={ this.props.signupDependencies && this.props.signupDependencies.designType } />
 		);
 	},
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -75,7 +75,7 @@ const DomainsStep = React.createClass( {
 	handleAddDomain: function( suggestion ) {
 		const stepData = {
 			stepName: this.props.stepName,
-			suggestion
+			suggestion,
 		};
 
 		this.props.recordAddDomainButtonClick( suggestion.domain_name, 'signup' );
@@ -122,7 +122,7 @@ const DomainsStep = React.createClass( {
 			domainItem = isPurchasingItem
 				? cartItems.domainRegistration( {
 					domain: suggestion.domain_name,
-					productSlug: suggestion.product_slug
+					productSlug: suggestion.product_slug,
 				} )
 				: undefined;
 
@@ -135,7 +135,7 @@ const DomainsStep = React.createClass( {
 			googleAppsCartItem,
 			isPurchasingItem,
 			siteUrl,
-			stepSectionName: this.props.stepSectionName
+			stepSectionName: this.props.stepSectionName,
 		}, this.getThemeArgs() ), [], { domainItem } );
 
 		this.props.goToNextStep();
@@ -157,7 +157,7 @@ const DomainsStep = React.createClass( {
 			domainItem,
 			isPurchasingItem,
 			siteUrl: domain,
-			stepSectionName: this.props.stepSectionName
+			stepSectionName: this.props.stepSectionName,
 		}, this.getThemeArgs() ) );
 
 		this.props.goToNextStep();
@@ -167,7 +167,7 @@ const DomainsStep = React.createClass( {
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
 			stepSectionName: this.props.stepSectionName,
-			[ sectionName ]: state
+			[ sectionName ]: state,
 		} );
 	},
 
@@ -194,7 +194,8 @@ const DomainsStep = React.createClass( {
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' }
-				designType={ this.props.signupDependencies && this.props.signupDependencies.designType } />
+				designType={ this.props.signupDependencies && this.props.signupDependencies.designType }
+			/>
 		);
 	},
 
@@ -213,7 +214,8 @@ const DomainsStep = React.createClass( {
 					products={ productsList.get() }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					initialQuery={ initialQuery }
-					analyticsSection="signup" />
+					analyticsSection="signup"
+				/>
 			</div>
 		);
 	},
@@ -255,7 +257,8 @@ const DomainsStep = React.createClass( {
 				fallbackSubHeaderText={ this.translate(
 					'Enter your site\'s name, or some key words that describe it - ' +
 					'we\'ll use this to create your new site\'s address.' ) }
-				stepContent={ content } />
+				stepContent={ content }
+			/>
 		);
 	}
 } );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import defer from 'lodash/defer';
+import pick from 'lodash/pick';
 import page from 'page';
 import i18n from 'i18n-calypso';
 
@@ -22,6 +23,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import signupUtils from 'signup/utils';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import { recordAddDomainButtonClick, recordAddDomainButtonClickInMapDomain } from 'state/domains/actions';
+import SignupDependencyStore from 'lib/signup/dependency-store';
 
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
@@ -171,6 +173,16 @@ const DomainsStep = React.createClass( {
 		} );
 	},
 
+	getSuggestionToken: function() {
+		const store = pick( SignupDependencyStore.get(), 'designType' );
+
+		if ( store && store.designType === 'blog' ) {
+			return 'blog';
+		}
+
+		return 'default';
+	},
+
 	domainForm: function() {
 		const initialState = this.props.step ? this.props.step.domainForm : this.state.domainForm;
 		const includeDotBlogSubdomain = ( this.props.flowName === 'subdomain' );
@@ -193,7 +205,8 @@ const DomainsStep = React.createClass( {
 				isSignupStep
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }
-				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' } />
+				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' }
+				suggestionToken={ this.getSuggestionToken() } />
 		);
 	},
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -173,14 +173,15 @@ const DomainsStep = React.createClass( {
 		} );
 	},
 
-	getSuggestionToken: function() {
+	getTldWeightOverrides: function() {
 		const store = pick( SignupDependencyStore.get(), 'designType' );
+		const tldWeightOverrides = [];
 
 		if ( store && store.designType === 'blog' ) {
-			return 'blog';
+			tldWeightOverrides.push( 'design_type_blog' );
 		}
 
-		return 'default';
+		return tldWeightOverrides;
 	},
 
 	domainForm: function() {
@@ -206,7 +207,7 @@ const DomainsStep = React.createClass( {
 				showExampleSuggestions
 				surveyVertical={ this.props.surveyVertical }
 				suggestion={ this.props.queryObject ? this.props.queryObject.new : '' }
-				suggestionToken={ this.getSuggestionToken() } />
+				tldWeightOverrides={ this.getTldWeightOverrides() } />
 		);
 	},
 


### PR DESCRIPTION
This PR adds a `suggestion_token` to the query string when requesting domain name suggestions from the WordPress.com REST API.

If the user selected `blog` in the design type step, then `blog` will be passed as the value for `suggestion_token`. Otherwise, `default` will be passed as the value for this query string variable.

The purpose of this is to allow the API to opt a user out of an domain suggestion weight A/B test if they selected `blog` as their design type.

For this PR to have any effect on search results generated, it depends on the API changes in D6510-code.

### Testing

* Build and run this branch locally.
* Browse to `http://calypso.localhost:3000/start` and select a "blog" as the type of site.
* When you get to the NUX step where you select a domain, make sure that the query string sent to the public-api includes `suggestions_token=blog`.
* Try again selecting a site type other than "blog" and make sure that the query string sent to the public api when searching for a domain name includes `suggestions_token=default`.
* The query string should also include `suggestions_token=default` when searching for a domain name from `http://calypso.localhost:3000/domains/add`
