### PR TITLE
Reader Comments: reply nesting arrow

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -51,6 +51,8 @@ class PostCommentList extends React.Component {
 		showCommentCount: React.PropTypes.bool,
 		startingCommentId: React.PropTypes.number,
 		commentCount: React.PropTypes.number,
+		maxDepth: React.PropTypes.number,
+		showNestingReplyArrow: React.PropTypes.bool,
 
 		// connect()ed props:
 		commentsTree: React.PropTypes.object,
@@ -62,6 +64,8 @@ class PostCommentList extends React.Component {
 		pageSize: NUMBER_OF_COMMENTS_PER_FETCH,
 		initialSize: NUMBER_OF_COMMENTS_PER_FETCH,
 		showCommentCount: true,
+		maxDepth: Infinity,
+		showNestingReplyArrow: false,
 	};
 
 	state = {
@@ -204,6 +208,8 @@ class PostCommentList extends React.Component {
 				onUpdateCommentText={ this.onUpdateCommentText }
 				onCommentSubmit={ this.resetActiveReplyComment }
 				depth={ 0 }
+				maxDepth={ this.props.maxDepth }
+				showNestingReplyArrow={ this.props.showNestingReplyArrow }
 			/>
 		);
 	};

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -51,8 +51,6 @@ class PostComment extends Component {
 		} );
 	};
 
-	getDepth = () => Math.min( this.props.depth, this.props.maxDepth );
-
 	renderRepliesList() {
 		const commentChildrenIds = get( this.props.commentsTree, [ this.props.commentId, 'children' ] );
 		// Hide children if more than maxChildrenToShow, but not if replying
@@ -103,7 +101,7 @@ class PostComment extends Component {
 							{ commentChildrenIds.map( childId =>
 								<PostComment
 									{ ...this.props }
-									depth={ this.getDepth() + 1 }
+									depth={ this.props.depth + 1 }
 									key={ childId }
 									commentId={ childId }
 								/>
@@ -157,7 +155,7 @@ class PostComment extends Component {
 	};
 
 	render() {
-		const { commentsTree, commentId } = this.props;
+		const { commentsTree, commentId, depth, maxDepth } = this.props;
 		const comment = get( commentsTree, [ commentId, 'data' ] );
 
 		// todo: connect this constants to the state (new selector)
@@ -193,8 +191,8 @@ class PostComment extends Component {
 			commentAuthorName: parentAuthorName,
 		} = this.getAuthorDetails( parentCommentId );
 
-		const postCommentClassnames = classnames( 'comments__comment depth-', {
-			[ 'depth-' + this.getDepth() ]: this.getDepth() < 4, // only indent up to 3
+		const postCommentClassnames = classnames( 'comments__comment', {
+			[ 'depth-' + depth ]: depth <= maxDepth && depth <= 3, // only indent up to 3
 		} );
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -200,7 +200,7 @@ class PostComment extends Component {
 							</strong> }
 						{ this.props.showNestingReplyArrow && parentAuthorUrl &&
 							<span className="comments__comment-respondee">
-								<Gridicon icon="chevron-right" size={ 18 } />
+								<Gridicon icon="chevron-right" size={ 16 } />
 								<a className="comments__comment-respondee-link" href={ parentAuthorUrl }>
 									{ parentAuthor.name }
 								</a>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -6,6 +6,7 @@ import { get, noop, some } from 'lodash';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -50,13 +51,13 @@ class PostComment extends Component {
 		} );
 	};
 
-	// current hack because our css basically just indents anything 0,1,2.  TODO: make depth meaningful
-	getDepth = () => this.props.depth > this.props.maxDepth ? 4 : this.props.depth;
+	getDepth = () => Math.min( this.props.depth, this.props.maxDepth );
 
 	renderRepliesList() {
 		const commentChildrenIds = get( this.props.commentsTree, [ this.props.commentId, 'children' ] );
 		// Hide children if more than maxChildrenToShow, but not if replying
-		const exceedsMaxChildrenToShow = commentChildrenIds && commentChildrenIds.length < this.props.maxChildrenToShow;
+		const exceedsMaxChildrenToShow =
+			commentChildrenIds && commentChildrenIds.length < this.props.maxChildrenToShow;
 		const showReplies = this.state.showReplies || exceedsMaxChildrenToShow;
 
 		// No children to show
@@ -70,7 +71,7 @@ class PostComment extends Component {
 			{
 				count: commentChildrenIds.length,
 				args: { numOfReplies: commentChildrenIds.length },
-			},
+			}
 		);
 
 		const hideRepliesText = translate(
@@ -79,7 +80,7 @@ class PostComment extends Component {
 			{
 				count: commentChildrenIds.length,
 				args: { numOfReplies: commentChildrenIds.length },
-			},
+			}
 		);
 
 		let replyVisibilityText = null;
@@ -105,7 +106,7 @@ class PostComment extends Component {
 									depth={ this.getDepth() + 1 }
 									key={ childId }
 									commentId={ childId }
-								/>,
+								/>
 							) }
 						</ol>
 					: null }
@@ -130,16 +131,40 @@ class PostComment extends Component {
 		);
 	}
 
+	getAuthorDetails = commentId => {
+		const comment = get( this.props.commentsTree, [ commentId, 'data' ], {} );
+		const commentAuthor = get( comment, 'author', {} );
+		const commentAuthorName = decodeEntities( commentAuthor.name );
+		const commentAuthorUrl = !! commentAuthor.site_ID
+			? getStreamUrl( null, commentAuthor.site_ID )
+			: commentAuthor && commentAuthor.URL;
+		return { comment, commentAuthor, commentAuthorUrl, commentAuthorName };
+	};
+
+	renderAuthorTag = ( { authorName, authorUrl, commentId, className } ) => {
+		return !! authorUrl
+			? <a
+					href={ authorUrl }
+					className={ className }
+					onClick={ this.handleAuthorClick }
+					id={ `comment-${ commentId }` }
+				>
+					{ authorName }
+				</a>
+			: <strong className={ className } id={ `comment-${ commentId }` }>
+					{ authorName }
+				</strong>;
+	};
+
 	render() {
-		// todo: connect this constants to the state (new selector)
-		const commentsTree = this.props.commentsTree;
-		const comment = get( commentsTree, [ this.props.commentId, 'data' ] );
+		const { commentsTree, commentId } = this.props;
+		const comment = get( commentsTree, [ commentId, 'data' ] );
 
 		// todo: connect this constants to the state (new selector)
 		const haveReplyWithError = some(
 			get( commentsTree, [ this.props.commentId, 'children' ] ),
 			childId =>
-				get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR,
+				get( commentsTree, [ childId, 'data', 'placeholderState' ] ) === PLACEHOLDER_STATE.ERROR
 		);
 
 		// If it's a pending comment, use the current user as the author
@@ -160,52 +185,44 @@ class PostComment extends Component {
 			return <PostTrackback { ...this.props } />;
 		}
 
-		// Author URL
-		let authorUrl;
-		if ( comment.author.site_ID ) {
-			authorUrl = getStreamUrl( null, comment.author.site_ID );
-		} else if ( comment.author.URL ) {
-			authorUrl = comment.author.URL;
-		}
+		// Author Details
+		const parentCommentId = get( comment, 'parent.ID' );
+		const { commentAuthorUrl, commentAuthorName } = this.getAuthorDetails( commentId );
+		const {
+			commentAuthorUrl: parentAuthorUrl,
+			commentAuthorName: parentAuthorName,
+		} = this.getAuthorDetails( parentCommentId );
 
-		const parentComment = get( commentsTree, [ get( comment, 'parent.ID' ), 'data' ], {} );
-		const parentAuthor = parentComment.author;
-		const parentAuthorUrl = parentAuthor && parentAuthor.site_ID
-			? getStreamUrl( null, parentComment.author.site_ID )
-			: parentAuthor && parentAuthor.URL;
+		const postCommentClassnames = classnames( 'comments__comment depth-', {
+			[ 'depth-' + this.getDepth() ]: this.getDepth() < 4, // only indent up to 3
+		} );
 
+		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
-			<li className={ 'comments__comment depth-' + this.getDepth() }>
+			<li className={ postCommentClassnames }>
 				<div className="comments__comment-author">
-					{ authorUrl
-						? <a href={ authorUrl } onClick={ this.handleAuthorClick }>
+					{ commentAuthorUrl
+						? <a href={ commentAuthorUrl } onClick={ this.handleAuthorClick }>
 								<Gravatar user={ comment.author } />
 							</a>
 						: <Gravatar user={ comment.author } /> }
 
-					{ authorUrl
-						? <a
-							href={ authorUrl }
-							className="comments__comment-username"
-							onClick={ this.handleAuthorClick }
-							id={ `comment-${ this.props.commentId }` }
-							>
-								{ comment.author.name }
-							</a>
-						: <strong
-							className="comments__comment-username"
-							id={ `comment-${ this.props.commentId }` }
-							>
-								{ comment.author.name }
-							</strong> }
-						{ this.props.showNestingReplyArrow && parentAuthorUrl &&
-							<span className="comments__comment-respondee">
-								<Gridicon icon="chevron-right" size={ 16 } />
-								<a className="comments__comment-respondee-link" href={ parentAuthorUrl }>
-									{ parentAuthor.name }
-								</a>
-							</span>
-						}
+					{ this.renderAuthorTag( {
+						authorUrl: commentAuthorUrl,
+						authorName: commentAuthorName,
+						commentId,
+						className: 'comments__comment-username',
+					} ) }
+					{ this.props.showNestingReplyArrow && parentAuthorName &&
+						<span className="comments__comment-respondee">
+							<Gridicon icon="chevron-right" size={ 16 } />
+							{ this.renderAuthorTag( {
+								className: 'comments__comment-respondee-link',
+								authorName: parentAuthorName,
+								authorUrl: parentAuthorUrl,
+								commentId: parentCommentId,
+							} ) }
+						</span> }
 					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>
 							<PostTime date={ comment.date } />

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -199,8 +199,9 @@ class PostComment extends Component {
 								{ comment.author.name }
 							</strong> }
 						{ this.props.showNestingReplyArrow && parentAuthorUrl &&
-							<span className="comments__comment-respondee"> >
-								<a href={ parentAuthorUrl }>
+							<span className="comments__comment-respondee">
+								<Gridicon icon="chevron-right" size={ 18 } />
+								<a className="comments__comment-respondee-link" href={ parentAuthorUrl }>
 									{ parentAuthor.name }
 								</a>
 							</span>

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -199,9 +199,11 @@ class PostComment extends Component {
 								{ comment.author.name }
 							</strong> }
 						{ this.props.showNestingReplyArrow && parentAuthorUrl &&
-							<span> > <a className="comments__comment-respondee" href={ parentAuthorUrl }>
-								{ parentAuthor.name }
-							</a> </span>
+							<span className="comments__comment-respondee"> >
+								<a href={ parentAuthorUrl }>
+									{ parentAuthor.name }
+								</a>
+							</span>
 						}
 					<div className="comments__comment-timestamp">
 						<a href={ comment.URL }>

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -259,6 +259,11 @@
 	}
 }
 
+.comments__comment-respondee {
+	color: $gray-dark;
+	font-size: 15px;
+}
+
 .comments__comment-author {
 	font-weight: 600;
 	color: darken( $gray, 30% );

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -262,24 +262,34 @@
 .comments__comment-respondee {
 	color: $gray;
 	font-size: 15px;
+
+	.gridicon {
+		margin-right: 3px;
+		position: relative;
+			top: 4px;
+	}
 }
 
-.comments__comment-respondee .comments__comment-respondee-link:hover,
 .comments__comment-respondee .comments__comment-respondee-link {
-	color: $gray;
+	color: darken( $gray, 10% );
+
+	&:hover {
+		color: $blue-light;
+	}
 }
 
 .comments__comment-author {
-	font-weight: 600;
 	color: darken( $gray, 30% );
+	display: flex;
+	font-weight: 600;
 
 	.gravatar {
 		position: absolute;
-			top: 14px;
+			top: 12px;
 			left: -41px;
 		border-radius: 48px;
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( ">480px" ) {
 			top: 12px;
 		}
 	}
@@ -319,17 +329,13 @@ a.comments__comment-username {
 }
 
 .comments__comment-timestamp {
-	margin-top: -8px;
-
-	@include breakpoint( "<480px" ) {
-		margin-top: -4px;
-	}
+	margin-left: 12px;
 }
 
 .comments__comment-timestamp a {
+	color: lighten( $gray, 10% );
 	font-weight: normal;
 	font-size: 13px;
-	color: lighten( $gray, 10% );
 	text-decoration: none;
 
 	&:hover {
@@ -346,7 +352,6 @@ a.comments__comment-username {
 
 .comments__comment-content {
 	@extend %content-font;
-	padding-top: 4px;
 	font-size: 15px;
 	line-height: 1.8;
 	word-break: break-word;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -262,6 +262,8 @@
 .comments__comment-respondee {
 	color: $gray;
 	font-size: 15px;
+	margin-right: 12px;
+	margin-left: -12px;
 
 	.gridicon {
 		margin-right: 3px;
@@ -282,6 +284,10 @@
 	color: darken( $gray, 30% );
 	display: flex;
 	font-weight: 600;
+
+	@include breakpoint( "<480px" ) {
+		flex-wrap: wrap;
+	}
 
 	.gravatar {
 		position: absolute;
@@ -318,6 +324,7 @@
 .comments__comment-username {
 	font-size: 15px;
 	color: darken( $gray, 30% );
+	margin-right: 12px;
 }
 
 a.comments__comment-username {
@@ -326,10 +333,6 @@ a.comments__comment-username {
 	&:hover {
 		color: $blue-light;
 	}
-}
-
-.comments__comment-timestamp {
-	margin-left: 12px;
 }
 
 .comments__comment-timestamp a {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -260,7 +260,7 @@
 }
 
 .comments__comment-respondee {
-	color: $gray-dark;
+	color: darken( $gray, 20% );
 	font-size: 15px;
 }
 

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -261,7 +261,6 @@
 
 .comments__comment-respondee {
 	color: $gray;
-	font-size: 15px;
 	margin-right: 12px;
 	margin-left: -12px;
 
@@ -283,6 +282,7 @@
 .comments__comment-author {
 	color: darken( $gray, 30% );
 	display: flex;
+	font-size: 14px;
 	font-weight: 500;
 
 	@include breakpoint( "<480px" ) {
@@ -322,7 +322,6 @@
 }
 
 .comments__comment-username {
-	font-size: 15px;
 	color: darken( $gray, 30% );
 	margin-right: 12px;
 }
@@ -338,7 +337,6 @@ a.comments__comment-username {
 .comments__comment-timestamp a {
 	color: lighten( $gray, 10% );
 	font-weight: normal;
-	font-size: 13px;
 	text-decoration: none;
 
 	&:hover {

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -125,16 +125,7 @@
 	margin: 0;
 
 	&.is-root {
-		margin-top: 0;
-	}
-
-	&.is-children {
-		margin-left: -2px;
-		border-left: 2px solid lighten( $gray, 10% );
-
-		.comments__comment-author .gravatar {
-			left: -15px;
-		}
+		margin-top: 20px;
 	}
 
 	.comments__form {
@@ -227,16 +218,16 @@
 
 // Individual Comment
 .comments__comment {
-	padding: 6px 0 0;
-	margin: 24px 0 0;
+	margin-top: 20px;
 	position: relative;
 
-	&.depth-0, &.depth-1, &.depth-2 {
-		padding-left: 48px;
-		margin-top: 12px;
+	&.depth-0,
+	&.depth-1,
+	&.depth-2 {
+		padding-left: 42px;
 
 		> .comments__comment-author .gravatar {
-			left: 8px;
+			left: 1px;
 		}
 	}
 
@@ -262,17 +253,17 @@
 .comments__comment-respondee {
 	color: $gray;
 	margin-right: 12px;
-	margin-left: -12px;
 
 	.gridicon {
-		margin-right: 3px;
 		position: relative;
-			top: 4px;
+			left: -5px;
+			top: 3px;
 	}
 }
 
 .comments__comment-respondee .comments__comment-respondee-link {
 	color: darken( $gray, 10% );
+	margin-left: -2px;
 
 	&:hover {
 		color: $blue-light;
@@ -282,22 +273,15 @@
 .comments__comment-author {
 	color: darken( $gray, 30% );
 	display: flex;
+	flex-wrap: wrap;
 	font-size: 14px;
 	font-weight: 500;
 
-	@include breakpoint( "<480px" ) {
-		flex-wrap: wrap;
-	}
-
 	.gravatar {
-		position: absolute;
-			top: 12px;
-			left: -41px;
 		border-radius: 48px;
-
-		@include breakpoint( ">480px" ) {
-			top: 12px;
-		}
+		position: absolute;
+			top: 8px;
+			left: -41px;
 	}
 }
 
@@ -323,11 +307,13 @@
 
 .comments__comment-username {
 	color: darken( $gray, 30% );
-	margin-right: 12px;
+	height: 21px;
+	margin-right: 7px;
 }
 
 a.comments__comment-username {
 	color: $blue-medium;
+	height: 21px;
 
 	&:hover {
 		color: $blue-light;
@@ -354,7 +340,7 @@ a.comments__comment-username {
 .comments__comment-content {
 	@extend %content-font;
 	font-size: 15px;
-	line-height: 1.8;
+	line-height: 25px;
 	word-break: break-word;
 
 	p {
@@ -378,9 +364,9 @@ a.comments__comment-username {
 // Actions for Individual Comments
 .comments__comment-actions {
 	list-style: none;
-	margin-left: -4px;
 	color: $gray;
 	font-size: 14px;
+	margin-top: 2px;
 
 	button {
 		display: inline-block;
@@ -401,6 +387,8 @@ a.comments__comment-username {
 		}
 
 		&.comments__comment-actions-reply {
+			margin-left: -7px;
+
 			.gridicon {
 				transform: rotate( 180deg );
 			}

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -283,7 +283,7 @@
 .comments__comment-author {
 	color: darken( $gray, 30% );
 	display: flex;
-	font-weight: 600;
+	font-weight: 500;
 
 	@include breakpoint( "<480px" ) {
 		flex-wrap: wrap;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -260,8 +260,13 @@
 }
 
 .comments__comment-respondee {
-	color: darken( $gray, 20% );
+	color: $gray;
 	font-size: 15px;
+}
+
+.comments__comment-respondee .comments__comment-respondee-link:hover,
+.comments__comment-respondee .comments__comment-respondee-link {
+	color: $gray;
 }
 
 .comments__comment-author {

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -34,6 +34,7 @@ export class ConversationCommentList extends React.Component {
 					{ map( commentIds, commentId => {
 						return (
 							<PostComment
+								showNestingReplyArrow
 								commentsTree={ commentsTree }
 								key={ commentId }
 								commentId={ commentId }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -163,7 +163,7 @@ export class FullPostView extends React.Component {
 		recordTrackForPost(
 			liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked',
 			this.props.post,
-			{ context: 'full-post', event_source: 'keyboard' },
+			{ context: 'full-post', event_source: 'keyboard' }
 		);
 	};
 
@@ -284,7 +284,7 @@ export class FullPostView extends React.Component {
 				components: {
 					wpLink: <a href="/" className="reader-related-card-v2__link" />,
 				},
-			},
+			}
 		);
 
 		if ( post.site_ID ) {
@@ -423,12 +423,14 @@ export class FullPostView extends React.Component {
 							<div className="reader-full-post__comments-wrapper" ref="commentsWrapper">
 								{ shouldShowComments( post )
 									? <Comments
+											showNestingReplyArrow
 											ref="commentsList"
 											post={ post }
 											initialSize={ startingCommentId ? commentCount : 10 }
 											pageSize={ 25 }
 											startingCommentId={ startingCommentId }
 											commentCount={ commentCount }
+											maxDepth={ 1 }
 										/>
 									: null }
 							</div>
@@ -466,7 +468,7 @@ const ConnectedFullPostView = connect(
 
 		return props;
 	},
-	{ setSection },
+	{ setSection }
 )( FullPostView );
 
 /**

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -67,6 +67,7 @@ import * as FeedStreamStoreActions from 'lib/feed-stream-store/actions';
 import { getLastStore } from 'reader/controller-helper';
 import { showSelectedPost } from 'reader/utils';
 import Emojify from 'components/emojify';
+import config from 'config';
 
 export class FullPostView extends React.Component {
 	static propTypes = {
@@ -423,7 +424,7 @@ export class FullPostView extends React.Component {
 							<div className="reader-full-post__comments-wrapper" ref="commentsWrapper">
 								{ shouldShowComments( post )
 									? <Comments
-											showNestingReplyArrow
+											showNestingReplyArrow={ config.isEnabled( 'reader/nesting-arrow' ) }
 											ref="commentsList"
 											post={ post }
 											initialSize={ startingCommentId ? commentCount : 10 }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -388,8 +388,8 @@
 	animation: appear .3s ease-in-out;
 }
 
-.post .comments__comment-timestamp {
-	margin-top: -4px;
+.post .comments__comment-author .gravatar{
+	top: 5px;
 }
 
 .post .comments__view-more {

--- a/config/development.json
+++ b/config/development.json
@@ -133,6 +133,7 @@
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
+		"reader/nesting-arrow": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -85,6 +85,7 @@
 		"reader/following-intro": true,
 		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,
+		"reader/nesting-arrow": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/tags-with-elasticsearch": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -98,6 +98,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/following-manage-refresh": true,
+		"reader/nesting-arrow": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,


### PR DESCRIPTION
>###  The problem
> We are currently nesting comments in Reader up to 3-levels deep. The problems with this are:
It looks visually cluttered.
Terrible readability on mobile, a lot of orphaned words. In this example, notice how some lines only have one to two words.
Commenting experience itself isn’t great because the form gets really narrow.
Not easy to identify comments that have been recently added (unless there is some sort of notification).

> ### Proposed Solution
> Nesting comments only two-levels deep.
Replies to a comment will display the name of the person being replied to. Adding “> name” communicates that the reply was intended for that person. It communicates the same thing as indenting minus the visual mess.

Example: 
<img width="626" alt="screenshot-2017-07-28-09-10-54" src="https://user-images.githubusercontent.com/4656974/28796393-5ccc6da4-760b-11e7-8aca-df4d433aabbd.png">
