### PR TITLE
Framework: Migrated sites requests mechanism to the data-layer.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -169,11 +169,10 @@ function fetchReduxSite( siteSlug, { dispatch, getState }, callback ) {
 		return;
 	}
 
-	// Have to manually call the thunk in order to access the promise on which
-	// to call `then`.
+	// Have to pass a function to be called when sites return with success
 	debug( 'fetchReduxSite: requesting all sites', siteSlug );
-	requestSites()( dispatch ).then( () =>
-		fetchReduxSite( siteSlug, { dispatch, getState }, callback ) );
+	dispatch( requestSites( () =>
+		fetchReduxSite( siteSlug, { dispatch, getState }, callback ) ) );
 }
 
 function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {

--- a/client/state/data-layer/wpcom/me/index.js
+++ b/client/state/data-layer/wpcom/me/index.js
@@ -6,10 +6,12 @@ import devices from './devices';
 import notification from './notification';
 import settings from './settings';
 import sendVerificationEmail from './send-verification-email';
+import sites from './sites';
 
 export default mergeHandlers(
 	devices,
 	notification,
 	settings,
 	sendVerificationEmail,
+	sites
 );

--- a/client/state/data-layer/wpcom/me/sites/index.js
+++ b/client/state/data-layer/wpcom/me/sites/index.js
@@ -1,0 +1,71 @@
+/**
+ * Internal dependencies
+ */
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { receiveSites } from 'state/sites/actions';
+import {
+	SITES_REQUEST,
+	SITES_REQUEST_FAILURE,
+	SITES_REQUEST_SUCCESS,
+} from 'state/action-types';
+
+/**
+ * Object holding query parameters for request all sites (exported for testing)
+ */
+export const SITES_REQUEST_QUERY_PARAMS = {
+	site_visibility: 'all',
+	include_domain_only: true,
+	site_activity: 'active',
+	fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
+	options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset' //eslint-disable-line max-len
+};
+
+/**
+ * Dispatches a request to fetch all sites of the current user
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @returns {Object}            dispatched http action
+ */
+export const requestSites = ( { dispatch }, action ) => dispatch( http( {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: '/me/sites',
+	query: SITES_REQUEST_QUERY_PARAMS
+}, action ) );
+
+/**
+ * Dispatches an error action when the fetch all sites request fails
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @param   {Function} next     data-layer-bypassing dispatcher
+ * @param   {Object}   error    object containing error information
+ * @returns {Object}            dispatched error action
+ */
+export const receiveSitesError = ( { dispatch }, action, next, error ) => (
+	dispatch( {
+		type: SITES_REQUEST_FAILURE,
+		error
+	} )
+);
+
+/**
+ * Dispatches required actions when the fetch all sites request succeeds
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @param   {Function} next     data-layer-bypassing dispatcher
+ * @param   {Object}   response object containing the fetched site
+ */
+export const receiveSitesSuccess = ( { dispatch }, action, next, response ) => {
+	dispatch( receiveSites( response.sites ) );
+	dispatch( {
+		type: SITES_REQUEST_SUCCESS
+	} );
+};
+
+export default {
+	[ SITES_REQUEST ]: [ dispatchRequest( requestSites, receiveSitesSuccess, receiveSitesError ) ],
+};

--- a/client/state/data-layer/wpcom/me/sites/index.js
+++ b/client/state/data-layer/wpcom/me/sites/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get, noop } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
@@ -64,6 +69,7 @@ export const receiveSitesSuccess = ( { dispatch }, action, next, response ) => {
 	dispatch( {
 		type: SITES_REQUEST_SUCCESS
 	} );
+	get( action, 'meta.onSuccess', noop )();
 };
 
 export default {

--- a/client/state/data-layer/wpcom/me/sites/test/index.js
+++ b/client/state/data-layer/wpcom/me/sites/test/index.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	SITES_REQUEST,
+	SITES_REQUEST_FAILURE,
+	SITES_REQUEST_SUCCESS,
+} from 'state/action-types';
+import { receiveSites } from 'state/sites/actions';
+import { requestSites, receiveSitesError, receiveSitesSuccess, SITES_REQUEST_QUERY_PARAMS } from '../';
+
+describe( 'wpcom-api', () => {
+	describe( 'sites request', () => {
+		describe( '#requestSites()', () => {
+			it( 'should dispatch an HTTP request to the me/sites endpoint', () => {
+				const dispatch = spy();
+				const action = {
+					type: SITES_REQUEST,
+				};
+				requestSites( { dispatch }, action );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith(
+					http(
+						{
+							apiVersion: '1.1',
+							method: 'GET',
+							path: '/me/sites',
+							query: SITES_REQUEST_QUERY_PARAMS
+						},
+						action,
+					),
+				);
+			} );
+		} );
+
+		describe( '#receiveSitesError()', () => {
+			it( 'should dispatch an error action', () => {
+				const dispatch = spy();
+				const error = 'DUMMY_ERROR';
+
+				receiveSitesError( { dispatch }, null, null, error );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITES_REQUEST_FAILURE,
+					error
+				} );
+			} );
+		} );
+
+		describe( '#receiveSitesSuccess()', () => {
+			it( 'should dispatch correct actions when request is successful', () => {
+				const dispatch = spy();
+				const response = {
+					sites: [ { ID: 'DUMMY' } ]
+				};
+
+				receiveSitesSuccess( { dispatch }, null, null, response );
+
+				expect( dispatch ).to.have.been.calledTwice;
+				expect( dispatch ).to.have.been.calledWith( receiveSites( response.sites ) );
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITES_REQUEST_SUCCESS
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/index.js
+++ b/client/state/data-layer/wpcom/sites/index.js
@@ -1,15 +1,118 @@
 /**
  * Internal dependencies
  */
-import { mergeHandlers } from 'state/action-watchers/utils';
+import {
+	SITE_DELETE,
+	SITE_DELETE_FAILURE,
+	SITE_DELETE_SUCCESS,
+	SITE_REQUEST,
+	SITE_REQUEST_FAILURE,
+	SITE_REQUEST_SUCCESS,
+} from 'state/action-types';
+import { receiveSite, receiveDeletedSite } from 'state/sites/actions';
+
 import activity from './activity';
 import automatedTransfer from './automated-transfer';
 import blogStickers from './blog-stickers';
 import comments from './comments';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
 import media from './media';
+import { mergeHandlers } from 'state/action-watchers/utils';
 import plugins from './plugins';
 import posts from './posts';
 import simplePayments from './simple-payments';
+
+/**
+ * Dispatches a request to delete a site
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @returns {Object}            dispatched http action
+ */
+export const deleteSite = ( { dispatch }, action ) => dispatch( http( {
+	apiVersion: '1.1',
+	method: 'POST',
+	path: `/sites/${ action.siteId }/delete`,
+}, action ) );
+
+/**
+ * Dispatches an error action when the delete site request fails
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @param   {Function} next     data-layer-bypassing dispatcher
+ * @param   {Object}   error    object containing error information
+ * @returns {Object}            dispatched error action
+ */
+export const deleteSiteError = ( { dispatch }, action, next, error ) => dispatch( {
+	type: SITE_DELETE_FAILURE,
+	siteId: action.siteId,
+	error
+} );
+
+/**
+ * Dispatches required actions when the delete site request succeeds
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ */
+export const deleteSiteSuccess = ( { dispatch }, action ) => {
+	dispatch( receiveDeletedSite( action.siteId ) );
+	dispatch( {
+		type: SITE_DELETE_SUCCESS,
+		siteId: action.siteId
+	} );
+};
+
+/**
+ * Dispatches a request to fetch a site
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @returns {Object}            dispatched http action
+ */
+export const requestSite = ( { dispatch }, action ) => dispatch( http( {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: `/sites/${ action.siteId }`,
+}, action ) );
+
+/**
+ * Dispatches an error action when the fetch site request fails
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @param   {Function} next     data-layer-bypassing dispatcher
+ * @param   {Object}   error    object containing error information
+ * @returns {Object}            dispatched error action
+ */
+export const receiveSiteError = ( { dispatch }, action, next, error ) => dispatch( {
+	type: SITE_REQUEST_FAILURE,
+	siteId: action.siteId,
+	error
+} );
+
+/**
+ * Dispatches required actions when the fetch site request succeeds
+ *
+ * @param   {Function} dispatch Redux dispatcher
+ * @param   {Object}   action   Redux action
+ * @param   {Function} next     data-layer-bypassing dispatcher
+ * @param   {Object}   response object containing the fetched site
+ */
+export const receiveSiteSuccess = ( { dispatch }, action, next, response ) => {
+	dispatch( receiveSite( response ) );
+	dispatch( {
+		type: SITE_REQUEST_SUCCESS,
+		siteId: action.siteId
+	} );
+};
+
+const siteHandlers = {
+	[ SITE_DELETE ]: [ dispatchRequest( deleteSite, deleteSiteSuccess, deleteSiteError ) ],
+	[ SITE_REQUEST ]: [ dispatchRequest( requestSite, receiveSiteSuccess, receiveSiteError ) ],
+};
 
 export default mergeHandlers(
 	activity,
@@ -20,4 +123,5 @@ export default mergeHandlers(
 	plugins,
 	posts,
 	simplePayments,
+	siteHandlers
 );

--- a/client/state/data-layer/wpcom/sites/test/index.js
+++ b/client/state/data-layer/wpcom/sites/test/index.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	SITE_DELETE,
+	SITE_DELETE_FAILURE,
+	SITE_DELETE_SUCCESS,
+	SITE_REQUEST,
+	SITE_REQUEST_FAILURE,
+	SITE_REQUEST_SUCCESS,
+} from 'state/action-types';
+import { receiveSite, receiveDeletedSite } from 'state/sites/actions';
+import {
+	deleteSite,
+	deleteSiteError,
+	deleteSiteSuccess,
+	requestSite,
+	receiveSiteError,
+	receiveSiteSuccess
+} from '../';
+
+describe( 'wpcom-api', () => {
+	describe( 'delete site', () => {
+		const action = {
+			type: SITE_DELETE,
+			siteId: 32232232
+		};
+		describe( '#deleteSite()', () => {
+			it( 'should dispatch an HTTP request to delete the site', () => {
+				const dispatch = spy();
+				deleteSite( { dispatch }, action );
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'POST',
+					path: `/sites/${ action.siteId }/delete`,
+				}, action )	);
+			} );
+		} );
+
+		describe( '#deleteSiteError()', () => {
+			it( 'should dispatch an error action', () => {
+				const dispatch = spy();
+				const error = 'DUMMY_ERROR';
+				deleteSiteError( { dispatch }, action, null, error );
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITE_DELETE_FAILURE,
+					siteId: action.siteId,
+					error
+				} );
+			} );
+		} );
+
+		describe( '#deleteSiteSuccess()', () => {
+			it( 'should dispatch correct actions when request is successful', () => {
+				const dispatch = spy();
+				deleteSiteSuccess( { dispatch }, action );
+				expect( dispatch ).to.have.been.calledTwice;
+				expect( dispatch ).to.have.been.calledWith( receiveDeletedSite( action.siteId ) );
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITE_DELETE_SUCCESS,
+					siteId: action.siteId
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'request site', () => {
+		const action = {
+			type: SITE_REQUEST,
+			siteId: 32232232
+		};
+		describe( '#requestSite()', () => {
+			it( 'should dispatch an HTTP request to request the site', () => {
+				const dispatch = spy();
+				requestSite( { dispatch }, action );
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( http( {
+					apiVersion: '1.1',
+					method: 'GET',
+					path: `/sites/${ action.siteId }`,
+				}, action )	);
+			} );
+		} );
+
+		describe( '#receiveSiteError()', () => {
+			it( 'should dispatch an error action', () => {
+				const dispatch = spy();
+				const error = 'DUMMY_ERROR';
+				receiveSiteError( { dispatch }, action, null, error );
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITE_REQUEST_FAILURE,
+					siteId: action.siteId,
+					error
+				} );
+			} );
+		} );
+
+		describe( '#receiveSiteSuccess()', () => {
+			it( 'should dispatch correct actions when request is successful', () => {
+				const dispatch = spy();
+				const response = { ID: 23232 };
+				receiveSiteSuccess( { dispatch }, action, null, response );
+				expect( dispatch ).to.have.been.calledTwice;
+				expect( dispatch ).to.have.been.calledWith( receiveSite( response ) );
+				expect( dispatch ).to.have.been.calledWith( {
+					type: SITE_REQUEST_SUCCESS,
+					siteId: action.siteId
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -1,25 +1,13 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
 import {
 	SITE_DELETE,
-	SITE_DELETE_FAILURE,
 	SITE_DELETE_RECEIVE,
-	SITE_DELETE_SUCCESS,
 	SITE_RECEIVE,
 	SITE_REQUEST,
-	SITE_REQUEST_FAILURE,
-	SITE_REQUEST_SUCCESS,
 	SITES_RECEIVE,
 	SITES_REQUEST,
-	SITES_REQUEST_SUCCESS,
-	SITES_REQUEST_FAILURE,
 	SITES_UPDATE
 } from 'state/action-types';
 
@@ -80,90 +68,37 @@ export function receiveSiteUpdates( sites ) {
 }
 
 /**
- * Triggers a network request to request all visible sites
- * @returns {Function}        Action thunk
+ * Returns an action object that signals the intention to request all visible sites
+ * @returns {Object}        Action object
  */
 export function requestSites() {
-	return ( dispatch ) => {
-		dispatch( {
-			type: SITES_REQUEST
-		} );
-
-		return wpcom.me().sites( {
-			site_visibility: 'all',
-			include_domain_only: true,
-			site_activity: 'active',
-			fields: 'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
-			options: 'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset' //eslint-disable-line max-len
-		} ).then( ( response ) => {
-			dispatch( receiveSites( response.sites ) );
-			dispatch( {
-				type: SITES_REQUEST_SUCCESS
-			} );
-		} ).catch( ( error ) => {
-			dispatch( {
-				type: SITES_REQUEST_FAILURE,
-				error
-			} );
-		} );
+	return {
+		type: SITES_REQUEST
 	};
 }
 
 /**
- * Returns a function which, when invoked, triggers a network request to fetch
- * a site.
+ * Returns an action object that signals the intention to fetch a site.
  *
  * @param  {Number}   siteId Site ID
- * @return {Function}        Action thunk
+ * @returns {Object}        Action object
  */
 export function requestSite( siteId ) {
-	return ( dispatch ) => {
-		dispatch( {
-			type: SITE_REQUEST,
-			siteId
-		} );
-
-		return wpcom.site( siteId ).get().then( ( site ) => {
-			dispatch( receiveSite( omit( site, '_headers' ) ) );
-			dispatch( {
-				type: SITE_REQUEST_SUCCESS,
-				siteId
-			} );
-		} ).catch( ( error ) => {
-			dispatch( {
-				type: SITE_REQUEST_FAILURE,
-				siteId,
-				error
-			} );
-		} );
+	return {
+		type: SITE_REQUEST,
+		siteId
 	};
 }
 
 /**
- * Returns a function which, when invoked, triggers a network request to delete
- * a site.
+ * Returns an action object that signals the intention to delete a site.
  *
  * @param  {Number}   siteId Site ID
- * @return {Function}        Action thunk
+ * @returns {Object}        Action object
  */
 export function deleteSite( siteId ) {
-	return dispatch => {
-		dispatch( {
-			type: SITE_DELETE,
-			siteId
-		} );
-		return wpcom.undocumented().deleteSite( siteId ).then( () => {
-			dispatch( receiveDeletedSite( siteId ) );
-			dispatch( {
-				type: SITE_DELETE_SUCCESS,
-				siteId
-			} );
-		} ).catch( error => {
-			dispatch( {
-				type: SITE_DELETE_FAILURE,
-				siteId,
-				error
-			} );
-		} );
+	return {
+		type: SITE_DELETE,
+		siteId
 	};
 }

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -69,9 +69,18 @@ export function receiveSiteUpdates( sites ) {
 
 /**
  * Returns an action object that signals the intention to request all visible sites
- * @returns {Object}        Action object
+ * @param  {Function}   onSuccess function to be called once sites are requested with success
+ * @returns {Object}              Action object
  */
-export function requestSites() {
+export function requestSites( onSuccess ) {
+	if ( onSuccess ) {
+		return {
+			type: SITES_REQUEST,
+			meta: {
+				onSuccess
+			}
+		};
+	}
 	return {
 		type: SITES_REQUEST
 	};

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -1,30 +1,21 @@
 /**
  * External dependencies
  */
-import { match } from 'sinon';
 import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-import useNock from 'test/helpers/use-nock';
 import {
 	SITE_DELETE,
-	SITE_DELETE_FAILURE,
-	SITE_DELETE_SUCCESS,
 	SITE_RECEIVE,
 	SITE_REQUEST,
-	SITE_REQUEST_FAILURE,
-	SITE_REQUEST_SUCCESS,
 	SITES_RECEIVE,
-	SITES_REQUEST,
-	SITES_REQUEST_FAILURE,
-	SITES_REQUEST_SUCCESS,
-	SITES_UPDATE
+	SITES_UPDATE,
+	SITES_REQUEST
 } from 'state/action-types';
 import {
 	deleteSite,
-	receiveDeletedSite,
 	receiveSite,
 	receiveSites,
 	receiveSiteUpdates,
@@ -32,17 +23,7 @@ import {
 	requestSite
 } from '../actions';
 
-import { useSandbox } from 'test/helpers/use-sinon';
-
 describe( 'actions', () => {
-	const mySitesPath = '/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active';
-	let sandbox, spy;
-
-	useSandbox( newSandbox => {
-		sandbox = newSandbox;
-		spy = sandbox.spy();
-	} );
-
 	describe( '#receiveSite()', () => {
 		it( 'should return an action object', () => {
 			const site = { ID: 2916284, name: 'WordPress.com Example Blog' };
@@ -82,173 +63,25 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#requestSites()', () => {
-		describe( 'success', () => {
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.filteringPath( () => mySitesPath )
-					.get( mySitesPath )
-					.reply( 200, {
-						sites: [
-							{ ID: 2916284, name: 'WordPress.com Example Blog' },
-							{ ID: 77203074, name: 'WordPress.com Example Blog 2' }
-						]
-					} );
-			} );
-
-			it( 'should dispatch request action when thunk triggered', () => {
-				requestSites()( spy );
-				expect( spy ).to.have.been.calledWith( {
-					type: SITES_REQUEST
-				} );
-			} );
-			it( 'should dispatch receive action when request completes', () => {
-				return requestSites()( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: SITES_RECEIVE,
-						sites: [
-							{ ID: 2916284, name: 'WordPress.com Example Blog' },
-							{ ID: 77203074, name: 'WordPress.com Example Blog 2' }
-						]
-					} );
-				} );
-			} );
-			it( 'should dispatch success action when request completes', () => {
-				return requestSites()( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: SITES_REQUEST_SUCCESS
-					} );
-				} );
-			} );
-		} );
-		describe( 'failure', () => {
-			useNock( ( nock ) => {
-				nock( 'https://public-api.wordpress.com:443' )
-					.persist()
-					.filteringPath( () => mySitesPath )
-					.get( mySitesPath )
-					.reply( 403, {
-						error: 'authorization_required',
-						message: 'An active access token must be used to access sites.'
-					} );
-			} );
-
-			it( 'should dispatch fail action when request fails', () => {
-				return requestSites()( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: SITES_REQUEST_FAILURE,
-						error: sandbox.match( { message: 'An active access token must be used to access sites.' } )
-					} );
-				} );
-			} );
+		const action = requestSites();
+		expect( action ).to.eql( {
+			type: SITES_REQUEST,
 		} );
 	} );
 
-	describe( 'requestSite()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.get( '/rest/v1.1/sites/2916284' )
-				.reply( 200, {
-					ID: 2916284,
-					name: 'WordPress.com Example Blog'
-				} )
-				.get( '/rest/v1.1/sites/77203074' )
-				.reply( 403, {
-					error: 'authorization_required',
-					message: 'User cannot access this private blog.'
-				} );
-		} );
-
-		it( 'should dispatch fetch action when thunk triggered', () => {
-			requestSite( 2916284 )( spy );
-
-			expect( spy ).to.have.been.calledWith( {
-				type: SITE_REQUEST,
-				siteId: 2916284
-			} );
-		} );
-
-		it( 'should dispatch receive site when request completes', () => {
-			return requestSite( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith(
-					receiveSite( {
-						ID: 2916284,
-						name: 'WordPress.com Example Blog'
-					} )
-				);
-			} );
-		} );
-
-		it( 'should dispatch request success action when request completes', () => {
-			return requestSite( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_REQUEST_SUCCESS,
-					siteId: 2916284
-				} );
-			} );
-		} );
-
-		it( 'should dispatch fail action when request fails', () => {
-			return requestSite( 77203074 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_REQUEST_FAILURE,
-					siteId: 77203074,
-					error: match( { message: 'User cannot access this private blog.' } )
-				} );
-			} );
+	describe( '#requestSite()', () => {
+		const action = requestSite( 232323232 );
+		expect( action ).to.eql( {
+			type: SITE_REQUEST,
+			siteId: 232323232,
 		} );
 	} );
 
-	describe( 'deleteSite()', () => {
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( '/rest/v1.1/sites/2916284/delete' )
-				.reply( 200, {
-					ID: 2916284
-				} )
-				.post( '/rest/v1.1/sites/77203074/delete' )
-				.reply( 403, {
-					error: 'unauthorized',
-					message: 'User cannot delete site.'
-				} );
-		} );
-
-		it( 'should dispatch delete action when thunk triggered', () => {
-			deleteSite( 2916284 )( spy );
-
-			expect( spy ).to.have.been.calledWith( {
-				type: SITE_DELETE,
-				siteId: 2916284
-			} );
-		} );
-
-		it( 'should dispatch receive deleted site when request completes', () => {
-			return deleteSite( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith(
-					receiveDeletedSite( 2916284 )
-				);
-			} );
-		} );
-
-		it( 'should dispatch delete success action when request completes', () => {
-			return deleteSite( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_DELETE_SUCCESS,
-					siteId: 2916284
-				} );
-			} );
-		} );
-
-		it( 'should dispatch fail action when request for delete fails', () => {
-			return deleteSite( 77203074 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_DELETE_FAILURE,
-					siteId: 77203074,
-					error: match( { message: 'User cannot delete site.' } )
-				} );
-			} );
+	describe( '#deleteSite()', () => {
+		const action = deleteSite( 3433434322 );
+		expect( action ).to.eql( {
+			type: SITE_DELETE,
+			siteId: 3433434322,
 		} );
 	} );
 } );


### PR DESCRIPTION
Watching by the number of uses of query sites component, requesting sites is one of the most common types of requests. 
Right now sites are being requested in 2 ways: action thunk and 
 in sites-list with polling (and then sync back to redux).
With the deprecation of sites-list, it would be good to consolidate site requests in the data-layer.
This allows sites-request to take advantage of current and future feature of data-layer e.g. retries, ignore duplicate requests, freshness etc...
I reused the existing actions creators. I converted the thunks to action creators that just create a normal object action used by the data-layer.

There was a function that directly accessed the promise in the thunk to set a function to be executed after the sites request is successful. To maintain the same logic I had to add an onSuccess meta property to the sitesRequest action. This function is called by the request site handler after success actions are dispatched. 
This does not look very right, so that change is isolated in a commit to be easy to revert. I don't know if we accept actions to contain a function given that we want them to serializable. But in this case to keep the same logic I was not finding other approaches. I did not change any already existing code in the data-layer. This mechanism just affects the action creator and the onSuccess handler of sites.
If someone has a better idea feel free to share and I will make the change. Maybe it is possible to use another approach to be notified of success that I'm not aware of.


**To test:**
Sites are used everywhere in the app so try to navigate around and check things look ok, go to places that trigger a specific site request e.g. image editor.
Add a new website and verify if things work as expected.
Delete a site so it is possible to test the delete site request.