### PR TITLE
WebPreview Docs: Set syntax to JSX & fix snippet indentation

### DIFF
--- a/client/components/web-preview/README.md
+++ b/client/components/web-preview/README.md
@@ -3,10 +3,12 @@ Web Preview
 
 This component facilitates the display of iframed content. See the `propTypes` for configurable options. Basic usage is:
 
-```js
-<WebPreview showPreview={ this.showPreview() }
+```jsx
+<WebPreview 
+	showPreview={ this.showPreview() }
 	onClose={ this.hidePreview }
-	previewUrl={ this.getUrlToIframe() } >
+	previewUrl={ this.getUrlToIframe() }
+>
 ```
 
 * * *
@@ -24,10 +26,11 @@ Calypso is meant to be run over HTTPS when in production. Since WebPreview uses 
 
 With those constraints in mind, usage is the following:
 
-```js
+```jsx
 <WithPreviewProps
-		url={ myFrontEndPreview }
-		isPreviewable={ isMySitePreviewable }>
+	url={ myFrontEndPreview }
+	isPreviewable={ isMySitePreviewable }
+>
 	{ ( props ) =>
 		<Button { ...props } icon={ isMySitePreviewable ? 'visible' : 'external' }>
 			View Site
@@ -38,7 +41,7 @@ With those constraints in mind, usage is the following:
 
 `isPreviewable` should be a boolean to determine whether the URL should be loaded in WebPreview or externally. Bear in mind that not all front-end links are previewable — Jetpack sites, for instance, may not be supported for a number of reasons, including absent HTTPS support. As of this writing, a suggestion is to rely on the `getSite` (state/sites/selectors) selector, which relies on `lib/site/computed-attributes` to return a `is_previewable` attribute:
 
-```js
+```jsx
 const site = getSite( state, siteId );
 const isPreviewable = get( site, 'is_previewable' );
 


### PR DESCRIPTION
I figured the `README.md` could use a couple of tweaks.

Updating to JSX gives slightly nicer highlighting (GH only, DevDocs aliases jsx to js) and the indentation shows the JSX closer to how it should appear in our code:

```js
<WebPreview showPreview={ this.showPreview() }
	onClose={ this.hidePreview }
	previewUrl={ this.getUrlToIframe() } >
```

```jsx
<WebPreview 
    showPreview={ this.showPreview() }
    onClose={ this.hidePreview }
    previewUrl={ this.getUrlToIframe() }
>
```

Please take a look & let me know if it's all copacetic :)
