### PR TITLE
Plugins: Remove auto updateing of plugins.

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -127,52 +127,6 @@ const recordEvent = ( eventType, plugin, site, error ) => {
 	analytics.mc.bumpStat( eventType, 'succeeded' );
 };
 
-// Updates a plugin without launching the events that notifies
-// the user that an update is going on.
-// Used for updating plugins automatically on the background.
-const autoupdatePlugin = ( site, plugin ) => {
-	Dispatcher.handleViewAction( {
-		type: 'AUTOUPDATE_PLUGIN',
-		action: 'AUTOUPDATE_PLUGIN',
-		site: site,
-		plugin: plugin
-	} );
-
-	analytics.tracks.recordEvent( 'calypso_plugin_update_automatic', {
-		site: site.ID,
-		plugin: plugin.slug
-	} );
-
-	analytics.mc.bumpStat( 'calypso_plugin_update_automatic' );
-
-	const boundEnableAU = getPluginBoundMethod( site, plugin.id, 'updateVersion' );
-	queueSitePluginAction( boundEnableAU, site.ID, plugin.id, ( error, data ) => {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_AUTOUPDATE_PLUGIN',
-			action: 'AUTOUPDATE_PLUGIN',
-			site: site,
-			plugin: plugin,
-			data: data,
-			error: error
-		} );
-		recordEvent( 'calypso_plugin_updated_automatic', plugin, site, error );
-	} );
-};
-
-const processAutoupdates = ( site, plugins ) => {
-	if ( site.canAutoupdateFiles &&
-		site.jetpack &&
-		site.canManage() &&
-		utils.userCan( 'manage_options', site )
-	) {
-		plugins.forEach( plugin => {
-			if ( plugin.update && plugin.autoupdate ) {
-				autoupdatePlugin( site, plugin );
-			}
-		} );
-	}
-};
-
 const PluginsActions = {
 	removePluginsNotices: logs => {
 		Dispatcher.handleViewAction( {
@@ -202,9 +156,6 @@ const PluginsActions = {
 				data: data,
 				error: error
 			} );
-			if ( ! error ) {
-				processAutoupdates( site, data.plugins );
-			}
 		};
 
 		if ( site.jetpack ) {


### PR DESCRIPTION
Since we now do all autoupdates of plugins from .com side anyways. 
We are removing autoupdating of plugins when the user visits the plugins page and the plugins need to be should be autoupdated from calypso. 

We want to simplify and more accurately track when how the autoupdates happen and report that info the other in the activity log. 

Fixes https://github.com/Automattic/wp-calypso/issues/16416

To test. 
Have plugin that needs autoupdating. Update the plugin version that that an autoupdate is triggered. Notice that the autoupdate still happens. 

Test out the other actions and make sure that they happen as expected. 
