### PR TITLE
Fix logout when no redirect_to is returned

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -430,7 +430,7 @@ export const logoutUser = ( redirectTo ) => ( dispatch, getState ) => {
 			client_secret: config( 'wpcom_signup_key' ),
 			logout_nonce: logoutNonce,
 		} ).then( ( response ) => {
-			const responseData = response.body && response.body.data;
+			const responseData = response.body && response.body.data || {};
 			dispatch( {
 				type: LOGOUT_REQUEST_SUCCESS,
 				data: responseData,

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -430,12 +430,14 @@ export const logoutUser = ( redirectTo ) => ( dispatch, getState ) => {
 			client_secret: config( 'wpcom_signup_key' ),
 			logout_nonce: logoutNonce,
 		} ).then( ( response ) => {
-			const responseData = response.body && response.body.data || {};
+			const data = get( response, 'body.data', {} );
+
 			dispatch( {
 				type: LOGOUT_REQUEST_SUCCESS,
-				data: responseData,
+				data,
 			} );
-			return Promise.resolve( responseData );
+
+			return Promise.resolve( data );
 		} ).catch( ( httpError ) => {
 			const error = getErrorFromHTTPError( httpError );
 


### PR DESCRIPTION
Fixes #16750

The `/wp-login.php?action=logout-endpoint` was modified last minute to return no data instead of a default `redirect_to` url (to be consistent with other endpoints it seems). The client code wasn't updated accordingly causing #16750.

### Testing Instructions
- Boot this branch and log in or use https://calypso.live/?branch=fix/logout-redirect-to-undef
- Go to `/me/account` and change your language to something else than english
- Try to logout
- This patch should make it work

### Reviews
- [x] Code
- [x] Product