### PR TITLE
Jetpack: Remove 'new site' test

### DIFF
--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -12,16 +12,11 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import { recordTracksEvent } from 'state/analytics/actions';
-import config from 'config';
-import { abtest } from 'lib/abtest';
 import { hasJetpackSites } from 'state/selectors';
 
 class SiteSelectorAddSite extends Component {
 	getAddNewSiteUrl() {
-		if ( this.props.hasJetpackSites || abtest( 'newSiteWithJetpack' ) === 'showNewJetpackSite' ) {
-			return '/jetpack/new/?ref=calypso-selector';
-		}
-		return config( 'signup_url' ) + '?ref=calypso-selector';
+		return '/jetpack/new/?ref=calypso-selector';
 	}
 
 	recordAddNewSite = () => {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -42,14 +42,6 @@ export default {
 		defaultVariation: 'original',
 		localeTargets: 'any',
 	},
-	newSiteWithJetpack: {
-		datestamp: '20170419',
-		variations: {
-			showNewJetpackSite: 50,
-			onlyDotComSites: 50,
-		},
-		defaultVariation: 'onlyDotComSites',
-	},
 	chatOfferOnCancel: {
 		datestamp: '20170421',
 		variations: {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -579,10 +579,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	getAddNewSiteUrl() {
-		if ( this.props.hasJetpackSites || abtest( 'newSiteWithJetpack' ) === 'showNewJetpackSite' ) {
-			return '/jetpack/new/?ref=calypso-selector';
-		}
-		return config( 'signup_url' ) + '?ref=calypso-selector';
+		return '/jetpack/new/?ref=calypso-selector';
 	}
 
 	addNewSite() {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -55,7 +55,6 @@ import {
 	isSitePreviewable,
 } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route/path';
-import { abtest } from 'lib/abtest';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
 


### PR DESCRIPTION
Well, not a big story to tell here: 

The type of new site interstitial test have been deemed successful, so we are removing the test and opening this up for 100% of the users, yay.

How to test
=======

1. Go to calypso
2. "switch site" and the "add a new site"
3. You should see 
![image](https://user-images.githubusercontent.com/1554855/28534303-8d242ef8-70a0-11e7-82e9-fa18a7fec2c9.png)


