### PR TITLE
Plugins: Don't show empty info card for custom plugins

### DIFF
--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -16,6 +16,7 @@ import Version from 'components/version';
 import PluginRatings from 'my-sites/plugins/plugin-ratings/';
 import versionCompare from 'lib/version-compare';
 import analytics from 'lib/analytics';
+import Card from 'components/card';
 
 export default React.createClass( {
 	_WPORG_PLUGINS_URL: 'wordpress.org/plugins/',
@@ -217,7 +218,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<div className="plugin-information">
+			<Card className="plugin-information">
 				<div className="plugin-information__wrapper">
 					<div className={ classes }>
 						<div className="plugin-information__version-shell">
@@ -255,7 +256,7 @@ export default React.createClass( {
 					downloaded={ this.props.plugin.downloaded }
 					numRatings={ this.props.plugin.num_ratings }
 					slug={ this.props.plugin.slug } />
-			</div>
+			</Card>
 		);
 	}
 } );

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -3,7 +3,6 @@
 	flex-wrap: wrap;
 	position: relative;
 	overflow: hidden;
-	margin-top: 16px;
 }
 
 .plugin-information__description {

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -3,6 +3,7 @@
 	flex-wrap: wrap;
 	position: relative;
 	overflow: hidden;
+	margin-top: 16px;
 }
 
 .plugin-information__description {

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -466,7 +466,6 @@ class PluginMeta extends Component {
 				}
 
 				{ ! this.props.isMock && get( this.props.selectedSite, 'jetpack' ) &&
-				<Card className="plugin-meta__plugin-information-wrapper">
 					<PluginInformation
 						plugin={ this.props.plugin }
 						isPlaceholder={ this.props.isPlaceholder }
@@ -475,7 +474,6 @@ class PluginMeta extends Component {
 						siteVersion={ this.props.selectedSite && this.props.selectedSite.options.software_version }
 						hasUpdate={ this.getAvailableNewVersions().length > 0 }
 					/>
-				</Card>
 				}
 
 				{ this.props.atEnabled &&

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -460,6 +460,7 @@ class PluginMeta extends Component {
 
 				{ path &&
 					<CompactCard
+						className="plugin-meta__settings-link"
 						href={ addSiteFragment( path, this.props.slug ) }>
 						{ this.props.translate( 'Edit plugin settings' ) }
 					</CompactCard>

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -72,10 +72,6 @@
 	margin-top: 0;
 }
 
-.plugin-meta .card {
-	margin: 0;
-}
-
 .plugin-meta__meta {
 	color: $gray;
 	white-space: pre;
@@ -150,10 +146,6 @@
 
 .plugin-meta__actions .plugin-meta__active {
 	color: $alert-green;
-}
-
-.card.plugin-meta__plugin-information-wrapper {
-	margin-top: 16px;
 }
 
 a.plugin-meta__settings-link {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -148,22 +148,7 @@
 	color: $alert-green;
 }
 
-a.plugin-meta__settings-link {
-	color: $gray;
-	display: block;
-	font-size: 11px;
-	line-height: 16px;
-	margin: 16px 9px 0 0;
-	text-transform: uppercase;
-
-	@include breakpoint( '>480px' ) {
-		display: inline-block;
-	}
-
-	.gridicon {
-		float: right;
-		position: relative;
-			left: 7px;
-			top: -3px;
-	}
+.card.plugin-meta__settings-link {
+	margin-top: -16px;
+	margin-bottom: 16px;
 }


### PR DESCRIPTION
Removes an empty 'information' card for plugins that are not in the .org repo. This is in preparation for showing some actual information in that position for uploaded plugins.

**Before**

<img width="979" alt="screen shot 2017-07-25 at 20 52 22" src="https://user-images.githubusercontent.com/7767559/28590762-3b223ca4-717b-11e7-892e-bf4ea6de1663.png">

**After**

<img width="980" alt="screen shot 2017-07-25 at 20 51 11" src="https://user-images.githubusercontent.com/7767559/28590770-4420fb10-717b-11e7-9913-32f20e520d4b.png">

Note that this PR removes a blanket css rule that zeroed margins for any card in plugin meta. This has some knock on effects, of which it is hard to unpick whether they were intentional to start with or not:

**Before**
<img width="980" alt="screen shot 2017-07-26 at 12 40 15" src="https://user-images.githubusercontent.com/7767559/28619569-e41b66a2-7200-11e7-9b16-7139cb15244f.png">

**After**
<img width="978" alt="screen shot 2017-07-26 at 12 39 56" src="https://user-images.githubusercontent.com/7767559/28619571-ec0bfa3e-7200-11e7-82f1-1de7ee5e5309.png">

**Before**
<img width="980" alt="screen shot 2017-07-26 at 12 47 04" src="https://user-images.githubusercontent.com/7767559/28619583-f7a7da02-7200-11e7-9498-eea52a4ec668.png">

**After**
<img width="978" alt="screen shot 2017-07-26 at 12 46 44" src="https://user-images.githubusercontent.com/7767559/28619594-fe231c98-7200-11e7-8793-507943ac11f1.png">

The after shots with the default card margins look at least as good as before in my opinion, but I would welcome some design input here, and I may have missed some cases.

**To Test**
* Check out this branch or use the calpyso.live link
* Go to plugins, pick a plugin, compare the displayed plugin page with master
* In particular, try with a custom plugin not available on .org, for example:
[mellow-brolly.zip](https://github.com/Automattic/wp-calypso/files/1176481/mellow-brolly.zip)
(You can upload this by going to /plugins/upload/{jetpack_site} in dev, or using wp-admin)
