### PR TITLE
DevDocs: Display the README below the component in single view

### DIFF
--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -19,20 +19,7 @@ See [`babel-plugin-transform-wpcalypso-async` documentation](https://github.com/
 
 The following props can be passed to the AsyncLoad component:
 
-### `require`
-
-<table>
-	<tr><td>Type</td><td>String (Function)</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-In general usage, this should be passed as a string of the module to be imported. During build, the string prop is [transformed to a function](https://github.com/Automattic/wp-calypso/tree/master/server/bundler/babel/babel-plugin-transform-wpcalypso-async) which is called to require the specified module.
-
-### `placeholder`
-
-<table>
-	<tr><td>Type</td><td>PropTypes.node</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-</table>
-
-A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown.
+| property      | type              | required | comment |
+| ------------- | ----------------- | -------- | ------- |
+| `require`     | String (Function) | yes      | In general usage, this should be passed as a string of the module to be imported. During build, the string prop is [transformed to a function](https://github.com/Automattic/wp-calypso/tree/master/server/bundler/babel/babel-plugin-transform-wpcalypso-async) which is called to require the specified module. |
+| `placeholder` | PropTypes.node    | no       | A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown. |

--- a/client/components/clipboard-button-input/README.md
+++ b/client/components/clipboard-button-input/README.md
@@ -22,32 +22,8 @@ export default function MyComponent() {
 
 The following props can be passed to the ClipboardButtonInput component. With the exception of `className`, all props, including those not listed below, will be passed to the child `<input />` element.
 
-### `value`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>""</code></td></tr>
-</table>
-
-The value of the `<input />` element, and the text to be copied when clicking the copy button.
-
-### `disabled`
-
-<table>
-	<tr><td>Type</td><td>Boolean</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>false</code></td></tr>
-</table>
-
-Whether the children `<input />` and `<button />` should be rendered as `disabled`.
-
-### `hideHttp`
-
-<table>
-	<tr><td>Type</td><td>Boolean</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>false</code></td></tr>
-</table>
-
-Allows URLs to be shown without `http://` or `https://` while keeping the scheme in the copyable value.
+| property   | type    | required | default | comment |
+| ---------- | ------- | -------- | ------- | ------- |
+| `value`    | String  | no       | `""`    | The value of the `<input />` element, and the text to be copied when clicking the copy button. |
+| `disabled` | Boolean | no       | `false` | Whether the children `<input />` and `<button />` should be rendered as `disabled`. |
+| `hideHttp` | Boolean | no       | `false` | Allows URLs to be shown without `http://` or `https://` while keeping the scheme in the copyable value. |

--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -24,64 +24,11 @@ export default function MyComponent( { onMenuItemClick } ) {
 
 ## Props
 
-### `onClick`
-
-<table>
-	<tr><td>Type</td><td>Function</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
-</table>
-
-Callback that will be invoked when menu button is clicked.
-Will be passed the click event.
-
-### `onToggle`
-
-<table>
-	<tr><td>Type</td><td>Function</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
-</table>
-
-Callback that will be invoked when menu is toggled.
-Will be passed the boolean visibility of the menu.
-
-### `toggleTitle`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-Override for the default "Toggle menu" `title` attribute on the toggle button.
-
-### `position`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu).
-
-### `children`
-
-<table>
-	<tr><td>Type</td><td><code>PropTypes.node</code></td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-Menu children to be rendered.
-
-### `disabled`
-
-<table>
-	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-If `true`, then the menu icon will be displayed in light gray and will not be clickable.
+| property      | type           | required | default | comment |
+| ------------- | -------------- | -------- | ------- | -------- |
+| `onClick`     | Function       | no       | noop    | Callback that will be invoked when menu button is clicked. Will be passed the click event. |
+| `onToggle`    | Function       | no       | noop    | Callback that will be invoked when menu is toggled. Will be passed the boolean visibility of the menu. |
+| `toggleTitle` | String         | no       | `null`  | Override for the default "Toggle menu" `title` attribute on the toggle button. |
+| `position`    | String         | no       | `null`  | The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu). |
+| `children`    | PropTypes.node | no       | `null`  | Menu children to be rendered. |
+| `disabled`    | PropTypes.bool | no       | `null`  | If `true`, then the menu icon will be displayed in light gray and will not be clickable. |

--- a/client/components/emojify/README.md
+++ b/client/components/emojify/README.md
@@ -19,22 +19,7 @@ var Emojify = require( 'components/emojify' ),
 
 ## Props
 
-### `children`
-
-<table>
-	<tr><th>Type</th><td>Text|Components</td></tr>
-	<tr><th>Required</th><td>Yes</td></tr>
-	<tr><th>Default</th><td><code>none</code></td></tr>
-</table>
-
-Typically a string that you want to search for UTF emoji
-
-### `imgClassName`
-
-<table>
-	<tr><th>Type</th><td>String</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>emojify__emoji</code></td></tr>
-</table>
-
-classname applied to the image
+| property       | type             | required | default            | comment |
+| -------------- | ---------------- | -------- | ------------------ | ------- |
+| `children`     | Text\|Components | yes      | none               | Typically a string that you want to search for UTF emoji |
+| `imgClassName` | String           | no       | `"emojify__emoji"` | classname applied to the image |

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -20,15 +20,9 @@ React.createClass( {
 ## Props
 The following props can be passed to the External Link component:
 
-### `icon`
-
-<table>
-	<tr><td>Type</td><td>Bool</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-</table>
-
-Set to true if you want to render a nice external Gridicon at the end of link.
-
+| property | type    | required | comment |
+| -------- | ------- | -------- | ------- |
+| `icon`   | Boolean | no       | Set to true if you want to render a nice external Gridicon at the end of link. |
 
 ## Other Props
 Any other props that you pass into the `a` tag will be rendered as expected.

--- a/client/components/gallery-shortcode/README.md
+++ b/client/components/gallery-shortcode/README.md
@@ -29,74 +29,15 @@ export default React.createClass( {
 
 The following props can be passed to the GalleryShortcode component. If a `className` is passed, it will be added to the rendered `.gallery-shortcode` element.
 
-### `siteId`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The site ID for which to render the shortcode.
-
-### `items`
-
-<table>
-	<tr><td>Type</td><td>Array&lt;Media&gt;</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>[]</code></td></tr>
-</table>
-
-The media items to include in the rendered gallery.
-
-### `type`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>"default"</code></td></tr>
-</table>
-
-The rendered style of the gallery. Available options include `default` (Thumbnail Grid), `rectangle` (Tiled Mosaic), `square` (Square Tiles), `circle` (Circles), `columns` (Tiled Columns), and `slideshow` (Slideshow). Defaults to `default`.
-
-### `columns`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>3</code></td></tr>
-</table>
-
-The number of columns. The gallery will include a break tag at the end of each row, and calculate the column width as appropriate.
-
-### `orderBy`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>"menu_order"</code></td></tr>
-</table>
-
-The rendered order of the gallery. Available options include `menu_order` (order specified by the media modal), `title` (order by the title of the image in the Media Library), `post_date` (sort by date/time uploaded), `rand` (order randomly) and `ID` (order by media item ID). Defaults to `menu_order`.
-
-### `link`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>''</code></td></tr>
-</table>
-
-The type of link that each image will link to. Available options include `''` (Empty string which specifies that the link goes to the image's attachment page), `file` (Link to the image file), `none` (No link). Defaults to `''` (attachment page).
-
-### `size`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>thumbnail</code></td></tr>
-</table>
-
-The image size to use for the gallery thumbnail display. Available options include `thumbnail`, `medium`, `large`, `full` and any other additional image size that was registered with on the site. Defaults to `thumbnail`. 
+| property  | type           | required | default        | comment |
+| --------- | -------------- | -------- | -------------- | ------- |
+| `siteId`  | Number         | yes      |                | The site ID for which to render the shortcode. |
+| `items`   | Array\<Media\> | no       | `[]`           | The media items to include in the rendered gallery. |
+| `type`    | String         | no       | `"default"`    | The rendered style of the gallery. Available options include `default` (Thumbnail Grid), `rectangle` (Tiled Mosaic), `square` (Square Tiles), `circle` (Circles), `columns` (Tiled Columns), and `slideshow` (Slideshow). Defaults to `default`. |
+| `columns` | Number         | no       | `3`            | The number of columns. The gallery will include a break tag at the end of each row, and calculate the column width as appropriate. |
+| `orderBy` | String         | no       | `"menu_order"` | The rendered order of the gallery. Available options include `menu_order` (order specified by the media modal), `title` (order by the title of the image in the Media Library), `post_date` (sort by date/time uploaded), `rand` (order randomly) and `ID` (order by media item ID). Defaults to `menu_order`. |
+| `link`    | String         | no       | `''`           | The type of link that each image will link to. Available options include `''` (Empty string which specifies that the link goes to the image's attachment page), `file` (Link to the image file), `none` (No link). Defaults to `''` (attachment page). |
+| `size`    | String         | no       | `"thumbnail"`  | The image size to use for the gallery thumbnail display. Available options include `thumbnail`, `medium`, `large`, `full` and any other additional image size that was registered with on the site. Defaults to `thumbnail`. |
 
 ## Resources
 

--- a/client/components/shortcode/README.md
+++ b/client/components/shortcode/README.md
@@ -28,33 +28,11 @@ export default React.createClass( {
 
 The following props can be passed to the Shortcode component. Any additional props will be applied to the rendered `iframe` element.
 
-### `siteId`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The site ID for which to render the shortcode.
-
-### `children`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The shortcode to render.
-
-### `filterRenderResult`
-
-<table>
-	<tr><td>Type</td><td>Function</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>( result ) => result</code></td></tr>
-</table>
-
-Function to override default render result. Passed the original result of the [shortcode render endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/shortcodes/render/) response, the function is expected to return a modified result.
+| property             | type     | required | default                | comment |
+| -------------------- | -------- | -------- | ---------------------- | ------- |
+| `siteId`             | Number   | yes      |                        | The site ID for which to render the shortcode. |
+| `children`           | String   | yes      |                        | The shortcode to render. |
+| `filterRenderResult` | Function | no       | `( result ) => result` | Function to override default render result. Passed the original result of the [shortcode render endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/shortcodes/render/) response, the function is expected to return a modified result. |
 
 ## Resources
 

--- a/client/components/spinner-line/README.md
+++ b/client/components/spinner-line/README.md
@@ -21,12 +21,6 @@ export default function MyComponent() {
 
 The following props can be passed to the `<SpinnerLine />` component:
 
-### `className`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-A custom class name to apply to the rendered element, in addition to the base `.spinner-line` class.
+| property    | type   | required | default | comment |
+| ----------- | ------ | -------- | ------- | ------- |
+| `className` | String | no       | `null`  | A custom class name to apply to the rendered element, in addition to the base `.spinner-line` class. |

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -24,22 +24,7 @@ React.createClass( {
 
 The following props can be passed to the Spinner component:
 
-### `size`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td>20</td></tr>
-</table>
-
-The width and height of the spinner, in pixels.
-
-### `duration`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td>3000</td></tr>
-</table>
-
-The duration of a single spin animation, in milliseconds.
+| property   | type   | required | default | comment |
+| ---------- | ------ | -------- | ------- | ------- |
+| `size`     | number | no       | `20`    | The width and height of the spinner, in pixels. |
+| `duration` | number | no       | `3000`  | The duration of a single spin animation, in milliseconds. |

--- a/client/components/tinymce/README.md
+++ b/client/components/tinymce/README.md
@@ -52,64 +52,13 @@ Many TinyMCE events can be hooked by passing its equivalent event name from the 
 
 Other props are defined in detail below:
 
-### `mode`
-
-<table>
-	<tr><th>Type</th><td>String</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>"tinymce"</code></td></tr>
-	<tr>
-		<th>Supported</th>
-		<td>
-			<ul>
-				<li><code>"tinymce"</code></li>
-				<li><code>"html"</code></li>
-			</ul>
-		</td>
-	</tr>
-</table>
-
-The editor can be toggled between two modes, `tinymce` and `html`. The `tinymce` mode will be rendered as the visual WYSIWYG editor. The `html` mode is rendered as a `<textarea>` element.
-
-### `isNew`
-
-<table>
-	<tr><th>Type</th><td>Boolean</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>false</code></td></tr>
-</table>
-
-Controls whether the editor instance should be autofocussed when initialized.
-
-### `tabIndex`
-
-<table>
-	<tr><th>Type</th><td>Number</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>null</code></td></tr>
-</table>
-
-Controls the `tabindex` attribute of both the TinyMCE visual editor and the `<textarea>` element.
-
-### `onTextEditorChange`
-
-<table>
-	<tr><th>Type</th><td>Function</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>null</code></td></tr>
-</table>
-
-If defined, a function to be triggered when the contents of the `<textarea>` element change.
-
-### `onTogglePin`
-
-<table>
-	<tr><th>Type</th><td>Function</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>null</code></td></tr>
-</table>
-
-If defined, a function to be triggered when the visual editor toolbar is pinned to the top of the screen. Currently, any instance of `<TinyMCE />` is hard-coded to pin its toolbar to the top of the viewport on larger displays when the Calypso master bar bumps against the top of the toolbar. The function should expect to be passed a string argument, `"pin"` or `"unpinned"`, when the toolbar is pinned or unpinned respectively.
+| property             | type                           | required | default     | comment |
+| -------------------- | ------------------------------ | -------- | ----------- | ------- |
+| `mode`               | String (`"tinymce"`, `"html"`) | no       | `"tinymce"` | The editor can be toggled between two modes, `tinymce` and `html`. The `tinymce` mode will be rendered as the visual WYSIWYG editor. The `html` mode is rendered as a `<textarea>` element. |
+| `isNew`              | Boolean                        | no       | `false`     | Controls whether the editor instance should be autofocused when initialized. |
+| `tabIndex`           | Number                         | no       | `null`      | Controls the `tabindex` attribute of both the TinyMCE visual editor and the `<textarea>` element. |
+| `onTextEditorChange` | Function                       | no       | `null`      | If defined, a function to be triggered when the contents of the `<textarea>` element change. |
+| `onTogglePin`        | Function                       | no       | `null`      | If defined, a function to be triggered when the visual editor toolbar is pinned to the top of the screen. Currently, any instance of `<TinyMCE />` is hard-coded to pin its toolbar to the top of the viewport on larger displays when the Calypso master bar bumps against the top of the toolbar. The function should expect to be passed a string argument, `"pin"` or `"unpinned"`, when the toolbar is pinned or unpinned respectively. |
 
 ## Plugins
 

--- a/client/components/version/README.md
+++ b/client/components/version/README.md
@@ -21,19 +21,7 @@ React.createClass( {
 
 The following props can be passed to the Version component:
 
-### `version`
-
-<table>
-	<tr><td>Type</td><td>String or Number</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The version number that you want to display
-### `icon`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-</table>
-
-The Gridicon you want to display next to the version. 
+| property  | type             | required | comment |
+| --------- | ---------------- | -------- | ------- |
+| `version` | String or Number | yes      | The version number that you want to display. |
+| `icon`    | String           | no       | The Gridicon you want to display next to the version. |


### PR DESCRIPTION
This is a continuation of the work here:
https://github.com/Automattic/wp-calypso/pull/9530

The end goal is to display the READMEs for each Calypso react component on /devdocs.
Each README will be placed underneath their respective component when viewed in isolation.

My plan is to:
* Convert the HTML tables to GFM
* Use [markdown-loader](https://www.npmjs.com/package/markdown-loader) to 'import' the README.md as a static asset (uses [marked](https://www.npmjs.com/package/marked))
* Create a blank readme-viewer to display the README and place it on the page for each component
* Render the README
* Experiment with [remarkable](https://www.npmjs.com/package/remarkable) / other markdown parsers

cc @ehg 