### PR TITLE
Hide Reader avatar from screen readers

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -93,7 +93,7 @@ const ReaderAvatar = ( {
 	const iconElements = [ siteIconElement, avatarElement ];
 
 	return (
-		<div className={ classes } onClick={ onClick }>
+		<div className={ classes } onClick={ onClick } aria-hidden="true">
 			{ siteUrl
 				? <a href={ siteUrl }>
 						{ iconElements }

--- a/client/blocks/reader-related-card-v2/index.jsx
+++ b/client/blocks/reader-related-card-v2/index.jsx
@@ -31,7 +31,7 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource } ) {
 
 	return (
 		<div className="reader-related-card-v2__meta">
-			<a href={ siteUrl } onClick={ onSiteClick }>
+			<a href={ siteUrl } onClick={ onSiteClick } aria-hidden="true">
 				<Gravatar user={ post.author } />
 			</a>
 			<div className="reader-related-card-v2__byline">


### PR DESCRIPTION
Applies an aria-hidden="true" on `ReaderAvatar`, to prevent screen readers reading the link and filename on avatars in the Reader. The avatar in Reader is always shown adjacent to the site or feed name, so the role of the avatar is presentational only and we can omit this element for screen reader users.

### To test

Visit http://calypso.localhost:3000/following/manage and tab into the recommended sites. Make sure you don't get a focus on the avatar, and are not read the avatar's link or image filename.

<img width="807" alt="screen shot 2017-07-28 at 18 24 09" src="https://user-images.githubusercontent.com/17325/28728815-f81b064a-73c1-11e7-87ae-b5bc1ce03bb4.png">