### PR TITLE
Publish Confirmation: Handle case where password is set before initial autosave of draft

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -92,7 +92,8 @@ class EditorConfirmationSidebar extends React.Component {
 			return;
 		}
 
-		const { password, type, status } = this.props.post || {};
+		const { password, type } = this.props.post || {};
+		const status = get( this.props.post, 'status', 'draft' );
 		const isPrivateSite = get( this.props, 'site.is_private' );
 		const savedStatus = get( this.props, 'savedPost.status' );
 		const savedPassword = get( this.props, 'savedPost.password' );

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -188,8 +188,6 @@ const EditorVisibility = React.createClass( {
 
 	updateVisibility( newVisibility ) {
 		const { siteId, postId } = this.props;
-		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
-		const postEdits = { status: defaultVisibility };
 		let reduxPostEdits;
 
 		switch ( newVisibility ) {
@@ -211,8 +209,6 @@ const EditorVisibility = React.createClass( {
 		recordEvent( 'Changed visibility', newVisibility );
 		tracks.recordEvent( 'calypso_editor_visibility_set', { context: this.props.context, visibility: newVisibility } );
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		postActions.edit( postEdits );
 		if ( reduxPostEdits ) {
 			this.props.editPost( siteId, postId, reduxPostEdits );
 		}

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -182,39 +182,11 @@ const EditorVisibility = React.createClass( {
 		);
 	},
 
-	updateVisibility( event ) {
-		const { siteId, postId } = this.props;
-		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
-		const newVisibility = event.target.value;
-		const postEdits = { status: defaultVisibility };
-		let reduxPostEdits;
-
-		switch ( newVisibility ) {
-			case 'public':
-				reduxPostEdits = { password: '' };
-				break;
-
-			case 'password':
-				reduxPostEdits = {
-					password: this.props.savedPassword || ' ',
-					sticky: false,
-				};
-				this.setState( { passwordIsValid: true } );
-				break;
-		}
-
-		recordStat( 'visibility-set-' + newVisibility );
-		recordEvent( 'Changed visibility', newVisibility );
-		tracks.recordEvent( 'calypso_editor_visibility_set', { context: this.props.context, visibility: newVisibility } );
-
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		postActions.edit( postEdits );
-		if ( reduxPostEdits ) {
-			this.props.editPost( siteId, postId, reduxPostEdits );
-		}
+	updateVisibilityFromRadioButton( event ) {
+		this.updateVisibility( event.target.value );
 	},
 
-	updateDropdownVisibility( newVisibility ) {
+	updateVisibility( newVisibility ) {
 		const { siteId, postId } = this.props;
 		const defaultVisibility = 'draft' === this.props.status ? 'draft' : 'publish';
 		const postEdits = { status: defaultVisibility };
@@ -226,7 +198,11 @@ const EditorVisibility = React.createClass( {
 				break;
 
 			case 'password':
-				reduxPostEdits = { password: this.props.savedPassword || ' ' };
+				reduxPostEdits = {
+					password: this.props.savedPassword || ' ',
+					// Password protected posts cannot be sticky
+					sticky: false,
+				};
 				this.setState( { passwordIsValid: true } );
 				break;
 		}
@@ -400,7 +376,7 @@ const EditorVisibility = React.createClass( {
 								<FormRadio
 									name="site-visibility"
 									value="public"
-									onChange={ this.updateVisibility }
+									onChange={ this.updateVisibilityFromRadioButton }
 									checked={ 'public' === visibility }
 								/>
 								<span>
@@ -440,7 +416,7 @@ const EditorVisibility = React.createClass( {
 								<FormRadio
 									name="site-visibility"
 									value="password"
-									onChange={ this.updateVisibility }
+									onChange={ this.updateVisibilityFromRadioButton }
 									checked={ 'password' === visibility }
 								/>
 								<span>
@@ -468,7 +444,7 @@ const EditorVisibility = React.createClass( {
 				icon: <Gridicon icon="globe" size={ 18 } />,
 				value: 'public',
 				onClick: () => {
-					this.updateDropdownVisibility( 'public' );
+					this.updateVisibility( 'public' );
 				}
 			},
 			{
@@ -482,7 +458,7 @@ const EditorVisibility = React.createClass( {
 				icon: <Gridicon icon="lock" size={ 18 } />,
 				value: 'password',
 				onClick: () => {
-					this.updateDropdownVisibility( 'password' );
+					this.updateVisibility( 'password' );
 				}
 			},
 		];


### PR DESCRIPTION
I have found that if you try and set a post to password protected WHILE the initial autosave of the draft is occuring, that the post will appear to auto publish. It won't actually be published, but the UI will lead you to believe that this has happened.

To reproduce issue:

1. Run master with feature flag enabled
2. Create new post
3. Click Publish...
5. Select Password Protected from privacy component (WHILE the initial autosave of the draft is occurring)
7. Wait a few seconds, don't do anything else
8. Observe that your post has appeared to have been auto published (the post-publish preview will appear)

To test fix:

- Checkout this branch
- Run this branch with the publish-confirmation feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
- Run through steps to reproduce issue
- Verify that post is not auto published
- Do light regression testing of other scenarios with privacy component on confirmation sidebar

