### PR TITLE
Editor: Update Post Scheduler logic and z-index

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -119,6 +119,7 @@ $z-layers: (
 		'.first-view': 175,
 		'.editor-confirmation-sidebar__overlay': 176,
 		'.editor-confirmation-sidebar__sidebar': 177,
+		'.popover.editor-ground-control__post-schedule-popover': 178,
 		'.popover.editor-visibility__popover': 179,
 		'.feature-example__gradient': 179,
 		'.global-notices': 179,

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -162,6 +162,7 @@ export class EditorGroundControl extends PureComponent {
 				position={ 'bottom left' }
 				context={ this.refs && this.refs.schedulePost }
 				id="editor-post-schedule"
+				className="editor-ground-control__post-schedule-popover"
 			>
 				<PostScheduler initialDate={ this.props.moment() }
 					post={ this.props.post }

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -256,3 +256,10 @@
 	}
 
 }
+
+.popover {
+	&.editor-ground-control__post-schedule-popover {
+		/* applying a lower z-index to ensure it is layered behind global notice */
+		z-index: z-index( 'root', '.popover.editor-ground-control__post-schedule-popover' );
+	}
+}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -919,8 +919,13 @@ export const PostEditor = React.createClass( {
 		}
 
 		const currentDate = this.moment( date );
-		const ModifiedDate = this.moment( savedPost.date );
-		const diff = !! currentDate.diff( ModifiedDate );
+		const modifiedDate = this.moment( savedPost.date );
+		const dateChange = ! (
+			currentDate.get( 'date' ) === modifiedDate.get( 'date' ) &&
+			currentDate.get( 'month' ) === modifiedDate.get( 'month' ) &&
+			currentDate.get( 'year' ) === modifiedDate.get( 'year' )
+		);
+		const diff = !! currentDate.diff( modifiedDate ) && !! dateChange;
 
 		if ( savedPost.type === 'post' && utils.isPublished( savedPost ) && diff ) {
 			this.warnPublishDateChange();


### PR DESCRIPTION
This fixes both #16572 and #16574 since they're both rather small and related. If necessary, I can break them out though.

For #16572, changing the time on a post (leaving the same date) should not show a warning since the post slug will not change.

> Are you sure about that? If you change the date, existing links to your post will stop working.

This PR updates the logic so a warning is not shown if a change results in the same date.

For #16574, the global warning notice is shown behind the post scheduler due to a z-index issue. This applies an additional class to the popover component used in the scheduler so we can set a z-index that appears behind the global notice.

## To Test
1. Start at http://calypso.localhost:3000/posts/ for a site.
2. Click "Edit" to open the editor for a published post on your site.
3. Click the calendar icon next to the "Update" button to open the schedule popover.
4. Change the time on the post. You should not receive a warning that changing the date will affect existing posts.
5. Change the date on the post. You should receive the warning mentioned above.

In both cases, the warning should appear in front of the post scheduler, not behind.

Here's a visual contrast for the z-index issue:

**Before**
<img width="943" alt="screen shot 2017-07-28 at 7 30 30 am" src="https://user-images.githubusercontent.com/7240478/28719303-aabb357e-7366-11e7-84b7-188b923d3b3b.png">

**After**
<img width="839" alt="screen shot 2017-07-28 at 7 17 02 am" src="https://user-images.githubusercontent.com/7240478/28719285-93b35fd2-7366-11e7-96c2-951c68575473.png">

Fixes #16572, Fixes #16574