### PR TITLE
WCS: Remove '-%' on undefined increases

### DIFF
--- a/client/extensions/woocommerce/components/delta/index.js
+++ b/client/extensions/woocommerce/components/delta/index.js
@@ -27,11 +27,12 @@ export default class Delta extends Component {
 	render() {
 		const { className, icon, iconSize, suffix, value } = this.props;
 		const deltaClasses = classnames( 'delta', className );
+		const undefinedIncrease = includes( className, 'is-undefined-increase' );
 		let deltaIcon;
 		if ( icon ) {
 			deltaIcon = icon;
 		} else {
-			deltaIcon = ( includes( className, 'is-increase' ) || includes( className, 'is-undefined-increase' ) )
+			deltaIcon = ( includes( className, 'is-increase' ) || undefinedIncrease )
 				? 'arrow-up'
 				: 'arrow-down';
 			deltaIcon = ( includes( className, 'is-neutral' ) )
@@ -42,9 +43,9 @@ export default class Delta extends Component {
 			<div className={ deltaClasses }>
 				<Gridicon className="delta__icon" icon={ deltaIcon } size={ iconSize } />
 				<span className="delta__labels">
-					<span className="delta__value">
-						{ value }
-					</span>
+					{ ! undefinedIncrease &&
+						<span className="delta__value">{ value }</span>
+					}
 					{ suffix &&
 						<span className="delta__suffix">{ suffix }</span>
 					}

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -2,6 +2,7 @@
 	align-items: center;
 	display: flex;
 	flex-direction: row;
+	margin: 0 auto;
 
 	&.is-favorable {
 		.delta__icon {


### PR DESCRIPTION
When a metric sees an increase from a prior period of zero, the percent change is undefined (divided by zero). Lets remove the `-%` to avoid confusion.

### Before
<img width="576" alt="screen shot 2017-07-25 at 3 16 57 pm" src="https://user-images.githubusercontent.com/1922453/28554369-3a591596-714d-11e7-98e9-352ed8b2b780.png">

### After 
<img width="584" alt="screen shot 2017-07-25 at 3 17 23 pm" src="https://user-images.githubusercontent.com/1922453/28554378-4465a7d4-714d-11e7-92ad-0ccda10c9a37.png">

Spacing issues aside, is this an improvement?

cc @westi @pmaiorana @greenafrican @martinremy 