### PR TITLE
Avoid duplicate avatar images

### DIFF
--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -90,7 +90,7 @@ const ReaderAvatar = ( {
 	const avatarElement =
 		( hasAvatar || showPlaceholder ) &&
 		<Gravatar key="author-avatar" user={ author } size={ gravatarSize } />;
-	const iconElements = [ siteIconElement, avatarElement ];
+	const iconElements = hasSiteIcon ? siteIconElement : avatarElement;
 
 	return (
 		<div className={ classes } onClick={ onClick }>


### PR DESCRIPTION
Should fix #16721

**Test**
1. Visit http://calypso.localhost:3000/ and check avatar appears?
2. Random click on author name. Should be at `http://calypso.localhost:3000/read/feeds/:feed-id` (e.g. http://calypso.localhost:3000/read/feeds/52425000) and check avatars do appear?
3. Random click post title (e.g. http://calypso.localhost:3000/read/feeds/52425000/posts/1442165915). Check avatar does appear in sidebar?