### PR TITLE
Media: add Google Photos to the 'add from URL' dropdown

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -76,6 +76,13 @@ const MediaLibraryContent = React.createClass( {
 		}
 	},
 
+	componentWillReceiveProps: function( nextProps ) {
+		if ( ! nextProps.isRequesting && nextProps.source !== '' && nextProps.connectedServices.length === 0 ) {
+			// Are we connected to anything yet?
+			this.props.requestKeyringConnections();
+		}
+	},
+
 	renderErrors: function() {
 		var errorTypes, notices;
 

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -55,6 +55,7 @@ const MediaLibraryContent = React.createClass( {
 		scrollable: React.PropTypes.bool,
 		onAddMedia: React.PropTypes.func,
 		onMediaScaleChange: React.PropTypes.func,
+		onSourceChange: React.PropTypes.func,
 		onEditItem: React.PropTypes.func,
 		postId: React.PropTypes.number
 	},
@@ -63,6 +64,7 @@ const MediaLibraryContent = React.createClass( {
 		return {
 			mediaValidationErrors: Object.freeze( {} ),
 			onAddMedia: noop,
+			onSourceChange: null,
 			source: '',
 		};
 	},
@@ -267,6 +269,7 @@ const MediaLibraryContent = React.createClass( {
 					site={ this.props.site }
 					filter={ this.props.filter }
 					onMediaScaleChange={ this.props.onMediaScaleChange }
+					onSourceChange={ this.props.onSourceChange }
 					onAddMedia={ this.props.onAddMedia }
 					onAddAndEditImage={ this.props.onAddAndEditImage }
 					selectedItems={ this.props.selectedItems }

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -27,6 +27,7 @@ export default React.createClass( {
 		filter: PropTypes.string,
 		sliderPositionCount: PropTypes.number,
 		onMediaScaleChange: React.PropTypes.func,
+		onSourceChange: React.PropTypes.func,
 		onAddMedia: PropTypes.func,
 		sticky: React.PropTypes.bool,
 	},
@@ -69,6 +70,28 @@ export default React.createClass( {
 		} );
 	},
 
+	onClickGoogle() {
+		this.props.onSourceChange( 'google_photos' );
+	},
+
+	getPopoverButtons() {
+		const buttons = [
+			<PopoverMenuItem onClick={ this.toggleAddViaUrl.bind( this, true ) } key={ 0 }>
+				{ this.translate( 'Add via URL', { context: 'Media upload' } ) }
+			</PopoverMenuItem>
+		];
+
+		if ( this.props.onSourceChange ) {
+			buttons.push(
+				<PopoverMenuItem onClick={ this.onClickGoogle } key={ 1 }>
+					{ this.translate( 'Add from Google', { context: 'Media upload' } ) }
+				</PopoverMenuItem>
+			);
+		}
+
+		return buttons;
+	},
+
 	renderUploadButtons() {
 		const { site, filter, onAddMedia } = this.props;
 
@@ -101,9 +124,7 @@ export default React.createClass( {
 						onClose={ this.toggleMoreOptions.bind( this, false ) }
 						position="bottom right"
 						className="is-dialog-visible media-library__header-popover">
-						<PopoverMenuItem onClick={ this.toggleAddViaUrl.bind( this, true ) }>
-							{ this.translate( 'Add via URL', { context: 'Media upload' } ) }
-						</PopoverMenuItem>
+						{ this.getPopoverButtons() }
 					</PopoverMenu>
 				</Button>
 			</ButtonGroup>

--- a/client/my-sites/media-library/header.jsx
+++ b/client/my-sites/media-library/header.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -19,33 +20,18 @@ import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import StickyPanel from 'components/sticky-panel';
 
-export default React.createClass( {
-	displayName: 'MediaLibraryHeader',
+class MediaLibraryHeader extends Component {
+	constructor( props ) {
+		super( props );
 
-	propTypes: {
-		site: PropTypes.object,
-		filter: PropTypes.string,
-		sliderPositionCount: PropTypes.number,
-		onMediaScaleChange: React.PropTypes.func,
-		onSourceChange: React.PropTypes.func,
-		onAddMedia: PropTypes.func,
-		sticky: React.PropTypes.bool,
-	},
-
-	getInitialState() {
-		return {
+		this.handleGoogle = this.onClickGoogle.bind( this );
+		this.handleAddUrlOpenOpen = this.toggleAddViaUrl.bind( this, true );
+		this.handleMoreOptions = this.setMoreOptionsContext.bind( this );
+		this.state = {
 			addingViaUrl: false,
 			isMoreOptionsVisible: false
 		};
-	},
-
-	getDefaultProps() {
-		return {
-			onAddMedia: () => {},
-			sliderPositionCount: 100,
-			sticky: false,
-		};
-	},
+	}
 
 	setMoreOptionsContext( component ) {
 		if ( ! component ) {
@@ -55,45 +41,49 @@ export default React.createClass( {
 		this.setState( {
 			moreOptionsContext: component
 		} );
-	},
+	}
 
 	toggleAddViaUrl( state ) {
 		this.setState( {
 			addingViaUrl: state,
 			isMoreOptionsVisible: false
 		} );
-	},
+	}
 
 	toggleMoreOptions( state ) {
 		this.setState( {
 			isMoreOptionsVisible: state
 		} );
-	},
+	}
 
 	onClickGoogle() {
 		this.props.onSourceChange( 'google_photos' );
-	},
+	}
 
 	getPopoverButtons() {
+		const { translate } = this.props;
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		const buttons = [
-			<PopoverMenuItem onClick={ this.toggleAddViaUrl.bind( this, true ) } key={ 0 }>
-				{ this.translate( 'Add via URL', { context: 'Media upload' } ) }
+			<PopoverMenuItem onClick={ this.handleAddUrlOpen } key={ 0 }>
+				{ translate( 'Add via URL', { context: 'Media upload' } ) }
 			</PopoverMenuItem>
 		];
 
 		if ( this.props.onSourceChange ) {
 			buttons.push(
-				<PopoverMenuItem onClick={ this.onClickGoogle } key={ 1 }>
-					{ this.translate( 'Add from Google', { context: 'Media upload' } ) }
+				<PopoverMenuItem onClick={ this.handleGoogle } key={ 1 }>
+					{ translate( 'Add from Google', { context: 'Media upload' } ) }
 				</PopoverMenuItem>
 			);
 		}
 
 		return buttons;
-	},
+	}
 
 	renderUploadButtons() {
 		const { site, filter, onAddMedia } = this.props;
+		const { translate } = this.props;
 
 		if ( ! userCan( 'upload_files', site ) ) {
 			return;
@@ -107,15 +97,15 @@ export default React.createClass( {
 					onAddMedia={ onAddMedia }
 					className="button is-compact">
 					<Gridicon icon="add-image" />
-					<span className="is-desktop">{ this.translate( 'Add New', { context: 'Media upload' } ) }</span>
+					<span className="is-desktop">{ translate( 'Add New', { context: 'Media upload' } ) }</span>
 				</UploadButton>
 				<Button
 					compact
-					ref={ this.setMoreOptionsContext }
+					ref={ this.handleMoreOptions }
 					onClick={ this.toggleMoreOptions.bind( this, ! this.state.isMoreOptionsVisible ) }
 					className="button media-library__upload-more">
 					<span className="screen-reader-text">
-						{ this.translate( 'More Options' ) }
+						{ translate( 'More Options' ) }
 					</span>
 					<Gridicon icon="chevron-down" size={ 20 }/>
 					<PopoverMenu
@@ -129,7 +119,8 @@ export default React.createClass( {
 				</Button>
 			</ButtonGroup>
 		);
-	},
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
 
 	render() {
 		const { site, onAddMedia } = this.props;
@@ -165,8 +156,26 @@ export default React.createClass( {
 					{ card }
 				</StickyPanel>
 			);
-		} else {
-			return card;
 		}
+
+		return card;
 	}
-} );
+}
+
+MediaLibraryHeader.propTypes = {
+	site: PropTypes.object,
+	filter: PropTypes.string,
+	sliderPositionCount: PropTypes.number,
+	onMediaScaleChange: React.PropTypes.func,
+	onSourceChange: React.PropTypes.func,
+	onAddMedia: PropTypes.func,
+	sticky: React.PropTypes.bool,
+};
+
+MediaLibraryHeader.defaultProps = {
+	onAddMedia: () => {},
+	sliderPositionCount: 100,
+	sticky: false,
+};
+
+export default localize( MediaLibraryHeader );

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -35,6 +35,7 @@ module.exports = React.createClass( {
 		onFilterChange: React.PropTypes.func,
 		onSearch: React.PropTypes.func,
 		onScaleChange: React.PropTypes.func,
+		onSourceChange: React.PropTypes.func,
 		onEditItem: React.PropTypes.func,
 		fullScreenDropZone: React.PropTypes.bool,
 		containerWidth: React.PropTypes.number,
@@ -48,6 +49,7 @@ module.exports = React.createClass( {
 			fullScreenDropZone: true,
 			onAddMedia: () => {},
 			onScaleChange: () => {},
+			onSourceChange: null,
 			scrollable: false,
 			source: '',
 		};
@@ -138,6 +140,7 @@ module.exports = React.createClass( {
 				onAddMedia={ this.onAddMedia }
 				onAddAndEditImage={ this.props.onAddAndEditImage }
 				onMediaScaleChange={ this.props.onScaleChange }
+				onSourceChange={ this.props.onSourceChange }
 				selectedItems={ this.props.mediaLibrarySelectedItems }
 				onDeleteItem={ this.props.onDeleteItem }
 				onEditItem={ this.props.onEditItem }

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -326,6 +326,13 @@ export class EditorMediaModal extends Component {
 		}
 	};
 
+	onSourceChange = source => {
+		this.setState( {
+			source,
+			search: undefined
+		} );
+	};
+
 	onSearch = search => {
 		this.setState( {
 			search: search || undefined
@@ -513,6 +520,7 @@ export class EditorMediaModal extends Component {
 						onAddAndEditImage={ this.onAddAndEditImage }
 						onFilterChange={ this.onFilterChange }
 						onScaleChange={ this.onScaleChange }
+						onSourceChange={ this.onSourceChange }
 						onSearch={ this.onSearch }
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }


### PR DESCRIPTION
Adds a link to the Google Photos library from the 'Add from URL' dropdown in the media library.

<img width="329" alt="add_from" src="https://user-images.githubusercontent.com/1277682/28571139-5cc05ce8-7139-11e7-9f85-60b020b61257.png">

Note that this option is not enabled on the main media page, only from the media modal.

## Testing

1. Edit a post and open the normal media library modal
1. Click the 'Add New' dropdown and select 'Add from Google'
1. Verify the media library swaps to your Google library

