### PR TITLE
Extensions: WPJM - Show warning for unsaved changes

### DIFF
--- a/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-listings/index.jsx
@@ -3,13 +3,14 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { FormSection, formValueSelector, reduxForm } from 'redux-form';
+import { FormSection, formValueSelector, isDirty, reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { ProtectFormGuard } from 'lib/protect-form';
 import Card from 'components/card';
 import ExternalLink from 'components/external-link';
 import FormButton from 'components/forms/form-button';
@@ -25,6 +26,7 @@ const form = 'extensions.wpJobManager.jobListings';
 
 class JobListings extends Component {
 	static propTypes = {
+		dirty: PropTypes.bool,
 		handleSubmit: PropTypes.func,
 		isFetching: PropTypes.bool,
 		onSubmit: PropTypes.func,
@@ -36,6 +38,7 @@ class JobListings extends Component {
 
 	render() {
 		const {
+			dirty,
 			handleSubmit,
 			isFetching,
 			perPage,
@@ -47,6 +50,8 @@ class JobListings extends Component {
 		return (
 			<div>
 				<form>
+					<ProtectFormGuard isChanged={ dirty } />
+
 					<FormSection name="listings">
 						<SectionHeader label={ translate( 'Listings' ) }>
 							<FormButton compact
@@ -278,7 +283,10 @@ class JobListings extends Component {
 const selector = formValueSelector( form );
 
 const connectComponent = connect(
-	state => ( { perPage: selector( state, 'listings.perPage' ) } )
+	state => ( {
+		dirty: isDirty( form ),
+		perPage: selector( state, 'listings.perPage' ),
+	} )
 );
 
 const createReduxForm = reduxForm( {

--- a/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/job-submission/index.jsx
@@ -3,13 +3,14 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { change, FormSection, formValueSelector, reduxForm } from 'redux-form';
+import { change, formValueSelector, FormSection, isDirty, reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { ProtectFormGuard } from 'lib/protect-form';
 import Card from 'components/card';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -26,6 +27,7 @@ const form = 'extensions.wpJobManager.submission';
 class JobSubmission extends Component {
 	static propTypes = {
 		change: PropTypes.func,
+		dirty: PropTypes.bool,
 		enableRegistration: PropTypes.bool,
 		generateUsername: PropTypes.bool,
 		handleSubmit: PropTypes.func,
@@ -53,6 +55,7 @@ class JobSubmission extends Component {
 
 	render() {
 		const {
+			dirty,
 			enableRegistration,
 			generateUsername,
 			handleSubmit,
@@ -66,6 +69,8 @@ class JobSubmission extends Component {
 		return (
 			<div>
 				<form>
+					<ProtectFormGuard isChanged={ dirty } />
+
 					<FormSection name="account">
 						<SectionHeader label={ translate( 'Account' ) }>
 							<FormButton compact
@@ -266,6 +271,7 @@ const selector = formValueSelector( form );
 
 const connectComponent = connect(
 	state => ( {
+		dirty: isDirty( form ),
 		enableRegistration: selector( state, 'account.enableRegistration' ),
 		generateUsername: selector( state, 'account.generateUsername' ),
 		submissionDuration: selector( state, 'duration.submissionDuration' ),

--- a/client/extensions/wp-job-manager/components/settings/pages/index.jsx
+++ b/client/extensions/wp-job-manager/components/settings/pages/index.jsx
@@ -3,13 +3,14 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { FormSection, reduxForm } from 'redux-form';
+import { FormSection, isDirty, reduxForm } from 'redux-form';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { ProtectFormGuard } from 'lib/protect-form';
 import Card from 'components/card';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -26,6 +27,7 @@ const query = { type: 'page' };
 
 class Pages extends Component {
 	static propTypes = {
+		dirty: PropTypes.bool,
 		handleSubmit: PropTypes.func,
 		isFetching: PropTypes.bool,
 		isFetchingPages: PropTypes.bool,
@@ -39,6 +41,7 @@ class Pages extends Component {
 
 	render() {
 		const {
+			dirty,
 			handleSubmit,
 			isFetching,
 			isFetchingPages,
@@ -56,6 +59,8 @@ class Pages extends Component {
 				}
 
 				<form>
+					<ProtectFormGuard isChanged={ dirty } />
+
 					<FormSection name="pages">
 						<SectionHeader label={ translate( 'Pages' ) }>
 							<FormButton compact
@@ -118,6 +123,7 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			dirty: isDirty( form ),
 			isFetchingPages: isRequestingSitePostsForQuery( state, siteId, query ),
 			siteId,
 		};

--- a/client/extensions/wp-job-manager/state/data-layer/settings/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/index.js
@@ -49,8 +49,11 @@ export const saveSettings = ( { dispatch, getState }, action ) => {
 };
 
 export const announceSuccess = ( { dispatch }, { form, siteId }, next, { data } ) => {
-	dispatch( initialize( form, fromApi( data ) ) );
+	const updatedData = fromApi( data );
+
 	dispatch( stopSave( form ) );
+	dispatch( initialize( form, updatedData ) );
+	dispatch( updateSettings( siteId, updatedData ) );
 	dispatch( successNotice( translate(
 		'Settings saved!' ),
 		{ id: 'wpjm-settings-save' }

--- a/client/extensions/wp-job-manager/state/data-layer/settings/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/index.js
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import {
-	startSubmit as startSave,
-	stopSubmit as stopSave,
-} from 'redux-form';
+import { initialize, startSubmit as startSave, stopSubmit as stopSave } from 'redux-form';
 
 /**
  * Internal dependencies
@@ -51,7 +48,8 @@ export const saveSettings = ( { dispatch, getState }, action ) => {
 	}, action ) );
 };
 
-export const announceSuccess = ( { dispatch }, { form } ) => {
+export const announceSuccess = ( { dispatch }, { form, siteId }, next, { data } ) => {
+	dispatch( initialize( form, fromApi( data ) ) );
 	dispatch( stopSave( form ) );
 	dispatch( successNotice( translate(
 		'Settings saved!' ),

--- a/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
+++ b/client/extensions/wp-job-manager/state/data-layer/settings/test/index.js
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { translate } from 'i18n-calypso';
+import { initialize, startSubmit as startSave, stopSubmit as stopSave } from 'redux-form';
 
 /**
  * Internal dependencies
@@ -32,10 +33,48 @@ const apiResponse = {
 };
 const saveAction = {
 	type: 'DUMMY_ACTION',
-	siteId: '101010',
 	data: {
 		hideFilledPositions: true,
 		perPage: 25,
+	},
+	form: 'my-form',
+	siteId: 101010,
+};
+const transformedData = {
+	account: {
+		enableRegistration: undefined,
+		generateUsername: undefined,
+		isAccountRequired: undefined,
+		role: undefined,
+		sendPassword: undefined,
+	},
+	apiKey: { googleMapsApiKey: undefined },
+	approval: {
+		canEdit: undefined,
+		isApprovalRequired: undefined,
+	},
+	categories: {
+		categoryFilterType: undefined,
+		enableCategories: undefined,
+		enableDefaultCategory: undefined,
+	},
+	duration: { submissionDuration: undefined },
+	format: { dateFormat: undefined },
+	listings: {
+		hideExpired: undefined,
+		hideExpiredContent: undefined,
+		hideFilledPositions: true,
+		perPage: 25,
+	},
+	method: { applicationMethod: undefined },
+	pages: {
+		dashboardPage: undefined,
+		listingsPage: undefined,
+		submitFormPage: undefined,
+	},
+	types: {
+		enableTypes: undefined,
+		multiJobType: undefined
 	}
 };
 
@@ -43,7 +82,7 @@ describe( '#fetchExtensionSettings()', () => {
 	it( 'should dispatch an HTTP request to the settings endpoint', () => {
 		const action = {
 			type: 'DUMMY_ACTION',
-			siteId: '101010',
+			siteId: 101010,
 		};
 		const dispatch = sinon.spy();
 
@@ -68,43 +107,7 @@ describe( '#updateExtensionSettings', () => {
 		updateExtensionSettings( { dispatch }, action, null, apiResponse );
 
 		expect( dispatch ).to.have.been.calledOnce;
-		expect( dispatch ).to.have.been.calledWith( updateSettings( 12345678, {
-			account: {
-				enableRegistration: undefined,
-				generateUsername: undefined,
-				isAccountRequired: undefined,
-				role: undefined,
-				sendPassword: undefined,
-			},
-			apiKey: { googleMapsApiKey: undefined },
-			approval: {
-				canEdit: undefined,
-				isApprovalRequired: undefined,
-			},
-			categories: {
-				enableCategories: undefined,
-				enableDefaultCategory: undefined,
-				categoryFilterType: undefined
-			},
-			duration: { submissionDuration: undefined },
-			format: { dateFormat: undefined },
-			listings: {
-				perPage: 25,
-				hideFilledPositions: true,
-				hideExpired: undefined,
-				hideExpiredContent: undefined
-			},
-			method: { applicationMethod: undefined },
-			pages: {
-				dashboardPage: undefined,
-				listingsPage: undefined,
-				submitFormPage: undefined,
-			},
-			types: {
-				enableTypes: undefined,
-				multiJobType: undefined
-			},
-		} ) );
+		expect( dispatch ).to.have.been.calledWith( updateSettings( 12345678, transformedData ) );
 	} );
 } );
 
@@ -121,6 +124,14 @@ describe( '#fetchExtensionError', () => {
 } );
 
 describe( '#saveSettings()', () => {
+	it( 'should dispatch `startSave`', () => {
+		const dispatch = sinon.spy();
+
+		saveSettings( { dispatch }, saveAction );
+
+		expect( dispatch ).to.have.been.calledWith( startSave( 'my-form' ) );
+	} );
+
 	it( 'should dispatch an HTTP POST request to the settings endpoint', () => {
 		const dispatch = sinon.spy();
 
@@ -147,10 +158,34 @@ describe( '#saveSettings()', () => {
 } );
 
 describe( '#announceSuccess()', () => {
+	it( 'should dispatch `stopSave`', () => {
+		const dispatch = sinon.spy();
+
+		announceSuccess( { dispatch }, saveAction, null, apiResponse );
+
+		expect( dispatch ).to.have.been.calledWith( stopSave( 'my-form' ) );
+	} );
+
+	it( 'should dispatch `initialize`', () => {
+		const dispatch = sinon.spy();
+
+		announceSuccess( { dispatch }, saveAction, null, apiResponse );
+
+		expect( dispatch ).to.have.been.calledWith( initialize( 'my-form', transformedData ) );
+	} );
+
+	it( 'should dispatch `updateSettings`', () => {
+		const dispatch = sinon.spy();
+
+		announceSuccess( { dispatch }, saveAction, null, apiResponse );
+
+		expect( dispatch ).to.have.been.calledWith( updateSettings( 101010, transformedData ) );
+	} );
+
 	it( 'should dispatch `successNotice`', () => {
 		const dispatch = sinon.spy();
 
-		announceSuccess( { dispatch }, saveAction );
+		announceSuccess( { dispatch }, saveAction, null, apiResponse );
 
 		expect( dispatch ).to.have.been.calledWith( successNotice( translate(
 			'Settings saved!' ),
@@ -160,6 +195,14 @@ describe( '#announceSuccess()', () => {
 } );
 
 describe( '#announceFailure()', () => {
+	it( 'should dispatch `stopSave`', () => {
+		const dispatch = sinon.spy();
+
+		announceFailure( { dispatch }, saveAction );
+
+		expect( dispatch ).to.have.been.calledWith( stopSave( 'my-form' ) );
+	} );
+
 	it( 'should dispatch `errorNotice`', () => {
 		const dispatch = sinon.spy();
 


### PR DESCRIPTION
## Problem

Currently, a user is able to navigate away from a settings tab that has unsaved changes.

Also, saving settings, switching to another tab, and then switching back to the original tab shows the original settings instead of the newly saved settings.

## Solution

This PR uses the [`ProtectFormGuard` component](https://github.com/Automattic/wp-calypso/tree/master/client/lib/protect-form), as well as Redux Form's [`initialize`](http://redux-form.com/7.0.3/docs/api/ActionCreators.md/#-code-initialize-form-string-data-object-keepdirty-boolean-options-keepdirty-boolean-keepsubmitsucceeded-boolean-code-) and [`isDirty` selector](http://redux-form.com/7.0.3/docs/api/Selectors.md/#-code-isdirty-formname-string-code-returns-code-state-gt-dirty-boolean-code-) to show a warning when trying to navigate away from a tab that has unsaved changes.

To address the issue with saved settings reverting to their original values, the `updateSettings` action is dispatched on a successful save in order to update the state with the new settings.

## Testing

For each settings tab, make a change, then click on another tab. You should see a confirmation dialog:

![confirmation-dialog](https://user-images.githubusercontent.com/1190420/28671058-4904df8c-72a9-11e7-923e-a14344cea929.jpg)

Clicking _OK_ will allow you to navigate away, while clicking _Cancel_ will leave you on the current page.

Then, after saving any changes, switch to another tab and then change back to the original tab. The fields should show the updated settings rather than reverting to what the settings were before saving.