### PR TITLE
Me: Correct typo in Gravatar info popover.

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -239,7 +239,7 @@ export class EditGravatar extends Component {
 						position="left" >
 						{ translate( '{{p}}The avatar you use on WordPress.com comes ' +
 							'from {{ExternalLink}}Gravatar{{/ExternalLink}}, a universal avatar service ' +
-							'(it stands or "Global Avatar," get it?).{{/p}}' +
+							'(it stands for "Global Avatar," get it?).{{/p}}' +
 							'{{p}}Your image may also appear on other sites using Gravatar ' +
 							"whenever you're logged in with your email address %(email)s.{{/p}}",
 							{


### PR DESCRIPTION
![screen shot 2017-07-27 at 1 10 54 pm](https://user-images.githubusercontent.com/349751/28690194-2d7e540e-72cd-11e7-8970-2a6eac389837.png)

This PR corrects the text to "it stands for".