### PR TITLE
Store Add 'stage' to extension environment ids & add 404 handling

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,6 +12,7 @@ import { translate } from 'i18n-calypso';
 import App from './app';
 
 import controller from 'my-sites/controller';
+import EmptyContent from 'components/empty-content';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
@@ -127,6 +128,20 @@ function createStoreNavigation( context, next, storePage ) {
 	next();
 }
 
+function notFoundError( context, next ) {
+	renderWithReduxStore(
+		React.createElement( EmptyContent, {
+			className: 'content-404',
+			illustration: '/calypso/images/illustrations/illustration-404.svg',
+			title: translate( 'Uh oh. Page not found.' ),
+			line: translate( 'Sorry, the page you were looking for doesn\'t exist or has been moved.' ),
+		} ),
+		document.getElementById( 'content' ),
+		context.store
+	);
+	next();
+}
+
 export default function() {
 	// Add pages that use the store navigation
 	getStorePages().forEach( function( storePage ) {
@@ -140,6 +155,11 @@ export default function() {
 		page( '/store/stats/:type/:unit', controller.siteSelection, controller.sites );
 		page( '/store/stats/:type/:unit/:site', siteSelection, navigation, StatsController );
 	}
+
+	page(
+		'/store/*',
+		notFoundError
+	);
 }
 
 // TODO: This could probably be done in a better way through the same mechanisms

--- a/client/extensions/woocommerce/package.json
+++ b/client/extensions/woocommerce/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic",
 	"description": "WooCommerce Store",
 	"version": "0.0.1",
-	"env_id": [ "development", "wpcalypso" ],
+	"env_id": [ "development", "wpcalypso", "stage" ],
 	"section": {
 		"name": "woocommerce",
 		"paths": [ "/store" ],

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -63,6 +63,15 @@
 			top: 115px;
 		}
 	}
+
+	.content-404 {
+		margin: 35px 200px 0 0;
+		max-width: initial;
+
+		@media( max-width: 660px ) {
+			margin: 0px;
+		}
+	}
 }
 
 .store-sidebar__sidebar {


### PR DESCRIPTION
To finish loading our extension in staging (and tomorrow, in production) we need to update `env_id` in our package.json as well.

This also adds some 404 handling for incorrect store routes per my systems request. 
> Please make sure that after deploy you actually handle all 404s properly

It returns the same message incorrect Calypso routes do using `EmptyContent`.

To Test:
* Go to a route that doesn't exist, like `http://calypso.localhost:3000/store/not-valid/:site`. You should see a 404.
* Go to a valid route, like `http://calypso.localhost:3000/store/orders/:site`, and make sure the route displays correctly.
