### PR TITLE
Components: HeaderCake's onClick is not required

### DIFF
--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -13,7 +13,7 @@ The "header cake" component should be used at the top of an item's detail page. 
 
 ## Props
 
-* `onClick` - (**required**) Function to trigger when the back text is clicked
+* `onClick` - Function to trigger when the back text is clicked
 * `onTitleClick` - Function to trigger when the title is clicked
 * `backText` - React Element or string to use in place of default "Back" text
 * `backHref` - URL to specify where the back button should redirect

--- a/client/extensions/zoninator/components/settings/zone-creator/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone-creator/index.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flowRight, noop } from 'lodash';
+import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const ZoneCreator = ( { siteSlug, translate } ) => (
 	<div>
-		<HeaderCake backHref={ `/extensions/zoninator/${ siteSlug }` } onClick={ noop }>
+		<HeaderCake backHref={ `/extensions/zoninator/${ siteSlug }` }>
 			{ translate( 'Add a zone' ) }
 		</HeaderCake>
 	</div>


### PR DESCRIPTION
It seems that HeaderCake's `onClick` property is not required after all.  
This PR aims to bring the README.md and the example in line with the actual state of the component to prevent confusion since we might have a few places that rely on `onClick` not being required.

Example PR's that rely on `onClick` not being required: #16613 and #16254.