### PR TITLE
Comments: On change status, remove the error notice before retrying

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/change-status/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/change-status/index.js
@@ -19,6 +19,8 @@ const changeCommentStatus = ( { dispatch, getState }, action ) => {
 	const { siteId, commentId, status } = action;
 	const previousStatus = get( getSiteComment( getState(), action.siteId, action.commentId ), 'status' );
 
+	dispatch( removeNotice( `comment-notice-${ commentId }` ) );
+
 	dispatch(
 		http(
 			{
@@ -39,8 +41,6 @@ const changeCommentStatus = ( { dispatch, getState }, action ) => {
 
 const announceFailure = ( { dispatch, getState }, action ) => {
 	const { commentId, status, previousStatus } = action;
-
-	dispatch( removeNotice( `comment-notice-${ action.commentId }` ) );
 
 	dispatch(
 		local( {


### PR DESCRIPTION
Fix a small bug introduced in #16678.
If an error happens when changing a comment status, a successful retry doesn't remove the error notice.

## Test (for A8C)

- Open the new comment management (still in development, disregard any issues and glitches) on a site **with** comments: `/comments/approved/{ siteSlug }`.
- Disable the proxy.
- Change a comment status (e.g. unapprove a comment) and wait for the error notice to show up (disregard the second notice that might show up).
- With no proxy, click "Try Again": the error notice should disappear and immediately reappear.
- Re-enable the proxy.
- Click "Try Again": the error notice should disappear for good.