### PR TITLE
Set plans copy change test to 100%

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -71,8 +71,8 @@ module.exports = {
 	signupPlansCopyChanges: {
 		datestamp: '20170623',
 		variations: {
-			original: 50,
-			modified: 50,
+			original: 0,
+			modified: 100, //Set to 100% while copy is translated
 		},
 		defaultVariation: 'original',
 	},


### PR DESCRIPTION
We just completed our plans test for WP.com and Jetpack. Both tests were a success. In this PR, I'd like to set the test to 100% of English viewers so I can get the copy translated for Non-English folks.

cc @markryall @taggon 