### PR TITLE
Sharing: Auto-activate Likes module for Jetpack sites when needed

### DIFF
--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -13,7 +13,7 @@ import ButtonsPreview from './preview';
 import ButtonsPreviewPlaceholder from './preview-placeholder';
 import ButtonsStyle from './style';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, isJetpackModuleActive } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { isPrivateSite } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -22,7 +22,6 @@ class SharingButtonsAppearance extends Component {
 		buttons: PropTypes.array,
 		initialized: PropTypes.bool,
 		isJetpack: PropTypes.bool,
-		isLikesModuleActive: PropTypes.bool,
 		isPrivate: PropTypes.bool,
 		onChange: PropTypes.func,
 		onButtonsChange: PropTypes.func,
@@ -68,10 +67,7 @@ class SharingButtonsAppearance extends Component {
 					style={ this.props.values.sharing_button_style }
 					label={ this.props.values.sharing_label }
 					buttons={ this.props.buttons }
-					showLike={
-						( ! this.props.isJetpack || this.props.isLikesModuleActive ) &&
-						this.isLikeButtonEnabled()
-					}
+					showLike={ this.isLikeButtonEnabled() }
 					showReblog={ ! this.props.isJetpack && this.isReblogButtonEnabled() }
 					onLabelChange={ changeLabel }
 					onButtonsChange={ this.props.onButtonsChange } />
@@ -101,34 +97,31 @@ class SharingButtonsAppearance extends Component {
 	getReblogLikeOptionsElement() {
 		const {
 			isJetpack,
-			isLikesModuleActive,
 			translate
 		} = this.props;
 
-		if ( ( ! isJetpack || isLikesModuleActive ) ) {
-			return (
-				<fieldset className="sharing-buttons__fieldset">
-					<legend className="sharing-buttons__fieldset-heading">
-						{
-							isJetpack
-								? translate( 'Like', { context: 'Sharing options: Header' } )
-								: translate( 'Reblog & Like', { context: 'Sharing options: Header' } )
-						}
-					</legend>
-					{ this.getReblogOptionElement() }
-					<label>
-						<input
-							name="disabled_likes"
-							type="checkbox"
-							checked={ this.isLikeButtonEnabled() }
-							onChange={ this.onReblogsLikesCheckboxClicked }
-							disabled={ ! this.props.initialized }
-						/>
-						<span>{ translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
-					</label>
-				</fieldset>
-			);
-		}
+		return (
+			<fieldset className="sharing-buttons__fieldset">
+				<legend className="sharing-buttons__fieldset-heading">
+					{
+						isJetpack
+							? translate( 'Like', { context: 'Sharing options: Header' } )
+							: translate( 'Reblog & Like', { context: 'Sharing options: Header' } )
+					}
+				</legend>
+				{ this.getReblogOptionElement() }
+				<label>
+					<input
+						name="disabled_likes"
+						type="checkbox"
+						checked={ this.isLikeButtonEnabled() }
+						onChange={ this.onReblogsLikesCheckboxClicked }
+						disabled={ ! this.props.initialized }
+					/>
+					<span>{ translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
+				</label>
+			</fieldset>
+		);
 	}
 
 	render() {
@@ -168,12 +161,10 @@ const connectComponent = connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
-		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
 		const isPrivate = isPrivateSite( state, siteId );
 
 		return {
 			isJetpack,
-			isLikesModuleActive,
 			isPrivate,
 		};
 	},

--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -101,8 +101,8 @@ class SharingButtonsAppearance extends Component {
 		} = this.props;
 
 		return (
-			<fieldset className="sharing-buttons__fieldset">
-				<legend className="sharing-buttons__fieldset-heading">
+			<fieldset className="buttons__fieldset sharing-buttons__fieldset">
+				<legend className="buttons__fieldset-heading sharing-buttons__fieldset-heading">
 					{
 						isJetpack
 							? translate( 'Like', { context: 'Sharing options: Header' } )

--- a/client/my-sites/sharing/buttons/buttons.jsx
+++ b/client/my-sites/sharing/buttons/buttons.jsx
@@ -23,7 +23,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
-import { activateModule, fetchModuleList } from 'state/jetpack/modules/actions';
+import { activateModule } from 'state/jetpack/modules/actions';
 import { protectForm } from 'lib/protect-form';
 
 class SharingButtons extends Component {
@@ -68,8 +68,7 @@ class SharingButtons extends Component {
 			return;
 		}
 
-		this.props.activateModule( siteId, 'likes', true )
-			.then( () => this.props.fetchModuleList( siteId ) );
+		this.props.activateModule( siteId, 'likes', true );
 	};
 
 	handleChange = ( option, value ) => {
@@ -181,7 +180,6 @@ const connectComponent = connect(
 	{
 		activateModule,
 		errorNotice,
-		fetchModuleList,
 		recordGoogleEvent,
 		saveSharingButtons,
 		saveSiteSettings,

--- a/client/my-sites/sharing/buttons/buttons.jsx
+++ b/client/my-sites/sharing/buttons/buttons.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { flowRight } from 'lodash';
+import { flowRight, get } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import ButtonsAppearance from './appearance';
 import ButtonsOptions from './options';
+import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QuerySharingButtons from 'components/data/query-sharing-buttons';
 import { saveSiteSettings } from 'state/site-settings/actions';
@@ -18,8 +19,11 @@ import { saveSharingButtons } from 'state/sites/sharing-buttons/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings, isSavingSiteSettings, isSiteSettingsSaveSuccessful } from 'state/site-settings/selectors';
 import { getSharingButtons, isSavingSharingButtons, isSharingButtonsSaveSuccessful } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackModuleActive } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { activateModule, fetchModuleList } from 'state/jetpack/modules/actions';
 import { protectForm } from 'lib/protect-form';
 
 class SharingButtons extends Component {
@@ -41,12 +45,32 @@ class SharingButtons extends Component {
 	};
 
 	saveChanges = event => {
+		const {
+			isJetpack,
+			isLikesModuleActive,
+			siteId
+		} = this.props;
+
 		event.preventDefault();
+
 		this.props.saveSiteSettings( this.props.siteId, this.state.values );
 		if ( this.state.buttonsPendingSave ) {
 			this.props.saveSharingButtons( this.props.siteId, this.state.buttonsPendingSave );
 		}
 		this.props.recordGoogleEvent( 'Sharing', 'Clicked Save Changes Button' );
+
+		if ( ! isJetpack || isLikesModuleActive !== false ) {
+			return;
+		}
+
+		const currentLikesSettingValue = get( this.props, [ 'settings', 'disabled_likes' ] );
+		const isLikesButtonEnabled = get( this.state, [ 'values', 'disabled_likes' ], currentLikesSettingValue ) === false;
+		if ( ! isLikesButtonEnabled ) {
+			return;
+		}
+
+		this.props.activateModule( siteId, 'likes', true )
+			.then( () => this.props.fetchModuleList( siteId ) );
 	};
 
 	handleChange = ( option, value ) => {
@@ -87,7 +111,13 @@ class SharingButtons extends Component {
 	}
 
 	render() {
-		const { buttons, isSaving, settings, siteId } = this.props;
+		const {
+			buttons,
+			isJetpack,
+			isSaving,
+			settings,
+			siteId
+		} = this.props;
 		const updatedSettings = Object.assign( {}, settings, this.state.values );
 		const updatedButtons = this.state.buttonsPendingSave || buttons;
 
@@ -95,6 +125,7 @@ class SharingButtons extends Component {
 			<form onSubmit={ this.saveChanges } id="sharing-buttons" className="sharing-settings sharing-buttons">
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySharingButtons siteId={ siteId } />
+				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<ButtonsAppearance
 					buttons={ updatedButtons }
 					values={ updatedSettings }
@@ -116,12 +147,16 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 		const settings = getSiteSettings( state, siteId );
 		const buttons = getSharingButtons( state, siteId );
+		const isJetpack = isJetpackSite( state, siteId );
+		const isLikesModuleActive = isJetpackModuleActive( state, siteId, 'likes' );
 		const isSavingSettings = isSavingSiteSettings( state, siteId );
 		const isSavingButtons = isSavingSharingButtons( state, siteId );
 		const isSaveSettingsSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
 		const isSaveButtonsSuccessful = isSharingButtonsSaveSuccessful( state, siteId );
 
 		return {
+			isJetpack,
+			isLikesModuleActive,
 			isSaving: isSavingSettings || isSavingButtons,
 			isSaveSettingsSuccessful,
 			isSaveButtonsSuccessful,
@@ -130,7 +165,15 @@ const connectComponent = connect(
 			siteId
 		};
 	},
-	{ errorNotice, recordGoogleEvent, saveSiteSettings, saveSharingButtons, successNotice }
+	{
+		activateModule,
+		errorNotice,
+		fetchModuleList,
+		recordGoogleEvent,
+		saveSharingButtons,
+		saveSiteSettings,
+		successNotice
+	}
 );
 
 export default flowRight(

--- a/client/my-sites/sharing/buttons/buttons.jsx
+++ b/client/my-sites/sharing/buttons/buttons.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { flowRight, get } from 'lodash';
+import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -63,9 +63,8 @@ class SharingButtons extends Component {
 			return;
 		}
 
-		const currentLikesSettingValue = get( this.props, [ 'settings', 'disabled_likes' ] );
-		const isLikesButtonEnabled = get( this.state, [ 'values', 'disabled_likes' ], currentLikesSettingValue ) === false;
-		if ( ! isLikesButtonEnabled ) {
+		const updatedSettings = this.getUpdatedSettings();
+		if ( updatedSettings.disabled_likes ) {
 			return;
 		}
 
@@ -110,6 +109,20 @@ class SharingButtons extends Component {
 		}
 	}
 
+	getUpdatedSettings() {
+		const {
+			isJetpack,
+			isLikesModuleActive,
+			settings,
+		} = this.props;
+		const disabledSettings = isJetpack && isLikesModuleActive === false ? {
+			// Like button should be disabled if the Likes Jetpack module is deactivated.
+			disabled_likes: true,
+		} : {};
+
+		return Object.assign( {}, settings, disabledSettings, this.state.values );
+	}
+
 	render() {
 		const {
 			buttons,
@@ -118,7 +131,7 @@ class SharingButtons extends Component {
 			settings,
 			siteId
 		} = this.props;
-		const updatedSettings = Object.assign( {}, settings, this.state.values );
+		const updatedSettings = this.getUpdatedSettings();
 		const updatedButtons = this.state.buttonsPendingSave || buttons;
 
 		return (


### PR DESCRIPTION
This PR updates the Sharing buttons settings to automatically activate the Likes module for Jetpack sites if necessary. Auto-activation will happen upon save of the Sharing Buttons settings if all of the following conditions are matched:

* The site is a Jetpack site
* The Likes module is not enabled.
* The "Show like button" setting is enabled.

Auto-activation is one-side only (this isn't expected to be a reversible process, so it'll always stay enabled, unless manually disabled), and will happen only once.

The PR also updates the appearance component to always display the likes setting - previously it would be hidden if the Likes module was disabled for a Jetpack site.

Fixes #12386.

To test:
* Checkout this branch
* Go to `/sharing/buttons/:site`, where `:site` is a Jetpack site.
* Disable the Likes module (use the following WP-CLI command: `wp jetpack module deactivate likes`)
* Verify the module gets activated once when saving with enabled "likes button" setting.
* Verify the module never gets activated anymore, unless necessary.
* Verify none of this affects .com sites.