### PR TITLE
UploadImage: add "edit" and "remove" buttons to uploaded image + styling

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -208,7 +208,8 @@ $z-layers: (
 		'.editor-media-modal .section-nav': 10,
 		'.editor-media-modal .notice': 10,
 		'.editor-contact-form-modal .section-nav': 10,
-		'.editor-media-modal-gallery__preview-toggle': 100
+		'.editor-media-modal-gallery__preview-toggle': 100,
+		'.upload-image__uploaded-image-remove': 1
 	),
 	'.site-settings__taxonomies': (
 		'.card__link-indicator': 1

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -208,8 +208,7 @@ $z-layers: (
 		'.editor-media-modal .section-nav': 10,
 		'.editor-media-modal .notice': 10,
 		'.editor-contact-form-modal .section-nav': 10,
-		'.editor-media-modal-gallery__preview-toggle': 100,
-		'.upload-image__uploaded-image-remove': 1
+		'.editor-media-modal-gallery__preview-toggle': 100
 	),
 	'.site-settings__taxonomies': (
 		'.card__link-indicator': 1

--- a/client/blocks/upload-image/README.md
+++ b/client/blocks/upload-image/README.md
@@ -37,10 +37,10 @@ To see a more complex example, have a look at `blocks/upload-image/docs/example`
 - `additionalImageEditorClasses`: string of additional CSS class names to apply to the `ImageEditor` modal.
 - `additionalClasses`: string of additional CSS class names to apply to the `UploadImage` component.
 - `doneButtonText`: text on the "Done" button in Image Editor modal.
-- `addAnImageText`: text on the placeholder when selecting an image.
+- `addAnImageText`: text on the image picker when selecting an image.
 - `dragUploadText`: text which shows when dragging an image to upload.
 
-There's a way to design and supply your own HTML for the placeholder (when no image is selected) by supplying the
-`placeholderContent` prop and for the uploading process (when image is being uploaded) by supplying the
+There's a way to design and supply your own HTML for the image picker (when no image is selected) by supplying the
+`imagePickerContent` prop and for the uploading process (when image is being uploaded) by supplying the
 `uploadingContent` prop. You can also supply your own HTML for when image is uploaded to Media library by passing the
 `uploadingDoneContent` prop.

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -53,7 +53,7 @@ class UploadImage extends Component {
 
 		additionalImageEditorClasses: PropTypes.string,
 		additionalClasses: PropTypes.string,
-		placeholderContent: PropTypes.element,
+		imagePickerContent: PropTypes.element,
 		uploadingContent: PropTypes.element,
 		uploadingDoneContent: PropTypes.element,
 		doneButtonText: PropTypes.string,
@@ -243,9 +243,7 @@ class UploadImage extends Component {
 		);
 	}
 
-	removeUploadedImage = event => {
-		event.stopPropagation(); // so it won't open File Picker.
-
+	removeUploadedImage = () => {
 		this.setState( { uploadedImage: null } );
 	};
 
@@ -261,20 +259,22 @@ class UploadImage extends Component {
 		this.uploadingImageTransientId = null;
 	}
 
-	renderPlaceholderContent() {
-		const { placeholderContent, addAnImageText, translate } = this.props;
+	renderImagePickerContent() {
+		const { imagePickerContent, addAnImageText, translate } = this.props;
 
-		if ( placeholderContent ) {
-			return placeholderContent;
+		if ( imagePickerContent ) {
+			return imagePickerContent;
 		}
 
 		return (
-			<div className="upload-image__placeholder">
-				<Gridicon icon="add-image" size={ 36 } />
-				<span>
-					{ addAnImageText || translate( 'Add an Image' ) }
-				</span>
-			</div>
+			<FilePicker accept="image/*" onPick={ this.receiveFiles }>
+				<div className="upload-image__image-picker">
+					<Gridicon icon="add-image" size={ 36 } />
+					<span>
+						{ addAnImageText || translate( 'Add an Image' ) }
+					</span>
+				</div>
+			</FilePicker>
 		);
 	}
 
@@ -341,24 +341,21 @@ class UploadImage extends Component {
 		return (
 			<div className={ classnames( 'upload-image', additionalClasses ) }>
 				{ this.renderImageEditor() }
+				<div
+					className={ classnames( 'upload-image__image-container', {
+						'is-uploading': isUploading,
+						'is-uploaded': ! isUploading && uploadedImage,
+					} ) }
+				>
+					<DropZone
+						textLabel={ dragUploadText ? dragUploadText : translate( 'Drop to upload image' ) }
+						onFilesDrop={ this.receiveFiles }
+					/>
 
-				<FilePicker accept="image/*" onPick={ this.receiveFiles }>
-					<div
-						className={ classnames( 'upload-image__image-container', {
-							'is-uploading': isUploading,
-							'is-uploaded': ! isUploading && uploadedImage,
-						} ) }
-					>
-						<DropZone
-							textLabel={ dragUploadText ? dragUploadText : translate( 'Drop to upload image' ) }
-							onFilesDrop={ this.receiveFiles }
-						/>
-
-						{ ! isUploading && ! uploadedImage && this.renderPlaceholderContent() }
-						{ isUploading && this.renderUploadingContent() }
-						{ ! isUploading && uploadedImage && this.renderUploadingDoneContent() }
-					</div>
-				</FilePicker>
+					{ ! isUploading && ! uploadedImage && this.renderImagePickerContent() }
+					{ isUploading && this.renderUploadingContent() }
+					{ ! isUploading && uploadedImage && this.renderUploadingDoneContent() }
+				</div>
 			</div>
 		);
 	}

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -300,7 +300,14 @@ class UploadImage extends Component {
 		if ( uploadedImage && uploadedImage.URL ) {
 			return (
 				<div className="upload-image__uploading-done-container">
-					<img src={ uploadedImage.URL } className="upload-image__uploaded-image" />
+					<div className="upload-image__uploaded-image-wrapper">
+						<img src={ uploadedImage.URL } className="upload-image__uploaded-image" />
+						<Gridicon
+							icon="pencil"
+							size={ 18 }
+							className="upload-image__uploaded-image-edit-icon"
+						/>
+					</div>
 				</div>
 			);
 		}

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -31,6 +31,7 @@ import MediaStore from 'lib/media/store';
 import MediaUtils from 'lib/media/utils';
 import MediaValidationStore from 'lib/media/validation-store';
 import { ValidationErrors } from 'lib/media/constants';
+import Button from 'components/button';
 
 class UploadImage extends Component {
 	state = {
@@ -300,6 +301,16 @@ class UploadImage extends Component {
 		if ( uploadedImage && uploadedImage.URL ) {
 			return (
 				<div className="upload-image__uploading-done-container">
+					<Button
+						onClick={ false }
+						compact
+						className="upload-image__uploaded-image-remove">
+						<Gridicon
+							icon="cross"
+							size={ 24 }
+							className="upload-image__uploaded-image-remove-icon"
+						/>
+					</Button>
 					<div className="upload-image__uploaded-image-wrapper">
 						<img src={ uploadedImage.URL } className="upload-image__uploaded-image" />
 						<Gridicon

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -212,7 +212,6 @@ class UploadImage extends Component {
 		this.setState( {
 			isEditingImage: false,
 			selectedImage: null,
-			selectedImageName: '',
 		} );
 	};
 
@@ -258,6 +257,15 @@ class UploadImage extends Component {
 
 		this.uploadingImageTransientId = null;
 	}
+
+	editUploadedImage = () => {
+		const { editedImage } = this.state;
+
+		this.setState( {
+			isEditingImage: true,
+			selectedImage: editedImage,
+		} );
+	};
 
 	renderImagePickerContent() {
 		const { imagePickerContent, addAnImageText, translate } = this.props;
@@ -321,7 +329,7 @@ class UploadImage extends Component {
 					<div className="upload-image__uploaded-image-wrapper">
 						<img src={ uploadedImage.URL } className="upload-image__uploaded-image" />
 						<Button
-							onClick={ false }
+							onClick={ this.editUploadedImage }
 							compact
 							className="upload-image__uploaded-image-edit-button"
 						>

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -243,6 +243,12 @@ class UploadImage extends Component {
 		);
 	}
 
+	removeUploadedImage = event => {
+		event.stopPropagation(); // so it won't open File Picker.
+
+		this.setState( { uploadedImage: null } );
+	};
+
 	componentWillUnmount() {
 		const { selectedImage, editedImage } = this.state;
 
@@ -302,9 +308,10 @@ class UploadImage extends Component {
 			return (
 				<div className="upload-image__uploading-done-container">
 					<Button
-						onClick={ false }
+						onClick={ this.removeUploadedImage }
 						compact
-						className="upload-image__uploaded-image-remove">
+						className="upload-image__uploaded-image-remove"
+					>
 						<Gridicon
 							icon="cross"
 							size={ 24 }

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -282,7 +282,7 @@ class UploadImage extends Component {
 
 		return (
 			<div className="upload-image__uploading-container">
-				<img src={ editedImage } />
+				<img src={ editedImage } className="upload-image__uploading-image" />
 				<Spinner className="upload-image__spinner" size={ 20 } />
 			</div>
 		);
@@ -300,7 +300,7 @@ class UploadImage extends Component {
 		if ( uploadedImage && uploadedImage.URL ) {
 			return (
 				<div className="upload-image__uploading-done-container">
-					<img src={ uploadedImage.URL } />
+					<img src={ uploadedImage.URL } className="upload-image__uploaded-image" />
 				</div>
 			);
 		}
@@ -321,6 +321,7 @@ class UploadImage extends Component {
 					<div
 						className={ classnames( 'upload-image__image-container', {
 							'is-uploading': isUploading,
+							'is-uploaded': ! isUploading && uploadedImage,
 						} ) }
 					>
 						<DropZone

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -320,11 +320,17 @@ class UploadImage extends Component {
 					</Button>
 					<div className="upload-image__uploaded-image-wrapper">
 						<img src={ uploadedImage.URL } className="upload-image__uploaded-image" />
-						<Gridicon
-							icon="pencil"
-							size={ 18 }
-							className="upload-image__uploaded-image-edit-icon"
-						/>
+						<Button
+							onClick={ false }
+							compact
+							className="upload-image__uploaded-image-edit-button"
+						>
+							<Gridicon
+								icon="pencil"
+								size={ 18 }
+								className="upload-image__uploaded-image-edit-icon"
+							/>
+						</Button>
 					</div>
 				</div>
 			);

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -315,17 +315,6 @@ class UploadImage extends Component {
 		if ( uploadedImage && uploadedImage.URL ) {
 			return (
 				<div className="upload-image__uploading-done-container">
-					<Button
-						onClick={ this.removeUploadedImage }
-						compact
-						className="upload-image__uploaded-image-remove"
-					>
-						<Gridicon
-							icon="cross"
-							size={ 24 }
-							className="upload-image__uploaded-image-remove-icon"
-						/>
-					</Button>
 					<div className="upload-image__uploaded-image-wrapper">
 						<img src={ uploadedImage.URL } className="upload-image__uploaded-image" />
 						<Button
@@ -340,6 +329,17 @@ class UploadImage extends Component {
 							/>
 						</Button>
 					</div>
+					<Button
+						onClick={ this.removeUploadedImage }
+						compact
+						className="upload-image__uploaded-image-remove"
+					>
+						<Gridicon
+							icon="cross"
+							size={ 24 }
+							className="upload-image__uploaded-image-remove-icon"
+						/>
+					</Button>
 				</div>
 			);
 		}

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -71,8 +71,22 @@
 	height: 100%;
 }
 
-.upload-image__uploading-image, .upload-image__uploaded-image {
+.upload-image__uploading-image {
 	position: relative;
 	top: 50%;
 	transform: perspective(1px) translateY(-50%);
+	line-height: 0;
+}
+
+.upload-image__uploaded-image-wrapper {
+	transform: perspective(1px) translateY(-50%);
+	position: relative;
+	top: 50%;
+	line-height: 0;
+}
+
+.upload-image__uploaded-image-edit-icon {
+	position: absolute;
+	bottom: 10px;
+	right: 7px;
 }

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -71,6 +71,10 @@
 	height: 100%;
 }
 
+.upload-image__uploading-container, .upload-image__uploaded-image-wrapper {
+	text-align: center;
+}
+
 .upload-image__uploading-done-container {
 	position: relative;
 }
@@ -100,18 +104,16 @@
 	color: lighten( $gray, 10% );
 }
 
-.upload-image__uploading-image {
+.upload-image__uploading-image, .upload-image__uploaded-image-wrapper {
 	position: relative;
 	top: 50%;
 	transform: perspective(1px) translateY(-50%);
 	line-height: 0;
 }
 
-.upload-image__uploaded-image-wrapper {
-	transform: perspective(1px) translateY(-50%);
-	position: relative;
-	top: 50%;
-	line-height: 0;
+.upload-image__uploading-image, .upload-image__uploaded-image {
+	max-width: 200px;
+	max-height: 200px;
 }
 
 .button.is-compact.upload-image__uploaded-image-edit-button {

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -30,7 +30,7 @@
 	height: 100%;
 }
 
-.upload-image__placeholder {
+.upload-image__image-picker {
 	width: 200px;
 	height: 200px;
 	display: flex;

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -71,6 +71,35 @@
 	height: 100%;
 }
 
+.upload-image__uploading-done-container {
+	position: relative;
+}
+
+.button.is-compact.upload-image__uploaded-image-remove {
+	position: absolute;
+		top: 0;
+		right: 0;
+	width: 24px;
+	height: 24px;
+	transform: translate(50%, -50%);
+	border: 1px solid lighten( $gray, 10% );
+	border-radius: 50%;
+	background-color: $gray-light;
+	cursor: pointer;
+	z-index: z-index( '.dialog__backdrop', '.upload-image__uploaded-image-remove' );
+}
+
+.button.is-compact .gridicon.upload-image__uploaded-image-remove-icon {
+	position: absolute;
+		top: 50%;
+		left: 50%;
+	transform: translate(-50%, -50%);
+	width: 20px;
+	height: 20px;
+	margin: 0;
+	color: lighten( $gray, 10% );
+}
+
 .upload-image__uploading-image {
 	position: relative;
 	top: 50%;

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -114,10 +114,21 @@
 	line-height: 0;
 }
 
-.upload-image__uploaded-image-edit-icon {
+.button.is-compact.upload-image__uploaded-image-edit-button {
 	position: absolute;
 		bottom: 10px;
 		right: 7px;
 	color: $white;
 	opacity: 0.9;
+	line-height: 0;
+	padding: 0;
+	border: none;
+	background: none;
+	border-radius: 0;
+
+	& .upload-image__uploaded-image-edit-icon {
+		position: static;
+		margin: 0;
+		padding: 0;
+	}
 }

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -60,4 +60,19 @@
 .upload-image__image-container {
 	width: 200px;
 	height: 200px;
+
+	&.is-uploaded, &.is-uploading {
+		border: 1px solid lighten( $gray, 10% );
+		background-color: lighten( $gray, 30% );
+	}
+}
+
+.upload-image__uploading-container, .upload-image__uploading-done-container {
+	height: 100%;
+}
+
+.upload-image__uploading-image, .upload-image__uploaded-image {
+	position: relative;
+	top: 50%;
+	transform: perspective(1px) translateY(-50%);
 }

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -116,6 +116,8 @@
 
 .upload-image__uploaded-image-edit-icon {
 	position: absolute;
-	bottom: 10px;
-	right: 7px;
+		bottom: 10px;
+		right: 7px;
+	color: $white;
+	opacity: 0.9;
 }

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -69,9 +69,6 @@
 
 .upload-image__uploading-container, .upload-image__uploading-done-container {
 	height: 100%;
-}
-
-.upload-image__uploading-container, .upload-image__uploaded-image-wrapper {
 	text-align: center;
 }
 
@@ -109,6 +106,10 @@
 	top: 50%;
 	transform: perspective(1px) translateY(-50%);
 	line-height: 0;
+}
+
+.upload-image__uploaded-image-wrapper {
+	display: inline-block;
 }
 
 .upload-image__uploading-image, .upload-image__uploaded-image {

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -87,7 +87,6 @@
 	border-radius: 50%;
 	background-color: $gray-light;
 	cursor: pointer;
-	z-index: z-index( '.dialog__backdrop', '.upload-image__uploaded-image-remove' );
 
 	&:hover {
 		border-color: darken( $gray, 10% );

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -56,3 +56,8 @@
 	top: 50%;
 	transform: translate( -50%, -50% );
 }
+
+.upload-image__image-container {
+	width: 200px;
+	height: 200px;
+}

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -88,6 +88,10 @@
 	background-color: $gray-light;
 	cursor: pointer;
 	z-index: z-index( '.dialog__backdrop', '.upload-image__uploaded-image-remove' );
+
+	&:hover {
+		border-color: darken( $gray, 10% );
+	}
 }
 
 .button.is-compact .gridicon.upload-image__uploaded-image-remove-icon {
@@ -99,6 +103,10 @@
 	height: 20px;
 	margin: 0;
 	color: lighten( $gray, 10% );
+
+	&:hover {
+		color: darken( $gray, 10% );
+	}
 }
 
 .upload-image__uploading-image, .upload-image__uploaded-image-wrapper {
@@ -118,16 +126,21 @@
 }
 
 .button.is-compact.upload-image__uploaded-image-edit-button {
+	opacity: 0.9;
 	position: absolute;
-		bottom: 10px;
-		right: 7px;
+		bottom: 8px;
+		right: 8px;
 	color: $white;
 	opacity: 0.9;
 	line-height: 0;
-	padding: 0;
+	padding: 4px;
 	border: none;
-	background: none;
-	border-radius: 0;
+	background: rgba(0, 0, 0, 0.2);
+	border-radius: 50%;
+
+	&:hover {
+		opacity: 1;
+	}
 
 	& .upload-image__uploaded-image-edit-icon {
 		position: static;

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -105,3 +105,7 @@
 	flex: none;
 	margin-left: 16px;
 }
+
+.editor-simple-payments-modal__form .upload-image {
+	margin-right: 25px;
+}

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -55,6 +55,10 @@
 	@include breakpoint( ">660px" ) {
 		display: flex;
 	}
+
+	.upload-image {
+		margin-right: 25px;
+	}
 }
 
 .editor-simple-payments-modal__product-image {
@@ -104,8 +108,4 @@
 .editor-simple-payments-modal__list-menu {
 	flex: none;
 	margin-left: 16px;
-}
-
-.editor-simple-payments-modal__form .upload-image {
-	margin-right: 25px;
 }


### PR DESCRIPTION
Part of Simple Payments project.

In this PR, we add "edit" and "remove" buttons to the uploaded image in `UploadImage` reusable block with some better styling around it. It looks like this now:

![selection_047](https://user-images.githubusercontent.com/4988512/28675226-8188b7e6-72e7-11e7-9109-4e8cf54e606d.png)

## Testing

Either using `UploadImage` block devdocs or "Add Payment button" Simple Payments, try to upload an image and see the buttons. Do they work? Are the styles nice?