### PR TITLE
Framework: [Polling approach] Add 2 sample usages of the new polling apprach

### DIFF
--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -1,14 +1,16 @@
 /**
  * External dependencies
  */
-import { Component, PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { partialRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { requestPostCounts } from 'state/posts/counts/actions';
 import { isRequestingPostCounts } from 'state/posts/counts/selectors';
+import PeriodicActionHandler from 'components/periodic-action-handler';
 
 class QueryPostCounts extends Component {
 	componentWillMount() {
@@ -25,7 +27,7 @@ class QueryPostCounts extends Component {
 	}
 
 	request( props ) {
-		if ( props.requesting ) {
+		if ( props.polling || props.requesting ) {
 			return;
 		}
 
@@ -33,6 +35,16 @@ class QueryPostCounts extends Component {
 	}
 
 	render() {
+		if ( this.props.polling ) {
+			return (
+				<PeriodicActionHandler
+					periodicActionId={ `PollPostCounts-${ this.props.siteId }-${ this.props.type }` }
+					interval={ 1000 }
+					actionToExecute={ requestPostCounts( this.props.siteId, this.props.type ) }
+					skipChecker={ partialRight( isRequestingPostCounts, this.props.siteId, this.props.type ) }
+					executeOnStart={ true } />
+			);
+		}
 		return null;
 	}
 }
@@ -41,7 +53,8 @@ QueryPostCounts.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	type: PropTypes.string.isRequired,
 	requesting: PropTypes.bool,
-	requestPostCounts: PropTypes.func
+	requestPostCounts: PropTypes.func,
+	polling: PropTypes.bool,
 };
 
 export default connect(

--- a/client/components/polling/poll-sites/index.jsx
+++ b/client/components/polling/poll-sites/index.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { partialRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import PeriodicActionHandler from 'components/periodic-action-handler';
+import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
+import { requestSites, requestSite } from 'state/sites/actions';
+
+const PollSites = ( { allSites, siteId, interval } ) => (
+	<PeriodicActionHandler
+		periodicActionId={ allSites ? 'fetch-AllSites' : `fetchSite-${ siteId }` }
+		interval={ interval }
+		actionToExecute={ allSites ? requestSites() : requestSite( siteId ) }
+		skipChecker={ allSites ? isRequestingSites : partialRight( isRequestingSite, siteId ) }
+		executeOnStart={ true } />
+);
+
+PollSites.propTypes = {
+	allSites: PropTypes.bool,
+	siteId: PropTypes.number,
+	interval: PropTypes.number,
+};
+
+PollSites.defaultProps = {
+	allSites: false,
+	interval: 1000
+};
+
+export default PollSites;


### PR DESCRIPTION
Do not merge!

This PR is the third in a series of 3 that proposes a new approach to polling. The 3 related PR’s are:
- https://github.com/Automattic/wp-calypso/pull/16489, Proposes a new middleware that handles periodic action dispatching.
- https://github.com/Automattic/wp-calypso/pull/16490, Proposes a component that uses react lifecycle to automatically signal interest and disinterest in the execution of a periodic action.
- (this one), It's just for demo purposes and shows possible use cases.

The idea of this PR is just to demonstrate possible use cases of our new polling approach so we can see the effort required for its usage.
It creates a new PollSites component that implements the same interface as QuerySites but fetch sites and keeps them updated by polling. 
Some usages of PollSites component:
`<PollSites allSites />` Fetch all sites with the dault interval.
`<PollSites siteId={ this.props.selectedSiteId } interval={ 5000 } />` Fetch current site each five seconds.
It also changes the QueryPostCounts component, it adds new prop named polling and if it is set to true besides just fetching sites, QueryPostCounts keeps the counts updated by continuously polling. It is possible to see that we can make use of our data components with this polling approach.
Sample usage of the component: 
`<QueryPostCounts siteId={ this.props.selectedSiteId } type="post" polling={ true } />`