### PR TITLE
Login: Fix empty_two_step_nonce errors because of network failures

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -99,6 +99,14 @@ function getErrorFromHTTPError( httpError ) {
 	let message;
 	let field = 'global';
 
+	if ( ! httpError.status ) {
+		return {
+			code: 'network_error',
+			message: httpError.message,
+			field
+		};
+	}
+
 	const code = get( httpError, 'response.body.data.errors[0]' );
 
 	if ( code ) {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -221,13 +221,17 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 			dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS } );
 		} )
 		.catch( ( httpError ) => {
-			const error = getErrorFromHTTPError( httpError );
+			const twoStepNonce = get( httpError, 'response.body.data.two_step_nonce' );
 
-			dispatch( {
-				type: TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
-				twoStepNonce: get( httpError, 'response.body.data.two_step_nonce' ),
-				nonceType: twoFactorAuthType,
-			} );
+			if ( twoStepNonce ) {
+				dispatch( {
+					type: TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
+					twoStepNonce,
+					nonceType: twoFactorAuthType,
+				} );
+			}
+
+			const error = getErrorFromHTTPError( httpError );
 
 			dispatch( {
 				type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/16456 by handling network failures correctly. More specifically, it makes sure the nonce stored in the global state tree is only updated when one is returned by the API. Previously it would be reset because of an `undefined` value, resulting in `empty_two_step_nonce` error.
  
#### Testing instructions

##### SMS and Authenticator methods

1. Run `git checkout fix/empty-nonce-error` and start your server, or open a [live branch](https://calypso.live/?branch=fix/empty-nonce-error)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Submit credentials for an account with 2FA (SMS or Authenticator) enabled
4. Click the `Continue` button on the `Two-Step Authentication` page
5. Assert that a `Please enter a verification code.` error is displayed
6. Check the [`Offline` feature](https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#offline) in the `Network` panel of the Chrome DevTools
7. Click the `Continue` button again
8. Assert that a `Request has been terminated [...]` error is displayed
9. Uncheck the `Offline` feature
10. Click the `Continue` button again
11. Assert that a `Please enter a verification code.` error is displayed
12. Submit a valid code
13. Assert that you are logged in successfully and redirected to the `Reader` page

##### WordPress.com app method

1. Run `git checkout fix/empty-nonce-error` and start your server, or open a [live branch](https://calypso.live/?branch=fix/empty-nonce-error)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Submit credentials for an account with 2FA (WordPress.com app) enabled
4. Assert that the [`Waiting Notification Approval` page](http://calypso.localhost:3000/log-in/push) is displayed
5. Check the `Offline` feature in the `Network` panel of the Chrome DevTools
6. Wait a few seconds ()
7. Uncheck the `Offline` feature
8. Approve the request from the WordPress.com app
9. Assert that you are logged in successfully and redirected to the `Reader` page


#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests