### PR TITLE
WCS: Pass selectedText to stats navigation

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/index.js
@@ -15,15 +15,17 @@ import { UNITS } from 'woocommerce/app/store-stats/constants';
 
 const StoreStatsNavigation = props => {
 	const { translate, slug, type, unit } = props;
+	const selectedText = UNITS[ unit ].title;
 	return (
 		<div className="store-stats-navigation">
-			<SectionNav selectedText={ UNITS[ unit ].title }>
+			<SectionNav selectedText={ selectedText }>
 				<StoreStatsNavigationTabs
 					label={ 'Stats' }
 					slug={ slug }
 					type={ type }
 					unit={ unit }
 					units={ UNITS }
+					selectedText={ selectedText }
 				/>
 				<SegmentedControl
 					initialSelected="store"

--- a/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-navigation/navtabs.js
@@ -10,9 +10,9 @@ import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 
 const StoreStatsNavigationTabs = props => {
-	const { label, slug, type, unit, units } = props;
+	const { label, selectedText, slug, type, unit, units } = props;
 	return (
-		<NavTabs label={ label }>
+		<NavTabs label={ label } selectedText={ selectedText }>
 			{ Object.keys( units ).map( key => (
 				<NavItem
 					key={ key }
@@ -28,6 +28,7 @@ const StoreStatsNavigationTabs = props => {
 
 StoreStatsNavigationTabs.propTypes = {
 	label: PropTypes.string,
+	selectedText: PropTypes.string,
 	slug: PropTypes.string,
 	type: PropTypes.string,
 	unit: PropTypes.string,


### PR DESCRIPTION
### Fix period not being displayed on mobile
<img width="438" alt="stats_ _care_for_animals_ _wordpress_com" src="https://user-images.githubusercontent.com/22080/28697246-4e303a92-72ef-11e7-90c8-1909c03643a2.png">

It turns out `<SectionNav />` was [passing down props to immediate children](https://github.com/Automattic/wp-calypso/blob/master/client/components/section-nav/index.jsx#L123-L128). If the DOM structure is not as expected, this fails and `<NavTabs />` does not have the correct props to render correctly on mobile.

### Fix
Explicitly pass the prop `selectedText`

Fixes https://github.com/Automattic/wp-calypso/issues/16667