### PR TITLE
Simple Payments: check status of a product returned by REST API

### DIFF
--- a/client/lib/simple-payments/utils.js
+++ b/client/lib/simple-payments/utils.js
@@ -3,5 +3,5 @@
  */
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 
-export const isValidSimplePaymentsProduct = ( product ) =>
-	product.type === SIMPLE_PAYMENTS_PRODUCT_POST_TYPE;
+export const isValidSimplePaymentsProduct = product =>
+	product.type === SIMPLE_PAYMENTS_PRODUCT_POST_TYPE && product.status === 'publish';


### PR DESCRIPTION
...and drop it if the status is not 'publish'. Prevents treating trashed payment buttons as if they still existed.

To test:
This change should remove the "funky" behavior described by @lamosty in https://github.com/Automattic/wp-calypso/pull/16618#issuecomment-318620723

1. Create a payment button on your blog post
2. Open the "Add Payment Button" modal and trash the button in the list
3. After going back to the post, the button should no longer be rendered -- the `[simple-payment id="123"]` shortcode now points to an invalid ID.
4. Open the payment button list again -- it shouldn't show the trashed button -- only the existing ones.