### PR TITLE
Store: WooCommerce: Add site descriptor field to Stripe settings

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -46,6 +46,9 @@ class PaymentMethodItem extends Component {
 			informationUrl: PropTypes.string,
 		} ),
 		openPaymentMethodForEdit: PropTypes.func.isRequired,
+		site: PropTypes.shape( {
+			title: PropTypes.string,
+		} ),
 	};
 
 	onEditHandler = () => {
@@ -97,7 +100,7 @@ class PaymentMethodItem extends Component {
 	}
 
 	outputEditComponent = () => {
-		const { currentlyEditingMethod, method } = this.props;
+		const { currentlyEditingMethod, method, site } = this.props;
 		if ( method.id === 'paypal' ) {
 			return (
 				<PaymentMethodPaypal
@@ -113,7 +116,8 @@ class PaymentMethodItem extends Component {
 					method={ currentlyEditingMethod }
 					onCancel={ this.onCancel }
 					onEditField={ this.onEditField }
-					onDone={ this.onDone } />
+					onDone={ this.onDone }
+					site={ site } />
 			);
 		}
 		if ( method.id === 'cheque' ) {

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -48,13 +48,14 @@ class SettingsPaymentsMethodList extends Component {
 	}
 
 	renderMethodItem = ( method ) => {
+		const { site } = this.props;
 		// Disable BACS and Cheque payment for now until #16630 and #16629 are fixed.
 		if ( 'bacs' === method.id ) {
 			return null;
 		}
 
 		return (
-			<PaymentMethodItem method={ method } key={ method.title } />
+			<PaymentMethodItem method={ method } key={ method.title } site={ site } />
 		);
 	}
 

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -13,6 +13,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormRadio from 'components/forms/form-radio';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 import SegmentedControl from 'components/segmented-control';
@@ -36,9 +37,19 @@ class PaymentMethodStripe extends Component {
 		onCancel: PropTypes.func.isRequired,
 		onEditField: PropTypes.func.isRequired,
 		onDone: PropTypes.func.isRequired,
+		site: PropTypes.shape( {
+			title: PropTypes.string,
+		} ),
 	};
 
 	onEditFieldHandler = ( e ) => {
+		// Limit the statement descriptor field to 22 characters
+		if ( e.target && e.target.name && 'statement_descriptor' === e.target.name ) {
+			if ( 22 < e.target.value.length ) {
+				return;
+			}
+		}
+		// All others may continue
 		this.props.onEditField( e.target.name, e.target.value );
 	}
 
@@ -104,6 +115,12 @@ class PaymentMethodStripe extends Component {
 		{ action: 'save', label: this.props.translate( 'Done' ), onClick: this.props.onDone, isPrimary: true },
 	];
 
+	getStatementDescriptorPlaceholder = () => {
+		const { site, translate } = this.props;
+		const domain = site.domain.substr( 0, 22 ).trim().toUpperCase();
+		return translate( 'e.g. %(domain)s', { args: { domain } } );
+	}
+
 	render() {
 		const { method, translate } = this.props;
 		return (
@@ -152,11 +169,26 @@ class PaymentMethodStripe extends Component {
 							value="no"
 							checked={ 'no' === method.settings.capture.value }
 							onChange={ this.onEditFieldHandler } />
-						<span>{ translate( 'Authorize the customers credit card but charge manually' ) }</span>
+						<span>{ translate( 'Authorize the customer\'s credit card but charge manually' ) }</span>
 					</FormLabel>
 				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						{ translate( 'Descriptor' ) }
+					</FormLabel>
+					<FormTextInput
+						name="statement_descriptor"
+						onChange={ this.onEditFieldHandler }
+						value={ method.settings.statement_descriptor.value }
+						placeholder={ this.getStatementDescriptorPlaceholder() } />
+					<FormSettingExplanation>
+						{ translate( 'Appears on your customer\'s credit card statement. 22 characters maximum' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>Use ApplePay</FormLabel>
+					<FormLabel>
+						{ translate( 'Use ApplePay' ) }
+					</FormLabel>
 					<PaymentMethodEditFormToggle
 						checked={ method.settings.apple_pay.value === 'yes' ? true : false }
 						name="apple_pay"

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -44,7 +44,8 @@ class PaymentMethodStripe extends Component {
 
 	onEditFieldHandler = ( e ) => {
 		// Limit the statement descriptor field to 22 characters
-		if ( e.target && e.target.name && 'statement_descriptor' === e.target.name ) {
+		// since that is all Stripe will accept
+		if ( e.target && 'statement_descriptor' === e.target.name ) {
 			if ( 22 < e.target.value.length ) {
 				return;
 			}


### PR DESCRIPTION
Fixes #16659 

To test:
* Go to http://calypso.localhost:3000/store/{site}
* Go to Settings > Payments > Stripe > Manage
* Make sure the descriptor is visible, editable, and that clearing it generates a suggested value based on the site's domain name
* Ensure you are not allowed to type more than 22 characters in the field
* Ensure that if you change the value, close the modal, and hit save, that the changes are persisted to the site

<img width="654" alt="screen shot 2017-07-31 at 3 12 30 pm" src="https://user-images.githubusercontent.com/1595739/28800839-7ca5bf2a-7603-11e7-8a60-7f427f84e705.png">
