### PR TITLE
Plugin uploads: Add jetpack version check and upgrade message

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -118,7 +118,7 @@ export default connect(
 			error,
 			progress,
 			installing: progress === 100,
-			upgradeJetpack: isJetpack && ! isJetpackMinimumVersion( state, siteId, 5.1 ),
+			upgradeJetpack: isJetpack && ! isJetpackMinimumVersion( state, siteId, '5.1' ),
 		};
 	},
 	{ uploadPlugin, clearPluginUpload }


### PR DESCRIPTION
Require latest Jetpack version (5.1) for plugin uploads to jetpack sites. This is not strictly necessary because the API shipped in 4.4, but seems a good way to encourage upgrades.

<img width="862" alt="screen shot 2017-07-31 at 15 09 27" src="https://user-images.githubusercontent.com/7767559/28782846-58134e18-7606-11e7-8a09-916f341ffb5e.png">

**To Test**
* Checkout this branch or use the calypso.live link
* Go to /plugins/upload/{jetpack_site}
* For sites with a Jetpack version < 5.1, you should see an upgrade message with a disabled dropzone and a call-to-action that links to the jetpack plugin page to upgrade
* for sites with Jetpack >= 5.1, upload should be available as normal
