### PR TITLE
Comments: Add overflow ellipsis to the reply placeholder

### DIFF
--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -464,6 +464,7 @@ a.comment-detail__author-more-element {
 
 		&:not( :focus ) {
 			border-color: $white;
+			padding-right: 16px;
 			resize: none;
 		}
 
@@ -474,6 +475,9 @@ a.comment-detail__author-more-element {
 
 		&::placeholder {
 			color: $gray-text-min;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 
 		&.has-scrollbar {


### PR DESCRIPTION
Add `text-overflow: ellipsis` to the `CommentDetail` reply textarea placeholder to prevent it wrapping and being cut off by the fixed height.

| Before | After |
| --- | --- |
| <img width="257" alt="screen shot 2017-07-24 at 20 00 22" src="https://user-images.githubusercontent.com/2070010/28539771-c6b0a782-70aa-11e7-9b53-d739d9efd16f.png"> | <img width="258" alt="screen shot 2017-07-24 at 20 00 04" src="https://user-images.githubusercontent.com/2070010/28539772-c6b71798-70aa-11e7-8171-b08b7234a6ba.png"> |

cc @Automattic/lannister 