### PR TITLE
Editor: Avoid setting sidebar layout focus on small windows

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -59,7 +59,7 @@ import Site from 'blocks/site';
 import StatusLabel from 'post-editor/editor-status-label';
 import { editedPostHasContent } from 'state/selectors';
 import EditorGroundControl from 'post-editor/editor-ground-control';
-import { isMobile } from 'lib/viewport';
+import { isWithinBreakpoint } from 'lib/viewport';
 import { isSitePreviewable } from 'state/sites/selectors';
 
 export const PostEditor = React.createClass( {
@@ -189,7 +189,7 @@ export const PostEditor = React.createClass( {
 
 	useDefaultSidebarFocus( nextProps ) {
 		const props = nextProps || this.props;
-		if ( ! isMobile() && ( props.editorSidebarPreference === 'open' || props.hasBrokenPublicizeConnection ) ) {
+		if ( isWithinBreakpoint( '>660px' ) && ( props.editorSidebarPreference === 'open' || props.hasBrokenPublicizeConnection ) ) {
 			this.props.setLayoutFocus( 'sidebar' );
 		}
 	},


### PR DESCRIPTION
When a post is loaded, the `EditorSidebar` component is shown by default, unless the screen is so small that there isn't enough room to show both the editor and the sidebar. In those cases, only the editor should be shown, since it's the most important element. If the user wants, they can open the sidebar, and the editor will be hidden while the sidebar is active.

When that logic was added in f70bfb8c2971c7fd124c714784bb13d956fac793, `isMobile()` was used to detect if the screen was too small to show the sidebar, but that maps to the `480px` breakpoint, and the breakpoint for a screen that's large enough to contain both the editor and sidebar is `660px`. So, if a window was opened with a size between those two breakpoints, the sidebar would be shown, but the editor would not be, resulting in confusion. An example of a window commonly at that size is the one created by the Press This bookmarklet.

To fix that, the `isMobile()` check was replaced with a check for the `660px` breakpoint.

Fixes #14882