### PR TITLE
Framework: [Polling approach] Created PeriodicActionHandler component.

### DIFF
--- a/client/components/periodic-action-handler/README.md
+++ b/client/components/periodic-action-handler/README.md
@@ -1,0 +1,21 @@
+Periodic Action Handler
+===========================
+
+The periodic action Handler component uses React lifecycle functions to abstract the subscription and unsubscription of periodic actions.
+
+Its objective is to allow any other component to declaratively set the need for the execution of a periodic action. E.g declaredly set that they required a webservice to be pulled one time per minute.
+
+For example, if a given component requires the plugins of the selected website to be fetched once each 30 seconds using this component that can be done in the following way:
+
+```jsx
+import { fetchPlugins } from 'state/plugins/installed/actions';
+import { isRequestingForSites } from 'state/plugins/installed/selectors';
+import PeriodicActionHandler from 'components/periodic-action-handler';
+...
+<PeriodicActionHandler
+	periodicActionId={ `fetchPlugins-${ this.props.selectedSiteId }` }
+	interval={ 30000 }
+	actionToExecute={ fetchPlugins( [ this.props.selectedSiteId ] ) }
+	skipChecker={ partialRight( isRequestingForSites, [ this.props.selectedSiteId ] ) }
+	/>
+```

--- a/client/components/periodic-action-handler/index.jsx
+++ b/client/components/periodic-action-handler/index.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { periodicActionSubscribe, periodicActionUnSubscribe } from 'state/periodic-actions/actions';
+
+class PeriodicActionHandler extends Component {
+	static propTypes = {
+		periodicActionId: PropTypes.string.isRequired,
+		actionToExecute: PropTypes.oneOfType( [
+			PropTypes.func,
+			PropTypes.object,
+		] ).isRequired,
+		interval: PropTypes.number,
+		skipChecker: PropTypes.func,
+		pauseWhenHidden: PropTypes.bool,
+		executeOnStart: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		interval: 30000,
+		skipChecker: null,
+		pauseWhenHidden: true,
+		executeOnStart: true
+	};
+
+	componentWillMount() {
+		this.subscribe( this.props );
+	}
+
+	componentWillUnmount() {
+		this.unsubscribe();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.periodicActionId !== this.props.periodicActionId ||
+			nextProps.interval !== this.props.interval ||
+			nextProps.pauseWhenHidden !== this.props.pauseWhenHidden ) {
+			this.unsubscribe();
+			this.subscribe( nextProps );
+		}
+	}
+
+	subscribe( { periodicActionId, actionToExecute, interval, skipChecker, pauseWhenHidden, executeOnStart } ) {
+		this.props.periodicActionSubscribe( periodicActionId, actionToExecute, interval, skipChecker, pauseWhenHidden, executeOnStart );
+	}
+
+	unsubscribe() {
+		this.props.periodicActionUnSubscribe( this.props.periodicActionId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	null,
+	{
+		periodicActionSubscribe,
+		periodicActionUnSubscribe,
+	}
+)( PeriodicActionHandler );


### PR DESCRIPTION
This PR is the second in a series of 3 that proposes a new approach to polling. The 3 related PR’s are:
- https://github.com/Automattic/wp-calypso/pull/16489, Proposes a new middleware that handles periodic action dispatching.
- (this one) Proposes a component that uses react lifecycle to automatically signal interest and disinterest in the execution of a periodic action.
- https://github.com/Automattic/wp-calypso/pull/16491, It's just for demo purposes and shows possible use cases.


The process necessary for a component to set interest in periodic polling of some information should be as easy as possible. So this PR proposes a component that allows any other component to declaratively set the need for the execution of a periodic action.
The component uses react lifecycle functions to automatically signal the interest and disinterest in the execution of a periodic action.

For example, if a give component requires the plugins of the selected website to be fetched once each 30 seconds using this component that can be done in the following way: 

```
import { fetchPlugins } from 'state/plugins/installed/actions';
import { isRequestingForSites } from 'state/plugins/installed/selectors';
import PeriodicActionHandler from 'components/periodic-action-handler';
```
...
```
<PeriodicActionHandler
	periodicActionId={ `fetchPlugins-${ this.props.selectedSiteId }` }
	interval={ 30000 }
	actionToExecute={ fetchPlugins( [ this.props.selectedSiteId ] ) }
	skipChecker={ partialRight( isRequestingForSites, [ this.props.selectedSiteId ] ) }
	/>
```

The component that adds this code does not need to worry about starting/ending polling. The component just knows that when it needs the information is being fetched each 30 seconds. If the selected site changes the polling will also change. If the components stop needing the information and no other components needs it anymore the polling will also stop. 
