### PR TITLE
Me: enable native Gravatar uploads in staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -56,6 +56,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -57,6 +57,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,6 +69,7 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
+		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,


### PR DESCRIPTION
Also enables in wpcalypso and horizon.

This is a follow-up to #15636 which enables changing your Gravatar directly from Calypso rather than linking to the Gravatar service.

## Testing

Visit http://calypso.localhost:3000/me and you should see Gravatar section in the Profile box:

<img width="184" alt="screen shot 2017-06-28 at 4 58 42 pm" src="https://user-images.githubusercontent.com/2036909/27659914-24792c6e-5c23-11e7-9ff5-549142850302.png">

Clicking on the image there, you should be able to follow the flow to upload a new image. When the upload is complete you should see a completion message:

<img width="561" alt="screen shot 2017-06-28 at 5 09 25 pm" src="https://user-images.githubusercontent.com/2036909/27660261-9372cf52-5c24-11e7-8ee7-026aa662fa0d.png">

Also view the Gravatar page at https://gravatar.com and be sure that the uploaded image is there:

<img width="448" alt="screen shot 2017-06-28 at 5 12 47 pm" src="https://user-images.githubusercontent.com/2036909/27660407-0cde9d12-5c25-11e7-864a-c925ed307283.png">

