### PR TITLE
Use DNS Templates to set up email records for mapped domains.

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -158,6 +158,7 @@ export {
 	hasMappedDomain,
 	hasPendingGoogleAppsUsers,
 	isInitialized,
+	isMappedDomain,
 	isRegisteredDomain,
 	isSubdomain
 };

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import page from 'page';
-import find from 'lodash/find';
 
 /**
  * Internal dependencies
@@ -15,12 +14,11 @@ import DomainMainPlaceholder from 'my-sites/domains/domain-management/components
 import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
 import paths from 'my-sites/domains/paths';
-import { getSelectedDomain, isRegisteredDomain } from 'lib/domains';
+import { getSelectedDomain, isMappedDomain, isRegisteredDomain } from 'lib/domains';
 import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import DnsTemplates from '../name-servers/dns-templates';
 import VerticalNav from 'components/vertical-nav';
-import { type as domainTypes } from 'lib/domains/constants';
 
 const Dns = React.createClass( {
 	propTypes: {
@@ -37,16 +35,11 @@ const Dns = React.createClass( {
 		return { addNew: true };
 	},
 
-	isMappedDomain() {
-		const domainInfo = find( this.props.domains.list, ( domain ) => {
-			return domain.name === this.props.selectedDomainName;
-		} );
-
-		return domainInfo.type === domainTypes.MAPPED;
-	},
-
 	renderDnsTemplates() {
-		if ( ! this.isMappedDomain() ) {
+		const { domains, selectedDomainName } = this.props;
+		const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
+
+		if ( ! isMappedDomain( selectedDomain ) ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -58,28 +58,28 @@ console.log( '^^^^^^^' );
 console.log( this.props );
 
 		return (
-				<Main className="dns">
-					<Header
-						onClick={ this.goBack }
-						selectedDomainName={ this.props.selectedDomainName }>
-						{ this.translate( 'DNS Records' ) }
-					</Header>
+			<Main className="dns">
+				<Header
+					onClick={ this.goBack }
+					selectedDomainName={ this.props.selectedDomainName }>
+					{ this.translate( 'DNS Records' ) }
+				</Header>
 
-					<SectionHeader label={ this.translate( 'DNS Records' ) } />
-					<Card>
-						<DnsDetails />
+				<SectionHeader label={ this.translate( 'DNS Records' ) } />
+				<Card>
+					<DnsDetails />
 
-						<DnsList
-							dns={ this.props.dns }
-							selectedSite={ this.props.selectedSite }
-							selectedDomainName={ this.props.selectedDomainName } />
+					<DnsList
+						dns={ this.props.dns }
+						selectedSite={ this.props.selectedSite }
+						selectedDomainName={ this.props.selectedDomainName } />
 
-						<DnsAddNew
-							isSubmittingForm={ this.props.dns.isSubmittingForm }
-							selectedDomainName={ this.props.selectedDomainName } />
-					</Card>
-					{ this.renderDnsTemplates() }
-				</Main>
+					<DnsAddNew
+						isSubmittingForm={ this.props.dns.isSubmittingForm }
+						selectedDomainName={ this.props.selectedDomainName } />
+				</Card>
+				{ this.renderDnsTemplates() }
+			</Main>
 		);
 	},
 

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -17,11 +17,14 @@ import paths from 'my-sites/domains/paths';
 import { getSelectedDomain, isRegisteredDomain } from 'lib/domains';
 import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
+import DnsTemplates from '../name-servers/dns-templates';
+import VerticalNav from 'components/vertical-nav';
 
 const Dns = React.createClass( {
 	propTypes: {
 		domains: React.PropTypes.object.isRequired,
 		dns: React.PropTypes.object.isRequired,
+		// isMappedDomain: React.PropTypes.bool.isRequired,
 		selectedDomainName: React.PropTypes.string.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
@@ -33,33 +36,50 @@ const Dns = React.createClass( {
 		return { addNew: true };
 	},
 
+	renderDnsTemplates() {
+console.log( this.props.selectedSite.options.is_mapped_domain );
+console.log( '^^^^^^^' );
+		if ( ! this.props.selectedSite.options.is_mapped_domain ) {
+			return null;
+		}
+
+		return (
+			<VerticalNav>
+				<DnsTemplates selectedDomainName={ this.props.selectedDomainName } />
+			</VerticalNav>
+		);
+	},
+
 	render() {
 		if ( ! this.props.dns.hasLoadedFromServer ) {
 			return <DomainMainPlaceholder goBack={ this.goBack } />;
 		}
 
+console.log( this.props );
+
 		return (
-			<Main className="dns">
-				<Header
-					onClick={ this.goBack }
-					selectedDomainName={ this.props.selectedDomainName }>
-					{ this.translate( 'DNS Records' ) }
-				</Header>
+				<Main className="dns">
+					<Header
+						onClick={ this.goBack }
+						selectedDomainName={ this.props.selectedDomainName }>
+						{ this.translate( 'DNS Records' ) }
+					</Header>
 
-				<SectionHeader label={ this.translate( 'DNS Records' ) } />
-				<Card>
-					<DnsDetails />
+					<SectionHeader label={ this.translate( 'DNS Records' ) } />
+					<Card>
+						<DnsDetails />
 
-					<DnsList
-						dns={ this.props.dns }
-						selectedSite={ this.props.selectedSite }
-						selectedDomainName={ this.props.selectedDomainName } />
+						<DnsList
+							dns={ this.props.dns }
+							selectedSite={ this.props.selectedSite }
+							selectedDomainName={ this.props.selectedDomainName } />
 
-					<DnsAddNew
-						isSubmittingForm={ this.props.dns.isSubmittingForm }
-						selectedDomainName={ this.props.selectedDomainName } />
-				</Card>
-			</Main>
+						<DnsAddNew
+							isSubmittingForm={ this.props.dns.isSubmittingForm }
+							selectedDomainName={ this.props.selectedDomainName } />
+					</Card>
+					{ this.renderDnsTemplates() }
+				</Main>
 		);
 	},
 

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
+import find from 'lodash/find';
 
 /**
  * Internal dependencies
@@ -19,12 +20,12 @@ import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import DnsTemplates from '../name-servers/dns-templates';
 import VerticalNav from 'components/vertical-nav';
+import { type as domainTypes } from 'lib/domains/constants';
 
 const Dns = React.createClass( {
 	propTypes: {
 		domains: React.PropTypes.object.isRequired,
 		dns: React.PropTypes.object.isRequired,
-		// isMappedDomain: React.PropTypes.bool.isRequired,
 		selectedDomainName: React.PropTypes.string.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
@@ -36,10 +37,16 @@ const Dns = React.createClass( {
 		return { addNew: true };
 	},
 
+	isMappedDomain() {
+		const domainInfo = find( this.props.domains.list, ( domain ) => {
+			return domain.name === this.props.selectedDomainName;
+		} );
+
+		return domainInfo.type === domainTypes.MAPPED;
+	},
+
 	renderDnsTemplates() {
-console.log( this.props.selectedSite.options.is_mapped_domain );
-console.log( '^^^^^^^' );
-		if ( ! this.props.selectedSite.options.is_mapped_domain ) {
+		if ( ! this.isMappedDomain() ) {
 			return null;
 		}
 
@@ -54,8 +61,6 @@ console.log( '^^^^^^^' );
 		if ( ! this.props.dns.hasLoadedFromServer ) {
 			return <DomainMainPlaceholder goBack={ this.goBack } />;
 		}
-
-console.log( this.props );
 
 		return (
 			<Main className="dns">

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -36,8 +36,7 @@ const Dns = React.createClass( {
 	},
 
 	renderDnsTemplates() {
-		const { domains, selectedDomainName } = this.props;
-		const selectedDomain = getSelectedDomain( { domains, selectedDomainName } );
+		const selectedDomain = getSelectedDomain( this.props );
 
 		if ( ! isMappedDomain( selectedDomain ) ) {
 			return null;

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -767,35 +767,35 @@ ul.email-forwarding__list {
 		margin-top: 10px;
 		padding-right: 15px;
 	}
+}
 
-	.name-servers__dns-templates-buttons {
-		margin-top: 20px;
-	}
+.name-servers__dns-templates-buttons {
+	margin-top: 20px;
+}
 
-	&.is-placeholder {
-		.name-servers__dns, .name-servers__dns-templates {
-			.name-servers__title {
-				@include placeholder();
-			}
-
-			.name-servers__toggle, .name-servers__dns-templates-buttons {
-				display: none;
-			}
-
-			.name-servers__explanation,
-			.name-servers__explanation a {
-				@include placeholder();
-			}
+.is-placeholder {
+	.name-servers__dns, .name-servers__dns-templates {
+		.name-servers__title {
+			@include placeholder();
 		}
 
-		.vertical-nav-item {
-			.noticon {
-				display: none;
-			}
+		.name-servers__toggle, .name-servers__dns-templates-buttons {
+			display: none;
+		}
 
-			span:nth-of-type( 2 ) {
-				@include placeholder();
-			}
+		.name-servers__explanation,
+		.name-servers__explanation a {
+			@include placeholder();
+		}
+	}
+
+	.vertical-nav-item {
+		.noticon {
+			display: none;
+		}
+
+		span:nth-of-type( 2 ) {
+			@include placeholder();
 		}
 	}
 }


### PR DESCRIPTION
Currently only registered domains can use the Domain Connect DNS templates to set up email services since there is no `name-servers` page for mapped domains.

In order to allow users with mapped domains to take advantage of this functionality, we could add the DNS templates component to the bottom of the `dns` page for mapped domains.

<img width="769" alt="dns_records_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/28547694-0b1b672a-709e-11e7-8c29-6ef0074e4bab.png">

### Testing

* Build and run this branch locally.
* Select a site that has a mapped domain and browse to http://calypso.localhost:3000/domains/manage/<mapped domain name>/dns/<primary domain name>. You should see the DNS Template component at the bottom of the page as in the image above.
* Make sure the DNS Template component does show up on the name servers page for a registered domain: http://calypso.localhost:3000/domains/manage/<primary domain name>/name-servers/<primary domain name>
* Make sure the DNS Template component does *not* show up on the dns editing page for a registered domain: http://calypso.localhost:3000/domains/manage/<primary domain name>/dns/<primary domain name>