### PR TITLE
Happychat: Stop misusing isAvailable

### DIFF
--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -145,7 +145,7 @@ export const getHappychatTimeline = createSelector(
  * @return {Boolean} Whether the user is able to send messages
  */
 export const canUserSendMessages = state => (
-	isHappychatAvailable( state ) &&
+	isHappychatClientConnected( state ) &&
 	! includes(
 		[
 			HAPPYCHAT_CHAT_STATUS_BLOCKED,

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -125,6 +125,20 @@ describe( 'selectors', () => {
 				expect( canUserSendMessages( state ) ).to.be.true;
 			} );
 		} );
+
+		it( 'should return true even when isAvailable is false', () => {
+			// This test is here to prevent a code regression — isAvailable is supposed to
+			// determine whether Happychat is capable of starting new chats, and should not be
+			// a factor when determining if a user should be able to send messages to the service.
+			const state = deepFreeze( {
+				happychat: {
+					connectionStatus: 'connected',
+					chatStatus: HAPPYCHAT_CHAT_STATUS_NEW,
+					isAvailable: false,
+				}
+			} );
+			expect( canUserSendMessages( state ) ).to.be.true;
+		} );
 	} );
 
 	describe( '#getLostFocusTimestamp', () => {

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -92,23 +92,21 @@ describe( 'selectors', () => {
 			HAPPYCHAT_CHAT_STATUS_NEW,
 		];
 
-		it( 'should return false if Happychat is unavailable', () => {
+		it( 'should return false if Happychat is not connected', () => {
 			const state = deepFreeze( {
 				happychat: {
 					connectionStatus: 'uninitialized',
-					isAvailable: false,
 					chatStatus: HAPPYCHAT_CHAT_STATUS_NEW
 				}
 			} );
 			expect( canUserSendMessages( state ) ).to.be.false;
 		} );
 
-		it( "should return false if Happychat is available but the chat status doesn't allow messaging", () => {
+		it( "should return false if Happychat is connected but the chat status doesn't allow messaging", () => {
 			messagingDisabledChatStatuses.forEach( status => {
 				const state = deepFreeze( {
 					happychat: {
 						connectionStatus: 'connected',
-						isAvailable: true,
 						chatStatus: status
 					}
 				} );
@@ -116,25 +114,11 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( 'should return true if Happychat is available but client is not connected', () => {
-			messagingEnabledChatStatuses.forEach( status => {
-				const state = deepFreeze( {
-					happychat: {
-						connectionStatus: 'uninitialized',
-						isAvailable: true,
-						chatStatus: status
-					}
-				} );
-				expect( canUserSendMessages( state ) ).to.be.false;
-			} );
-		} );
-
-		it( 'should return true if Happychat is available and the chat status allows messaging', () => {
+		it( 'should return true if Happychat is connected and the chat status allows messaging', () => {
 			messagingEnabledChatStatuses.forEach( status => {
 				const state = deepFreeze( {
 					happychat: {
 						connectionStatus: 'connected',
-						isAvailable: true,
 						chatStatus: status
 					}
 				} );


### PR DESCRIPTION
**Note: Needs to be deployed the same time 721-gh-happychat is deployed.** If deployed before, blocked customers will still be able to chat with the operator.

This PR stop all misuse of the `isAvailable` Happychat state variable. This variable is _meant_ to represent "Will Happychat accept a new chat from this customer?" but it's been used to mean "Is Happychat active?"

Thankfully it looks like there was only one such instance, which has been corrected. `canUserSendMessages` _should_ depend on the HC connection status, but it should _not_ depend on whether Happychat will accept a new chat from the user.

This unblocks some other Happychat stability work, in which all chats may be set to `accept: false` because of Happychat availability but not related at all to whether active customers should be able to chat. Without this code, all chats would suddenly "turn off" when availability went to 0.

### How to test

Open a Happychat session. Try disconnecting the user by, for example, killing the happychat process. Ensure that the user can no longer chat.

Go to http://calypso.localhost:3000/me/chat — the chat box should be disabled while a connection is being established.