### PR TITLE
Site Settings: Disable Manage Connection for Atomic sites

### DIFF
--- a/client/my-sites/site-settings/manage-connection/index.jsx
+++ b/client/my-sites/site-settings/manage-connection/index.jsx
@@ -17,6 +17,7 @@ import Main from 'components/main';
 import SiteOwnership from './site-ownership';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { isSiteAutomatedTransfer } from 'state/selectors';
 
 class ManageConnection extends Component {
 	componentDidMount() {
@@ -28,7 +29,7 @@ class ManageConnection extends Component {
 	}
 
 	verifySiteIsJetpack() {
-		if ( this.props.siteIsJetpack === false ) {
+		if ( this.props.siteIsJetpack === false || this.props.siteIsAtomic ) {
 			this.redirectToGeneral();
 		}
 	}
@@ -59,8 +60,13 @@ class ManageConnection extends Component {
 }
 
 export default connect(
-	( state ) => ( {
-		siteIsJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
-		siteSlug: getSelectedSiteSlug( state ),
-	} )
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			siteIsAtomic: isSiteAutomatedTransfer( state, siteId ),
+			siteIsJetpack: isJetpackSite( state, siteId ),
+			siteSlug: getSelectedSiteSlug( state ),
+		};
+	}
 )( localize( ManageConnection ) );


### PR DESCRIPTION
This PR updates the Manage Connection page to disable it for Atomic sites. Since users shouldn't be able to manage connection for Atomic sites at all, this PR suggests that we disable the Manage Connection page and redirect the users to General settings section, just like we do for WordPress.com sites. Kudos to @seear for realizing this.

To test:
* Checkout this branch
* Go to `/settings/manage-connection/:site`, where `:site` is an Atomic site.
* Verify you're redirected to General settings.
* Test with a clean Redux state and verify it works as expected.
* Verify .com sites and Jetpack sites work like they did before.