### PR TITLE
Store: WooCommerce: Add order creation date to the order details

### DIFF
--- a/client/extensions/woocommerce/app/order/order-created.js
+++ b/client/extensions/woocommerce/app/order/order-created.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import Gridicon from 'gridicons';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import React, { Component, PropTypes } from 'react';
 
 class OrderCreated extends Component {
@@ -13,7 +13,7 @@ class OrderCreated extends Component {
 	}
 
 	render() {
-		const { order, translate } = this.props;
+		const { moment, order, translate } = this.props;
 		if ( ! order ) {
 			return null;
 		}

--- a/client/extensions/woocommerce/app/order/order-created.js
+++ b/client/extensions/woocommerce/app/order/order-created.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import Gridicon from 'gridicons';
+import { localize, moment } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
+
+class OrderCreated extends Component {
+	static propTypes = {
+		order: PropTypes.shape( {
+			date_created_gmt: PropTypes.string.isRequired,
+		} ),
+	}
+
+	render() {
+		const { order, translate } = this.props;
+		if ( ! order ) {
+			return null;
+		}
+
+		const createdMoment = moment( order.date_created_gmt + 'Z' );
+		const createdLabel = translate(
+			'Order created on %(createdDate)s at %(createdTime)s',
+			{
+				args: {
+					createdDate: createdMoment.format( 'll' ),
+					createdTime: createdMoment.format( 'LT' ),
+				}
+			}
+		);
+
+		return (
+			<div className="order__details-created">
+				<div className="order__details-created-label">
+					<Gridicon icon="time" size={ 24 } />
+					{ createdLabel }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( OrderCreated );

--- a/client/extensions/woocommerce/app/order/order-details.js
+++ b/client/extensions/woocommerce/app/order/order-details.js
@@ -10,6 +10,7 @@ import React, { Component, PropTypes } from 'react';
  */
 import Card from 'components/card';
 import FormSelect from 'components/forms/form-select';
+import OrderCreated from './order-created';
 import OrderDetailsTable from './order-details-table';
 import OrderFulfillment from './order-fulfillment';
 import OrderRefundCard from './order-refund-card';
@@ -96,6 +97,7 @@ class OrderDetails extends Component {
 				</SectionHeader>
 				<Card className="order__details-card">
 					<OrderDetailsTable order={ order } site={ site } />
+					<OrderCreated order={ order } site={ site } />
 					<OrderRefundCard order={ order } site={ site } />
 					<OrderFulfillment order={ order } site={ site } />
 				</Card>

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -159,6 +159,7 @@
 	}
 }
 
+.order__details-created,
 .order__details-refund,
 .order__details-fulfillment {
 	margin: 0 -16px;
@@ -172,6 +173,7 @@
 		padding: 24px;
 	}
 
+	.order__details-created-label,
 	.order__details-refund-label,
 	.order__details-fulfillment-label {
 		display: flex;


### PR DESCRIPTION
Fixes #16381 

To test, go look at an individual order. The time is, like that for posts, presented in the browser's timzeone.

<img width="744" alt="screen shot 2017-07-31 at 5 25 40 pm" src="https://user-images.githubusercontent.com/1595739/28804034-a6b7c10c-7615-11e7-82af-af00ebf7a675.png">

cc @kellychoffman @jameskoster for design review 
