### PR TITLE
Reader Permalink: fix when linking to different comments on current post

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -82,7 +82,7 @@ class PostCommentList extends React.Component {
 	 * @returns {boolean} - whether or not we should scroll to a comment
 	 */
 	shouldScrollToComment = ( props = this.props ) => {
-		return (
+		return !! (
 			props.startingCommentId &&
 			props.commentsTree[ this.props.startingCommentId ] &&
 			props.commentsFetchingStatus.hasReceivedBefore &&
@@ -93,7 +93,7 @@ class PostCommentList extends React.Component {
 	};
 
 	shouldFetchInitialComment = ( { startingCommentId, initialComment } ) => {
-		return startingCommentId && ! initialComment;
+		return !! ( startingCommentId && ! initialComment );
 	};
 
 	shouldFetchInitialPages = ( { startingCommentId, commentsTree } ) =>

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -81,16 +81,20 @@ class PostCommentList extends React.Component {
 	 * @param {object} props - the propes to use when evaluating if window should be scrolled down to a comment.
 	 * @returns {boolean} - whether or not we should scroll to a comment
 	 */
-	shouldScrollToComment = ( props = this.props ) =>
-		props.startingCommentId &&
-		props.commentsTree[ this.props.startingCommentId ] &&
-		props.commentsFetchingStatus.hasReceivedBefore &&
-		props.commentsFetchingStatus.hasReceivedAfter &&
-		! this.hasScrolledToComment &&
-		window.document.getElementById( `comment-${ props.startingCommentId }` );
+	shouldScrollToComment = ( props = this.props ) => {
+		return (
+			props.startingCommentId &&
+			props.commentsTree[ this.props.startingCommentId ] &&
+			props.commentsFetchingStatus.hasReceivedBefore &&
+			props.commentsFetchingStatus.hasReceivedAfter &&
+			! this.hasScrolledToComment &&
+			window.document.getElementById( `comment-${ props.startingCommentId }` )
+		);
+	};
 
-	shouldFetchInitialComment = ( { startingCommentId, initialComment } ) =>
-		startingCommentId && ! initialComment;
+	shouldFetchInitialComment = ( { startingCommentId, initialComment } ) => {
+		return startingCommentId && ! initialComment;
+	};
 
 	shouldFetchInitialPages = ( { startingCommentId, commentsTree } ) =>
 		startingCommentId &&
@@ -149,7 +153,14 @@ class PostCommentList extends React.Component {
 		const status = get( nextProps, 'commentsFilter' );
 
 		if ( this.shouldFetchInitialComment( nextProps ) ) {
-			this.props.requestComment( { siteId, commentId: nextProps.startingCommentId } );
+			// there is an edgecase the initialComment can change while on the same post
+			// in this case we can't just load the exact comment in question because
+			// we could create a gap in the list.
+			if ( this.props.commentsTree ) {
+				this.viewEarlierCommentsHandler();
+			} else {
+				this.props.requestComment( { siteId, commentId: nextProps.startingCommentId } );
+			}
 			this.hasScrolledToComment = false;
 		} else if ( this.shouldFetchInitialPages( nextProps ) ) {
 			this.viewEarlierCommentsHandler();
@@ -159,10 +170,13 @@ class PostCommentList extends React.Component {
 			nextProps.requestPostComments( { siteId, postId, status } );
 		}
 
-		if ( this.shouldScrollToComment( nextProps ) ) {
-			// defer so that the above/below comments have time to render
-			delay( () => this.scrollToComment(), 50 );
-		}
+		// first defer is to give the startingCommentId time to render to the dom
+		// second defer is to give the above/below comments to render to the dom
+		delay( () => {
+			if ( this.shouldScrollToComment( nextProps ) ) {
+				delay( () => this.scrollToComment(), 50 );
+			}
+		}, 50 );
 	}
 
 	renderComment = commentId => {
@@ -270,7 +284,7 @@ class PostCommentList extends React.Component {
 				prevSum +
 				this.getCommentsCount( get( this.props.commentsTree, [ commentId, 'children' ] ) ) +
 				1,
-			0,
+			0
 		);
 	};
 
@@ -328,11 +342,13 @@ class PostCommentList extends React.Component {
 			haveLaterCommentsToFetch,
 		} = this.props.commentsFetchingStatus;
 
-		const { amountOfCommentsToTake } = this.state;
+		const amountOfCommentsToTake = !! this.props.startingCommentId
+			? Infinity
+			: this.state.amountOfCommentsToTake;
 
 		const { displayedComments, displayedCommentsCount } = this.getDisplayedComments(
 			commentsTree.children,
-			amountOfCommentsToTake,
+			amountOfCommentsToTake
 		);
 
 		// Note: we might show fewer comments than commentsCount because some comments might be
@@ -421,13 +437,13 @@ export default connect(
 			state,
 			ownProps.post.site_ID,
 			ownProps.post.ID,
-			ownProps.commentsFilter,
+			ownProps.commentsFilter
 		),
 		commentsFetchingStatus: commentsFetchingStatus(
 			state,
 			ownProps.post.site_ID,
 			ownProps.post.ID,
-			ownProps.commentCount,
+			ownProps.commentCount
 		),
 		initialComment: getCommentById( {
 			state,
@@ -435,5 +451,5 @@ export default connect(
 			commentId: ownProps.startingCommentId,
 		} ),
 	} ),
-	{ requestPostComments, requestComment },
+	{ requestPostComments, requestComment }
 )( PostCommentList );

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -24,7 +24,7 @@ export const getDateSortedPostComments = createSelector(
 		const comments = getPostCommentItems( state, siteId, postId );
 		return sortBy( comments, comment => new Date( comment.date ) );
 	},
-	( state, siteId, postId ) => [ get( state.comments, 'items' )[ getStateKey( siteId, postId ) ] ],
+	( state, siteId, postId ) => [ get( state.comments, 'items' )[ getStateKey( siteId, postId ) ] ]
 );
 
 export const getCommentById = createSelector(
@@ -36,11 +36,16 @@ export const getCommentById = createSelector(
 		const commentsForSite = flatMap(
 			filter( state.comments && state.comments.items, ( comment, key ) => {
 				return deconstructStateKey( key ).siteId === siteId;
-			} ),
+			} )
 		);
 		return find( commentsForSite, comment => commentId === comment.ID );
 	},
-	( { state } ) => [ get( state.comments, 'items' ), get( state.comments, 'errors' ) ],
+	( { state, commentId, siteId } ) => [
+		commentId,
+		siteId,
+		get( state.comments, 'items' ),
+		get( state.comments, 'errors' ),
+	]
 );
 /***
  * Get total number of comments on the server for a given post
@@ -109,19 +114,19 @@ export const getPostCommentsTree = createSelector(
 					children: map( filter( items, { parent: { ID: item.ID } } ), 'ID' ).reverse(),
 					data: item,
 				} ) ),
-				'data.ID',
+				'data.ID'
 			),
 			children: map( filter( items, { parent: false } ), 'ID' ).reverse(),
 		};
 	},
-	getPostCommentItems,
+	getPostCommentItems
 );
 
 export const commentsFetchingStatus = ( state, siteId, postId, commentTotal = 0 ) => {
 	const fetchStatus = get(
 		state.comments.fetchStatus,
 		getStateKey( siteId, postId ),
-		fetchStatusInitialState,
+		fetchStatusInitialState
 	);
 	const hasMoreComments = commentTotal > size( getPostCommentItems( state, siteId, postId ) );
 


### PR DESCRIPTION
With deep linking there had been two remaining known bugs:
1. When on a full-post where all of the comments are loaded but not all are visible on the DOM, and then you switch startingCommentIds (either manually or by clicking a notification)
2. When on a full-post where not all of the comments are loaded

There were 3 changes I made to address this issue:
1. cache key function for `createSelector` was broken because it didn't incorporate commentId.
2. when directing to a specific comment, show all comments instead of artificially hiding some.
3. when directing to a specific comment, then moving to one not-loaded yet, then load all comments until it is found so we don't create a gap.

To Test
------
here are some notes of good examples I found:

all loaded in first batch but not viewable in dom:
	http://calypso.localhost:3000/read/feeds/25823/posts/1438725065
	late: comment-236192
	early: comment-234395

not all loaded in first batch:
	http://calypso.localhost:3000/read/feeds/25823/posts/1511329507#comments
	first: comment-261314
	last: comment-266573