### PR TITLE
Post-Editor Publish Date: Display times selected in the past.

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -27,6 +27,7 @@ import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
+import EditorPublishDate from 'post-editor/editor-publish-date';
 import EditorVisibility from 'post-editor/editor-visibility';
 
 export class EditPostStatus extends Component {
@@ -119,36 +120,12 @@ export class EditPostStatus extends Component {
 			this.props.site.options &&
 			this.props.site.options.admin_url;
 
-		const fullDate = postScheduleUtils.convertDateToUserLocation(
-			( this.props.postDate || new Date() ),
-			siteUtils.timezone( this.props.site ),
-			siteUtils.gmtOffset( this.props.site )
-		).format( 'll LT' );
-
 		const isPostPublishFlow = config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
 			abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
 
 		return (
 			<div className="edit-post-status">
-				<span
-					ref="postStatusTooltip"
-					className="edit-post-status__full-date"
-					onMouseEnter={ this.showTZTooltip }
-					onMouseLeave={ this.hideTZTooltip }
-					onClick={ this.togglePostSchedulePopover }
-				>
-					{
-						postUtils.isFutureDated( this.props.savedPost )
-							? <span className="edit-post-status__future-label">
-									{ translate( 'Future' ) }
-								</span>
-							: <Gridicon icon="time" size={ 18 } />
-					}
-
-					{ fullDate }
-					{ this.renderTZTooltop() }
-					{ this.renderPostSchedulePopover() }
-				</span>
+				{ this.renderPostScheduling() }
 				{
 					isPostPublishFlow
 						? this.renderPostVisibility()
@@ -203,6 +180,48 @@ export class EditPostStatus extends Component {
 					adminUrl={ adminUrl }
 				/>
 			</div>
+		);
+	}
+
+	renderPostScheduling() {
+		const isPostPublishFlow = config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+			abtest( 'postPublishConfirmation' ) === 'showPublishConfirmation';
+
+		const fullDate = postScheduleUtils.convertDateToUserLocation(
+			( this.props.postDate || new Date() ),
+			siteUtils.timezone( this.props.site ),
+			siteUtils.gmtOffset( this.props.site )
+		).format( 'll LT' );
+
+		if ( isPostPublishFlow ) {
+			return (
+				<EditorPublishDate
+					post={ this.props.post }
+					setPostDate={ this.props.setPostDate }
+				/>
+			);
+		}
+
+		return (
+			<span
+				ref="postStatusTooltip"
+				className="edit-post-status__full-date"
+				onMouseEnter={ this.showTZTooltip }
+				onMouseLeave={ this.hideTZTooltip }
+				onClick={ this.togglePostSchedulePopover }
+			>
+				{
+					postUtils.isFutureDated( this.props.savedPost )
+						? <span className="edit-post-status__future-label">
+								{ this.props.translate( 'Future' ) }
+							</span>
+						: <Gridicon icon="time" size={ 18 } />
+				}
+
+				{ fullDate }
+				{ this.renderTZTooltop() }
+				{ this.renderPostSchedulePopover() }
+			</span>
 		);
 	}
 

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -144,20 +144,6 @@ class EditorConfirmationSidebar extends React.Component {
 		);
 	}
 
-	renderPublishDateComponent() {
-		const postDate = this.props.post && this.props.post.date
-			? this.props.post.date
-			: null;
-
-		return (
-			<EditorPublishDate
-				post={ this.props.post }
-				postDate={ postDate }
-				setPostDate={ this.props.setPostDate }
-			/>
-		);
-	}
-
 	render() {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
@@ -201,7 +187,10 @@ class EditorConfirmationSidebar extends React.Component {
 									} )
 							}
 						</div>
-						{ this.renderPublishDateComponent() }
+						<EditorPublishDate
+							post={ this.props.post }
+							setPostDate={ this.props.setPostDate }
+						/>
 						<div className="editor-confirmation-sidebar__privacy-control">
 							{ this.renderPrivacyControl() }
 						</div>

--- a/client/post-editor/editor-publish-date/README.md
+++ b/client/post-editor/editor-publish-date/README.md
@@ -11,7 +11,6 @@ import EditorPublishDate from 'post-editor/editor-publish-date';
 export default function MyComponent() {
 	const props = {
 		post: post,
-		postDate: postDate,
 		setPostDate: setPostDate,
 	};
 
@@ -26,5 +25,4 @@ export default function MyComponent() {
 The following props are used with the Editor Publish Date component:
 
 - `post`: (object) The post object
-- `postDate`: (string) The publish date for the post
 - `setPostDate`: (func) A callback that receives a Moment object with the updated date on change

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -80,7 +80,7 @@ export class EditorPublishDate extends React.Component {
 		}
 
 		if ( isBackDated ) {
-			return this.props.translate( 'Back-date' );
+			return this.props.translate( 'Backdate' );
 		}
 
 		return this.props.translate( 'Publish Immediately' );

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -54,7 +54,7 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	setImmediate = () => {
-		this.props.setPostDate( this.props.moment() );
+		this.props.setPostDate( null );
 		this.setState( { isOpen: false } );
 	}
 
@@ -62,26 +62,70 @@ export class EditorPublishDate extends React.Component {
 		this.setState( { isOpen: ! this.state.isOpen } );
 	}
 
+	getHeaderDescription() {
+		const isScheduled = utils.isFutureDated( this.props.post );
+		const isBackDated = utils.isBackDated( this.props.post );
+		const isPublished = utils.isPublished( this.props.post );
+
+		if ( isPublished && isScheduled ) {
+			return this.props.translate( 'Scheduled' );
+		}
+
+		if ( isScheduled ) {
+			return this.props.translate( 'Schedule' );
+		}
+
+		if ( isPublished && isBackDated ) {
+			return this.props.translate( 'Published' );
+		}
+
+		if ( isBackDated ) {
+			return this.props.translate( 'Back-date' );
+		}
+
+		return this.props.translate( 'Publish Immediately' );
+	}
+
+	renderCalendarHeader() {
+		const isScheduled = utils.isFutureDated( this.props.post );
+		const isBackDated = utils.isBackDated( this.props.post );
+
+		if ( ! isScheduled && ! isBackDated ) {
+			return (
+				<div className="editor-publish-date__choose-header">
+					{ this.props.translate( 'Choose a date to schedule' ) }
+				</div>
+			);
+		}
+
+		return (
+			<Button borderless={ true } className="editor-publish-date__immediate" onClick={ this.setImmediate }>
+				{ this.props.translate( 'Publish Immediately' ) }
+			</Button>
+		);
+	}
+
 	renderHeader() {
 		const isScheduled = utils.isFutureDated( this.props.post );
+		const isBackDated = utils.isBackDated( this.props.post );
 		const className = classNames( 'editor-publish-date__header', {
 			'is-scheduled': isScheduled,
+			'is-back-dated': isBackDated,
 		} );
+		const selectedDay = this.props.post && this.props.post.date
+			? this.props.post.date
+			: null;
 
 		return (
 			<div className={ className } onClick={ this.toggleOpenState }>
 				<Gridicon icon="calendar" size={ 18 } />
 				<div className="editor-publish-date__header-wrapper">
 					<div className="editor-publish-date__header-description">
-						{
-							isScheduled
-							? this.props.translate( 'Scheduled' )
-							: this.props.translate( 'Publish Immediately' )
-						}
+						{ this.getHeaderDescription() }
 					</div>
-					{ isScheduled && (
+					{ ( isScheduled || isBackDated ) && (
 						<div className="editor-publish-date__header-chrono">
-							{ this.props.moment( this.props.postDate ).calendar() }
+							{ this.props.moment( selectedDay ).calendar() }
 						</div>
 					) }
 				</div>
@@ -90,13 +134,13 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	renderSchedule() {
-		const selectedDay = this.props.postDate ? this.props.moment( this.props.postDate ) : null;
+		const selectedDay = this.props.post && this.props.post.date
+			? this.props.post.date
+			: null;
 
 		return (
 			<div className="editor-publish-date__schedule">
-				<Button borderless={ true } className="editor-publish-date__immediate" onClick={ this.setImmediate }>
-					{ this.props.translate( 'Publish Immediately' ) }
-				</Button>
+				{ this.renderCalendarHeader() }
 				<PostSchedule
 					displayInputChrono={ false }
 					onDateChange={ this.props.setPostDate }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -35,7 +35,8 @@
 		vertical-align: text-bottom;
 	}
 
-	&.is-scheduled {
+	&.is-scheduled,
+	&.is-back-dated {
 		color: $blue-wordpress;
 	}
 
@@ -73,7 +74,8 @@
 }
 
 .editor-publish-date__header-description {
-	.editor-publish-date__header.is-scheduled & {
+	.editor-publish-date__header.is-scheduled &,
+	.editor-publish-date__header.is-back-dated & {
 		margin-top: -4px;
 		font-size: 10px;
 		line-height: initial;
@@ -92,6 +94,15 @@
 	&:active {
 		color: $link-highlight;
 	}
+}
+
+.editor-publish-date__choose-header {
+	text-align: center;
+	margin: 4px auto 0 auto;
+	font-size: 14px;
+	line-height: 21px;
+	padding-top: 7px;
+	padding-bottom: 9px;
 }
 
 .editor-publish-date__header-chrono {


### PR DESCRIPTION
This PR updates the PublishDate component to display times selected in the past. It also updates the header label based on whether or not the post has been published.

Additionally, it incorporates the component into post-settings if the publish confirmation flow is enabled.

![image](https://user-images.githubusercontent.com/363749/28574445-a3786bd8-7113-11e7-9096-39f77e01a303.png)

To Test:
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170713":"showPublishConfirmation"}')`
* Draft a new post, and then select "Publish..." to continue to the confirmation sidebar.
* Verify that the publish date component shows up and that changing the date updates the date for the post.
* Before publishing, change the date and close the confirmation sidebar. Verify the date is updated in the post-settings sidebar.
* Verify that changing the date to a previous date results in the label "Back-date".
* Verify that changing the date to a future date results in the label "Schedule".
* On a published post, verify that a future-date results in the label "Scheduled".
* On a published post, verify that a date in the past results in the label "Published".