### PR TITLE
Store Orders: Use dialog component buttons prop for the dialog actions

### DIFF
--- a/client/extensions/woocommerce/app/order/order-fulfillment.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment.js
@@ -113,6 +113,11 @@ class OrderFulfillment extends Component {
 			return null;
 		}
 
+		const dialogButtons = [
+			<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>,
+			<Button primary onClick={ this.submit }>{ translate( 'Fulfill' ) }</Button>,
+		];
+
 		const classes = classNames( {
 			'order__details-fulfillment': true,
 			'is-completed': 'completed' === order.status,
@@ -131,7 +136,7 @@ class OrderFulfillment extends Component {
 					}
 				</div>
 
-				<Dialog isVisible={ showDialog } onClose={ this.toggleDialog } className={ dialogClass }>
+				<Dialog isVisible={ showDialog } onClose={ this.toggleDialog } className={ dialogClass } buttons={ dialogButtons }>
 					<h1>{ translate( 'Fulfill order' ) }</h1>
 					<form>
 						<FormFieldset className="order__fulfillment-tracking">
@@ -149,11 +154,7 @@ class OrderFulfillment extends Component {
 							<FormInputCheckbox checked={ this.state.shouldEmail } onChange={ this.updateCustomerEmail } />
 							<span>{ translate( 'Email tracking number to customer' ) }</span>
 						</FormLabel>
-						<div className="order__fulfillment-actions">
-							{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
-							<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>
-							<Button primary onClick={ this.submit }>{ translate( 'Fulfill' ) }</Button>
-						</div>
+						{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
 					</form>
 				</Dialog>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-refund-card.js
+++ b/client/extensions/woocommerce/app/order/order-refund-card.js
@@ -171,6 +171,11 @@ class OrderRefundCard extends Component {
 		}
 		refundTotal = refundTotal.replace( /[^0-9.,]/g, '' );
 
+		const dialogButtons = [
+			<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>,
+			<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>{ translate( 'Refund' ) }</Button>,
+		];
+
 		return (
 			<div className="order__details-refund">
 				<div className="order__details-refund-label">
@@ -188,6 +193,7 @@ class OrderRefundCard extends Component {
 					isVisible={ showDialog }
 					onClose={ this.toggleDialog }
 					className={ dialogClass }
+					buttons={ dialogButtons }
 					additionalClassNames="order__refund-dialog woocommerce">
 					<h1>{ translate( 'Refund order' ) }</h1>
 					<OrderDetailsTable order={ order } isEditable onChange={ this.recalculateRefund } site={ site } />
@@ -212,11 +218,7 @@ class OrderRefundCard extends Component {
 							{ this.renderCreditCard() }
 						</FormFieldset>
 
-						<div className="order__refund-actions">
-							{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
-							<Button onClick={ this.toggleDialog }>{ translate( 'Cancel' ) }</Button>
-							<Button primary onClick={ this.sendRefund } disabled={ isPaymentLoading }>{ translate( 'Refund' ) }</Button>
-						</div>
+						{ errorMessage && <Notice status="is-error" showDismiss={ false }>{ errorMessage }</Notice> }
 					</form>
 				</Dialog>
 			</div>

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -260,19 +260,6 @@
 		text-align: right;
 	}
 
-	.order__refund-actions,
-	.order__fulfillment-actions {
-		margin: 0 -24px;
-		padding: 24px 24px 0;
-		min-width: 100%;
-		border-top: 1px solid lighten( $gray, 30% );
-		text-align: right;
-
-		button + button {
-			margin-left: 8px;
-		}
-	}
-
 	&.order__fulfillment {
 		.form-text-input {
 			text-align: left;
@@ -295,7 +282,7 @@
 	}
 
 	.order__refund-note {
-		margin-bottom: 16px;
+		margin-bottom: 0;
 
 		.form-textarea {
 			margin-top: 8px;
@@ -304,6 +291,7 @@
 
 	.order__refund-details {
 		margin-left: 50px;
+		margin-bottom: 0;
 	}
 
 	.order__refund-amount {


### PR DESCRIPTION
Fixes #15911 

This PR moves the action buttons on the refund and fulfillment modals to the `buttons` prop on the dialog component. This enables the "sticky buttons" so that they're stuck to the bottom of the modal, rather than accidentally scrolled offscreen.

Refunds modal example:

<img width="731" alt="screen shot 2017-07-31 at 11 21 57 am" src="https://user-images.githubusercontent.com/541093/28784817-7c63791a-75e2-11e7-91c3-6fc0de539602.png">

**To test:**

- Click into an order `/store/orders/:site`
- Open the refunds modal ("Submit Refund")
- Check that the buttons always appear even if you have a short browser window
- Open the fulfillment modal ("Fulfill")
- Check that the buttons appear normally (this is a very small modal, you probably won't see it scroll)
