### PR TITLE
Login: Remove the deprecated login error messages

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -45,37 +45,6 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import wpcom from 'lib/wp';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 
-// TODO: Remove when we're done with the fallback.
-function getErrorMessageFromErrorCode( code ) {
-	const errorMessages = {
-		account_unactivated: translate( "This account hasn't been activated yet — check your email for a message from " +
-			"WordPress.com and click the activation link. You'll be able to log in after that." ),
-		empty_password: translate( "Don't forget to enter your password." ),
-		empty_two_step_code: translate( 'Please enter a verification code.' ),
-		empty_username: translate( 'Please enter a username or email address.' ),
-		forbidden_for_automattician: 'Cannot use social login with an Automattician account',
-		incorrect_password: translate( "Oops, that's not the right password. Please try again!" ),
-		invalid_email: translate( "Oops, looks like that's not the right address. Please try again!" ),
-		invalid_two_step_code: translate( "Hmm, that's not a valid verification code. Please double-check your app and try again." ),
-		invalid_two_step_nonce: translate( 'Your session has expired, please go back to the login screen.' ),
-		invalid_username: translate( "We don't seem to have an account with that name. Double-check the spelling and try again!" ),
-		login_limit_exceeded: translate( "Slow down, you're trying to log in too fast." ),
-		push_authentication_throttled: translate( 'You can only request a code via the WordPress mobile app once every ' +
-			'two minutes. Please wait and try again.' ),
-		sms_code_throttled: translate( 'You can only request a code via text message once per minute. Please wait and try again.' ),
-		sms_recovery_code_throttled: translate( 'You can only request a recovery code via text message once per minute. ' +
-			'Please wait and try again.' ),
-		unknown: translate( "Hmm, we can't find a WordPress.com account with this username and password combo. " +
-			'Please double check your information and try again.' ),
-	};
-
-	if ( code in errorMessages ) {
-		return errorMessages[ code ];
-	}
-
-	return code;
-}
-
 function getSMSMessageFromResponse( response ) {
 	const phoneNumber = get( response, 'body.data.phone_number' );
 	return translate( 'Message sent to phone number ending in %(phoneNumber)s', {
@@ -102,7 +71,6 @@ const errorFields = {
  * @returns {{code: string?, message: string, field: string}} an error message and the id of the corresponding field, if not global
  */
 function getErrorFromHTTPError( httpError ) {
-	let message;
 	let field = 'global';
 
 	if ( ! httpError.status ) {
@@ -113,34 +81,22 @@ function getErrorFromHTTPError( httpError ) {
 		};
 	}
 
-	// TODO: Simplify this block when we're done with the fallback.
-	let code = get( httpError, 'response.body.data.errors[0]' );
-	if ( typeof code === 'object' ) {
-		message = code.message;
-		code = code.code;
-	} else {
-		message = getErrorMessageFromErrorCode( code );
-	}
+	const code = get( httpError, 'response.body.data.errors[0].code' );
 
 	if ( code ) {
 		if ( code in errorFields ) {
 			field = errorFields[ code ];
 		}
+	}
 
-		if ( ! message ) {
-			message = get( httpError, 'response.body.data', httpError.message );
-		}
+	let message = get( httpError, 'response.body.data.errors[0].message' );
+
+	if ( ! message ) {
+		message = get( httpError, 'response.body.data', httpError.message );
 	}
 
 	return { code, message, field };
 }
-
-// TODO: Remove when we're done with the fallback.
-const wpcomErrorMessages = {
-	user_exists: translate( 'Your Google email address is already in use WordPress.com. ' +
-		'Log in to your account using your email address or username, and your password. ' +
-		'To create a new WordPress.com account, use a different Google account.' )
-};
 
 /**
  * Transforms WPCOM error to the error object we use for login purposes
@@ -149,8 +105,7 @@ const wpcomErrorMessages = {
  * @returns {{message: string, field: string, code: string}} an error message and the id of the corresponding field
  */
 const getErrorFromWPCOMError = ( wpcomError ) => ( {
-	// TODO: Remove wpcomErrorMessages[] reference when we're done with the fallback.
-	message: wpcomError.message || wpcomErrorMessages[ wpcomError.error ],
+	message: wpcomError.message,
 	code: wpcomError.error,
 	field: 'global',
 } );


### PR DESCRIPTION
This pull request finalises #15476 by removing the error messages that D6126 deprecates.

#### Testing instructions

1. Run `git checkout followup/15476-remove-deprecated-login-error-messages` and start your server, or open a [live branch](https://calypso.live/log-in?branch=followup/15476-remove-deprecated-login-error-messages)
2. ~~Apply D6126 to your sandbox~~, and sandbox `public-api.wordpress.com`, `wordpress.com` and any `*.wordpress.com` locales you're testing.
2. Open the [`Log In` page](http://calypso.localhost:3000/log-in)
3. Check that the correct error messages appear for login failures.

#### Deploy Notes

1. ~~Once #16901 has had 24 hours to take effect, this PR can be merged.~~
2. ~~Deploy D6126.~~
3. Merge and deploy this PR.

#### Reviews

- [ ] Code
- [ ] Product