### PR TITLE
Preview: Add SpinnerLine for initial and subsequent loadings

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -78,6 +78,7 @@ $z-layers: (
 		'.thank-you-card__header': 1,
 		'.comment-detail.card.is-collapsed:hover': 1,
 		'.comment-detail.card.accessible-focus:focus': 1,
+		'.web-preview__inner .spinner-line': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -19,6 +19,7 @@ import touchDetect from 'lib/touch-detect';
 import { isMobile } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import Spinner from 'components/spinner';
+import SpinnerLine from 'components/spinner-line';
 import SeoPreviewPane from 'components/seo-preview-pane';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -32,7 +33,8 @@ export class WebPreviewContent extends Component {
 	state = {
 		iframeUrl: null,
 		device: this.props.defaultViewportDevice || 'computer',
-		loaded: false
+		loaded: false,
+		isLoadingSubpage: false
 	};
 
 	setIframeInstance = ( ref ) => {
@@ -115,11 +117,15 @@ export class WebPreviewContent extends Component {
 			case 'focus':
 				this.removeSelection();
 				return;
+			case 'loading':
+				this.setState( { isLoadingSubpage: true } );
+				return;
 		}
 	}
 
 	handleLocationChange = ( payload ) => {
 		this.props.onLocationUpdate( payload.pathname );
+		this.setState( { isLoadingSubpage: false } );
 	}
 
 	removeSelection = () => {
@@ -196,7 +202,7 @@ export class WebPreviewContent extends Component {
 	}
 
 	setLoaded = () => {
-		if ( this.state.loaded ) {
+		if ( this.state.loaded && ! this.state.isLoadingSubpage ) {
 			debug( 'already loaded' );
 			return;
 		}
@@ -210,7 +216,7 @@ export class WebPreviewContent extends Component {
 		} else {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
-		this.setState( { loaded: true } );
+		this.setState( { loaded: true, isLoadingSubpage: false } );
 
 		this.focusIfNeeded();
 	}
@@ -237,7 +243,11 @@ export class WebPreviewContent extends Component {
 					showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
 					showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
 					selectSeoPreview={ this.selectSEO }
+					isLoading={ this.state.isLoadingSubpage }
 				/>
+				{ ( ! this.state.loaded || this.state.isLoadingSubpage ) &&
+					<SpinnerLine />
+				}
 				<div className="web-preview__placeholder">
 					{ this.props.showPreview && ! this.state.loaded && 'seo' !== this.state.device &&
 						<div className="web-preview__loading-message-wrapper">

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -310,6 +310,7 @@ a.web-preview__external.button {
 
 .web-preview__inner .spinner-line {
 	position: absolute;
+		top: 22px;
 	width: 100%;
-	top: 20px;
+	z-index: z-index( 'root', '.web-preview__inner .spinner-line' );
 }

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -282,6 +282,7 @@ a.web-preview__external.button {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+	position: relative;
 }
 
 .web-preview .spinner {
@@ -305,4 +306,10 @@ a.web-preview__external.button {
 	display: block;
 	margin: 48px 0;
 	height: 100%;
+}
+
+.web-preview__inner .spinner-line {
+	position: absolute;
+	width: 100%;
+	top: 20px;
 }


### PR DESCRIPTION
This PR adds a `SpinnerLine` component to the `WebPreviewContent` to indicate loading state. This will work for both initial preview load and also for subsequent loads that happen when the user clicks a link inside the preview. 

After some discussions in this PR, I aligned it just under the of `PreviewToolbar` so it doesn't collide with buttons that are present in theme modal preview. It will overlay top 2px of previewed page during the load but I don't see that as a problem. 

**Visual:**

https://videopress.com/v/9iTNH0fu?hd=1

**To test:**

- go to [calypso.live/view/?branch=…](https://calypso.live/view/?branch=experiment/preview-loading-for-inner-navigation) and pick your favorite
- watch the spinner spin
- navigate to subpage or post inside the preview
- watch the spinner spin
- [like a record](https://www.youtube.com/watch?v=PGNiXGX2nLU)