### PR TITLE
Store Orders: Update order list filters & add searching

### DIFF
--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -1,36 +1,23 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
-import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import OrdersList from './orders-list';
 
-class Orders extends Component {
-	render() {
-		const { className, translate } = this.props;
-		return (
-			<Main className={ className }>
-				<ActionHeader breadcrumbs={ ( <span>{ translate( 'Orders' ) }</span> ) } />
-				<OrdersList />
-			</Main>
-		);
-	}
+function Orders( { className, translate } ) {
+	return (
+		<Main className={ className }>
+			<ActionHeader breadcrumbs={ ( <span>{ translate( 'Orders' ) }</span> ) } />
+			<OrdersList />
+		</Main>
+	);
 }
 
-export default connect(
-	state => {
-		const site = getSelectedSiteWithFallback( state );
-
-		return {
-			site,
-		};
-	}
-)( localize( Orders ) );
+export default localize( Orders );

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -11,11 +11,11 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Main from 'components/main';
 import OrdersList from './orders-list';
 
-function Orders( { className, translate } ) {
+function Orders( { className, params, translate } ) {
 	return (
 		<Main className={ className }>
 			<ActionHeader breadcrumbs={ ( <span>{ translate( 'Orders' ) }</span> ) } />
-			<OrdersList />
+			<OrdersList currentStatus={ params && params.filter } />
 		</Main>
 	);
 }

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -44,13 +44,14 @@ class OrdersFilterNav extends Component {
 				</NavTabs>
 
 				<Search
+					ref={ this.props.searchRef }
 					pinned
 					fitsContainer
 					onSearch={ this.doSearch }
 					onSearchClose={ this.clearSearch }
 					placeholder={ translate( 'Search orders' ) }
 					analyticsGroup="Orders"
-					delaySearch={ true }
+					delaySearch
 				/>
 			</SectionNav>
 		);

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import SectionNav from 'components/section-nav';
+
+class OrdersFilterNav extends Component {
+	render() {
+		const { translate, site, status } = this.props;
+		return (
+			<SectionNav>
+				<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
+					<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ 'any' === status }>
+						{ translate( 'All orders' ) }
+					</NavItem>
+					<NavItem path={ getLink( '/store/orders/processing/:site', site ) } selected={ 'processing' === status }>
+						{ translate( 'Processing' ) }
+					</NavItem>
+					<NavItem path={ getLink( '/store/orders/completed/:site', site ) } selected={ 'completed' === status }>
+						{ translate( 'Completed' ) }
+					</NavItem>
+				</NavTabs>
+			</SectionNav>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		site: getSelectedSiteWithFallback( state ),
+	} )
+)( localize( OrdersFilterNav ) );

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
@@ -9,12 +10,23 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { getLink } from 'woocommerce/lib/nav-utils';
+import { getOrdersCurrentSearch } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { updateCurrentOrdersQuery } from 'woocommerce/state/ui/orders/actions';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
+import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 
 class OrdersFilterNav extends Component {
+	doSearch = ( search ) => {
+		this.props.updateCurrentOrdersQuery( this.props.site.ID, { search } );
+	}
+
+	clearSearch = () => {
+		this.doSearch( '' );
+	}
+
 	render() {
 		const { translate, site, status } = this.props;
 		return (
@@ -30,6 +42,16 @@ class OrdersFilterNav extends Component {
 						{ translate( 'Completed' ) }
 					</NavItem>
 				</NavTabs>
+
+				<Search
+					pinned
+					fitsContainer
+					onSearch={ this.doSearch }
+					onSearchClose={ this.clearSearch }
+					placeholder={ translate( 'Search orders' ) }
+					analyticsGroup="Orders"
+					delaySearch={ true }
+				/>
 			</SectionNav>
 		);
 	}
@@ -38,5 +60,7 @@ class OrdersFilterNav extends Component {
 export default connect(
 	state => ( {
 		site: getSelectedSiteWithFallback( state ),
-	} )
+		search: getOrdersCurrentSearch( state ),
+	} ),
+	dispatch => bindActionCreators( { updateCurrentOrdersQuery }, dispatch )
 )( localize( OrdersFilterNav ) );

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -35,8 +35,8 @@ class Orders extends Component {
 		const { siteId, currentPage, currentSearch, currentStatus } = this.props;
 		const query = {
 			page: currentPage,
-			status: currentStatus,
 			search: currentSearch,
+			status: currentStatus,
 		};
 		if ( siteId ) {
 			this.props.fetchOrders( siteId, query );

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -241,12 +241,16 @@ export default connect(
 		const currentPage = getOrdersCurrentPage( state, siteId );
 		const currentSearch = getOrdersCurrentSearch( state, siteId );
 		const currentStatus = props.currentStatus || 'any';
-		const total = getTotalOrders( state, { status: currentStatus }, siteId );
 
-		const query = { page: currentPage, search: currentSearch, status: currentStatus };
+		const query = {
+			page: currentPage,
+			search: currentSearch,
+			status: currentStatus,
+		};
 		const orders = getOrders( state, query, siteId );
 		const ordersLoading = areOrdersLoading( state, query, siteId );
 		const ordersLoaded = areOrdersLoaded( state, query, siteId );
+		const total = getTotalOrders( state, query, siteId );
 
 		return {
 			currentPage,

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -32,12 +32,13 @@ import TableItem from 'woocommerce/components/table/table-item';
 
 class Orders extends Component {
 	componentDidMount() {
-		const { siteId, currentPage, currentSearch, currentStatus } = this.props;
+		const { siteId, currentStatus } = this.props;
 		const query = {
-			page: currentPage,
-			search: currentSearch,
+			page: 1,
+			search: '',
 			status: currentStatus,
 		};
+		this.props.updateCurrentOrdersQuery( this.props.siteId, { page: 1, search: '' } );
 		if ( siteId ) {
 			this.props.fetchOrders( siteId, query );
 		}

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -19,14 +19,12 @@ import {
 	getTotalOrders
 } from 'woocommerce/state/sites/orders/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import { getOrdersCurrentPage, getOrdersCurrentStatus } from 'woocommerce/state/ui/orders/selectors';
+import { getOrdersCurrentPage } from 'woocommerce/state/ui/orders/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import humanDate from 'lib/human-date';
 import { updateCurrentOrdersQuery } from 'woocommerce/state/ui/orders/actions';
-import NavItem from 'components/section-nav/item';
-import NavTabs from 'components/section-nav/tabs';
+import OrdersFilterNav from './orders-filter-nav';
 import Pagination from 'components/pagination';
-import SectionNav from 'components/section-nav';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -129,10 +127,10 @@ class Orders extends Component {
 	render() {
 		const {
 			currentPage,
+			currentStatus,
 			orders,
 			ordersLoading,
 			ordersLoaded,
-			site,
 			total,
 			translate
 		} = this.props;
@@ -159,11 +157,7 @@ class Orders extends Component {
 
 		return (
 			<div className="orders__container">
-				<SectionNav>
-					<NavTabs label={ translate( 'Status' ) } selectedText={ translate( 'All orders' ) }>
-						<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ true }>{ translate( 'All orders' ) }</NavItem>
-					</NavTabs>
-				</SectionNav>
+				<OrdersFilterNav status={ currentStatus } />
 
 				<Table className="orders__table" header={ headers } horizontalScroll>
 					{ ordersLoading
@@ -183,11 +177,11 @@ class Orders extends Component {
 }
 
 export default connect(
-	state => {
+	( state, props ) => {
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site ? site.ID : false;
 		const currentPage = getOrdersCurrentPage( state, siteId );
-		const currentStatus = getOrdersCurrentStatus( state, siteId );
+		const currentStatus = props.currentStatus || 'any';
 		const total = getTotalOrders( state, { status: currentStatus }, siteId );
 
 		const query = { page: currentPage, status: currentStatus };

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -4,6 +4,7 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { range } from 'lodash';
 import React, { Component } from 'react';
 
 /**
@@ -103,7 +104,20 @@ class Orders extends Component {
 		);
 	}
 
-	renderOrderItems = ( order, i ) => {
+	renderPlacholder = () => {
+		return range( 5 ).map( ( i ) => {
+			return (
+				<TableRow key={ i } className="orders__row-placeholder">
+					<TableItem className="orders__table-name" isRowHeader><span /></TableItem>
+					<TableItem className="orders__table-date"><span /></TableItem>
+					<TableItem className="orders__table-status"><span /></TableItem>
+					<TableItem className="orders__table-total"><span /></TableItem>
+				</TableRow>
+			);
+		} );
+	}
+
+	renderOrderItem = ( order, i ) => {
 		const { site } = this.props;
 		return (
 			<TableRow key={ i } href={ getLink( `/store/order/:site/${ order.number }`, site ) }>
@@ -165,14 +179,16 @@ class Orders extends Component {
 			</TableRow>
 		);
 
+		const ordersList = orders ? orders.map( this.renderOrderItem ) : null;
+
 		return (
 			<div className="orders__container">
 				<OrdersFilterNav status={ currentStatus } />
 
 				<Table className="orders__table" header={ headers } horizontalScroll>
 					{ ordersLoading
-						? null
-						: orders.map( this.renderOrderItems ) }
+						? this.renderPlacholder()
+						: ordersList }
 				</Table>
 
 				<Pagination

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -124,6 +124,30 @@ class Orders extends Component {
 		} );
 	}
 
+	renderNoContent = () => {
+		const { currentSearch, currentStatus, site, translate } = this.props;
+		let emptyMessage = translate( 'Your orders will appear here as they come in.' );
+		if ( currentSearch ) {
+			emptyMessage = translate( 'No orders matching your search.' );
+		} else if ( 'pending' === currentStatus ) {
+			emptyMessage = translate( 'You don\'t have any orders awaiting payment.' );
+		} else if ( 'processing' === currentStatus ) {
+			emptyMessage = translate( 'You don\'t have any orders awaiting fulfillment.' );
+		}
+
+		return (
+			<TableRow>
+				<TableItem colSpan={ 4 }>
+					<EmptyContent
+						title={ emptyMessage }
+						action={ translate( 'View all orders' ) }
+						actionURL={ getLink( '/store/orders/:site', site ) }
+					/>
+				</TableItem>
+			</TableRow>
+		);
+	}
+
 	renderOrderItem = ( order, i ) => {
 		const { site } = this.props;
 		return (
@@ -186,7 +210,7 @@ class Orders extends Component {
 			</TableRow>
 		);
 
-		const ordersList = orders ? orders.map( this.renderOrderItem ) : null;
+		const ordersList = ( orders && orders.length ) ? orders.map( this.renderOrderItem ) : this.renderNoContent();
 
 		return (
 			<div className="orders__container">

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -144,8 +144,9 @@ class Orders extends Component {
 			translate
 		} = this.props;
 
-		// Orders are done loading, and there are definitely no orders for this query
-		if ( ordersLoaded && ! total ) {
+		// Orders are done loading, and there are definitely no orders for this site
+		// @todo Display some other placeholder if a single status is empty
+		if ( ordersLoaded && ! total && 'any' === currentStatus ) {
 			return (
 				<div className="orders__container">
 					<EmptyContent

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -111,7 +111,7 @@ class Orders extends Component {
 		);
 	}
 
-	renderPlacholder = () => {
+	renderPlaceholders = () => {
 		return range( 5 ).map( ( i ) => {
 			return (
 				<TableRow key={ i } className="orders__row-placeholder">
@@ -194,7 +194,7 @@ class Orders extends Component {
 
 				<Table className="orders__table" header={ headers } horizontalScroll>
 					{ ordersLoading
-						? this.renderPlacholder()
+						? this.renderPlaceholders()
 						: ordersList }
 				</Table>
 

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -191,7 +191,6 @@ class Orders extends Component {
 		} = this.props;
 
 		// Orders are done loading, and there are definitely no orders for this site
-		// @todo Display some other placeholder if a single status is empty
 		if ( ordersLoaded && ! total && 'any' === currentStatus ) {
 			return (
 				<div className="orders__container">

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -47,13 +47,19 @@ class Orders extends Component {
 			newProps.currentStatus !== this.props.currentStatus ||
 			newProps.siteId !== this.props.siteId
 		);
-		if ( newProps.siteId && hasAnythingChanged ) {
-			const query = {
-				page: newProps.currentPage,
-				status: newProps.currentStatus,
-			};
-			this.props.fetchOrders( newProps.siteId, query );
+		if ( ! newProps.siteId || ! hasAnythingChanged ) {
+			return;
 		}
+
+		const query = {
+			page: newProps.currentPage,
+			status: newProps.currentStatus,
+		};
+		if ( newProps.currentStatus !== this.props.currentStatus ) {
+			this.props.updateCurrentOrdersQuery( this.props.siteId, { page: 1 } );
+			query.page = 1;
+		}
+		this.props.fetchOrders( newProps.siteId, query );
 	}
 
 	getOrderStatus = ( status ) => {
@@ -121,7 +127,10 @@ class Orders extends Component {
 	}
 
 	onPageClick = page => {
-		this.props.updateCurrentOrdersQuery( this.props.siteId, { page } );
+		this.props.updateCurrentOrdersQuery( this.props.siteId, {
+			page,
+			status: this.props.currentStatus,
+		} );
 	}
 
 	render() {

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -17,6 +17,12 @@
 			background: lighten( $gray, 35% );
 		}
 	}
+
+	.orders__row-placeholder span {
+		display: inline-block;
+		width: 75%;
+		@include placeholder();
+	}
 }
 
 .orders__item-link,

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -65,6 +65,12 @@ const getStorePages = () => {
 			path: '/store/orders/:site',
 		},
 		{
+			container: Orders,
+			configKey: 'woocommerce/extension-orders',
+			documentTitle: translate( 'Orders' ),
+			path: '/store/orders/:filter/:site',
+		},
+		{
 			container: Order,
 			configKey: 'woocommerce/extension-orders',
 			documentTitle: translate( 'Order Details' ),

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import qs from 'querystring';
-
+import { omitBy } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -49,7 +49,8 @@ export const fetchOrders = ( siteId, requestedQuery = {} ) => ( dispatch, getSta
 	};
 	dispatch( fetchAction );
 
-	return request( siteId ).getWithHeaders( 'orders?' + qs.stringify( query ) ).then( ( response ) => {
+	const queryString = qs.stringify( omitBy( query, val => '' === val ) );
+	return request( siteId ).getWithHeaders( 'orders?' + queryString ).then( ( response ) => {
 		const { headers, data } = response;
 		const total = headers[ 'X-WP-Total' ];
 		dispatch( {

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -6,6 +6,7 @@ import { omitBy } from 'lodash';
 export const DEFAULT_QUERY = {
 	page: 1,
 	per_page: 50,
+	search: '',
 	status: 'any',
 };
 

--- a/client/extensions/woocommerce/state/ui/orders/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/reducer.js
@@ -32,7 +32,7 @@ export function currentSearch( state = '', action ) {
 	const { type, query } = action;
 	switch ( type ) {
 		case WOOCOMMERCE_UI_ORDERS_SET_QUERY:
-			return query && query.search ? query.search : state;
+			return query && ( 'undefined' !== typeof query.search ) ? query.search : state;
 		default:
 			return state;
 	}

--- a/client/extensions/woocommerce/state/ui/orders/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/reducer.js
@@ -28,11 +28,11 @@ export function currentPage( state = 1, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function currentStatus( state = 'any', action ) {
+export function currentSearch( state = '', action ) {
 	const { type, query } = action;
 	switch ( type ) {
 		case WOOCOMMERCE_UI_ORDERS_SET_QUERY:
-			return query && query.status ? query.status : state;
+			return query && query.search ? query.search : state;
 		default:
 			return state;
 	}
@@ -40,7 +40,7 @@ export function currentStatus( state = 'any', action ) {
 
 const ordersReducer = combineReducers( {
 	currentPage,
-	currentStatus
+	currentSearch
 } );
 
 export default keyedReducer( 'siteId', ordersReducer );

--- a/client/extensions/woocommerce/state/ui/orders/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/selectors.js
@@ -20,8 +20,8 @@ export const getOrdersCurrentPage = ( state, siteId = getSelectedSiteId( state )
 /**
  * @param {Object} state Whole Redux state tree
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @return {String} The current status filter being shown to the user. Defaults to "any".
+ * @return {String} The current search term being shown to the user. Defaults to "".
  */
-export const getOrdersCurrentStatus = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'currentStatus' ], 'any' );
+export const getOrdersCurrentSearch = ( state, siteId = getSelectedSiteId( state ) ) => {
+	return get( state, [ 'extensions', 'woocommerce', 'ui', 'orders', siteId, 'currentSearch' ], '' );
 };

--- a/client/extensions/woocommerce/state/ui/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/actions.js
@@ -17,11 +17,11 @@ describe( 'actions', () => {
 		it( 'should dispatch an action', () => {
 			const getState = () => ( {} );
 			const dispatch = spy();
-			updateCurrentOrdersQuery( siteId, { page: 2, status: 'completed' } )( dispatch, getState );
+			updateCurrentOrdersQuery( siteId, { page: 2, search: 'test' } )( dispatch, getState );
 			expect( dispatch ).to.have.been.calledWith( {
 				type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 				siteId,
-				query: { page: 2, status: 'completed' }
+				query: { page: 2, search: 'test' }
 			} );
 		} );
 	} );

--- a/client/extensions/woocommerce/state/ui/orders/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/reducer.js
@@ -28,7 +28,7 @@ describe( 'reducer', () => {
 		expect( newState ).to.eql( { 123: { currentPage: 2, currentSearch: '' } } );
 	} );
 
-	it( 'should should update the current page when changed', () => {
+	it( 'should update the current page when changed', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 123,
@@ -41,7 +41,7 @@ describe( 'reducer', () => {
 		expect( newState ).to.eql( { 123: { currentPage: 2, currentSearch: '' } } );
 	} );
 
-	it( 'should should update the current search when changed', () => {
+	it( 'should update the current search when changed', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 123,
@@ -54,7 +54,7 @@ describe( 'reducer', () => {
 		expect( newState ).to.eql( { 123: { currentPage: 3, currentSearch: 'example' } } );
 	} );
 
-	it( 'should should store the current query for more than one site', () => {
+	it( 'should store the current query for more than one site', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 234,
@@ -70,7 +70,7 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	it( 'should should remove the key when page is re-set to initial state', () => {
+	it( 'should remove the key when page is re-set to initial state', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 123,
@@ -83,7 +83,7 @@ describe( 'reducer', () => {
 		expect( newState ).to.eql( {} );
 	} );
 
-	it( 'should should remove the key when search is re-set to initial state', () => {
+	it( 'should remove the key when search is re-set to initial state', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 123,

--- a/client/extensions/woocommerce/state/ui/orders/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/reducer.js
@@ -25,7 +25,7 @@ describe( 'reducer', () => {
 			},
 		};
 		const newState = reducer( undefined, action );
-		expect( newState ).to.eql( { 123: { currentPage: 2, currentStatus: 'any' } } );
+		expect( newState ).to.eql( { 123: { currentPage: 2, currentSearch: '' } } );
 	} );
 
 	it( 'should should update the current page when changed', () => {
@@ -36,22 +36,22 @@ describe( 'reducer', () => {
 				page: 2,
 			},
 		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentStatus: 'any' } } );
+		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
 		const newState = reducer( originalState, action );
-		expect( newState ).to.eql( { 123: { currentPage: 2, currentStatus: 'any' } } );
+		expect( newState ).to.eql( { 123: { currentPage: 2, currentSearch: '' } } );
 	} );
 
-	it( 'should should update the current status when changed', () => {
+	it( 'should should update the current search when changed', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 123,
 			query: {
-				status: 'completed'
+				search: 'example'
 			},
 		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentStatus: 'any' } } );
+		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
 		const newState = reducer( originalState, action );
-		expect( newState ).to.eql( { 123: { currentPage: 3, currentStatus: 'completed' } } );
+		expect( newState ).to.eql( { 123: { currentPage: 3, currentSearch: 'example' } } );
 	} );
 
 	it( 'should should store the current query for more than one site', () => {
@@ -59,14 +59,14 @@ describe( 'reducer', () => {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 234,
 			query: {
-				status: 'on-hold'
+				search: 'test'
 			},
 		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentStatus: 'any' } } );
+		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
 		const newState = reducer( originalState, action );
 		expect( newState ).to.eql( {
-			123: { currentPage: 3, currentStatus: 'any' },
-			234: { currentPage: 1, currentStatus: 'on-hold' }
+			123: { currentPage: 3, currentSearch: '' },
+			234: { currentPage: 1, currentSearch: 'test' }
 		} );
 	} );
 
@@ -78,7 +78,7 @@ describe( 'reducer', () => {
 				page: 1,
 			}
 		};
-		const originalState = deepFreeze( { 123: { currentPage: 3, currentStatus: 'any' } } );
+		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
 		const newState = reducer( originalState, action );
 		expect( newState ).to.eql( {} );
 	} );

--- a/client/extensions/woocommerce/state/ui/orders/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/reducer.js
@@ -70,7 +70,7 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	it( 'should should remove the key when re-set to initial state', () => {
+	it( 'should should remove the key when page is re-set to initial state', () => {
 		const action = {
 			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
 			siteId: 123,
@@ -79,6 +79,19 @@ describe( 'reducer', () => {
 			}
 		};
 		const originalState = deepFreeze( { 123: { currentPage: 3, currentSearch: '' } } );
+		const newState = reducer( originalState, action );
+		expect( newState ).to.eql( {} );
+	} );
+
+	it( 'should should remove the key when search is re-set to initial state', () => {
+		const action = {
+			type: WOOCOMMERCE_UI_ORDERS_SET_QUERY,
+			siteId: 123,
+			query: {
+				search: '',
+			}
+		};
+		const originalState = deepFreeze( { 123: { currentPage: 1, currentSearch: 'test' } } );
 		const newState = reducer( originalState, action );
 		expect( newState ).to.eql( {} );
 	} );

--- a/client/extensions/woocommerce/state/ui/orders/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/test/selectors.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getOrdersCurrentPage,
-	getOrdersCurrentStatus
+	getOrdersCurrentSearch
 } from '../selectors';
 
 const preInitializedState = {
@@ -25,11 +25,11 @@ const state = {
 				orders: {
 					123: {
 						currentPage: 2,
-						currentStatus: 'any',
+						currentSearch: 'example',
 					},
 					234: {
 						currentPage: 5,
-						currentStatus: 'pending',
+						currentSearch: 'test',
 					},
 				},
 			},
@@ -56,21 +56,21 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getOrdersCurrentStatus', () => {
+	describe( '#getOrdersCurrentSearch', () => {
 		it( 'should be any (default) when woocommerce state is not available', () => {
-			expect( getOrdersCurrentStatus( preInitializedState, 123 ) ).to.eql( 'any' );
+			expect( getOrdersCurrentSearch( preInitializedState, 123 ) ).to.eql( '' );
 		} );
 
-		it( 'should get the current order status', () => {
-			expect( getOrdersCurrentStatus( state, 123 ) ).to.eql( 'any' );
+		it( 'should get the current search term', () => {
+			expect( getOrdersCurrentSearch( state, 123 ) ).to.eql( 'example' );
 		} );
 
-		it( 'should get the current order status for a second site in the state', () => {
-			expect( getOrdersCurrentStatus( state, 234 ) ).to.eql( 'pending' );
+		it( 'should get the current search term for a second site in the state', () => {
+			expect( getOrdersCurrentSearch( state, 234 ) ).to.eql( 'test' );
 		} );
 
 		it( 'should get the siteId from the UI tree if not provided', () => {
-			expect( getOrdersCurrentStatus( state ) ).to.eql( 'any' );
+			expect( getOrdersCurrentSearch( state ) ).to.eql( 'example' );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -118,9 +118,11 @@ class StoreSidebar extends Component {
 	orders = () => {
 		const { orders, site, siteSuffix, translate } = this.props;
 		const link = '/store/orders' + siteSuffix;
-		// We don't use the addLink yet, but this ensures the item is selected on single views
-		const addLink = '/store/order' + siteSuffix;
-		const selected = this.isItemLinkSelected( [ link, addLink ] );
+		const childLinks = [
+			'/store/order',
+			'/store/orders',
+		];
+		const selected = this.isItemLinkSelected( childLinks );
 		const classes = classNames( {
 			orders: true,
 			'is-placeholder': ! site,


### PR DESCRIPTION
Fixes #16288, Fixes #16443 

This PR adds real order status filters to the nav bar above the orders table. Currently this PR only shows "processing" and "completed"– eventually this will change to "All orders", "Awaiting fulfillment", and "Awaiting payment" (but we need https://github.com/woocommerce/wc-api-dev/pull/31 finished first), so this PR is more about laying out the filter functionality.

This also adds searching to the filter bar.

![screen shot 2017-07-26 at 1 02 24 pm](https://user-images.githubusercontent.com/541093/28633697-afbef0de-7202-11e7-9eee-9b6fc8cf154e.png)
![screen shot 2017-07-26 at 1 02 41 pm](https://user-images.githubusercontent.com/541093/28633707-b92e552e-7202-11e7-8769-dd300580ea7a.png)

It adds a placeholder while items are loading:

<img width="786" alt="screen shot 2017-07-25 at 12 18 07 pm" src="https://user-images.githubusercontent.com/541093/28582433-5b4791d4-7133-11e7-9a8f-92d8c0a75130.png">

And empty states when there are no orders for a status or search:

![screen shot 2017-07-26 at 1 03 42 pm](https://user-images.githubusercontent.com/541093/28633764-e0719d58-7202-11e7-8f6b-fe660225687a.png)

It will alternately say "You don't have any orders awaiting payment." or "You don\'t have any orders awaiting fulfillment." for those statuses (once they're properly hooked up).

Part of adding searching was also tracking search terms in the UI redux state, and it turns out we don't need to track status in redux state because it's tracked by the path itself. So there's also a change to swap the status-related code to search term tracking.

**To test**

- Visit `/store/orders/:site`
- Click around on the filters, make sure correct orders are showing
- If you have more than 50 orders, check that pagination + filters work (or tweak the per_page number in `<Pagination…` in `order-list.js` and in `state/sites/orders/utils.js`)
  - Switching the status should jump you back to page 1 of that status
  - but changing page should not change the status
- Search through your orders, pagination should still work
- Run `npm test` to make sure that the status/search switch works.