### PR TITLE
Reader canonicalImage: fix jetpack featured_image

### DIFF
--- a/client/lib/post-normalizer/rule-pick-canonical-media.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-media.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { find } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -49,18 +49,22 @@ export default function pickCanonicalMedia( post ) {
 	}
 
 	// jetpack lies about thumbnails/featured_images so we need to make sure its actually an image
-	if ( post.featured_image && isUrlLikelyAnImage( post.featured_image ) &&
-			isImageLargeEnoughForFeature( post.post_thumbnail ) ) {
+	if (
+		isUrlLikelyAnImage( post.featured_image ) &&
+		( ( ! post.post_thumbnail && post.is_jetpack ) || // some jetpack sites dont create post_thumbnail
+			isImageLargeEnoughForFeature( post.post_thumbnail ) )
+	) {
 		post.canonical_media = {
 			src: post.featured_image,
-			height: post.post_thumbnail.height,
-			width: post.post_thumbnail.width,
+			height: get( post, 'post_thumbnail.height' ),
+			width: get( post, 'post_thumbnail.width' ),
 			mediaType: 'image',
 		};
 		return post;
 	}
 
 	const canonicalMedia = find( post.content_media, isCandidateForFeature );
+
 	if ( canonicalMedia ) {
 		post.canonical_media = canonicalMedia;
 	}

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -105,6 +105,10 @@ export function domForHtml( html ) {
  * @returns {boolean} - true or false depending on if it is probably an image (has the right extension)
  */
 export function isUrlLikelyAnImage( uri ) {
+	if ( ! uri ) {
+		return false;
+	}
+
 	const withoutQuery = url.parse( uri ).pathname;
 	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ext => endsWith( withoutQuery, ext ) );
 }


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/16514

Essentially when a jp post has a featured_image but it does not appear within the content (b/c excerpts are turned on),  we should still let the featured image be used. 

open questions: 
- should this only apply to `use_excerpts` sites or should we do this for all jp sites?
currently have the fix for any jp site even if use_excerpts is false.
- we have no way of knowing if the image is tiny or not. could look silly in some cases