### PR TITLE
Keep login form enabled for 2FA login

### DIFF
--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -68,6 +68,7 @@ export const isFormDisabled = createReducer( null, {
 	[ LOGIN_REQUEST ]: () => true,
 	[ LOGIN_REQUEST_FAILURE ]: () => false,
 	[ LOGIN_REQUEST_SUCCESS ]: () => true,
+	[ ROUTE_SET ]: () => false,
 	[ SOCIAL_LOGIN_REQUEST ]: () => true,
 	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: () => false,
 	[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: () => true,


### PR DESCRIPTION
This PR fixes an issue in the login page which keeps the form disabled for 2FA users when they come back to the initial login screen after entering valid credentials:

![image](https://user-images.githubusercontent.com/230230/28579198-35d81ac6-715c-11e7-875f-d7ebddba73c7.png)

### Testing Instructions
- Boot this branch `git checkout fix/login-form-disabled && npm start`
- Go to http://calypso.localhost:3000/log-in
- Enter your credentials for a valid 2fa account
- verify that the form is enabled when you come back to it.

### Reviews
- [ ] Code
- [x] Product
