### PR TITLE
Jetpack Plugins: Update Manage Connection link to lead to that page

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -66,12 +66,12 @@ export class PluginActivateToggle extends Component {
 		return (
 			<span className="plugin-activate-toggle__link">
 				<a onClick={ this.trackManageConnectionLink }
-					href={ '/settings/general/' + site.slug } >
+					href={ '/settings/manage-connection/' + site.slug } >
 					{ translate( 'Manage Connection', { comment: 'manage Jetpack connnection settings link' } ) }
 				</a>
 				<a className="plugin-activate-toggle__icon"
 					onClick={ this.trackManageConnectionLink }
-					href={ '/settings/general/' + site.slug } >
+					href={ '/settings/manage-connection/' + site.slug } >
 					<Gridicon icon="cog" size={ 18 } />
 				</a>
 			</span>


### PR DESCRIPTION
This PR updates the "Manage Connection" link in the Jetpack plugin card to lead to the new Manage Connection page in site settings. This was suggested by @rickybanister in p6TEKc-18b-p2.

The link appears in two distinct locations:

**Installed plugins page:**
![](https://cldup.com/UWw98QBJSc.png)

**Installed Jetpack plugin page:**
![](https://cldup.com/ltnNLOxWX3.png)

To test:
* Checkout this branch
* Let `:site` is a Jetpack site.
* Go to `/plugins/:site`, and verify the **Manage Connection** link leads to the new Manage Connection page.
* Go to `/plugins/jetpack/:site` and verify the **Manage Connection** link leads to the new Manage Connection page.