### PR TITLE
Remove config option for Store Stats

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -457,8 +457,8 @@ const navigateToSite = ( siteId, {
 		}
 
 		if ( path.match( /^\/store\/stats\// ) ) {
-			const isWooConnect = site.jetpack && isPluginActive( state, site.ID, 'woocommerce' );
-			if ( ! isWooConnect ) {
+			const isStore = site.jetpack && isPluginActive( state, site.ID, 'woocommerce' );
+			if ( ! isStore ) {
 				path = '/stats/day';
 			}
 		}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -151,10 +151,8 @@ export default function() {
 	} );
 
 	// Add pages that use my-sites navigation instead
-	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
-		page( '/store/stats/:type/:unit', controller.siteSelection, controller.sites );
-		page( '/store/stats/:type/:unit/:site', siteSelection, navigation, StatsController );
-	}
+	page( '/store/stats/:type/:unit', controller.siteSelection, controller.sites );
+	page( '/store/stats/:type/:unit/:site', siteSelection, navigation, StatsController );
 
 	page(
 		'/store/*',

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -201,7 +201,7 @@ export default connect(
 		return {
 			isJetpack,
 			hasPodcasts: getSiteOption( state, siteId, 'podcasting_archive' ),
-			isWooConnect: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
+			isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
 			siteId,
 			slug: getSelectedSiteSlug( state )
 		};

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -16,7 +16,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import config from 'config';
 
 const StatsNavigation = ( props ) => {
-	const { translate, section, slug, siteId, isJetpack, isWooConnect } = props;
+	const { translate, section, slug, siteId, isJetpack, isStore } = props;
 	const siteFragment = slug ? '/' + slug : '';
 	const sectionTitles = {
 		insights: translate( 'Insights' ),
@@ -29,7 +29,7 @@ const StatsNavigation = ( props ) => {
 
 	let statsControl;
 
-	if ( isWooConnect ) {
+	if ( isStore ) {
 		statsControl = (
 			<SegmentedControl
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -84,7 +84,7 @@ const StatsNavigation = ( props ) => {
 
 StatsNavigation.propTypes = {
 	isJetpack: PropTypes.bool,
-	isWooConnect: PropTypes.bool,
+	isStore: PropTypes.bool,
 	section: PropTypes.string.isRequired,
 	slug: PropTypes.string,
 	siteId: PropTypes.number,

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -29,26 +29,24 @@ const StatsNavigation = ( props ) => {
 
 	let statsControl;
 
-	if ( config.isEnabled( 'woocommerce/extension-stats' ) ) {
-		if ( isWooConnect ) {
-			statsControl = (
-				<SegmentedControl
-					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-					className="stats-navigation__control is-store"
-					initialSelected="site"
-					options={ [
-						{
-							value: 'site',
-							label: translate( 'Site' )
-						},
-						{
-							value: 'store',
-							label: translate( 'Store' ),
-							path: `/store/stats/orders/${ section }/${ slug }` }
-					] }
-				/>
-			);
-		}
+	if ( isWooConnect ) {
+		statsControl = (
+			<SegmentedControl
+				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+				className="stats-navigation__control is-store"
+				initialSelected="site"
+				options={ [
+					{
+						value: 'site',
+						label: translate( 'Site' )
+					},
+					{
+						value: 'store',
+						label: translate( 'Store' ),
+						path: `/store/stats/orders/${ section }/${ slug }` }
+				] }
+			/>
+		);
 	}
 
 	const ActivityTab = config.isEnabled( 'jetpack/activity-log' ) && isJetpack

--- a/config/development.json
+++ b/config/development.json
@@ -170,7 +170,6 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
-		"woocommerce/extension-stats": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/production.json
+++ b/config/production.json
@@ -109,7 +109,6 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
-		"woocommerce/extension-stats": true,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -116,7 +116,6 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
-		"woocommerce/extension-stats": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -132,7 +132,6 @@
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-tax": true,
-		"woocommerce/extension-stats": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
Now we have launched Store Stats lets remove the config option and checking for it.

When we start working on the next iteration we can re-introduce config checking for the in-development features.