### PR TITLE
Form Components: Add displayName back to example

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -38,6 +38,8 @@ import PhoneInput from 'components/phone-input';
 var countriesList = require( 'lib/countries-list' ).forSms();
 
 class FormFields extends React.PureComponent {
+	displayName: 'FormFields' // Needed for devdocs/design
+
 	state = {
 		checkedRadio: 'first',
 		toggled: false,


### PR DESCRIPTION
Follow-up to #16619.

Removal of `displayName` caused the devdocs heading to break:

![image](https://user-images.githubusercontent.com/96308/28776031-15c0b994-75f5-11e7-8c20-bae7a8f71e8a.png)
