### PR TITLE
Enable publish confirmation flow in development.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -118,7 +118,7 @@
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"plans/jetpack-config-v2": true,
-		"post-editor/delta-post-publish-flow": false,
+		"post-editor/delta-post-publish-flow": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
This PR makes testing of the publish confirmation flow on mobile easier by enabling it in development.

This is part of a larger epic (See p3Ex-2ri-p2).

DO NOT MERGE!