### PR TITLE
 Reader Conversations: use compact card + hook up comments

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -13,10 +13,8 @@ import { getPostCommentsTree } from 'state/comments/selectors';
 
 export class ConversationCommentList extends React.Component {
 	static propTypes = {
-		blogId: PropTypes.number.isRequired,
-		postId: PropTypes.number.isRequired,
+		post: PropTypes.object.isRequired, // required by PostComment
 		commentIds: PropTypes.array.isRequired,
-		post: PropTypes.object, // required by PostComment
 	};
 
 	render() {
@@ -44,8 +42,10 @@ export class ConversationCommentList extends React.Component {
 }
 
 const ConnectedConversationCommentList = connect( ( state, ownProps ) => {
+	const { site_ID: siteId, ID: postId } = ownProps.post;
+
 	return {
-		commentsTree: getPostCommentsTree( state, ownProps.blogId, ownProps.postId, 'all' ),
+		commentsTree: getPostCommentsTree( state, siteId, postId, 'all' ),
 	};
 } )( ConversationCommentList );
 

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -2,6 +2,8 @@
  * External Dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
+import { take, map } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -11,36 +13,47 @@ import Emojify from 'components/emojify';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import FeaturedAsset from './featured-asset';
+import { getDateSortedPostComments } from 'state/comments/selectors';
+import ConversationsComments from 'blocks/conversations/list';
 
-const CompactPost = ( { post, postByline, children, isDiscover } ) => {
+const CompactPost = ( { post, postByline, children, isDiscover, comments } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	const commentIdsToShow = map( take( comments, 3 ), 'ID' );
 	return (
-		<div className="reader-post-card__post">
-			<FeaturedAsset
-				canonicalMedia={ post.canonical_media }
-				postUrl={ post.URL }
-				allowVideoPlaying={ false }
-			/>
-			<div className="reader-post-card__post-details">
-				{ postByline }
-				<ReaderPostOptionsMenu
-					className="ignore-click"
-					showFollow={ true }
-					post={ post }
-					position="bottom"
+		<div>
+			<div className="reader-post-card__post">
+				<FeaturedAsset
+					canonicalMedia={ post.canonical_media }
+					postUrl={ post.URL }
+					allowVideoPlaying={ false }
 				/>
-				<AutoDirection>
-					<h1 className="reader-post-card__title">
-						<a className="reader-post-card__title-link" href={ post.URL }>
-							<Emojify>
-								{ post.title }
-							</Emojify>
-						</a>
-					</h1>
-				</AutoDirection>
-				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
-				{ children }
+				<div className="reader-post-card__post-details">
+					{ postByline }
+					<ReaderPostOptionsMenu
+						className="ignore-click"
+						showFollow={ true }
+						post={ post }
+						position="bottom"
+					/>
+					<AutoDirection>
+						<h1 className="reader-post-card__title">
+							<a className="reader-post-card__title-link" href={ post.URL }>
+								<Emojify>
+									{ post.title }
+								</Emojify>
+							</a>
+						</h1>
+					</AutoDirection>
+					<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+					{ children }
+				</div>
 			</div>
+			<ConversationsComments
+				post={ post }
+				postId={ post.ID }
+				blogId={ post.site_ID }
+				commentIds={ commentIdsToShow }
+			/>
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
@@ -48,8 +61,13 @@ const CompactPost = ( { post, postByline, children, isDiscover } ) => {
 
 CompactPost.propTypes = {
 	post: React.PropTypes.object.isRequired,
-	postByline: React.PropTypes.string,
+	postByline: React.PropTypes.object,
 	isDiscover: React.PropTypes.bool,
 };
 
-export default CompactPost;
+export default connect( ( state, ownProps ) => {
+	const { site_ID: siteId, ID: postId } = ownProps.post;
+	return {
+		comments: getDateSortedPostComments( state, siteId, postId ),
+	};
+} )( CompactPost );

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -2,8 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { take, map } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -13,47 +11,36 @@ import Emojify from 'components/emojify';
 import ReaderExcerpt from 'blocks/reader-excerpt';
 import ReaderPostOptionsMenu from 'blocks/reader-post-options-menu';
 import FeaturedAsset from './featured-asset';
-import { getDateSortedPostComments } from 'state/comments/selectors';
-import ConversationsComments from 'blocks/conversations/list';
 
-const CompactPost = ( { post, postByline, children, isDiscover, comments } ) => {
+const CompactPost = ( { post, postByline, children, isDiscover } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const commentIdsToShow = map( take( comments, 3 ), 'ID' );
 	return (
-		<div>
-			<div className="reader-post-card__post">
-				<FeaturedAsset
-					canonicalMedia={ post.canonical_media }
-					postUrl={ post.URL }
-					allowVideoPlaying={ false }
-				/>
-				<div className="reader-post-card__post-details">
-					{ postByline }
-					<ReaderPostOptionsMenu
-						className="ignore-click"
-						showFollow={ true }
-						post={ post }
-						position="bottom"
-					/>
-					<AutoDirection>
-						<h1 className="reader-post-card__title">
-							<a className="reader-post-card__title-link" href={ post.URL }>
-								<Emojify>
-									{ post.title }
-								</Emojify>
-							</a>
-						</h1>
-					</AutoDirection>
-					<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
-					{ children }
-				</div>
-			</div>
-			<ConversationsComments
-				post={ post }
-				postId={ post.ID }
-				blogId={ post.site_ID }
-				commentIds={ commentIdsToShow }
+		<div className="reader-post-card__post">
+			<FeaturedAsset
+				canonicalMedia={ post.canonical_media }
+				postUrl={ post.URL }
+				allowVideoPlaying={ false }
 			/>
+			<div className="reader-post-card__post-details">
+				{ postByline }
+				<ReaderPostOptionsMenu
+					className="ignore-click"
+					showFollow={ true }
+					post={ post }
+					position="bottom"
+				/>
+				<AutoDirection>
+					<h1 className="reader-post-card__title">
+						<a className="reader-post-card__title-link" href={ post.URL }>
+							<Emojify>
+								{ post.title }
+							</Emojify>
+						</a>
+					</h1>
+				</AutoDirection>
+				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+				{ children }
+			</div>
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
@@ -65,9 +52,4 @@ CompactPost.propTypes = {
 	isDiscover: React.PropTypes.bool,
 };
 
-export default connect( ( state, ownProps ) => {
-	const { site_ID: siteId, ID: postId } = ownProps.post;
-	return {
-		comments: getDateSortedPostComments( state, siteId, postId ),
-	};
-} )( CompactPost );
+export default CompactPost;

--- a/client/blocks/reader-post-card/conversation-post.jsx
+++ b/client/blocks/reader-post-card/conversation-post.jsx
@@ -1,0 +1,40 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { map, take } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import ConversationPostList from 'blocks/conversations/list';
+import CompactPostCard from 'blocks/reader-post-card/compact';
+import { getDateSortedPostComments } from 'state/comments/selectors';
+
+class ConversationPost extends React.Component {
+	static propTypes = {
+		post: React.PropTypes.object.isRequired,
+		comments: React.PropTypes.object.isRequired,
+	};
+
+	render() {
+		const commentIdsToShow = map( take( this.props.comments, 3 ), 'ID' );
+		return (
+			<div className="reader-post-card__conversation-post">
+				<CompactPostCard { ...this.props } />
+				<ConversationPostList
+					post={ this.props.post }
+					commentIds={ commentIdsToShow }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	const { site_ID: siteId, ID: postId } = ownProps.post;
+	return {
+		comments: getDateSortedPostComments( state, siteId, postId ),
+	};
+} )( ConversationPost );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -19,7 +19,7 @@ import PostByline from './byline';
 import GalleryPost from './gallery';
 import PhotoPost from './photo';
 import StandardPost from './standard';
-import CompactPost from './compact';
+import ConversationPost from './conversation-post';
 import FollowButton from 'reader/follow-button';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
@@ -198,7 +198,7 @@ class ReaderPostCard extends React.Component {
 		let readerPostCard;
 		if ( compact ) {
 			readerPostCard = (
-				<CompactPost
+				<ConversationPost
 					post={ post }
 					title={ title }
 					isDiscover={ isDiscover }

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -126,9 +126,9 @@ class ReaderPostCard extends React.Component {
 			compact,
 		} = this.props;
 
-		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY );
-		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY );
-		const isVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO );
+		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY ) && ! compact;
+		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY ) && ! compact;
+		const isVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO ) && ! compact;
 		const isDiscover = post.is_discover;
 		const title = truncate( post.title, { length: 140, separator: /,? +/ } );
 		const classes = classnames( 'reader-post-card', {

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -16,6 +16,7 @@ export default function( props ) {
 			shouldCombineCards={ false }
 			className="conversations__stream"
 			followSource="conversations"
+			useCompactCards={ true }
 			trackScrollPage={ props.trackScrollPage }
 		/>
 	);

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -86,6 +86,7 @@ class ReaderStream extends React.Component {
 		followSource: PropTypes.string,
 		isDiscoverStream: PropTypes.bool,
 		shouldCombineCards: PropTypes.bool,
+		useCompactCards: PropTypes.bool,
 		transformStreamItems: PropTypes.func,
 		isMain: PropTypes.bool,
 	};
@@ -103,6 +104,7 @@ class ReaderStream extends React.Component {
 		shouldCombineCards: true,
 		transformStreamItems: identity,
 		isMain: true,
+		useCompactCards: false,
 	};
 
 	getStateFromStores( props = this.props ) {
@@ -434,6 +436,7 @@ class ReaderStream extends React.Component {
 				index={ index }
 				selectedPostKey={ selectedPostKey }
 				recStoreId={ recStoreId }
+				compact={ this.props.useCompactCards }
 			/>
 		);
 	};

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -88,6 +88,7 @@ class ReaderPostCardAdapter extends React.Component {
 				showSiteName={ this.props.showSiteName }
 				isDiscoverStream={ this.props.isDiscoverStream }
 				postKey={ this.props.postKey }
+				compact={ this.props.compact }
 			>
 				{ feedId && <QueryReaderFeed feedId={ feedId } includeMeta={ false } /> }
 				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -1,7 +1,7 @@
 /***
  * External dependencies
  */
-import { filter, find, get, keyBy, last, first, map, size, flatMap } from 'lodash';
+import { filter, find, get, keyBy, last, first, map, size, flatMap, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +18,14 @@ import { getStateKey, deconstructStateKey, fetchStatusInitialState } from './red
  */
 export const getPostCommentItems = ( state, siteId, postId ) =>
 	get( state.comments.items, `${ siteId }-${ postId }` );
+
+export const getDateSortedPostComments = createSelector(
+	( state, siteId, postId ) => {
+		const comments = getPostCommentItems( state, siteId, postId );
+		return sortBy( comments, comment => new Date( comment.date ) );
+	},
+	( state, siteId, postId ) => [ get( state.comments, 'items' )[ getStateKey( siteId, postId ) ] ],
+);
 
 export const getCommentById = createSelector(
 	( { state, commentId, siteId } ) => {


### PR DESCRIPTION
The reader conversations tool should use the compact cards we've designed specifically for it.

<img width="1168" alt="screen shot 2017-07-26 at 1 45 44 pm" src="https://user-images.githubusercontent.com/4656974/28635483-c3ddc7d8-7208-11e7-9370-76fbf56490c5.png">

Note: this exposes css tweaks needed. 