### PR TITLE
Editor Confirmation Sidebar: Update ab test percentage and start date

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -86,7 +86,7 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	postPublishConfirmation: {
-		datestamp: '20170802',
+		datestamp: '20170801',
 		allowExistingUsers: true,
 		variations: {
 			showPublishConfirmation: 5,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -86,11 +86,11 @@ module.exports = {
 		allowExistingUsers: true,
 	},
 	postPublishConfirmation: {
-		datestamp: '20170713',
+		datestamp: '20170802',
 		allowExistingUsers: true,
 		variations: {
-			showPublishConfirmation: 30,
-			noPublishConfirmation: 70,
+			showPublishConfirmation: 5,
+			noPublishConfirmation: 95,
 		},
 		defaultVariation: 'noPublishConfirmation',
 	},


### PR DESCRIPTION
This PR updates the start date and percentage for the test setup in #16171.

This is part of a larger epic (See p3Ex-2ri-p2).

Test details:

• Name: `postPublishConfirmation`
• Date: 2017-08-01
• Variations:
  • `showPublishConfirmation`: (5) A confirmation sidebar will be shown on Publish.
  • `noShowPublishConfirmation`: (Default | 95) No confirmation sidebar is shown on Publish.
