### PR TITLE
a11y: prevent screen readers reading image filename for SiteIcon

### DIFF
--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -36,7 +36,7 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 		<div className={ classes } style={ style }>
 			{ ! site && siteId > 0 && <QuerySites siteId={ siteId } /> }
 			{ iconSrc
-				? <Image className="site-icon__img" src={ iconSrc } />
+				? <Image className="site-icon__img" src={ iconSrc } alt="" />
 				: <Gridicon icon="globe" size={ Math.round( size / 1.3 ) } /> }
 			{ isTransientIcon && <Spinner /> }
 		</div>


### PR DESCRIPTION
Screen readers currently read the image filename for site icons, which is a pretty awful experience.

The SiteIcon component is currently always rendered adjacent to the site title, so its role is presentational and should be omitted for screen readers.

The aim here is to set a sensible ~default~ alt value for the `SiteIcon` component across Calypso.

### To test

Visit http://calypso.localhost:3000/devdocs/blocks/site and ensure that the site icons have an empty `alt=""` attribute (Chrome may display this as `alt`, not `alt=""` due to the bug mentioned below).
