### PR TITLE
Plugins: Fix occasional "cannot read property 'active' of undefined" errors.

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -436,7 +436,9 @@ class PluginMeta extends Component {
 			'is-placeholder': !! this.props.isPlaceholder
 		} );
 
-		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
+		const plugin = this.props.selectedSite && this.props.sites[ 0 ] && this.props.sites[ 0 ].plugin
+			? this.props.sites[ 0 ].plugin
+			: this.props.plugin;
 		const path = ( ! this.props.selectedSite || plugin.active ) && this.getExtensionSettingsPath( plugin );
 
 		return (


### PR DESCRIPTION
Occasionally when installing plugins with a site selected, we can end up with `plugins` being undefined in the `render()` method of `PluginsMeta`. This PR ensures we always display the `plugin` object passed by props (the .org plugin info) until we have explicit plugin info for the site in question. Looks like it was introduced in #16222 .

![screen shot 2017-07-28 at 2 10 22 pm](https://user-images.githubusercontent.com/349751/28738567-08aad94a-73a9-11e7-877a-ec14c18b327b.png)

**Testing**
* We've been seeing this sporadically and it's difficult to force; one test for this PR would be to check for `this.props.sites[ 0 ]` and if present, `delete this.props.sites[ 0 ].plugin` directly above the code change.
* example URL would be: `https://wordpress.com/plugins/hello-dolly/example.com`