### PR TITLE
Reader: experiment with logged out full-post view

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -263,7 +263,7 @@ PostCommentForm.propTypes = {
 	onCommentSubmit: React.PropTypes.func,
 
 	// connect()ed props:
-	currentUser: React.PropTypes.object.isRequired,
+	currentUser: React.PropTypes.object,
 	writeComment: React.PropTypes.func.isRequired,
 	deleteComment: React.PropTypes.func.isRequired,
 	replyComment: React.PropTypes.func.isRequired,

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -250,7 +250,7 @@ PostComment.propTypes = {
 	onCommentSubmit: React.PropTypes.func,
 
 	// connect()ed props:
-	currentUser: React.PropTypes.object.isRequired,
+	currentUser: React.PropTypes.object,
 };
 
 PostComment.defaultProps = {

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -248,10 +248,16 @@ sections.push( {
 
 sections.push( {
 	name: 'reader',
-	paths: [ '/read/feeds/[^\\/]+/posts/[^\\/]+', '/read/blogs/[^\\/]+/posts/[^\\/]+' ],
+	paths: [
+		'/read/feeds/[^\\/]+/posts/[^\\/]+',
+		'/read/blogs/[^\\/]+/posts/[^\\/]+',
+		'/read/feeds/',
+		'/read/blogs/'
+	],
 	module: 'reader/full-post',
 	secondary: false,
-	group: 'reader'
+	group: 'reader',
+	enableLoggedOut: true,
 } );
 
 sections.push( {


### PR DESCRIPTION
We've discussed opening full-post page up to nonmembers for awhile.  This PR attempts to explore how much engineering effort it would be.

What do we need?
- log in modals when any interactions are clicked
- reader sign in? social sign in?

What are the problems
- can we stop google from indexing it?


#### To Test
In a logged out browser window, visit: https://calypso.live/read/blogs/70135762/posts/76722?branch=try/reader/nonmember-fullpost

