### PR TITLE
Store Orders: Display all taxes on orders, and add correct tax during refunds

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -54,7 +54,13 @@ class OrderDetailsTable extends Component {
 			if ( ! this.props.order.line_items[ i ] ) {
 				return 0;
 			}
-			return parseFloat( this.props.order.line_items[ i ].price ) * q;
+			const price = parseFloat( this.props.order.line_items[ i ].price );
+			const tax = parseFloat( this.props.order.line_items[ i ].total_tax );
+			const taxIncludedPrice = price + tax;
+			if ( this.props.order.prices_include_tax ) {
+				return price * q;
+			}
+			return taxIncludedPrice * q;
 		} ) );
 		const total = subtotal + ( parseFloat( this.state.shippingTotal ) || 0 );
 		this.props.onChange( total );

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 import { sum } from 'lodash';
@@ -139,6 +140,11 @@ class OrderDetailsTable extends Component {
 		}
 
 		const showTax = this.shouldShowTax();
+		const totalsClasses = classnames( {
+			'order__details-totals': true,
+			'has-taxes': showTax,
+			'is-refund-modal': isEditable,
+		} );
 
 		return (
 			<div>
@@ -146,7 +152,7 @@ class OrderDetailsTable extends Component {
 					{ order.line_items.map( this.renderOrderItems ) }
 				</Table>
 
-				<div className="order__details-totals">
+				<div className={ totalsClasses }>
 					<OrderDiscountRow order={ order } showTax={ showTax } />
 					{ isEditable
 						? <OrderShippingRefundRow

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -11,7 +11,11 @@ import { sum } from 'lodash';
 import formatCurrency from 'lib/format-currency';
 import FormTextInput from 'components/forms/form-text-input';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import PriceInput from 'woocommerce/components/price-input';
+import OrderDiscountRow from './order-discount-row';
+import OrderRefundRow from './order-refund-row';
+import OrderShippingRefundRow from './order-shipping-refund-row';
+import OrderShippingRow from './order-shipping-row';
+import OrderTotalRow from './order-total-row';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
@@ -40,10 +44,6 @@ class OrderDetailsTable extends Component {
 			quantities: [],
 			shippingTotal: 0,
 		};
-	}
-
-	getRefundedTotal = ( order ) => {
-		return order.refunds.reduce( ( total, i ) => total + ( i.total * 1 ), 0 );
 	}
 
 	recalculateRefund = () => {
@@ -86,7 +86,7 @@ class OrderDetailsTable extends Component {
 				<TableItem isHeader className="order__detail-item-product">{ translate( 'Product' ) }</TableItem>
 				<TableItem isHeader className="order__detail-item-cost">{ translate( 'Cost' ) }</TableItem>
 				<TableItem isHeader className="order__detail-item-quantity">{ translate( 'Quantity' ) }</TableItem>
-				<TableItem isHeader className="order__detail-item-total">{ translate( 'Tax' ) }</TableItem>
+				<TableItem isHeader className="order__detail-item-tax">{ translate( 'Tax' ) }</TableItem>
 				<TableItem isHeader className="order__detail-item-total">{ translate( 'Total' ) }</TableItem>
 			</TableRow>
 		);
@@ -115,7 +115,7 @@ class OrderDetailsTable extends Component {
 						: item.quantity
 					}
 				</TableItem>
-				<TableItem className="order__detail-item-total">
+				<TableItem className="order__detail-item-tax">
 					{ formatCurrency( item.total_tax, order.currency ) || item.total_tax }
 				</TableItem>
 				<TableItem className="order__detail-item-total">{ formatCurrency( item.total, order.currency ) || item.total }</TableItem>
@@ -123,25 +123,8 @@ class OrderDetailsTable extends Component {
 		);
 	}
 
-	renderRefundValue = () => {
-		const { order, translate } = this.props;
-		const refundValue = order.refunds.length ? this.getRefundedTotal( order ) : false;
-		if ( ! refundValue ) {
-			return null;
-		}
-
-		return (
-			<div className="order__details-total-refund">
-				<div className="order__details-totals-label">{ translate( 'Refunded' ) }</div>
-				<div className="order__details-totals-value">
-					{ formatCurrency( refundValue, order.currency ) || refundValue }
-				</div>
-			</div>
-		);
-	}
-
 	render() {
-		const { isEditable, order, translate } = this.props;
+		const { isEditable, order } = this.props;
 		if ( ! order ) {
 			return null;
 		}
@@ -153,38 +136,17 @@ class OrderDetailsTable extends Component {
 				</Table>
 
 				<div className="order__details-totals">
-					<div className="order__details-total-discount">
-						<div className="order__details-totals-label">{ translate( 'Discount' ) }</div>
-						<div className="order__details-totals-value">
-							{ formatCurrency( order.discount_total, order.currency ) || order.discount_total }
-						</div>
-					</div>
-					<div className="order__details-total-shipping">
-						<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
-						<div className="order__details-totals-value">
-							{ isEditable
-								? <PriceInput
-									name="shipping_total"
-									onChange={ this.onChange }
-									currency={ order.currency }
-									value={ this.state.shippingTotal } />
-								: formatCurrency( order.shipping_total, order.currency ) || order.shipping_total
-							}
-						</div>
-					</div>
-					<div className="order__details-total-tax">
-						<div className="order__details-totals-label">{ translate( 'Tax' ) }</div>
-						<div className="order__details-totals-value">
-							{ formatCurrency( order.total_tax, order.currency ) || order.total_tax }
-						</div>
-					</div>
-					<div className="order__details-total">
-						<div className="order__details-totals-label">{ translate( 'Total' ) }</div>
-						<div className="order__details-totals-value">
-							{ formatCurrency( order.total, order.currency ) || order.total }
-						</div>
-					</div>
-					{ this.renderRefundValue() }
+					<OrderDiscountRow order={ order } />
+					<OrderShippingRow order={ order } />
+					{ isEditable
+						? <OrderShippingRefundRow
+							currency={ order.currency }
+							onChange={ this.onChange }
+							shippingTotal={ this.state.shippingTotal } />
+						: null
+					}
+					<OrderTotalRow order={ order } />
+					<OrderRefundRow order={ order } />
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -102,7 +102,7 @@ class OrderDetailsTable extends Component {
 					</a>
 					<span className="order__detail-item-sku">{ item.sku }</span>
 				</TableItem>
-				<TableItem className="order__detail-item-cost">{ formatCurrency( item.price, order.currency ) || item.price }</TableItem>
+				<TableItem className="order__detail-item-cost">{ formatCurrency( item.price, order.currency ) }</TableItem>
 				<TableItem className="order__detail-item-quantity">
 					{ isEditable
 						? <FormTextInput
@@ -116,9 +116,9 @@ class OrderDetailsTable extends Component {
 					}
 				</TableItem>
 				<TableItem className="order__detail-item-tax">
-					{ formatCurrency( item.total_tax, order.currency ) || item.total_tax }
+					{ formatCurrency( item.total_tax, order.currency ) }
 				</TableItem>
-				<TableItem className="order__detail-item-total">{ formatCurrency( item.total, order.currency ) || item.total }</TableItem>
+				<TableItem className="order__detail-item-total">{ formatCurrency( item.total, order.currency ) }</TableItem>
 			</TableRow>
 		);
 	}

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -55,7 +55,7 @@ class OrderDetailsTable extends Component {
 				return 0;
 			}
 			const price = parseFloat( this.props.order.line_items[ i ].price );
-			const tax = parseFloat( this.props.order.line_items[ i ].total_tax );
+			const tax = parseFloat( this.props.order.line_items[ i ].total_tax ) / this.props.order.line_items[ i ].quantity;
 			const taxIncludedPrice = price + tax;
 			if ( this.props.order.prices_include_tax ) {
 				return price * q;

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -42,7 +42,7 @@ class OrderDetailsTable extends Component {
 		super( props );
 		this.state = {
 			quantities: [],
-			shippingTotal: 0,
+			shippingTotal: parseFloat( props.order.shipping_tax ) + parseFloat( props.order.shipping_total ),
 		};
 	}
 
@@ -137,13 +137,12 @@ class OrderDetailsTable extends Component {
 
 				<div className="order__details-totals">
 					<OrderDiscountRow order={ order } />
-					<OrderShippingRow order={ order } />
 					{ isEditable
 						? <OrderShippingRefundRow
 							currency={ order.currency }
 							onChange={ this.onChange }
 							shippingTotal={ this.state.shippingTotal } />
-						: null
+						: <OrderShippingRow order={ order } />
 					}
 					<OrderTotalRow order={ order } />
 					<OrderRefundRow order={ order } />

--- a/client/extensions/woocommerce/app/order/order-details-table.js
+++ b/client/extensions/woocommerce/app/order/order-details-table.js
@@ -46,6 +46,15 @@ class OrderDetailsTable extends Component {
 		};
 	}
 
+	shouldShowTax = () => {
+		const { order } = this.props;
+		if ( ! order ) {
+			return false;
+		}
+		// If there are any items in `tax_lines`, we have taxes on this order.
+		return !! order.tax_lines.length;
+	}
+
 	recalculateRefund = () => {
 		if ( ! this.props.order ) {
 			return 0;
@@ -129,6 +138,8 @@ class OrderDetailsTable extends Component {
 			return null;
 		}
 
+		const showTax = this.shouldShowTax();
+
 		return (
 			<div>
 				<Table className="order__details-table" header={ this.renderTableHeader() }>
@@ -136,16 +147,16 @@ class OrderDetailsTable extends Component {
 				</Table>
 
 				<div className="order__details-totals">
-					<OrderDiscountRow order={ order } />
+					<OrderDiscountRow order={ order } showTax={ showTax } />
 					{ isEditable
 						? <OrderShippingRefundRow
 							currency={ order.currency }
 							onChange={ this.onChange }
 							shippingTotal={ this.state.shippingTotal } />
-						: <OrderShippingRow order={ order } />
+						: <OrderShippingRow order={ order } showTax={ showTax } />
 					}
-					<OrderTotalRow order={ order } />
-					<OrderRefundRow order={ order } />
+					<OrderTotalRow order={ order } showTax={ showTax } />
+					<OrderRefundRow order={ order } showTax={ showTax } />
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-discount-row.js
+++ b/client/extensions/woocommerce/app/order/order-discount-row.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+
+class OrderDiscountRow extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			discount_tax: PropTypes.string.isRequired,
+			discount_total: PropTypes.string.isRequired,
+		} ),
+	}
+
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<div className="order__details-total-discount">
+				<div className="order__details-totals-label">{ translate( 'Discount' ) }</div>
+				<div className="order__details-totals-tax">
+					{ formatCurrency( order.discount_tax, order.currency ) || order.discount_tax }
+				</div>
+				<div className="order__details-totals-value">
+					{ formatCurrency( order.discount_total, order.currency ) || order.discount_total }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderDiscountRow );

--- a/client/extensions/woocommerce/app/order/order-discount-row.js
+++ b/client/extensions/woocommerce/app/order/order-discount-row.js
@@ -28,10 +28,10 @@ class OrderDiscountRow extends Component {
 			<div className="order__details-total-discount">
 				<div className="order__details-totals-label">{ translate( 'Discount' ) }</div>
 				<div className="order__details-totals-tax">
-					{ formatCurrency( order.discount_tax, order.currency ) || order.discount_tax }
+					{ formatCurrency( order.discount_tax, order.currency ) }
 				</div>
 				<div className="order__details-totals-value">
-					{ formatCurrency( order.discount_total, order.currency ) || order.discount_total }
+					{ formatCurrency( order.discount_total, order.currency ) }
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-discount-row.js
+++ b/client/extensions/woocommerce/app/order/order-discount-row.js
@@ -16,20 +16,25 @@ class OrderDiscountRow extends Component {
 			discount_tax: PropTypes.string.isRequired,
 			discount_total: PropTypes.string.isRequired,
 		} ),
+		showTax: PropTypes.bool,
 	}
 
 	render() {
-		const { order, translate } = this.props;
+		const { order, showTax, translate } = this.props;
 		if ( ! order ) {
 			return null;
 		}
 
+		const tax = (
+			<div className="order__details-totals-tax">
+				{ formatCurrency( order.discount_tax, order.currency ) }
+			</div>
+		);
+
 		return (
 			<div className="order__details-total-discount">
 				<div className="order__details-totals-label">{ translate( 'Discount' ) }</div>
-				<div className="order__details-totals-tax">
-					{ formatCurrency( order.discount_tax, order.currency ) }
-				</div>
+				{ showTax && tax }
 				<div className="order__details-totals-value">
 					{ formatCurrency( order.discount_total, order.currency ) }
 				</div>

--- a/client/extensions/woocommerce/app/order/order-refund-row.js
+++ b/client/extensions/woocommerce/app/order/order-refund-row.js
@@ -33,7 +33,7 @@ class OrderRefundRow extends Component {
 				<div className="order__details-totals-label">{ translate( 'Refunded' ) }</div>
 				<div className="order__details-totals-tax"></div>
 				<div className="order__details-totals-value">
-					{ formatCurrency( refundValue, order.currency ) || refundValue }
+					{ formatCurrency( refundValue, order.currency ) }
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-refund-row.js
+++ b/client/extensions/woocommerce/app/order/order-refund-row.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+
+class OrderRefundRow extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			refunds: PropTypes.array.isRequired,
+		} ),
+	}
+
+	getRefundedTotal = ( order ) => {
+		return order.refunds.reduce( ( total, i ) => total + ( i.total * 1 ), 0 );
+	}
+
+	render() {
+		const { order, translate } = this.props;
+		const refundValue = order.refunds.length ? this.getRefundedTotal( order ) : false;
+		if ( ! refundValue ) {
+			return null;
+		}
+
+		return (
+			<div className="order__details-total-refund">
+				<div className="order__details-totals-label">{ translate( 'Refunded' ) }</div>
+				<div className="order__details-totals-tax"></div>
+				<div className="order__details-totals-value">
+					{ formatCurrency( refundValue, order.currency ) || refundValue }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderRefundRow );

--- a/client/extensions/woocommerce/app/order/order-refund-row.js
+++ b/client/extensions/woocommerce/app/order/order-refund-row.js
@@ -15,6 +15,7 @@ class OrderRefundRow extends Component {
 			currency: PropTypes.string.isRequired,
 			refunds: PropTypes.array.isRequired,
 		} ),
+		showTax: PropTypes.bool,
 	}
 
 	getRefundedTotal = ( order ) => {
@@ -22,7 +23,7 @@ class OrderRefundRow extends Component {
 	}
 
 	render() {
-		const { order, translate } = this.props;
+		const { order, showTax, translate } = this.props;
 		const refundValue = order.refunds.length ? this.getRefundedTotal( order ) : false;
 		if ( ! refundValue ) {
 			return null;
@@ -31,7 +32,7 @@ class OrderRefundRow extends Component {
 		return (
 			<div className="order__details-total-refund">
 				<div className="order__details-totals-label">{ translate( 'Refunded' ) }</div>
-				<div className="order__details-totals-tax"></div>
+				{ showTax && <div className="order__details-totals-tax"></div> }
 				<div className="order__details-totals-value">
 					{ formatCurrency( refundValue, order.currency ) }
 				</div>

--- a/client/extensions/woocommerce/app/order/order-shipping-refund-row.js
+++ b/client/extensions/woocommerce/app/order/order-shipping-refund-row.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PriceInput from 'woocommerce/components/price-input';
+
+class OrderShippingRefundRow extends Component {
+	static propTypes = {
+		currency: PropTypes.string.isRequired,
+		onChange: PropTypes.func.isRequired,
+		shippingTotal: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.number,
+		] ).isRequired,
+	}
+
+	render() {
+		const {
+			currency,
+			onChange,
+			shippingTotal
+		} = this.props;
+
+		return (
+			<div className="order__details-total-shipping-refund">
+				<div className="order__details-totals-value">
+					<PriceInput
+						name="shipping_total"
+						onChange={ onChange }
+						currency={ currency }
+						value={ shippingTotal } />
+				</div>
+			</div>
+		);
+	}
+}
+
+export default OrderShippingRefundRow;

--- a/client/extensions/woocommerce/app/order/order-shipping-refund-row.js
+++ b/client/extensions/woocommerce/app/order/order-shipping-refund-row.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 
 /**
@@ -22,11 +23,13 @@ class OrderShippingRefundRow extends Component {
 		const {
 			currency,
 			onChange,
-			shippingTotal
+			shippingTotal,
+			translate
 		} = this.props;
 
 		return (
 			<div className="order__details-total-shipping-refund">
+				<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
 				<div className="order__details-totals-value">
 					<PriceInput
 						name="shipping_total"
@@ -39,4 +42,4 @@ class OrderShippingRefundRow extends Component {
 	}
 }
 
-export default OrderShippingRefundRow;
+export default localize( OrderShippingRefundRow );

--- a/client/extensions/woocommerce/app/order/order-shipping-row.js
+++ b/client/extensions/woocommerce/app/order/order-shipping-row.js
@@ -16,20 +16,25 @@ class OrderShippingRow extends Component {
 			shipping_tax: PropTypes.string.isRequired,
 			shipping_total: PropTypes.string.isRequired,
 		} ),
+		showTax: PropTypes.bool,
 	}
 
 	render() {
-		const { order, translate } = this.props;
+		const { order, showTax, translate } = this.props;
 		if ( ! order ) {
 			return null;
 		}
 
+		const tax = (
+			<div className="order__details-totals-tax">
+				{ formatCurrency( order.shipping_tax, order.currency ) }
+			</div>
+		);
+
 		return (
 			<div className="order__details-total-shipping">
 				<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
-				<div className="order__details-totals-tax">
-					{ formatCurrency( order.shipping_tax, order.currency ) }
-				</div>
+				{ showTax && tax }
 				<div className="order__details-totals-value">
 					{ formatCurrency( order.shipping_total, order.currency ) }
 				</div>

--- a/client/extensions/woocommerce/app/order/order-shipping-row.js
+++ b/client/extensions/woocommerce/app/order/order-shipping-row.js
@@ -28,10 +28,10 @@ class OrderShippingRow extends Component {
 			<div className="order__details-total-shipping">
 				<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
 				<div className="order__details-totals-tax">
-					{ formatCurrency( order.shipping_tax, order.currency ) || order.shipping_tax }
+					{ formatCurrency( order.shipping_tax, order.currency ) }
 				</div>
 				<div className="order__details-totals-value">
-					{ formatCurrency( order.shipping_total, order.currency ) || order.shipping_total }
+					{ formatCurrency( order.shipping_total, order.currency ) }
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-shipping-row.js
+++ b/client/extensions/woocommerce/app/order/order-shipping-row.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+
+class OrderShippingRow extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			shipping_tax: PropTypes.string.isRequired,
+			shipping_total: PropTypes.string.isRequired,
+		} ),
+	}
+
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<div className="order__details-total-shipping">
+				<div className="order__details-totals-label">{ translate( 'Shipping' ) }</div>
+				<div className="order__details-totals-tax">
+					{ formatCurrency( order.shipping_tax, order.currency ) || order.shipping_tax }
+				</div>
+				<div className="order__details-totals-value">
+					{ formatCurrency( order.shipping_total, order.currency ) || order.shipping_total }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderShippingRow );

--- a/client/extensions/woocommerce/app/order/order-total-row.js
+++ b/client/extensions/woocommerce/app/order/order-total-row.js
@@ -28,10 +28,10 @@ class OrderTotalRow extends Component {
 			<div className="order__details-total">
 				<div className="order__details-totals-label">{ translate( 'Total' ) }</div>
 				<div className="order__details-totals-tax">
-					{ formatCurrency( order.total_tax, order.currency ) || order.total_tax }
+					{ formatCurrency( order.total_tax, order.currency ) }
 				</div>
 				<div className="order__details-totals-value">
-					{ formatCurrency( order.total, order.currency ) || order.total }
+					{ formatCurrency( order.total, order.currency ) }
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-total-row.js
+++ b/client/extensions/woocommerce/app/order/order-total-row.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+
+class OrderTotalRow extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			total: PropTypes.string.isRequired,
+			total_tax: PropTypes.string.isRequired,
+		} ),
+	}
+
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		return (
+			<div className="order__details-total">
+				<div className="order__details-totals-label">{ translate( 'Total' ) }</div>
+				<div className="order__details-totals-tax">
+					{ formatCurrency( order.total_tax, order.currency ) || order.total_tax }
+				</div>
+				<div className="order__details-totals-value">
+					{ formatCurrency( order.total, order.currency ) || order.total }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderTotalRow );

--- a/client/extensions/woocommerce/app/order/order-total-row.js
+++ b/client/extensions/woocommerce/app/order/order-total-row.js
@@ -16,20 +16,25 @@ class OrderTotalRow extends Component {
 			total: PropTypes.string.isRequired,
 			total_tax: PropTypes.string.isRequired,
 		} ),
+		showTax: PropTypes.bool,
 	}
 
 	render() {
-		const { order, translate } = this.props;
+		const { order, showTax, translate } = this.props;
 		if ( ! order ) {
 			return null;
 		}
 
+		const tax = (
+			<div className="order__details-totals-tax">
+				{ formatCurrency( order.total_tax, order.currency ) }
+			</div>
+		);
+
 		return (
 			<div className="order__details-total">
 				<div className="order__details-totals-label">{ translate( 'Total' ) }</div>
-				<div className="order__details-totals-tax">
-					{ formatCurrency( order.total_tax, order.currency ) }
-				</div>
+				{ showTax && tax }
 				<div className="order__details-totals-value">
 					{ formatCurrency( order.total, order.currency ) }
 				</div>

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -147,12 +147,16 @@
 			flex: 1 0 92px;
 		}
 	}
-	
+
 	.order__details-total-refund {
 		color: $alert-red;
 	}
 
 	.order__details-total-shipping-refund {
+		.order__details-totals-value {
+			flex: 1 0 192px;
+		}
+
 		.form-text-input-with-affixes {
 			width: 130px;
 		}

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -72,11 +72,13 @@
 
 	.order__detail-item-cost,
 	.order__detail-item-quantity,
+	.order__detail-item-tax,
 	.order__detail-item-total {
 		text-align: right;
+		width: 70px;
 
 		input {
-			width: 5em;
+			width: 70px;
 		}
 	}
 
@@ -129,7 +131,7 @@
 
 	.order__details-total-discount,
 	.order__details-total-shipping,
-	.order__details-total-tax,
+	.order__details-total-shipping-refund,
 	.order__details-total-refund,
 	.order__details-total {
 		margin-bottom: 8px;
@@ -137,15 +139,18 @@
 		align-items: center;
 
 		.order__details-totals-label {
-			width: 75%;
+			flex: 1 0 calc( 100% - 204px );
 		}
 
+		.order__details-totals-tax,
 		.order__details-totals-value {
-			width: 25%;
+			flex: 1 0 92px;
+		}
+	}
 
-			.form-text-input-with-affixes {
-				width: 85%;
-			}
+	.order__details-total-shipping-refund {
+		.form-text-input-with-affixes {
+			width: 130px;
 		}
 	}
 

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -139,7 +139,7 @@
 		align-items: center;
 
 		.order__details-totals-label {
-			flex: 1 0 calc( 100% - 204px );
+			flex: 1 0 calc( 100% - 104px );
 		}
 
 		.order__details-totals-tax,
@@ -148,18 +148,33 @@
 		}
 	}
 
-	.order__details-total-refund {
-		color: $alert-red;
+	&.is-refund-modal,
+	&.has-taxes {
+		.order__details-total-discount,
+		.order__details-total-refund,
+		.order__details-total-shipping,
+		.order__details-total-shipping-refund,
+		.order__details-total {
+			.order__details-totals-label {
+				flex: 1 0 calc( 100% - 204px );
+			}
+		}
+	}
+
+	&.has-taxes {
+		.order__details-total-shipping-refund .order__details-totals-value {
+			flex: 1 0 192px;
+		}
 	}
 
 	.order__details-total-shipping-refund {
-		.order__details-totals-value {
-			flex: 1 0 192px;
-		}
-
 		.form-text-input-with-affixes {
 			width: 130px;
 		}
+	}
+
+	.order__details-total-refund {
+		color: $alert-red;
 	}
 
 	& > div:last-child {

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -147,6 +147,10 @@
 			flex: 1 0 92px;
 		}
 	}
+	
+	.order__details-total-refund {
+		color: $alert-red;
+	}
 
 	.order__details-total-shipping-refund {
 		.form-text-input-with-affixes {


### PR DESCRIPTION
Fixes #16645, fixes #16634

This PR has been pretty drastically updated. It used to be:

> This PR updates the price computed by changing the quantity in the refund modal to include tax on the item. It does check first that tax is not already included on the item (based on the API response, I couldn't actually get my test site into a state where it included tax on the products).

Now it's a refactor of the order details page, specifically the discount/shipping/total rows. It also includes these refund-with-tax fixes. The two big changes are:

- Now the discount, shipping, and total rows also have a Tax column, which line up with the product list table's tax and total columns.
- The refund modal, which also uses this table component, has a separate row for the refund input, so that users can see the shipping total and tax values.

Details table:
![screen shot 2017-08-04 at 6 56 02 pm](https://user-images.githubusercontent.com/541093/28990301-18032630-794a-11e7-832d-fc6d84304f9f.png)

Refund modal:
![screen shot 2017-08-04 at 6 55 29 pm](https://user-images.githubusercontent.com/541093/28990302-1807ea76-794a-11e7-8634-faa53d0dcccf.png)

To test:

- With a site that has taxes enabled, create an order or view an existing taxed order
- On the details view, make sure the discount, shipping, total, and refunds display as expected
- Try to give a refund on the order by changing the quantity in the refunds modal
- The price refunded should include the tax per-item
- You can see the shipping total and tax, and can enter that into the shipping refund input
- Refunding now, you can refund the entire order cost.