### PR TITLE
Posts & Editor: show post format if non-standard

### DIFF
--- a/client/components/post-format/index.js
+++ b/client/components/post-format/index.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+
+const icons = {
+	aside: 'pages',
+	image: 'image',
+	video: 'video',
+	quote: 'quote',
+	link: 'link',
+	gallery: 'image-multiple',
+	audio: 'audio',
+};
+
+class PostFormat extends Component {
+	static defaultProps = {
+		format: 'standard',
+		size: 24,
+	}
+
+	getIcon() {
+		return icons[ this.props.format ];
+	}
+
+	getLabel() {
+		const { format, translate } = this.props;
+		switch ( format ) {
+			case 'aside': return translate( 'Aside' );
+			case 'image': return translate( 'Image' );
+			case 'video': return translate( 'Video' );
+			case 'quote': return translate( 'Quote' );
+			case 'link': return translate( 'Link' );
+			case 'gallery': return translate( 'Gallery' );
+			case 'audio': return translate( 'Audio' );
+		}
+	}
+
+	render() {
+		const icon = this.getIcon();
+		return icon
+			? <span className="post-format__icon" title={ this.getLabel() }>
+					<Gridicon
+						icon={ icon }
+						size={ this.props.size }
+					/>
+				</span>
+			: null;
+	}
+}
+
+export default localize( PostFormat );

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -15,6 +15,7 @@ import { partial, noop } from 'lodash';
 import { isEnabled } from 'config';
 import Card from 'components/card';
 import PostControls from './post-controls';
+import PostFormat from 'components/post-format';
 import PostHeader from './post-header';
 import PostImage from '../post/post-image';
 import PostExcerpt from 'components/post-excerpt';
@@ -132,7 +133,10 @@ class Post extends Component {
 					className="post__title-link post__content-link"
 					target={ this.getContentLinkTarget() }
 					onClick={ this.props.recordPostTitleClick }>
-					<h4 className="post__title">{ this.props.post.title }</h4>
+					<h4 className="post__title">
+						<PostFormat format={ this.props.post.format } />
+						{ this.props.post.title }
+					</h4>
 				</a>
 			);
 		}

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -111,6 +111,12 @@
 		line-height: (32 / 24) * 1em;
 		font-family: $serif;
 		font-weight: 700;
+
+		.gridicon {
+			color: $gray-text-min;
+			margin-bottom: -3px;
+			margin-right: 6px;
+		}
 	}
 
 	.post__excerpt {

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -13,6 +13,7 @@ import EditorSticky from 'post-editor/editor-sticky';
 import utils from 'lib/posts/utils';
 import Tooltip from 'components/tooltip';
 import Button from 'components/button';
+import PostFormat from 'components/post-format';
 import EditorActionBarViewLabel from './view-label';
 import EditorStatusLabel from 'post-editor/editor-status-label';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -42,7 +43,8 @@ class EditorActionBar extends Component {
 		// update based on post changes. Flux changes are passed down from parent components.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
 		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
-		const { isPostPrivate, postAuthor } = this.props;
+		const { isPostPrivate, post, postAuthor } = this.props;
+		const postFormat = post && post.format;
 
 		return (
 			<div className="editor-action-bar">
@@ -68,6 +70,7 @@ class EditorActionBar extends Component {
 						! isPasswordProtected && ! isPostPrivate &&
 						<EditorSticky />
 					}
+					<PostFormat format={ postFormat } size={ 26 } />
 					{ utils.isPublished( this.props.savedPost ) && (
 						<Button
 							href={ this.props.savedPost.URL }

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -60,6 +60,16 @@
 	&.is-right {
 		justify-content: flex-end;
 	}
+
+	.post-format__icon {
+		color: darken( $gray, 10% );
+		margin-left: 18px;
+		margin-top: 3px;
+
+		.gridicon {
+			vertical-align: top;
+		}
+	}
 }
 
 .post-editor__content .editor-action-bar {

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -53,6 +53,14 @@ const EditorSticky = React.createClass( {
 		this.setState( { tooltip: false } );
 	},
 
+	enableTooltip: function() {
+		this.setState( { tooltip: true } );
+	},
+
+	disableTooltip: function() {
+		this.setState( { tooltip: false } );
+	},
+
 	render: function() {
 		const classes = classnames(
 			'editor-sticky',
@@ -64,8 +72,8 @@ const EditorSticky = React.createClass( {
 				borderless
 				className={ classes }
 				onClick={ this.toggleStickyStatus }
-				onMouseEnter={ () => this.setState( { tooltip: true } ) }
-				onMouseLeave={ () => this.setState( { tooltip: false } ) }
+				onMouseEnter={ this.enableTooltip }
+				onMouseLeave={ this.disableTooltip }
 				aria-label={ this.translate( 'Stick post to the front page' ) }
 				ref="stickyPostButton"
 			>


### PR DESCRIPTION
Fixes #240 

Per discussion in #240, only show the format if it isn't set to the default (`standard`):

- In Posts (`/posts`):

<img width="363" alt="post-format-in-posts" src="https://user-images.githubusercontent.com/150562/28545858-849380ac-70c0-11e7-9a00-7aa57d329472.png">

- In Editor (`/post`):

<img width="614" alt="post-format-in-editor" src="https://user-images.githubusercontent.com/150562/28545867-88297d48-70c0-11e7-8f67-af9e11544062.png">
