### PR TITLE
Store: Add back the ability to manage the check payment method (now with description!)

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
+
+class PaymentMethodCheque extends Component {
+
+	static propTypes = {
+		method: PropTypes.shape( {
+			settings: PropTypes.shape( {
+				title: PropTypes.shape( {
+					id: PropTypes.string.isRequired,
+					label: PropTypes.string.isRequired,
+					type: PropTypes.string.isRequired,
+					value: PropTypes.string.isRequired,
+				} ),
+			} ),
+		} ),
+		translate: PropTypes.func.isRequired,
+		onCancel: PropTypes.func.isRequired,
+		onEditField: PropTypes.func.isRequired,
+		onDone: PropTypes.func.isRequired,
+	};
+
+	onEditFieldHandler = ( e ) => {
+		this.props.onEditField( e.target.name, e.target.value );
+	}
+
+	buttons = [
+		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
+		{ action: 'save', label: this.props.translate( 'Done' ), onClick: this.props.onDone, isPrimary: true },
+	];
+
+	render() {
+		const { method, method: { settings }, translate } = this.props;
+		return (
+			<Dialog
+				additionalClassNames="payments__dialog woocommerce"
+				buttons={ this.buttons }
+				isVisible>
+				<FormFieldset className="payments__method-edit-field-container" >
+					<FormLabel>{ translate( 'Title' ) }</FormLabel>
+					<FormTextInput
+						name="title"
+						onChange={ this.onEditFieldHandler }
+						value={ settings.title.value }
+					/>
+				</FormFieldset>
+				<FormFieldset className="payments__method-edit-field-container" >
+					<FormLabel>{ translate( 'Description' ) }</FormLabel>
+					<FormTextarea
+						name="description"
+						onChange={ this.onEditFieldHandler }
+						value={ method.description }
+					/>
+				</FormFieldset>
+				<FormFieldset className="payments__method-edit-field-container" >
+					<FormLabel>{ translate( 'Instructions' ) }</FormLabel>
+					<FormTextarea
+						name="instructions"
+						onChange={ this.onEditFieldHandler }
+						value={ settings.instructions.value }
+					/>
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( PaymentMethodCheque );

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
@@ -62,7 +62,7 @@ class PaymentMethodCheque extends Component {
 						name="description"
 						onChange={ this.onEditFieldHandler }
 						value={ method.description }
-						placeholder={ translate( 'Please send a check to…' ) }
+						placeholder={ translate( 'Pay for this order by check.' ) }
 					/>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container" >
@@ -71,7 +71,7 @@ class PaymentMethodCheque extends Component {
 						name="instructions"
 						onChange={ this.onEditFieldHandler }
 						value={ settings.instructions.value }
-						placeholder={ translate( 'Please send a check to…' ) }
+						placeholder={ translate( 'Make your check payable to…' ) }
 					/>
 				</FormFieldset>
 			</Dialog>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-cheque.js
@@ -57,19 +57,21 @@ class PaymentMethodCheque extends Component {
 					/>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container" >
-					<FormLabel>{ translate( 'Description' ) }</FormLabel>
+					<FormLabel>{ translate( 'Instructions for customer at checkout' ) }</FormLabel>
 					<FormTextarea
 						name="description"
 						onChange={ this.onEditFieldHandler }
 						value={ method.description }
+						placeholder={ translate( 'Please send a check to…' ) }
 					/>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container" >
-					<FormLabel>{ translate( 'Instructions' ) }</FormLabel>
+					<FormLabel>{ translate( 'Instructions for customer in order email notification' ) }</FormLabel>
 					<FormTextarea
 						name="instructions"
 						onChange={ this.onEditFieldHandler }
 						value={ settings.instructions.value }
+						placeholder={ translate( 'Please send a check to…' ) }
 					/>
 				</FormFieldset>
 			</Dialog>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -28,6 +28,7 @@ import PaymentMethodEditDialog from './payment-method-edit-dialog';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 import PaymentMethodPaypal from './payment-method-paypal';
 import PaymentMethodStripe from './payment-method-stripe';
+import PaymentMethodCheque from './payment-method-cheque';
 
 class PaymentMethodItem extends Component {
 	static propTypes = {
@@ -109,6 +110,15 @@ class PaymentMethodItem extends Component {
 		if ( method.id === 'stripe' ) {
 			return (
 				<PaymentMethodStripe
+					method={ currentlyEditingMethod }
+					onCancel={ this.onCancel }
+					onEditField={ this.onEditField }
+					onDone={ this.onDone } />
+			);
+		}
+		if ( method.id === 'cheque' ) {
+			return (
+				<PaymentMethodCheque
 					method={ currentlyEditingMethod }
 					onCancel={ this.onCancel }
 					onEditField={ this.onEditField }

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -49,7 +49,7 @@ class SettingsPaymentsMethodList extends Component {
 
 	renderMethodItem = ( method ) => {
 		// Disable BACS and Cheque payment for now until #16630 and #16629 are fixed.
-		if ( 'bacs' === method.id || 'cheque' === method.id ) {
+		if ( 'bacs' === method.id ) {
 			return null;
 		}
 

--- a/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
+++ b/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
@@ -25,6 +25,7 @@ export default {
 
 			const payload = {
 				settings,
+				description: method.description,
 			};
 
 			/**

--- a/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
@@ -58,6 +58,10 @@ export const getPaymentMethodsWithEdits = ( state, siteId = getSelectedSiteId( s
 				method.enabled = update[ updateKey ];
 				return;
 			}
+			if ( 'description' === updateKey ) {
+				method.description = update[ updateKey ].value;
+				return;
+			}
 			method.settings[ updateKey ] = {
 				...method.settings[ updateKey ],
 				value: update[ updateKey ].value,
@@ -113,10 +117,15 @@ export const getCurrentlyEditingPaymentMethod = ( state, siteId = getSelectedSit
 		return { ...method };
 	}
 	const settings = { ...method.settings };
+	let description = method.description;
 	Object.keys( edits.currentlyEditingChanges ).forEach( function( edit ) {
-		settings[ edit ] = { ...settings[ edit ], ...edits.currentlyEditingChanges[ edit ] };
+		if ( 'description' === edit ) {
+			description = edits.currentlyEditingChanges[ edit ].value;
+		} else {
+			settings[ edit ] = { ...settings[ edit ], ...edits.currentlyEditingChanges[ edit ] };
+		}
 	} );
-	return { ...method, settings };
+	return { ...method, settings, description };
 };
 
 /**

--- a/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
@@ -107,6 +107,22 @@ describe( 'selectors', () => {
 			] );
 		} );
 
+		it( 'should apply the description "edits" changes to the method list', () => {
+			siteState.paymentMethods = [
+				{ id: 1, enabled: true, description: 'test', settings: { name: { value: 'Method1' } } },
+			];
+			uiState.methods = {
+				creates: [],
+				deletes: [],
+				updates: [
+					{ id: 1, enabled: true, description: { value: 'update' } },
+				],
+			};
+			expect( getPaymentMethodsWithEdits( state ) ).to.deep.equal( [
+				{ id: 1, enabled: true, description: 'update', settings: { name: { value: 'Method1' } } },
+			] );
+		} );
+
 		it( 'should NOT apply the uncommited changes made in the modal', () => {
 			siteState.paymentMethods = [
 				{ id: 1, settings: { name: { value: 'Method1' } } },
@@ -169,16 +185,20 @@ describe( 'selectors', () => {
 
 		it( 'should return method with changes when there is a method being edited, with changes in that method', () => {
 			siteState.paymentMethods = [
-				{ id: 1, settings: { name: { value: 'MyMethod' } } },
+				{ id: 1, description: 'test', settings: { name: { value: 'MyMethod' } } },
 			];
 			uiState.methods = {
 				creates: [],
-				updates: [ { id: 1, name: { value: 'MyNewMethod' } } ],
+				updates: [ { id: 1, description: { value: 'update' }, name: { value: 'MyNewMethod' } } ],
 				deletes: [],
 				currentlyEditingId: 1,
 			};
 
-			expect( getCurrentlyEditingPaymentMethod( state ) ).to.deep.equal( { id: 1, settings: { name: { value: 'MyNewMethod' } } } );
+			expect( getCurrentlyEditingPaymentMethod( state ) ).to.deep.equal( {
+				id: 1,
+				description: 'update',
+				settings: { name: { value: 'MyNewMethod' } }
+			} );
 		} );
 
 		it( 'should return new method from creates when there is a newly created method being edited', () => {


### PR DESCRIPTION
We removed the check payment method before launch because you couldn't properly configure the description field, which is displayed on the checkout form.

This adds it back in, with the ability to manage the description properly.

This fixes #16629.
Also see #16658 -- which we will keep open to handle a few other things like not having this enabled by default, and pre-filling the store address into the description.

To test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/settings/payments/:site` and make sure you see check payments under "offline".
* Click manage, and make sure you can edit the title, description, and instructions. Hit cancel.
* Click manage again and make sure all these fields reset. Update them again and this time hit done.
* Click manage again and verify your changes are still present.
* Hit the save button. Verify your description and other fields saved.