### PR TITLE
Login: Only show TOS if social is enabled

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -180,6 +180,7 @@ export class LoginForm extends Component {
 						</label>
 					</div>
 
+					{ config.isEnabled( 'signup/social' ) && (
 					<p className="login__form-terms">
 						{
 							preventWidows( this.props.translate(
@@ -194,6 +195,7 @@ export class LoginForm extends Component {
 
 						}
 					</p>
+					) }
 
 					<div className="login__form-action">
 						<FormsButton primary { ...isDisabled }>


### PR DESCRIPTION
New TOS copy was added to `/log-in` in #16370 but this copy includes text about "any of the options below". Without the social buttons, this copy doesn't make sense. Let's only show this TOS copy if social is enabled.

**With Social**
<img width="455" alt="screen shot 2017-07-25 at 11 41 34" src="https://user-images.githubusercontent.com/448298/28581238-c082ec46-712f-11e7-87d0-d17cd7f474b8.png">

**Without Social**
<img width="445" alt="screen shot 2017-07-25 at 11 51 57" src="https://user-images.githubusercontent.com/448298/28581229-bb66172e-712f-11e7-8699-ee6df873170d.png">

#### Testing
1. Run `git checkout update/login-tos` and start your server.
2. Visit the [login screen](http://calypso.localhost:3000/log-in) at `/log-in`.
3. Assert you see the TOS copy along with the social options.
4. Stop your server.
5. Edit your config file at `/config/development.json` and set the `signup/social` feature flag to `false` at [line 148](https://github.com/Automattic/wp-calypso/blob/update/login-tos/config/development.json#L148).
6. Restart your server.
7. Visit the [login screen](http://calypso.localhost:3000/log-in) at `/log-in` again.
8. Assert the TOS copy and social login options are gone.

#### Reviews
- [x] Code
- [ ] Product