### PR TITLE
Confirmation Sidebar: Fix bug with password validity check

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -76,12 +76,14 @@ const EditorVisibility = React.createClass( {
 			return;
 		}
 
-		const oldPassword = this.props.password;
-		const newPassword = nextProps.password;
+		const currentPassword = this.props.password + ''; // force to string
+		const nextPassword = nextProps.password + '';     // force to string
 
-		const passwordIsValid =
-			oldPassword === '' && newPassword === ' ' || // visibility selection changed from public to private (without a saved password)
-			newPassword.trim().length > 0;
+		// visibility selection changed from public to private (without a saved password)
+		const isChangeFromPublicToPrivate = currentPassword === '' && nextPassword === ' ';
+		const isPasswordNotEmpty = nextPassword.trim().length > 0;
+
+		const passwordIsValid = isChangeFromPublicToPrivate || isPasswordNotEmpty;
 
 		this.setState( { passwordIsValid } );
 	},


### PR DESCRIPTION
This PR fixes an error that was occurring when the `EditorVisibility` component was mounted.

![image](https://user-images.githubusercontent.com/363749/28693526-bb06a4d0-72ea-11e7-82f9-5facf96ebb7b.png)


To test:
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170713":"showPublishConfirmation"}')`
* Draft a post. Change it to Password Protected from the confirmation sidebar.
* Make sure that the error above is not visible in your console.