### PR TITLE
WebPreview: Center URL in toolbar

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -169,7 +169,7 @@ a.web-preview__external.button {
 		text-align: center;
 	}
 
-	&:hover .form-text-input {
+	&:hover .form-text-input:not(:focus) {
 		border-color: lighten( $gray, 20% );
 	}
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -141,6 +141,12 @@ a.web-preview__external.button {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-end;
+
+	@include breakpoint( ">960px" ) {
+		// Matches __device-switcher width + margin
+		// and allows the center area to flex equally
+		width: 212px;
+	}
 }
 
 .web-preview__device-switcher {
@@ -160,6 +166,7 @@ a.web-preview__external.button {
 		height: 35px;
 		border-color: transparent;
 		text-overflow: ellipsis;
+		text-align: center;
 	}
 
 	&:hover .form-text-input {
@@ -172,16 +179,6 @@ a.web-preview__external.button {
 
 	&:hover .clipboard-button {
 		display: block;
-	}
-
-	@include breakpoint( ">660px" ) {
-		max-width: 50%;
-	}
-
-	@include breakpoint( ">960px" ) {
-		margin: 6px auto;
-		width: 35%;
-		flex-grow: inherit;
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -161,7 +161,7 @@ a.web-preview__external.button {
 	width: auto;
 
 	.form-text-input {
-		color: $gray;
+		color: $gray-text-min;
 		font-size: 14px;
 		height: 35px;
 		border-color: transparent;


### PR DESCRIPTION
### Summary
Following functional changes in #16329 and some of the concerns raised about how the URL is displayed, this PR aims to make visual improvements to the component.

### Test Plan
- Go to `/posts/{ your-mapped-domain }`
- Click edit to edit one of your posts
- Click the 'Update' button, wait for the preview to load.
- Have a :eyes: at the URL bar at different screen widths (note: you'll have to refresh the page at certain widths to show or hide different elements in the toolbar)
