### PR TITLE
Show the correct "Loading" UI when opening the "Rest of the world" zone.

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -139,10 +139,10 @@ Shipping.propTypes = {
 };
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const loaded = areShippingZonesFullyLoaded( state ) && areSettingsGeneralLoaded( state );
 		const zone = loaded && getCurrentlyEditingShippingZone( state );
-		const isRestOfTheWorld = zone && 0 === zone.id;
+		const isRestOfTheWorld = 0 === Number( ownProps.params.zone );
 
 		return {
 			siteId: getSelectedSiteId( state ),


### PR DESCRIPTION
For all the regular shipping zones, there are 3 sections:
* Locations
* Shipping Methods
* Zone name

While the zone is loading, all these sections are displayed with a
"pulsating" placeholder. But in the "Rest of the world" zone, once it's
loaded, the `Locations` and the `Zone name` sections suddenly
dissapear because they're not editable. This PR fixes that, hiding the
`Locations` and `Zone name` sections even while the page is loading.

To test:
* Go to the "Edit shipping zone" page directly. The `Rest of the world` zone is always `id=0`, so that URL will look like `/store/settings/shipping/zone/yoursite.blog/0`
* See that there's only the `Shipping methods` placeholder while the page loads.
* Open any other shipping zone page and check that it works as before (the 3 sections have their placeholders).