### PR TITLE
SimplePayments: add formatted_price

### DIFF
--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -24,6 +24,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
+import formatCurrency from 'lib/format-currency';
 
 /**
  * Reduce function for product attributes stored in post metadata
@@ -60,6 +61,11 @@ export function customPostToProduct( product ) {
  * @returns { Object } custom post type data
  */
 export function productToCustomPost( product ) {
+	// add formatted_price to display money correctly
+	if ( ! product.formatted_price ) {
+		product.formatted_price = formatCurrency( product.price, product.currency );
+	}
+
 	return Object.keys( product ).reduce(
 		function( payload, current ) {
 			if ( metadataSchema[ current ] ) {

--- a/client/state/simple-payments/product-list/schema.js
+++ b/client/state/simple-payments/product-list/schema.js
@@ -7,6 +7,7 @@ export const metadataSchema = {
 	multiple: { type: 'number', metaKey: 'spay_multiple' },
 	status: { type: 'number', metaKey: 'spay_status' },
 	email: { type: 'string', metaKey: 'spay_email' },
+	formatted_price: { type: 'string', metaKey: 'spay_formatted_price' },
 };
 
 /**


### PR DESCRIPTION
This PR adds the `formatted_price` metadata when a button instance is created.
It allows showing a better way to show the price of the product to the user.

### Testing

1) Apply the patch
2) Start to create a new button through of the simple-payments dialog
3) Save the dialog

Pay attention to the request. It could be achieved taking a look at the network tab of the chrome dev tool. You should see the `formatted_price` field and its value should be consistent with the `currency` and `price` fields.

![image](https://user-images.githubusercontent.com/77539/28553943-dae51bee-70cc-11e7-9b31-ea915876165b.png)

Above, currency is `USD` and the price is `12.99` so the formatted price is `$12.99`.