### PR TITLE
Simple Payments: add an EllipsisMenu to the product list item

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item.jsx
@@ -1,0 +1,74 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+import CompactCard from 'components/card/compact';
+import EllipsisMenu from 'components/ellipsis-menu';
+import FormRadio from 'components/forms/form-radio';
+import PopoverMenuItem from 'components/popover/menu-item';
+
+class ProductListItem extends Component {
+	static propTypes = {
+		onSelectedChange: PropTypes.func,
+		onEditClick: PropTypes.func,
+		onTrashClick: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onSelectedChange: noop,
+		onEditClick: noop,
+		onTrashClick: noop,
+	};
+
+	handleRadioChange = () => this.props.onSelectedChange( this.props.paymentId );
+	handleEditClick = () => this.props.onEditClick( this.props.paymentId );
+	handleTrashClick = () => this.props.onTrashClick( this.props.paymentId );
+
+	render() {
+		const { paymentId, title, price, currency, isSelected, translate } = this.props;
+		const radioId = `simple-payments-list-item-radio-${ paymentId }`;
+
+		return (
+			<CompactCard className="editor-simple-payments-modal__list-item">
+				<FormRadio
+					name="selection"
+					id={ radioId }
+					value={ paymentId }
+					checked={ isSelected }
+					onChange={ this.handleRadioChange }
+				/>
+				<label className="editor-simple-payments-modal__list-label" htmlFor={ radioId }>
+					<div>
+						{ title }
+					</div>
+					<div>
+						{ formatCurrency( price, currency ) }
+					</div>
+				</label>
+				<EllipsisMenu
+					className="editor-simple-payments-modal__list-menu"
+					popoverClassName="is-dialog-visible"
+					position="bottom left"
+				>
+					<PopoverMenuItem icon="pencil" onClick={ this.handleEditClick }>
+						{ translate( 'Edit' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem icon="trash" onClick={ this.handleTrashClick }>
+						{ translate( 'Trash' ) }
+					</PopoverMenuItem>
+				</EllipsisMenu>
+			</CompactCard>
+		);
+	}
+}
+
+export default localize( ProductListItem );

--- a/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
@@ -4,58 +4,56 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import formatCurrency from 'lib/format-currency';
-import CompactCard from 'components/card/compact';
-import FormRadio from 'components/forms/form-radio';
+import ProductListItem from './list-item';
 
 class ProductList extends Component {
 	static propTypes = {
 		paymentButtons: PropTypes.array.isRequired,
 		selectedPaymentId: PropTypes.number,
 		onSelectedChange: PropTypes.func,
+		onEditClick: PropTypes.func,
+		onTrashClick: PropTypes.func,
 	};
 
 	static defaultProps = {
 		selectedPaymentId: null,
 		onSelectedChange: noop,
-	};
-
-	handleRadioChange = event => {
-		this.props.onSelectedChange( parseInt( event.target.value ) );
+		onEditClick: noop,
+		onTrashClick: noop,
 	};
 
 	render() {
-		const { paymentButtons, selectedPaymentId } = this.props;
+		const {
+			paymentButtons,
+			selectedPaymentId,
+			onSelectedChange,
+			onEditClick,
+			onTrashClick,
+		} = this.props;
 
 		return (
 			<div className="editor-simple-payments-modal__list">
-				{ paymentButtons.map( ( { ID: paymentId, title, price, currency } ) => {
-					const radioId = `simple-payments-list-item-radio-${ paymentId }`;
-
-					return (
-						<CompactCard className="editor-simple-payments-modal__list-item" key={ paymentId }>
-							<FormRadio
-								name="selection"
-								id={ radioId }
-								value={ paymentId }
-								checked={ selectedPaymentId === paymentId }
-								onChange={ this.handleRadioChange }
-							/>
-							<label className="editor-simple-payments-modal__list-label" htmlFor={ radioId }>
-								<div>{ title }</div><div>{ formatCurrency( price, currency ) }</div>
-							</label>
-						</CompactCard>
-					);
-				} ) }
+				{ paymentButtons.map( ( { ID: paymentId, title, price, currency } ) =>
+					<ProductListItem
+						key={ paymentId }
+						paymentId={ paymentId }
+						isSelected={ selectedPaymentId === paymentId }
+						title={ title }
+						price={ price }
+						currency={ currency }
+						onSelectedChange={ onSelectedChange }
+						onEditClick={ onEditClick }
+						onTrashClick={ onTrashClick }
+					/>,
+				) }
 			</div>
 		);
 	}
 }
 
-export default localize( ProductList );
+export default ProductList;

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -100,3 +100,8 @@
 	font-family: $serif;
 	font-weight: bold;
 }
+
+.editor-simple-payments-modal__list-menu {
+	flex: none;
+	margin-left: 16px;
+}


### PR DESCRIPTION
First, move the `ProductListItem` to a separate React component -- it's getting complex enough to deserve one.

Second, show an `EllipsisMenu` with "Edit" and "Trash" actions on every item. Clicking on them doesn't do anything yet, we're just adding the UI in this PR.

To test:
- open the Simple Payments dialog by clicking "Add Payment Button" in the post editor
- go to the payment buttons list
- check that there is an ellipsis icon on the right side of each list item and that clicking on it shows the menu
- verify that the menu is displayed on top of the modal dialog -- I had to add a `is-dialog-visible` CSS class to the menu popover in order to get the z-indexes right
- resize the browser viewport to trigger various responsive modes -- check that nothing breaks
