### PR TITLE
Sharing: Remove reblogs from sharing settings title for Jetpack sites

### DIFF
--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -99,11 +99,21 @@ class SharingButtonsAppearance extends Component {
 	}
 
 	getReblogLikeOptionsElement() {
-		if ( ( ! this.props.isJetpack || this.props.isLikesModuleActive ) ) {
+		const {
+			isJetpack,
+			isLikesModuleActive,
+			translate
+		} = this.props;
+
+		if ( ( ! isJetpack || isLikesModuleActive ) ) {
 			return (
 				<fieldset className="sharing-buttons__fieldset">
 					<legend className="sharing-buttons__fieldset-heading">
-						{ this.props.translate( 'Reblog & Like', { context: 'Sharing options: Header' } ) }
+						{
+							isJetpack
+								? translate( 'Like', { context: 'Sharing options: Header' } )
+								: translate( 'Reblog & Like', { context: 'Sharing options: Header' } )
+						}
 					</legend>
 					{ this.getReblogOptionElement() }
 					<label>
@@ -114,7 +124,7 @@ class SharingButtonsAppearance extends Component {
 							onChange={ this.onReblogsLikesCheckboxClicked }
 							disabled={ ! this.props.initialized }
 						/>
-						<span>{ this.props.translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
+						<span>{ translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
 					</label>
 				</fieldset>
 			);


### PR DESCRIPTION
This PR updates the title of the likes section in Sharing Settings to remove the "Reblogs" part from it. Addresses part of #9816, fixes #12787, also #12386 is related.

Before:
![](https://cldup.com/GaBhkD-WM7.png)

After:
![](https://cldup.com/ajGNMVZFIm.png)

To test:
* Checkout this branch
* Go to `/sharing/buttons/:site` for a Jetpack site.
* Verify the title of the likes section is now only "Likes".
* Go to `/sharing/buttons/:site` for a WordPress.com site.
* Verify the title of the likes/reblogs section is still "Reblog & Like".