### PR TITLE
Sharing: Remove Reblogs button from sharing buttons placeholder

### DIFF
--- a/client/my-sites/sharing/buttons/preview-placeholder.jsx
+++ b/client/my-sites/sharing/buttons/preview-placeholder.jsx
@@ -24,9 +24,6 @@ module.exports = React.createClass( {
 					<div className="sharing-buttons-preview__buttons" />
 
 					<div className="sharing-buttons-preview__reblog-like">
-						<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__reblog">
-							<span className="noticon noticon-reblog" />{ this.translate( 'Reblog' ) }
-						</a>
 						<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
 							<span className="noticon noticon-like" />{ this.translate( 'Like' ) }
 						</a>


### PR DESCRIPTION
This PR removes the Reblogs button from the sharing buttons placeholder. We're removing it because it can be confusing for Jetpack sites that don't support that feature.

Fixes #9816.

Before:
![](https://cldup.com/jCl8joxz-8.png)

After:
![](https://cldup.com/o6t4CEx8ho.png)

To test:
* Checkout this branch or get it going on calypso.live.
* Clear your Redux state.
* Go to `/sharing/buttons/:site` for both a Jetpack site and .com site.
* Verify the placeholder no longer contains the Reblog option.