### PR TITLE
Store: Update product attribute copy

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -173,8 +173,7 @@ class ProductFormAdditionalDetailsCard extends Component {
 			>
 				<p>
 					{ translate( 'Include additional details about your products, like \‘fabric\’ or \‘type\’ ' +
-						'for apparel. This will help customers find the right products by ' +
-						'filtering for their preferred options, like a cotton shirt in a women\’s cut.' ) }
+						'for apparel. These details will be displayed alongside your product.' ) }
 				</p>
 
 				<div className="products__additional-details-container">


### PR DESCRIPTION
While doing some estimating today, I realized that attributes as we have implemented them can't be used for filtering on the front end. Long story short, those are "global attributes", and our additional details box are "product attributes". We will be working on that functionality in the future -- but in the meantime for tomorrow's launch, we should update the copy.

To test:
* Go to `http://calypso.localhost:3000/store/product/:site`
* Click additional details
* Make sure copy is updated
