### PR TITLE
Editor Publish Date: Do not display prompt for published posts

### DIFF
--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -89,6 +89,11 @@ export class EditorPublishDate extends React.Component {
 	renderCalendarHeader() {
 		const isScheduled = utils.isFutureDated( this.props.post );
 		const isBackDated = utils.isBackDated( this.props.post );
+		const isPublished = utils.isPublished( this.props.post );
+
+		if ( isPublished ) {
+			return;
+		}
 
 		if ( ! isScheduled && ! isBackDated ) {
 			return (


### PR DESCRIPTION
This PR updates the `EditorPublishDate` component such that no prompt is displayed for published posts.

This PR is part of a larger epic. See p8F9tW-3F-p2.

Before:
![image](https://user-images.githubusercontent.com/363749/28783908-6df1930e-75d7-11e7-85f0-c5ea50763f7d.png)
![image](https://user-images.githubusercontent.com/363749/28783928-7bc188f4-75d7-11e7-8745-6d81c3fab15e.png)


After:
![image](https://user-images.githubusercontent.com/363749/28783938-84d3f1ac-75d7-11e7-9fd8-bd149beb20f9.png)

To test:
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170801":"showPublishConfirmation"}')`
* Edit an existing post. Within post-settings, make sure that the EditorPublishDate component reads "Published" and that expanding the component results in neither the display of "Publish Immediately" nor "Choose a date to schedule"