### PR TITLE
Use lodash's "get" instead of plain object property access for the getCurrentUserId selector.

### DIFF
--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -15,7 +15,7 @@ import { getUser } from 'state/users/selectors';
  * @return {?Number}        Current user ID
  */
 export function getCurrentUserId( state ) {
-	return state.currentUser.id;
+	return get( state, [ 'currentUser', 'id' ] );
 }
 
 /**


### PR DESCRIPTION
That prevents the page from crashing if the `state` object doesn't have a `currentUser` property.
This is causing problems for `woocommerce-services`, we are using the `<Tooltip>` component and it (indirectly) uses the `getCurrentUserId` selector, which in `woocommerce-services` doesn't make sense.