### PR TITLE
Store: Adjust sidebar link position on mobile

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -161,7 +161,7 @@
 			a {
 				position: fixed;
 				z-index: 1;
-				top: 10px;
+				margin-top: 10px;
 				background: transparent;
 				border: none;
 			}


### PR DESCRIPTION
The link to open the sidebar on mobile was present, but was hidden/positioned behind an element in the masterbar. It was working in a responsive-view on Chrome, but not on an actual device.

The adjustment in this PR is working for me both on responsive-desktop, and on my device.

Closes #15593.

To test
* I recommend using the calypso.live link from your real mobile device: https://calypso.live/?branch=fix/store-sidebar-link.
* After booting the branch, select your AT site from the AT list, and go to `Store (Beta)`.
* You should see the "<" link for opening up the sidebar on mobile displays.
* Select and make sure the sidebar properly opens.

<img width="595" alt="screen shot 2017-07-28 at 11 17 24 am" src="https://user-images.githubusercontent.com/689165/28730841-64756bdc-7386-11e7-8b87-264d512dded8.png">
