### PR TITLE
Site Settings: Remove Disconnect button from General settings for JP < 3.3

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { get, flowRight } from 'lodash';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +15,6 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Button from 'components/button';
 import LanguageSelector from 'components/forms/language-selector';
-import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
 import SectionHeader from 'components/section-header';
 import config from 'config';
 import notices from 'notices';
@@ -231,25 +230,6 @@ class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	jetpackDisconnectOption() {
-		const { site, siteIsJetpack, translate } = this.props;
-		const isAutomatedTransfer = get( site, 'options.is_automated_transfer', false );
-
-		if ( ! siteIsJetpack || isAutomatedTransfer ) {
-			return null;
-		}
-
-		const disconnectText = translate( 'Disconnect Site', {
-			context: 'Jetpack: Action user takes to disconnect Jetpack site from .com link in general site settings'
-		} );
-
-		return <DisconnectJetpackButton
-				site={ site }
-				text= { disconnectText }
-				redirect= "/stats"
-				linkDisplay={ false } />;
-	}
-
 	holidaySnowOption() {
 		// Note that years and months below are zero indexed
 		const { fields, handleToggle, isRequestingSettings, moment, supportsHolidaySnowOption, translate } = this.props,
@@ -321,7 +301,7 @@ class SiteSettingsFormGeneral extends Component {
 			translate
 		} = this.props;
 		if ( siteIsJetpack && ! site.hasMinimumJetpackVersion ) {
-			return this.jetpackDisconnectOption();
+			return null;
 		}
 
 		const classes = classNames( 'site-settings__general-settings', {


### PR DESCRIPTION
This PR removes the disconnect button from the General settings section.

The button currently appears for sites that have Jetpack older than 3.3, but it's no longer necessary, because we've moved the button to the Manage Connection page. Users can click the "Manage Connection" link and disconnect from there anyway.

Before:
![](https://cldup.com/SNOr4F_JqA.png)

After:
![](https://cldup.com/QShLLXrQ5p.png)

To test:
* Checkout this branch, or get it going on calypso.live
* Go to `/settings/general/:site`, where `:site` is a Jetpack site with Jetpack older than 3.3.
* Verify you no longer see the Disconnect button.
* Verify everything works properly for sites with Jetpack >= 3.3.