### PR TITLE
EditorGroundControl: ES6ify

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -47,7 +47,7 @@ export class EditorGroundControl extends PureComponent {
 		userUtils: PropTypes.object,
 		toggleSidebar: PropTypes.func,
 		translate: PropTypes.func,
-		type: PropTypes.string
+		type: PropTypes.string,
 	}
 
 	static defaultProps = {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -150,7 +150,7 @@ class EditorGroundControl extends PureComponent {
 	closeSchedulePopover = ( wasCanceled ) => {
 		if ( wasCanceled ) {
 			const date = this.props.savedPost && this.props.savedPost.date
-				? this.moment( this.props.savedPost.date )
+				? this.props.moment( this.props.savedPost.date )
 				: null;
 
 			this.props.setPostDate( date );
@@ -210,7 +210,7 @@ class EditorGroundControl extends PureComponent {
 
 	getFirstDayOfTheMonth( date ) {
 		const tz = siteUtils.timezone( this.props.site );
-		date = date || this.moment();
+		date = date || this.props.moment();
 
 		return postUtils.getOffsetDate( date, tz ).set( {
 			year: date.year(),
@@ -336,7 +336,7 @@ class EditorGroundControl extends PureComponent {
 						}
 						<span className="editor-ground-control__time-button-label">
 										{ postUtils.isFutureDated( this.props.post )
-											? this.moment( this.props.post.date ).calendar()
+											? this.props.moment( this.props.post.date ).calendar()
 											: this.props.translate( 'Choose Date' )
 										}
 									</span>

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -66,7 +66,7 @@ export class EditorGroundControl extends PureComponent {
 		translate: identity,
 		user: null,
 		userUtils: null,
-		setPostDate: noop
+		setPostDate: noop,
 	};
 
 	state = {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -48,7 +48,7 @@ export class EditorGroundControl extends PureComponent {
 		toggleSidebar: PropTypes.func,
 		translate: PropTypes.func,
 		type: PropTypes.string
-	};
+	}
 
 	static defaultProps = {
 		hasContent: false,
@@ -67,7 +67,7 @@ export class EditorGroundControl extends PureComponent {
 		user: null,
 		userUtils: null,
 		setPostDate: noop,
-	};
+	}
 
 	state = {
 		showSchedulePopover: false,
@@ -75,7 +75,7 @@ export class EditorGroundControl extends PureComponent {
 		firstDayOfTheMonth: this.getFirstDayOfTheMonth(),
 		lastDayOfTheMonth: this.getLastDayOfTheMonth(),
 		needsVerification: this.props.userUtils && this.props.userUtils.needsVerificationForSite( this.props.site ),
-	};
+	}
 
 	componentDidMount() {
 		if ( ! this.props.user ) {
@@ -101,7 +101,7 @@ export class EditorGroundControl extends PureComponent {
 		this.setState( {
 			needsVerification: this.props.userUtils && this.props.userUtils.needsVerificationForSite( this.props.site ),
 		} );
-	};
+	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.setState( {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -3,8 +3,9 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
+import { identity, noop } from 'lodash';
 import classNames from 'classnames';
+import moment from 'moment';
 import page from 'page';
 import i18n, { localize } from 'i18n-calypso';
 
@@ -24,7 +25,7 @@ import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
 
-class EditorGroundControl extends PureComponent {
+export class EditorGroundControl extends PureComponent {
 	static propTypes = {
 		hasContent: PropTypes.bool,
 		isConfirmationSidebarEnabled: PropTypes.bool,
@@ -32,6 +33,7 @@ class EditorGroundControl extends PureComponent {
 		isSaveBlocked: PropTypes.bool,
 		isPublishing: PropTypes.bool,
 		isSaving: PropTypes.bool,
+		moment: PropTypes.func,
 		onPreview: PropTypes.func,
 		onPublish: PropTypes.func,
 		onSave: PropTypes.func,
@@ -44,6 +46,7 @@ class EditorGroundControl extends PureComponent {
 		user: PropTypes.object,
 		userUtils: PropTypes.object,
 		toggleSidebar: PropTypes.func,
+		translate: PropTypes.func,
 		type: PropTypes.string
 	};
 
@@ -54,11 +57,13 @@ class EditorGroundControl extends PureComponent {
 		isSaveBlocked: false,
 		isPublishing: false,
 		isSaving: false,
+		moment,
 		onPublish: noop,
 		onSaveDraft: noop,
 		post: null,
 		savedPost: null,
 		site: {},
+		translate: identity,
 		user: null,
 		userUtils: null,
 		setPostDate: noop

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -7,7 +7,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 import page from 'page';
-import i18n from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
 
-export default React.createClass( {
+export default localize( React.createClass( {
 	displayName: 'EditorGroundControl',
 
 	propTypes: {
@@ -134,10 +134,10 @@ export default React.createClass( {
 
 	getPreviewLabel: function() {
 		if ( postUtils.isPublished( this.props.savedPost ) && this.props.site.jetpack ) {
-			return this.translate( 'View' );
+			return this.props.translate( 'View' );
 		}
 
-		return this.translate( 'Preview' );
+		return this.props.translate( 'Preview' );
 	},
 
 	getVerificationNoticeLabel: function() {
@@ -240,14 +240,14 @@ export default React.createClass( {
 
 	getSaveStatusLabel: function() {
 		if ( this.props.isSaving ) {
-			return this.translate( 'Saving…' );
+			return this.props.translate( 'Saving…' );
 		}
 
 		if ( ! this.props.post || postUtils.isPublished( this.props.post ) || ! this.props.post.ID ) {
 			return null;
 		}
 
-		return this.translate( 'Saved' );
+		return this.props.translate( 'Saved' );
 	},
 
 	isSaveEnabled: function() {
@@ -293,69 +293,71 @@ export default React.createClass( {
 			'is-standalone': ! this.canPublishPost() || this.props.isConfirmationSidebarEnabled
 		} );
 
-		return ( <div className="editor-ground-control__action-buttons">
-			<Button
-				borderless
-				className="editor-ground-control__preview-button"
-				disabled={ ! this.isPreviewEnabled() }
-				onClick={ this.onPreviewButtonClick }
-				tabIndex={ 4 }
-			>
-				<Gridicon icon="visible" /> <span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
-			</Button>
-			<Button
-				borderless
-				className="editor-ground-control__toggle-sidebar"
-				onClick={ this.props.toggleSidebar }
-			>
-				<Gridicon icon="cog" /> <span className="editor-ground-control__button-label"><EditorPostType isSettings /></span>
-			</Button>
-			<div className={ publishComboClasses }>
-				<EditorPublishButton
-					site={ this.props.site }
-					post={ this.props.post }
-					savedPost={ this.props.savedPost }
-					onSave={ this.props.onSave }
-					onPublish={ this.props.onPublish }
-					tabIndex={ 5 }
-					isConfirmationSidebarEnabled={ this.props.isConfirmationSidebarEnabled }
-					isPublishing={ this.props.isPublishing }
-					isSaveBlocked={ this.props.isSaveBlocked }
-					hasContent={ this.props.hasContent }
-					needsVerification={ this.state.needsVerification }
-					busy={ this.props.isPublishing || ( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving ) }
-				/>
+		return (
+			<div className="editor-ground-control__action-buttons">
+				<Button
+					borderless
+					className="editor-ground-control__preview-button"
+					disabled={ ! this.isPreviewEnabled() }
+					onClick={ this.onPreviewButtonClick }
+					tabIndex={ 4 }
+				>
+					<Gridicon icon="visible" /> <span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
+				</Button>
+				<Button
+					borderless
+					className="editor-ground-control__toggle-sidebar"
+					onClick={ this.props.toggleSidebar }
+				>
+					<Gridicon icon="cog" /> <span className="editor-ground-control__button-label"><EditorPostType isSettings /></span>
+				</Button>
+				<div className={ publishComboClasses }>
+					<EditorPublishButton
+						site={ this.props.site }
+						post={ this.props.post }
+						savedPost={ this.props.savedPost }
+						onSave={ this.props.onSave }
+						onPublish={ this.props.onPublish }
+						tabIndex={ 5 }
+						isConfirmationSidebarEnabled={ this.props.isConfirmationSidebarEnabled }
+						isPublishing={ this.props.isPublishing }
+						isSaveBlocked={ this.props.isSaveBlocked }
+						hasContent={ this.props.hasContent }
+						needsVerification={ this.state.needsVerification }
+						busy={ this.props.isPublishing || ( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving ) }
+					/>
+					{ this.canPublishPost() &&
+					! this.props.isConfirmationSidebarEnabled &&
+					<Button
+						primary
+						compact
+						ref="schedulePost"
+						className="editor-ground-control__time-button"
+						onClick={ this.toggleSchedulePopover }
+						aria-label={ this.props.translate( 'Schedule date and time to publish post.' ) }
+						aria-pressed={ !! this.state.showSchedulePopover }
+						title={ this.props.translate( 'Set date and time' ) }
+						tabIndex={ 6 }
+					>
+						{ postUtils.isFutureDated( this.props.post )
+							? <Gridicon icon="scheduled" />
+							: <Gridicon icon="calendar" />
+						}
+						<span className="editor-ground-control__time-button-label">
+										{ postUtils.isFutureDated( this.props.post )
+											? this.moment( this.props.post.date ).calendar()
+											: this.props.translate( 'Choose Date' )
+										}
+									</span>
+					</Button>
+					}
+				</div>
 				{ this.canPublishPost() &&
 				! this.props.isConfirmationSidebarEnabled &&
-				<Button
-					primary
-					compact
-					ref="schedulePost"
-					className="editor-ground-control__time-button"
-					onClick={ this.toggleSchedulePopover }
-					aria-label={ this.translate( 'Schedule date and time to publish post.' ) }
-					aria-pressed={ !! this.state.showSchedulePopover }
-					title={ this.translate( 'Set date and time' ) }
-					tabIndex={ 6 }
-				>
-					{ postUtils.isFutureDated( this.props.post )
-						? <Gridicon icon="scheduled" />
-						: <Gridicon icon="calendar" />
-					}
-					<span className="editor-ground-control__time-button-label">
-									{ postUtils.isFutureDated( this.props.post )
-										? this.moment( this.props.post.date ).calendar()
-										: this.translate( 'Choose Date' )
-									}
-								</span>
-				</Button>
+				this.schedulePostPopover()
 				}
 			</div>
-			{ this.canPublishPost() &&
-			! this.props.isConfirmationSidebarEnabled &&
-			this.schedulePostPopover()
-			}
-		</div> );
+		);
 	},
 
 	render: function() {
@@ -366,7 +368,7 @@ export default React.createClass( {
 					className="editor-ground-control__back"
 					href={ '' }
 					onClick={ page.back.bind( page, this.props.allPostsUrl ) }
-					aria-label={ this.translate( 'Go back' ) }
+					aria-label={ this.props.translate( 'Go back' ) }
 				>
 					<Gridicon icon="arrow-left" />
 				</Button>
@@ -386,7 +388,9 @@ export default React.createClass( {
 							className="editor-ground-control__email-verification-notice-icon" />
 						{ this.getVerificationNoticeLabel() }
 						{ ' ' }
-						<span className="editor-ground-control__email-verification-notice-more">{ this.translate( 'Learn More' ) }</span>
+						<span className="editor-ground-control__email-verification-notice-more">
+							{ this.props.translate( 'Learn More' ) }
+						</span>
 					</div>
 				}
 				<div className="editor-ground-control__status">
@@ -396,7 +400,7 @@ export default React.createClass( {
 							onClick={ this.onSaveButtonClick }
 							tabIndex={ 3 }
 						>
-							{ this.translate( 'Save' ) }
+							{ this.props.translate( 'Save' ) }
 						</button>
 					}
 					{ ! this.isSaveEnabled() &&
@@ -409,4 +413,4 @@ export default React.createClass( {
 			</Card>
 		);
 	}
-} );
+} ) );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -1,29 +1,28 @@
 /**
  * External dependencies
  */
-const noop = require( 'lodash/noop' ),
-	React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	i18n = require( 'i18n-calypso' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import { noop } from 'lodash';
+import classNames from 'classnames';
 import page from 'page';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-const Card = require( 'components/card' ),
-	Gridicon = require( 'gridicons' ),
-	Popover = require( 'components/popover' ),
-	Site = require( 'blocks/site' ),
-	postUtils = require( 'lib/posts/utils' ),
-	siteUtils = require( 'lib/site/utils' ),
-	PostListFetcher = require( 'components/post-list-fetcher' ),
-	stats = require( 'lib/posts/stats' );
-
+import Card from 'components/card';
+import Gridicon from 'gridicons';
+import Popover from 'components/popover';
+import Site from 'blocks/site';
+import postUtils from 'lib/posts/utils';
+import siteUtils from 'lib/site/utils';
+import PostListFetcher from 'components/post-list-fetcher';
+import stats from 'lib/posts/stats';
 import AsyncLoad from 'components/async-load';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
-import classNames from 'classnames';
 
 export default React.createClass( {
 	displayName: 'EditorGroundControl',

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import PureRenderMixin from 'react-pure-render/mixin';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 import page from 'page';
@@ -25,10 +24,8 @@ import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
 
-export default localize( React.createClass( {
-	displayName: 'EditorGroundControl',
-
-	propTypes: {
+class EditorGroundControl extends PureComponent {
+	static propTypes = {
 		hasContent: PropTypes.bool,
 		isConfirmationSidebarEnabled: PropTypes.bool,
 		isDirty: PropTypes.bool,
@@ -48,30 +45,34 @@ export default localize( React.createClass( {
 		userUtils: PropTypes.object,
 		toggleSidebar: PropTypes.func,
 		type: PropTypes.string
-	},
+	};
 
-	mixins: [ PureRenderMixin ],
+	static defaultProps = {
+		hasContent: false,
+		isConfirmationSidebarEnabled: true,
+		isDirty: false,
+		isSaveBlocked: false,
+		isPublishing: false,
+		isSaving: false,
+		onPublish: noop,
+		onSaveDraft: noop,
+		post: null,
+		savedPost: null,
+		site: {},
+		user: null,
+		userUtils: null,
+		setPostDate: noop
+	};
 
-	getDefaultProps: function() {
-		return {
-			hasContent: false,
-			isConfirmationSidebarEnabled: true,
-			isDirty: false,
-			isSaveBlocked: false,
-			isPublishing: false,
-			isSaving: false,
-			onPublish: noop,
-			onSaveDraft: noop,
-			post: null,
-			savedPost: null,
-			site: {},
-			user: null,
-			userUtils: null,
-			setPostDate: noop
-		};
-	},
+	state = {
+		showSchedulePopover: false,
+		showAdvanceStatus: false,
+		firstDayOfTheMonth: this.getFirstDayOfTheMonth(),
+		lastDayOfTheMonth: this.getLastDayOfTheMonth(),
+		needsVerification: this.props.userUtils && this.props.userUtils.needsVerificationForSite( this.props.site ),
+	};
 
-	componentDidMount: function() {
+	componentDidMount() {
 		if ( ! this.props.user ) {
 			return;
 		}
@@ -79,9 +80,9 @@ export default localize( React.createClass( {
 		this.props.user
 			.on( 'change', this.updateNeedsVerification )
 			.on( 'verify', this.updateNeedsVerification );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		if ( ! this.props.user ) {
 			return;
 		}
@@ -89,25 +90,15 @@ export default localize( React.createClass( {
 		this.props.user
 			.off( 'change', this.updateNeedsVerification )
 			.off( 'verify', this.updateNeedsVerification );
-	},
+	}
 
-	updateNeedsVerification: function() {
+	updateNeedsVerification = () => {
 		this.setState( {
 			needsVerification: this.props.userUtils && this.props.userUtils.needsVerificationForSite( this.props.site ),
 		} );
-	},
+	};
 
-	getInitialState: function() {
-		return {
-			showSchedulePopover: false,
-			showAdvanceStatus: false,
-			firstDayOfTheMonth: this.getFirstDayOfTheMonth(),
-			lastDayOfTheMonth: this.getLastDayOfTheMonth(),
-			needsVerification: this.props.userUtils && this.props.userUtils.needsVerificationForSite( this.props.site ),
-		};
-	},
-
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		this.setState( {
 			needsVerification: nextProps.userUtils && nextProps.userUtils.needsVerificationForSite( nextProps.site ),
 		} );
@@ -123,24 +114,24 @@ export default localize( React.createClass( {
 				.on( 'change', this.updateNeedsVerification )
 				.on( 'verify', this.updateNeedsVerification );
 		}
-	},
+	}
 
-	setCurrentMonth: function( date ) {
+	setCurrentMonth = ( date ) => {
 		this.setState( {
 			firstDayOfTheMonth: this.getFirstDayOfTheMonth( date ),
 			lastDayOfTheMonth: this.getLastDayOfTheMonth( date )
 		} );
-	},
+	}
 
-	getPreviewLabel: function() {
+	getPreviewLabel() {
 		if ( postUtils.isPublished( this.props.savedPost ) && this.props.site.jetpack ) {
 			return this.props.translate( 'View' );
 		}
 
 		return this.props.translate( 'Preview' );
-	},
+	}
 
-	getVerificationNoticeLabel: function() {
+	getVerificationNoticeLabel() {
 		const primaryButtonState = getPublishButtonStatus( this.props.site, this.props.post, this.props.savedPost ),
 			buttonLabels = {
 				update: i18n.translate( 'To update, check your email and confirm your address.' ),
@@ -150,13 +141,13 @@ export default localize( React.createClass( {
 			};
 
 		return buttonLabels[ primaryButtonState ];
-	},
+	}
 
-	toggleSchedulePopover: function() {
+	toggleSchedulePopover = () => {
 		this.setState( { showSchedulePopover: ! this.state.showSchedulePopover } );
-	},
+	}
 
-	closeSchedulePopover: function( wasCanceled ) {
+	closeSchedulePopover = ( wasCanceled ) => {
 		if ( wasCanceled ) {
 			const date = this.props.savedPost && this.props.savedPost.date
 				? this.moment( this.props.savedPost.date )
@@ -166,9 +157,9 @@ export default localize( React.createClass( {
 		}
 
 		this.setState( { showSchedulePopover: false } );
-	},
+	}
 
-	renderPostScheduler: function() {
+	renderPostScheduler() {
 		const tz = siteUtils.timezone( this.props.site ),
 			gmtOffset = siteUtils.gmtOffset( this.props.site ),
 			postDate = this.props.post && this.props.post.date
@@ -186,9 +177,9 @@ export default localize( React.createClass( {
 				site={ this.props.site }
 			/>
 		);
-	},
+	}
 
-	schedulePostPopover: function() {
+	schedulePostPopover() {
 		const postScheduler = this.renderPostScheduler();
 
 		return (
@@ -215,9 +206,9 @@ export default localize( React.createClass( {
 				</span>
 			</Popover>
 		);
-	},
+	}
 
-	getFirstDayOfTheMonth: function( date ) {
+	getFirstDayOfTheMonth( date ) {
 		const tz = siteUtils.timezone( this.props.site );
 		date = date || this.moment();
 
@@ -230,15 +221,15 @@ export default localize( React.createClass( {
 			seconds: 0,
 			milliseconds: 0
 		} );
-	},
+	}
 
-	getLastDayOfTheMonth: function( date ) {
+	getLastDayOfTheMonth( date ) {
 		return this.getFirstDayOfTheMonth( date )
 			.add( 1, 'month' )
 			.second( -1 );
-	},
+	}
 
-	getSaveStatusLabel: function() {
+	getSaveStatusLabel() {
 		if ( this.props.isSaving ) {
 			return this.props.translate( 'Saving…' );
 		}
@@ -248,47 +239,47 @@ export default localize( React.createClass( {
 		}
 
 		return this.props.translate( 'Saved' );
-	},
+	}
 
-	isSaveEnabled: function() {
+	isSaveEnabled() {
 		return ! this.props.isSaving &&
 			! this.props.isSaveBlocked &&
 			this.props.isDirty &&
 			this.props.hasContent &&
 			!! this.props.post &&
 			! postUtils.isPublished( this.props.post );
-	},
+	}
 
-	isPreviewEnabled: function() {
+	isPreviewEnabled() {
 		return this.props.hasContent &&
 			! ( this.props.isNew && ! this.props.isDirty ) &&
 			! this.props.isSaveBlocked;
-	},
+	}
 
-	canPublishPost: function() {
+	canPublishPost() {
 		return siteUtils.userCan( 'publish_posts', this.props.site );
-	},
+	}
 
-	toggleAdvancedStatus: function() {
+	toggleAdvancedStatus = () => {
 		this.setState( { showAdvanceStatus: ! this.state.showAdvanceStatus } );
-	},
+	}
 
-	onSaveButtonClick: function() {
+	onSaveButtonClick = () => {
 		this.props.onSave();
 		const eventLabel = postUtils.isPage( this.props.page ) ? 'Clicked Save Page Button' : 'Clicked Save Post Button';
 		stats.recordEvent( eventLabel );
 		stats.recordStat( 'save_draft_clicked' );
-	},
+	}
 
-	onPreviewButtonClick: function( event ) {
+	onPreviewButtonClick = ( event ) => {
 		if ( this.isPreviewEnabled() ) {
 			this.props.onPreview( event );
 			const eventLabel = postUtils.isPage( this.props.page ) ? 'Clicked Preview Page Button' : 'Clicked Preview Post Button';
 			stats.recordEvent( eventLabel );
 		}
-	},
+	}
 
-	renderGroundControlActionButtons: function() {
+	renderGroundControlActionButtons() {
 		const publishComboClasses = classNames( 'editor-ground-control__publish-combo', {
 			'is-standalone': ! this.canPublishPost() || this.props.isConfirmationSidebarEnabled
 		} );
@@ -358,9 +349,9 @@ export default localize( React.createClass( {
 				}
 			</div>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<Card className="editor-ground-control">
 				<Button
@@ -413,4 +404,6 @@ export default localize( React.createClass( {
 			</Card>
 		);
 	}
-} ) );
+}
+
+export default localize( EditorGroundControl );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -18,7 +18,7 @@ import Site from 'blocks/site';
 import postUtils from 'lib/posts/utils';
 import siteUtils from 'lib/site/utils';
 import PostListFetcher from 'components/post-list-fetcher';
-import stats from 'lib/posts/stats';
+import { recordEvent, recordStat } from 'lib/posts/stats';
 import AsyncLoad from 'components/async-load';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
@@ -267,15 +267,15 @@ class EditorGroundControl extends PureComponent {
 	onSaveButtonClick = () => {
 		this.props.onSave();
 		const eventLabel = postUtils.isPage( this.props.page ) ? 'Clicked Save Page Button' : 'Clicked Save Post Button';
-		stats.recordEvent( eventLabel );
-		stats.recordStat( 'save_draft_clicked' );
+		recordEvent( eventLabel );
+		recordStat( 'save_draft_clicked' );
 	}
 
 	onPreviewButtonClick = ( event ) => {
 		if ( this.isPreviewEnabled() ) {
 			this.props.onPreview( event );
 			const eventLabel = postUtils.isPage( this.props.page ) ? 'Clicked Preview Page Button' : 'Clicked Preview Post Button';
-			stats.recordEvent( eventLabel );
+			recordEvent( eventLabel );
 		}
 	}
 

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { noop } from 'lodash';
 import classNames from 'classnames';
@@ -28,25 +29,25 @@ export default React.createClass( {
 	displayName: 'EditorGroundControl',
 
 	propTypes: {
-		hasContent: React.PropTypes.bool,
-		isConfirmationSidebarEnabled: React.PropTypes.bool,
-		isDirty: React.PropTypes.bool,
-		isSaveBlocked: React.PropTypes.bool,
-		isPublishing: React.PropTypes.bool,
-		isSaving: React.PropTypes.bool,
-		onPreview: React.PropTypes.func,
-		onPublish: React.PropTypes.func,
-		onSave: React.PropTypes.func,
-		onSaveDraft: React.PropTypes.func,
-		onMoreInfoAboutEmailVerify: React.PropTypes.func,
-		post: React.PropTypes.object,
-		savedPost: React.PropTypes.object,
-		setPostDate: React.PropTypes.func,
-		site: React.PropTypes.object,
-		user: React.PropTypes.object,
-		userUtils: React.PropTypes.object,
-		toggleSidebar: React.PropTypes.func,
-		type: React.PropTypes.string
+		hasContent: PropTypes.bool,
+		isConfirmationSidebarEnabled: PropTypes.bool,
+		isDirty: PropTypes.bool,
+		isSaveBlocked: PropTypes.bool,
+		isPublishing: PropTypes.bool,
+		isSaving: PropTypes.bool,
+		onPreview: PropTypes.func,
+		onPublish: PropTypes.func,
+		onSave: PropTypes.func,
+		onSaveDraft: PropTypes.func,
+		onMoreInfoAboutEmailVerify: PropTypes.func,
+		post: PropTypes.object,
+		savedPost: PropTypes.object,
+		setPostDate: PropTypes.func,
+		site: PropTypes.object,
+		user: PropTypes.object,
+		userUtils: PropTypes.object,
+		toggleSidebar: PropTypes.func,
+		type: PropTypes.string
 	},
 
 	mixins: [ PureRenderMixin ],

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 import { noop } from 'lodash';
 import React from 'react';
+import { shallow } from 'enzyme';
 import mockery from 'mockery';
 
 /**
@@ -24,15 +25,12 @@ const MOCK_SITE = {
 };
 
 describe( 'EditorGroundControl', function() {
-	let shallow, i18n, EditorGroundControl;
+	let EditorGroundControl;
 
 	useMockery();
 	useFakeDom();
 
 	before( function() {
-		shallow = require( 'enzyme' ).shallow;
-		i18n = require( 'i18n-calypso' );
-
 		mockery.registerMock( 'components/card', EmptyComponent );
 		mockery.registerMock( 'components/popover', EmptyComponent );
 		mockery.registerMock( 'blocks/site', EmptyComponent );
@@ -46,15 +44,7 @@ describe( 'EditorGroundControl', function() {
 			recordEvent: noop,
 			recordStat: noop
 		} );
-		EditorGroundControl = require( '../' );
-
-		EditorGroundControl.prototype.translate = i18n.translate;
-		EditorGroundControl.prototype.moment = i18n.moment;
-	} );
-
-	after( function() {
-		delete EditorGroundControl.prototype.translate;
-		delete EditorGroundControl.prototype.moment;
+		EditorGroundControl = require( '../' ).EditorGroundControl;
 	} );
 
 	describe( '#getPreviewLabel()', function() {


### PR DESCRIPTION
Preparing to replace `PostListFetcher` with `QueryPosts`.

To test:
* [Take your protein pills and put your helmet on.](https://www.youtube.com/watch?v=iYYRH4apXDo)
* Go to http://calypso.localhost:3000/posts/my/<yoursite>
* Click on any post's 'Edit' button.
* Make sure that `EditorGroundControl` still works. That's this component:

![image](https://user-images.githubusercontent.com/96308/28544509-bcc27034-70c3-11e7-93c2-98ca056b1ec8.png)
