### PR TITLE
WPSC: Add HeaderCake

### DIFF
--- a/client/extensions/wp-super-cache/components/navigation/index.jsx
+++ b/client/extensions/wp-super-cache/components/navigation/index.jsx
@@ -2,14 +2,17 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import HeaderCake from 'components/header-cake';
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
+import { addSiteFragment } from 'lib/route/path';
 import { Tabs } from '../../app/constants';
 
 const Navigation = ( { activeTab, site, translate } ) => {
@@ -65,12 +68,19 @@ const Navigation = ( { activeTab, site, translate } ) => {
 		} );
 	};
 
+	const pluginUrl = addSiteFragment( '/plugins/wp-super-cache', get( site, 'slug' ) );
 	return (
-		<SectionNav selectedText="Settings">
-			<SectionNavTabs>
-				{ renderTabItems( getTabs() ) }
-			</SectionNavTabs>
-		</SectionNav>
+		<div>
+			<HeaderCake backText={ translate( 'Plugin Overview' ) }
+				backHref={ pluginUrl }>
+				WP Super Cache
+			</HeaderCake>
+			<SectionNav selectedText="Settings">
+				<SectionNavTabs>
+					{ renderTabItems( getTabs() ) }
+				</SectionNavTabs>
+			</SectionNav>
+		</div>
 	);
 };
 


### PR DESCRIPTION
To indicate in which extension section the user currently is, as discussed at p4TIVU-7v4-p2.

![image](https://user-images.githubusercontent.com/96308/28662148-67b73c12-72b9-11e7-8c87-f2d94e9a4413.png)


To test:
* Land at http://calypso.localhost:3000/extensions/wp-super-cache/<yourJPsite>
* The 'Plugin Overview' link will take you to http://calypso.localhost:3000/plugins/wp-super-cache/<yourJPsite>