### PR TITLE
Allow link social account on signup

### DIFF
--- a/client/blocks/login/error-notice.jsx
+++ b/client/blocks/login/error-notice.jsx
@@ -36,7 +36,7 @@ class ErrorNotice extends Component {
 		) {
 			window.scrollTo( 0, 0 );
 		}
-	}
+	};
 
 	getCreateAccountError() {
 		const { createAccountError } = this.props;
@@ -62,10 +62,10 @@ class ErrorNotice extends Component {
 		}
 
 		/*
-		 * The existing_wpcom_user error is caught in SocialLoginForm.
+		 * The user_exists error is caught in SocialLoginForm.
 		 * The relevant messages are displayed inline in LoginForm.
 		*/
-		if ( error.code === 'existing_wpcom_user' ) {
+		if ( error.code === 'user_exists' ) {
 			return null;
 		}
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { capitalize, defer } from 'lodash';
+import { defer } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -25,6 +25,9 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import {
 	getRequestError,
 	isFormDisabled,
+	getSocialAccountIsLinking,
+	getSocialAccountLinkEmail,
+	getSocialAccountLinkService,
 } from 'state/login/selectors';
 import Notice from 'components/notice';
 import SocialLoginForm from './social';
@@ -38,17 +41,18 @@ export class LoginForm extends Component {
 		privateSite: PropTypes.bool,
 		redirectTo: PropTypes.string,
 		requestError: PropTypes.object,
+		socialAccountIsLinking: PropTypes.bool.isRequired,
+		socialAccountLinkEmail: PropTypes.string.isRequired,
+		socialAccountLinkService: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		isFormDisabled: PropTypes.bool,
 	};
 
 	state = {
 		isDisabledWhileLoading: true,
-		usernameOrEmail: '',
+		usernameOrEmail: this.props.socialAccountLinkEmail || '',
 		password: '',
 		rememberMe: false,
-		linkingSocialUser: false,
-		linkingSocialService: '',
 	};
 
 	componentDidMount() {
@@ -73,6 +77,15 @@ export class LoginForm extends Component {
 		}
 	}
 
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.socialAccountIsLinking !== nextProps.socialAccountIsLinking &&
+			nextProps.socialAccountIsLinking ) {
+			if ( ! this.state.usernameOrEmail ) {
+				this.setState( { usernameOrEmail: nextProps.socialAccountLinkEmail } );
+			}
+		}
+	}
+
 	onChangeField = ( event ) => {
 		this.props.formUpdate();
 		this.setState( {
@@ -91,10 +104,10 @@ export class LoginForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
-		const { linkingSocialUser, password, usernameOrEmail } = this.state;
+		const { usernameOrEmail, password } = this.state;
 		const { onSuccess, redirectTo } = this.props;
 
-		const rememberMe = linkingSocialUser ? true : this.state.rememberMe;
+		const rememberMe = this.props.socialAccountIsLinking ? true : this.state.rememberMe;
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
@@ -118,14 +131,6 @@ export class LoginForm extends Component {
 		this.usernameOrEmail = input;
 	};
 
-	linkSocialUser = ( service, usernameOrEmail ) => {
-		this.setState( {
-			usernameOrEmail: usernameOrEmail,
-			linkingSocialUser: true,
-			linkingSocialService: capitalize( service ),
-		} );
-	};
-
 	renderPrivateSiteNotice() {
 		if ( this.props.privateSite && ! this.props.isLoggedIn ) {
 			return (
@@ -146,6 +151,7 @@ export class LoginForm extends Component {
 		}
 
 		const { requestError } = this.props;
+		const linkingSocialUser = this.props.socialAccountIsLinking;
 
 		return (
 			<form onSubmit={ this.onSubmitForm } method="post">
@@ -153,14 +159,14 @@ export class LoginForm extends Component {
 
 				<Card className="login__form">
 					<div className="login__form-userdata">
-						{ this.state.linkingSocialUser && (
+						{ linkingSocialUser && (
 							<div className="login__form-link-social-notice">
 								<p>
 									{ this.props.translate( 'We found a WordPress.com account with the email address "%(email)s". ' +
 										'Log in to this account to connect it to your %(service)s profile.', {
 											args: {
-												email: this.state.usernameOrEmail,
-												service: this.state.linkingSocialService,
+												email: this.props.socialAccountLinkEmail,
+												service: this.props.socialAccountLinkService,
 											}
 										}
 									) }
@@ -213,7 +219,7 @@ export class LoginForm extends Component {
 						) }
 					</div>
 
-					{ ! this.state.linkingSocialUser && (
+					{ ! linkingSocialUser && (
 						<div className="login__form-remember-me">
 							<label>
 								<FormCheckbox
@@ -253,8 +259,10 @@ export class LoginForm extends Component {
 					<Card className="login__form-social">
 						<SocialLoginForm
 							onSuccess={ this.props.onSuccess }
-							linkSocialUser={ this.linkSocialUser }
-							linkingSocialService={ this.state.linkingSocialService } />
+							linkingSocialService={ this.props.socialAccountIsLinking
+								? this.props.socialAccountLinkService
+								: null
+							} />
 					</Card>
 				) }
 			</form>
@@ -267,6 +275,9 @@ export default connect(
 		redirectTo: getCurrentQueryArguments( state ).redirect_to,
 		requestError: getRequestError( state ),
 		isFormDisabled: isFormDisabled( state ),
+		socialAccountIsLinking: getSocialAccountIsLinking( state ),
+		socialAccountLinkEmail: getSocialAccountLinkEmail( state ),
+		socialAccountLinkService: getSocialAccountLinkService( state ),
 		isLoggedIn: Boolean( getCurrentUserId( state ) )
 	} ),
 	{

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -5,13 +5,14 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import GoogleLoginButton from 'components/social-buttons/google';
 import { localize } from 'i18n-calypso';
+import { capitalize } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
 import { getCurrentQueryArguments } from 'state/ui/selectors';
-import { loginSocialUser, createSocialUser } from 'state/login/actions';
+import { loginSocialUser, createSocialUser, createSocialUserFailed } from 'state/login/actions';
 import {
 	getCreatedSocialAccountUsername,
 	getCreatedSocialAccountBearerToken,
@@ -29,7 +30,6 @@ class SocialLoginForm extends Component {
 		onSuccess: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		loginSocialUser: PropTypes.func.isRequired,
-		linkSocialUser: PropTypes.func.isRequired,
 		linkingSocialService: PropTypes.string,
 	};
 
@@ -67,8 +67,8 @@ class SocialLoginForm extends Component {
 									error_message: createAccountError.message
 								} )
 							);
-					} else if ( error.code === 'existing_wpcom_user' ) {
-						this.props.linkSocialUser( 'google', error.email );
+					} else if ( error.code === 'user_exists' ) {
+						this.props.createSocialUserFailed( 'google', response.Zi.id_token, error );
 					}
 
 					this.recordEvent( 'calypso_login_social_login_failure', {
@@ -94,7 +94,7 @@ class SocialLoginForm extends Component {
 				<p className="login__social-text">
 					{ this.props.translate( 'Or, choose a different %(service)s account:', {
 						args: {
-							service: this.props.linkingSocialService,
+							service: capitalize( this.props.linkingSocialService ),
 						}
 					} ) }
 				</p>
@@ -146,6 +146,7 @@ export default connect(
 	{
 		loginSocialUser,
 		createSocialUser,
+		createSocialUserFailed,
 		recordTracksEvent,
 	}
 )( localize( SocialLoginForm ) );

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -26,7 +26,7 @@ describe( 'LoginForm', function() {
 	context( 'component rendering', () => {
 		it( 'displays a login form', () => {
 			const wrapper = shallow(
-				<LoginForm translate={ noop } />
+				<LoginForm translate={ noop } socialAccountLink={ { isLinking: false } } />
 			);
 			expect( wrapper.find( FormTextInput ).length ).to.equal( 1 );
 			expect( wrapper.find( FormPasswordInput ).length ).to.equal( 1 );

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -7,6 +7,8 @@ import { map, forEach, head, includes, keys } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
+import page from 'page';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,6 +33,7 @@ import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { mergeFormWithValue } from 'signup/utils';
 import SocialSignupForm from './social';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { createSocialUserFailed } from 'state/login/actions';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -113,7 +116,48 @@ class SignupForm extends Component {
 		const initialState = this.formStateController.getInitialState();
 		const stateWithFilledUsername = this.autoFillUsername( initialState );
 
+		this.maybeRedirectToSocialConnect( this.props );
+
 		this.setState( { form: stateWithFilledUsername } );
+	}
+
+	getUserExistsError( props ) {
+		const { step } = props;
+
+		if ( ! step || step.status !== 'invalid' ) {
+			return null;
+		}
+
+		const userExistsError = find( step.errors, error => error.error === 'user_exists' );
+
+		return userExistsError;
+	}
+
+	/***
+	 * If the step is invalid because we had an error that the user exists,
+	 * we should prompt user with a request to connect his social account
+	 * to his existing WPCOM account
+	 *
+	 * @param {Object} props react component props that has step info
+	 */
+	maybeRedirectToSocialConnect( props ) {
+		const userExistsError = this.getUserExistsError( props );
+
+		if ( userExistsError ) {
+			const { service, token } = props.step;
+			this.props.createSocialUserFailed( service, token, userExistsError );
+			page(
+				login( {
+					isNative: config.isEnabled( 'login/native-login-links' ),
+				} )
+			);
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.step && nextProps.step && this.props.step.status !== nextProps.step.status ) {
+			this.maybeRedirectToSocialConnect( nextProps );
+		}
 	}
 
 	sanitizeEmail( email ) {
@@ -494,6 +538,10 @@ class SignupForm extends Component {
 	}
 
 	render() {
+		if ( this.getUserExistsError( this.props ) ) {
+			return null;
+		}
+
 		return (
 			<div className={ classNames( 'signup-form', this.props.className ) }>
 
@@ -525,6 +573,7 @@ class SignupForm extends Component {
 export default connect(
 	null,
 	{
-		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' )
+		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),
+		createSocialUserFailed
 	}
 )( localize( SignupForm ) );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -14,6 +14,7 @@ import {
 import async from 'async';
 import { parse as parseURL } from 'url';
 import page from 'page';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -297,7 +298,9 @@ module.exports = {
 				id_token,
 				signup_flow_name: flowName,
 			}, ( error, response ) => {
-				const errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined;
+				const errors = error && error.error
+					? [ { error: error.error, message: error.message, email: get( error, 'data.email' ) } ]
+					: undefined;
 
 				if ( errors ) {
 					callback( errors );

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import request from 'superagent';
-import { get } from 'lodash';
+import { get, omit } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -111,6 +111,7 @@ const getErrorFromWPCOMError = ( wpcomError ) => ( {
 	message: wpcomError.message,
 	code: wpcomError.error,
 	field: 'global',
+	...omit( wpcomError, [ 'error', 'message', 'field' ] )
 } );
 
 /**
@@ -330,6 +331,13 @@ export const connectSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 		return Promise.reject( error );
 	} );
 };
+
+export const createSocialUserFailed = ( service, token, error ) => ( {
+	type: SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,
+	service,
+	token,
+	error: error.field ? error : getErrorFromWPCOMError( error )
+} );
 
 /**
  * Sends a two factor authentication recovery code to the 2FA user

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -27,8 +27,8 @@ import {
 	SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,
 	SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS,
 	SOCIAL_CONNECT_ACCOUNT_REQUEST,
-	SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE,
 	SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS,
+	SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE,
 	TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS,
@@ -167,13 +167,14 @@ export const twoFactorAuthPushPoll = createReducer( { inProgress: false, success
 	[ TWO_FACTOR_AUTHENTICATION_PUSH_POLL_COMPLETED ]: state => ( { ...state, inProgress: false, success: true } ),
 } );
 
-export const socialAccount = createReducer( { isCreating: false }, {
+export const socialAccount = createReducer( { isCreating: false, createError: null, }, {
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST ]: () => ( { isCreating: true } ),
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error } ) => ( { isCreating: false, createError: error } ),
 	[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: ( state, { data: { username, bearerToken } } ) => ( {
 		isCreating: false,
 		username,
-		bearerToken
+		bearerToken,
+		createError: null,
 	} ),
 	[ SOCIAL_LOGIN_REQUEST_FAILURE ]: ( state, { error, authInfo } ) => ( {
 		...state,
@@ -181,7 +182,7 @@ export const socialAccount = createReducer( { isCreating: false }, {
 		email: error.email,
 		authInfo
 	} ),
-	[ USER_RECEIVE ]: state => ( { ...state, bearerToken: null, username: null } ),
+	[ USER_RECEIVE ]: state => ( { ...state, bearerToken: null, username: null, createError: null, } ),
 	[ LOGIN_REQUEST ]: state => ( { ...state, createError: null } ),
 } );
 
@@ -189,6 +190,23 @@ export const oauth2ClientData = createReducer( null, {
 	[ OAUTH2_CLIENT_DATA_REQUEST ]: () => null,
 	[ OAUTH2_CLIENT_DATA_REQUEST_FAILURE ]: ( state, { error } ) => error,
 	[ OAUTH2_CLIENT_DATA_REQUEST_SUCCESS ]: ( state, { data } ) => data,
+} );
+
+export const socialAccountLink = createReducer( { isLinking: false }, {
+	[ SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE ]: ( state, { error, token, service } ) => {
+		if ( error.code === 'user_exists' ) {
+			return {
+				isLinking: true,
+				email: error.email,
+				token,
+				service,
+			};
+		}
+
+		return state;
+	},
+	[ SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS ]: () => ( { isLinking: false } ),
+	[ USER_RECEIVE ]: () => ( { isLinking: false } ),
 } );
 
 export default combineReducers( {
@@ -206,4 +224,5 @@ export default combineReducers( {
 	twoFactorAuthPushPoll,
 	socialAccount,
 	oauth2ClientData,
+	socialAccountLink,
 } );

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -248,3 +248,27 @@ export const getLinkingSocialAuthInfo = ( state ) => get( state, 'login.socialAc
  * @return {Object}          OAuth2 client data
  */
 export const getOAuth2ClientData = ( state ) => get( state, 'login.oauth2ClientData', null );
+
+/***
+ * Gets social account linking status
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?Boolean}         Boolean describing social account linking status
+ */
+export const getSocialAccountIsLinking = ( state ) => get( state, 'login.socialAccountLink.isLinking', null );
+
+/***
+ * Gets social account linking email
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?String}         wpcom email that is being linked
+ */
+export const getSocialAccountLinkEmail = ( state ) => get( state, 'login.socialAccountLink.email', null );
+
+/***
+ * Gets social account linking service
+ *
+ * @param  {Object}   state  Global state tree
+ * @return {?String}         service name that is being linked
+ */
+export const getSocialAccountLinkService = ( state ) => get( state, 'login.socialAccountLink.service', null );

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -25,7 +25,10 @@ import {
 	SOCIAL_CONNECT_ACCOUNT_REQUEST,
 	SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE,
 	SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS,
+	SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,
+	SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS,
 	ROUTE_SET,
+	USER_RECEIVE,
 } from 'state/action-types';
 import reducer, {
 	isRequesting,
@@ -36,6 +39,8 @@ import reducer, {
 	requestSuccess,
 	twoFactorAuth,
 	twoFactorAuthRequestError,
+	socialAccount,
+	socialAccountLink,
 } from '../reducer';
 
 describe( 'reducer', () => {
@@ -50,6 +55,7 @@ describe( 'reducer', () => {
 			'requestNotice',
 			'requestSuccess',
 			'socialAccount',
+			'socialAccountLink',
 			'twoFactorAuth',
 			'isRequestingTwoFactorAuth',
 			'twoFactorAuthRequestError',
@@ -581,6 +587,115 @@ describe( 'reducer', () => {
 				two_step_id: 12345678,
 				two_step_nonce_sms: 'foo'
 			} );
+		} );
+	} );
+
+	describe( 'socialAccount', () => {
+		it( 'should store error from create account failure', () => {
+			const error = { message: 'Bad', code: 'this_is_a_test' };
+			const service = 'google';
+			const token = '123';
+
+			const state = socialAccount( {}, {
+				type: SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,
+				error,
+				service,
+				token,
+			} );
+
+			expect( state.createError ).to.eql( error );
+		} );
+
+		it( 'default value for create error should be null', () => {
+			expect( socialAccount( undefined, { type: 'does not matter' } ).createError ).to.be.null;
+		} );
+
+		it( 'should reset create error on create success', () => {
+			const state = {
+				createError: { message: 'error' }
+			};
+
+			const newState = socialAccount(
+				state,
+				{
+					type: SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS,
+					data: { username: 'test', bearerToken: '123' }
+				}
+			);
+
+			expect( newState.createError ).to.be.null;
+		} );
+
+		it( 'should reset create error when user is received', () => {
+			const state = { createError: {} };
+
+			const newState = socialAccount(
+				state,
+				{
+					type: USER_RECEIVE,
+				}
+			);
+
+			expect( newState.createError ).to.be.null;
+		} );
+
+		it( 'should reset create error when login is performed', () => {
+			const state = { createError: {} };
+
+			const newState = socialAccount(	state, { type: LOGIN_REQUEST, } );
+
+			expect( newState.createError ).to.be.null;
+		} );
+	} );
+
+	describe( 'socialAccountLink', () => {
+		it( 'should set linking mode on user_exists create error', () => {
+			const error = { message: 'Bad', code: 'user_exists', email: 'hello@test.com' };
+			const service = 'google';
+			const token = '123';
+
+			const state = socialAccountLink( {}, {
+				type: SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE,
+				error,
+				service,
+				token,
+			} );
+
+			expect( state ).to.eql( {
+				isLinking: true,
+				service,
+				token,
+				email: error.email
+			} );
+		} );
+
+		it( 'should reset linking mode on create success', () => {
+			const state = {
+				createError: { message: 'error' }
+			};
+
+			const newState = socialAccountLink(
+				state,
+				{
+					type: SOCIAL_CREATE_ACCOUNT_REQUEST_SUCCESS,
+					data: { username: 'test', bearerToken: '123' }
+				}
+			);
+
+			expect( newState ).to.to.eql( { isLinking: false } );
+		} );
+
+		it( 'should reset linking mode when user is received', () => {
+			const state = { createError: {} };
+
+			const newState = socialAccountLink(
+				state,
+				{
+					type: USER_RECEIVE,
+				}
+			);
+
+			expect( newState ).to.to.eql( { isLinking: false } );
 		} );
 	} );
 } );

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -25,6 +25,10 @@ import {
 	getLinkingSocialUser,
 	getLinkingSocialService,
 	getLinkingSocialAuthInfo,
+	getCreateSocialAccountError,
+	getSocialAccountIsLinking,
+	getSocialAccountLinkEmail,
+	getSocialAccountLinkService,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -350,6 +354,69 @@ describe( 'selectors', () => {
 					}
 				}
 			} ) ).to.deep.eql( socialAccountInfo );
+		} );
+	} );
+
+	describe( 'getCreateSocialAccountError()', () => {
+		it( 'return null if create error not set', () => {
+			expect(
+				getCreateSocialAccountError( {
+					login: {
+						socialAccount: {
+						}
+					}
+				} )
+			).to.be.null;
+		} );
+
+		it( 'return error object if create error is set', () => {
+			const createError = { message: 'hello' };
+
+			expect(
+				getCreateSocialAccountError( {
+					login: {
+						socialAccount: {
+							createError
+						}
+					}
+				} )
+			).to.eql( createError );
+		} );
+	} );
+
+	describe( 'getSocialAccountIsLinking()', () => {
+		it( 'return social account linking status', () => {
+			const socialAccountLink = { isLinking: true };
+
+			expect( getSocialAccountIsLinking( {
+				login: {
+					socialAccountLink
+				}
+			} ) ).to.eql( true );
+		} );
+	} );
+
+	describe( 'getSocialAccountLinkEmail()', () => {
+		it( 'return social account linking email', () => {
+			const socialAccountLink = { email: 'test@hello.world' };
+
+			expect( getSocialAccountLinkEmail( {
+				login: {
+					socialAccountLink
+				}
+			} ) ).to.eql( 'test@hello.world' );
+		} );
+	} );
+
+	describe( 'getSocialAccountLinkService()', () => {
+		it( 'return social account linking service', () => {
+			const socialAccountLink = { service: 'google' };
+
+			expect( getSocialAccountLinkService( {
+				login: {
+					socialAccountLink
+				}
+			} ) ).to.eql( 'google' );
 		} );
 	} );
 } );


### PR DESCRIPTION
If a user already exists on social login during signup, we redirect the user to social connect prompt.
Test with D6588
  
  
#### Testing instructions
  
1. Run `git checkout add/social-link-on-signup` and start your server, or open a [live branch](https://calypso.live/?branch=add/social-link-on-signup)
2. Open the [`start/social` page](http://calypso.localhost:3000/start/social)
3. Check that "signup" with existing google account takes to social connect and you are able to connect the account
4. Check that in login [flow](http://calypso.localhost:3000/log-in) you can still link a social account to existing WPCOM account
  
#### Todo
- [x] Hardcoded google
- [x] unify `user_exists` and `wpcom_user_exists`
- [x] Handle edgecases when connect has error (like bad password)
- [x] Add tests  
  
#### Reviews
  
- [x] Code
- [x] Product
- [ ] Tests
