### PR TITLE
Image editor: canvas load error notice cannot be dismissed

### DIFF
--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -228,7 +228,7 @@ const ImageEditor = React.createClass( {
 	onLoadCanvasError() {
 		const { translate } = this.props;
 		this.showNotice(
-			translate( 'We are unable to edit this image.' ),
+			translate( 'Sorry, there was a problem loading the image. Please close this editor and try selecting the image again.' ),
 			'is-error'
 		);
 	},


### PR DESCRIPTION
I couldn't find a reported issue to link this PR to.

## Problem

When `image.onerror` is triggered in`<ImageEditorCanvas />`, an error notification appears on the Modal.

<img width="883" alt="screen shot 2017-07-24 at 12 44 01" src="https://user-images.githubusercontent.com/6458278/28507354-9f76c942-7075-11e7-9da1-594f919dcd56.png">

Because, however, `this.props.onImageEditorCancel` is `undefined`, dismissing the notice does nothing. 

<img width="484" alt="screen shot 2017-07-24 at 12 46 32" src="https://user-images.githubusercontent.com/6458278/28507374-b438eb58-7075-11e7-9e49-73b7e16c24b9.png">

Maybe a copy/paste error, since the parent Component ( [client/my-sites/media/main.jsx](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/media/main.jsx) ) owns the method of that name.

## Solution
We've removed the X icon, and updated the copy to communicate to the user that the image cannot be loaded, and that he or she should close the modal manually and try again.

> Sorry, there was a problem loading the image. Please close the image editor and try selecting it again.

## Result
<img width="804" alt="screen shot 2017-07-28 at 20 16 06" src="https://user-images.githubusercontent.com/6458278/28713262-b61c7084-73d1-11e7-8373-0d633ccb690f.png">


CC: @gwwar 

