### PR TITLE
Store: Temporarily hide BACS and Check payment options

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -48,6 +48,11 @@ class SettingsPaymentsMethodList extends Component {
 	}
 
 	renderMethodItem = ( method ) => {
+		// Disable BACS and Cheque payment for now until #16630 and #16629 are fixed.
+		if ( 'bacs' === method.id || 'cheque' === method.id ) {
+			return null;
+		}
+
 		return (
 			<PaymentMethodItem method={ method } key={ method.title } />
 		);


### PR DESCRIPTION
You can't fully configure these payment options yet, so we are hiding them until #16630 and #16629 are resolved. We'll get a design written up for these and implemented so we can add the methods back in.

To test:
* Go to `http://calypso.localhost:3000/store/settings/payments/:site` and make sure that COD is the only method displaying.