### PR TITLE
Framework: Added freshness verification to comments.

### DIFF
--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { get, isDate, startsWith, pickBy } from 'lodash';
+import { get, isDate, noop, startsWith, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -232,6 +232,6 @@ export const announceDeleteFailure = ( { dispatch, getState }, action ) => {
 };
 
 export default {
-	[ COMMENTS_REQUEST ]: [ dispatchRequest( fetchPostComments, addComments, announceFailure ) ],
+	[ COMMENTS_REQUEST ]: [ dispatchRequest( fetchPostComments, addComments, announceFailure, noop, { freshness: 10000 } ) ],
 	[ COMMENTS_DELETE ]: [ dispatchRequest( deleteComment, announceDeleteSuccess, announceDeleteFailure ) ],
 };


### PR DESCRIPTION
This PR makes the data-layer ignore requests for comments if an identical request was recently made. Right now each time comments are hide and shown a requests is made even if the last one is very recent this PR corrects that.

This PR is dependent on PR https://github.com/Automattic/wp-calypso/pull/16728 that implements freshness verification.