### PR TITLE
PostPost: Use post.URL to display the primary domain in URL bar

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -674,9 +674,9 @@ export const PostEditor = React.createClass( {
 	},
 
 	getPreviewUrl: function() {
-		const { post, previewAction, previewUrl } = this.state;
+		const { isPostPublishPreview, post, previewAction, previewUrl } = this.state;
 
-		if ( previewAction === 'view' ) {
+		if ( previewAction === 'view' || isPostPublishPreview ) {
 			return post.URL;
 		}
 


### PR DESCRIPTION
### Summary

As noted in #16470, the URL shown in post-post includes the unmapped domain even if the primary is another, mapped domain - this PR aims to fix #16470 

From what I could tell `onPreview` is not called when post-post is shown so the `previewAction` isn't set and so instead I'm looking at `state.isPostPublishPreview` to determine whether or not to use `post.URL`.

Another though tI had was to remove the conditional completely - this seemed to work but I feel like this conditional was there for good reason and removing it may have caused issues elsewhere (<kbd>cmd</kbd> clicking 'preview' for example).

### Test Plan 
- Go to `/posts/{ your-mapped-domain }
- Click edit to edit one of your posts
- Click the 'Update' button, wait for the preview to load.
- Note that the base of the URL shown in the URL bar is your mapped, primary domain, not your `xx.wordpress.com`
- Make sure other areas of preview work as expected
    - Clicking the 'Preview' button opens a preview modal
    - <kbd>cmd</kbd> clicking 'Preview' opens a new tab with the expected URL.
    - Clicking the external link opens a new tab with the expected URL.

cc: @jeremeylduvall - do you mind giving this a quick look over please? I see that you worked on this area quite recently :)