### PR TITLE
Framework: Removed JetpackSite dependency from jetpack-plugins-setup.

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -23,13 +23,12 @@ import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 import analytics from 'lib/analytics';
-import JetpackSite from 'lib/site/jetpack';
 import support from 'lib/url/support';
 import utils from 'lib/site/utils';
 
 // Redux actions & selectors
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, isRequestingSites, getRawSite } from 'state/sites/selectors';
+import { getJetpackSiteRemoteManagementUrl, isRequestingSites } from 'state/sites/selectors';
 import { hasInitializedSites } from 'state/selectors';
 import { getPlugin } from 'state/plugins/wporg/selectors';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
@@ -124,7 +123,7 @@ const PlansSetup = React.createClass( {
 		if ( site &&
 			site.jetpack &&
 			site.canUpdateFiles &&
-			site.canManage() &&
+			site.canManage &&
 			this.allPluginsHaveWporgData() &&
 			! this.props.isInstalling &&
 			this.props.nextPlugin
@@ -138,7 +137,7 @@ const PlansSetup = React.createClass( {
 		if ( ! site ||
 			! site.jetpack ||
 			! site.canUpdateFiles ||
-			! site.canManage() ||
+			! site.canManage ||
 			this.props.isFinished
 		) {
 			return;
@@ -200,7 +199,7 @@ const PlansSetup = React.createClass( {
 		} else if ( ! site.hasMinimumJetpackVersion ) {
 			reason = translate( 'You need to update your version of Jetpack.' );
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error_jpversion', { jetpack_version: site.options.jetpack_version } );
-		} else if ( ! site.isMainNetworkSite() ) {
+		} else if ( ! site.isMainNetworkSite ) {
 			reason = translate( 'We can\'t install plugins on multisite sites.' );
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error_multisite' );
 		} else if ( site.options.is_multi_network ) {
@@ -505,8 +504,8 @@ const PlansSetup = React.createClass( {
 		}
 
 		let turnOnManage;
-		if ( site && ! site.canManage() ) {
-			const manageUrl = site.getRemoteManagementURL() + '&section=plugins-setup';
+		if ( site && ! site.canManage ) {
+			const manageUrl = this.props.remoteManagementUrl + '&section=plugins-setup';
 			turnOnManage = (
 				<Card className="jetpack-plugins-setup__need-manage">
 					<p>{
@@ -549,13 +548,8 @@ const PlansSetup = React.createClass( {
 export default connect(
 	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
-		const site = getSelectedSite( state );
+		const selectedSite = getSelectedSite( state );
 		const whitelist = ownProps.whitelist || false;
-
-		// We need to pass the raw redux site to JetpackSite() in order to properly build the site.
-		const selectedSite = site && isJetpackSite( state, siteId )
-			? JetpackSite( getRawSite( state, siteId ) )
-			: site;
 
 		return {
 			wporg: state.plugins.wporg.items,
@@ -568,6 +562,7 @@ export default connect(
 			nextPlugin: getNextPlugin( state, siteId, whitelist ),
 			selectedSite: selectedSite,
 			isRequestingSites: isRequestingSites( state ),
+			remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, siteId ),
 			sitesInitialized: hasInitializedSites( state ),
 			siteId
 		};


### PR DESCRIPTION
This PR removes JetpackSite dependency from jetpack-plugins-setup.

It is dependent on  PR https://github.com/Automattic/wp-calypso/pull/16266 that make changes to lib/plugins that make it compatible with the new site object.

The changes applied were just the replacement of JetpackSite prototype functions with site computed properties, or with selectors.

To test:
Access http://calypso.localhost:3000/plugins/setup/{jetpack-site} make sure no errors appear.
Inspect the component with react devtools change properties and make sure in the possible combinations of props the component does not render any error or invalid data.

