### PR TITLE
FormToggle: Use enzyme to fix broken test

### DIFF
--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -39,17 +39,13 @@ describe( 'FormToggle', function() {
 
 	describe( 'rendering', function() {
 		it( 'should have form-toggle class', function() {
-			var toggle = TestUtils.renderIntoDocument( <FormToggle /> ),
-				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'form-toggle' );
-
-			assert( 0 < toggleInput.length, 'a form toggle was rendered' );
+			const toggle = shallow( <FormToggle /> );
+			assert( toggle.find( '.form-toggle' ).length === 1 );
 		} );
 
 		it( 'should not have is-compact class', function() {
-			var toggle = TestUtils.renderIntoDocument( <FormToggle /> ),
-				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'is-compact' );
-
-			assert( 0 === toggleInput.length, 'no form toggle with is-compact class' );
+			const toggle = shallow( <FormToggle /> );
+			assert( toggle.find( '.is-compact' ).length === 0 );
 		} );
 
 		it( 'should be checked when checked is true', function() {

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -5,6 +5,7 @@ import assert from 'assert';
 import ReactDom from 'react-dom';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import { shallow } from 'enzyme';
 import { uniq } from 'lodash';
 
 /**
@@ -25,11 +26,8 @@ describe( 'index', function() {
 	require( 'test/helpers/use-fake-dom' )();
 	describe( 'rendering', function() {
 		it( 'should have is-compact class', function() {
-			var toggle = TestUtils.renderIntoDocument( <CompactFormToggle /> ),
-				toggleInput = TestUtils.scryRenderedDOMComponentsWithClass( toggle, 'form-toggle' );
-
-			assert( 0 < toggleInput.length, 'a form toggle was rendered' );
-			assert( toggleInput[ 0 ].className.indexOf( 'is-compact' ) >= 0, 'is-compact class exists' );
+			const toggle = shallow( <CompactFormToggle /> );
+			assert( toggle.hasClass( 'is-compact' ) );
 		} );
 	} );
 } );

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -23,7 +23,6 @@ const Wrapper = ( { children } ) => (
 );
 
 describe( 'index', function() {
-	require( 'test/helpers/use-fake-dom' )();
 	describe( 'rendering', function() {
 		it( 'should have is-compact class', function() {
 			const toggle = shallow( <CompactFormToggle /> );

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -16,11 +16,10 @@ import CompactFormToggle from '../compact';
 /**
  * Module variables
  */
-class Wrapper extends React.Component {
-    render() {
-		return <div>{ this.props.children }</div>;
-	}
-}
+
+const Wrapper = ( { children } ) => (
+  <div>{ children }</div>
+);
 
 describe( 'index', function() {
 	require( 'test/helpers/use-fake-dom' )();


### PR DESCRIPTION
As discussed in https://github.com/Automattic/wp-calypso/pull/16749.
That test was a bit circuitous anyway.

To test: Watch CircleCI for greenness.