### PR TITLE
Fix Google signup scope

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -28,7 +28,7 @@ class GoogleLoginButton extends Component {
 	};
 
 	static defaultProps = {
-		scope: 'https://www.googleapis.com/auth/plus.login',
+		scope: 'https://www.googleapis.com/auth/userinfo.profile',
 		fetchBasicProfile: true,
 		onClick: noop,
 	};


### PR DESCRIPTION
Fixes #15391 
Changed scope according to docs https://developers.google.com/identity/protocols/googlescopes#oauth2v2

**Test**
1. Visit http://calypso.localhost:3000/log-in
2. Click "Continue with Google"

Thanks @scruffian for the file suggestion.