### PR TITLE
View Site: Remove text selection on iframe focus

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -112,11 +112,31 @@ export class WebPreviewContent extends Component {
 			case 'location-change':
 				this.handleLocationChange( data.payload );
 				return;
+			case 'focus':
+				this.removeSelection();
+				return;
 		}
 	}
 
 	handleLocationChange = ( payload ) => {
 		this.props.onLocationUpdate( payload.pathname );
+	}
+
+	removeSelection = () => {
+		// remove all textual selections when user gives focus to preview iframe
+		// they might be confusing
+		if ( global.window ) {
+			if ( typeof window.getSelection !== 'undefined' ) {
+				const selection = window.getSelection();
+				if ( typeof selection.empty === 'function' ) {
+					selection.empty();
+				} else if ( typeof selection.removeAllRanges === 'function' ) {
+					selection.removeAllRanges();
+				}
+			} else if ( document.selection !== undefined && typeof document.selection.empty === 'function' ) {
+				document.selection.empty();
+			}
+		}
 	}
 
 	focusIfNeeded = () => {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debugModule from 'debug';
-import { noop } from 'lodash';
+import { noop, isFunction } from 'lodash';
 import page from 'page';
 import shallowCompare from 'react-addons-shallow-compare';
 import { v4 as uuid } from 'uuid';
@@ -126,14 +126,14 @@ export class WebPreviewContent extends Component {
 		// remove all textual selections when user gives focus to preview iframe
 		// they might be confusing
 		if ( global.window ) {
-			if ( typeof window.getSelection !== 'undefined' ) {
+			if ( isFunction( window.getSelection ) ) {
 				const selection = window.getSelection();
-				if ( typeof selection.empty === 'function' ) {
+				if ( isFunction( selection.empty ) ) {
 					selection.empty();
-				} else if ( typeof selection.removeAllRanges === 'function' ) {
+				} else if ( isFunction( selection.removeAllRanges ) ) {
 					selection.removeAllRanges();
 				}
-			} else if ( document.selection !== undefined && typeof document.selection.empty === 'function' ) {
+			} else if ( document.selection && isFunction( document.selection.empty ) ) {
 				document.selection.empty();
 			}
 		}


### PR DESCRIPTION
This will fix the bug reported in https://github.com/Automattic/wp-calypso/pull/16524#issuecomment-317761022

Test:
- ~Sandbox some dotcom site with D6551-code applied~ Diff landed to production
- On this branch, run `localStorage.debug = 'calypso:web-preview'`
- Go to: /view/thatsite.wordpress.com
- Click URL to select it
- Click some whitespace on site frontend to focus it
- Watch URL selection disappear