### PR TITLE
Preview: Initial loading state

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -78,6 +78,7 @@ $z-layers: (
 		'.thank-you-card__header': 1,
 		'.comment-detail.card.is-collapsed:hover': 1,
 		'.comment-detail.card.accessible-focus:focus': 1,
+		'.web-preview__loading-message-wrapper': 1,
 		'.web-preview__inner .spinner-line': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -247,7 +247,7 @@ export class WebPreviewContent extends Component {
 					<SpinnerLine />
 				}
 				<div className="web-preview__placeholder">
-					{ this.props.showPreview && ! this.state.loaded && 'seo' !== this.state.device &&
+					{ ( this.props.showPreview || ! this.props.isModalWindow ) && ! this.state.loaded && 'seo' !== this.state.device &&
 						<div className="web-preview__loading-message-wrapper">
 							<Spinner />
 							{ this.props.loadingMessage &&

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -18,7 +18,6 @@ import Toolbar from './toolbar';
 import touchDetect from 'lib/touch-detect';
 import { isWithinBreakpoint } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
-import Spinner from 'components/spinner';
 import SpinnerLine from 'components/spinner-line';
 import SeoPreviewPane from 'components/seo-preview-pane';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -233,6 +232,13 @@ export class WebPreviewContent extends Component {
 			'is-loaded': this.state.loaded,
 		} );
 
+		const showLoadingMessage = (
+			! this.state.loaded &&
+			this.props.loadingMessage &&
+			( this.props.showPreview || ! this.props.isModalWindow ) &&
+			this.state.device !== 'seo'
+		);
+
 		return (
 			<div className={ className }>
 				<Toolbar setDeviceViewport={ this.setDeviceViewport }
@@ -247,14 +253,11 @@ export class WebPreviewContent extends Component {
 					<SpinnerLine />
 				}
 				<div className="web-preview__placeholder">
-					{ ( this.props.showPreview || ! this.props.isModalWindow ) && ! this.state.loaded && 'seo' !== this.state.device &&
+					{ showLoadingMessage &&
 						<div className="web-preview__loading-message-wrapper">
-							<Spinner />
-							{ this.props.loadingMessage &&
-								<span className="web-preview__loading-message">
-									{ this.props.loadingMessage }
-								</span>
-							}
+							<span className="web-preview__loading-message">
+								{ this.props.loadingMessage }
+							</span>
 						</div>
 					}
 					<div

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -307,7 +307,7 @@ a.web-preview__external.button {
 }
 
 .web-preview__loading-message strong {
-	color: #537994;
+	color: $gray-text-min;
 	display: block;
 	font-size: 24px;
 	margin-bottom: 5px;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -300,14 +300,32 @@ a.web-preview__external.button {
 	left: initial;
 }
 
+.web-preview__loading-message-wrapper {
+	display: flex;
+	justify-content: center;
+	height: 100%;
+	flex-direction: column;
+	position: relative;
+	z-index: z-index( 'root', '.web-preview__loading-message-wrapper' );
+}
+
+.web-preview__loading-message-wrapper .spinner__image {
+	margin: 0 auto 16px;
+}
+
 .web-preview__loading-message {
-	color: $gray;
-	font-size: 18px;
+	color: $gray-text-min;
 	font-weight: 300;
 	text-align: center;
 	display: block;
-	margin: 48px 0;
-	height: 100%;
+	font-size: 16px;
+}
+
+.web-preview__loading-message strong {
+	color: #537994;
+	display: block;
+	font-size: 24px;
+	margin-bottom: 5px;
 }
 
 .web-preview__inner .spinner-line {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -289,19 +289,6 @@ a.web-preview__external.button {
 	position: relative;
 }
 
-.web-preview .spinner {
-	margin-left: -10px;
-	position: absolute;
-		top: 45%;
-		left: 50%;
-}
-
-.web-preview .pulsing-dot {
-	right: 24px;
-	top: 22px;
-	left: initial;
-}
-
 .web-preview__loading-message-wrapper {
 	display: flex;
 	justify-content: center;
@@ -309,10 +296,6 @@ a.web-preview__external.button {
 	flex-direction: column;
 	position: relative;
 	z-index: z-index( 'root', '.web-preview__loading-message-wrapper' );
-}
-
-.web-preview__loading-message-wrapper .spinner__image {
-	margin: 0 auto 16px;
 }
 
 .web-preview__loading-message {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -244,9 +244,11 @@ a.web-preview__external.button {
 	opacity: 0;
 	transition: opacity 0.2s ease-in-out;
 	margin: 0 auto;
+	pointer-events: none;
 
 	.is-loaded & {
 		opacity: 1;
+		pointer-events: all;
 	}
 }
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -292,17 +292,17 @@ a.web-preview__external.button {
 .web-preview__loading-message-wrapper {
 	display: flex;
 	justify-content: center;
-	height: 100%;
 	flex-direction: column;
-	position: relative;
+	position: absolute;
+	height: 100%;
+	width: 100%;
 	z-index: z-index( 'root', '.web-preview__loading-message-wrapper' );
+	text-align: center;
 }
 
 .web-preview__loading-message {
 	color: $gray-text-min;
 	font-weight: 300;
-	text-align: center;
-	display: block;
 	font-size: 16px;
 }
 

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -145,6 +145,11 @@ class PreviewMain extends React.Component {
 					onClose={ this.focusSidebar }
 					previewUrl={ this.state.previewUrl }
 					externalUrl={ this.state.externalUrl }
+					loadingMessage={
+						this.props.translate( '{{strong}}One moment please…{{/strong}} loading your site.',
+							{ components: { strong: <strong /> } }
+						)
+					}
 				/>
 			</Main>
 		);

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -23,27 +23,6 @@
     }
 }
 
-.editor-preview .web-preview__loading-message-wrapper {
-	display: flex;
-	justify-content: center;
-	height: 100%;
-}
-
-.editor-preview .web-preview__loading-message {
-	font-size: 16px;
-	height: initial;
-	position: relative;
-		top: 30%;
-		z-index: z-index( 'root', '.editor-preview' );
-
-	strong {
-		color: $gray-text-min;
-		display: block;
-		font-size: 24px;
-		margin-bottom: 5px;
-	}
-}
-
 .editor-preview .web-preview__close.button,
 .editor-preview a.web-preview__external.button,
 .editor-preview .web-preview__edit.button {


### PR DESCRIPTION
This PR takes the loader styling from `EditorPreview` and brings it to general `WebPreviewContent` component so everybody can use it without the need for extra CSS.

It also adds the preview message to "View Site" section (/view/:slug).

The loading message can only be seen for the initial load of the preview. All subsequent page loads (that user triggers by clicking links in preview) have no loading state, yet.

This PR also adds `pointer-events: none` to the preview iframe that is hidden so you cannot interact with invisible iframe.

**Test:**

- go to https://calypso.live/view/?branch=update/view-site-loading-state and pick your favorite site
- instead of the grey screen, see our new loading message

**Visual:**

<img width="1435" alt="screen shot 2017-07-28 at 12 37 33" src="https://user-images.githubusercontent.com/156676/28713987-9f3a64e2-7391-11e7-8847-2724510d04c8.png">

**For designers:**

The spinner circle above the text was there all the time but it was broken by CSS, thus invisible. Should we keep it there? I'd personally remove it and keep just the text content there (that's what you can currently see in post-post) and combine this with the `SpinnerLine` from #16675.

**Todo:**
- [x] based on design review, maybe remove the circular spinner