### PR TITLE
Comments: Fix broken CommentDetail docs

### DIFF
--- a/client/blocks/comment-detail/index.jsx
+++ b/client/blocks/comment-detail/index.jsx
@@ -288,7 +288,7 @@ export class CommentDetail extends Component {
 
 const mapStateToProps = ( state, ownProps ) => {
 	const { commentId, siteId } = ownProps;
-	const comment = getSiteComment( state, siteId, commentId );
+	const comment = ownProps.comment || getSiteComment( state, siteId, commentId );
 
 	const postId = get( comment, 'post.ID' );
 


### PR DESCRIPTION
Fixes #16583 

Add back the possibility of manually passing a comment object instead of selecting it from the Redux state.

cc @Automattic/lannister 