### PR TITLE
Image Editor: after editing image, the transient media has incorrect width/height 

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -242,19 +242,25 @@ export class EditorMediaModal extends Component {
 			fileName,
 			site,
 			ID,
-			resetAllImageEditorState
+			resetAllImageEditorState,
+			width,
+			height
 		} = imageEditorProps;
 
 		const mimeType = MediaUtils.getMimeType( fileName );
 
-		const item = {
-			ID: ID,
-			media: {
-				fileName: fileName,
-				fileContents: blob,
-				mimeType: mimeType
-			}
-		};
+		const item = Object.assign(
+			{
+				ID: ID,
+				media: {
+					fileName: fileName,
+					fileContents: blob,
+					mimeType: mimeType
+				}
+			},
+			width && { width },
+			height && { height }
+		);
 
 		MediaActions.update( site.ID, item, true );
 


### PR DESCRIPTION
This fixes issue: #9183

As described in the issue, the transient image created in the post body _after a user has edited an image_ retains the original dimensions up until the point at which the server delivers the newly edited image.

The fix involved using the canvas blob to create a temporary image, from which we grab the new height and width.

## Current behaviour
The post briefly displays the cropped image with the larger, original dimensions. 
![crop_transient_01](https://user-images.githubusercontent.com/6458278/28818662-177850e4-76ef-11e7-99c8-a341c01300ee.gif)

##  Changes in this PR 
We apply the new dimensions directly.
![crop_transient_02](https://user-images.githubusercontent.com/6458278/28818669-2091343e-76ef-11e7-8d8c-a20b077a3011.gif)

