### PR TITLE
Login: Use GET HTTP method to test server-side patch

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -143,7 +143,7 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 		type: LOGIN_REQUEST,
 	} );
 
-	return request.post( 'https://wordpress.com/wp-login.php?action=login-endpoint' )
+	return request.get( 'https://wordpress.com/wp-login.php?action=login-endpoint' )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )


### PR DESCRIPTION
This pull request is just to test patch D6498-code, **it must not be merged**.

#### Testing instructions
 
1. Run `git checkout test/d6498` and start your server, or open a [live branch](https://calypso.live/?branch=test/d6498)
2. Point `wordpress.com` to your sandbox
3. Open the [`Login` page](http://calypso.localhost:3000/log-in)
4. Submit the form
5. Assert that you are presented with a `Request has been terminated [...]` error
6. Apply the patch D6498-code
7. Submit the form again
8. Assert that you are presented with a `That method is not allowed`  this time