### PR TITLE
Session Restore: Enable "restore-last-location" in stage

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -90,6 +90,7 @@
 		"reader/search": true,
 		"resume-editing": true,
 		"republicize": true,
+		"restore-last-location": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
This is no longer blocked by #16592 -- when this is merged we need to announce internally.

## TO TEST

Follow test plan in #16592 with and without the `restore-last-location` flag enabled. 