### PR TITLE
SimplePaymentsDialog: use a Gridicon for the 'Add New' button

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component, PropTypes } from 'react';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -48,8 +49,8 @@ class SimplePaymentsDialogNavigation extends Component {
 				label={ translate( 'Payment Buttons' ) }
 				count={ paymentButtons.length }
 			>
-				<Button compact onClick={ this.onChangeTabs( 'form' ) }>
-					{ translate( '+ Add New' ) }
+				<Button compact icon onClick={ this.onChangeTabs( 'form' ) }>
+					<Gridicon icon="plus-small" /> { translate( 'Add New' ) }
 				</Button>
 			</SectionHeader>
 		);


### PR DESCRIPTION
Open the Simple Payments modal -- the list has an "Add New" button in the header. This PR changes the '+' icon from text to a Gridicon.

Before (text):
<img width="90" alt="add-new-text" src="https://user-images.githubusercontent.com/664258/28676172-438c2588-72ea-11e7-91ae-17eb04aadc1d.png">

After (icon):
<img width="103" alt="add-new-icon" src="https://user-images.githubusercontent.com/664258/28676167-41771906-72ea-11e7-9501-fba652bda468.png">
