### PR TITLE
Post Schedule Component: add tracks event for date change

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -889,6 +889,15 @@ export const PostEditor = React.createClass( {
 			this.props.editPost( siteId, postId, { date: dateValue } );
 		}
 
+		if (
+			config.isEnabled( 'post-editor/delta-post-publish-flow' ) &&
+			this.isPostPublishConfirmationABTest
+		) {
+			analytics.tracks.recordEvent( 'calypso_editor_publish_date_change', {
+				context: 'open' === this.state.confirmationSidebar ? 'confirmation-sidebar' : 'post-settings',
+			} );
+		}
+
 		this.checkForDateChange( dateValue );
 	},
 


### PR DESCRIPTION
This PR adds a track event for a date change in the editor, including the context of whether that date change was triggered from the confirmation sidebar or from post settings.

This PR is part of a larger epic and is behind a feature flag. See p8F9tW-3F-p2.

To test:
* Set your console to log Tracks events: `localStorage.setItem('debug','calypso:analytics:tracks');`
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170713":"showPublishConfirmation"}')`
* Draft a post and change its date via post-settings. Verify that a Tracks event is triggered and that its context is 'post-settings'
* While publishing the post, change its date from the confirmation sidebar. Verify that a Tracks event is triggered and that its context is 'confirmation-sidebar'