### PR TITLE
Signup: Fix misaligned labels on domains page.

### DIFF
--- a/client/components/domains/domain-mapping-suggestion/style.scss
+++ b/client/components/domains/domain-mapping-suggestion/style.scss
@@ -2,21 +2,10 @@
 	display: flex;
 
 	.domain-product-price {
-		@include breakpoint( ">660px" ) {
-			margin-top: 5px;
-		}
-
 		&.is-free-domain {
 			@include breakpoint( ">660px" ) {
 				margin-top: 5px;
 			}
-		}
-	}
-	.domain-suggestion__action {
-			margin-top: 20px;
-
-		@include breakpoint( ">660px" ) {
-			margin-top: 10px;
 		}
 	}
 }

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -18,6 +18,11 @@
 		small {
 			font-size: 12px;
 		}
+
+		@include breakpoint( ">660px" ) {
+			display: flex;
+			align-items: center;
+		}
 	}
 
 	.map-domain-step & {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -6,6 +6,9 @@
 
 	@include breakpoint( ">660px" ) {
 		min-width: 130px;
+		display: flex;
+		align-items: center;
+		margin-top: -4px;
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -17,11 +20,6 @@
 
 		small {
 			font-size: 12px;
-		}
-
-		@include breakpoint( ">660px" ) {
-			display: flex;
-			align-items: center;
 		}
 	}
 


### PR DESCRIPTION
This PR will fix the styles of "included in WordPress.com Premium" label to align them vertically center.

![](https://user-images.githubusercontent.com/212034/28823116-029bb8ca-76f7-11e7-9b2e-5fbdaffa54db.png)

Resolve #16560, #11521 