### PR TITLE
Plugin Uploads: Added Tracks Messages

### DIFF
--- a/client/lib/analytics/README.md
+++ b/client/lib/analytics/README.md
@@ -24,6 +24,9 @@ Automatticians may refer to internal documentation for more information about MC
 
 # Usage
 
+Note: In most situations it is best to use the [Analytics middleware](https://github.com/Automattic/wp-calypso/tree/master/client/state/analytics), which has no direct browser dependencies and therefore will not complicate any unit testing of the modules where it is used.
+
+If you do still want to use this library directly:
 ```js
 // require the module
 import analytics from 'lib/analytics';

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -16,9 +16,12 @@ import {
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 export const uploadPlugin = ( { dispatch }, action ) => {
 	const { siteId, file } = action;
+
+	dispatch( recordTracksEvent( 'calypso_plugin_upload' ) );
 
 	dispatch( http( {
 		method: 'POST',
@@ -62,6 +65,11 @@ const showErrorNotice = ( dispatch, error ) => {
 
 export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
 	const { slug: pluginId } = data;
+
+	dispatch( recordTracksEvent( 'calypso_plugin_upload_complete', {
+		plugin_id: pluginId
+	} ) );
+
 	dispatch( completePluginUpload( siteId, pluginId ) );
 	dispatch( {
 		type: PLUGIN_INSTALL_REQUEST_SUCCESS,
@@ -74,6 +82,12 @@ export const uploadComplete = ( { dispatch }, { siteId }, next, data ) => {
 };
 
 export const receiveError = ( { dispatch }, { siteId }, next, error ) => {
+
+	dispatch( recordTracksEvent( 'calypso_plugin_upload_error', {
+		error_code: error.error,
+		error_message: error.message
+	} ) );
+
 	showErrorNotice( dispatch, error );
 	dispatch( pluginUploadError( siteId, error ) );
 };


### PR DESCRIPTION
Allow analytics on Plugin Uploads successes and failures.

To Test:

1. Set debug command in Developer Console with: `localStorage.setItem('debug', 'calypso:analytics:tracks')`
2. Go to this page to test: http://calypso.localhost:3000/plugins/upload
3. Upload a plugin, and it will generate a `calypso_plugin_upload` in Tracks.
* If there is an error it will generate a `calypso_plugin_upload_error ` in Tracks with the corresponding error messages.
* If there is a success it will generate a `calypso_plugin_upload_complete ` in Tracks, and also include the Plugin's ID.
4. Open Developer Console to verify messages being sent to Tracks, like here: 

![screencap](https://user-images.githubusercontent.com/2140796/28723717-a47c7a96-7385-11e7-82e4-783d6517d7c3.png)
