### PR TITLE
Store: Fix spelling of agree for Stripe / ApplePay

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -163,7 +163,7 @@ class PaymentMethodStripe extends Component {
 						onChange={ this.onEditFieldHandler } />
 					<span>
 						{ translate(
-							'By using ApplePay you aggree to Stripe and ' +
+							'By using ApplePay you agree to Stripe and ' +
 							'Apple\'s terms of service'
 						) }
 					</span>


### PR DESCRIPTION
Fixes #16664 

To test:
* Navigate to https://wordpress.com/store/settings/{site}
* Click on the Setup button for Stripe
* Verify agree is spelled correctly in the ApplePay section of the dialog