### PR TITLE
WebPreview: Center URL in toolbar - Round 2

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -169,7 +169,7 @@ a.web-preview__external.button {
 		text-align: center;
 	}
 
-	&:hover .form-text-input {
+	&:hover .form-text-input:not(:focus) {
 		border-color: lighten( $gray, 20% );
 	}
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -141,6 +141,12 @@ a.web-preview__external.button {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-end;
+
+	@include breakpoint( ">960px" ) {
+		// Matches __device-switcher width + margin
+		// and allows the center area to flex equally
+		min-width: 212px;
+	}
 }
 
 .web-preview__device-switcher {
@@ -160,6 +166,7 @@ a.web-preview__external.button {
 		height: 35px;
 		border-color: transparent;
 		text-overflow: ellipsis;
+		text-align: center;
 	}
 
 	&:hover .form-text-input {
@@ -172,16 +179,6 @@ a.web-preview__external.button {
 
 	&:hover .clipboard-button {
 		display: block;
-	}
-
-	@include breakpoint( ">660px" ) {
-		max-width: 50%;
-	}
-
-	@include breakpoint( ">960px" ) {
-		margin: 6px auto;
-		width: 35%;
-		flex-grow: inherit;
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -161,7 +161,7 @@ a.web-preview__external.button {
 	width: auto;
 
 	.form-text-input {
-		color: $gray;
+		color: $gray-text-min;
 		font-size: 14px;
 		height: 35px;
 		border-color: transparent;


### PR DESCRIPTION
### Summary

I recently deployed some changes (#16524) that had to be reverted soon after going live (#16573) due to an issue with giving the `toolbar-actions` a fixed width - any instance where this component contained elements that exceeded 212px would get squished and pushed down over multiple lines.

This can be seen by visiting `http://calypso.localhost:3000/theme/altofocus/your-site.wordpress.com` with the revert code. Here are some screenshots for your convenience:

#### While loading iframe content:
<img width="1674" alt="before-load" src="https://user-images.githubusercontent.com/4335450/28677934-e5e8272c-72e6-11e7-89cd-be8c084b4638.png">
#### After the iframe content is loaded, covering the UI elements:
<img width="1677" alt="after-load" src="https://user-images.githubusercontent.com/4335450/28677935-e871124c-72e6-11e7-8944-9d72c94198fd.png">

It seems that swapping out the `width` to `min-width` (which I _almost_ went with originally!) fixes the issue, allowing this section to grow above `212px`

### Testing
Follow the original steps:
- Go to `/posts/{ your-mapped-domain }`
- Click edit to edit one of your posts
- Click the 'Update' button, wait for the preview to load.
- Have a :eyes: at the URL bar at different screen widths (note: you'll have to refresh the page at certain widths to show or hide different elements in the toolbar)

And additionally:
- Go to: http://calypso.localhost:3000/theme/altofocus/your-site.wordpress.com
- Click: Open Live Demo
- Make sure that the design looks as expected (all of the left hand tools/buttons should be inline in a single row

### Notes:
setting `212px` as the width/min-width causes the left and right sides of the toolbar to match each other, allowing the middle area to be truly centered without setting arbitrary widths at different breakpoints.

On that note - Another idea that I had was to use the `showDeviceSwitcher` prop to give a className which might be a more explicit way to determine whether we should set this width or not, rather than just setting it based on a breakpoint, I'm not sure but would love feedback on taht idea! ¯\_(ツ)_/¯
