### PR TITLE
Plugin uploads: Disable for sites on multisite networks

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -15,6 +15,7 @@ import Card from 'components/card';
 import ProgressBar from 'components/progress-bar';
 import UploadDropZone from 'blocks/upload-drop-zone';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import EmptyContent from 'components/empty-content';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
@@ -24,7 +25,12 @@ import {
 	isPluginUploadComplete,
 	isPluginUploadInProgress,
 } from 'state/selectors';
-import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import {
+	getSiteAdminUrl,
+	isJetpackMinimumVersion,
+	isJetpackSite,
+	isJetpackSiteMultiSite,
+} from 'state/sites/selectors';
 
 class PluginUpload extends React.Component {
 
@@ -80,9 +86,24 @@ class PluginUpload extends React.Component {
 		);
 	}
 
+	renderNotAvailableForMultisite() {
+		const { translate, siteAdminUrl } = this.props;
+
+		return (
+			<EmptyContent
+				title={ translate( 'Not available on multisite networks' ) }
+				line={ translate( 'Use the WP Admin interface instead' ) }
+				action={ translate( 'Open WP Admin' ) }
+				actionURL={ siteAdminUrl }
+				illustration={ '/calypso/images/illustrations/illustration-jetpack.svg' }
+			/>
+		);
+	}
+
 	render() {
 		const {
 			translate,
+			isJetpackMultisite,
 			upgradeJetpack,
 			siteId,
 		} = this.props;
@@ -95,7 +116,8 @@ class PluginUpload extends React.Component {
 					siteId={ siteId }
 					featureExample={ this.renderUploadCard() }
 					version="5.1" /> }
-				{ ! upgradeJetpack && this.renderUploadCard() }
+				{ isJetpackMultisite && this.renderNotAvailableForMultisite() }
+				{ ! upgradeJetpack && ! isJetpackMultisite && this.renderUploadCard() }
 			</Main>
 		);
 	}
@@ -119,6 +141,8 @@ export default connect(
 			progress,
 			installing: progress === 100,
 			upgradeJetpack: isJetpack && ! isJetpackMinimumVersion( state, siteId, '5.1' ),
+			isJetpackMultisite: isJetpackSiteMultiSite( state, siteId ),
+			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		};
 	},
 	{ uploadPlugin, clearPluginUpload }

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -91,8 +91,7 @@ class PluginUpload extends React.Component {
 
 		return (
 			<EmptyContent
-				title={ translate( 'Not available on multisite networks' ) }
-				line={ translate( 'Visit WP Admin to install your plugin.' ) }
+				title={ translate( 'Visit WP Admin to install your plugin.' ) }
 				action={ translate( 'Go to WP Admin' ) }
 				actionURL={ `${ siteAdminUrl }/plugin-install.php` }
 				illustration={ '/calypso/images/illustrations/illustration-jetpack.svg' }

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -129,6 +129,7 @@ export default connect(
 		const error = getPluginUploadError( state, siteId );
 		const progress = getPluginUploadProgress( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
+		const isJetpackMultisite = isJetpackSiteMultiSite( state, siteId );
 		return {
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
@@ -140,8 +141,8 @@ export default connect(
 			error,
 			progress,
 			installing: progress === 100,
-			upgradeJetpack: isJetpack && ! isJetpackMinimumVersion( state, siteId, '5.1' ),
-			isJetpackMultisite: isJetpackSiteMultiSite( state, siteId ),
+			upgradeJetpack: isJetpack && ! isJetpackMultisite && ! isJetpackMinimumVersion( state, siteId, '5.1' ),
+			isJetpackMultisite,
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		};
 	},

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -92,9 +92,9 @@ class PluginUpload extends React.Component {
 		return (
 			<EmptyContent
 				title={ translate( 'Not available on multisite networks' ) }
-				line={ translate( 'Use the WP Admin interface instead' ) }
-				action={ translate( 'Open WP Admin' ) }
-				actionURL={ siteAdminUrl }
+				line={ translate( 'Visit WP Admin to install your plugin.' ) }
+				action={ translate( 'Go to WP Admin' ) }
+				actionURL={ `${ siteAdminUrl }/plugin-install.php` }
 				illustration={ '/calypso/images/illustrations/illustration-jetpack.svg' }
 			/>
 		);


### PR DESCRIPTION
The current jetpack theme and plugin upload APIs do [not currently work](https://github.com/Automattic/jetpack/pull/6201) for Jetpack sites on multisite networks, so disable the plugin upload feature for now on those sites.

<img width="1247" alt="screen shot 2017-07-31 at 16 10 15" src="https://user-images.githubusercontent.com/7767559/28784413-4c6fcf3c-760b-11e7-88ef-a4ab84fd68dc.png">

**To Test**
* Checkout this branch or use the calypso.live link
* Go to /plugins/upload/{jetpack_sites}
* For sites on a multisite network you should see a message as in the screenshot above
* Regular jetpack sites should allow uploads as usual
* If you don't have a multisite install available for testing, modify the code so that the new `isJetpackMultisite` prop is always true
