### PR TITLE
Private site: Add the site name to the private site screen

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -12,7 +12,7 @@ import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 
 export default {
 	login( context, next ) {
-		const { lang, path, params: { flow, twoFactorAuthType } } = context;
+		const { lang, path, params: { flow, twoFactorAuthType }, query: { site } } = context;
 
 		context.primary = (
 			<WPLogin
@@ -20,7 +20,8 @@ export default {
 				path={ path }
 				twoFactorAuthType={ twoFactorAuthType }
 				socialConnect={ flow === 'social-connect' }
-				privateSite={ flow === 'private-site' } />
+				privateSite={ flow === 'private-site' }
+				site={ site } />
 		);
 
 		next();

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -87,13 +87,14 @@ export class Login extends React.Component {
 		const {
 			isLoggedIn,
 			privateSite,
+			site,
 			socialConnect,
 			twoFactorAuthType,
 		} = this.props;
 
 		if ( privateSite && isLoggedIn ) {
 			return (
-				<PrivateSite />
+				<PrivateSite site={ site } />
 			);
 		}
 

--- a/client/login/wp-login/private-site.jsx
+++ b/client/login/wp-login/private-site.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import { addSchemeIfMissing } from 'lib/url';
 
 class PrivateSite extends Component {
 	static propTypes = {
@@ -16,7 +17,7 @@ class PrivateSite extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { translate, site } = this.props;
 
 		return (
 			<Card className="wp-login__private-site">
@@ -25,7 +26,11 @@ class PrivateSite extends Component {
 				</div>
 
 				<h2 className="wp-login__private-site-header">
-					{ translate( 'This is a private WordPress.com site.' ) }
+					{ translate( 'The site %(site)s is a private WordPress.com site.', {
+						args: {
+							site: addSchemeIfMissing( site, 'https' )
+						}
+					} ) }
 				</h2>
 
 				<p>


### PR DESCRIPTION
@danhauk suggested we add a site name to the private site screen:

<img width="451" alt="screen shot 2017-07-28 at 11 31 39" src="https://user-images.githubusercontent.com/275961/28713962-2142d00e-7389-11e7-9914-49d7ea39cb9a.png">
<img width="545" alt="screen shot 2017-07-28 at 11 31 26" src="https://user-images.githubusercontent.com/275961/28713963-21441a68-7389-11e7-9ac9-68155bd8213a.png">

The approach I am proposing here uses a value from the query string to show the site. The problem is that anyone could update this value if they wanted to. Are we concerned about this?

For example: http://calypso.localhost:3000/log-in/private-site?site=google.com