### PR TITLE
Reader: add sidebar titles for teams, lists and tags

### DIFF
--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import last from 'lodash/last';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -31,7 +32,7 @@ export class ReaderSidebarListsListItem extends Component {
 	}
 
 	render() {
-		const list = this.props.list;
+		const { list, translate } = this.props;
 		const listRelativeUrl = `/read/list/${ list.owner }/${ list.slug }`;
 		const listManagementUrls = [
 			listRelativeUrl + '/tags',
@@ -46,7 +47,7 @@ export class ReaderSidebarListsListItem extends Component {
 			ReaderSidebarHelper.pathStartsWithOneOf( [ listRelativeUrl ], this.props.path );
 		const isActionButtonSelected = ReaderSidebarHelper.pathStartsWithOneOf(
 			listManagementUrls,
-			this.props.path,
+			this.props.path
 		);
 
 		const classes = classNames( {
@@ -55,7 +56,15 @@ export class ReaderSidebarListsListItem extends Component {
 
 		return (
 			<li className={ classes } key={ list.ID }>
-				<a className="sidebar__menu-item-label" href={ listRelativeUrl }>
+				<a
+					className="sidebar__menu-item-label"
+					href={ listRelativeUrl }
+					title={ translate( "View list '%(currentListName)s'", {
+						args: {
+							currentListName: list.title,
+						},
+					} ) }
+				>
 					<div className="sidebar__menu-item-listname">
 						{ list.title }
 					</div>
@@ -65,4 +74,4 @@ export class ReaderSidebarListsListItem extends Component {
 	}
 }
 
-export default ReaderSidebarListsListItem;
+export default localize( ReaderSidebarListsListItem );

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -54,6 +54,7 @@ export class ReaderSidebarListsListItem extends Component {
 			selected: isCurrentList || isActionButtonSelected,
 		} );
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className={ classes } key={ list.ID }>
 				<a
@@ -71,6 +72,7 @@ export class ReaderSidebarListsListItem extends Component {
 				</a>
 			</li>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -44,6 +44,7 @@ export class ReaderSidebarTagsListItem extends Component {
 		const { tag, path, onUnfollow, translate } = this.props;
 		const tagName = tag.displayName || tag.slug;
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li
 				key={ tag.id }
@@ -78,6 +79,7 @@ export class ReaderSidebarTagsListItem extends Component {
 					</button> }
 			</li>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -42,6 +42,7 @@ export class ReaderSidebarTagsListItem extends Component {
 
 	render() {
 		const { tag, path, onUnfollow, translate } = this.props;
+		const tagName = tag.displayName || tag.slug;
 
 		return (
 			<li
@@ -54,23 +55,27 @@ export class ReaderSidebarTagsListItem extends Component {
 					className="sidebar__menu-item-label"
 					href={ tag.url }
 					onClick={ this.handleTagSidebarClick }
+					title={ translate( "View tag '%(currentTagName)s'", {
+						args: {
+							currentTagName: tagName,
+						},
+					} ) }
 				>
 					<div className="sidebar__menu-item-tagname">
-						{ tag.displayName || tag.slug }
+						{ tagName }
 					</div>
 				</a>
-				{ tag.id !== 'pending'
-					? <button
-							className="sidebar__menu-action"
-							data-tag-slug={ tag.slug }
-							onClick={ onUnfollow }
-						>
-							<Gridicon icon="cross-small" />
-							<span className="sidebar__menu-action-label">
-								{ translate( 'Unfollow' ) }
-							</span>
-						</button>
-					: null }
+				{ tag.id !== 'pending' &&
+					<button
+						className="sidebar__menu-action"
+						data-tag-slug={ tag.slug }
+						onClick={ onUnfollow }
+					>
+						<Gridicon icon="cross-small" />
+						<span className="sidebar__menu-action-label">
+							{ translate( 'Unfollow' ) }
+						</span>
+					</button> }
 			</li>
 		);
 	}

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -71,6 +71,11 @@ export class ReaderSidebarTagsListItem extends Component {
 						className="sidebar__menu-action"
 						data-tag-slug={ tag.slug }
 						onClick={ onUnfollow }
+						title={ translate( "Unfollow tag '%(currentTagName)s'", {
+							args: {
+								currentTagName: tagName,
+							},
+						} ) }
 					>
 						<Gridicon icon="cross-small" />
 						<span className="sidebar__menu-action-label">

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -11,6 +11,7 @@ import ReaderSidebarHelper from '../helper';
 
 export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 	const teamUri = '/read/' + encodeURIComponent( team.slug );
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<li
 			key={ team.slug }
@@ -42,6 +43,7 @@ export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 			</a>
 		</li>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 ReaderSidebarTeamsListItem.propTypes = {

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -2,13 +2,14 @@
  * External Dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
 import ReaderSidebarHelper from '../helper';
 
-export const ReaderSidebarTeamsListItem = ( { path, team } ) => {
+export const ReaderSidebarTeamsListItem = ( { path, team, translate } ) => {
 	const teamUri = '/read/' + encodeURIComponent( team.slug );
 	return (
 		<li
@@ -17,7 +18,14 @@ export const ReaderSidebarTeamsListItem = ( { path, team } ) => {
 				'sidebar-streams__team': true,
 			} ) }
 		>
-			<a href={ teamUri }>
+			<a
+				href={ teamUri }
+				title={ translate( "View team '%(currentTeamName)s'", {
+					args: {
+						currentTeamName: team.title,
+					},
+				} ) }
+			>
 				<svg
 					className={ 'gridicon gridicon-' + team.slug }
 					width="24"
@@ -41,4 +49,4 @@ ReaderSidebarTeamsListItem.propTypes = {
 	path: React.PropTypes.string.isRequired,
 };
 
-export default ReaderSidebarTeamsListItem;
+export default localize( ReaderSidebarTeamsListItem );


### PR DESCRIPTION
Add a `title` attribute to the Reader sidebar for teams, lists and tags, where the link text itself doesn't fully communicate what the link does. This should help screen reader users as well as those mousing over the links.

### To test

Visit http://calypso.localhost:3000/ and hover over a team, list or tag stream link. On hover, you should see:

View team 'x'
View list 'x'
View tag 'x'
