### PR TITLE
Editor Confirmation Sidebar: Update sidebar header for scheduled posts

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -22,6 +22,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import { isEditedPostPrivate, isPrivateEditedPostPasswordValid } from 'state/posts/selectors';
+import utils from 'lib/posts/utils';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
@@ -148,6 +149,44 @@ class EditorConfirmationSidebar extends React.Component {
 		);
 	}
 
+	renderSidebarHeader() {
+		const isScheduled = utils.isFutureDated( this.props.post );
+
+		if ( isScheduled ) {
+			return (
+				<div className="editor-confirmation-sidebar__header">
+					{
+						this.props.translate( '{{strong}}Almost there!{{/strong}} ' +
+							'You can double-check your post’s settings below. When you’re happy, ' +
+							'use the big green button to schedule your post!', {
+								comment: 'This string appears as the header for the confirmation sidebar ' +
+								'when a user schedules the publishing of a post or page.',
+								components: {
+									strong: <strong />
+								},
+							} )
+					}
+				</div>
+			);
+		}
+
+		return (
+			<div className="editor-confirmation-sidebar__header">
+				{
+					this.props.translate( '{{strong}}Almost there!{{/strong}} ' +
+						'You can double-check your post’s settings below. When you’re happy, ' +
+						'use the big green button to send your post out into the world!', {
+							comment: 'This string appears as the header for the confirmation sidebar ' +
+							'when a user publishes a post or page.',
+							components: {
+								strong: <strong />
+							},
+						} )
+				}
+			</div>
+		);
+	}
+
 	render() {
 		const isSidebarActive = this.props.status === 'open';
 		const isOverlayActive = this.props.status !== 'closed';
@@ -178,19 +217,7 @@ class EditorConfirmationSidebar extends React.Component {
 						</div>
 					</div>
 					<div className="editor-confirmation-sidebar__content-wrap">
-						<div className="editor-confirmation-sidebar__header">
-							{
-								this.props.translate( '{{strong}}Almost there!{{/strong}} ' +
-									'You can double-check your post’s settings below. When you’re happy, ' +
-									'use the big green button to send your post out into the world!', {
-										comment: 'This string appears as the header for the confirmation sidebar ' +
-										'when a user publishes a post or page.',
-										components: {
-											strong: <strong />
-										},
-									} )
-							}
-						</div>
+						{ this.renderSidebarHeader() }
 						<EditorPublishDate
 							post={ this.props.post }
 							setPostDate={ this.props.setPostDate }


### PR DESCRIPTION
This PR updates the confirmation sidebar header text so that it makes sense in the context of scheduling a post.

This PR is part of a larger epic. See p8F9tW-3F-p2.

Before:
![image](https://user-images.githubusercontent.com/363749/28787908-c81e0fc2-75e3-11e7-9f98-41c8cf66db1c.png)

After:
![image](https://user-images.githubusercontent.com/363749/28787948-eea6152c-75e3-11e7-8340-4cf16e5cc155.png)


To Test:
* Checkout the branch and run with the feature enabled: `ENABLE_FEATURES=post-editor/delta-post-publish-flow make run`
* Make sure you're part of the ab test by entering the following in your console: `localStorage.setItem('ABTests','{"postPublishConfirmation_20170801":"showPublishConfirmation"}')`
* Draft a post and schedule it via the confirmation sidebar. Make sure the header text updates when the post enters scheduled status.