### PR TITLE
Components: Show empty SectionHeader with a one-line height

### DIFF
--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -39,6 +39,9 @@ var Cards = React.createClass( {
 
 				<SectionHeader label={ this.translate( 'Team' ) } count={ 10 } href="/devdocs/design/section-header">
 				</SectionHeader>
+
+				<h3>Empty SectionHeader</h3>
+				<SectionHeader />
 			</div>
 		);
 	}

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -10,28 +10,22 @@ import classNames from 'classnames';
 import CompactCard from 'components/card/compact';
 import Count from 'components/count';
 
-export default React.createClass( {
-	getDefaultProps() {
-		return {
-			label: '',
-			href: null
-		};
-	},
+export default class SectionHeader extends PureComponent {
+	static defaultProps = {
+		label: '',
+		href: null,
+	};
 
 	render() {
-		const classes = classNames(
-			this.props.className,
-			'section-header'
-		);
+		const classes = classNames( this.props.className, 'section-header' );
 
 		return (
 			<CompactCard className={ classes } href={ this.props.href }>
 				<div className="section-header__label">
-					<span className="section-header__label-text">{ this.props.label }</span>
-					{
-						'number' === typeof this.props.count &&
-							<Count count={ this.props.count } />
-					}
+					<span className="section-header__label-text">
+						{ this.props.label }
+					</span>
+					{ 'number' === typeof this.props.count && <Count count={ this.props.count } /> }
 				</div>
 				<div className="section-header__actions">
 					{ this.props.children }
@@ -39,4 +33,4 @@ export default React.createClass( {
 			</CompactCard>
 		);
 	}
-} );
+}

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -17,7 +17,9 @@ export default class SectionHeader extends PureComponent {
 	};
 
 	render() {
-		const classes = classNames( this.props.className, 'section-header' );
+		const hasCount = 'number' === typeof this.props.count;
+		const isEmpty = ! ( this.props.label || hasCount || this.props.children );
+		const classes = classNames( this.props.className, 'section-header', { 'is-empty': isEmpty } );
 
 		return (
 			<CompactCard className={ classes } href={ this.props.href }>
@@ -25,7 +27,7 @@ export default class SectionHeader extends PureComponent {
 					<span className="section-header__label-text">
 						{ this.props.label }
 					</span>
-					{ 'number' === typeof this.props.count && <Count count={ this.props.count } /> }
+					{ hasCount && <Count count={ this.props.count } /> }
 				</div>
 				<div className="section-header__actions">
 					{ this.props.children }

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -9,6 +9,10 @@
 	&:after {
 		content: '';
 	}
+
+	&.is-empty .section-header__label:after {
+		content: '\00a0';
+	}
 }
 
 .section-header__label {


### PR DESCRIPTION
When rendering an empty `<SectionHeader />`, render it with the same height as if it had a `label` and/or `children`. The empty `SectionHeader` is useful as a placeholder when the content is loading. The `/posts` page displays a similar empty `SectionNav` when the posts are loading.

Implemented by adding a nbsp after the label content (`::after { content: '\00a0' }`). The same technique is used by the `placeholder` mixin.

The first commit in this does a drive-by ES6-ification of the `SectionHeader` component. The real changes are in the second commit.

Before:
<img width="651" alt="section-header-before" src="https://user-images.githubusercontent.com/664258/28717169-fca0d044-73a0-11e7-9814-68a5d15e5ecd.png">

After:
<img width="649" alt="section-header-after" src="https://user-images.githubusercontent.com/664258/28717173-008dd3c8-73a1-11e7-88d8-ca50ec180ce1.png">

Edit: changed the impl to insert the nbsp only when the component is completely empty.
~Does the new extra nbsp after the label have any observable and unwanted effects? The only change I found is that it forces a space between the label and actions elements when they are too close together -- see below.~

Before:
<img width="343" alt="section-header-wrap-before" src="https://user-images.githubusercontent.com/664258/28717176-03fec418-73a1-11e7-86f1-0fadb1f300ab.png">
After:
<img width="342" alt="section-header-wrap-after" src="https://user-images.githubusercontent.com/664258/28717182-07003868-73a1-11e7-843f-dcfb083d4f54.png">
