### PR TITLE
Media: show error for external library if it fails

### DIFF
--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -16,7 +16,8 @@ export const ValidationErrors = keyMirror( {
 	UPLOAD_VIA_URL_404: null,
 	EXCEEDS_MAX_UPLOAD_SIZE: null,
 	EXCEEDS_PLAN_STORAGE_LIMIT: null,
-	NOT_ENOUGH_SPACE: null
+	NOT_ENOUGH_SPACE: null,
+	SERVICE_FAILED: null,
 } );
 
 export const ThumbnailSizeDimensions = {

--- a/client/lib/media/test/validation-store.js
+++ b/client/lib/media/test/validation-store.js
@@ -14,8 +14,9 @@ import useMockery from 'test/helpers/use-mockery';
 /**
  * Module variables
  */
-var DUMMY_SITE_ID = 1,
-	DUMMY_MEDIA_OBJECT = { ID: 100, title: 'Image', extension: 'exe' };
+const DUMMY_SITE_ID = 1;
+const DUMMY_MEDIA_OBJECT = { ID: 100, title: 'Image', extension: 'exe' };
+const ERROR_GLOBAL_ITEM_ID = 0;
 
 describe( 'MediaValidationStore', function() {
 	let sandbox, MediaValidationStore, handler, Dispatcher, MediaValidationErrors;
@@ -57,6 +58,19 @@ describe( 'MediaValidationStore', function() {
 	after( function() {
 		sandbox.restore();
 	} );
+
+	function dispatchError( error ) {
+		handler( {
+			action: {
+				type: 'RECEIVE_MEDIA_ITEM',
+				siteId: DUMMY_SITE_ID,
+				data: DUMMY_MEDIA_OBJECT,
+				error: {
+					error: error,
+				},
+			}
+		} );
+	}
 
 	function dispatchCreateMediaItem( action ) {
 		handler( {
@@ -339,6 +353,31 @@ describe( 'MediaValidationStore', function() {
 				[ DUMMY_MEDIA_OBJECT.ID ]: [ MediaValidationErrors.FILE_TYPE_UNSUPPORTED ],
 				101: [ MediaValidationErrors.FILE_TYPE_UNSUPPORTED ]
 			} );
+		} );
+
+		it( 'should detect an external media error and set error on item ERROR_GLOBAL_ITEM_ID', () => {
+			dispatchError( 'servicefail' );
+
+			const errors = MediaValidationStore.getErrors( DUMMY_SITE_ID, ERROR_GLOBAL_ITEM_ID );
+
+			expect( errors ).to.eql( [ MediaValidationErrors.SERVICE_FAILED ] );
+		} );
+
+		it( 'should require an action ID for all errors other than external media', () => {
+			dispatchError( 'someothererror' );
+
+			const errors = MediaValidationStore.getErrors( DUMMY_SITE_ID, ERROR_GLOBAL_ITEM_ID );
+
+			expect( errors ).to.eql( [] );
+		} );
+
+		it( 'should remove all validation errors when changing the data source', () => {
+			dispatchError( 'servicefail' );
+			handler( { action: { type: 'CHANGE_MEDIA_SOURCE', siteId: DUMMY_SITE_ID } } );
+
+			const errors = MediaValidationStore.getErrors( DUMMY_SITE_ID, ERROR_GLOBAL_ITEM_ID );
+
+			expect( errors ).to.eql( [] );
 		} );
 	} );
 } );

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -92,6 +92,7 @@ const MediaLibraryContent = React.createClass( {
 			let status = 'is-error';
 			let upgradeNudgeName = undefined;
 			let upgradeNudgeFeature = undefined;
+			let tryAgain = false;
 
 			switch ( errorType ) {
 				case MediaValidationErrors.FILE_TYPE_NOT_IN_PLAN:
@@ -143,6 +144,10 @@ const MediaLibraryContent = React.createClass( {
 						i18nOptions
 					);
 					break;
+				case MediaValidationErrors.SERVICE_FAILED:
+					message = translate( 'We are unable to retrieve your full media library.' );
+					tryAgain = true;
+					break;
 				default:
 					message = this.translate(
 						'%d file could not be uploaded because an error occurred while uploading.',
@@ -155,11 +160,24 @@ const MediaLibraryContent = React.createClass( {
 			return (
 				<Notice status={ status } text={ message } onDismissClick={ onDismiss } >
 					{ this.renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) }
+					{ tryAgain && this.renderTryAgain() }
 				</Notice>
 			);
 		} );
 
 		return createFragment( notices );
+	},
+
+	renderTryAgain() {
+		return (
+			<NoticeAction onClick={ this.retryList }>
+				{ translate( 'Retry' ) }
+			</NoticeAction>
+		);
+	},
+
+	retryList() {
+		MediaActions.sourceChanged( this.props.site.ID );
 	},
 
 	renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) {


### PR DESCRIPTION
Some external media services can be a bit flaky (no fingers pointed, but rhymes with boogle). The media library already handles failed upload attempts, but doesn't handle failed list attempts. This PR catches this and shows an error with retry button.

<img width="649" alt="failed" src="https://user-images.githubusercontent.com/1277682/28672148-d75d82ac-72d6-11e7-8a8a-dc1c739ec001.png">

Note that loading placeholders will remain when an error is triggered as this is the current behaviour of the media library for other errors.

## Testing

Run included unit test to verify that the error is only detected for external media, and that it doesn't affect error detection for WP media

`npm run test-client client/lib/media/test/validation-store.js`

To test the UI:
- Sandbox the API and modify the external library API (ask me for a patch) to return an error
- View GPhotos and verify that an error is shown
- Click retry button and verify that the current error is cleared and another attempt is made
