### PR TITLE
Session Restore: Do not restore paths that start with /read

### DIFF
--- a/client/lib/restore-last-path/index.js
+++ b/client/lib/restore-last-path/index.js
@@ -13,7 +13,7 @@ import { isOutsideCalypso } from 'lib/url';
 const debug = debugFactory( 'calypso:restore-last-path' );
 
 const LAST_PATH = 'last_path';
-const ALLOWED_PATHS_FOR_RESTORING = /^\/(read|stats|plans|view|posts|pages|media|types|themes|sharing|people|plugins|domains)/i;
+const ALLOWED_PATHS_FOR_RESTORING = /^\/(stats|plans|view|posts|pages|media|types|themes|sharing|people|plugins|domains)/i;
 
 function isWhitelistedForRestoring( path ) {
 	return !! path.match( ALLOWED_PATHS_FOR_RESTORING );


### PR DESCRIPTION
If we're going to persist things in this section, let's do it smartly behind a whitelist.

## To Test
* run without the chance of skipping state hydration: `ENABLE_FEATURES=no-force-sympathy npm start`
* Browse to an item in the Reader
* Open a new tab & browse to http://calypso.localhost:3000
* You should land at the Reader on `/` -- not the content from before
* Other paths in the whitelist should still work