### PR TITLE
Comments: Add back to sidebar button

### DIFF
--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -13,6 +13,7 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import CommentList from './comment-list';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 export class CommentsManagement extends Component {
 	static propTypes = {
@@ -38,8 +39,9 @@ export class CommentsManagement extends Component {
 
 		return (
 			<Main className="comments" wideLayout>
-				<PageViewTracker path={ basePath } title="Manage Comments" />
-				<DocumentHead title={ translate( 'Manage Comments' ) } />
+				<PageViewTracker path={ basePath } title="Conversations" />
+				<DocumentHead title={ translate( 'Conversations' ) } />
+				<SidebarNavigation />
 				<CommentList
 					siteId={ siteId }
 					siteFragment={ siteFragment }


### PR DESCRIPTION
Fixes #16435

Add the `SidebarNavigation` component to the Comment Management in order to display a "back to sidebar" button on small screens.

<img width="524" alt="screen shot 2017-07-24 at 12 37 03" src="https://user-images.githubusercontent.com/2070010/28521804-31a6084a-706d-11e7-80f6-4adbd39f3516.png">


cc @Automattic/lannister 