### PR TITLE
Plugins: Enable plugin upload page on staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -44,6 +44,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": true,
+		"manage/plugins/upload": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,6 +45,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": true,
+		"manage/plugins/upload": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,6 +56,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": true,
+		"manage/plugins/upload": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/site-settings/analytics": true,


### PR DESCRIPTION
Will still only be accessible by entering the URL, because there are not yet any links to the page, but will allow some early testing.

URL is /plugins/upload/{jetpack_or_atomic_site}

<img width="832" alt="screen shot 2017-07-27 at 14 01 15" src="https://user-images.githubusercontent.com/7767559/28671303-1fc14f4a-72d4-11e7-946e-2bc0f9783fb2.png">
