### PR TITLE
Media: add external source dropdown

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -44,6 +44,7 @@ const EXPECTED_FILE_OBJECT = {
 	mime_type: 'image/jpeg',
 	guid: DUMMY_FILENAME,
 	URL: DUMMY_FILENAME,
+	external: true,
 };
 
 describe( 'MediaUtils', function() {

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -543,6 +543,7 @@ const MediaUtils = {
 				mime_type: file.mime_type,
 				guid: file.URL,
 				URL: file.URL,
+				external: true,
 			} );
 		} else {
 			// Handle the case where a an object has been passed that wraps a

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -262,6 +262,11 @@ class MediaLibraryContent extends React.Component {
 					onMediaScaleChange={ this.props.onMediaScaleChange }
 					site={ this.props.site }
 					visible={ ! this.props.isRequesting }
+					canCopy={ this.props.postId === undefined }
+					source={ this.props.source }
+					onSourceChange={ this.props.onSourceChange }
+					selectedItems={ this.props.selectedItems }
+					sticky={ ! this.props.scrollable }
 				/>
 			);
 		}

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import PopoverMenu from 'components/popover/menu';
+import PopoverMenuItem from 'components/popover/menu-item';
+import config from 'config';
+
+export class MediaLibraryDataSource extends Component {
+	static propTypes = {
+		source: PropTypes.string.isRequired,
+		onSourceChange: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = { popover: false };
+	}
+
+	togglePopover = () => {
+		this.setState( { popover: ! this.state.popover } );
+	}
+
+	changeSource = item => {
+		const { target } = item;
+		const action = target.getAttribute( 'action' ) ? target.getAttribute( 'action' ) : target.parentNode.getAttribute( 'action' );
+		const newSource = action ? action : '';
+
+		if ( newSource !== this.props.source ) {
+			this.props.onSourceChange( newSource );
+		}
+	}
+
+	renderScreenReader( selected ) {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<span className="screen-reader-text">
+				{ selected && selected.label }
+			</span>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+
+	renderMenuItems( sources ) {
+		return sources.map( item =>
+			<PopoverMenuItem
+				action={ item.value }
+				key={ item.value }
+				onClick={ this.changeSource }
+			>
+				{ item.icon }
+				{ item.label }
+			</PopoverMenuItem>
+		);
+	}
+
+	render() {
+		const { translate, source } = this.props;
+		const sources = [
+			{
+				value: '',
+				label: translate( 'WordPress library' ),
+				icon: <Gridicon icon="my-sites" size={ 24 } />
+			},
+			{
+				value: 'google_photos',
+				label: translate( 'Photos from Your Google library' ),
+				icon: <img src="/calypso/images/sharing/google-photos-logo.svg" width="24" height="24" />
+			},
+		];
+		const currentSelected = find( sources, item => item.value === source );
+		const classes = classnames( {
+			button: true,
+			'media-library__source-button': true,
+			'is-open': this.state.popover,
+		} );
+
+		if ( ! config.isEnabled( 'external-media' ) ) {
+			return null;
+		}
+
+		return (
+			<div className="media-library__datasource">
+				<Button
+					borderless
+					ref="popoverMenuButton"
+					className={ classes }
+					onClick={ this.togglePopover }
+					title={ translate( 'Choose media library source' ) }
+				>
+					{ currentSelected && currentSelected.icon }
+					{ this.renderScreenReader( currentSelected ) }
+
+					<PopoverMenu
+						context={ this.refs && this.refs.popoverMenuButton }
+						isVisible={ this.state.popover }
+						position="bottom right"
+						onClose={ this.togglePopover }
+						className="is-dialog-visible media-library__header-popover">
+
+						{ this.renderMenuItems( sources ) }
+					</PopoverMenu>
+				</Button>
+			</div>
+		);
+	}
+}
+
+export default localize( MediaLibraryDataSource );

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -20,7 +20,7 @@ import Search from 'components/search';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlanStorage from 'blocks/plan-storage';
 import FilterItem from './filter-item';
-import TitleItem from './title-item';
+import DataSource from './data-source';
 
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {
@@ -42,6 +42,7 @@ export class MediaLibraryFilterBar extends Component {
 		filter: '',
 		basePath: '/media',
 		onFilterChange: noop,
+		onSourceChange: noop,
 		onSearch: noop,
 		translate: identity,
 		source: '',
@@ -95,16 +96,6 @@ export class MediaLibraryFilterBar extends Component {
 		this.props.onFilterChange( filter );
 	};
 
-	renderSectionTitle() {
-		const { translate } = this.props;
-
-		if ( this.props.source === 'google_photos' ) {
-			return <TitleItem>{ translate( 'Recent photos from Google' ) }</TitleItem>;
-		}
-
-		return null;
-	}
-
 	renderTabItems() {
 		if ( this.props.source !== '' ) {
 			return null;
@@ -140,10 +131,12 @@ export class MediaLibraryFilterBar extends Component {
 			return null;
 		}
 
+		const isPinned = this.props.source === '';
+
 		return (
 			<Search
 				analyticsGroup="Media"
-				pinned
+				pinned={ isPinned }
 				fitsContainer
 				onSearch={ this.props.onSearch }
 				initialValue={ this.props.search }
@@ -166,12 +159,13 @@ export class MediaLibraryFilterBar extends Component {
 		// Dropdown is disabled when viewing any external data source
 		return (
 			<div className="media-library__filter-bar">
+				<DataSource source={ this.props.source } onSourceChange={ this.props.onSourceChange } />
+
 				<SectionNav
 					selectedText={ this.getFilterLabel( this.props.filter ) }
 					hasSearch={ true }
 					allowDropdown={ ! this.props.source }
 				>
-					{ this.renderSectionTitle() }
 					{ this.renderTabItems() }
 					{ this.renderSearchSection() }
 				</SectionNav>

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -133,8 +133,10 @@ export class MediaLibraryFilterBar extends Component {
 
 		const isPinned = this.props.source === '';
 
+		// Set the 'key' value so if the source is changed the component is refreshed, forcing it to clear the existing state
 		return (
 			<Search
+				key={ this.props.source }
 				analyticsGroup="Media"
 				pinned={ isPinned }
 				fitsContainer

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -60,9 +60,17 @@
 	align-items: stretch;
 	position: relative;
 
+	@include breakpoint( "<480px" ) {
+		flex-wrap: wrap;
+	}
+
 	.section-nav {
 		flex: 1 auto;
 		z-index: z-index( 'root', '.media-library .search.is-expanded-to-container' );
+
+		@include breakpoint( "<480px" ) {
+			width: auto;
+		}
 	}
 
 	.plan-storage {
@@ -90,6 +98,87 @@
 			margin-bottom: 17px;
 		}
 	}
+
+	.media-library__datasource {
+		box-shadow:
+		  0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		  0 1px 2px lighten( $gray, 30% );
+		background-color: $white;
+		box-sizing: border-box;
+		display: flex;
+		align-items: center;
+		width: 65px;
+		min-height: 50px;
+		min-width: 65px;
+		margin-bottom: 17px;
+
+		@include breakpoint( "<480px" ) {
+			margin-bottom: 9px;
+			align-items: normal;
+			padding-top: 6px;
+		}
+	}
+}
+
+.editor-media-modal .media-library__datasource {
+	margin-bottom: 16px;
+
+	@include breakpoint( "<480px" ) {
+		margin-bottom: 9px;
+	}
+}
+
+.media-library__source-button.is-borderless {
+	padding: 5px;
+	padding-left: 12px;
+	height: 38px;
+
+	img {
+		min-width: 24px;
+		min-height: 24px;
+		margin-top: 2px;
+	}
+
+	.gridicons-chevron-down {
+		top: -3px;
+	}
+
+	.gridicon {
+		top: 4px;
+	}
+
+	&:after {
+		@include noticon( '\f431', 20px );
+		line-height: 16px;
+		color: rgba( $gray, 0.5 );
+		padding-top: 6px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		.gridicons-chevron-down {
+			width: 18px;
+			height: 18px;
+			color: rgba( $gray, 0.5 );
+		}
+
+		.gridicon {
+			top: 2px;
+		}
+
+		&:after {
+			padding-top: 3px;
+		}
+	}
+}
+
+.media-library__source-button.is-open.is-borderless {
+	&:after {
+		@include noticon( '\f432', 20px );
+	}
+
+	.gridicon {
+		color: $gray-dark;
+	}
 }
 
 .editor-media-modal .media-library__filter-bar {
@@ -114,6 +203,17 @@
 
 .media-library__upload-buttons {
 	display: inline;
+}
+
+.media-library__header-popover {
+	.popover__menu-item {
+		padding-left: 12px;
+	}
+
+	.popover__menu img, .popover__menu svg {
+		margin-right: 8px;
+		vertical-align: middle;
+	}
 }
 
 .media-library__scale-toggle {

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -19,6 +19,7 @@ import MediaUtils from 'lib/media/utils';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import accept from 'lib/accept';
+import searchUrl from 'lib/search-url';
 
 class Media extends Component {
 
@@ -224,6 +225,11 @@ class Media extends Component {
 	};
 
 	handleSourceChange = ( source, cb ) => {
+		if ( this.props.search ) {
+			// Before we change the source reset the search value - it is confusing to jump between sources while searching
+			searchUrl( '', this.props.search );
+		}
+
 		MediaActions.sourceChanged( this.props.selectedSite.ID );
 		this.setState( { source }, cb );
 	};

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -25,7 +25,8 @@ class Media extends Component {
 	static propTypes = {
 		selectedSite: PropTypes.object,
 		filter: PropTypes.string,
-		search: PropTypes.string
+		search: PropTypes.string,
+		source: PropTypes.string,
 	};
 
 	state = {
@@ -33,6 +34,7 @@ class Media extends Component {
 		editedImageItem: null,
 		editedVideoItem: null,
 		selectedItems: [],
+		source: '',
 	};
 
 	componentDidMount() {
@@ -221,6 +223,11 @@ class Media extends Component {
 		this.deleteMedia();
 	};
 
+	handleSourceChange = ( source, cb ) => {
+		MediaActions.sourceChanged( this.props.selectedSite.ID );
+		this.setState( { source }, cb );
+	};
+
 	deleteMediaByItemDetail = () => {
 		this.deleteMedia( () => this.closeDetailsModal() );
 	};
@@ -289,9 +296,11 @@ class Media extends Component {
 							site={ site }
 							single={ false }
 							filter={ this.props.filter }
+							source={ this.state.source }
 							onEditItem={ this.openDetailsModalForASingleImage }
 							onViewDetails={ this.openDetailsModalForAllSelected }
 							onDeleteItem={ this.handleDeleteMediaEvent }
+							onSourceChange={ this.handleSourceChange }
 							modal={ false }
 							containerWidth={ this.state.containerWidth } />
 					</MediaLibrarySelectedData>

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -423,7 +423,7 @@ export class EditorMediaModal extends Component {
 		if ( this.state.source !== '' ) {
 			buttons.push( {
 				action: 'confirm',
-				label: this.props.labels.confirm || this.props.translate( 'Copy to media library' ),
+				label: this.props.translate( 'Copy to media library' ),
 				isPrimary: true,
 				disabled: isDisabled || 0 === selectedItems.length,
 				onClick: this.confirmSelection

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -52,7 +52,8 @@ function areMediaActionsDisabled( modalView, mediaItems ) {
 			// Transients can't be handled by the editor if they are being
 			// uploaded via an external URL
 			( ! MediaUtils.isTransientPreviewable( item ) ||
-			MediaUtils.getMimePrefix( item ) !== 'image' || ModalViews.GALLERY === modalView )
+			MediaUtils.getMimePrefix( item ) !== 'image' || modalView === ModalViews.GALLERY ||
+			item.external )
 		)
 	);
 }

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -365,6 +365,11 @@ export class EditorMediaModal extends Component {
 		} );
 	};
 
+	onSourceChange = source => {
+		MediaActions.sourceChanged( this.props.site.ID );
+		this.setState( { source, search: undefined } );
+	};
+
 	onClose = () => {
 		this.props.onClose();
 	};
@@ -523,6 +528,7 @@ export class EditorMediaModal extends Component {
 						onAddAndEditImage={ this.onAddAndEditImage }
 						onFilterChange={ this.onFilterChange }
 						onScaleChange={ this.onScaleChange }
+						onSourceChange={ this.onSourceChange }
 						onSearch={ this.onSearch }
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }


### PR DESCRIPTION
Adds a dropdown to the media library to toggle between the data source (currently WordPress and Google). This will affect the media modal when editing a post and also the main media page.

When viewing WordPress the standard files and buttons appear:

<img width="310" alt="wp_1" src="https://user-images.githubusercontent.com/1277682/29356646-cd4c1f6c-826c-11e7-801b-f2ae0d9c803d.png">

On a smaller screen this reduces down to:

<img width="388" alt="mobile" src="https://user-images.githubusercontent.com/1277682/29356693-f4aa6cbc-826c-11e7-9e75-c56000db82d3.png">

Clicking the dropdown shows a menu:

<img width="328" alt="popover" src="https://user-images.githubusercontent.com/1277682/29362636-ae72404a-8284-11e7-8888-c9ae0aa63826.png">

When viewing Google the filter bar disappears and the search bar is shown full time:

<img width="296" alt="gphotos" src="https://user-images.githubusercontent.com/1277682/29360691-0ca41fca-827c-11e7-977d-37547dcef652.png">

## Testing

- While editing a post click the media button. Verify that the new dropdown is shown in the top left of the media library modal
- Verify that normal WP media functions operate as expected
- Click the dropdown and change to Google Photos
- Verify that you view and copy a photo
- Switch back to WordPress media
- Exit the media library modal and open the main Media page
- Verify the dropdown is present and switches between the data sources
- Verify that you the new 'copy to library' exists when you have selected a Google Photo, and that clicking it switches to WordPress and copies the image across. This button should stick to the top of the page as you scroll down
- Go to the site settings page and click 'Change' on the site icon. Verify that the dropdown appears in the media library and operates as expected
- Verify the above when viewing in mobile/responsive mode, and that the dropdown adjusts appropriately