### PR TITLE
SimplePayments: cast boolean meta data values

### DIFF
--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -63,9 +63,15 @@ export function productToCustomPost( product ) {
 	return Object.keys( product ).reduce(
 		function( payload, current ) {
 			if ( metadataSchema[ current ] ) {
+				let value = product[ current ];
+
+				if ( typeof( value ) === 'boolean' ) {
+					value = value ? 1 : 0;
+				}
+
 				payload.metadata.push( {
 					key: metadataSchema[ current ].metaKey,
-					value: product[ current ]
+					value
 				} );
 			}
 			return payload;


### PR DESCRIPTION
We need to convert boolean values to strings in order to rightly recognized by WordPress.com as post meta data.
So when the value is `true` it will be transformed to `1` and when it's `false` it will be to `0`.

### Testing

1) Edit/Create a post `http://calypso.localhost:3000/post/<your-testing-post>`
2) Add a simple-payment block.

<img src="https://user-images.githubusercontent.com/77539/28532951-ceecc0ae-7071-11e7-95b0-b8621f739f0f.png" width="300px" />

3) Take look at the request using chrome network tab. If you enable `Allow people to buy more than one item at a time.` then you should see the `spay_multiple` field as `1`.
Otherwise, it must be zero.

<img src="https://user-images.githubusercontent.com/77539/28533020-11d10362-7072-11e7-8c73-060302065b89.png" width="400px" />

<img src="https://user-images.githubusercontent.com/77539/28533023-15b5a42e-7072-11e7-9e8a-df76746c11f2.png" width="400px" />
