### PR TITLE
Simple Payment: Update modal styling

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -8,6 +8,7 @@
 		padding: 0;
 		display: flex;
 		flex-direction: column;
+		max-width: none;
 
 		@include breakpoint( ">660px" ) {
 			top: 5%;
@@ -24,11 +25,18 @@
 		}
 	}
 
+	.header-cake.card {
+		@include breakpoint( "<660px" ) {
+			margin-top: 0;
+		}
+	}
+
 	.dialog__content {
 		display: flex;
 		flex-direction: column;
 		flex: auto;
 		min-height: 0; // permits the to shrink below its min height and scroll
+		padding: 0;
 	}
 
 	.dialog__action-buttons {
@@ -52,12 +60,20 @@
 	flex: auto;
 	overflow-y: auto;
 
+	@include breakpoint( ">480px" ) {
+		padding: 24px;
+	}
+
 	@include breakpoint( ">660px" ) {
 		display: flex;
+
+		.upload-image {
+			margin-right: 25px;
+		}
 	}
 
 	.upload-image {
-		margin-right: 25px;
+		margin-bottom: 20px;
 	}
 }
 


### PR DESCRIPTION
Some style fixes for the modal.

* Remove paddings from the modal wrapper
* 100% width for small screens
* Larger inner padding for large screens
* Add bottom margin to the image upload square for small screens

![screen-shot-2017-08-01-at-12 23 23_02](https://user-images.githubusercontent.com/908665/28823324-daa58766-76b4-11e7-806b-5f1b30c29a76.jpg)
