### PR TITLE
Login: Fix navigating back from Lost Password page

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -39,7 +39,7 @@ export class LoginLinks extends React.Component {
 		this.props.recordTracksEvent( 'calypso_login_help_link_click' );
 	};
 
-	recordLostPhoneLinkClick = ( event ) => {
+	handleLostPhoneLinkClick = ( event ) => {
 		event.preventDefault();
 
 		this.props.recordTracksEvent( 'calypso_login_lost_phone_link_click' );
@@ -47,7 +47,7 @@ export class LoginLinks extends React.Component {
 		page( login( { isNative: true, twoFactorAuthType: 'backup' } ) );
 	};
 
-	recordMagicLoginLinkClick = ( event ) => {
+	handleMagicLoginLinkClick = ( event ) => {
 		event.preventDefault();
 
 		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' );
@@ -97,7 +97,7 @@ export class LoginLinks extends React.Component {
 		}
 
 		return (
-			<a href="#" key="lost-phone-link" onClick={ this.recordLostPhoneLinkClick }>
+			<a href="#" key="lost-phone-link" onClick={ this.handleLostPhoneLinkClick }>
 				{ this.props.translate( "I can't access my phone" ) }
 			</a>
 		);
@@ -113,7 +113,7 @@ export class LoginLinks extends React.Component {
 		}
 
 		return (
-			<a href="#" key="magic-login-link" onClick={ this.recordMagicLoginLinkClick }>
+			<a href="#" key="magic-login-link" onClick={ this.handleMagicLoginLinkClick }>
 				{ this.props.translate( 'Email me a login link' ) }
 			</a>
 		);

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -85,7 +85,8 @@ export class LoginLinks extends React.Component {
 				icon={ true }
 				onClick={ this.recordHelpLinkClick }
 				target="_blank"
-				href="https://en.support.wordpress.com/security/two-step-authentication/">
+				href="https://en.support.wordpress.com/security/two-step-authentication/"
+			>
 				{ this.props.translate( 'Get help' ) }
 			</ExternalLink>
 		);
@@ -129,6 +130,7 @@ export class LoginLinks extends React.Component {
 				href={ addQueryArgs( { action: 'lostpassword' }, login( { locale: this.props.locale } ) ) }
 				key="lost-password-link"
 				onClick={ this.recordResetPasswordLinkClick }
+				rel="external"
 			>
 				{ this.props.translate( 'Lost your password?' ) }
 			</a>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -14,13 +14,14 @@ import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'gridicons';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { recordPageView, recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { login } from 'lib/paths';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
+		isLoggedIn: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		privateSite: PropTypes.bool,
 		recordPageView: PropTypes.func.isRequired,
@@ -107,7 +108,7 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
-		if ( this.props.currentUser ) {
+		if ( this.props.isLoggedIn ) {
 			return null;
 		}
 
@@ -148,7 +149,7 @@ export class LoginLinks extends React.Component {
 }
 
 const mapState = ( state ) => ( {
-	currentUser: getCurrentUser( state ),
+	isLoggedIn: Boolean( getCurrentUserId( state ) )
 } );
 
 const mapDispatch = {


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/16140 so the `Login` page is displayed when coming from the `Lost Password` page.
 
#### Testing instructions
 
1. Run `git checkout fix/login-lost-password` and start your server
2. Update the [`Lost your password?` link](https://github.com/Automattic/wp-calypso/blob/929d8965ac669a40ab06e54608bd0a0cecb123a1/client/login/wp-login/login-links.jsx#L130) to point to http://calypso.localhost:3000/themes
4. Open the [`Login` page](http://calypso.localhost:3000/log-in)
5. Click the `Lost your password?` link in the footer
6. Assert that you are presented with the [`Themes` page](http://calypso.localhost:3000/themes)
7. Assert that a `Document` network request to http://calypso.localhost:3000/themes was triggered
8. Hit your browser's `Back` button
9. Assert that you're back on the `Login` page
 
#### Reviews
 
- [x] Code
- [x] Product
- [ ] Tests