### PR TITLE
Creative mornings signup flow

### DIFF
--- a/client/lib/signup/themes-data.js
+++ b/client/lib/signup/themes-data.js
@@ -1,32 +1,5 @@
 export const themes = [
 	{
-		name: 'Affinity',
-		slug: 'affinity',
-		repo: 'pub',
-		fallback: false,
-		design: 'page',
-		demo_uri: 'https://affinitydemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Apostrophe',
-		slug: 'apostrophe-2',
-		repo: 'pub',
-		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://apostrophe2demo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Baskerville',
-		slug: 'baskerville-2',
-		repo: 'pub',
-		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://baskerville2demo.wordpress.com',
-		verticals: []
-	},
-	{
 		name: 'Button',
 		slug: 'button-2',
 		repo: 'pub',
@@ -36,75 +9,12 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Cubic',
-		slug: 'cubic',
-		repo: 'pub',
-		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://cubicdemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Dyad',
-		slug: 'dyad-2',
-		repo: 'pub',
-		fallback: true,
-		design: 'grid',
-		demo_uri: 'https://dyad2demo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Edin',
-		slug: 'edin',
-		repo: 'pub',
-		fallback: true,
-		design: 'page',
-		demo_uri: 'https://edindemo.wordpress.com',
-		verticals: []
-	},
-	{
 		name: 'Franklin',
 		slug: 'franklin',
 		repo: 'pub',
 		fallback: false,
 		design: 'blog',
 		demo_uri: 'https://franklindemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Gateway',
-		slug: 'gateway',
-		repo: 'pub',
-		fallback: false,
-		design: 'page',
-		demo_uri: 'https://gatewaydemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Gazette',
-		slug: 'gazette',
-		repo: 'pub',
-		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://gazettedemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Goran',
-		slug: 'goran',
-		repo: 'pub',
-		fallback: false,
-		design: 'page',
-		demo_uri: 'https://gorandemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Harmonic',
-		slug: 'harmonic',
-		repo: 'pub',
-		fallback: true,
-		design: 'page',
-		demo_uri: 'https://harmonicdemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -121,7 +31,7 @@ export const themes = [
 		slug: 'independent-publisher-2',
 		repo: 'pub',
 		fallback: false,
-		design: '',
+		design: 'blog',
 		demo_uri: 'http://independentpublisher2demo.wordpress.com',
 		verticals: []
 	},
@@ -132,15 +42,6 @@ export const themes = [
 		fallback: true,
 		design: 'blog',
 		demo_uri: 'https://intergalactic2demo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Karuna',
-		slug: 'karuna',
-		repo: 'pub',
-		fallback: false,
-		design: 'page',
-		demo_uri: 'https://karunademo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -171,12 +72,75 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Pictorico',
-		slug: 'pictorico',
+		name: 'Sapor',
+		slug: 'sapor',
 		repo: 'pub',
 		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://pictoricodemo.wordpress.com',
+		design: 'blog',
+		demo_uri: 'https://sapordemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Twenty Sixteen',
+		slug: 'twentysixteen',
+		repo: 'pub',
+		fallback: true,
+		design: 'blog',
+		demo_uri: 'https://twentysixteendemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Affinity',
+		slug: 'affinity',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		demo_uri: 'https://affinitydemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Edin',
+		slug: 'edin',
+		repo: 'pub',
+		fallback: true,
+		design: 'page',
+		demo_uri: 'https://edindemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Gateway',
+		slug: 'gateway',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		demo_uri: 'https://gatewaydemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Goran',
+		slug: 'goran',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		demo_uri: 'https://gorandemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Harmonic',
+		slug: 'harmonic',
+		repo: 'pub',
+		fallback: true,
+		design: 'page',
+		demo_uri: 'https://harmonicdemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Karuna',
+		slug: 'karuna',
+		repo: 'pub',
+		fallback: false,
+		design: 'page',
+		demo_uri: 'https://karunademo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -186,51 +150,6 @@ export const themes = [
 		fallback: false,
 		design: 'page',
 		demo_uri: 'https://piquedemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Publication',
-		slug: 'publication',
-		repo: 'pub',
-		fallback: true,
-		design: '',
-		demo_uri: 'https://publicationdemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Rebalance',
-		slug: 'rebalance',
-		repo: 'pub',
-		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://rebalancedemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Revelar',
-		slug: 'revelar',
-		repo: 'pub',
-		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://revelardemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Rowling',
-		slug: 'rowling',
-		repo: 'pub',
-		fallback: false,
-		design: 'grid',
-		demo_uri: 'https://rowlingdemo.wordpress.com',
-		verticals: []
-	},
-	{
-		name: 'Sapor',
-		slug: 'sapor',
-		repo: 'pub',
-		fallback: false,
-		design: 'blog',
-		demo_uri: 'https://sapordemo.wordpress.com',
 		verticals: []
 	},
 	{
@@ -252,12 +171,30 @@ export const themes = [
 		verticals: []
 	},
 	{
-		name: 'Twenty Sixteen',
-		slug: 'twentysixteen',
+		name: 'AltoFocus',
+		slug: 'altofocus',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		demo_uri: 'https://altofocusdemo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Apostrophe',
+		slug: 'apostrophe-2',
+		repo: 'pub',
+		fallback: false,
+		design: 'grid',
+		demo_uri: 'https://apostrophe2demo.wordpress.com',
+		verticals: []
+	},
+	{
+		name: 'Dyad',
+		slug: 'dyad-2',
 		repo: 'pub',
 		fallback: true,
-		design: 'blog',
-		demo_uri: 'https://twentysixteendemo.wordpress.com',
+		design: 'grid',
+		demo_uri: 'https://dyad2demo.wordpress.com',
 		verticals: []
 	},
 ];

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -95,6 +95,13 @@ const flows = {
 		lastModified: '2016-01-27'
 	},
 
+	'creative-mornings': {
+		steps: [ 'portfolio-themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'Signup flow for creative mornings partnership',
+		lastModified: '2017-08-01'
+	},
+
 	subdomain: {
 		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -35,6 +35,7 @@ export default {
 	'survey-user': UserSignupComponent,
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	themes: ThemeSelectionComponent,
+	'portfolio-themes': ThemeSelectionComponent,
 	'themes-site-selected': ThemeSelectionComponent,
 	user: UserSignupComponent,
 	'user-social': UserSignupComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -24,6 +24,15 @@ export default {
 		providesDependencies: [ 'themeSlugWithRepo' ]
 	},
 
+	'portfolio-themes': {
+		stepName: 'portfolio-themes',
+		props: {
+			designType: 'grid'
+		},
+		dependencies: [ 'siteSlug' ],
+		providesDependencies: [ 'themeSlugWithRepo' ]
+	},
+
 	// `themes` does not update the theme for an existing site as we normally
 	// do this when the site is created. In flows where a site is merely being
 	// updated, we need to use a different API request function.


### PR DESCRIPTION
This PR creates a new signup flow for the Creative Mornings partnership as outlined in p7EOS0-2lS-p2.  I also did some cleanup on our signup themes by:
- Removing themes that weren't being used.
- Removing all grid themes except the very best.
- Grouping similar themes for easier file usage. 

Creative mornings testing instructions:
- Visit `/start/creative-mornings`
- You should only see `Altofocus`, `Apostrophe`, and `Dyad` — order doesn't matter. Now pick a theme, domain, plan, create account
- New site should be created with the theme

Regular testing instructions
- Visit `/start`
- Pick `portfolio` from site types
- You should only see `Altofocus`, `Apostrophe`, and `Dyad` — order doesn't matter.

@markryall can you take a look?