### PR TITLE
Site Settings: Hide Manage Connection link for Atomic sites

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -16,7 +16,7 @@ import SectionHeader from 'components/section-header';
 import SiteToolsLink from './link';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite, getSiteAdminUrl } from 'state/sites/selectors';
-import { isVipSite } from 'state/selectors';
+import { isSiteAutomatedTransfer, isVipSite } from 'state/selectors';
 import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
@@ -181,6 +181,7 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSelectedSiteSlug( state );
+		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 		const isVip = isVipSite( state, siteId );
 		const sitePurchasesLoaded = hasLoadedSitePurchasesFromServer( state );
@@ -202,7 +203,7 @@ export default connect(
 			showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
 			showDeleteContent: ! isJetpack && ! isVip,
 			showDeleteSite: ! isJetpack && ! isVip && sitePurchasesLoaded,
-			showManageConnection: isJetpack,
+			showManageConnection: isJetpack && ! isAtomic,
 		};
 	}
 )( localize( SiteTools ) );


### PR DESCRIPTION
In #16542 we made the Manage Connection unavailable for Atomic site, but we forgot to also hide the corresponding link from Site Tools in General settings 🤦‍♂️ .

So, this PR hides the Manage Connection link from Site Tools for Atomic sites.

To test:
* Checkout this branch.
* Go to `/settings/general/:site`, where `:site` is an Atomic site.
* Verify the "Manage Connection" link is no longer shown.
* Go to `/settings/general/:site`, where `:site` is a WordPress.com site.
* Verify the "Manage Connection" not shown, just like before.
* Go to `/settings/general/:site`, where `:site` is a Jetpack site.
* Verify the "Manage Connection" link is shown, just like before.