### PR TITLE
DevDocs: Display the README below the component in single view

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -78,6 +78,7 @@ $z-layers: (
 		'.thank-you-card__header': 1,
 		'.comment-detail.card.is-collapsed:hover': 1,
 		'.comment-detail.card.accessible-focus:focus': 1,
+		'.web-preview__inner .spinner-line': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,

--- a/client/components/async-load/README.md
+++ b/client/components/async-load/README.md
@@ -19,20 +19,7 @@ See [`babel-plugin-transform-wpcalypso-async` documentation](https://github.com/
 
 The following props can be passed to the AsyncLoad component:
 
-### `require`
-
-<table>
-	<tr><td>Type</td><td>String (Function)</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-In general usage, this should be passed as a string of the module to be imported. During build, the string prop is [transformed to a function](https://github.com/Automattic/wp-calypso/tree/master/server/bundler/babel/babel-plugin-transform-wpcalypso-async) which is called to require the specified module.
-
-### `placeholder`
-
-<table>
-	<tr><td>Type</td><td>PropTypes.node</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-</table>
-
-A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown.
+| property      | type              | required | comment |
+| ------------- | ----------------- | -------- | ------- |
+| `require`     | String (Function) | yes      | In general usage, this should be passed as a string of the module to be imported. During build, the string prop is [transformed to a function](https://github.com/Automattic/wp-calypso/tree/master/server/bundler/babel/babel-plugin-transform-wpcalypso-async) which is called to require the specified module. |
+| `placeholder` | PropTypes.node    | no       | A placeholder to be shown while the module is being asynchronously required. If omitted, a default placeholder will be shown. |

--- a/client/components/clipboard-button-input/README.md
+++ b/client/components/clipboard-button-input/README.md
@@ -22,32 +22,8 @@ export default function MyComponent() {
 
 The following props can be passed to the ClipboardButtonInput component. With the exception of `className`, all props, including those not listed below, will be passed to the child `<input />` element.
 
-### `value`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>""</code></td></tr>
-</table>
-
-The value of the `<input />` element, and the text to be copied when clicking the copy button.
-
-### `disabled`
-
-<table>
-	<tr><td>Type</td><td>Boolean</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>false</code></td></tr>
-</table>
-
-Whether the children `<input />` and `<button />` should be rendered as `disabled`.
-
-### `hideHttp`
-
-<table>
-	<tr><td>Type</td><td>Boolean</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>false</code></td></tr>
-</table>
-
-Allows URLs to be shown without `http://` or `https://` while keeping the scheme in the copyable value.
+| property   | type    | required | default | comment |
+| ---------- | ------- | -------- | ------- | ------- |
+| `value`    | String  | no       | `""`    | The value of the `<input />` element, and the text to be copied when clicking the copy button. |
+| `disabled` | Boolean | no       | `false` | Whether the children `<input />` and `<button />` should be rendered as `disabled`. |
+| `hideHttp` | Boolean | no       | `false` | Allows URLs to be shown without `http://` or `https://` while keeping the scheme in the copyable value. |

--- a/client/components/ellipsis-menu/README.md
+++ b/client/components/ellipsis-menu/README.md
@@ -24,64 +24,11 @@ export default function MyComponent( { onMenuItemClick } ) {
 
 ## Props
 
-### `onClick`
-
-<table>
-	<tr><td>Type</td><td>Function</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
-</table>
-
-Callback that will be invoked when menu button is clicked.
-Will be passed the click event.
-
-### `onToggle`
-
-<table>
-	<tr><td>Type</td><td>Function</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>noop</code></td></tr>
-</table>
-
-Callback that will be invoked when menu is toggled.
-Will be passed the boolean visibility of the menu.
-
-### `toggleTitle`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-Override for the default "Toggle menu" `title` attribute on the toggle button.
-
-### `position`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu).
-
-### `children`
-
-<table>
-	<tr><td>Type</td><td><code>PropTypes.node</code></td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-Menu children to be rendered.
-
-### `disabled`
-
-<table>
-	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-If `true`, then the menu icon will be displayed in light gray and will not be clickable.
+| property      | type           | required | default | comment |
+| ------------- | -------------- | -------- | ------- | -------- |
+| `onClick`     | Function       | no       | noop    | Callback that will be invoked when menu button is clicked. Will be passed the click event. |
+| `onToggle`    | Function       | no       | noop    | Callback that will be invoked when menu is toggled. Will be passed the boolean visibility of the menu. |
+| `toggleTitle` | String         | no       | `null`  | Override for the default "Toggle menu" `title` attribute on the toggle button. |
+| `position`    | String         | no       | `null`  | The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu). |
+| `children`    | PropTypes.node | no       | `null`  | Menu children to be rendered. |
+| `disabled`    | PropTypes.bool | no       | `null`  | If `true`, then the menu icon will be displayed in light gray and will not be clickable. |

--- a/client/components/emojify/README.md
+++ b/client/components/emojify/README.md
@@ -19,22 +19,7 @@ var Emojify = require( 'components/emojify' ),
 
 ## Props
 
-### `children`
-
-<table>
-	<tr><th>Type</th><td>Text|Components</td></tr>
-	<tr><th>Required</th><td>Yes</td></tr>
-	<tr><th>Default</th><td><code>none</code></td></tr>
-</table>
-
-Typically a string that you want to search for UTF emoji
-
-### `imgClassName`
-
-<table>
-	<tr><th>Type</th><td>String</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>emojify__emoji</code></td></tr>
-</table>
-
-classname applied to the image
+| property       | type             | required | default            | comment |
+| -------------- | ---------------- | -------- | ------------------ | ------- |
+| `children`     | Text\|Components | yes      | none               | Typically a string that you want to search for UTF emoji |
+| `imgClassName` | String           | no       | `"emojify__emoji"` | classname applied to the image |

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -20,15 +20,9 @@ React.createClass( {
 ## Props
 The following props can be passed to the External Link component:
 
-### `icon`
-
-<table>
-	<tr><td>Type</td><td>Bool</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-</table>
-
-Set to true if you want to render a nice external Gridicon at the end of link.
-
+| property | type    | required | comment |
+| -------- | ------- | -------- | ------- |
+| `icon`   | Boolean | no       | Set to true if you want to render a nice external Gridicon at the end of link. |
 
 ## Other Props
 Any other props that you pass into the `a` tag will be rendered as expected.

--- a/client/components/gallery-shortcode/README.md
+++ b/client/components/gallery-shortcode/README.md
@@ -29,74 +29,15 @@ export default React.createClass( {
 
 The following props can be passed to the GalleryShortcode component. If a `className` is passed, it will be added to the rendered `.gallery-shortcode` element.
 
-### `siteId`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The site ID for which to render the shortcode.
-
-### `items`
-
-<table>
-	<tr><td>Type</td><td>Array&lt;Media&gt;</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>[]</code></td></tr>
-</table>
-
-The media items to include in the rendered gallery.
-
-### `type`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>"default"</code></td></tr>
-</table>
-
-The rendered style of the gallery. Available options include `default` (Thumbnail Grid), `rectangle` (Tiled Mosaic), `square` (Square Tiles), `circle` (Circles), `columns` (Tiled Columns), and `slideshow` (Slideshow). Defaults to `default`.
-
-### `columns`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>3</code></td></tr>
-</table>
-
-The number of columns. The gallery will include a break tag at the end of each row, and calculate the column width as appropriate.
-
-### `orderBy`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>"menu_order"</code></td></tr>
-</table>
-
-The rendered order of the gallery. Available options include `menu_order` (order specified by the media modal), `title` (order by the title of the image in the Media Library), `post_date` (sort by date/time uploaded), `rand` (order randomly) and `ID` (order by media item ID). Defaults to `menu_order`.
-
-### `link`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>''</code></td></tr>
-</table>
-
-The type of link that each image will link to. Available options include `''` (Empty string which specifies that the link goes to the image's attachment page), `file` (Link to the image file), `none` (No link). Defaults to `''` (attachment page).
-
-### `size`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>thumbnail</code></td></tr>
-</table>
-
-The image size to use for the gallery thumbnail display. Available options include `thumbnail`, `medium`, `large`, `full` and any other additional image size that was registered with on the site. Defaults to `thumbnail`. 
+| property  | type           | required | default        | comment |
+| --------- | -------------- | -------- | -------------- | ------- |
+| `siteId`  | Number         | yes      |                | The site ID for which to render the shortcode. |
+| `items`   | Array\<Media\> | no       | `[]`           | The media items to include in the rendered gallery. |
+| `type`    | String         | no       | `"default"`    | The rendered style of the gallery. Available options include `default` (Thumbnail Grid), `rectangle` (Tiled Mosaic), `square` (Square Tiles), `circle` (Circles), `columns` (Tiled Columns), and `slideshow` (Slideshow). Defaults to `default`. |
+| `columns` | Number         | no       | `3`            | The number of columns. The gallery will include a break tag at the end of each row, and calculate the column width as appropriate. |
+| `orderBy` | String         | no       | `"menu_order"` | The rendered order of the gallery. Available options include `menu_order` (order specified by the media modal), `title` (order by the title of the image in the Media Library), `post_date` (sort by date/time uploaded), `rand` (order randomly) and `ID` (order by media item ID). Defaults to `menu_order`. |
+| `link`    | String         | no       | `''`           | The type of link that each image will link to. Available options include `''` (Empty string which specifies that the link goes to the image's attachment page), `file` (Link to the image file), `none` (No link). Defaults to `''` (attachment page). |
+| `size`    | String         | no       | `"thumbnail"`  | The image size to use for the gallery thumbnail display. Available options include `thumbnail`, `medium`, `large`, `full` and any other additional image size that was registered with on the site. Defaults to `thumbnail`. |
 
 ## Resources
 

--- a/client/components/section-nav/docs/example.jsx
+++ b/client/components/section-nav/docs/example.jsx
@@ -84,7 +84,9 @@ var SectionNavigation = React.createClass( {
 	render: function() {
 		var demoSections = {};
 
-		forEach( omit( this.props, 'isolated', 'uniqueInstance' ), function( prop, key ) {
+		// this will potentially break every time a new prop is added
+		// perhaps it should be refactored to explicitly iterate only the props it cares about
+		forEach( omit( this.props, 'isolated', 'uniqueInstance', 'readmeFilePath' ), function( prop, key ) {
 			demoSections[ key ] = [];
 
 			prop.forEach( function( item, index ) {

--- a/client/components/shortcode/README.md
+++ b/client/components/shortcode/README.md
@@ -28,33 +28,11 @@ export default React.createClass( {
 
 The following props can be passed to the Shortcode component. Any additional props will be applied to the rendered `iframe` element.
 
-### `siteId`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The site ID for which to render the shortcode.
-
-### `children`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The shortcode to render.
-
-### `filterRenderResult`
-
-<table>
-	<tr><td>Type</td><td>Function</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>( result ) => result</code></td></tr>
-</table>
-
-Function to override default render result. Passed the original result of the [shortcode render endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/shortcodes/render/) response, the function is expected to return a modified result.
+| property             | type     | required | default                | comment |
+| -------------------- | -------- | -------- | ---------------------- | ------- |
+| `siteId`             | Number   | yes      |                        | The site ID for which to render the shortcode. |
+| `children`           | String   | yes      |                        | The shortcode to render. |
+| `filterRenderResult` | Function | no       | `( result ) => result` | Function to override default render result. Passed the original result of the [shortcode render endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/shortcodes/render/) response, the function is expected to return a modified result. |
 
 ## Resources
 

--- a/client/components/spinner-line/README.md
+++ b/client/components/spinner-line/README.md
@@ -21,12 +21,6 @@ export default function MyComponent() {
 
 The following props can be passed to the `<SpinnerLine />` component:
 
-### `className`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td><code>null</code></td></tr>
-</table>
-
-A custom class name to apply to the rendered element, in addition to the base `.spinner-line` class.
+| property    | type   | required | default | comment |
+| ----------- | ------ | -------- | ------- | ------- |
+| `className` | String | no       | `null`  | A custom class name to apply to the rendered element, in addition to the base `.spinner-line` class. |

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -24,22 +24,7 @@ React.createClass( {
 
 The following props can be passed to the Spinner component:
 
-### `size`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td>20</td></tr>
-</table>
-
-The width and height of the spinner, in pixels.
-
-### `duration`
-
-<table>
-	<tr><td>Type</td><td>Number</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-	<tr><td>Default</td><td>3000</td></tr>
-</table>
-
-The duration of a single spin animation, in milliseconds.
+| property   | type   | required | default | comment |
+| ---------- | ------ | -------- | ------- | ------- |
+| `size`     | number | no       | `20`    | The width and height of the spinner, in pixels. |
+| `duration` | number | no       | `3000`  | The duration of a single spin animation, in milliseconds. |

--- a/client/components/tinymce/README.md
+++ b/client/components/tinymce/README.md
@@ -52,64 +52,13 @@ Many TinyMCE events can be hooked by passing its equivalent event name from the 
 
 Other props are defined in detail below:
 
-### `mode`
-
-<table>
-	<tr><th>Type</th><td>String</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>"tinymce"</code></td></tr>
-	<tr>
-		<th>Supported</th>
-		<td>
-			<ul>
-				<li><code>"tinymce"</code></li>
-				<li><code>"html"</code></li>
-			</ul>
-		</td>
-	</tr>
-</table>
-
-The editor can be toggled between two modes, `tinymce` and `html`. The `tinymce` mode will be rendered as the visual WYSIWYG editor. The `html` mode is rendered as a `<textarea>` element.
-
-### `isNew`
-
-<table>
-	<tr><th>Type</th><td>Boolean</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>false</code></td></tr>
-</table>
-
-Controls whether the editor instance should be autofocussed when initialized.
-
-### `tabIndex`
-
-<table>
-	<tr><th>Type</th><td>Number</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>null</code></td></tr>
-</table>
-
-Controls the `tabindex` attribute of both the TinyMCE visual editor and the `<textarea>` element.
-
-### `onTextEditorChange`
-
-<table>
-	<tr><th>Type</th><td>Function</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>null</code></td></tr>
-</table>
-
-If defined, a function to be triggered when the contents of the `<textarea>` element change.
-
-### `onTogglePin`
-
-<table>
-	<tr><th>Type</th><td>Function</td></tr>
-	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td><code>null</code></td></tr>
-</table>
-
-If defined, a function to be triggered when the visual editor toolbar is pinned to the top of the screen. Currently, any instance of `<TinyMCE />` is hard-coded to pin its toolbar to the top of the viewport on larger displays when the Calypso master bar bumps against the top of the toolbar. The function should expect to be passed a string argument, `"pin"` or `"unpinned"`, when the toolbar is pinned or unpinned respectively.
+| property             | type                           | required | default     | comment |
+| -------------------- | ------------------------------ | -------- | ----------- | ------- |
+| `mode`               | String (`"tinymce"`, `"html"`) | no       | `"tinymce"` | The editor can be toggled between two modes, `tinymce` and `html`. The `tinymce` mode will be rendered as the visual WYSIWYG editor. The `html` mode is rendered as a `<textarea>` element. |
+| `isNew`              | Boolean                        | no       | `false`     | Controls whether the editor instance should be autofocused when initialized. |
+| `tabIndex`           | Number                         | no       | `null`      | Controls the `tabindex` attribute of both the TinyMCE visual editor and the `<textarea>` element. |
+| `onTextEditorChange` | Function                       | no       | `null`      | If defined, a function to be triggered when the contents of the `<textarea>` element change. |
+| `onTogglePin`        | Function                       | no       | `null`      | If defined, a function to be triggered when the visual editor toolbar is pinned to the top of the screen. Currently, any instance of `<TinyMCE />` is hard-coded to pin its toolbar to the top of the viewport on larger displays when the Calypso master bar bumps against the top of the toolbar. The function should expect to be passed a string argument, `"pin"` or `"unpinned"`, when the toolbar is pinned or unpinned respectively. |
 
 ## Plugins
 

--- a/client/components/version/README.md
+++ b/client/components/version/README.md
@@ -21,19 +21,7 @@ React.createClass( {
 
 The following props can be passed to the Version component:
 
-### `version`
-
-<table>
-	<tr><td>Type</td><td>String or Number</td></tr>
-	<tr><td>Required</td><td>Yes</td></tr>
-</table>
-
-The version number that you want to display
-### `icon`
-
-<table>
-	<tr><td>Type</td><td>String</td></tr>
-	<tr><td>Required</td><td>No</td></tr>
-</table>
-
-The Gridicon you want to display next to the version. 
+| property  | type             | required | comment |
+| --------- | ---------------- | -------- | ------- |
+| `version` | String or Number | yes      | The version number that you want to display. |
+| `icon`    | String           | no       | The Gridicon you want to display next to the version. |

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -19,6 +19,7 @@ import touchDetect from 'lib/touch-detect';
 import { isMobile } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import Spinner from 'components/spinner';
+import SpinnerLine from 'components/spinner-line';
 import SeoPreviewPane from 'components/seo-preview-pane';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -32,7 +33,8 @@ export class WebPreviewContent extends Component {
 	state = {
 		iframeUrl: null,
 		device: this.props.defaultViewportDevice || 'computer',
-		loaded: false
+		loaded: false,
+		isLoadingSubpage: false
 	};
 
 	setIframeInstance = ( ref ) => {
@@ -115,11 +117,15 @@ export class WebPreviewContent extends Component {
 			case 'focus':
 				this.removeSelection();
 				return;
+			case 'loading':
+				this.setState( { isLoadingSubpage: true } );
+				return;
 		}
 	}
 
 	handleLocationChange = ( payload ) => {
 		this.props.onLocationUpdate( payload.pathname );
+		this.setState( { isLoadingSubpage: false } );
 	}
 
 	removeSelection = () => {
@@ -196,7 +202,7 @@ export class WebPreviewContent extends Component {
 	}
 
 	setLoaded = () => {
-		if ( this.state.loaded ) {
+		if ( this.state.loaded && ! this.state.isLoadingSubpage ) {
 			debug( 'already loaded' );
 			return;
 		}
@@ -210,7 +216,7 @@ export class WebPreviewContent extends Component {
 		} else {
 			debug( 'preview loaded for url:', this.state.iframeUrl );
 		}
-		this.setState( { loaded: true } );
+		this.setState( { loaded: true, isLoadingSubpage: false } );
 
 		this.focusIfNeeded();
 	}
@@ -237,7 +243,11 @@ export class WebPreviewContent extends Component {
 					showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
 					showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
 					selectSeoPreview={ this.selectSEO }
+					isLoading={ this.state.isLoadingSubpage }
 				/>
+				{ ( ! this.state.loaded || this.state.isLoadingSubpage ) &&
+					<SpinnerLine />
+				}
 				<div className="web-preview__placeholder">
 					{ this.props.showPreview && ! this.state.loaded && 'seo' !== this.state.device &&
 						<div className="web-preview__loading-message-wrapper">

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -282,6 +282,7 @@ a.web-preview__external.button {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+	position: relative;
 }
 
 .web-preview .spinner {
@@ -305,4 +306,11 @@ a.web-preview__external.button {
 	display: block;
 	margin: 48px 0;
 	height: 100%;
+}
+
+.web-preview__inner .spinner-line {
+	position: absolute;
+		top: 22px;
+	width: 100%;
+	z-index: z-index( 'root', '.web-preview__inner .spinner-line' );
 }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -125,7 +125,7 @@ let DesignAssets = React.createClass( {
 					<ClipboardButtonInput readmeFilePath="components/clipboard-button-input" />
 					<ClipboardButtons readmeFilePath="components/forms/clipboard-button" />
 					<Count readmeFilePath="components/count" />
-					<CountedTextareas readmeFilePath="components/forms/counted-text-area" />
+					<CountedTextareas readmeFilePath="components/forms/counted-textarea" />
 					<DatePicker readmeFilePath="components/date-picker" />
 					<DropZones searchKeywords="drag" readmeFilePath="components/drop-zone" />
 					<EllipsisMenu readmeFilePath="components/ellipsis-menu" />
@@ -139,23 +139,23 @@ let DesignAssets = React.createClass( {
 					<FormattedHeader readmeFilePath="components/formatted-header" />
 					<FormFields searchKeywords="input textbox textarea radio" readmeFilePath="components/forms" />
 					<Gauge readmeFilePath="components/gauge" />
-					<GlobalNotices readmeFilePath="components/global-notices" />
+					<GlobalNotices />
 					<Gravatar readmeFilePath="components/gravatar" />
-					<Gridicons readmeFilePath="components/gridicons" />
+					<Gridicons />
 					<Headers readmeFilePath="components/header-cake" />
 					<ImagePreloader readmeFilePath="components/image-preloader" />
 					<InfoPopover readmeFilePath="components/info-popover" />
 					<Tooltip readmeFilePath="components/tooltip" />
 					<InputChrono readmeFilePath="components/input-chrono" />
 					<LanguagePicker readmeFilePath="components/language-picker" />
-					<Notices readmeFilePath="components/notice" />
+					<Notices />
 					<PaginationExample readmeFilePath="components/pagination" />
 					<PaymentLogo readmeFilePath="components/payment-logo" />
 					<Popovers readmeFilePath="components/popover" />
 					<ProgressBar readmeFilePath="components/progress-bar" />
 					<Ranges readmeFilePath="components/forms/range" />
 					<Rating readmeFilePath="components/rating" />
-					<Ribbon readmeFilePath="components/ribbon" />
+					<Ribbon />
 					<ScreenReaderTextExample />
 					<SearchDemo readmeFilePath="components/search" />
 					<SectionHeader readmeFilePath="components/section-header" />

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -116,60 +116,60 @@ let DesignAssets = React.createClass( {
 						/> }
 
 				<Collection component={ component } filter={ filter }>
-					<Accordions componentUsageStats={ componentsUsageStats.accordion } readmeFilePath="components/accordion" />
-					<Banner readmeFilePath="components/banner" />
-					<BulkSelect readmeFilePath="components/bulk-select" />
-					<ButtonGroups readmeFilePath="components/button-group" />
-					<Buttons componentUsageStats={ componentsUsageStats.button } readmeFilePath="components/button" />
-					<Cards readmeFilePath="components/card" />
-					<ClipboardButtonInput readmeFilePath="components/clipboard-button-input" />
-					<ClipboardButtons readmeFilePath="components/forms/clipboard-button" />
-					<Count readmeFilePath="components/count" />
-					<CountedTextareas readmeFilePath="components/forms/counted-textarea" />
-					<DatePicker readmeFilePath="components/date-picker" />
-					<DropZones searchKeywords="drag" readmeFilePath="components/drop-zone" />
-					<EllipsisMenu readmeFilePath="components/ellipsis-menu" />
-					<EmojifyExample readmeFilePath="components/emojify" />
-					<EmptyContent readmeFilePath="components/empty-content" />
-					<ExternalLink readmeFilePath="components/external-link" />
-					<FAQ readmeFilePath="components/faq" />
-					<FeatureGate readmeFilePath="components/feature-example" />
-					<FilePickers readmeFilePath="components/file-picker" />
-					<FoldableCard readmeFilePath="components/foldable-card" />
-					<FormattedHeader readmeFilePath="components/formatted-header" />
-					<FormFields searchKeywords="input textbox textarea radio" readmeFilePath="components/forms" />
-					<Gauge readmeFilePath="components/gauge" />
+					<Accordions componentUsageStats={ componentsUsageStats.accordion } readmeFilePath="accordion" />
+					<Banner readmeFilePath="banner" />
+					<BulkSelect readmeFilePath="bulk-select" />
+					<ButtonGroups readmeFilePath="button-group" />
+					<Buttons componentUsageStats={ componentsUsageStats.button } readmeFilePath="button" />
+					<Cards readmeFilePath="card" />
+					<ClipboardButtonInput readmeFilePath="clipboard-button-input" />
+					<ClipboardButtons readmeFilePath="forms/clipboard-button" />
+					<Count readmeFilePath="count" />
+					<CountedTextareas readmeFilePath="forms/counted-textarea" />
+					<DatePicker readmeFilePath="date-picker" />
+					<DropZones searchKeywords="drag" readmeFilePath="drop-zone" />
+					<EllipsisMenu readmeFilePath="ellipsis-menu" />
+					<EmojifyExample readmeFilePath="emojify" />
+					<EmptyContent readmeFilePath="empty-content" />
+					<ExternalLink readmeFilePath="external-link" />
+					<FAQ readmeFilePath="faq" />
+					<FeatureGate readmeFilePath="feature-example" />
+					<FilePickers readmeFilePath="file-picker" />
+					<FoldableCard readmeFilePath="foldable-card" />
+					<FormattedHeader readmeFilePath="formatted-header" />
+					<FormFields searchKeywords="input textbox textarea radio" readmeFilePath="forms" />
+					<Gauge readmeFilePath="gauge" />
 					<GlobalNotices />
-					<Gravatar readmeFilePath="components/gravatar" />
+					<Gravatar readmeFilePath="gravatar" />
 					<Gridicons />
-					<Headers readmeFilePath="components/header-cake" />
-					<ImagePreloader readmeFilePath="components/image-preloader" />
-					<InfoPopover readmeFilePath="components/info-popover" />
-					<Tooltip readmeFilePath="components/tooltip" />
-					<InputChrono readmeFilePath="components/input-chrono" />
-					<LanguagePicker readmeFilePath="components/language-picker" />
+					<Headers readmeFilePath="header-cake" />
+					<ImagePreloader readmeFilePath="image-preloader" />
+					<InfoPopover readmeFilePath="info-popover" />
+					<Tooltip readmeFilePath="tooltip" />
+					<InputChrono readmeFilePath="input-chrono" />
+					<LanguagePicker readmeFilePath="language-picker" />
 					<Notices />
-					<PaginationExample readmeFilePath="components/pagination" />
-					<PaymentLogo readmeFilePath="components/payment-logo" />
-					<Popovers readmeFilePath="components/popover" />
-					<ProgressBar readmeFilePath="components/progress-bar" />
-					<Ranges readmeFilePath="components/forms/range" />
-					<Rating readmeFilePath="components/rating" />
+					<PaginationExample readmeFilePath="pagination" />
+					<PaymentLogo readmeFilePath="payment-logo" />
+					<Popovers readmeFilePath="popover" />
+					<ProgressBar readmeFilePath="progress-bar" />
+					<Ranges readmeFilePath="forms/range" />
+					<Rating readmeFilePath="rating" />
 					<Ribbon />
 					<ScreenReaderTextExample />
-					<SearchDemo readmeFilePath="components/search" />
-					<SectionHeader readmeFilePath="components/section-header" />
-					<SectionNav readmeFilePath="components/section-nav" />
-					<SegmentedControl readmeFilePath="components/segmented-control" />
-					<SelectDropdown searchKeywords="menu" readmeFilePath="components/select-dropdown" />
+					<SearchDemo readmeFilePath="search" />
+					<SectionHeader readmeFilePath="section-header" />
+					<SectionNav readmeFilePath="section-nav" />
+					<SegmentedControl readmeFilePath="segmented-control" />
+					<SelectDropdown searchKeywords="menu" readmeFilePath="select-dropdown" />
 					<SocialLogos />
-					<Spinner searchKeywords="loading" readmeFilePath="components/spinner" />
-					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="components/spinner-button" />
-					<SpinnerLine searchKeywords="loading" readmeFilePath="components/spinner-line" />
-					<Timezone readmeFilePath="components/timezone" />
-					<TokenFields readmeFilePath="components/token-field" />
-					<VerticalMenu readmeFilePath="components/vertical-menu" />
-					<Version readmeFilePath="components/version" />
+					<Spinner searchKeywords="loading" readmeFilePath="spinner" />
+					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />
+					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
+					<Timezone readmeFilePath="timezone" />
+					<TokenFields readmeFilePath="token-field" />
+					<VerticalMenu readmeFilePath="vertical-menu" />
+					<Version readmeFilePath="version" />
 				</Collection>
 			</Main>
 		);

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -116,7 +116,7 @@ let DesignAssets = React.createClass( {
 						/> }
 
 				<Collection component={ component } filter={ filter }>
-					<Accordions componentUsageStats={ componentsUsageStats.accordion } />
+					<Accordions componentUsageStats={ componentsUsageStats.accordion } readmeFilePath="components/accordion" />
 					<Banner />
 					<BulkSelect />
 					<ButtonGroups />

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -117,59 +117,59 @@ let DesignAssets = React.createClass( {
 
 				<Collection component={ component } filter={ filter }>
 					<Accordions componentUsageStats={ componentsUsageStats.accordion } readmeFilePath="components/accordion" />
-					<Banner />
-					<BulkSelect />
-					<ButtonGroups />
-					<Buttons componentUsageStats={ componentsUsageStats.button } />
-					<Cards />
-					<ClipboardButtonInput />
-					<ClipboardButtons />
-					<Count />
-					<CountedTextareas />
-					<DatePicker />
-					<DropZones searchKeywords="drag" />
-					<EllipsisMenu />
-					<EmojifyExample />
-					<EmptyContent />
-					<ExternalLink />
-					<FAQ />
-					<FeatureGate />
-					<FilePickers />
-					<FoldableCard />
-					<FormattedHeader />
-					<FormFields searchKeywords="input textbox textarea radio" />
-					<Gauge />
-					<GlobalNotices />
-					<Gravatar />
-					<Gridicons />
-					<Headers />
-					<ImagePreloader />
-					<InfoPopover />
-					<Tooltip />
-					<InputChrono />
-					<LanguagePicker />
-					<Notices />
-					<PaginationExample />
-					<PaymentLogo />
-					<Popovers />
-					<ProgressBar />
-					<Ranges />
-					<Rating />
-					<Ribbon />
+					<Banner readmeFilePath="components/banner" />
+					<BulkSelect readmeFilePath="components/bulk-select" />
+					<ButtonGroups readmeFilePath="components/button-group" />
+					<Buttons componentUsageStats={ componentsUsageStats.button } readmeFilePath="components/button" />
+					<Cards readmeFilePath="components/card" />
+					<ClipboardButtonInput readmeFilePath="components/clipboard-button-input" />
+					<ClipboardButtons readmeFilePath="components/forms/clipboard-button" />
+					<Count readmeFilePath="components/count" />
+					<CountedTextareas readmeFilePath="components/forms/counted-text-area" />
+					<DatePicker readmeFilePath="components/date-picker" />
+					<DropZones searchKeywords="drag" readmeFilePath="components/drop-zone" />
+					<EllipsisMenu readmeFilePath="components/ellipsis-menu" />
+					<EmojifyExample readmeFilePath="components/emojify" />
+					<EmptyContent readmeFilePath="components/empty-content" />
+					<ExternalLink readmeFilePath="components/external-link" />
+					<FAQ readmeFilePath="components/faq" />
+					<FeatureGate readmeFilePath="components/feature-example" />
+					<FilePickers readmeFilePath="components/file-picker" />
+					<FoldableCard readmeFilePath="components/foldable-card" />
+					<FormattedHeader readmeFilePath="components/formatted-header" />
+					<FormFields searchKeywords="input textbox textarea radio" readmeFilePath="components/forms" />
+					<Gauge readmeFilePath="components/gauge" />
+					<GlobalNotices readmeFilePath="components/global-notices" />
+					<Gravatar readmeFilePath="components/gravatar" />
+					<Gridicons readmeFilePath="components/gridicons" />
+					<Headers readmeFilePath="components/header-cake" />
+					<ImagePreloader readmeFilePath="components/image-preloader" />
+					<InfoPopover readmeFilePath="components/info-popover" />
+					<Tooltip readmeFilePath="components/tooltip" />
+					<InputChrono readmeFilePath="components/input-chrono" />
+					<LanguagePicker readmeFilePath="components/language-picker" />
+					<Notices readmeFilePath="components/notice" />
+					<PaginationExample readmeFilePath="components/pagination" />
+					<PaymentLogo readmeFilePath="components/payment-logo" />
+					<Popovers readmeFilePath="components/popover" />
+					<ProgressBar readmeFilePath="components/progress-bar" />
+					<Ranges readmeFilePath="components/forms/range" />
+					<Rating readmeFilePath="components/rating" />
+					<Ribbon readmeFilePath="components/ribbon" />
 					<ScreenReaderTextExample />
-					<SearchDemo />
-					<SectionHeader />
-					<SectionNav />
-					<SegmentedControl />
-					<SelectDropdown searchKeywords="menu" />
+					<SearchDemo readmeFilePath="components/search" />
+					<SectionHeader readmeFilePath="components/section-header" />
+					<SectionNav readmeFilePath="components/section-nav" />
+					<SegmentedControl readmeFilePath="components/segmented-control" />
+					<SelectDropdown searchKeywords="menu" readmeFilePath="components/select-dropdown" />
 					<SocialLogos />
-					<Spinner searchKeywords="loading" />
-					<SpinnerButton searchKeywords="loading input submit" />
-					<SpinnerLine searchKeywords="loading" />
-					<Timezone />
-					<TokenFields />
-					<VerticalMenu />
-					<Version />
+					<Spinner searchKeywords="loading" readmeFilePath="components/spinner" />
+					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="components/spinner-button" />
+					<SpinnerLine searchKeywords="loading" readmeFilePath="components/spinner-line" />
+					<Timezone readmeFilePath="components/timezone" />
+					<TokenFields readmeFilePath="components/token-field" />
+					<VerticalMenu readmeFilePath="components/vertical-menu" />
+					<Version readmeFilePath="components/version" />
 				</Collection>
 			</Main>
 		);

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -59,7 +59,6 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 			);
 		}
 
-		const readmeFilePath = example.props.readmeFilePath;
 		return (
 			<DocsExampleWrapper
 				name={ exampleName }

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -59,7 +59,6 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 			);
 		}
 
-		const readmeFilePath = example.props.readmeFilePath;
 		return (
 			<DocsExampleWrapper
 				name={ exampleName }
@@ -67,7 +66,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 				url={ exampleLink }
 			>
 				{ example }
-				{ component && readmeFilePath && <ReadmeViewer readmeFilePath={ readmeFilePath } /> }
+				{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
 			</DocsExampleWrapper>
 		);
 	} );

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -11,6 +11,7 @@ import {
 	camelCaseToSlug,
 	getComponentName,
 } from 'devdocs/docs-example/util';
+import ReadmeViewer from 'devdocs/docs-example/readme-viewer';
 
 const shouldShowInstance = ( example, filter, component ) => {
 	const name = getComponentName( example );
@@ -65,6 +66,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 				url={ exampleLink }
 			>
 				{ example }
+				{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
 			</DocsExampleWrapper>
 		);
 	} );

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -59,6 +59,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 			);
 		}
 
+		const readmeFilePath = example.props.readmeFilePath;
 		return (
 			<DocsExampleWrapper
 				name={ exampleName }
@@ -66,7 +67,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 				url={ exampleLink }
 			>
 				{ example }
-				{ component && <ReadmeViewer readmeFilePath={ example.props.readmeFilePath } /> }
+				{ component && readmeFilePath && <ReadmeViewer readmeFilePath={ readmeFilePath } /> }
 			</DocsExampleWrapper>
 		);
 	} );

--- a/client/devdocs/docs-example/readme-viewer.jsx
+++ b/client/devdocs/docs-example/readme-viewer.jsx
@@ -7,13 +7,8 @@ import React, { Component, PropTypes } from 'react';
  * Internal Dependencies
  */
 import FoldableCard from 'components/foldable-card';
-import SectionHeader from 'components/section-header';
 
 class ReadmeViewer extends Component {
-	static propTypes = {
-		readmeFilePath: PropTypes.string.isRequired
-	};
-
 	constructor( props ) {
 		super( props );
 	}
@@ -23,10 +18,22 @@ class ReadmeViewer extends Component {
 	}
 
 	render() {
+		const headerText = this.props.readmeFilePath
+			? 'README.md'
+			: "Oh no. There's no README.";
+		const header = <span className="docs-example__readme-viewer-header">{ headerText } </span>;
+
+		const body = this.props.readmeFilePath
+			? <div dangerouslySetInnerHTML={ this.getReadmeHTML() } />
+			: 'Please write one!';
+
 		return (
-			<FoldableCard header="README" clickableHeader={ true }>
-				<div dangerouslySetInnerHTML={ this.getReadmeHTML() } />
-			</FoldableCard>
+			<div className="docs-example__readme-viewer">
+				<hr className="docs-example__readme-viewer-hr"/>
+				<FoldableCard header={ header } clickableHeader={ true } compact={ true }>
+					{ body }
+				</FoldableCard>
+			</div>
 		);
 	}
 }

--- a/client/devdocs/docs-example/readme-viewer.jsx
+++ b/client/devdocs/docs-example/readme-viewer.jsx
@@ -28,7 +28,7 @@ class ReadmeViewer extends Component {
 				</span>;
 
 		const body = this.props.readmeFilePath
-			? <div dangerouslySetInnerHTML={ this.props.getReadmeHTML() } />
+			? <div dangerouslySetInnerHTML={ this.props.getReadmeHTML( this.props.readmeFilePath ) } />
 			: <div>Please write one!</div>;
 
 		return (
@@ -43,7 +43,9 @@ class ReadmeViewer extends Component {
 }
 
 ReadmeViewer.defaultProps = {
-	getReadmeHTML: () => { __html: require( `../../${ this.props.readmeFilePath }/README.md` ) }
+	getReadmeHTML: ( readmeFilePath ) => {
+		return { __html: require( `../../components/${ readmeFilePath }/README.md` ) };
+	}
 };
 
 export default ReadmeViewer;

--- a/client/devdocs/docs-example/readme-viewer.jsx
+++ b/client/devdocs/docs-example/readme-viewer.jsx
@@ -1,0 +1,34 @@
+/**
+ * External Dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+import SectionHeader from 'components/section-header';
+
+class ReadmeViewer extends Component {
+	static propTypes = {
+		readmeFilePath: PropTypes.string.isRequired
+	};
+
+	constructor( props ) {
+		super( props );
+	}
+
+	getReadmeHTML() {
+		return { __html: require( `../../${ this.props.readmeFilePath }/README.md` ) };
+	}
+
+	render() {
+		return (
+			<FoldableCard header="README" clickableHeader={ true }>
+				<div dangerouslySetInnerHTML={ this.getReadmeHTML() } />
+			</FoldableCard>
+		);
+	}
+}
+
+export default ReadmeViewer;

--- a/client/devdocs/docs-example/readme-viewer.jsx
+++ b/client/devdocs/docs-example/readme-viewer.jsx
@@ -9,23 +9,27 @@ import React, { Component, PropTypes } from 'react';
 import FoldableCard from 'components/foldable-card';
 
 class ReadmeViewer extends Component {
+	static propTypes = {
+		getReadmeHTML: PropTypes.func,
+		readmeFilePath: PropTypes.string
+	};
+
 	constructor( props ) {
 		super( props );
 	}
 
-	getReadmeHTML() {
-		return { __html: require( `../../${ this.props.readmeFilePath }/README.md` ) };
-	}
-
 	render() {
-		const headerText = this.props.readmeFilePath
-			? 'README.md'
-			: "Oh no. There's no README.";
-		const header = <span className="docs-example__readme-viewer-header">{ headerText } </span>;
+		const header = this.props.readmeFilePath
+			? <span id="docs-example__readme-present-header" className="docs-example__readme-viewer-header">
+					README.md
+				</span>
+			: <span id="docs-example__readme-not-present-header" className="docs-example__readme-viewer-header">
+					Oh no. There's no README.
+				</span>;
 
 		const body = this.props.readmeFilePath
-			? <div dangerouslySetInnerHTML={ this.getReadmeHTML() } />
-			: 'Please write one!';
+			? <div dangerouslySetInnerHTML={ this.props.getReadmeHTML() } />
+			: <div>Please write one!</div>;
 
 		return (
 			<div className="docs-example__readme-viewer">
@@ -37,5 +41,9 @@ class ReadmeViewer extends Component {
 		);
 	}
 }
+
+ReadmeViewer.defaultProps = {
+	getReadmeHTML: () => { __html: require( `../../${ this.props.readmeFilePath }/README.md` ) }
+};
 
 export default ReadmeViewer;

--- a/client/devdocs/docs-example/readme-viewer.jsx
+++ b/client/devdocs/docs-example/readme-viewer.jsx
@@ -2,6 +2,8 @@
  * External Dependencies
  */
 import React, { Component, PropTypes } from 'react';
+import { Parser } from 'html-to-react';
+const htmlToReactParser = new Parser();
 
 /**
  * Internal Dependencies
@@ -10,7 +12,7 @@ import FoldableCard from 'components/foldable-card';
 
 class ReadmeViewer extends Component {
 	static propTypes = {
-		getReadmeHTML: PropTypes.func,
+		getReadme: PropTypes.func,
 		readmeFilePath: PropTypes.string
 	};
 
@@ -27,15 +29,13 @@ class ReadmeViewer extends Component {
 					Oh no. There's no README.
 				</span>;
 
-		const body = this.props.readmeFilePath
-			? <div dangerouslySetInnerHTML={ this.props.getReadmeHTML( this.props.readmeFilePath ) } />
-			: <div>Please write one!</div>;
+		const readme = this.props.readmeFilePath && this.props.getReadme( this.props.readmeFilePath );
 
 		return (
 			<div className="docs-example__readme-viewer">
-				<hr className="docs-example__readme-viewer-hr"/>
+				<hr className="docs-example__readme-viewer-hr" />
 				<FoldableCard header={ header } clickableHeader={ true } compact={ true }>
-					{ body }
+					{ readme || 'Please write one!' }
 				</FoldableCard>
 			</div>
 		);
@@ -43,8 +43,9 @@ class ReadmeViewer extends Component {
 }
 
 ReadmeViewer.defaultProps = {
-	getReadmeHTML: ( readmeFilePath ) => {
-		return { __html: require( `../../components/${ readmeFilePath }/README.md` ) };
+	getReadme: ( readmeFilePath ) => {
+		return htmlToReactParser.parse(
+			require( `../../components/${ readmeFilePath }/README.md` ) );
 	}
 };
 

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -63,3 +63,99 @@
 		}
 	}
 }
+
+.docs-example__readme-viewer {
+	p, li {
+		font-size: 1.5rem;
+		font-weight: 400;
+	}
+
+	p {
+		margin-bottom: .5rem
+	}
+
+	code {
+		color: $orange-jazzy;
+	}
+
+	table {
+		border-collapse: collapse;
+		border-spacing: 0;
+
+		th, td {
+			border: 1px solid $gray;
+			font-size: .83em;
+			padding: 8px;
+			text-align: left;
+		}
+
+		th {
+			background-color: $gray-light;
+			padding-top: 11px;
+			padding-bottom: 11px;
+		}
+
+		td {
+			font-weight: 300;
+		}
+	}
+
+	h1, h2, h3, h4, h5, h6 {
+		display: block;
+		font-weight: 400;
+		margin-bottom: 0.5em;
+		margin-left: 0;
+	}
+
+	h1 {
+		font-size: 1.33em;
+	}
+
+	h2 {
+		font-size: 1.17em;
+	}
+
+	h3 {
+    font-size: 1em;
+	}
+
+	h4 {
+		font-size: .83em;
+	}
+
+	h5 {
+		font-size: .67em;
+	}
+
+	h6 {
+		font-size: .5em;
+	}
+}
+
+.docs-example__readme-viewer-header {
+	font-size: .83em;
+	font-weight: 500;
+}
+
+.docs-example__readme-viewer-hr {
+	background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+	border: 0;
+	display: block;
+	height: 1px;
+	margin-bottom: 2em;
+	position: relative;
+	text-align: center;
+	top: 1em;
+	width: 100%;
+}
+
+.docs-example__readme-viewer-hr:after {
+	background: $gray-light;
+	color: $blue-wordpress;
+	content: '\0000A7';
+	display: inline-block;
+	font-size: 18px;
+	padding: 0 10px;
+	position: relative;
+	top: -15px;
+}

--- a/client/devdocs/docs-example/test/readme-viewer.jsx
+++ b/client/devdocs/docs-example/test/readme-viewer.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { assert, expect } from 'chai';
+import React from 'react';
+import { render } from 'enzyme';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import ReadmeViewer from 'devdocs/docs-example/readme-viewer';
+
+describe( 'ReadmeViewer', () => {
+	it( 'should render README.md when given readmeFilePath', () => {
+		const getReadmeHTML = sinon.spy();
+		const readmeViewer = render( <ReadmeViewer readmeFilePath="foo" getReadmeHTML={ getReadmeHTML } /> );
+		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length(1);
+		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length(0);
+		assert.isTrue( getReadmeHTML.called );
+	} );
+
+	it( 'should not render a README.md when not given readmeFilePath', () => {
+		const getReadmeHTML = sinon.spy();
+		const readmeViewer = render( <ReadmeViewer getReadmeHTML={ getReadmeHTML } /> );
+		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length(0);
+		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length(1);
+		assert.isTrue( getReadmeHTML.notCalled );
+	} );
+} );

--- a/client/devdocs/docs-example/test/readme-viewer.jsx
+++ b/client/devdocs/docs-example/test/readme-viewer.jsx
@@ -15,16 +15,16 @@ describe( 'ReadmeViewer', () => {
 	it( 'should render README.md when given readmeFilePath', () => {
 		const getReadmeHTML = sinon.spy();
 		const readmeViewer = render( <ReadmeViewer readmeFilePath="foo" getReadmeHTML={ getReadmeHTML } /> );
-		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length(1);
-		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length(0);
+		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length( 1 );
+		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length( 0 );
 		assert.isTrue( getReadmeHTML.called );
 	} );
 
 	it( 'should not render a README.md when not given readmeFilePath', () => {
 		const getReadmeHTML = sinon.spy();
 		const readmeViewer = render( <ReadmeViewer getReadmeHTML={ getReadmeHTML } /> );
-		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length(0);
-		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length(1);
+		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length( 0 );
+		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length( 1 );
 		assert.isTrue( getReadmeHTML.notCalled );
 	} );
 } );

--- a/client/devdocs/docs-example/test/readme-viewer.jsx
+++ b/client/devdocs/docs-example/test/readme-viewer.jsx
@@ -13,18 +13,18 @@ import ReadmeViewer from 'devdocs/docs-example/readme-viewer';
 
 describe( 'ReadmeViewer', () => {
 	it( 'should render README.md when given readmeFilePath', () => {
-		const getReadmeHTML = sinon.spy();
-		const readmeViewer = render( <ReadmeViewer readmeFilePath="foo" getReadmeHTML={ getReadmeHTML } /> );
+		const getReadme = sinon.spy();
+		const readmeViewer = render( <ReadmeViewer readmeFilePath="foo" getReadme={ getReadme } /> );
 		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length( 1 );
 		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length( 0 );
-		assert.isTrue( getReadmeHTML.called );
+		assert.isTrue( getReadme.called );
 	} );
 
 	it( 'should not render a README.md when not given readmeFilePath', () => {
-		const getReadmeHTML = sinon.spy();
-		const readmeViewer = render( <ReadmeViewer getReadmeHTML={ getReadmeHTML } /> );
+		const getReadme = sinon.spy();
+		const readmeViewer = render( <ReadmeViewer getReadme={ getReadme } /> );
 		expect( readmeViewer.find( '#docs-example__readme-present-header' ) ).to.have.length( 0 );
 		expect( readmeViewer.find( '#docs-example__readme-not-present-header' ) ).to.have.length( 1 );
-		assert.isTrue( getReadmeHTML.notCalled );
+		assert.isTrue( getReadme.notCalled );
 	} );
 } );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -436,7 +436,9 @@ class PluginMeta extends Component {
 			'is-placeholder': !! this.props.isPlaceholder
 		} );
 
-		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
+		const plugin = this.props.selectedSite && this.props.sites[ 0 ] && this.props.sites[ 0 ].plugin
+			? this.props.sites[ 0 ].plugin
+			: this.props.plugin;
 		const path = ( ! this.props.selectedSite || plugin.active ) && this.getExtensionSettingsPath( plugin );
 
 		return (

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -112,7 +112,7 @@ class PreviewMain extends React.Component {
 
 		return (
 			<Main className="preview">
-				<DocumentHead title={ translate( 'Site Preview' ) } />
+				<DocumentHead title={ translate( 'Your Site' ) } />
 				<WebPreviewContent
 					onLocationUpdate={ this.updateSiteLocation }
 					showUrl={ !! this.state.externalUrl }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "hard-source-webpack-plugin": "0.3.12",
     "he": "0.5.0",
     "html-loader": "0.4.0",
+    "html-to-react": "1.2.11",
     "i18n-calypso": "1.7.3",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "lodash": "4.15.0",
     "lru": "3.1.0",
     "lunr": "0.5.7",
+    "markdown-loader": "2.0.1",
     "marked": "0.3.5",
     "mkdirp": "0.5.1",
     "moment": "2.10.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,22 @@ function getAliasesForExtensions() {
 	return aliasesMap;
 }
 
+function getAliasesForDirectory( prefix, directory ) {
+	const filenames = fs
+		.readdirSync( directory )
+		.filter( filename =>
+			fs.lstatSync(
+				path.join( directory, filename )
+			).isDirectory()
+		);
+
+	const aliasesMap = {};
+	filenames.forEach( filename =>
+		aliasesMap[ prefix + filename ] = path.join( directory, filename )
+	);
+	return aliasesMap;
+}
+
 const babelLoader = {
 	loader: 'babel-loader',
 	options: {
@@ -111,6 +127,18 @@ const webpackConfig = {
 			{
 				test: /node_modules[\/\\]tinymce/,
 				use: 'imports-loader?this=>window',
+			},
+			{
+				test: /README\.md$/,
+				use: [
+					{ loader: 'html-loader' },
+					{
+						loader: 'markdown-loader',
+						options: {
+							sanitize: true
+						}
+					}
+				]
 			}
 		]
 	},
@@ -125,7 +153,8 @@ const webpackConfig = {
 				'react-virtualized': 'react-virtualized/dist/commonjs',
 				'social-logos/example': 'social-logos/build/example'
 			},
-			getAliasesForExtensions()
+			getAliasesForExtensions(),
+			getAliasesForDirectory( 'component-readme-', path.join( __dirname, 'client', 'components' ) )
 		),
 	},
 	node: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,29 +28,20 @@ const bundleEnv = config( 'env' );
 const isWindows = os.type() === 'Windows_NT';
 
 /**
- * This function scans the /client/extensions directory in order to generate a map that looks like this:
+ * This function scans the specified directory in order to generate an alias to path map that looks like this:
  * {
  *   sensei: 'absolute/path/to/wp-calypso/client/extensions/sensei',
  *   woocommerce: 'absolute/path/to/wp-calypso/client/extensions/woocommerce',
  *   ....
  * }
  *
- * Providing webpack with these aliases instead of telling it to scan client/extensions for every
+ * Providing webpack with these aliases instead of telling it to scan the directory for every
  * module resolution speeds up builds significantly.
+ *
+ * @param { String } prefix - A unique prefix for the alias to prevent alias collisions.
+ * @param { String } directory - A directory to scan for modules.
+ * @return { Object } aliasesMap - The alias to path map.
  */
-function getAliasesForExtensions() {
-	const extensionsDirectory = path.join( __dirname, 'client', 'extensions' );
-	const extensionsNames = fs
-		.readdirSync( extensionsDirectory )
-		.filter( filename => filename.indexOf( '.' ) === -1 ); // heuristic for finding directories
-
-	const aliasesMap = {};
-	extensionsNames.forEach( extensionName =>
-		aliasesMap[ extensionName ] = path.join( extensionsDirectory, extensionName )
-	);
-	return aliasesMap;
-}
-
 function getAliasesForDirectory( prefix, directory ) {
 	const filenames = fs
 		.readdirSync( directory )
@@ -153,7 +144,7 @@ const webpackConfig = {
 				'react-virtualized': 'react-virtualized/dist/commonjs',
 				'social-logos/example': 'social-logos/build/example'
 			},
-			getAliasesForExtensions(),
+			getAliasesForDirectory( '', path.join( __dirname, 'client', 'extensions' ) ),
 			getAliasesForDirectory( 'component-readme-', path.join( __dirname, 'client', 'components' ) )
 		),
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
 const NameAllModulesPlugin = require( 'name-all-modules-plugin' );
 const os = require( 'os' );
 const path = require( 'path' );
-const prism = require ( 'prismjs' );
+const prism = require( 'prismjs' );
 const webpack = require( 'webpack' );
 
 /**
@@ -118,7 +118,7 @@ const webpackConfig = {
 			},
 			{
 				test: /node_modules[\/\\]tinymce/,
-				use: 'imports-loader?this=>window',
+				use: 'imports-loader?this=>window'
 			},
 			{
 				test: /README\.md$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,7 +120,7 @@ const webpackConfig = {
 				use: 'imports-loader?this=>window',
 			},
 			{
-				test: /client[\/\\]components[\/\\].*[\/\\]README\.md$/,
+				test: /README\.md$/,
 				use: [
 					{ loader: 'html-loader' },
 					{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,7 +129,7 @@ const webpackConfig = {
 				use: 'imports-loader?this=>window',
 			},
 			{
-				test: /README\.md$/,
+				test: /client[\/\\]components[\/\\].*[\/\\]README\.md$/,
 				use: [
 					{ loader: 'html-loader' },
 					{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,8 +149,7 @@ const webpackConfig = {
 				'react-virtualized': 'react-virtualized/dist/commonjs',
 				'social-logos/example': 'social-logos/build/example'
 			},
-			getAliasesForDirectory( path.join( __dirname, 'client', 'extensions' ) ),
-			getAliasesForDirectory( path.join( __dirname, 'client', 'components' ), 'component-readme-' )
+			getAliasesForDirectory( path.join( __dirname, 'client', 'extensions' ) )
 		)
 	},
 	node: {


### PR DESCRIPTION
`[Status] Needs Review`
This is a continuation of the work here:
#9530

The end goal is to display the READMEs for each Calypso react component on /devdocs.
Each README will be placed underneath their respective component when viewed in isolation.

The way I set this up is by using a webpack loader to load all of the README.md files.
I didn't want to have to manually import the READMEs into each component, so I wrote a function to scan the package for READMEs.

This PR `[Status] Needs Review`.
* There are a couple READMEs with HTML that need to get translated to .md. I'll do this in a separate PR.

![readmeviewer](https://user-images.githubusercontent.com/30010510/28772649-9d0af23e-759b-11e7-8c31-d512986cb656.gif)

cc @bluefuton