### PR TITLE
PostCommentList: comment translation fix for Load more comments

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -402,7 +402,7 @@ class PostCommentList extends React.Component {
 				{ showViewMoreComments &&
 					this.props.startingCommentId &&
 					<span className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
-						{ translate( 'Load More Comments (Showing %(shown)d of %(total)d)', {
+						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
 							args: {
 								shown: displayedCommentsCount,
 								total: actualCommentsCount,


### PR DESCRIPTION
As pointed out [here](https://github.com/Automattic/wp-calypso/pull/15882#issuecomment-317935798), the two translate strings should match within `post-comments-list.jsx`

One had been 'Load more comments', the other 'Load More Comments'.  Both should be the former.


