### PR TITLE
Add tick-time analytics

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -184,5 +184,6 @@
 	"woocommerce_blog_id": 113771570,
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
-	"statsd_analytics_response_time_max_logs_per_second": 50
+	"statsd_analytics_response_time_max_logs_per_second": 50,
+	"statsd_analytics_tick_time_logs_per_second": 50
 }

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -6,7 +6,10 @@ var path = require( 'path' ),
 	config = require( 'config' ),
 	express = require( 'express' ),
 	morgan = require( 'morgan' ),
-	pages = require( 'pages' );
+	pages = require( 'pages' ),
+	startTickTimer = require( 'lib/analytics/tick-timer' ).startTickTimer;
+
+const TICK_TIMER_MILLIS = 1000 / config( 'statsd_analytics_tick_time_logs_per_second' );
 
 /**
  * Returns the server HTTP request handler "app".
@@ -73,6 +76,9 @@ function setup() {
 
 	// attach the pages module
 	app.use( pages() );
+
+	// Start up tick-time analytics interval
+	startTickTimer( TICK_TIMER_MILLIS );
 
 	return app;
 }

--- a/server/lib/analytics/test/tick-timer.js
+++ b/server/lib/analytics/test/tick-timer.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import {
+	logTimingOfNextTick,
+	startTickTimer,
+	stopTickTimer
+} from '../tick-timer';
+import analytics from '../';
+
+describe( 'Node Tick Timer', function() {
+	beforeEach( function() {
+		sinon.stub( analytics.statsd, 'recordTiming' );
+
+		// Just fake the Date
+		this.clock = sinon.useFakeTimers( 'Date' );
+	} );
+
+	afterEach( function() {
+		analytics.statsd.recordTiming.restore();
+		this.clock.restore();
+	} );
+
+	describe( 'logTimingOfNextTick', function() {
+		it( 'logs to statsd the elapsed time of the next iteration of the event loop', function( done ) {
+			// Initiate measuring the next tick
+			logTimingOfNextTick();
+
+			// After this tick of the event loop, bump the clock time by 100ms.
+			// This will be the captured timing data of the next tick.
+			setImmediate( () => this.clock.tick( 100 ) );
+
+			// Wait two ticks, and ensure that our timing was recorded. See the
+			// comment in the implementation of logTimingOfNextTick to
+			// understand why we need to use setImmediate rather than
+			// setTimeout here. Basically, it guarantees that two ticks
+			// actually go by.
+			setImmediate( () => {
+				setImmediate( () => {
+					expect( analytics.statsd.recordTiming ).to.have.been.calledWith(
+						'tick-timer', 'timing', 100
+					);
+					done();
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'startTickTimer', function() {
+		beforeEach( function() {
+			sinon.stub( global, 'setInterval' );
+		} );
+
+		afterEach( function() {
+			global.setInterval.restore();
+		} );
+
+		it( 'starts an interval to periodically log tick timing', function() {
+			startTickTimer( 100 );
+
+			expect( global.setInterval ).to.have.been.calledOnce;
+			expect( global.setInterval.getCall( 0 ).args[ 0 ] ).to.equal( logTimingOfNextTick );
+		} );
+
+		it( 'runs the interval based on the given period', function() {
+			startTickTimer( 100 );
+
+			expect( global.setInterval.getCall( 0 ).args[ 1 ] ).to.equal( 100 );
+		} );
+	} );
+
+	describe( 'stopTickTimer', function() {
+		beforeEach( function() {
+			sinon.spy( global, 'clearInterval' );
+		} );
+
+		afterEach( function() {
+			global.clearInterval.restore();
+		} );
+
+		it( 'stops the given timer', function() {
+			const timer = startTickTimer( 100 );
+
+			stopTickTimer( timer );
+
+			expect( timer ).not.to.be.undefined;
+			expect( global.clearInterval ).to.have.been.calledWith( timer );
+		} );
+	} );
+} );

--- a/server/lib/analytics/tick-timer.js
+++ b/server/lib/analytics/tick-timer.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import analytics from './index';
+
+export function logTimingOfNextTick() {
+	/*
+	 * Call setImmediate once to enqueue a function at the end of the current
+	 * iteration of the event loop. From within the queued function, call
+	 * setImmedate a second time to schedule a callback to be called at the end
+	 * of the following event loop. As per the documentation, a setImmediate
+	 * callback scheduled within another setImmediate callback is guaranteed to
+	 * be run in the following iteration of the event loop.
+	 *
+	 * See:
+	 * https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/
+	 * https://nodejs.org/api/timers.html#timers_setimmediate_callback_args
+	 */
+	setImmediate( () => {
+		const startTime = new Date();
+
+		setImmediate( () => {
+			analytics.statsd.recordTiming(
+				'tick-timer', 'timing', new Date() - startTime
+			);
+		} );
+	} );
+}
+
+export function startTickTimer( interval ) {
+	return setInterval( logTimingOfNextTick, interval );
+}
+
+export function stopTickTimer( timer ) {
+	clearInterval( timer );
+}


### PR DESCRIPTION
Building upon #15792.

This PR logs the duration of an iteration of the event loop to `statsd` at a configurable interval (initially configured at 50 logs per second). This will let us know if there is something causing the event loop to take a long time.

## Testing

- Set `boom_analytics_enabled` to `true` in `config/development.json`

- If you have access to the `statsd` analytics created by requests to `https://pixel.wp.com/boom.gif`, you should be able to load any page in Calypso, and see the analytics data come through.

- If you do not have that access, one way to verify this feature is to change the URL in `client/lib/analytics/statsd.js`. Change `https://pixel.wp.com/boom.gif` to `http://calypso.localhost:3000/boom.gif`. Then, on loading any page in Calypso, you should see the `boom.gif` request in the server logs with the correct attributes.

cc @ehg 