### PR TITLE
Create SUPPORT.md

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -18,7 +18,7 @@ If you are a developer who needs help with *WordPress.com APIs and related
 tools*, please [contact us](https://developer.wordpress.com/contact/).
 
 If you need help with your *WordPress.com site or account*, please [contact our
-happiness engineers](http://en.support.wordpress.com/contact/).
+happiness engineers](http://support.wordpress.com/contact/).
 
 ## Twitter
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -17,7 +17,7 @@ blog](https://developer.wordpress.com/blog/) for technical news.
 If you are a developer who needs help with *WordPress.com APIs and related
 tools*, please [contact us](https://developer.wordpress.com/contact/).
 
-If you need help with your *ordPress.com site or account*, please [contact our
+If you need help with your *WordPress.com site or account*, please [contact our
 happiness engineers](http://en.support.wordpress.com/contact/).
 
 ## Twitter

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,26 @@
+# Community & Support
+
+## Issue tracker
+
+Create a bug report on [our bug tracking
+system](https://github.com/Automattic/wp-calypso/issues/new) or check on the
+status of an existing bug in our [issue
+tracker](https://github.com/Automattic/wp-calypso/issues).
+
+## Developer Blog
+
+Check out the [Wordpress.com developer
+blog](https://developer.wordpress.com/blog/) for technical news.
+
+## Support
+
+If you are a developer who needs help with *WordPress.com APIs and related
+tools*, please [contact us](https://developer.wordpress.com/contact/).
+
+If you need help with your *ordPress.com site or account*, please [contact our
+happiness engineers](http://en.support.wordpress.com/contact/).
+
+## Twitter
+
+For the latest news [follow
+@AutomatticEng](https://twitter.com/AutomatticEng).


### PR DESCRIPTION
Just read about it at https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1066#issuecomment-318285436

Issue creator would be notified about support in the notice above form
![support notice](https://user-images.githubusercontent.com/282759/28368719-5cd94648-6c63-11e7-8eca-c38b5342e8f2.png)
With this we could avoid support issues, better separate dev from support.

Created based on https://github.com/piwik/developer-documentation/blob/master/docs/support.md
The committed text definitely needs editing.