### PR TITLE
SimplePaymentsDialog: Show a placeholder while loading the payment button list

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -35,6 +35,9 @@ import {
 	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
 
+// Utility function for checking the state of the Payment Buttons list
+const isEmptyArray = a => Array.isArray( a ) && a.length === 0;
+
 class SimplePaymentsDialog extends Component {
 	static propTypes = {
 		showDialog: PropTypes.bool.isRequired,
@@ -60,15 +63,17 @@ class SimplePaymentsDialog extends Component {
 
 		this._isMounted = false;
 
+		const { editPaymentId, paymentButtons } = this.props;
+
 		this.formStateController = formState.Controller( {
-			initialFields: this.getInitialFormFields( this.props.editPaymentId ),
+			initialFields: this.getInitialFormFields( editPaymentId ),
 			onNewState: form => this._isMounted && this.setState( { form } ),
 			validatorFunction: this.validateFormFields,
 		} );
 
 		this.state = {
-			activeTab: 'form',
-			editedPaymentId: this.props.editPaymentId,
+			activeTab: editPaymentId || isEmptyArray( paymentButtons ) ? 'form' : 'list',
+			editedPaymentId: editPaymentId,
 			selectedPaymentId: null,
 			form: this.formStateController.getInitialState(),
 			isSubmitting: false,
@@ -80,7 +85,21 @@ class SimplePaymentsDialog extends Component {
 	componentWillReceiveProps( nextProps ) {
 		// When transitioning from hidden to visible, show and initialize the form
 		if ( nextProps.showDialog && ! this.props.showDialog ) {
-			this.editPaymentButton( nextProps.editPaymentId );
+			if ( nextProps.editPaymentId ) {
+				// Explicitly ordered to edit a particular button
+				this.editPaymentButton( nextProps.editPaymentId );
+			} else if ( isEmptyArray( nextProps.paymentButtons ) ) {
+				// If the button list is loaded and empty, show the "Add New" form
+				this.editPaymentButton( null );
+			} else {
+				// If the list is loading or is non-empty, show it
+				this.setState( { activeTab: 'list' } );
+			}
+		}
+
+		// If the list has finished loading and is empty, switch from list to the "Add New" form
+		if ( this.props.paymentButtons === null && isEmptyArray( nextProps.paymentButtons ) ) {
+			this.editPaymentButton( null );
 		}
 
 		// clear the form when dialog is being closed -- it'll be blank next time it's opened
@@ -316,9 +335,11 @@ class SimplePaymentsDialog extends Component {
 		const { showDialog, onClose, siteId, paymentButtons, currencyCode } = this.props;
 		const { activeTab, errorMessage } = this.state;
 
-		// Don't show navigation when directly editing a payment button
-		const showNavigation = activeTab === 'list' || ! this.isDirectEdit();
-		const currencyDefaults = getCurrencyDefaults( currencyCode );
+		// Don't show navigation on 'form' tab if the list is empty or if directly editing
+		// a payment button. On the 'list' tab, always show it.
+		const showNavigation =
+			activeTab === 'list' ||
+			( activeTab === 'form' && ! this.isDirectEdit() && ! isEmptyArray( paymentButtons ) );
 
 		return (
 			<Dialog
@@ -341,7 +362,7 @@ class SimplePaymentsDialog extends Component {
 					<Notice status="is-error" text={ errorMessage } onDismissClick={ this.dismissError } /> }
 				{ activeTab === 'form'
 					? <ProductForm
-							currencyDefaults={ currencyDefaults }
+							currencyDefaults={ getCurrencyDefaults( currencyCode ) }
 							fieldValues={ this.getFormValues() }
 							isFieldInvalid={ this.isFormFieldInvalid }
 							onFieldChange={ this.handleFormFieldChange }
@@ -365,7 +386,7 @@ export default connect( state => {
 
 	return {
 		siteId,
-		paymentButtons: getSimplePayments( state, siteId ) || [],
+		paymentButtons: getSimplePayments( state, siteId ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 	};
 } )( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/dialog/list-item-placeholder.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list-item-placeholder.jsx
@@ -1,0 +1,30 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+
+const ProductListItemPlaceholder = ( { translate } ) =>
+	<CompactCard className="editor-simple-payments-modal__list-item is-placeholder">
+		<div className="editor-simple-payments-modal__list-label">
+			<div>
+				<span className="placeholder-text">
+					{ translate( 'Loading payment buttons…' ) }
+				</span>
+			</div>
+			<div>
+				<span className="placeholder-text">
+					{ '$1000' }
+				</span>
+			</div>
+		</div>
+	</CompactCard>;
+
+export default localize( ProductListItemPlaceholder );

--- a/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/list.jsx
@@ -4,16 +4,17 @@
  * External dependencies
  */
 import React, { Component, PropTypes } from 'react';
-import { noop } from 'lodash';
+import { noop, range } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ProductListItem from './list-item';
+import ProductListItemPlaceholder from './list-item-placeholder';
 
 class ProductList extends Component {
 	static propTypes = {
-		paymentButtons: PropTypes.array.isRequired,
+		paymentButtons: PropTypes.array,
 		selectedPaymentId: PropTypes.number,
 		onSelectedChange: PropTypes.func,
 		onEditClick: PropTypes.func,
@@ -27,7 +28,7 @@ class ProductList extends Component {
 		onTrashClick: noop,
 	};
 
-	render() {
+	renderListItems() {
 		const {
 			paymentButtons,
 			selectedPaymentId,
@@ -36,21 +37,30 @@ class ProductList extends Component {
 			onTrashClick,
 		} = this.props;
 
+		if ( ! paymentButtons ) {
+			// Render 2 placeholder items
+			return range( 2 ).map( i => <ProductListItemPlaceholder key={ i } /> );
+		}
+
+		return paymentButtons.map( ( { ID: paymentId, title, price, currency } ) =>
+			<ProductListItem
+				key={ paymentId }
+				paymentId={ paymentId }
+				isSelected={ selectedPaymentId === paymentId }
+				title={ title }
+				price={ price }
+				currency={ currency }
+				onSelectedChange={ onSelectedChange }
+				onEditClick={ onEditClick }
+				onTrashClick={ onTrashClick }
+			/>,
+		);
+	}
+
+	render() {
 		return (
 			<div className="editor-simple-payments-modal__list">
-				{ paymentButtons.map( ( { ID: paymentId, title, price, currency } ) =>
-					<ProductListItem
-						key={ paymentId }
-						paymentId={ paymentId }
-						isSelected={ selectedPaymentId === paymentId }
-						title={ title }
-						price={ price }
-						currency={ currency }
-						onSelectedChange={ onSelectedChange }
-						onEditClick={ onEditClick }
-						onTrashClick={ onTrashClick }
-					/>,
-				) }
+				{ this.renderListItems() }
 			</div>
 		);
 	}

--- a/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/navigation.jsx
@@ -16,7 +16,7 @@ class SimplePaymentsDialogNavigation extends Component {
 	static propTypes = {
 		activeTab: PropTypes.oneOf( [ 'list', 'form' ] ).isRequired,
 		onChangeTabs: PropTypes.func.isRequired,
-		paymentButtons: PropTypes.array.isRequired,
+		paymentButtons: PropTypes.array,
 	};
 
 	onChangeTabs = tab => () => this.props.onChangeTabs( tab );
@@ -27,12 +27,7 @@ class SimplePaymentsDialogNavigation extends Component {
 		const classNames = 'editor-simple-payments-modal__navigation';
 
 		if ( activeTab === 'form' ) {
-			if ( ! paymentButtons.length ) {
-				// We are on "Add New" view without previously made payment buttons.
-				return null;
-			}
-
-			// We are on "Add New" view with previously made payment buttons.
+			// Navigation for the editing form
 			return (
 				<HeaderCake
 					className={ classNames }
@@ -43,6 +38,11 @@ class SimplePaymentsDialogNavigation extends Component {
 		}
 
 		// We are on "Payment Buttons" view.
+		if ( ! paymentButtons ) {
+			// Render an empty SectionHeader as a placeholder
+			return <SectionHeader className={ classNames } />;
+		}
+
 		return (
 			<SectionHeader
 				className={ classNames }

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -28,6 +28,7 @@
 		display: flex;
 		flex-direction: column;
 		flex: auto;
+		padding: 0;
 		min-height: 0; // permits the to shrink below its min height and scroll
 	}
 

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -98,6 +98,15 @@
 		margin: 0;
 		margin-right: 24px;
 	}
+
+	&.is-placeholder {
+		padding-left: 64px; // 2*24px of padding + 16px of radio width
+		padding-right: 72px; // 2*24px of padding + 24px gridicon width
+	}
+
+	.placeholder-text {
+		@include placeholder();
+	}
 }
 
 .editor-simple-payments-modal__list-label {


### PR DESCRIPTION
If the payment buttons list is still loading (i.e., the `paymentButtons` prop is null) show a placeholder list to indicate that.

While loading:
<img width="919" alt="list-placeholder" src="https://user-images.githubusercontent.com/664258/28821026-2d4b0af0-76b4-11e7-8a87-0f5f50cd0037.png">
(the empty `SectionHeader` at the top depends on #16683. Without it, its height will be smaller)

After loaded:
<img width="919" alt="list-loaded" src="https://user-images.githubusercontent.com/664258/28821029-301b6cac-76b4-11e7-9e61-19fe90a3f81c.png">

Also, implements the correct behavior when opening the dialog in order to "Add Payment Button":
- if the list is loading, show the loading placeholder
- if the list is loaded and empty, open the "Add New" form right away
- if the list is not empty, show the list of existing buttons to choose from. The "Add New" action is available, but you need to click a button to get there.

To test:
- check that the placeholder is displayed while loading. Warning: the list is in unloaded state only if there are no existing payment buttons on the edited post. Otherwise, the list is pre-populated with the existing buttons and already has some content, although incomplete.
- test the logic that decided whether to display the list or the form, as described above
