### PR TITLE
Simple Payments: fix data-layer to not depend on non-SSR ready code

### DIFF
--- a/client/lib/posts/utils-ssr-ready.js
+++ b/client/lib/posts/utils-ssr-ready.js
@@ -1,0 +1,29 @@
+// Put util functions here which don't depend on anything that is not SSR-ready (such as sites-list).
+
+/**
+ * Returns the ID of the featured image assigned to the specified post, or
+ * `undefined` otherwise. A utility function is useful because the format
+ * of a post varies between the retrieve and update endpoints. When
+ * retrieving a post, the thumbnail ID is assigned in `post_thumbnail`, but
+ * in creating a post, the thumbnail ID is assigned to `featured_image`.
+ *
+ * @param  {Object} post Post object
+ * @return {Number}      The featured image ID
+ */
+export const getFeaturedImageId = ( post ) => {
+	if ( ! post ) {
+		return;
+	}
+
+	if ( 'featured_image' in post && ! /^https?:\/\//.test( post.featured_image ) ) {
+		// Return the `featured_image` property if it does not appear to be
+		// formatted as a URL
+		return post.featured_image;
+	}
+
+	if ( post.post_thumbnail ) {
+		// After the initial load from the REST API, pull the numeric ID
+		// from the thumbnail object if one exists
+		return post.post_thumbnail.ID;
+	}
+};

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -12,7 +12,11 @@ import includes from 'lodash/includes';
 var postNormalizer = require( 'lib/post-normalizer' ),
 	sites = require( 'lib/sites-list' )();
 
+import { getFeaturedImageId } from './utils-ssr-ready';
+
 var utils = {
+
+	getFeaturedImageId,
 
 	getEditURL: function( post, site ) {
 		let basePath = '';
@@ -210,34 +214,6 @@ var utils = {
 		pathParts[ pathParts.length - 1 ] = '';
 
 		return pathParts.join( '/' );
-	},
-
-	/**
-	 * Returns the ID of the featured image assigned to the specified post, or
-	 * `undefined` otherwise. A utility function is useful because the format
-	 * of a post varies between the retrieve and update endpoints. When
-	 * retrieving a post, the thumbnail ID is assigned in `post_thumbnail`, but
-	 * in creating a post, the thumbnail ID is assigned to `featured_image`.
-	 *
-	 * @param  {Object} post Post object
-	 * @return {Number}      The featured image ID
-	 */
-	getFeaturedImageId: function( post ) {
-		if ( ! post ) {
-			return;
-		}
-
-		if ( 'featured_image' in post && ! /^https?:\/\//.test( post.featured_image ) ) {
-			// Return the `featured_image` property if it does not appear to be
-			// formatted as a URL
-			return post.featured_image;
-		}
-
-		if ( post.post_thumbnail ) {
-			// After the initial load from the REST API, pull the numeric ID
-			// from the thumbnail object if one exists
-			return post.post_thumbnail.ID;
-		}
 	},
 
 	/**

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -25,7 +25,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 import formatCurrency from 'lib/format-currency';
-import { getFeaturedImageId } from 'lib/posts/utils';
+import { getFeaturedImageId } from 'lib/posts/utils-ssr-ready';
 
 /**
  * Reduce function for product attributes stored in post metadata


### PR DESCRIPTION
This was causing tests to fail. Big props to @ockham for identifying the
issue and helping me to fix it.

## Testing

- Wait for tests to run: did they run successfully. You can also run tests locally with `make test`.
- Try to add a new post (or edit one): does it work? Can you add a featured image? Are there no JS console errors?
- Is adding featured image to Simple Payments working like before? You can do so by running Calypso locally, going to some site (preferably Jetpack one since Simple Payments endpoints are working properly for them), add a new post and in editor, click on the "inserter" menu (where "add contact form" is) and select "Add Payment button". Then proceed to fill the payment form and add an image to it. After inserting the product, save the post and do full page reload. Did the product load? It will show a placeholder image since featured images are not yet displayed. For that, you'll need to use the Redux store explorer Chrome extension. Navigate to `simplePayments.productList.items.<your-site-id>.<a-product>.featuredImageId`. Is it a valid number?