### PR TITLE
Revert "WebPreview: Center URL in toolbar"

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -169,7 +169,7 @@ a.web-preview__external.button {
 		text-align: center;
 	}
 
-	&:hover .form-text-input:not(:focus) {
+	&:hover .form-text-input {
 		border-color: lighten( $gray, 20% );
 	}
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -161,7 +161,7 @@ a.web-preview__external.button {
 	width: auto;
 
 	.form-text-input {
-		color: $gray-text-min;
+		color: $gray;
 		font-size: 14px;
 		height: 35px;
 		border-color: transparent;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -141,12 +141,6 @@ a.web-preview__external.button {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-end;
-
-	@include breakpoint( ">960px" ) {
-		// Matches __device-switcher width + margin
-		// and allows the center area to flex equally
-		width: 212px;
-	}
 }
 
 .web-preview__device-switcher {
@@ -166,7 +160,6 @@ a.web-preview__external.button {
 		height: 35px;
 		border-color: transparent;
 		text-overflow: ellipsis;
-		text-align: center;
 	}
 
 	&:hover .form-text-input {
@@ -179,6 +172,16 @@ a.web-preview__external.button {
 
 	&:hover .clipboard-button {
 		display: block;
+	}
+
+	@include breakpoint( ">660px" ) {
+		max-width: 50%;
+	}
+
+	@include breakpoint( ">960px" ) {
+		margin: 6px auto;
+		width: 35%;
+		flex-grow: inherit;
 	}
 }
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#16524

Looks like modal based previews suffer layout issues given these changes - need to re-address these changes with that in mind.