### PR TITLE
Signup: Fix an error that is caused by refreshing during signup.

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -16,6 +16,7 @@ var debug = require( 'debug' )( 'calypso:signup:flow-controller' ), // eslint-di
 	find = require( 'lodash/find' ),
 	pick = require( 'lodash/pick' ),
 	keys = require( 'lodash/keys' ),
+	get = require( 'lodash/get' ),
 	page = require( 'page' );
 
 /**
@@ -228,10 +229,8 @@ assign( SignupFlowController.prototype, {
 
 	_getStoredDependencies() {
 		const requiredDependencies = this._flow.steps.reduce( ( current, stepName ) => {
-			if ( ! steps[ stepName ] || ! steps[ stepName ].providesDependencies ) {
-				return current;
-			}
-			return current.concat( steps[ stepName ].providesDependencies );
+			const providesDependencies = get( steps, [ stepName, 'providesDependencies' ] );
+			return providesDependencies ? current.concat( providesDependencies ) : current;
 		}, [] );
 
 		return SignupProgressStore.get().reduce(

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -230,7 +230,29 @@ assign( SignupFlowController.prototype, {
 
 		SignupProgressStore.reset();
 		SignupDependencyStore.reset();
-	}
+	},
+
+	canResumeAt( stepName ) {
+		const currentSteps = this._flow.steps;
+		const stepIndex = currentSteps.indexOf( stepName );
+
+		if ( 1 > stepIndex ) {
+			return false;
+		}
+
+		return every(
+			pick( steps, currentSteps.slice( 0, stepIndex ) ),
+			step => {
+				if ( ! step.providesDependencies ) {
+					return true;
+				}
+
+				const dependenciesNotProvided = difference( step.providesDependencies, keys( SignupDependencyStore.get() ) );
+
+				return isEmpty( dependenciesNotProvided );
+			}
+		);
+	},
 } );
 
 module.exports = SignupFlowController;

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -133,7 +133,11 @@ function handleChange() {
 }
 
 function addStorableDependencies( step, action ) {
-	const { unstorableDependencies } = steps[ step.stepName ];
+	let unstorableDependencies;
+
+	if ( steps[ step.stepName ] ) {
+		unstorableDependencies = steps[ step.stepName ].unstorableDependencies;
+	}
 
 	if ( isEmpty( action.providedDependencies ) ) {
 		return step;

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -132,6 +132,20 @@ function handleChange() {
 	store.set( STORAGE_KEY, omitUserData( signupProgress ) );
 }
 
+function addStorableDependencies( step, action ) {
+	const { unstorableDependencies } = steps[ step.stepName ];
+
+	if ( isEmpty( action.providedDependencies ) ) {
+		return step;
+	}
+
+	const providedDependencies = isEmpty( unstorableDependencies )
+		? action.providedDependencies
+		: omit( action.providedDependencies, unstorableDependencies );
+
+	return { ...step, providedDependencies };
+}
+
 SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
 	var action = payload.action,
 		step = addTimestamp( action.data );
@@ -147,18 +161,18 @@ SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
 			loadProgressFromCache();
 			break;
 		case 'SAVE_SIGNUP_STEP':
-			saveStep( step );
+			saveStep( addStorableDependencies( step, action ) );
 			break;
 		case 'SUBMIT_SIGNUP_STEP':
 			debug( 'submit step' );
-			submitStep( step );
+			submitStep( addStorableDependencies( step, action ) );
 			break;
 		case 'PROCESS_SIGNUP_STEP':
-			processStep( step );
+			processStep( addStorableDependencies( step, action ) );
 			break;
 		case 'PROCESSED_SIGNUP_STEP':
 			debug( 'complete step' );
-			completeStep( step );
+			completeStep( addStorableDependencies( step, action ) );
 			break;
 	}
 } );

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -8,6 +8,7 @@ var debug = require( 'debug' )( 'calypso:signup-progress-store' ), // eslint-dis
 	find = require( 'lodash/find' ),
 	map = require( 'lodash/map' ),
 	isEmpty = require( 'lodash/isEmpty' ),
+	get = require( 'lodash/get' ),
 	clone = require( 'lodash/clone' );
 
 /**
@@ -133,19 +134,13 @@ function handleChange() {
 }
 
 function addStorableDependencies( step, action ) {
-	let unstorableDependencies;
-
-	if ( steps[ step.stepName ] ) {
-		unstorableDependencies = steps[ step.stepName ].unstorableDependencies;
-	}
+	const unstorableDependencies = get( steps, [ step.stepName, 'unstorableDependencies' ] );
 
 	if ( isEmpty( action.providedDependencies ) ) {
 		return step;
 	}
 
-	const providedDependencies = isEmpty( unstorableDependencies )
-		? action.providedDependencies
-		: omit( action.providedDependencies, unstorableDependencies );
+	const providedDependencies = omit( action.providedDependencies, unstorableDependencies );
 
 	return { ...step, providedDependencies };
 }

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -73,7 +73,8 @@ export default {
 		stepName: 'user',
 		apiRequestFunction: stepActions.createAccount,
 		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username' ]
+		providesDependencies: [ 'bearer_token', 'username' ],
+		unstorableDependencies: [ 'bearer_token' ],
 	},
 
 	'user-social': {
@@ -81,6 +82,7 @@ export default {
 		apiRequestFunction: stepActions.createAccount,
 		providesToken: true,
 		providesDependencies: [ 'bearer_token', 'username' ],
+		unstorableDependencies: [ 'bearer_token' ],
 		props: {
 			headerText: i18n.translate( 'Create your account.' ),
 			isSocialSignupEnabled: true

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -168,11 +168,7 @@ const Signup = React.createClass( {
 			step => ( -1 !== flowSteps.indexOf( step.stepName ) ),
 		);
 
-		if (
-			flowStepsInProgressStore.length > 0 &&
-			! flow.disallowResume &&
-			this.signupFlowController.canResumeAt( this.firstUnsubmittedStepName() )
-		) {
+		if ( flowStepsInProgressStore.length > 0 && ! flow.disallowResume ) {
 			// we loaded progress from local storage, attempt to resume progress
 			return this.resumeProgress();
 		}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -168,7 +168,11 @@ const Signup = React.createClass( {
 			step => ( -1 !== flowSteps.indexOf( step.stepName ) ),
 		);
 
-		if ( flowStepsInProgressStore.length > 0 && ! flow.disallowResume ) {
+		if (
+			flowStepsInProgressStore.length > 0 &&
+			! flow.disallowResume &&
+			this.signupFlowController.canResumeAt( this.firstUnsubmittedStepName() )
+		) {
 			// we loaded progress from local storage, attempt to resume progress
 			return this.resumeProgress();
 		}


### PR DESCRIPTION
Resolve #16199

If you refresh the browser at any point after completing step 1 of sign up process, the process never completes due to a fatal error that occurs on the confirmation page. It is because refreshing the page causes lack of some required dependency information.

This commit redirects to the first step if any mandatory data is missed.

See #16199 for more detail.

## How to test

1. Starting at URL: https://wordpress.com/start
2. At any point after completing Step 1 of the process refresh the browser
3. ~~The page should be redirected to the first step.~~  
  **UPDATED!** You should be able to resume the process where you left off.
4. Attempt to complete the signup