### PR TITLE
Remove/plans signup test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,16 +68,8 @@ module.exports = {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	signupPlansCopyChanges: {
-		datestamp: '20170623',
-		variations: {
-			original: 0,
-			modified: 100, //Set to 100% while copy is translated
-		},
-		defaultVariation: 'original',
-	},
-	jetpackConnectPlansCopyChanges: {
-		datestamp: '20170728',
+	showCartAbandonmentNotice: {
+		datestamp: '20170630',
 		variations: {
 			original: 50,
 			modified: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,8 +68,8 @@ module.exports = {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	showCartAbandonmentNotice: {
-		datestamp: '20170630',
+	jetpackConnectPlansCopyChanges: {
+		datestamp: '20170728',
 		variations: {
 			original: 50,
 			modified: 50,

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -132,16 +132,16 @@ export const FEATURE_MARKETING_AUTOMATION = 'marketing-automation';
 export const PLANS_LIST = {
 	[ PLAN_FREE ]: {
 		getTitle: () => i18n.translate( 'Free' ),
-		getAudience: () => 'Best for students', //PLANS A/B TEST: Translate if test passes
-		getBlogAudience: () => 'Best for students', //PLANS A/B TEST: Translate if test passes
-		getPortfolioAudience: () => 'Best for students', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for students' ),
+		getBlogAudience: () => i18n.translate( 'Best for students' ),
+		getPortfolioAudience: () => i18n.translate( 'Best for students' ),
 		getPriceTitle: () => i18n.translate( 'Free for life' ), //TODO: DO NOT USE
 		getProductId: () => 1,
 		getStoreSlug: () => PLAN_FREE,
 		getPathSlug: () => 'beginner',
 		getDescription: () => i18n.translate( 'Get a free website and be on your way to publishing your ' +
 			'first post in less than five minutes.' ),
-		getFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getFeatures: () => [ // pay attention to ordering, shared features should align on /plan page
 			FEATURE_WP_SUBDOMAIN,
 			FEATURE_JETPACK_ESSENTIAL,
 			FEATURE_COMMUNITY_SUPPORT,
@@ -149,17 +149,17 @@ export const PLANS_LIST = {
 			FEATURE_BASIC_DESIGN,
 			FEATURE_3GB_STORAGE
 		],
-		getSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getSignupFeatures: () => [
 			FEATURE_COMMUNITY_SUPPORT,
 			FEATURE_WP_SUBDOMAIN_SIGNUP,
 			FEATURE_FREE_THEMES_SIGNUP,
 		],
-		getBlogSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getBlogSignupFeatures: () => [
 			FEATURE_COMMUNITY_SUPPORT,
 			FEATURE_WP_SUBDOMAIN_SIGNUP,
 			FEATURE_FREE_THEMES_SIGNUP,
 		],
-		getPortfolioSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getPortfolioSignupFeatures: () => [
 			FEATURE_COMMUNITY_SUPPORT,
 			FEATURE_WP_SUBDOMAIN_SIGNUP,
 			FEATURE_FREE_THEMES_SIGNUP,
@@ -169,9 +169,9 @@ export const PLANS_LIST = {
 
 	[ PLAN_PERSONAL ]: {
 		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => 'Best for hobbyists', //PLANS A/B TEST: Translate if test passes
-		getBlogAudience: () => 'Best for hobbyists', //PLANS A/B TEST: Translate if test passes
-		getPortfolioAudience: () => 'Best for hobbyists', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for hobbyists' ),
+		getBlogAudience: () => i18n.translate( 'Best for hobbyists' ),
+		getPortfolioAudience: () => i18n.translate( 'Best for hobbyists' ),
 		getProductId: () => 1009,
 		getStoreSlug: () => PLAN_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_FREE ], plan ),
@@ -183,7 +183,7 @@ export const PLANS_LIST = {
 					strong: <strong className="plans__features plan-features__targeted-description-heading" />
 				}
 			} ),
-		getFeatures: () => [
+		getFeatures: () => [ // pay attention to ordering, shared features should align on /plan page
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_JETPACK_ESSENTIAL,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
@@ -197,12 +197,12 @@ export const PLANS_LIST = {
 			FEATURE_FREE_DOMAIN,
 			FEATURE_ALL_FREE_FEATURES
 		],
-		getBlogSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getBlogSignupFeatures: () => [
 			FEATURE_FREE_DOMAIN,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
 			FEATURE_ALL_FREE_FEATURES,
 		],
-		getPortfolioSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getPortfolioSignupFeatures: () => [
 			FEATURE_FREE_DOMAIN,
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
 			FEATURE_ALL_FREE_FEATURES,
@@ -212,9 +212,9 @@ export const PLANS_LIST = {
 
 	[ PLAN_PREMIUM ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
-		getAudience: () => 'Best for entrepreneurs', //PLANS A/B TEST: Translate if test passes
-		getBlogAudience: () => 'Best for professionals', //PLANS A/B TEST: Translate if test passes
-		getPortfolioAudience: () => 'Best for freelancers', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for entrepreneurs' ),
+		getBlogAudience: () => i18n.translate( 'Best for professionals' ),
+		getPortfolioAudience: () => i18n.translate( 'Best for freelancers' ),
 		getPriceTitle: () => i18n.translate( '$99 per year' ), //TODO: DO NOT USE
 		getProductId: () => 1003,
 		getPathSlug: () => 'premium',
@@ -246,17 +246,17 @@ export const PLANS_LIST = {
 			FEATURE_ADVANCED_DESIGN,
 			FEATURE_13GB_STORAGE
 		],
-		getSignupFeatures: () => compact( [ // pay attention to ordering, shared features should align on /plan page
+		getSignupFeatures: () => compact( [
 			FEATURE_ADVANCED_CUSTOMIZATION,
 			FEATURE_PREMIUM_THEMES,
 			FEATURE_ALL_PERSONAL_FEATURES
 		] ),
-		getBlogSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getBlogSignupFeatures: () => [
 			FEATURE_MONETISE,
 			FEATURE_PREMIUM_THEMES,
 			FEATURE_ALL_PERSONAL_FEATURES,
 		],
-		getPortfolioSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getPortfolioSignupFeatures: () => [
 			FEATURE_ADVANCED_CUSTOMIZATION,
 			FEATURE_PREMIUM_THEMES,
 			FEATURE_ALL_PERSONAL_FEATURES,
@@ -266,9 +266,9 @@ export const PLANS_LIST = {
 
 	[ PLAN_BUSINESS ]: {
 		getTitle: () => i18n.translate( 'Business' ),
-		getAudience: () => 'Best for small businesses', //PLANS A/B TEST: Translate if test passes
-		getBlogAudience: () => 'Best for brands', //PLANS A/B TEST: Translate if test passes
-		getPortfolioAudience: () => 'Best for small businesses', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for small businesses' ),
+		getBlogAudience: () => i18n.translate( 'Best for brands' ),
+		getPortfolioAudience: () => i18n.translate( 'Best for small businesses' ),
 		getPriceTitle: () => i18n.translate( '$299 per year' ), //TODO: DO NOT USE
 		getProductId: () => 1008,
 		getStoreSlug: () => PLAN_BUSINESS,
@@ -326,12 +326,12 @@ export const PLANS_LIST = {
 			FEATURE_GOOGLE_ANALYTICS_SIGNUP,
 			FEATURE_ALL_PREMIUM_FEATURES
 		],
-		getBlogSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getBlogSignupFeatures: () => [
 			FEATURE_UPLOAD_THEMES_PLUGINS,
 			FEATURE_ADVANCED_SEO_TOOLS,
 			FEATURE_ALL_PREMIUM_FEATURES,
 		],
-		getPortfolioSignupFeatures: () => [ // pay attention to ordering, it is used on /plan page
+		getPortfolioSignupFeatures: () => [
 			FEATURE_UPLOAD_THEMES_PLUGINS,
 			FEATURE_UNLIMITED_STORAGE_SIGNUP,
 			FEATURE_ALL_PREMIUM_FEATURES,
@@ -341,7 +341,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_JETPACK_FREE ]: {
 		getTitle: () => i18n.translate( 'Free' ),
-		getAudience: () => 'Best for students', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for students' ),
 		getProductId: () => 2002,
 		getStoreSlug: () => PLAN_JETPACK_FREE,
 
@@ -349,7 +349,7 @@ export const PLANS_LIST = {
 			'The features most needed by WordPress sites' +
 			' — perfectly packaged and optimized for everyone.'
 		),
-		getFeatures: () => [
+		getFeatures: () => [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_STANDARD_SECURITY_TOOLS,
 			FEATURE_SITE_STATS,
 			FEATURE_TRAFFIC_TOOLS,
@@ -374,7 +374,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_JETPACK_PREMIUM ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
-		getAudience: () => 'Best for small businesses', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for small businesses' ),
 		getSubtitle: () => i18n.translate( 'Protection, speed, and revenue.' ),
 		getProductId: () => 2000,
 		getStoreSlug: () => PLAN_JETPACK_PREMIUM,
@@ -389,7 +389,7 @@ export const PLANS_LIST = {
 				'Automated backups and malware scanning, expert priority ' +
 				'support, marketing automation, and more.'
 		),
-		getFeatures: () => compact( [
+		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -422,7 +422,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_JETPACK_PREMIUM_MONTHLY ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
-		getAudience: () => 'Best for small businesses', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for small businesses' ),
 		getProductId: () => 2003,
 		getStoreSlug: () => PLAN_JETPACK_PREMIUM_MONTHLY,
 		getPathSlug: () => 'premium-monthly',
@@ -431,7 +431,7 @@ export const PLANS_LIST = {
 				'Automated backups and malware scanning, expert priority ' +
 				'support, marketing automation, and more.'
 		),
-		getFeatures: () => compact( [
+		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -459,12 +459,12 @@ export const PLANS_LIST = {
 			FEATURE_ALL_PERSONAL_FEATURES,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
-		getSignupBillingTimeFrame: () => 'per month', //PLANS A/B TEST: Translate if test passes
+		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 	},
 
 	[ PLAN_JETPACK_PERSONAL ]: {
 		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => 'Best for hobbyists', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for hobbyists' ),
 		getProductId: () => 2005,
 		getStoreSlug: () => PLAN_JETPACK_PERSONAL,
 		availableFor: ( plan ) => includes( [ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL_MONTHLY ], plan ),
@@ -473,7 +473,7 @@ export const PLANS_LIST = {
 				'Security essentials for every WordPress site including ' +
 				'automated backups and priority support.'
 		),
-		getFeatures: () => [
+		getFeatures: () => [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -501,7 +501,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_JETPACK_PERSONAL_MONTHLY ]: {
 		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => 'Best for hobbyists', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for hobbyists' ),
 		getStoreSlug: () => PLAN_JETPACK_PERSONAL_MONTHLY,
 		getProductId: () => 2006,
 		getPathSlug: () => 'jetpack-personal-monthly',
@@ -510,7 +510,7 @@ export const PLANS_LIST = {
 				'Security essentials for every WordPress site including ' +
 				'automated backups and priority support.'
 		),
-		getFeatures: () => [
+		getFeatures: () => [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_DAILY,
 			FEATURE_BACKUP_ARCHIVE_30,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -533,12 +533,12 @@ export const PLANS_LIST = {
 			FEATURE_ALL_FREE_FEATURES,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
-		getSignupBillingTimeFrame: () => 'per month', //PLANS A/B TEST: Translate if test passes
+		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 	},
 
 	[ PLAN_JETPACK_BUSINESS ]: {
 		getTitle: () => i18n.translate( 'Professional' ),
-		getAudience: () => 'Best for organizations', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for organizations' ),
 		getProductId: () => 2001,
 		availableFor: ( plan ) => includes( [
 			PLAN_JETPACK_BUSINESS_MONTHLY,
@@ -549,12 +549,11 @@ export const PLANS_LIST = {
 			PLAN_JETPACK_PERSONAL_MONTHLY
 		], plan ),
 		getPathSlug: () => 'professional',
-
 		getDescription: () => i18n.translate(
 			'WordPress sites from start to finish: unlimited premium ' +
 			'themes, business class security, and marketing automation.'
 		),
-		getFeatures: () => compact( [
+		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
 			FEATURE_BACKUP_ARCHIVE_UNLIMITED,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -591,7 +590,7 @@ export const PLANS_LIST = {
 
 	[ PLAN_JETPACK_BUSINESS_MONTHLY ]: {
 		getTitle: () => i18n.translate( 'Professional' ),
-		getAudience: () => 'Best for organizations', //PLANS A/B TEST: Translate if test passes
+		getAudience: () => i18n.translate( 'Best for organizations' ),
 		getSubtitle: () => i18n.translate( 'Ultimate security and traffic tools.' ),
 		getProductId: () => 2004,
 		getPathSlug: () => 'professional-monthly',
@@ -606,7 +605,7 @@ export const PLANS_LIST = {
 			'WordPress sites from start to finish: unlimited premium ' +
 			'themes, business class security, and marketing automation.'
 		),
-		getFeatures: () => compact( [
+		getFeatures: () => compact( [  // pay attention to ordering, shared features should align on /plan page
 			FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
 			FEATURE_BACKUP_ARCHIVE_UNLIMITED,
 			FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED,
@@ -638,7 +637,7 @@ export const PLANS_LIST = {
 			FEATURE_ALL_PREMIUM_FEATURES,
 		],
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
-		getSignupBillingTimeFrame: () => 'per month', //PLANS A/B TEST: Translate if test passes
+		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 	}
 };
 
@@ -650,97 +649,97 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_ALL_FREE_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_FREE_FEATURES,
-		getTitle: () => 'All free features', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'All free features' ),
 	},
 
 	[ FEATURE_ALL_PERSONAL_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_PERSONAL_FEATURES,
-		getTitle: () => 'All Personal features', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'All Personal features' ),
 	},
 
 	[ FEATURE_ALL_PREMIUM_FEATURES ]: {
 		getSlug: () => FEATURE_ALL_PREMIUM_FEATURES,
-		getTitle: () => 'All Premium features', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'All Premium features' ),
 	},
 
 	[ FEATURE_ADVANCED_CUSTOMIZATION ]: {
 		getSlug: () => FEATURE_ADVANCED_CUSTOMIZATION,
-		getTitle: () => 'Advanced customization', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Advanced customization' ),
 	},
 
 	[ FEATURE_FREE_DOMAIN ]: {
 		getSlug: () => FEATURE_FREE_DOMAIN,
-		getTitle: () => 'Free custom domain', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Free custom domain' ),
 	},
 
 	[ FEATURE_PREMIUM_THEMES ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES,
-		getTitle: () => 'Unlimited premium themes', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
 	},
 
 	[ FEATURE_MONETISE ]: {
 		getSlug: () => FEATURE_MONETISE,
-		getTitle: () => 'Monetize your site with ads', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Monetize your site with ads' ),
 	},
 
 	[ FEATURE_UPLOAD_THEMES_PLUGINS ]: {
 		getSlug: () => FEATURE_UPLOAD_THEMES_PLUGINS,
-		getTitle: () => 'Upload themes and plugins', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Upload themes and plugins' ),
 	},
 
 	[ FEATURE_GOOGLE_ANALYTICS_SIGNUP ]: {
 		getSlug: () => FEATURE_GOOGLE_ANALYTICS_SIGNUP,
-		getTitle: () => 'Google Analytics', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Google Analytics' ),
 	},
 
 	[ FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP ]: {
 		getSlug: () => FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
-		getTitle: () => 'Email and live chat support', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Email and live chat support' ),
 	},
 
 	[ FEATURE_FREE_THEMES_SIGNUP ]: {
 		getSlug: () => FEATURE_FREE_THEMES_SIGNUP,
-		getTitle: () => 'Hundreds of free themes', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Hundreds of free themes' ),
 	},
 
 	[ FEATURE_WP_SUBDOMAIN_SIGNUP ]: {
 		getSlug: () => FEATURE_WP_SUBDOMAIN_SIGNUP,
-		getTitle: () => 'WordPress.com subdomain', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'WordPress.com subdomain' ),
 	},
 
 	[ FEATURE_UNLIMITED_STORAGE_SIGNUP ]: {
 		getSlug: () => FEATURE_UNLIMITED_STORAGE_SIGNUP,
-		getTitle: () => 'Unlimited storage', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Unlimited storage' ),
 	},
 
 	[ FEATURE_ADVANCED_SEO_TOOLS ]: {
 		getSlug: () => FEATURE_ADVANCED_SEO_TOOLS,
-		getTitle: () => 'Advanced SEO tools', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Advanced SEO tools' ),
 	},
 
 	[ FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP ]: {
 		getSlug: () => FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP,
-		getTitle: () => 'Unlimited Backup Space', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Unlimited Backup Space' ),
 	},
 
 	[ FEATURE_FREE_WORDPRESS_THEMES ]: {
 		getSlug: () => FEATURE_FREE_WORDPRESS_THEMES,
-		getTitle: () => 'Free WordPress Themes', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Free WordPress Themes' ),
 	},
 
 	[ FEATURE_VIDEO_CDN_LIMITED ]: {
 		getSlug: () => FEATURE_VIDEO_CDN_LIMITED,
-		getTitle: () => '13GB Video Storage', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( '13GB Video Storage' ),
 	},
 
 	[ FEATURE_VIDEO_CDN_UNLIMITED ]: {
 		getSlug: () => FEATURE_VIDEO_CDN_UNLIMITED,
-		getTitle: () => 'Unlimited Video Storage', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'Unlimited Video Storage' ),
 	},
 
 	[ FEATURE_SEO_PREVIEW_TOOLS ]: {
 		getSlug: () => FEATURE_SEO_PREVIEW_TOOLS,
-		getTitle: () => 'SEO Preview Tools', //PLANS A/B TEST: Translate if test passes
+		getTitle: () => i18n.translate( 'SEO Preview Tools' ),
 	},
 
 	[ FEATURE_GOOGLE_ANALYTICS ]: {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -40,10 +40,10 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 class PlanFeaturesHeader extends Component {
 
 	render() {
-		const { isInSignupTest } = this.props;
+		const { isInSignup } = this.props;
 		let content = this.renderPlansHeader();
 
-		if ( isInSignupTest ) {
+		if ( isInSignup ) {
 			content = this.renderSignupHeader();
 		}
 
@@ -128,7 +128,7 @@ class PlanFeaturesHeader extends Component {
 			translate,
 			isSiteAT,
 			hideMonthly,
-			isInSignupTest
+			isInSignup
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -137,7 +137,7 @@ class PlanFeaturesHeader extends Component {
 			'is-placeholder': isPlaceholder
 		} );
 
-		if ( isInSignupTest ) {
+		if ( isInSignup ) {
 			return (
 				<span>
 					<span>{ billingTimeFrame }</span>
@@ -236,10 +236,10 @@ class PlanFeaturesHeader extends Component {
 			isPlaceholder,
 			relatedMonthlyPlan,
 			site,
-			isInSignupTest
+			isInSignup
 		} = this.props;
 
-		if ( isPlaceholder && ! isInSignupTest ) {
+		if ( isPlaceholder && ! isInSignup ) {
 			const isJetpackSite = !! site.jetpack;
 			const classes = classNames( 'is-placeholder', {
 				'plan-features__price': ! isJetpackSite,
@@ -257,13 +257,13 @@ class PlanFeaturesHeader extends Component {
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ rawPrice }
-						isInSignupTest={ isInSignupTest }
+						isInSignup={ isInSignup }
 						original
 					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ discountPrice }
-						isInSignupTest={ isInSignupTest }
+						isInSignup={ isInSignup }
 						discounted
 					/>
 				</span>
@@ -277,13 +277,13 @@ class PlanFeaturesHeader extends Component {
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ originalPrice }
-						isInSignupTest={ isInSignupTest }
+						isInSignup={ isInSignup }
 						original
 					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ rawPrice }
-						isInSignupTest={ isInSignupTest }
+						isInSignup={ isInSignup }
 						discounted
 					/>
 				</span>
@@ -294,7 +294,7 @@ class PlanFeaturesHeader extends Component {
 			<PlanPrice
 				currencyCode={ currencyCode }
 				rawPrice={ rawPrice }
-				isInSignupTest={ isInSignupTest }
+				isInSignup={ isInSignup }
 			/>
 		);
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -56,21 +56,21 @@ class PlanFeatures extends Component {
 	render() {
 		const {
 			planProperties,
-			isInSignupTest
+			isInSignup
 		} = this.props;
 		const tableClasses = classNames( 'plan-features__table',
 			`has-${ planProperties.length }-cols` );
 		const planClasses = classNames(
 			'plan-features',
-			{ 'plan-features--signup': isInSignupTest }
+			{ 'plan-features--signup': isInSignup }
 		);
 		const planWrapperClasses = classNames(
-			{ 'plans-wrapper': isInSignupTest }
+			{ 'plans-wrapper': isInSignup }
 		);
 		let mobileView, planDescriptions;
 		let bottomButtons = null;
 
-		if ( ! isInSignupTest ) {
+		if ( ! isInSignup ) {
 			mobileView = (
 				<div className="plan-features__mobile">
 					{ this.renderMobileView() }
@@ -117,12 +117,12 @@ class PlanFeatures extends Component {
 
 	setScrollLeft = ( plansWrapper ) => {
 		const {
-			isInSignupTest,
+			isInSignup,
 			displayJetpackPlans
 		} = this.props;
 
 		// center plans
-		if ( isInSignupTest && plansWrapper ) {
+		if ( isInSignup && plansWrapper ) {
 			displayJetpackPlans
 				? plansWrapper.scrollLeft = 190
 				: plansWrapper.scrollLeft = 495;
@@ -244,7 +244,6 @@ class PlanFeatures extends Component {
 			site,
 			basePlansPath,
 			isInSignup,
-			isInSignupTest,
 			siteType,
 			displayJetpackPlans
 		} = this.props;
@@ -266,7 +265,7 @@ class PlanFeatures extends Component {
 			let audience = planConstantObj.getAudience();
 			let billingTimeFrame = planConstantObj.getBillingTimeFrame();
 
-			if ( isInSignupTest && ! displayJetpackPlans ) {
+			if ( isInSignup && ! displayJetpackPlans ) {
 				switch ( siteType ) {
 					case 'blog':
 						audience = planConstantObj.getBlogAudience();
@@ -279,7 +278,7 @@ class PlanFeatures extends Component {
 				}
 			}
 
-			if ( isInSignupTest && displayJetpackPlans ) {
+			if ( isInSignup && displayJetpackPlans ) {
 				billingTimeFrame = planConstantObj.getSignupBillingTimeFrame();
 			}
 
@@ -303,7 +302,6 @@ class PlanFeatures extends Component {
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						isInSignup={ isInSignup }
-						isInSignupTest= { isInSignupTest }
 					/>
 				</td>
 			);
@@ -513,7 +511,6 @@ PlanFeatures.propTypes = {
 	basePlansPath: PropTypes.string,
 	selectedFeature: PropTypes.string,
 	intervalType: PropTypes.string,
-	isInSignupTest: PropTypes.bool,
 	site: PropTypes.object,
 	displayJetpackPlans: PropTypes.bool,
 };
@@ -521,7 +518,6 @@ PlanFeatures.propTypes = {
 PlanFeatures.defaultProps = {
 	onUpgradeClick: noop,
 	isInSignup: false,
-	isInSignupTest: false,
 	basePlansPath: null,
 	intervalType: 'yearly',
 	site: {},
@@ -530,7 +526,7 @@ PlanFeatures.defaultProps = {
 
 export default connect(
 	( state, ownProps ) => {
-		const { isInSignup, placeholder, plans, onUpgradeClick, isLandingPage, site, isInSignupTest, displayJetpackPlans } = ownProps;
+		const { isInSignup, placeholder, plans, onUpgradeClick, isLandingPage, site, displayJetpackPlans } = ownProps;
 		const selectedSiteId = site ? site.ID : null;
 		const sitePlan = getSitePlan( state, selectedSiteId );
 		const sitePlans = getPlansBySiteId( state, selectedSiteId );
@@ -558,7 +554,7 @@ export default connect(
 					isPlaceholder = true;
 				}
 
-				if ( isInSignupTest ) {
+				if ( isInSignup ) {
 					switch ( siteType ) {
 						case 'blog':
 							if ( planConstantObj.getBlogSignupFeatures ) {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -429,7 +429,9 @@ $plan-features-sidebar-width: 272px;
  }
 
 
-/* Signup test */
+/*= Plans in Signup 
+========================================*/
+
 .price-toggle {
 	width: 250px;
 	margin: 0 auto 20px;

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -18,7 +18,7 @@ export default class PlanPrice extends Component {
 			original,
 			discounted,
 			className,
-			isInSignupTest,
+			isInSignup,
 		} = this.props;
 
 		if ( ! currencyCode || ( rawPrice !== 0 && ! rawPrice ) ) {
@@ -30,7 +30,7 @@ export default class PlanPrice extends Component {
 			'is-discounted': discounted
 		} );
 
-		if ( isInSignupTest ) {
+		if ( isInSignup ) {
 			return (
 				<span className={ classes }>{ price.symbol }{ price.integer }{ rawPrice > 0 && price.fraction }</span>
 			);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -35,14 +35,6 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
-	isInSignupTest() {
-		const {
-			isInSignup
-		} = this.props;
-
-		return ( ( isInSignup ) && ( abtest( 'signupPlansCopyChanges' ) === 'modified' ) );
-	}
-
 	getPlanFeatures() {
 		const {
 			site,
@@ -80,7 +72,6 @@ class PlansFeaturesMain extends Component {
 						intervalType={ intervalType }
 						site={ site }
 						domainName={ domainName }
-						isInSignupTest = { this.isInSignupTest() }
 						displayJetpackPlans = { displayJetpackPlans }
 					/>
 				</div>
@@ -109,7 +100,6 @@ class PlansFeaturesMain extends Component {
 						intervalType={ intervalType }
 						site={ site }
 						domainName={ domainName }
-						isInSignupTest = { this.isInSignupTest() }
 						displayJetpackPlans = { displayJetpackPlans }
 					/>
 				</div>
@@ -138,7 +128,6 @@ class PlansFeaturesMain extends Component {
 					intervalType={ intervalType }
 					site={ site }
 					domainName={ domainName }
-					isInSignupTest = { this.isInSignupTest() }
 					displayJetpackPlans = { displayJetpackPlans }
 				/>
 			</div>
@@ -383,13 +372,13 @@ class PlansFeaturesMain extends Component {
 				: this.getFAQ( site );
 		let faqs = null;
 
-		if ( ! this.isInSignupTest() || ( displayJetpackPlans && ! isInSignup ) ) {
+		if ( ! isInSignup ) {
 			faqs = renderFAQ();
 		}
 
 		return (
 			<div className="plans-features-main">
-				{ ( displayJetpackPlans && this.isInSignupTest() ) ? this.getIntervalTypeToggle() : null }
+				{ ( displayJetpackPlans && isInSignup ) ? this.getIntervalTypeToggle() : null }
 				<QueryPlans />
 				<QuerySitePlans siteId={ get( site, 'ID' ) } />
 				{ this.getPlanFeatures() }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -32,7 +32,6 @@ import purchasesPaths from 'me/purchases/paths';
 import { plansLink } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
-import { abtest } from 'lib/abtest';
 
 class PlansFeaturesMain extends Component {
 	getPlanFeatures() {


### PR DESCRIPTION
We've completed our [Plans signup test](https://github.com/Automattic/wp-calypso/pull/15481) for WP.com and Jetpack. The test was successful so this PR removes the test and adds translation strings to all the new strings. 

@taggon @markryall can you please review?