### PR TITLE
Revert "Login: Move error messages to the API (#15485)"

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -45,7 +45,6 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import wpcom from 'lib/wp';
 import i18nUtils from 'lib/i18n-utils';
 
-// TODO: Remove when we're done with the PR15485 fallback.
 function getErrorMessageFromErrorCode( code ) {
 	const errorMessages = {
 		account_unactivated: translate( "This account hasn't been activated yet — check your email for a message from " +
@@ -110,7 +109,7 @@ function getLocalizedLoginURL( action ) {
  * @returns {{code: string?, message: string, field: string}} an error message and the id of the corresponding field, if not global
  */
 function getErrorFromHTTPError( httpError ) {
-	let message, code;
+	let message;
 	let field = 'global';
 
 	if ( ! httpError.status ) {
@@ -121,14 +120,8 @@ function getErrorFromHTTPError( httpError ) {
 		};
 	}
 
-	code = get( httpError, 'response.body.data.errors.code' );
-	if ( code ) {
-		message = get( httpError, 'response.body.data.errors.message' );
-	} else {
-		// TODO: Remove when we're done with the PR15485 fallback.
-		code = get( httpError, 'response.body.data.errors[0]', false );
-		message = getErrorMessageFromErrorCode( code );
-	}
+	const code = get( httpError, 'response.body.data.errors.code' );
+	message = get( httpError, 'response.body.data.errors.message' );
 
 	if ( code ) {
 		if ( code in errorFields ) {
@@ -141,7 +134,6 @@ function getErrorFromHTTPError( httpError ) {
 	return { code, message, field };
 }
 
-// TODO: Remove when we're done with the PR15485 fallback.
 const wpcomErrorMessages = {
 	user_exists: translate( 'Your Google email address is already in use WordPress.com. ' +
 		'Log in to your account using your email address or username, and your password. ' +
@@ -155,8 +147,7 @@ const wpcomErrorMessages = {
  * @returns {{message: string, field: string, code: string}} an error message and the id of the corresponding field
  */
 const getErrorFromWPCOMError = ( wpcomError ) => ( {
-	// TODO: Remove wpcomErrorMessages[] reference when we're done with the PR15485 fallback.
-	message: wpcomError.message || wpcomErrorMessages[ wpcomError.error ],
+	message: wpcomErrorMessages[ wpcomError.error ] || wpcomError.message,
 	code: wpcomError.error,
 	field: 'global',
 } );

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -43,7 +43,6 @@ import {
 } from 'state/login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import wpcom from 'lib/wp';
-import i18nUtils from 'lib/i18n-utils';
 
 function getErrorMessageFromErrorCode( code ) {
 	const errorMessages = {
@@ -94,14 +93,6 @@ const errorFields = {
 	invalid_username: 'usernameOrEmail',
 };
 
-function getLocalizedLoginURL( action ) {
-	if ( 'en' === i18nUtils.getLocaleSlug() ) {
-		return 'https://wordpress.com/wp-login.php?action=' + action;
-	}
-
-	return 'https://' + i18nUtils.getLocaleSlug() + '.wordpress.com/wp-login.php?action=' + action;
-}
-
 /**
  * Retrieves the first error message from the specified HTTP error.
  *
@@ -120,10 +111,11 @@ function getErrorFromHTTPError( httpError ) {
 		};
 	}
 
-	const code = get( httpError, 'response.body.data.errors.code' );
-	message = get( httpError, 'response.body.data.errors.message' );
+	const code = get( httpError, 'response.body.data.errors[0]' );
 
 	if ( code ) {
+		message = getErrorMessageFromErrorCode( code );
+
 		if ( code in errorFields ) {
 			field = errorFields[ code ];
 		}
@@ -166,7 +158,7 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 		type: LOGIN_REQUEST,
 	} );
 
-	return request.post( getLocalizedLoginURL( 'login-endpoint' ) )
+	return request.post( 'https://wordpress.com/wp-login.php?action=login-endpoint' )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -216,7 +208,7 @@ export const loginUser = ( usernameOrEmail, password, rememberMe, redirectTo ) =
 export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAuthType ) => ( dispatch, getState ) => {
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 
-	return request.post( getLocalizedLoginURL( 'two-step-authentication-endpoint' ) )
+	return request.post( 'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint' )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -265,7 +257,7 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 export const loginSocialUser = ( service, token, redirectTo ) => dispatch => {
 	dispatch( { type: SOCIAL_LOGIN_REQUEST } );
 
-	return request.post( getLocalizedLoginURL( 'social-login-endpoint' ) )
+	return request.post( 'https://wordpress.com/wp-login.php?action=social-login-endpoint' )
 		.withCredentials()
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
@@ -378,7 +370,7 @@ export const sendSmsCode = () => ( dispatch, getState ) => {
 		},
 	} );
 
-	return request.post( getLocalizedLoginURL( 'send-sms-code-endpoint' ) )
+	return request.post( 'https://wordpress.com/wp-login.php?action=send-sms-code-endpoint' )
 		.set( 'Content-Type', 'application/x-www-form-urlencoded' )
 		.accept( 'application/json' )
 		.send( {


### PR DESCRIPTION
#15485 makes localized login request fail with the following errror
```
Request has been terminated Possible causes: the network is offline, Origin is not allowed by Access-Control-Allow-Origin, the page is being unloaded, etc.
```

This is because we don't set the CORS headers for localized origins. We will need to fix that.
Reverting in the meantime