### PR TITLE
Framework: Implemented data-layer freshness verification.

### DIFF
--- a/client/state/data-layer/wpcom-api-middleware.js
+++ b/client/state/data-layer/wpcom-api-middleware.js
@@ -98,13 +98,14 @@ export const middleware = handlers => store => next => {
 		// this guarantees that we don't double-dispatch
 		const nextActions = new Set();
 		const safeNext = a => nextActions.add( a );
-
-		handlerChain.forEach( handler => handler( store, action, safeNext ) );
+		let shouldIgnore = false;
+		const ignoreAction = () => shouldIgnore = true;
+		handlerChain.forEach( handler => handler( store, action, safeNext, ignoreAction ) );
 
 		// make sure we pass along this action
 		// eventually this will return to the
 		// simpler `return next( action )`
-		if ( shouldNext( action ) ) {
+		if ( shouldNext( action ) && ! shouldIgnore ) {
 			nextActions.add( action );
 		}
 		nextActions.forEach( localNext );

--- a/client/state/data-layer/wpcom-http/freshness-verifier.js
+++ b/client/state/data-layer/wpcom-http/freshness-verifier.js
@@ -1,0 +1,69 @@
+export const CLEAN_OLDER_THAN = 3 * 60 * 1000;
+
+/** @type {Date} holds timestamp of the last time a cleaning operation was performed */
+let lastCleaningTime;
+
+/** @type {Map} holds request action keys, and last execution times */
+const history = new Map();
+
+/**
+ * Generate a deterministic key for comparing request actions
+ *
+ * @param   {Object} action redux action
+ * @returns {String}        action key
+ */
+const buildActionKey = ( action ) => JSON.stringify(
+	action.meta ? { ...action, meta: undefined } : action
+);
+
+/**
+ * Performs a cleaning operation in the data structure used to hold action keys and execution times
+ * this is useful to reduce memory usage in the structure
+ * by cleaning requests that are very old and irrelevant to the freshness mechanism
+ */
+export const cleanHistoryIfNecessary = () => {
+	const now = Date.now();
+	if ( lastCleaningTime && now - lastCleaningTime < CLEAN_OLDER_THAN ) {
+		return;
+	}
+	lastCleaningTime = now;
+	history.forEach( ( lastExecutionTime, key ) => {
+		if ( now - lastExecutionTime > CLEAN_OLDER_THAN ) {
+			history.delete( key );
+		}
+	} );
+};
+
+/**
+ * Abort a request if our data is fresh-enough
+ *
+ * @param {Function}   initiator issues actual network requests
+ * @param {Number}     freshness number of milliseconds since the last execution for the request be considered fresh
+ * @returns {Function}           wrapped request initiator
+ */
+export const initiatorWithFreshness = ( initiator, freshness ) => ( store, action, next, ignoreAction ) => {
+	const lastUpdate = history.get( buildActionKey( action ) ) || -Infinity;
+	const now = Date.now();
+
+	const staleness = now - lastUpdate;
+
+	// our data is fresher than we need it to be
+	// so just skip this fetch and discard the action
+	if ( staleness <= freshness ) {
+		ignoreAction();
+		return;
+	}
+	return initiator( store, action, next );
+};
+
+/**
+ * Wraps onSuccess with functionality needed for freshness mechanism
+ *
+ * @param {Function}   onSuccess actual onSuccess function
+ * @returns {Function}           wrapped onSuccess function
+ */
+export const onSuccessWithFreshness = ( onSuccess ) => ( store, action, next, data ) => {
+	cleanHistoryIfNecessary();
+	history.set( buildActionKey( action ), Date.now() );
+	return onSuccess( store, action, next, data );
+};


### PR DESCRIPTION
Data-layer freshness verification allows requesters to avoid requests that were recently done.
Automatic tests are not yet created, when we are confident that this is the path to go and this API's are ok, I will implement automatic tests.

Sample usage: https://github.com/Automattic/wp-calypso/pull/16729.

I changed our middleware to allow actions to be ignored /discarded avoiding them to arrive in the reducers this is required to avoid the reducer setting a isRequesting state when in fact it is not requesting and it would never leave that state.