### PR TITLE
Search component: add aria-label

### DIFF
--- a/client/components/search/docs/example.jsx
+++ b/client/components/search/docs/example.jsx
@@ -25,12 +25,14 @@ var SearchDemo = React.createClass( {
 			<div>
 				<Search
 					onSearch={ noop }
-					placeholder="Placeholder text..."
+					placeholder="What are you looking for?"
+					inputLabel="What do you seek? This is different on purpose."
 				/>
 				<h2>Search Card</h2>
 				<SearchCard
 					onSearch={ noop }
-					placeholder="Placeholder text..."
+					placeholder="Seek and you shall find"
+					inputLabel="Seek and you shall find"
 				/>
 			</div>
 		);

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -31,11 +31,10 @@ function keyListener( methodToCall, event ) {
 }
 
 const Search = React.createClass( {
-
 	displayName: 'Search',
 
 	statics: {
-		instances: 0
+		instances: 0,
 	},
 
 	propTypes: {
@@ -72,7 +71,7 @@ const Search = React.createClass( {
 		return {
 			keyword: this.props.initialValue || '',
 			isOpen: !! this.props.isOpen,
-			hasFocus: false
+			hasFocus: false,
 		};
 	},
 
@@ -104,7 +103,7 @@ const Search = React.createClass( {
 
 	componentWillMount: function() {
 		this.setState( {
-			instanceId: ++Search.instances
+			instanceId: ++Search.instances,
 		} );
 
 		this.closeListener = keyListener.bind( this, 'closeSearch' );
@@ -126,9 +125,9 @@ const Search = React.createClass( {
 		}
 
 		if (
-			( this.props.value !== nextProps.value ) &&
+			this.props.value !== nextProps.value &&
 			( nextProps.value || nextProps.value === '' ) &&
-			( nextProps.value !== this.state.keyword )
+			nextProps.value !== this.state.keyword
 		) {
 			this.setState( { keyword: nextProps.value } );
 		}
@@ -176,11 +175,12 @@ const Search = React.createClass( {
 	},
 
 	scrollOverlay: function() {
-		this.refs.overlay && window.requestAnimationFrame( () => {
-			if ( this.refs.overlay && this.refs.searchInput ) {
-				this.refs.overlay.scrollLeft = this.getScrollLeft( this.refs.searchInput );
-			}
-		} );
+		this.refs.overlay &&
+			window.requestAnimationFrame( () => {
+				if ( this.refs.overlay && this.refs.searchInput ) {
+					this.refs.overlay.scrollLeft = this.getScrollLeft( this.refs.searchInput );
+				}
+			} );
 	},
 
 	//This is fix for IE11. Does not work on Edge.
@@ -196,14 +196,21 @@ const Search = React.createClass( {
 		const inputStyle = window.getComputedStyle( inputElement, undefined );
 		const paddingLeft = parseFloat( inputStyle.paddingLeft );
 		const rangeRect = range.getBoundingClientRect();
-		const scrollLeft = inputElement.getBoundingClientRect().left + inputElement.clientLeft + paddingLeft - rangeRect.left;
+		const scrollLeft =
+			inputElement.getBoundingClientRect().left +
+			inputElement.clientLeft +
+			paddingLeft -
+			rangeRect.left;
 		return scrollLeft;
 	},
 
 	focus: function() {
 		// if we call focus before the element has been entirely synced up with the DOM, we stand a decent chance of
 		// causing the browser to scroll somewhere odd. Instead, defer the focus until a future turn of the event loop.
-		setTimeout( () => this.refs.searchInput && ReactDom.findDOMNode( this.refs.searchInput ).focus(), 0 );
+		setTimeout(
+			() => this.refs.searchInput && ReactDom.findDOMNode( this.refs.searchInput ).focus(),
+			0
+		);
 	},
 
 	blur: function() {
@@ -228,7 +235,7 @@ const Search = React.createClass( {
 
 	onChange: function() {
 		this.setState( {
-			keyword: this.getCurrentSearchValue()
+			keyword: this.getCurrentSearchValue(),
 		} );
 	},
 
@@ -236,7 +243,7 @@ const Search = React.createClass( {
 		event.preventDefault();
 		this.setState( {
 			keyword: '',
-			isOpen: true
+			isOpen: true,
 		} );
 
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Open Search' );
@@ -253,7 +260,7 @@ const Search = React.createClass( {
 
 		this.setState( {
 			keyword: '',
-			isOpen: this.props.isOpen || false
+			isOpen: this.props.isOpen || false,
 		} );
 
 		input.value = ''; // will not trigger onChange
@@ -305,23 +312,21 @@ const Search = React.createClass( {
 		}
 
 		this.setState( { hasFocus: true } );
-		this.props.onSearchOpen( );
+		this.props.onSearchOpen();
 	},
 
 	render: function() {
 		const searchValue = this.state.keyword;
-		const placeholder = this.props.placeholder ||
-				i18n.translate( 'Search…', { textOnly: true } );
-
+		const placeholder = this.props.placeholder || i18n.translate( 'Search…', { textOnly: true } );
+		const inputLabel = this.props.inputLabel;
 		const enableOpenIcon = this.props.pinned && ! this.state.isOpen;
-		const isOpenUnpinnedOrQueried = this.state.isOpen ||
-				! this.props.pinned ||
-				this.props.initialValue;
+		const isOpenUnpinnedOrQueried =
+			this.state.isOpen || ! this.props.pinned || this.props.initialValue;
 
 		const autocorrect = this.props.disableAutocorrect && {
 			autoComplete: 'off',
 			autoCorrect: 'off',
-			spellCheck: 'false'
+			spellCheck: 'false',
 		};
 
 		const searchClass = classNames( this.props.additionalClasses, this.props.dir, {
@@ -331,7 +336,7 @@ const Search = React.createClass( {
 			'is-compact': this.props.compact,
 			'has-focus': this.state.hasFocus,
 			'has-open-icon': ! this.props.hideOpenIcon,
-			search: true
+			search: true,
 		} );
 
 		const fadeDivClass = classNames( 'search__input-fade', this.props.dir );
@@ -345,15 +350,19 @@ const Search = React.createClass( {
 					ref="openIcon"
 					onClick={ enableOpenIcon ? this.openSearch : this.focus }
 					tabIndex={ enableOpenIcon ? '0' : null }
-					onKeyDown={ enableOpenIcon
-						? this.openListener
-						: null
-					}
+					onKeyDown={ enableOpenIcon ? this.openListener : null }
 					aria-controls={ 'search-component-' + this.state.instanceId }
-					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
+					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }
+				>
 					{ ! this.props.hideOpenIcon && <Gridicon icon="search" className="search__open-icon" /> }
 				</div>
 				<div className={ fadeDivClass }>
+					<label
+						for={ 'search-component-' + this.state.instanceId }
+						className="search__input-label"
+					>
+						{ inputLabel ? inputLabel : i18n.translate( 'Search' ) }
+					</label>
 					<input
 						type="search"
 						id={ 'search-component-' + this.state.instanceId }
@@ -362,7 +371,10 @@ const Search = React.createClass( {
 						role="search"
 						value={ searchValue }
 						ref="searchInput"
-						onInput={ this.onChange /* onChange has bug IE11 React15 https://github.com/facebook/react/issues/7027 */ }
+						onInput={
+							this.onChange
+							/* onChange has bug IE11 React15 https://github.com/facebook/react/issues/7027 */
+						}
 						onKeyUp={ this.keyUp }
 						onKeyDown={ this.keyDown }
 						onMouseUp={ this.props.onClick }
@@ -399,14 +411,15 @@ const Search = React.createClass( {
 					tabIndex="0"
 					onKeyDown={ this.closeListener }
 					aria-controls={ 'search-component-' + this.state.instanceId }
-					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
+					aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }
+				>
 					<Gridicon icon="cross" className="search__close-icon" />
 				</div>
 			);
 		}
 
 		return null;
-	}
+	},
 } );
 
 module.exports = Search;

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -65,6 +65,7 @@ const Search = React.createClass( {
 		hideClose: PropTypes.bool,
 		compact: PropTypes.bool,
 		hideOpenIcon: PropTypes.bool,
+		inputLabel: PropTypes.string,
 	},
 
 	getInitialState: function() {
@@ -357,12 +358,6 @@ const Search = React.createClass( {
 					{ ! this.props.hideOpenIcon && <Gridicon icon="search" className="search__open-icon" /> }
 				</div>
 				<div className={ fadeDivClass }>
-					<label
-						for={ 'search-component-' + this.state.instanceId }
-						className="search__input-label"
-					>
-						{ inputLabel ? inputLabel : i18n.translate( 'Search' ) }
-					</label>
 					<input
 						type="search"
 						id={ 'search-component-' + this.state.instanceId }
@@ -381,6 +376,7 @@ const Search = React.createClass( {
 						onFocus={ this.onFocus }
 						onBlur={ this.onBlur }
 						disabled={ this.props.disabled }
+						aria-label={ inputLabel ? inputLabel : i18n.translate( 'Search' ) }
 						aria-hidden={ ! isOpenUnpinnedOrQueried }
 						autoCapitalize="none"
 						dir={ this.props.dir }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -208,3 +208,14 @@
 .animating.search-opening .search input {
 		opacity: 1;
 }
+
+// http://a11yproject.com/posts/how-to-hide-content/
+.search__input-label  {
+    position: absolute !important;
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 0 !important;
+    border: 0 !important;
+    height: 1px !important;
+    width: 1px !important;
+    overflow: hidden;
+}

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -208,14 +208,3 @@
 .animating.search-opening .search input {
 		opacity: 1;
 }
-
-// http://a11yproject.com/posts/how-to-hide-content/
-.search__input-label  {
-    position: absolute !important;
-    clip: rect(1px, 1px, 1px, 1px);
-    padding: 0 !important;
-    border: 0 !important;
-    height: 1px !important;
-    width: 1px !important;
-    overflow: hidden;
-}


### PR DESCRIPTION
The main search input for the Search component does not currently have a `label` element or `aria-label` attribute.

https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_text_01

This PR adds a default `aria-label` of "Search" and allows the developer to specify a custom label with the `inputLabel` prop.

There are also some minor formatting changes introduced by Prettier. The component needs modernising/ES6-ifying, but I suggest we do that in a followup PR.

## To test 

http://calypso.localhost:3000/devdocs/design/search