### PR TITLE
Login: Redirect old browsers to wp-login.php

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -114,7 +114,20 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				}
 
 				if ( ! isSupported() ) {
-					window.location = 'https://wordpress.com/browsehappy?url=' + encodeURIComponent( window.location );
+					if ( window.location.pathname.match( /^\/log-in/ ) ) {
+
+						var login = 'https://wordpress.com/wp-login.php';
+						if ( window.location.search ) {
+							login += window.location.search + '&';
+						} else {
+							login += '?';
+						}
+						login += 'no_calypso=1';
+
+						window.location = login;
+					} else {
+						window.location = 'https://wordpress.com/browsehappy?url=' + encodeURIComponent( window.location );
+					}
 				}
 			})();
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -85,7 +85,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		script.
 			(function() {
 				function isSupported() {
-					var ios, version, ua;
+					var ios, version, ua, android;
 
 					ua = window.navigator.userAgent;
 
@@ -108,6 +108,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					if ( ios && version < 6 ) {
 						// disable for now because it is breaking Chrome on iOS
 						//return false;
+					}
+
+					android = getFirstMatch( /android (\d+)/i );
+					if ( android && android < 3 ) {
+						return false;
 					}
 
 					return true;

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -85,7 +85,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		script.
 			(function() {
 				function isSupported() {
-					var ios, version, ua, android;
+					var ios, version, ua, android, matches;
 
 					ua = window.navigator.userAgent;
 
@@ -119,9 +119,15 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				}
 
 				if ( ! isSupported() ) {
-					if ( window.location.pathname.match( /^\/log-in/ ) ) {
+					if ( matches = window.location.pathname.match( /^\/log-in(?:\/([a-z]{2}))?\/?$/ ) ) {
+						var login = 'https://'
 
-						var login = 'https://wordpress.com/wp-login.php';
+						if ( matches[1] ) {
+							login += matches[1] + '.';
+						}
+
+						login += 'wordpress.com/wp-login.php';
+
 						if ( window.location.search ) {
 							login += window.location.search + '&';
 						} else {


### PR DESCRIPTION
This pull request addresses #16670 by redirecting old browsers visiting `/log-in` to `wp-login.php`.

#### Testing instructions

1. Run `git checkout add/16670-redirect-old-browser-logins` and start your server, or open a [live branch](https://calypso.live/log-in?branch=add/16670-redirect-old-browser-logins)
2. Apply D6600 to your sandbox, sandbox wordpress.com, and any locale subdomains you're testing.
2. Open the [`Log In` page](http://calypso.localhost:3000/log-in) in an old browser
3. Check that you're redirected to `wp-login.php`
4. Check that all query args survive the redirection.

#### Reviews

- [x] Code
- [x] Product
- [ ] Tests