### PR TITLE
Me: Remove old Gravatar upload code and clean up ProfileGravatar

### DIFF
--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -13,12 +12,7 @@ import Animate from 'components/animate';
 import Gravatar from 'components/gravatar';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const debug = debugFactory( 'calypso:me:sidebar-gravatar' );
-
 class ProfileGravatar extends Component {
-	componentDidMount() {
-		debug( 'The ProfileGravatar component is mounted.' );
-	}
 
 	recordGravatarMisclick = () => {
 		this.props.recordGoogleEvent( 'Me',

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -12,8 +12,6 @@ import { connect } from 'react-redux';
 import Animate from 'components/animate';
 import Gravatar from 'components/gravatar';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import { isEnabled } from 'config';
-import ExternalLink from 'components/external-link';
 
 const debug = debugFactory( 'calypso:me:sidebar-gravatar' );
 
@@ -22,70 +20,33 @@ class ProfileGravatar extends Component {
 		debug( 'The ProfileGravatar component is mounted.' );
 	}
 
-	handleImageClick = () => {
+	recordGravatarMisclick = () => {
 		this.props.recordGoogleEvent( 'Me',
 			'Clicked on Unclickable Gravatar Image in Sidebar'
 		);
 	};
 
-	handleExternalLinkClick = () => {
-		this.props.recordGoogleEvent( 'Me',
-			'Clicked on Gravatar Update Profile Photo in Sidebar'
-		);
-	};
-
 	render() {
-		const profileURL = `https://gravatar.com/${ this.props.user.username }`;
 		// use imgSize = 400 for caching
 		// it's the popular value for large Gravatars in Calypso
 		const GRAVATAR_IMG_SIZE = 400;
 
-		if ( isEnabled( 'me/edit-gravatar' ) ) {
-			return (
-				<div className="profile-gravatar">
-					<div className="profile-gravatar__gravatar-container" onClick={ this.handleImageClick }>
-						<Gravatar user={ this.props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
-					</div>
-					<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
-					<div className="profile-gravatar__user-secondary-info">
-						<ExternalLink
-							href={ profileURL }
-							target="_blank"
-							rel="noopener noreferrer" >
-							@{ this.props.user.username }
-						</ExternalLink>
-					</div>
-				</div>
-			);
-		}
-
 		return (
 			<div className="profile-gravatar">
-				<Animate type="appear">
-					<ExternalLink
-						href="https://secure.gravatar.com/site/wpcom?wpcc-no-close"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="profile-gravatar__edit"
-						onClick={ this.handleExternalLinkClick } >
-
-						<Gravatar user={ this.props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
-
-						<span className="profile-gravatar__edit-label-wrap">
-							<span className="profile-gravatar__edit-label">
-								{ this.props.translate( 'Update Profile Photo' ) }
-							</span>
-						</span>
-					</ExternalLink>
-				</Animate>
-				<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
+				<div onClick={ this.recordGravatarMisclick }>
+					<Animate type="appear">
+						<Gravatar
+							user={ this.props.user }
+							size={ 150 }
+							imgSize={ GRAVATAR_IMG_SIZE }
+						/>
+					</Animate>
+				</div>
+				<h2 className="profile-gravatar__user-display-name">
+					{ this.props.user.display_name }
+				</h2>
 				<div className="profile-gravatar__user-secondary-info">
-					<ExternalLink
-						href={ profileURL }
-						target="_blank"
-						rel="noopener noreferrer" >
-						@{ this.props.user.username }
-					</ExternalLink>
+					@{ this.props.user.username }
 				</div>
 			</div>
 		);

--- a/client/me/profile-gravatar/style.scss
+++ b/client/me/profile-gravatar/style.scss
@@ -5,103 +5,11 @@
 	}
 }
 
-.profile-gravatar__edit-label-wrap {
-	text-align: center;
-	position: absolute;
-	top: -5px;
-	opacity: 0;
-	width: 150px;
-	height: 150px;
-	line-height: 150px;
-	border-radius: 50%;
-	background: rgba( $gray-dark, 0 );
-	color: $blue-wordpress;
-	transition: all 0.3s ease-in-out;
-	-webkit-appearance: preserve-3d;
-
-	@include breakpoint( '<660px' ) {
-		opacity: 1;
-		top: 110px;
-		background: rgba( $gray-dark, 0.8 );
-		color: $white;
-	}
-
-	&:after {
-		@include noticon( '\f441', 64px );
-		transition: all 0.3s ease-in-out;
-		-webkit-appearance: preserve-3d;
-
-		@include breakpoint( '<660px' ) {
-			color: $blue-light;
-			font-size: 32px;
-			left: 58px;
-			top: 2px;
-		}
-
-		color: $white;
-		display: block;
-		left: 43px;
-		position: absolute;
-		top: 5px;
-		z-index: z-index( '.profile-gravatar__edit-label-wrap', '.profile-gravatar__edit-label-wrap:after' );
-	}
-
-	.profile-gravatar__edit-label {
-		position: relative;
-		top: 10px;
-		z-index: z-index( '.profile-gravatar__edit-label-wrap', '.profile-gravatar__edit-label' );
-	}
-}
-
-.profile-gravatar__edit {
-	position: relative;
-	display: block;
-	overflow: hidden;
-	width: 150px;
-	height: 150px;
-	line-height: 150px;
-	border-radius: 50%;
-	margin:0 auto;
-	outline: none;
-	transition: all 0.3s ease-in-out;
-	-webkit-appearance: preserve-3d;
-
-	&:hover {
-		border-color: lighten( $gray, 10% );
-
-		.profile-gravatar__edit-label-wrap {
-			opacity: 1;
-			top: 0px;
-			background: rgba( $gray-dark, 0.8 );
-			color: $white;
-
-			&:after {
-				top: 15px;
-				color: $blue-light;
-
-				@include breakpoint( '<660px' ) {
-					font-size: 64px;
-					left: 43px;
-				}
-			}
-		}
-	}
-
-	.gravatar {
-		position: relative;
-		transition: all 0.3s ease-in-out;
-		-webkit-appearance: preserve-3d;
-	}
-}
-
 .profile-gravatar__user-secondary-info {
 	margin-bottom: 30px;
 	text-align: center;
-
-	a {
-		color: darken( $gray, 20% );
-		font-size: 14px;
-	}
+	color: darken( $gray, 20% );
+	font-size: 14px;
 }
 
 .profile-gravatar__user-display-name {

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -25,7 +25,6 @@ import Card from 'components/card';
 import observe from 'lib/mixins/data-observe';
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
-import { isEnabled } from 'config';
 import SectionHeader from 'components/section-header';
 
 const debug = debugFactory( 'calypso:me:profile' );
@@ -53,7 +52,7 @@ export default protectForm( React.createClass( {
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<SectionHeader label={ this.translate( 'Profile' ) } />
 				<Card className="me-profile-settings">
-					{ isEnabled( 'me/edit-gravatar' ) && <EditGravatar /> }
+					<EditGravatar />
 
 					<form onSubmit={ this.submitForm } onChange={ this.props.markChanged }>
 						<FormFieldset>

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -55,7 +55,6 @@
 		"manage/themes/details/jetpack": true,
 		"manage/themes/upload": true,
 		"me/account": true,
-		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,

--- a/config/development.json
+++ b/config/development.json
@@ -97,7 +97,6 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
-		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -59,7 +59,6 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
-		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,

--- a/config/production.json
+++ b/config/production.json
@@ -56,7 +56,6 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
-		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -60,7 +60,6 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
-		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,7 +69,6 @@
 		"manage/themes/logged-out": true,
 		"manage/themes/upload": true,
 		"me/account": true,
-		"me/edit-gravatar": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/next-steps": true,


### PR DESCRIPTION
This PR has these changes:
- remove all `me/edit-gravatar` checks
- remove the `me/edit-gravatar` flag from all environment config files
- remove unused code from `<ProfileGravatar />` and update it with these things:
  - remove debug
  - remove unneeded CSS
  - remove username link to Gravatar profile page
  - add CSS to make the plain text username look the same as before when it was a link
  - add an animation to the Gravatar image - the same one that's currently being used in production

`<ProfileGravatar />` before:

<img width="317" alt="before" src="https://user-images.githubusercontent.com/11487924/28600269-f5caa91c-717e-11e7-8748-41de11181b67.png">

While hovering:

<img width="314" alt="before-hover" src="https://user-images.githubusercontent.com/11487924/28600271-fc931e6e-717e-11e7-8963-dd3279d99021.png">

Link:

<img width="333" alt="before-link" src="https://user-images.githubusercontent.com/11487924/28600285-130bbbc4-717f-11e7-979d-47b296b5b573.png">

After:

<img width="323" alt="after" src="https://user-images.githubusercontent.com/11487924/28600289-1f5fc8d4-717f-11e7-995a-75ffe19efb54.png">