### PR TITLE
Use proper preview URL and external URL for post publish preview

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -406,7 +406,7 @@ export const PostEditor = React.createClass( {
 							isLoading={ this.state.isLoading }
 							isFullScreen={ this.state.isPostPublishPreview }
 							previewUrl={ this.getPreviewUrl() }
-							externalUrl={ this.getPreviewUrl() }
+							externalUrl={ this.getExternalUrl() }
 							editUrl={ this.props.editPath }
 							defaultViewportDevice={ this.state.isPostPublishPreview ? 'computer' : 'tablet' }
 							revision={ get( this.state, 'post.revisions.length', 0 ) }
@@ -676,13 +676,23 @@ export const PostEditor = React.createClass( {
 	},
 
 	getPreviewUrl: function() {
-		const { isPostPublishPreview, post, previewAction, previewUrl } = this.state;
+		const { post, previewAction, previewUrl } = this.state;
 
-		if ( previewAction === 'view' || isPostPublishPreview ) {
+		if ( previewAction === 'view' && post ) {
 			return post.URL;
 		}
 
 		return previewUrl;
+	},
+
+	getExternalUrl: function() {
+		const { post } = this.state;
+
+		if ( post ) {
+			return post.URL;
+		}
+
+		return this.getPreviewUrl();
 	},
 
 	onPreview: function( action, event ) {


### PR DESCRIPTION
Fixes #16639 and #16640.

This PR restores the post publish preview functionality for two cases (#16639 and #16640) that were broken with #16512.

To test, run through reproduction steps in the above mentioned issues and confirm that post publish preview works for all HTTPS-enabled sites, as before.

Note to internal tester: easiest way to test this is to open an existing post on our team site and click Update -- I found it failed with our team site. Also, try a mapped domain site.