### PR TITLE
Me: ES6ify some module imports

### DIFF
--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -17,9 +17,10 @@ import Security2faProgress from 'me/security-2fa-progress';
 import analytics from 'lib/analytics';
 import observe from 'lib/mixins/data-observe';
 import { protectForm } from 'lib/protect-form';
+import { forSms } from 'lib/countries-list';
 
 const debug = debugFactory( 'calypso:me:security:2fa-sms-settings' );
-var countriesList = require( 'lib/countries-list' ).forSms();
+const countriesList = forSms();
 
 module.exports = protectForm( React.createClass( {
 

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -1,24 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
-	debug = require( 'debug' )( 'calypso:me:security:2fa-sms-settings' ),
-	observe = require( 'lib/mixins/data-observe' );
+import React from 'react';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-var countriesList = require( 'lib/countries-list' ).forSms(),
-	FormPhoneInput = require( 'components/forms/form-phone-input' ),
-	formBase = require( 'me/form-base' ),
-	FormButton = require( 'components/forms/form-button' ),
-	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
-	Security2faProgress = require( 'me/security-2fa-progress' ),
-	analytics = require( 'lib/analytics' );
-
-import { protectForm } from 'lib/protect-form';
+import FormPhoneInput from 'components/forms/form-phone-input';
+import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
 import Notice from 'components/notice';
+import formBase from 'me/form-base';
+import Security2faProgress from 'me/security-2fa-progress';
+import analytics from 'lib/analytics';
+import observe from 'lib/mixins/data-observe';
+import { protectForm } from 'lib/protect-form';
+
+const debug = debugFactory( 'calypso:me:security:2fa-sms-settings' );
+var countriesList = require( 'lib/countries-list' ).forSms();
 
 module.exports = protectForm( React.createClass( {
 

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -1,17 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isEmpty = require( 'lodash/isEmpty' );
+import React from 'react';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
-var FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormPhoneInput = require( 'components/forms/form-phone-input' ),
-	FormInputValidation = require( 'components/forms/form-input-validation' ),
-	countriesList = require( 'lib/countries-list' ).forSms(),
-	Buttons = require( './buttons' );
+import FormFieldset from 'components/forms/form-fieldset';
+import FormPhoneInput from 'components/forms/form-phone-input';
+import FormInputValidation from 'components/forms/form-input-validation';
+import Buttons from './buttons';
+
+/**
+ * Internal dependencies
+ */
+var countriesList = require( 'lib/countries-list' ).forSms();
 
 module.exports = React.createClass( {
 	displayName: 'SecurityAccountRecoveryRecoveryPhoneEdit',

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-const React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-const CountedTextarea = require( 'components/forms/counted-textarea' ),
-	FormTextarea = require( 'components/forms/form-textarea' ),
-	PostActions = require( 'lib/posts/actions' ),
-	stats = require( 'lib/posts/stats' ),
-	TrackInputChanges = require( 'components/track-input-changes' ),
-	InfoPopover = require( 'components/info-popover' );
+import CountedTextarea from 'components/forms/counted-textarea';
+import FormTextarea from 'components/forms/form-textarea';
+import InfoPopover from 'components/info-popover';
+import TrackInputChanges from 'components/track-input-changes';
+import PostActions from 'lib/posts/actions';
+import stats from 'lib/posts/stats';
 
 export default React.createClass( {
 	displayName: 'PublicizeMessage',


### PR DESCRIPTION
Purports to fix https://github.com/Automattic/wp-calypso/issues/16747. (Was broken because of #16619)

`FormPhoneInput` and `CountedTextarea` are the only form component modules that come with a `default` _and_ a named `export`, which is what causes trouble with commonjs imports.

To test -- verify that https://github.com/Automattic/wp-calypso/issues/16747 is fixed :slightly_smiling_face: 