### PR TITLE
Simple Payments: implement trashing and editing buttons

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -29,7 +29,10 @@ import {
 	customPostToProduct,
 	productToCustomPost,
 } from 'state/data-layer/wpcom/sites/simple-payments/index.js';
-import { receiveUpdateProduct } from 'state/simple-payments/product-list/actions';
+import {
+	receiveUpdateProduct,
+	receiveDeleteProduct,
+} from 'state/simple-payments/product-list/actions';
 
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
@@ -174,6 +177,20 @@ class SimplePaymentsDialog extends Component {
 			.then( () => this.setIsSubmitting( false ) );
 	};
 
+	trashPaymentButton = paymentId => {
+		this.setIsSubmitting( true );
+
+		const { siteId, dispatch, translate } = this.props;
+
+		wpcom
+			.site( siteId )
+			.post( paymentId )
+			.delete()
+			.then( () => dispatch( receiveDeleteProduct( siteId, paymentId ) ) )
+			.catch( () => this.showError( translate( 'The payment button could not be deleted.' ) ) )
+			.then( () => this.setIsSubmitting( false ) );
+	};
+
 	getActionButtons() {
 		const { translate } = this.props;
 		const { activeTab, isSubmitting } = this.state;
@@ -234,6 +251,7 @@ class SimplePaymentsDialog extends Component {
 							paymentButtons={ paymentButtons }
 							selectedPaymentId={ this.state.selectedPaymentId }
 							onSelectedChange={ this.handleSelectedChange }
+							onTrashClick={ this.trashPaymentButton }
 						/> }
 			</Dialog>
 		);

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -78,6 +78,11 @@ class SimplePaymentsDialog extends Component {
 		if ( nextProps.showDialog && ! this.props.showDialog ) {
 			this.setState( { activeTab: 'form' } );
 		}
+
+		// clear the form when dialog is being closed -- it'll be blank next time it's opened
+		if ( ! nextProps.showDialog && this.props.showDialog ) {
+			this.formStateController.resetFields( this.constructor.initialFields );
+		}
 	}
 
 	componentDidMount() {
@@ -126,12 +131,6 @@ class SimplePaymentsDialog extends Component {
 
 	handleSelectedChange = selectedPaymentId => this.setState( { selectedPaymentId } );
 
-	handleClose = () => {
-		// clear the form after a successful submit -- it'll be blank next time it's opened
-		this.formStateController.resetFields( this.constructor.initialFields );
-		this.props.onClose();
-	};
-
 	setIsSubmitting( isSubmitting ) {
 		this._isMounted && this.setState( { isSubmitting } );
 	}
@@ -167,12 +166,7 @@ class SimplePaymentsDialog extends Component {
 		}
 
 		productId
-			.then( id => {
-				this.props.onInsert( { id } );
-
-				// clear the form after a successful submit -- it'll be blank next time it's opened
-				this.formStateController.resetFields( this.constructor.initialFields );
-			} )
+			.then( id => this.props.onInsert( { id } ) )
 			.catch( () => this.showError( translate( 'The payment button could not be inserted.' ) ) )
 			.then( () => this.setIsSubmitting( false ) );
 	};
@@ -192,7 +186,7 @@ class SimplePaymentsDialog extends Component {
 	};
 
 	getActionButtons() {
-		const { translate } = this.props;
+		const { onClose, translate } = this.props;
 		const { activeTab, isSubmitting } = this.state;
 
 		const insertDisabled =
@@ -200,7 +194,7 @@ class SimplePaymentsDialog extends Component {
 			( activeTab === 'list' && this.state.selectedPaymentId === null );
 
 		return [
-			<Button onClick={ this.handleClose } disabled={ isSubmitting }>
+			<Button onClick={ onClose } disabled={ isSubmitting }>
 				{ translate( 'Cancel' ) }
 			</Button>,
 			<Button

--- a/client/components/tinymce/plugins/simple-payments/plugin.jsx
+++ b/client/components/tinymce/plugins/simple-payments/plugin.jsx
@@ -9,7 +9,7 @@ import { unmountComponentAtNode } from 'react-dom';
  * Internal Dependencies
  */
 import SimplePaymentsDialog from './dialog';
-import { serialize } from './shortcode-utils';
+import { serialize, deserialize } from './shortcode-utils';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 const simplePayments = editor => {
@@ -27,16 +27,17 @@ const simplePayments = editor => {
 	} );
 
 	editor.addCommand( 'simplePaymentsButton', content => {
-		let isEdit = false;
+		let editPaymentId = null;
 		if ( content ) {
-			isEdit = true;
+			const shortCodeData = deserialize( content );
+			editPaymentId = shortCodeData.id || null;
 		}
 
 		function renderModal( visibility = 'show' ) {
 			renderWithReduxStore(
 				createElement( SimplePaymentsDialog, {
 					showDialog: visibility === 'show',
-					isEdit,
+					editPaymentId,
 					onInsert( productData ) {
 						editor.execCommand(
 							'mceInsertContent',


### PR DESCRIPTION
This PR implements three features. See the commit messages and code comments to get more info what the code changes mean.

**Trash an existing button from the list**
- open the Simple Payments dialog from the editor menu's "Add Payment Button" action
- go to the list of existing Payment Buttons
- open the ellipsis menu and click on "Trash"
- verify that the button was really removed (network request sent, list UI updated)

Notes:
- if there is any shortcode that references this button in any post, it will stay there and will be pointing to ID that doesn't exist. We don't delete them.
- in a future PR, I'd like to show some "Deleting..." indicator over the list item that's being deleted.

**Edit an existing button from the list**
- in the list of existing Payment Buttons, open ellipsis menu and click "Edit"
- verify that the edit form is displayed and is filled with the button's data
- is the "Save" button displayed instead of "Insert"?
- make some changes and hit "Save"
- verify that the changes were successfully saved and we were returned back to the list
- simulate a save error by setting network to offline in devtools
- try to click "Save" on an edited button
- verify that error notice is displayed and the form continues to be displayed

Notes:
- while editing a button, I can still click on the "<- Payment Buttons" link to go back to list. In that case, the editing process is cancelled without warning and changes are lost. I'm not very happy about this and would like to fix it soon
- while editing, the meaning of the "Cancel" button could be ambiguous. Clicking on it closes the whole modal dialog. But the user could expect to cancel just the editing and go back to the list...

Maybe @iamtakashi has some suggestions or ideas about the two points above?

**Edit a button directly from the editor**
I can also edit an existing button directly from the editor by clicking on the 'pencil' icon:
<img width="691" alt="simple-payment-direct-edit" src="https://user-images.githubusercontent.com/664258/28668447-1e101d56-72d0-11e7-92e7-9416dfc21a37.png">

In this case, the edit should work the same way as when triggered from the button list. But we don't display the navigation header at all and there is no way to go to the button list -- only the form is displayed and nothing else.
