### PR TITLE
Simple Payments: update product image to editor preview

### DIFF
--- a/assets/stylesheets/editor.scss
+++ b/assets/stylesheets/editor.scss
@@ -1,5 +1,6 @@
 @import 'shared/colors';
 @import 'shared/typography';
+@import 'shared/mixins/breakpoints';
 
 @import 'components/tinymce/iframe';
 @import 'components/tinymce/plugins/media/style';

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -6,6 +6,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependecies
@@ -16,34 +17,36 @@ import { getSimplePayments } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import formatCurrency from 'lib/format-currency';
 import QuerySimplePayments from 'components/data/query-simple-payments';
+import QueryMedia from 'components/data/query-media';
+import { getMediaItem } from 'state/selectors';
 
 class SimplePaymentsView extends Component {
 	render() {
-		const { productId, product, siteId } = this.props;
+		const { productId, product, siteId, productImage } = this.props;
 
 		if ( ! product ) {
 			return ( <QuerySimplePayments siteId={ siteId } productId={ productId } /> );
 		}
 
-		const { title, description, price, currency } = product;
-
-		// TODO: add from product.
-		const imageUrl = 'https://cldup.com/nKM0_KspYE.png';
+		const { title, description, price, currency, featuredImageId: productImageId } = product;
 
 		// TODO: make proper icon and store on some proper place.
 		const paypalButtonImageUrl = 'https://cldup.com/DoIAwrACBs.png';
 
 		return (
 			<div className="wpview-content wpview-type-simple-payments">
+				{ productImageId && <QueryMedia siteId={ siteId } mediaId={ productImageId } /> }
 				<div className="wpview-type-simple-payments__wrapper">
+				{ productImage &&
 					<div className="wpview-type-simple-payments__image-part">
 						<figure className="wpview-type-simple-payments__image-figure">
 							<img
 								className="wpview-type-simple-payments__image"
-								src={ imageUrl }
+								src={ productImage.URL }
 							/>
 						</figure>
 					</div>
+				}
 					<div className="wpview-type-simple-payments__text-part">
 						<div className="wpview-type-simple-payments__title">
 							{ title }
@@ -84,12 +87,14 @@ SimplePaymentsView = connect( ( state, props ) => {
 
 	const { id: productId = null } = shortcodeData;
 	const siteId = getSelectedSiteId( state );
+	const product = getSimplePayments( state, siteId, productId );
 
 	return {
 		shortcodeData,
 		productId,
 		siteId,
-		product: getSimplePayments( state, siteId, productId ),
+		product,
+		productImage: getMediaItem( state, siteId, get( product, 'featuredImageId' ) ),
 	};
 } )( localize( SimplePaymentsView ) );
 

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -22,12 +22,13 @@ import { getMediaItem } from 'state/selectors';
 
 class SimplePaymentsView extends Component {
 	render() {
-		const { productId, product, siteId, productImage } = this.props;
+		const { productId, product, siteId } = this.props;
 
 		if ( ! product ) {
 			return ( <QuerySimplePayments siteId={ siteId } productId={ productId } /> );
 		}
 
+		const { productImage } = this.props;
 		const { title, description, price, currency, featuredImageId: productImageId } = product;
 
 		// TODO: make proper icon and store on some proper place.

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -3,18 +3,18 @@
 	flex-direction: column;
 	padding: 10px;
 
-	// @include breakpoint( ">480px" ) {
-	// 	flex-direction: row;
-	// }
+	@include breakpoint( ">480px" ) {
+		flex-direction: row;
+	}
 }
 
 .wpview-type-simple-payments__image-part {
 	flex: 0 0 30%;
 	margin-bottom: 24px;
 
-	// @include breakpoint( ">480px" ) {
-	// 	margin-bottom: 0
-	// }
+	@include breakpoint( ">480px" ) {
+		margin-bottom: 0
+	}
 }
 
 .wpview-type-simple-payments__image-figure {
@@ -43,10 +43,10 @@
 }
 
 .wpview-type-simple-payments__image-part + .wpview-type-simple-payments__text-part {
-	// @include breakpoint( ">480px" ) {
-	// 	flex-basis: 70%;
-	// 	padding-left: 16px;
-	// }
+	@include breakpoint( ">480px" ) {
+	flex-basis: 70%;
+		padding-left: 16px;
+	}
 }
 
 .wpview-type-simple-payments__title {

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -1,47 +1,87 @@
 .wpview-type-simple-payments__wrapper {
 	display: flex;
-	margin: 10px;
+	flex-direction: column;
+	padding: 10px;
+
+	// @include breakpoint( ">480px" ) {
+	// 	flex-direction: row;
+	// }
+}
+
+.wpview-type-simple-payments__image-part {
+	flex: 0 0 30%;
+	margin-bottom: 24px;
+
+	// @include breakpoint( ">480px" ) {
+	// 	margin-bottom: 0
+	// }
+}
+
+.wpview-type-simple-payments__image-figure {
+	border: 1px solid lighten( $gray, 10% );
+	background-color: lighten( $gray, 30% );
+	margin: 0;
+	min-width: 70px;
+	padding-top: calc(100% - 2px);
+	position: relative;
+}
+
+.wpview-type-simple-payments__image {
+	height: auto;
+	left: 50%;
+	margin: 0;
+	max-height: 100%;
+	max-width: 100%;
+	position: absolute;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	width: auto;
 }
 
 .wpview-type-simple-payments__text-part {
-	margin-left: 15px;
+	flex-basis: 100%;
+}
+
+.wpview-type-simple-payments__image-part + .wpview-type-simple-payments__text-part {
+	// @include breakpoint( ">480px" ) {
+	// 	flex-basis: 70%;
+	// 	padding-left: 16px;
+	// }
 }
 
 .wpview-type-simple-payments__title {
 	font-weight: bold;
-	margin-bottom: 10px;
+	margin-bottom: 24px;
+}
+
+.wpview-type-simple-payments__description {
+	margin-bottom: 24px;
 }
 
 .wpview-type-simple-payments__price-part {
-	margin: 20px 0;
 	font-weight: bold;
+	margin-bottom: 24px;
 }
 
 .wpview-type-simple-payments__pay-part {
 	display: flex;
 }
 
+.wpview-type-simple-payments__pay-quantity {
+	flex: 0 0 auto;
+	margin-right: 10px;
+}
+
 .wpview-type-simple-payments__pay-quantity-input {
 	border: 1px solid lighten( $gray, 10% );
-	padding: 10px;
-	width: 70px;
+	padding: 6px 8px;
+	max-width: 42px;
 }
 
 .wpview-type-simple-payments__pay-paypal-button-wrapper {
-	margin-left: 10px;
+	flex: 0 0 auto;
 }
 
 .wpview-type-simple-payments__pay-paypal-button {
 	width: 150px;
-}
-
-.wpview-type-simple-payments__image-figure {
-	margin: 0;
-	height: 100%;
-	border: 1px solid lighten( $gray, 10% );
-	background-color: lighten( $gray, 30% );
-}
-
-.wpview-type-simple-payments__image {
-	max-width: 200px;
 }


### PR DESCRIPTION
This updates the product image in the editor preview

**Screens** 
Wide breakpoint with portrait, landscape and square images
![untitled](https://user-images.githubusercontent.com/744755/28850878-e525957c-76d3-11e7-9c85-c62cc2f50f6f.png)


Narrow breakpoint
![screen shot 2017-08-01 at 4 04 59 pm](https://user-images.githubusercontent.com/744755/28850823-ad76f8b4-76d3-11e7-853b-4bf510d196d1.png)

**Testing**
- Payment buttons with an image should display the correct image in the editor preview
- Payment buttons without an image should not display an image in the editor preview