### PR TITLE
View Site: Update document title

### DIFF
--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -112,7 +112,7 @@ class PreviewMain extends React.Component {
 
 		return (
 			<Main className="preview">
-				<DocumentHead title={ translate( 'Site Preview' ) } />
+				<DocumentHead title={ translate( 'Your Site' ) } />
 				<WebPreviewContent
 					onLocationUpdate={ this.updateSiteLocation }
 					showUrl={ !! this.state.externalUrl }


### PR DESCRIPTION
We want the word "Preview" gone for this section yet we still have it in the title from our first version of this view. 

**Test:**

- go to https://calypso.live/view/?branch=update/view-site-title
- pick a site, any site
- watch title of your current tab for the new title