### PR TITLE
SimplePaymentsDialog: move 'activeTab' to component state

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -13,7 +13,7 @@ import Button from 'components/button';
 
 class SimplePaymentsDialogNavigation extends Component {
 	static propTypes = {
-		activeTab: PropTypes.oneOf( [ 'paymentButtons', 'addNew' ] ).isRequired,
+		activeTab: PropTypes.oneOf( [ 'list', 'form' ] ).isRequired,
 		onChangeTabs: PropTypes.func.isRequired,
 		paymentButtons: PropTypes.array.isRequired,
 	};
@@ -25,7 +25,7 @@ class SimplePaymentsDialogNavigation extends Component {
 
 		const classNames = 'editor-simple-payments-modal__navigation';
 
-		if ( activeTab === 'addNew' ) {
+		if ( activeTab === 'form' ) {
 			if ( ! paymentButtons.length ) {
 				// We are on "Add New" view without previously made payment buttons.
 				return null;
@@ -35,7 +35,7 @@ class SimplePaymentsDialogNavigation extends Component {
 			return (
 				<HeaderCake
 					className={ classNames }
-					onClick={ this.onChangeTabs( 'paymentButtons' ) }
+					onClick={ this.onChangeTabs( 'list' ) }
 					backText={ translate( 'Payment Buttons' ) }
 				/>
 			);
@@ -48,7 +48,7 @@ class SimplePaymentsDialogNavigation extends Component {
 				label={ translate( 'Payment Buttons' ) }
 				count={ paymentButtons.length }
 			>
-				<Button compact onClick={ this.onChangeTabs( 'addNew' ) }>
+				<Button compact onClick={ this.onChangeTabs( 'form' ) }>
 					{ translate( '+ Add New' ) }
 				</Button>
 			</SectionHeader>

--- a/client/components/tinymce/plugins/simple-payments/plugin.jsx
+++ b/client/components/tinymce/plugins/simple-payments/plugin.jsx
@@ -32,11 +32,10 @@ const simplePayments = editor => {
 			isEdit = true;
 		}
 
-		function renderModal( visibility = 'show', activeTab = 'addNew' ) {
+		function renderModal( visibility = 'show' ) {
 			renderWithReduxStore(
 				createElement( SimplePaymentsDialog, {
 					showDialog: visibility === 'show',
-					activeTab,
 					isEdit,
 					onInsert( productData ) {
 						editor.execCommand(
@@ -44,14 +43,11 @@ const simplePayments = editor => {
 							false,
 							serialize( productData )
 						);
-						renderModal( 'hide', activeTab );
+						renderModal( 'hide' );
 					},
 					onClose() {
 						editor.focus();
-						renderModal( 'hide', activeTab );
-					},
-					onChangeTabs( tab ) {
-						renderModal( 'show', tab );
+						renderModal( 'hide' );
 					},
 				} ),
 				node,


### PR DESCRIPTION
Move the `activeTab` property to the SimplePaymentsDialog component state, instead of
maintaining it outside and passing it down as props.

We'll need to switch tabs internally when implementing the "Edit" action -- in that case,
we'll switch from the 'list' tab to the 'form' and back.

When the dialog is being shown, ensure that it always shows the 'form' immediately after
being opened by implementing a check in `componentWillReceiveProps`.

I also renamed the `activeTab` values from `paymentButtons`/`addNew` to `list`/`form`. It's
shorter, and we'll be showing the `form` not only when adding a new button, but also when editing
a new one.