### PR TITLE
Framework: Revert react-modal version to fix shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1405,7 +1405,7 @@
       "version": "1.0.0"
     },
     "depd": {
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     "des.js": {
       "version": "1.0.0"
@@ -2123,7 +2123,7 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.51.0",
+      "version": "0.51.1",
       "dev": true
     },
     "flux": {
@@ -2980,6 +2980,9 @@
     "http-errors": {
       "version": "1.6.1",
       "dependencies": {
+        "depd": {
+          "version": "1.1.0"
+        },
         "inherits": {
           "version": "2.0.3"
         }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "react-docgen": "2.13.0",
     "react-dom": "15.4.0",
     "react-hot-loader": "1.3.1",
-	"react-modal": "2.2.1",
+    "react-modal": "1.6.5",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.3",
     "react-virtualized": "9.4.0",


### PR DESCRIPTION
This commit reverts react-modal back to 1.6.5 to fix shrink-wrapping.

`react-dom-factories` is a dependency of `react-modal@2.2.1`. `react-modal@2.2.1` requires `react@^15.5.4`.

This is an issue because our React version is currently pinned to `15.5.0`.

I have verified with @jameskoster that reverting this dependency should not affect his changes here: 0345ff0