### PR TITLE
Hide ground control buttons when the confirmation sidebar is open.

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -28,6 +28,7 @@ export class EditorGroundControl extends PureComponent {
 	static propTypes = {
 		hasContent: PropTypes.bool,
 		isConfirmationSidebarEnabled: PropTypes.bool,
+		confirmationSidebarStatus: PropTypes.string,
 		isDirty: PropTypes.bool,
 		isSaveBlocked: PropTypes.bool,
 		isPublishing: PropTypes.bool,
@@ -222,6 +223,10 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	renderGroundControlActionButtons() {
+		if ( this.props.confirmationSidebarStatus === 'open' ) {
+			return;
+		}
+
 		const publishComboClasses = classNames( 'editor-ground-control__publish-combo', {
 			'is-standalone': ! this.canPublishPost() || this.props.isConfirmationSidebarEnabled
 		} );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -290,6 +290,7 @@ export const PostEditor = React.createClass( {
 						setPostDate={ this.setPostDate }
 						hasContent={ this.state.hasContent }
 						isConfirmationSidebarEnabled={ isConfirmationFeatureEnabled }
+						confirmationSidebarStatus={ this.state.confirmationSidebar }
 						isDirty={ this.state.isDirty || this.props.dirty }
 						isSaveBlocked={ this.isSaveBlocked() }
 						isPublishing={ this.state.isPublishing }


### PR DESCRIPTION
This PR hides the action buttons on the editor ground control while the publish confirmation sidebar is open.

<img width="850" alt="before-after" src="https://user-images.githubusercontent.com/1017839/28692543-538418f6-7321-11e7-8e2b-94ba59d757a6.png">

This is part of a larger epic (See p3Ex-2ri-p2).

To test:

- Checkout this branch
- Run this branch with the publish-confirmation feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Draft a post
- Click "Publish..."
- Verify that the Preview, Post Settings, and Publish/Schedule/Update buttons are hidden