### PR TITLE
Store: Add order ID to the order detail page

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -54,14 +54,14 @@ class Order extends Component {
 	}
 
 	render() {
-		const { className, isSaving, order, site, translate } = this.props;
+		const { className, isSaving, order, orderId, site, translate } = this.props;
 		if ( ! order ) {
 			return null;
 		}
 
 		const breadcrumbs = [
 			( <a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> ),
-			( <span>{ translate( 'Order Details' ) }</span> ),
+			( <span>{ translate( 'Order Details %(orderId)s', { args: { orderId: `#${ orderId }` } } ) }</span> ),
 		];
 		return (
 			<Main className={ className }>

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -61,7 +61,7 @@ class Order extends Component {
 
 		const breadcrumbs = [
 			( <a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a> ),
-			( <span>{ translate( 'Order Details %(orderId)s', { args: { orderId: `#${ orderId }` } } ) }</span> ),
+			( <span>{ translate( 'Order %(orderId)s Details', { args: { orderId: `#${ orderId }` } } ) }</span> ),
 		];
 		return (
 			<Main className={ className }>

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -91,7 +91,7 @@ class OrderDetails extends Component {
 
 		return (
 			<div className="order__details">
-				<SectionHeader label={ translate( 'Order Details' ) }>
+				<SectionHeader label={ translate( 'Order Details %(orderId)s', { args: { orderId: `#${ order.id }` } } ) }>
 					<span>{ this.renderStatus() }</span>
 				</SectionHeader>
 				<Card className="order__details-card">

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -91,7 +91,7 @@ class OrderDetails extends Component {
 
 		return (
 			<div className="order__details">
-				<SectionHeader label={ translate( 'Order Details %(orderId)s', { args: { orderId: `#${ order.id }` } } ) }>
+				<SectionHeader label={ translate( 'Order %(orderId)s Details', { args: { orderId: `#${ order.id }` } } ) }>
 					<span>{ this.renderStatus() }</span>
 				</SectionHeader>
 				<Card className="order__details-card">


### PR DESCRIPTION
Fixes #16495

This adds the ID number to the breadcrumbs bar and the card header:

<img width="341" alt="screen shot 2017-07-26 at 3 05 43 pm" src="https://user-images.githubusercontent.com/541093/28638814-0d845fea-7214-11e7-8f12-9ef26837f60d.png">

To test:

- Look at an order on your site
- Check the breadcrumbs banner for ID
- Check the card header for ID