### PR TITLE
Publish Date Component: display 'Published' for published posts

### DIFF
--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -75,7 +75,7 @@ export class EditorPublishDate extends React.Component {
 			return this.props.translate( 'Schedule' );
 		}
 
-		if ( isPublished && isBackDated ) {
+		if ( isPublished ) {
 			return this.props.translate( 'Published' );
 		}
 
@@ -108,9 +108,11 @@ export class EditorPublishDate extends React.Component {
 	renderHeader() {
 		const isScheduled = utils.isFutureDated( this.props.post );
 		const isBackDated = utils.isBackDated( this.props.post );
+		const isPublished = utils.isPublished( this.props.post );
 		const className = classNames( 'editor-publish-date__header', {
 			'is-scheduled': isScheduled,
 			'is-back-dated': isBackDated,
+			'is-published': isPublished,
 		} );
 		const selectedDay = this.props.post && this.props.post.date
 			? this.props.post.date
@@ -123,7 +125,7 @@ export class EditorPublishDate extends React.Component {
 					<div className="editor-publish-date__header-description">
 						{ this.getHeaderDescription() }
 					</div>
-					{ ( isScheduled || isBackDated ) && (
+					{ ( isScheduled || isBackDated || isPublished ) && (
 						<div className="editor-publish-date__header-chrono">
 							{ this.props.moment( selectedDay ).calendar() }
 						</div>

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -36,7 +36,8 @@
 	}
 
 	&.is-scheduled,
-	&.is-back-dated {
+	&.is-back-dated,
+	&.is-published {
 		color: $blue-wordpress;
 	}
 
@@ -75,7 +76,8 @@
 
 .editor-publish-date__header-description {
 	.editor-publish-date__header.is-scheduled &,
-	.editor-publish-date__header.is-back-dated & {
+	.editor-publish-date__header.is-back-dated &,
+	.editor-publish-date__header.is-published & {
 		margin-top: -4px;
 		font-size: 10px;
 		line-height: initial;


### PR DESCRIPTION
This PR fixes a bug where "Publish Immediately" was shown for published posts. Published posts now show "Published" along with the time with which they were published.

This PR is part of a larger epic and is behind a feature flag. See p8F9tW-3F-p2.

Before:
![image](https://user-images.githubusercontent.com/363749/28685393-2e603eaa-72cd-11e7-928f-d6467afa16bd.png)

After:
![image](https://user-images.githubusercontent.com/363749/28685248-ccddf398-72cc-11e7-8c5d-1b432db65403.png)

To test:
* Set your console to log Tracks events: `localStorage.setItem('debug','calypso:analytics:tracks');`
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170713":"showPublishConfirmation"}')`
* Draft a post. Publish the post and then double-check within post-settings that the component displays "Published" along with the time at which the post was published.

