### PR TITLE
Precommit Hook: fix extra commas

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -10,7 +10,7 @@ const path = require( 'path' );
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
 		'under the GNU General Public License v2 (or later). All materials must have ' +
-		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n',
+		'GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n'
 );
 
 // Make quick pass over config files on every change
@@ -68,7 +68,7 @@ if ( lintResult.status ) {
 		chalk.red( 'COMMIT ABORTED:' ),
 		'The linter reported some problems. ' +
 			'If you are aware of them and it is OK, ' +
-			'repeat the commit command with --no-verify to avoid this check.',
+			'repeat the commit command with --no-verify to avoid this check.'
 	);
 	process.exit( 1 );
 }


### PR DESCRIPTION
A couple extra commas exist in the precommit hook that break es5 compatibility.
The commas were added here: https://github.com/Automattic/wp-calypso/commit/c4b6f40d41eb588a2c4d6490bf7730479b1287ab