### PR TITLE
Confirmation Sidebar: Fix ground control vertical scroll

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -74,6 +74,7 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
+	min-height: 46px;
 	position: relative;
 		top: 0;
 		left: 0;


### PR DESCRIPTION
This PR assures that the confirmation sidebar does not collapse by enforcing a minimum height.

Before:
![image](https://user-images.githubusercontent.com/363749/28724729-af1d3968-7380-11e7-9ec7-c1fee7a997b7.png)

After:
![image](https://user-images.githubusercontent.com/363749/28724713-9fb07a58-7380-11e7-95ec-59cb21219314.png)

To test:
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170713":"showPublishConfirmation"}')`
* Draft a post and when the confirmation sidebar is shown, resize your window to reduce vertical space.