### PR TITLE
Comment: Update CommentDetailPlaceholder style

### DIFF
--- a/client/blocks/comment-detail/comment-detail-placeholder.jsx
+++ b/client/blocks/comment-detail/comment-detail-placeholder.jsx
@@ -9,9 +9,9 @@ import React from 'react';
 import Card from 'components/card';
 
 export const CommentDetailPlaceholder = () =>
-	<Card className="comment-detail comment-detail__placeholder is-expanded">
+	<Card className="comment-detail comment-detail__placeholder">
 		<div className="comment-detail__header is-preview">
-			<div className="comment-detail__author-info">
+			<div className="comment-detail__author-preview">
 				<div className="comment-detail__author-avatar gravatar" />
 			</div>
 			<div className="comment-detail__comment-preview" />

--- a/client/blocks/comment-detail/style.scss
+++ b/client/blocks/comment-detail/style.scss
@@ -523,25 +523,29 @@ a.comment-detail__author-more-element {
 		background-color: lighten( $gray, 30% );
 		color: transparent;
 		height: 32px;
-		margin: 0 8px;
 		&:after {
 			background: transparent;
 		}
 	}
 
-	&.is-expanded .comment-detail__header {
-		border: none;
+	.comment-detail__header.is-preview {
+		cursor: default;
 	}
 
 	.gravatar {
 		width: 32px;
 	}
 
+	.comment-detail__author-preview {
+		width: 48px;
+	}
+
 	.comment-detail__author-info {
-		text-overflow: initial;
+		display: none;
 	}
 
 	.comment-detail__comment-preview {
+		margin: 0 8px;
 		width: 100%;
 	}
 


### PR DESCRIPTION
This is a small update to the `CommentDetailPlaceholder` style in order to use it as a simple class (`.comment-detail__placeholder`) on a normal `CommentDetail`.

It will be useful once we lazy-load comments.
We know the number of comments to show, render them as placeholders, and gradually replace them with the real deal.

This does not change the placeholder appearance in any way. It just does a better job at hiding the incomplete parts that might be shown while the comment is loading.

<img width="478" alt="screen shot 2017-07-27 at 18 11 26" src="https://user-images.githubusercontent.com/2070010/28683052-0a51e732-72f7-11e7-8781-f053807d546c.png">

### Test

- Open `/devdocs/blocks/comment-detail` and make sure the placeholder looks like the attached screenshot.
- Open `/comments/{status}/{siteSlug}` (possibly on a status without any comment, so that the placeholder is shown forever), and again compare with the screenshot.

cc @Automattic/lannister 